### PR TITLE
fix(ci): disable docker login in gitops update step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,6 +54,7 @@ jobs:
       yaml_key_mappings: '{"midaz-crm.tag": ".crm.image.tag", "midaz-ledger.tag": ".ledger.image.tag"}'
       commit_message_prefix: "midaz"
       enable_argocd_sync: true
+      enable_docker_login: false
     secrets: inherit
 
   # =========================

--- a/components/ledger/Dockerfile
+++ b/components/ledger/Dockerfile
@@ -26,3 +26,4 @@ EXPOSE 3002
 USER nonroot:nonroot
 
 ENTRYPOINT ["/app"]
+


### PR DESCRIPTION
# Midaz Pull Request Checklist

## Pull Request Type

- [ ] Documentation
- [x] Pipeline
- [ ] Infra
- [ ] Ledger
- [ ] Onboarding
- [ ] Transaction
- [ ] CRM
- [ ] Tests

## Checklist

- [x] I have tested these changes locally.
- [ ] I have updated the documentation accordingly.
- [x] I have added necessary comments to the code, especially in complex areas.
- [x] I have ensured that my changes adhere to the project's coding standards.
- [x] I have checked for any potential security issues.
- [ ] I have ensured that all tests pass.
- [ ] I have updated the version appropriately (if applicable).
- [x] I have confirmed this code is ready for review.

## Additional Notes

The `update_gitops` job was failing intermittently on the "Log in to Docker Hub" step with:

```
toomanyrequests: too many failed login attempts for username or IP address
```

The gitops update workflow only modifies YAML tags in the gitops repository — it does not pull or push Docker images. The Docker login step is unnecessary and was causing failures due to Docker Hub authentication rate limiting.

This PR sets `enable_docker_login: false` for the gitops update job. A blank line was added to `components/ledger/Dockerfile` to trigger the build pipeline for testing.