### PR TITLE
fix(transaction): propagate tenantID to goroutines in commitOrCancelTransaction

### DIFF
--- a/components/transaction/internal/adapters/http/in/transaction-state-handlers.go
+++ b/components/transaction/internal/adapters/http/in/transaction-state-handlers.go
@@ -14,6 +14,7 @@ import (
 	libCommons "github.com/LerianStudio/lib-commons/v4/commons"
 	libLog "github.com/LerianStudio/lib-commons/v4/commons/log"
 	libOpentelemetry "github.com/LerianStudio/lib-commons/v4/commons/opentelemetry"
+	tmcore "github.com/LerianStudio/lib-commons/v4/commons/tenant-manager/core"
 	"github.com/LerianStudio/midaz/v3/components/transaction/internal/adapters/postgres/transaction"
 	"github.com/LerianStudio/midaz/v3/pkg"
 	"github.com/LerianStudio/midaz/v3/pkg/constant"
@@ -520,10 +521,12 @@ func (handler *TransactionHandler) commitOrCancelTransaction(c *fiber.Ctx, tran 
 		return http.WithError(c, err)
 	}
 
-	go handler.Command.SendLogTransactionAuditQueue(ctx, operations, organizationID, ledgerID, tran.IDtoUUID())
+	tenantCtx := tmcore.ContextWithTenantID(context.Background(), tmcore.GetTenantIDFromContext(ctx))
+
+	go handler.Command.SendLogTransactionAuditQueue(tenantCtx, operations, organizationID, ledgerID, tran.IDtoUUID())
 
 	if strings.ToLower(os.Getenv("RABBITMQ_TRANSACTION_ASYNC")) == "true" {
-		go handler.Command.UpdateWriteBehindTransaction(context.Background(), organizationID, ledgerID, tran)
+		go handler.Command.UpdateWriteBehindTransaction(tenantCtx, organizationID, ledgerID, tran)
 	}
 
 	return http.Created(c, tran)


### PR DESCRIPTION
When committing or cancelling a transaction with `RABBITMQ_TRANSACTION_ASYNC=true`, two goroutines were launched without the tenant context:

- `UpdateWriteBehindTransaction` received `context.Background()`, causing Redis write-behind cache entries to be stored without the `tenant:{id}:` key prefix.
- `SendLogTransactionAuditQueue` received the Fiber `ctx` directly, which is recycled after the handler returns and causes the multi-tenant RabbitMQ producer to fail silently (it requires tenantID in context).

The create path (`CreateWriteBehindTransaction`) passed `ctx` correctly, so the create entry had the prefix while the update entry did not — resulting in two orphaned Redis keys for the same transaction.

## Fix

Creates a `tenantCtx` derived from `context.Background()` with only the tenantID extracted from the request context, then passes it to both goroutines. This avoids Fiber context lifecycle issues (span already ended, `fasthttp.RequestCtx` recycled)
while preserving the tenant namespace in Redis and RabbitMQ. 

## Testing

All unit tests pass.