### PR TITLE
ci: force ledger rebuild to sync image with beta.59

### DIFF
--- a/components/ledger/Dockerfile
+++ b/components/ledger/Dockerfile
@@ -1,4 +1,5 @@
 FROM --platform=$BUILDPLATFORM golang:1.25.8-alpine AS builder
+# ci: force rebuild to sync ledger image with beta.59
 
 WORKDIR /ledger-app
 


### PR DESCRIPTION
## Context

The ledger image on Firmino dev is stuck at `3.6.0-beta.56` even though the latest beta is `59`.

**Root cause:** betas 57, 58 and 59 only modified `components/transaction`. The build pipeline detects changes per-component and skips unchanged ones, so `lerianstudio/midaz-ledger:3.6.0-beta.{57,58,59}` were never built or pushed to Docker Hub. The GitOps update job follows the same logic and never updated the ledger tag in `values.yaml`.

**This PR:** adds a no-op comment to `components/ledger/Dockerfile` to trigger a build, so the ledger image gets published at whatever beta version is current when this merges.

**Follow-up:** we should look into a way to force a full rebuild of all components on a new beta tag, without requiring a code change in each component. Tracked separately.