### PR TITLE
docs: update ledger-settings documentation

### DIFF
--- a/components/onboarding/api/onboarding_docs.go
+++ b/components/onboarding/api/onboarding_docs.go
@@ -1063,8 +1063,7 @@ const docTemplateonboarding = `{
                     "200": {
                         "description": "Successfully retrieved ledger settings",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": true
+                            "$ref": "#/definitions/mmodel.LedgerSettings"
                         }
                     },
                     "401": {
@@ -1139,8 +1138,7 @@ const docTemplateonboarding = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": true
+                            "$ref": "#/definitions/mmodel.LedgerSettings"
                         }
                     }
                 ],
@@ -1148,8 +1146,7 @@ const docTemplateonboarding = `{
                     "200": {
                         "description": "Successfully updated ledger settings",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": true
+                            "$ref": "#/definitions/mmodel.LedgerSettings"
                         }
                     },
                     "400": {
@@ -4763,9 +4760,12 @@ const docTemplateonboarding = `{
                     "example": "00000000-0000-0000-0000-000000000000"
                 },
                 "settings": {
-                    "description": "Dynamic configuration settings for this ledger\nexample: {\"accounting\": {\"validateAccountType\": true}}",
-                    "type": "object",
-                    "additionalProperties": {}
+                    "description": "Dynamic configuration settings for this ledger. May be null if no settings are configured.\nexample: {\"accounting\": {\"validateAccountType\": true}}",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/mmodel.LedgerSettings"
+                        }
+                    ]
                 },
                 "status": {
                     "description": "Current operating status of the ledger",

--- a/components/onboarding/api/onboarding_docs.go
+++ b/components/onboarding/api/onboarding_docs.go
@@ -95,6 +95,20 @@ const docTemplateonboarding = `{
                         "description": "Sort direction for results based on creation date",
                         "name": "sort_order",
                         "in": "query"
+                    },
+                    {
+                        "maxLength": 256,
+                        "type": "string",
+                        "description": "Filter organizations by legal name (case-insensitive, prefix match)",
+                        "name": "legal_name",
+                        "in": "query"
+                    },
+                    {
+                        "maxLength": 256,
+                        "type": "string",
+                        "description": "Filter organizations by doing business as name (case-insensitive, prefix match)",
+                        "name": "doing_business_as",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -561,6 +575,13 @@ const docTemplateonboarding = `{
                         "description": "Sort direction for results based on creation date",
                         "name": "sort_order",
                         "in": "query"
+                    },
+                    {
+                        "maxLength": 256,
+                        "type": "string",
+                        "description": "Filter ledgers by name (case-insensitive, prefix match)",
+                        "name": "name",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -986,6 +1007,171 @@ const docTemplateonboarding = `{
                     },
                     "404": {
                         "description": "Ledger or organization not found",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    }
+                }
+            }
+        },
+        "/v1/organizations/{organization_id}/ledgers/{id}/settings": {
+            "get": {
+                "description": "Returns the current configuration settings for a specific ledger. If no settings have been persisted, returns the default settings object.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Ledgers"
+                ],
+                "summary": "Get ledger settings",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Authorization Bearer Token with format: Bearer {token}",
+                        "name": "Authorization",
+                        "in": "header",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Request ID for tracing",
+                        "name": "X-Request-Id",
+                        "in": "header"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Organization ID in UUID format",
+                        "name": "organization_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Ledger ID in UUID format",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successfully retrieved ledger settings",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized access",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden access",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "404": {
+                        "description": "Ledger not found",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    }
+                }
+            },
+            "patch": {
+                "description": "Updates the configuration settings for a specific ledger using schema-aware deep merge. Only known settings fields are allowed - unknown fields return error 0147 (ErrUnknownSettingsField). Type validation is enforced - incorrect types return error 0148 (ErrInvalidSettingsFieldType). Nested objects (like 'accounting') are deep-merged, preserving existing properties not specified in the update. Example: updating only 'accounting.validateRoutes' preserves the existing 'accounting.validateAccountType' value. Setting a key to null stores a JSON null value. Allowed fields: accounting.validateAccountType (boolean), accounting.validateRoutes (boolean).",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Ledgers"
+                ],
+                "summary": "Update ledger settings",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Authorization Bearer Token with format: Bearer {token}",
+                        "name": "Authorization",
+                        "in": "header",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Request ID for tracing",
+                        "name": "X-Request-Id",
+                        "in": "header"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Organization ID in UUID format",
+                        "name": "organization_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Ledger ID in UUID format",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Settings to merge with existing settings. Only known fields allowed: accounting.validateAccountType (bool), accounting.validateRoutes (bool)",
+                        "name": "settings",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successfully updated ledger settings",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request body, unknown field (0147), or invalid field type (0148)",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized access",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden access",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "404": {
+                        "description": "Ledger not found",
                         "schema": {
                             "$ref": "#/definitions/Error"
                         }
@@ -4099,6 +4285,12 @@ const docTemplateonboarding = `{
                     "minLength": 2,
                     "example": "US"
                 },
+                "description": {
+                    "description": "A descriptive label for the address (e.g., \"Home\", \"Office\", \"Billing\")\nexample: Home\nmaxLength: 100",
+                    "type": "string",
+                    "maxLength": 100,
+                    "example": "Home"
+                },
                 "line1": {
                     "description": "Primary address line (street address or PO Box)\nexample: 123 Financial Avenue\nmaxLength: 256",
                     "type": "string",
@@ -4360,6 +4552,14 @@ const docTemplateonboarding = `{
                     "type": "string",
                     "maxLength": 256
                 },
+                "settings": {
+                    "description": "Dynamic configuration settings for this ledger. When nil, no settings are persisted (optional).\nexample: {\"accounting\": {\"validateAccountType\": true}}",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/mmodel.LedgerSettings"
+                        }
+                    ]
+                },
                 "status": {
                     "description": "Current operating status of the ledger (defaults to ACTIVE if not specified)\nrequired: false",
                     "allOf": [
@@ -4561,6 +4761,11 @@ const docTemplateonboarding = `{
                     "type": "string",
                     "format": "uuid",
                     "example": "00000000-0000-0000-0000-000000000000"
+                },
+                "settings": {
+                    "description": "Dynamic configuration settings for this ledger\nexample: {\"accounting\": {\"validateAccountType\": true}}",
+                    "type": "object",
+                    "additionalProperties": {}
                 },
                 "status": {
                     "description": "Current operating status of the ledger",
@@ -5036,6 +5241,32 @@ const docTemplateonboarding = `{
                     "allOf": [
                         {
                             "$ref": "#/definitions/Status"
+                        }
+                    ]
+                }
+            }
+        },
+        "mmodel.AccountingValidation": {
+            "type": "object",
+            "properties": {
+                "validateAccountType": {
+                    "description": "ValidateAccountType enables validation of account types during transaction processing.\nWhen true, accounts must have types that match the operation route rules.\nDefault: false (permissive - no validation)",
+                    "type": "boolean"
+                },
+                "validateRoutes": {
+                    "description": "ValidateRoutes enables validation of transaction routes during processing.\nWhen true, transactions must specify valid route IDs that exist in the ledger.\nDefault: false (permissive - no validation)",
+                    "type": "boolean"
+                }
+            }
+        },
+        "mmodel.LedgerSettings": {
+            "type": "object",
+            "properties": {
+                "accounting": {
+                    "description": "Accounting contains validation settings for accounting operations.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/mmodel.AccountingValidation"
                         }
                     ]
                 }

--- a/components/onboarding/api/onboarding_swagger.json
+++ b/components/onboarding/api/onboarding_swagger.json
@@ -1012,7 +1012,7 @@
         },
         "/v1/organizations/{organization_id}/ledgers/{id}/settings": {
             "get": {
-                "description": "Returns the current configuration settings for a specific ledger. Returns an empty object {} if no settings have been defined.",
+                "description": "Returns the current configuration settings for a specific ledger. If no settings have been persisted, returns the default settings object.",
                 "produces": [
                     "application/json"
                 ],
@@ -1053,7 +1053,8 @@
                     "200": {
                         "description": "Successfully retrieved ledger settings",
                         "schema": {
-                            "$ref": "#/definitions/LedgerSettings"
+                            "type": "object",
+                            "additionalProperties": true
                         }
                     },
                     "401": {
@@ -1083,7 +1084,7 @@
                 }
             },
             "patch": {
-                "description": "Updates the configuration settings for a specific ledger using schema-aware deep merge. Only known settings fields are allowed - unknown fields return error 0147 (ErrUnknownSettingsField). Type validation is enforced - incorrect types return error 0148 (ErrInvalidSettingsFieldType). Nested objects (like 'accounting') are deep-merged, preserving existing properties not specified in the update. Example: updating only 'accounting.validateRoutes' preserves the existing 'accounting.validateAccountType' value. Setting a key to null stores a JSON null value. Allowed fields: accounting.validateAccountType (boolean | null), accounting.validateRoutes (boolean | null).",
+                "description": "Updates the configuration settings for a specific ledger using schema-aware deep merge. Only known settings fields are allowed - unknown fields return error 0147 (ErrUnknownSettingsField). Type validation is enforced - incorrect types return error 0148 (ErrInvalidSettingsFieldType). Nested objects (like 'accounting') are deep-merged, preserving existing properties not specified in the update. Example: updating only 'accounting.validateRoutes' preserves the existing 'accounting.validateAccountType' value. Setting a key to null stores a JSON null value. Allowed fields: accounting.validateAccountType (boolean), accounting.validateRoutes (boolean).",
                 "consumes": [
                     "application/json"
                 ],
@@ -1123,12 +1124,13 @@
                         "required": true
                     },
                     {
-                        "description": "Settings to merge with existing settings. Only known fields allowed: accounting.validateAccountType (boolean | null), accounting.validateRoutes (boolean | null)",
+                        "description": "Settings to merge with existing settings. Only known fields allowed: accounting.validateAccountType (bool), accounting.validateRoutes (bool)",
                         "name": "settings",
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/LedgerSettings"
+                            "type": "object",
+                            "additionalProperties": true
                         }
                     }
                 ],
@@ -1136,7 +1138,8 @@
                     "200": {
                         "description": "Successfully updated ledger settings",
                         "schema": {
-                            "$ref": "#/definitions/LedgerSettings"
+                            "type": "object",
+                            "additionalProperties": true
                         }
                     },
                     "400": {
@@ -4272,6 +4275,12 @@
                     "minLength": 2,
                     "example": "US"
                 },
+                "description": {
+                    "description": "A descriptive label for the address (e.g., \"Home\", \"Office\", \"Billing\")\nexample: Home\nmaxLength: 100",
+                    "type": "string",
+                    "maxLength": 100,
+                    "example": "Home"
+                },
                 "line1": {
                     "description": "Primary address line (street address or PO Box)\nexample: 123 Financial Avenue\nmaxLength: 256",
                     "type": "string",
@@ -4533,6 +4542,14 @@
                     "type": "string",
                     "maxLength": 256
                 },
+                "settings": {
+                    "description": "Dynamic configuration settings for this ledger. When nil, no settings are persisted (optional).\nexample: {\"accounting\": {\"validateAccountType\": true}}",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/mmodel.LedgerSettings"
+                        }
+                    ]
+                },
                 "status": {
                     "description": "Current operating status of the ledger (defaults to ACTIVE if not specified)\nrequired: false",
                     "allOf": [
@@ -4736,7 +4753,9 @@
                     "example": "00000000-0000-0000-0000-000000000000"
                 },
                 "settings": {
-                    "$ref": "#/definitions/LedgerSettings"
+                    "description": "Dynamic configuration settings for this ledger\nexample: {\"accounting\": {\"validateAccountType\": true}}",
+                    "type": "object",
+                    "additionalProperties": {}
                 },
                 "status": {
                     "description": "Current operating status of the ledger",
@@ -4753,30 +4772,6 @@
                     "example": "2021-01-01T00:00:00Z"
                 }
             }
-        },
-        "LedgerSettings": {
-            "description": "Ledger configuration settings. Only known fields are allowed; unknown fields return error 0147 (ErrUnknownSettingsField). Invalid types return error 0148 (ErrInvalidSettingsFieldType).",
-            "type": "object",
-            "properties": {
-                "accounting": {
-                    "description": "Accounting validation settings",
-                    "type": "object",
-                    "properties": {
-                        "validateAccountType": {
-                            "description": "When true, validates account types against route rules. Default false. May be JSON null.",
-                            "type": "boolean",
-                            "x-nullable": true
-                        },
-                        "validateRoutes": {
-                            "description": "When true, validates transaction routes. Default false. May be JSON null.",
-                            "type": "boolean",
-                            "x-nullable": true
-                        }
-                    },
-                    "additionalProperties": false
-                }
-            },
-            "additionalProperties": false
         },
         "Organization": {
             "description": "Complete organization entity containing all fields including system-generated fields like ID, creation timestamps, and metadata. This is the response format for organization operations. Organizations are the top-level entities in the Midaz platform hierarchy.",
@@ -5236,6 +5231,32 @@
                     "allOf": [
                         {
                             "$ref": "#/definitions/Status"
+                        }
+                    ]
+                }
+            }
+        },
+        "mmodel.AccountingValidation": {
+            "type": "object",
+            "properties": {
+                "validateAccountType": {
+                    "description": "ValidateAccountType enables validation of account types during transaction processing.\nWhen true, accounts must have types that match the operation route rules.\nDefault: false (permissive - no validation)",
+                    "type": "boolean"
+                },
+                "validateRoutes": {
+                    "description": "ValidateRoutes enables validation of transaction routes during processing.\nWhen true, transactions must specify valid route IDs that exist in the ledger.\nDefault: false (permissive - no validation)",
+                    "type": "boolean"
+                }
+            }
+        },
+        "mmodel.LedgerSettings": {
+            "type": "object",
+            "properties": {
+                "accounting": {
+                    "description": "Accounting contains validation settings for accounting operations.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/mmodel.AccountingValidation"
                         }
                     ]
                 }

--- a/components/onboarding/api/onboarding_swagger.json
+++ b/components/onboarding/api/onboarding_swagger.json
@@ -1053,8 +1053,7 @@
                     "200": {
                         "description": "Successfully retrieved ledger settings",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": true
+                            "$ref": "#/definitions/mmodel.LedgerSettings"
                         }
                     },
                     "401": {
@@ -1129,8 +1128,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": true
+                            "$ref": "#/definitions/mmodel.LedgerSettings"
                         }
                     }
                 ],
@@ -1138,8 +1136,7 @@
                     "200": {
                         "description": "Successfully updated ledger settings",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": true
+                            "$ref": "#/definitions/mmodel.LedgerSettings"
                         }
                     },
                     "400": {
@@ -4753,9 +4750,12 @@
                     "example": "00000000-0000-0000-0000-000000000000"
                 },
                 "settings": {
-                    "description": "Dynamic configuration settings for this ledger\nexample: {\"accounting\": {\"validateAccountType\": true}}",
-                    "type": "object",
-                    "additionalProperties": {}
+                    "description": "Dynamic configuration settings for this ledger. May be null if no settings are configured.\nexample: {\"accounting\": {\"validateAccountType\": true}}",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/mmodel.LedgerSettings"
+                        }
+                    ]
                 },
                 "status": {
                     "description": "Current operating status of the ledger",

--- a/components/onboarding/api/onboarding_swagger.yaml
+++ b/components/onboarding/api/onboarding_swagger.yaml
@@ -203,6 +203,14 @@ definitions:
         maxLength: 2
         minLength: 2
         type: string
+      description:
+        description: |-
+          A descriptive label for the address (e.g., "Home", "Office", "Billing")
+          example: Home
+          maxLength: 100
+        example: Home
+        maxLength: 100
+        type: string
       line1:
         description: |-
           Primary address line (street address or PO Box)
@@ -472,6 +480,12 @@ definitions:
           maxLength: 256
         maxLength: 256
         type: string
+      settings:
+        allOf:
+        - $ref: '#/definitions/mmodel.LedgerSettings'
+        description: |-
+          Dynamic configuration settings for this ledger. When nil, no settings are persisted (optional).
+          example: {"accounting": {"validateAccountType": true}}
       status:
         allOf:
         - $ref: '#/definitions/Status'
@@ -693,7 +707,11 @@ definitions:
         format: uuid
         type: string
       settings:
-        $ref: '#/definitions/LedgerSettings'
+        additionalProperties: {}
+        description: |-
+          Dynamic configuration settings for this ledger
+          example: {"accounting": {"validateAccountType": true}}
+        type: object
       status:
         allOf:
         - $ref: '#/definitions/Status'
@@ -707,26 +725,6 @@ definitions:
         format: date-time
         type: string
     type: object
-  LedgerSettings:
-    description: Ledger configuration settings. Only known fields are allowed; unknown
-      fields return error 0147 (ErrUnknownSettingsField). Invalid types return error
-      0148 (ErrInvalidSettingsFieldType).
-    type: object
-    properties:
-      accounting:
-        description: Accounting validation settings
-        type: object
-        properties:
-          validateAccountType:
-            description: When true, validates account types against route rules. Default false. May be JSON null.
-            type: boolean
-            x-nullable: true
-          validateRoutes:
-            description: When true, validates transaction routes. Default false. May be JSON null.
-            type: boolean
-            x-nullable: true
-        additionalProperties: false
-    additionalProperties: false
   Organization:
     description: Complete organization entity containing all fields including system-generated
       fields like ID, creation timestamps, and metadata. This is the response format
@@ -1169,6 +1167,28 @@ definitions:
         allOf:
         - $ref: '#/definitions/Status'
         description: Updated status of the segment (active, inactive, pending)
+    type: object
+  mmodel.AccountingValidation:
+    properties:
+      validateAccountType:
+        description: |-
+          ValidateAccountType enables validation of account types during transaction processing.
+          When true, accounts must have types that match the operation route rules.
+          Default: false (permissive - no validation)
+        type: boolean
+      validateRoutes:
+        description: |-
+          ValidateRoutes enables validation of transaction routes during processing.
+          When true, transactions must specify valid route IDs that exist in the ledger.
+          Default: false (permissive - no validation)
+        type: boolean
+    type: object
+  mmodel.LedgerSettings:
+    properties:
+      accounting:
+        allOf:
+        - $ref: '#/definitions/mmodel.AccountingValidation'
+        description: Accounting contains validation settings for accounting operations.
     type: object
 host: localhost:3000
 info:
@@ -1816,7 +1836,8 @@ paths:
         "200":
           description: Successfully retrieved ledger settings
           schema:
-            $ref: '#/definitions/LedgerSettings'
+            additionalProperties: true
+            type: object
         "401":
           description: Unauthorized access
           schema:
@@ -1847,7 +1868,7 @@ paths:
         not specified in the update. Example: updating only ''accounting.validateRoutes''
         preserves the existing ''accounting.validateAccountType'' value. Setting a
         key to null stores a JSON null value. Allowed fields: accounting.validateAccountType
-        (boolean | null), accounting.validateRoutes (boolean | null).'
+        (boolean), accounting.validateRoutes (boolean).'
       parameters:
       - description: 'Authorization Bearer Token with format: Bearer {token}'
         in: header
@@ -1869,20 +1890,22 @@ paths:
         required: true
         type: string
       - description: 'Settings to merge with existing settings. Only known fields
-          allowed: accounting.validateAccountType (boolean | null), accounting.validateRoutes
-          (boolean | null)'
+          allowed: accounting.validateAccountType (bool), accounting.validateRoutes
+          (bool)'
         in: body
         name: settings
         required: true
         schema:
-          $ref: '#/definitions/LedgerSettings'
+          additionalProperties: true
+          type: object
       produces:
       - application/json
       responses:
         "200":
           description: Successfully updated ledger settings
           schema:
-            $ref: '#/definitions/LedgerSettings'
+            additionalProperties: true
+            type: object
         "400":
           description: Invalid request body, unknown field (0147), or invalid field
             type (0148)

--- a/components/onboarding/api/onboarding_swagger.yaml
+++ b/components/onboarding/api/onboarding_swagger.yaml
@@ -707,11 +707,11 @@ definitions:
         format: uuid
         type: string
       settings:
-        additionalProperties: {}
+        allOf:
+        - $ref: '#/definitions/mmodel.LedgerSettings'
         description: |-
-          Dynamic configuration settings for this ledger
+          Dynamic configuration settings for this ledger. May be null if no settings are configured.
           example: {"accounting": {"validateAccountType": true}}
-        type: object
       status:
         allOf:
         - $ref: '#/definitions/Status'
@@ -1836,8 +1836,7 @@ paths:
         "200":
           description: Successfully retrieved ledger settings
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/mmodel.LedgerSettings'
         "401":
           description: Unauthorized access
           schema:
@@ -1896,16 +1895,14 @@ paths:
         name: settings
         required: true
         schema:
-          additionalProperties: true
-          type: object
+          $ref: '#/definitions/mmodel.LedgerSettings'
       produces:
       - application/json
       responses:
         "200":
           description: Successfully updated ledger settings
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/mmodel.LedgerSettings'
         "400":
           description: Invalid request body, unknown field (0147), or invalid field
             type (0148)

--- a/components/onboarding/api/openapi.yaml
+++ b/components/onboarding/api/openapi.yaml
@@ -4193,7 +4193,8 @@ components:
         organizationId: 00000000-0000-0000-0000-000000000000
         createdAt: 2021-01-01T00:00:00Z
         settings:
-          key: '{}'
+          accounting:
+            validateAccountType: true
         deletedAt: 2021-01-01T00:00:00Z
         metadata:
           key: '{}'
@@ -4905,7 +4906,8 @@ components:
         - organizationId: 00000000-0000-0000-0000-000000000000
           createdAt: 2021-01-01T00:00:00Z
           settings:
-            key: '{}'
+            accounting:
+              validateAccountType: true
           deletedAt: 2021-01-01T00:00:00Z
           metadata:
             key: '{}'
@@ -4916,7 +4918,8 @@ components:
         - organizationId: 00000000-0000-0000-0000-000000000000
           createdAt: 2021-01-01T00:00:00Z
           settings:
-            key: '{}'
+            accounting:
+              validateAccountType: true
           deletedAt: 2021-01-01T00:00:00Z
           metadata:
             key: '{}'

--- a/components/onboarding/api/openapi.yaml
+++ b/components/onboarding/api/openapi.yaml
@@ -69,6 +69,20 @@ paths:
           - asc
           - desc
           type: string
+      - description: Filter organizations by legal name (case-insensitive, prefix
+          match)
+        in: query
+        name: legal_name
+        schema:
+          maxLength: 256
+          type: string
+      - description: Filter organizations by doing business as name (case-insensitive,
+          prefix match)
+        in: query
+        name: doing_business_as
+        schema:
+          maxLength: 256
+          type: string
       responses:
         "200":
           content:
@@ -451,6 +465,12 @@ paths:
           - asc
           - desc
           type: string
+      - description: Filter ledgers by name (case-insensitive, prefix match)
+        in: query
+        name: name
+        schema:
+          maxLength: 256
+          type: string
       responses:
         "200":
           content:
@@ -817,7 +837,7 @@ paths:
   /v1/organizations/{organization_id}/ledgers/{id}/settings:
     get:
       description: Returns the current configuration settings for a specific ledger.
-        Returns an empty object {} if no settings have been defined.
+        If no settings have been persisted, returns the default settings object.
       parameters:
       - description: 'Authorization Bearer Token with format: Bearer {token}'
         in: header
@@ -847,7 +867,8 @@ paths:
           content:
             application/json:
               schema:
-                additionalProperties: true
+                additionalProperties:
+                  type: object
                 type: object
           description: Successfully retrieved ledger settings
         "401":
@@ -878,12 +899,15 @@ paths:
       tags:
       - Ledgers
     patch:
-      description: Updates the configuration settings for a specific ledger. New settings
-        are merged at TOP LEVEL only (shallow merge). Nested objects are REPLACED
-        entirely, not deep-merged. To update a nested key, you must send the complete
-        nested object. Setting a key to null will set its value to null; keys are
-        retained, not removed. Server-side validation limits apply - maximum payload
-        size of 64KB, maximum 100 top-level keys, and maximum nesting depth of 10 levels.
+      description: 'Updates the configuration settings for a specific ledger using
+        schema-aware deep merge. Only known settings fields are allowed - unknown
+        fields return error 0147 (ErrUnknownSettingsField). Type validation is enforced
+        - incorrect types return error 0148 (ErrInvalidSettingsFieldType). Nested
+        objects (like ''accounting'') are deep-merged, preserving existing properties
+        not specified in the update. Example: updating only ''accounting.validateRoutes''
+        preserves the existing ''accounting.validateAccountType'' value. Setting a
+        key to null stores a JSON null value. Allowed fields: accounting.validateAccountType
+        (boolean), accounting.validateRoutes (boolean).'
       parameters:
       - description: 'Authorization Bearer Token with format: Bearer {token}'
         in: header
@@ -912,16 +936,18 @@ paths:
         content:
           application/json:
             schema:
-              additionalProperties: true
               type: object
-        description: Settings to merge with existing settings
+        description: 'Settings to merge with existing settings. Only known fields
+          allowed: accounting.validateAccountType (bool), accounting.validateRoutes
+          (bool)'
         required: true
       responses:
         "200":
           content:
             application/json:
               schema:
-                additionalProperties: true
+                additionalProperties:
+                  type: object
                 type: object
           description: Successfully updated ledger settings
         "400":
@@ -929,7 +955,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-          description: Invalid request body
+          description: Invalid request body, unknown field (0147), or invalid field
+            type (0148)
         "401":
           content:
             application/json:
@@ -3621,6 +3648,14 @@ components:
           maxLength: 2
           minLength: 2
           type: string
+        description:
+          description: |-
+            A descriptive label for the address (e.g., "Home", "Office", "Billing")
+            example: Home
+            maxLength: 100
+          example: Home
+          maxLength: 100
+          type: string
         line1:
           description: |-
             Primary address line (street address or PO Box)
@@ -3924,6 +3959,7 @@ components:
         units within an organization that group related financial accounts and assets
         together.
       example:
+        settings: '{}'
         metadata:
           key: '{}'
         name: name
@@ -3944,6 +3980,13 @@ components:
             maxLength: 256
           maxLength: 256
           type: string
+        settings:
+          allOf:
+          - $ref: '#/components/schemas/mmodel.LedgerSettings'
+          description: |-
+            Dynamic configuration settings for this ledger. When nil, no settings are persisted (optional).
+            example: {"accounting": {"validateAccountType": true}}
+          type: object
         status:
           allOf:
           - $ref: '#/components/schemas/Status'
@@ -4149,6 +4192,8 @@ components:
       example:
         organizationId: 00000000-0000-0000-0000-000000000000
         createdAt: 2021-01-01T00:00:00Z
+        settings:
+          key: '{}'
         deletedAt: 2021-01-01T00:00:00Z
         metadata:
           key: '{}'
@@ -4204,6 +4249,13 @@ components:
           example: 00000000-0000-0000-0000-000000000000
           format: uuid
           type: string
+        settings:
+          additionalProperties:
+            type: object
+          description: |-
+            Dynamic configuration settings for this ledger
+            example: {"accounting": {"validateAccountType": true}}
+          type: object
         status:
           allOf:
           - $ref: '#/components/schemas/Status'
@@ -4769,6 +4821,29 @@ components:
           description: Updated status of the segment (active, inactive, pending)
           type: object
       type: object
+    mmodel.AccountingValidation:
+      properties:
+        validateAccountType:
+          description: |-
+            ValidateAccountType enables validation of account types during transaction processing.
+            When true, accounts must have types that match the operation route rules.
+            Default: false (permissive - no validation)
+          type: boolean
+        validateRoutes:
+          description: |-
+            ValidateRoutes enables validation of transaction routes during processing.
+            When true, transactions must specify valid route IDs that exist in the ledger.
+            Default: false (permissive - no validation)
+          type: boolean
+      type: object
+    mmodel.LedgerSettings:
+      properties:
+        accounting:
+          allOf:
+          - $ref: '#/components/schemas/mmodel.AccountingValidation'
+          description: Accounting contains validation settings for accounting operations.
+          type: object
+      type: object
     inline_response_200:
       example:
         Pagination:
@@ -4829,6 +4904,8 @@ components:
         items:
         - organizationId: 00000000-0000-0000-0000-000000000000
           createdAt: 2021-01-01T00:00:00Z
+          settings:
+            key: '{}'
           deletedAt: 2021-01-01T00:00:00Z
           metadata:
             key: '{}'
@@ -4838,6 +4915,8 @@ components:
           updatedAt: 2021-01-01T00:00:00Z
         - organizationId: 00000000-0000-0000-0000-000000000000
           createdAt: 2021-01-01T00:00:00Z
+          settings:
+            key: '{}'
           deletedAt: 2021-01-01T00:00:00Z
           metadata:
             key: '{}'

--- a/components/onboarding/internal/adapters/http/in/ledger.go
+++ b/components/onboarding/internal/adapters/http/in/ledger.go
@@ -384,7 +384,7 @@ func (handler *LedgerHandler) CountLedgers(c *fiber.Ctx) error {
 // GetLedgerSettings retrieves the settings for a specific ledger.
 //
 //	@Summary		Get ledger settings
-//	@Description	Returns the current configuration settings for a specific ledger. Returns an empty object {} if no settings have been defined.
+//	@Description	Returns the current configuration settings for a specific ledger. If no settings have been persisted, returns the default settings object.
 //	@Tags			Ledgers
 //	@Produce		json
 //	@Param			Authorization	header		string	true	"Authorization Bearer Token with format: Bearer {token}"


### PR DESCRIPTION
## Summary

Enhance ledger settings API documentation with comprehensive endpoint descriptions, schema definitions, and validation behavior. Add filter parameters to list endpoints and document new model fields.

## Motivation

The ledger settings feature lacked proper API documentation, making it difficult for API consumers to understand:
- How to retrieve and update ledger settings
- What fields are allowed in the settings schema
- How validation works (error codes 0147, 0148)
- The deep merge behavior for nested objects

## Semantic Decision

This is a **documentation-only** change with no impact on runtime behavior.

## Changes

### New Files
| File | Purpose |
|------|---------|
| N/A | No new files created |

### Refactored Code
| Before | After |
|--------|-------|
| GET settings: "Returns an empty object {} if no settings have been defined" | GET settings: "If no settings have been persisted, returns the default settings object" |
| PATCH settings: Generic shallow merge description | PATCH settings: Schema-aware deep merge with field validation, error codes documented |
| No filter parameters on list endpoints | Added `legal_name`, `doing_business_as` filters for organizations; `name` filter for ledgers |
| Missing schema definitions for LedgerSettings | Added `mmodel.LedgerSettings` and `mmodel.AccountingValidation` schemas |
| Ledger model missing settings field | Added `settings` field documentation to Ledger input/output models |
| Address model missing description field | Added `description` field documentation to Address model |

### API Documentation Updates

**Ledger Settings Endpoints:**
- `GET /v1/organizations/{organization_id}/ledgers/{id}/settings` - Full documentation with response schemas
- `PATCH /v1/organizations/{organization_id}/ledgers/{id}/settings` - Updated description explaining:
  - Schema-aware deep merge behavior
  - Allowed fields: `accounting.validateAccountType` (boolean), `accounting.validateRoutes` (boolean)
  - Error codes: 0147 (ErrUnknownSettingsField), 0148 (ErrInvalidSettingsFieldType)

**New Filter Parameters:**
- Organizations list: `legal_name`, `doing_business_as` (case-insensitive, prefix match)
- Ledgers list: `name` (case-insensitive, prefix match)

**New Schema Definitions:**
- `mmodel.LedgerSettings` - Container for ledger configuration
- `mmodel.AccountingValidation` - Accounting validation settings (`validateAccountType`, `validateRoutes`)

## Test Plan
- [x] Verify swagger documentation generates correctly with `make gen-openapi-onboarding`
- [x] Confirm all new endpoints appear in generated documentation
- [x] Validate schema definitions are correctly referenced
