### PR TITLE
feat: Support multiple transactions with the same account in From/To fields;

### DIFF
--- a/components/transaction/internal/adapters/rabbitmq/producer.rabbitmq.go
+++ b/components/transaction/internal/adapters/rabbitmq/producer.rabbitmq.go
@@ -46,7 +46,7 @@ func (prmq *ProducerRabbitMQRepository) ProducerDefault(ctx context.Context, exc
 	logger := libCommons.NewLoggerFromContext(ctx)
 	tracer := libCommons.NewTracerFromContext(ctx)
 
-	logger.Infof("Init sent message")
+	logger.Infof("Init sent message to exchange: %s, key: %s", exchange, key)
 
 	_, spanProducer := tracer.Start(ctx, "rabbitmq.producer.publish_message")
 	defer spanProducer.End()
@@ -81,7 +81,7 @@ func (prmq *ProducerRabbitMQRepository) ProducerDefault(ctx context.Context, exc
 		return nil, err
 	}
 
-	logger.Infoln("Messages sent successfully")
+	logger.Infof("Messages sent successfully to exchange: %s, key: %s", exchange, key)
 
 	return nil, nil
 }

--- a/components/transaction/internal/services/query/get-balances.go
+++ b/components/transaction/internal/services/query/get-balances.go
@@ -146,7 +146,7 @@ func (uc *UseCase) GetAccountAndLock(ctx context.Context, organizationID, ledger
 					return nil, err
 				}
 
-				b.Alias = k
+				b.Alias = balance.Alias
 
 				newBalances = append(newBalances, b)
 			}
@@ -163,13 +163,11 @@ func (uc *UseCase) GetAccountAndLock(ctx context.Context, organizationID, ledger
 					return nil, err
 				}
 
-				b.Alias = k
+				b.Alias = balance.Alias
 
 				newBalances = append(newBalances, b)
 			}
 		}
-
 	}
-
 	return newBalances, nil
 }

--- a/components/transaction/internal/services/query/get-balances.go
+++ b/components/transaction/internal/services/query/get-balances.go
@@ -147,7 +147,7 @@ func (uc *UseCase) GetAccountAndLock(ctx context.Context, organizationID, ledger
 					return nil, err
 				}
 
-				b.Alias = balance.Alias
+				b.Alias = k
 
 				newBalances = append(newBalances, b)
 			}
@@ -164,7 +164,7 @@ func (uc *UseCase) GetAccountAndLock(ctx context.Context, organizationID, ledger
 					return nil, err
 				}
 
-				b.Alias = balance.Alias
+				b.Alias = k
 
 				newBalances = append(newBalances, b)
 			}

--- a/components/transaction/internal/services/query/get-balances.go
+++ b/components/transaction/internal/services/query/get-balances.go
@@ -130,7 +130,6 @@ func (uc *UseCase) GetAccountAndLock(ctx context.Context, organizationID, ledger
 	defer span.End()
 
 	newBalances := make([]*mmodel.Balance, 0)
-
 	for _, balance := range balances {
 		internalKey := libCommons.LockInternalKey(organizationID, ledgerID, balance.Alias)
 
@@ -146,6 +145,7 @@ func (uc *UseCase) GetAccountAndLock(ctx context.Context, organizationID, ledger
 
 					return nil, err
 				}
+
 				b.Alias = k
 
 				newBalances = append(newBalances, b)
@@ -162,6 +162,7 @@ func (uc *UseCase) GetAccountAndLock(ctx context.Context, organizationID, ledger
 
 					return nil, err
 				}
+
 				b.Alias = k
 
 				newBalances = append(newBalances, b)

--- a/components/transaction/internal/services/query/get-balances.go
+++ b/components/transaction/internal/services/query/get-balances.go
@@ -130,6 +130,7 @@ func (uc *UseCase) GetAccountAndLock(ctx context.Context, organizationID, ledger
 	defer span.End()
 
 	newBalances := make([]*mmodel.Balance, 0)
+
 	for _, balance := range balances {
 		internalKey := libCommons.LockInternalKey(organizationID, ledgerID, balance.Alias)
 
@@ -169,5 +170,6 @@ func (uc *UseCase) GetAccountAndLock(ctx context.Context, organizationID, ledger
 			}
 		}
 	}
+
 	return newBalances, nil
 }

--- a/components/transaction/internal/services/query/get-balances_test.go
+++ b/components/transaction/internal/services/query/get-balances_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/LerianStudio/midaz/components/transaction/internal/adapters/postgres/balance"
 	"github.com/LerianStudio/midaz/components/transaction/internal/adapters/rabbitmq"
 	"github.com/LerianStudio/midaz/components/transaction/internal/adapters/redis"
+	"github.com/LerianStudio/midaz/pkg/constant"
 	"github.com/LerianStudio/midaz/pkg/mmodel"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
@@ -38,8 +39,25 @@ func TestGetBalances(t *testing.T) {
 		aliases := []string{"alias1", "alias2", "alias3"}
 		validate := &libTransaction.Responses{
 			Aliases: aliases,
-			From:    make(map[string]libTransaction.Amount),
-			To:      make(map[string]libTransaction.Amount),
+			From: map[string]libTransaction.Amount{
+				"alias1": {
+					Asset: "USD",
+					Value: int64(50),
+					Scale: int64(2),
+				},
+			},
+			To: map[string]libTransaction.Amount{
+				"alias2": {
+					Asset: "EUR",
+					Value: int64(40),
+					Scale: int64(2),
+				},
+				"alias3": {
+					Asset: "GBP",
+					Value: int64(30),
+					Scale: int64(2),
+				},
+			},
 		}
 
 		// Redis balance for alias1
@@ -122,9 +140,16 @@ func TestGetBalances(t *testing.T) {
 			Return(databaseBalances, nil).
 			Times(1)
 
-		// Mock Redis.LockBalanceRedis for all balances
-		for _, b := range append([]*mmodel.Balance{
-			{
+		// Mock Redis.LockBalanceRedis for alias1 with DEBIT operation
+		mockRedisRepo.EXPECT().
+			LockBalanceRedis(
+				gomock.Any(),
+				internalKey1,
+				gomock.Any(),
+				validate.From["alias1"],
+				constant.DEBIT,
+			).
+			Return(&mmodel.Balance{
 				ID:             balanceRedis.ID,
 				AccountID:      balanceRedis.AccountID,
 				OrganizationID: organizationID.String(),
@@ -138,14 +163,32 @@ func TestGetBalances(t *testing.T) {
 				AllowSending:   balanceRedis.AllowSending == 1,
 				AllowReceiving: balanceRedis.AllowReceiving == 1,
 				AssetCode:      balanceRedis.AssetCode,
-			},
-		}, databaseBalances...) {
-			internalKey := libCommons.LockInternalKey(organizationID, ledgerID, b.Alias)
-			mockRedisRepo.EXPECT().
-				LockBalanceRedis(gomock.Any(), internalKey, gomock.Any(), gomock.Any(), gomock.Any()).
-				Return(b, nil).
-				Times(1)
-		}
+			}, nil).
+			Times(1)
+
+		// Mock Redis.LockBalanceRedis for alias2 with CREDIT operation
+		mockRedisRepo.EXPECT().
+			LockBalanceRedis(
+				gomock.Any(),
+				internalKey2,
+				gomock.Any(),
+				validate.To["alias2"],
+				constant.CREDIT,
+			).
+			Return(databaseBalances[0], nil).
+			Times(1)
+
+		// Mock Redis.LockBalanceRedis for alias3 with CREDIT operation
+		mockRedisRepo.EXPECT().
+			LockBalanceRedis(
+				gomock.Any(),
+				internalKey3,
+				gomock.Any(),
+				validate.To["alias3"],
+				constant.CREDIT,
+			).
+			Return(databaseBalances[1], nil).
+			Times(1)
 
 		// Call the method
 		balances, err := uc.GetBalances(ctx, organizationID, ledgerID, validate)
@@ -153,9 +196,6 @@ func TestGetBalances(t *testing.T) {
 		// Assertions
 		assert.NoError(t, err)
 		assert.Len(t, balances, 3)
-		assert.Equal(t, "alias1", balances[0].Alias)
-		assert.Equal(t, "alias2", balances[1].Alias)
-		assert.Equal(t, "alias3", balances[2].Alias)
 	})
 
 	t.Run("all balances from redis", func(t *testing.T) {
@@ -163,8 +203,20 @@ func TestGetBalances(t *testing.T) {
 		aliases := []string{"alias1", "alias2"}
 		validate := &libTransaction.Responses{
 			Aliases: aliases,
-			From:    make(map[string]libTransaction.Amount),
-			To:      make(map[string]libTransaction.Amount),
+			From: map[string]libTransaction.Amount{
+				"alias1": {
+					Asset: "USD",
+					Value: int64(50),
+					Scale: int64(2),
+				},
+			},
+			To: map[string]libTransaction.Amount{
+				"alias2": {
+					Asset: "EUR",
+					Value: int64(40),
+					Scale: int64(2),
+				},
+			},
 		}
 
 		// Redis balances
@@ -214,9 +266,16 @@ func TestGetBalances(t *testing.T) {
 			Return(string(balance2JSON), nil).
 			Times(1)
 
-		// Mock Redis.LockBalanceRedis for both balances
-		expectedBalances := []*mmodel.Balance{
-			{
+		// Mock Redis.LockBalanceRedis for alias1 with DEBIT operation
+		mockRedisRepo.EXPECT().
+			LockBalanceRedis(
+				gomock.Any(),
+				internalKey1,
+				gomock.Any(),
+				validate.From["alias1"],
+				constant.DEBIT,
+			).
+			Return(&mmodel.Balance{
 				ID:             balance1.ID,
 				AccountID:      balance1.AccountID,
 				OrganizationID: organizationID.String(),
@@ -230,8 +289,19 @@ func TestGetBalances(t *testing.T) {
 				AllowSending:   balance1.AllowSending == 1,
 				AllowReceiving: balance1.AllowReceiving == 1,
 				AssetCode:      balance1.AssetCode,
-			},
-			{
+			}, nil).
+			Times(1)
+
+		// Mock Redis.LockBalanceRedis for alias2 with CREDIT operation
+		mockRedisRepo.EXPECT().
+			LockBalanceRedis(
+				gomock.Any(),
+				internalKey2,
+				gomock.Any(),
+				validate.To["alias2"],
+				constant.CREDIT,
+			).
+			Return(&mmodel.Balance{
 				ID:             balance2.ID,
 				AccountID:      balance2.AccountID,
 				OrganizationID: organizationID.String(),
@@ -245,16 +315,8 @@ func TestGetBalances(t *testing.T) {
 				AllowSending:   balance2.AllowSending == 1,
 				AllowReceiving: balance2.AllowReceiving == 1,
 				AssetCode:      balance2.AssetCode,
-			},
-		}
-
-		for _, b := range expectedBalances {
-			internalKey := libCommons.LockInternalKey(organizationID, ledgerID, b.Alias)
-			mockRedisRepo.EXPECT().
-				LockBalanceRedis(gomock.Any(), internalKey, gomock.Any(), gomock.Any(), gomock.Any()).
-				Return(b, nil).
-				Times(1)
-		}
+			}, nil).
+			Times(1)
 
 		// Call the method
 		balances, err := uc.GetBalances(ctx, organizationID, ledgerID, validate)
@@ -262,74 +324,6 @@ func TestGetBalances(t *testing.T) {
 		// Assertions
 		assert.NoError(t, err)
 		assert.Len(t, balances, 2)
-		assert.Equal(t, "alias1", balances[0].Alias)
-		assert.Equal(t, "alias2", balances[1].Alias)
-	})
-}
-
-func TestValidateIfBalanceExistsOnRedis(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	mockRedisRepo := redis.NewMockRedisRepository(ctrl)
-
-	uc := &UseCase{
-		RedisRepo: mockRedisRepo,
-	}
-
-	ctx := context.Background()
-	organizationID := uuid.New()
-	ledgerID := uuid.New()
-
-	t.Run("some balances in redis", func(t *testing.T) {
-		// Test data
-		aliases := []string{"alias1", "alias2", "alias3"}
-
-		// Redis balance for alias1
-		balance1 := mmodel.BalanceRedis{
-			ID:             uuid.New().String(),
-			AccountID:      uuid.New().String(),
-			Available:      int64(100),
-			OnHold:         int64(0),
-			Scale:          int64(2),
-			Version:        1,
-			AccountType:    "deposit",
-			AllowSending:   1,
-			AllowReceiving: 1,
-			AssetCode:      "USD",
-		}
-		balance1JSON, _ := json.Marshal(balance1)
-
-		// Mock Redis.Get for all aliases
-		internalKey1 := libCommons.LockInternalKey(organizationID, ledgerID, "alias1")
-		mockRedisRepo.EXPECT().
-			Get(gomock.Any(), internalKey1).
-			Return(string(balance1JSON), nil).
-			Times(1)
-
-		internalKey2 := libCommons.LockInternalKey(organizationID, ledgerID, "alias2")
-		mockRedisRepo.EXPECT().
-			Get(gomock.Any(), internalKey2).
-			Return("", nil).
-			Times(1)
-
-		internalKey3 := libCommons.LockInternalKey(organizationID, ledgerID, "alias3")
-		mockRedisRepo.EXPECT().
-			Get(gomock.Any(), internalKey3).
-			Return("", nil).
-			Times(1)
-
-		// Call the method
-		balances, remainingAliases := uc.ValidateIfBalanceExistsOnRedis(ctx, organizationID, ledgerID, aliases)
-
-		// Assertions
-		assert.Len(t, balances, 1)
-		assert.Equal(t, balance1.ID, balances[0].ID)
-		assert.Equal(t, "alias1", balances[0].Alias)
-
-		assert.Len(t, remainingAliases, 2)
-		assert.Contains(t, remainingAliases, "alias2")
-		assert.Contains(t, remainingAliases, "alias3")
 	})
 }
 
@@ -400,14 +394,31 @@ func TestGetAccountAndLock(t *testing.T) {
 			},
 		}
 
-		// Mock Redis.LockBalanceRedis for both balances
-		for _, b := range balances {
-			internalKey := libCommons.LockInternalKey(organizationID, ledgerID, b.Alias)
-			mockRedisRepo.EXPECT().
-				LockBalanceRedis(gomock.Any(), internalKey, gomock.Any(), gomock.Any(), gomock.Any()).
-				Return(b, nil).
-				Times(1)
-		}
+		// Mock Redis.LockBalanceRedis for alias1 with DEBIT operation
+		internalKey1 := libCommons.LockInternalKey(organizationID, ledgerID, "alias1")
+		mockRedisRepo.EXPECT().
+			LockBalanceRedis(
+				gomock.Any(),
+				internalKey1,
+				gomock.Any(),
+				validate.From["alias1"],
+				constant.DEBIT,
+			).
+			Return(balances[0], nil).
+			Times(1)
+
+		// Mock Redis.LockBalanceRedis for alias2 with CREDIT operation
+		internalKey2 := libCommons.LockInternalKey(organizationID, ledgerID, "alias2")
+		mockRedisRepo.EXPECT().
+			LockBalanceRedis(
+				gomock.Any(),
+				internalKey2,
+				gomock.Any(),
+				validate.To["alias2"],
+				constant.CREDIT,
+			).
+			Return(balances[1], nil).
+			Times(1)
 
 		// Call the method
 		lockedBalances, err := uc.GetAccountAndLock(ctx, organizationID, ledgerID, validate, balances)
@@ -415,8 +426,72 @@ func TestGetAccountAndLock(t *testing.T) {
 		// Assertions
 		assert.NoError(t, err)
 		assert.Len(t, lockedBalances, 2)
-		assert.Equal(t, "alias1", lockedBalances[0].Alias)
-		assert.Equal(t, "alias2", lockedBalances[1].Alias)
+	})
+}
+
+func TestValidateIfBalanceExistsOnRedis(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockRedisRepo := redis.NewMockRedisRepository(ctrl)
+
+	uc := &UseCase{
+		RedisRepo: mockRedisRepo,
+	}
+
+	ctx := context.Background()
+	organizationID := uuid.New()
+	ledgerID := uuid.New()
+
+	t.Run("some balances in redis", func(t *testing.T) {
+		// Test data
+		aliases := []string{"alias1", "alias2", "alias3"}
+
+		// Redis balance for alias1
+		balance1 := mmodel.BalanceRedis{
+			ID:             uuid.New().String(),
+			AccountID:      uuid.New().String(),
+			Available:      int64(100),
+			OnHold:         int64(0),
+			Scale:          int64(2),
+			Version:        1,
+			AccountType:    "deposit",
+			AllowSending:   1,
+			AllowReceiving: 1,
+			AssetCode:      "USD",
+		}
+		balance1JSON, _ := json.Marshal(balance1)
+
+		// Mock Redis.Get for all aliases
+		internalKey1 := libCommons.LockInternalKey(organizationID, ledgerID, "alias1")
+		mockRedisRepo.EXPECT().
+			Get(gomock.Any(), internalKey1).
+			Return(string(balance1JSON), nil).
+			Times(1)
+
+		internalKey2 := libCommons.LockInternalKey(organizationID, ledgerID, "alias2")
+		mockRedisRepo.EXPECT().
+			Get(gomock.Any(), internalKey2).
+			Return("", nil).
+			Times(1)
+
+		internalKey3 := libCommons.LockInternalKey(organizationID, ledgerID, "alias3")
+		mockRedisRepo.EXPECT().
+			Get(gomock.Any(), internalKey3).
+			Return("", nil).
+			Times(1)
+
+		// Call the method
+		balances, remainingAliases := uc.ValidateIfBalanceExistsOnRedis(ctx, organizationID, ledgerID, aliases)
+
+		// Assertions
+		assert.Len(t, balances, 1)
+		assert.Equal(t, balance1.ID, balances[0].ID)
+		assert.Equal(t, "alias1", balances[0].Alias)
+
+		assert.Len(t, remainingAliases, 2)
+		assert.Contains(t, remainingAliases, "alias2")
+		assert.Contains(t, remainingAliases, "alias3")
 	})
 }
 

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ toolchain go1.24.1
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2
 	github.com/LerianStudio/lib-auth v1.14.0
-	github.com/LerianStudio/lib-commons v1.8.0
+	github.com/LerianStudio/lib-commons v1.9.0
 	github.com/Masterminds/squirrel v1.5.4
 	github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2
 	github.com/antlr4-go/antlr/v4 v4.13.1
@@ -95,8 +95,8 @@ require (
 	golang.org/x/net v0.40.0 // indirect
 	golang.org/x/text v0.25.0 // indirect
 	golang.org/x/tools v0.33.0 // indirect
-	google.golang.org/genproto/googleapis/api v0.0.0-20250505200425-f936aa4a68b2 // indirect
-	google.golang.org/genproto/googleapis/rpc v0.0.0-20250505200425-f936aa4a68b2 // indirect
+	google.golang.org/genproto/googleapis/api v0.0.0-20250512202823-5a2f75b736a9 // indirect
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20250512202823-5a2f75b736a9 // indirect
 	google.golang.org/grpc v1.72.0 // indirect
 	google.golang.org/protobuf v1.36.6 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -7,8 +7,8 @@ github.com/KyleBanks/depth v1.2.1 h1:5h8fQADFrWtarTdtDudMmGsC7GPbOAu6RVB3ffsVFHc
 github.com/KyleBanks/depth v1.2.1/go.mod h1:jzSb9d0L43HxTQfT+oSA1EEp2q+ne2uh6XgeJcm8brE=
 github.com/LerianStudio/lib-auth v1.14.0 h1:9SRDwhhggNS9lUPFkUa7IkMpONkVfK6pS0SeTVAHe0w=
 github.com/LerianStudio/lib-auth v1.14.0/go.mod h1:nkkH8gKYltGMO6l9gLxSBZ7IoVHT/cwQ3OEOqTrD9gU=
-github.com/LerianStudio/lib-commons v1.8.0 h1:GBJUmQeWEJHN0X+DxjAOI9BbdCKQkZV0Ylv0qopXvvs=
-github.com/LerianStudio/lib-commons v1.8.0/go.mod h1:/DbXWohyeU7RBI+SapJDECGav4QrSe6LHNJP2sSCGYM=
+github.com/LerianStudio/lib-commons v1.9.0 h1:nykqq1prwE8a+Uj4aCp99RxD2v9cLWa+c8X7zsq2QIs=
+github.com/LerianStudio/lib-commons v1.9.0/go.mod h1:unURsb1L7jViur3CiRZzPWH0qOuyK0NiLGRKHI7Nuxc=
 github.com/Masterminds/squirrel v1.5.4 h1:uUcX/aBc8O7Fg9kaISIUsHXdKuqehiXAMQTYX8afzqM=
 github.com/Masterminds/squirrel v1.5.4/go.mod h1:NNaOrjSoIDfDA40n7sr2tPNZRfjzjA400rg+riTZj10=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
@@ -405,10 +405,10 @@ golang.org/x/tools v0.33.0/go.mod h1:CIJMaWEY88juyUfo7UbgPqbC8rU2OqfAV1h2Qp0oMYI
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-google.golang.org/genproto/googleapis/api v0.0.0-20250505200425-f936aa4a68b2 h1:vPV0tzlsK6EzEDHNNH5sa7Hs9bd7iXR7B1tSiPepkV0=
-google.golang.org/genproto/googleapis/api v0.0.0-20250505200425-f936aa4a68b2/go.mod h1:pKLAc5OolXC3ViWGI62vvC0n10CpwAtRcTNCFwTKBEw=
-google.golang.org/genproto/googleapis/rpc v0.0.0-20250505200425-f936aa4a68b2 h1:IqsN8hx+lWLqlN+Sc3DoMy/watjofWiU8sRFgQ8fhKM=
-google.golang.org/genproto/googleapis/rpc v0.0.0-20250505200425-f936aa4a68b2/go.mod h1:qQ0YXyHHx3XkvlzUtpXDkS29lDSafHMZBAZDc03LQ3A=
+google.golang.org/genproto/googleapis/api v0.0.0-20250512202823-5a2f75b736a9 h1:WvBuA5rjZx9SNIzgcU53OohgZy6lKSus++uY4xLaWKc=
+google.golang.org/genproto/googleapis/api v0.0.0-20250512202823-5a2f75b736a9/go.mod h1:W3S/3np0/dPWsWLi1h/UymYctGXaGBM2StwzD0y140U=
+google.golang.org/genproto/googleapis/rpc v0.0.0-20250512202823-5a2f75b736a9 h1:IkAfh6J/yllPtpYFU0zZN1hUPYdT0ogkBT/9hMxHjvg=
+google.golang.org/genproto/googleapis/rpc v0.0.0-20250512202823-5a2f75b736a9/go.mod h1:qQ0YXyHHx3XkvlzUtpXDkS29lDSafHMZBAZDc03LQ3A=
 google.golang.org/grpc v1.72.0 h1:S7UkcVa60b5AAQTaO6ZKamFp1zMZSU0fGDK2WZLbBnM=
 google.golang.org/grpc v1.72.0/go.mod h1:wH5Aktxcg25y1I3w7H69nHfXdOG3UiadoBtjh3izSDM=
 google.golang.org/protobuf v1.36.6 h1:z1NpPI8ku2WgiWnf+t9wTPsn6eP1L7ksHUlkfLvd9xY=


### PR DESCRIPTION
# Midaz Pull Request Checklist

## Pull Request Type
[//]: # (Check the appropriate box for the type of pull request.)

- [ ] Infra
- [ ] Onboarding
- [ ] Mdz
- [x] Transaction
- [ ] Pipeline
- [ ] Documentation

## Checklist
Please check each item after it's completed.

- [x] I have tested these changes locally.
- [ ] I have updated the documentation accordingly.
- [ ] I have added necessary comments to the code, especially in complex areas.
- [x] I have ensured that my changes adhere to the project's coding standards.
- [x] I have checked for any potential security issues.
- [x] I have ensured that all tests pass.
- [ ] I have updated the version appropriately (if applicable).
- [x] I have confirmed this code is ready for review.

## Obs: Please, always remember to target your PR to develop branch instead of main.
## Additional Notes
[//]: # (Add any additional notes, context, or explanation that could be helpful for reviewers.)

TICKET: #703

This commit implements the ability to use the same account multiple times in From or To fields by:

1. Modifying the transaction handler to properly handle duplicate account aliases
2. Updating the balance locking mechanism to process each From/To entry individually
3. Using SplitAlias function to correctly match accounts regardless of alias format
4. Improving logging in RabbitMQ producer with more detailed exchange/key information
5. Updating lib-commons dependency to version 1.9.0
6. Update Tests.

These changes ensure that multiple transactions can be processed for the same account within a single operation, improving flexibility for complex transaction scenarios.
