### PR TITLE
chore(ci): bump shared workflows to v1.13.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   build:
-    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/build.yml@v1.11.0
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/build.yml@v1.13.1
     with:
       runner_type: "blacksmith-4vcpu-ubuntu-2404"
       filter_paths: |-
@@ -40,7 +40,7 @@ jobs:
   update_gitops:
     needs: [build]
     if: needs.build.result == 'success'
-    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/gitops-update.yml@feature/gitops-multi-server-deploy
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/gitops-update.yml@v1.13.1
     with:
       runner_type: "firmino-lxc-runners"
       gitops_repository: "LerianStudio/midaz-firmino-gitops"
@@ -59,7 +59,7 @@ jobs:
   api_dog_e2e_tests:
     needs: [update_gitops]
     if: needs.update_gitops.result == 'success'
-    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/api-dog-e2e-tests.yml@v1.11.0
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/api-dog-e2e-tests.yml@v1.13.1
     with:
       runner_type: "firmino-lxc-runners"
       auto_detect_environment: true

--- a/.github/workflows/go-combined-analysis.yml
+++ b/.github/workflows/go-combined-analysis.yml
@@ -25,7 +25,7 @@ on:
 jobs:
   go-analysis:
     name: Go Analysis
-    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/go-pr-analysis.yml@v1.11.0
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/go-pr-analysis.yml@v1.13.1
     with:
       runner_type: "blacksmith-4vcpu-ubuntu-2404"
       filter_paths: '["components/onboarding", "components/transaction", "components/crm", "components/ledger"]'

--- a/.github/workflows/gptchangelog.yml
+++ b/.github/workflows/gptchangelog.yml
@@ -23,7 +23,7 @@ jobs:
   changelog:
     # Run if: manual trigger OR Release workflow succeeded
     if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
-    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/gptchangelog.yml@v1.11.0
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/gptchangelog.yml@v1.13.1
     with:
       runner_type: "blacksmith-4vcpu-ubuntu-2404"
       # No filter_paths = single app mode (non-monorepo)

--- a/.github/workflows/pr-security-scan.yml
+++ b/.github/workflows/pr-security-scan.yml
@@ -24,7 +24,7 @@ on:
 
 jobs:
   security-scan:
-    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/pr-security-scan.yml@v1.11.0
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/pr-security-scan.yml@v1.13.1
     with:
       runner_type: "blacksmith-4vcpu-ubuntu-2404"
       filter_paths: |-

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   validate:
-    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/pr-validation.yml@v1.11.0
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/pr-validation.yml@v1.13.1
     with:
       runner_type: "blacksmith-4vcpu-ubuntu-2404"
       pr_title_types: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
   # =========================
   release:
     name: Create Release
-    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/release.yml@v1.11.0
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/release.yml@v1.13.1
     with:
       runner_type: "blacksmith-4vcpu-ubuntu-2404"
     secrets: inherit

--- a/components/crm/Dockerfile
+++ b/components/crm/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.4
 
-FROM --platform=$BUILDPLATFORM golang:1.25.6-alpine AS builder
+FROM --platform=$BUILDPLATFORM golang:1.25.7-alpine AS builder
 
 WORKDIR /crm-app
 

--- a/components/ledger/Dockerfile
+++ b/components/ledger/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.25.6-alpine AS builder
+FROM --platform=$BUILDPLATFORM golang:1.25.7-alpine AS builder
 
 WORKDIR /ledger-app
 

--- a/components/onboarding/Dockerfile
+++ b/components/onboarding/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.25.6-alpine AS builder
+FROM --platform=$BUILDPLATFORM golang:1.25.7-alpine AS builder
 
 WORKDIR /onboarding-app
 
@@ -24,5 +24,3 @@ EXPOSE 3000
 
 # Set entrypoint to the compiled binary
 ENTRYPOINT ["/app"]
-
-

--- a/components/transaction/Dockerfile
+++ b/components/transaction/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.25.6-alpine AS builder
+FROM --platform=$BUILDPLATFORM golang:1.25.7-alpine AS builder
 
 WORKDIR /transaction-app
 


### PR DESCRIPTION
## Summary

Updates all shared workflow references to v1.13.1.

## Changes

| Workflow | Updated To |
|----------|------------|
| build.yml | v1.13.1 |
| go-combined-analysis.yml | v1.13.1 |
| gptchangelog.yml | v1.13.1 |
| pr-security-scan.yml | v1.13.1 |
| pr-validation.yml | v1.13.1 |
| release.yml | v1.13.1 |

## What's New in v1.13.1

- Makefile integration for lint, test, security, and build jobs
- Coverage filtering with `.ignorecoverunit` support
- Improved SARIF generation for security scanning
- Security scan gate for PR merge blocking
- Trivy action update to v0.34.1 with Trivy v0.69.2
- Multi-server deployment support

## Related

- Shared workflows release: https://github.com/LerianStudio/github-actions-shared-workflows/releases/tag/v1.13.1