### PR TITLE
Feature/MIDAZ-792

### DIFF
--- a/components/onboarding/api/docs.go
+++ b/components/onboarding/api/docs.go
@@ -1208,6 +1208,86 @@ const docTemplate = `{
                 }
             }
         },
+        "/v1/organizations/{organization_id}/ledgers/{ledger_id}/accounts/external/{code}": {
+            "get": {
+                "description": "Returns detailed information about an account identified by its alias within the specified ledger",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Accounts"
+                ],
+                "summary": "Retrieve an account by alias",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Authorization Bearer Token with format: Bearer {token}",
+                        "name": "Authorization",
+                        "in": "header",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Request ID for tracing",
+                        "name": "X-Request-Id",
+                        "in": "header"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Organization ID in UUID format",
+                        "name": "organization_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Ledger ID in UUID format",
+                        "name": "ledger_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Account External Code (e.g. BRL)",
+                        "name": "code",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successfully retrieved account",
+                        "schema": {
+                            "$ref": "#/definitions/Account"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized access",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden access",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "404": {
+                        "description": "Account with the specified alias, ledger, or organization not found",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    }
+                }
+            }
+        },
         "/v1/organizations/{organization_id}/ledgers/{ledger_id}/accounts/{id}": {
             "get": {
                 "description": "Returns detailed information about an account identified by its UUID within the specified ledger",

--- a/components/onboarding/api/openapi.yaml
+++ b/components/onboarding/api/openapi.yaml
@@ -979,6 +979,75 @@ paths:
       summary: Retrieve an account by alias
       tags:
       - Accounts
+  /v1/organizations/{organization_id}/ledgers/{ledger_id}/accounts/external/{code}:
+    get:
+      description: Returns detailed information about an account identified by its
+        alias within the specified ledger
+      parameters:
+      - description: 'Authorization Bearer Token with format: Bearer {token}'
+        in: header
+        name: Authorization
+        required: true
+        schema:
+          type: string
+      - description: Request ID for tracing
+        in: header
+        name: X-Request-Id
+        schema:
+          type: string
+      - description: Organization ID in UUID format
+        in: path
+        name: organization_id
+        required: true
+        schema:
+          type: string
+      - description: Ledger ID in UUID format
+        in: path
+        name: ledger_id
+        required: true
+        schema:
+          type: string
+      - description: Account External Code (e.g. BRL)
+        in: path
+        name: code
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Account'
+          description: Successfully retrieved account
+        "401":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unauthorized access
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Forbidden access
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Account with the specified alias, ledger, or organization not
+            found
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal server error
+      summary: Retrieve an account by alias
+      tags:
+      - Accounts
   /v1/organizations/{organization_id}/ledgers/{ledger_id}/accounts/{id}:
     delete:
       description: Permanently removes an account from the specified ledger. This

--- a/components/onboarding/api/swagger.json
+++ b/components/onboarding/api/swagger.json
@@ -1202,6 +1202,86 @@
                 }
             }
         },
+        "/v1/organizations/{organization_id}/ledgers/{ledger_id}/accounts/external/{code}": {
+            "get": {
+                "description": "Returns detailed information about an account identified by its alias within the specified ledger",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Accounts"
+                ],
+                "summary": "Retrieve an account by alias",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Authorization Bearer Token with format: Bearer {token}",
+                        "name": "Authorization",
+                        "in": "header",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Request ID for tracing",
+                        "name": "X-Request-Id",
+                        "in": "header"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Organization ID in UUID format",
+                        "name": "organization_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Ledger ID in UUID format",
+                        "name": "ledger_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Account External Code (e.g. BRL)",
+                        "name": "code",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successfully retrieved account",
+                        "schema": {
+                            "$ref": "#/definitions/Account"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized access",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden access",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "404": {
+                        "description": "Account with the specified alias, ledger, or organization not found",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    }
+                }
+            }
+        },
         "/v1/organizations/{organization_id}/ledgers/{ledger_id}/accounts/{id}": {
             "get": {
                 "description": "Returns detailed information about an account identified by its UUID within the specified ledger",

--- a/components/onboarding/api/swagger.yaml
+++ b/components/onboarding/api/swagger.yaml
@@ -2031,6 +2031,62 @@ paths:
       summary: Retrieve an account by alias
       tags:
       - Accounts
+  /v1/organizations/{organization_id}/ledgers/{ledger_id}/accounts/external/{code}:
+    get:
+      description: Returns detailed information about an account identified by its
+        alias within the specified ledger
+      parameters:
+      - description: 'Authorization Bearer Token with format: Bearer {token}'
+        in: header
+        name: Authorization
+        required: true
+        type: string
+      - description: Request ID for tracing
+        in: header
+        name: X-Request-Id
+        type: string
+      - description: Organization ID in UUID format
+        in: path
+        name: organization_id
+        required: true
+        type: string
+      - description: Ledger ID in UUID format
+        in: path
+        name: ledger_id
+        required: true
+        type: string
+      - description: Account External Code (e.g. BRL)
+        in: path
+        name: code
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Successfully retrieved account
+          schema:
+            $ref: '#/definitions/Account'
+        "401":
+          description: Unauthorized access
+          schema:
+            $ref: '#/definitions/Error'
+        "403":
+          description: Forbidden access
+          schema:
+            $ref: '#/definitions/Error'
+        "404":
+          description: Account with the specified alias, ledger, or organization not
+            found
+          schema:
+            $ref: '#/definitions/Error'
+        "500":
+          description: Internal server error
+          schema:
+            $ref: '#/definitions/Error'
+      summary: Retrieve an account by alias
+      tags:
+      - Accounts
   /v1/organizations/{organization_id}/ledgers/{ledger_id}/assets:
     get:
       description: Returns a paginated list of assets within the specified ledger,

--- a/components/onboarding/internal/adapters/http/in/account.go
+++ b/components/onboarding/internal/adapters/http/in/account.go
@@ -6,6 +6,7 @@ import (
 	libPostgres "github.com/LerianStudio/lib-commons/commons/postgres"
 	"github.com/LerianStudio/midaz/components/onboarding/internal/services/command"
 	"github.com/LerianStudio/midaz/components/onboarding/internal/services/query"
+	"github.com/LerianStudio/midaz/pkg/constant"
 	"github.com/LerianStudio/midaz/pkg/mmodel"
 	"github.com/LerianStudio/midaz/pkg/net/http"
 	"github.com/gofiber/fiber/v2"
@@ -220,6 +221,54 @@ func (handler *AccountHandler) GetAccountByID(c *fiber.Ctx) error {
 	logger.Infof("Successfully retrieved Account with Account ID: %s", id.String())
 
 	return http.OK(c, account)
+}
+
+// GetAccountExternalByCode is a method that retrieves External Account information by a given asset code.
+//
+//	@Summary		Retrieve an account by alias
+//	@Description	Returns detailed information about an account identified by its alias within the specified ledger
+//	@Tags			Accounts
+//	@Produce		json
+//	@Param			Authorization	header		string	true	"Authorization Bearer Token with format: Bearer {token}"
+//	@Param			X-Request-Id	header		string	false	"Request ID for tracing"
+//	@Param			organization_id	path		string	true	"Organization ID in UUID format"
+//	@Param			ledger_id		path		string	true	"Ledger ID in UUID format"
+//	@Param			code			path		string	true	"Account External Code (e.g. BRL)"
+//	@Success		200				{object}	mmodel.Account	"Successfully retrieved account"
+//	@Failure		401				{object}	mmodel.Error	"Unauthorized access"
+//	@Failure		403				{object}	mmodel.Error	"Forbidden access"
+//	@Failure		404				{object}	mmodel.Error	"Account with the specified alias, ledger, or organization not found"
+//	@Failure		500				{object}	mmodel.Error	"Internal server error"
+//	@Router			/v1/organizations/{organization_id}/ledgers/{ledger_id}/accounts/external/{code} [get]
+func (handler *AccountHandler) GetAccountExternalByCode(c *fiber.Ctx) error {
+	ctx := c.UserContext()
+
+	logger := libCommons.NewLoggerFromContext(ctx)
+	tracer := libCommons.NewTracerFromContext(ctx)
+
+	ctx, span := tracer.Start(ctx, "handler.get_account_external_by_code")
+	defer span.End()
+
+	organizationID := c.Locals("organization_id").(uuid.UUID)
+	ledgerID := c.Locals("ledger_id").(uuid.UUID)
+	code := c.Params("code")
+	alias := constant.DefaultExternalAccountAliasPrefix + code
+
+	logger.Infof("Initiating retrieval of Account with Account Alias: %s", alias)
+
+	account, err := handler.Query.GetAccountByAlias(ctx, organizationID, ledgerID, nil, alias)
+	if err != nil {
+		libOpentelemetry.HandleSpanError(&span, "Failed to retrieve Account on query", err)
+
+		logger.Errorf("Failed to retrieve Account with Account Alias: %s, Error: %s", alias, err.Error())
+
+		return http.WithError(c, err)
+	}
+
+	logger.Infof("Successfully retrieved Account with Account Alias: %s", alias)
+
+	return http.OK(c, account)
+
 }
 
 // GetAccountByAlias is a method that retrieves Account information by a given account alias.

--- a/components/onboarding/internal/adapters/http/in/account.go
+++ b/components/onboarding/internal/adapters/http/in/account.go
@@ -268,7 +268,6 @@ func (handler *AccountHandler) GetAccountExternalByCode(c *fiber.Ctx) error {
 	logger.Infof("Successfully retrieved Account with Account Alias: %s", alias)
 
 	return http.OK(c, account)
-
 }
 
 // GetAccountByAlias is a method that retrieves Account information by a given account alias.

--- a/components/onboarding/internal/adapters/http/in/routes.go
+++ b/components/onboarding/internal/adapters/http/in/routes.go
@@ -67,6 +67,7 @@ func NewRouter(lg libLog.Logger, tl *libOpentelemetry.Telemetry, auth *middlewar
 	f.Get("/v1/organizations/:organization_id/ledgers/:ledger_id/accounts", auth.Authorize(midazName, "accounts", "get"), http.ParseUUIDPathParameters, ah.GetAllAccounts)
 	f.Get("/v1/organizations/:organization_id/ledgers/:ledger_id/accounts/:id", auth.Authorize(midazName, "accounts", "get"), http.ParseUUIDPathParameters, ah.GetAccountByID)
 	f.Get("/v1/organizations/:organization_id/ledgers/:ledger_id/accounts/alias/:alias", auth.Authorize(midazName, "accounts", "get"), http.ParseUUIDPathParameters, ah.GetAccountByAlias)
+	f.Get("/v1/organizations/:organization_id/ledgers/:ledger_id/accounts/external/:code", auth.Authorize(midazName, "accounts", "get"), http.ParseUUIDPathParameters, ah.GetAccountExternalByCode)
 	f.Delete("/v1/organizations/:organization_id/ledgers/:ledger_id/accounts/:id", auth.Authorize(midazName, "accounts", "delete"), http.ParseUUIDPathParameters, ah.DeleteAccountByID)
 
 	// Health

--- a/components/transaction/internal/bootstrap/config.go
+++ b/components/transaction/internal/bootstrap/config.go
@@ -114,7 +114,7 @@ func InitServers() *Service {
 		MaxIdleConnections:      cfg.MaxIdleConnections,
 	}
 
-	mongoSource := fmt.Sprintf("%s://%s:%s@%s:%s/",
+	mongoSource := fmt.Sprintf("%s://%s:%s@%s:%s",
 		cfg.MongoURI, cfg.MongoDBUser, cfg.MongoDBPassword, cfg.MongoDBHost, cfg.MongoDBPort)
 
 	if cfg.MaxPoolSize <= 0 {

--- a/pkg/constant/asset_transaction.go
+++ b/pkg/constant/asset_transaction.go
@@ -1,7 +1,0 @@
-package constant
-
-// TODO: temporary default asset code to be removed when multi-asset transaction is implemented.
-
-const (
-	DefaultAssetCode = "BRL"
-)

--- a/postman/MIDAZ.postman_collection.json
+++ b/postman/MIDAZ.postman_collection.json
@@ -1693,6 +1693,129 @@
           ]
         },
         {
+          "name": "Retrieve an account by alias",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{authToken}}",
+                "description": "Authorization Bearer Token with format: Bearer {token}",
+                "disabled": false
+              },
+              {
+                "key": "X-Request-Id",
+                "value": "{{$guid}}",
+                "description": "Request ID for tracing",
+                "disabled": true
+              }
+            ],
+            "url": {
+              "raw": "{{onboardingUrl}}/v1/organizations/{organization_id}/ledgers/{ledger_id}/accounts/external/{code}",
+              "host": [
+                "{{onboardingUrl}}"
+              ],
+              "path": [
+                "v1",
+                "organizations",
+                "{{organizationId}}",
+                "ledgers",
+                "{{ledgerId}}",
+                "accounts",
+                "external",
+                "{{code}}"
+              ],
+              "variable": [
+                {
+                  "key": "organization_id",
+                  "value": "{{organizationId}}",
+                  "description": "Organization ID in UUID format"
+                },
+                {
+                  "key": "ledger_id",
+                  "value": "{{ledgerId}}",
+                  "description": "Ledger ID in UUID format"
+                },
+                {
+                  "key": "code",
+                  "value": "",
+                  "description": "Account External Code (e.g. BRL)"
+                }
+              ]
+            },
+            "description": "Returns detailed information about an account identified by its alias within the specified ledger"
+          },
+          "response": [],
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "",
+                  "// Check for auth token",
+                  "if (!pm.environment.get(\"authToken\")) {",
+                  "  console.log(\"Warning: authToken is not set in the environment\");",
+                  "}",
+                  "",
+                  "// Set authorization header if it exists",
+                  "if (pm.environment.get(\"authToken\")) {",
+                  "  pm.request.headers.upsert({",
+                  "    key: \"Authorization\",",
+                  "    value: \"Bearer \" + pm.environment.get(\"authToken\")",
+                  "  });",
+                  "}",
+                  "",
+                  "// Set request ID for tracing",
+                  "pm.request.headers.upsert({",
+                  "  key: \"X-Request-Id\",",
+                  "  value: pm.variables.replaceIn(\"{{$guid}}\")",
+                  "});",
+                  ""
+                ]
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "",
+                  "// Test for successful response status",
+                  "if (pm.request.method === \"POST\") {",
+                  "  pm.test(\"Status code is 200 or 201\", function () {",
+                  "    pm.expect(pm.response.code).to.be.oneOf([200, 201]);",
+                  "  });",
+                  "} else if (pm.request.method === \"DELETE\") {",
+                  "  pm.test(\"Status code is 204 No Content\", function () {",
+                  "    pm.expect(pm.response.code).to.equal(204);",
+                  "  });",
+                  "} else {",
+                  "  pm.test(\"Status code is 200 OK\", function () {",
+                  "    pm.expect(pm.response.code).to.equal(200);",
+                  "  });",
+                  "}",
+                  "",
+                  "// Validate response has the expected format",
+                  "pm.test(\"Response has the correct structure\", function() {",
+                  "  // For DELETE operations that return 204 No Content, the body is empty by design",
+                  "  if (pm.response.code === 204) {",
+                  "    pm.expect(true).to.be.true; // Always pass for 204 responses",
+                  "    return;",
+                  "  }",
+                  "  ",
+                  "  // For responses with content, validate JSON structure",
+                  "  pm.response.to.be.json;",
+                  "  ",
+                  "  // Add specific validation based on response schema here",
+                  "});",
+                  ""
+                ]
+              }
+            }
+          ]
+        },
+        {
           "name": "Retrieve a specific account",
           "request": {
             "method": "GET",


### PR DESCRIPTION
# Midaz Pull Request Checklist

## Pull Request Type
[//]: # (Check the appropriate box for the type of pull request.)

- [ ] Infra
- [x] Onboarding
- [ ] Mdz
- [ ] Transaction
- [ ] Pipeline
- [x] Documentation

## Checklist
Please check each item after it's completed.

- [x] I have tested these changes locally.
- [x] I have updated the documentation accordingly.
- [x] I have added necessary comments to the code, especially in complex areas.
- [x] I have ensured that my changes adhere to the project's coding standards.
- [x] I have checked for any potential security issues.
- [x] I have ensured that all tests pass.
- [ ] I have updated the version appropriately (if applicable).
- [x] I have confirmed this code is ready for review.

## Obs: Please, always remember to target your PR to develop branch instead of main.
## Additional Notes
[//]: # (Add any additional notes, context, or explanation that could be helpful for reviewers.)

[#792](https://github.com/LerianStudio/midaz/issues/792)

This commit adds a new endpoint to retrieve external accounts by their code (e.g., BRL, USD) 
rather than having to use the full alias. The implementation includes:

- New GET endpoint: /v1/organizations/{organization_id}/ledgers/{ledger_id}/accounts/external/{code}
- Added GetAccountExternalByCode handler that converts the code to the proper external account alias format
- Updated API documentation and Swagger specifications
- Added route registration in the router
- Updated Postman collection with the new endpoint

This enhancement simplifies access to external accounts by allowing clients to use 
currency codes directly instead of constructing the full alias with the prefix.
