### PR TITLE
feat: add batch synchronization and aggregation - balance update

### DIFF
--- a/components/transaction/internal/adapters/postgres/balance/balance.postgresql.go
+++ b/components/transaction/internal/adapters/postgres/balance/balance.postgresql.go
@@ -68,6 +68,7 @@ type Repository interface {
 	Delete(ctx context.Context, organizationID, ledgerID, id uuid.UUID) error
 	DeleteAllByIDs(ctx context.Context, organizationID, ledgerID uuid.UUID, ids []uuid.UUID) error
 	Sync(ctx context.Context, organizationID, ledgerID uuid.UUID, b mmodel.BalanceRedis) (bool, error)
+	SyncBatch(ctx context.Context, organizationID, ledgerID uuid.UUID, balances []mmodel.BalanceRedis) (int64, error)
 	UpdateAllByAccountID(ctx context.Context, organizationID, ledgerID, accountID uuid.UUID, balance mmodel.UpdateBalance) error
 	ListByAccountID(ctx context.Context, organizationID, ledgerID, accountID uuid.UUID) ([]*mmodel.Balance, error)
 	ListByAccountIDAtTimestamp(ctx context.Context, organizationID, ledgerID, accountID uuid.UUID, timestamp time.Time) ([]*mmodel.Balance, error)
@@ -1406,6 +1407,125 @@ func (r *BalancePostgreSQLRepository) Sync(ctx context.Context, organizationID, 
 	}
 
 	return affected > 0, nil
+}
+
+// SyncBatch persists multiple balances from cache to database in a single transaction.
+// This is more efficient than calling Sync in a loop as it:
+// 1. Uses a single database transaction for all updates
+// 2. Reduces round-trips between application and database
+// 3. Provides atomicity - all updates succeed or all fail
+//
+// Uses optimistic locking: only updates balances where version < incoming version.
+// Returns count of actually updated rows.
+func (r *BalancePostgreSQLRepository) SyncBatch(ctx context.Context, organizationID, ledgerID uuid.UUID, balances []mmodel.BalanceRedis) (int64, error) {
+	if len(balances) == 0 {
+		return 0, nil
+	}
+
+	logger, tracer, _, _ := libCommons.NewTrackingFromContext(ctx)
+
+	ctx, span := tracer.Start(ctx, "postgres.sync_batch")
+	defer span.End()
+
+	db, err := r.getDB(ctx)
+	if err != nil {
+		libOpentelemetry.HandleSpanError(&span, "Failed to get database connection", err)
+
+		logger.Errorf("Failed to get database connection: %v", err)
+
+		return 0, err
+	}
+
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		libOpentelemetry.HandleSpanError(&span, "Failed to begin transaction", err)
+
+		logger.Errorf("Failed to begin transaction: %v", err)
+
+		return 0, err
+	}
+
+	committed := false
+
+	defer func() {
+		if committed {
+			return
+		}
+
+		if rollbackErr := tx.Rollback(); rollbackErr != nil {
+			logger.Errorf("Failed to rollback transaction: %v", rollbackErr)
+		}
+	}()
+
+	var totalUpdated int64
+
+	now := time.Now()
+
+	for _, balance := range balances {
+		// Check for context cancellation before processing each balance
+		if ctx.Err() != nil {
+			libOpentelemetry.HandleSpanError(&span, "Context cancelled during batch sync", ctx.Err())
+
+			logger.Warnf("SyncBatch cancelled: %v", ctx.Err())
+
+			return 0, ctx.Err()
+		}
+
+		id, parseErr := uuid.Parse(balance.ID)
+		if parseErr != nil {
+			libOpentelemetry.HandleSpanError(&span, "Invalid balance ID", parseErr)
+
+			logger.Errorf("Invalid balance ID %s: %v", balance.ID, parseErr)
+
+			return 0, parseErr
+		}
+
+		result, execErr := tx.ExecContext(ctx, `
+			UPDATE balance
+			SET available = $1, on_hold = $2, version = $3, updated_at = $4
+			WHERE organization_id = $5
+			  AND ledger_id = $6
+			  AND id = $7
+			  AND version < $3
+			  AND deleted_at IS NULL
+		`, balance.Available, balance.OnHold, balance.Version, now, organizationID, ledgerID, id)
+		if execErr != nil {
+			libOpentelemetry.HandleSpanError(&span, "Failed to update balance", execErr)
+
+			logger.Errorf("Failed to update balance %s: %v", balance.ID, execErr)
+
+			return 0, execErr
+		}
+
+		rowsAffected, rowsErr := result.RowsAffected()
+		if rowsErr != nil {
+			libOpentelemetry.HandleSpanError(&span, "Failed to get rows affected", rowsErr)
+
+			logger.Errorf("Failed to get rows affected for balance %s: %v", balance.ID, rowsErr)
+
+			return 0, rowsErr
+		}
+
+		totalUpdated += rowsAffected
+
+		if rowsAffected == 0 {
+			logger.Debugf("Balance %s skipped: version %d not newer than DB", balance.ID, balance.Version)
+		}
+	}
+
+	if commitErr := tx.Commit(); commitErr != nil {
+		libOpentelemetry.HandleSpanError(&span, "Failed to commit transaction", commitErr)
+
+		logger.Errorf("Failed to commit batch sync: %v", commitErr)
+
+		return 0, commitErr
+	}
+
+	committed = true
+
+	logger.Infof("SyncBatch: updated %d of %d balances", totalUpdated, len(balances))
+
+	return totalUpdated, nil
 }
 
 func (r *BalancePostgreSQLRepository) UpdateAllByAccountID(ctx context.Context, organizationID, ledgerID, accountID uuid.UUID, balance mmodel.UpdateBalance) error {

--- a/components/transaction/internal/adapters/postgres/balance/balance.postgresql_integration_test.go
+++ b/components/transaction/internal/adapters/postgres/balance/balance.postgresql_integration_test.go
@@ -941,6 +941,308 @@ func TestIntegration_BalanceRepository_Sync_IgnoresOlderVersion(t *testing.T) {
 }
 
 // ============================================================================
+// SyncBatch Tests (Batch Redis → Postgres)
+// ============================================================================
+
+func TestIntegration_BalanceRepository_SyncBatch_UpdatesMultipleBalances(t *testing.T) {
+	container := pgtestutil.SetupContainer(t)
+
+	repo := createRepository(t, container)
+
+	orgID := libCommons.GenerateUUIDv7()
+	ledgerID := libCommons.GenerateUUIDv7()
+	accountID := createTestAccountID()
+
+	// Create two balances
+	params1 := pgtestutil.DefaultBalanceParams()
+	params1.Alias = "@batch-1"
+	params1.Available = decimal.NewFromInt(100)
+	balanceID1 := pgtestutil.CreateTestBalance(t, container.DB, orgID, ledgerID, accountID, params1)
+
+	params2 := pgtestutil.DefaultBalanceParams()
+	params2.Alias = "@batch-2"
+	params2.Available = decimal.NewFromInt(200)
+	balanceID2 := pgtestutil.CreateTestBalance(t, container.DB, orgID, ledgerID, accountID, params2)
+
+	ctx := context.Background()
+
+	// Batch of balances to sync
+	balances := []mmodel.BalanceRedis{
+		{
+			ID:        balanceID1.String(),
+			Available: decimal.NewFromInt(500),
+			OnHold:    decimal.NewFromInt(10),
+			Version:   10,
+		},
+		{
+			ID:        balanceID2.String(),
+			Available: decimal.NewFromInt(600),
+			OnHold:    decimal.NewFromInt(20),
+			Version:   10,
+		},
+	}
+
+	// Act
+	updated, err := repo.SyncBatch(ctx, orgID, ledgerID, balances)
+
+	// Assert
+	require.NoError(t, err, "SyncBatch should not return error")
+	assert.Equal(t, int64(2), updated, "should update both balances")
+
+	// Verify first balance
+	found1, err := repo.Find(ctx, orgID, ledgerID, balanceID1)
+	require.NoError(t, err)
+	assert.True(t, found1.Available.Equal(decimal.NewFromInt(500)), "balance 1 available should be synced")
+	assert.True(t, found1.OnHold.Equal(decimal.NewFromInt(10)), "balance 1 on_hold should be synced")
+
+	// Verify second balance
+	found2, err := repo.Find(ctx, orgID, ledgerID, balanceID2)
+	require.NoError(t, err)
+	assert.True(t, found2.Available.Equal(decimal.NewFromInt(600)), "balance 2 available should be synced")
+	assert.True(t, found2.OnHold.Equal(decimal.NewFromInt(20)), "balance 2 on_hold should be synced")
+}
+
+func TestIntegration_BalanceRepository_SyncBatch_IgnoresOlderVersions(t *testing.T) {
+	container := pgtestutil.SetupContainer(t)
+
+	repo := createRepository(t, container)
+
+	orgID := libCommons.GenerateUUIDv7()
+	ledgerID := libCommons.GenerateUUIDv7()
+	accountID := createTestAccountID()
+
+	// Insert balance with version 10
+	balanceID := libCommons.GenerateUUIDv7()
+	now := time.Now().Truncate(time.Microsecond)
+
+	_, err := container.DB.Exec(`
+		INSERT INTO balance (id, organization_id, ledger_id, account_id, alias, key, asset_code, available, on_hold, version, account_type, allow_sending, allow_receiving, created_at, updated_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)
+	`, balanceID, orgID, ledgerID, accountID, "@batch-old", "default", "USD",
+		decimal.NewFromInt(1000), decimal.Zero, 10, "deposit", true, true, now, now)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	// Try to sync with older version
+	balances := []mmodel.BalanceRedis{
+		{
+			ID:        balanceID.String(),
+			Available: decimal.NewFromInt(500),
+			OnHold:    decimal.NewFromInt(25),
+			Version:   5, // older than 10
+		},
+	}
+
+	// Act
+	updated, err := repo.SyncBatch(ctx, orgID, ledgerID, balances)
+
+	// Assert
+	require.NoError(t, err, "SyncBatch should not error for old version")
+	assert.Equal(t, int64(0), updated, "should indicate no balances were updated")
+
+	// Verify original values unchanged
+	found, err := repo.Find(ctx, orgID, ledgerID, balanceID)
+	require.NoError(t, err)
+	assert.True(t, found.Available.Equal(decimal.NewFromInt(1000)), "available should be unchanged")
+	assert.Equal(t, int64(10), found.Version, "version should be unchanged")
+}
+
+func TestIntegration_BalanceRepository_SyncBatch_EmptyBatchReturnsZero(t *testing.T) {
+	container := pgtestutil.SetupContainer(t)
+
+	repo := createRepository(t, container)
+
+	orgID := libCommons.GenerateUUIDv7()
+	ledgerID := libCommons.GenerateUUIDv7()
+
+	ctx := context.Background()
+
+	// Act - empty batch
+	updated, err := repo.SyncBatch(ctx, orgID, ledgerID, []mmodel.BalanceRedis{})
+
+	// Assert
+	require.NoError(t, err, "SyncBatch should not error for empty batch")
+	assert.Equal(t, int64(0), updated, "should return 0 for empty batch")
+}
+
+func TestIntegration_BalanceRepository_SyncBatch_PartialUpdate(t *testing.T) {
+	container := pgtestutil.SetupContainer(t)
+
+	repo := createRepository(t, container)
+
+	orgID := libCommons.GenerateUUIDv7()
+	ledgerID := libCommons.GenerateUUIDv7()
+	accountID := createTestAccountID()
+
+	// Create balance with version 5
+	params := pgtestutil.DefaultBalanceParams()
+	params.Alias = "@partial"
+	params.Available = decimal.NewFromInt(100)
+	balanceID := pgtestutil.CreateTestBalance(t, container.DB, orgID, ledgerID, accountID, params)
+
+	// Create another balance with version 10 (via direct insert)
+	balanceID2 := libCommons.GenerateUUIDv7()
+	now := time.Now().Truncate(time.Microsecond)
+	_, err := container.DB.Exec(`
+		INSERT INTO balance (id, organization_id, ledger_id, account_id, alias, key, asset_code, available, on_hold, version, account_type, allow_sending, allow_receiving, created_at, updated_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)
+	`, balanceID2, orgID, ledgerID, accountID, "@partial-high", "default", "USD",
+		decimal.NewFromInt(200), decimal.Zero, 10, "deposit", true, true, now, now)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	// Batch: first one newer (should update), second one older (should skip)
+	balances := []mmodel.BalanceRedis{
+		{
+			ID:        balanceID.String(),
+			Available: decimal.NewFromInt(500),
+			OnHold:    decimal.NewFromInt(10),
+			Version:   10, // higher than default (1), should update
+		},
+		{
+			ID:        balanceID2.String(),
+			Available: decimal.NewFromInt(600),
+			OnHold:    decimal.NewFromInt(20),
+			Version:   5, // lower than 10, should skip
+		},
+	}
+
+	// Act
+	updated, err := repo.SyncBatch(ctx, orgID, ledgerID, balances)
+
+	// Assert
+	require.NoError(t, err, "SyncBatch should not return error")
+	assert.Equal(t, int64(1), updated, "should update only one balance")
+
+	// Verify first balance was updated
+	found1, err := repo.Find(ctx, orgID, ledgerID, balanceID)
+	require.NoError(t, err)
+	assert.True(t, found1.Available.Equal(decimal.NewFromInt(500)), "balance 1 should be updated")
+
+	// Verify second balance was NOT updated
+	found2, err := repo.Find(ctx, orgID, ledgerID, balanceID2)
+	require.NoError(t, err)
+	assert.True(t, found2.Available.Equal(decimal.NewFromInt(200)), "balance 2 should be unchanged")
+	assert.Equal(t, int64(10), found2.Version, "balance 2 version should be unchanged")
+}
+
+func TestIntegration_BalanceRepository_SyncBatch_RespectsContextCancellation(t *testing.T) {
+	container := pgtestutil.SetupContainer(t)
+
+	repo := createRepository(t, container)
+
+	orgID := libCommons.GenerateUUIDv7()
+	ledgerID := libCommons.GenerateUUIDv7()
+
+	// Create a cancelled context
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Cancel immediately
+
+	// Batch with balances
+	balances := []mmodel.BalanceRedis{
+		{
+			ID:        libCommons.GenerateUUIDv7().String(),
+			Available: decimal.NewFromInt(500),
+			OnHold:    decimal.NewFromInt(10),
+			Version:   10,
+		},
+	}
+
+	// Act
+	updated, err := repo.SyncBatch(ctx, orgID, ledgerID, balances)
+
+	// Assert
+	require.Error(t, err, "SyncBatch should return error for cancelled context")
+	assert.Equal(t, int64(0), updated, "should return 0 updates")
+	assert.ErrorIs(t, err, context.Canceled, "error should be context.Canceled")
+}
+
+func TestIntegration_BalanceRepository_SyncBatch_InvalidUUID(t *testing.T) {
+	container := pgtestutil.SetupContainer(t)
+
+	repo := createRepository(t, container)
+
+	orgID := libCommons.GenerateUUIDv7()
+	ledgerID := libCommons.GenerateUUIDv7()
+
+	ctx := context.Background()
+
+	// Batch with invalid UUID
+	balances := []mmodel.BalanceRedis{
+		{
+			ID:        "not-a-valid-uuid",
+			Available: decimal.NewFromInt(500),
+			OnHold:    decimal.NewFromInt(10),
+			Version:   10,
+		},
+	}
+
+	// Act
+	updated, err := repo.SyncBatch(ctx, orgID, ledgerID, balances)
+
+	// Assert
+	require.Error(t, err, "SyncBatch should return error for invalid UUID")
+	assert.Equal(t, int64(0), updated, "should return 0 updates")
+	assert.Contains(t, err.Error(), "invalid", "error should mention invalid")
+}
+
+func TestIntegration_BalanceRepository_SyncBatch_LargeBatch(t *testing.T) {
+	container := pgtestutil.SetupContainer(t)
+
+	repo := createRepository(t, container)
+
+	orgID := libCommons.GenerateUUIDv7()
+	ledgerID := libCommons.GenerateUUIDv7()
+
+	// Create 150 test balances in the database
+	balanceIDs := make([]uuid.UUID, 150)
+	for i := range 150 {
+		accountID := createTestAccountID()
+		params := pgtestutil.BalanceParams{
+			Alias:          "@batch-" + accountID.String()[:8],
+			Key:            "default",
+			AssetCode:      "USD",
+			Available:      decimal.NewFromInt(int64(100 + i)),
+			OnHold:         decimal.Zero,
+			AccountType:    "deposit",
+			AllowSending:   true,
+			AllowReceiving: true,
+		}
+		balanceIDs[i] = pgtestutil.CreateTestBalance(t, container.DB, orgID, ledgerID, accountID, params)
+	}
+
+	ctx := context.Background()
+
+	// Prepare batch update with all 150 balances
+	balances := make([]mmodel.BalanceRedis, 150)
+	for i := range 150 {
+		balances[i] = mmodel.BalanceRedis{
+			ID:        balanceIDs[i].String(),
+			Available: decimal.NewFromInt(int64(1000 + i)),
+			OnHold:    decimal.NewFromInt(int64(i)),
+			Version:   100, // Higher than initial version (1)
+		}
+	}
+
+	// Act
+	updated, err := repo.SyncBatch(ctx, orgID, ledgerID, balances)
+
+	// Assert
+	require.NoError(t, err, "SyncBatch should handle large batch without error")
+	assert.Equal(t, int64(150), updated, "should update all 150 balances")
+
+	// Verify a sample of updates
+	for _, idx := range []int{0, 50, 100, 149} {
+		found, err := repo.Find(ctx, orgID, ledgerID, balanceIDs[idx])
+		require.NoError(t, err)
+		assert.True(t, found.Available.Equal(decimal.NewFromInt(int64(1000+idx))),
+			"balance %d available should be updated", idx)
+	}
+}
+
+// ============================================================================
 // ListAll Tests (covers date filtering and pagination)
 // ============================================================================
 

--- a/components/transaction/internal/adapters/postgres/balance/balance.postgresql_mock.go
+++ b/components/transaction/internal/adapters/postgres/balance/balance.postgresql_mock.go
@@ -12,7 +12,7 @@ package balance
 import (
 	context "context"
 	reflect "reflect"
-	"time"
+	time "time"
 
 	http "github.com/LerianStudio/lib-commons/v3/commons/net/http"
 	mmodel "github.com/LerianStudio/midaz/v3/pkg/mmodel"
@@ -281,6 +281,21 @@ func (m *MockRepository) Sync(ctx context.Context, organizationID, ledgerID uuid
 func (mr *MockRepositoryMockRecorder) Sync(ctx, organizationID, ledgerID, b any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Sync", reflect.TypeOf((*MockRepository)(nil).Sync), ctx, organizationID, ledgerID, b)
+}
+
+// SyncBatch mocks base method.
+func (m *MockRepository) SyncBatch(ctx context.Context, organizationID, ledgerID uuid.UUID, balances []mmodel.BalanceRedis) (int64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SyncBatch", ctx, organizationID, ledgerID, balances)
+	ret0, _ := ret[0].(int64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// SyncBatch indicates an expected call of SyncBatch.
+func (mr *MockRepositoryMockRecorder) SyncBatch(ctx, organizationID, ledgerID, balances any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SyncBatch", reflect.TypeOf((*MockRepository)(nil).SyncBatch), ctx, organizationID, ledgerID, balances)
 }
 
 // Update mocks base method.

--- a/components/transaction/internal/adapters/redis/balance/aggregation.go
+++ b/components/transaction/internal/adapters/redis/balance/aggregation.go
@@ -1,0 +1,176 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package balance
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	libCommons "github.com/LerianStudio/lib-commons/v3/commons"
+	"github.com/LerianStudio/midaz/v3/pkg/mmodel"
+	"github.com/google/uuid"
+)
+
+// BalanceCompositeKey uniquely identifies a balance for aggregation purposes.
+// This key is used to deduplicate balance updates by grouping them.
+type BalanceCompositeKey struct {
+	OrganizationID uuid.UUID
+	LedgerID       uuid.UUID
+	AccountID      string
+	AssetCode      string
+	PartitionKey   string
+}
+
+// String returns a string representation of the composite key.
+// Format: "orgID:ledgerID:accountID:assetCode:partitionKey"
+func (k BalanceCompositeKey) String() string {
+	return fmt.Sprintf("%s:%s:%s:%s:%s",
+		k.OrganizationID.String(),
+		k.LedgerID.String(),
+		k.AccountID,
+		k.AssetCode,
+		k.PartitionKey,
+	)
+}
+
+// BalanceCompositeKeyFromRedisKey extracts a composite key from a Redis balance key.
+// Redis key format: "balance:{transactions}:orgID:ledgerID:alias#partitionKey"
+func BalanceCompositeKeyFromRedisKey(redisKey string) (BalanceCompositeKey, error) {
+	// Expected format: balance:{transactions}:orgID:ledgerID:alias#key
+	parts := strings.Split(redisKey, ":")
+	if len(parts) < 5 {
+		return BalanceCompositeKey{}, fmt.Errorf("invalid redis key format: expected 5 parts, got %d", len(parts))
+	}
+
+	// Parts: [balance, {transactions}, orgID, ledgerID, alias#key]
+	orgID, err := uuid.Parse(parts[2])
+	if err != nil {
+		return BalanceCompositeKey{}, fmt.Errorf("invalid organization ID at position 2: %w", err)
+	}
+
+	ledgerID, err := uuid.Parse(parts[3])
+	if err != nil {
+		return BalanceCompositeKey{}, fmt.Errorf("invalid ledger ID at position 3: %w", err)
+	}
+
+	// The last part contains alias#partitionKey
+	aliasAndKey := parts[4]
+	aliasParts := strings.Split(aliasAndKey, "#")
+
+	alias := aliasParts[0]
+	partitionKey := "default"
+
+	if len(aliasParts) > 1 {
+		partitionKey = aliasParts[1]
+	}
+
+	return BalanceCompositeKey{
+		OrganizationID: orgID,
+		LedgerID:       ledgerID,
+		AccountID:      alias,
+		AssetCode:      "", // Will be populated from balance data
+		PartitionKey:   partitionKey,
+	}, nil
+}
+
+// AggregatedBalance holds a balance with its Redis key for batch operations.
+type AggregatedBalance struct {
+	RedisKey string
+	Balance  *mmodel.BalanceRedis
+	Key      BalanceCompositeKey
+}
+
+// BalanceAggregator defines the interface for aggregating balance updates.
+type BalanceAggregator interface {
+	// Aggregate takes a slice of balances and returns deduplicated balances
+	// with only the highest version per composite key.
+	// The result is sorted by composite key for deterministic output.
+	Aggregate(ctx context.Context, balances []*AggregatedBalance) []*AggregatedBalance
+}
+
+// InMemoryAggregator implements BalanceAggregator using in-memory map.
+// It groups balances by composite key and retains only the highest version.
+type InMemoryAggregator struct{}
+
+// NewInMemoryAggregator creates a new in-memory balance aggregator.
+func NewInMemoryAggregator() *InMemoryAggregator {
+	return &InMemoryAggregator{}
+}
+
+// Aggregate groups balances by composite key and returns only the highest version per key.
+// The result is sorted by composite key string for deterministic output.
+//
+// Algorithm:
+// 1. For each balance, compute its composite key (populating AssetCode from balance data)
+// 2. If key not seen, store balance
+// 3. If key seen, compare versions and keep higher (equal versions keep first encountered)
+// 4. Return deduplicated list sorted by composite key
+//
+// Note: This method intentionally mutates the input AggregatedBalance.Key.AssetCode field
+// when it is empty and the balance data contains the asset code. This avoids allocation
+// overhead from cloning and is safe because the input balances are not reused after aggregation.
+//
+// Time complexity: O(n + m log m) where n is input size and m is unique keys
+// Space complexity: O(m) where m is number of unique composite keys
+func (a *InMemoryAggregator) Aggregate(ctx context.Context, balances []*AggregatedBalance) []*AggregatedBalance {
+	//nolint:dogsled // standard pattern used throughout codebase
+	_, tracer, _, _ := libCommons.NewTrackingFromContext(ctx)
+
+	_, span := tracer.Start(ctx, "aggregator.aggregate")
+	defer span.End()
+
+	if len(balances) == 0 {
+		return []*AggregatedBalance{}
+	}
+
+	// Map: composite key string -> AggregatedBalance with highest version
+	grouped := make(map[string]*AggregatedBalance, len(balances))
+
+	for _, ab := range balances {
+		// Skip nil balances (may occur if Redis key expired between schedule read and value fetch)
+		if ab == nil || ab.Balance == nil {
+			continue
+		}
+
+		// Populate AssetCode from balance data if not already set.
+		// This intentionally mutates the input to avoid cloning overhead.
+		// Safe because input balances are not reused after aggregation.
+		if ab.Key.AssetCode == "" && ab.Balance.AssetCode != "" {
+			ab.Key.AssetCode = ab.Balance.AssetCode
+		}
+
+		keyStr := ab.Key.String()
+
+		existing, found := grouped[keyStr]
+		if !found {
+			// First time seeing this key
+			grouped[keyStr] = ab
+			continue
+		}
+
+		// Keep the one with higher version (equal versions keep first encountered)
+		if ab.Balance.Version > existing.Balance.Version {
+			grouped[keyStr] = ab
+		}
+	}
+
+	// Convert map to slice
+	result := make([]*AggregatedBalance, 0, len(grouped))
+	for _, ab := range grouped {
+		result = append(result, ab)
+	}
+
+	// Sort by composite key for deterministic output
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].Key.String() < result[j].Key.String()
+	})
+
+	return result
+}
+
+// Ensure InMemoryAggregator implements BalanceAggregator at compile time
+var _ BalanceAggregator = (*InMemoryAggregator)(nil)

--- a/components/transaction/internal/adapters/redis/balance/aggregation.go
+++ b/components/transaction/internal/adapters/redis/balance/aggregation.go
@@ -164,9 +164,16 @@ func (a *InMemoryAggregator) Aggregate(ctx context.Context, balances []*Aggregat
 		result = append(result, ab)
 	}
 
+	// Precompute key strings to avoid repeated allocations during sort.
+	// sort.Slice comparator is called O(n log n) times; caching reduces allocations to O(n).
+	keys := make([]string, len(result))
+	for k := range result {
+		keys[k] = result[k].Key.String()
+	}
+
 	// Sort by composite key for deterministic output
 	sort.Slice(result, func(i, j int) bool {
-		return result[i].Key.String() < result[j].Key.String()
+		return keys[i] < keys[j]
 	})
 
 	return result

--- a/components/transaction/internal/adapters/redis/balance/aggregation.go
+++ b/components/transaction/internal/adapters/redis/balance/aggregation.go
@@ -164,16 +164,9 @@ func (a *InMemoryAggregator) Aggregate(ctx context.Context, balances []*Aggregat
 		result = append(result, ab)
 	}
 
-	// Precompute key strings to avoid repeated allocations during sort.
-	// sort.Slice comparator is called O(n log n) times; caching reduces allocations to O(n).
-	keys := make([]string, len(result))
-	for k := range result {
-		keys[k] = result[k].Key.String()
-	}
-
 	// Sort by composite key for deterministic output
 	sort.Slice(result, func(i, j int) bool {
-		return keys[i] < keys[j]
+		return result[i].Key.String() < result[j].Key.String()
 	})
 
 	return result

--- a/components/transaction/internal/adapters/redis/balance/aggregation_test.go
+++ b/components/transaction/internal/adapters/redis/balance/aggregation_test.go
@@ -1,0 +1,611 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package balance
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/LerianStudio/midaz/v3/pkg/mmodel"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBalanceCompositeKey_String(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+	ledgerID := uuid.MustParse("22222222-2222-2222-2222-222222222222")
+
+	tests := []struct {
+		name     string
+		key      BalanceCompositeKey
+		expected string
+	}{
+		{
+			name: "full composite key",
+			key: BalanceCompositeKey{
+				OrganizationID: orgID,
+				LedgerID:       ledgerID,
+				AccountID:      "acc-123",
+				AssetCode:      "USD",
+				PartitionKey:   "default",
+			},
+			expected: "11111111-1111-1111-1111-111111111111:22222222-2222-2222-2222-222222222222:acc-123:USD:default",
+		},
+		{
+			name: "different partition",
+			key: BalanceCompositeKey{
+				OrganizationID: orgID,
+				LedgerID:       ledgerID,
+				AccountID:      "acc-456",
+				AssetCode:      "BRL",
+				PartitionKey:   "custom",
+			},
+			expected: "11111111-1111-1111-1111-111111111111:22222222-2222-2222-2222-222222222222:acc-456:BRL:custom",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			result := tt.key.String()
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestBalanceCompositeKeyFromRedisKey(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		redisKey    string
+		wantOrgID   uuid.UUID
+		wantLedger  uuid.UUID
+		wantAccount string
+		wantPartKey string
+		wantErr     bool
+	}{
+		{
+			name:        "valid key format with partition",
+			redisKey:    "balance:{transactions}:11111111-1111-1111-1111-111111111111:22222222-2222-2222-2222-222222222222:@account#default",
+			wantOrgID:   uuid.MustParse("11111111-1111-1111-1111-111111111111"),
+			wantLedger:  uuid.MustParse("22222222-2222-2222-2222-222222222222"),
+			wantAccount: "@account",
+			wantPartKey: "default",
+			wantErr:     false,
+		},
+		{
+			name:        "valid key format without explicit partition",
+			redisKey:    "balance:{transactions}:11111111-1111-1111-1111-111111111111:22222222-2222-2222-2222-222222222222:@account",
+			wantOrgID:   uuid.MustParse("11111111-1111-1111-1111-111111111111"),
+			wantLedger:  uuid.MustParse("22222222-2222-2222-2222-222222222222"),
+			wantAccount: "@account",
+			wantPartKey: "default",
+			wantErr:     false,
+		},
+		{
+			name:     "invalid format - too few parts",
+			redisKey: "invalid-key",
+			wantErr:  true,
+		},
+		{
+			name:     "invalid organization ID",
+			redisKey: "balance:{transactions}:not-a-uuid:22222222-2222-2222-2222-222222222222:@account#default",
+			wantErr:  true,
+		},
+		{
+			name:     "invalid ledger ID",
+			redisKey: "balance:{transactions}:11111111-1111-1111-1111-111111111111:not-a-uuid:@account#default",
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			key, err := BalanceCompositeKeyFromRedisKey(tt.redisKey)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.Equal(t, tt.wantOrgID, key.OrganizationID)
+			assert.Equal(t, tt.wantLedger, key.LedgerID)
+			assert.Equal(t, tt.wantAccount, key.AccountID)
+			assert.Equal(t, tt.wantPartKey, key.PartitionKey)
+		})
+	}
+}
+
+func TestInMemoryAggregator_Aggregate(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+	ledgerID := uuid.MustParse("22222222-2222-2222-2222-222222222222")
+
+	tests := []struct {
+		name             string
+		input            []*AggregatedBalance
+		expectedCount    int
+		expectedVersions map[string]int64 // composite key -> expected version
+	}{
+		{
+			name:          "empty input returns empty",
+			input:         []*AggregatedBalance{},
+			expectedCount: 0,
+		},
+		{
+			name: "single balance unchanged",
+			input: []*AggregatedBalance{
+				{
+					RedisKey: "key1",
+					Balance: &mmodel.BalanceRedis{
+						ID:        "bal-1",
+						Alias:     "@acc1",
+						AssetCode: "USD",
+						Version:   5,
+					},
+					Key: BalanceCompositeKey{
+						OrganizationID: orgID,
+						LedgerID:       ledgerID,
+						AccountID:      "@acc1",
+						AssetCode:      "USD",
+						PartitionKey:   "default",
+					},
+				},
+			},
+			expectedCount: 1,
+			expectedVersions: map[string]int64{
+				orgID.String() + ":" + ledgerID.String() + ":@acc1:USD:default": 5,
+			},
+		},
+		{
+			name: "same balance multiple versions keeps highest",
+			input: []*AggregatedBalance{
+				{
+					RedisKey: "key1",
+					Balance: &mmodel.BalanceRedis{
+						ID:        "bal-1",
+						Alias:     "@acc1",
+						AssetCode: "USD",
+						Version:   5,
+					},
+					Key: BalanceCompositeKey{
+						OrganizationID: orgID,
+						LedgerID:       ledgerID,
+						AccountID:      "@acc1",
+						AssetCode:      "USD",
+						PartitionKey:   "default",
+					},
+				},
+				{
+					RedisKey: "key1",
+					Balance: &mmodel.BalanceRedis{
+						ID:        "bal-1",
+						Alias:     "@acc1",
+						AssetCode: "USD",
+						Version:   10,
+					},
+					Key: BalanceCompositeKey{
+						OrganizationID: orgID,
+						LedgerID:       ledgerID,
+						AccountID:      "@acc1",
+						AssetCode:      "USD",
+						PartitionKey:   "default",
+					},
+				},
+				{
+					RedisKey: "key1",
+					Balance: &mmodel.BalanceRedis{
+						ID:        "bal-1",
+						Alias:     "@acc1",
+						AssetCode: "USD",
+						Version:   3,
+					},
+					Key: BalanceCompositeKey{
+						OrganizationID: orgID,
+						LedgerID:       ledgerID,
+						AccountID:      "@acc1",
+						AssetCode:      "USD",
+						PartitionKey:   "default",
+					},
+				},
+			},
+			expectedCount: 1,
+			expectedVersions: map[string]int64{
+				orgID.String() + ":" + ledgerID.String() + ":@acc1:USD:default": 10,
+			},
+		},
+		{
+			name: "different balances kept separately",
+			input: []*AggregatedBalance{
+				{
+					RedisKey: "key1",
+					Balance: &mmodel.BalanceRedis{
+						ID:        "bal-1",
+						Alias:     "@acc1",
+						AssetCode: "USD",
+						Version:   5,
+					},
+					Key: BalanceCompositeKey{
+						OrganizationID: orgID,
+						LedgerID:       ledgerID,
+						AccountID:      "@acc1",
+						AssetCode:      "USD",
+						PartitionKey:   "default",
+					},
+				},
+				{
+					RedisKey: "key2",
+					Balance: &mmodel.BalanceRedis{
+						ID:        "bal-2",
+						Alias:     "@acc2",
+						AssetCode: "USD",
+						Version:   3,
+					},
+					Key: BalanceCompositeKey{
+						OrganizationID: orgID,
+						LedgerID:       ledgerID,
+						AccountID:      "@acc2",
+						AssetCode:      "USD",
+						PartitionKey:   "default",
+					},
+				},
+			},
+			expectedCount: 2,
+			expectedVersions: map[string]int64{
+				orgID.String() + ":" + ledgerID.String() + ":@acc1:USD:default": 5,
+				orgID.String() + ":" + ledgerID.String() + ":@acc2:USD:default": 3,
+			},
+		},
+		{
+			name: "nil balance entries skipped",
+			input: []*AggregatedBalance{
+				{
+					RedisKey: "key1",
+					Balance:  nil,
+					Key: BalanceCompositeKey{
+						OrganizationID: orgID,
+						LedgerID:       ledgerID,
+						AccountID:      "@acc1",
+						AssetCode:      "USD",
+						PartitionKey:   "default",
+					},
+				},
+				{
+					RedisKey: "key2",
+					Balance: &mmodel.BalanceRedis{
+						ID:        "bal-2",
+						Alias:     "@acc2",
+						AssetCode: "USD",
+						Version:   3,
+					},
+					Key: BalanceCompositeKey{
+						OrganizationID: orgID,
+						LedgerID:       ledgerID,
+						AccountID:      "@acc2",
+						AssetCode:      "USD",
+						PartitionKey:   "default",
+					},
+				},
+			},
+			expectedCount: 1,
+		},
+		{
+			name: "nil AggregatedBalance entry skipped",
+			input: []*AggregatedBalance{
+				nil,
+				{
+					RedisKey: "key2",
+					Balance: &mmodel.BalanceRedis{
+						ID:        "bal-2",
+						Alias:     "@acc2",
+						AssetCode: "USD",
+						Version:   3,
+					},
+					Key: BalanceCompositeKey{
+						OrganizationID: orgID,
+						LedgerID:       ledgerID,
+						AccountID:      "@acc2",
+						AssetCode:      "USD",
+						PartitionKey:   "default",
+					},
+				},
+			},
+			expectedCount: 1,
+		},
+		{
+			name: "populates AssetCode from balance data when key has empty AssetCode",
+			input: []*AggregatedBalance{
+				{
+					RedisKey: "key1",
+					Balance: &mmodel.BalanceRedis{
+						ID:        "bal-1",
+						Alias:     "@acc1",
+						AssetCode: "USD",
+						Version:   5,
+					},
+					Key: BalanceCompositeKey{
+						OrganizationID: orgID,
+						LedgerID:       ledgerID,
+						AccountID:      "@acc1",
+						AssetCode:      "", // Empty - should be populated from balance
+						PartitionKey:   "default",
+					},
+				},
+				{
+					RedisKey: "key2",
+					Balance: &mmodel.BalanceRedis{
+						ID:        "bal-2",
+						Alias:     "@acc1",
+						AssetCode: "BRL",
+						Version:   3,
+					},
+					Key: BalanceCompositeKey{
+						OrganizationID: orgID,
+						LedgerID:       ledgerID,
+						AccountID:      "@acc1",
+						AssetCode:      "", // Empty - should be populated from balance
+						PartitionKey:   "default",
+					},
+				},
+			},
+			expectedCount: 2, // Different assets should NOT collide
+			expectedVersions: map[string]int64{
+				orgID.String() + ":" + ledgerID.String() + ":@acc1:USD:default": 5,
+				orgID.String() + ":" + ledgerID.String() + ":@acc1:BRL:default": 3,
+			},
+		},
+	}
+
+	aggregator := NewInMemoryAggregator()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := context.Background()
+			result := aggregator.Aggregate(ctx, tt.input)
+
+			assert.Len(t, result, tt.expectedCount)
+
+			if tt.expectedVersions != nil {
+				for _, ab := range result {
+					expectedVersion, ok := tt.expectedVersions[ab.Key.String()]
+					if ok {
+						assert.Equal(t, expectedVersion, ab.Balance.Version,
+							"version mismatch for key %s", ab.Key.String())
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestInMemoryAggregator_Aggregate_EqualVersions(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+	ledgerID := uuid.MustParse("22222222-2222-2222-2222-222222222222")
+
+	// Test that equal versions keep first encountered (documented behavior)
+	input := []*AggregatedBalance{
+		{
+			RedisKey: "key1-first",
+			Balance: &mmodel.BalanceRedis{
+				ID:        "bal-first",
+				Alias:     "@acc1",
+				AssetCode: "USD",
+				Version:   5,
+			},
+			Key: BalanceCompositeKey{
+				OrganizationID: orgID,
+				LedgerID:       ledgerID,
+				AccountID:      "@acc1",
+				AssetCode:      "USD",
+				PartitionKey:   "default",
+			},
+		},
+		{
+			RedisKey: "key1-second",
+			Balance: &mmodel.BalanceRedis{
+				ID:        "bal-second",
+				Alias:     "@acc1",
+				AssetCode: "USD",
+				Version:   5, // Same version
+			},
+			Key: BalanceCompositeKey{
+				OrganizationID: orgID,
+				LedgerID:       ledgerID,
+				AccountID:      "@acc1",
+				AssetCode:      "USD",
+				PartitionKey:   "default",
+			},
+		},
+	}
+
+	aggregator := NewInMemoryAggregator()
+	ctx := context.Background()
+	result := aggregator.Aggregate(ctx, input)
+
+	assert.Len(t, result, 1)
+	// First encountered should be kept when versions are equal
+	assert.Equal(t, "bal-first", result[0].Balance.ID)
+	assert.Equal(t, "key1-first", result[0].RedisKey)
+}
+
+func TestInMemoryAggregator_Aggregate_DeterministicOrder(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+	ledgerID := uuid.MustParse("22222222-2222-2222-2222-222222222222")
+
+	// Create balances in random order
+	input := []*AggregatedBalance{
+		{
+			RedisKey: "key-z",
+			Balance: &mmodel.BalanceRedis{
+				ID:        "bal-z",
+				Alias:     "@acc-z",
+				AssetCode: "USD",
+				Version:   1,
+			},
+			Key: BalanceCompositeKey{
+				OrganizationID: orgID,
+				LedgerID:       ledgerID,
+				AccountID:      "@acc-z",
+				AssetCode:      "USD",
+				PartitionKey:   "default",
+			},
+		},
+		{
+			RedisKey: "key-a",
+			Balance: &mmodel.BalanceRedis{
+				ID:        "bal-a",
+				Alias:     "@acc-a",
+				AssetCode: "USD",
+				Version:   2,
+			},
+			Key: BalanceCompositeKey{
+				OrganizationID: orgID,
+				LedgerID:       ledgerID,
+				AccountID:      "@acc-a",
+				AssetCode:      "USD",
+				PartitionKey:   "default",
+			},
+		},
+		{
+			RedisKey: "key-m",
+			Balance: &mmodel.BalanceRedis{
+				ID:        "bal-m",
+				Alias:     "@acc-m",
+				AssetCode: "USD",
+				Version:   3,
+			},
+			Key: BalanceCompositeKey{
+				OrganizationID: orgID,
+				LedgerID:       ledgerID,
+				AccountID:      "@acc-m",
+				AssetCode:      "USD",
+				PartitionKey:   "default",
+			},
+		},
+	}
+
+	aggregator := NewInMemoryAggregator()
+	ctx := context.Background()
+
+	// Run multiple times to verify deterministic order
+	for i := 0; i < 10; i++ {
+		result := aggregator.Aggregate(ctx, input)
+
+		assert.Len(t, result, 3)
+		// Should be sorted by composite key (account ID is the varying part)
+		assert.Equal(t, "@acc-a", result[0].Key.AccountID, "first should be @acc-a")
+		assert.Equal(t, "@acc-m", result[1].Key.AccountID, "second should be @acc-m")
+		assert.Equal(t, "@acc-z", result[2].Key.AccountID, "third should be @acc-z")
+	}
+}
+
+func TestInMemoryAggregator_Aggregate_ConcurrentSafety(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+	ledgerID := uuid.MustParse("22222222-2222-2222-2222-222222222222")
+
+	aggregator := NewInMemoryAggregator()
+
+	// Create a shared input slice
+	input := make([]*AggregatedBalance, 100)
+	for i := 0; i < 100; i++ {
+		input[i] = &AggregatedBalance{
+			RedisKey: "key-" + uuid.New().String(),
+			Balance: &mmodel.BalanceRedis{
+				ID:        "bal-" + uuid.New().String(),
+				Alias:     "@acc-" + uuid.New().String(),
+				AssetCode: "USD",
+				Version:   int64(i),
+			},
+			Key: BalanceCompositeKey{
+				OrganizationID: orgID,
+				LedgerID:       ledgerID,
+				AccountID:      "@acc-" + uuid.New().String(),
+				AssetCode:      "USD",
+				PartitionKey:   "default",
+			},
+		}
+	}
+
+	// Run concurrent aggregations
+	var wg sync.WaitGroup
+	results := make([][]*AggregatedBalance, 10)
+
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+
+		go func(idx int) {
+			defer wg.Done()
+
+			ctx := context.Background()
+			results[idx] = aggregator.Aggregate(ctx, input)
+		}(i)
+	}
+
+	wg.Wait()
+
+	// Verify all goroutines completed without panic
+	for i, result := range results {
+		assert.NotNil(t, result, "result %d should not be nil", i)
+		assert.Equal(t, 100, len(result), "result %d should have 100 elements", i)
+	}
+}
+
+func TestInMemoryAggregator_Aggregate_LargeBatch(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+	ledgerID := uuid.MustParse("22222222-2222-2222-2222-222222222222")
+
+	// Create 150 unique balances
+	input := make([]*AggregatedBalance, 150)
+	for i := 0; i < 150; i++ {
+		accountID := "@acc-" + uuid.New().String()
+		input[i] = &AggregatedBalance{
+			RedisKey: "key-" + accountID,
+			Balance: &mmodel.BalanceRedis{
+				ID:        "bal-" + accountID,
+				Alias:     accountID,
+				AssetCode: "USD",
+				Version:   int64(i + 1),
+			},
+			Key: BalanceCompositeKey{
+				OrganizationID: orgID,
+				LedgerID:       ledgerID,
+				AccountID:      accountID,
+				AssetCode:      "USD",
+				PartitionKey:   "default",
+			},
+		}
+	}
+
+	aggregator := NewInMemoryAggregator()
+	ctx := context.Background()
+	result := aggregator.Aggregate(ctx, input)
+
+	assert.Len(t, result, 150, "should preserve all 150 unique balances")
+
+	// Verify all balances are present and sorted
+	for i := 1; i < len(result); i++ {
+		assert.True(t, result[i-1].Key.String() < result[i].Key.String(),
+			"results should be sorted by composite key")
+	}
+}


### PR DESCRIPTION
## Summary
Add batch synchronization capabilities for balance updates between Redis cache and PostgreSQL database, along with an in-memory aggregator for deduplicating and versioning balance updates.

## Motivation
When syncing large numbers of balance updates from Redis to PostgreSQL, calling `Sync` in a loop is inefficient due to multiple database round-trips and lack of transactional atomicity. The new `SyncBatch` method provides batch processing within a single transaction, while the `InMemoryAggregator` deduplicates balance updates by composite key, retaining only the highest version per key before persistence.

## Semantic Decision
`feat` - New functionality for batch balance synchronization and aggregation

## Changes

### New Files
| File | Purpose |
|------|---------|
| `components/transaction/internal/adapters/redis/balance/aggregation.go` | In-memory balance aggregator with composite key handling and version-based deduplication |
| `components/transaction/internal/adapters/redis/balance/aggregation_test.go` | Comprehensive unit tests for aggregation logic including concurrent access scenarios |

### Refactored Code
| Before | After |
|--------|-------|
| `Repository` interface with single `Sync` method | Added `SyncBatch(ctx, orgID, ledgerID, balances) (int64, error)` method |
| N/A | `BalanceCompositeKey` struct for unique balance identification |
| N/A | `BalanceCompositeKeyFromRedisKey()` function to parse Redis keys |
| N/A | `AggregatedBalance` struct for batch operations |
| N/A | `BalanceAggregator` interface with `InMemoryAggregator` implementation |

### Key Implementation Details

**SyncBatch Method:**
- Processes multiple balance updates in a single database transaction
- Uses optimistic locking: only updates where `version < incoming version`
- Returns count of actually updated rows
- Respects context cancellation for graceful shutdown
- Includes proper error handling with transaction rollback

**InMemoryAggregator:**
- Groups balances by composite key (OrgID:LedgerID:AccountID:AssetCode:PartitionKey)
- Retains only the highest version per composite key
- Returns deterministic output via sorted results
- Thread-safe for concurrent use
- Handles nil balances gracefully (expired Redis keys)

## Test Plan
- [x] `TestIntegration_BalanceRepository_SyncBatch_UpdatesMultipleBalances` - verifies batch update of multiple balances
- [x] `TestIntegration_BalanceRepository_SyncBatch_IgnoresOlderVersions` - verifies optimistic locking behavior
- [x] `TestIntegration_BalanceRepository_SyncBatch_EmptyBatchReturnsZero` - verifies empty batch handling
- [x] `TestIntegration_BalanceRepository_SyncBatch_PartialUpdate` - verifies mixed version scenarios
- [x] `TestIntegration_BalanceRepository_SyncBatch_RespectsContextCancellation` - verifies graceful shutdown
- [x] `TestBalanceCompositeKey_String` - verifies composite key string representation
- [x] `TestBalanceCompositeKeyFromRedisKey` - verifies Redis key parsing
- [x] `TestInMemoryAggregator_Aggregate` - verifies deduplication and version selection
- [x] Unit tests for concurrent access patterns
- [x] Unit tests for nil balance handling
