### PR TITLE
fix: enable cross-module PG injection for onboarding middleware in unified mode

### DIFF
--- a/components/ledger/internal/bootstrap/config.go
+++ b/components/ledger/internal/bootstrap/config.go
@@ -309,15 +309,37 @@ func buildUnifiedRouteSetup(
 		return setup, nil
 	}
 
-	onboardingMiddleware, err := buildModuleTenantMiddleware(
-		"onboarding",
-		logger,
-		onboardingService.GetPGManager(),
-		onboardingService.GetMongoManager(),
-	)
-	if err != nil {
-		return nil, err
+	onboardingPGManager, ok := onboardingService.GetPGManager().(*tmpostgres.Manager)
+	if !ok || onboardingPGManager == nil {
+		return nil, fmt.Errorf("onboarding multi-tenant PostgreSQL manager not available")
 	}
+
+	onboardingMongoManager, ok := onboardingService.GetMongoManager().(*tmmongo.Manager)
+	if !ok || onboardingMongoManager == nil {
+		return nil, fmt.Errorf("onboarding multi-tenant MongoDB manager not available")
+	}
+
+	transactionPGManager, ok := transactionService.GetPGManager().(*tmpostgres.Manager)
+	if !ok || transactionPGManager == nil {
+		return nil, fmt.Errorf("transaction multi-tenant PostgreSQL manager not available")
+	}
+
+	// Build onboarding middleware with cross-module injection so that
+	// in-process calls from onboarding into the transaction module
+	// (e.g. CreateAccount → CreateBalanceSync) find the "transaction"
+	// PG connection already present in the request context.
+	onboardingMiddleware := tmmiddleware.NewMultiPoolMiddleware(
+		tmmiddleware.WithDefaultRoute("onboarding", onboardingPGManager, onboardingMongoManager),
+		tmmiddleware.WithRoute(nil, "transaction", transactionPGManager, nil),
+		tmmiddleware.WithCrossModuleInjection(),
+		tmmiddleware.WithMultiPoolLogger(logger),
+		tmmiddleware.WithErrorMapper(midazErrorMapper),
+	)
+
+	logger.Log(context.Background(), libLog.LevelInfo, "Module-scoped tenant middleware configured",
+		libLog.String("module", "onboarding"),
+		libLog.Bool("cross_module_injection", true),
+	)
 
 	transactionMiddleware, err := buildModuleTenantMiddleware(
 		"transaction",


### PR DESCRIPTION
## Summary

- Fixes "tenant postgres connection missing from context" errors when `CreateAccount` (onboarding) calls `CreateBalanceSync` (transaction) in-process during unified mode
- Registers the transaction PG pool on the onboarding middleware using `WithRoute` + `WithCrossModuleInjection()` from lib-commons v4, so both module connections are resolved and injected into context on every onboarding request

## Root cause

In unified mode, each module's `MultiPoolMiddleware` only injected its own PG connection into the context. When the onboarding handler called into the transaction module's balance repository in-process (without going through an HTTP boundary), the context lacked the `tenantPGConnection:transaction` key, causing `getDB()` in `balance.postgresql.go` to fail.

## What changed

`components/ledger/internal/bootstrap/config.go` — replaced the `buildModuleTenantMiddleware("onboarding", ...)` call in `buildUnifiedRouteSetup` with direct `NewMultiPoolMiddleware` construction that adds `WithRoute(nil, "transaction", transactionPGManager, nil)` and `WithCrossModuleInjection()`. The transaction middleware is unchanged since transaction routes don't call into onboarding.