### PR TITLE
chore(ci): replace inline release notification with shared workflow

### DIFF
--- a/.github/workflows/release-notification.yml
+++ b/.github/workflows/release-notification.yml
@@ -5,53 +5,14 @@ on:
     types: [published]
 
 jobs:
-  github-release-notification:
-    name: Notify Discord and Slack of New Release
-    runs-on: ubuntu-24.04
-    steps:
-      # Create a GitHub App token for authentication with higher rate limits
-      - uses: actions/create-github-app-token@v1
-        id: app-token
-        with:
-          app-id: ${{ secrets.LERIAN_STUDIO_MIDAZ_PUSH_BOT_APP_ID }}
-          private-key: ${{ secrets.LERIAN_STUDIO_MIDAZ_PUSH_BOT_PRIVATE_KEY }}
-
-      # Checkout the repository code
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      # Install GitHub CLI to interact with GitHub API
-      - name: Install GitHub CLI
-        run: sudo apt-get install -y gh
-
-      # Fetch the latest release information using GitHub CLI
-      - name: Fetch Latest Release
-        id: latest_release
-        env:
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
-        run: |
-          RAW_RELEASE=$(gh release list --repo $GITHUB_REPOSITORY --limit 1 --json tagName --jq '.[0].tagName')
-          echo "Raw release: $RAW_RELEASE"
-          echo "tag=$RAW_RELEASE" >> $GITHUB_OUTPUT
-
-      # Send release notification to Discord (skip beta releases)
-      - name: Releases to Discord
-        uses: SethCohen/github-releases-to-discord@v1.16.2
-        if: ${{ !contains(github.ref, '-beta.') }}
-        with:
-          webhook_url: ${{ secrets.DISCORD_WEBHOOK_URL }}
-          color: "2105893"  # Green color
-          username: "Release Changelog"
-          content: "<@&1346912737380274176>"  # Mention specific Discord role
-          footer_timestamp: true
-
-      # Send release notification to Slack
-      - name: Notify Slack of New Release
-        uses: rtCamp/action-slack-notify@v2
-        env:
-          SLACK_CHANNEL: "lerian-product-release"
-          SLACK_COLOR: "#36a64f"  # Green color
-          SLACK_ICON_EMOJI: ":rocket"
-          SLACK_TITLE: "Midaz New Release: ${{ steps.latest_release.outputs.tag }}"
-          SLACK_MESSAGE: "🎉 *New Release Published!* \n \n <https://github.com/${{ github.repository }}/releases/tag/${{ steps.latest_release.outputs.tag }} | *Click here for details*>"
-          SLACK_WEBHOOK: ${{ secrets.RELEASE_WEBHOOK_NOTIFICATION_URL }}
+  notify:
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/release-notification.yml@develop
+    with:
+      product_name: "Midaz"
+      slack_channel: "lerian-product-release"
+      discord_content: "<@&1346912737380274176>"
+    secrets:
+      APP_ID: ${{ secrets.LERIAN_STUDIO_MIDAZ_PUSH_BOT_APP_ID }}
+      APP_PRIVATE_KEY: ${{ secrets.LERIAN_STUDIO_MIDAZ_PUSH_BOT_PRIVATE_KEY }}
+      DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+      SLACK_WEBHOOK_URL: ${{ secrets.RELEASE_WEBHOOK_NOTIFICATION_URL }}

--- a/components/crm/cmd/app/main.go
+++ b/components/crm/cmd/app/main.go
@@ -45,3 +45,4 @@ func main() {
 
 	service.Run()
 }
+


### PR DESCRIPTION
# Midaz Pull Request Checklist

## Pull Request Type

- [ ] Documentation
- [x] Pipeline
- [ ] Infra
- [ ] Ledger
- [ ] Onboarding
- [ ] Transaction
- [ ] CRM
- [ ] Tests

## Checklist

- [x] I have tested these changes locally.
- [ ] I have updated the documentation accordingly.
- [x] I have added necessary comments to the code, especially in complex areas.
- [x] I have ensured that my changes adhere to the project's coding standards.
- [x] I have checked for any potential security issues.
- [x] I have ensured that all tests pass.
- [ ] I have updated the version appropriately (if applicable).
- [x] I have confirmed this code is ready for review.

**Important:** Always target your PR to the develop branch instead of main.

## Additional Notes

Replaces the inline release notification workflow (Discord + Slack) with a call to the shared `release-notification` reusable workflow from `github-actions-shared-workflows`.

All business logic (GitHub App token, release tag fetch, Discord beta-skip, Slack message formatting) now lives in the shared module. The caller only provides triggers, inputs, and secrets.

Currently pointing to `@develop` for validation. Should be updated to a stable tag after the shared-workflows PR is merged and released: https://github.com/LerianStudio/github-actions-shared-workflows/pull/130