### PR TITLE
fix(transaction): preserve operation IDs in Redis backup for crash recovery consistency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,16 +6,20 @@ ide/
 tmp/
 CLAUDE.md
 .claude/
+.mcp.json
 .windsurf/
+.windsurfrules
 .cursor/
 .run/onboarding.run.xml
 .run/transaction.run.xml
+.ring/
+docs/ring*/
 
 # OS generated files
 .DS_Store
 
 # Build and binary files
-*__debug_bin1675735721
+*__debug_bin*
 dist/
 coverage.out
 scripts/coverage_ignore.txt
@@ -38,9 +42,7 @@ scripts/demo-data/sdk-source/
 # Other
 postman/backups
 
-.windsurfrules
 cert/
-.mcp.json
 
 # Security scan reports
 *.sarif

--- a/components/transaction/internal/adapters/http/in/transaction.go
+++ b/components/transaction/internal/adapters/http/in/transaction.go
@@ -1055,6 +1055,8 @@ func (handler *TransactionHandler) createTransaction(c *fiber.Ctx, transactionIn
 	tran.Destination = getAliasWithoutKey(validate.Destinations)
 	tran.Operations = operations
 
+	handler.Command.UpdateTransactionBackupOperations(ctx, organizationID, ledgerID, transactionID.String(), operations)
+
 	err = handler.Command.WriteTransaction(ctx, organizationID, ledgerID, &transactionInput, validate, balances, tran)
 	if err != nil {
 		err := pkg.ValidateBusinessError(constant.ErrMessageBrokerUnavailable, "failed to update BTO")

--- a/components/transaction/internal/adapters/postgres/operation/operation.go
+++ b/components/transaction/internal/adapters/postgres/operation/operation.go
@@ -10,6 +10,7 @@ import (
 
 	libCommons "github.com/LerianStudio/lib-commons/v2/commons"
 	"github.com/LerianStudio/midaz/v3/pkg/constant"
+	"github.com/LerianStudio/midaz/v3/pkg/mmodel"
 	"github.com/shopspring/decimal"
 )
 
@@ -355,6 +356,108 @@ func (t *OperationPostgreSQLModel) FromEntity(operation *Operation) {
 	if operation.DeletedAt != nil {
 		deletedAtCopy := *operation.DeletedAt
 		t.DeletedAt = sql.NullTime{Time: deletedAtCopy, Valid: true}
+	}
+}
+
+// ToRedis converts an Operation to its flat Redis cache representation.
+func (op *Operation) ToRedis() mmodel.OperationRedis {
+	r := mmodel.OperationRedis{
+		ID:              op.ID,
+		TransactionID:   op.TransactionID,
+		Description:     op.Description,
+		Type:            op.Type,
+		AssetCode:       op.AssetCode,
+		ChartOfAccounts: op.ChartOfAccounts,
+		BalanceID:       op.BalanceID,
+		AccountID:       op.AccountID,
+		AccountAlias:    op.AccountAlias,
+		BalanceKey:      op.BalanceKey,
+		OrganizationID:  op.OrganizationID,
+		LedgerID:        op.LedgerID,
+		CreatedAt:       op.CreatedAt,
+		UpdatedAt:       op.UpdatedAt,
+		Route:           op.Route,
+		BalanceAffected: op.BalanceAffected,
+		Metadata:        op.Metadata,
+	}
+
+	if op.Amount.Value != nil {
+		r.AmountValue = *op.Amount.Value
+	}
+
+	if op.Balance.Available != nil {
+		r.BalanceAvailable = *op.Balance.Available
+	}
+
+	if op.Balance.OnHold != nil {
+		r.BalanceOnHold = *op.Balance.OnHold
+	}
+
+	if op.Balance.Version != nil {
+		r.BalanceVersion = *op.Balance.Version
+	}
+
+	if op.BalanceAfter.Available != nil {
+		r.BalanceAfterAvailable = *op.BalanceAfter.Available
+	}
+
+	if op.BalanceAfter.OnHold != nil {
+		r.BalanceAfterOnHold = *op.BalanceAfter.OnHold
+	}
+
+	if op.BalanceAfter.Version != nil {
+		r.BalanceAfterVersion = *op.BalanceAfter.Version
+	}
+
+	r.StatusCode = op.Status.Code
+	r.StatusDescription = op.Status.Description
+
+	return r
+}
+
+// OperationFromRedis converts a flat Redis cache representation back into an Operation.
+func OperationFromRedis(r mmodel.OperationRedis) *Operation {
+	amountVal := r.AmountValue
+	balAvail := r.BalanceAvailable
+	balOnHold := r.BalanceOnHold
+	balVersion := r.BalanceVersion
+	balAfterAvail := r.BalanceAfterAvailable
+	balAfterOnHold := r.BalanceAfterOnHold
+	balAfterVersion := r.BalanceAfterVersion
+
+	return &Operation{
+		ID:              r.ID,
+		TransactionID:   r.TransactionID,
+		Description:     r.Description,
+		Type:            r.Type,
+		AssetCode:       r.AssetCode,
+		ChartOfAccounts: r.ChartOfAccounts,
+		Amount:          Amount{Value: &amountVal},
+		Balance: Balance{
+			Available: &balAvail,
+			OnHold:    &balOnHold,
+			Version:   &balVersion,
+		},
+		BalanceAfter: Balance{
+			Available: &balAfterAvail,
+			OnHold:    &balAfterOnHold,
+			Version:   &balAfterVersion,
+		},
+		BalanceID:      r.BalanceID,
+		AccountID:      r.AccountID,
+		AccountAlias:   r.AccountAlias,
+		BalanceKey:     r.BalanceKey,
+		OrganizationID: r.OrganizationID,
+		LedgerID:       r.LedgerID,
+		CreatedAt:      r.CreatedAt,
+		UpdatedAt:      r.UpdatedAt,
+		Route:          r.Route,
+		Status: Status{
+			Code:        r.StatusCode,
+			Description: r.StatusDescription,
+		},
+		BalanceAffected: r.BalanceAffected,
+		Metadata:        r.Metadata,
 	}
 }
 

--- a/pkg/mmodel/balance.go
+++ b/pkg/mmodel/balance.go
@@ -504,4 +504,5 @@ type TransactionRedisQueue struct {
 	Validate          *pkgTransaction.Responses  `json:"validate"`
 	TransactionStatus string                     `json:"transaction_status"`
 	TransactionDate   time.Time                  `json:"transaction_date"`
+	Operations        []OperationRedis           `json:"operations,omitempty"`
 }

--- a/pkg/mmodel/operation.go
+++ b/pkg/mmodel/operation.go
@@ -1,0 +1,44 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package mmodel
+
+import (
+	"time"
+
+	"github.com/shopspring/decimal"
+)
+
+// OperationRedis is a flat Redis cache representation of an operation.
+// It mirrors the essential fields from the internal operation.Operation type
+// without nested structs, enabling storage in pkg/mmodel without importing
+// component-internal packages.
+type OperationRedis struct {
+	ID                    string          `json:"id"`
+	TransactionID         string          `json:"transactionId"`
+	Description           string          `json:"description"`
+	Type                  string          `json:"type"`
+	AssetCode             string          `json:"assetCode"`
+	ChartOfAccounts       string          `json:"chartOfAccounts"`
+	AmountValue           decimal.Decimal `json:"amountValue"`
+	BalanceAvailable      decimal.Decimal `json:"balanceAvailable"`
+	BalanceOnHold         decimal.Decimal `json:"balanceOnHold"`
+	BalanceVersion        int64           `json:"balanceVersion"`
+	BalanceAfterAvailable decimal.Decimal `json:"balanceAfterAvailable"`
+	BalanceAfterOnHold    decimal.Decimal `json:"balanceAfterOnHold"`
+	BalanceAfterVersion   int64           `json:"balanceAfterVersion"`
+	StatusCode            string          `json:"statusCode,omitempty"`
+	StatusDescription     *string         `json:"statusDescription,omitempty"`
+	BalanceID             string          `json:"balanceId"`
+	AccountID             string          `json:"accountId"`
+	AccountAlias          string          `json:"accountAlias"`
+	BalanceKey            string          `json:"balanceKey"`
+	OrganizationID        string          `json:"organizationId"`
+	LedgerID              string          `json:"ledgerId"`
+	CreatedAt             time.Time       `json:"createdAt"`
+	UpdatedAt             time.Time       `json:"updatedAt"`
+	Route                 string          `json:"route"`
+	BalanceAffected       bool            `json:"balanceAffected"`
+	Metadata              map[string]any  `json:"metadata,omitempty"`
+}


### PR DESCRIPTION
## Summary

- Materialize complete `Operation` objects in the Redis transaction backup after `BuildOperations`, so that the crash-recovery consumer reuses the same IDs originally returned to the client
- Add `Operations` field to `TransactionRedisQueue` struct with `omitempty` for backward compatibility with existing backups
- Add `UpdateTransactionBackupOperations` best-effort method (non-blocking, warn-on-failure) that enriches the backup via read-modify-write (HGet + HSet)
- Update Redis consumer to use materialized operations directly when present, falling back to `BuildOperations` for legacy backups (`Operations == nil`)
- Add idempotency guard in the Postgres operation repository (`UpsertOperations`) using `ON CONFLICT DO NOTHING` to safely handle duplicate writes

## Problem

In async mode (`RABBITMQ_TRANSACTION_ASYNC=true`), when the RabbitMQ consumer fails after the client receives HTTP 201, the Redis backup consumer regenerates operations with **new UUIDs** via `BuildOperations`. This causes a mismatch between the IDs returned to the client and the IDs persisted in the database, breaking lookups, audit trails, and financial reconciliation.

## Approach

Instead of pre-generating IDs or changing `BuildOperations` signature, we store the fully-built operations in the existing Redis backup **after** they are generated (between `BuildOperations` and `WriteTransaction`). The consumer checks for materialized operations first and only falls back to regeneration for old-format backups.

The backup update is best-effort: if it fails, the transaction proceeds normally and the consumer falls back to current behavior — no new failure modes are introduced in the hot path.

## Test plan

- [x] Unit tests for `UpdateTransactionBackupOperations` (success, read failure, unmarshal failure, marshal failure, write failure)
- [x] Unit tests for `UpsertOperations` Postgres repository method
- [x] Verify existing integration tests pass unchanged
- [x] Manual validation: create async transaction, simulate RabbitMQ consumer failure, verify recovered operations match original IDs