### PR TITLE
fix: propagate TenantManagerAPIKey to multi-tenant consumer

### DIFF
--- a/components/ledger/internal/bootstrap/config.go
+++ b/components/ledger/internal/bootstrap/config.go
@@ -184,6 +184,7 @@ func InitServersWithOptions(opts *Options) (*Service, error) {
 		TenantServiceName:           tenantServiceName,
 		TenantEnvironment:           cfg.MultiTenantEnvironment,
 		TenantManagerURL:            strings.TrimSpace(cfg.MultiTenantURL),
+		TenantManagerAPIKey:         strings.TrimSpace(cfg.TenantManagerAPIKey),
 	}
 
 	// Initialize transaction module first to get the BalancePort

--- a/components/transaction/bootstrap.go
+++ b/components/transaction/bootstrap.go
@@ -74,11 +74,12 @@ type Options struct {
 	SettingsPort mbootstrap.SettingsPort
 
 	// Multi-tenant configuration (only used in unified mode)
-	MultiTenantEnabled bool
-	TenantClient       *tmclient.Client
-	TenantServiceName  string
-	TenantEnvironment  string
-	TenantManagerURL   string
+	MultiTenantEnabled    bool
+	TenantClient          *tmclient.Client
+	TenantServiceName     string
+	TenantEnvironment     string
+	TenantManagerURL      string
+	TenantManagerAPIKey   string
 }
 
 // InitService initializes the transaction service.
@@ -117,5 +118,6 @@ func InitServiceWithOptionsOrError(opts *Options) (TransactionService, error) {
 		TenantServiceName:           opts.TenantServiceName,
 		TenantEnvironment:           opts.TenantEnvironment,
 		TenantManagerURL:            opts.TenantManagerURL,
+		TenantManagerAPIKey:         opts.TenantManagerAPIKey,
 	})
 }

--- a/components/transaction/internal/bootstrap/config.go
+++ b/components/transaction/internal/bootstrap/config.go
@@ -227,11 +227,12 @@ type Options struct {
 	SettingsPort mbootstrap.SettingsPort
 
 	// Multi-tenant configuration (only used in unified ledger mode).
-	MultiTenantEnabled bool
-	TenantClient       *tmclient.Client
-	TenantServiceName  string
-	TenantEnvironment  string
-	TenantManagerURL   string
+	MultiTenantEnabled  bool
+	TenantClient        *tmclient.Client
+	TenantServiceName   string
+	TenantEnvironment   string
+	TenantManagerURL    string
+	TenantManagerAPIKey string
 }
 
 // InitServers initiate http and grpc servers.

--- a/components/transaction/internal/bootstrap/config.rabbitmq.go
+++ b/components/transaction/internal/bootstrap/config.rabbitmq.go
@@ -108,6 +108,7 @@ func initMultiTenantRabbitMQ(
 		SyncInterval:     syncInterval,
 		PrefetchCount:    prefetchCount,
 		MultiTenantURL:   opts.TenantManagerURL,
+		ServiceAPIKey:    opts.TenantManagerAPIKey,
 		Service:          opts.TenantServiceName,
 		Environment:      opts.TenantEnvironment,
 		DiscoveryTimeout: discoveryTimeout,


### PR DESCRIPTION
## Problem

The `TENANT_MANAGER_API_KEY` environment variable was validated during ledger bootstrap (`config.go`) but never propagated through `transaction.Options` to the `MultiTenantConfig` used by the RabbitMQ consumer. This caused a crashloop on Clotilde-dev when `MULTI_TENANT_ENABLED=true` (since `3.6.0-beta.52`):

```
Failed to initialize ledger service: failed to initialize transaction module:
failed to initialize multi-tenant consumer: consumer.NewMultiTenantConsumerWithError:
invalid MultiTenantURL: client.NewClient: service API key is required: use WithServiceAPIKey() with a non-empty key
```

## Root Cause

The API key was passed to `tmclient.Client` (used by middleware) but the consumer creates its **own** client internally via `MultiTenantConfig`. The `ServiceAPIKey` field in `MultiTenantConfig` was never set.

## Fix

- Add `TenantManagerAPIKey` to `transaction.Options` (public API)
- Add `TenantManagerAPIKey` to internal `bootstrap.Options`
- Wire it from ledger bootstrap → transaction options → consumer config
- Set `ServiceAPIKey` in the `MultiTenantConfig` struct

## Files Changed

| File | Change |
|------|--------|
| `components/transaction/bootstrap.go` | Add field + propagate to internal opts |
| `components/transaction/internal/bootstrap/config.go` | Add field to internal Options |
| `components/transaction/internal/bootstrap/config.rabbitmq.go` | Set `ServiceAPIKey` in consumer config |
| `components/ledger/internal/bootstrap/config.go` | Pass API key from ledger cfg to transaction opts |

## Testing

- `go build ./components/ledger/...` ✅
- `go build ./components/transaction/...` ✅
