### PR TITLE
fix: update Getting Started link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Lerian Midaz implements true double-entry accounting with sophisticated transact
 
 ## Getting Started
 
-To start using Lerian Midaz, please follow our [Getting Started Guide](https://docs.lerian.studio/docs/getting-started). For comprehensive documentation on Midaz features, API references, and best practices, visit our [Official Documentation](https://docs.lerian.studio).
+To start using Lerian Midaz, please follow our [Getting Started Guide](https://docs.lerian.studio/en/getting-started). For comprehensive documentation on Midaz features, API references, and best practices, visit our [Official Documentation](https://docs.lerian.studio).
 
 ## Community & Support
 


### PR DESCRIPTION
The Getting Started Guide URL in README.md was pointing to `/docs/getting-started` which returns 404. Updated to `/en/getting-started` which is the current docs path.

Reported by @brunogomes in #product-midaz.