### PR TITLE
fix(transaction): add RABBITMQ_TLS env var for Amazon MQ connections

### DIFF
--- a/components/transaction/internal/bootstrap/config.go
+++ b/components/transaction/internal/bootstrap/config.go
@@ -159,6 +159,7 @@ type Config struct {
 	RabbitMQNumbersOfWorkers                 int    `env:"RABBITMQ_NUMBERS_OF_WORKERS"`
 	RabbitMQNumbersOfPrefetch                int    `env:"RABBITMQ_NUMBERS_OF_PREFETCH"`
 	RabbitMQHealthCheckURL                   string `env:"RABBITMQ_HEALTH_CHECK_URL"`
+	RabbitMQTLS                             bool   `env:"RABBITMQ_TLS"`
 	RabbitMQTransactionBalanceOperationQueue string `env:"RABBITMQ_TRANSACTION_BALANCE_OPERATION_QUEUE"`
 	OtelServiceName                          string `env:"OTEL_RESOURCE_SERVICE_NAME"`
 	OtelLibraryName                          string `env:"OTEL_LIBRARY_NAME"`

--- a/components/transaction/internal/bootstrap/config.rabbitmq.go
+++ b/components/transaction/internal/bootstrap/config.rabbitmq.go
@@ -79,11 +79,19 @@ func initMultiTenantRabbitMQ(
 		return nil, fmt.Errorf("TenantClient is required for multi-tenant RabbitMQ initialization")
 	}
 
+	rmqOpts := []tmrabbitmq.Option{
+		tmrabbitmq.WithLogger(logger),
+		tmrabbitmq.WithModule(ApplicationName),
+	}
+
+	if cfg.RabbitMQTLS {
+		rmqOpts = append(rmqOpts, tmrabbitmq.WithTLS())
+	}
+
 	tenantRabbitMQ := tmrabbitmq.NewManager(
 		opts.TenantClient,
 		opts.TenantServiceName,
-		tmrabbitmq.WithLogger(logger),
-		tmrabbitmq.WithModule(ApplicationName),
+		rmqOpts...,
 	)
 
 	// Get Redis UniversalClient for tenant discovery cache (SMEMBERS on active tenants key)


### PR DESCRIPTION
## Summary

- Add `RABBITMQ_TLS` env var (`bool`) to enable TLS for multi-tenant RabbitMQ connections
- When `true`, passes `tmrabbitmq.WithTLS()` to the manager, using `amqps://` scheme instead of `amqp://`
- Fixes Amazon MQ connection failures where port 5671 (TLS) was used but TLS was not enabled

## Root Cause

Amazon MQ (managed RabbitMQ) requires TLS on port 5671. The `tmrabbitmq.Manager` was created without `WithTLS()`, so it connected via plaintext `amqp://` — which Amazon MQ rejects.

Log evidence:
```
connecting to RabbitMQ vhost: tenant=org_xxx, vhost=ledger_org_xxx, tls=false
```

## Changes

| File | Change |
|------|--------|
| `components/transaction/internal/bootstrap/config.go` | Add `RabbitMQTLS bool` field with `env:"RABBITMQ_TLS"` |
| `components/transaction/internal/bootstrap/config.rabbitmq.go` | Conditionally pass `WithTLS()` when `cfg.RabbitMQTLS` is true |

## Usage

```bash
RABBITMQ_TLS=true  # Enable for Amazon MQ / any TLS-enabled broker
```

## Test plan

- [ ] Deploy to staging with `RABBITMQ_TLS=true`
- [ ] Verify log shows `tls=true` on connection
- [ ] Verify tenant messages are produced and consumed successfully via Amazon MQ

🤖 Generated with [Claude Code](https://claude.com/claude-code)