### PR TITLE
chore(deps): upgrade lib-commons to v4.2.0-beta.9

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -100,7 +100,7 @@ require (
 )
 
 require (
-	github.com/LerianStudio/lib-commons/v4 v4.2.0-beta.7
+	github.com/LerianStudio/lib-commons/v4 v4.2.0-beta.9
 	github.com/Shopify/toxiproxy/v2 v2.12.0
 	github.com/docker/docker v28.5.2+incompatible
 	github.com/docker/go-connections v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -19,8 +19,8 @@ github.com/KyleBanks/depth v1.2.1 h1:5h8fQADFrWtarTdtDudMmGsC7GPbOAu6RVB3ffsVFHc
 github.com/KyleBanks/depth v1.2.1/go.mod h1:jzSb9d0L43HxTQfT+oSA1EEp2q+ne2uh6XgeJcm8brE=
 github.com/LerianStudio/lib-auth/v2 v2.5.0-beta.8 h1:Cl8e8hXgxVVavy2/f6goUxmVyOnTXSwsrqSHOJJTTW0=
 github.com/LerianStudio/lib-auth/v2 v2.5.0-beta.8/go.mod h1:xdXYO1Ncgf++1WAHKZYPCs7YPrcvVt3/zso/X+qUuaI=
-github.com/LerianStudio/lib-commons/v4 v4.2.0-beta.7 h1:P/CxbiPlmMR8h1tq44jg/Dab5APUw1c9y51uhkRvyqU=
-github.com/LerianStudio/lib-commons/v4 v4.2.0-beta.7/go.mod h1:89mzZKE3Hf0aDdKo3qfjfPL38ZsQRciqRbEeR718O+g=
+github.com/LerianStudio/lib-commons/v4 v4.2.0-beta.9 h1:B6S5rHeaPOi4sMTWfGFa+AdVrJiUwU0P+/JUiOmy/HQ=
+github.com/LerianStudio/lib-commons/v4 v4.2.0-beta.9/go.mod h1:89mzZKE3Hf0aDdKo3qfjfPL38ZsQRciqRbEeR718O+g=
 github.com/Masterminds/squirrel v1.5.4 h1:uUcX/aBc8O7Fg9kaISIUsHXdKuqehiXAMQTYX8afzqM=
 github.com/Masterminds/squirrel v1.5.4/go.mod h1:NNaOrjSoIDfDA40n7sr2tPNZRfjzjA400rg+riTZj10=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=


### PR DESCRIPTION
## Summary

Bumps `lib-commons/v4` from `v4.2.0-beta.7` to `v4.2.0-beta.9`.

## What's included in v4.2.0-beta.9

- `tmmongo.WithSettingsCheckInterval` — periodic tenant config revalidation for MongoDB managers (lib-commons#377)
- `NewTelemetry` cyclomatic complexity reduced from 20 to ≤16 (lib-commons#378)

## Test plan

- [x] `go build ./...` passes
- [x] All component tests pass