### PR TITLE
fix: rabbitmq consumer fails to resolve tenant PG connection due to module name mismatch

### DIFF
--- a/components/ledger/internal/bootstrap/config.rabbitmq.go
+++ b/components/ledger/internal/bootstrap/config.rabbitmq.go
@@ -156,10 +156,12 @@ func initMultiTenantRabbitMQ(
 			func(ctx context.Context, delivery amqp.Delivery) error {
 				ctx, err := resolveTenantConnections(ctx, rmqComponents)
 				if err != nil {
+					logger.Log(ctx, libLog.LevelError, fmt.Sprintf("Failed to resolve tenant connections for consumer message: %v", err))
 					return err
 				}
 
 				if err := handlerBTO(ctx, delivery.Body, useCase); err != nil {
+					logger.Log(ctx, libLog.LevelError, fmt.Sprintf("Failed to process consumer message: %v", err))
 					return err
 				}
 
@@ -212,7 +214,9 @@ func resolveTenantConnections(ctx context.Context, rmq *rabbitMQComponents) (con
 
 		emitTenantCounter(ctx, rmq.metricsFactory, utils.TenantConnectionsTotal, tenantID, "postgresql")
 
-		ctx = tmcore.ContextWithModulePGConnection(ctx, ApplicationName, db)
+		// Module name must be "transaction" to match the per-tenant PG schema naming
+		// and the middleware's module-scoped connection resolution.
+		ctx = tmcore.ContextWithModulePGConnection(ctx, "transaction", db)
 	}
 
 	if rmq.mongoManager != nil {


### PR DESCRIPTION
## Summary

Fixes RabbitMQ messages being infinitely redelivered because the multi-tenant consumer handler sets the wrong module name when injecting the PostgreSQL connection into context.

## Root cause

After the unified ledger refactor, resolveTenantConnections calls ContextWithModulePGConnection(ctx, ApplicationName, db) where ApplicationName is now "ledger". However, the transaction repos resolve their DB connection using module name "transaction" (set by the HTTP middleware's WithDefaultRoute("transaction", ...)). This mismatch means the handler's context carries a PG connection keyed as "ledger", but the use case repos look for one keyed as "transaction" -- they get nil, error, and the message is nacked and redelivered.

## Fix

- Changed ContextWithModulePGConnection module name from ApplicationName to "transaction"
- Added error logging in the consumer handler so these failures appear in logs instead of being silently nacked and redelivered