### PR TITLE
fix: point Getting Started to Midaz-specific guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Lerian Midaz implements true double-entry accounting with sophisticated transact
 
 ## Getting Started
 
-Follow our [Getting Started Guide](https://docs.lerian.studio/en/getting-started) to begin. For features, API references, and best practices, visit our [Official Documentation](https://docs.lerian.studio).
+Follow our [Getting Started Guide](https://docs.lerian.studio/en/midaz/midaz-getting-started) to begin. For features, API references, and best practices, visit our [Official Documentation](https://docs.lerian.studio).
 
 ## Community & Support
 


### PR DESCRIPTION
The previous PR (#1909) updated the broken link but pointed to the generic Getting Started page (`/en/getting-started`). This updates it to the Midaz-specific guide at `/en/midaz/midaz-getting-started`.

Co-authored-by: Fabi Kawazoe <fabi@lerian.studio>