### PR TITLE
debug(transaction): log tenantID and raw key in write-behind cache create/delete

### DIFF
--- a/components/transaction/internal/services/command/create-write-behind-transaction.go
+++ b/components/transaction/internal/services/command/create-write-behind-transaction.go
@@ -11,6 +11,7 @@ import (
 
 	libCommons "github.com/LerianStudio/lib-commons/v4/commons"
 	libOpentelemetry "github.com/LerianStudio/lib-commons/v4/commons/opentelemetry"
+	tmcore "github.com/LerianStudio/lib-commons/v4/commons/tenant-manager/core"
 	"github.com/LerianStudio/midaz/v3/components/transaction/internal/adapters/postgres/transaction"
 	pkgTransaction "github.com/LerianStudio/midaz/v3/pkg/transaction"
 	"github.com/LerianStudio/midaz/v3/pkg/utils"
@@ -29,7 +30,9 @@ func (uc *UseCase) CreateWriteBehindTransaction(ctx context.Context, organizatio
 	ctx, span := tracer.Start(ctx, "command.create_write_behind_transaction")
 	defer span.End()
 
-	logger.Log(ctx, libLog.LevelInfo, "Storing transaction in write-behind cache")
+	tenantID := tmcore.GetTenantIDFromContext(ctx)
+
+	logger.Log(ctx, libLog.LevelInfo, fmt.Sprintf("[DEBUG] CreateWriteBehindTransaction: tenantID=%q", tenantID))
 
 	tran.Body = parserDSL
 
@@ -42,6 +45,8 @@ func (uc *UseCase) CreateWriteBehindTransaction(ctx context.Context, organizatio
 	}
 
 	key := utils.WriteBehindTransactionKey(organizationID, ledgerID, tran.ID)
+
+	logger.Log(ctx, libLog.LevelInfo, fmt.Sprintf("[DEBUG] CreateWriteBehindTransaction: raw_key=%s", key))
 
 	// 86400 seconds = 24 hours (SetBytes multiplies by time.Second internally)
 	if err := uc.RedisRepo.SetBytes(ctx, key, data, time.Duration(86400)); err != nil {

--- a/components/transaction/internal/services/command/delete-write-behind-transaction.go
+++ b/components/transaction/internal/services/command/delete-write-behind-transaction.go
@@ -10,6 +10,7 @@ import (
 
 	libCommons "github.com/LerianStudio/lib-commons/v4/commons"
 	libOpentelemetry "github.com/LerianStudio/lib-commons/v4/commons/opentelemetry"
+	tmcore "github.com/LerianStudio/lib-commons/v4/commons/tenant-manager/core"
 	"github.com/LerianStudio/midaz/v3/pkg/utils"
 	"github.com/google/uuid"
 
@@ -25,9 +26,11 @@ func (uc *UseCase) DeleteWriteBehindTransaction(ctx context.Context, organizatio
 	ctx, span := tracer.Start(ctx, "command.delete_write_behind_transaction")
 	defer span.End()
 
-	logger.Log(ctx, libLog.LevelInfo, "Removing transaction from write-behind cache")
+	tenantID := tmcore.GetTenantIDFromContext(ctx)
 
 	key := utils.WriteBehindTransactionKey(organizationID, ledgerID, transactionID)
+
+	logger.Log(ctx, libLog.LevelInfo, fmt.Sprintf("[DEBUG] DeleteWriteBehindTransaction: tenantID=%q raw_key=%s", tenantID, key))
 
 	if err := uc.RedisRepo.Del(ctx, key); err != nil {
 		libOpentelemetry.HandleSpanError(span, "Failed to remove transaction from write-behind cache", err)


### PR DESCRIPTION
Adds debug log lines to `CreateWriteBehindTransaction` and `DeleteWriteBehindTransaction` to expose the tenantID in context and the raw Redis key at both create and delete time.

This will allow us to compare:
- The tenantID extracted from the HTTP handler context (create path)
- The tenantID extracted from the RabbitMQ consumer context (delete path)
- The raw key used in both operations

Also bumps the ledger Dockerfile rebuild comment.

**To revert:** remove the `[DEBUG]` log lines and the `tmcore` imports.