### PR TITLE
fix: propagate AccountingEntries on operation route update

### DIFF
--- a/components/transaction/internal/services/command/update-operation-route.go
+++ b/components/transaction/internal/services/command/update-operation-route.go
@@ -29,10 +29,11 @@ func (uc *UseCase) UpdateOperationRoute(ctx context.Context, organizationID, led
 	logger.Log(ctx, libLog.LevelInfo, fmt.Sprintf("Trying to update operation route: %v", input))
 
 	operationRoute := &mmodel.OperationRoute{
-		Title:       input.Title,
-		Description: input.Description,
-		Code:        input.Code,
-		Account:     input.Account,
+		Title:             input.Title,
+		Description:       input.Description,
+		Code:              input.Code,
+		Account:           input.Account,
+		AccountingEntries: input.AccountingEntries,
 	}
 
 	operationRouteUpdated, err := uc.OperationRouteRepo.Update(ctx, organizationID, ledgerID, id, operationRoute)


### PR DESCRIPTION
## Summary

- The `UpdateOperationRoute` use case was building the `OperationRoute` entity without the `AccountingEntries` field, causing PATCH requests with `accountingEntries` to be silently ignored despite passing HTTP validation and the repository already supporting persistence.

## Changes

- Added `AccountingEntries: input.AccountingEntries` to the struct literal in `update-operation-route.go`

## Known limitations

This fix resolves the first layer of the problem. Two additional issues remain and will be addressed in follow-up PRs:

1. The repository does full column replacement instead of JSON merge, so partial `accountingEntries` updates overwrite the entire column
2. The `WithBody` middleware rejects `null` values in `accountingEntries` fields, preventing removal via JSON Merge Patch semantics