### PR TITLE
fix(transaction): add operation metadata retrieval in GetAllMetadataT…

### DIFF
--- a/components/transaction/internal/services/query/get-all-metadata-transactions.go
+++ b/components/transaction/internal/services/query/get-all-metadata-transactions.go
@@ -71,30 +71,8 @@ func (uc *UseCase) GetAllMetadataTransactions(ctx context.Context, organizationI
 		return nil, libHTTP.CursorPagination{}, err
 	}
 
-	operationIDsAll := make([]string, 0)
-
-	for _, t := range trans {
-		for _, op := range t.Operations {
-			operationIDsAll = append(operationIDsAll, op.ID)
-		}
-	}
-
-	var operationMetadataMap map[string]map[string]any
-
-	if len(operationIDsAll) > 0 {
-		operationMetadata, err := uc.MetadataRepo.FindByEntityIDs(ctx, reflect.TypeOf(operation.Operation{}).Name(), operationIDsAll)
-		if err != nil {
-			libOpentelemetry.HandleSpanBusinessErrorEvent(&span, "Failed to get operation metadata", err)
-
-			logger.Warnf("Error getting operation metadata: %v", err)
-
-			return nil, libHTTP.CursorPagination{}, err
-		}
-
-		operationMetadataMap = make(map[string]map[string]any, len(operationMetadata))
-		for _, meta := range operationMetadata {
-			operationMetadataMap[meta.EntityID] = meta.Data
-		}
+	if err := uc.enrichTransactionsWithOperationMetadata(ctx, trans); err != nil {
+		return nil, libHTTP.CursorPagination{}, err
 	}
 
 	for i := range trans {
@@ -102,10 +80,6 @@ func (uc *UseCase) GetAllMetadataTransactions(ctx context.Context, organizationI
 		destination := make([]string, 0)
 
 		for _, op := range trans[i].Operations {
-			if opData, ok := operationMetadataMap[op.ID]; ok {
-				op.Metadata = opData
-			}
-
 			switch op.Type {
 			case constant.DEBIT:
 				source = append(source, op.AccountAlias)
@@ -123,4 +97,53 @@ func (uc *UseCase) GetAllMetadataTransactions(ctx context.Context, organizationI
 	}
 
 	return trans, cur, nil
+}
+
+// enrichTransactionsWithOperationMetadata fetches operation metadata in bulk and assigns it to operations
+func (uc *UseCase) enrichTransactionsWithOperationMetadata(ctx context.Context, trans []*transaction.Transaction) error {
+	logger, tracer, _, _ := libCommons.NewTrackingFromContext(ctx)
+
+	ctx, span := tracer.Start(ctx, "query.get_all_metadata_transactions_enrich_operations")
+	defer span.End()
+
+	var totalOps int
+	for _, t := range trans {
+		totalOps += len(t.Operations)
+	}
+
+	if totalOps == 0 {
+		return nil
+	}
+
+	operationIDsAll := make([]string, 0, totalOps)
+
+	for _, t := range trans {
+		for _, op := range t.Operations {
+			operationIDsAll = append(operationIDsAll, op.ID)
+		}
+	}
+
+	operationMetadata, err := uc.MetadataRepo.FindByEntityIDs(ctx, reflect.TypeOf(operation.Operation{}).Name(), operationIDsAll)
+	if err != nil {
+		libOpentelemetry.HandleSpanBusinessErrorEvent(&span, "Failed to get operation metadata", err)
+
+		logger.Warnf("Error getting operation metadata: %v", err)
+
+		return err
+	}
+
+	opMetadataMap := make(map[string]map[string]any, len(operationMetadata))
+	for _, meta := range operationMetadata {
+		opMetadataMap[meta.EntityID] = meta.Data
+	}
+
+	for i := range trans {
+		for _, op := range trans[i].Operations {
+			if data, ok := opMetadataMap[op.ID]; ok {
+				op.Metadata = data
+			}
+		}
+	}
+
+	return nil
 }

--- a/components/transaction/internal/services/query/get-all-metadata-transactions_test.go
+++ b/components/transaction/internal/services/query/get-all-metadata-transactions_test.go
@@ -101,6 +101,19 @@ func TestGetAllMetadataTransactionsWithOperations(t *testing.T) {
 		},
 	}
 
+	opMeta := []*mongodb.Metadata{
+		{
+			EntityID:   "op1-" + txID1Str,
+			EntityName: "Operation",
+			Data:       map[string]any{"op_key1": "op_value1"},
+		},
+		{
+			EntityID:   "op2-" + txID2Str,
+			EntityName: "Operation",
+			Data:       map[string]any{"op_key2": "op_value2"},
+		},
+	}
+
 	ops1 := []*operation.Operation{{
 		ID:           "op1-" + txID1Str,
 		Type:         constant.DEBIT,
@@ -134,6 +147,15 @@ func TestGetAllMetadataTransactionsWithOperations(t *testing.T) {
 	mockTransactionRepo.EXPECT().
 		FindOrListAllWithOperations(gomock.Any(), orgID, ledgerID, []uuid.UUID{txID1, txID2}, filter.ToCursorPagination()).
 		Return(transactions, libHTTP.CursorPagination{}, nil)
+
+	// Expect operation metadata lookup with both operation IDs
+	mockMetadataRepo.EXPECT().
+		FindByEntityIDs(
+			gomock.Any(),
+			reflect.TypeOf(operation.Operation{}).Name(),
+			[]string{"op1-" + txID1Str, "op2-" + txID2Str},
+		).
+		Return(opMeta, nil)
 
 	uc := &UseCase{
 		MetadataRepo:    mockMetadataRepo,

--- a/components/transaction/internal/services/query/get-all-metadata-transactions_test.go
+++ b/components/transaction/internal/services/query/get-all-metadata-transactions_test.go
@@ -172,13 +172,16 @@ func TestGetAllMetadataTransactionsWithOperations(t *testing.T) {
 		assert.NotEmpty(t, tx.Operations, "Transaction operations should be populated")
 		assert.NotNil(t, tx.Metadata, "Transaction metadata should be populated")
 		assert.Equal(t, "value", tx.Metadata["key"])
+		assert.NotNil(t, tx.Operations[0].Metadata, "Operation metadata should be populated")
 
 		if tx.ID == txID1Str {
 			assert.Equal(t, "op1-"+txID1Str, tx.Operations[0].ID)
 			assert.Contains(t, tx.Source, "source1")
+			assert.Equal(t, "op_value1", tx.Operations[0].Metadata["op_key1"])
 		} else if tx.ID == txID2Str {
 			assert.Equal(t, "op2-"+txID2Str, tx.Operations[0].ID)
 			assert.Contains(t, tx.Destination, "destination2")
+			assert.Equal(t, "op_value2", tx.Operations[0].Metadata["op_key2"])
 		}
 	}
 }


### PR DESCRIPTION
…ransactions

# Midaz Pull Request Checklist

## Pull Request Type
[//]: # (Check the appropriate box for the type of pull request.)

- [ ] Console
- [ ] Documentation
- [ ] Infra
- [ ] Mdz
- [ ] Onboarding
- [ ] Pipeline
- [x] Transaction

## Checklist
Please check each item after it's completed.

- [x] I have tested these changes locally.
- [ ] I have updated the documentation accordingly.
- [ ] I have added necessary comments to the code, especially in complex areas.
- [x] I have ensured that my changes adhere to the project's coding standards.
- [x] I have checked for any potential security issues.
- [x] I have ensured that all tests pass.
- [ ] I have updated the version appropriately (if applicable).
- [x] I have confirmed this code is ready for review.

## Obs: Please, always remember to target your PR to develop branch instead of main.
## Additional Notes
[//]: # (Add any additional notes, context, or explanation that could be helpful for reviewers.)


---

<!-- kody-pr-summary:start -->
This pull request enhances the `GetAllMetadataTransactions` service by adding the capability to retrieve and associate metadata for individual operations within a transaction.

Previously, this service would fetch transactions and their operations, but it did not include the specific metadata for each operation. With this change, the service now:
1.  Collects all operation IDs from the transactions being retrieved.
2.  Queries the metadata repository to fetch metadata associated with these operation IDs.
3.  Assigns the retrieved metadata to the corresponding operations within each transaction.

This ensures that when `GetAllMetadataTransactions` is called, the returned transaction objects contain complete metadata for all their associated operations, providing a richer data set. The accompanying test changes validate this new behavior.
<!-- kody-pr-summary:end -->