### PR TITLE
test: validate multi-server gitops deployment workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,18 +40,17 @@ jobs:
   update_gitops:
     needs: [build]
     if: needs.build.result == 'success'
-    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/gitops-update.yml@v1.11.0
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/gitops-update.yml@feature/gitops-multi-server-deploy
     with:
       runner_type: "firmino-lxc-runners"
       gitops_repository: "LerianStudio/midaz-firmino-gitops"
-      gitops_server: "firmino"
       app_name: "midaz"
+      deploy_in_firmino: true
+      deploy_in_clotilde: true
       artifact_pattern: "gitops-tags-midaz-*"
       yaml_key_mappings: '{"midaz-onboarding.tag": ".onboarding.image.tag", "midaz-transaction.tag": ".transaction.image.tag", "midaz-crm.tag": ".crm.image.tag", "midaz-ledger.tag": ".ledger.image.tag"}'
       commit_message_prefix: "midaz"
       enable_argocd_sync: true
-      argocd_app_name: "firmino-midaz"
-      use_dynamic_mapping: true
     secrets: inherit
 
   # =========================

--- a/components/onboarding/Dockerfile
+++ b/components/onboarding/Dockerfile
@@ -24,3 +24,4 @@ EXPOSE 3000
 
 # Set entrypoint to the compiled binary
 ENTRYPOINT ["/app"]
+

--- a/components/transaction/Dockerfile
+++ b/components/transaction/Dockerfile
@@ -22,4 +22,5 @@ COPY --from=builder /transaction-app/components/transaction/migrations /componen
 
 EXPOSE 3001 3011
 
+# Run the application
 ENTRYPOINT ["/app"]


### PR DESCRIPTION
## Summary
This PR tests the new multi-server GitOps deployment workflow from `github-actions-shared-workflows`.

## Changes
- Update `build.yml` to use `gitops-update.yml@feature/gitops-multi-server-deploy`
- Add `deploy_in_firmino: true` and `deploy_in_clotilde: true` inputs
- Remove obsolete inputs: `gitops_server`, `argocd_app_name`, `use_dynamic_mapping`
- Minor Dockerfile changes to trigger builds for onboarding and transaction components

## Testing
This will test the new workflow features:
1. Dynamic path generation for both Firmino and Clotilde servers
2. File existence validation (warns on missing, doesn't fail)
3. Matrix-based ArgoCD sync for each server/env combination
4. App existence check before ArgoCD sync

## Related
- Shared workflow branch: `LerianStudio/github-actions-shared-workflows@feature/gitops-multi-server-deploy`

## Note
**This is a test PR** - once validated, the shared workflow will be merged and released as a new version.