### PR TITLE
feat: implement bulk recorder for async processing 

### DIFF
--- a/components/transaction/.env.example
+++ b/components/transaction/.env.example
@@ -177,3 +177,30 @@ RABBITMQ_CIRCUIT_BREAKER_TIMEOUT=30
 RABBITMQ_CIRCUIT_BREAKER_HEALTH_CHECK_INTERVAL=30
 # HealthCheckTimeout: Timeout for health check operation in seconds (default: 10)
 RABBITMQ_CIRCUIT_BREAKER_HEALTH_CHECK_TIMEOUT=10
+
+# BULK RECORDER
+# Bulk recorder collects multiple RabbitMQ messages before processing them together
+# for improved throughput. Only effective when RABBITMQ_TRANSACTION_ASYNC=true.
+#
+# Enable/disable bulk processing (default: true)
+BULK_RECORDER_ENABLED=true
+#
+# Messages per bulk (default: derived from RABBITMQ_NUMBERS_OF_WORKERS × RABBITMQ_NUMBERS_OF_PREFETCH)
+# IMPORTANT: For optimal performance, bulk size MUST match RabbitMQ prefetch.
+# Mismatch causes either partial bulks (size > prefetch) or memory pressure (size < prefetch).
+# Default: 5 workers × 10 prefetch = 50 messages per bulk
+# BULK_RECORDER_SIZE=50
+#
+# Max wait time before flushing incomplete bulk, in milliseconds (default: 100)
+BULK_RECORDER_FLUSH_TIMEOUT_MS=100
+#
+# Max rows per INSERT statement (default: 1000)
+# PostgreSQL has a limit of 65,535 parameters per statement.
+# Transactions have 16 columns, so 1000 rows = 16,000 params (safe).
+# Operations have 30 columns, so 1000 rows = 30,000 params (safe).
+BULK_RECORDER_MAX_ROWS_PER_INSERT=1000
+#
+# Fall back to individual inserts when bulk processing fails (default: true)
+# When enabled: on bulk failure, retries each message individually (partial success possible)
+# When disabled: on bulk failure, all messages are NACKed with requeue
+BULK_RECORDER_FALLBACK_ENABLED=true

--- a/components/transaction/internal/adapters/postgres/operation/operation.postgresql.go
+++ b/components/transaction/internal/adapters/postgres/operation/operation.postgresql.go
@@ -60,11 +60,15 @@ type Repository interface {
 	FindLastOperationsForAccountBeforeTimestamp(ctx context.Context, organizationID, ledgerID, accountID uuid.UUID, timestamp time.Time, filter http.Pagination) ([]*Operation, libHTTP.CursorPagination, error)
 }
 
+// defaultOperationChunkSize is the default maximum rows per INSERT statement to stay under PostgreSQL's 65,535 parameter limit.
+const defaultOperationChunkSize = 1000
+
 // OperationPostgreSQLRepository is a Postgresql-specific implementation of the OperationRepository.
 type OperationPostgreSQLRepository struct {
 	connection    *libPostgres.Client
 	tableName     string
 	requireTenant bool
+	chunkSize     int // Maximum rows per bulk INSERT, defaults to 1000
 }
 
 var operationColumnList = []string{
@@ -120,13 +124,44 @@ var operationPointInTimeColumns = []string{
 }
 
 // NewOperationPostgreSQLRepository returns a new instance of OperationPostgreSQLRepository using the given Postgres connection.
-func NewOperationPostgreSQLRepository(pc *libPostgres.Client, requireTenant ...bool) *OperationPostgreSQLRepository {
+// OperationRepoOption is a functional option for configuring OperationPostgreSQLRepository.
+type OperationRepoOption func(*OperationPostgreSQLRepository)
+
+// WithOperationChunkSize sets the maximum rows per bulk INSERT statement.
+// If not set or set to 0, defaults to 1000.
+func WithOperationChunkSize(size int) OperationRepoOption {
+	return func(r *OperationPostgreSQLRepository) {
+		if size > 0 {
+			r.chunkSize = size
+		}
+	}
+}
+
+// WithOperationRequireTenant configures whether tenant context is required.
+func WithOperationRequireTenant(require bool) OperationRepoOption {
+	return func(r *OperationPostgreSQLRepository) {
+		r.requireTenant = require
+	}
+}
+
+// NewOperationPostgreSQLRepository returns a new instance of OperationPostgreSQLRepository using the given Postgres connection.
+// Accepts optional configuration via OperationRepoOption functions.
+// For backward compatibility, also accepts a single bool parameter for requireTenant.
+func NewOperationPostgreSQLRepository(pc *libPostgres.Client, opts ...any) *OperationPostgreSQLRepository {
 	c := &OperationPostgreSQLRepository{
 		connection: pc,
 		tableName:  "operation",
+		chunkSize:  defaultOperationChunkSize,
 	}
-	if len(requireTenant) > 0 {
-		c.requireTenant = requireTenant[0]
+
+	for _, opt := range opts {
+		switch v := opt.(type) {
+		case bool:
+			// Backward compatibility: single bool arg means requireTenant
+			c.requireTenant = v
+		case OperationRepoOption:
+			v(c)
+		}
 	}
 
 	return c
@@ -341,9 +376,12 @@ func (r *OperationPostgreSQLRepository) createBulkInternal(
 
 	result := &repository.BulkInsertResult{Attempted: int64(len(operations))}
 
-	// Chunk into bulks of ~1,000 rows to stay within PostgreSQL's parameter limit
+	// Chunk into bulks to stay within PostgreSQL's parameter limit
 	// Operation has 30 columns, so 1000 rows = 30,000 parameters (under 65,535 limit)
-	const chunkSize = 1000
+	chunkSize := r.chunkSize
+	if chunkSize <= 0 {
+		chunkSize = defaultOperationChunkSize
+	}
 
 	for i := 0; i < len(operations); i += chunkSize {
 		// Check for context cancellation between chunks

--- a/components/transaction/internal/adapters/postgres/operation/operation_createbulk_test.go
+++ b/components/transaction/internal/adapters/postgres/operation/operation_createbulk_test.go
@@ -595,3 +595,63 @@ func TestOperationCreateBulk_ContextCancellation(t *testing.T) {
 	assert.Equal(t, int64(0), result.Inserted, "No rows inserted when context cancelled before first chunk")
 	assert.Equal(t, int64(0), result.Ignored)
 }
+
+// =============================================================================
+// UNIT TESTS - Configurable Chunk Size (Issue 2)
+// =============================================================================
+
+func TestNewOperationPostgreSQLRepository_DefaultChunkSize(t *testing.T) {
+	t.Parallel()
+
+	repo := NewOperationPostgreSQLRepository(nil)
+
+	assert.Equal(t, defaultOperationChunkSize, repo.chunkSize, "Should use default chunk size of 1000")
+}
+
+func TestNewOperationPostgreSQLRepository_CustomChunkSize(t *testing.T) {
+	t.Parallel()
+
+	customSize := 500
+	repo := NewOperationPostgreSQLRepository(nil, WithOperationChunkSize(customSize))
+
+	assert.Equal(t, customSize, repo.chunkSize, "Should use custom chunk size")
+}
+
+func TestNewOperationPostgreSQLRepository_ZeroChunkSizeDefaultsTo1000(t *testing.T) {
+	t.Parallel()
+
+	repo := NewOperationPostgreSQLRepository(nil, WithOperationChunkSize(0))
+
+	assert.Equal(t, defaultOperationChunkSize, repo.chunkSize, "Zero chunk size should use default")
+}
+
+func TestNewOperationPostgreSQLRepository_NegativeChunkSizeDefaultsTo1000(t *testing.T) {
+	t.Parallel()
+
+	repo := NewOperationPostgreSQLRepository(nil, WithOperationChunkSize(-100))
+
+	assert.Equal(t, defaultOperationChunkSize, repo.chunkSize, "Negative chunk size should use default")
+}
+
+func TestNewOperationPostgreSQLRepository_BackwardCompatibility(t *testing.T) {
+	t.Parallel()
+
+	// Test backward compatibility with single bool argument
+	repo := NewOperationPostgreSQLRepository(nil, true)
+
+	assert.True(t, repo.requireTenant, "Bool argument should set requireTenant")
+	assert.Equal(t, defaultOperationChunkSize, repo.chunkSize, "Should use default chunk size")
+}
+
+func TestNewOperationPostgreSQLRepository_MixedOptions(t *testing.T) {
+	t.Parallel()
+
+	customSize := 250
+	repo := NewOperationPostgreSQLRepository(nil,
+		WithOperationRequireTenant(true),
+		WithOperationChunkSize(customSize),
+	)
+
+	assert.True(t, repo.requireTenant, "Should set requireTenant")
+	assert.Equal(t, customSize, repo.chunkSize, "Should use custom chunk size")
+}

--- a/components/transaction/internal/adapters/postgres/transaction/transaction.postgresql.go
+++ b/components/transaction/internal/adapters/postgres/transaction/transaction.postgresql.go
@@ -94,21 +94,55 @@ type Repository interface {
 // transactionColumns is derived from transactionColumnList for use with squirrel.Select.
 var transactionColumns = strings.Join(transactionColumnList, ", ")
 
+// defaultChunkSize is the default maximum rows per INSERT statement to stay under PostgreSQL's 65,535 parameter limit.
+const defaultChunkSize = 1000
+
 // TransactionPostgreSQLRepository is a Postgresql-specific implementation of the TransactionRepository.
 type TransactionPostgreSQLRepository struct {
 	connection    *libPostgres.Client
 	tableName     string
 	requireTenant bool
+	chunkSize     int // Maximum rows per bulk INSERT, defaults to 1000
+}
+
+// TransactionRepoOption is a functional option for configuring TransactionPostgreSQLRepository.
+type TransactionRepoOption func(*TransactionPostgreSQLRepository)
+
+// WithTransactionChunkSize sets the maximum rows per bulk INSERT statement.
+// If not set or set to 0, defaults to 1000.
+func WithTransactionChunkSize(size int) TransactionRepoOption {
+	return func(r *TransactionPostgreSQLRepository) {
+		if size > 0 {
+			r.chunkSize = size
+		}
+	}
+}
+
+// WithRequireTenant configures whether tenant context is required.
+func WithRequireTenant(require bool) TransactionRepoOption {
+	return func(r *TransactionPostgreSQLRepository) {
+		r.requireTenant = require
+	}
 }
 
 // NewTransactionPostgreSQLRepository returns a new instance of TransactionPostgreSQLRepository using the given Postgres connection.
-func NewTransactionPostgreSQLRepository(pc *libPostgres.Client, requireTenant ...bool) *TransactionPostgreSQLRepository {
+// Accepts optional configuration via TransactionRepoOption functions.
+// For backward compatibility, also accepts a single bool parameter for requireTenant.
+func NewTransactionPostgreSQLRepository(pc *libPostgres.Client, opts ...any) *TransactionPostgreSQLRepository {
 	c := &TransactionPostgreSQLRepository{
 		connection: pc,
 		tableName:  "transaction",
+		chunkSize:  defaultChunkSize,
 	}
-	if len(requireTenant) > 0 {
-		c.requireTenant = requireTenant[0]
+
+	for _, opt := range opts {
+		switch v := opt.(type) {
+		case bool:
+			// Backward compatibility: single bool arg means requireTenant
+			c.requireTenant = v
+		case TransactionRepoOption:
+			v(c)
+		}
 	}
 
 	return c
@@ -295,9 +329,12 @@ func (r *TransactionPostgreSQLRepository) createBulkInternal(
 
 	result := &repository.BulkInsertResult{Attempted: int64(len(transactions))}
 
-	// Chunk into bulks of ~1,000 rows to stay within PostgreSQL's parameter limit
-	// Transaction has 15 columns, so 1000 rows = 15,000 parameters (under 65,535 limit)
-	const chunkSize = 1000
+	// Chunk into bulks to stay within PostgreSQL's parameter limit
+	// Transaction has 16 columns, so 1000 rows = 16,000 parameters (under 65,535 limit)
+	chunkSize := r.chunkSize
+	if chunkSize <= 0 {
+		chunkSize = defaultChunkSize
+	}
 
 	for i := 0; i < len(transactions); i += chunkSize {
 		// Check for context cancellation between chunks
@@ -442,9 +479,12 @@ func (r *TransactionPostgreSQLRepository) BulkUpdateTransactionStatus(ctx contex
 
 	result := &repository.BulkInsertResult{Attempted: int64(len(transactions))}
 
-	// Chunk into bulks of ~1,000 rows to stay within PostgreSQL's parameter limit
+	// Chunk into bulks to stay within PostgreSQL's parameter limit
 	// Update has 3 parameters per row (id, status, status_description), so 1000 rows = 3,000 parameters
-	const chunkSize = 1000
+	chunkSize := r.chunkSize
+	if chunkSize <= 0 {
+		chunkSize = defaultChunkSize
+	}
 
 	for i := 0; i < len(transactions); i += chunkSize {
 		// Check for context cancellation between chunks

--- a/components/transaction/internal/adapters/postgres/transaction/transaction.postgresql.go
+++ b/components/transaction/internal/adapters/postgres/transaction/transaction.postgresql.go
@@ -80,6 +80,7 @@ type Repository interface {
 	Create(ctx context.Context, transaction *Transaction) (*Transaction, error)
 	CreateBulk(ctx context.Context, transactions []*Transaction) (*repository.BulkInsertResult, error)
 	CreateBulkTx(ctx context.Context, tx repository.DBExecutor, transactions []*Transaction) (*repository.BulkInsertResult, error)
+	BulkUpdateTransactionStatus(ctx context.Context, transactions []*Transaction) (*repository.BulkInsertResult, error)
 	FindAll(ctx context.Context, organizationID, ledgerID uuid.UUID, filter http.Pagination) ([]*Transaction, libHTTP.CursorPagination, error)
 	Find(ctx context.Context, organizationID, ledgerID, id uuid.UUID) (*Transaction, error)
 	FindByParentID(ctx context.Context, organizationID, ledgerID, parentID uuid.UUID) (*Transaction, error)
@@ -366,6 +367,7 @@ func (r *TransactionPostgreSQLRepository) insertTransactionChunk(ctx context.Con
 			record.UpdatedAt,
 			record.DeletedAt,
 			record.Route,
+			record.RouteID,
 		)
 	}
 
@@ -381,6 +383,149 @@ func (r *TransactionPostgreSQLRepository) insertTransactionChunk(ctx context.Con
 	execResult, err := db.ExecContext(ctx, query, args...)
 	if err != nil {
 		libOpentelemetry.HandleSpanError(span, "Failed to execute bulk insert", err)
+
+		return 0, err
+	}
+
+	rowsAffected, err := execResult.RowsAffected()
+	if err != nil {
+		libOpentelemetry.HandleSpanError(span, "Failed to get rows affected", err)
+
+		return 0, err
+	}
+
+	return rowsAffected, nil
+}
+
+// BulkUpdateTransactionStatus updates the status of multiple transactions from PENDING to a final state.
+// This method is used for PENDING→APPROVED or PENDING→CANCELED transitions.
+// Transactions are sorted by ID before update to prevent deadlocks in concurrent scenarios.
+// Large bulks are automatically chunked to stay within PostgreSQL's parameter limits.
+//
+// NOTE: Only transactions with status='PENDING' are updated. Non-PENDING transactions are silently ignored.
+// The result.Ignored count reflects transactions that were not updated (either not found or not PENDING).
+//
+// NOTE: The input slice is sorted in-place by ID. Callers should not rely on original order after this call.
+func (r *TransactionPostgreSQLRepository) BulkUpdateTransactionStatus(ctx context.Context, transactions []*Transaction) (*repository.BulkInsertResult, error) {
+	logger, tracer, _, _ := libCommons.NewTrackingFromContext(ctx)
+
+	ctx, span := tracer.Start(ctx, "postgres.bulk_update_transaction_status")
+	defer span.End()
+
+	// Early return for empty input before acquiring DB connection
+	if len(transactions) == 0 {
+		return &repository.BulkInsertResult{}, nil
+	}
+
+	db, err := r.getDB(ctx)
+	if err != nil {
+		libOpentelemetry.HandleSpanError(span, "Failed to get database connection", err)
+		logger.Log(ctx, libLog.LevelError, fmt.Sprintf("Failed to get database connection: %v", err))
+
+		return nil, err
+	}
+
+	// Validate no nil elements to prevent panic during sort or update
+	for i, txn := range transactions {
+		if txn == nil {
+			err := fmt.Errorf("nil transaction at index %d", i)
+			libOpentelemetry.HandleSpanError(span, "Invalid input: nil transaction", err)
+
+			return nil, err
+		}
+	}
+
+	// Sort by ID (string UUID) to prevent deadlocks in concurrent bulk operations
+	sort.Slice(transactions, func(i, j int) bool {
+		return transactions[i].ID < transactions[j].ID
+	})
+
+	result := &repository.BulkInsertResult{Attempted: int64(len(transactions))}
+
+	// Chunk into bulks of ~1,000 rows to stay within PostgreSQL's parameter limit
+	// Update has 3 parameters per row (id, status, status_description), so 1000 rows = 3,000 parameters
+	const chunkSize = 1000
+
+	for i := 0; i < len(transactions); i += chunkSize {
+		// Check for context cancellation between chunks
+		select {
+		case <-ctx.Done():
+			libOpentelemetry.HandleSpanError(span, "Context cancelled during bulk update", ctx.Err())
+			logger.Log(ctx, libLog.LevelWarn, fmt.Sprintf("Context cancelled during bulk update: %v", ctx.Err()))
+
+			return result, ctx.Err()
+		default:
+		}
+
+		end := min(i+chunkSize, len(transactions))
+
+		chunkUpdated, err := r.updateTransactionStatusChunk(ctx, db, transactions[i:end])
+		if err != nil {
+			libOpentelemetry.HandleSpanError(span, "Failed to update transaction status chunk", err)
+			logger.Log(ctx, libLog.LevelError, fmt.Sprintf("Failed to update transaction status chunk: %v", err))
+
+			return result, err
+		}
+
+		result.Inserted += chunkUpdated // Using Inserted to track updated count for consistency
+	}
+
+	result.Ignored = result.Attempted - result.Inserted
+
+	logger.Log(ctx, libLog.LevelInfo, fmt.Sprintf("Bulk update transaction status: attempted=%d, updated=%d, ignored=%d",
+		result.Attempted, result.Inserted, result.Ignored))
+
+	return result, nil
+}
+
+// updateTransactionStatusChunk updates a chunk of transaction statuses using a single UPDATE statement.
+// Uses VALUES clause to pass multiple rows and joins with the transaction table.
+// Only updates transactions with status='PENDING'.
+func (r *TransactionPostgreSQLRepository) updateTransactionStatusChunk(ctx context.Context, db repository.DBExecutor, transactions []*Transaction) (int64, error) {
+	logger, tracer, _, _ := libCommons.NewTrackingFromContext(ctx)
+
+	ctx, span := tracer.Start(ctx, "postgres.update_transaction_status_chunk")
+	defer span.End()
+
+	if len(transactions) == 0 {
+		return 0, nil
+	}
+
+	logger.Log(ctx, libLog.LevelDebug, fmt.Sprintf("Updating status for chunk of %d transactions", len(transactions)))
+
+	// Build VALUES clause: ($1, $2, $3), ($4, $5, $6), ...
+	var (
+		valuesClauses []string
+		args          []any
+	)
+
+	paramIdx := 1
+
+	for _, tx := range transactions {
+		valuesClauses = append(valuesClauses, fmt.Sprintf("($%d::uuid, $%d, $%d)", paramIdx, paramIdx+1, paramIdx+2))
+
+		statusDesc := ""
+		if tx.Status.Description != nil {
+			statusDesc = *tx.Status.Description
+		}
+
+		args = append(args, tx.ID, tx.Status.Code, statusDesc)
+		paramIdx += 3
+	}
+
+	// Build the UPDATE query using FROM VALUES
+	query := fmt.Sprintf(`
+		UPDATE %s AS t
+		SET status = data.status,
+		    status_description = data.status_description,
+		    updated_at = now()
+		FROM (VALUES %s) AS data(id, status, status_description)
+		WHERE t.id = data.id AND t.status = 'PENDING'`,
+		r.tableName, strings.Join(valuesClauses, ", "))
+
+	execResult, err := db.ExecContext(ctx, query, args...)
+	if err != nil {
+		libOpentelemetry.HandleSpanError(span, "Failed to execute bulk status update", err)
 
 		return 0, err
 	}

--- a/components/transaction/internal/adapters/postgres/transaction/transaction.postgresql_mock.go
+++ b/components/transaction/internal/adapters/postgres/transaction/transaction.postgresql_mock.go
@@ -44,6 +44,21 @@ func (m *MockRepository) EXPECT() *MockRepositoryMockRecorder {
 	return m.recorder
 }
 
+// BulkUpdateTransactionStatus mocks base method.
+func (m *MockRepository) BulkUpdateTransactionStatus(ctx context.Context, transactions []*Transaction) (*repository.BulkInsertResult, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "BulkUpdateTransactionStatus", ctx, transactions)
+	ret0, _ := ret[0].(*repository.BulkInsertResult)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// BulkUpdateTransactionStatus indicates an expected call of BulkUpdateTransactionStatus.
+func (mr *MockRepositoryMockRecorder) BulkUpdateTransactionStatus(ctx, transactions any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BulkUpdateTransactionStatus", reflect.TypeOf((*MockRepository)(nil).BulkUpdateTransactionStatus), ctx, transactions)
+}
+
 // Create mocks base method.
 func (m *MockRepository) Create(ctx context.Context, transaction *Transaction) (*Transaction, error) {
 	m.ctrl.T.Helper()

--- a/components/transaction/internal/adapters/postgres/transaction/transaction_createbulk_test.go
+++ b/components/transaction/internal/adapters/postgres/transaction/transaction_createbulk_test.go
@@ -537,3 +537,230 @@ func TestCreateBulk_ContextCancellation(t *testing.T) {
 	assert.Equal(t, int64(0), result.Inserted, "No rows inserted when context cancelled before first chunk")
 	assert.Equal(t, int64(0), result.Ignored)
 }
+
+// =============================================================================
+// UNIT TESTS - BulkUpdateTransactionStatus
+// =============================================================================
+
+func TestBulkUpdateTransactionStatus_EmptyInput(t *testing.T) {
+	t.Parallel()
+
+	repo := &TransactionPostgreSQLRepository{
+		connection: nil, // Will return empty result before DB call
+		tableName:  "transaction",
+	}
+
+	result, err := repo.BulkUpdateTransactionStatus(context.Background(), []*Transaction{})
+
+	require.NoError(t, err, "empty input should not error")
+	assert.Equal(t, int64(0), result.Attempted)
+	assert.Equal(t, int64(0), result.Inserted)
+	assert.Equal(t, int64(0), result.Ignored)
+}
+
+func TestBulkUpdateTransactionStatus_NilInput(t *testing.T) {
+	t.Parallel()
+
+	repo := &TransactionPostgreSQLRepository{
+		connection: nil,
+		tableName:  "transaction",
+	}
+
+	result, err := repo.BulkUpdateTransactionStatus(context.Background(), nil)
+
+	require.NoError(t, err, "nil input should be treated as empty")
+	assert.Equal(t, int64(0), result.Attempted)
+	assert.Equal(t, int64(0), result.Inserted)
+	assert.Equal(t, int64(0), result.Ignored)
+}
+
+func TestBulkUpdateTransactionStatus_NilElementInSlice(t *testing.T) {
+	t.Parallel()
+
+	mockDB := &bulkMockDB{}
+	ctx := tmcore.ContextWithModulePGConnection(context.Background(), "transaction", mockDB)
+
+	repo := &TransactionPostgreSQLRepository{
+		connection:    nil,
+		tableName:     "transaction",
+		requireTenant: false,
+	}
+
+	transactions := []*Transaction{
+		generateTestTransaction(""),
+		nil, // nil element
+		generateTestTransaction(""),
+	}
+
+	result, err := repo.BulkUpdateTransactionStatus(ctx, transactions)
+
+	require.Error(t, err, "should error on nil element")
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "nil transaction at index 1")
+}
+
+func TestBulkUpdateTransactionStatus_SortsInputByID(t *testing.T) {
+	t.Parallel()
+
+	// Create transactions with IDs that will sort differently
+	tx1 := generateTestTransaction("ffffffff-ffff-ffff-ffff-ffffffffffff")
+	tx1.Status = Status{Code: "APPROVED"}
+	tx2 := generateTestTransaction("00000000-0000-0000-0000-000000000001")
+	tx2.Status = Status{Code: "APPROVED"}
+	tx3 := generateTestTransaction("88888888-8888-8888-8888-888888888888")
+	tx3.Status = Status{Code: "APPROVED"}
+
+	input := []*Transaction{tx1, tx2, tx3}
+
+	// Verify initial order: tx1 (highest) is first
+	assert.Equal(t, tx1.ID, input[0].ID, "original order should have tx1 first")
+
+	// Create mock DB that returns success
+	mockDB := &bulkMockDB{
+		rowsAffected: 3,
+	}
+
+	ctx := tmcore.ContextWithModulePGConnection(context.Background(), "transaction", mockDB)
+
+	repo := &TransactionPostgreSQLRepository{
+		connection:    nil,
+		tableName:     "transaction",
+		requireTenant: false,
+	}
+
+	result, err := repo.BulkUpdateTransactionStatus(ctx, input)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	// Verify the slice was sorted in-place by ID (ascending)
+	assert.Equal(t, tx2.ID, input[0].ID, "after BulkUpdateTransactionStatus, first element should be tx2 (lowest ID)")
+	assert.Equal(t, tx3.ID, input[1].ID, "after BulkUpdateTransactionStatus, second element should be tx3 (middle ID)")
+	assert.Equal(t, tx1.ID, input[2].ID, "after BulkUpdateTransactionStatus, third element should be tx1 (highest ID)")
+}
+
+func TestBulkUpdateTransactionStatus_Success(t *testing.T) {
+	t.Parallel()
+
+	tx1 := generateTestTransaction("")
+	tx1.Status = Status{Code: "APPROVED"}
+	description := "Approved"
+	tx1.Status.Description = &description
+
+	tx2 := generateTestTransaction("")
+	tx2.Status = Status{Code: "CANCELED"}
+	cancelDesc := "Canceled"
+	tx2.Status.Description = &cancelDesc
+
+	transactions := []*Transaction{tx1, tx2}
+
+	mockDB := &bulkMockDB{
+		rowsAffected: 2, // Both rows updated
+	}
+
+	ctx := tmcore.ContextWithModulePGConnection(context.Background(), "transaction", mockDB)
+
+	repo := &TransactionPostgreSQLRepository{
+		connection:    nil,
+		tableName:     "transaction",
+		requireTenant: false,
+	}
+
+	result, err := repo.BulkUpdateTransactionStatus(ctx, transactions)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, int64(2), result.Attempted)
+	assert.Equal(t, int64(2), result.Inserted) // Inserted tracks updated rows
+	assert.Equal(t, int64(0), result.Ignored)
+}
+
+func TestBulkUpdateTransactionStatus_PartialUpdate(t *testing.T) {
+	t.Parallel()
+
+	tx1 := generateTestTransaction("")
+	tx1.Status = Status{Code: "APPROVED"}
+	tx2 := generateTestTransaction("")
+	tx2.Status = Status{Code: "APPROVED"}
+
+	transactions := []*Transaction{tx1, tx2}
+
+	// Mock returns only 1 row affected (other was not in PENDING state)
+	mockDB := &bulkMockDB{
+		rowsAffected: 1,
+	}
+
+	ctx := tmcore.ContextWithModulePGConnection(context.Background(), "transaction", mockDB)
+
+	repo := &TransactionPostgreSQLRepository{
+		connection:    nil,
+		tableName:     "transaction",
+		requireTenant: false,
+	}
+
+	result, err := repo.BulkUpdateTransactionStatus(ctx, transactions)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, int64(2), result.Attempted)
+	assert.Equal(t, int64(1), result.Inserted) // Only 1 updated
+	assert.Equal(t, int64(1), result.Ignored)  // 1 ignored (not in PENDING state)
+}
+
+func TestBulkUpdateTransactionStatus_DatabaseError(t *testing.T) {
+	t.Parallel()
+
+	tx1 := generateTestTransaction("")
+	tx1.Status = Status{Code: "APPROVED"}
+
+	transactions := []*Transaction{tx1}
+
+	dbErr := errors.New("database connection lost")
+	mockDB := &bulkMockDB{
+		execErr: dbErr,
+	}
+
+	ctx := tmcore.ContextWithModulePGConnection(context.Background(), "transaction", mockDB)
+
+	repo := &TransactionPostgreSQLRepository{
+		connection:    nil,
+		tableName:     "transaction",
+		requireTenant: false,
+	}
+
+	result, err := repo.BulkUpdateTransactionStatus(ctx, transactions)
+
+	require.Error(t, err)
+	assert.Equal(t, dbErr, err)
+	require.NotNil(t, result)
+	assert.Equal(t, int64(1), result.Attempted)
+	assert.Equal(t, int64(0), result.Inserted)
+}
+
+func TestBulkUpdateTransactionStatus_NilStatusDescription(t *testing.T) {
+	t.Parallel()
+
+	tx1 := generateTestTransaction("")
+	tx1.Status = Status{Code: "APPROVED", Description: nil} // nil description
+
+	transactions := []*Transaction{tx1}
+
+	mockDB := &bulkMockDB{
+		rowsAffected: 1,
+	}
+
+	ctx := tmcore.ContextWithModulePGConnection(context.Background(), "transaction", mockDB)
+
+	repo := &TransactionPostgreSQLRepository{
+		connection:    nil,
+		tableName:     "transaction",
+		requireTenant: false,
+	}
+
+	result, err := repo.BulkUpdateTransactionStatus(ctx, transactions)
+
+	require.NoError(t, err, "nil status description should be handled")
+	require.NotNil(t, result)
+	assert.Equal(t, int64(1), result.Attempted)
+	assert.Equal(t, int64(1), result.Inserted)
+}

--- a/components/transaction/internal/adapters/postgres/transaction/transaction_createbulk_test.go
+++ b/components/transaction/internal/adapters/postgres/transaction/transaction_createbulk_test.go
@@ -384,7 +384,7 @@ func TestInsertTransactionChunk_ColumnCount(t *testing.T) {
 
 	// Verify that transactionColumnList has expected number of columns
 	// This ensures the bulk insert won't have column/value mismatch
-	expectedColumns := 15 // Based on transactionColumnList definition
+	expectedColumns := 16 // Based on transactionColumnList definition
 	assert.Equal(t, expectedColumns, len(transactionColumnList),
 		"transactionColumnList should have %d columns", expectedColumns)
 }
@@ -394,7 +394,7 @@ func TestInsertTransactionChunk_ParameterLimitCalculation(t *testing.T) {
 
 	// Verify that 1000 rows * 15 columns stays under PostgreSQL's 65,535 limit
 	const chunkSize = 1000
-	const columnCount = 15 // transactionColumnList length
+	const columnCount = 16 // transactionColumnList length
 	const postgresLimit = 65535
 
 	parametersPerChunk := chunkSize * columnCount

--- a/components/transaction/internal/adapters/postgres/transaction/transaction_createbulk_test.go
+++ b/components/transaction/internal/adapters/postgres/transaction/transaction_createbulk_test.go
@@ -764,3 +764,63 @@ func TestBulkUpdateTransactionStatus_NilStatusDescription(t *testing.T) {
 	assert.Equal(t, int64(1), result.Attempted)
 	assert.Equal(t, int64(1), result.Inserted)
 }
+
+// =============================================================================
+// UNIT TESTS - Configurable Chunk Size (Issue 2)
+// =============================================================================
+
+func TestNewTransactionPostgreSQLRepository_DefaultChunkSize(t *testing.T) {
+	t.Parallel()
+
+	repo := NewTransactionPostgreSQLRepository(nil)
+
+	assert.Equal(t, defaultChunkSize, repo.chunkSize, "Should use default chunk size of 1000")
+}
+
+func TestNewTransactionPostgreSQLRepository_CustomChunkSize(t *testing.T) {
+	t.Parallel()
+
+	customSize := 500
+	repo := NewTransactionPostgreSQLRepository(nil, WithTransactionChunkSize(customSize))
+
+	assert.Equal(t, customSize, repo.chunkSize, "Should use custom chunk size")
+}
+
+func TestNewTransactionPostgreSQLRepository_ZeroChunkSizeDefaultsTo1000(t *testing.T) {
+	t.Parallel()
+
+	repo := NewTransactionPostgreSQLRepository(nil, WithTransactionChunkSize(0))
+
+	assert.Equal(t, defaultChunkSize, repo.chunkSize, "Zero chunk size should use default")
+}
+
+func TestNewTransactionPostgreSQLRepository_NegativeChunkSizeDefaultsTo1000(t *testing.T) {
+	t.Parallel()
+
+	repo := NewTransactionPostgreSQLRepository(nil, WithTransactionChunkSize(-100))
+
+	assert.Equal(t, defaultChunkSize, repo.chunkSize, "Negative chunk size should use default")
+}
+
+func TestNewTransactionPostgreSQLRepository_BackwardCompatibility(t *testing.T) {
+	t.Parallel()
+
+	// Test backward compatibility with single bool argument
+	repo := NewTransactionPostgreSQLRepository(nil, true)
+
+	assert.True(t, repo.requireTenant, "Bool argument should set requireTenant")
+	assert.Equal(t, defaultChunkSize, repo.chunkSize, "Should use default chunk size")
+}
+
+func TestNewTransactionPostgreSQLRepository_MixedOptions(t *testing.T) {
+	t.Parallel()
+
+	customSize := 250
+	repo := NewTransactionPostgreSQLRepository(nil,
+		WithRequireTenant(true),
+		WithTransactionChunkSize(customSize),
+	)
+
+	assert.True(t, repo.requireTenant, "Should set requireTenant")
+	assert.Equal(t, customSize, repo.chunkSize, "Should use custom chunk size")
+}

--- a/components/transaction/internal/adapters/rabbitmq/bulk_collector.go
+++ b/components/transaction/internal/adapters/rabbitmq/bulk_collector.go
@@ -1,0 +1,245 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package rabbitmq
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"time"
+
+	libLog "github.com/LerianStudio/lib-commons/v4/commons/log"
+	amqp "github.com/rabbitmq/amqp091-go"
+)
+
+// BulkCollector configuration errors.
+var (
+	// ErrInvalidBulkSize is returned when bulk size is less than or equal to 0.
+	ErrInvalidBulkSize = errors.New("bulk size must be greater than 0")
+
+	// ErrInvalidFlushTimeout is returned when flush timeout is less than or equal to 0.
+	ErrInvalidFlushTimeout = errors.New("flush timeout must be greater than 0")
+
+	// ErrNilFlushFunc is returned when flush function is nil.
+	ErrNilFlushFunc = errors.New("flush function must not be nil")
+
+	// ErrNilLogger is returned when logger is nil.
+	ErrNilLogger = errors.New("logger must not be nil")
+)
+
+// BulkFlushFunc is called when the bulk is ready to be processed.
+// It receives the collected messages and returns an error if processing fails.
+// The function is responsible for acknowledging or rejecting the messages.
+type BulkFlushFunc func(ctx context.Context, messages []amqp.Delivery) error
+
+// BulkCollector accumulates RabbitMQ messages until either the bulk size threshold
+// is reached or the flush timeout expires, then calls the flush callback.
+//
+// Thread-safety: BulkCollector is designed to be used by a single goroutine.
+// The Run method blocks and processes messages sequentially from the input channel.
+// Do not call Add from multiple goroutines concurrently.
+type BulkCollector struct {
+	size         int
+	flushTimeout time.Duration
+	flushFunc    BulkFlushFunc
+	logger       libLog.Logger
+	messages     []amqp.Delivery
+	firstArrival time.Time
+	mu           sync.Mutex
+}
+
+// BulkCollectorConfig holds configuration for the BulkCollector.
+type BulkCollectorConfig struct {
+	// Size is the number of messages to collect before flushing.
+	// Must be greater than 0.
+	Size int
+
+	// FlushTimeout is the maximum time to wait before flushing an incomplete bulk.
+	// Must be greater than 0.
+	FlushTimeout time.Duration
+
+	// FlushFunc is called when the bulk is ready to be processed.
+	// Must not be nil.
+	FlushFunc BulkFlushFunc
+
+	// Logger for logging bulk operations.
+	// Must not be nil.
+	Logger libLog.Logger
+}
+
+// NewBulkCollector creates a new BulkCollector with the given configuration.
+// Returns an error if the configuration is invalid.
+func NewBulkCollector(cfg BulkCollectorConfig) (*BulkCollector, error) {
+	if cfg.Size <= 0 {
+		return nil, ErrInvalidBulkSize
+	}
+
+	if cfg.FlushTimeout <= 0 {
+		return nil, ErrInvalidFlushTimeout
+	}
+
+	if cfg.FlushFunc == nil {
+		return nil, ErrNilFlushFunc
+	}
+
+	if cfg.Logger == nil {
+		return nil, ErrNilLogger
+	}
+
+	return &BulkCollector{
+		size:         cfg.Size,
+		flushTimeout: cfg.FlushTimeout,
+		flushFunc:    cfg.FlushFunc,
+		logger:       cfg.Logger,
+		messages:     make([]amqp.Delivery, 0, cfg.Size),
+	}, nil
+}
+
+// Run starts the bulk collector loop, reading from the messages channel until
+// the context is cancelled or the channel is closed.
+//
+// The collector will flush when:
+// - The bulk size threshold is reached (size-based flush)
+// - The flush timeout expires since the first message arrived (time-based flush)
+// - The context is cancelled (graceful shutdown)
+// - The messages channel is closed (channel closure)
+//
+// This method blocks until the context is cancelled or the channel is closed.
+func (bc *BulkCollector) Run(ctx context.Context, messages <-chan amqp.Delivery) {
+	bc.logger.Log(ctx, libLog.LevelInfo, "BulkCollector started",
+		libLog.Int("bulkSize", bc.size),
+		libLog.Any("flushTimeout", bc.flushTimeout))
+
+	// Use a reusable timer to avoid memory leak from time.After in hot loop
+	timer := time.NewTimer(bc.flushTimeout)
+	defer timer.Stop()
+
+	for {
+		// Calculate timeout for select and reset timer
+		timeout := bc.calculateTimeout()
+
+		// Stop and drain timer before reset to avoid race
+		if !timer.Stop() {
+			select {
+			case <-timer.C:
+			default:
+			}
+		}
+
+		timer.Reset(timeout)
+
+		select {
+		case <-ctx.Done():
+			// Graceful shutdown: flush any pending messages
+			bc.logger.Log(ctx, libLog.LevelInfo, "BulkCollector shutting down, flushing pending messages",
+				libLog.Int("pendingCount", bc.Len()))
+			bc.flush(ctx, "shutdown")
+
+			return
+
+		case msg, ok := <-messages:
+			if !ok {
+				// Channel closed: flush any pending messages
+				bc.logger.Log(ctx, libLog.LevelInfo, "BulkCollector channel closed, flushing pending messages",
+					libLog.Int("pendingCount", bc.Len()))
+				bc.flush(ctx, "channel_closed")
+
+				return
+			}
+
+			bc.add(msg)
+
+			// Check if size threshold reached (use locked accessor)
+			if bc.Len() >= bc.size {
+				bc.flush(ctx, "size_threshold")
+			}
+
+		case <-timer.C:
+			// Timeout expired: flush if we have pending messages (use locked accessor)
+			if bc.Len() > 0 {
+				bc.flush(ctx, "timeout")
+			}
+		}
+	}
+}
+
+// add appends a message to the bulk buffer.
+func (bc *BulkCollector) add(msg amqp.Delivery) {
+	bc.mu.Lock()
+	defer bc.mu.Unlock()
+
+	if len(bc.messages) == 0 {
+		bc.firstArrival = time.Now()
+	}
+
+	bc.messages = append(bc.messages, msg)
+}
+
+// flush processes the accumulated messages and resets the buffer.
+func (bc *BulkCollector) flush(ctx context.Context, trigger string) {
+	bc.mu.Lock()
+	if len(bc.messages) == 0 {
+		bc.mu.Unlock()
+		return
+	}
+
+	// Take ownership of messages and reset buffer
+	messagesToFlush := bc.messages
+	bc.messages = make([]amqp.Delivery, 0, bc.size)
+	bc.firstArrival = time.Time{}
+	bc.mu.Unlock()
+
+	bc.logger.Log(ctx, libLog.LevelDebug, "BulkCollector flushing",
+		libLog.String("trigger", trigger),
+		libLog.Int("messageCount", len(messagesToFlush)))
+
+	// Call the flush function with the collected messages
+	if err := bc.flushFunc(ctx, messagesToFlush); err != nil {
+		bc.logger.Log(ctx, libLog.LevelError, "BulkCollector flush callback failed",
+			libLog.String("trigger", trigger),
+			libLog.Int("messageCount", len(messagesToFlush)),
+			libLog.Err(err))
+		// Note: Error handling (ack/nack) is the responsibility of the flush function
+	}
+}
+
+// calculateTimeout returns the time until the next timeout-based flush should occur.
+// Returns flushTimeout if no messages are pending, otherwise returns the remaining
+// time until the timeout expires since the first message arrived.
+func (bc *BulkCollector) calculateTimeout() time.Duration {
+	bc.mu.Lock()
+	defer bc.mu.Unlock()
+
+	if len(bc.messages) == 0 {
+		// No messages: use full timeout (will be reset when first message arrives)
+		return bc.flushTimeout
+	}
+
+	// Calculate remaining time until timeout
+	elapsed := time.Since(bc.firstArrival)
+	remaining := bc.flushTimeout - elapsed
+
+	if remaining <= 0 {
+		// Timeout already expired, return minimal duration to trigger immediate flush
+		return time.Millisecond
+	}
+
+	return remaining
+}
+
+// Len returns the current number of messages in the buffer.
+// This is primarily useful for testing and monitoring.
+func (bc *BulkCollector) Len() int {
+	bc.mu.Lock()
+	defer bc.mu.Unlock()
+
+	return len(bc.messages)
+}
+
+// FlushNow forces an immediate flush of pending messages.
+// This is primarily useful for testing.
+func (bc *BulkCollector) FlushNow(ctx context.Context) {
+	bc.flush(ctx, "manual")
+}

--- a/components/transaction/internal/adapters/rabbitmq/bulk_collector_test.go
+++ b/components/transaction/internal/adapters/rabbitmq/bulk_collector_test.go
@@ -1,0 +1,649 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package rabbitmq
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	libLog "github.com/LerianStudio/lib-commons/v4/commons/log"
+	libZap "github.com/LerianStudio/lib-commons/v4/commons/zap"
+	amqp "github.com/rabbitmq/amqp091-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// bulkTestLogger is initialized once for bulk collector tests.
+var (
+	bulkTestLogger     libLog.Logger
+	bulkTestLoggerOnce sync.Once
+)
+
+func getBulkTestLogger() libLog.Logger {
+	bulkTestLoggerOnce.Do(func() {
+		logger, err := libZap.New(libZap.Config{
+			Environment:     libZap.EnvironmentLocal,
+			Level:           "error", // Suppress debug logs in tests
+			OTelLibraryName: "midaz-bulk-collector-tests",
+		})
+		if err != nil {
+			panic(err)
+		}
+
+		bulkTestLogger = logger
+	})
+
+	return bulkTestLogger
+}
+
+// =============================================================================
+// UNIT TESTS - NewBulkCollector Configuration Validation
+// =============================================================================
+
+func TestNewBulkCollector_ConfigValidation(t *testing.T) {
+	t.Parallel()
+
+	logger := getBulkTestLogger()
+	noopFlushFunc := func(_ context.Context, _ []amqp.Delivery) error { return nil }
+
+	tests := []struct {
+		name        string
+		cfg         BulkCollectorConfig
+		expectError error
+	}{
+		{
+			name: "valid_config",
+			cfg: BulkCollectorConfig{
+				Size:         50,
+				FlushTimeout: 100 * time.Millisecond,
+				FlushFunc:    noopFlushFunc,
+				Logger:       logger,
+			},
+			expectError: nil,
+		},
+		{
+			name: "zero_size_returns_error",
+			cfg: BulkCollectorConfig{
+				Size:         0,
+				FlushTimeout: 100 * time.Millisecond,
+				FlushFunc:    noopFlushFunc,
+				Logger:       logger,
+			},
+			expectError: ErrInvalidBulkSize,
+		},
+		{
+			name: "negative_size_returns_error",
+			cfg: BulkCollectorConfig{
+				Size:         -1,
+				FlushTimeout: 100 * time.Millisecond,
+				FlushFunc:    noopFlushFunc,
+				Logger:       logger,
+			},
+			expectError: ErrInvalidBulkSize,
+		},
+		{
+			name: "zero_timeout_returns_error",
+			cfg: BulkCollectorConfig{
+				Size:         50,
+				FlushTimeout: 0,
+				FlushFunc:    noopFlushFunc,
+				Logger:       logger,
+			},
+			expectError: ErrInvalidFlushTimeout,
+		},
+		{
+			name: "negative_timeout_returns_error",
+			cfg: BulkCollectorConfig{
+				Size:         50,
+				FlushTimeout: -1 * time.Millisecond,
+				FlushFunc:    noopFlushFunc,
+				Logger:       logger,
+			},
+			expectError: ErrInvalidFlushTimeout,
+		},
+		{
+			name: "nil_flush_func_returns_error",
+			cfg: BulkCollectorConfig{
+				Size:         50,
+				FlushTimeout: 100 * time.Millisecond,
+				FlushFunc:    nil,
+				Logger:       logger,
+			},
+			expectError: ErrNilFlushFunc,
+		},
+		{
+			name: "nil_logger_returns_error",
+			cfg: BulkCollectorConfig{
+				Size:         50,
+				FlushTimeout: 100 * time.Millisecond,
+				FlushFunc:    noopFlushFunc,
+				Logger:       nil,
+			},
+			expectError: ErrNilLogger,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			bc, err := NewBulkCollector(tt.cfg)
+
+			if tt.expectError != nil {
+				assert.ErrorIs(t, err, tt.expectError)
+				assert.Nil(t, bc)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, bc)
+			}
+		})
+	}
+}
+
+// =============================================================================
+// UNIT TESTS - BulkCollector Size-Based Flush
+// =============================================================================
+
+func TestBulkCollector_SizeBasedFlush(t *testing.T) {
+	t.Parallel()
+
+	logger := getBulkTestLogger()
+
+	const bulkSize = 5
+	flushCount := 0
+	var flushMu sync.Mutex
+	var receivedMessages []amqp.Delivery
+
+	flushFunc := func(_ context.Context, msgs []amqp.Delivery) error {
+		flushMu.Lock()
+		defer flushMu.Unlock()
+
+		flushCount++
+		receivedMessages = append(receivedMessages, msgs...)
+
+		return nil
+	}
+
+	bc, err := NewBulkCollector(BulkCollectorConfig{
+		Size:         bulkSize,
+		FlushTimeout: 10 * time.Second, // Long timeout to ensure size trigger
+		FlushFunc:    flushFunc,
+		Logger:       logger,
+	})
+	require.NoError(t, err)
+
+	// Create a channel with exactly bulkSize messages
+	msgChan := make(chan amqp.Delivery, bulkSize)
+	for i := 0; i < bulkSize; i++ {
+		msgChan <- amqp.Delivery{Body: []byte{byte(i)}}
+	}
+
+	close(msgChan)
+
+	// Run collector
+	ctx := context.Background()
+	bc.Run(ctx, msgChan)
+
+	// Verify flush was called once with all messages
+	flushMu.Lock()
+	defer flushMu.Unlock()
+
+	assert.Equal(t, 1, flushCount, "Expected exactly one flush")
+	assert.Len(t, receivedMessages, bulkSize, "Expected all messages to be flushed")
+}
+
+// =============================================================================
+// UNIT TESTS - BulkCollector Time-Based Flush
+// =============================================================================
+
+func TestBulkCollector_TimeBasedFlush(t *testing.T) {
+	t.Parallel()
+
+	logger := getBulkTestLogger()
+
+	const bulkSize = 100 // Large size to ensure timeout triggers first
+	const messageCount = 3
+	flushCount := 0
+	var flushMu sync.Mutex
+	var receivedMessages []amqp.Delivery
+
+	flushFunc := func(_ context.Context, msgs []amqp.Delivery) error {
+		flushMu.Lock()
+		defer flushMu.Unlock()
+
+		flushCount++
+		receivedMessages = append(receivedMessages, msgs...)
+
+		return nil
+	}
+
+	bc, err := NewBulkCollector(BulkCollectorConfig{
+		Size:         bulkSize,
+		FlushTimeout: 50 * time.Millisecond, // Short timeout
+		FlushFunc:    flushFunc,
+		Logger:       logger,
+	})
+	require.NoError(t, err)
+
+	// Create a channel with fewer messages than bulk size
+	msgChan := make(chan amqp.Delivery, messageCount)
+	for i := 0; i < messageCount; i++ {
+		msgChan <- amqp.Delivery{Body: []byte{byte(i)}}
+	}
+
+	// Start collector in goroutine
+	ctx, cancel := context.WithCancel(context.Background())
+
+	go func() {
+		bc.Run(ctx, msgChan)
+	}()
+
+	// Wait for timeout-based flush
+	time.Sleep(150 * time.Millisecond)
+
+	// Cancel to stop the collector
+	cancel()
+	close(msgChan)
+
+	// Give collector time to process shutdown
+	time.Sleep(50 * time.Millisecond)
+
+	// Verify flush was called with partial messages
+	flushMu.Lock()
+	defer flushMu.Unlock()
+
+	assert.GreaterOrEqual(t, flushCount, 1, "Expected at least one flush")
+	assert.Len(t, receivedMessages, messageCount, "Expected all messages to be flushed")
+}
+
+// =============================================================================
+// UNIT TESTS - BulkCollector Graceful Shutdown
+// =============================================================================
+
+func TestBulkCollector_GracefulShutdown(t *testing.T) {
+	t.Parallel()
+
+	logger := getBulkTestLogger()
+
+	const bulkSize = 100 // Large size to prevent size-based flush
+	const messageCount = 3
+	var flushMu sync.Mutex
+	var receivedMessages []amqp.Delivery
+
+	flushFunc := func(_ context.Context, msgs []amqp.Delivery) error {
+		flushMu.Lock()
+		defer flushMu.Unlock()
+
+		receivedMessages = append(receivedMessages, msgs...)
+
+		return nil
+	}
+
+	bc, err := NewBulkCollector(BulkCollectorConfig{
+		Size:         bulkSize,
+		FlushTimeout: 10 * time.Second, // Long timeout
+		FlushFunc:    flushFunc,
+		Logger:       logger,
+	})
+	require.NoError(t, err)
+
+	// Create a channel with messages
+	msgChan := make(chan amqp.Delivery, messageCount)
+	for i := 0; i < messageCount; i++ {
+		msgChan <- amqp.Delivery{Body: []byte{byte(i)}}
+	}
+
+	// Start collector in goroutine
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+
+	go func() {
+		bc.Run(ctx, msgChan)
+		close(done)
+	}()
+
+	// Let collector receive messages
+	time.Sleep(50 * time.Millisecond)
+
+	// Trigger graceful shutdown
+	cancel()
+
+	// Wait for collector to finish
+	select {
+	case <-done:
+		// Success
+	case <-time.After(1 * time.Second):
+		t.Fatal("Collector did not shutdown within timeout")
+	}
+
+	// Verify pending messages were flushed
+	flushMu.Lock()
+	defer flushMu.Unlock()
+
+	assert.Len(t, receivedMessages, messageCount, "Expected pending messages to be flushed on shutdown")
+}
+
+// =============================================================================
+// UNIT TESTS - BulkCollector Empty Bulk Handling
+// =============================================================================
+
+func TestBulkCollector_EmptyBulk(t *testing.T) {
+	t.Parallel()
+
+	logger := getBulkTestLogger()
+
+	flushCount := 0
+	var flushMu sync.Mutex
+
+	flushFunc := func(_ context.Context, msgs []amqp.Delivery) error {
+		flushMu.Lock()
+		defer flushMu.Unlock()
+
+		flushCount++
+
+		return nil
+	}
+
+	bc, err := NewBulkCollector(BulkCollectorConfig{
+		Size:         50,
+		FlushTimeout: 50 * time.Millisecond,
+		FlushFunc:    flushFunc,
+		Logger:       logger,
+	})
+	require.NoError(t, err)
+
+	// Create and immediately close an empty channel
+	msgChan := make(chan amqp.Delivery)
+	close(msgChan)
+
+	// Run collector
+	bc.Run(context.Background(), msgChan)
+
+	// Verify no flush was called for empty buffer
+	flushMu.Lock()
+	defer flushMu.Unlock()
+
+	assert.Equal(t, 0, flushCount, "Expected no flush for empty buffer")
+}
+
+// =============================================================================
+// UNIT TESTS - BulkCollector Channel Closure
+// =============================================================================
+
+func TestBulkCollector_ChannelClosure(t *testing.T) {
+	t.Parallel()
+
+	logger := getBulkTestLogger()
+
+	const messageCount = 3
+	var flushMu sync.Mutex
+	var receivedMessages []amqp.Delivery
+
+	flushFunc := func(_ context.Context, msgs []amqp.Delivery) error {
+		flushMu.Lock()
+		defer flushMu.Unlock()
+
+		receivedMessages = append(receivedMessages, msgs...)
+
+		return nil
+	}
+
+	bc, err := NewBulkCollector(BulkCollectorConfig{
+		Size:         100, // Large size
+		FlushTimeout: 10 * time.Second,
+		FlushFunc:    flushFunc,
+		Logger:       logger,
+	})
+	require.NoError(t, err)
+
+	// Create a channel with messages
+	msgChan := make(chan amqp.Delivery, messageCount)
+	for i := 0; i < messageCount; i++ {
+		msgChan <- amqp.Delivery{Body: []byte{byte(i)}}
+	}
+
+	// Close channel to trigger flush
+	close(msgChan)
+
+	// Run collector
+	bc.Run(context.Background(), msgChan)
+
+	// Verify messages were flushed on channel closure
+	flushMu.Lock()
+	defer flushMu.Unlock()
+
+	assert.Len(t, receivedMessages, messageCount, "Expected messages to be flushed on channel closure")
+}
+
+// =============================================================================
+// UNIT TESTS - BulkCollector Len Method
+// =============================================================================
+
+func TestBulkCollector_Len(t *testing.T) {
+	t.Parallel()
+
+	logger := getBulkTestLogger()
+
+	bc, err := NewBulkCollector(BulkCollectorConfig{
+		Size:         100,
+		FlushTimeout: 10 * time.Second,
+		FlushFunc:    func(_ context.Context, _ []amqp.Delivery) error { return nil },
+		Logger:       logger,
+	})
+	require.NoError(t, err)
+
+	// Initially empty
+	assert.Equal(t, 0, bc.Len())
+
+	// Add messages manually using the internal add method
+	bc.add(amqp.Delivery{Body: []byte{1}})
+	assert.Equal(t, 1, bc.Len())
+
+	bc.add(amqp.Delivery{Body: []byte{2}})
+	assert.Equal(t, 2, bc.Len())
+
+	// Flush and verify empty
+	bc.FlushNow(context.Background())
+	assert.Equal(t, 0, bc.Len())
+}
+
+// =============================================================================
+// UNIT TESTS - BulkCollector FlushNow
+// =============================================================================
+
+func TestBulkCollector_FlushNow(t *testing.T) {
+	t.Parallel()
+
+	logger := getBulkTestLogger()
+
+	const messageCount = 3
+	var flushMu sync.Mutex
+	var receivedMessages []amqp.Delivery
+	flushTriggers := make([]string, 0)
+
+	flushFunc := func(_ context.Context, msgs []amqp.Delivery) error {
+		flushMu.Lock()
+		defer flushMu.Unlock()
+
+		receivedMessages = append(receivedMessages, msgs...)
+		flushTriggers = append(flushTriggers, "manual")
+
+		return nil
+	}
+
+	bc, err := NewBulkCollector(BulkCollectorConfig{
+		Size:         100,
+		FlushTimeout: 10 * time.Second,
+		FlushFunc:    flushFunc,
+		Logger:       logger,
+	})
+	require.NoError(t, err)
+
+	// Add messages manually
+	for i := 0; i < messageCount; i++ {
+		bc.add(amqp.Delivery{Body: []byte{byte(i)}})
+	}
+
+	// Manual flush
+	bc.FlushNow(context.Background())
+
+	// Verify
+	flushMu.Lock()
+	defer flushMu.Unlock()
+
+	assert.Len(t, receivedMessages, messageCount)
+	assert.Len(t, flushTriggers, 1)
+}
+
+// =============================================================================
+// UNIT TESTS - BulkCollector FlushFunc Error Handling
+// =============================================================================
+
+func TestBulkCollector_FlushFuncError(t *testing.T) {
+	t.Parallel()
+
+	logger := getBulkTestLogger()
+
+	flushError := errors.New("flush callback failed")
+	flushCallCount := 0
+	var flushMu sync.Mutex
+
+	flushFunc := func(_ context.Context, _ []amqp.Delivery) error {
+		flushMu.Lock()
+		defer flushMu.Unlock()
+
+		flushCallCount++
+
+		return flushError
+	}
+
+	bc, err := NewBulkCollector(BulkCollectorConfig{
+		Size:         2,
+		FlushTimeout: 10 * time.Second,
+		FlushFunc:    flushFunc,
+		Logger:       logger,
+	})
+	require.NoError(t, err)
+
+	// Add messages manually
+	bc.add(amqp.Delivery{Body: []byte{1}})
+	bc.add(amqp.Delivery{Body: []byte{2}})
+
+	// Manual flush - should call flushFunc which returns error
+	bc.FlushNow(context.Background())
+
+	// Verify flush was called even though it returned error
+	flushMu.Lock()
+	defer flushMu.Unlock()
+
+	assert.Equal(t, 1, flushCallCount, "FlushFunc should be called once")
+	assert.Equal(t, 0, bc.Len(), "Buffer should be cleared even after flush error")
+}
+
+func TestBulkCollector_FlushFuncError_ContinuesProcessing(t *testing.T) {
+	t.Parallel()
+
+	logger := getBulkTestLogger()
+
+	const bulkSize = 2
+	flushCallCount := 0
+	var flushMu sync.Mutex
+
+	// First flush fails, second succeeds
+	flushFunc := func(_ context.Context, msgs []amqp.Delivery) error {
+		flushMu.Lock()
+		flushCallCount++
+		count := flushCallCount
+		flushMu.Unlock()
+
+		if count == 1 {
+			return errors.New("first flush fails")
+		}
+
+		return nil
+	}
+
+	bc, err := NewBulkCollector(BulkCollectorConfig{
+		Size:         bulkSize,
+		FlushTimeout: 10 * time.Second,
+		FlushFunc:    flushFunc,
+		Logger:       logger,
+	})
+	require.NoError(t, err)
+
+	// Create channel with enough messages for 2 flushes
+	msgChan := make(chan amqp.Delivery, bulkSize*2)
+	for i := 0; i < bulkSize*2; i++ {
+		msgChan <- amqp.Delivery{Body: []byte{byte(i)}}
+	}
+
+	close(msgChan)
+
+	// Run collector
+	bc.Run(context.Background(), msgChan)
+
+	// Verify both flushes were attempted (error didn't stop processing)
+	flushMu.Lock()
+	defer flushMu.Unlock()
+
+	assert.Equal(t, 2, flushCallCount, "Both flushes should be attempted despite first error")
+}
+
+// =============================================================================
+// UNIT TESTS - BulkCollector Multiple Bulk Cycles
+// =============================================================================
+
+func TestBulkCollector_MultipleBulkCycles(t *testing.T) {
+	t.Parallel()
+
+	logger := getBulkTestLogger()
+
+	const bulkSize = 3
+	const totalMessages = 10 // Should result in 4 flushes (3+3+3+1)
+	flushCount := 0
+	var flushMu sync.Mutex
+	flushSizes := make([]int, 0)
+
+	flushFunc := func(_ context.Context, msgs []amqp.Delivery) error {
+		flushMu.Lock()
+		defer flushMu.Unlock()
+
+		flushCount++
+		flushSizes = append(flushSizes, len(msgs))
+
+		return nil
+	}
+
+	bc, err := NewBulkCollector(BulkCollectorConfig{
+		Size:         bulkSize,
+		FlushTimeout: 10 * time.Second,
+		FlushFunc:    flushFunc,
+		Logger:       logger,
+	})
+	require.NoError(t, err)
+
+	// Create channel with total messages
+	msgChan := make(chan amqp.Delivery, totalMessages)
+	for i := 0; i < totalMessages; i++ {
+		msgChan <- amqp.Delivery{Body: []byte{byte(i)}}
+	}
+
+	close(msgChan)
+
+	// Run collector
+	bc.Run(context.Background(), msgChan)
+
+	// Verify multiple flush cycles
+	flushMu.Lock()
+	defer flushMu.Unlock()
+
+	assert.Equal(t, 4, flushCount, "Expected 4 flush cycles (3+3+3+1)")
+
+	// Verify flush sizes
+	assert.Equal(t, []int{3, 3, 3, 1}, flushSizes)
+}

--- a/components/transaction/internal/bootstrap/config.go
+++ b/components/transaction/internal/bootstrap/config.go
@@ -209,6 +209,18 @@ type Config struct {
 	// Multi-tenant consumer configuration
 	RabbitMQMultiTenantSyncInterval     int `env:"RABBITMQ_MULTI_TENANT_SYNC_INTERVAL"`     // Stored in seconds
 	RabbitMQMultiTenantDiscoveryTimeout int `env:"RABBITMQ_MULTI_TENANT_DISCOVERY_TIMEOUT"` // Stored in milliseconds
+
+	// Bulk Recorder configuration
+	// Enables bulk message processing for improved throughput (only effective when RABBITMQ_TRANSACTION_ASYNC=true)
+	BulkRecorderEnabled bool `env:"BULK_RECORDER_ENABLED" default:"true"`
+	// Messages per bulk; if 0 or not set, defaults to workers × prefetch (5 × 10 = 50)
+	BulkRecorderSize int `env:"BULK_RECORDER_SIZE"`
+	// Maximum wait time before flushing an incomplete bulk (milliseconds)
+	BulkRecorderFlushTimeoutMs int `env:"BULK_RECORDER_FLUSH_TIMEOUT_MS" default:"100"`
+	// Maximum rows per INSERT statement to avoid PostgreSQL parameter limit
+	BulkRecorderMaxRowsPerInsert int `env:"BULK_RECORDER_MAX_ROWS_PER_INSERT" default:"1000"`
+	// Fall back to individual inserts when bulk processing fails
+	BulkRecorderFallbackEnabled bool `env:"BULK_RECORDER_FALLBACK_ENABLED" default:"true"`
 }
 
 // Options contains optional dependencies that can be injected by callers.
@@ -378,6 +390,58 @@ func initBalanceSyncWorker(opts *Options, cfg *Config, logger libLog.Logger, com
 	logger.Log(context.Background(), libLog.LevelInfo, fmt.Sprintf("BalanceSyncWorker enabled with %d max workers.", balanceSyncMaxWorkers))
 
 	return balanceSyncWorker
+}
+
+// BulkRecorderConfig holds the resolved bulk recorder configuration values.
+// Use GetBulkRecorderConfig to obtain an instance with properly derived defaults.
+type BulkRecorderConfig struct {
+	Enabled          bool
+	Size             int
+	FlushTimeoutMs   int
+	MaxRowsPerInsert int
+	FallbackEnabled  bool
+}
+
+// defaultBulkRecorderSize is the fallback when neither BulkRecorderSize nor prefetch derivation yields a value.
+const defaultBulkRecorderSize = 50
+
+// defaultBulkRecorderFlushTimeoutMs is the default flush timeout in milliseconds.
+const defaultBulkRecorderFlushTimeoutMs = 100
+
+// defaultBulkRecorderMaxRowsPerInsert is the default max rows per INSERT to stay under PostgreSQL's 65,535 parameter limit.
+const defaultBulkRecorderMaxRowsPerInsert = 1000
+
+// GetBulkRecorderConfig returns the resolved bulk recorder configuration.
+// It derives BulkRecorderSize from RabbitMQ workers × prefetch if not explicitly set.
+func (c *Config) GetBulkRecorderConfig() BulkRecorderConfig {
+	size := c.BulkRecorderSize
+	if size <= 0 {
+		// Derive from RabbitMQ prefetch configuration: workers × prefetch
+		prefetch := c.RabbitMQNumbersOfWorkers * c.RabbitMQNumbersOfPrefetch
+		if prefetch > 0 {
+			size = prefetch
+		} else {
+			size = defaultBulkRecorderSize
+		}
+	}
+
+	flushTimeout := c.BulkRecorderFlushTimeoutMs
+	if flushTimeout <= 0 {
+		flushTimeout = defaultBulkRecorderFlushTimeoutMs
+	}
+
+	maxRows := c.BulkRecorderMaxRowsPerInsert
+	if maxRows <= 0 {
+		maxRows = defaultBulkRecorderMaxRowsPerInsert
+	}
+
+	return BulkRecorderConfig{
+		Enabled:          c.BulkRecorderEnabled,
+		Size:             size,
+		FlushTimeoutMs:   flushTimeout,
+		MaxRowsPerInsert: maxRows,
+		FallbackEnabled:  c.BulkRecorderFallbackEnabled,
+	}
 }
 
 // InitServersWithOptions initiates http and grpc servers with optional dependency injection.

--- a/components/transaction/internal/bootstrap/config.postgres.go
+++ b/components/transaction/internal/bootstrap/config.postgres.go
@@ -21,6 +21,22 @@ import (
 	"github.com/LerianStudio/midaz/v3/pkg/utils"
 )
 
+// PostgreSQL bind parameter limit is 65,535. Safe ceilings computed per entity column count
+// to prevent "too many bind parameters" errors during bulk INSERT operations.
+const (
+	transactionSafeCeiling = 4096 // 65,535 / 16 columns
+	operationSafeCeiling   = 2185 // 65,535 / 30 columns
+)
+
+// clampChunkSize returns the minimum of configured and safe ceiling values.
+func clampChunkSize(configured, safeCeiling int) int {
+	if configured > safeCeiling {
+		return safeCeiling
+	}
+
+	return configured
+}
+
 // postgresComponents holds PostgreSQL-related components initialized during bootstrap.
 type postgresComponents struct {
 	connection           *libPostgres.Client
@@ -65,19 +81,28 @@ func initMultiTenantPostgres(opts *Options, cfg *Config, logger libLog.Logger) (
 		return nil, fmt.Errorf("failed to connect to PostgreSQL (multi-tenant): %w", err)
 	}
 
-	// Get bulk recorder chunk size from config (defaults to 1000 if not set)
+	// Get bulk recorder chunk size from config (defaults to 1000 if not set).
+	// Clamp per-repo to avoid exceeding PostgreSQL's 65,535 bind parameter limit.
 	bulkCfg := cfg.GetBulkRecorderConfig()
+	txChunkSize := clampChunkSize(bulkCfg.MaxRowsPerInsert, transactionSafeCeiling)
+	opChunkSize := clampChunkSize(bulkCfg.MaxRowsPerInsert, operationSafeCeiling)
+
+	if bulkCfg.MaxRowsPerInsert > operationSafeCeiling {
+		logger.Log(context.Background(), libLog.LevelWarn,
+			fmt.Sprintf("Configured MaxRowsPerInsert %d exceeds operation safe ceiling %d; clamped to avoid PostgreSQL bind parameter limit",
+				bulkCfg.MaxRowsPerInsert, operationSafeCeiling))
+	}
 
 	return &postgresComponents{
 		connection: conn,
 		pgManager:  pgMgr,
 		transactionRepo: transaction.NewTransactionPostgreSQLRepository(conn,
 			transaction.WithRequireTenant(true),
-			transaction.WithTransactionChunkSize(bulkCfg.MaxRowsPerInsert),
+			transaction.WithTransactionChunkSize(txChunkSize),
 		),
 		operationRepo: operation.NewOperationPostgreSQLRepository(conn,
 			operation.WithOperationRequireTenant(true),
-			operation.WithOperationChunkSize(bulkCfg.MaxRowsPerInsert),
+			operation.WithOperationChunkSize(opChunkSize),
 		),
 		assetRateRepo:        assetrate.NewAssetRatePostgreSQLRepository(conn, true),
 		balanceRepo:          balance.NewBalancePostgreSQLRepository(conn, true),
@@ -98,16 +123,25 @@ func initSingleTenantPostgres(cfg *Config, logger libLog.Logger) (*postgresCompo
 		return nil, fmt.Errorf("failed to run PostgreSQL migrations: %w", err)
 	}
 
-	// Get bulk recorder chunk size from config (defaults to 1000 if not set)
+	// Get bulk recorder chunk size from config (defaults to 1000 if not set).
+	// Clamp per-repo to avoid exceeding PostgreSQL's 65,535 bind parameter limit.
 	bulkCfg := cfg.GetBulkRecorderConfig()
+	txChunkSize := clampChunkSize(bulkCfg.MaxRowsPerInsert, transactionSafeCeiling)
+	opChunkSize := clampChunkSize(bulkCfg.MaxRowsPerInsert, operationSafeCeiling)
+
+	if bulkCfg.MaxRowsPerInsert > operationSafeCeiling {
+		logger.Log(context.Background(), libLog.LevelWarn,
+			fmt.Sprintf("Configured MaxRowsPerInsert %d exceeds operation safe ceiling %d; clamped to avoid PostgreSQL bind parameter limit",
+				bulkCfg.MaxRowsPerInsert, operationSafeCeiling))
+	}
 
 	return &postgresComponents{
 		connection: conn,
 		transactionRepo: transaction.NewTransactionPostgreSQLRepository(conn,
-			transaction.WithTransactionChunkSize(bulkCfg.MaxRowsPerInsert),
+			transaction.WithTransactionChunkSize(txChunkSize),
 		),
 		operationRepo: operation.NewOperationPostgreSQLRepository(conn,
-			operation.WithOperationChunkSize(bulkCfg.MaxRowsPerInsert),
+			operation.WithOperationChunkSize(opChunkSize),
 		),
 		assetRateRepo:        assetrate.NewAssetRatePostgreSQLRepository(conn),
 		balanceRepo:          balance.NewBalancePostgreSQLRepository(conn),

--- a/components/transaction/internal/bootstrap/config.postgres.go
+++ b/components/transaction/internal/bootstrap/config.postgres.go
@@ -65,11 +65,20 @@ func initMultiTenantPostgres(opts *Options, cfg *Config, logger libLog.Logger) (
 		return nil, fmt.Errorf("failed to connect to PostgreSQL (multi-tenant): %w", err)
 	}
 
+	// Get bulk recorder chunk size from config (defaults to 1000 if not set)
+	bulkCfg := cfg.GetBulkRecorderConfig()
+
 	return &postgresComponents{
-		connection:           conn,
-		pgManager:            pgMgr,
-		transactionRepo:      transaction.NewTransactionPostgreSQLRepository(conn, true),
-		operationRepo:        operation.NewOperationPostgreSQLRepository(conn, true),
+		connection: conn,
+		pgManager:  pgMgr,
+		transactionRepo: transaction.NewTransactionPostgreSQLRepository(conn,
+			transaction.WithRequireTenant(true),
+			transaction.WithTransactionChunkSize(bulkCfg.MaxRowsPerInsert),
+		),
+		operationRepo: operation.NewOperationPostgreSQLRepository(conn,
+			operation.WithOperationRequireTenant(true),
+			operation.WithOperationChunkSize(bulkCfg.MaxRowsPerInsert),
+		),
 		assetRateRepo:        assetrate.NewAssetRatePostgreSQLRepository(conn, true),
 		balanceRepo:          balance.NewBalancePostgreSQLRepository(conn, true),
 		operationRouteRepo:   operationroute.NewOperationRoutePostgreSQLRepository(conn, true),
@@ -89,10 +98,17 @@ func initSingleTenantPostgres(cfg *Config, logger libLog.Logger) (*postgresCompo
 		return nil, fmt.Errorf("failed to run PostgreSQL migrations: %w", err)
 	}
 
+	// Get bulk recorder chunk size from config (defaults to 1000 if not set)
+	bulkCfg := cfg.GetBulkRecorderConfig()
+
 	return &postgresComponents{
-		connection:           conn,
-		transactionRepo:      transaction.NewTransactionPostgreSQLRepository(conn),
-		operationRepo:        operation.NewOperationPostgreSQLRepository(conn),
+		connection: conn,
+		transactionRepo: transaction.NewTransactionPostgreSQLRepository(conn,
+			transaction.WithTransactionChunkSize(bulkCfg.MaxRowsPerInsert),
+		),
+		operationRepo: operation.NewOperationPostgreSQLRepository(conn,
+			operation.WithOperationChunkSize(bulkCfg.MaxRowsPerInsert),
+		),
 		assetRateRepo:        assetrate.NewAssetRatePostgreSQLRepository(conn),
 		balanceRepo:          balance.NewBalancePostgreSQLRepository(conn),
 		operationRouteRepo:   operationroute.NewOperationRoutePostgreSQLRepository(conn),

--- a/components/transaction/internal/bootstrap/config_test.go
+++ b/components/transaction/internal/bootstrap/config_test.go
@@ -586,6 +586,264 @@ func FuzzEnvFallback_Inputs(f *testing.F) {
 	})
 }
 
+// =============================================================================
+// UNIT TESTS - GetBulkRecorderConfig
+// =============================================================================
+
+// TestGetBulkRecorderConfig_DerivedFromPrefetch verifies that bulk size is correctly
+// derived from workers × prefetch when BULK_RECORDER_SIZE is not set (zero).
+func TestGetBulkRecorderConfig_DerivedFromPrefetch(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		workers         int
+		prefetch        int
+		bulkSize        int
+		expectedSize    int
+		expectedDerived bool
+	}{
+		{
+			name:            "derives_from_workers_x_prefetch_when_size_not_set",
+			workers:         5,
+			prefetch:        10,
+			bulkSize:        0,
+			expectedSize:    50, // 5 × 10 = 50
+			expectedDerived: true,
+		},
+		{
+			name:            "uses_explicit_size_when_set",
+			workers:         5,
+			prefetch:        10,
+			bulkSize:        100,
+			expectedSize:    100, // Explicit override
+			expectedDerived: false,
+		},
+		{
+			name:            "uses_default_when_workers_zero",
+			workers:         0,
+			prefetch:        10,
+			bulkSize:        0,
+			expectedSize:    50, // defaultBulkRecorderSize
+			expectedDerived: true,
+		},
+		{
+			name:            "uses_default_when_prefetch_zero",
+			workers:         5,
+			prefetch:        0,
+			bulkSize:        0,
+			expectedSize:    50, // defaultBulkRecorderSize
+			expectedDerived: true,
+		},
+		{
+			name:            "uses_default_when_both_zero",
+			workers:         0,
+			prefetch:        0,
+			bulkSize:        0,
+			expectedSize:    50, // defaultBulkRecorderSize
+			expectedDerived: true,
+		},
+		{
+			name:            "derives_from_different_worker_prefetch_values",
+			workers:         10,
+			prefetch:        20,
+			bulkSize:        0,
+			expectedSize:    200, // 10 × 20 = 200
+			expectedDerived: true,
+		},
+		{
+			name:            "negative_bulk_size_uses_derivation",
+			workers:         5,
+			prefetch:        10,
+			bulkSize:        -1,
+			expectedSize:    50, // Derived from workers × prefetch
+			expectedDerived: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := &Config{
+				RabbitMQNumbersOfWorkers:  tt.workers,
+				RabbitMQNumbersOfPrefetch: tt.prefetch,
+				BulkRecorderSize:          tt.bulkSize,
+				BulkRecorderEnabled:       true,
+			}
+
+			result := cfg.GetBulkRecorderConfig()
+
+			assert.Equal(t, tt.expectedSize, result.Size,
+				"bulk size should be %d for workers=%d, prefetch=%d, explicit_size=%d",
+				tt.expectedSize, tt.workers, tt.prefetch, tt.bulkSize)
+		})
+	}
+}
+
+// TestGetBulkRecorderConfig_DefaultsApplied verifies that all default values are
+// correctly applied when configuration fields are zero or not set.
+func TestGetBulkRecorderConfig_DefaultsApplied(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name                 string
+		cfg                  Config
+		expectedSize         int
+		expectedFlushTimeout int
+		expectedMaxRows      int
+		expectedEnabled      bool
+		expectedFallback     bool
+	}{
+		{
+			name:                 "all_defaults_when_zero_config",
+			cfg:                  Config{},
+			expectedSize:         50,   // defaultBulkRecorderSize
+			expectedFlushTimeout: 100,  // defaultBulkRecorderFlushTimeoutMs
+			expectedMaxRows:      1000, // defaultBulkRecorderMaxRowsPerInsert
+			expectedEnabled:      false,
+			expectedFallback:     false,
+		},
+		{
+			name: "enabled_and_fallback_flags_preserved",
+			cfg: Config{
+				BulkRecorderEnabled:         true,
+				BulkRecorderFallbackEnabled: true,
+			},
+			expectedSize:         50,
+			expectedFlushTimeout: 100,
+			expectedMaxRows:      1000,
+			expectedEnabled:      true,
+			expectedFallback:     true,
+		},
+		{
+			name: "flush_timeout_default_when_zero",
+			cfg: Config{
+				BulkRecorderFlushTimeoutMs: 0,
+			},
+			expectedSize:         50,
+			expectedFlushTimeout: 100, // Default applied
+			expectedMaxRows:      1000,
+			expectedEnabled:      false,
+			expectedFallback:     false,
+		},
+		{
+			name: "flush_timeout_default_when_negative",
+			cfg: Config{
+				BulkRecorderFlushTimeoutMs: -50,
+			},
+			expectedSize:         50,
+			expectedFlushTimeout: 100, // Default applied for negative
+			expectedMaxRows:      1000,
+			expectedEnabled:      false,
+			expectedFallback:     false,
+		},
+		{
+			name: "max_rows_default_when_zero",
+			cfg: Config{
+				BulkRecorderMaxRowsPerInsert: 0,
+			},
+			expectedSize:         50,
+			expectedFlushTimeout: 100,
+			expectedMaxRows:      1000, // Default applied
+			expectedEnabled:      false,
+			expectedFallback:     false,
+		},
+		{
+			name: "max_rows_default_when_negative",
+			cfg: Config{
+				BulkRecorderMaxRowsPerInsert: -100,
+			},
+			expectedSize:         50,
+			expectedFlushTimeout: 100,
+			expectedMaxRows:      1000, // Default applied for negative
+			expectedEnabled:      false,
+			expectedFallback:     false,
+		},
+		{
+			name: "explicit_values_preserved",
+			cfg: Config{
+				BulkRecorderEnabled:          true,
+				BulkRecorderSize:             200,
+				BulkRecorderFlushTimeoutMs:   500,
+				BulkRecorderMaxRowsPerInsert: 2000,
+				BulkRecorderFallbackEnabled:  true,
+			},
+			expectedSize:         200,
+			expectedFlushTimeout: 500,
+			expectedMaxRows:      2000,
+			expectedEnabled:      true,
+			expectedFallback:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			result := tt.cfg.GetBulkRecorderConfig()
+
+			assert.Equal(t, tt.expectedSize, result.Size, "Size mismatch")
+			assert.Equal(t, tt.expectedFlushTimeout, result.FlushTimeoutMs, "FlushTimeoutMs mismatch")
+			assert.Equal(t, tt.expectedMaxRows, result.MaxRowsPerInsert, "MaxRowsPerInsert mismatch")
+			assert.Equal(t, tt.expectedEnabled, result.Enabled, "Enabled mismatch")
+			assert.Equal(t, tt.expectedFallback, result.FallbackEnabled, "FallbackEnabled mismatch")
+		})
+	}
+}
+
+// TestGetBulkRecorderConfig_Invariants verifies key invariants of the configuration.
+func TestGetBulkRecorderConfig_Invariants(t *testing.T) {
+	t.Parallel()
+
+	t.Run("size_always_positive", func(t *testing.T) {
+		t.Parallel()
+
+		// Any configuration should produce a positive size
+		configs := []Config{
+			{},
+			{BulkRecorderSize: -1},
+			{BulkRecorderSize: 0},
+			{RabbitMQNumbersOfWorkers: -1, RabbitMQNumbersOfPrefetch: -1},
+		}
+
+		for i, cfg := range configs {
+			result := cfg.GetBulkRecorderConfig()
+			assert.Greater(t, result.Size, 0, "Config %d: Size must always be positive", i)
+		}
+	})
+
+	t.Run("flush_timeout_always_positive", func(t *testing.T) {
+		t.Parallel()
+
+		configs := []Config{
+			{},
+			{BulkRecorderFlushTimeoutMs: -1},
+			{BulkRecorderFlushTimeoutMs: 0},
+		}
+
+		for i, cfg := range configs {
+			result := cfg.GetBulkRecorderConfig()
+			assert.Greater(t, result.FlushTimeoutMs, 0, "Config %d: FlushTimeoutMs must always be positive", i)
+		}
+	})
+
+	t.Run("max_rows_always_positive", func(t *testing.T) {
+		t.Parallel()
+
+		configs := []Config{
+			{},
+			{BulkRecorderMaxRowsPerInsert: -1},
+			{BulkRecorderMaxRowsPerInsert: 0},
+		}
+
+		for i, cfg := range configs {
+			result := cfg.GetBulkRecorderConfig()
+			assert.Greater(t, result.MaxRowsPerInsert, 0, "Config %d: MaxRowsPerInsert must always be positive", i)
+		}
+	})
+}
+
 // FuzzEnvFallbackInt_Inputs fuzzes utils.EnvFallbackInt to verify it never panics and
 // correctly returns prefixed when non-zero, fallback otherwise.
 func FuzzEnvFallbackInt_Inputs(f *testing.F) {

--- a/components/transaction/internal/services/command/create-bulk-transaction-operations-async.go
+++ b/components/transaction/internal/services/command/create-bulk-transaction-operations-async.go
@@ -172,20 +172,30 @@ func (uc *UseCase) CreateBulkTransactionOperationsAsync(
 		return result, messageResults, nil
 	}
 
-	// Bulk insert succeeded: mark all valid messages as successful
-	for _, idx := range validPayloadIndices {
-		messageResults[idx] = BulkMessageResult{Index: idx, Success: true}
-	}
+	// Phase 7: Post-processing (metadata, events) - strict behavior
+	metadataFailures := uc.postProcessBulk(ctx, logger, payloads, validPayloadIndices, messages)
 
-	// Phase 7: Post-processing (metadata, events) - best effort
-	uc.postProcessBulk(ctx, logger, payloads, validPayloadIndices, messages)
+	// Mark message results based on metadata success/failure
+	for _, idx := range validPayloadIndices {
+		if err, failed := metadataFailures[idx]; failed {
+			messageResults[idx] = BulkMessageResult{Index: idx, Success: false, Error: err}
+		} else {
+			messageResults[idx] = BulkMessageResult{Index: idx, Success: true}
+		}
+	}
 
 	logger.Log(ctx, libLog.LevelInfo, "Bulk transaction processing completed",
 		libLog.Any("transactionsInserted", result.TransactionsInserted),
 		libLog.Any("transactionsIgnored", result.TransactionsIgnored),
 		libLog.Any("transactionsUpdated", result.TransactionsUpdated),
 		libLog.Any("operationsInserted", result.OperationsInserted),
-		libLog.Any("operationsIgnored", result.OperationsIgnored))
+		libLog.Any("operationsIgnored", result.OperationsIgnored),
+		libLog.Int("metadataFailures", len(metadataFailures)))
+
+	// Return error if any metadata creation failed (strict behavior)
+	if len(metadataFailures) > 0 {
+		return result, messageResults, fmt.Errorf("metadata creation failed for %d message(s)", len(metadataFailures))
+	}
 
 	return result, messageResults, nil
 }
@@ -247,7 +257,12 @@ func (uc *UseCase) processBalances(
 		results[i] = BulkMessageResult{Index: i, Success: true}
 
 		if payload == nil {
-			results[i] = BulkMessageResult{Index: i, Success: false, Error: errors.New("nil payload")}
+			// Only set error if no prior error exists (e.g., from unmarshal phase)
+			// This preserves the root cause error for debugging
+			if results[i].Error == nil {
+				results[i] = BulkMessageResult{Index: i, Success: false, Error: errors.New("nil payload")}
+			}
+
 			continue
 		}
 
@@ -257,7 +272,11 @@ func (uc *UseCase) processBalances(
 		}
 
 		if payload.Validate == nil {
-			results[i] = BulkMessageResult{Index: i, Success: false, Error: errors.New("nil Validate field")}
+			// Only set error if no prior error exists (preserve root cause)
+			if results[i].Error == nil {
+				results[i] = BulkMessageResult{Index: i, Success: false, Error: errors.New("nil Validate field")}
+			}
+
 			continue
 		}
 
@@ -273,7 +292,10 @@ func (uc *UseCase) processBalances(
 				libLog.Int("index", i),
 				libLog.Err(err))
 
-			results[i] = BulkMessageResult{Index: i, Success: false, Error: err}
+			// Only set error if no prior error exists (preserve root cause)
+			if results[i].Error == nil {
+				results[i] = BulkMessageResult{Index: i, Success: false, Error: err}
+			}
 		}
 	}
 
@@ -547,8 +569,10 @@ func (uc *UseCase) processFallback(
 			continue
 		}
 
-		// Create operations individually
+		// Create operations individually with metadata (strict behavior)
 		allOpsSuccess := true
+
+		var opFailErr error
 
 		for _, op := range tran.Operations {
 			// Defensive nil check to prevent panic
@@ -559,17 +583,32 @@ func (uc *UseCase) processFallback(
 			_, opErr := uc.OperationRepo.Create(ctx, op)
 			if opErr != nil {
 				var pgErr *pgconn.PgError
-				if errors.As(opErr, &pgErr) && pgErr.Code == constant.UniqueViolationCode {
-					// Duplicate operation is fine (idempotency)
-					continue
-				}
 
-				logger.Log(ctx, libLog.LevelError, "Fallback: failed to create operation",
+				// Non-duplicate errors are fatal; duplicates are idempotent (continue to metadata)
+				isDuplicate := errors.As(opErr, &pgErr) && pgErr.Code == constant.UniqueViolationCode
+				if !isDuplicate {
+					logger.Log(ctx, libLog.LevelError, "Fallback: failed to create operation",
+						libLog.Int("index", idx),
+						libLog.String("operationID", op.ID),
+						libLog.Err(opErr))
+
+					allOpsSuccess = false
+					opFailErr = opErr
+
+					break
+				}
+			}
+
+			// Create operation metadata (strict: failure is an error)
+			// Matches the individual flow in CreateBalanceTransactionOperationsAsync
+			if metaErr := uc.CreateMetadataAsync(ctx, logger, op.Metadata, op.ID, reflect.TypeOf(operation.Operation{}).Name()); metaErr != nil {
+				logger.Log(ctx, libLog.LevelError, "Fallback: failed to create operation metadata",
 					libLog.Int("index", idx),
 					libLog.String("operationID", op.ID),
-					libLog.Err(opErr))
+					libLog.Err(metaErr))
 
 				allOpsSuccess = false
+				opFailErr = fmt.Errorf("failed to create operation metadata: %w", metaErr)
 
 				break
 			}
@@ -585,7 +624,7 @@ func (uc *UseCase) processFallback(
 			go uc.RemoveTransactionFromRedisQueue(asyncCtx, logger, msg.OrganizationID, msg.LedgerID, tran.ID)
 			go uc.DeleteWriteBehindTransaction(asyncCtx, msg.OrganizationID, msg.LedgerID, tran.ID)
 		} else {
-			results = append(results, BulkMessageResult{Index: idx, Success: false, Error: errors.New("operation insert failed")})
+			results = append(results, BulkMessageResult{Index: idx, Success: false, Error: opFailErr})
 		}
 	}
 
@@ -593,6 +632,7 @@ func (uc *UseCase) processFallback(
 }
 
 // createTransactionIndividually creates a single transaction using the existing pattern.
+// Strict behavior: returns error if metadata creation fails, consistent with individual flow.
 func (uc *UseCase) createTransactionIndividually(
 	ctx context.Context,
 	logger libLog.Logger,
@@ -604,25 +644,30 @@ func (uc *UseCase) createTransactionIndividually(
 		return nil, err
 	}
 
-	// Create metadata for transaction
+	// Create metadata for transaction (strict: failure is an error)
 	if err := uc.CreateMetadataAsync(ctx, logger, tran.Metadata, tran.ID, reflect.TypeOf(transaction.Transaction{}).Name()); err != nil {
-		logger.Log(ctx, libLog.LevelWarn, "Fallback: failed to create transaction metadata",
+		logger.Log(ctx, libLog.LevelError, "Fallback: failed to create transaction metadata",
 			libLog.String("transactionID", tran.ID),
 			libLog.Err(err))
-		// Continue despite metadata error
+
+		return nil, fmt.Errorf("failed to create transaction metadata: %w", err)
 	}
 
 	return tran, nil
 }
 
 // postProcessBulk handles metadata creation and event sending for bulk-inserted transactions.
+// Returns a map of indices that failed metadata creation with their respective errors.
+// Strict behavior: metadata failure is reported as an error, consistent with the individual flow.
 func (uc *UseCase) postProcessBulk(
 	ctx context.Context,
 	logger libLog.Logger,
 	payloads []*transaction.TransactionProcessingPayload,
 	validIndices []int,
 	messages []mmodel.Queue,
-) {
+) map[int]error {
+	failedIndices := make(map[int]error)
+
 	for _, idx := range validIndices {
 		payload := payloads[idx]
 		msg := messages[idx]
@@ -633,31 +678,49 @@ func (uc *UseCase) postProcessBulk(
 
 		tran := payload.Transaction
 
-		// Create metadata (best effort)
+		var metadataFailed bool
+
+		// Create transaction metadata (strict: failure is an error)
 		if err := uc.CreateMetadataAsync(ctx, logger, tran.Metadata, tran.ID, reflect.TypeOf(transaction.Transaction{}).Name()); err != nil {
-			logger.Log(ctx, libLog.LevelWarn, "Bulk: failed to create transaction metadata",
+			logger.Log(ctx, libLog.LevelError, "Bulk: failed to create transaction metadata",
 				libLog.String("transactionID", tran.ID),
 				libLog.Err(err))
+
+			failedIndices[idx] = fmt.Errorf("failed to create transaction metadata: %w", err)
+			metadataFailed = true
 		}
 
-		// Create operation metadata
-		for _, op := range tran.Operations {
-			if op != nil && op.Metadata != nil {
-				if err := uc.CreateMetadataAsync(ctx, logger, op.Metadata, op.ID, reflect.TypeOf(operation.Operation{}).Name()); err != nil {
-					logger.Log(ctx, libLog.LevelWarn, "Bulk: failed to create operation metadata",
-						libLog.String("operationID", op.ID),
-						libLog.Err(err))
+		// Create operation metadata (strict: failure is an error)
+		// Only attempt if transaction metadata succeeded
+		if !metadataFailed {
+			for _, op := range tran.Operations {
+				if op != nil {
+					if err := uc.CreateMetadataAsync(ctx, logger, op.Metadata, op.ID, reflect.TypeOf(operation.Operation{}).Name()); err != nil {
+						logger.Log(ctx, libLog.LevelError, "Bulk: failed to create operation metadata",
+							libLog.String("operationID", op.ID),
+							libLog.Err(err))
+
+						failedIndices[idx] = fmt.Errorf("failed to create operation metadata for %s: %w", op.ID, err)
+						metadataFailed = true
+
+						break
+					}
 				}
 			}
 		}
 
-		// Async cleanup and events
-		// Use detached context so async work completes even if request context is canceled
-		asyncCtx := context.WithoutCancel(ctx)
-		go uc.SendTransactionEvents(asyncCtx, tran)
-		go uc.RemoveTransactionFromRedisQueue(asyncCtx, logger, msg.OrganizationID, msg.LedgerID, tran.ID)
-		go uc.DeleteWriteBehindTransaction(asyncCtx, msg.OrganizationID, msg.LedgerID, tran.ID)
+		// Only send events and cleanup if metadata succeeded
+		if !metadataFailed {
+			// Async cleanup and events
+			// Use detached context so async work completes even if request context is canceled
+			asyncCtx := context.WithoutCancel(ctx)
+			go uc.SendTransactionEvents(asyncCtx, tran)
+			go uc.RemoveTransactionFromRedisQueue(asyncCtx, logger, msg.OrganizationID, msg.LedgerID, tran.ID)
+			go uc.DeleteWriteBehindTransaction(asyncCtx, msg.OrganizationID, msg.LedgerID, tran.ID)
+		}
 	}
+
+	return failedIndices
 }
 
 // sortTransactionsByID sorts transactions by ID to prevent deadlocks during bulk insert.

--- a/components/transaction/internal/services/command/create-bulk-transaction-operations-async.go
+++ b/components/transaction/internal/services/command/create-bulk-transaction-operations-async.go
@@ -23,6 +23,10 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
+// bulkUpdateThreshold determines when to use bulk update vs individual updates.
+// If the number of transactions to update exceeds this threshold, bulk update is used.
+const bulkUpdateThreshold = 10
+
 // BulkResult aggregates the results from bulk insert operations.
 // It contains counts for both transactions and operations.
 type BulkResult struct {
@@ -30,6 +34,10 @@ type BulkResult struct {
 	TransactionsAttempted int64
 	TransactionsInserted  int64
 	TransactionsIgnored   int64
+
+	// Transaction update results (PENDING → APPROVED/CANCELED)
+	TransactionsUpdateAttempted int64
+	TransactionsUpdated         int64
 
 	// Operation insert results
 	OperationsAttempted int64
@@ -125,15 +133,16 @@ func (uc *UseCase) CreateBulkTransactionOperationsAsync(
 		return result, messageResults, fmt.Errorf("all messages failed balance processing")
 	}
 
-	// Phase 3: Extract transactions and operations from valid payloads
-	transactions, operations := uc.extractEntities(payloads, validPayloadIndices)
+	// Phase 3: Classify and extract transactions and operations from valid payloads
+	toInsert, toUpdate, operations := uc.classifyAndExtractEntities(payloads, validPayloadIndices)
 
 	// Phase 4: Sort by ID to prevent deadlocks
-	sortTransactionsByID(transactions)
+	sortTransactionsByID(toInsert)
+	sortTransactionsByID(toUpdate)
 	sortOperationsByID(operations)
 
-	// Phase 5: Attempt bulk insert
-	bulkErr := uc.performBulkInsert(ctx, logger, tracer, transactions, operations, result)
+	// Phase 5: Attempt bulk insert and update
+	bulkErr := uc.performBulkInsertAndUpdate(ctx, logger, tracer, toInsert, toUpdate, operations, result)
 	if bulkErr != nil {
 		logger.Log(ctx, libLog.LevelWarn, "Bulk insert failed, checking fallback",
 			libLog.Err(bulkErr),
@@ -173,6 +182,7 @@ func (uc *UseCase) CreateBulkTransactionOperationsAsync(
 	logger.Log(ctx, libLog.LevelInfo, "Bulk transaction processing completed",
 		libLog.Any("transactionsInserted", result.TransactionsInserted),
 		libLog.Any("transactionsIgnored", result.TransactionsIgnored),
+		libLog.Any("transactionsUpdated", result.TransactionsUpdated),
 		libLog.Any("operationsInserted", result.OperationsInserted),
 		libLog.Any("operationsIgnored", result.OperationsIgnored))
 
@@ -269,13 +279,20 @@ func (uc *UseCase) processBalances(
 	return results
 }
 
-// extractEntities extracts transactions and operations from valid payloads.
-func (uc *UseCase) extractEntities(
+// classifyAndExtractEntities extracts transactions and operations from valid payloads,
+// classifying transactions into those that need insert vs those that need status update.
+//
+// Classification logic (matching CreateOrUpdateTransaction):
+//   - toUpdate: transactions where Validate.Pending == true AND status is APPROVED or CANCELED
+//     (these are PENDING→final transitions that need UPDATE instead of INSERT)
+//   - toInsert: all other transactions (new transactions to be inserted)
+func (uc *UseCase) classifyAndExtractEntities(
 	payloads []*transaction.TransactionProcessingPayload,
 	validIndices []int,
-) ([]*transaction.Transaction, []*operation.Operation) {
-	transactions := make([]*transaction.Transaction, 0, len(validIndices))
-	operations := make([]*operation.Operation, 0, len(validIndices)*5) // Estimate 5 ops per transaction
+) (toInsert []*transaction.Transaction, toUpdate []*transaction.Transaction, operations []*operation.Operation) {
+	toInsert = make([]*transaction.Transaction, 0, len(validIndices))
+	toUpdate = make([]*transaction.Transaction, 0)
+	operations = make([]*operation.Operation, 0, len(validIndices)*5) // Estimate 5 ops per transaction
 
 	for _, idx := range validIndices {
 		payload := payloads[idx]
@@ -299,9 +316,19 @@ func (uc *UseCase) extractEntities(
 			tran.Body = *payload.Input
 		}
 
-		transactions = append(transactions, tran)
+		// Classification: check if this is a PENDING→final transition
+		// Matching logic from CreateOrUpdateTransaction
+		needsUpdate := payload.Validate != nil &&
+			payload.Validate.Pending &&
+			(tran.Status.Code == constant.APPROVED || tran.Status.Code == constant.CANCELED)
 
-		// Collect operations
+		if needsUpdate {
+			toUpdate = append(toUpdate, tran)
+		} else {
+			toInsert = append(toInsert, tran)
+		}
+
+		// Collect operations (needed for both insert and update cases)
 		for _, op := range tran.Operations {
 			if op != nil {
 				operations = append(operations, op)
@@ -309,61 +336,148 @@ func (uc *UseCase) extractEntities(
 		}
 	}
 
-	return transactions, operations
+	return toInsert, toUpdate, operations
 }
 
-// performBulkInsert executes bulk inserts for transactions and operations.
-func (uc *UseCase) performBulkInsert(
+// performBulkInsertAndUpdate executes bulk inserts for new transactions and updates for
+// transactions transitioning from PENDING to a final state (APPROVED/CANCELED).
+func (uc *UseCase) performBulkInsertAndUpdate(
 	ctx context.Context,
 	logger libLog.Logger,
 	tracer trace.Tracer,
-	transactions []*transaction.Transaction,
+	toInsert []*transaction.Transaction,
+	toUpdate []*transaction.Transaction,
 	operations []*operation.Operation,
 	result *BulkResult,
 ) error {
-	// Bulk insert transactions
-	ctxTxInsert, spanTxInsert := tracer.Start(ctx, "command.bulk.insert_transactions")
+	// Bulk insert transactions (if any)
+	if len(toInsert) > 0 {
+		ctxTxInsert, spanTxInsert := tracer.Start(ctx, "command.bulk.insert_transactions")
 
-	txResult, err := uc.TransactionRepo.CreateBulk(ctxTxInsert, transactions)
+		txResult, err := uc.TransactionRepo.CreateBulk(ctxTxInsert, toInsert)
 
-	spanTxInsert.End()
+		spanTxInsert.End()
 
-	if err != nil {
-		logger.Log(ctx, libLog.LevelError, "Bulk transaction insert failed", libLog.Err(err))
+		if err != nil {
+			logger.Log(ctx, libLog.LevelError, "Bulk transaction insert failed", libLog.Err(err))
 
-		return fmt.Errorf("bulk transaction insert failed: %w", err)
+			return fmt.Errorf("bulk transaction insert failed: %w", err)
+		}
+
+		result.TransactionsAttempted = txResult.Attempted
+		result.TransactionsInserted = txResult.Inserted
+		result.TransactionsIgnored = txResult.Ignored
+
+		logger.Log(ctx, libLog.LevelDebug, "Bulk transaction insert completed",
+			libLog.Any("attempted", txResult.Attempted),
+			libLog.Any("inserted", txResult.Inserted),
+			libLog.Any("ignored", txResult.Ignored))
 	}
 
-	result.TransactionsAttempted = txResult.Attempted
-	result.TransactionsInserted = txResult.Inserted
-	result.TransactionsIgnored = txResult.Ignored
+	// Update transactions transitioning from PENDING to final state (if any)
+	if len(toUpdate) > 0 {
+		result.TransactionsUpdateAttempted = int64(len(toUpdate))
 
-	logger.Log(ctx, libLog.LevelDebug, "Bulk transaction insert completed",
-		libLog.Any("attempted", txResult.Attempted),
-		libLog.Any("inserted", txResult.Inserted),
-		libLog.Any("ignored", txResult.Ignored))
+		if len(toUpdate) > bulkUpdateThreshold {
+			// Use bulk update for large batches
+			if err := uc.performBulkStatusUpdate(ctx, logger, tracer, toUpdate, result); err != nil {
+				return err
+			}
+		} else {
+			// Use individual updates for small batches
+			if err := uc.performIndividualStatusUpdates(ctx, logger, tracer, toUpdate, result); err != nil {
+				return err
+			}
+		}
+	}
 
 	// Bulk insert operations
-	ctxOpInsert, spanOpInsert := tracer.Start(ctx, "command.bulk.insert_operations")
+	if len(operations) > 0 {
+		ctxOpInsert, spanOpInsert := tracer.Start(ctx, "command.bulk.insert_operations")
 
-	opResult, err := uc.OperationRepo.CreateBulk(ctxOpInsert, operations)
+		opResult, err := uc.OperationRepo.CreateBulk(ctxOpInsert, operations)
 
-	spanOpInsert.End()
+		spanOpInsert.End()
 
-	if err != nil {
-		logger.Log(ctx, libLog.LevelError, "Bulk operation insert failed", libLog.Err(err))
+		if err != nil {
+			logger.Log(ctx, libLog.LevelError, "Bulk operation insert failed", libLog.Err(err))
 
-		return fmt.Errorf("bulk operation insert failed: %w", err)
+			return fmt.Errorf("bulk operation insert failed: %w", err)
+		}
+
+		result.OperationsAttempted = opResult.Attempted
+		result.OperationsInserted = opResult.Inserted
+		result.OperationsIgnored = opResult.Ignored
+
+		logger.Log(ctx, libLog.LevelDebug, "Bulk operation insert completed",
+			libLog.Any("attempted", opResult.Attempted),
+			libLog.Any("inserted", opResult.Inserted),
+			libLog.Any("ignored", opResult.Ignored))
 	}
 
-	result.OperationsAttempted = opResult.Attempted
-	result.OperationsInserted = opResult.Inserted
-	result.OperationsIgnored = opResult.Ignored
+	return nil
+}
 
-	logger.Log(ctx, libLog.LevelDebug, "Bulk operation insert completed",
-		libLog.Any("attempted", opResult.Attempted),
-		libLog.Any("inserted", opResult.Inserted),
-		libLog.Any("ignored", opResult.Ignored))
+// performBulkStatusUpdate executes a bulk update for PENDING→final transitions.
+func (uc *UseCase) performBulkStatusUpdate(
+	ctx context.Context,
+	logger libLog.Logger,
+	tracer trace.Tracer,
+	toUpdate []*transaction.Transaction,
+	result *BulkResult,
+) error {
+	ctxTxUpdate, spanTxUpdate := tracer.Start(ctx, "command.bulk.update_transaction_status")
+	defer spanTxUpdate.End()
+
+	updateResult, err := uc.TransactionRepo.BulkUpdateTransactionStatus(ctxTxUpdate, toUpdate)
+	if err != nil {
+		logger.Log(ctx, libLog.LevelError, "Bulk transaction status update failed", libLog.Err(err))
+
+		return fmt.Errorf("bulk transaction status update failed: %w", err)
+	}
+
+	result.TransactionsUpdated = updateResult.Inserted // Inserted tracks updated rows
+
+	logger.Log(ctx, libLog.LevelDebug, "Bulk transaction status update completed",
+		libLog.Any("attempted", updateResult.Attempted),
+		libLog.Any("updated", updateResult.Inserted),
+		libLog.Any("ignored", updateResult.Ignored))
+
+	return nil
+}
+
+// performIndividualStatusUpdates executes individual updates for PENDING→final transitions.
+// Used when the number of updates is below the bulk threshold.
+func (uc *UseCase) performIndividualStatusUpdates(
+	ctx context.Context,
+	logger libLog.Logger,
+	tracer trace.Tracer,
+	toUpdate []*transaction.Transaction,
+	result *BulkResult,
+) error {
+	ctxTxUpdate, spanTxUpdate := tracer.Start(ctx, "command.bulk.update_transaction_status_individual")
+	defer spanTxUpdate.End()
+
+	var updatedCount int64
+
+	for _, tran := range toUpdate {
+		_, err := uc.UpdateTransactionStatus(ctxTxUpdate, tran)
+		if err != nil {
+			logger.Log(ctx, libLog.LevelError, "Individual transaction status update failed",
+				libLog.String("transactionID", tran.ID),
+				libLog.Err(err))
+
+			return fmt.Errorf("transaction status update failed for %s: %w", tran.ID, err)
+		}
+
+		updatedCount++
+	}
+
+	result.TransactionsUpdated = updatedCount
+
+	logger.Log(ctx, libLog.LevelDebug, "Individual transaction status updates completed",
+		libLog.Any("attempted", len(toUpdate)),
+		libLog.Any("updated", updatedCount))
 
 	return nil
 }

--- a/components/transaction/internal/services/command/create-bulk-transaction-operations-async.go
+++ b/components/transaction/internal/services/command/create-bulk-transaction-operations-async.go
@@ -191,12 +191,13 @@ func (uc *UseCase) unmarshalPayloads(
 	for i, msg := range messages {
 		results[i] = BulkMessageResult{Index: i, Success: true}
 
-		// Check for empty QueueData
-		if len(msg.QueueData) == 0 {
-			logger.Log(ctx, libLog.LevelError, "Empty QueueData in message",
-				libLog.Int("index", i))
+		// Validate exactly one queue item per message
+		if len(msg.QueueData) != 1 {
+			logger.Log(ctx, libLog.LevelError, "Invalid QueueData count in message",
+				libLog.Int("index", i),
+				libLog.Int("count", len(msg.QueueData)))
 
-			results[i] = BulkMessageResult{Index: i, Success: false, Error: errors.New("empty QueueData")}
+			results[i] = BulkMessageResult{Index: i, Success: false, Error: fmt.Errorf("expected 1 queue item, got %d", len(msg.QueueData))}
 			payloads[i] = nil
 
 			continue
@@ -204,22 +205,18 @@ func (uc *UseCase) unmarshalPayloads(
 
 		var payload transaction.TransactionProcessingPayload
 
-		for _, item := range msg.QueueData {
-			if err := msgpack.Unmarshal(item.Value, &payload); err != nil {
-				logger.Log(ctx, libLog.LevelError, "Failed to unmarshal queue message",
-					libLog.Int("index", i),
-					libLog.Err(err))
+		if err := msgpack.Unmarshal(msg.QueueData[0].Value, &payload); err != nil {
+			logger.Log(ctx, libLog.LevelError, "Failed to unmarshal queue message",
+				libLog.Int("index", i),
+				libLog.Err(err))
 
-				results[i] = BulkMessageResult{Index: i, Success: false, Error: err}
-				payloads[i] = nil
+			results[i] = BulkMessageResult{Index: i, Success: false, Error: err}
+			payloads[i] = nil
 
-				break
-			}
+			continue
 		}
 
-		if results[i].Success {
-			payloads[i] = &payload
-		}
+		payloads[i] = &payload
 	}
 
 	return payloads, results

--- a/components/transaction/internal/services/command/create-bulk-transaction-operations-async.go
+++ b/components/transaction/internal/services/command/create-bulk-transaction-operations-async.go
@@ -1,0 +1,571 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package command
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"reflect"
+	"sort"
+
+	libCommons "github.com/LerianStudio/lib-commons/v4/commons"
+	libLog "github.com/LerianStudio/lib-commons/v4/commons/log"
+	"github.com/LerianStudio/midaz/v3/components/transaction/internal/adapters/postgres/operation"
+	"github.com/LerianStudio/midaz/v3/components/transaction/internal/adapters/postgres/transaction"
+	"github.com/LerianStudio/midaz/v3/pkg/constant"
+	"github.com/LerianStudio/midaz/v3/pkg/mmodel"
+	pkgTransaction "github.com/LerianStudio/midaz/v3/pkg/transaction"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/vmihailenco/msgpack/v5"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// BulkResult aggregates the results from bulk insert operations.
+// It contains counts for both transactions and operations.
+type BulkResult struct {
+	// Transaction insert results
+	TransactionsAttempted int64
+	TransactionsInserted  int64
+	TransactionsIgnored   int64
+
+	// Operation insert results
+	OperationsAttempted int64
+	OperationsInserted  int64
+	OperationsIgnored   int64
+
+	// Fallback tracking
+	FallbackUsed  bool
+	FallbackCount int
+}
+
+// BulkMessageResult tracks the processing result for individual messages
+// when fallback mode is used.
+type BulkMessageResult struct {
+	Index   int
+	Success bool
+	Error   error
+}
+
+// CreateBulkTransactionOperationsAsync processes multiple transaction messages in bulk.
+// This method:
+// 1. Unmarshals all payloads from the queue messages
+// 2. Processes balances for each transaction (required for hot balance)
+// 3. Extracts and sorts transactions/operations by ID (deadlock prevention)
+// 4. Performs bulk INSERTs for transactions and operations
+// 5. On bulk failure, falls back to individual processing if enabled
+//
+// The method returns a BulkResult with counts of attempted/inserted/ignored rows.
+// Individual message acknowledgment is the responsibility of the caller.
+func (uc *UseCase) CreateBulkTransactionOperationsAsync(
+	ctx context.Context,
+	messages []mmodel.Queue,
+	fallbackEnabled bool,
+) (*BulkResult, []BulkMessageResult, error) {
+	logger, tracer, _, _ := libCommons.NewTrackingFromContext(ctx)
+
+	ctx, span := tracer.Start(ctx, "command.create_bulk_transaction_operations_async")
+	defer span.End()
+
+	result := &BulkResult{}
+	messageResults := make([]BulkMessageResult, len(messages))
+
+	// Initialize all message results as pending
+	for i := range messageResults {
+		messageResults[i] = BulkMessageResult{Index: i, Success: false}
+	}
+
+	if len(messages) == 0 {
+		return result, messageResults, nil
+	}
+
+	logger.Log(ctx, libLog.LevelInfo, "Starting bulk transaction processing",
+		libLog.Int("messageCount", len(messages)))
+
+	// Phase 1: Unmarshal all payloads and process balances
+	payloads, unmarshalResults := uc.unmarshalPayloads(ctx, logger, messages)
+
+	// Always merge unmarshal results into messageResults (handles partial failures)
+	for i, res := range unmarshalResults {
+		if !res.Success {
+			messageResults[i] = res
+		}
+	}
+
+	// Count successful unmarshals
+	successfulUnmarshals := 0
+
+	for _, p := range payloads {
+		if p != nil {
+			successfulUnmarshals++
+		}
+	}
+
+	if successfulUnmarshals == 0 {
+		return result, messageResults, fmt.Errorf("all messages failed to unmarshal")
+	}
+
+	// Phase 2: Process balances for each transaction (required before insert)
+	balanceResults := uc.processBalances(ctx, logger, tracer, messages, payloads)
+
+	// Track which messages had balance failures
+	validPayloadIndices := make([]int, 0, len(payloads))
+
+	for i, res := range balanceResults {
+		if !res.Success {
+			messageResults[i] = res
+		} else {
+			validPayloadIndices = append(validPayloadIndices, i)
+		}
+	}
+
+	if len(validPayloadIndices) == 0 {
+		return result, messageResults, fmt.Errorf("all messages failed balance processing")
+	}
+
+	// Phase 3: Extract transactions and operations from valid payloads
+	transactions, operations := uc.extractEntities(payloads, validPayloadIndices)
+
+	// Phase 4: Sort by ID to prevent deadlocks
+	sortTransactionsByID(transactions)
+	sortOperationsByID(operations)
+
+	// Phase 5: Attempt bulk insert
+	bulkErr := uc.performBulkInsert(ctx, logger, tracer, transactions, operations, result)
+	if bulkErr != nil {
+		logger.Log(ctx, libLog.LevelWarn, "Bulk insert failed, checking fallback",
+			libLog.Err(bulkErr),
+			libLog.Bool("fallbackEnabled", fallbackEnabled))
+
+		if !fallbackEnabled {
+			// No fallback: mark all valid messages as failed
+			for _, idx := range validPayloadIndices {
+				messageResults[idx] = BulkMessageResult{Index: idx, Success: false, Error: bulkErr}
+			}
+
+			return result, messageResults, bulkErr
+		}
+
+		// Phase 6: Fallback to individual processing
+		result.FallbackUsed = true
+		fallbackResults := uc.processFallback(ctx, logger, tracer, messages, payloads, validPayloadIndices)
+
+		for _, res := range fallbackResults {
+			messageResults[res.Index] = res
+			if res.Success {
+				result.FallbackCount++
+			}
+		}
+
+		return result, messageResults, nil
+	}
+
+	// Bulk insert succeeded: mark all valid messages as successful
+	for _, idx := range validPayloadIndices {
+		messageResults[idx] = BulkMessageResult{Index: idx, Success: true}
+	}
+
+	// Phase 7: Post-processing (metadata, events) - best effort
+	uc.postProcessBulk(ctx, logger, payloads, validPayloadIndices, messages)
+
+	logger.Log(ctx, libLog.LevelInfo, "Bulk transaction processing completed",
+		libLog.Any("transactionsInserted", result.TransactionsInserted),
+		libLog.Any("transactionsIgnored", result.TransactionsIgnored),
+		libLog.Any("operationsInserted", result.OperationsInserted),
+		libLog.Any("operationsIgnored", result.OperationsIgnored))
+
+	return result, messageResults, nil
+}
+
+// unmarshalPayloads unmarshals all queue messages into TransactionProcessingPayload.
+func (uc *UseCase) unmarshalPayloads(
+	ctx context.Context,
+	logger libLog.Logger,
+	messages []mmodel.Queue,
+) ([]*transaction.TransactionProcessingPayload, []BulkMessageResult) {
+	payloads := make([]*transaction.TransactionProcessingPayload, len(messages))
+	results := make([]BulkMessageResult, len(messages))
+
+	for i, msg := range messages {
+		results[i] = BulkMessageResult{Index: i, Success: true}
+
+		// Check for empty QueueData
+		if len(msg.QueueData) == 0 {
+			logger.Log(ctx, libLog.LevelError, "Empty QueueData in message",
+				libLog.Int("index", i))
+
+			results[i] = BulkMessageResult{Index: i, Success: false, Error: errors.New("empty QueueData")}
+			payloads[i] = nil
+
+			continue
+		}
+
+		var payload transaction.TransactionProcessingPayload
+
+		for _, item := range msg.QueueData {
+			if err := msgpack.Unmarshal(item.Value, &payload); err != nil {
+				logger.Log(ctx, libLog.LevelError, "Failed to unmarshal queue message",
+					libLog.Int("index", i),
+					libLog.Err(err))
+
+				results[i] = BulkMessageResult{Index: i, Success: false, Error: err}
+				payloads[i] = nil
+
+				break
+			}
+		}
+
+		if results[i].Success {
+			payloads[i] = &payload
+		}
+	}
+
+	return payloads, results
+}
+
+// processBalances processes balance updates for each transaction.
+func (uc *UseCase) processBalances(
+	ctx context.Context,
+	logger libLog.Logger,
+	tracer trace.Tracer,
+	messages []mmodel.Queue,
+	payloads []*transaction.TransactionProcessingPayload,
+) []BulkMessageResult {
+	results := make([]BulkMessageResult, len(payloads))
+
+	for i, payload := range payloads {
+		results[i] = BulkMessageResult{Index: i, Success: true}
+
+		if payload == nil {
+			results[i] = BulkMessageResult{Index: i, Success: false, Error: errors.New("nil payload")}
+			continue
+		}
+
+		// Skip balance update for NOTED transactions
+		if payload.Transaction != nil && payload.Transaction.Status.Code == constant.NOTED {
+			continue
+		}
+
+		if payload.Validate == nil {
+			results[i] = BulkMessageResult{Index: i, Success: false, Error: errors.New("nil Validate field")}
+			continue
+		}
+
+		ctxBalance, spanBalance := tracer.Start(ctx, "command.bulk.update_balances")
+
+		err := uc.UpdateBalances(ctxBalance, messages[i].OrganizationID, messages[i].LedgerID,
+			*payload.Validate, payload.Balances, payload.BalancesAfter)
+
+		spanBalance.End()
+
+		if err != nil {
+			logger.Log(ctx, libLog.LevelError, "Failed to update balances in bulk",
+				libLog.Int("index", i),
+				libLog.Err(err))
+
+			results[i] = BulkMessageResult{Index: i, Success: false, Error: err}
+		}
+	}
+
+	return results
+}
+
+// extractEntities extracts transactions and operations from valid payloads.
+func (uc *UseCase) extractEntities(
+	payloads []*transaction.TransactionProcessingPayload,
+	validIndices []int,
+) ([]*transaction.Transaction, []*operation.Operation) {
+	transactions := make([]*transaction.Transaction, 0, len(validIndices))
+	operations := make([]*operation.Operation, 0, len(validIndices)*5) // Estimate 5 ops per transaction
+
+	for _, idx := range validIndices {
+		payload := payloads[idx]
+		if payload == nil || payload.Transaction == nil {
+			continue
+		}
+
+		tran := payload.Transaction
+
+		// Clear body for storage (same as individual processing)
+		tran.Body = pkgTransaction.Transaction{}
+
+		// Update status for CREATED transactions
+		if tran.Status.Code == constant.CREATED {
+			description := constant.APPROVED
+			tran.Status = transaction.Status{
+				Code:        description,
+				Description: &description,
+			}
+		} else if tran.Status.Code == constant.PENDING && payload.Input != nil {
+			tran.Body = *payload.Input
+		}
+
+		transactions = append(transactions, tran)
+
+		// Collect operations
+		for _, op := range tran.Operations {
+			if op != nil {
+				operations = append(operations, op)
+			}
+		}
+	}
+
+	return transactions, operations
+}
+
+// performBulkInsert executes bulk inserts for transactions and operations.
+func (uc *UseCase) performBulkInsert(
+	ctx context.Context,
+	logger libLog.Logger,
+	tracer trace.Tracer,
+	transactions []*transaction.Transaction,
+	operations []*operation.Operation,
+	result *BulkResult,
+) error {
+	// Bulk insert transactions
+	ctxTxInsert, spanTxInsert := tracer.Start(ctx, "command.bulk.insert_transactions")
+
+	txResult, err := uc.TransactionRepo.CreateBulk(ctxTxInsert, transactions)
+
+	spanTxInsert.End()
+
+	if err != nil {
+		logger.Log(ctx, libLog.LevelError, "Bulk transaction insert failed", libLog.Err(err))
+
+		return fmt.Errorf("bulk transaction insert failed: %w", err)
+	}
+
+	result.TransactionsAttempted = txResult.Attempted
+	result.TransactionsInserted = txResult.Inserted
+	result.TransactionsIgnored = txResult.Ignored
+
+	logger.Log(ctx, libLog.LevelDebug, "Bulk transaction insert completed",
+		libLog.Any("attempted", txResult.Attempted),
+		libLog.Any("inserted", txResult.Inserted),
+		libLog.Any("ignored", txResult.Ignored))
+
+	// Bulk insert operations
+	ctxOpInsert, spanOpInsert := tracer.Start(ctx, "command.bulk.insert_operations")
+
+	opResult, err := uc.OperationRepo.CreateBulk(ctxOpInsert, operations)
+
+	spanOpInsert.End()
+
+	if err != nil {
+		logger.Log(ctx, libLog.LevelError, "Bulk operation insert failed", libLog.Err(err))
+
+		return fmt.Errorf("bulk operation insert failed: %w", err)
+	}
+
+	result.OperationsAttempted = opResult.Attempted
+	result.OperationsInserted = opResult.Inserted
+	result.OperationsIgnored = opResult.Ignored
+
+	logger.Log(ctx, libLog.LevelDebug, "Bulk operation insert completed",
+		libLog.Any("attempted", opResult.Attempted),
+		libLog.Any("inserted", opResult.Inserted),
+		libLog.Any("ignored", opResult.Ignored))
+
+	return nil
+}
+
+// processFallback processes each message individually when bulk insert fails.
+func (uc *UseCase) processFallback(
+	ctx context.Context,
+	logger libLog.Logger,
+	tracer trace.Tracer,
+	messages []mmodel.Queue,
+	payloads []*transaction.TransactionProcessingPayload,
+	validIndices []int,
+) []BulkMessageResult {
+	results := make([]BulkMessageResult, 0, len(validIndices))
+
+	logger.Log(ctx, libLog.LevelInfo, "Starting fallback to individual processing",
+		libLog.Int("messageCount", len(validIndices)))
+
+	for _, idx := range validIndices {
+		payload := payloads[idx]
+		msg := messages[idx]
+
+		if payload == nil || payload.Transaction == nil {
+			results = append(results, BulkMessageResult{Index: idx, Success: false, Error: errors.New("nil payload")})
+			continue
+		}
+
+		ctxFallback, spanFallback := tracer.Start(ctx, "command.bulk.fallback_individual")
+
+		// Try to create transaction individually
+		tran, err := uc.createTransactionIndividually(ctxFallback, logger, tracer, payload)
+
+		spanFallback.End()
+
+		if err != nil {
+			// Check if it's a duplicate error (idempotency - treat as success)
+			var pgErr *pgconn.PgError
+			if errors.As(err, &pgErr) && pgErr.Code == constant.UniqueViolationCode {
+				logger.Log(ctx, libLog.LevelInfo, "Fallback: transaction already exists (duplicate)",
+					libLog.Int("index", idx),
+					libLog.String("transactionID", payload.Transaction.ID))
+
+				results = append(results, BulkMessageResult{Index: idx, Success: true})
+
+				continue
+			}
+
+			logger.Log(ctx, libLog.LevelError, "Fallback: failed to create transaction",
+				libLog.Int("index", idx),
+				libLog.Err(err))
+
+			results = append(results, BulkMessageResult{Index: idx, Success: false, Error: err})
+
+			continue
+		}
+
+		// Create operations individually
+		allOpsSuccess := true
+
+		for _, op := range tran.Operations {
+			// Defensive nil check to prevent panic
+			if op == nil {
+				continue
+			}
+
+			_, opErr := uc.OperationRepo.Create(ctx, op)
+			if opErr != nil {
+				var pgErr *pgconn.PgError
+				if errors.As(opErr, &pgErr) && pgErr.Code == constant.UniqueViolationCode {
+					// Duplicate operation is fine (idempotency)
+					continue
+				}
+
+				logger.Log(ctx, libLog.LevelError, "Fallback: failed to create operation",
+					libLog.Int("index", idx),
+					libLog.String("operationID", op.ID),
+					libLog.Err(opErr))
+
+				allOpsSuccess = false
+
+				break
+			}
+		}
+
+		if allOpsSuccess {
+			results = append(results, BulkMessageResult{Index: idx, Success: true})
+
+			// Post-processing for successful fallback
+			// Use detached context so async work completes even if request context is canceled
+			asyncCtx := context.WithoutCancel(ctx)
+			go uc.SendTransactionEvents(asyncCtx, tran)
+			go uc.RemoveTransactionFromRedisQueue(asyncCtx, logger, msg.OrganizationID, msg.LedgerID, tran.ID)
+			go uc.DeleteWriteBehindTransaction(asyncCtx, msg.OrganizationID, msg.LedgerID, tran.ID)
+		} else {
+			results = append(results, BulkMessageResult{Index: idx, Success: false, Error: errors.New("operation insert failed")})
+		}
+	}
+
+	return results
+}
+
+// createTransactionIndividually creates a single transaction using the existing pattern.
+func (uc *UseCase) createTransactionIndividually(
+	ctx context.Context,
+	logger libLog.Logger,
+	tracer trace.Tracer,
+	payload *transaction.TransactionProcessingPayload,
+) (*transaction.Transaction, error) {
+	tran, err := uc.CreateOrUpdateTransaction(ctx, logger, tracer, *payload)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create metadata for transaction
+	if err := uc.CreateMetadataAsync(ctx, logger, tran.Metadata, tran.ID, reflect.TypeOf(transaction.Transaction{}).Name()); err != nil {
+		logger.Log(ctx, libLog.LevelWarn, "Fallback: failed to create transaction metadata",
+			libLog.String("transactionID", tran.ID),
+			libLog.Err(err))
+		// Continue despite metadata error
+	}
+
+	return tran, nil
+}
+
+// postProcessBulk handles metadata creation and event sending for bulk-inserted transactions.
+func (uc *UseCase) postProcessBulk(
+	ctx context.Context,
+	logger libLog.Logger,
+	payloads []*transaction.TransactionProcessingPayload,
+	validIndices []int,
+	messages []mmodel.Queue,
+) {
+	for _, idx := range validIndices {
+		payload := payloads[idx]
+		msg := messages[idx]
+
+		if payload == nil || payload.Transaction == nil {
+			continue
+		}
+
+		tran := payload.Transaction
+
+		// Create metadata (best effort)
+		if err := uc.CreateMetadataAsync(ctx, logger, tran.Metadata, tran.ID, reflect.TypeOf(transaction.Transaction{}).Name()); err != nil {
+			logger.Log(ctx, libLog.LevelWarn, "Bulk: failed to create transaction metadata",
+				libLog.String("transactionID", tran.ID),
+				libLog.Err(err))
+		}
+
+		// Create operation metadata
+		for _, op := range tran.Operations {
+			if op != nil && op.Metadata != nil {
+				if err := uc.CreateMetadataAsync(ctx, logger, op.Metadata, op.ID, reflect.TypeOf(operation.Operation{}).Name()); err != nil {
+					logger.Log(ctx, libLog.LevelWarn, "Bulk: failed to create operation metadata",
+						libLog.String("operationID", op.ID),
+						libLog.Err(err))
+				}
+			}
+		}
+
+		// Async cleanup and events
+		// Use detached context so async work completes even if request context is canceled
+		asyncCtx := context.WithoutCancel(ctx)
+		go uc.SendTransactionEvents(asyncCtx, tran)
+		go uc.RemoveTransactionFromRedisQueue(asyncCtx, logger, msg.OrganizationID, msg.LedgerID, tran.ID)
+		go uc.DeleteWriteBehindTransaction(asyncCtx, msg.OrganizationID, msg.LedgerID, tran.ID)
+	}
+}
+
+// sortTransactionsByID sorts transactions by ID to prevent deadlocks during bulk insert.
+// Nil elements are sorted to the beginning of the slice (defensive programming).
+func sortTransactionsByID(transactions []*transaction.Transaction) {
+	sort.Slice(transactions, func(i, j int) bool {
+		// Defensive nil checks to prevent panic
+		if transactions[i] == nil {
+			return true // nil sorts first
+		}
+
+		if transactions[j] == nil {
+			return false
+		}
+
+		return transactions[i].ID < transactions[j].ID
+	})
+}
+
+// sortOperationsByID sorts operations by ID to prevent deadlocks during bulk insert.
+// Nil elements are sorted to the beginning of the slice (defensive programming).
+func sortOperationsByID(operations []*operation.Operation) {
+	sort.Slice(operations, func(i, j int) bool {
+		// Defensive nil checks to prevent panic
+		if operations[i] == nil {
+			return true // nil sorts first
+		}
+
+		if operations[j] == nil {
+			return false
+		}
+
+		return operations[i].ID < operations[j].ID
+	})
+}

--- a/components/transaction/internal/services/command/create-bulk-transaction-operations-async.go
+++ b/components/transaction/internal/services/command/create-bulk-transaction-operations-async.go
@@ -124,10 +124,14 @@ func (uc *UseCase) CreateBulkTransactionOperationsAsync(
 
 	for i, res := range balanceResults {
 		if !res.Success {
-			messageResults[i] = res
-		} else {
-			validPayloadIndices = append(validPayloadIndices, i)
+			if messageResults[i].Error == nil {
+				messageResults[i] = res
+			}
+
+			continue
 		}
+
+		validPayloadIndices = append(validPayloadIndices, i)
 	}
 
 	if len(validPayloadIndices) == 0 {

--- a/components/transaction/internal/services/command/create-bulk-transaction-operations-async.go
+++ b/components/transaction/internal/services/command/create-bulk-transaction-operations-async.go
@@ -38,6 +38,7 @@ type BulkResult struct {
 	// Transaction update results (PENDING → APPROVED/CANCELED)
 	TransactionsUpdateAttempted int64
 	TransactionsUpdated         int64
+	TransactionsUpdateFailed    int64
 
 	// Operation insert results
 	OperationsAttempted int64
@@ -448,6 +449,7 @@ func (uc *UseCase) performBulkStatusUpdate(
 
 // performIndividualStatusUpdates executes individual updates for PENDING→final transitions.
 // Used when the number of updates is below the bulk threshold.
+// The function attempts all updates even if some fail, tracking partial success.
 func (uc *UseCase) performIndividualStatusUpdates(
 	ctx context.Context,
 	logger libLog.Logger,
@@ -460,6 +462,8 @@ func (uc *UseCase) performIndividualStatusUpdates(
 
 	var updatedCount int64
 
+	var failedCount int64
+
 	for _, tran := range toUpdate {
 		_, err := uc.UpdateTransactionStatus(ctxTxUpdate, tran)
 		if err != nil {
@@ -467,17 +471,26 @@ func (uc *UseCase) performIndividualStatusUpdates(
 				libLog.String("transactionID", tran.ID),
 				libLog.Err(err))
 
-			return fmt.Errorf("transaction status update failed for %s: %w", tran.ID, err)
+			failedCount++
+
+			continue
 		}
 
 		updatedCount++
 	}
 
 	result.TransactionsUpdated = updatedCount
+	result.TransactionsUpdateFailed = failedCount
 
 	logger.Log(ctx, libLog.LevelDebug, "Individual transaction status updates completed",
 		libLog.Any("attempted", len(toUpdate)),
-		libLog.Any("updated", updatedCount))
+		libLog.Any("updated", updatedCount),
+		libLog.Any("failed", failedCount))
+
+	// Return error only if all updates failed
+	if updatedCount == 0 && failedCount > 0 {
+		return fmt.Errorf("all %d transaction status updates failed", failedCount)
+	}
 
 	return nil
 }

--- a/components/transaction/internal/services/command/create-bulk-transaction-operations-async_test.go
+++ b/components/transaction/internal/services/command/create-bulk-transaction-operations-async_test.go
@@ -1609,10 +1609,11 @@ func TestCreateBulkTransactionOperationsAsync_UpdateFailureReturnsError(t *testi
 	result, messageResults, err := uc.CreateBulkTransactionOperationsAsync(ctx, messages, false)
 
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "transaction status update failed")
+	assert.Contains(t, err.Error(), "transaction status updates failed")
 	assert.NotNil(t, result)
 	assert.Equal(t, int64(1), result.TransactionsUpdateAttempted)
 	assert.Equal(t, int64(0), result.TransactionsUpdated)
+	assert.Equal(t, int64(1), result.TransactionsUpdateFailed)
 	assert.Len(t, messageResults, 1)
 	assert.False(t, messageResults[0].Success)
 }

--- a/components/transaction/internal/services/command/create-bulk-transaction-operations-async_test.go
+++ b/components/transaction/internal/services/command/create-bulk-transaction-operations-async_test.go
@@ -925,7 +925,7 @@ func TestCreateBulkTransactionOperationsAsync_EmptyQueueData(t *testing.T) {
 	assert.Len(t, messageResults, 1)
 	assert.False(t, messageResults[0].Success)
 	assert.NotNil(t, messageResults[0].Error)
-	assert.Contains(t, messageResults[0].Error.Error(), "empty QueueData")
+	assert.Contains(t, messageResults[0].Error.Error(), "expected 1 queue item, got 0")
 }
 
 // =============================================================================

--- a/components/transaction/internal/services/command/create-bulk-transaction-operations-async_test.go
+++ b/components/transaction/internal/services/command/create-bulk-transaction-operations-async_test.go
@@ -552,13 +552,15 @@ func TestCreateBulkTransactionOperationsAsync_DuplicatesIgnored(t *testing.T) {
 			Ignored:   1, // One duplicate
 		}, nil)
 
+	// Operations CreateBulk may not be called if there are no operations
 	mockOperationRepo.EXPECT().
 		CreateBulk(gomock.Any(), gomock.Any()).
 		Return(&repository.BulkInsertResult{
 			Attempted: 0,
 			Inserted:  0,
 			Ignored:   0,
-		}, nil)
+		}, nil).
+		AnyTimes()
 
 	mockMetadataRepo.EXPECT().
 		Create(gomock.Any(), gomock.Any(), gomock.Any()).
@@ -704,13 +706,15 @@ func TestCreateBulkTransactionOperationsAsync_WithBalanceProcessing(t *testing.T
 			Ignored:   0,
 		}, nil)
 
+	// Operations CreateBulk may not be called if there are no operations
 	mockOperationRepo.EXPECT().
 		CreateBulk(gomock.Any(), gomock.Any()).
 		Return(&repository.BulkInsertResult{
 			Attempted: 0,
 			Inserted:  0,
 			Ignored:   0,
-		}, nil)
+		}, nil).
+		AnyTimes()
 
 	mockMetadataRepo.EXPECT().
 		Create(gomock.Any(), gomock.Any(), gomock.Any()).
@@ -850,13 +854,15 @@ func TestCreateBulkTransactionOperationsAsync_PartialUnmarshalFailure(t *testing
 			Ignored:   0,
 		}, nil)
 
+	// Operations CreateBulk may not be called if there are no operations
 	mockOperationRepo.EXPECT().
 		CreateBulk(gomock.Any(), gomock.Any()).
 		Return(&repository.BulkInsertResult{
 			Attempted: 0,
 			Inserted:  0,
 			Ignored:   0,
-		}, nil)
+		}, nil).
+		AnyTimes()
 
 	mockMetadataRepo.EXPECT().
 		Create(gomock.Any(), gomock.Any(), gomock.Any()).
@@ -1004,4 +1010,609 @@ func TestSortOperationsByID_AllNil(t *testing.T) {
 	for _, op := range operations {
 		assert.Nil(t, op)
 	}
+}
+
+// =============================================================================
+// UNIT TESTS - classifyAndExtractEntities
+// =============================================================================
+
+func TestClassifyAndExtractEntities_AllNewTransactions(t *testing.T) {
+	t.Parallel()
+
+	organizationID := uuid.New()
+	ledgerID := uuid.New()
+
+	// Create transactions with CREATED status (should go to toInsert)
+	createdStatus := constant.CREATED
+	tran1 := &transaction.Transaction{
+		ID:             uuid.New().String(),
+		OrganizationID: organizationID.String(),
+		LedgerID:       ledgerID.String(),
+		Status: transaction.Status{
+			Code:        createdStatus,
+			Description: &createdStatus,
+		},
+		Operations: []*operation.Operation{
+			{ID: uuid.New().String()},
+		},
+	}
+
+	payloads := []*transaction.TransactionProcessingPayload{
+		{
+			Transaction: tran1,
+			Validate:    &pkgTransaction.Responses{Pending: false}, // Not a pending transition
+		},
+	}
+
+	uc := &UseCase{}
+	toInsert, toUpdate, operations := uc.classifyAndExtractEntities(payloads, []int{0})
+
+	assert.Len(t, toInsert, 1, "Should have 1 transaction to insert")
+	assert.Len(t, toUpdate, 0, "Should have 0 transactions to update")
+	assert.Len(t, operations, 1, "Should have 1 operation")
+	assert.Equal(t, constant.APPROVED, toInsert[0].Status.Code, "CREATED should be converted to APPROVED")
+}
+
+func TestClassifyAndExtractEntities_AllPendingToApproved(t *testing.T) {
+	t.Parallel()
+
+	organizationID := uuid.New()
+	ledgerID := uuid.New()
+
+	// Create transaction with APPROVED status and Validate.Pending=true (should go to toUpdate)
+	approvedStatus := constant.APPROVED
+	tran1 := &transaction.Transaction{
+		ID:             uuid.New().String(),
+		OrganizationID: organizationID.String(),
+		LedgerID:       ledgerID.String(),
+		Status: transaction.Status{
+			Code:        approvedStatus,
+			Description: &approvedStatus,
+		},
+		Operations: []*operation.Operation{
+			{ID: uuid.New().String()},
+		},
+	}
+
+	payloads := []*transaction.TransactionProcessingPayload{
+		{
+			Transaction: tran1,
+			Validate:    &pkgTransaction.Responses{Pending: true}, // This is a pending transition
+		},
+	}
+
+	uc := &UseCase{}
+	toInsert, toUpdate, operations := uc.classifyAndExtractEntities(payloads, []int{0})
+
+	assert.Len(t, toInsert, 0, "Should have 0 transactions to insert")
+	assert.Len(t, toUpdate, 1, "Should have 1 transaction to update")
+	assert.Len(t, operations, 1, "Should have 1 operation")
+	assert.Equal(t, constant.APPROVED, toUpdate[0].Status.Code)
+}
+
+func TestClassifyAndExtractEntities_AllPendingToCanceled(t *testing.T) {
+	t.Parallel()
+
+	organizationID := uuid.New()
+	ledgerID := uuid.New()
+
+	// Create transaction with CANCELED status and Validate.Pending=true (should go to toUpdate)
+	canceledStatus := constant.CANCELED
+	tran1 := &transaction.Transaction{
+		ID:             uuid.New().String(),
+		OrganizationID: organizationID.String(),
+		LedgerID:       ledgerID.String(),
+		Status: transaction.Status{
+			Code:        canceledStatus,
+			Description: &canceledStatus,
+		},
+		Operations: []*operation.Operation{},
+	}
+
+	payloads := []*transaction.TransactionProcessingPayload{
+		{
+			Transaction: tran1,
+			Validate:    &pkgTransaction.Responses{Pending: true}, // This is a pending transition
+		},
+	}
+
+	uc := &UseCase{}
+	toInsert, toUpdate, operations := uc.classifyAndExtractEntities(payloads, []int{0})
+
+	assert.Len(t, toInsert, 0, "Should have 0 transactions to insert")
+	assert.Len(t, toUpdate, 1, "Should have 1 transaction to update")
+	assert.Len(t, operations, 0, "Should have 0 operations")
+	assert.Equal(t, constant.CANCELED, toUpdate[0].Status.Code)
+}
+
+func TestClassifyAndExtractEntities_MixedBatch(t *testing.T) {
+	t.Parallel()
+
+	organizationID := uuid.New()
+	ledgerID := uuid.New()
+
+	// Transaction 1: CREATED (goes to toInsert)
+	createdStatus := constant.CREATED
+	tran1 := &transaction.Transaction{
+		ID:             uuid.New().String(),
+		OrganizationID: organizationID.String(),
+		LedgerID:       ledgerID.String(),
+		Status: transaction.Status{
+			Code:        createdStatus,
+			Description: &createdStatus,
+		},
+		Operations: []*operation.Operation{{ID: uuid.New().String()}},
+	}
+
+	// Transaction 2: APPROVED with Pending=true (goes to toUpdate)
+	approvedStatus := constant.APPROVED
+	tran2 := &transaction.Transaction{
+		ID:             uuid.New().String(),
+		OrganizationID: organizationID.String(),
+		LedgerID:       ledgerID.String(),
+		Status: transaction.Status{
+			Code:        approvedStatus,
+			Description: &approvedStatus,
+		},
+		Operations: []*operation.Operation{{ID: uuid.New().String()}},
+	}
+
+	// Transaction 3: NOTED (goes to toInsert, no status change needed)
+	notedStatus := constant.NOTED
+	tran3 := &transaction.Transaction{
+		ID:             uuid.New().String(),
+		OrganizationID: organizationID.String(),
+		LedgerID:       ledgerID.String(),
+		Status: transaction.Status{
+			Code:        notedStatus,
+			Description: &notedStatus,
+		},
+		Operations: []*operation.Operation{{ID: uuid.New().String()}},
+	}
+
+	payloads := []*transaction.TransactionProcessingPayload{
+		{Transaction: tran1, Validate: &pkgTransaction.Responses{Pending: false}},
+		{Transaction: tran2, Validate: &pkgTransaction.Responses{Pending: true}},
+		{Transaction: tran3, Validate: &pkgTransaction.Responses{Pending: false}},
+	}
+
+	uc := &UseCase{}
+	toInsert, toUpdate, operations := uc.classifyAndExtractEntities(payloads, []int{0, 1, 2})
+
+	assert.Len(t, toInsert, 2, "Should have 2 transactions to insert (CREATED and NOTED)")
+	assert.Len(t, toUpdate, 1, "Should have 1 transaction to update (APPROVED with Pending)")
+	assert.Len(t, operations, 3, "Should have 3 operations total")
+}
+
+func TestClassifyAndExtractEntities_NilValidate(t *testing.T) {
+	t.Parallel()
+
+	organizationID := uuid.New()
+	ledgerID := uuid.New()
+
+	// Create transaction with APPROVED status but nil Validate (should go to toInsert)
+	approvedStatus := constant.APPROVED
+	tran1 := &transaction.Transaction{
+		ID:             uuid.New().String(),
+		OrganizationID: organizationID.String(),
+		LedgerID:       ledgerID.String(),
+		Status: transaction.Status{
+			Code:        approvedStatus,
+			Description: &approvedStatus,
+		},
+		Operations: []*operation.Operation{},
+	}
+
+	payloads := []*transaction.TransactionProcessingPayload{
+		{
+			Transaction: tran1,
+			Validate:    nil, // Nil Validate should not trigger update
+		},
+	}
+
+	uc := &UseCase{}
+	toInsert, toUpdate, _ := uc.classifyAndExtractEntities(payloads, []int{0})
+
+	assert.Len(t, toInsert, 1, "Should have 1 transaction to insert (nil Validate)")
+	assert.Len(t, toUpdate, 0, "Should have 0 transactions to update")
+}
+
+func TestClassifyAndExtractEntities_ApprovedWithPendingFalse(t *testing.T) {
+	t.Parallel()
+
+	organizationID := uuid.New()
+	ledgerID := uuid.New()
+
+	// Create transaction with APPROVED status but Pending=false (should go to toInsert)
+	approvedStatus := constant.APPROVED
+	tran1 := &transaction.Transaction{
+		ID:             uuid.New().String(),
+		OrganizationID: organizationID.String(),
+		LedgerID:       ledgerID.String(),
+		Status: transaction.Status{
+			Code:        approvedStatus,
+			Description: &approvedStatus,
+		},
+		Operations: []*operation.Operation{},
+	}
+
+	payloads := []*transaction.TransactionProcessingPayload{
+		{
+			Transaction: tran1,
+			Validate:    &pkgTransaction.Responses{Pending: false}, // Pending=false should not trigger update
+		},
+	}
+
+	uc := &UseCase{}
+	toInsert, toUpdate, _ := uc.classifyAndExtractEntities(payloads, []int{0})
+
+	assert.Len(t, toInsert, 1, "Should have 1 transaction to insert (Pending=false)")
+	assert.Len(t, toUpdate, 0, "Should have 0 transactions to update")
+}
+
+// =============================================================================
+// UNIT TESTS - BulkResult with Update Fields
+// =============================================================================
+
+func TestBulkResult_UpdateFields(t *testing.T) {
+	t.Parallel()
+
+	result := &BulkResult{
+		TransactionsAttempted:       10,
+		TransactionsInserted:        8,
+		TransactionsIgnored:         2,
+		TransactionsUpdateAttempted: 5,
+		TransactionsUpdated:         5,
+		OperationsAttempted:         30,
+		OperationsInserted:          28,
+		OperationsIgnored:           2,
+	}
+
+	assert.Equal(t, int64(10), result.TransactionsAttempted)
+	assert.Equal(t, int64(8), result.TransactionsInserted)
+	assert.Equal(t, int64(2), result.TransactionsIgnored)
+	assert.Equal(t, int64(5), result.TransactionsUpdateAttempted)
+	assert.Equal(t, int64(5), result.TransactionsUpdated)
+}
+
+// =============================================================================
+// UNIT TESTS - Bulk Update Threshold
+// =============================================================================
+
+func TestBulkUpdateThreshold_Constant(t *testing.T) {
+	t.Parallel()
+
+	// Verify the threshold constant is set to expected value
+	assert.Equal(t, 10, bulkUpdateThreshold, "Bulk update threshold should be 10")
+}
+
+// =============================================================================
+// UNIT TESTS - CreateBulkTransactionOperationsAsync with Updates
+// =============================================================================
+
+func TestCreateBulkTransactionOperationsAsync_WithPendingToApproved(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockTransactionRepo := transaction.NewMockRepository(ctrl)
+	mockOperationRepo := operation.NewMockRepository(ctrl)
+	mockMetadataRepo := mongodb.NewMockRepository(ctrl)
+	mockBalanceRepo := balance.NewMockRepository(ctrl)
+	mockRabbitMQRepo := rabbitmq.NewMockProducerRepository(ctrl)
+	mockRedisRepo := redis.NewMockRedisRepository(ctrl)
+
+	uc := &UseCase{
+		TransactionRepo: mockTransactionRepo,
+		OperationRepo:   mockOperationRepo,
+		MetadataRepo:    mockMetadataRepo,
+		BalanceRepo:     mockBalanceRepo,
+		RabbitMQRepo:    mockRabbitMQRepo,
+		RedisRepo:       mockRedisRepo,
+	}
+
+	ctx := context.Background()
+	organizationID := uuid.New()
+	ledgerID := uuid.New()
+	transactionID := uuid.New().String()
+
+	// Create an APPROVED transaction with Validate.Pending=true (PENDING→APPROVED transition)
+	approvedStatus := constant.APPROVED
+	tran := &transaction.Transaction{
+		ID:             transactionID,
+		OrganizationID: organizationID.String(),
+		LedgerID:       ledgerID.String(),
+		Status: transaction.Status{
+			Code:        approvedStatus,
+			Description: &approvedStatus,
+		},
+		Operations: []*operation.Operation{
+			{ID: uuid.New().String(), TransactionID: transactionID},
+		},
+	}
+
+	payload := transaction.TransactionProcessingPayload{
+		Transaction: tran,
+		Validate:    &pkgTransaction.Responses{Pending: true}, // This triggers update instead of insert
+	}
+
+	payloadBytes, err := msgpack.Marshal(payload)
+	require.NoError(t, err)
+
+	messages := []mmodel.Queue{
+		{
+			OrganizationID: organizationID,
+			LedgerID:       ledgerID,
+			QueueData: []mmodel.QueueData{
+				{ID: uuid.New(), Value: payloadBytes},
+			},
+		},
+	}
+
+	// Mock balance update
+	mockBalanceRepo.EXPECT().
+		SyncBatch(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(int64(1), nil).
+		AnyTimes()
+
+	mockBalanceRepo.EXPECT().
+		BalancesUpdate(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(nil).
+		AnyTimes()
+
+	// No CreateBulk call expected (toInsert is empty)
+	// Individual status update expected (1 transaction < threshold)
+	mockTransactionRepo.EXPECT().
+		Update(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(tran, nil)
+
+	// Operations still need to be inserted
+	mockOperationRepo.EXPECT().
+		CreateBulk(gomock.Any(), gomock.Any()).
+		Return(&repository.BulkInsertResult{
+			Attempted: 1,
+			Inserted:  1,
+			Ignored:   0,
+		}, nil)
+
+	// Mock metadata creation
+	mockMetadataRepo.EXPECT().
+		Create(gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(nil).
+		AnyTimes()
+
+	// Mock Redis cleanup
+	mockRedisRepo.EXPECT().
+		RemoveMessageFromQueue(gomock.Any(), gomock.Any()).
+		Return(nil).
+		AnyTimes()
+
+	mockRedisRepo.EXPECT().
+		Del(gomock.Any(), gomock.Any()).
+		Return(nil).
+		AnyTimes()
+
+	// Mock RabbitMQ for events
+	mockRabbitMQRepo.EXPECT().
+		ProducerDefault(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(nil, nil).
+		AnyTimes()
+
+	result, messageResults, err := uc.CreateBulkTransactionOperationsAsync(ctx, messages, true)
+
+	require.NoError(t, err)
+	assert.NotNil(t, result)
+	assert.Equal(t, int64(0), result.TransactionsInserted, "No inserts expected")
+	assert.Equal(t, int64(1), result.TransactionsUpdateAttempted, "1 update attempted")
+	assert.Equal(t, int64(1), result.TransactionsUpdated, "1 update succeeded")
+	assert.Equal(t, int64(1), result.OperationsInserted)
+	assert.False(t, result.FallbackUsed)
+	assert.Len(t, messageResults, 1)
+	assert.True(t, messageResults[0].Success)
+
+	// Wait for goroutines to complete
+	<-time.After(100 * time.Millisecond)
+}
+
+func TestCreateBulkTransactionOperationsAsync_MixedInsertAndUpdate(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockTransactionRepo := transaction.NewMockRepository(ctrl)
+	mockOperationRepo := operation.NewMockRepository(ctrl)
+	mockMetadataRepo := mongodb.NewMockRepository(ctrl)
+	mockBalanceRepo := balance.NewMockRepository(ctrl)
+	mockRabbitMQRepo := rabbitmq.NewMockProducerRepository(ctrl)
+	mockRedisRepo := redis.NewMockRedisRepository(ctrl)
+
+	uc := &UseCase{
+		TransactionRepo: mockTransactionRepo,
+		OperationRepo:   mockOperationRepo,
+		MetadataRepo:    mockMetadataRepo,
+		BalanceRepo:     mockBalanceRepo,
+		RabbitMQRepo:    mockRabbitMQRepo,
+		RedisRepo:       mockRedisRepo,
+	}
+
+	ctx := context.Background()
+	organizationID := uuid.New()
+	ledgerID := uuid.New()
+
+	createPayload := func(t *testing.T, status string, pending bool) []byte {
+		t.Helper()
+
+		tran := &transaction.Transaction{
+			ID:             uuid.New().String(),
+			OrganizationID: organizationID.String(),
+			LedgerID:       ledgerID.String(),
+			Status: transaction.Status{
+				Code:        status,
+				Description: &status,
+			},
+			Operations: []*operation.Operation{},
+		}
+		payload := transaction.TransactionProcessingPayload{
+			Transaction: tran,
+			Validate:    &pkgTransaction.Responses{Pending: pending},
+		}
+		bytes, err := msgpack.Marshal(payload)
+		require.NoError(t, err)
+
+		return bytes
+	}
+
+	messages := []mmodel.Queue{
+		// Message 1: NOTED transaction (insert)
+		{
+			OrganizationID: organizationID,
+			LedgerID:       ledgerID,
+			QueueData:      []mmodel.QueueData{{ID: uuid.New(), Value: createPayload(t, constant.NOTED, false)}},
+		},
+		// Message 2: APPROVED with Pending=true (update)
+		{
+			OrganizationID: organizationID,
+			LedgerID:       ledgerID,
+			QueueData:      []mmodel.QueueData{{ID: uuid.New(), Value: createPayload(t, constant.APPROVED, true)}},
+		},
+	}
+
+	// Mock for insert (1 NOTED transaction)
+	mockTransactionRepo.EXPECT().
+		CreateBulk(gomock.Any(), gomock.Any()).
+		Return(&repository.BulkInsertResult{
+			Attempted: 1,
+			Inserted:  1,
+			Ignored:   0,
+		}, nil)
+
+	// Mock for individual update (1 APPROVED transaction)
+	mockTransactionRepo.EXPECT().
+		Update(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(&transaction.Transaction{}, nil)
+
+	// No operations to insert
+	mockOperationRepo.EXPECT().
+		CreateBulk(gomock.Any(), gomock.Any()).
+		Return(&repository.BulkInsertResult{
+			Attempted: 0,
+			Inserted:  0,
+			Ignored:   0,
+		}, nil).
+		AnyTimes()
+
+	mockMetadataRepo.EXPECT().
+		Create(gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(nil).
+		AnyTimes()
+
+	mockRedisRepo.EXPECT().
+		RemoveMessageFromQueue(gomock.Any(), gomock.Any()).
+		Return(nil).
+		AnyTimes()
+
+	mockRedisRepo.EXPECT().
+		Del(gomock.Any(), gomock.Any()).
+		Return(nil).
+		AnyTimes()
+
+	mockRabbitMQRepo.EXPECT().
+		ProducerDefault(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(nil, nil).
+		AnyTimes()
+
+	result, messageResults, err := uc.CreateBulkTransactionOperationsAsync(ctx, messages, true)
+
+	require.NoError(t, err)
+	assert.NotNil(t, result)
+	assert.Equal(t, int64(1), result.TransactionsInserted, "1 insert expected")
+	assert.Equal(t, int64(1), result.TransactionsUpdateAttempted, "1 update attempted")
+	assert.Equal(t, int64(1), result.TransactionsUpdated, "1 update succeeded")
+	assert.Len(t, messageResults, 2)
+
+	// Wait for goroutines to complete
+	<-time.After(100 * time.Millisecond)
+}
+
+func TestCreateBulkTransactionOperationsAsync_UpdateFailureReturnsError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockTransactionRepo := transaction.NewMockRepository(ctrl)
+	mockOperationRepo := operation.NewMockRepository(ctrl)
+	mockMetadataRepo := mongodb.NewMockRepository(ctrl)
+	mockBalanceRepo := balance.NewMockRepository(ctrl)
+	mockRabbitMQRepo := rabbitmq.NewMockProducerRepository(ctrl)
+	mockRedisRepo := redis.NewMockRedisRepository(ctrl)
+
+	uc := &UseCase{
+		TransactionRepo: mockTransactionRepo,
+		OperationRepo:   mockOperationRepo,
+		MetadataRepo:    mockMetadataRepo,
+		BalanceRepo:     mockBalanceRepo,
+		RabbitMQRepo:    mockRabbitMQRepo,
+		RedisRepo:       mockRedisRepo,
+	}
+
+	ctx := context.Background()
+	organizationID := uuid.New()
+	ledgerID := uuid.New()
+	transactionID := uuid.New().String()
+
+	// Create an APPROVED transaction with Validate.Pending=true
+	approvedStatus := constant.APPROVED
+	tran := &transaction.Transaction{
+		ID:             transactionID,
+		OrganizationID: organizationID.String(),
+		LedgerID:       ledgerID.String(),
+		Status: transaction.Status{
+			Code:        approvedStatus,
+			Description: &approvedStatus,
+		},
+		Operations: []*operation.Operation{},
+	}
+
+	payload := transaction.TransactionProcessingPayload{
+		Transaction: tran,
+		Validate:    &pkgTransaction.Responses{Pending: true},
+	}
+
+	payloadBytes, err := msgpack.Marshal(payload)
+	require.NoError(t, err)
+
+	messages := []mmodel.Queue{
+		{
+			OrganizationID: organizationID,
+			LedgerID:       ledgerID,
+			QueueData: []mmodel.QueueData{
+				{ID: uuid.New(), Value: payloadBytes},
+			},
+		},
+	}
+
+	// Mock balance update
+	mockBalanceRepo.EXPECT().
+		SyncBatch(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(int64(1), nil).
+		AnyTimes()
+
+	mockBalanceRepo.EXPECT().
+		BalancesUpdate(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(nil).
+		AnyTimes()
+
+	// Mock update failure
+	updateErr := errors.New("database connection lost")
+	mockTransactionRepo.EXPECT().
+		Update(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(nil, updateErr)
+
+	// Fallback disabled - should return error
+	result, messageResults, err := uc.CreateBulkTransactionOperationsAsync(ctx, messages, false)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "transaction status update failed")
+	assert.NotNil(t, result)
+	assert.Equal(t, int64(1), result.TransactionsUpdateAttempted)
+	assert.Equal(t, int64(0), result.TransactionsUpdated)
+	assert.Len(t, messageResults, 1)
+	assert.False(t, messageResults[0].Success)
 }

--- a/components/transaction/internal/services/command/create-bulk-transaction-operations-async_test.go
+++ b/components/transaction/internal/services/command/create-bulk-transaction-operations-async_test.go
@@ -1,0 +1,1007 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package command
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/LerianStudio/midaz/v3/components/transaction/internal/adapters/mongodb"
+	"github.com/LerianStudio/midaz/v3/components/transaction/internal/adapters/postgres/balance"
+	"github.com/LerianStudio/midaz/v3/components/transaction/internal/adapters/postgres/operation"
+	"github.com/LerianStudio/midaz/v3/components/transaction/internal/adapters/postgres/transaction"
+	"github.com/LerianStudio/midaz/v3/components/transaction/internal/adapters/rabbitmq"
+	"github.com/LerianStudio/midaz/v3/components/transaction/internal/adapters/redis"
+	"github.com/LerianStudio/midaz/v3/pkg/constant"
+	"github.com/LerianStudio/midaz/v3/pkg/mmodel"
+	"github.com/LerianStudio/midaz/v3/pkg/repository"
+	pkgTransaction "github.com/LerianStudio/midaz/v3/pkg/transaction"
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/vmihailenco/msgpack/v5"
+	"go.uber.org/mock/gomock"
+)
+
+// =============================================================================
+// UNIT TESTS - BulkResult Struct
+// =============================================================================
+
+func TestBulkResult_ZeroValues(t *testing.T) {
+	t.Parallel()
+
+	result := &BulkResult{}
+
+	assert.Equal(t, int64(0), result.TransactionsAttempted)
+	assert.Equal(t, int64(0), result.TransactionsInserted)
+	assert.Equal(t, int64(0), result.TransactionsIgnored)
+	assert.Equal(t, int64(0), result.OperationsAttempted)
+	assert.Equal(t, int64(0), result.OperationsInserted)
+	assert.Equal(t, int64(0), result.OperationsIgnored)
+	assert.False(t, result.FallbackUsed)
+	assert.Equal(t, 0, result.FallbackCount)
+}
+
+// =============================================================================
+// UNIT TESTS - BulkMessageResult Struct
+// =============================================================================
+
+func TestBulkMessageResult_Success(t *testing.T) {
+	t.Parallel()
+
+	result := BulkMessageResult{
+		Index:   5,
+		Success: true,
+		Error:   nil,
+	}
+
+	assert.Equal(t, 5, result.Index)
+	assert.True(t, result.Success)
+	assert.Nil(t, result.Error)
+}
+
+func TestBulkMessageResult_Failure(t *testing.T) {
+	t.Parallel()
+
+	testErr := errors.New("test error")
+	result := BulkMessageResult{
+		Index:   3,
+		Success: false,
+		Error:   testErr,
+	}
+
+	assert.Equal(t, 3, result.Index)
+	assert.False(t, result.Success)
+	assert.Equal(t, testErr, result.Error)
+}
+
+// =============================================================================
+// UNIT TESTS - sortTransactionsByID
+// =============================================================================
+
+func TestSortTransactionsByID(t *testing.T) {
+	t.Parallel()
+
+	transactions := []*transaction.Transaction{
+		{ID: "c-transaction"},
+		{ID: "a-transaction"},
+		{ID: "b-transaction"},
+	}
+
+	sortTransactionsByID(transactions)
+
+	assert.Equal(t, "a-transaction", transactions[0].ID)
+	assert.Equal(t, "b-transaction", transactions[1].ID)
+	assert.Equal(t, "c-transaction", transactions[2].ID)
+}
+
+func TestSortTransactionsByID_Empty(t *testing.T) {
+	t.Parallel()
+
+	transactions := []*transaction.Transaction{}
+
+	// Should not panic
+	sortTransactionsByID(transactions)
+
+	assert.Empty(t, transactions)
+}
+
+func TestSortTransactionsByID_Single(t *testing.T) {
+	t.Parallel()
+
+	transactions := []*transaction.Transaction{
+		{ID: "only-transaction"},
+	}
+
+	sortTransactionsByID(transactions)
+
+	assert.Len(t, transactions, 1)
+	assert.Equal(t, "only-transaction", transactions[0].ID)
+}
+
+// =============================================================================
+// UNIT TESTS - sortOperationsByID
+// =============================================================================
+
+func TestSortOperationsByID(t *testing.T) {
+	t.Parallel()
+
+	operations := []*operation.Operation{
+		{ID: "z-operation"},
+		{ID: "a-operation"},
+		{ID: "m-operation"},
+	}
+
+	sortOperationsByID(operations)
+
+	assert.Equal(t, "a-operation", operations[0].ID)
+	assert.Equal(t, "m-operation", operations[1].ID)
+	assert.Equal(t, "z-operation", operations[2].ID)
+}
+
+func TestSortOperationsByID_Empty(t *testing.T) {
+	t.Parallel()
+
+	operations := []*operation.Operation{}
+
+	// Should not panic
+	sortOperationsByID(operations)
+
+	assert.Empty(t, operations)
+}
+
+// =============================================================================
+// UNIT TESTS - CreateBulkTransactionOperationsAsync - Empty Messages
+// =============================================================================
+
+func TestCreateBulkTransactionOperationsAsync_EmptyMessages(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	uc := &UseCase{}
+	ctx := context.Background()
+
+	result, messageResults, err := uc.CreateBulkTransactionOperationsAsync(ctx, []mmodel.Queue{}, true)
+
+	require.NoError(t, err)
+	assert.NotNil(t, result)
+	assert.Empty(t, messageResults)
+	assert.Equal(t, int64(0), result.TransactionsAttempted)
+}
+
+// =============================================================================
+// UNIT TESTS - CreateBulkTransactionOperationsAsync - Success Path
+// =============================================================================
+
+func TestCreateBulkTransactionOperationsAsync_Success(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockTransactionRepo := transaction.NewMockRepository(ctrl)
+	mockOperationRepo := operation.NewMockRepository(ctrl)
+	mockMetadataRepo := mongodb.NewMockRepository(ctrl)
+	mockBalanceRepo := balance.NewMockRepository(ctrl)
+	mockRabbitMQRepo := rabbitmq.NewMockProducerRepository(ctrl)
+	mockRedisRepo := redis.NewMockRedisRepository(ctrl)
+
+	uc := &UseCase{
+		TransactionRepo: mockTransactionRepo,
+		OperationRepo:   mockOperationRepo,
+		MetadataRepo:    mockMetadataRepo,
+		BalanceRepo:     mockBalanceRepo,
+		RabbitMQRepo:    mockRabbitMQRepo,
+		RedisRepo:       mockRedisRepo,
+	}
+
+	ctx := context.Background()
+	organizationID := uuid.New()
+	ledgerID := uuid.New()
+	transactionID := uuid.New().String()
+
+	// Create a NOTED transaction (skips balance update)
+	notedStatus := constant.NOTED
+	tran := &transaction.Transaction{
+		ID:             transactionID,
+		OrganizationID: organizationID.String(),
+		LedgerID:       ledgerID.String(),
+		Status: transaction.Status{
+			Code:        notedStatus,
+			Description: &notedStatus,
+		},
+		Operations: []*operation.Operation{
+			{ID: uuid.New().String(), TransactionID: transactionID},
+		},
+	}
+
+	payload := transaction.TransactionProcessingPayload{
+		Transaction: tran,
+		Validate:    &pkgTransaction.Responses{},
+	}
+
+	payloadBytes, err := msgpack.Marshal(payload)
+	require.NoError(t, err)
+
+	messages := []mmodel.Queue{
+		{
+			OrganizationID: organizationID,
+			LedgerID:       ledgerID,
+			QueueData: []mmodel.QueueData{
+				{ID: uuid.New(), Value: payloadBytes},
+			},
+		},
+	}
+
+	// Mock expectations for bulk insert
+	mockTransactionRepo.EXPECT().
+		CreateBulk(gomock.Any(), gomock.Any()).
+		Return(&repository.BulkInsertResult{
+			Attempted: 1,
+			Inserted:  1,
+			Ignored:   0,
+		}, nil)
+
+	mockOperationRepo.EXPECT().
+		CreateBulk(gomock.Any(), gomock.Any()).
+		Return(&repository.BulkInsertResult{
+			Attempted: 1,
+			Inserted:  1,
+			Ignored:   0,
+		}, nil)
+
+	// Mock metadata creation (best effort, can return error)
+	mockMetadataRepo.EXPECT().
+		Create(gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(nil).
+		AnyTimes()
+
+	// Mock Redis cleanup (best effort) - multiple methods called in goroutines
+	mockRedisRepo.EXPECT().
+		RemoveMessageFromQueue(gomock.Any(), gomock.Any()).
+		Return(nil).
+		AnyTimes()
+
+	mockRedisRepo.EXPECT().
+		Del(gomock.Any(), gomock.Any()).
+		Return(nil).
+		AnyTimes()
+
+	// Mock RabbitMQ for events (best effort)
+	mockRabbitMQRepo.EXPECT().
+		ProducerDefault(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(nil, nil).
+		AnyTimes()
+
+	result, messageResults, err := uc.CreateBulkTransactionOperationsAsync(ctx, messages, true)
+
+	require.NoError(t, err)
+	assert.NotNil(t, result)
+	assert.Equal(t, int64(1), result.TransactionsInserted)
+	assert.Equal(t, int64(1), result.OperationsInserted)
+	assert.False(t, result.FallbackUsed)
+	assert.Len(t, messageResults, 1)
+	assert.True(t, messageResults[0].Success)
+
+	// Wait for goroutines to complete
+	// Note: In production, these run async but for tests we need to wait
+	// to avoid race conditions with mock controller cleanup
+	<-time.After(100 * time.Millisecond)
+}
+
+// =============================================================================
+// UNIT TESTS - CreateBulkTransactionOperationsAsync - Fallback on Failure
+// =============================================================================
+
+func TestCreateBulkTransactionOperationsAsync_FallbackOnBulkFailure(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockTransactionRepo := transaction.NewMockRepository(ctrl)
+	mockOperationRepo := operation.NewMockRepository(ctrl)
+	mockMetadataRepo := mongodb.NewMockRepository(ctrl)
+	mockBalanceRepo := balance.NewMockRepository(ctrl)
+	mockRabbitMQRepo := rabbitmq.NewMockProducerRepository(ctrl)
+	mockRedisRepo := redis.NewMockRedisRepository(ctrl)
+
+	uc := &UseCase{
+		TransactionRepo: mockTransactionRepo,
+		OperationRepo:   mockOperationRepo,
+		MetadataRepo:    mockMetadataRepo,
+		BalanceRepo:     mockBalanceRepo,
+		RabbitMQRepo:    mockRabbitMQRepo,
+		RedisRepo:       mockRedisRepo,
+	}
+
+	ctx := context.Background()
+	organizationID := uuid.New()
+	ledgerID := uuid.New()
+	transactionID := uuid.New().String()
+
+	// Create a NOTED transaction (skips balance update)
+	notedStatus := constant.NOTED
+	tran := &transaction.Transaction{
+		ID:             transactionID,
+		OrganizationID: organizationID.String(),
+		LedgerID:       ledgerID.String(),
+		Status: transaction.Status{
+			Code:        notedStatus,
+			Description: &notedStatus,
+		},
+		Operations: []*operation.Operation{},
+	}
+
+	payload := transaction.TransactionProcessingPayload{
+		Transaction: tran,
+		Validate:    &pkgTransaction.Responses{},
+	}
+
+	payloadBytes, err := msgpack.Marshal(payload)
+	require.NoError(t, err)
+
+	messages := []mmodel.Queue{
+		{
+			OrganizationID: organizationID,
+			LedgerID:       ledgerID,
+			QueueData: []mmodel.QueueData{
+				{ID: uuid.New(), Value: payloadBytes},
+			},
+		},
+	}
+
+	// Mock bulk insert failure
+	mockTransactionRepo.EXPECT().
+		CreateBulk(gomock.Any(), gomock.Any()).
+		Return(nil, errors.New("bulk insert failed"))
+
+	// Mock individual transaction creation (fallback)
+	mockTransactionRepo.EXPECT().
+		Create(gomock.Any(), gomock.Any()).
+		Return(tran, nil)
+
+	// Mock metadata creation (best effort)
+	mockMetadataRepo.EXPECT().
+		Create(gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(nil).
+		AnyTimes()
+
+	// Mock Redis cleanup (best effort) - multiple methods called in goroutines
+	mockRedisRepo.EXPECT().
+		RemoveMessageFromQueue(gomock.Any(), gomock.Any()).
+		Return(nil).
+		AnyTimes()
+
+	mockRedisRepo.EXPECT().
+		Del(gomock.Any(), gomock.Any()).
+		Return(nil).
+		AnyTimes()
+
+	// Mock RabbitMQ for events (best effort)
+	mockRabbitMQRepo.EXPECT().
+		ProducerDefault(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(nil, nil).
+		AnyTimes()
+
+	result, messageResults, err := uc.CreateBulkTransactionOperationsAsync(ctx, messages, true)
+
+	require.NoError(t, err) // Fallback should succeed
+	assert.NotNil(t, result)
+	assert.True(t, result.FallbackUsed)
+	assert.Equal(t, 1, result.FallbackCount)
+	assert.Len(t, messageResults, 1)
+	assert.True(t, messageResults[0].Success)
+
+	// Wait for goroutines to complete
+	<-time.After(100 * time.Millisecond)
+}
+
+// =============================================================================
+// UNIT TESTS - CreateBulkTransactionOperationsAsync - No Fallback
+// =============================================================================
+
+func TestCreateBulkTransactionOperationsAsync_NoFallbackOnFailure(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockTransactionRepo := transaction.NewMockRepository(ctrl)
+	mockOperationRepo := operation.NewMockRepository(ctrl)
+	mockMetadataRepo := mongodb.NewMockRepository(ctrl)
+	mockBalanceRepo := balance.NewMockRepository(ctrl)
+	mockRabbitMQRepo := rabbitmq.NewMockProducerRepository(ctrl)
+	mockRedisRepo := redis.NewMockRedisRepository(ctrl)
+
+	uc := &UseCase{
+		TransactionRepo: mockTransactionRepo,
+		OperationRepo:   mockOperationRepo,
+		MetadataRepo:    mockMetadataRepo,
+		BalanceRepo:     mockBalanceRepo,
+		RabbitMQRepo:    mockRabbitMQRepo,
+		RedisRepo:       mockRedisRepo,
+	}
+
+	ctx := context.Background()
+	organizationID := uuid.New()
+	ledgerID := uuid.New()
+	transactionID := uuid.New().String()
+
+	// Create a NOTED transaction (skips balance update)
+	notedStatus := constant.NOTED
+	tran := &transaction.Transaction{
+		ID:             transactionID,
+		OrganizationID: organizationID.String(),
+		LedgerID:       ledgerID.String(),
+		Status: transaction.Status{
+			Code:        notedStatus,
+			Description: &notedStatus,
+		},
+		Operations: []*operation.Operation{},
+	}
+
+	payload := transaction.TransactionProcessingPayload{
+		Transaction: tran,
+		Validate:    &pkgTransaction.Responses{},
+	}
+
+	payloadBytes, err := msgpack.Marshal(payload)
+	require.NoError(t, err)
+
+	messages := []mmodel.Queue{
+		{
+			OrganizationID: organizationID,
+			LedgerID:       ledgerID,
+			QueueData: []mmodel.QueueData{
+				{ID: uuid.New(), Value: payloadBytes},
+			},
+		},
+	}
+
+	// Mock bulk insert failure
+	mockTransactionRepo.EXPECT().
+		CreateBulk(gomock.Any(), gomock.Any()).
+		Return(nil, errors.New("bulk insert failed"))
+
+	// Fallback disabled - should return error
+	result, messageResults, err := uc.CreateBulkTransactionOperationsAsync(ctx, messages, false)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "bulk insert failed")
+	assert.NotNil(t, result)
+	assert.False(t, result.FallbackUsed)
+	assert.Len(t, messageResults, 1)
+	assert.False(t, messageResults[0].Success)
+}
+
+// =============================================================================
+// UNIT TESTS - CreateBulkTransactionOperationsAsync - Duplicates Ignored
+// =============================================================================
+
+func TestCreateBulkTransactionOperationsAsync_DuplicatesIgnored(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockTransactionRepo := transaction.NewMockRepository(ctrl)
+	mockOperationRepo := operation.NewMockRepository(ctrl)
+	mockMetadataRepo := mongodb.NewMockRepository(ctrl)
+	mockBalanceRepo := balance.NewMockRepository(ctrl)
+	mockRabbitMQRepo := rabbitmq.NewMockProducerRepository(ctrl)
+	mockRedisRepo := redis.NewMockRedisRepository(ctrl)
+
+	uc := &UseCase{
+		TransactionRepo: mockTransactionRepo,
+		OperationRepo:   mockOperationRepo,
+		MetadataRepo:    mockMetadataRepo,
+		BalanceRepo:     mockBalanceRepo,
+		RabbitMQRepo:    mockRabbitMQRepo,
+		RedisRepo:       mockRedisRepo,
+	}
+
+	ctx := context.Background()
+	organizationID := uuid.New()
+	ledgerID := uuid.New()
+
+	// Create 2 NOTED transactions (one will be duplicate)
+	notedStatus := constant.NOTED
+
+	createPayload := func(t *testing.T, id string) []byte {
+		t.Helper()
+
+		tran := &transaction.Transaction{
+			ID:             id,
+			OrganizationID: organizationID.String(),
+			LedgerID:       ledgerID.String(),
+			Status: transaction.Status{
+				Code:        notedStatus,
+				Description: &notedStatus,
+			},
+			Operations: []*operation.Operation{},
+		}
+		payload := transaction.TransactionProcessingPayload{
+			Transaction: tran,
+			Validate:    &pkgTransaction.Responses{},
+		}
+		bytes, err := msgpack.Marshal(payload)
+		require.NoError(t, err)
+
+		return bytes
+	}
+
+	messages := []mmodel.Queue{
+		{
+			OrganizationID: organizationID,
+			LedgerID:       ledgerID,
+			QueueData:      []mmodel.QueueData{{ID: uuid.New(), Value: createPayload(t, "tx-1")}},
+		},
+		{
+			OrganizationID: organizationID,
+			LedgerID:       ledgerID,
+			QueueData:      []mmodel.QueueData{{ID: uuid.New(), Value: createPayload(t, "tx-2")}},
+		},
+	}
+
+	// Mock bulk insert with 1 duplicate
+	mockTransactionRepo.EXPECT().
+		CreateBulk(gomock.Any(), gomock.Any()).
+		Return(&repository.BulkInsertResult{
+			Attempted: 2,
+			Inserted:  1,
+			Ignored:   1, // One duplicate
+		}, nil)
+
+	mockOperationRepo.EXPECT().
+		CreateBulk(gomock.Any(), gomock.Any()).
+		Return(&repository.BulkInsertResult{
+			Attempted: 0,
+			Inserted:  0,
+			Ignored:   0,
+		}, nil)
+
+	mockMetadataRepo.EXPECT().
+		Create(gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(nil).
+		AnyTimes()
+
+	mockRedisRepo.EXPECT().
+		RemoveMessageFromQueue(gomock.Any(), gomock.Any()).
+		Return(nil).
+		AnyTimes()
+
+	mockRedisRepo.EXPECT().
+		Del(gomock.Any(), gomock.Any()).
+		Return(nil).
+		AnyTimes()
+
+	// Mock RabbitMQ for events (best effort)
+	mockRabbitMQRepo.EXPECT().
+		ProducerDefault(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(nil, nil).
+		AnyTimes()
+
+	result, messageResults, err := uc.CreateBulkTransactionOperationsAsync(ctx, messages, true)
+
+	require.NoError(t, err)
+	assert.NotNil(t, result)
+	assert.Equal(t, int64(2), result.TransactionsAttempted)
+	assert.Equal(t, int64(1), result.TransactionsInserted)
+	assert.Equal(t, int64(1), result.TransactionsIgnored) // Duplicate detected
+	assert.False(t, result.FallbackUsed)
+	assert.Len(t, messageResults, 2)
+
+	// Wait for goroutines to complete
+	<-time.After(100 * time.Millisecond)
+}
+
+// =============================================================================
+// UNIT TESTS - CreateBulkTransactionOperationsAsync - Balance Processing
+// =============================================================================
+
+func TestCreateBulkTransactionOperationsAsync_WithBalanceProcessing(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockTransactionRepo := transaction.NewMockRepository(ctrl)
+	mockOperationRepo := operation.NewMockRepository(ctrl)
+	mockMetadataRepo := mongodb.NewMockRepository(ctrl)
+	mockBalanceRepo := balance.NewMockRepository(ctrl)
+	mockRabbitMQRepo := rabbitmq.NewMockProducerRepository(ctrl)
+	mockRedisRepo := redis.NewMockRedisRepository(ctrl)
+
+	uc := &UseCase{
+		TransactionRepo: mockTransactionRepo,
+		OperationRepo:   mockOperationRepo,
+		MetadataRepo:    mockMetadataRepo,
+		BalanceRepo:     mockBalanceRepo,
+		RabbitMQRepo:    mockRabbitMQRepo,
+		RedisRepo:       mockRedisRepo,
+	}
+
+	ctx := context.Background()
+	organizationID := uuid.New()
+	ledgerID := uuid.New()
+	transactionID := uuid.New().String()
+
+	// Create a CREATED transaction (requires balance update)
+	createdStatus := constant.CREATED
+	approvedStatus := constant.APPROVED
+
+	balances := []*mmodel.Balance{
+		{
+			ID:             uuid.New().String(),
+			AccountID:      uuid.New().String(),
+			OrganizationID: organizationID.String(),
+			LedgerID:       ledgerID.String(),
+			Alias:          "alias1",
+			Available:      decimal.NewFromInt(100),
+			OnHold:         decimal.NewFromInt(0),
+			Version:        1,
+			AccountType:    "deposit",
+			AllowSending:   true,
+			AllowReceiving: true,
+			AssetCode:      "USD",
+		},
+	}
+
+	tran := &transaction.Transaction{
+		ID:             transactionID,
+		OrganizationID: organizationID.String(),
+		LedgerID:       ledgerID.String(),
+		Status: transaction.Status{
+			Code:        createdStatus,
+			Description: &approvedStatus,
+		},
+		Operations: []*operation.Operation{},
+	}
+
+	validate := &pkgTransaction.Responses{
+		Aliases: []string{"alias1"},
+		From: map[string]pkgTransaction.Amount{
+			"alias1": {Asset: "USD", Value: decimal.NewFromInt(50)},
+		},
+	}
+
+	payload := transaction.TransactionProcessingPayload{
+		Transaction:   tran,
+		Validate:      validate,
+		Balances:      balances,
+		BalancesAfter: balances, // Same for simplicity
+	}
+
+	payloadBytes, err := msgpack.Marshal(payload)
+	require.NoError(t, err)
+
+	messages := []mmodel.Queue{
+		{
+			OrganizationID: organizationID,
+			LedgerID:       ledgerID,
+			QueueData: []mmodel.QueueData{
+				{ID: uuid.New(), Value: payloadBytes},
+			},
+		},
+	}
+
+	// Mock balance sync batch for balance update
+	mockBalanceRepo.EXPECT().
+		SyncBatch(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(int64(1), nil).
+		AnyTimes()
+
+	// Mock BalancesUpdate for individual balance updates
+	mockBalanceRepo.EXPECT().
+		BalancesUpdate(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(nil).
+		AnyTimes()
+
+	// Mock bulk insert
+	mockTransactionRepo.EXPECT().
+		CreateBulk(gomock.Any(), gomock.Any()).
+		Return(&repository.BulkInsertResult{
+			Attempted: 1,
+			Inserted:  1,
+			Ignored:   0,
+		}, nil)
+
+	mockOperationRepo.EXPECT().
+		CreateBulk(gomock.Any(), gomock.Any()).
+		Return(&repository.BulkInsertResult{
+			Attempted: 0,
+			Inserted:  0,
+			Ignored:   0,
+		}, nil)
+
+	mockMetadataRepo.EXPECT().
+		Create(gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(nil).
+		AnyTimes()
+
+	mockRedisRepo.EXPECT().
+		RemoveMessageFromQueue(gomock.Any(), gomock.Any()).
+		Return(nil).
+		AnyTimes()
+
+	mockRedisRepo.EXPECT().
+		Del(gomock.Any(), gomock.Any()).
+		Return(nil).
+		AnyTimes()
+
+	// Mock RabbitMQ for events (best effort)
+	mockRabbitMQRepo.EXPECT().
+		ProducerDefault(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(nil, nil).
+		AnyTimes()
+
+	result, messageResults, err := uc.CreateBulkTransactionOperationsAsync(ctx, messages, true)
+
+	require.NoError(t, err)
+	assert.NotNil(t, result)
+	assert.Equal(t, int64(1), result.TransactionsInserted)
+	assert.Len(t, messageResults, 1)
+	assert.True(t, messageResults[0].Success)
+
+	// Wait for goroutines to complete
+	<-time.After(100 * time.Millisecond)
+}
+
+// =============================================================================
+// UNIT TESTS - CreateBulkTransactionOperationsAsync - Unmarshal Failure
+// =============================================================================
+
+func TestCreateBulkTransactionOperationsAsync_UnmarshalFailure(t *testing.T) {
+	t.Parallel()
+
+	uc := &UseCase{}
+	ctx := context.Background()
+	organizationID := uuid.New()
+	ledgerID := uuid.New()
+
+	// Create message with invalid msgpack data
+	messages := []mmodel.Queue{
+		{
+			OrganizationID: organizationID,
+			LedgerID:       ledgerID,
+			QueueData: []mmodel.QueueData{
+				{ID: uuid.New(), Value: []byte("invalid msgpack data that cannot be unmarshaled")},
+			},
+		},
+	}
+
+	result, messageResults, err := uc.CreateBulkTransactionOperationsAsync(ctx, messages, true)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unmarshal")
+	assert.NotNil(t, result)
+	assert.Len(t, messageResults, 1)
+	assert.False(t, messageResults[0].Success)
+	assert.NotNil(t, messageResults[0].Error)
+}
+
+func TestCreateBulkTransactionOperationsAsync_PartialUnmarshalFailure(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockTransactionRepo := transaction.NewMockRepository(ctrl)
+	mockOperationRepo := operation.NewMockRepository(ctrl)
+	mockMetadataRepo := mongodb.NewMockRepository(ctrl)
+	mockBalanceRepo := balance.NewMockRepository(ctrl)
+	mockRabbitMQRepo := rabbitmq.NewMockProducerRepository(ctrl)
+	mockRedisRepo := redis.NewMockRedisRepository(ctrl)
+
+	uc := &UseCase{
+		TransactionRepo: mockTransactionRepo,
+		OperationRepo:   mockOperationRepo,
+		MetadataRepo:    mockMetadataRepo,
+		BalanceRepo:     mockBalanceRepo,
+		RabbitMQRepo:    mockRabbitMQRepo,
+		RedisRepo:       mockRedisRepo,
+	}
+
+	ctx := context.Background()
+	organizationID := uuid.New()
+	ledgerID := uuid.New()
+	transactionID := uuid.New().String()
+
+	// Create one valid and one invalid message
+	notedStatus := constant.NOTED
+	tran := &transaction.Transaction{
+		ID:             transactionID,
+		OrganizationID: organizationID.String(),
+		LedgerID:       ledgerID.String(),
+		Status: transaction.Status{
+			Code:        notedStatus,
+			Description: &notedStatus,
+		},
+		Operations: []*operation.Operation{},
+	}
+
+	payload := transaction.TransactionProcessingPayload{
+		Transaction: tran,
+		Validate:    &pkgTransaction.Responses{},
+	}
+
+	validPayloadBytes, err := msgpack.Marshal(payload)
+	require.NoError(t, err)
+
+	messages := []mmodel.Queue{
+		{
+			OrganizationID: organizationID,
+			LedgerID:       ledgerID,
+			QueueData: []mmodel.QueueData{
+				{ID: uuid.New(), Value: []byte("invalid data")}, // Invalid
+			},
+		},
+		{
+			OrganizationID: organizationID,
+			LedgerID:       ledgerID,
+			QueueData: []mmodel.QueueData{
+				{ID: uuid.New(), Value: validPayloadBytes}, // Valid
+			},
+		},
+	}
+
+	// Mock bulk insert for the one valid message
+	mockTransactionRepo.EXPECT().
+		CreateBulk(gomock.Any(), gomock.Any()).
+		Return(&repository.BulkInsertResult{
+			Attempted: 1,
+			Inserted:  1,
+			Ignored:   0,
+		}, nil)
+
+	mockOperationRepo.EXPECT().
+		CreateBulk(gomock.Any(), gomock.Any()).
+		Return(&repository.BulkInsertResult{
+			Attempted: 0,
+			Inserted:  0,
+			Ignored:   0,
+		}, nil)
+
+	mockMetadataRepo.EXPECT().
+		Create(gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(nil).
+		AnyTimes()
+
+	mockRedisRepo.EXPECT().
+		RemoveMessageFromQueue(gomock.Any(), gomock.Any()).
+		Return(nil).
+		AnyTimes()
+
+	mockRedisRepo.EXPECT().
+		Del(gomock.Any(), gomock.Any()).
+		Return(nil).
+		AnyTimes()
+
+	mockRabbitMQRepo.EXPECT().
+		ProducerDefault(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(nil, nil).
+		AnyTimes()
+
+	result, messageResults, err := uc.CreateBulkTransactionOperationsAsync(ctx, messages, true)
+
+	// Should succeed because at least one message was valid
+	require.NoError(t, err)
+	assert.NotNil(t, result)
+	assert.Len(t, messageResults, 2)
+
+	// First message (invalid) should fail
+	assert.False(t, messageResults[0].Success)
+	assert.NotNil(t, messageResults[0].Error)
+
+	// Second message (valid) should succeed
+	assert.True(t, messageResults[1].Success)
+
+	// Wait for goroutines to complete
+	<-time.After(100 * time.Millisecond)
+}
+
+// =============================================================================
+// UNIT TESTS - CreateBulkTransactionOperationsAsync - Empty QueueData
+// =============================================================================
+
+func TestCreateBulkTransactionOperationsAsync_EmptyQueueData(t *testing.T) {
+	t.Parallel()
+
+	uc := &UseCase{}
+	ctx := context.Background()
+	organizationID := uuid.New()
+	ledgerID := uuid.New()
+
+	// Create message with empty QueueData
+	messages := []mmodel.Queue{
+		{
+			OrganizationID: organizationID,
+			LedgerID:       ledgerID,
+			QueueData:      []mmodel.QueueData{}, // Empty
+		},
+	}
+
+	result, messageResults, err := uc.CreateBulkTransactionOperationsAsync(ctx, messages, true)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unmarshal")
+	assert.NotNil(t, result)
+	assert.Len(t, messageResults, 1)
+	assert.False(t, messageResults[0].Success)
+	assert.NotNil(t, messageResults[0].Error)
+	assert.Contains(t, messageResults[0].Error.Error(), "empty QueueData")
+}
+
+// =============================================================================
+// UNIT TESTS - Sorting Functions with Nil Elements
+// =============================================================================
+
+func TestSortTransactionsByID_WithNilElements(t *testing.T) {
+	t.Parallel()
+
+	transactions := []*transaction.Transaction{
+		{ID: "c-transaction"},
+		nil, // Nil element
+		{ID: "a-transaction"},
+		nil, // Another nil element
+		{ID: "b-transaction"},
+	}
+
+	// Should not panic
+	sortTransactionsByID(transactions)
+
+	// Verify nils are sorted to the beginning
+	assert.Nil(t, transactions[0])
+	assert.Nil(t, transactions[1])
+	// Remaining elements should be sorted
+	assert.Equal(t, "a-transaction", transactions[2].ID)
+	assert.Equal(t, "b-transaction", transactions[3].ID)
+	assert.Equal(t, "c-transaction", transactions[4].ID)
+}
+
+func TestSortTransactionsByID_AllNil(t *testing.T) {
+	t.Parallel()
+
+	transactions := []*transaction.Transaction{nil, nil, nil}
+
+	// Should not panic
+	sortTransactionsByID(transactions)
+
+	// All should still be nil
+	for _, tx := range transactions {
+		assert.Nil(t, tx)
+	}
+}
+
+func TestSortOperationsByID_WithNilElements(t *testing.T) {
+	t.Parallel()
+
+	operations := []*operation.Operation{
+		{ID: "z-operation"},
+		nil, // Nil element
+		{ID: "a-operation"},
+		nil, // Another nil element
+		{ID: "m-operation"},
+	}
+
+	// Should not panic
+	sortOperationsByID(operations)
+
+	// Verify nils are sorted to the beginning
+	assert.Nil(t, operations[0])
+	assert.Nil(t, operations[1])
+	// Remaining elements should be sorted
+	assert.Equal(t, "a-operation", operations[2].ID)
+	assert.Equal(t, "m-operation", operations[3].ID)
+	assert.Equal(t, "z-operation", operations[4].ID)
+}
+
+func TestSortOperationsByID_AllNil(t *testing.T) {
+	t.Parallel()
+
+	operations := []*operation.Operation{nil, nil, nil}
+
+	// Should not panic
+	sortOperationsByID(operations)
+
+	// All should still be nil
+	for _, op := range operations {
+		assert.Nil(t, op)
+	}
+}

--- a/components/transaction/internal/services/command/create-bulk-transaction-operations-async_test.go
+++ b/components/transaction/internal/services/command/create-bulk-transaction-operations-async_test.go
@@ -1617,3 +1617,542 @@ func TestCreateBulkTransactionOperationsAsync_UpdateFailureReturnsError(t *testi
 	assert.Len(t, messageResults, 1)
 	assert.False(t, messageResults[0].Success)
 }
+
+// =============================================================================
+// UNIT TESTS - Error Preservation (Issue 3)
+// =============================================================================
+
+func TestCreateBulkTransactionOperationsAsync_UnmarshalErrorPreservedOverNilPayload(t *testing.T) {
+	t.Parallel()
+
+	// This test verifies that when a message fails to unmarshal, the original
+	// unmarshal error is preserved even when processBalances later encounters
+	// a nil payload for the same entry.
+
+	uc := &UseCase{}
+	ctx := context.Background()
+	organizationID := uuid.New()
+	ledgerID := uuid.New()
+
+	// Create message with invalid msgpack data - will cause unmarshal error
+	messages := []mmodel.Queue{
+		{
+			OrganizationID: organizationID,
+			LedgerID:       ledgerID,
+			QueueData: []mmodel.QueueData{
+				{ID: uuid.New(), Value: []byte("invalid msgpack data")},
+			},
+		},
+	}
+
+	result, messageResults, err := uc.CreateBulkTransactionOperationsAsync(ctx, messages, true)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unmarshal")
+	assert.NotNil(t, result)
+	assert.Len(t, messageResults, 1)
+	assert.False(t, messageResults[0].Success)
+
+	// The error should be the original unmarshal error, NOT "nil payload"
+	assert.NotNil(t, messageResults[0].Error)
+	assert.NotContains(t, messageResults[0].Error.Error(), "nil payload",
+		"Error should be the original unmarshal error, not overwritten by 'nil payload'")
+}
+
+func TestProcessBalances_PreservesExistingError(t *testing.T) {
+	t.Parallel()
+
+	// This test directly tests the processBalances function to ensure it
+	// preserves existing errors instead of overwriting them with "nil payload"
+
+	uc := &UseCase{}
+	ctx := context.Background()
+	organizationID := uuid.New()
+	ledgerID := uuid.New()
+
+	messages := []mmodel.Queue{
+		{
+			OrganizationID: organizationID,
+			LedgerID:       ledgerID,
+			QueueData: []mmodel.QueueData{
+				{ID: uuid.New(), Value: []byte("test")},
+			},
+		},
+	}
+
+	// Create payloads with nil entry (simulating unmarshal failure)
+	payloads := []*transaction.TransactionProcessingPayload{nil}
+
+	// Call processBalances directly
+	results := uc.processBalances(ctx, nil, nil, messages, payloads)
+
+	// Verify that processBalances sets error for nil payload
+	assert.Len(t, results, 1)
+	assert.False(t, results[0].Success)
+	assert.NotNil(t, results[0].Error)
+	assert.Contains(t, results[0].Error.Error(), "nil payload")
+}
+
+func TestProcessBalances_SetsErrorWhenNoExistingError(t *testing.T) {
+	t.Parallel()
+
+	// This test verifies that processBalances correctly sets error
+	// when there is no existing error for an entry
+
+	uc := &UseCase{}
+	ctx := context.Background()
+	organizationID := uuid.New()
+	ledgerID := uuid.New()
+
+	messages := []mmodel.Queue{
+		{
+			OrganizationID: organizationID,
+			LedgerID:       ledgerID,
+			QueueData: []mmodel.QueueData{
+				{ID: uuid.New(), Value: []byte("test")},
+			},
+		},
+	}
+
+	// Create payloads with valid payload but nil Validate field
+	payloads := []*transaction.TransactionProcessingPayload{
+		{
+			Transaction: &transaction.Transaction{
+				ID: uuid.New().String(),
+				Status: transaction.Status{
+					Code: constant.CREATED,
+				},
+			},
+			Validate: nil, // This should trigger "nil Validate field" error
+		},
+	}
+
+	// Call processBalances directly
+	results := uc.processBalances(ctx, nil, nil, messages, payloads)
+
+	assert.Len(t, results, 1)
+	assert.False(t, results[0].Success)
+	assert.NotNil(t, results[0].Error)
+	assert.Contains(t, results[0].Error.Error(), "nil Validate field")
+}
+
+// =============================================================================
+// UNIT TESTS - Metadata Strict Behavior (Issue 1)
+// =============================================================================
+
+func TestCreateBulkTransactionOperationsAsync_MetadataFailureReturnsError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockTransactionRepo := transaction.NewMockRepository(ctrl)
+	mockOperationRepo := operation.NewMockRepository(ctrl)
+	mockMetadataRepo := mongodb.NewMockRepository(ctrl)
+	mockBalanceRepo := balance.NewMockRepository(ctrl)
+	mockRabbitMQRepo := rabbitmq.NewMockProducerRepository(ctrl)
+	mockRedisRepo := redis.NewMockRedisRepository(ctrl)
+
+	uc := &UseCase{
+		TransactionRepo: mockTransactionRepo,
+		OperationRepo:   mockOperationRepo,
+		MetadataRepo:    mockMetadataRepo,
+		BalanceRepo:     mockBalanceRepo,
+		RabbitMQRepo:    mockRabbitMQRepo,
+		RedisRepo:       mockRedisRepo,
+	}
+
+	ctx := context.Background()
+	organizationID := uuid.New()
+	ledgerID := uuid.New()
+	transactionID := uuid.New().String()
+
+	// Create a NOTED transaction (skips balance update)
+	notedStatus := constant.NOTED
+	tran := &transaction.Transaction{
+		ID:             transactionID,
+		OrganizationID: organizationID.String(),
+		LedgerID:       ledgerID.String(),
+		Status: transaction.Status{
+			Code:        notedStatus,
+			Description: &notedStatus,
+		},
+		Metadata:   map[string]any{"key": "value"}, // Has metadata
+		Operations: []*operation.Operation{},
+	}
+
+	payload := transaction.TransactionProcessingPayload{
+		Transaction: tran,
+		Validate:    &pkgTransaction.Responses{},
+	}
+
+	payloadBytes, err := msgpack.Marshal(payload)
+	require.NoError(t, err)
+
+	messages := []mmodel.Queue{
+		{
+			OrganizationID: organizationID,
+			LedgerID:       ledgerID,
+			QueueData: []mmodel.QueueData{
+				{ID: uuid.New(), Value: payloadBytes},
+			},
+		},
+	}
+
+	// Mock bulk insert success
+	mockTransactionRepo.EXPECT().
+		CreateBulk(gomock.Any(), gomock.Any()).
+		Return(&repository.BulkInsertResult{
+			Attempted: 1,
+			Inserted:  1,
+			Ignored:   0,
+		}, nil)
+
+	mockOperationRepo.EXPECT().
+		CreateBulk(gomock.Any(), gomock.Any()).
+		Return(&repository.BulkInsertResult{
+			Attempted: 0,
+			Inserted:  0,
+			Ignored:   0,
+		}, nil).
+		AnyTimes()
+
+	// Mock metadata creation failure (strict behavior should return error)
+	metadataErr := errors.New("mongodb connection refused")
+	mockMetadataRepo.EXPECT().
+		Create(gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(metadataErr)
+
+	result, messageResults, err := uc.CreateBulkTransactionOperationsAsync(ctx, messages, true)
+
+	// Should return error because metadata creation failed (strict behavior)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "metadata creation failed")
+	assert.NotNil(t, result)
+	assert.Len(t, messageResults, 1)
+	assert.False(t, messageResults[0].Success)
+	assert.NotNil(t, messageResults[0].Error)
+	assert.Contains(t, messageResults[0].Error.Error(), "metadata")
+}
+
+func TestCreateBulkTransactionOperationsAsync_OperationMetadataFailureReturnsError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockTransactionRepo := transaction.NewMockRepository(ctrl)
+	mockOperationRepo := operation.NewMockRepository(ctrl)
+	mockMetadataRepo := mongodb.NewMockRepository(ctrl)
+	mockBalanceRepo := balance.NewMockRepository(ctrl)
+	mockRabbitMQRepo := rabbitmq.NewMockProducerRepository(ctrl)
+	mockRedisRepo := redis.NewMockRedisRepository(ctrl)
+
+	uc := &UseCase{
+		TransactionRepo: mockTransactionRepo,
+		OperationRepo:   mockOperationRepo,
+		MetadataRepo:    mockMetadataRepo,
+		BalanceRepo:     mockBalanceRepo,
+		RabbitMQRepo:    mockRabbitMQRepo,
+		RedisRepo:       mockRedisRepo,
+	}
+
+	ctx := context.Background()
+	organizationID := uuid.New()
+	ledgerID := uuid.New()
+	transactionID := uuid.New().String()
+	operationID := uuid.New().String()
+
+	// Create a NOTED transaction with metadata and operation that has metadata
+	notedStatus := constant.NOTED
+	tran := &transaction.Transaction{
+		ID:             transactionID,
+		OrganizationID: organizationID.String(),
+		LedgerID:       ledgerID.String(),
+		Status: transaction.Status{
+			Code:        notedStatus,
+			Description: &notedStatus,
+		},
+		Metadata: map[string]any{"txKey": "txValue"}, // Transaction has metadata
+		Operations: []*operation.Operation{
+			{
+				ID:            operationID,
+				TransactionID: transactionID,
+				Metadata:      map[string]any{"opKey": "opValue"},
+			},
+		},
+	}
+
+	payload := transaction.TransactionProcessingPayload{
+		Transaction: tran,
+		Validate:    &pkgTransaction.Responses{},
+	}
+
+	payloadBytes, err := msgpack.Marshal(payload)
+	require.NoError(t, err)
+
+	messages := []mmodel.Queue{
+		{
+			OrganizationID: organizationID,
+			LedgerID:       ledgerID,
+			QueueData: []mmodel.QueueData{
+				{ID: uuid.New(), Value: payloadBytes},
+			},
+		},
+	}
+
+	// Mock bulk insert success
+	mockTransactionRepo.EXPECT().
+		CreateBulk(gomock.Any(), gomock.Any()).
+		Return(&repository.BulkInsertResult{
+			Attempted: 1,
+			Inserted:  1,
+			Ignored:   0,
+		}, nil)
+
+	mockOperationRepo.EXPECT().
+		CreateBulk(gomock.Any(), gomock.Any()).
+		Return(&repository.BulkInsertResult{
+			Attempted: 1,
+			Inserted:  1,
+			Ignored:   0,
+		}, nil)
+
+	// Transaction metadata succeeds, operation metadata fails
+	metadataErr := errors.New("mongodb operation metadata failure")
+	mockMetadataRepo.EXPECT().
+		Create(gomock.Any(), "Transaction", gomock.Any()).
+		Return(nil) // Transaction metadata succeeds
+	mockMetadataRepo.EXPECT().
+		Create(gomock.Any(), "Operation", gomock.Any()).
+		Return(metadataErr) // Operation metadata fails
+
+	result, messageResults, err := uc.CreateBulkTransactionOperationsAsync(ctx, messages, true)
+
+	// Should return error because operation metadata creation failed
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "metadata creation failed")
+	assert.NotNil(t, result)
+	assert.Len(t, messageResults, 1)
+	assert.False(t, messageResults[0].Success)
+	assert.NotNil(t, messageResults[0].Error)
+	assert.Contains(t, messageResults[0].Error.Error(), "operation metadata")
+}
+
+func TestFallbackPath_CreatesOperationMetadata(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockTransactionRepo := transaction.NewMockRepository(ctrl)
+	mockOperationRepo := operation.NewMockRepository(ctrl)
+	mockMetadataRepo := mongodb.NewMockRepository(ctrl)
+	mockBalanceRepo := balance.NewMockRepository(ctrl)
+	mockRabbitMQRepo := rabbitmq.NewMockProducerRepository(ctrl)
+	mockRedisRepo := redis.NewMockRedisRepository(ctrl)
+
+	uc := &UseCase{
+		TransactionRepo: mockTransactionRepo,
+		OperationRepo:   mockOperationRepo,
+		MetadataRepo:    mockMetadataRepo,
+		BalanceRepo:     mockBalanceRepo,
+		RabbitMQRepo:    mockRabbitMQRepo,
+		RedisRepo:       mockRedisRepo,
+	}
+
+	ctx := context.Background()
+	organizationID := uuid.New()
+	ledgerID := uuid.New()
+	transactionID := uuid.New().String()
+	operationID := uuid.New().String()
+
+	// Create a NOTED transaction with metadata and operation with metadata
+	notedStatus := constant.NOTED
+	tran := &transaction.Transaction{
+		ID:             transactionID,
+		OrganizationID: organizationID.String(),
+		LedgerID:       ledgerID.String(),
+		Status: transaction.Status{
+			Code:        notedStatus,
+			Description: &notedStatus,
+		},
+		Metadata: map[string]any{"txKey": "txValue"}, // Transaction has metadata
+		Operations: []*operation.Operation{
+			{
+				ID:            operationID,
+				TransactionID: transactionID,
+				Metadata:      map[string]any{"opKey": "opValue"},
+			},
+		},
+	}
+
+	payload := transaction.TransactionProcessingPayload{
+		Transaction: tran,
+		Validate:    &pkgTransaction.Responses{},
+	}
+
+	payloadBytes, err := msgpack.Marshal(payload)
+	require.NoError(t, err)
+
+	messages := []mmodel.Queue{
+		{
+			OrganizationID: organizationID,
+			LedgerID:       ledgerID,
+			QueueData: []mmodel.QueueData{
+				{ID: uuid.New(), Value: payloadBytes},
+			},
+		},
+	}
+
+	// Mock bulk insert FAILURE to trigger fallback
+	mockTransactionRepo.EXPECT().
+		CreateBulk(gomock.Any(), gomock.Any()).
+		Return(nil, errors.New("bulk insert failed"))
+
+	// Fallback: individual transaction creation
+	mockTransactionRepo.EXPECT().
+		Create(gomock.Any(), gomock.Any()).
+		Return(tran, nil)
+
+	// Fallback: transaction metadata creation
+	mockMetadataRepo.EXPECT().
+		Create(gomock.Any(), "Transaction", gomock.Any()).
+		Return(nil)
+
+	// Fallback: individual operation creation
+	mockOperationRepo.EXPECT().
+		Create(gomock.Any(), gomock.Any()).
+		Return(tran.Operations[0], nil)
+
+	// Fallback: operation metadata creation (this is what we're testing - it should be called!)
+	mockMetadataRepo.EXPECT().
+		Create(gomock.Any(), "Operation", gomock.Any()).
+		Return(nil)
+
+	// Mock Redis cleanup (best effort)
+	mockRedisRepo.EXPECT().
+		RemoveMessageFromQueue(gomock.Any(), gomock.Any()).
+		Return(nil).
+		AnyTimes()
+
+	mockRedisRepo.EXPECT().
+		Del(gomock.Any(), gomock.Any()).
+		Return(nil).
+		AnyTimes()
+
+	// Mock RabbitMQ for events
+	mockRabbitMQRepo.EXPECT().
+		ProducerDefault(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(nil, nil).
+		AnyTimes()
+
+	result, messageResults, err := uc.CreateBulkTransactionOperationsAsync(ctx, messages, true)
+
+	require.NoError(t, err)
+	assert.NotNil(t, result)
+	assert.True(t, result.FallbackUsed)
+	assert.Equal(t, 1, result.FallbackCount)
+	assert.Len(t, messageResults, 1)
+	assert.True(t, messageResults[0].Success)
+
+	// Wait for goroutines to complete
+	<-time.After(100 * time.Millisecond)
+}
+
+func TestFallbackPath_OperationMetadataFailureReturnsError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockTransactionRepo := transaction.NewMockRepository(ctrl)
+	mockOperationRepo := operation.NewMockRepository(ctrl)
+	mockMetadataRepo := mongodb.NewMockRepository(ctrl)
+	mockBalanceRepo := balance.NewMockRepository(ctrl)
+	mockRabbitMQRepo := rabbitmq.NewMockProducerRepository(ctrl)
+	mockRedisRepo := redis.NewMockRedisRepository(ctrl)
+
+	uc := &UseCase{
+		TransactionRepo: mockTransactionRepo,
+		OperationRepo:   mockOperationRepo,
+		MetadataRepo:    mockMetadataRepo,
+		BalanceRepo:     mockBalanceRepo,
+		RabbitMQRepo:    mockRabbitMQRepo,
+		RedisRepo:       mockRedisRepo,
+	}
+
+	ctx := context.Background()
+	organizationID := uuid.New()
+	ledgerID := uuid.New()
+	transactionID := uuid.New().String()
+	operationID := uuid.New().String()
+
+	// Create a NOTED transaction with metadata and operation with metadata
+	notedStatus := constant.NOTED
+	tran := &transaction.Transaction{
+		ID:             transactionID,
+		OrganizationID: organizationID.String(),
+		LedgerID:       ledgerID.String(),
+		Status: transaction.Status{
+			Code:        notedStatus,
+			Description: &notedStatus,
+		},
+		Metadata: map[string]any{"txKey": "txValue"}, // Transaction has metadata
+		Operations: []*operation.Operation{
+			{
+				ID:            operationID,
+				TransactionID: transactionID,
+				Metadata:      map[string]any{"opKey": "opValue"},
+			},
+		},
+	}
+
+	payload := transaction.TransactionProcessingPayload{
+		Transaction: tran,
+		Validate:    &pkgTransaction.Responses{},
+	}
+
+	payloadBytes, err := msgpack.Marshal(payload)
+	require.NoError(t, err)
+
+	messages := []mmodel.Queue{
+		{
+			OrganizationID: organizationID,
+			LedgerID:       ledgerID,
+			QueueData: []mmodel.QueueData{
+				{ID: uuid.New(), Value: payloadBytes},
+			},
+		},
+	}
+
+	// Mock bulk insert FAILURE to trigger fallback
+	mockTransactionRepo.EXPECT().
+		CreateBulk(gomock.Any(), gomock.Any()).
+		Return(nil, errors.New("bulk insert failed"))
+
+	// Fallback: individual transaction creation
+	mockTransactionRepo.EXPECT().
+		Create(gomock.Any(), gomock.Any()).
+		Return(tran, nil)
+
+	// Fallback: transaction metadata creation
+	mockMetadataRepo.EXPECT().
+		Create(gomock.Any(), "Transaction", gomock.Any()).
+		Return(nil)
+
+	// Fallback: individual operation creation
+	mockOperationRepo.EXPECT().
+		Create(gomock.Any(), gomock.Any()).
+		Return(tran.Operations[0], nil)
+
+	// Fallback: operation metadata creation fails
+	metadataErr := errors.New("mongodb operation metadata failure")
+	mockMetadataRepo.EXPECT().
+		Create(gomock.Any(), "Operation", gomock.Any()).
+		Return(metadataErr)
+
+	result, messageResults, err := uc.CreateBulkTransactionOperationsAsync(ctx, messages, true)
+
+	// Fallback should succeed but message should be marked as failed
+	require.NoError(t, err) // Overall succeeds because fallback completed
+	assert.NotNil(t, result)
+	assert.True(t, result.FallbackUsed)
+	assert.Equal(t, 0, result.FallbackCount) // No successful fallbacks
+	assert.Len(t, messageResults, 1)
+	assert.False(t, messageResults[0].Success)
+	assert.NotNil(t, messageResults[0].Error)
+	assert.Contains(t, messageResults[0].Error.Error(), "operation metadata")
+}


### PR DESCRIPTION

## Summary

Implements bulk message processing for the transaction layer, enabling multi-row INSERTs for transactions and operations collected from RabbitMQ. This reduces database round-trips from N+1 to 2, achieving 10-100x throughput improvement for high-volume scenarios.

## Motivation

The current transaction processing handles RabbitMQ messages one at a time, with each transaction and its operations inserted individually. For a bulk of 50 transactions with 5 operations each, this requires 300 database round-trips and 50 RabbitMQ ACKs. The bulk recorder reduces this to 2 database round-trips (1 for transactions, 1 for operations) and 1 bulk ACK.

## Semantic Decision

**Type:** `feat` (new feature)

This is a performance enhancement that introduces new bulk processing capabilities without breaking existing behavior. When `BULK_RECORDER_ENABLED=false` or `RABBITMQ_TRANSACTION_ASYNC=false`, the system continues with individual processing unchanged.

## Changes

### New Files
| File | Purpose |
|------|---------|
| `components/transaction/internal/adapters/rabbitmq/bulk_collector.go` | Accumulates RabbitMQ messages until bulk size threshold or timeout, then triggers flush |
| `components/transaction/internal/adapters/rabbitmq/bulk_collector_test.go` | Unit tests for BulkCollector with size/timeout/shutdown scenarios |
| `components/transaction/internal/services/command/create-bulk-transaction-operations-async.go` | Service layer for bulk transaction/operation INSERT with fallback support |
| `components/transaction/internal/services/command/create-bulk-transaction-operations-async_test.go` | Unit tests for bulk processing service |
| `components/transaction/internal/bootstrap/config_test.go` | Unit tests for bulk recorder configuration derivation |

### Environment Variables - Bulk Recorder
| Variable | Type | Default | Description |
|----------|------|---------|-------------|
| `BULK_RECORDER_ENABLED` | bool | `true` | Enable bulk mode (requires `RABBITMQ_TRANSACTION_ASYNC=true`) |
| `BULK_RECORDER_SIZE` | int | (derived) | Messages per bulk; defaults to `workers × prefetch` |
| `BULK_RECORDER_FLUSH_TIMEOUT_MS` | int | `100` | Max wait before flushing incomplete bulk |
| `BULK_RECORDER_MAX_ROWS_PER_INSERT` | int | `1000` | Max rows per INSERT statement (PostgreSQL limit safety) |
| `BULK_RECORDER_FALLBACK_ENABLED` | bool | `true` | Fall back to individual inserts on bulk failure |

### Refactored Code
| Before | After |
|--------|-------|
| `OperationPostgreSQLRepository` with single-row Create | Added `CreateBulk()` method with chunking and `ON CONFLICT DO NOTHING` |
| `TransactionPostgreSQLRepository` with single-row Create | Added `CreateBulk()` and `BulkUpdateTransactionStatus()` methods |
| `Config` struct with RabbitMQ settings only | Added `BulkRecorderConfig` with derived defaults from prefetch settings |

### Key Implementation Details

**Idempotency:**
- Bulk INSERTs use `ON CONFLICT (id) DO NOTHING` for duplicates
- `RowsAffected()` tracks actual inserts vs ignored duplicates
- Consistent with existing individual INSERT pattern

**PostgreSQL Parameter Limit Safety:**
- PostgreSQL limit: 65,535 parameters per statement
- Transactions: 16 columns × 1000 rows = 16,000 params (safe)
- Operations: 30 columns × 1000 rows = 30,000 params (safe)
- Safe ceiling calculation ensures chunk sizes respect the limit

**Deadlock Prevention:**
- Transactions and operations sorted by ID before bulk INSERT
- Consistent ordering across concurrent workers

**Fallback Safety:**
- On bulk INSERT failure, falls back to individual inserts
- Successfully processed messages ACKed, failed messages NACKed with requeue
- Configurable via `BULK_RECORDER_FALLBACK_ENABLED`

## Test Plan
- [x] Unit tests for `BulkCollector` - size threshold, timeout, shutdown
- [x] Unit tests for `CreateBulk` repository methods - chunking, idempotency
- [x] Unit tests for `BulkUpdateTransactionStatus` - partial failures, error tracking
- [x] Unit tests for `CreateBulkTransactionOperationsAsync` service - end-to-end bulk flow
- [x] Unit tests for `BulkRecorderConfig` derivation from RabbitMQ settings
- [x] Test coverage for fallback mode with partial failures
- [x] Test coverage for PostgreSQL parameter limit chunking
