### PR TITLE
fix: update Getting Started link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Lerian Midaz implements true double-entry accounting with sophisticated transact
 
 ## Getting Started
 
-Follow our [Getting Started Guide](https://docs.lerian.studio/docs/getting-started) to begin. For features, API references, and best practices, visit our [Official Documentation](https://docs.lerian.studio).
+Follow our [Getting Started Guide](https://docs.lerian.studio/en/getting-started) to begin. For features, API references, and best practices, visit our [Official Documentation](https://docs.lerian.studio).
 
 ## Community & Support
 


### PR DESCRIPTION
The Getting Started Guide URL in README.md was pointing to `/docs/getting-started` which returns 404. Updated to `/en/getting-started` which is the current docs path.

Base branch: `develop`.

Reported by @brunogomes in #product-midaz.