### PR TITLE
feat: add WithSettingsCheckInterval to PG and MongoDB managers for tenant config revalidation

### DIFF
--- a/components/crm/internal/bootstrap/config.go
+++ b/components/crm/internal/bootstrap/config.go
@@ -56,7 +56,7 @@ type Config struct {
 	MultiTenantCircuitBreakerThreshold  int    `env:"MULTI_TENANT_CIRCUIT_BREAKER_THRESHOLD"`   // failures before circuit opens
 	MultiTenantCircuitBreakerTimeoutSec int    `env:"MULTI_TENANT_CIRCUIT_BREAKER_TIMEOUT_SEC"` // seconds before circuit resets
 	MultiTenantServiceAPIKey            string `env:"MULTI_TENANT_SERVICE_API_KEY"`
-	MultiTenantSettingsCheckIntervalSec int    `env:"MULTI_TENANT_SETTINGS_CHECK_INTERVAL_SEC"`
+	MultiTenantSettingsCheckIntervalSec int    `env:"MULTI_TENANT_SETTINGS_CHECK_INTERVAL_SEC"` // seconds between tenant config revalidation checks
 	ApplicationName                     string `env:"APPLICATION_NAME"`
 }
 

--- a/components/crm/internal/bootstrap/config.go
+++ b/components/crm/internal/bootstrap/config.go
@@ -56,6 +56,7 @@ type Config struct {
 	MultiTenantCircuitBreakerThreshold  int    `env:"MULTI_TENANT_CIRCUIT_BREAKER_THRESHOLD"`   // failures before circuit opens
 	MultiTenantCircuitBreakerTimeoutSec int    `env:"MULTI_TENANT_CIRCUIT_BREAKER_TIMEOUT_SEC"` // seconds before circuit resets
 	MultiTenantServiceAPIKey            string `env:"MULTI_TENANT_SERVICE_API_KEY"`
+	MultiTenantSettingsCheckIntervalSec int    `env:"MULTI_TENANT_SETTINGS_CHECK_INTERVAL_SEC"`
 }
 
 // Options contains optional dependencies that can be injected by callers.

--- a/components/crm/internal/bootstrap/config.tenant.go
+++ b/components/crm/internal/bootstrap/config.tenant.go
@@ -141,6 +141,12 @@ func buildMongoManagerOptions(cfg *Config, logger libLog.Logger) []tmmongo.Optio
 		mongoOpts = append(mongoOpts, tmmongo.WithIdleTimeout(time.Duration(cfg.MultiTenantIdleTimeoutSec)*time.Second))
 	}
 
+	if cfg.MultiTenantSettingsCheckIntervalSec > 0 {
+		mongoOpts = append(mongoOpts, tmmongo.WithSettingsCheckInterval(
+			time.Duration(cfg.MultiTenantSettingsCheckIntervalSec)*time.Second,
+		))
+	}
+
 	return mongoOpts
 }
 

--- a/components/ledger/internal/bootstrap/config.go
+++ b/components/ledger/internal/bootstrap/config.go
@@ -63,7 +63,7 @@ type Config struct {
 	MultiTenantMaxTenantPools               int    `env:"MULTI_TENANT_MAX_TENANT_POOLS"`
 	MultiTenantIdleTimeoutSec               int    `env:"MULTI_TENANT_IDLE_TIMEOUT_SEC"`
 	MultiTenantServiceAPIKey                string `env:"MULTI_TENANT_SERVICE_API_KEY"`
-	MultiTenantSettingsCheckIntervalSec     int    `env:"MULTI_TENANT_SETTINGS_CHECK_INTERVAL_SEC"`
+	MultiTenantSettingsCheckIntervalSec     int    `env:"MULTI_TENANT_SETTINGS_CHECK_INTERVAL_SEC"` // seconds between tenant config revalidation checks
 }
 
 // Options contains optional dependencies that can be injected by callers.

--- a/components/onboarding/internal/bootstrap/config.go
+++ b/components/onboarding/internal/bootstrap/config.go
@@ -153,7 +153,7 @@ type Config struct {
 	// Format: Go duration string (e.g., "5m", "1h", "30s"). Default: 5m.
 	SettingsCacheTTL string `env:"SETTINGS_CACHE_TTL"`
 
-	MultiTenantSettingsCheckIntervalSec int `env:"MULTI_TENANT_SETTINGS_CHECK_INTERVAL_SEC"`
+	MultiTenantSettingsCheckIntervalSec int `env:"MULTI_TENANT_SETTINGS_CHECK_INTERVAL_SEC"` // seconds between tenant config revalidation checks
 }
 
 // Options contains optional dependencies that can be injected when running

--- a/components/onboarding/internal/bootstrap/config.mongo.go
+++ b/components/onboarding/internal/bootstrap/config.mongo.go
@@ -31,7 +31,7 @@ type mongoComponents struct {
 // Dispatches to single-tenant or multi-tenant initialization based on Options.
 func initMongo(opts *Options, cfg *Config, logger libLog.Logger) (*mongoComponents, error) {
 	if opts != nil && opts.MultiTenantEnabled {
-		return initMultiTenantMongo(opts, logger)
+		return initMultiTenantMongo(opts, cfg, logger)
 	}
 
 	return initSingleTenantMongo(cfg, logger)
@@ -41,18 +41,28 @@ func initMongo(opts *Options, cfg *Config, logger libLog.Logger) (*mongoComponen
 // Creates a tmmongo.Manager that resolves per-tenant databases via Tenant Manager.
 // The Manager is NOT injected into the repository — the middleware (PR 5) uses it
 // to inject *mongo.Database into context, and the repository reads from context.
-func initMultiTenantMongo(opts *Options, logger libLog.Logger) (*mongoComponents, error) {
+func initMultiTenantMongo(opts *Options, cfg *Config, logger libLog.Logger) (*mongoComponents, error) {
 	logger.Log(context.Background(), libLog.LevelInfo, "Initializing multi-tenant MongoDB for onboarding")
 
 	if opts.TenantClient == nil {
 		return nil, fmt.Errorf("TenantClient is required for multi-tenant MongoDB initialization")
 	}
 
+	mongoOpts := []tmmongo.Option{
+		tmmongo.WithModule(ApplicationName),
+		tmmongo.WithLogger(logger),
+	}
+
+	if cfg.MultiTenantSettingsCheckIntervalSec > 0 {
+		mongoOpts = append(mongoOpts, tmmongo.WithSettingsCheckInterval(
+			time.Duration(cfg.MultiTenantSettingsCheckIntervalSec)*time.Second,
+		))
+	}
+
 	mongoMgr := tmmongo.NewManager(
 		opts.TenantClient,
 		opts.TenantServiceName,
-		tmmongo.WithModule(ApplicationName),
-		tmmongo.WithLogger(logger),
+		mongoOpts...,
 	)
 
 	return &mongoComponents{

--- a/components/onboarding/internal/bootstrap/config.mongo_test.go
+++ b/components/onboarding/internal/bootstrap/config.mongo_test.go
@@ -131,6 +131,51 @@ func TestInitMultiTenantMongo_NilTenantClient_ReturnsError(t *testing.T) {
 	assert.Contains(t, err.Error(), "TenantClient is required")
 }
 
+func TestInitMultiTenantMongo_WithSettingsCheckInterval(t *testing.T) {
+	t.Parallel()
+
+	logger := libLog.NewNop()
+	client := mustTenantClient(t, logger)
+
+	tests := []struct {
+		name     string
+		interval int
+	}{
+		{
+			name:     "positive interval applies WithSettingsCheckInterval option",
+			interval: 60,
+		},
+		{
+			name:     "zero interval skips WithSettingsCheckInterval option",
+			interval: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			opts := &Options{
+				MultiTenantEnabled: true,
+				TenantClient:       client,
+				TenantServiceName:  "onboarding",
+			}
+
+			cfg := &Config{
+				MultiTenantSettingsCheckIntervalSec: tt.interval,
+			}
+
+			result, err := initMultiTenantMongo(opts, cfg, logger)
+			require.NoError(t, err)
+			require.NotNil(t, result)
+
+			assert.NotNil(t, result.mongoManager, "mongoManager must be set in multi-tenant mode")
+			assert.NotNil(t, result.metadataRepo, "metadataRepo must be set in multi-tenant mode")
+			assert.Nil(t, result.connection, "connection must be nil in multi-tenant mode")
+		})
+	}
+}
+
 func TestInitSingleTenantMongo_CreatesComponents(t *testing.T) {
 	t.Parallel()
 

--- a/components/onboarding/internal/bootstrap/config.mongo_test.go
+++ b/components/onboarding/internal/bootstrap/config.mongo_test.go
@@ -101,7 +101,9 @@ func TestInitMultiTenantMongo_Success(t *testing.T) {
 		TenantServiceName:  "onboarding",
 	}
 
-	result, err := initMultiTenantMongo(opts, logger)
+	cfg := &Config{}
+
+	result, err := initMultiTenantMongo(opts, cfg, logger)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 
@@ -121,7 +123,9 @@ func TestInitMultiTenantMongo_NilTenantClient_ReturnsError(t *testing.T) {
 		TenantServiceName:  "onboarding",
 	}
 
-	result, err := initMultiTenantMongo(opts, logger)
+	cfg := &Config{}
+
+	result, err := initMultiTenantMongo(opts, cfg, logger)
 	require.Error(t, err)
 	assert.Nil(t, result)
 	assert.Contains(t, err.Error(), "TenantClient is required")

--- a/components/transaction/internal/bootstrap/config.go
+++ b/components/transaction/internal/bootstrap/config.go
@@ -210,7 +210,7 @@ type Config struct {
 	RabbitMQMultiTenantSyncInterval     int `env:"RABBITMQ_MULTI_TENANT_SYNC_INTERVAL"`     // Stored in seconds
 	RabbitMQMultiTenantDiscoveryTimeout int `env:"RABBITMQ_MULTI_TENANT_DISCOVERY_TIMEOUT"` // Stored in milliseconds
 
-	MultiTenantSettingsCheckIntervalSec int `env:"MULTI_TENANT_SETTINGS_CHECK_INTERVAL_SEC"`
+	MultiTenantSettingsCheckIntervalSec int `env:"MULTI_TENANT_SETTINGS_CHECK_INTERVAL_SEC"` // seconds between tenant config revalidation checks
 }
 
 // Options contains optional dependencies that can be injected by callers.

--- a/components/transaction/internal/bootstrap/config.mongo.go
+++ b/components/transaction/internal/bootstrap/config.mongo.go
@@ -32,25 +32,35 @@ type mongoComponents struct {
 // Dispatches to single-tenant or multi-tenant initialization based on Options.
 func initMongo(opts *Options, cfg *Config, logger libLog.Logger) (*mongoComponents, error) {
 	if opts != nil && opts.MultiTenantEnabled {
-		return initMultiTenantMongo(opts, logger)
+		return initMultiTenantMongo(opts, cfg, logger)
 	}
 
 	return initSingleTenantMongo(cfg, logger)
 }
 
 // initMultiTenantMongo initializes MongoDB in multi-tenant mode.
-func initMultiTenantMongo(opts *Options, logger libLog.Logger) (*mongoComponents, error) {
+func initMultiTenantMongo(opts *Options, cfg *Config, logger libLog.Logger) (*mongoComponents, error) {
 	logger.Log(context.Background(), libLog.LevelInfo, "Initializing multi-tenant MongoDB for transaction")
 
 	if opts.TenantClient == nil {
 		return nil, fmt.Errorf("TenantClient is required for multi-tenant MongoDB initialization")
 	}
 
+	mongoOpts := []tmmongo.Option{
+		tmmongo.WithModule(ApplicationName),
+		tmmongo.WithLogger(logger),
+	}
+
+	if cfg.MultiTenantSettingsCheckIntervalSec > 0 {
+		mongoOpts = append(mongoOpts, tmmongo.WithSettingsCheckInterval(
+			time.Duration(cfg.MultiTenantSettingsCheckIntervalSec)*time.Second,
+		))
+	}
+
 	mongoMgr := tmmongo.NewManager(
 		opts.TenantClient,
 		opts.TenantServiceName,
-		tmmongo.WithModule(ApplicationName),
-		tmmongo.WithLogger(logger),
+		mongoOpts...,
 	)
 
 	return &mongoComponents{

--- a/components/transaction/internal/bootstrap/config.mongo_test.go
+++ b/components/transaction/internal/bootstrap/config.mongo_test.go
@@ -130,6 +130,51 @@ func TestInitMultiTenantMongo_NilTenantClient_ReturnsError(t *testing.T) {
 	assert.Contains(t, err.Error(), "TenantClient is required")
 }
 
+func TestInitMultiTenantMongo_WithSettingsCheckInterval(t *testing.T) {
+	t.Parallel()
+
+	logger := libLog.NewNop()
+	client := mustTenantClient(t, logger)
+
+	tests := []struct {
+		name     string
+		interval int
+	}{
+		{
+			name:     "positive interval applies WithSettingsCheckInterval option",
+			interval: 60,
+		},
+		{
+			name:     "zero interval skips WithSettingsCheckInterval option",
+			interval: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			opts := &Options{
+				MultiTenantEnabled: true,
+				TenantClient:       client,
+				TenantServiceName:  "transaction",
+			}
+
+			cfg := &Config{
+				MultiTenantSettingsCheckIntervalSec: tt.interval,
+			}
+
+			result, err := initMultiTenantMongo(opts, cfg, logger)
+			require.NoError(t, err)
+			require.NotNil(t, result)
+
+			assert.NotNil(t, result.mongoManager, "mongoManager must be set in multi-tenant mode")
+			assert.NotNil(t, result.metadataRepo, "metadataRepo must be set in multi-tenant mode")
+			assert.Nil(t, result.connection, "connection must be nil in multi-tenant mode")
+		})
+	}
+}
+
 func TestInitSingleTenantMongo_CreatesComponents(t *testing.T) {
 	t.Parallel()
 

--- a/components/transaction/internal/bootstrap/config.mongo_test.go
+++ b/components/transaction/internal/bootstrap/config.mongo_test.go
@@ -100,7 +100,9 @@ func TestInitMultiTenantMongo_Success(t *testing.T) {
 		TenantServiceName:  "transaction",
 	}
 
-	result, err := initMultiTenantMongo(opts, logger)
+	cfg := &Config{}
+
+	result, err := initMultiTenantMongo(opts, cfg, logger)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 
@@ -120,7 +122,9 @@ func TestInitMultiTenantMongo_NilTenantClient_ReturnsError(t *testing.T) {
 		TenantServiceName:  "transaction",
 	}
 
-	result, err := initMultiTenantMongo(opts, logger)
+	cfg := &Config{}
+
+	result, err := initMultiTenantMongo(opts, cfg, logger)
 	require.Error(t, err)
 	assert.Nil(t, result)
 	assert.Contains(t, err.Error(), "TenantClient is required")

--- a/go.mod
+++ b/go.mod
@@ -100,7 +100,7 @@ require (
 )
 
 require (
-	github.com/LerianStudio/lib-commons/v4 v4.2.0-beta.7.0.20260321191739-69cc4e4ddff6
+	github.com/LerianStudio/lib-commons/v4 v4.2.0-beta.9
 	github.com/Shopify/toxiproxy/v2 v2.12.0
 	github.com/docker/docker v28.5.2+incompatible
 	github.com/docker/go-connections v0.6.0

--- a/go.mod
+++ b/go.mod
@@ -100,7 +100,7 @@ require (
 )
 
 require (
-	github.com/LerianStudio/lib-commons/v4 v4.2.0-beta.7
+	github.com/LerianStudio/lib-commons/v4 v4.2.0-beta.7.0.20260321191739-69cc4e4ddff6
 	github.com/Shopify/toxiproxy/v2 v2.12.0
 	github.com/docker/docker v28.5.2+incompatible
 	github.com/docker/go-connections v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -19,8 +19,8 @@ github.com/KyleBanks/depth v1.2.1 h1:5h8fQADFrWtarTdtDudMmGsC7GPbOAu6RVB3ffsVFHc
 github.com/KyleBanks/depth v1.2.1/go.mod h1:jzSb9d0L43HxTQfT+oSA1EEp2q+ne2uh6XgeJcm8brE=
 github.com/LerianStudio/lib-auth/v2 v2.5.0-beta.8 h1:Cl8e8hXgxVVavy2/f6goUxmVyOnTXSwsrqSHOJJTTW0=
 github.com/LerianStudio/lib-auth/v2 v2.5.0-beta.8/go.mod h1:xdXYO1Ncgf++1WAHKZYPCs7YPrcvVt3/zso/X+qUuaI=
-github.com/LerianStudio/lib-commons/v4 v4.2.0-beta.7.0.20260321191739-69cc4e4ddff6 h1:8HmggODjp1RghwLJR0FV5Q16M5BvqMNZywp2vJeTVdY=
-github.com/LerianStudio/lib-commons/v4 v4.2.0-beta.7.0.20260321191739-69cc4e4ddff6/go.mod h1:89mzZKE3Hf0aDdKo3qfjfPL38ZsQRciqRbEeR718O+g=
+github.com/LerianStudio/lib-commons/v4 v4.2.0-beta.9 h1:B6S5rHeaPOi4sMTWfGFa+AdVrJiUwU0P+/JUiOmy/HQ=
+github.com/LerianStudio/lib-commons/v4 v4.2.0-beta.9/go.mod h1:89mzZKE3Hf0aDdKo3qfjfPL38ZsQRciqRbEeR718O+g=
 github.com/Masterminds/squirrel v1.5.4 h1:uUcX/aBc8O7Fg9kaISIUsHXdKuqehiXAMQTYX8afzqM=
 github.com/Masterminds/squirrel v1.5.4/go.mod h1:NNaOrjSoIDfDA40n7sr2tPNZRfjzjA400rg+riTZj10=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=

--- a/go.sum
+++ b/go.sum
@@ -19,8 +19,8 @@ github.com/KyleBanks/depth v1.2.1 h1:5h8fQADFrWtarTdtDudMmGsC7GPbOAu6RVB3ffsVFHc
 github.com/KyleBanks/depth v1.2.1/go.mod h1:jzSb9d0L43HxTQfT+oSA1EEp2q+ne2uh6XgeJcm8brE=
 github.com/LerianStudio/lib-auth/v2 v2.5.0-beta.8 h1:Cl8e8hXgxVVavy2/f6goUxmVyOnTXSwsrqSHOJJTTW0=
 github.com/LerianStudio/lib-auth/v2 v2.5.0-beta.8/go.mod h1:xdXYO1Ncgf++1WAHKZYPCs7YPrcvVt3/zso/X+qUuaI=
-github.com/LerianStudio/lib-commons/v4 v4.2.0-beta.7 h1:P/CxbiPlmMR8h1tq44jg/Dab5APUw1c9y51uhkRvyqU=
-github.com/LerianStudio/lib-commons/v4 v4.2.0-beta.7/go.mod h1:89mzZKE3Hf0aDdKo3qfjfPL38ZsQRciqRbEeR718O+g=
+github.com/LerianStudio/lib-commons/v4 v4.2.0-beta.7.0.20260321191739-69cc4e4ddff6 h1:8HmggODjp1RghwLJR0FV5Q16M5BvqMNZywp2vJeTVdY=
+github.com/LerianStudio/lib-commons/v4 v4.2.0-beta.7.0.20260321191739-69cc4e4ddff6/go.mod h1:89mzZKE3Hf0aDdKo3qfjfPL38ZsQRciqRbEeR718O+g=
 github.com/Masterminds/squirrel v1.5.4 h1:uUcX/aBc8O7Fg9kaISIUsHXdKuqehiXAMQTYX8afzqM=
 github.com/Masterminds/squirrel v1.5.4/go.mod h1:NNaOrjSoIDfDA40n7sr2tPNZRfjzjA400rg+riTZj10=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=


### PR DESCRIPTION
## Summary

Enables periodic revalidation of tenant config in both PostgreSQL and MongoDB managers. When a tenant is suspended/purged, the manager detects it and evicts the cached connection automatically.

## Changes

- `MULTI_TENANT_SETTINGS_CHECK_INTERVAL_SEC` env var in onboarding, transaction, ledger, and CRM Config structs
- PostgreSQL managers: `tmpostgres.WithSettingsCheckInterval` (onboarding + transaction)
- MongoDB managers: `tmmongo.WithSettingsCheckInterval` (onboarding + transaction + CRM)
- Upgrades lib-commons to v4.2.0-beta.9

## How it works

Per-tenant, lazy evaluation on each request:
1. Request arrives for tenant X
2. Manager checks if interval has passed since last check
3. If yes, spawns goroutine → calls tenant-manager `/connections`
4. If tenant is suspended/purged → evicts connection from pool
5. Next request creates fresh connection with new credentials

## Test plan

- [x] `go build ./...` passes
- [x] All component tests pass (onboarding, transaction, crm, ledger)