### PR TITLE
fix(transaction): fix missing ON_HOLD operation in committed transactions on multi-tenant async mode

### DIFF
--- a/components/transaction/internal/adapters/http/in/transaction-state-handlers.go
+++ b/components/transaction/internal/adapters/http/in/transaction-state-handlers.go
@@ -489,7 +489,13 @@ func (handler *TransactionHandler) commitOrCancelTransaction(c *fiber.Ctx, tran 
 
 	tran.Source = getAliasWithoutKey(validate.Sources)
 	tran.Destination = getAliasWithoutKey(validate.Destinations)
-	tran.Operations = operations
+
+	// Preserve pending-phase operations (e.g. ON_HOLD) so the write-behind cache
+	// and the HTTP response contain the complete set of operations. BuildOperations
+	// returns only the commit/cancel-phase operations; without merging, the earlier
+	// pending operations would be lost from the cache entry.
+	pendingOps := tran.Operations
+	tran.Operations = append(pendingOps, operations...)
 
 	ctxBackup, spanBackup := tracer.Start(ctx, "handler.commit_or_cancel_transaction.send_to_redis_queue")
 

--- a/components/transaction/internal/services/command/create-balance-transaction-operations-async.go
+++ b/components/transaction/internal/services/command/create-balance-transaction-operations-async.go
@@ -146,7 +146,7 @@ func (uc *UseCase) CreateBalanceTransactionOperationsAsync(ctx context.Context, 
 
 	go uc.RemoveTransactionFromRedisQueue(ctx, logger, data.OrganizationID, data.LedgerID, tran.ID)
 
-	go uc.DeleteWriteBehindTransaction(ctx, data.OrganizationID, data.LedgerID, tran.ID)
+	uc.DeleteWriteBehindTransaction(ctx, data.OrganizationID, data.LedgerID, tran.ID)
 
 	return nil
 }


### PR DESCRIPTION
## What

Two bugs caused GET on a committed pending transaction to return 2 operations instead of 3 in multi-tenant async mode (`RABBITMQ_TRANSACTION_ASYNC=true`):

**Bug 1 — pending operations overwritten in write-behind cache**
`commitOrCancelTransaction` replaced `tran.Operations` with only the commit/cancel-phase operations (e.g. DEBIT + CREDIT), discarding the pending-phase ON_HOLD operation that was already on the `tran` object. The write-behind cache and the commit HTTP response both lost the ON_HOLD op.

**Bug 2 — cache delete racing against a goroutine**
`DeleteWriteBehindTransaction` was launched as a goroutine inside `CreateBalanceTransactionOperationsAsync`. If the RabbitMQ consumer's context was cancelled after the handler returned, the goroutine's Redis `Del` call failed silently (context.Canceled), leaving the stale cache entry alive. A subsequent GET would then hit the incomplete cache entry.

## Fix

- Preserve pending-phase operations before appending commit-phase operations so the full set (pending + commit) is written to cache and returned in the response.
- Make `DeleteWriteBehindTransaction` synchronous in the consumer so it completes while the context is still active.

## Testing

All 4235 unit tests pass.