### PR TITLE
chore(ledger): force rebuild for develop branch

### DIFF
--- a/components/ledger/Dockerfile
+++ b/components/ledger/Dockerfile
@@ -1,5 +1,6 @@
 FROM --platform=$BUILDPLATFORM golang:1.25.8-alpine AS builder
 # ci: force rebuild
+# Force rebuild for develop branch - 2026-03-20
 
 WORKDIR /ledger-app
 


### PR DESCRIPTION
## Context

The ledger image on Firmino dev is stuck at beta.56 because builds beta.57-59 only touched the `transaction` component. The CI pipeline skips components without changes, so `lerianstudio/midaz-ledger:3.6.0-beta.{57,58,59}` were never published to Docker Hub.

## Change

Add a comment to the ledger Dockerfile to trigger a fresh image build on the develop branch.

## Related

Similar to #1922 but targeting `develop` branch.