### PR TITLE
fix(crm): use APPLICATION_NAME env to resolve tenant-manager service

### DIFF
--- a/components/crm/.env.example
+++ b/components/crm/.env.example
@@ -46,6 +46,9 @@ LCRYPTO_ENCRYPT_SECRET_KEY=my-encrypt-secret-key
 PLUGIN_AUTH_ADDRESS=http://plugin-auth:4000
 PLUGIN_AUTH_ENABLED=false
 
+# APPLICATION
+APPLICATION_NAME=ledger
+
 # MULTI-TENANT
 # When enabled, the CRM resolves per-tenant database connections via the Tenant Manager API.
 # Default: disabled (single-tenant mode, identical to current behavior)

--- a/components/crm/internal/adapters/http/in/routes.go
+++ b/components/crm/internal/adapters/http/in/routes.go
@@ -18,7 +18,6 @@ import (
 )
 
 const ApplicationName = "plugin-crm"
-const ModuleName = "crm"
 
 func NewRouter(lg libLog.Logger, tl *libOpenTelemetry.Telemetry, auth *middleware.AuthClient, tenantMw fiber.Handler, hh *HolderHandler, ah *AliasHandler) *fiber.App {
 	f := fiber.New(fiber.Config{

--- a/components/crm/internal/adapters/http/in/routes.go
+++ b/components/crm/internal/adapters/http/in/routes.go
@@ -18,6 +18,7 @@ import (
 )
 
 const ApplicationName = "plugin-crm"
+const ModuleName = "crm"
 
 func NewRouter(lg libLog.Logger, tl *libOpenTelemetry.Telemetry, auth *middleware.AuthClient, tenantMw fiber.Handler, hh *HolderHandler, ah *AliasHandler) *fiber.App {
 	f := fiber.New(fiber.Config{

--- a/components/crm/internal/bootstrap/config.go
+++ b/components/crm/internal/bootstrap/config.go
@@ -56,6 +56,7 @@ type Config struct {
 	MultiTenantCircuitBreakerThreshold  int    `env:"MULTI_TENANT_CIRCUIT_BREAKER_THRESHOLD"`   // failures before circuit opens
 	MultiTenantCircuitBreakerTimeoutSec int    `env:"MULTI_TENANT_CIRCUIT_BREAKER_TIMEOUT_SEC"` // seconds before circuit resets
 	MultiTenantServiceAPIKey            string `env:"MULTI_TENANT_SERVICE_API_KEY"`
+	ApplicationName                     string `env:"APPLICATION_NAME"`
 }
 
 // Options contains optional dependencies that can be injected by callers.

--- a/components/crm/internal/bootstrap/config.tenant.go
+++ b/components/crm/internal/bootstrap/config.tenant.go
@@ -129,7 +129,7 @@ func redactedTenantManagerURL(raw string) string {
 
 func buildMongoManagerOptions(cfg *Config, logger libLog.Logger) []tmmongo.Option {
 	mongoOpts := []tmmongo.Option{
-		tmmongo.WithModule(in.ApplicationName),
+		tmmongo.WithModule("crm"),
 		tmmongo.WithLogger(logger),
 	}
 

--- a/components/crm/internal/bootstrap/config.tenant.go
+++ b/components/crm/internal/bootstrap/config.tenant.go
@@ -129,7 +129,7 @@ func redactedTenantManagerURL(raw string) string {
 
 func buildMongoManagerOptions(cfg *Config, logger libLog.Logger) []tmmongo.Option {
 	mongoOpts := []tmmongo.Option{
-		tmmongo.WithModule("crm"),
+		tmmongo.WithModule(in.ModuleName),
 		tmmongo.WithLogger(logger),
 	}
 

--- a/components/crm/internal/bootstrap/config.tenant.go
+++ b/components/crm/internal/bootstrap/config.tenant.go
@@ -23,6 +23,8 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 )
 
+const moduleName = "crm"
+
 // initTenantMiddleware creates the tenant middleware for multi-tenant mode.
 // Returns nil when multi-tenant is disabled or the URL is not configured.
 // The middleware extracts tenantId from JWT, resolves the tenant-specific
@@ -129,7 +131,7 @@ func redactedTenantManagerURL(raw string) string {
 
 func buildMongoManagerOptions(cfg *Config, logger libLog.Logger) []tmmongo.Option {
 	mongoOpts := []tmmongo.Option{
-		tmmongo.WithModule(in.ModuleName),
+		tmmongo.WithModule(moduleName),
 		tmmongo.WithLogger(logger),
 	}
 

--- a/components/crm/internal/bootstrap/config.tenant.go
+++ b/components/crm/internal/bootstrap/config.tenant.go
@@ -50,14 +50,14 @@ func initTenantMiddleware(cfg *Config, logger libLog.Logger, telemetry *libOpent
 
 	mongoOpts := buildMongoManagerOptions(cfg, logger)
 
-	mongoManager := tmmongo.NewManager(tmClient, in.ApplicationName, mongoOpts...)
+	mongoManager := tmmongo.NewManager(tmClient, cfg.ApplicationName, mongoOpts...)
 
 	tenantMid := tmmiddleware.NewTenantMiddleware(
 		tmmiddleware.WithMongoManager(mongoManager),
 	)
 
 	logger.Log(context.Background(), libLog.LevelInfo, fmt.Sprintf("Multi-tenant middleware initialized: target=%s service=%s",
-		redactedTenantManagerURL(mtURL), in.ApplicationName))
+		redactedTenantManagerURL(mtURL), cfg.ApplicationName))
 
 	return wrapTenantMiddlewareWithMetrics(tenantMid.WithTenantDB, telemetry, logger), nil
 }


### PR DESCRIPTION
## Summary

CRM credentials are registered as module `plugin-crm` under service `ledger` in the tenant-manager. The code was calling `/associations/plugin-crm/connections` which returned 404. Now uses `APPLICATION_NAME=ledger` to call `/associations/ledger/connections` and picks `databases["plugin-crm"]` from the response.

## Changes

- `config.go`: Added `ApplicationName` field with `env:"APPLICATION_NAME"`
- `config.tenant.go`: Uses `cfg.ApplicationName` as service name in `tmmongo.NewManager`
- `.env` / `.env.example`: Added `APPLICATION_NAME=ledger`

## Test plan

- [x] `go test ./components/crm/... -short` — all pass
- [ ] Verify CRM connects to MongoDB via tenant-manager in multi-tenant mode