### PR TITLE
refactor: optimize docker build caching by separating go modules download layer :hammer:

### DIFF
--- a/components/audit/Dockerfile
+++ b/components/audit/Dockerfile
@@ -2,6 +2,10 @@ FROM golang:1.23-alpine AS builder
 
 WORKDIR /audit-app
 
+COPY go.mod go.sum ./
+
+RUN go mod download
+
 COPY . .
 
 RUN CGO_ENABLED=0 GOOS=linux go build -a -tags netgo -ldflags '-w -extldflags "-static"' -o /app components/audit/cmd/app/main.go

--- a/components/ledger/Dockerfile
+++ b/components/ledger/Dockerfile
@@ -2,6 +2,10 @@ FROM golang:1.23-alpine AS builder
 
 WORKDIR /ledger-app
 
+COPY go.mod go.sum ./
+
+RUN go mod download
+
 COPY . .
 
 RUN CGO_ENABLED=0 GOOS=linux go build -a -tags netgo -ldflags '-w -extldflags "-static"' -o /app components/ledger/cmd/app/main.go

--- a/components/transaction/Dockerfile
+++ b/components/transaction/Dockerfile
@@ -2,6 +2,10 @@ FROM golang:1.23-alpine AS builder
 
 WORKDIR /transaction-app
 
+COPY go.mod go.sum ./
+
+RUN go mod download
+
 COPY . .
 
 RUN CGO_ENABLED=0 GOOS=linux go build -a -tags netgo -ldflags '-w -extldflags "-static"' -o /app components/transaction/cmd/app/main.go


### PR DESCRIPTION
# Midaz Pull Request Checklist

## Pull Request Type
[//]: # (Check the appropriate box for the type of pull request.)

- [ ] Auth
- [ ] Infra
- [x] Ledger
- [ ] Mdz
- [x] Transaction
- [x] Audit
- [ ] Pipeline
- [ ] Documentation

## Checklist
Please check each item after it's completed.

- [x] I have tested these changes locally.
- [ ] I have updated the documentation accordingly.
- [ ] I have added necessary comments to the code, especially in complex areas.
- [ ] I have ensured that my changes adhere to the project's coding standards.
- [ ] I have checked for any potential security issues.
- [x] I have ensured that all tests pass.
- [ ] I have updated the version appropriately (if applicable).
- [x] I have confirmed this code is ready for review.

## Additional Notes
[//]: # (Add any additional notes, context, or explanation that could be helpful for reviewers.)
 - Related to #497 
Evidences:
On this screenshot we can see that during build the go modules download were not cached.
![1  cache invalidated](https://github.com/user-attachments/assets/1cbbd43d-8d5f-44df-9f15-c06b4a076a9e)

Now, on this next screenshot, we can see the go modules were cached.
![2  cache still valid](https://github.com/user-attachments/assets/faf5fc14-26f7-4104-9208-99151639bd7d)

## Obs: Please, always remember to target your PR to develop branch instead of main.