### PR TITLE
fix: enable cross-module PG injection for transaction middleware in unified mode

### DIFF
--- a/components/ledger/internal/bootstrap/config.go
+++ b/components/ledger/internal/bootstrap/config.go
@@ -341,15 +341,29 @@ func buildUnifiedRouteSetup(
 		libLog.Bool("cross_module_injection", true),
 	)
 
-	transactionMiddleware, err := buildModuleTenantMiddleware(
-		"transaction",
-		logger,
-		transactionService.GetPGManager(),
-		transactionService.GetMongoManager(),
-	)
-	if err != nil {
-		return nil, err
+	transactionMongoManager, ok := transactionService.GetMongoManager().(*tmmongo.Manager)
+	if !ok || transactionMongoManager == nil {
+		return nil, fmt.Errorf("transaction multi-tenant MongoDB manager not available")
 	}
+
+	// Build transaction middleware with cross-module injection so that
+	// in-process calls from transaction into the onboarding module
+	// (e.g. GetLedgerSettings → SettingsPort → LedgerRepo) find the "onboarding"
+	// PG connection already present in the request context.
+	transactionMiddleware := tmmiddleware.NewMultiPoolMiddleware(
+		tmmiddleware.WithDefaultRoute("transaction", transactionPGManager, transactionMongoManager),
+		tmmiddleware.WithRoute(nil, "onboarding", onboardingPGManager, nil),
+		tmmiddleware.WithCrossModuleInjection(),
+		tmmiddleware.WithMultiPoolLogger(logger),
+		tmmiddleware.WithErrorMapper(midazErrorMapper),
+	)
+
+	logger.Log(context.Background(), libLog.LevelInfo, "Module-scoped tenant middleware configured",
+		libLog.String("module", "transaction"),
+		libLog.Bool("cross_module_injection", true),
+	)
+
+	var err error
 
 	setup.onboardingMongoManager, err = requireMongoManager("onboarding", onboardingService.GetMongoManager())
 	if err != nil {


### PR DESCRIPTION
## Summary

Symmetric fix to #1937: the transaction middleware now also resolves the onboarding PG connection into context on every transaction request.

## Root cause

`GetLedgerSettings` (transaction) calls `SettingsPort` (onboarding.QueryUseCase) → `LedgerRepo.GetSettings` → `LedgerPostgreSQLRepository.getDB`, which expects `tenantPGConnection:onboarding` in context. But requests arriving on transaction routes only had `tenantPGConnection:transaction` injected — the onboarding pool was never resolved.

## What changed

`components/ledger/internal/bootstrap/config.go` — replaced the `buildModuleTenantMiddleware("transaction", ...)` call in `buildUnifiedRouteSetup` with direct `NewMultiPoolMiddleware` construction that adds `WithRoute(nil, "onboarding", onboardingPGManager, nil)` + `WithCrossModuleInjection()`, mirroring the approach used for the onboarding middleware in #1937.

The `transactionMongoManager` type assertion (previously done inside `buildModuleTenantMiddleware`) is now explicit at the call site.

## Cross-module call chain

```
transaction route → transactionMiddleware.WithTenantDB
  → injects tenantPGConnection:transaction ✅
  → (WithCrossModuleInjection) injects tenantPGConnection:onboarding ✅
  → handler → GetLedgerSettings → SettingsPort → LedgerRepo.getDB
      → GetModulePostgresForTenant(ctx, "onboarding") ✅
```