### PR TITLE
chore(deps): bump lib-commons to v4.1.0-beta.10

### DIFF
--- a/components/crm/Dockerfile
+++ b/components/crm/Dockerfile
@@ -1,4 +1,5 @@
-# syntax=docker/dockerfile:1.4 
+# syntax=docker/dockerfile:1.4
+# ci: force rebuild to sync crm image with lib-commons beta.10
 
 FROM --platform=$BUILDPLATFORM golang:1.25.8-alpine AS builder
 

--- a/components/ledger/Dockerfile
+++ b/components/ledger/Dockerfile
@@ -1,5 +1,5 @@
 FROM --platform=$BUILDPLATFORM golang:1.25.8-alpine AS builder
-# ci: force rebuild to sync ledger image with beta.59
+# ci: force rebuild to sync ledger image with beta.10
 
 WORKDIR /ledger-app
 

--- a/go.mod
+++ b/go.mod
@@ -100,7 +100,7 @@ require (
 )
 
 require (
-	github.com/LerianStudio/lib-commons/v4 v4.1.0-beta.9
+	github.com/LerianStudio/lib-commons/v4 v4.1.0-beta.10
 	github.com/Shopify/toxiproxy/v2 v2.12.0
 	github.com/docker/docker v28.5.2+incompatible
 	github.com/docker/go-connections v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -19,8 +19,8 @@ github.com/KyleBanks/depth v1.2.1 h1:5h8fQADFrWtarTdtDudMmGsC7GPbOAu6RVB3ffsVFHc
 github.com/KyleBanks/depth v1.2.1/go.mod h1:jzSb9d0L43HxTQfT+oSA1EEp2q+ne2uh6XgeJcm8brE=
 github.com/LerianStudio/lib-auth/v2 v2.5.0-beta.8 h1:Cl8e8hXgxVVavy2/f6goUxmVyOnTXSwsrqSHOJJTTW0=
 github.com/LerianStudio/lib-auth/v2 v2.5.0-beta.8/go.mod h1:xdXYO1Ncgf++1WAHKZYPCs7YPrcvVt3/zso/X+qUuaI=
-github.com/LerianStudio/lib-commons/v4 v4.1.0-beta.9 h1:XcHPbySG7K63MndkFNuSTrurJVpNIzf1iXuSU8WaftE=
-github.com/LerianStudio/lib-commons/v4 v4.1.0-beta.9/go.mod h1:WMQ17ouiJ13uUVhH/eY+p++4xb/NOtR44yIMGZ0r8Ow=
+github.com/LerianStudio/lib-commons/v4 v4.1.0-beta.10 h1:TWVgforICH6KWpXAu3HSAjWz/0+7/uchn2kIFyNSEmk=
+github.com/LerianStudio/lib-commons/v4 v4.1.0-beta.10/go.mod h1:WMQ17ouiJ13uUVhH/eY+p++4xb/NOtR44yIMGZ0r8Ow=
 github.com/Masterminds/squirrel v1.5.4 h1:uUcX/aBc8O7Fg9kaISIUsHXdKuqehiXAMQTYX8afzqM=
 github.com/Masterminds/squirrel v1.5.4/go.mod h1:NNaOrjSoIDfDA40n7sr2tPNZRfjzjA400rg+riTZj10=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=


### PR DESCRIPTION
## Summary

Bumps `lib-commons` from `v4.1.0-beta.9` → `v4.1.0-beta.10`.

### What's included in beta.10
- fix: revert Ping response from `"pong"` → `"healthy"` for lib-auth compatibility ([#363](https://github.com/LerianStudio/lib-commons/pull/363))
- fix: propagate `AllowInsecureHTTP` to internal tenant manager client ([#357](https://github.com/LerianStudio/lib-commons/pull/357))
- fix(otel): normalize endpoint URL and infer insecure mode from scheme ([#362](https://github.com/LerianStudio/lib-commons/pull/362))
- fix(mongo): default `authSource=admin` in `buildMongoURI` ([#361](https://github.com/LerianStudio/lib-commons/pull/361))

### Why
The health check endpoint in lib-commons was returning `"pong"` while lib-auth expects `"healthy"`. This PR brings Midaz in sync with the correct response.