### PR TITLE
feat: add WithSettingsCheckInterval for tenant config revalidation

### DIFF
--- a/components/ledger/internal/bootstrap/config.go
+++ b/components/ledger/internal/bootstrap/config.go
@@ -60,9 +60,10 @@ type Config struct {
 	MultiTenantEnvironment              string `env:"MULTI_TENANT_ENVIRONMENT"`
 	MultiTenantCircuitBreakerThreshold  int    `env:"MULTI_TENANT_CIRCUIT_BREAKER_THRESHOLD"`
 	MultiTenantCircuitBreakerTimeoutSec int    `env:"MULTI_TENANT_CIRCUIT_BREAKER_TIMEOUT_SEC"`
-	MultiTenantMaxTenantPools           int    `env:"MULTI_TENANT_MAX_TENANT_POOLS"`
-	MultiTenantIdleTimeoutSec           int    `env:"MULTI_TENANT_IDLE_TIMEOUT_SEC"`
-	MultiTenantServiceAPIKey            string `env:"MULTI_TENANT_SERVICE_API_KEY"`
+	MultiTenantMaxTenantPools               int    `env:"MULTI_TENANT_MAX_TENANT_POOLS"`
+	MultiTenantIdleTimeoutSec               int    `env:"MULTI_TENANT_IDLE_TIMEOUT_SEC"`
+	MultiTenantServiceAPIKey                string `env:"MULTI_TENANT_SERVICE_API_KEY"`
+	MultiTenantSettingsCheckIntervalSec     int    `env:"MULTI_TENANT_SETTINGS_CHECK_INTERVAL_SEC"`
 }
 
 // Options contains optional dependencies that can be injected by callers.

--- a/components/onboarding/internal/bootstrap/config.go
+++ b/components/onboarding/internal/bootstrap/config.go
@@ -152,6 +152,8 @@ type Config struct {
 	// SettingsCacheTTL is the TTL for cached ledger settings.
 	// Format: Go duration string (e.g., "5m", "1h", "30s"). Default: 5m.
 	SettingsCacheTTL string `env:"SETTINGS_CACHE_TTL"`
+
+	MultiTenantSettingsCheckIntervalSec int `env:"MULTI_TENANT_SETTINGS_CHECK_INTERVAL_SEC"`
 }
 
 // Options contains optional dependencies that can be injected when running

--- a/components/onboarding/internal/bootstrap/config.postgres.go
+++ b/components/onboarding/internal/bootstrap/config.postgres.go
@@ -52,11 +52,19 @@ func initMultiTenantPostgres(opts *Options, cfg *Config, logger libLog.Logger) (
 		return nil, fmt.Errorf("TenantClient is required for multi-tenant PostgreSQL initialization")
 	}
 
+	pgOpts := []tmpostgres.Option{
+		tmpostgres.WithModule(ApplicationName),
+		tmpostgres.WithLogger(logger),
+	}
+
+	if cfg.MultiTenantSettingsCheckIntervalSec > 0 {
+		pgOpts = append(pgOpts, tmpostgres.WithSettingsCheckInterval(time.Duration(cfg.MultiTenantSettingsCheckIntervalSec)*time.Second))
+	}
+
 	pgMgr := tmpostgres.NewManager(
 		opts.TenantClient,
 		opts.TenantServiceName,
-		tmpostgres.WithModule(ApplicationName),
-		tmpostgres.WithLogger(logger),
+		pgOpts...,
 	)
 
 	// Build and connect. In multi-tenant mode, this connection serves as

--- a/components/transaction/internal/bootstrap/config.go
+++ b/components/transaction/internal/bootstrap/config.go
@@ -209,6 +209,8 @@ type Config struct {
 	// Multi-tenant consumer configuration
 	RabbitMQMultiTenantSyncInterval     int `env:"RABBITMQ_MULTI_TENANT_SYNC_INTERVAL"`     // Stored in seconds
 	RabbitMQMultiTenantDiscoveryTimeout int `env:"RABBITMQ_MULTI_TENANT_DISCOVERY_TIMEOUT"` // Stored in milliseconds
+
+	MultiTenantSettingsCheckIntervalSec int `env:"MULTI_TENANT_SETTINGS_CHECK_INTERVAL_SEC"`
 }
 
 // Options contains optional dependencies that can be injected by callers.

--- a/components/transaction/internal/bootstrap/config.postgres.go
+++ b/components/transaction/internal/bootstrap/config.postgres.go
@@ -51,11 +51,19 @@ func initMultiTenantPostgres(opts *Options, cfg *Config, logger libLog.Logger) (
 		return nil, fmt.Errorf("TenantClient is required for multi-tenant PostgreSQL initialization")
 	}
 
+	pgOpts := []tmpostgres.Option{
+		tmpostgres.WithModule(ApplicationName),
+		tmpostgres.WithLogger(logger),
+	}
+
+	if cfg.MultiTenantSettingsCheckIntervalSec > 0 {
+		pgOpts = append(pgOpts, tmpostgres.WithSettingsCheckInterval(time.Duration(cfg.MultiTenantSettingsCheckIntervalSec)*time.Second))
+	}
+
 	pgMgr := tmpostgres.NewManager(
 		opts.TenantClient,
 		opts.TenantServiceName,
-		tmpostgres.WithModule(ApplicationName),
-		tmpostgres.WithLogger(logger),
+		pgOpts...,
 	)
 
 	// Build and connect. In multi-tenant mode, this connection serves as


### PR DESCRIPTION
## Summary

Enables periodic revalidation of tenant config in PostgreSQL managers. When a tenant is suspended/purged, the manager detects the `TenantSuspendedError` from tenant-manager and evicts the cached connection automatically.

## Changes

- Added `MULTI_TENANT_SETTINGS_CHECK_INTERVAL_SEC` env var to onboarding, transaction, and ledger Config structs
- PostgreSQL managers in onboarding and transaction now pass `WithSettingsCheckInterval` when the env var is set (> 0)
- Default: lib-commons uses 30s internally when not explicitly set
- MongoDB managers not changed (tmmongo lacks this option)

## How it works

Per-tenant, lazy evaluation:
1. Request arrives for tenant X
2. Manager checks if `settingsCheckInterval` has passed since last check
3. If yes, spawns goroutine → calls tenant-manager `/connections`
4. If tenant is suspended/purged → evicts connection from pool
5. Next request creates fresh connection with new credentials

## Test plan

- [x] `go build ./...` passes
- [x] All component tests pass
- [ ] Verify purge → revalidation → connection eviction in staging