### PR TITLE
feat: add balance scheduling tests and async persistence support - balance update

### DIFF
--- a/components/transaction/internal/adapters/redis/balance_schedule_test.go
+++ b/components/transaction/internal/adapters/redis/balance_schedule_test.go
@@ -1,0 +1,45 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package redis
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/LerianStudio/midaz/v3/pkg/utils"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestLuaScript_ContainsScheduleLogic is a structural verification test that checks
+// if the Lua script contains the expected scheduling tokens (ZADD, scheduleSync, etc.).
+//
+// IMPORTANT: This test only asserts string presence, not runtime behavior.
+// It protects against accidental removal of scheduling logic during refactors.
+// Actual scheduling behavior is tested in integration tests (balance.worker_integration_test.go).
+func TestLuaScript_ContainsScheduleLogic(t *testing.T) {
+	// Verify the script has ZADD for scheduling
+	assert.True(t, strings.Contains(balanceAtomicOperationLua, "ZADD"),
+		"Lua script should contain ZADD for balance scheduling")
+
+	// Verify the script checks scheduleSync flag
+	assert.True(t, strings.Contains(balanceAtomicOperationLua, "scheduleSync"),
+		"Lua script should check scheduleSync flag")
+
+	// Verify the script uses scheduleKey from KEYS[3]
+	assert.True(t, strings.Contains(balanceAtomicOperationLua, "KEYS[3]"),
+		"Lua script should reference schedule key from KEYS[3]")
+
+	// Verify the script calculates dueAt for pre-expiry warning
+	assert.True(t, strings.Contains(balanceAtomicOperationLua, "dueAt"),
+		"Lua script should calculate dueAt for scheduling")
+}
+
+// TestScheduleKeyConstant verifies the schedule key constant matches
+// what the BalanceSyncWorker expects.
+func TestScheduleKeyConstant(t *testing.T) {
+	expectedKey := "schedule:{transactions}:balance-sync"
+	assert.Equal(t, expectedKey, utils.BalanceSyncScheduleKey,
+		"Schedule key constant should match expected format")
+}

--- a/components/transaction/internal/adapters/redis/consumer.redis.go
+++ b/components/transaction/internal/adapters/redis/consumer.redis.go
@@ -356,6 +356,20 @@ func balanceRedisToBalance(b mmodel.BalanceRedis, mapBalances map[string]*mmodel
 	}
 }
 
+// ProcessBalanceAtomicOperation executes the balance_atomic_operation.lua script.
+//
+// BALANCE SCHEDULING FLOW:
+//  1. This method calls the Lua script with scheduleSync=1 (when balanceSyncEnabled is true)
+//  2. Lua script updates hot balance in Redis atomically
+//  3. Lua script calculates dueAt = now + ttl - 600 (10 min before expiry)
+//  4. Lua script calls ZADD to schedule:{transactions}:balance-sync with score=dueAt
+//  5. BalanceSyncWorker polls the sorted set for due balances
+//  6. Worker calls SyncBalancesBatch to persist to database
+//
+// This enables decoupled balance persistence:
+//   - Transaction handler is append-only (no blocking on balance DB write)
+//   - Balance DB writes are aggregated and batched by the worker
+//   - Only the latest version per balance is persisted (aggregation)
 func (rr *RedisConsumerRepository) ProcessBalanceAtomicOperation(ctx context.Context, organizationID, ledgerID, transactionID uuid.UUID, transactionStatus string, pending bool, balancesOperation []mmodel.BalanceOperation) (*mmodel.BalanceAtomicResult, error) {
 	logger, tracer, _, _ := libCommons.NewTrackingFromContext(ctx)
 

--- a/components/transaction/internal/services/command/create-balance-transaction-operations-async.go
+++ b/components/transaction/internal/services/command/create-balance-transaction-operations-async.go
@@ -28,7 +28,16 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
-// CreateBalanceTransactionOperationsAsync func that is responsible to create all transactions at the same async.
+// CreateBalanceTransactionOperationsAsync processes transaction asynchronously.
+// This is an append-only handler for transactions and operations:
+// - Hot balance already updated atomically by Lua script during validation
+// - Cold balance scheduled for async sync via sorted set (Lua script does ZADD)
+// - Transaction and operations persisted to database
+// - Events sent asynchronously
+//
+// Balance persistence is fully async via BalanceSyncWorker.
+// The Lua script (balance_atomic_operation.lua) does ZADD to schedule:balance-sync
+// when scheduleSync=1, which is the default for all balance-affecting transactions.
 func (uc *UseCase) CreateBalanceTransactionOperationsAsync(ctx context.Context, data mmodel.Queue) error {
 	logger, tracer, _, _ := libCommons.NewTrackingFromContext(ctx)
 
@@ -40,22 +49,6 @@ func (uc *UseCase) CreateBalanceTransactionOperationsAsync(ctx context.Context, 
 		err := msgpack.Unmarshal(item.Value, &t)
 		if err != nil {
 			logger.Errorf("failed to unmarshal response: %v", err.Error())
-
-			return err
-		}
-	}
-
-	if t.Transaction.Status.Code != constant.NOTED {
-		ctxProcessBalances, spanUpdateBalances := tracer.Start(ctx, "command.create_balance_transaction_operations.update_balances")
-		defer spanUpdateBalances.End()
-
-		logger.Infof("Trying to update balances")
-
-		err := uc.UpdateBalances(ctxProcessBalances, data.OrganizationID, data.LedgerID, *t.Validate, t.Balances, t.BalancesAfter)
-		if err != nil {
-			libOpentelemetry.HandleSpanBusinessErrorEvent(&spanUpdateBalances, "Failed to update balances", err)
-
-			logger.Errorf("Failed to update balances: %v", err.Error())
 
 			return err
 		}

--- a/components/transaction/internal/services/command/create-balance-transaction-operations-async_test.go
+++ b/components/transaction/internal/services/command/create-balance-transaction-operations-async_test.go
@@ -56,7 +56,7 @@ func (m *MockLogger) WithDefaultMessageTemplate(template string) libLog.Logger {
 func (m *MockLogger) WithFields(args ...any) libLog.Logger                     { return m }
 
 func TestCreateBalanceTransactionOperationsAsync(t *testing.T) {
-	t.Run("success", func(t *testing.T) {
+	t.Run("success_append_only_transaction_and_operations", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 
@@ -148,7 +148,8 @@ func TestCreateBalanceTransactionOperationsAsync(t *testing.T) {
 			Input:       transactionInput,
 		}
 
-		transactionBytes, _ := msgpack.Marshal(transactionQueue)
+		transactionBytes, marshalErr := msgpack.Marshal(transactionQueue)
+		require.NoError(t, marshalErr, "failed to marshal transaction queue")
 		queueData := []mmodel.QueueData{
 			{
 				ID:    uuid.New(),
@@ -162,21 +163,8 @@ func TestCreateBalanceTransactionOperationsAsync(t *testing.T) {
 			QueueData:      queueData,
 		}
 
-		// Mock RedisRepo.ListBalanceByKey for stale balance check (return nil to proceed with update)
-		mockRedisRepo.EXPECT().
-			ListBalanceByKey(gomock.Any(), organizationID, ledgerID, "alias1").
-			Return(nil, nil).
-			AnyTimes()
-		mockRedisRepo.EXPECT().
-			ListBalanceByKey(gomock.Any(), organizationID, ledgerID, "alias2").
-			Return(nil, nil).
-			AnyTimes()
-
-		// Mock BalanceRepo.BalancesUpdate
-		mockBalanceRepo.EXPECT().
-			BalancesUpdate(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-			Return(nil).
-			Times(1)
+		// NOTE: No BalancesUpdate mock - balance persistence is now async via worker
+		// Hot balance is updated by Lua script, cold balance synced by BalanceSyncWorker
 
 		// Mock TransactionRepo.Create
 		mockTransactionRepo.EXPECT().
@@ -212,116 +200,6 @@ func TestCreateBalanceTransactionOperationsAsync(t *testing.T) {
 		err := uc.CreateBalanceTransactionOperationsAsync(ctx, queue)
 
 		assert.NoError(t, err)
-	})
-
-	t.Run("error_update_balances", func(t *testing.T) {
-		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
-
-		mockTransactionRepo := transaction.NewMockRepository(ctrl)
-		mockOperationRepo := operation.NewMockRepository(ctrl)
-		mockMetadataRepo := mongodb.NewMockRepository(ctrl)
-		mockBalanceRepo := balance.NewMockRepository(ctrl)
-		mockRabbitMQRepo := rabbitmq.NewMockProducerRepository(ctrl)
-		mockRedisRepo := redis.NewMockRedisRepository(ctrl)
-
-		// Create a UseCase with mock repositories
-		uc := &UseCase{
-			TransactionRepo: mockTransactionRepo,
-			OperationRepo:   mockOperationRepo,
-			MetadataRepo:    mockMetadataRepo,
-			BalanceRepo:     mockBalanceRepo,
-			RabbitMQRepo:    mockRabbitMQRepo,
-			RedisRepo:       mockRedisRepo,
-		}
-
-		ctx := context.Background()
-		organizationID := uuid.New()
-		ledgerID := uuid.New()
-		transactionID := uuid.New().String()
-
-		// Mock transaction data with correct types
-		validate := &pkgTransaction.Responses{
-			Aliases: []string{"alias1", "alias2"},
-			From: map[string]pkgTransaction.Amount{
-				"alias1": {
-					Asset: "USD",
-					Value: decimal.NewFromInt(50),
-				},
-			},
-			To: map[string]pkgTransaction.Amount{
-				"alias2": {
-					Asset: "EUR",
-					Value: decimal.NewFromInt(40),
-				},
-			},
-		}
-
-		balances := []*mmodel.Balance{
-			{
-				ID:             uuid.New().String(),
-				AccountID:      uuid.New().String(),
-				OrganizationID: organizationID.String(),
-				LedgerID:       ledgerID.String(),
-				Alias:          "alias1",
-				Available:      decimal.NewFromInt(100),
-				OnHold:         decimal.NewFromInt(0),
-				Version:        1,
-				AccountType:    "deposit",
-				AllowSending:   true,
-				AllowReceiving: true,
-				AssetCode:      "USD",
-			},
-		}
-
-		tran := &transaction.Transaction{
-			ID:             transactionID,
-			OrganizationID: organizationID.String(),
-			LedgerID:       ledgerID.String(),
-			Operations:     []*operation.Operation{},
-			Metadata:       map[string]interface{}{},
-		}
-
-		transactionInput := &pkgTransaction.Transaction{}
-
-		transactionQueue := transaction.TransactionProcessingPayload{
-			Transaction: tran,
-			Validate:    validate,
-			Balances:    balances,
-			Input:       transactionInput,
-		}
-
-		transactionBytes, _ := msgpack.Marshal(transactionQueue)
-		queueData := []mmodel.QueueData{
-			{
-				ID:    uuid.New(),
-				Value: transactionBytes,
-			},
-		}
-
-		queue := mmodel.Queue{
-			OrganizationID: organizationID,
-			LedgerID:       ledgerID,
-			QueueData:      queueData,
-		}
-
-		// Mock RedisRepo.ListBalanceByKey for stale balance check (return nil to proceed with update)
-		mockRedisRepo.EXPECT().
-			ListBalanceByKey(gomock.Any(), organizationID, ledgerID, "alias1").
-			Return(nil, nil).
-			AnyTimes()
-
-		// Mock BalanceRepo.BalancesUpdate to return an error
-		mockBalanceRepo.EXPECT().
-			BalancesUpdate(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-			Return(errors.New("failed to update balances")).
-			Times(1)
-
-		// Call the method
-		err := uc.CreateBalanceTransactionOperationsAsync(ctx, queue)
-
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "failed to update balances")
 	})
 
 	t.Run("error_duplicate_transaction", func(t *testing.T) {
@@ -395,7 +273,8 @@ func TestCreateBalanceTransactionOperationsAsync(t *testing.T) {
 			Input:       transactionInput,
 		}
 
-		transactionBytes, _ := msgpack.Marshal(transactionQueue)
+		transactionBytes, marshalErr := msgpack.Marshal(transactionQueue)
+		require.NoError(t, marshalErr, "failed to marshal transaction queue")
 		queueData := []mmodel.QueueData{
 			{
 				ID:    uuid.New(),
@@ -409,17 +288,7 @@ func TestCreateBalanceTransactionOperationsAsync(t *testing.T) {
 			QueueData:      queueData,
 		}
 
-		// Mock RedisRepo.ListBalanceByKey for stale balance check (return nil to proceed with update)
-		mockRedisRepo.EXPECT().
-			ListBalanceByKey(gomock.Any(), organizationID, ledgerID, "alias1").
-			Return(nil, nil).
-			AnyTimes()
-
-		// Mock BalanceRepo.BalancesUpdate
-		mockBalanceRepo.EXPECT().
-			BalancesUpdate(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-			Return(nil).
-			Times(1)
+		// NOTE: No BalancesUpdate mock - balance persistence is now async via worker
 
 		// Mock TransactionRepo.Create with duplicate key error
 		pgErr := &pgconn.PgError{Code: "23505"}
@@ -592,7 +461,8 @@ func TestCreateBalanceTransactionOperationsAsync(t *testing.T) {
 			Input:       transactionInput,
 		}
 
-		transactionBytes, _ := msgpack.Marshal(transactionQueue)
+		transactionBytes, marshalErr := msgpack.Marshal(transactionQueue)
+		require.NoError(t, marshalErr, "failed to marshal transaction queue")
 		queueData := []mmodel.QueueData{
 			{
 				ID:    uuid.New(),
@@ -606,21 +476,7 @@ func TestCreateBalanceTransactionOperationsAsync(t *testing.T) {
 			QueueData:      queueData,
 		}
 
-		// Mock RedisRepo.ListBalanceByKey for stale balance check (return nil to proceed with update)
-		mockRedisRepo.EXPECT().
-			ListBalanceByKey(gomock.Any(), organizationID, ledgerID, "alias1").
-			Return(nil, nil).
-			AnyTimes()
-		mockRedisRepo.EXPECT().
-			ListBalanceByKey(gomock.Any(), organizationID, ledgerID, "alias2").
-			Return(nil, nil).
-			AnyTimes()
-
-		// Mock BalanceRepo.BalancesUpdate
-		mockBalanceRepo.EXPECT().
-			BalancesUpdate(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-			Return(nil).
-			Times(1)
+		// NOTE: No BalancesUpdate mock - balance persistence is now async via worker
 
 		// Mock TransactionRepo.Create
 		mockTransactionRepo.EXPECT().
@@ -790,7 +646,8 @@ func TestCreateBalanceTransactionOperationsAsync(t *testing.T) {
 			Input:       transactionInput,
 		}
 
-		transactionBytes, _ := msgpack.Marshal(transactionQueue)
+		transactionBytes, marshalErr := msgpack.Marshal(transactionQueue)
+		require.NoError(t, marshalErr, "failed to marshal transaction queue")
 		queueData := []mmodel.QueueData{
 			{
 				ID:    uuid.New(),
@@ -804,17 +661,7 @@ func TestCreateBalanceTransactionOperationsAsync(t *testing.T) {
 			QueueData:      queueData,
 		}
 
-		// Mock RedisRepo.ListBalanceByKey for stale balance check (return nil to proceed with update)
-		mockRedisRepo.EXPECT().
-			ListBalanceByKey(gomock.Any(), organizationID, ledgerID, "alias1").
-			Return(nil, nil).
-			AnyTimes()
-
-		// Mock BalanceRepo.BalancesUpdate
-		mockBalanceRepo.EXPECT().
-			BalancesUpdate(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-			Return(nil).
-			Times(1)
+		// NOTE: No BalancesUpdate mock - balance persistence is now async via worker
 
 		// Mock TransactionRepo.Create
 		mockTransactionRepo.EXPECT().
@@ -951,7 +798,8 @@ func TestCreateBalanceTransactionOperationsAsync(t *testing.T) {
 			Input:       transactionInput,
 		}
 
-		transactionBytes, _ := msgpack.Marshal(transactionQueue)
+		transactionBytes, marshalErr := msgpack.Marshal(transactionQueue)
+		require.NoError(t, marshalErr, "failed to marshal transaction queue")
 		queueData := []mmodel.QueueData{
 			{
 				ID:    uuid.New(),
@@ -965,17 +813,7 @@ func TestCreateBalanceTransactionOperationsAsync(t *testing.T) {
 			QueueData:      queueData,
 		}
 
-		// Mock RedisRepo.ListBalanceByKey for stale balance check (return nil to proceed with update)
-		mockRedisRepo.EXPECT().
-			ListBalanceByKey(gomock.Any(), organizationID, ledgerID, "alias1").
-			Return(nil, nil).
-			AnyTimes()
-
-		// Mock BalanceRepo.BalancesUpdate
-		mockBalanceRepo.EXPECT().
-			BalancesUpdate(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-			Return(nil).
-			Times(1)
+		// NOTE: No BalancesUpdate mock - balance persistence is now async via worker
 
 		// Mock TransactionRepo.Create
 		mockTransactionRepo.EXPECT().
@@ -1120,7 +958,8 @@ func TestCreateBalanceTransactionOperationsAsync(t *testing.T) {
 			Input:       transactionInput,
 		}
 
-		transactionBytes, _ := msgpack.Marshal(transactionQueue)
+		transactionBytes, marshalErr := msgpack.Marshal(transactionQueue)
+		require.NoError(t, marshalErr, "failed to marshal transaction queue")
 		queueData := []mmodel.QueueData{
 			{
 				ID:    uuid.New(),
@@ -1134,17 +973,7 @@ func TestCreateBalanceTransactionOperationsAsync(t *testing.T) {
 			QueueData:      queueData,
 		}
 
-		// Mock RedisRepo.ListBalanceByKey for stale balance check (return nil to proceed with update)
-		mockRedisRepo.EXPECT().
-			ListBalanceByKey(gomock.Any(), organizationID, ledgerID, "alias1").
-			Return(nil, nil).
-			AnyTimes()
-
-		// Mock BalanceRepo.BalancesUpdate
-		mockBalanceRepo.EXPECT().
-			BalancesUpdate(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-			Return(nil).
-			Times(1)
+		// NOTE: No BalancesUpdate mock - balance persistence is now async via worker
 
 		// Mock TransactionRepo.Create
 		mockTransactionRepo.EXPECT().
@@ -1293,7 +1122,8 @@ func TestCreateBTOAsync(t *testing.T) {
 		Input:       transactionInput,
 	}
 
-	transactionBytes, _ := msgpack.Marshal(transactionQueue)
+	transactionBytes, marshalErr := msgpack.Marshal(transactionQueue)
+	require.NoError(t, marshalErr, "failed to marshal transaction queue")
 	queueData := []mmodel.QueueData{
 		{
 			ID:    uuid.New(),
@@ -1307,17 +1137,7 @@ func TestCreateBTOAsync(t *testing.T) {
 		QueueData:      queueData,
 	}
 
-	// Mock RedisRepo.ListBalanceByKey for stale balance check (return nil to proceed with update)
-	mockRedisRepo.EXPECT().
-		ListBalanceByKey(gomock.Any(), organizationID, ledgerID, "alias1").
-		Return(nil, nil).
-		AnyTimes()
-
-	// Mock all the necessary calls to avoid nil pointer dereference
-	mockBalanceRepo.EXPECT().
-		BalancesUpdate(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-		Return(nil).
-		AnyTimes()
+	// NOTE: No BalancesUpdate mock - balance persistence is now async via worker
 
 	mockTransactionRepo.EXPECT().
 		Create(gomock.Any(), gomock.Any()).

--- a/components/transaction/internal/services/command/write-transaction_test.go
+++ b/components/transaction/internal/services/command/write-transaction_test.go
@@ -108,31 +108,18 @@ func createTestData(organizationID, ledgerID uuid.UUID) *testData {
 }
 
 // setupMocksForFallback sets up all mocks needed for CreateBalanceTransactionOperationsAsync
-// which is called as a fallback when RabbitMQ fails
+// which is called as a fallback when RabbitMQ fails.
+// Note: Balance repository and UUIDs are not needed because balance persistence
+// is now async via BalanceSyncWorker (hot balance updated by Lua script).
 func setupMocksForFallback(
-	mockBalanceRepo *balance.MockRepository,
 	mockTransactionRepo *transaction.MockRepository,
 	mockMetadataRepo *mongodb.MockRepository,
 	mockRabbitMQRepo *rabbitmq.MockProducerRepository,
 	mockRedisRepo *redis.MockRedisRepository,
 	tran *transaction.Transaction,
-	organizationID, ledgerID uuid.UUID,
 ) {
-	// Mock RedisRepo.ListBalanceByKey for stale balance check
-	mockRedisRepo.EXPECT().
-		ListBalanceByKey(gomock.Any(), organizationID, ledgerID, "alias1").
-		Return(nil, nil).
-		AnyTimes()
-	mockRedisRepo.EXPECT().
-		ListBalanceByKey(gomock.Any(), organizationID, ledgerID, "alias2").
-		Return(nil, nil).
-		AnyTimes()
-
-	// Mock BalanceRepo.BalancesUpdate
-	mockBalanceRepo.EXPECT().
-		BalancesUpdate(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-		Return(nil).
-		AnyTimes()
+	// NOTE: No BalancesUpdate mock - balance persistence is now async via worker
+	// Hot balance is updated by Lua script, cold balance synced by BalanceSyncWorker
 
 	// Mock TransactionRepo.Create
 	mockTransactionRepo.EXPECT().
@@ -260,7 +247,7 @@ func TestWriteTransaction(t *testing.T) {
 		}
 
 		// Setup mocks for sync path (CreateBalanceTransactionOperationsAsync)
-		setupMocksForFallback(mockBalanceRepo, mockTransactionRepo, mockMetadataRepo, mockRabbitMQRepo, mockRedisRepo, td.tran, organizationID, ledgerID)
+		setupMocksForFallback(mockTransactionRepo, mockMetadataRepo, mockRabbitMQRepo, mockRedisRepo, td.tran)
 
 		err := uc.WriteTransaction(ctx, organizationID, ledgerID, td.transactionInput, td.validate, td.balances, nil, td.tran)
 
@@ -296,7 +283,7 @@ func TestWriteTransaction(t *testing.T) {
 		}
 
 		// Setup mocks for sync path (CreateBalanceTransactionOperationsAsync)
-		setupMocksForFallback(mockBalanceRepo, mockTransactionRepo, mockMetadataRepo, mockRabbitMQRepo, mockRedisRepo, td.tran, organizationID, ledgerID)
+		setupMocksForFallback(mockTransactionRepo, mockMetadataRepo, mockRabbitMQRepo, mockRedisRepo, td.tran)
 
 		err := uc.WriteTransaction(ctx, organizationID, ledgerID, td.transactionInput, td.validate, td.balances, nil, td.tran)
 
@@ -330,7 +317,7 @@ func TestWriteTransaction(t *testing.T) {
 		}
 
 		// Setup mocks for sync path (CreateBalanceTransactionOperationsAsync)
-		setupMocksForFallback(mockBalanceRepo, mockTransactionRepo, mockMetadataRepo, mockRabbitMQRepo, mockRedisRepo, td.tran, organizationID, ledgerID)
+		setupMocksForFallback(mockTransactionRepo, mockMetadataRepo, mockRabbitMQRepo, mockRedisRepo, td.tran)
 
 		err := uc.WriteTransaction(ctx, organizationID, ledgerID, td.transactionInput, td.validate, td.balances, nil, td.tran)
 
@@ -407,7 +394,7 @@ func TestWriteTransactionAsync(t *testing.T) {
 			Times(1)
 
 		// Setup mocks for fallback path (CreateBalanceTransactionOperationsAsync)
-		setupMocksForFallback(mockBalanceRepo, mockTransactionRepo, mockMetadataRepo, mockRabbitMQRepo, mockRedisRepo, td.tran, organizationID, ledgerID)
+		setupMocksForFallback(mockTransactionRepo, mockMetadataRepo, mockRabbitMQRepo, mockRedisRepo, td.tran)
 
 		err := uc.WriteTransactionAsync(ctx, organizationID, ledgerID, td.transactionInput, td.validate, td.balances, nil, td.tran)
 
@@ -447,20 +434,12 @@ func TestWriteTransactionAsync(t *testing.T) {
 			Return(nil, errors.New("rabbitmq connection failed")).
 			Times(1)
 
-		// Mock RedisRepo.ListBalanceByKey for stale balance check
-		mockRedisRepo.EXPECT().
-			ListBalanceByKey(gomock.Any(), organizationID, ledgerID, "alias1").
-			Return(nil, nil).
-			AnyTimes()
-		mockRedisRepo.EXPECT().
-			ListBalanceByKey(gomock.Any(), organizationID, ledgerID, "alias2").
-			Return(nil, nil).
-			AnyTimes()
+		// NOTE: No BalancesUpdate mock - balance persistence is now async via worker
 
-		// Fallback also fails - BalancesUpdate returns error
-		mockBalanceRepo.EXPECT().
-			BalancesUpdate(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-			Return(errors.New("database connection failed")).
+		// Fallback also fails - TransactionRepo.Create returns error
+		mockTransactionRepo.EXPECT().
+			Create(gomock.Any(), gomock.Any()).
+			Return(nil, errors.New("database connection failed")).
 			Times(1)
 
 		err := uc.WriteTransactionAsync(ctx, organizationID, ledgerID, td.transactionInput, td.validate, td.balances, nil, td.tran)
@@ -529,7 +508,7 @@ func TestWriteTransactionSync(t *testing.T) {
 		}
 
 		// Setup mocks for CreateBalanceTransactionOperationsAsync
-		setupMocksForFallback(mockBalanceRepo, mockTransactionRepo, mockMetadataRepo, mockRabbitMQRepo, mockRedisRepo, td.tran, organizationID, ledgerID)
+		setupMocksForFallback(mockTransactionRepo, mockMetadataRepo, mockRabbitMQRepo, mockRedisRepo, td.tran)
 
 		err := uc.WriteTransactionSync(ctx, organizationID, ledgerID, td.transactionInput, td.validate, td.balances, nil, td.tran)
 
@@ -537,51 +516,6 @@ func TestWriteTransactionSync(t *testing.T) {
 		time.Sleep(100 * time.Millisecond)
 
 		assert.NoError(t, err)
-	})
-
-	t.Run("error_propagates_from_balance_update", func(t *testing.T) {
-		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
-
-		mockBalanceRepo := balance.NewMockRepository(ctrl)
-		mockTransactionRepo := transaction.NewMockRepository(ctrl)
-		mockMetadataRepo := mongodb.NewMockRepository(ctrl)
-		mockRabbitMQRepo := rabbitmq.NewMockProducerRepository(ctrl)
-		mockRedisRepo := redis.NewMockRedisRepository(ctrl)
-
-		ctx := context.Background()
-		organizationID := uuid.New()
-		ledgerID := uuid.New()
-		td := createTestData(organizationID, ledgerID)
-
-		uc := &UseCase{
-			BalanceRepo:     mockBalanceRepo,
-			TransactionRepo: mockTransactionRepo,
-			MetadataRepo:    mockMetadataRepo,
-			RabbitMQRepo:    mockRabbitMQRepo,
-			RedisRepo:       mockRedisRepo,
-		}
-
-		// Mock RedisRepo.ListBalanceByKey for stale balance check
-		mockRedisRepo.EXPECT().
-			ListBalanceByKey(gomock.Any(), organizationID, ledgerID, "alias1").
-			Return(nil, nil).
-			AnyTimes()
-		mockRedisRepo.EXPECT().
-			ListBalanceByKey(gomock.Any(), organizationID, ledgerID, "alias2").
-			Return(nil, nil).
-			AnyTimes()
-
-		// BalancesUpdate fails
-		mockBalanceRepo.EXPECT().
-			BalancesUpdate(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-			Return(errors.New("failed to update balances")).
-			Times(1)
-
-		err := uc.WriteTransactionSync(ctx, organizationID, ledgerID, td.transactionInput, td.validate, td.balances, nil, td.tran)
-
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "failed to update balances")
 	})
 
 	t.Run("error_propagates_from_transaction_create", func(t *testing.T) {
@@ -607,21 +541,7 @@ func TestWriteTransactionSync(t *testing.T) {
 			RedisRepo:       mockRedisRepo,
 		}
 
-		// Mock RedisRepo.ListBalanceByKey for stale balance check
-		mockRedisRepo.EXPECT().
-			ListBalanceByKey(gomock.Any(), organizationID, ledgerID, "alias1").
-			Return(nil, nil).
-			AnyTimes()
-		mockRedisRepo.EXPECT().
-			ListBalanceByKey(gomock.Any(), organizationID, ledgerID, "alias2").
-			Return(nil, nil).
-			AnyTimes()
-
-		// BalancesUpdate succeeds
-		mockBalanceRepo.EXPECT().
-			BalancesUpdate(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-			Return(nil).
-			Times(1)
+		// NOTE: No BalancesUpdate mock - balance persistence is now async via worker
 
 		// TransactionRepo.Create fails (not a duplicate key error)
 		mockTransactionRepo.EXPECT().
@@ -693,17 +613,7 @@ func TestWriteTransactionSync(t *testing.T) {
 			RedisRepo:       mockRedisRepo,
 		}
 
-		// Mock RedisRepo.ListBalanceByKey for stale balance check
-		mockRedisRepo.EXPECT().
-			ListBalanceByKey(gomock.Any(), organizationID, ledgerID, "alias1").
-			Return(nil, nil).
-			AnyTimes()
-
-		// Mock BalanceRepo.BalancesUpdate
-		mockBalanceRepo.EXPECT().
-			BalancesUpdate(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-			Return(nil).
-			AnyTimes()
+		// NOTE: No BalancesUpdate mock - balance persistence is now async via worker
 
 		// Mock TransactionRepo.Create
 		mockTransactionRepo.EXPECT().


### PR DESCRIPTION
## Summary

Add unit tests for balance scheduling logic and update transaction processing to support async balance persistence via Lua script. This PR completes the decoupling of balance persistence from the synchronous transaction handler path.

## Motivation

The transaction handler was blocking on balance database writes during transaction processing. This refactoring moves balance persistence to an async worker pattern where:
- Hot balance is updated atomically by the Lua script during validation
- Cold balance sync is scheduled via Redis sorted set (ZADD in Lua script)
- BalanceSyncWorker polls and persists balances in aggregated batches

This enables higher throughput and lower latency for transaction processing.

## Semantic Decision

`feat` - Adds new unit tests and updates transaction processing behavior to support async balance persistence.

## Changes

### New Files
| File | Purpose |
|------|---------|
| `components/transaction/internal/adapters/redis/balance_schedule_test.go` | Unit tests verifying Lua script contains scheduling logic (ZADD, scheduleSync, KEYS[3], dueAt) and schedule key constant matches expected format |

### Refactored Code
| Before | After |
|--------|-------|
| `CreateBalanceTransactionOperationsAsync` called `UpdateBalances()` synchronously for cold balance persistence | Removed sync balance update - cold balance persistence is now async via BalanceSyncWorker (Lua script handles scheduling with ZADD) |
| Test mocks included `BalancesUpdate`, `ListBalanceByKey` for stale balance checks | Tests simplified - no balance repo mocks needed since persistence is async |
| `setupMocksForFallback` required balance repo, organization/ledger IDs | Function simplified - only transaction, metadata, RabbitMQ, and Redis mocks needed |

### Documentation Improvements
| File | Documentation Added |
|------|---------------------|
| `consumer.redis.go` | Added BALANCE SCHEDULING FLOW documentation explaining the 6-step flow from Lua script to worker persistence |
| `create-balance-transaction-operations-async.go` | Added append-only handler documentation explaining async balance sync pattern |

## Test Plan
- [x] `TestLuaScript_ContainsScheduleLogic` - Structural verification that Lua script contains ZADD, scheduleSync, KEYS[3], dueAt tokens
- [x] `TestScheduleKeyConstant` - Verifies schedule key constant matches expected format
- [x] `TestCreateBalanceTransactionOperationsAsync/success_append_only_transaction_and_operations` - Verifies append-only path without sync balance update
- [x] `TestWriteTransaction/*` - All test cases updated to reflect async balance persistence
- [x] `TestWriteTransactionAsync/*` - Fallback path tests updated
- [x] `TestWriteTransactionSync/*` - Sync path tests updated
