### PR TITLE
refactor: balance sync always enabled

### DIFF
--- a/components/ledger/.env.example
+++ b/components/ledger/.env.example
@@ -205,7 +205,7 @@ MAX_PAGINATION_LIMIT=100
 MAX_PAGINATION_MONTH_DATE_RANGE=3
 
 # BALANCE SYNC WORKER
-# When enabled, balances are scheduled for sync to PostgreSQL before Redis TTL expires.
-# Default: true (if not set, the worker is enabled)
+# DEPRECATED: BALANCE_SYNC_WORKER_ENABLED is ignored - balance sync is always enabled.
+# This env var is kept for backwards compatibility but has no effect.
 # BALANCE_SYNC_WORKER_ENABLED=true
 BALANCE_SYNC_MAX_WORKERS=5

--- a/components/transaction/.env.example
+++ b/components/transaction/.env.example
@@ -153,8 +153,8 @@ MAX_PAGINATION_LIMIT=100
 MAX_PAGINATION_MONTH_DATE_RANGE=1
 
 # BALANCE SYNC WORKER
-# When enabled, balances are scheduled for sync to PostgreSQL before Redis TTL expires.
-# Default: true (if not set, the worker is enabled)
+# DEPRECATED: BALANCE_SYNC_WORKER_ENABLED is ignored - balance sync is always enabled.
+# This env var is kept for backwards compatibility but has no effect.
 # BALANCE_SYNC_WORKER_ENABLED=true
 BALANCE_SYNC_MAX_WORKERS=5
 

--- a/components/transaction/internal/adapters/http/in/transaction_integration_test.go
+++ b/components/transaction/internal/adapters/http/in/transaction_integration_test.go
@@ -103,7 +103,7 @@ func setupTestInfra(t *testing.T) *testInfra {
 	operationRepo := operation.NewOperationPostgreSQLRepository(infra.pgConn)
 	balanceRepo := balance.NewBalancePostgreSQLRepository(infra.pgConn)
 	metadataRepo := mongodb.NewMetadataMongoDBRepository(mongoConn)
-	redisRepo, err := redis.NewConsumerRedis(redisConn, false)
+	redisRepo, err := redis.NewConsumerRedis(redisConn)
 	require.NoError(t, err, "failed to create Redis repository")
 
 	// Store repositories for test assertions
@@ -607,7 +607,7 @@ func setupAsyncTestInfra(t *testing.T) *testAsyncInfra {
 	operationRepo := operation.NewOperationPostgreSQLRepository(infra.pgConn)
 	balanceRepo := balance.NewBalancePostgreSQLRepository(infra.pgConn)
 	metadataRepo := mongodb.NewMetadataMongoDBRepository(mongoConn)
-	redisRepo, err := redis.NewConsumerRedis(redisConn, false)
+	redisRepo, err := redis.NewConsumerRedis(redisConn)
 	require.NoError(t, err, "failed to create Redis repository")
 
 	// Store Redis repository for test assertions

--- a/components/transaction/internal/adapters/redis/consumer.redis.go
+++ b/components/transaction/internal/adapters/redis/consumer.redis.go
@@ -87,17 +87,14 @@ type RedisRepository interface {
 
 // RedisConsumerRepository is a Redis implementation of the Redis consumer.
 type RedisConsumerRepository struct {
-	conn               *libRedis.RedisConnection
-	balanceSyncEnabled bool
+	conn *libRedis.RedisConnection
 }
 
 // NewConsumerRedis returns a new instance of RedisRepository using the given Redis connection.
-// The balanceSyncEnabled parameter controls whether balance keys are scheduled for sync.
-// When false, the ZADD to the balance sync schedule is skipped in the Lua script.
-func NewConsumerRedis(rc *libRedis.RedisConnection, balanceSyncEnabled bool) (*RedisConsumerRepository, error) {
+// Balance sync is always enabled - balances are scheduled for sync to PostgreSQL.
+func NewConsumerRedis(rc *libRedis.RedisConnection) (*RedisConsumerRepository, error) {
 	r := &RedisConsumerRepository{
-		conn:               rc,
-		balanceSyncEnabled: balanceSyncEnabled,
+		conn: rc,
 	}
 	if _, err := r.conn.GetClient(context.Background()); err != nil {
 		return nil, fmt.Errorf("failed to connect on redis: %w", err)
@@ -359,7 +356,7 @@ func balanceRedisToBalance(b mmodel.BalanceRedis, mapBalances map[string]*mmodel
 // ProcessBalanceAtomicOperation executes the balance_atomic_operation.lua script.
 //
 // BALANCE SCHEDULING FLOW:
-//  1. This method calls the Lua script with scheduleSync=1 (when balanceSyncEnabled is true)
+//  1. This method calls the Lua script with scheduleSync=1 (balance sync is always enabled)
 //  2. Lua script updates hot balance in Redis atomically
 //  3. Lua script calculates dueAt = now + ttl - 600 (10 min before expiry)
 //  4. Lua script calls ZADD to schedule:{transactions}:balance-sync with score=dueAt
@@ -435,11 +432,8 @@ func (rr *RedisConsumerRepository) ProcessBalanceAtomicOperation(ctx context.Con
 
 	transactionKey := utils.TransactionInternalKey(organizationID, ledgerID, transactionID.String())
 
-	// Prepend balanceSyncEnabled flag (1 = enabled, 0 = disabled) to args
-	scheduleSync := 0
-	if rr.balanceSyncEnabled {
-		scheduleSync = 1
-	}
+	// Balance sync is always enabled - prepend flag (1 = enabled) to args
+	scheduleSync := 1
 
 	finalArgs := append([]any{scheduleSync}, args...)
 
@@ -791,7 +785,7 @@ func (rr *RedisConsumerRepository) RemoveBalanceSyncKey(ctx context.Context, mem
 // This preserves the earliest scheduled sync time for each balance key.
 // Large inputs are processed in chunks of maxRedisBatchSize to prevent oversized payloads.
 func (rr *RedisConsumerRepository) ScheduleBalanceSyncBatch(ctx context.Context, members []redis.Z) error {
-	if len(members) == 0 || !rr.balanceSyncEnabled {
+	if len(members) == 0 {
 		return nil
 	}
 

--- a/components/transaction/internal/adapters/redis/consumer.redis_chaos_test.go
+++ b/components/transaction/internal/adapters/redis/consumer.redis_chaos_test.go
@@ -90,8 +90,7 @@ func setupRedisChaosNetworkInfra(t *testing.T) *chaosNetworkTestInfra {
 	}
 
 	proxyRepo := &RedisConsumerRepository{
-		conn:               proxyConn,
-		balanceSyncEnabled: false,
+		conn: proxyConn,
 	}
 
 	return &chaosNetworkTestInfra{

--- a/components/transaction/internal/adapters/redis/consumer.redis_fuzz_test.go
+++ b/components/transaction/internal/adapters/redis/consumer.redis_fuzz_test.go
@@ -171,7 +171,7 @@ func FuzzKeyNamespacing_MGet(f *testing.F) {
 
 		// Use a fresh recording client — no panic must occur.
 		conn, recorder := newRecordingConnection(t)
-		repo := &RedisConsumerRepository{conn: conn, balanceSyncEnabled: false}
+		repo := &RedisConsumerRepository{conn: conn}
 
 		if keyCount == 0 {
 			// Empty slice path — MGet returns early with an empty map.
@@ -311,7 +311,7 @@ func FuzzKeyNamespacing_QueueKey(f *testing.F) {
 		}
 
 		conn, recorder := newRecordingConnection(t)
-		repo := &RedisConsumerRepository{conn: conn, balanceSyncEnabled: false}
+		repo := &RedisConsumerRepository{conn: conn}
 
 		// Exercise AddMessageToQueue — must not panic.
 		err := repo.AddMessageToQueue(ctx, msgKey, []byte("fuzz-payload"))

--- a/components/transaction/internal/adapters/redis/consumer.redis_get_balances_test.go
+++ b/components/transaction/internal/adapters/redis/consumer.redis_get_balances_test.go
@@ -41,8 +41,7 @@ func newMockMGetConnection(client *mockMGetClient) *libRedis.RedisConnection {
 func TestGetBalancesByKeys_EmptyInput(t *testing.T) {
 	// Create a repository with nil connection to test early return
 	repo := &RedisConsumerRepository{
-		conn:               nil,
-		balanceSyncEnabled: true,
+		conn: nil,
 	}
 
 	// Empty input should return empty map without any Redis call
@@ -64,8 +63,7 @@ func TestGetBalancesByKeys_EmptyInput_NoRedisCall(t *testing.T) {
 	}
 
 	repo := &RedisConsumerRepository{
-		conn:               newMockMGetConnection(mockClient),
-		balanceSyncEnabled: true,
+		conn: newMockMGetConnection(mockClient),
 	}
 
 	result, err := repo.GetBalancesByKeys(context.Background(), []string{})
@@ -87,8 +85,7 @@ func TestGetBalancesByKeys_SingleKey_Found(t *testing.T) {
 	}
 
 	repo := &RedisConsumerRepository{
-		conn:               newMockMGetConnection(mockClient),
-		balanceSyncEnabled: true,
+		conn: newMockMGetConnection(mockClient),
 	}
 
 	result, err := repo.GetBalancesByKeys(context.Background(), []string{"balance:key1"})
@@ -113,8 +110,7 @@ func TestGetBalancesByKeys_SingleKey_NotFound(t *testing.T) {
 	}
 
 	repo := &RedisConsumerRepository{
-		conn:               newMockMGetConnection(mockClient),
-		balanceSyncEnabled: true,
+		conn: newMockMGetConnection(mockClient),
 	}
 
 	result, err := repo.GetBalancesByKeys(context.Background(), []string{"balance:key1"})
@@ -139,8 +135,7 @@ func TestGetBalancesByKeys_MultipleKeys_MixedResults(t *testing.T) {
 	}
 
 	repo := &RedisConsumerRepository{
-		conn:               newMockMGetConnection(mockClient),
-		balanceSyncEnabled: true,
+		conn: newMockMGetConnection(mockClient),
 	}
 
 	result, err := repo.GetBalancesByKeys(context.Background(), []string{"key1", "key2", "key3"})
@@ -175,8 +170,7 @@ func TestGetBalancesByKeys_MalformedJSON(t *testing.T) {
 	}
 
 	repo := &RedisConsumerRepository{
-		conn:               newMockMGetConnection(mockClient),
-		balanceSyncEnabled: true,
+		conn: newMockMGetConnection(mockClient),
 	}
 
 	result, err := repo.GetBalancesByKeys(context.Background(), []string{"key1", "key2", "key3"})
@@ -209,8 +203,7 @@ func TestGetBalancesByKeys_ByteSliceValue(t *testing.T) {
 	}
 
 	repo := &RedisConsumerRepository{
-		conn:               newMockMGetConnection(mockClient),
-		balanceSyncEnabled: true,
+		conn: newMockMGetConnection(mockClient),
 	}
 
 	result, err := repo.GetBalancesByKeys(context.Background(), []string{"balance:key1"})
@@ -234,8 +227,7 @@ func TestGetBalancesByKeys_UnexpectedValueType(t *testing.T) {
 	}
 
 	repo := &RedisConsumerRepository{
-		conn:               newMockMGetConnection(mockClient),
-		balanceSyncEnabled: true,
+		conn: newMockMGetConnection(mockClient),
 	}
 
 	result, err := repo.GetBalancesByKeys(context.Background(), []string{"balance:key1"})
@@ -259,8 +251,7 @@ func TestGetBalancesByKeys_RedisError(t *testing.T) {
 	}
 
 	repo := &RedisConsumerRepository{
-		conn:               newMockMGetConnection(mockClient),
-		balanceSyncEnabled: true,
+		conn: newMockMGetConnection(mockClient),
 	}
 
 	result, err := repo.GetBalancesByKeys(context.Background(), []string{"balance:key1"})
@@ -281,8 +272,7 @@ func TestGetBalancesByKeys_AllKeysNotFound(t *testing.T) {
 	}
 
 	repo := &RedisConsumerRepository{
-		conn:               newMockMGetConnection(mockClient),
-		balanceSyncEnabled: true,
+		conn: newMockMGetConnection(mockClient),
 	}
 
 	result, err := repo.GetBalancesByKeys(context.Background(), []string{"key1", "key2", "key3"})

--- a/components/transaction/internal/adapters/redis/consumer.redis_integration_test.go
+++ b/components/transaction/internal/adapters/redis/consumer.redis_integration_test.go
@@ -80,8 +80,7 @@ func setupRedisIntegrationInfra(t *testing.T) *integrationTestInfra {
 
 	// Create repository with balance sync enabled
 	repo := &RedisConsumerRepository{
-		conn:               conn,
-		balanceSyncEnabled: true,
+		conn: conn,
 	}
 
 	return &integrationTestInfra{
@@ -102,8 +101,7 @@ func setupRedisChaosInfra(t *testing.T) *chaosTestInfra {
 
 	// Create repository with balance sync enabled
 	repo := &RedisConsumerRepository{
-		conn:               conn,
-		balanceSyncEnabled: true,
+		conn: conn,
 	}
 
 	// Create chaos orchestrator
@@ -151,8 +149,7 @@ func setupRedisNetworkChaosInfra(t *testing.T) *networkChaosTestInfra {
 	}
 
 	proxyRepo := &RedisConsumerRepository{
-		conn:               proxyConn,
-		balanceSyncEnabled: true,
+		conn: proxyConn,
 	}
 
 	return &networkChaosTestInfra{

--- a/components/transaction/internal/adapters/redis/consumer.redis_integration_test.go
+++ b/components/transaction/internal/adapters/redis/consumer.redis_integration_test.go
@@ -78,7 +78,7 @@ func setupRedisIntegrationInfra(t *testing.T) *integrationTestInfra {
 	// Create lib-commons Redis connection
 	conn := redistestutil.CreateConnection(t, redisContainer.Addr)
 
-	// Create repository with balance sync enabled
+	// Create repository
 	repo := &RedisConsumerRepository{
 		conn: conn,
 	}
@@ -99,7 +99,7 @@ func setupRedisChaosInfra(t *testing.T) *chaosTestInfra {
 	// Create lib-commons Redis connection
 	conn := redistestutil.CreateConnection(t, redisContainer.Addr)
 
-	// Create repository with balance sync enabled
+	// Create repository
 	repo := &RedisConsumerRepository{
 		conn: conn,
 	}

--- a/components/transaction/internal/adapters/redis/consumer.redis_namespace_test.go
+++ b/components/transaction/internal/adapters/redis/consumer.redis_namespace_test.go
@@ -315,7 +315,7 @@ func TestKeyNamespacing_SimpleKeyMethods(t *testing.T) {
 			t.Parallel()
 
 			conn, recorder := newRecordingConnection(t)
-			repo := &RedisConsumerRepository{conn: conn, balanceSyncEnabled: false}
+			repo := &RedisConsumerRepository{conn: conn}
 
 			ctx := context.Background()
 			if tc.tenantID != "" {
@@ -410,7 +410,7 @@ func TestKeyNamespacing_MGet(t *testing.T) {
 			t.Parallel()
 
 			conn, recorder := newRecordingConnection(t)
-			repo := &RedisConsumerRepository{conn: conn, balanceSyncEnabled: false}
+			repo := &RedisConsumerRepository{conn: conn}
 
 			ctx := context.Background()
 			if tc.tenantID != "" {
@@ -477,7 +477,7 @@ func TestKeyNamespacing_QueueOperations(t *testing.T) {
 			t.Parallel()
 
 			conn, recorder := newRecordingConnection(t)
-			repo := &RedisConsumerRepository{conn: conn, balanceSyncEnabled: false}
+			repo := &RedisConsumerRepository{conn: conn}
 
 			ctx := context.Background()
 			if tc.tenantID != "" {
@@ -571,7 +571,7 @@ func TestKeyNamespacing_ListBalanceByKey(t *testing.T) {
 			// Configure the Get stub to return valid BalanceRedis JSON.
 			recorder.getReturnVal = string(balanceRedisJSON)
 
-			repo := &RedisConsumerRepository{conn: conn, balanceSyncEnabled: false}
+			repo := &RedisConsumerRepository{conn: conn}
 
 			ctx := context.Background()
 			if tc.tenantID != "" {
@@ -636,7 +636,7 @@ func TestKeyNamespacing_ProcessBalanceAtomicOperation(t *testing.T) {
 			t.Parallel()
 
 			conn, scripter := newScriptCapturingConnection(t)
-			repo := &RedisConsumerRepository{conn: conn, balanceSyncEnabled: true}
+			repo := &RedisConsumerRepository{conn: conn}
 
 			ctx := context.Background()
 			if tc.tenantID != "" {
@@ -736,7 +736,7 @@ func TestKeyNamespacing_GetBalanceSyncKeys(t *testing.T) {
 			t.Parallel()
 
 			conn, scripter := newScriptCapturingConnection(t)
-			repo := &RedisConsumerRepository{conn: conn, balanceSyncEnabled: true}
+			repo := &RedisConsumerRepository{conn: conn}
 
 			ctx := context.Background()
 			if tc.tenantID != "" {
@@ -794,7 +794,7 @@ func TestKeyNamespacing_RemoveBalanceSyncKey(t *testing.T) {
 			t.Parallel()
 
 			conn, scripter := newScriptCapturingConnection(t)
-			repo := &RedisConsumerRepository{conn: conn, balanceSyncEnabled: true}
+			repo := &RedisConsumerRepository{conn: conn}
 
 			ctx := context.Background()
 			if tc.tenantID != "" {
@@ -835,7 +835,7 @@ func TestKeyNamespacing_BackwardsCompatible_NoTenantInContext(t *testing.T) {
 		t.Parallel()
 
 		conn, recorder := newRecordingConnection(t)
-		repo := &RedisConsumerRepository{conn: conn, balanceSyncEnabled: false}
+		repo := &RedisConsumerRepository{conn: conn}
 
 		originalKey := "my:original:key"
 
@@ -861,7 +861,7 @@ func TestKeyNamespacing_BackwardsCompatible_NoTenantInContext(t *testing.T) {
 		t.Parallel()
 
 		conn, recorder := newRecordingConnection(t)
-		repo := &RedisConsumerRepository{conn: conn, balanceSyncEnabled: false}
+		repo := &RedisConsumerRepository{conn: conn}
 
 		originalKeys := []string{"key:a", "key:b"}
 		_, _ = repo.MGet(ctx, originalKeys)
@@ -875,7 +875,7 @@ func TestKeyNamespacing_BackwardsCompatible_NoTenantInContext(t *testing.T) {
 		t.Parallel()
 
 		conn, recorder := newRecordingConnection(t)
-		repo := &RedisConsumerRepository{conn: conn, balanceSyncEnabled: false}
+		repo := &RedisConsumerRepository{conn: conn}
 
 		msgKey := "tx:orig-key"
 		_ = repo.AddMessageToQueue(ctx, msgKey, []byte("data"))

--- a/components/transaction/internal/adapters/redis/consumer.redis_property_test.go
+++ b/components/transaction/internal/adapters/redis/consumer.redis_property_test.go
@@ -164,7 +164,7 @@ func TestProperty_MGet_OutputKeysMatchOriginal(t *testing.T) {
 		originalKeys := []string{keyA, keyB}
 
 		conn, _ := newRecordingConnection(t)
-		repo := &RedisConsumerRepository{conn: conn, balanceSyncEnabled: false}
+		repo := &RedisConsumerRepository{conn: conn}
 
 		ctx := context.Background()
 		if tenantID != "" {

--- a/components/transaction/internal/adapters/redis/consumer.redis_test.go
+++ b/components/transaction/internal/adapters/redis/consumer.redis_test.go
@@ -163,8 +163,7 @@ func TestProcessBalanceAtomicOperation_NotedStatus(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			// Arrange - fail-on-call connection ensures Redis is never used for NOTED status
 			repo := &RedisConsumerRepository{
-				conn:               newFailOnCallConnection(t),
-				balanceSyncEnabled: true,
+				conn: newFailOnCallConnection(t),
 			}
 
 			organizationID := libCommons.GenerateUUIDv7()
@@ -220,8 +219,7 @@ func TestProcessBalanceAtomicOperation_NotedStatus(t *testing.T) {
 func TestScheduleBalanceSyncBatch_EmptyInput(t *testing.T) {
 	// Create a repository with nil connection to test early return
 	repo := &RedisConsumerRepository{
-		conn:               nil,
-		balanceSyncEnabled: true,
+		conn: nil,
 	}
 
 	// Empty input should return nil without any Redis call
@@ -241,39 +239,12 @@ func TestScheduleBalanceSyncBatch_EmptyInput_NoRedisCall(t *testing.T) {
 	}
 
 	repo := &RedisConsumerRepository{
-		conn:               newMockZAddNXConnection(mockClient),
-		balanceSyncEnabled: true,
+		conn: newMockZAddNXConnection(mockClient),
 	}
 
 	err := repo.ScheduleBalanceSyncBatch(context.Background(), []redis.Z{})
 
 	assert.NoError(t, err, "Empty batch should return nil without error")
-}
-
-func TestScheduleBalanceSyncBatch_BalanceSyncDisabled_NoRedisCall(t *testing.T) {
-	// Create mock that fails if ZAddNX is called - regression test for feature toggle
-	mockClient := &mockZAddNXClient{
-		zAddNXFunc: func(_ context.Context, _ string, _ ...redis.Z) *redis.IntCmd {
-			t.Fatal("ZAddNX should not be called when balanceSyncEnabled is false")
-
-			return nil
-		},
-	}
-
-	repo := &RedisConsumerRepository{
-		conn:               newMockZAddNXConnection(mockClient),
-		balanceSyncEnabled: false, // Feature toggle disabled
-	}
-
-	// Non-empty members - should still skip Redis call due to disabled feature
-	members := []redis.Z{
-		{Score: float64(time.Now().Unix()), Member: "balance:key1"},
-		{Score: float64(time.Now().Unix()), Member: "balance:key2"},
-	}
-
-	err := repo.ScheduleBalanceSyncBatch(context.Background(), members)
-
-	assert.NoError(t, err, "Disabled feature should return nil without error")
 }
 
 func TestScheduleBalanceSyncBatch_SingleMember(t *testing.T) {
@@ -294,8 +265,7 @@ func TestScheduleBalanceSyncBatch_SingleMember(t *testing.T) {
 	}
 
 	repo := &RedisConsumerRepository{
-		conn:               newMockZAddNXConnection(mockClient),
-		balanceSyncEnabled: true,
+		conn: newMockZAddNXConnection(mockClient),
 	}
 
 	members := []redis.Z{
@@ -325,8 +295,7 @@ func TestScheduleBalanceSyncBatch_MultipleMembers(t *testing.T) {
 	}
 
 	repo := &RedisConsumerRepository{
-		conn:               newMockZAddNXConnection(mockClient),
-		balanceSyncEnabled: true,
+		conn: newMockZAddNXConnection(mockClient),
 	}
 
 	now := time.Now().Unix()
@@ -355,8 +324,7 @@ func TestScheduleBalanceSyncBatch_RedisError(t *testing.T) {
 	}
 
 	repo := &RedisConsumerRepository{
-		conn:               newMockZAddNXConnection(mockClient),
-		balanceSyncEnabled: true,
+		conn: newMockZAddNXConnection(mockClient),
 	}
 
 	members := []redis.Z{
@@ -382,8 +350,7 @@ func TestScheduleBalanceSyncBatch_PartialAdd(t *testing.T) {
 	}
 
 	repo := &RedisConsumerRepository{
-		conn:               newMockZAddNXConnection(mockClient),
-		balanceSyncEnabled: true,
+		conn: newMockZAddNXConnection(mockClient),
 	}
 
 	members := []redis.Z{
@@ -413,8 +380,7 @@ func TestScheduleBalanceSyncBatch_DeduplicatesWithMinScore(t *testing.T) {
 	}
 
 	repo := &RedisConsumerRepository{
-		conn:               newMockZAddNXConnection(mockClient),
-		balanceSyncEnabled: true,
+		conn: newMockZAddNXConnection(mockClient),
 	}
 
 	// Input has duplicate members with different scores
@@ -453,8 +419,7 @@ func TestScheduleBalanceSyncBatch_DeduplicatesWithMinScore(t *testing.T) {
 func TestRemoveBalanceSyncKeysBatch_EmptyInput(t *testing.T) {
 	// Create a repository with nil connection to test early return
 	repo := &RedisConsumerRepository{
-		conn:               nil,
-		balanceSyncEnabled: true,
+		conn: nil,
 	}
 
 	// Empty input should return 0 without any Redis call
@@ -475,8 +440,7 @@ func TestRemoveBalanceSyncKeysBatch_EmptyInput_NoRedisCall(t *testing.T) {
 	}
 
 	repo := &RedisConsumerRepository{
-		conn:               newMockEvalConnection(mockClient),
-		balanceSyncEnabled: true,
+		conn: newMockEvalConnection(mockClient),
 	}
 
 	count, err := repo.RemoveBalanceSyncKeysBatch(context.Background(), []string{})
@@ -506,8 +470,7 @@ func TestRemoveBalanceSyncKeysBatch_SingleKey(t *testing.T) {
 	}
 
 	repo := &RedisConsumerRepository{
-		conn:               newMockEvalConnection(mockClient),
-		balanceSyncEnabled: true,
+		conn: newMockEvalConnection(mockClient),
 	}
 
 	count, err := repo.RemoveBalanceSyncKeysBatch(context.Background(), []string{"balance:key1"})
@@ -534,8 +497,7 @@ func TestRemoveBalanceSyncKeysBatch_MultipleKeys(t *testing.T) {
 	}
 
 	repo := &RedisConsumerRepository{
-		conn:               newMockEvalConnection(mockClient),
-		balanceSyncEnabled: true,
+		conn: newMockEvalConnection(mockClient),
 	}
 
 	count, err := repo.RemoveBalanceSyncKeysBatch(context.Background(), []string{"key1", "key2", "key3"})
@@ -559,8 +521,7 @@ func TestRemoveBalanceSyncKeysBatch_PartialRemoval(t *testing.T) {
 	}
 
 	repo := &RedisConsumerRepository{
-		conn:               newMockEvalConnection(mockClient),
-		balanceSyncEnabled: true,
+		conn: newMockEvalConnection(mockClient),
 	}
 
 	count, err := repo.RemoveBalanceSyncKeysBatch(context.Background(), []string{"key1", "key2", "key3"})
@@ -582,8 +543,7 @@ func TestRemoveBalanceSyncKeysBatch_RedisError(t *testing.T) {
 	}
 
 	repo := &RedisConsumerRepository{
-		conn:               newMockEvalConnection(mockClient),
-		balanceSyncEnabled: true,
+		conn: newMockEvalConnection(mockClient),
 	}
 
 	count, err := repo.RemoveBalanceSyncKeysBatch(context.Background(), []string{"balance:key1"})
@@ -605,8 +565,7 @@ func TestRemoveBalanceSyncKeysBatch_UnexpectedResultType(t *testing.T) {
 	}
 
 	repo := &RedisConsumerRepository{
-		conn:               newMockEvalConnection(mockClient),
-		balanceSyncEnabled: true,
+		conn: newMockEvalConnection(mockClient),
 	}
 
 	count, err := repo.RemoveBalanceSyncKeysBatch(context.Background(), []string{"balance:key1"})
@@ -649,8 +608,7 @@ func TestRemoveBalanceSyncKeysBatch_ScriptUsesCorrectPattern(t *testing.T) {
 	}
 
 	repo := &RedisConsumerRepository{
-		conn:               newMockEvalConnection(mockClient),
-		balanceSyncEnabled: true,
+		conn: newMockEvalConnection(mockClient),
 	}
 
 	_, err := repo.RemoveBalanceSyncKeysBatch(context.Background(), []string{"balance:key1"})
@@ -674,8 +632,7 @@ func TestRemoveBalanceSyncKeysBatch_ZeroKeysRemoved(t *testing.T) {
 	}
 
 	repo := &RedisConsumerRepository{
-		conn:               newMockEvalConnection(mockClient),
-		balanceSyncEnabled: true,
+		conn: newMockEvalConnection(mockClient),
 	}
 
 	count, err := repo.RemoveBalanceSyncKeysBatch(context.Background(), []string{"nonexistent:key1", "nonexistent:key2"})

--- a/components/transaction/internal/bootstrap/balance.worker_integration_test.go
+++ b/components/transaction/internal/bootstrap/balance.worker_integration_test.go
@@ -40,7 +40,7 @@ func TestIntegration_BalanceSyncSchedule_FullFlow(t *testing.T) {
 	container := redistestutil.SetupContainer(t)
 	conn := redistestutil.CreateConnection(t, container.Addr)
 
-	repo, err := redis.NewConsumerRedis(conn, true)
+	repo, err := redis.NewConsumerRedis(conn)
 	require.NoError(t, err, "should create Redis repository")
 
 	ctx := context.Background()
@@ -158,7 +158,7 @@ func TestIntegration_BalanceSyncSchedule_FutureKeys(t *testing.T) {
 	container := redistestutil.SetupContainer(t)
 	conn := redistestutil.CreateConnection(t, container.Addr)
 
-	repo, err := redis.NewConsumerRedis(conn, true)
+	repo, err := redis.NewConsumerRedis(conn)
 	require.NoError(t, err, "should create Redis repository")
 
 	ctx := context.Background()

--- a/components/transaction/internal/bootstrap/config.go
+++ b/components/transaction/internal/bootstrap/config.go
@@ -230,7 +230,7 @@ type handlers struct {
 }
 
 // initRedis creates the Redis connection and consumer repository.
-func initRedis(cfg *Config, logger libLog.Logger, balanceSyncWorkerEnabled bool) (*redis.RedisConsumerRepository, *libRedis.RedisConnection, error) {
+func initRedis(cfg *Config, logger libLog.Logger) (*redis.RedisConsumerRepository, *libRedis.RedisConnection, error) {
 	redisConnection := &libRedis.RedisConnection{
 		Address:                      strings.Split(cfg.RedisHost, ","),
 		Password:                     cfg.RedisPassword,
@@ -256,7 +256,7 @@ func initRedis(cfg *Config, logger libLog.Logger, balanceSyncWorkerEnabled bool)
 		MaxRetryBackoff:              time.Duration(cfg.RedisMaxRetryBackoff) * time.Second,
 	}
 
-	redisConsumerRepository, err := redis.NewConsumerRedis(redisConnection, balanceSyncWorkerEnabled)
+	redisConsumerRepository, err := redis.NewConsumerRedis(redisConnection)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to initialize redis: %w", err)
 	}
@@ -305,11 +305,6 @@ func initBalanceSyncWorker(opts *Options, cfg *Config, logger libLog.Logger, com
 		logger.Infof("BalanceSyncWorker using default: BALANCE_SYNC_MAX_WORKERS=%d", defaultBalanceSyncMaxWorkers)
 	}
 
-	if !cfg.BalanceSyncWorkerEnabled {
-		logger.Info("BalanceSyncWorker disabled.")
-		return nil
-	}
-
 	var balanceSyncWorker *BalanceSyncWorker
 
 	if opts != nil && opts.MultiTenantEnabled {
@@ -336,9 +331,8 @@ func InitServersWithOptions(opts *Options) (*Service, error) {
 		return nil, fmt.Errorf("failed to initialize logger: %w", err)
 	}
 
-	// BalanceSyncWorkerEnabled defaults to true via struct tag
-	balanceSyncWorkerEnabled := cfg.BalanceSyncWorkerEnabled
-	logger.Infof("BalanceSyncWorker: BALANCE_SYNC_WORKER_ENABLED=%v", balanceSyncWorkerEnabled)
+	// BALANCE_SYNC_WORKER_ENABLED is deprecated - balance sync is always enabled
+	logger.Info("BalanceSyncWorker: always enabled (BALANCE_SYNC_WORKER_ENABLED env var is deprecated)")
 
 	telemetry, err := libOpentelemetry.InitializeTelemetryWithError(&libOpentelemetry.TelemetryConfig{
 		LibraryName:               cfg.OtelLibraryName,
@@ -365,7 +359,7 @@ func InitServersWithOptions(opts *Options) (*Service, error) {
 		return nil, fmt.Errorf("failed to initialize MongoDB: %w", err)
 	}
 
-	redisConsumerRepository, redisConnection, err := initRedis(cfg, logger, balanceSyncWorkerEnabled)
+	redisConsumerRepository, redisConnection, err := initRedis(cfg, logger)
 	if err != nil {
 		return nil, err
 	}
@@ -454,7 +448,7 @@ func InitServersWithOptions(opts *Options) (*Service, error) {
 		MultiTenantConsumer:      rmq.multiTenantConsumer,
 		RedisQueueConsumer:       redisConsumer,
 		BalanceSyncWorker:        balanceSyncWorker,
-		BalanceSyncWorkerEnabled: balanceSyncWorkerEnabled,
+		BalanceSyncWorkerEnabled: true, // Always enabled (env var is deprecated)
 		CircuitBreakerManager:    rmq.circuitBreakerManager,
 		Logger:                   logger,
 		Ports: Ports{

--- a/components/transaction/internal/services/command/sync-balances-batch.go
+++ b/components/transaction/internal/services/command/sync-balances-batch.go
@@ -62,17 +62,22 @@ func (uc *UseCase) SyncBalancesBatch(ctx context.Context, organizationID, ledger
 	}
 
 	aggregatedBalances := make([]*redisBalance.AggregatedBalance, 0, len(keys))
+	orphanedKeys := make([]string, 0)
 
 	for _, key := range keys {
 		balance := balanceMap[key]
 		if balance == nil {
-			logger.Debugf("Balance key %s has no data (expired), skipping", key)
+			logger.Debugf("Balance key %s has no data (expired), marking as orphaned", key)
+			orphanedKeys = append(orphanedKeys, key)
+
 			continue
 		}
 
 		compositeKey, parseErr := redisBalance.BalanceCompositeKeyFromRedisKey(key)
 		if parseErr != nil {
 			logger.Warnf("Failed to parse composite key from %s: %v", key, parseErr)
+			orphanedKeys = append(orphanedKeys, key)
+
 			continue
 		}
 
@@ -89,13 +94,34 @@ func (uc *UseCase) SyncBalancesBatch(ctx context.Context, organizationID, ledger
 	deduplicated := aggregator.Aggregate(ctx, aggregatedBalances)
 	result.BalancesAggregated = len(deduplicated)
 
+	// Handle case where all keys are orphaned (no valid balances to sync)
 	if len(deduplicated) == 0 {
-		logger.Info("No balances to sync after aggregation")
+		if len(orphanedKeys) > 0 {
+			logger.Infof("No valid balances to sync, cleaning up %d orphaned keys", len(orphanedKeys))
+
+			removed, cleanupErr := uc.RedisRepo.RemoveBalanceSyncKeysBatch(ctx, orphanedKeys)
+			if cleanupErr != nil {
+				logger.Warnf("Failed to remove orphaned keys from schedule: %v", cleanupErr)
+
+				metricFactory.Counter(utils.BalanceSyncCleanupFailures).WithLabels(map[string]string{
+					"organization_id": organizationID.String(),
+					"ledger_id":       ledgerID.String(),
+				}).AddOne(ctx)
+			}
+
+			result.KeysRemoved = removed
+		} else {
+			logger.Info("No balances to sync after aggregation")
+		}
+
 		return result, nil
 	}
 
 	balancesToSync := make([]mmodel.BalanceRedis, 0, len(deduplicated))
-	keysToRemove := make([]string, 0, len(deduplicated))
+	keysToRemove := make([]string, 0, len(deduplicated)+len(orphanedKeys))
+
+	// Add orphaned keys first (they need cleanup regardless of DB sync outcome)
+	keysToRemove = append(keysToRemove, orphanedKeys...)
 
 	for _, ab := range deduplicated {
 		balancesToSync = append(balancesToSync, *ab.Balance)

--- a/components/transaction/internal/services/command/sync-balances-batch_test.go
+++ b/components/transaction/internal/services/command/sync-balances-batch_test.go
@@ -38,7 +38,7 @@ func TestSyncBalancesBatch_EmptyKeys(t *testing.T) {
 }
 
 // TestSyncBalancesBatch_AllKeysExpired verifies that when all keys have expired
-// (nil balance data), the use case returns zero synced without error.
+// (nil balance data), the orphaned keys are cleaned up from the schedule.
 func TestSyncBalancesBatch_AllKeysExpired(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -60,6 +60,15 @@ func TestSyncBalancesBatch_AllKeysExpired(t *testing.T) {
 		}, nil).
 		Times(1)
 
+	// With the fix: orphaned keys are cleaned up even when no valid balances exist
+	mockRedis.EXPECT().
+		RemoveBalanceSyncKeysBatch(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, keysToRemove []string) (int64, error) {
+			assert.Len(t, keysToRemove, 2, "Both expired keys should be removed")
+			return 2, nil
+		}).
+		Times(1)
+
 	uc := UseCase{
 		RedisRepo: mockRedis,
 	}
@@ -71,6 +80,7 @@ func TestSyncBalancesBatch_AllKeysExpired(t *testing.T) {
 	assert.Equal(t, 2, result.KeysProcessed)
 	assert.Equal(t, 0, result.BalancesAggregated)
 	assert.Equal(t, int64(0), result.BalancesSynced)
+	assert.Equal(t, int64(2), result.KeysRemoved, "Orphaned keys should be removed")
 }
 
 // TestSyncBalancesBatch_SuccessWithAggregation verifies the full flow:
@@ -146,7 +156,7 @@ func TestSyncBalancesBatch_SuccessWithAggregation(t *testing.T) {
 }
 
 // TestSyncBalancesBatch_PartialData verifies that when some keys have data
-// and others are nil (expired), only valid balances are processed.
+// and others are nil (expired), only valid balances are synced but all keys are removed.
 func TestSyncBalancesBatch_PartialData(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -168,7 +178,7 @@ func TestSyncBalancesBatch_PartialData(t *testing.T) {
 			Version:   5,
 			Available: decimal.NewFromInt(1000),
 		},
-		keys[1]: nil, // expired
+		keys[1]: nil, // expired - orphaned key
 	}
 
 	mockRedis := redis.NewMockRedisRepository(ctrl)
@@ -187,9 +197,10 @@ func TestSyncBalancesBatch_PartialData(t *testing.T) {
 		}).
 		Times(1)
 
+	// Both keys removed: 1 valid + 1 orphaned
 	mockRedis.EXPECT().
 		RemoveBalanceSyncKeysBatch(gomock.Any(), gomock.Any()).
-		Return(int64(1), nil).
+		Return(int64(2), nil).
 		Times(1)
 
 	uc := UseCase{
@@ -421,7 +432,7 @@ func TestSyncBalancesBatch_AggregationKeepsHighestVersion(t *testing.T) {
 }
 
 // TestSyncBalancesBatch_InvalidKeyFormat verifies that malformed Redis keys
-// are gracefully skipped without failing the entire batch operation.
+// are gracefully skipped for processing but still removed from the schedule.
 func TestSyncBalancesBatch_InvalidKeyFormat(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -484,12 +495,16 @@ func TestSyncBalancesBatch_InvalidKeyFormat(t *testing.T) {
 		}).
 		Times(1)
 
+	// All 4 keys removed: 1 valid + 3 invalid (orphaned due to parse errors)
 	mockRedis.EXPECT().
 		RemoveBalanceSyncKeysBatch(gomock.Any(), gomock.Any()).
 		DoAndReturn(func(_ context.Context, keysToRemove []string) (int64, error) {
-			assert.Len(t, keysToRemove, 1, "Only valid key should be in removal list")
-			assert.Equal(t, validKey, keysToRemove[0])
-			return 1, nil
+			assert.Len(t, keysToRemove, 4, "All keys should be removed (valid + invalid)")
+			assert.Contains(t, keysToRemove, validKey, "valid key should be removed")
+			assert.Contains(t, keysToRemove, invalidKey1, "invalid key 1 should be removed")
+			assert.Contains(t, keysToRemove, invalidKey2, "invalid key 2 should be removed")
+			assert.Contains(t, keysToRemove, invalidKey3, "invalid key 3 should be removed")
+			return 4, nil
 		}).
 		Times(1)
 
@@ -505,11 +520,11 @@ func TestSyncBalancesBatch_InvalidKeyFormat(t *testing.T) {
 	assert.Equal(t, 4, result.KeysProcessed, "All keys were attempted")
 	assert.Equal(t, 1, result.BalancesAggregated, "Only valid key produced a balance")
 	assert.Equal(t, int64(1), result.BalancesSynced)
-	assert.Equal(t, int64(1), result.KeysRemoved)
+	assert.Equal(t, int64(4), result.KeysRemoved, "All 4 keys removed")
 }
 
-// TestSyncBalancesBatch_ExactKeysRemoved verifies that exactly the synced keys
-// are passed to RemoveBalanceSyncKeysBatch (not more, not less).
+// TestSyncBalancesBatch_ExactKeysRemoved verifies that all processed keys
+// (both valid and orphaned) are removed from the schedule.
 func TestSyncBalancesBatch_ExactKeysRemoved(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -532,7 +547,7 @@ func TestSyncBalancesBatch_ExactKeysRemoved(t *testing.T) {
 			AssetCode: "USD",
 			Version:   5,
 		},
-		key2: nil, // Expired - should not be in removal list
+		key2: nil, // Expired - orphaned key, MUST be removed to prevent infinite loop
 		key3: {
 			ID:        balanceID2.String(),
 			Alias:     "@acc3",
@@ -554,15 +569,15 @@ func TestSyncBalancesBatch_ExactKeysRemoved(t *testing.T) {
 		Return(int64(2), nil).
 		Times(1)
 
-	// Verify EXACT keys are removed: only key1 and key3 (not key2 which was nil)
+	// Verify ALL keys are removed: key1, key2 (orphaned), and key3
 	mockRedis.EXPECT().
 		RemoveBalanceSyncKeysBatch(gomock.Any(), gomock.Any()).
 		DoAndReturn(func(_ context.Context, keysToRemove []string) (int64, error) {
-			assert.Len(t, keysToRemove, 2, "Expected exactly 2 keys to be removed")
+			assert.Len(t, keysToRemove, 3, "Expected all 3 keys to be removed")
 			assert.Contains(t, keysToRemove, key1, "key1 should be in removal list")
+			assert.Contains(t, keysToRemove, key2, "key2 (orphaned) MUST be in removal list")
 			assert.Contains(t, keysToRemove, key3, "key3 should be in removal list")
-			assert.NotContains(t, keysToRemove, key2, "key2 (expired) should NOT be in removal list")
-			return 2, nil
+			return 3, nil
 		}).
 		Times(1)
 
@@ -578,7 +593,7 @@ func TestSyncBalancesBatch_ExactKeysRemoved(t *testing.T) {
 	assert.Equal(t, 3, result.KeysProcessed)
 	assert.Equal(t, 2, result.BalancesAggregated)
 	assert.Equal(t, int64(2), result.BalancesSynced)
-	assert.Equal(t, int64(2), result.KeysRemoved)
+	assert.Equal(t, int64(3), result.KeysRemoved, "All 3 keys removed (2 valid + 1 orphaned)")
 }
 
 // TestSyncBalancesBatch_ContextCancellation verifies that the operation respects
@@ -615,4 +630,79 @@ func TestSyncBalancesBatch_ContextCancellation(t *testing.T) {
 	assert.Error(t, err)
 	assert.Nil(t, result)
 	assert.ErrorIs(t, err, context.Canceled)
+}
+
+// TestSyncBalancesBatch_OrphanedKeysCleanedUp verifies that keys with nil balance values
+// (expired TTL) are removed from the schedule to prevent infinite reprocessing loops.
+// Bug fix: Previously these keys were skipped but never added to keysToRemove.
+func TestSyncBalancesBatch_OrphanedKeysCleanedUp(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	organizationID := libCommons.GenerateUUIDv7()
+	ledgerID := libCommons.GenerateUUIDv7()
+	balanceID := libCommons.GenerateUUIDv7()
+
+	// Mix of valid keys and orphaned keys (nil balance - expired TTL)
+	validKey := "balance:{transactions}:" + organizationID.String() + ":" + ledgerID.String() + ":@valid-account#default"
+	orphanedKey1 := "balance:{transactions}:" + organizationID.String() + ":" + ledgerID.String() + ":@orphaned-1#default"
+	orphanedKey2 := "balance:{transactions}:" + organizationID.String() + ":" + ledgerID.String() + ":@orphaned-2#default"
+
+	keys := []string{validKey, orphanedKey1, orphanedKey2}
+
+	balanceData := map[string]*mmodel.BalanceRedis{
+		validKey: {
+			ID:        balanceID.String(),
+			Alias:     "@valid-account",
+			AssetCode: "USD",
+			Version:   5,
+			Available: decimal.NewFromInt(1000),
+		},
+		orphanedKey1: nil, // Expired - orphaned key
+		orphanedKey2: nil, // Expired - orphaned key
+	}
+
+	mockRedis := redis.NewMockRedisRepository(ctrl)
+	mockBalance := balance.NewMockRepository(ctrl)
+
+	mockRedis.EXPECT().
+		GetBalancesByKeys(gomock.Any(), keys).
+		Return(balanceData, nil).
+		Times(1)
+
+	// Only valid balance is synced to DB
+	mockBalance.EXPECT().
+		SyncBatch(gomock.Any(), organizationID, ledgerID, gomock.Any()).
+		DoAndReturn(func(_ context.Context, _, _ uuid.UUID, balances []mmodel.BalanceRedis) (int64, error) {
+			assert.Len(t, balances, 1, "Only valid key should produce a balance")
+			return 1, nil
+		}).
+		Times(1)
+
+	// KEY ASSERTION: ALL 3 keys should be removed (1 valid + 2 orphaned)
+	// This is the bug fix: orphaned keys MUST be in removal list
+	mockRedis.EXPECT().
+		RemoveBalanceSyncKeysBatch(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, keysToRemove []string) (int64, error) {
+			assert.Len(t, keysToRemove, 3, "Expected 3 keys to be removed (1 valid + 2 orphaned)")
+			assert.Contains(t, keysToRemove, validKey, "valid key should be in removal list")
+			assert.Contains(t, keysToRemove, orphanedKey1, "orphaned key 1 should be in removal list")
+			assert.Contains(t, keysToRemove, orphanedKey2, "orphaned key 2 should be in removal list")
+			return 3, nil
+		}).
+		Times(1)
+
+	uc := UseCase{
+		RedisRepo:   mockRedis,
+		BalanceRepo: mockBalance,
+	}
+
+	result, err := uc.SyncBalancesBatch(context.TODO(), organizationID, ledgerID, keys)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, result)
+	assert.Equal(t, 3, result.KeysProcessed, "All 3 keys were processed")
+	assert.Equal(t, 1, result.BalancesAggregated, "Only 1 valid balance aggregated")
+	assert.Equal(t, int64(1), result.BalancesSynced)
+	assert.Equal(t, int64(3), result.KeysRemoved, "All 3 keys removed (including orphaned)")
 }

--- a/components/transaction/internal/services/command/update-balance_integration_test.go
+++ b/components/transaction/internal/services/command/update-balance_integration_test.go
@@ -34,7 +34,7 @@ func TestIntegration_FilterStaleBalances_CacheNewerVersion_FiltersBalance(t *tes
 	ctx := context.Background()
 
 	conn := redistestutil.CreateConnection(t, container.Addr)
-	redisRepo, err := redis.NewConsumerRedis(conn, false)
+	redisRepo, err := redis.NewConsumerRedis(conn)
 	require.NoError(t, err, "failed to create Redis repository")
 
 	uc := &UseCase{
@@ -91,7 +91,7 @@ func TestIntegration_FilterStaleBalances_CacheOlderVersion_IncludesBalance(t *te
 	ctx := context.Background()
 
 	conn := redistestutil.CreateConnection(t, container.Addr)
-	redisRepo, err := redis.NewConsumerRedis(conn, false)
+	redisRepo, err := redis.NewConsumerRedis(conn)
 	require.NoError(t, err, "failed to create Redis repository")
 
 	uc := &UseCase{
@@ -150,7 +150,7 @@ func TestIntegration_FilterStaleBalances_CacheMiss_IncludesBalance(t *testing.T)
 	ctx := context.Background()
 
 	conn := redistestutil.CreateConnection(t, container.Addr)
-	redisRepo, err := redis.NewConsumerRedis(conn, false)
+	redisRepo, err := redis.NewConsumerRedis(conn)
 	require.NoError(t, err, "failed to create Redis repository")
 
 	uc := &UseCase{
@@ -189,7 +189,7 @@ func TestIntegration_FilterStaleBalances_MultipleBalances_FiltersOnlyStale(t *te
 	ctx := context.Background()
 
 	conn := redistestutil.CreateConnection(t, container.Addr)
-	redisRepo, err := redis.NewConsumerRedis(conn, false)
+	redisRepo, err := redis.NewConsumerRedis(conn)
 	require.NoError(t, err, "failed to create Redis repository")
 
 	uc := &UseCase{

--- a/pkg/mmodel/settings.go
+++ b/pkg/mmodel/settings.go
@@ -193,6 +193,7 @@ var settingsSchema = map[string]map[string]string{
 // Automatically derived from settingsSchema to ensure consistency.
 var knownNestedFieldNames = func() map[string]string {
 	result := make(map[string]string)
+
 	for parentKey, nestedFields := range settingsSchema {
 		for fieldName := range nestedFields {
 			result[fieldName] = parentKey


### PR DESCRIPTION
## Summary

Remove conditional logic that could disable the balance sync worker, ensuring balances are always synchronized to PostgreSQL regardless of environment configuration.

## Motivation

The `BALANCE_SYNC_WORKER_ENABLED` env var was intended to default to `true`, but `lib-commons.SetConfigFromEnvVars` ignores the `default` struct tag for boolean fields and uses `false` when the env var is not set. This caused the balance sync worker to be disabled in deployments where the env var was not explicitly configured, preventing balances from syncing to PostgreSQL before Redis TTL expiration.

## Semantic Decision

This is a **fix** (not a breaking change). The intended behavior was always-enabled balance sync. The env var is deprecated but retained for backwards compatibility (ignored at runtime).

## Changes

### Refactored Code

| Before | After |
|--------|-------|
| `RedisConsumerRepository` struct had `balanceSyncEnabled bool` field | Field removed - sync is always enabled |
| `NewConsumerRedis(rc, balanceSyncEnabled bool)` | `NewConsumerRedis(rc)` - single parameter |
| `scheduleSync` conditionally set based on `rr.balanceSyncEnabled` | `scheduleSync := 1` - always enabled |
| `initRedis(cfg, logger, balanceSyncWorkerEnabled)` | `initRedis(cfg, logger)` - parameter removed |
| Conditional check `if !cfg.BalanceSyncWorkerEnabled { return nil }` | Removed - worker always created |
| Log message: "BalanceSyncWorker disabled." | Log message: "BalanceSyncWorker: always enabled (BALANCE_SYNC_WORKER_ENABLED env var is deprecated)" |

### Environment Variables - Balance Sync Worker

| Variable | Type | Default | Description |
|----------|------|---------|-------------|
| `BALANCE_SYNC_WORKER_ENABLED` | bool | N/A | **DEPRECATED** - Ignored at runtime. Balance sync is always enabled. Kept for backwards compatibility. |
| `BALANCE_SYNC_MAX_WORKERS` | int | 5 | Number of concurrent workers for balance sync (unchanged) |

### Files Changed

| File | Purpose |
|------|---------|
| `components/transaction/internal/adapters/redis/consumer.redis.go` | Remove `balanceSyncEnabled` field, update constructor, set `scheduleSync=1` |
| `components/transaction/internal/bootstrap/config.go` | Remove conditional logic, update `initRedis` signature, update log message |
| `components/transaction/internal/bootstrap/balance.worker_integration_test.go` | Update `NewConsumerRedis` calls |
| `components/transaction/internal/services/command/update-balance_integration_test.go` | Update `NewConsumerRedis` calls |
| `components/transaction/internal/adapters/http/in/transaction_integration_test.go` | Update `NewConsumerRedis` calls |
| `components/transaction/internal/adapters/redis/consumer.redis_test.go` | Update `NewConsumerRedis` calls |
| `components/transaction/internal/adapters/redis/consumer.redis_integration_test.go` | Update `NewConsumerRedis` calls |
| `components/transaction/internal/adapters/redis/consumer.redis_chaos_test.go` | Update `NewConsumerRedis` calls |
| `components/transaction/internal/adapters/redis/consumer.redis_fuzz_test.go` | Update `NewConsumerRedis` calls |
| `components/transaction/internal/adapters/redis/consumer.redis_get_balances_test.go` | Update `NewConsumerRedis` calls |
| `components/transaction/internal/adapters/redis/consumer.redis_namespace_test.go` | Update `NewConsumerRedis` calls |
| `components/transaction/internal/adapters/redis/consumer.redis_property_test.go` | Update `NewConsumerRedis` calls |
| `components/transaction/.env.example` | Add deprecation notice for `BALANCE_SYNC_WORKER_ENABLED` |
| `components/ledger/.env.example` | Add deprecation notice for `BALANCE_SYNC_WORKER_ENABLED` |

## Test Plan

- [x] All `NewConsumerRedis` calls updated to single-parameter signature
- [x] `go build ./components/transaction/...` passes
- [x] `go build ./components/ledger/...` passes
- [x] `golangci-lint run --new-from-rev=develop` reports 0 issues
- [x] Run integration tests: `go test ./components/transaction/... -tags=integration`
- [x] Verify balance sync worker starts in logs: "BalanceSyncWorker: always enabled"
- [x] Verify balances are synced to PostgreSQL before Redis TTL expires
