### PR TITLE
debug(transaction): force LevelError on wb cache debug logs

### DIFF
--- a/components/transaction/internal/services/command/create-write-behind-transaction.go
+++ b/components/transaction/internal/services/command/create-write-behind-transaction.go
@@ -32,7 +32,7 @@ func (uc *UseCase) CreateWriteBehindTransaction(ctx context.Context, organizatio
 
 	tenantID := tmcore.GetTenantIDFromContext(ctx)
 
-	logger.Log(ctx, libLog.LevelInfo, fmt.Sprintf("[DEBUG] CreateWriteBehindTransaction: tenantID=%q", tenantID))
+	logger.Log(ctx, libLog.LevelError, fmt.Sprintf("[DEBUG] CreateWriteBehindTransaction: tenantID=%q", tenantID))
 
 	tran.Body = parserDSL
 
@@ -46,7 +46,7 @@ func (uc *UseCase) CreateWriteBehindTransaction(ctx context.Context, organizatio
 
 	key := utils.WriteBehindTransactionKey(organizationID, ledgerID, tran.ID)
 
-	logger.Log(ctx, libLog.LevelInfo, fmt.Sprintf("[DEBUG] CreateWriteBehindTransaction: raw_key=%s", key))
+	logger.Log(ctx, libLog.LevelError, fmt.Sprintf("[DEBUG] CreateWriteBehindTransaction: raw_key=%s", key))
 
 	// 86400 seconds = 24 hours (SetBytes multiplies by time.Second internally)
 	if err := uc.RedisRepo.SetBytes(ctx, key, data, time.Duration(86400)); err != nil {

--- a/components/transaction/internal/services/command/delete-write-behind-transaction.go
+++ b/components/transaction/internal/services/command/delete-write-behind-transaction.go
@@ -30,7 +30,7 @@ func (uc *UseCase) DeleteWriteBehindTransaction(ctx context.Context, organizatio
 
 	key := utils.WriteBehindTransactionKey(organizationID, ledgerID, transactionID)
 
-	logger.Log(ctx, libLog.LevelInfo, fmt.Sprintf("[DEBUG] DeleteWriteBehindTransaction: tenantID=%q raw_key=%s", tenantID, key))
+	logger.Log(ctx, libLog.LevelError, fmt.Sprintf("[DEBUG] DeleteWriteBehindTransaction: tenantID=%q raw_key=%s", tenantID, key))
 
 	if err := uc.RedisRepo.Del(ctx, key); err != nil {
 		libOpentelemetry.HandleSpanError(span, "Failed to remove transaction from write-behind cache", err)


### PR DESCRIPTION
Changes debug log level from Info to Error so logs appear regardless of LOG_LEVEL env var configuration. This is a temporary debug PR to diagnose the write-behind cache delete issue.