### PR TITLE
Fix: Include NextResponse to return

### DIFF
--- a/components/console/src/core/application/controllers/segment-controller.ts
+++ b/components/console/src/core/application/controllers/segment-controller.ts
@@ -19,6 +19,7 @@ import {
 } from '@/lib/http/server/decorators'
 import type { SegmentSearchEntity } from '@/core/domain/entities/segment-entity'
 import { BaseController } from '@/lib/http/server/base-controller'
+import { NextResponse } from 'next/server'
 
 const CreateSchema = z.object({
   name: segment.name
@@ -109,10 +110,12 @@ export class SegmentController extends BaseController {
     @Param('ledgerId') ledgerId: string,
     @Param('segmentId') segmentId: string
   ) {
-    return await this.deleteSegmentUseCase.execute(
+    await this.deleteSegmentUseCase.execute(
       organizationId,
       ledgerId,
       segmentId!
     )
+
+    return NextResponse.json({}, { status: 200 })
   }
 }


### PR DESCRIPTION
# Midaz Pull Request Checklist

## Pull Request Type
[//]: # (Check the appropriate box for the type of pull request.)

- [x] Console
- [ ] Documentation
- [ ] Infra
- [ ] Mdz
- [ ] Onboarding
- [ ] Pipeline
- [ ] Transaction

## Checklist
Please check each item after it's completed.

- [x] I have tested these changes locally.
- [ ] I have updated the documentation accordingly.
- [ ] I have added necessary comments to the code, especially in complex areas.
- [x] I have ensured that my changes adhere to the project's coding standards.
- [ ] I have checked for any potential security issues.
- [ ] I have ensured that all tests pass.
- [ ] I have updated the version appropriately (if applicable).
- [x] I have confirmed this code is ready for review.

## Additional Notes
The delete method now explicitly returns NextResponse.json({}, { status: 200 }) after executing the use case, following the pattern of other controllers like account-controller. The error occurred because the use case returns void, and the decorator route-decorator.ts:42 tried to serialize undefined with NextResponse.json(response), causing the error "Value is not JSON serializable".
