### PR TITLE
fix: populate RouteCode on operations during transaction creation

### DIFF
--- a/components/transaction/internal/adapters/http/in/transaction-builder-routecode_test.go
+++ b/components/transaction/internal/adapters/http/in/transaction-builder-routecode_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/LerianStudio/midaz/v3/components/transaction/internal/adapters/postgres/operation"
 	"github.com/LerianStudio/midaz/v3/components/transaction/internal/adapters/postgres/transaction"
 	"github.com/LerianStudio/midaz/v3/pkg/mmodel"
 	pkgTransaction "github.com/LerianStudio/midaz/v3/pkg/transaction"
@@ -173,4 +174,178 @@ func TestBuildDoubleEntryCanceledOps_ReturnsTwoOperations(t *testing.T) {
 	require.Len(t, ops, 2, "should return exactly 2 operations")
 	assert.Equal(t, "txn-1", ops[0].TransactionID)
 	assert.Equal(t, "txn-1", ops[1].TransactionID)
+}
+
+// TestResolveRouteCodesFromCache_NilCache verifies that a nil cache is handled gracefully.
+func TestResolveRouteCodesFromCache_NilCache(t *testing.T) {
+	routeID := "route-uuid-1"
+	ops := []*operation.Operation{
+		{ID: "op-1", RouteID: &routeID},
+	}
+
+	resolveRouteCodesFromCache(ops, nil)
+
+	assert.Nil(t, ops[0].RouteCode, "RouteCode should remain nil when cache is nil")
+}
+
+// TestResolveRouteCodesFromCache_NoRouteID verifies that operations without a RouteID are skipped.
+func TestResolveRouteCodesFromCache_NoRouteID(t *testing.T) {
+	cache := &mmodel.TransactionRouteCache{
+		Actions: map[string]mmodel.ActionRouteCache{
+			"direct": {
+				Source: map[string]mmodel.OperationRouteCache{
+					"route-uuid-1": {Code: "RT-SRC-001"},
+				},
+				Destination:   map[string]mmodel.OperationRouteCache{},
+				Bidirectional: map[string]mmodel.OperationRouteCache{},
+			},
+		},
+	}
+
+	ops := []*operation.Operation{
+		{ID: "op-1", RouteID: nil},
+	}
+
+	resolveRouteCodesFromCache(ops, cache)
+
+	assert.Nil(t, ops[0].RouteCode, "RouteCode should remain nil when RouteID is nil")
+}
+
+// TestResolveRouteCodesFromCache_SourceRoute verifies that RouteCode is resolved from source routes.
+func TestResolveRouteCodesFromCache_SourceRoute(t *testing.T) {
+	routeID := "route-uuid-1"
+	cache := &mmodel.TransactionRouteCache{
+		Actions: map[string]mmodel.ActionRouteCache{
+			"direct": {
+				Source: map[string]mmodel.OperationRouteCache{
+					"route-uuid-1": {Code: "RT-SRC-001"},
+				},
+				Destination:   map[string]mmodel.OperationRouteCache{},
+				Bidirectional: map[string]mmodel.OperationRouteCache{},
+			},
+		},
+	}
+
+	ops := []*operation.Operation{
+		{ID: "op-1", RouteID: &routeID},
+	}
+
+	resolveRouteCodesFromCache(ops, cache)
+
+	require.NotNil(t, ops[0].RouteCode, "RouteCode should be populated from source route cache")
+	assert.Equal(t, "RT-SRC-001", *ops[0].RouteCode)
+}
+
+// TestResolveRouteCodesFromCache_DestinationRoute verifies resolution from destination routes.
+func TestResolveRouteCodesFromCache_DestinationRoute(t *testing.T) {
+	routeID := "route-uuid-2"
+	cache := &mmodel.TransactionRouteCache{
+		Actions: map[string]mmodel.ActionRouteCache{
+			"direct": {
+				Source: map[string]mmodel.OperationRouteCache{},
+				Destination: map[string]mmodel.OperationRouteCache{
+					"route-uuid-2": {Code: "RT-DST-002"},
+				},
+				Bidirectional: map[string]mmodel.OperationRouteCache{},
+			},
+		},
+	}
+
+	ops := []*operation.Operation{
+		{ID: "op-1", RouteID: &routeID},
+	}
+
+	resolveRouteCodesFromCache(ops, cache)
+
+	require.NotNil(t, ops[0].RouteCode, "RouteCode should be populated from destination route cache")
+	assert.Equal(t, "RT-DST-002", *ops[0].RouteCode)
+}
+
+// TestResolveRouteCodesFromCache_BidirectionalRoute verifies resolution from bidirectional routes.
+func TestResolveRouteCodesFromCache_BidirectionalRoute(t *testing.T) {
+	routeID := "route-uuid-3"
+	cache := &mmodel.TransactionRouteCache{
+		Actions: map[string]mmodel.ActionRouteCache{
+			"hold": {
+				Source:      map[string]mmodel.OperationRouteCache{},
+				Destination: map[string]mmodel.OperationRouteCache{},
+				Bidirectional: map[string]mmodel.OperationRouteCache{
+					"route-uuid-3": {Code: "RT-BIDIR-003"},
+				},
+			},
+		},
+	}
+
+	ops := []*operation.Operation{
+		{ID: "op-1", RouteID: &routeID},
+	}
+
+	resolveRouteCodesFromCache(ops, cache)
+
+	require.NotNil(t, ops[0].RouteCode, "RouteCode should be populated from bidirectional route cache")
+	assert.Equal(t, "RT-BIDIR-003", *ops[0].RouteCode)
+}
+
+// TestResolveRouteCodesFromCache_MultipleOperations verifies that multiple operations
+// are resolved independently from different route types.
+func TestResolveRouteCodesFromCache_MultipleOperations(t *testing.T) {
+	srcRouteID := "route-src"
+	dstRouteID := "route-dst"
+	unknownRouteID := "route-unknown"
+
+	cache := &mmodel.TransactionRouteCache{
+		Actions: map[string]mmodel.ActionRouteCache{
+			"direct": {
+				Source: map[string]mmodel.OperationRouteCache{
+					"route-src": {Code: "SRC-CODE"},
+				},
+				Destination: map[string]mmodel.OperationRouteCache{
+					"route-dst": {Code: "DST-CODE"},
+				},
+				Bidirectional: map[string]mmodel.OperationRouteCache{},
+			},
+		},
+	}
+
+	ops := []*operation.Operation{
+		{ID: "op-1", RouteID: &srcRouteID},
+		{ID: "op-2", RouteID: &dstRouteID},
+		{ID: "op-3", RouteID: &unknownRouteID},
+		{ID: "op-4", RouteID: nil},
+	}
+
+	resolveRouteCodesFromCache(ops, cache)
+
+	require.NotNil(t, ops[0].RouteCode)
+	assert.Equal(t, "SRC-CODE", *ops[0].RouteCode)
+
+	require.NotNil(t, ops[1].RouteCode)
+	assert.Equal(t, "DST-CODE", *ops[1].RouteCode)
+
+	assert.Nil(t, ops[2].RouteCode, "unknown route ID should leave RouteCode nil")
+	assert.Nil(t, ops[3].RouteCode, "nil route ID should leave RouteCode nil")
+}
+
+// TestResolveRouteCodesFromCache_EmptyRouteID verifies that an empty string RouteID is skipped.
+func TestResolveRouteCodesFromCache_EmptyRouteID(t *testing.T) {
+	emptyRouteID := ""
+	cache := &mmodel.TransactionRouteCache{
+		Actions: map[string]mmodel.ActionRouteCache{
+			"direct": {
+				Source: map[string]mmodel.OperationRouteCache{
+					"": {Code: "SHOULD-NOT-MATCH"},
+				},
+				Destination:   map[string]mmodel.OperationRouteCache{},
+				Bidirectional: map[string]mmodel.OperationRouteCache{},
+			},
+		},
+	}
+
+	ops := []*operation.Operation{
+		{ID: "op-1", RouteID: &emptyRouteID},
+	}
+
+	resolveRouteCodesFromCache(ops, cache)
+
+	assert.Nil(t, ops[0].RouteCode, "RouteCode should remain nil for empty RouteID")
 }

--- a/components/transaction/internal/adapters/http/in/transaction-creation-helpers.go
+++ b/components/transaction/internal/adapters/http/in/transaction-creation-helpers.go
@@ -155,6 +155,7 @@ func (handler *TransactionHandler) BuildOperations(
 	transactionDate time.Time,
 	isAnnotation bool,
 	routeValidationEnabled bool,
+	transactionRouteCache *mmodel.TransactionRouteCache,
 ) ([]*operation.Operation, []*mmodel.Balance, error) {
 	var operations []*operation.Operation
 
@@ -232,7 +233,50 @@ func (handler *TransactionHandler) BuildOperations(
 		}
 	}
 
+	resolveRouteCodesFromCache(operations, transactionRouteCache)
+
 	return operations, preBalances, nil
+}
+
+// resolveRouteCodesFromCache populates the RouteCode field on each operation by
+// looking up the operation's RouteID in the transaction route cache. The cache
+// is keyed by routeID within each action's Source, Destination, and Bidirectional
+// maps, and each entry carries the human-readable Code of the operation route.
+func resolveRouteCodesFromCache(operations []*operation.Operation, cache *mmodel.TransactionRouteCache) {
+	if cache == nil {
+		return
+	}
+
+	for _, op := range operations {
+		if op.RouteID == nil || *op.RouteID == "" {
+			continue
+		}
+
+		routeID := *op.RouteID
+
+		for _, actionCache := range cache.Actions {
+			if rc, ok := actionCache.Source[routeID]; ok && rc.Code != "" {
+				code := rc.Code
+				op.RouteCode = &code
+
+				break
+			}
+
+			if rc, ok := actionCache.Destination[routeID]; ok && rc.Code != "" {
+				code := rc.Code
+				op.RouteCode = &code
+
+				break
+			}
+
+			if rc, ok := actionCache.Bidirectional[routeID]; ok && rc.Code != "" {
+				code := rc.Code
+				op.RouteCode = &code
+
+				break
+			}
+		}
+	}
 }
 
 // zeroAnnotationBalances zeroes out the Available, OnHold, and Version fields of the
@@ -777,7 +821,7 @@ func (handler *TransactionHandler) createTransaction(c *fiber.Ctx, transactionIn
 		action = constant.ActionHold
 	}
 
-	balancesBefore, balancesAfter, _, err := handler.Query.GetBalances(ctx, scope.OrganizationID, scope.LedgerID, transactionID, &transactionInput, validate, transactionStatus, action)
+	balancesBefore, balancesAfter, routeCache, err := handler.Query.GetBalances(ctx, scope.OrganizationID, scope.LedgerID, transactionID, &transactionInput, validate, transactionStatus, action)
 	if err != nil {
 		libOpentelemetry.HandleSpanBusinessErrorEvent(spanGetBalances, "Failed to get balances", err)
 
@@ -819,7 +863,7 @@ func (handler *TransactionHandler) createTransaction(c *fiber.Ctx, transactionIn
 		},
 	}
 
-	operations, _, err := handler.BuildOperations(ctx, balancesBefore, fromTo, transactionInput, *tran, validate, transactionDate, transactionStatus == constant.NOTED, ledgerSettings.Accounting.ValidateRoutes)
+	operations, _, err := handler.BuildOperations(ctx, balancesBefore, fromTo, transactionInput, *tran, validate, transactionDate, transactionStatus == constant.NOTED, ledgerSettings.Accounting.ValidateRoutes, routeCache)
 	if err != nil {
 		libOpentelemetry.HandleSpanError(span, "Failed to validate balances", err)
 

--- a/components/transaction/internal/adapters/http/in/transaction-state-handlers.go
+++ b/components/transaction/internal/adapters/http/in/transaction-state-handlers.go
@@ -452,7 +452,7 @@ func (handler *TransactionHandler) commitOrCancelTransaction(c *fiber.Ctx, tran 
 		action = constant.ActionCancel
 	}
 
-	balancesBefore, balancesAfter, _, err := handler.Query.GetBalances(ctx, organizationID, ledgerID, tran.IDtoUUID(), nil, validate, transactionStatus, action)
+	balancesBefore, balancesAfter, routeCache, err := handler.Query.GetBalances(ctx, organizationID, ledgerID, tran.IDtoUUID(), nil, validate, transactionStatus, action)
 	if err != nil {
 		libOpentelemetry.HandleSpanBusinessErrorEvent(spanGetBalances, "Failed to get balances", err)
 
@@ -477,7 +477,7 @@ func (handler *TransactionHandler) commitOrCancelTransaction(c *fiber.Ctx, tran 
 		Description: &transactionStatus,
 	}
 
-	operations, preBalances, err := handler.BuildOperations(ctx, balancesBefore, fromTo, transactionInput, *tran, validate, time.Now(), false, ledgerSettings.Accounting.ValidateRoutes)
+	operations, preBalances, err := handler.BuildOperations(ctx, balancesBefore, fromTo, transactionInput, *tran, validate, time.Now(), false, ledgerSettings.Accounting.ValidateRoutes, routeCache)
 	if err != nil {
 		libOpentelemetry.HandleSpanError(span, "Failed to validate balances", err)
 

--- a/components/transaction/internal/bootstrap/redis.consumer.go
+++ b/components/transaction/internal/bootstrap/redis.consumer.go
@@ -28,6 +28,7 @@ import (
 	"github.com/LerianStudio/midaz/v3/pkg/mmodel"
 	pkgTransaction "github.com/LerianStudio/midaz/v3/pkg/transaction"
 	"github.com/LerianStudio/midaz/v3/pkg/utils"
+	"github.com/google/uuid"
 )
 
 const (
@@ -389,10 +390,26 @@ func (r *RedisQueueConsumer) processMessage(ctx context.Context, key string, m m
 
 		ledgerSettings := r.TransactionHandler.Query.GetLedgerSettings(msgCtxWithSpan, m.OrganizationID, m.LedgerID)
 
+		var routeCache *mmodel.TransactionRouteCache
+
+		if ledgerSettings.Accounting.ValidateRoutes && m.Validate.TransactionRoute != "" {
+			trID, parseErr := uuid.Parse(m.Validate.TransactionRoute)
+			if parseErr != nil {
+				logger.Log(ctx, libLog.LevelDebug, fmt.Sprintf("Failed to parse TransactionRoute UUID %s: %v", m.Validate.TransactionRoute, parseErr))
+			} else {
+				cache, cacheErr := r.TransactionHandler.Query.GetOrCreateTransactionRouteCache(msgCtxWithSpan, m.OrganizationID, m.LedgerID, trID)
+				if cacheErr != nil {
+					logger.Log(ctx, libLog.LevelDebug, fmt.Sprintf("Failed to get route cache for org=%s ledger=%s route=%s: %v", m.OrganizationID, m.LedgerID, trID, cacheErr))
+				} else {
+					routeCache = &cache
+				}
+			}
+		}
+
 		var buildErr error
 
 		operations, _, buildErr = r.TransactionHandler.BuildOperations(
-			msgCtxWithSpan, balances, fromTo, m.TransactionInput, *tran, m.Validate, m.TransactionDate, m.TransactionStatus == constant.NOTED, ledgerSettings.Accounting.ValidateRoutes,
+			msgCtxWithSpan, balances, fromTo, m.TransactionInput, *tran, m.Validate, m.TransactionDate, m.TransactionStatus == constant.NOTED, ledgerSettings.Accounting.ValidateRoutes, routeCache,
 		)
 		if buildErr != nil {
 			libOpentelemetry.HandleSpanError(msgSpan, "Failed to validate balances", buildErr)


### PR DESCRIPTION
## Summary

- RouteCode was wired through DB, Redis, and API response but never populated at creation time — operations always returned `routeCode: null`
- The transaction route cache from `ValidateAccountingRules` was being discarded (`_`) at both call sites, so `BuildOperations` had no way to resolve the code
- This fix captures the cache, passes it through, and resolves each operation's RouteCode from its RouteID via a new `resolveRouteCodesFromCache` function

## Changes

### Core fix
- **transaction-creation-helpers.go** — added `transactionRouteCache` parameter to `BuildOperations`; added `resolveRouteCodesFromCache` that scans Source/Destination/Bidirectional maps per action to populate `RouteCode` on each operation
- **transaction-creation-helpers.go** — capture `routeCache` from `GetBalances` (was `_`) and pass it to `BuildOperations`
- **transaction-state-handlers.go** — same: capture and pass `routeCache` for the commit/cancel/revert path

### Redis consumer
- **redis.consumer.go** — fetch route cache via `GetOrCreateTransactionRouteCache` in the write-behind consumer path; added debug-level logging when UUID parse or cache retrieval fails

### Housekeeping
- Renamed `transaction_creation_helpers.go` → `transaction-creation-helpers.go` and `transaction_state_handlers.go` → `transaction-state-handlers.go` (kebab-case per project convention)
### Tests
- 7 new unit tests for `resolveRouteCodesFromCache` covering nil cache, nil/empty RouteID, source/destination/bidirectional resolution, multiple operations, and unknown route IDs