### PR TITLE
feat(multi-tenant): add MULTI_TENANT_CACHE_TTL_SEC env var

### DIFF
--- a/components/crm/internal/bootstrap/config.go
+++ b/components/crm/internal/bootstrap/config.go
@@ -57,6 +57,7 @@ type Config struct {
 	MultiTenantCircuitBreakerTimeoutSec int    `env:"MULTI_TENANT_CIRCUIT_BREAKER_TIMEOUT_SEC"` // seconds before circuit resets
 	MultiTenantServiceAPIKey            string `env:"MULTI_TENANT_SERVICE_API_KEY"`
 	MultiTenantSettingsCheckIntervalSec int    `env:"MULTI_TENANT_SETTINGS_CHECK_INTERVAL_SEC"` // seconds between tenant config revalidation checks
+	MultiTenantCacheTTLSec              int    `env:"MULTI_TENANT_CACHE_TTL_SEC" default:"120"` // seconds for tenant config cache TTL (0 = disabled)
 	ApplicationName                     string `env:"APPLICATION_NAME"`
 }
 

--- a/components/crm/internal/bootstrap/config.tenant.go
+++ b/components/crm/internal/bootstrap/config.tenant.go
@@ -69,6 +69,10 @@ func buildTenantClientOptions(cfg *Config, mtURL string) ([]tmclient.ClientOptio
 
 	clientOpts = append(clientOpts, tmclient.WithServiceAPIKey(cfg.MultiTenantServiceAPIKey))
 
+	if cfg.MultiTenantCacheTTLSec >= 0 {
+		clientOpts = append(clientOpts, tmclient.WithCacheTTL(time.Duration(cfg.MultiTenantCacheTTLSec)*time.Second))
+	}
+
 	if cfg.MultiTenantTimeout > 0 {
 		clientOpts = append(clientOpts, tmclient.WithTimeout(time.Duration(cfg.MultiTenantTimeout)*time.Second))
 	}

--- a/components/ledger/internal/bootstrap/config.go
+++ b/components/ledger/internal/bootstrap/config.go
@@ -97,6 +97,7 @@ type Config struct {
 	MultiTenantIdleTimeoutSec           int    `env:"MULTI_TENANT_IDLE_TIMEOUT_SEC"`
 	MultiTenantServiceAPIKey            string `env:"MULTI_TENANT_SERVICE_API_KEY"`
 	MultiTenantSettingsCheckIntervalSec int    `env:"MULTI_TENANT_SETTINGS_CHECK_INTERVAL_SEC"`
+	MultiTenantCacheTTLSec              int    `env:"MULTI_TENANT_CACHE_TTL_SEC" default:"120"` // seconds for tenant config cache TTL (0 = disabled)
 
 	// --- Onboarding PostgreSQL fields (DB_ONBOARDING_* env tags) ---
 	OnbPrefixedPrimaryDBHost     string `env:"DB_ONBOARDING_HOST"`
@@ -757,11 +758,19 @@ func initTenantClient(cfg *Config, logger libLog.Logger) (*tmclient.Client, stri
 		cbTimeoutSec = 30
 	}
 
+	clientOpts := []tmclient.ClientOption{
+		tmclient.WithServiceAPIKey(tenantManagerAPIKey),
+		tmclient.WithCircuitBreaker(cbThreshold, time.Duration(cbTimeoutSec)*time.Second),
+	}
+
+	if cfg.MultiTenantCacheTTLSec >= 0 {
+		clientOpts = append(clientOpts, tmclient.WithCacheTTL(time.Duration(cfg.MultiTenantCacheTTLSec)*time.Second))
+	}
+
 	tenantClient, err := tmclient.NewClient(
 		tenantManagerURL,
 		logger,
-		tmclient.WithServiceAPIKey(tenantManagerAPIKey),
-		tmclient.WithCircuitBreaker(cbThreshold, time.Duration(cbTimeoutSec)*time.Second),
+		clientOpts...,
 	)
 	if err != nil {
 		return nil, "", fmt.Errorf("failed to initialize tenant manager client: %w", err)


### PR DESCRIPTION
## Summary

Add `MULTI_TENANT_CACHE_TTL_SEC` env var (default 120s) to control tenant config in-memory cache TTL.

- Ledger + CRM: `WithCacheTTL` added to client creation
- `0` = disabled (every request hits tenant-manager)

Works with `MULTI_TENANT_SETTINGS_CHECK_INTERVAL_SEC` for proactive refresh (lib-commons #384).

> ♻️ Recreated from #1962 (original branch was too far behind after a large merge on develop). Changes adapted to current repo structure (transaction/onboarding were consolidated into ledger).