### PR TITLE
fix(transactions): skip fee calculation for external accounts

### DIFF
--- a/components/console/src/app/(routes)/transactions/create/transaction-review.tsx
+++ b/components/console/src/app/(routes)/transactions/create/transaction-review.tsx
@@ -87,7 +87,17 @@ export const TransactionReview = () => {
       const feesEnabled = process.env.NEXT_PUBLIC_PLUGIN_FEES_ENABLED === 'true'
 
       if (feesEnabled) {
-        calculateFees({ transaction: values })
+        const hasExternalAccount =
+          values.source?.some((source) =>
+            source.accountAlias?.startsWith('@external/')
+          ) ||
+          values.destination?.some((destination) =>
+            destination.accountAlias?.startsWith('@external/')
+          )
+
+        if (!hasExternalAccount) {
+          calculateFees({ transaction: values })
+        }
       }
     }
   }, [values, currentOrganization.id, currentLedger.id])
@@ -104,8 +114,6 @@ export const TransactionReview = () => {
       amount: value.toString()
     }))
   })
-
-  const _isDeductibleFrom = calculatedFees?.transaction?.isDeductibleFrom
 
   const getTransactionPayload = () => {
     if (calculatedFees && calculatedFees.transaction) {
@@ -168,9 +176,6 @@ export const TransactionReview = () => {
       )
       const accountsWithPrincipal = new Set(
         nonFeeOperations.map((op: any) => op.accountAlias)
-      )
-      const _overlappingAccounts = new Set(
-        [...accountsWithFees].filter((acc) => accountsWithPrincipal.has(acc))
       )
 
       // Keep fee operations separate from principal operations
@@ -262,8 +267,7 @@ export const TransactionReview = () => {
             .filter((rule: any) => rule.isDeductibleFrom)
             .map((rule: any) => rule.creditAccount)
             .join(',')
-        },
-        _consolidatedData: consolidatedData
+        }
       }
     }
     return parse(values)
@@ -295,8 +299,7 @@ export const TransactionReview = () => {
     }
 
     setSendAnother(true)
-    const { _consolidatedData, ...payloadForApi } = payload as any
-    createTransaction(payloadForApi)
+    createTransaction(payload)
   }
 
   const handleSubmit = () => {
@@ -325,8 +328,7 @@ export const TransactionReview = () => {
     }
 
     setSendAnother(false)
-    const { _consolidatedData, ...payloadForApi } = payload as any
-    createTransaction(payloadForApi)
+    createTransaction(payload)
   }
 
   return (

--- a/components/console/src/core/infrastructure/fee/repositories/http-fee-repository.ts
+++ b/components/console/src/core/infrastructure/fee/repositories/http-fee-repository.ts
@@ -81,12 +81,12 @@ export class HttpFeeRepository implements FeeRepository {
             throw new FeeConfigurationError('Fee service URL not configured')
           }
 
+          const defaults = await this.httpService['createDefaults']()
+
           const result = await this.httpService.post<any>(`${baseUrl}/fees`, {
             headers: {
-              'Content-Type': 'application/json',
-              'X-Organization-Id': organizationId,
-              'X-Correlation-Id':
-                context.correlationId || this.generateCorrelationId()
+              ...defaults.headers,
+              'X-Organization-Id': organizationId
             },
             body: JSON.stringify(feeEngineRequest)
           })


### PR DESCRIPTION
- Skip fee calculation when source or destination contains external accounts (starting with @external/)
- Remove unused variables and consolidated data from transaction payload
- Use default headers from httpService instead of manually setting headers

This prevents unnecessary fee calculation attempts for transactions involving external accounts, which cannot have fees applied to them.

# Midaz Pull Request Checklist

## Pull Request Type
[//]: # (Check the appropriate box for the type of pull request.)

- [ ] Console
- [ ] Documentation
- [ ] Infra
- [ ] Mdz
- [ ] Onboarding
- [ ] Pipeline
- [ ] Transaction

## Checklist
Please check each item after it's completed.

- [ ] I have tested these changes locally.
- [ ] I have updated the documentation accordingly.
- [ ] I have added necessary comments to the code, especially in complex areas.
- [ ] I have ensured that my changes adhere to the project's coding standards.
- [ ] I have checked for any potential security issues.
- [ ] I have ensured that all tests pass.
- [ ] I have updated the version appropriately (if applicable).
- [ ] I have confirmed this code is ready for review.

## Obs: Please, always remember to target your PR to develop branch instead of main.
## Additional Notes
[//]: # (Add any additional notes, context, or explanation that could be helpful for reviewers.)
