### PR TITLE
fix: Correctly mentioning a role on Discord Release Notification

### DIFF
--- a/.github/workflows/release-notification.yml
+++ b/.github/workflows/release-notification.yml
@@ -29,32 +29,32 @@ jobs:
           echo "Raw release: $RAW_RELEASE"
           echo "{name}={value}" >> $RAW_RELEASE
 
-      # - name: Beta releases to Discord
-      #   uses: SethCohen/github-releases-to-discord@v1.13.1
-      #   if: contains(github.ref, '-beta.')
-      #   with:
-      #     webhook_url: ${{ secrets.DISCORD_BETA_WEBHOOK_URL }}
-      #     color: "2105893"
-      #     username: "Release Changelog"
-      #     content: "<@&1346912481829982229>"
-      #     footer_timestamp: true
+      - name: Beta releases to Discord
+        uses: SethCohen/github-releases-to-discord@v1.13.1
+        if: contains(github.ref, '-beta.')
+        with:
+          webhook_url: ${{ secrets.DISCORD_BETA_WEBHOOK_URL }}
+          color: "2105893"
+          username: "Release Changelog"
+          content: "<@&1346912481829982229>"
+          footer_timestamp: true
 
-      # - name: Releases to Discord
-      #   uses: SethCohen/github-releases-to-discord@v1.16.2
-      #   if: ${{ !contains(github.ref, '-beta.') }}
-      #   with:
-      #     webhook_url: ${{ secrets.DISCORD_WEBHOOK_URL }}
-      #     color: "2105893"
-      #     username: "Release Changelog"
-      #     content: "<@&1346912737380274176>"
-      #     footer_timestamp: true
+      - name: Releases to Discord
+        uses: SethCohen/github-releases-to-discord@v1.16.2
+        if: ${{ !contains(github.ref, '-beta.') }}
+        with:
+          webhook_url: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          color: "2105893"
+          username: "Release Changelog"
+          content: "<@&1346912737380274176>"
+          footer_timestamp: true
 
-      # - name: Notify Slack of New Release
-      #   uses: rtCamp/action-slack-notify@v2
-      #   env:
-      #     SLACK_CHANNEL: "lerian-product-release"
-      #     SLACK_COLOR: "#36a64f"
-      #     SLACK_ICON_EMOJI: ":rocket"
-      #     SLACK_TITLE: "Midaz New Release: ${{ steps.latest_release.outputs.tag }}"
-      #     SLACK_MESSAGE: "🎉 *Nova Release Publicada!* \n \n <https://github.com/${{ github.repository }}/releases/tag/${{ steps.latest_release.outputs.tag }} | *Clique aqui para detalhes*>"
-      #     SLACK_WEBHOOK: ${{ secrets.RELEASE_WEBHOOK_NOTIFICATION_URL }}
+      - name: Notify Slack of New Release
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_CHANNEL: "lerian-product-release"
+          SLACK_COLOR: "#36a64f"
+          SLACK_ICON_EMOJI: ":rocket"
+          SLACK_TITLE: "Midaz New Release: ${{ steps.latest_release.outputs.tag }}"
+          SLACK_MESSAGE: "🎉 *Nova Release Publicada!* \n \n <https://github.com/${{ github.repository }}/releases/tag/${{ steps.latest_release.outputs.tag }} | *Clique aqui para detalhes*>"
+          SLACK_WEBHOOK: ${{ secrets.RELEASE_WEBHOOK_NOTIFICATION_URL }}

--- a/.github/workflows/release-notification.yml
+++ b/.github/workflows/release-notification.yml
@@ -22,8 +22,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install GitHub CLI
-        run: sudo apt-get install -y gh
+      # - name: Install GitHub CLI
+      #   run: sudo apt-get install -y gh
 
       # - name: Fetch Latest Release
       #   id: latest_release
@@ -34,15 +34,21 @@ jobs:
       #     echo "Raw release: $RAW_RELEASE"
       #     echo "{name}={value}" >> $RAW_RELEASE
 
-      - name: Beta releases to Discord
-        uses: SethCohen/github-releases-to-discord@v1.13.1
-        # if: contains(github.ref, '-beta.')
+      # - name: Beta releases to Discord
+      #   uses: SethCohen/github-releases-to-discord@v1.13.1
+      #   # if: contains(github.ref, '-beta.')
+      #   with:
+      #     webhook_url: ${{ secrets.DISCORD_BETA_WEBHOOK_URL }}
+      #     color: "2105893"
+      #     username: "Release Changelog"
+      #     content: "<@&1346912481829982229>"
+      #     footer_timestamp: true
+
+      - name: Discord Webhook Action
+        uses: tsickert/discord-webhook@v7.0.0
         with:
-          webhook_url: ${{ secrets.DISCORD_BETA_WEBHOOK_URL }}
-          color: "2105893"
-          username: "Release Changelog"
-          content: "<@&1346912481829982229>"
-          footer_timestamp: true
+          webhook-url: ${{ secrets.DISCORD_BETA_WEBHOOK_URL }}
+          content: "Test mentioning <@&1346912481829982229>"
 
       # - name: Releases to Discord
       #   uses: SethCohen/github-releases-to-discord@v1.16.2

--- a/.github/workflows/release-notification.yml
+++ b/.github/workflows/release-notification.yml
@@ -1,7 +1,11 @@
 name: "Release Notifications"
 on:
-  release:
-    types: [published]
+  #release:
+    #types: [published]
+  branches:
+      - fix/release-notification-workflow 
+      
+
 
 jobs:
   github-releases-to-discord:

--- a/.github/workflows/release-notification.yml
+++ b/.github/workflows/release-notification.yml
@@ -23,7 +23,7 @@ jobs:
           webhook_url: ${{ secrets.DISCORD_BETA_WEBHOOK_URL }}
           color: "2105893"
           username: "Release Changelog"
-          content: "@beta-release-notification"
+          content: "||@beta-release-notification||"
           footer_timestamp: true
 
       - name: Releases to Discord
@@ -33,7 +33,7 @@ jobs:
           webhook_url: ${{ secrets.DISCORD_WEBHOOK_URL }}
           color: "2105893"
           username: "Release Changelog"
-          content: "@release-notification"
+          content: "||@release-notification||"
           footer_timestamp: true
 
       - name: Install GitHub CLI

--- a/.github/workflows/release-notification.yml
+++ b/.github/workflows/release-notification.yml
@@ -1,14 +1,14 @@
 name: "Release Notifications"
 on:
+  push:
+    branches:
+      - fix/release-notification-workflow 
   #release:
     #types: [published]
-  branches:
-      - fix/release-notification-workflow 
-      
-
 
 jobs:
-  github-releases-to-discord:
+  github-release-notification:
+    name: Notify Discord and Slack of New Release
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/create-github-app-token@v1
@@ -20,44 +20,44 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Install GitHub CLI
+        run: sudo apt-get install -y gh
+
+      # - name: Fetch Latest Release
+      #   id: latest_release
+      #   env:
+      #     GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+      #   run: |
+      #     RAW_RELEASE=$(gh release list --repo $GITHUB_REPOSITORY --limit 1 --json tagName --jq '.[0].tagName')
+      #     echo "Raw release: $RAW_RELEASE"
+      #     echo "{name}={value}" >> $RAW_RELEASE
+
       - name: Beta releases to Discord
         uses: SethCohen/github-releases-to-discord@v1.13.1
-        if: contains(github.ref, '-beta.')
+        # if: contains(github.ref, '-beta.')
         with:
           webhook_url: ${{ secrets.DISCORD_BETA_WEBHOOK_URL }}
           color: "2105893"
           username: "Release Changelog"
-          content: "||@beta-release-notification||"
+          content: "<@&1346912481829982229>"
           footer_timestamp: true
 
-      - name: Releases to Discord
-        uses: SethCohen/github-releases-to-discord@v1.13.1
-        if: ${{ !contains(github.ref, '-beta.') }}
-        with:
-          webhook_url: ${{ secrets.DISCORD_WEBHOOK_URL }}
-          color: "2105893"
-          username: "Release Changelog"
-          content: "||@release-notification||"
-          footer_timestamp: true
+      # - name: Releases to Discord
+      #   uses: SethCohen/github-releases-to-discord@v1.16.2
+      #   # if: ${{ !contains(github.ref, '-beta.') }}
+      #   with:
+      #     webhook_url: ${{ secrets.DISCORD_WEBHOOK_URL }}
+      #     color: "2105893"
+      #     username: "Release Changelog"
+      #     content: "<@&1346912737380274176>"
+      #     footer_timestamp: true
 
-      - name: Install GitHub CLI
-        run: sudo apt-get install -y gh
-
-      - name: Fetch Latest Release
-        id: latest_release
-        env:
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
-        run: |
-          RAW_RELEASE=$(gh release list --repo $GITHUB_REPOSITORY --limit 1 --json tagName --jq '.[0].tagName')
-          echo "Raw release: $RAW_RELEASE"
-          echo "::set-output name=tag::$RAW_RELEASE"
-
-      - name: Notify Slack of New Release
-        uses: rtCamp/action-slack-notify@v2
-        env:
-          SLACK_CHANNEL: "lerian-product-release" # Channel of Slack
-          SLACK_COLOR: "#36a64f"
-          SLACK_ICON_EMOJI: ":rocket"
-          SLACK_TITLE: "Midaz New Release: ${{ steps.latest_release.outputs.tag }}"
-          SLACK_MESSAGE: "🎉 *Nova Release Publicada!* \n \n <https://github.com/${{ github.repository }}/releases/tag/${{ steps.latest_release.outputs.tag }} | *Clique aqui para detalhes*>"
-          SLACK_WEBHOOK: ${{ secrets.RELEASE_WEBHOOK_NOTIFICATION_URL }} # Webhook Release Notification
+      # - name: Notify Slack of New Release
+      #   uses: rtCamp/action-slack-notify@v2
+      #   env:
+      #     SLACK_CHANNEL: "lerian-product-release" # Channel of Slack
+      #     SLACK_COLOR: "#36a64f"
+      #     SLACK_ICON_EMOJI: ":rocket"
+      #     SLACK_TITLE: "Midaz New Release: ${{ steps.latest_release.outputs.tag }}"
+      #     SLACK_MESSAGE: "🎉 *Nova Release Publicada!* \n \n <https://github.com/${{ github.repository }}/releases/tag/${{ steps.latest_release.outputs.tag }} | *Clique aqui para detalhes*>"
+      #     SLACK_WEBHOOK: ${{ secrets.RELEASE_WEBHOOK_NOTIFICATION_URL }} # Webhook Release Notification

--- a/.github/workflows/release-notification.yml
+++ b/.github/workflows/release-notification.yml
@@ -1,12 +1,7 @@
 name: "Release Notifications"
 on:
-  push:
-    branches:
-      - fix/release-notification-workflow 
-  #release:
-    #types: [published]
-      
-
+  release:
+    types: [published]
 
 jobs:
   github-release-notification:
@@ -22,21 +17,21 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      # - name: Install GitHub CLI
-      #   run: sudo apt-get install -y gh
+      - name: Install GitHub CLI
+        run: sudo apt-get install -y gh
 
-      # - name: Fetch Latest Release
-      #   id: latest_release
-      #   env:
-      #     GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
-      #   run: |
-      #     RAW_RELEASE=$(gh release list --repo $GITHUB_REPOSITORY --limit 1 --json tagName --jq '.[0].tagName')
-      #     echo "Raw release: $RAW_RELEASE"
-      #     echo "{name}={value}" >> $RAW_RELEASE
+      - name: Fetch Latest Release
+        id: latest_release
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          RAW_RELEASE=$(gh release list --repo $GITHUB_REPOSITORY --limit 1 --json tagName --jq '.[0].tagName')
+          echo "Raw release: $RAW_RELEASE"
+          echo "{name}={value}" >> $RAW_RELEASE
 
       # - name: Beta releases to Discord
       #   uses: SethCohen/github-releases-to-discord@v1.13.1
-      #   # if: contains(github.ref, '-beta.')
+      #   if: contains(github.ref, '-beta.')
       #   with:
       #     webhook_url: ${{ secrets.DISCORD_BETA_WEBHOOK_URL }}
       #     color: "2105893"
@@ -44,15 +39,9 @@ jobs:
       #     content: "<@&1346912481829982229>"
       #     footer_timestamp: true
 
-      - name: Discord Webhook Action
-        uses: tsickert/discord-webhook@v7.0.0
-        with:
-          webhook-url: ${{ secrets.DISCORD_BETA_WEBHOOK_URL }}
-          content: "Test mentioning <@&1346912481829982229>"
-
       # - name: Releases to Discord
       #   uses: SethCohen/github-releases-to-discord@v1.16.2
-      #   # if: ${{ !contains(github.ref, '-beta.') }}
+      #   if: ${{ !contains(github.ref, '-beta.') }}
       #   with:
       #     webhook_url: ${{ secrets.DISCORD_WEBHOOK_URL }}
       #     color: "2105893"
@@ -63,9 +52,9 @@ jobs:
       # - name: Notify Slack of New Release
       #   uses: rtCamp/action-slack-notify@v2
       #   env:
-      #     SLACK_CHANNEL: "lerian-product-release" # Channel of Slack
+      #     SLACK_CHANNEL: "lerian-product-release"
       #     SLACK_COLOR: "#36a64f"
       #     SLACK_ICON_EMOJI: ":rocket"
       #     SLACK_TITLE: "Midaz New Release: ${{ steps.latest_release.outputs.tag }}"
       #     SLACK_MESSAGE: "🎉 *Nova Release Publicada!* \n \n <https://github.com/${{ github.repository }}/releases/tag/${{ steps.latest_release.outputs.tag }} | *Clique aqui para detalhes*>"
-      #     SLACK_WEBHOOK: ${{ secrets.RELEASE_WEBHOOK_NOTIFICATION_URL }} # Webhook Release Notification
+      #     SLACK_WEBHOOK: ${{ secrets.RELEASE_WEBHOOK_NOTIFICATION_URL }}

--- a/.github/workflows/release-notification.yml
+++ b/.github/workflows/release-notification.yml
@@ -1,7 +1,10 @@
 name: "Release Notifications"
 on:
-  release:
-    types: [published]
+  # release:
+  #   types: [published]
+  push:
+    branches:
+      - fix/release-notification-workflow
 
 jobs:
   github-release-notification:

--- a/.github/workflows/release-notification.yml
+++ b/.github/workflows/release-notification.yml
@@ -27,7 +27,7 @@ jobs:
         run: |
           RAW_RELEASE=$(gh release list --repo $GITHUB_REPOSITORY --limit 1 --json tagName --jq '.[0].tagName')
           echo "Raw release: $RAW_RELEASE"
-          echo "{name}={value}" >> $RAW_RELEASE
+          echo "tag=$RAW_RELEASE" >> $GITHUB_OUTPUT
 
       - name: Beta releases to Discord
         uses: SethCohen/github-releases-to-discord@v1.13.1

--- a/.github/workflows/release-notification.yml
+++ b/.github/workflows/release-notification.yml
@@ -1,10 +1,7 @@
 name: "Release Notifications"
 on:
-  # release:
-  #   types: [published]
-  push:
-    branches:
-      - fix/release-notification-workflow
+  release:
+    types: [published]
 
 jobs:
   github-release-notification:


### PR DESCRIPTION
Correctly mentioning a role on Discord Release Notification and plus, updated the [`set-output`](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/) that is marked as deprecated.

Yes, again, since this uses the content of a release tag to generate the message, the only way to test is by creating a beta release. I hope this is the last PR of the type.


# Midaz Pull Request Checklist

## Pull Request Type
[//]: # (Check the appropriate box for the type of pull request.)

- [ ] Infra
- [ ] Onboarding
- [ ] Mdz
- [ ] Transaction
- [x] Pipeline
- [ ] Documentation

## Checklist
Please check each item after it's completed.

- [x] I have tested these changes locally. _As much as I can do it locally_
- [ ] I have updated the documentation accordingly.
- [ ] I have added necessary comments to the code, especially in complex areas.
- [ ] I have ensured that my changes adhere to the project's coding standards.
- [ ] I have checked for any potential security issues.
- [ ] I have ensured that all tests pass.
- [ ] I have updated the version appropriately (if applicable).
- [x] I have confirmed this code is ready for review.
