### PR TITLE
fix: implement RFC 7396 JSON Merge Patch for accounting_entries with validation

### DIFF
--- a/components/transaction/internal/adapters/http/in/operation-route-validation_test.go
+++ b/components/transaction/internal/adapters/http/in/operation-route-validation_test.go
@@ -6,6 +6,7 @@ package in
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 
 	"github.com/LerianStudio/midaz/v3/pkg/mmodel"
@@ -144,6 +145,93 @@ func TestOperationRouteHandler_validateAccountingEntries(t *testing.T) {
 				assert.Contains(t, err.Error(), tt.errorField, "error message should reference the invalid field path")
 			} else {
 				require.NoError(t, err, "expected no validation error")
+			}
+		})
+	}
+}
+
+func TestFindUnknownAccountingEntryKeys(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		raw        json.RawMessage
+		expectNil  bool
+		expectKeys []string
+	}{
+		{
+			name:       "all valid keys",
+			raw:        json.RawMessage(`{"direct":{"debit":{}},"hold":{"debit":{}},"commit":{"debit":{}},"cancel":{"debit":{}},"revert":{"debit":{}}}`),
+			expectNil:  true,
+			expectKeys: nil,
+		},
+		{
+			name:       "single valid key",
+			raw:        json.RawMessage(`{"direct":{"debit":{"code":"1001"}}}`),
+			expectNil:  true,
+			expectKeys: nil,
+		},
+		{
+			name:       "valid key with null value",
+			raw:        json.RawMessage(`{"hold":null}`),
+			expectNil:  true,
+			expectKeys: nil,
+		},
+		{
+			name:       "unknown key with value",
+			raw:        json.RawMessage(`{"foobar":{"debit":{"code":"1001"}}}`),
+			expectNil:  false,
+			expectKeys: []string{"foobar"},
+		},
+		{
+			name:       "unknown key with null value",
+			raw:        json.RawMessage(`{"foobar":null}`),
+			expectNil:  false,
+			expectKeys: []string{"foobar"},
+		},
+		{
+			name:       "mix of valid and unknown keys",
+			raw:        json.RawMessage(`{"direct":{"debit":{}},"foobar":{"debit":{}},"hold":null}`),
+			expectNil:  false,
+			expectKeys: []string{"foobar"},
+		},
+		{
+			name:       "multiple unknown keys",
+			raw:        json.RawMessage(`{"foo":{"debit":{}},"bar":null,"direct":{"debit":{}}}`),
+			expectNil:  false,
+			expectKeys: []string{"bar", "foo"},
+		},
+		{
+			name:       "empty object",
+			raw:        json.RawMessage(`{}`),
+			expectNil:  true,
+			expectKeys: nil,
+		},
+		{
+			name:       "invalid JSON returns nil",
+			raw:        json.RawMessage(`{invalid}`),
+			expectNil:  true,
+			expectKeys: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			result := findUnknownAccountingEntryKeys(tt.raw)
+
+			if tt.expectNil {
+				assert.Nil(t, result, "expected nil for valid keys")
+			} else {
+				require.NotNil(t, result, "expected unknown keys to be detected")
+
+				var actualKeys []string
+				for k := range result {
+					actualKeys = append(actualKeys, k)
+				}
+
+				assert.ElementsMatch(t, tt.expectKeys, actualKeys, "unexpected keys mismatch")
 			}
 		})
 	}

--- a/components/transaction/internal/adapters/http/in/operation-route.go
+++ b/components/transaction/internal/adapters/http/in/operation-route.go
@@ -6,6 +6,7 @@ package in
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"reflect"
 	"strings"
@@ -78,6 +79,24 @@ func (handler *OperationRouteHandler) CreateOperationRoute(i any, c *fiber.Ctx) 
 
 	if err := handler.validateAccountingEntries(ctx, payload.AccountingEntries); err != nil {
 		return http.WithError(c, err)
+	}
+
+	// Reject unknown keys inside accountingEntries (e.g., "foobar") that Go's
+	// json.Unmarshal silently ignores but could confuse clients into thinking
+	// their data was accepted.
+	if payload.AccountingEntries != nil {
+		var rawBody map[string]json.RawMessage
+
+		if err := json.Unmarshal(c.Body(), &rawBody); err == nil {
+			if raw, ok := rawBody["accountingEntries"]; ok {
+				if unknowns := findUnknownAccountingEntryKeys(raw); len(unknowns) > 0 {
+					return http.WithError(c, pkg.ValidateBadRequestFieldsError(
+						pkg.FieldValidations{}, pkg.FieldValidations{}, "",
+						map[string]any{"accountingEntries": unknowns},
+					))
+				}
+			}
+		}
 	}
 
 	operationRoute, err := handler.Command.CreateOperationRoute(ctx, organizationID, ledgerID, payload)
@@ -208,6 +227,26 @@ func (handler *OperationRouteHandler) UpdateOperationRoute(i any, c *fiber.Ctx) 
 
 	if err := handler.validateAccountingEntries(ctx, payload.AccountingEntries); err != nil {
 		return http.WithError(c, err)
+	}
+
+	// Extract the raw JSON for accountingEntries from the request body to preserve
+	// explicit null values for RFC 7396 JSON Merge Patch semantics. This allows the
+	// repository to distinguish "field absent" (keep existing) from "field: null" (remove).
+	if payload.AccountingEntries != nil {
+		var rawBody map[string]json.RawMessage
+
+		if err := json.Unmarshal(c.Body(), &rawBody); err == nil {
+			if raw, ok := rawBody["accountingEntries"]; ok {
+				if unknowns := findUnknownAccountingEntryKeys(raw); len(unknowns) > 0 {
+					return http.WithError(c, pkg.ValidateBadRequestFieldsError(
+						pkg.FieldValidations{}, pkg.FieldValidations{}, "",
+						map[string]any{"accountingEntries": unknowns},
+					))
+				}
+
+				payload.AccountingEntriesRaw = raw
+			}
+		}
 	}
 
 	recordSafePayloadAttributes(span, payload)
@@ -580,4 +619,38 @@ func (handler *OperationRouteHandler) validateAccountingEntries(ctx context.Cont
 	}
 
 	return nil
+}
+
+// validAccountingEntryKeys defines the allowed top-level keys inside accountingEntries.
+var validAccountingEntryKeys = map[string]struct{}{
+	"direct": {},
+	"hold":   {},
+	"commit": {},
+	"cancel": {},
+	"revert": {},
+}
+
+// findUnknownAccountingEntryKeys parses the raw JSON for accountingEntries and returns
+// a map of keys that are not in the allowed set (direct, hold, commit, cancel, revert).
+// Returns nil when all keys are valid. The returned map is suitable for use with
+// ValidateBadRequestFieldsError to produce a standard 0053 "Unexpected Fields" error.
+func findUnknownAccountingEntryKeys(raw json.RawMessage) map[string]any {
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &fields); err != nil {
+		return nil
+	}
+
+	unknowns := make(map[string]any)
+
+	for key := range fields {
+		if _, ok := validAccountingEntryKeys[key]; !ok {
+			unknowns[key] = string(fields[key])
+		}
+	}
+
+	if len(unknowns) == 0 {
+		return nil
+	}
+
+	return unknowns
 }

--- a/components/transaction/internal/adapters/postgres/operationroute/merge_patch_test.go
+++ b/components/transaction/internal/adapters/postgres/operationroute/merge_patch_test.go
@@ -1,0 +1,152 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package operationroute
+
+import (
+	"encoding/json"
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSplitMergePatch(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name             string
+		raw              json.RawMessage
+		expectMergeKeys  []string
+		expectRemoveKeys []string
+		expectMergeNil   bool
+	}{
+		{
+			name:             "only_non_null_keys_go_to_merge",
+			raw:              json.RawMessage(`{"direct":{"debit":{"code":"1001","description":"Cash"},"credit":{"code":"2001","description":"Revenue"}}}`),
+			expectMergeKeys:  []string{"direct"},
+			expectRemoveKeys: nil,
+			expectMergeNil:   false,
+		},
+		{
+			name:             "only_null_keys_go_to_remove",
+			raw:              json.RawMessage(`{"hold":null,"cancel":null}`),
+			expectMergeKeys:  nil,
+			expectRemoveKeys: []string{"cancel", "hold"},
+			expectMergeNil:   true,
+		},
+		{
+			name:             "mix_of_merge_and_remove",
+			raw:              json.RawMessage(`{"direct":{"debit":{"code":"1001"},"credit":{"code":"2001"}},"hold":null}`),
+			expectMergeKeys:  []string{"direct"},
+			expectRemoveKeys: []string{"hold"},
+			expectMergeNil:   false,
+		},
+		{
+			name:             "empty_object_returns_nil_for_both",
+			raw:              json.RawMessage(`{}`),
+			expectMergeKeys:  nil,
+			expectRemoveKeys: nil,
+			expectMergeNil:   true,
+		},
+		{
+			name:             "multiple_non_null_entries",
+			raw:              json.RawMessage(`{"direct":{"debit":{"code":"1001"}},"hold":{"debit":{"code":"1002"}},"commit":{"debit":{"code":"1003"}}}`),
+			expectMergeKeys:  []string{"commit", "direct", "hold"},
+			expectRemoveKeys: nil,
+			expectMergeNil:   false,
+		},
+		{
+			name:             "all_keys_null",
+			raw:              json.RawMessage(`{"direct":null,"hold":null,"commit":null,"cancel":null,"revert":null}`),
+			expectMergeKeys:  nil,
+			expectRemoveKeys: []string{"cancel", "commit", "direct", "hold", "revert"},
+			expectMergeNil:   true,
+		},
+		{
+			name:             "update_and_remove_simultaneously",
+			raw:              json.RawMessage(`{"direct":{"debit":{"code":"9999"},"credit":{"code":"8888"}},"hold":null,"commit":{"debit":{"code":"7777"}}}`),
+			expectMergeKeys:  []string{"commit", "direct"},
+			expectRemoveKeys: []string{"hold"},
+			expectMergeNil:   false,
+		},
+		{
+			name:             "invalid_json_returns_raw_as_merge",
+			raw:              json.RawMessage(`{invalid}`),
+			expectMergeKeys:  nil, // can't parse, returned as-is
+			expectRemoveKeys: nil,
+			expectMergeNil:   false, // raw is returned as mergeJSON
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			mergeJSON, removeKeys := splitMergePatch(tt.raw)
+
+			// Verify removeKeys
+			sort.Strings(removeKeys)
+			sort.Strings(tt.expectRemoveKeys)
+			assert.Equal(t, tt.expectRemoveKeys, removeKeys, "removeKeys mismatch")
+
+			// Verify mergeJSON
+			if tt.expectMergeNil {
+				assert.Nil(t, mergeJSON, "mergeJSON should be nil")
+			} else {
+				require.NotNil(t, mergeJSON, "mergeJSON should not be nil")
+
+				if tt.name == "invalid_json_returns_raw_as_merge" {
+					// For invalid JSON, the raw input is returned as-is
+					assert.Equal(t, []byte(tt.raw), mergeJSON)
+				} else {
+					// Parse and verify keys
+					var parsed map[string]json.RawMessage
+					err := json.Unmarshal(mergeJSON, &parsed)
+					require.NoError(t, err, "mergeJSON should be valid JSON")
+
+					var actualKeys []string
+					for k := range parsed {
+						actualKeys = append(actualKeys, k)
+					}
+					sort.Strings(actualKeys)
+
+					assert.Equal(t, tt.expectMergeKeys, actualKeys, "merge keys mismatch")
+
+					// Verify no null values in merge output
+					for k, v := range parsed {
+						assert.NotEqual(t, "null", string(v), "key %q should not have null value in mergeJSON", k)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestSplitMergePatch_PreservesNestedStructure(t *testing.T) {
+	t.Parallel()
+
+	raw := json.RawMessage(`{"direct":{"debit":{"code":"1001","description":"Cash"},"credit":{"code":"2001","description":"Revenue"}}}`)
+
+	mergeJSON, removeKeys := splitMergePatch(raw)
+
+	assert.Nil(t, removeKeys)
+	require.NotNil(t, mergeJSON)
+
+	// Verify the nested structure is preserved exactly
+	var parsed map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(mergeJSON, &parsed))
+
+	directRaw, ok := parsed["direct"]
+	require.True(t, ok, "direct key should exist")
+
+	var entry map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(directRaw, &entry))
+
+	_, hasDebit := entry["debit"]
+	_, hasCredit := entry["credit"]
+	assert.True(t, hasDebit, "debit should be preserved")
+	assert.True(t, hasCredit, "credit should be preserved")
+}

--- a/components/transaction/internal/adapters/postgres/operationroute/operationroute.postgresql.go
+++ b/components/transaction/internal/adapters/postgres/operationroute/operationroute.postgresql.go
@@ -7,6 +7,7 @@ package operationroute
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"reflect"
@@ -29,6 +30,7 @@ import (
 	"github.com/bxcodec/dbresolver/v2"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/lib/pq"
 
 	// Repository provides an interface for operations related to operation route entities.
 	// It defines methods for creating, retrieving, updating, and deleting operation routes.
@@ -393,8 +395,27 @@ func (r *OperationRoutePostgreSQLRepository) Update(ctx context.Context, organiz
 		}
 	}
 
-	if record.AccountingEntries != nil {
-		updates = append(updates, "accounting_entries = $"+strconv.Itoa(len(args)+1))
+	if rawJSON := operationRoute.AccountingEntriesRaw; len(rawJSON) > 0 {
+		mergeJSON, removeKeys := splitMergePatch(rawJSON)
+
+		if len(mergeJSON) > 0 {
+			paramIdx := strconv.Itoa(len(args) + 1)
+			expr := "COALESCE(accounting_entries, '{}'::jsonb) || $" + paramIdx + "::jsonb"
+			args = append(args, mergeJSON)
+
+			if len(removeKeys) > 0 {
+				expr += " - $" + strconv.Itoa(len(args)+1) + "::text[]"
+				args = append(args, pq.Array(removeKeys))
+			}
+
+			updates = append(updates, "accounting_entries = "+expr)
+		} else if len(removeKeys) > 0 {
+			paramIdx := strconv.Itoa(len(args) + 1)
+			updates = append(updates, "accounting_entries = COALESCE(accounting_entries, '{}'::jsonb) - $"+paramIdx+"::text[]")
+			args = append(args, pq.Array(removeKeys))
+		}
+	} else if record.AccountingEntries != nil {
+		updates = append(updates, "accounting_entries = COALESCE(accounting_entries, '{}'::jsonb) || $"+strconv.Itoa(len(args)+1)+"::jsonb")
 		args = append(args, record.AccountingEntries)
 	}
 
@@ -720,4 +741,36 @@ func (r *OperationRoutePostgreSQLRepository) FindTransactionRouteIDs(ctx context
 	}
 
 	return transactionRouteIDs, nil
+}
+
+// splitMergePatch separates a raw JSON object into two parts for RFC 7396 merge-patch:
+//   - mergeJSON: a JSON object containing only the keys with non-null values (for JSONB || merge)
+//   - removeKeys: a list of keys whose value is explicitly null (for JSONB - removal)
+//
+// Example: {"direct":{"debit":{...}},"hold":null}
+//   - mergeJSON = {"direct":{"debit":{...}}}
+//   - removeKeys = ["hold"]
+func splitMergePatch(raw json.RawMessage) (mergeJSON []byte, removeKeys []string) {
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &fields); err != nil {
+		// If we can't parse it, return the raw as merge (fallback to full replacement)
+		return raw, nil
+	}
+
+	merge := make(map[string]json.RawMessage, len(fields))
+
+	for k, v := range fields {
+		trimmed := strings.TrimSpace(string(v))
+		if trimmed == "null" {
+			removeKeys = append(removeKeys, k)
+		} else {
+			merge[k] = v
+		}
+	}
+
+	if len(merge) > 0 {
+		mergeJSON, _ = json.Marshal(merge)
+	}
+
+	return mergeJSON, removeKeys
 }

--- a/components/transaction/internal/adapters/postgres/operationroute/operationroute.postgresql.go
+++ b/components/transaction/internal/adapters/postgres/operationroute/operationroute.postgresql.go
@@ -401,6 +401,7 @@ func (r *OperationRoutePostgreSQLRepository) Update(ctx context.Context, organiz
 		if len(mergeJSON) > 0 {
 			paramIdx := strconv.Itoa(len(args) + 1)
 			expr := "COALESCE(accounting_entries, '{}'::jsonb) || $" + paramIdx + "::jsonb"
+
 			args = append(args, mergeJSON)
 
 			if len(removeKeys) > 0 {

--- a/components/transaction/internal/adapters/postgres/operationroute/operationroute.postgresql.go
+++ b/components/transaction/internal/adapters/postgres/operationroute/operationroute.postgresql.go
@@ -770,7 +770,11 @@ func splitMergePatch(raw json.RawMessage) (mergeJSON []byte, removeKeys []string
 	}
 
 	if len(merge) > 0 {
-		mergeJSON, _ = json.Marshal(merge)
+		var err error
+		if mergeJSON, err = json.Marshal(merge); err != nil {
+			// If we can't re-serialize, fall back to the raw input (full replacement)
+			return raw, nil
+		}
 	}
 
 	return mergeJSON, removeKeys

--- a/components/transaction/internal/services/command/update-operation-route.go
+++ b/components/transaction/internal/services/command/update-operation-route.go
@@ -29,11 +29,12 @@ func (uc *UseCase) UpdateOperationRoute(ctx context.Context, organizationID, led
 	logger.Log(ctx, libLog.LevelInfo, fmt.Sprintf("Trying to update operation route: %v", input))
 
 	operationRoute := &mmodel.OperationRoute{
-		Title:             input.Title,
-		Description:       input.Description,
-		Code:              input.Code,
-		Account:           input.Account,
-		AccountingEntries: input.AccountingEntries,
+		Title:                input.Title,
+		Description:          input.Description,
+		Code:                 input.Code,
+		Account:              input.Account,
+		AccountingEntries:    input.AccountingEntries,
+		AccountingEntriesRaw: input.AccountingEntriesRaw,
 	}
 
 	operationRouteUpdated, err := uc.OperationRouteRepo.Update(ctx, organizationID, ledgerID, id, operationRoute)

--- a/pkg/mmodel/operation-route.go
+++ b/pkg/mmodel/operation-route.go
@@ -5,6 +5,7 @@
 package mmodel
 
 import (
+	"encoding/json"
 	"time"
 
 	"github.com/google/uuid"
@@ -100,6 +101,9 @@ type OperationRoute struct {
 	Action string `json:"action,omitempty" example:"direct" enums:"direct,hold,commit,cancel,revert"`
 	// Optional accounting entries for each action type associated with this operation route.
 	AccountingEntries *AccountingEntries `json:"accountingEntries,omitempty"`
+	// AccountingEntriesRaw holds the raw JSON for accountingEntries for merge-patch updates.
+	// This is not serialized to API responses; it is only used internally during updates.
+	AccountingEntriesRaw json.RawMessage `json:"-"`
 	// Additional metadata stored as JSON
 	Metadata map[string]any `json:"metadata,omitempty" validate:"dive,keys,keymax=100,endkeys,omitempty,nonested,valuemax=2000"`
 	// The account selection rule configuration.
@@ -145,6 +149,11 @@ type UpdateOperationRouteInput struct {
 	Code string `json:"code,omitempty" validate:"max=100" example:"EXT-001"`
 	// Optional accounting entries for each action type associated with this operation route.
 	AccountingEntries *AccountingEntries `json:"accountingEntries,omitempty"`
+	// AccountingEntriesRaw holds the raw JSON for accountingEntries exactly as sent in the request.
+	// This preserves explicit null values for RFC 7396 JSON Merge Patch semantics,
+	// allowing the repository to distinguish between "field absent" (keep existing)
+	// and "field: null" (remove entry).
+	AccountingEntriesRaw json.RawMessage `json:"-"`
 	// Additional metadata stored as JSON
 	Metadata map[string]any `json:"metadata" validate:"dive,keys,keymax=100,endkeys,omitempty,nonested,valuemax=2000"`
 	// The account selection rule configuration.

--- a/pkg/net/http/withBody.go
+++ b/pkg/net/http/withBody.go
@@ -849,6 +849,7 @@ func FindUnknownFields(original, marshaled map[string]any) map[string]any {
 			}
 
 			diffFields[key] = value
+
 			continue
 		}
 

--- a/pkg/net/http/withBody.go
+++ b/pkg/net/http/withBody.go
@@ -840,6 +840,14 @@ func FindUnknownFields(original, marshaled map[string]any) map[string]any {
 
 		marshaledValue, ok := marshaled[key]
 		if !ok {
+			// A nil value in the original means the client explicitly sent "field": null.
+			// When the struct uses omitempty, json.Marshal omits nil pointer fields, so
+			// the key disappears from the marshaled map. This is not an unknown field —
+			// it is a valid RFC 7396 JSON Merge Patch request to remove/null-out the field.
+			if value == nil {
+				continue
+			}
+
 			diffFields[key] = value
 			continue
 		}

--- a/pkg/net/http/withBody_test.go
+++ b/pkg/net/http/withBody_test.go
@@ -269,6 +269,59 @@ func TestFindUnknownFields(t *testing.T) {
 				"amount": "200.45",
 			},
 		},
+		{
+			name: "null value in original is not an unknown field",
+			original: map[string]any{
+				"name":  "John",
+				"email": nil,
+			},
+			marshaled: map[string]any{
+				"name": "John",
+			},
+			expected: map[string]any{},
+		},
+		{
+			name: "nested null value in original is not an unknown field",
+			original: map[string]any{
+				"accountingEntries": map[string]any{
+					"direct": map[string]any{"code": "1001"},
+					"hold":   nil,
+				},
+			},
+			marshaled: map[string]any{
+				"accountingEntries": map[string]any{
+					"direct": map[string]any{"code": "1001"},
+				},
+			},
+			expected: map[string]any{},
+		},
+		{
+			name: "non-null missing field is still unknown",
+			original: map[string]any{
+				"name":    "John",
+				"unknown": "value",
+			},
+			marshaled: map[string]any{
+				"name": "John",
+			},
+			expected: map[string]any{
+				"unknown": "value",
+			},
+		},
+		{
+			name: "mixed null and non-null unknown fields",
+			original: map[string]any{
+				"name":       "John",
+				"nullField":  nil,
+				"extraField": "not allowed",
+			},
+			marshaled: map[string]any{
+				"name": "John",
+			},
+			expected: map[string]any{
+				"extraField": "not allowed",
+			},
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
## Summary

Implements RFC 7396 JSON Merge Patch semantics for `accountingEntries` updates on operation routes, fixing data loss when partial updates are sent. Adds validation to reject unknown entry keys and middleware tolerance for explicit null values.

## Changes

### 1. **JSONB Merge-Patch in Repository** (Closes MDZ-1926)

- Changed `SET accounting_entries = $N` (full replacement) to `COALESCE(accounting_entries, '{}') || $N::jsonb` (merge) plus key removal with `- $N::text[]`
- Handler extracts raw JSON from request body to preserve the distinction between "field absent" (keep existing) and "field: null" (remove entry)
- Added `splitMergePatch` utility to separate merge operations from key removals based on null values
- Includes comprehensive test coverage for merge scenarios

**Impact**: Partial updates like `{"accountingEntries": {"direct": {...}}}` now preserve existing entries like `hold`, `commit`, etc., instead of deleting them.

### 2. **Middleware: Null-Tolerance in FindUnknownFields**

- Fields with explicit `null` values in the request body were incorrectly flagged as "Unexpected Fields" (code 0053)
- `json.Marshal` with `omitempty` drops nil pointers, making them disappear from the re-serialized map comparison
- A null value is a valid RFC 7396 signal to remove/unset a field, not an unknown field
- Added 4 test cases covering null values at top-level and nested levels

**Impact**: Clients can now send `{"accountingEntries": {"hold": null}}` to explicitly remove the hold entry without getting rejected.

### 3. **Input Validation: Unknown Keys Rejection**

- Only `"direct"`, `"hold"`, `"commit"`, `"cancel"`, and `"revert"` are valid top-level keys inside `accountingEntries`
- Unknown keys (e.g., `"foobar"`) were silently ignored by `json.Unmarshal` and, with the null fix, null-valued unknown keys could pass undetected
- Added `findUnknownAccountingEntryKeys` function to validate raw JSON in both create and update handlers
- Returns error code 0053 "Unexpected Fields" for unrecognized keys, consistent with API error conventions
- Includes 9 unit test cases

**Impact**: Invalid requests like `{"accountingEntries": {"foobar": null}}` are now rejected with clear error messaging.

## Testing

### Unit Tests Added
- `merge_patch_test.go`: 9 cases covering merge, removal, preservation, and edge cases
- `withBody_test.go`: 4 cases for null-value handling in FindUnknownFields
- `operation-route-validation_test.go`: 9 cases for unknown key detection

## Breaking Changes

None. The changes maintain backward compatibility:
- Valid payloads work as before (and now preserve unmentioned entries)
- Invalid payloads now return 400 (previously silently ignored)

## Related Issues
- Closes MDZ-1926: `accounting_entries` PATCH overwrites entire column instead of merging
- Addresses the "Known failure" scenarios

## Implementation Notes

1. The raw JSON extraction happens in the HTTP handler after all validation passes, ensuring safety
2. Merge semantics operate at the JSONB column level in Postgres for data consistency
3. The `omitempty` struct tag is preserved to avoid serializing unnecessary null values in API responses
4. All 5 accounting entry action types are validated consistently (direct, hold, commit, cancel, revert)