### PR TITLE
hotfix/MIDAZ-971

### DIFF
--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -55,6 +55,6 @@ branches:
   - main
   - name: develop
     prerelease: beta
-  - name: hotfix/organization-id
+  - name: hotfix/MIDAZ-971
     prerelease: false
     channel: false

--- a/components/transaction/internal/adapters/postgres/operation/operation.go
+++ b/components/transaction/internal/adapters/postgres/operation/operation.go
@@ -18,8 +18,8 @@ type OperationPostgreSQLModel struct {
 	Amount                *int64         // Operation amount value
 	AmountScale           *int64         // Decimal places for amount
 	AvailableBalance      *int64         // Available balance before operation
-	BalanceScale          *int64         // Decimal places for balance
 	OnHoldBalance         *int64         // On-hold balance before operation
+	BalanceScale          *int64         // Decimal places for balance
 	AvailableBalanceAfter *int64         // Available balance after operation
 	OnHoldBalanceAfter    *int64         // On-hold balance after operation
 	BalanceScaleAfter     *int64         // Decimal places for balance after operation

--- a/components/transaction/internal/adapters/postgres/operation/operation.postgresql.go
+++ b/components/transaction/internal/adapters/postgres/operation/operation.postgresql.go
@@ -204,8 +204,8 @@ func (r *OperationPostgreSQLRepository) FindAll(ctx context.Context, organizatio
 			&operation.Amount,
 			&operation.AmountScale,
 			&operation.AvailableBalance,
-			&operation.BalanceScale,
 			&operation.OnHoldBalance,
+			&operation.BalanceScale,
 			&operation.AvailableBalanceAfter,
 			&operation.OnHoldBalanceAfter,
 			&operation.BalanceScaleAfter,
@@ -292,8 +292,8 @@ func (r *OperationPostgreSQLRepository) ListByIDs(ctx context.Context, organizat
 			&operation.Amount,
 			&operation.AmountScale,
 			&operation.AvailableBalance,
-			&operation.BalanceScale,
 			&operation.OnHoldBalance,
+			&operation.BalanceScale,
 			&operation.AvailableBalanceAfter,
 			&operation.OnHoldBalanceAfter,
 			&operation.BalanceScaleAfter,
@@ -358,8 +358,8 @@ func (r *OperationPostgreSQLRepository) Find(ctx context.Context, organizationID
 		&operation.Amount,
 		&operation.AmountScale,
 		&operation.AvailableBalance,
-		&operation.BalanceScale,
 		&operation.OnHoldBalance,
+		&operation.BalanceScale,
 		&operation.AvailableBalanceAfter,
 		&operation.OnHoldBalanceAfter,
 		&operation.BalanceScaleAfter,
@@ -419,8 +419,8 @@ func (r *OperationPostgreSQLRepository) FindByAccount(ctx context.Context, organ
 		&operation.Amount,
 		&operation.AmountScale,
 		&operation.AvailableBalance,
-		&operation.BalanceScale,
 		&operation.OnHoldBalance,
+		&operation.BalanceScale,
 		&operation.AvailableBalanceAfter,
 		&operation.OnHoldBalanceAfter,
 		&operation.BalanceScaleAfter,
@@ -606,7 +606,7 @@ func (r *OperationPostgreSQLRepository) FindAllByAccount(ctx context.Context, or
 		Where(squirrel.LtOrEq{"created_at": libCommons.NormalizeDate(filter.EndDate, libPointers.Int(2))}).
 		PlaceholderFormat(squirrel.Dollar)
 
-	if operationType != nil {
+	if !libCommons.IsNilOrEmpty(operationType) {
 		findAll = findAll.Where(squirrel.Expr("type = ?", *operationType))
 	}
 
@@ -642,8 +642,8 @@ func (r *OperationPostgreSQLRepository) FindAllByAccount(ctx context.Context, or
 			&operation.Amount,
 			&operation.AmountScale,
 			&operation.AvailableBalance,
-			&operation.BalanceScale,
 			&operation.OnHoldBalance,
+			&operation.BalanceScale,
 			&operation.AvailableBalanceAfter,
 			&operation.OnHoldBalanceAfter,
 			&operation.BalanceScaleAfter,


### PR DESCRIPTION
## Pull Request Type
[//]: # (Check the appropriate box for the type of pull request.)

- [ ] Console
- [ ] Documentation
- [ ] Infra
- [ ] Mdz
- [ ] Onboarding
- [ ] Pipeline
- [x] Transaction

## Checklist
Please check each item after it's completed.

- [x] I have tested these changes locally.
- [x] I have updated the documentation accordingly.
- [x] I have added necessary comments to the code, especially in complex areas.
- [x] I have ensured that my changes adhere to the project's coding standards.
- [x] I have checked for any potential security issues.
- [x] I have ensured that all tests pass.
- [ ] I have updated the version appropriately (if applicable).
- [x] I have confirmed this code is ready for review.

## Obs: Please, always remember to target your PR to develop branch instead of main.
## Additional Notes
[//]: # (Add any additional notes, context, or explanation that could be helpful for reviewers.)


# Field Order Correction in Operation Models

This PR fixes the field order in the Operation model to align the application code with the database schema and JSON structure.

## Changes

* **Reordered fields in OperationPostgreSQLModel**:
  - Changed order of `BalanceScale` and `OnHoldBalance` to match the expected field order in Balance struct (Available -> OnHold -> Scale)
  - Updated all scan operations in repository methods to align with the new field order

* **Improved null check in FindAllByAccount**:
  - Replaced direct nil check (`operationType != nil`) with more comprehensive `!libCommons.IsNilOrEmpty(operationType)` function

## Why

This change ensures consistency between the database model, application structs, and JSON serialization, preventing potential field misalignment issues in conversions between different representations.

