### PR TITLE
feat: add name-based search filters to Organizations and Ledgers list endpoints

### DIFF
--- a/components/onboarding/internal/adapters/http/in/ledger_test.go
+++ b/components/onboarding/internal/adapters/http/in/ledger_test.go
@@ -515,7 +515,7 @@ func TestHandler_GetAllLedgers(t *testing.T) {
 			queryParams: "",
 			setupMocks: func(ledgerRepo *ledger.MockRepository, metadataRepo *mongodb.MockRepository, orgID uuid.UUID) {
 				ledgerRepo.EXPECT().
-					FindAll(gomock.Any(), orgID, gomock.Any()).
+					FindAll(gomock.Any(), orgID, gomock.Any(), gomock.Any()).
 					Return([]*mmodel.Ledger{}, nil).
 					Times(1)
 			},
@@ -543,7 +543,7 @@ func TestHandler_GetAllLedgers(t *testing.T) {
 				ledger2ID := uuid.New().String()
 
 				ledgerRepo.EXPECT().
-					FindAll(gomock.Any(), orgID, gomock.Any()).
+					FindAll(gomock.Any(), orgID, gomock.Any(), gomock.Any()).
 					Return([]*mmodel.Ledger{
 						{
 							ID:             ledger1ID,
@@ -704,7 +704,7 @@ func TestHandler_GetAllLedgers(t *testing.T) {
 			queryParams: "",
 			setupMocks: func(ledgerRepo *ledger.MockRepository, metadataRepo *mongodb.MockRepository, orgID uuid.UUID) {
 				ledgerRepo.EXPECT().
-					FindAll(gomock.Any(), orgID, gomock.Any()).
+					FindAll(gomock.Any(), orgID, gomock.Any(), gomock.Any()).
 					Return(nil, pkg.InternalServerError{
 						Code:    "0046",
 						Title:   "Internal Server Error",

--- a/components/onboarding/internal/adapters/http/in/organization_test.go
+++ b/components/onboarding/internal/adapters/http/in/organization_test.go
@@ -502,7 +502,7 @@ func TestHandler_GetAllOrganizations(t *testing.T) {
 			queryParams: "",
 			setupMocks: func(orgRepo *organization.MockRepository, metadataRepo *mongodb.MockRepository) {
 				orgRepo.EXPECT().
-					FindAll(gomock.Any(), gomock.Any()).
+					FindAll(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 					Return([]*mmodel.Organization{}, nil).
 					Times(1)
 			},
@@ -530,7 +530,7 @@ func TestHandler_GetAllOrganizations(t *testing.T) {
 				org2ID := uuid.New().String()
 
 				orgRepo.EXPECT().
-					FindAll(gomock.Any(), gomock.Any()).
+					FindAll(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 					Return([]*mmodel.Organization{
 						{
 							ID:            org1ID,
@@ -691,7 +691,7 @@ func TestHandler_GetAllOrganizations(t *testing.T) {
 			queryParams: "",
 			setupMocks: func(orgRepo *organization.MockRepository, metadataRepo *mongodb.MockRepository) {
 				orgRepo.EXPECT().
-					FindAll(gomock.Any(), gomock.Any()).
+					FindAll(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(nil, pkg.InternalServerError{
 						Code:    "0046",
 						Title:   "Internal Server Error",
@@ -1099,7 +1099,7 @@ func TestProperty_Headers_InvalidFormats(t *testing.T) {
 
 	// Mock repo to return empty list (we're testing HTTP layer, not business logic)
 	mockOrgRepo.EXPECT().
-		FindAll(gomock.Any(), gomock.Any()).
+		FindAll(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 		Return([]*mmodel.Organization{}, nil).
 		AnyTimes()
 

--- a/components/onboarding/internal/adapters/postgres/ledger/ledger.postgresql.go
+++ b/components/onboarding/internal/adapters/postgres/ledger/ledger.postgresql.go
@@ -44,7 +44,7 @@ var ledgerColumnList = []string{
 type Repository interface {
 	Create(ctx context.Context, ledger *mmodel.Ledger) (*mmodel.Ledger, error)
 	Find(ctx context.Context, organizationID, id uuid.UUID) (*mmodel.Ledger, error)
-	FindAll(ctx context.Context, organizationID uuid.UUID, filter http.Pagination) ([]*mmodel.Ledger, error)
+	FindAll(ctx context.Context, organizationID uuid.UUID, filter http.Pagination, name *string) ([]*mmodel.Ledger, error)
 	FindByName(ctx context.Context, organizationID uuid.UUID, name string) (bool, error)
 	ListByIDs(ctx context.Context, organizationID uuid.UUID, ids []uuid.UUID) ([]*mmodel.Ledger, error)
 	Update(ctx context.Context, organizationID, id uuid.UUID, ledger *mmodel.Ledger) (*mmodel.Ledger, error)
@@ -207,7 +207,7 @@ func (r *LedgerPostgreSQLRepository) Find(ctx context.Context, organizationID, i
 }
 
 // FindAll retrieves Ledgers entities from the database.
-func (r *LedgerPostgreSQLRepository) FindAll(ctx context.Context, organizationID uuid.UUID, filter http.Pagination) ([]*mmodel.Ledger, error) {
+func (r *LedgerPostgreSQLRepository) FindAll(ctx context.Context, organizationID uuid.UUID, filter http.Pagination, name *string) ([]*mmodel.Ledger, error) {
 	logger, tracer, _, _ := libCommons.NewTrackingFromContext(ctx)
 
 	ctx, span := tracer.Start(ctx, "postgres.find_all_ledgers")
@@ -234,6 +234,11 @@ func (r *LedgerPostgreSQLRepository) FindAll(ctx context.Context, organizationID
 		Limit(libCommons.SafeIntToUint64(filter.Limit)).
 		Offset(libCommons.SafeIntToUint64((filter.Page - 1) * filter.Limit)).
 		PlaceholderFormat(squirrel.Dollar)
+
+	if name != nil && *name != "" {
+		sanitized := http.EscapeSearchMetacharacters(*name)
+		findAll = findAll.Where(squirrel.ILike{"name": sanitized + "%"})
+	}
 
 	query, args, err := findAll.ToSql()
 	if err != nil {

--- a/components/onboarding/internal/adapters/postgres/ledger/ledger.postgresql_mock.go
+++ b/components/onboarding/internal/adapters/postgres/ledger/ledger.postgresql_mock.go
@@ -103,18 +103,18 @@ func (mr *MockRepositoryMockRecorder) Find(ctx, organizationID, id any) *gomock.
 }
 
 // FindAll mocks base method.
-func (m *MockRepository) FindAll(ctx context.Context, organizationID uuid.UUID, filter http.Pagination) ([]*mmodel.Ledger, error) {
+func (m *MockRepository) FindAll(ctx context.Context, organizationID uuid.UUID, filter http.Pagination, name *string) ([]*mmodel.Ledger, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "FindAll", ctx, organizationID, filter)
+	ret := m.ctrl.Call(m, "FindAll", ctx, organizationID, filter, name)
 	ret0, _ := ret[0].([]*mmodel.Ledger)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // FindAll indicates an expected call of FindAll.
-func (mr *MockRepositoryMockRecorder) FindAll(ctx, organizationID, filter any) *gomock.Call {
+func (mr *MockRepositoryMockRecorder) FindAll(ctx, organizationID, filter, name any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindAll", reflect.TypeOf((*MockRepository)(nil).FindAll), ctx, organizationID, filter)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindAll", reflect.TypeOf((*MockRepository)(nil).FindAll), ctx, organizationID, filter, name)
 }
 
 // FindByName mocks base method.

--- a/components/onboarding/internal/adapters/postgres/organization/organization.postgresql_mock.go
+++ b/components/onboarding/internal/adapters/postgres/organization/organization.postgresql_mock.go
@@ -103,18 +103,18 @@ func (mr *MockRepositoryMockRecorder) Find(ctx, id any) *gomock.Call {
 }
 
 // FindAll mocks base method.
-func (m *MockRepository) FindAll(ctx context.Context, filter http.Pagination) ([]*mmodel.Organization, error) {
+func (m *MockRepository) FindAll(ctx context.Context, filter http.Pagination, legalName, doingBusinessAs *string) ([]*mmodel.Organization, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "FindAll", ctx, filter)
+	ret := m.ctrl.Call(m, "FindAll", ctx, filter, legalName, doingBusinessAs)
 	ret0, _ := ret[0].([]*mmodel.Organization)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // FindAll indicates an expected call of FindAll.
-func (mr *MockRepositoryMockRecorder) FindAll(ctx, filter any) *gomock.Call {
+func (mr *MockRepositoryMockRecorder) FindAll(ctx, filter, legalName, doingBusinessAs any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindAll", reflect.TypeOf((*MockRepository)(nil).FindAll), ctx, filter)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindAll", reflect.TypeOf((*MockRepository)(nil).FindAll), ctx, filter, legalName, doingBusinessAs)
 }
 
 // ListByIDs mocks base method.

--- a/components/onboarding/internal/services/query/get-all-ledgers.go
+++ b/components/onboarding/internal/services/query/get-all-ledgers.go
@@ -28,7 +28,7 @@ func (uc *UseCase) GetAllLedgers(ctx context.Context, organizationID uuid.UUID, 
 
 	logger.Infof("Retrieving ledgers")
 
-	ledgers, err := uc.LedgerRepo.FindAll(ctx, organizationID, filter.ToOffsetPagination())
+	ledgers, err := uc.LedgerRepo.FindAll(ctx, organizationID, filter.ToOffsetPagination(), filter.Name)
 	if err != nil {
 		logger.Errorf("Error getting ledgers on repo: %v", err)
 

--- a/components/onboarding/internal/services/query/get-all-ledgers_test.go
+++ b/components/onboarding/internal/services/query/get-all-ledgers_test.go
@@ -48,7 +48,7 @@ func TestGetAllLedgers(t *testing.T) {
 			name: "success - ledgers retrieved with metadata",
 			setupMocks: func() {
 				mockLedgerRepo.EXPECT().
-					FindAll(gomock.Any(), organizationID, filter.ToOffsetPagination()).
+					FindAll(gomock.Any(), organizationID, filter.ToOffsetPagination(), gomock.Any()).
 					Return([]*mmodel.Ledger{
 						{ID: "ledger1"},
 						{ID: "ledger2"},
@@ -73,7 +73,7 @@ func TestGetAllLedgers(t *testing.T) {
 			name: "failure - ledgers not found",
 			setupMocks: func() {
 				mockLedgerRepo.EXPECT().
-					FindAll(gomock.Any(), organizationID, filter.ToOffsetPagination()).
+					FindAll(gomock.Any(), organizationID, filter.ToOffsetPagination(), gomock.Any()).
 					Return(nil, errors.New("No ledgers were found in the search. Please review the search criteria and try again.")).
 					Times(1)
 			},
@@ -84,7 +84,7 @@ func TestGetAllLedgers(t *testing.T) {
 			name: "failure - repository error retrieving ledgers",
 			setupMocks: func() {
 				mockLedgerRepo.EXPECT().
-					FindAll(gomock.Any(), organizationID, filter.ToOffsetPagination()).
+					FindAll(gomock.Any(), organizationID, filter.ToOffsetPagination(), gomock.Any()).
 					Return(nil, errors.New("failed to retrieve ledgers")).
 					Times(1)
 			},
@@ -95,7 +95,7 @@ func TestGetAllLedgers(t *testing.T) {
 			name: "failure - metadata retrieval error",
 			setupMocks: func() {
 				mockLedgerRepo.EXPECT().
-					FindAll(gomock.Any(), organizationID, filter.ToOffsetPagination()).
+					FindAll(gomock.Any(), organizationID, filter.ToOffsetPagination(), gomock.Any()).
 					Return([]*mmodel.Ledger{
 						{ID: "ledger1"},
 						{ID: "ledger2"},

--- a/components/onboarding/internal/services/query/get-all-organizations.go
+++ b/components/onboarding/internal/services/query/get-all-organizations.go
@@ -27,7 +27,7 @@ func (uc *UseCase) GetAllOrganizations(ctx context.Context, filter http.QueryHea
 
 	logger.Infof("Retrieving organizations")
 
-	organizations, err := uc.OrganizationRepo.FindAll(ctx, filter.ToOffsetPagination())
+	organizations, err := uc.OrganizationRepo.FindAll(ctx, filter.ToOffsetPagination(), filter.LegalName, filter.DoingBusinessAs)
 	if err != nil {
 		logger.Errorf("Error getting organizations on repo: %v", err)
 

--- a/components/onboarding/internal/services/query/get-all-organizations_test.go
+++ b/components/onboarding/internal/services/query/get-all-organizations_test.go
@@ -49,7 +49,7 @@ func TestGetAllOrganizations(t *testing.T) {
 			mockSetup: func() {
 				validUUID := uuid.New()
 				mockOrganizationRepo.EXPECT().
-					FindAll(gomock.Any(), filter.ToOffsetPagination()).
+					FindAll(gomock.Any(), filter.ToOffsetPagination(), gomock.Any(), gomock.Any()).
 					Return([]*mmodel.Organization{
 						{ID: validUUID.String(), LegalName: "Test Organization", Status: mmodel.Status{Code: "active"}},
 					}, nil)
@@ -72,7 +72,7 @@ func TestGetAllOrganizations(t *testing.T) {
 			},
 			mockSetup: func() {
 				mockOrganizationRepo.EXPECT().
-					FindAll(gomock.Any(), filter.ToOffsetPagination()).
+					FindAll(gomock.Any(), filter.ToOffsetPagination(), gomock.Any(), gomock.Any()).
 					Return(nil, services.ErrDatabaseItemNotFound)
 			},
 			expectErr:      true,
@@ -87,7 +87,7 @@ func TestGetAllOrganizations(t *testing.T) {
 			mockSetup: func() {
 				validUUID := uuid.New()
 				mockOrganizationRepo.EXPECT().
-					FindAll(gomock.Any(), filter.ToOffsetPagination()).
+					FindAll(gomock.Any(), filter.ToOffsetPagination(), gomock.Any(), gomock.Any()).
 					Return([]*mmodel.Organization{
 						{ID: validUUID.String(), LegalName: "Test Organization", Status: mmodel.Status{Code: "active"}},
 					}, nil)

--- a/tests/utils/postgres/fixtures.go
+++ b/tests/utils/postgres/fixtures.go
@@ -19,10 +19,11 @@ import (
 
 // OrganizationParams holds parameters for creating a test organization.
 type OrganizationParams struct {
-	LegalName     string
-	LegalDocument string
-	Status        string
-	DeletedAt     *time.Time
+	LegalName       string
+	LegalDocument   string
+	DoingBusinessAs *string
+	Status          string
+	DeletedAt       *time.Time
 }
 
 // DefaultOrganizationParams returns default parameters for creating a test organization.
@@ -48,9 +49,9 @@ func CreateTestOrganizationWithParams(t *testing.T, db *sql.DB, params Organizat
 	now := time.Now().Truncate(time.Microsecond)
 
 	_, err := db.Exec(`
-		INSERT INTO organization (id, legal_name, legal_document, address, status, created_at, updated_at, deleted_at)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
-	`, id, params.LegalName, params.LegalDocument, `{"city":"Test"}`, params.Status, now, now, params.DeletedAt)
+		INSERT INTO organization (id, legal_name, legal_document, doing_business_as, address, status, created_at, updated_at, deleted_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+	`, id, params.LegalName, params.LegalDocument, params.DoingBusinessAs, `{"city":"Test"}`, params.Status, now, now, params.DeletedAt)
 	require.NoError(t, err, "failed to create test organization")
 
 	return id


### PR DESCRIPTION
## Summary

- Add `legal_name` and `doing_business_as` query parameters to `GET /organizations` for case-insensitive prefix search
- Add `name` query parameter to `GET /ledgers` for case-insensitive prefix search
- Implement SQL wildcard injection prevention via `EscapeSearchMetacharacters` (escapes `%`, `_`, `\`)
- Enforce mutual exclusivity between metadata filters and name filters (returns 400 when combined)
- Validate search term length (1-256 UTF-8 characters), trim whitespace, and nil-out empty values

## Changes

### Core Logic (`pkg/net/http/httputils.go`)
- Add `Name`, `LegalName`, `DoingBusinessAs` fields to `QueryHeader` struct
- Add `HasNameFilters()` method for mutual exclusivity checks
- Add `EscapeSearchMetacharacters()` to sanitize SQL ILIKE metacharacters
- Add `validateSearchTermLength()` with double-pointer nil-out for empty/whitespace values
- Extend `ValidateParameters()` switch to parse new query params (using exact `key ==` match)

### Organization Endpoint
- Handler: mutual exclusivity check (metadata vs name filters), pass filters to service layer
- Service: forward `LegalName` and `DoingBusinessAs` to repository `FindAll`
- Repository: build `squirrel.ILike` clauses with escaped prefix pattern (`term%`)
- Swagger: document new `legal_name` and `doing_business_as` query parameters

### Ledger Endpoint
- Handler: mutual exclusivity check (metadata vs name filter), pass filter to service layer
- Service: forward `Name` to repository `FindAll`
- Repository: build `squirrel.ILike` clause with escaped prefix pattern (`term%`)
- Swagger: document new `name` query parameter

### Tests
- **Unit tests** (`httputils_test.go`): parameter parsing, trimming, length validation, `HasNameFilters()`, `EscapeSearchMetacharacters`
- **Handler tests**: mock service calls with new filter params, mutual exclusivity validation
- **Service tests**: verify filter values flow correctly to repository
- **Integration tests** (Organization + Ledger): prefix matching, case insensitivity, wildcard injection prevention (`%`, `_`, `\`), literal special characters in stored names, nil filter behavior

## Security

- SQL injection: prevented by `squirrel` parameterized queries (`ILIKE $N`)
- Wildcard injection: prevented by `EscapeSearchMetacharacters` (backslash escaped first, then `%` and `_`)
- Input validation: 1-256 UTF-8 rune limit via `utf8.RuneCountInString`
- Integration tests verify `%`, `_`, `\` characters don't act as SQL wildcards

## Known Limitations / Follow-up

- **Database indexes**: ILIKE prefix queries would benefit from `text_pattern_ops` or `pg_trgm` indexes on `legal_name`, `doing_business_as`, and `name` columns. Should be added as a separate migration for production performance optimization.
- **Parameter scope**: `legal_name` and `doing_business_as` are accepted but silently ignored on the Ledger endpoint (follows existing codebase pattern where `ValidateParameters` is shared across endpoints).

## Test plan

- [x] Unit tests pass for `EscapeSearchMetacharacters`, `validateSearchTermLength`, `HasNameFilters`, `ValidateParameters`
- [x] Handler tests pass for Organization and Ledger endpoints
- [x] Service layer tests pass with new filter params
- [x] Integration tests pass: prefix match, case insensitivity, wildcard injection prevention, literal special chars
- [x] Build succeeds (`go build ./...`)
- [x] All existing tests continue to pass