### PR TITLE
fix/MIDAZ-506 | fix: make "name" required when creating asset

### DIFF
--- a/pkg/mmodel/asset.go
+++ b/pkg/mmodel/asset.go
@@ -8,7 +8,7 @@ import "time"
 //
 //	@Description	CreateAssetInput is the input payload to create an asset.
 type CreateAssetInput struct {
-	Name     string         `json:"name" validate:"max=256" example:"Brazilian Real"`
+	Name     string         `json:"name" validate:"required,max=256" example:"Brazilian Real"`
 	Type     string         `json:"type" example:"currency"`
 	Code     string         `json:"code" validate:"required,max=100" example:"BRL"`
 	Status   Status         `json:"status"`


### PR DESCRIPTION
# Midaz Pull Request Checklist

## Pull Request Type
[//]: # (Check the appropriate box for the type of pull request.)

- [ ] Auth
- [ ] Infra
- [x] Ledger
- [ ] Mdz
- [ ] Transaction
- [ ] Audit
- [ ] Pipeline
- [ ] Documentation

## Checklist
Please check each item after it's completed.

- [x] I have tested these changes locally.
- [ ] I have updated the documentation accordingly.
- [ ] I have added necessary comments to the code, especially in complex areas.
- [ ] I have ensured that my changes adhere to the project's coding standards.
- [ ] I have checked for any potential security issues.
- [x] I have ensured that all tests pass.
- [ ] I have updated the version appropriately (if applicable).
- [x] I have confirmed this code is ready for review.

## Additional Notes
[//]: # (Add any additional notes, context, or explanation that could be helpful for reviewers.)
Related to #506 

Evidence showing now API will return error if no name is provided
![image](https://github.com/user-attachments/assets/b80c44f2-0bce-4bc6-88fe-a904c14474e6)

## Obs: Please, always remember to target your PR to develop branch instead of main.