### PR TITLE
fix/operation-route-code

### DIFF
--- a/components/transaction/internal/adapters/postgres/operationroute/operationroute.go
+++ b/components/transaction/internal/adapters/postgres/operationroute/operationroute.go
@@ -99,27 +99,27 @@ func (m *OperationRoutePostgreSQLModel) FromEntity(e *mmodel.OperationRoute) {
 
 	if e.Account != nil {
 		m.AccountRuleType = e.Account.RuleType
+	}
 
-		if e.Account.ValidIf != nil {
-			switch strings.ToLower(e.Account.RuleType) {
-			case constant.AccountRuleTypeAccountType:
-				if values, ok := e.Account.ValidIf.([]string); ok {
-					m.AccountRuleValidIf = strings.Join(values, ",")
-				} else if values, ok := e.Account.ValidIf.([]any); ok {
-					stringValues := make([]string, len(values))
+	if e.Account != nil && e.Account.ValidIf != nil {
+		switch strings.ToLower(e.Account.RuleType) {
+		case constant.AccountRuleTypeAccountType:
+			if values, ok := e.Account.ValidIf.([]string); ok {
+				m.AccountRuleValidIf = strings.Join(values, ",")
+			} else if values, ok := e.Account.ValidIf.([]any); ok {
+				stringValues := make([]string, len(values))
 
-					for i, v := range values {
-						if str, ok := v.(string); ok {
-							stringValues[i] = str
-						}
+				for i, v := range values {
+					if str, ok := v.(string); ok {
+						stringValues[i] = str
 					}
+				}
 
-					m.AccountRuleValidIf = strings.Join(stringValues, ",")
-				}
-			default:
-				if value, ok := e.Account.ValidIf.(string); ok {
-					m.AccountRuleValidIf = value
-				}
+				m.AccountRuleValidIf = strings.Join(stringValues, ",")
+			}
+		default:
+			if value, ok := e.Account.ValidIf.(string); ok {
+				m.AccountRuleValidIf = value
 			}
 		}
 	}

--- a/components/transaction/internal/adapters/postgres/operationroute/operationroute.go
+++ b/components/transaction/internal/adapters/postgres/operationroute/operationroute.go
@@ -107,11 +107,11 @@ func (m *OperationRoutePostgreSQLModel) FromEntity(e *mmodel.OperationRoute) {
 			if values, ok := e.Account.ValidIf.([]string); ok {
 				m.AccountRuleValidIf = strings.Join(values, ",")
 			} else if values, ok := e.Account.ValidIf.([]any); ok {
-				stringValues := make([]string, len(values))
+				stringValues := make([]string, 0, len(values))
 
-				for i, v := range values {
+				for _, v := range values {
 					if str, ok := v.(string); ok {
-						stringValues[i] = str
+						stringValues = append(stringValues, str)
 					}
 				}
 

--- a/components/transaction/internal/adapters/postgres/operationroute/operationroute.go
+++ b/components/transaction/internal/adapters/postgres/operationroute/operationroute.go
@@ -12,18 +12,18 @@ import (
 
 // OperationRoutePostgreSQLModel represents the database model for operation routes
 type OperationRoutePostgreSQLModel struct {
-	ID                 uuid.UUID    `db:"id"`
-	OrganizationID     uuid.UUID    `db:"organization_id"`
-	LedgerID           uuid.UUID    `db:"ledger_id"`
-	Title              string       `db:"title"`
-	Description        string       `db:"description"`
-	Code               string       `db:"code"`
-	OperationType      string       `db:"operation_type"`
-	AccountRuleType    string       `db:"account_rule_type"`
-	AccountRuleValidIf string       `db:"account_rule_valid_if"`
-	CreatedAt          time.Time    `db:"created_at"`
-	UpdatedAt          time.Time    `db:"updated_at"`
-	DeletedAt          sql.NullTime `db:"deleted_at"`
+	ID                 uuid.UUID      `db:"id"`
+	OrganizationID     uuid.UUID      `db:"organization_id"`
+	LedgerID           uuid.UUID      `db:"ledger_id"`
+	Title              string         `db:"title"`
+	Description        string         `db:"description"`
+	Code               sql.NullString `db:"code"`
+	OperationType      string         `db:"operation_type"`
+	AccountRuleType    string         `db:"account_rule_type"`
+	AccountRuleValidIf string         `db:"account_rule_valid_if"`
+	CreatedAt          time.Time      `db:"created_at"`
+	UpdatedAt          time.Time      `db:"updated_at"`
+	DeletedAt          sql.NullTime   `db:"deleted_at"`
 }
 
 // ToEntity converts the database model to a domain model
@@ -32,13 +32,18 @@ func (m *OperationRoutePostgreSQLModel) ToEntity() *mmodel.OperationRoute {
 		return nil
 	}
 
+	codeValue := ""
+	if m.Code.Valid {
+		codeValue = m.Code.String
+	}
+
 	e := &mmodel.OperationRoute{
 		ID:             m.ID,
 		OrganizationID: m.OrganizationID,
 		LedgerID:       m.LedgerID,
 		Title:          m.Title,
 		Description:    m.Description,
-		Code:           m.Code,
+		Code:           codeValue,
 		OperationType:  m.OperationType,
 		CreatedAt:      m.CreatedAt,
 		UpdatedAt:      m.UpdatedAt,
@@ -83,7 +88,13 @@ func (m *OperationRoutePostgreSQLModel) FromEntity(e *mmodel.OperationRoute) {
 	m.LedgerID = e.LedgerID
 	m.Title = e.Title
 	m.Description = e.Description
-	m.Code = e.Code
+
+	if strings.TrimSpace(e.Code) == "" {
+		m.Code = sql.NullString{}
+	} else {
+		m.Code = sql.NullString{String: e.Code, Valid: true}
+	}
+
 	m.OperationType = strings.ToLower(e.OperationType)
 
 	if e.Account != nil {


### PR DESCRIPTION
# Midaz Pull Request Checklist

## Pull Request Type
[//]: # (Check the appropriate box for the type of pull request.)

- [ ] Console
- [ ] Documentation
- [ ] Infra
- [ ] Mdz
- [ ] Onboarding
- [ ] Pipeline
- [x] Transaction

## Checklist
Please check each item after it's completed.

- [x] I have tested these changes locally.
- [ ] I have updated the documentation accordingly.
- [ ] I have added necessary comments to the code, especially in complex areas.
- [x] I have ensured that my changes adhere to the project's coding standards.
- [x] I have checked for any potential security issues.
- [x] I have ensured that all tests pass.
- [ ] I have updated the version appropriately (if applicable).
- [x] I have confirmed this code is ready for review.

## Obs: Please, always remember to target your PR to develop branch instead of main.
## Additional Notes
[//]: # (Add any additional notes, context, or explanation that could be helpful for reviewers.)


---

<!-- kody-pr-summary:start -->
This pull request modifies the `OperationRoute` PostgreSQL adapter to allow the `Code` field to be nullable in the database.

Key changes include:

*   **Database Model Update**: The `Code` field in the `OperationRoutePostgreSQLModel` struct has been changed from `string` to `sql.NullString`, enabling it to store `NULL` values in the database.
*   **`ToEntity` Conversion**: The `ToEntity` method now correctly handles `sql.NullString` for the `Code` field. If the database `Code` is `NULL`, it will be converted to an empty string in the domain entity.
*   **`FromEntity` Conversion**: The `FromEntity` method now converts an empty or whitespace `Code` from the domain entity into a `NULL` value when storing it in the database.
*   **Refactoring `AccountRuleValidIf`**: The logic for processing `AccountRuleValidIf` in the `FromEntity` method has been refactored to explicitly check for `nil` values for both `e.Account` and `e.Account.ValidIf` before processing.
<!-- kody-pr-summary:end -->