### PR TITLE
feat: enrich transaction route listing with linked operation routes

### DIFF
--- a/components/ledger/internal/adapters/http/in/transaction-route_test.go
+++ b/components/ledger/internal/adapters/http/in/transaction-route_test.go
@@ -644,14 +644,14 @@ func TestTransactionRouteHandler_GetAllTransactionRoutes(t *testing.T) {
 	tests := []struct {
 		name           string
 		queryParams    string
-		setupMocks     func(transactionRouteRepo *transactionroute.MockRepository, metadataRepo *mongodb.MockRepository, orgID, ledgerID uuid.UUID)
+		setupMocks     func(transactionRouteRepo *transactionroute.MockRepository, operationRouteRepo *operationroute.MockRepository, metadataRepo *mongodb.MockRepository, orgID, ledgerID uuid.UUID)
 		expectedStatus int
 		validateBody   func(t *testing.T, body []byte)
 	}{
 		{
 			name:        "empty list returns 200 with pagination structure",
 			queryParams: "",
-			setupMocks: func(transactionRouteRepo *transactionroute.MockRepository, metadataRepo *mongodb.MockRepository, orgID, ledgerID uuid.UUID) {
+			setupMocks: func(transactionRouteRepo *transactionroute.MockRepository, operationRouteRepo *operationroute.MockRepository, metadataRepo *mongodb.MockRepository, orgID, ledgerID uuid.UUID) {
 				transactionRouteRepo.EXPECT().
 					FindAll(gomock.Any(), orgID, ledgerID, gomock.Any()).
 					Return([]*mmodel.TransactionRoute{}, libHTTP.CursorPagination{}, nil).
@@ -683,7 +683,7 @@ func TestTransactionRouteHandler_GetAllTransactionRoutes(t *testing.T) {
 		{
 			name:        "success with items returns transaction routes",
 			queryParams: "?limit=5",
-			setupMocks: func(transactionRouteRepo *transactionroute.MockRepository, metadataRepo *mongodb.MockRepository, orgID, ledgerID uuid.UUID) {
+			setupMocks: func(transactionRouteRepo *transactionroute.MockRepository, operationRouteRepo *operationroute.MockRepository, metadataRepo *mongodb.MockRepository, orgID, ledgerID uuid.UUID) {
 				tr1ID := uuid.New()
 				tr2ID := uuid.New()
 
@@ -725,6 +725,12 @@ func TestTransactionRouteHandler_GetAllTransactionRoutes(t *testing.T) {
 						},
 					}, nil).
 					Times(1)
+
+				// Enrichment: junction query returns empty map (no linked operation routes)
+				transactionRouteRepo.EXPECT().
+					FindOperationRouteIDsByTransactionRouteIDs(gomock.Any(), gomock.Any()).
+					Return(map[uuid.UUID][]uuid.UUID{}, nil).
+					Times(1)
 			},
 			expectedStatus: 200,
 			validateBody: func(t *testing.T, body []byte) {
@@ -757,7 +763,7 @@ func TestTransactionRouteHandler_GetAllTransactionRoutes(t *testing.T) {
 		{
 			name:        "with metadata filter returns filtered transaction routes",
 			queryParams: "?metadata.category=settlement",
-			setupMocks: func(transactionRouteRepo *transactionroute.MockRepository, metadataRepo *mongodb.MockRepository, orgID, ledgerID uuid.UUID) {
+			setupMocks: func(transactionRouteRepo *transactionroute.MockRepository, operationRouteRepo *operationroute.MockRepository, metadataRepo *mongodb.MockRepository, orgID, ledgerID uuid.UUID) {
 				trID := uuid.New()
 
 				// GetAllMetadataTransactionRoutes first calls FindList to get metadata matching filter
@@ -790,6 +796,12 @@ func TestTransactionRouteHandler_GetAllTransactionRoutes(t *testing.T) {
 						Prev: "",
 					}, nil).
 					Times(1)
+
+				// Enrichment: junction query returns empty map (no linked operation routes)
+				transactionRouteRepo.EXPECT().
+					FindOperationRouteIDsByTransactionRouteIDs(gomock.Any(), gomock.Any()).
+					Return(map[uuid.UUID][]uuid.UUID{}, nil).
+					Times(1)
 			},
 			expectedStatus: 200,
 			validateBody: func(t *testing.T, body []byte) {
@@ -811,7 +823,7 @@ func TestTransactionRouteHandler_GetAllTransactionRoutes(t *testing.T) {
 		{
 			name:        "repository error returns 500",
 			queryParams: "",
-			setupMocks: func(transactionRouteRepo *transactionroute.MockRepository, metadataRepo *mongodb.MockRepository, orgID, ledgerID uuid.UUID) {
+			setupMocks: func(transactionRouteRepo *transactionroute.MockRepository, operationRouteRepo *operationroute.MockRepository, metadataRepo *mongodb.MockRepository, orgID, ledgerID uuid.UUID) {
 				transactionRouteRepo.EXPECT().
 					FindAll(gomock.Any(), orgID, ledgerID, gomock.Any()).
 					Return(nil, libHTTP.CursorPagination{}, pkg.InternalServerError{
@@ -842,11 +854,13 @@ func TestTransactionRouteHandler_GetAllTransactionRoutes(t *testing.T) {
 			ledgerID := uuid.New()
 
 			mockTransactionRouteRepo := transactionroute.NewMockRepository(ctrl)
+			mockOperationRouteRepo := operationroute.NewMockRepository(ctrl)
 			mockMetadataRepo := mongodb.NewMockRepository(ctrl)
-			tt.setupMocks(mockTransactionRouteRepo, mockMetadataRepo, orgID, ledgerID)
+			tt.setupMocks(mockTransactionRouteRepo, mockOperationRouteRepo, mockMetadataRepo, orgID, ledgerID)
 
 			queryUC := &query.UseCase{
 				TransactionRouteRepo:    mockTransactionRouteRepo,
+				OperationRouteRepo:      mockOperationRouteRepo,
 				TransactionMetadataRepo: mockMetadataRepo,
 			}
 			handler := &TransactionRouteHandler{Query: queryUC}

--- a/components/ledger/internal/adapters/postgres/transactionroute/transactionroute.postgresql.go
+++ b/components/ledger/internal/adapters/postgres/transactionroute/transactionroute.postgresql.go
@@ -43,6 +43,7 @@ type Repository interface {
 	Update(ctx context.Context, organizationID, ledgerID, id uuid.UUID, transactionRoute *mmodel.TransactionRoute, toAdd, toRemove []uuid.UUID) (*mmodel.TransactionRoute, error)
 	Delete(ctx context.Context, organizationID, ledgerID, id uuid.UUID, toRemove []uuid.UUID) error
 	FindAll(ctx context.Context, organizationID, ledgerID uuid.UUID, filter http.Pagination) ([]*mmodel.TransactionRoute, libHTTP.CursorPagination, error)
+	FindOperationRouteIDsByTransactionRouteIDs(ctx context.Context, transactionRouteIDs []uuid.UUID) (map[uuid.UUID][]uuid.UUID, error)
 }
 
 // TransactionRoutePostgreSQLRepository is a PostgreSQL implementation of the TransactionRouteRepository.
@@ -702,6 +703,84 @@ func (r *TransactionRoutePostgreSQLRepository) FindAll(ctx context.Context, orga
 	}
 
 	return transactionRoutes, cur, nil
+}
+
+// FindOperationRouteIDsByTransactionRouteIDs queries the junction table in batch to return
+// a mapping of transaction route IDs to their linked operation route IDs.
+// Returns an empty map (not nil) when no links are found or input is empty.
+func (r *TransactionRoutePostgreSQLRepository) FindOperationRouteIDsByTransactionRouteIDs(ctx context.Context, transactionRouteIDs []uuid.UUID) (map[uuid.UUID][]uuid.UUID, error) {
+	logger, tracer, _, _ := libCommons.NewTrackingFromContext(ctx)
+
+	ctx, span := tracer.Start(ctx, "postgres.find_operation_route_ids_by_transaction_route_ids")
+	defer span.End()
+
+	result := make(map[uuid.UUID][]uuid.UUID)
+
+	if len(transactionRouteIDs) == 0 {
+		return result, nil
+	}
+
+	db, err := r.getDB(ctx)
+	if err != nil {
+		libOpentelemetry.HandleSpanError(span, "Failed to get database connection", err)
+
+		logger.Log(ctx, libLog.LevelError, fmt.Sprintf("Failed to get database connection: %v", err))
+
+		return nil, err
+	}
+
+	query := squirrel.Select("otr.transaction_route_id", "otr.operation_route_id").
+		From("operation_transaction_route otr").
+		Join("operation_route orr ON otr.operation_route_id = orr.id AND orr.deleted_at IS NULL").
+		Where(squirrel.Eq{"otr.transaction_route_id": transactionRouteIDs}).
+		Where(squirrel.Eq{"otr.deleted_at": nil}).
+		PlaceholderFormat(squirrel.Dollar)
+
+	sqlQuery, args, err := query.ToSql()
+	if err != nil {
+		libOpentelemetry.HandleSpanError(span, "Failed to build query", err)
+
+		logger.Log(ctx, libLog.LevelError, fmt.Sprintf("Failed to build query: %v", err))
+
+		return nil, err
+	}
+
+	ctx, spanQuery := tracer.Start(ctx, "postgres.find_operation_route_ids.query")
+	defer spanQuery.End()
+
+	rows, err := db.QueryContext(ctx, sqlQuery, args...)
+	if err != nil {
+		libOpentelemetry.HandleSpanError(spanQuery, "Failed to execute query", err)
+
+		logger.Log(ctx, libLog.LevelError, fmt.Sprintf("Failed to execute query: %v", err))
+
+		return nil, err
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var trID, orID uuid.UUID
+
+		if err := rows.Scan(&trID, &orID); err != nil {
+			libOpentelemetry.HandleSpanError(span, "Failed to scan junction row", err)
+
+			logger.Log(ctx, libLog.LevelError, fmt.Sprintf("Failed to scan junction row: %v", err))
+
+			return nil, err
+		}
+
+		result[trID] = append(result[trID], orID)
+	}
+
+	if err := rows.Err(); err != nil {
+		libOpentelemetry.HandleSpanError(span, "Failed to iterate rows", err)
+
+		logger.Log(ctx, libLog.LevelError, fmt.Sprintf("Failed to iterate rows: %v", err))
+
+		return nil, err
+	}
+
+	return result, nil
 }
 
 // updateOperationRouteRelationships handles the logic of updating operation route relationships within an existing transaction.

--- a/components/ledger/internal/adapters/postgres/transactionroute/transactionroute.postgresql_chaos_test.go
+++ b/components/ledger/internal/adapters/postgres/transactionroute/transactionroute.postgresql_chaos_test.go
@@ -1,0 +1,561 @@
+//go:build integration
+
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+// Chaos tests for FindOperationRouteIDsByTransactionRouteIDs and getDB
+// in the transactionroute PostgreSQL repository.
+//
+// These tests exercise fault-tolerance of the repository when the underlying
+// PostgreSQL connection experiences failures (connection loss, latency,
+// network partition). They are a subset of integration tests and run
+// only when CHAOS=1 is set.
+//
+// Run with:
+//
+//	CHAOS=1 go test -tags integration -v -run TestIntegration_Chaos_TransactionRoute ./components/ledger/internal/adapters/postgres/transactionroute/...
+package transactionroute
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	libCommons "github.com/LerianStudio/lib-commons/v4/commons"
+	libPostgres "github.com/LerianStudio/lib-commons/v4/commons/postgres"
+	tmcore "github.com/LerianStudio/lib-commons/v4/commons/tenant-manager/core"
+	"github.com/LerianStudio/midaz/v3/pkg/mmodel"
+	"github.com/LerianStudio/midaz/v3/tests/utils/chaos"
+	pgtestutil "github.com/LerianStudio/midaz/v3/tests/utils/postgres"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// =============================================================================
+// CHAOS TEST INFRASTRUCTURE
+// =============================================================================
+
+// chaosNetworkTransactionRouteInfra holds all resources for transaction route
+// chaos tests with Toxiproxy network fault injection.
+type chaosNetworkTransactionRouteInfra struct {
+	pgResult   *pgtestutil.ContainerResult
+	chaosInfra *chaos.Infrastructure
+	repo       *TransactionRoutePostgreSQLRepository
+	conn       *libPostgres.Client
+	proxy      *chaos.Proxy
+	orgID      uuid.UUID
+	ledgerID   uuid.UUID
+}
+
+// setupTransactionRouteChaosNetworkInfra creates the full chaos test infrastructure:
+//  1. Creates a Docker network + Toxiproxy container via chaos.Infrastructure
+//  2. Starts a PostgreSQL container on the host network
+//  3. Registers the container with Infrastructure to get UpstreamAddr
+//  4. Creates a Toxiproxy proxy that forwards through to PostgreSQL
+//  5. Builds a TransactionRoutePostgreSQLRepository connected through the proxy
+//
+// All cleanup (proxy deletion, container termination, network removal) is
+// registered with t.Cleanup() automatically.
+func setupTransactionRouteChaosNetworkInfra(t *testing.T) *chaosNetworkTransactionRouteInfra {
+	t.Helper()
+
+	// 1. Create chaos infrastructure (Docker network + Toxiproxy)
+	chaosInfra := chaos.NewInfrastructure(t)
+
+	// 2. Start PostgreSQL container on the host network
+	pgResult := pgtestutil.SetupContainer(t)
+
+	// 3. Register the container with chaos infrastructure
+	_, err := chaosInfra.RegisterContainerWithPort("postgres", pgResult.Container, "5432/tcp")
+	require.NoError(t, err, "failed to register PostgreSQL container with chaos infrastructure")
+
+	// 4. Create a Toxiproxy proxy for PostgreSQL using port 8666 (pre-exposed)
+	proxy, err := chaosInfra.CreateProxyFor("postgres", "8666/tcp")
+	require.NoError(t, err, "failed to create Toxiproxy proxy for PostgreSQL")
+
+	// 5. Resolve the proxy listen address
+	containerInfo, ok := chaosInfra.GetContainer("postgres")
+	require.True(t, ok, "PostgreSQL container must be registered in chaos infrastructure")
+	require.NotEmpty(t, containerInfo.ProxyListen, "proxy listen address must be non-empty")
+
+	// 6. Build TransactionRoutePostgreSQLRepository connected through proxy
+	migrationsPath := pgtestutil.FindMigrationsPath(t, "transaction")
+
+	proxyConnStr := pgtestutil.BuildConnectionStringWithHost(containerInfo.ProxyListen, pgResult.Config)
+
+	conn := pgtestutil.CreatePostgresClient(t, proxyConnStr, proxyConnStr, pgResult.Config.DBName, migrationsPath)
+
+	repo := NewTransactionRoutePostgreSQLRepository(conn)
+
+	// Use fake UUIDs for external entities (no FK constraints between components)
+	orgID := uuid.Must(libCommons.GenerateUUIDv7())
+	ledgerID := uuid.Must(libCommons.GenerateUUIDv7())
+
+	return &chaosNetworkTransactionRouteInfra{
+		pgResult:   pgResult,
+		chaosInfra: chaosInfra,
+		repo:       repo,
+		conn:       conn,
+		proxy:      proxy,
+		orgID:      orgID,
+		ledgerID:   ledgerID,
+	}
+}
+
+// createTransactionRouteWithLinks creates a transaction route with linked operation routes
+// through the proxy for chaos testing. Returns the transaction route ID and
+// the list of operation route IDs that were linked.
+func (infra *chaosNetworkTransactionRouteInfra) createTransactionRouteWithLinks(t *testing.T, title string, opRouteCount int) (uuid.UUID, []uuid.UUID) {
+	t.Helper()
+
+	trID := pgtestutil.CreateTestTransactionRouteSimple(t, infra.pgResult.DB, infra.orgID, infra.ledgerID, title)
+
+	opRouteIDs := make([]uuid.UUID, 0, opRouteCount)
+
+	for i := 0; i < opRouteCount; i++ {
+		opRouteID := pgtestutil.CreateTestOperationRouteSimple(t, infra.pgResult.DB, infra.orgID, infra.ledgerID,
+			title+" OpRoute "+string(rune('A'+i)), "source")
+		pgtestutil.CreateTestOperationTransactionRouteLink(t, infra.pgResult.DB, opRouteID, trID)
+
+		opRouteIDs = append(opRouteIDs, opRouteID)
+	}
+
+	return trID, opRouteIDs
+}
+
+// =============================================================================
+// CONNECTION LOSS
+// =============================================================================
+
+// TestIntegration_Chaos_TransactionRoute_ConnectionLoss verifies that
+// FindOperationRouteIDsByTransactionRouteIDs and FindByID return errors
+// (not panics) when the PostgreSQL connection is fully dropped via Toxiproxy.
+//
+// This tests the scenario where the enrichment junction query is executed
+// during a total database outage. The repository must propagate an error,
+// not crash.
+//
+// 5-Phase structure:
+//  1. Normal   -- FindOperationRouteIDsByTransactionRouteIDs succeeds through the proxy
+//  2. Inject   -- Toxiproxy proxy is disabled (full connection loss)
+//  3. Verify   -- Repository operations return error, no panic
+//  4. Restore  -- Toxiproxy proxy is re-enabled
+//  5. Recovery -- Repository operations succeed again
+func TestIntegration_Chaos_TransactionRoute_ConnectionLoss(t *testing.T) {
+	if os.Getenv("CHAOS") != "1" {
+		t.Skip("Set CHAOS=1 to run chaos tests")
+	}
+
+	if testing.Short() {
+		t.Skip("Skipping chaos test in short mode")
+	}
+
+	infra := setupTransactionRouteChaosNetworkInfra(t)
+
+	ctx := context.Background()
+
+	// --- Phase 1: Normal ---
+	// Verify repository operations work through the proxy before any fault.
+	t.Log("Phase 1 (Normal): verifying FindOperationRouteIDsByTransactionRouteIDs succeeds through proxy")
+
+	trID1, expectedOpRouteIDs := infra.createTransactionRouteWithLinks(t, "Chaos ConnLoss TR1", 2)
+	trID2, _ := infra.createTransactionRouteWithLinks(t, "Chaos ConnLoss TR2", 1)
+
+	result, err := infra.repo.FindOperationRouteIDsByTransactionRouteIDs(ctx, []uuid.UUID{trID1, trID2})
+	require.NoError(t, err, "Phase 1: FindOperationRouteIDsByTransactionRouteIDs should succeed before fault injection")
+	require.Len(t, result[trID1], 2, "Phase 1: trID1 should have 2 linked operation routes")
+	require.Len(t, result[trID2], 1, "Phase 1: trID2 should have 1 linked operation route")
+
+	t.Logf("Phase 1: junction query returned %d entries for trID1, %d for trID2", len(result[trID1]), len(result[trID2]))
+
+	// Also verify FindByID works
+	found, err := infra.repo.FindByID(ctx, infra.orgID, infra.ledgerID, trID1)
+	require.NoError(t, err, "Phase 1: FindByID should succeed before fault injection")
+	assert.Equal(t, trID1, found.ID, "Phase 1: data should match")
+
+	// --- Phase 2: Inject ---
+	// Disable the Toxiproxy proxy to simulate full connection loss.
+	t.Log("Phase 2 (Inject): disabling Toxiproxy proxy to simulate connection loss")
+
+	err = infra.proxy.Disconnect()
+	require.NoError(t, err, "Phase 2: Toxiproxy Disconnect should not fail")
+
+	// --- Phase 3: Verify ---
+	// All repository operations must return errors, not panic.
+	t.Log("Phase 3 (Verify): repository operations must return error, not panic")
+
+	// 3a. FindOperationRouteIDsByTransactionRouteIDs must fail gracefully.
+	var junctionErr error
+
+	require.NotPanics(t, func() {
+		junctionCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
+		defer cancel()
+
+		_, junctionErr = infra.repo.FindOperationRouteIDsByTransactionRouteIDs(junctionCtx, []uuid.UUID{trID1, trID2})
+	}, "Phase 3: FindOperationRouteIDsByTransactionRouteIDs must not panic on connection loss")
+
+	// The operation may succeed if the connection pool still has cached connections,
+	// or it may fail. Both outcomes are acceptable during the partition window.
+	// The key invariant is: no panic.
+	if junctionErr != nil {
+		t.Logf("Phase 3: FindOperationRouteIDsByTransactionRouteIDs returned expected error: %v", junctionErr)
+	} else {
+		t.Log("Phase 3: FindOperationRouteIDsByTransactionRouteIDs succeeded (pool had cached connections)")
+	}
+
+	// 3b. FindByID must fail gracefully.
+	var findErr error
+
+	require.NotPanics(t, func() {
+		findCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
+		defer cancel()
+
+		_, findErr = infra.repo.FindByID(findCtx, infra.orgID, infra.ledgerID, trID1)
+	}, "Phase 3: FindByID must not panic on connection loss")
+
+	if findErr != nil {
+		t.Logf("Phase 3: FindByID returned expected error: %v", findErr)
+	} else {
+		t.Log("Phase 3: FindByID succeeded (pool had cached connections)")
+	}
+
+	// 3c. Create must fail gracefully.
+	var createErr error
+
+	require.NotPanics(t, func() {
+		createCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
+		defer cancel()
+
+		createTR := &mmodel.TransactionRoute{
+			ID:              uuid.Must(libCommons.GenerateUUIDv7()),
+			OrganizationID:  infra.orgID,
+			LedgerID:        infra.ledgerID,
+			Title:           "Should Fail TR",
+			OperationRoutes: []mmodel.OperationRoute{},
+			CreatedAt:       time.Now(),
+			UpdatedAt:       time.Now(),
+		}
+
+		_, createErr = infra.repo.Create(createCtx, infra.orgID, infra.ledgerID, createTR)
+	}, "Phase 3: Create must not panic on connection loss")
+
+	if createErr != nil {
+		t.Logf("Phase 3: Create returned expected error: %v", createErr)
+	} else {
+		t.Log("Phase 3: Create succeeded (pool had cached connections)")
+	}
+
+	// --- Phase 4: Restore ---
+	// Re-enable the proxy to restore connectivity.
+	t.Log("Phase 4 (Restore): re-enabling Toxiproxy proxy")
+
+	err = infra.proxy.Reconnect()
+	require.NoError(t, err, "Phase 4: Toxiproxy Reconnect should not fail")
+
+	// --- Phase 5: Recovery ---
+	// After the proxy is restored, repository operations must succeed again.
+	t.Log("Phase 5 (Recovery): verifying operations succeed after proxy restoration")
+
+	chaos.AssertRecoveryWithin(t, func() error {
+		_, err := infra.repo.FindOperationRouteIDsByTransactionRouteIDs(ctx, []uuid.UUID{trID1})
+		return err
+	}, 30*time.Second, "Phase 5: FindOperationRouteIDsByTransactionRouteIDs should recover after proxy restoration")
+
+	recoveredResult, err := infra.repo.FindOperationRouteIDsByTransactionRouteIDs(ctx, []uuid.UUID{trID1, trID2})
+	require.NoError(t, err, "Phase 5: FindOperationRouteIDsByTransactionRouteIDs must succeed after recovery")
+	assert.Len(t, recoveredResult[trID1], 2, "Phase 5: trID1 should still have 2 linked operation routes after recovery")
+	assert.Len(t, recoveredResult[trID2], 1, "Phase 5: trID2 should still have 1 linked operation route after recovery")
+
+	// Verify data integrity: same operation route IDs as before
+	recoveredIDs := make(map[uuid.UUID]bool)
+	for _, id := range recoveredResult[trID1] {
+		recoveredIDs[id] = true
+	}
+
+	for _, expectedID := range expectedOpRouteIDs {
+		assert.True(t, recoveredIDs[expectedID],
+			"Phase 5: operation route %s must be preserved after recovery", expectedID)
+	}
+
+	t.Log("PASS: getDB returns error (not panic) when connection is lost, recovers correctly")
+}
+
+// =============================================================================
+// HIGH LATENCY
+// =============================================================================
+
+// TestIntegration_Chaos_TransactionRoute_HighLatency verifies that
+// FindOperationRouteIDsByTransactionRouteIDs handles slow DB responses
+// correctly. Specifically, context timeout must propagate through getDB
+// so callers can abort slow queries without hanging indefinitely.
+//
+// 5-Phase structure:
+//  1. Normal   -- Junction query succeeds with low latency
+//  2. Inject   -- 5000 ms latency added via Toxiproxy
+//  3. Verify   -- Junction query with 1 s context deadline returns timeout error, no panic
+//  4. Restore  -- Latency toxic removed
+//  5. Recovery -- Junction query succeeds within normal latency again
+func TestIntegration_Chaos_TransactionRoute_HighLatency(t *testing.T) {
+	if os.Getenv("CHAOS") != "1" {
+		t.Skip("Set CHAOS=1 to run chaos tests")
+	}
+
+	if testing.Short() {
+		t.Skip("Skipping chaos test in short mode")
+	}
+
+	infra := setupTransactionRouteChaosNetworkInfra(t)
+
+	ctx := context.Background()
+
+	// --- Phase 1: Normal ---
+	// Verify operations work with normal latency.
+	t.Log("Phase 1 (Normal): verifying FindOperationRouteIDsByTransactionRouteIDs succeeds with normal latency")
+
+	trID, _ := infra.createTransactionRouteWithLinks(t, "Chaos HighLatency TR", 2)
+
+	start := time.Now()
+	result, err := infra.repo.FindOperationRouteIDsByTransactionRouteIDs(ctx, []uuid.UUID{trID})
+	baselineLatency := time.Since(start)
+
+	require.NoError(t, err, "Phase 1: junction query should succeed with normal latency")
+	assert.Len(t, result[trID], 2, "Phase 1: should have 2 linked operation routes")
+	t.Logf("Phase 1: baseline junction query completed in %v", baselineLatency)
+
+	// --- Phase 2: Inject ---
+	// Add 5000 ms latency to the proxy to simulate a very slow database.
+	t.Log("Phase 2 (Inject): adding 5000 ms network latency via Toxiproxy")
+
+	err = infra.proxy.AddLatency(5*time.Second, 500*time.Millisecond)
+	require.NoError(t, err, "Phase 2: AddLatency should not fail")
+
+	// --- Phase 3: Verify ---
+	// Junction query with a 1-second context deadline must return a timeout/deadline error.
+	// The key assertion: getDB propagates context deadlines correctly.
+	t.Log("Phase 3 (Verify): junction query with 1s deadline must timeout, not hang or panic")
+
+	var timeoutErr error
+
+	require.NotPanics(t, func() {
+		shortCtx, cancel := context.WithTimeout(ctx, 1*time.Second)
+		defer cancel()
+
+		_, timeoutErr = infra.repo.FindOperationRouteIDsByTransactionRouteIDs(shortCtx, []uuid.UUID{trID})
+	}, "Phase 3: FindOperationRouteIDsByTransactionRouteIDs must not panic under high latency")
+
+	require.Error(t, timeoutErr, "Phase 3: junction query must return error when context deadline is exceeded")
+	t.Logf("Phase 3: received expected timeout error: %v", timeoutErr)
+
+	// Also verify that a longer deadline succeeds (the DB itself is still healthy).
+	t.Log("Phase 3 (supplementary): junction query with 10s deadline should succeed despite latency")
+
+	start = time.Now()
+
+	longCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	slowResult, slowErr := infra.repo.FindOperationRouteIDsByTransactionRouteIDs(longCtx, []uuid.UUID{trID})
+	slowElapsed := time.Since(start)
+
+	if slowErr == nil {
+		assert.Len(t, slowResult[trID], 2, "Phase 3: data should be correct despite latency")
+		assert.Greater(t, slowElapsed, 3*time.Second,
+			"Phase 3: latency should be noticeable (injected 5s, got %v)", slowElapsed)
+		t.Logf("Phase 3: slow junction query completed in %v", slowElapsed)
+	} else {
+		t.Logf("Phase 3: slow junction query also failed (acceptable under heavy jitter): %v", slowErr)
+	}
+
+	// --- Phase 4: Restore ---
+	// Remove all toxics to restore normal latency.
+	t.Log("Phase 4 (Restore): removing all toxics from proxy")
+
+	err = infra.proxy.RemoveAllToxics()
+	require.NoError(t, err, "Phase 4: RemoveAllToxics should not fail")
+
+	// --- Phase 5: Recovery ---
+	// After toxics are removed, operations must complete with normal latency.
+	t.Log("Phase 5 (Recovery): verifying junction query succeeds with normal latency after restore")
+
+	chaos.AssertRecoveryWithin(t, func() error {
+		recoveryCtx, recoveryCancel := context.WithTimeout(ctx, 5*time.Second)
+		defer recoveryCancel()
+
+		_, err := infra.repo.FindOperationRouteIDsByTransactionRouteIDs(recoveryCtx, []uuid.UUID{trID})
+		return err
+	}, 30*time.Second, "Phase 5: junction query should recover to normal latency after toxic removal")
+
+	start = time.Now()
+
+	recovered, err := infra.repo.FindOperationRouteIDsByTransactionRouteIDs(ctx, []uuid.UUID{trID})
+	recoveryLatency := time.Since(start)
+
+	require.NoError(t, err, "Phase 5: junction query must succeed after latency is removed")
+	assert.Len(t, recovered[trID], 2, "Phase 5: data integrity must be preserved")
+	t.Logf("Phase 5: recovery junction query completed in %v (baseline was %v)", recoveryLatency, baselineLatency)
+
+	t.Log("PASS: getDB handles high latency correctly via context timeout propagation")
+}
+
+// =============================================================================
+// NETWORK PARTITION (tenant path fails, static path fallback)
+// =============================================================================
+
+// TestIntegration_Chaos_TransactionRoute_NetworkPartition verifies that getDB
+// falls back gracefully when the network is partitioned. In a multi-tenant
+// scenario, if the tenant DB path fails, getDB should attempt the static
+// connection. In this chaos test, since both paths go through the same proxy,
+// we verify that:
+//   - FindOperationRouteIDsByTransactionRouteIDs fails gracefully during partition (no panic)
+//   - Data is recovered after partition heals
+//   - The getDB fallback logic (tenant -> static) does not mask errors silently
+//
+// 5-Phase structure:
+//  1. Normal   -- Junction query succeeds (both with and without tenant context)
+//  2. Inject   -- Network partition via Toxiproxy disconnect
+//  3. Verify   -- Operations fail gracefully, getDB returns error not panic
+//  4. Restore  -- Network partition healed via Toxiproxy reconnect
+//  5. Recovery -- Operations resume, data integrity confirmed
+func TestIntegration_Chaos_TransactionRoute_NetworkPartition(t *testing.T) {
+	if os.Getenv("CHAOS") != "1" {
+		t.Skip("Set CHAOS=1 to run chaos tests")
+	}
+
+	if testing.Short() {
+		t.Skip("Skipping chaos test in short mode")
+	}
+
+	infra := setupTransactionRouteChaosNetworkInfra(t)
+
+	ctx := context.Background()
+
+	// Build a tenant context that uses the same proxied DB (simulating the
+	// tenant path going through the same PostgreSQL instance).
+	tenantDB, err := infra.conn.Resolver(context.Background())
+	require.NoError(t, err, "setup: must be able to get DB from proxied connection")
+
+	tenantCtx := tmcore.ContextWithModulePGConnection(ctx, "transaction", tenantDB)
+
+	// --- Phase 1: Normal ---
+	// Verify operations work both with plain context (static path) and with
+	// tenant context (tenant path).
+	t.Log("Phase 1 (Normal): verifying operations succeed on both code paths")
+
+	trID, expectedOpRouteIDs := infra.createTransactionRouteWithLinks(t, "Chaos Partition TR", 2)
+
+	// 1a. Static path (no tenant in context).
+	staticResult, err := infra.repo.FindOperationRouteIDsByTransactionRouteIDs(ctx, []uuid.UUID{trID})
+	require.NoError(t, err, "Phase 1: static junction query should succeed")
+	assert.Len(t, staticResult[trID], 2, "Phase 1: static path should return 2 operation route IDs")
+
+	// 1b. Tenant path (tenant DB injected into context).
+	tenantResult, err := infra.repo.FindOperationRouteIDsByTransactionRouteIDs(tenantCtx, []uuid.UUID{trID})
+	require.NoError(t, err, "Phase 1: tenant junction query should succeed")
+	assert.Len(t, tenantResult[trID], 2, "Phase 1: tenant path should return 2 operation route IDs")
+
+	t.Logf("Phase 1: junction query for %s accessible via both static and tenant paths", trID)
+
+	// --- Phase 2: Inject ---
+	// Disconnect the proxy to simulate a network partition.
+	// Both tenant and static paths use the same proxied PostgreSQL, so both
+	// become unavailable simultaneously.
+	t.Log("Phase 2 (Inject): disconnecting Toxiproxy proxy to simulate network partition")
+
+	err = infra.proxy.Disconnect()
+	require.NoError(t, err, "Phase 2: Toxiproxy Disconnect should not fail")
+
+	// --- Phase 3: Verify ---
+	// Operations on both code paths must fail gracefully (return error, no panic).
+	t.Log("Phase 3 (Verify): operations must return error, not panic, during partition")
+
+	// 3a. Static path during partition.
+	var staticPartitionErr error
+
+	require.NotPanics(t, func() {
+		partitionCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
+		defer cancel()
+
+		_, staticPartitionErr = infra.repo.FindOperationRouteIDsByTransactionRouteIDs(partitionCtx, []uuid.UUID{trID})
+	}, "Phase 3: static junction query must not panic during partition")
+
+	if staticPartitionErr != nil {
+		t.Logf("Phase 3: static junction query returned expected error: %v", staticPartitionErr)
+	} else {
+		t.Log("Phase 3: static junction query succeeded (pool had cached connections)")
+	}
+
+	// 3b. Tenant path during partition.
+	var tenantPartitionErr error
+
+	require.NotPanics(t, func() {
+		partitionTenantCtx, cancel := context.WithTimeout(tenantCtx, 3*time.Second)
+		defer cancel()
+
+		_, tenantPartitionErr = infra.repo.FindOperationRouteIDsByTransactionRouteIDs(partitionTenantCtx, []uuid.UUID{trID})
+	}, "Phase 3: tenant junction query must not panic during partition")
+
+	if tenantPartitionErr != nil {
+		t.Logf("Phase 3: tenant junction query returned expected error: %v", tenantPartitionErr)
+	} else {
+		t.Log("Phase 3: tenant junction query succeeded (pool had cached connections)")
+	}
+
+	// 3c. FindByID during partition must not panic.
+	var findPartitionErr error
+
+	require.NotPanics(t, func() {
+		findCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
+		defer cancel()
+
+		_, findPartitionErr = infra.repo.FindByID(findCtx, infra.orgID, infra.ledgerID, trID)
+	}, "Phase 3: FindByID must not panic during partition")
+
+	if findPartitionErr != nil {
+		t.Logf("Phase 3: FindByID returned expected error: %v", findPartitionErr)
+	} else {
+		t.Log("Phase 3: FindByID succeeded (pool had cached connections)")
+	}
+
+	// --- Phase 4: Restore ---
+	// Reconnect the proxy to heal the network partition.
+	t.Log("Phase 4 (Restore): reconnecting Toxiproxy proxy to heal partition")
+
+	err = infra.proxy.Reconnect()
+	require.NoError(t, err, "Phase 4: Toxiproxy Reconnect should not fail")
+
+	// --- Phase 5: Recovery ---
+	// After partition heals, both paths must work again.
+	t.Log("Phase 5 (Recovery): verifying operations resume on both paths")
+
+	// 5a. Static path recovery.
+	chaos.AssertRecoveryWithin(t, func() error {
+		_, err := infra.repo.FindOperationRouteIDsByTransactionRouteIDs(ctx, []uuid.UUID{trID})
+		return err
+	}, 30*time.Second, "Phase 5: static junction query should recover after partition heals")
+
+	// 5b. Tenant path recovery.
+	chaos.AssertRecoveryWithin(t, func() error {
+		_, err := infra.repo.FindOperationRouteIDsByTransactionRouteIDs(tenantCtx, []uuid.UUID{trID})
+		return err
+	}, 30*time.Second, "Phase 5: tenant junction query should recover after partition heals")
+
+	// 5c. Data integrity verification.
+	recoveredResult, err := infra.repo.FindOperationRouteIDsByTransactionRouteIDs(ctx, []uuid.UUID{trID})
+	require.NoError(t, err, "Phase 5: junction query must succeed after partition recovery")
+	require.Len(t, recoveredResult[trID], 2, "Phase 5: should still have 2 operation route IDs after recovery")
+
+	recoveredIDs := make(map[uuid.UUID]bool)
+	for _, id := range recoveredResult[trID] {
+		recoveredIDs[id] = true
+	}
+
+	for _, expectedID := range expectedOpRouteIDs {
+		assert.True(t, recoveredIDs[expectedID],
+			"Phase 5: operation route %s must be preserved after partition recovery", expectedID)
+	}
+
+	t.Log("PASS: getDB falls back gracefully during network partition, both paths recover")
+}

--- a/components/ledger/internal/adapters/postgres/transactionroute/transactionroute.postgresql_chaos_test.go
+++ b/components/ledger/internal/adapters/postgres/transactionroute/transactionroute.postgresql_chaos_test.go
@@ -19,6 +19,7 @@ package transactionroute
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"testing"
 	"time"
@@ -117,7 +118,7 @@ func (infra *chaosNetworkTransactionRouteInfra) createTransactionRouteWithLinks(
 
 	for i := 0; i < opRouteCount; i++ {
 		opRouteID := pgtestutil.CreateTestOperationRouteSimple(t, infra.pgResult.DB, infra.orgID, infra.ledgerID,
-			title+" OpRoute "+string(rune('A'+i)), "source")
+			fmt.Sprintf("%s OpRoute %d", title, i+1), "source")
 		pgtestutil.CreateTestOperationTransactionRouteLink(t, infra.pgResult.DB, opRouteID, trID)
 
 		opRouteIDs = append(opRouteIDs, opRouteID)

--- a/components/ledger/internal/adapters/postgres/transactionroute/transactionroute.postgresql_integration_test.go
+++ b/components/ledger/internal/adapters/postgres/transactionroute/transactionroute.postgresql_integration_test.go
@@ -771,3 +771,277 @@ func TestIntegration_TransactionRouteRepository_FindAll_IsolatedByOrganization(t
 	assert.Len(t, routes, 1, "should only return routes from org1")
 	assert.Equal(t, "Org1 Route", routes[0].Title, "should be org1's route")
 }
+
+// ============================================================================
+// FindOperationRouteIDsByTransactionRouteIDs Tests (T-010)
+// ============================================================================
+
+func TestIntegration_TransactionRouteRepository_FindOperationRouteIDsByTransactionRouteIDs_MultipleRoutes(t *testing.T) {
+	container := pgtestutil.SetupContainer(t)
+	repo := createRepository(t, container)
+
+	orgID := uuid.Must(libCommons.GenerateUUIDv7())
+	ledgerID := uuid.Must(libCommons.GenerateUUIDv7())
+
+	ctx := context.Background()
+
+	// Create 3 transaction routes
+	trID1 := pgtestutil.CreateTestTransactionRouteSimple(t, container.DB, orgID, ledgerID, "TR with 2 OpRoutes")
+	trID2 := pgtestutil.CreateTestTransactionRouteSimple(t, container.DB, orgID, ledgerID, "TR with 1 OpRoute")
+	trID3 := pgtestutil.CreateTestTransactionRouteSimple(t, container.DB, orgID, ledgerID, "TR with 0 OpRoutes")
+
+	// Create operation routes
+	opRouteA := pgtestutil.CreateTestOperationRouteSimple(t, container.DB, orgID, ledgerID, "OpRoute A", "source")
+	opRouteB := pgtestutil.CreateTestOperationRouteSimple(t, container.DB, orgID, ledgerID, "OpRoute B", "destination")
+	opRouteC := pgtestutil.CreateTestOperationRouteSimple(t, container.DB, orgID, ledgerID, "OpRoute C", "source")
+
+	// Link: trID1 -> opRouteA, opRouteB; trID2 -> opRouteC; trID3 -> nothing
+	pgtestutil.CreateTestOperationTransactionRouteLink(t, container.DB, opRouteA, trID1)
+	pgtestutil.CreateTestOperationTransactionRouteLink(t, container.DB, opRouteB, trID1)
+	pgtestutil.CreateTestOperationTransactionRouteLink(t, container.DB, opRouteC, trID2)
+
+	// Act
+	result, err := repo.FindOperationRouteIDsByTransactionRouteIDs(ctx, []uuid.UUID{trID1, trID2, trID3})
+
+	// Assert
+	require.NoError(t, err, "FindOperationRouteIDsByTransactionRouteIDs should not return error")
+	require.NotNil(t, result, "result map should not be nil")
+
+	// trID1 should have opRouteA and opRouteB
+	require.Len(t, result[trID1], 2, "trID1 should have 2 operation route links")
+	orIDs1 := make(map[uuid.UUID]bool)
+	for _, id := range result[trID1] {
+		orIDs1[id] = true
+	}
+	assert.True(t, orIDs1[opRouteA], "trID1 should contain opRouteA")
+	assert.True(t, orIDs1[opRouteB], "trID1 should contain opRouteB")
+
+	// trID2 should have opRouteC
+	require.Len(t, result[trID2], 1, "trID2 should have 1 operation route link")
+	assert.Equal(t, opRouteC, result[trID2][0], "trID2 should contain opRouteC")
+
+	// trID3 should have no entries in the map (key absent or empty slice)
+	assert.Empty(t, result[trID3], "trID3 should have no operation route links")
+}
+
+func TestIntegration_TransactionRouteRepository_FindOperationRouteIDsByTransactionRouteIDs_EmptyInput(t *testing.T) {
+	container := pgtestutil.SetupContainer(t)
+	repo := createRepository(t, container)
+
+	ctx := context.Background()
+
+	// Act - pass empty slice
+	result, err := repo.FindOperationRouteIDsByTransactionRouteIDs(ctx, []uuid.UUID{})
+
+	// Assert
+	require.NoError(t, err, "FindOperationRouteIDsByTransactionRouteIDs with empty input should not return error")
+	require.NotNil(t, result, "result should be empty map, not nil")
+	assert.Empty(t, result, "result should have no entries")
+}
+
+func TestIntegration_TransactionRouteRepository_FindOperationRouteIDsByTransactionRouteIDs_NilInput(t *testing.T) {
+	container := pgtestutil.SetupContainer(t)
+	repo := createRepository(t, container)
+
+	ctx := context.Background()
+
+	// Act - pass nil slice
+	result, err := repo.FindOperationRouteIDsByTransactionRouteIDs(ctx, nil)
+
+	// Assert
+	require.NoError(t, err, "FindOperationRouteIDsByTransactionRouteIDs with nil input should not return error")
+	require.NotNil(t, result, "result should be empty map, not nil")
+	assert.Empty(t, result, "result should have no entries")
+}
+
+func TestIntegration_TransactionRouteRepository_FindOperationRouteIDsByTransactionRouteIDs_NoMatchingJunctionRows(t *testing.T) {
+	container := pgtestutil.SetupContainer(t)
+	repo := createRepository(t, container)
+
+	orgID := uuid.Must(libCommons.GenerateUUIDv7())
+	ledgerID := uuid.Must(libCommons.GenerateUUIDv7())
+
+	ctx := context.Background()
+
+	// Create transaction routes but do NOT create any junction links
+	trID1 := pgtestutil.CreateTestTransactionRouteSimple(t, container.DB, orgID, ledgerID, "Unlinked Route 1")
+	trID2 := pgtestutil.CreateTestTransactionRouteSimple(t, container.DB, orgID, ledgerID, "Unlinked Route 2")
+
+	// Act
+	result, err := repo.FindOperationRouteIDsByTransactionRouteIDs(ctx, []uuid.UUID{trID1, trID2})
+
+	// Assert
+	require.NoError(t, err, "FindOperationRouteIDsByTransactionRouteIDs should not return error for unlinked routes")
+	require.NotNil(t, result, "result should be empty map, not nil")
+	assert.Empty(t, result, "result should have no entries when no junction rows exist")
+}
+
+func TestIntegration_TransactionRouteRepository_FindOperationRouteIDsByTransactionRouteIDs_NonExistentIDs(t *testing.T) {
+	container := pgtestutil.SetupContainer(t)
+	repo := createRepository(t, container)
+
+	ctx := context.Background()
+
+	// IDs that don't exist in the database at all
+	fakeID1 := uuid.Must(libCommons.GenerateUUIDv7())
+	fakeID2 := uuid.Must(libCommons.GenerateUUIDv7())
+
+	// Act
+	result, err := repo.FindOperationRouteIDsByTransactionRouteIDs(ctx, []uuid.UUID{fakeID1, fakeID2})
+
+	// Assert
+	require.NoError(t, err, "FindOperationRouteIDsByTransactionRouteIDs should not error for non-existent IDs")
+	require.NotNil(t, result, "result should be empty map, not nil")
+	assert.Empty(t, result, "result should have no entries for non-existent IDs")
+}
+
+func TestIntegration_TransactionRouteRepository_FindOperationRouteIDsByTransactionRouteIDs_ExcludesSoftDeletedLinks(t *testing.T) {
+	container := pgtestutil.SetupContainer(t)
+	repo := createRepository(t, container)
+
+	orgID := uuid.Must(libCommons.GenerateUUIDv7())
+	ledgerID := uuid.Must(libCommons.GenerateUUIDv7())
+
+	ctx := context.Background()
+
+	// Create transaction route
+	trID := pgtestutil.CreateTestTransactionRouteSimple(t, container.DB, orgID, ledgerID, "TR with mixed links")
+
+	// Create operation routes
+	opRouteActive := pgtestutil.CreateTestOperationRouteSimple(t, container.DB, orgID, ledgerID, "Active Link", "source")
+	opRouteDeleted := pgtestutil.CreateTestOperationRouteSimple(t, container.DB, orgID, ledgerID, "Deleted Link", "destination")
+
+	// Create links - one active, one soft-deleted
+	pgtestutil.CreateTestOperationTransactionRouteLink(t, container.DB, opRouteActive, trID)
+	softDeletedLinkID := pgtestutil.CreateTestOperationTransactionRouteLink(t, container.DB, opRouteDeleted, trID)
+	pgtestutil.SoftDeleteOperationTransactionRouteLink(t, container.DB, softDeletedLinkID)
+
+	// Act
+	result, err := repo.FindOperationRouteIDsByTransactionRouteIDs(ctx, []uuid.UUID{trID})
+
+	// Assert
+	require.NoError(t, err, "FindOperationRouteIDsByTransactionRouteIDs should not return error")
+	require.NotNil(t, result, "result map should not be nil")
+	require.Len(t, result[trID], 1, "should only return 1 active link, soft-deleted excluded")
+	assert.Equal(t, opRouteActive, result[trID][0], "active operation route should be present")
+}
+
+// ============================================================================
+// Enrichment Round-Trip Test (T-010: IS-4)
+// ============================================================================
+
+func TestIntegration_TransactionRouteRepository_FindAll_EnrichmentRoundTrip(t *testing.T) {
+	container := pgtestutil.SetupContainer(t)
+	repo := createRepository(t, container)
+
+	orgID := uuid.Must(libCommons.GenerateUUIDv7())
+	ledgerID := uuid.Must(libCommons.GenerateUUIDv7())
+
+	ctx := context.Background()
+
+	// Create 2 transaction routes
+	trID1 := pgtestutil.CreateTestTransactionRouteSimple(t, container.DB, orgID, ledgerID, "Enriched Route A")
+	trID2 := pgtestutil.CreateTestTransactionRouteSimple(t, container.DB, orgID, ledgerID, "Enriched Route B")
+
+	// Create operation routes
+	opRouteA := pgtestutil.CreateTestOperationRouteSimple(t, container.DB, orgID, ledgerID, "OpRoute Alpha", "source")
+	opRouteB := pgtestutil.CreateTestOperationRouteSimple(t, container.DB, orgID, ledgerID, "OpRoute Beta", "destination")
+
+	// Link: trID1 -> opRouteA & opRouteB; trID2 -> none
+	pgtestutil.CreateTestOperationTransactionRouteLink(t, container.DB, opRouteA, trID1)
+	pgtestutil.CreateTestOperationTransactionRouteLink(t, container.DB, opRouteB, trID1)
+
+	// Step 1: FindAll to get all transaction routes
+	startDate := time.Now().Add(-24 * time.Hour)
+	endDate := time.Now().Add(24 * time.Hour)
+	filter := http.Pagination{
+		Limit:     10,
+		StartDate: startDate,
+		EndDate:   endDate,
+	}
+
+	routes, _, err := repo.FindAll(ctx, orgID, ledgerID, filter)
+	require.NoError(t, err, "FindAll should not return error")
+	require.Len(t, routes, 2, "should return both transaction routes")
+
+	// Step 2: Use FindOperationRouteIDsByTransactionRouteIDs to enrich
+	trIDs := make([]uuid.UUID, len(routes))
+	for i, r := range routes {
+		trIDs[i] = r.ID
+	}
+
+	junctionMap, err := repo.FindOperationRouteIDsByTransactionRouteIDs(ctx, trIDs)
+	require.NoError(t, err, "FindOperationRouteIDsByTransactionRouteIDs should not return error")
+
+	// Step 3: Verify the junction map
+	// trID1 should have 2 operation route IDs
+	require.Len(t, junctionMap[trID1], 2, "trID1 should have 2 operation route IDs in junction map")
+
+	orIDs := make(map[uuid.UUID]bool)
+	for _, id := range junctionMap[trID1] {
+		orIDs[id] = true
+	}
+	assert.True(t, orIDs[opRouteA], "trID1 junction should include opRouteA")
+	assert.True(t, orIDs[opRouteB], "trID1 junction should include opRouteB")
+
+	// trID2 should have no entries
+	assert.Empty(t, junctionMap[trID2], "trID2 should have no operation route IDs in junction map")
+}
+
+// ============================================================================
+// Enrichment with Soft-Deleted Junction Rows (T-010: IS-5)
+// ============================================================================
+
+func TestIntegration_TransactionRouteRepository_FindAll_EnrichmentExcludesSoftDeletedJunctionRows(t *testing.T) {
+	container := pgtestutil.SetupContainer(t)
+	repo := createRepository(t, container)
+
+	orgID := uuid.Must(libCommons.GenerateUUIDv7())
+	ledgerID := uuid.Must(libCommons.GenerateUUIDv7())
+
+	ctx := context.Background()
+
+	// Create transaction route
+	trID := pgtestutil.CreateTestTransactionRouteSimple(t, container.DB, orgID, ledgerID, "TR Soft Delete Test")
+
+	// Create 3 operation routes
+	opRouteKeep1 := pgtestutil.CreateTestOperationRouteSimple(t, container.DB, orgID, ledgerID, "Keep 1", "source")
+	opRouteKeep2 := pgtestutil.CreateTestOperationRouteSimple(t, container.DB, orgID, ledgerID, "Keep 2", "destination")
+	opRouteSoftDeleted := pgtestutil.CreateTestOperationRouteSimple(t, container.DB, orgID, ledgerID, "Soft Deleted", "source")
+
+	// Create links
+	pgtestutil.CreateTestOperationTransactionRouteLink(t, container.DB, opRouteKeep1, trID)
+	pgtestutil.CreateTestOperationTransactionRouteLink(t, container.DB, opRouteKeep2, trID)
+	softDeletedLinkID := pgtestutil.CreateTestOperationTransactionRouteLink(t, container.DB, opRouteSoftDeleted, trID)
+
+	// Soft-delete one of the junction links
+	pgtestutil.SoftDeleteOperationTransactionRouteLink(t, container.DB, softDeletedLinkID)
+
+	// Step 1: FindAll
+	startDate := time.Now().Add(-24 * time.Hour)
+	endDate := time.Now().Add(24 * time.Hour)
+	filter := http.Pagination{
+		Limit:     10,
+		StartDate: startDate,
+		EndDate:   endDate,
+	}
+
+	routes, _, err := repo.FindAll(ctx, orgID, ledgerID, filter)
+	require.NoError(t, err, "FindAll should not return error")
+	require.Len(t, routes, 1, "should return the transaction route")
+
+	// Step 2: Use FindOperationRouteIDsByTransactionRouteIDs to enrich
+	junctionMap, err := repo.FindOperationRouteIDsByTransactionRouteIDs(ctx, []uuid.UUID{trID})
+	require.NoError(t, err, "FindOperationRouteIDsByTransactionRouteIDs should not return error")
+
+	// Assert: only 2 active links returned, soft-deleted link excluded
+	require.Len(t, junctionMap[trID], 2, "should only have 2 active junction links")
+
+	activeIDs := make(map[uuid.UUID]bool)
+	for _, id := range junctionMap[trID] {
+		activeIDs[id] = true
+	}
+	assert.True(t, activeIDs[opRouteKeep1], "active link opRouteKeep1 should be present")
+	assert.True(t, activeIDs[opRouteKeep2], "active link opRouteKeep2 should be present")
+	assert.False(t, activeIDs[opRouteSoftDeleted], "soft-deleted link opRouteSoftDeleted should be excluded")
+}

--- a/components/ledger/internal/adapters/postgres/transactionroute/transactionroute.postgresql_mock.go
+++ b/components/ledger/internal/adapters/postgres/transactionroute/transactionroute.postgresql_mock.go
@@ -103,6 +103,21 @@ func (mr *MockRepositoryMockRecorder) FindByID(arg0, arg1, arg2, arg3 any) *gomo
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindByID", reflect.TypeOf((*MockRepository)(nil).FindByID), arg0, arg1, arg2, arg3)
 }
 
+// FindOperationRouteIDsByTransactionRouteIDs mocks base method.
+func (m *MockRepository) FindOperationRouteIDsByTransactionRouteIDs(arg0 context.Context, arg1 []uuid.UUID) (map[uuid.UUID][]uuid.UUID, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FindOperationRouteIDsByTransactionRouteIDs", arg0, arg1)
+	ret0, _ := ret[0].(map[uuid.UUID][]uuid.UUID)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// FindOperationRouteIDsByTransactionRouteIDs indicates an expected call of FindOperationRouteIDsByTransactionRouteIDs.
+func (mr *MockRepositoryMockRecorder) FindOperationRouteIDsByTransactionRouteIDs(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindOperationRouteIDsByTransactionRouteIDs", reflect.TypeOf((*MockRepository)(nil).FindOperationRouteIDsByTransactionRouteIDs), arg0, arg1)
+}
+
 // Update mocks base method.
 func (m *MockRepository) Update(arg0 context.Context, arg1, arg2, arg3 uuid.UUID, arg4 *mmodel.TransactionRoute, arg5, arg6 []uuid.UUID) (*mmodel.TransactionRoute, error) {
 	m.ctrl.T.Helper()

--- a/components/ledger/internal/services/query/enrich-transaction-routes.go
+++ b/components/ledger/internal/services/query/enrich-transaction-routes.go
@@ -1,0 +1,111 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package query
+
+import (
+	"context"
+	"fmt"
+
+	libCommons "github.com/LerianStudio/lib-commons/v4/commons"
+	libLog "github.com/LerianStudio/lib-commons/v4/commons/log"
+	libOpentelemetry "github.com/LerianStudio/lib-commons/v4/commons/opentelemetry"
+	"github.com/LerianStudio/midaz/v3/pkg/mmodel"
+	"github.com/google/uuid"
+)
+
+// enrichTransactionRoutesWithOperationRoutes performs a post-query batch enrichment
+// of transaction routes with their linked OperationRoute objects.
+// It executes at most 2 additional queries (junction + batch FindByIDs) regardless of
+// result size, avoiding N+1 query problems.
+//
+// Each transaction route in the slice will have its OperationRoutes field set:
+//   - populated []OperationRoute when links exist
+//   - empty []OperationRoute{} (not nil) when no links exist
+func (uc *UseCase) enrichTransactionRoutesWithOperationRoutes(ctx context.Context, transactionRoutes []*mmodel.TransactionRoute) error {
+	logger, tracer, _, _ := libCommons.NewTrackingFromContext(ctx)
+
+	ctx, span := tracer.Start(ctx, "query.enrich_transaction_routes_with_operation_routes")
+	defer span.End()
+
+	if len(transactionRoutes) == 0 {
+		return nil
+	}
+
+	// Step 1: Collect all transaction route IDs
+	trIDs := make([]uuid.UUID, len(transactionRoutes))
+	for i, tr := range transactionRoutes {
+		trIDs[i] = tr.ID
+	}
+
+	// Step 2: Batch query junction table
+	junctionMap, err := uc.TransactionRouteRepo.FindOperationRouteIDsByTransactionRouteIDs(ctx, trIDs)
+	if err != nil {
+		libOpentelemetry.HandleSpanError(span, "Failed to fetch operation route IDs from junction table", err)
+
+		logger.Log(ctx, libLog.LevelError, fmt.Sprintf("Failed to fetch operation route IDs from junction table: %v", err))
+
+		return err
+	}
+
+	// Step 3: Collect all unique operation route IDs
+	uniqueORIDs := make(map[uuid.UUID]struct{})
+
+	for _, orIDs := range junctionMap {
+		for _, orID := range orIDs {
+			uniqueORIDs[orID] = struct{}{}
+		}
+	}
+
+	// Step 4: Batch fetch operation route objects (only if there are any)
+	orMap := make(map[uuid.UUID]*mmodel.OperationRoute)
+
+	if len(uniqueORIDs) > 0 {
+		orIDSlice := make([]uuid.UUID, 0, len(uniqueORIDs))
+		for orID := range uniqueORIDs {
+			orIDSlice = append(orIDSlice, orID)
+		}
+
+		// Use the first transaction route's org/ledger IDs (all share the same scope)
+		orgID := transactionRoutes[0].OrganizationID
+		ledgerID := transactionRoutes[0].LedgerID
+
+		opRoutes, err := uc.OperationRouteRepo.FindByIDs(ctx, orgID, ledgerID, orIDSlice)
+		if err != nil {
+			libOpentelemetry.HandleSpanError(span, "Failed to batch fetch operation routes", err)
+
+			logger.Log(ctx, libLog.LevelError, fmt.Sprintf("Failed to batch fetch operation routes: %v", err))
+
+			return err
+		}
+
+		for _, or := range opRoutes {
+			orMap[or.ID] = or
+		}
+	}
+
+	// Step 5: Assign operation routes to their parent transaction routes
+	for _, tr := range transactionRoutes {
+		orIDs, exists := junctionMap[tr.ID]
+		if !exists || len(orIDs) == 0 {
+			tr.OperationRoutes = make([]mmodel.OperationRoute, 0)
+
+			continue
+		}
+
+		routes := make([]mmodel.OperationRoute, 0, len(orIDs))
+
+		for _, orID := range orIDs {
+			if or, ok := orMap[orID]; ok {
+				routes = append(routes, *or)
+			}
+		}
+
+		tr.OperationRoutes = routes
+	}
+
+	logger.Log(ctx, libLog.LevelDebug, fmt.Sprintf("Enriched %d transaction routes with operation routes", len(transactionRoutes)))
+
+	return nil
+}

--- a/components/ledger/internal/services/query/enrich-transaction-routes_fuzz_test.go
+++ b/components/ledger/internal/services/query/enrich-transaction-routes_fuzz_test.go
@@ -1,0 +1,348 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package query
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/LerianStudio/midaz/v3/components/ledger/internal/adapters/postgres/operationroute"
+	"github.com/LerianStudio/midaz/v3/components/ledger/internal/adapters/postgres/transactionroute"
+	"github.com/LerianStudio/midaz/v3/pkg/mmodel"
+	"github.com/google/uuid"
+	"go.uber.org/mock/gomock"
+)
+
+// FuzzEnrichTransactionRoutes_SliceSize exercises the enrichment function with
+// varying numbers of transaction routes (0 to N), varying junction mappings, and
+// varying operation route results. The function must never panic regardless of
+// input size or the shape of the mock-returned data.
+//
+// Fuzz inputs:
+//   - numRoutes: number of transaction routes to create (bounded to 200)
+//   - junctionMissRate: percentage (0-100) of routes that have NO junction entry
+//   - opRouteMissRate: percentage (0-100) of junction entries whose operation
+//     route is missing from the FindByIDs result (simulates partial fetch)
+//   - junctionError: if true, the junction query returns an error
+//   - findByIDsError: if true, the FindByIDs batch query returns an error
+func FuzzEnrichTransactionRoutes_SliceSize(f *testing.F) {
+	// Seed 1: empty slice (boundary — zero routes)
+	f.Add(uint8(0), uint8(0), uint8(0), false, false)
+
+	// Seed 2: single route, all linked, no errors (valid — minimal happy path)
+	f.Add(uint8(1), uint8(0), uint8(0), false, false)
+
+	// Seed 3: many routes, all linked, no errors (boundary — large input)
+	f.Add(uint8(200), uint8(0), uint8(0), false, false)
+
+	// Seed 4: many routes, 100% junction miss (empty junction map)
+	f.Add(uint8(50), uint8(100), uint8(0), false, false)
+
+	// Seed 5: many routes with partial opRoute misses (data inconsistency)
+	f.Add(uint8(30), uint8(20), uint8(50), false, false)
+
+	// Seed 6: junction query error path
+	f.Add(uint8(10), uint8(0), uint8(0), true, false)
+
+	// Seed 7: FindByIDs error path
+	f.Add(uint8(10), uint8(0), uint8(0), false, true)
+
+	// Seed 8: single route, junction error (security — error on smallest input)
+	f.Add(uint8(1), uint8(0), uint8(0), true, false)
+
+	// Seed 9: maximum miss rates (boundary — worst case data quality)
+	f.Add(uint8(100), uint8(100), uint8(100), false, false)
+
+	f.Fuzz(func(t *testing.T, numRoutes uint8, junctionMissRate uint8, opRouteMissRate uint8, junctionError bool, findByIDsError bool) {
+		// Input bounding: cap route count to prevent excessive allocations
+		if numRoutes > 200 {
+			numRoutes = 200
+		}
+
+		// Normalize miss rates to 0-100
+		jmr := junctionMissRate % 101
+		omr := opRouteMissRate % 101
+
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockTRRepo := transactionroute.NewMockRepository(ctrl)
+		mockORRepo := operationroute.NewMockRepository(ctrl)
+
+		uc := &UseCase{
+			TransactionRouteRepo: mockTRRepo,
+			OperationRouteRepo:   mockORRepo,
+		}
+
+		orgID := uuid.New()
+		ledgerID := uuid.New()
+
+		// Build the input slice of transaction routes
+		routes := make([]*mmodel.TransactionRoute, int(numRoutes))
+		for i := range routes {
+			routes[i] = &mmodel.TransactionRoute{
+				ID:             uuid.New(),
+				OrganizationID: orgID,
+				LedgerID:       ledgerID,
+				Title:          "fuzz-route",
+			}
+		}
+
+		// If empty slice, enrichment returns early — no mock expectations needed
+		if numRoutes == 0 {
+			err := uc.enrichTransactionRoutesWithOperationRoutes(context.Background(), routes)
+			if err != nil {
+				t.Errorf("expected nil error for empty slice, got: %v", err)
+			}
+
+			return
+		}
+
+		// Build junction map based on miss rate
+		junctionMap := make(map[uuid.UUID][]uuid.UUID)
+		var allORIDs []uuid.UUID
+
+		for i, tr := range routes {
+			// Deterministic miss: routes at indices < (jmr% of total) are missed
+			if uint8(i*100/int(numRoutes)) < jmr {
+				continue // Not in junction map — simulates no links
+			}
+
+			orID := uuid.New()
+			junctionMap[tr.ID] = []uuid.UUID{orID}
+			allORIDs = append(allORIDs, orID)
+		}
+
+		if junctionError {
+			mockTRRepo.EXPECT().
+				FindOperationRouteIDsByTransactionRouteIDs(gomock.Any(), gomock.Any()).
+				Return(nil, errors.New("fuzz junction error"))
+
+			err := uc.enrichTransactionRoutesWithOperationRoutes(context.Background(), routes)
+			if err == nil {
+				t.Error("expected error from junction query, got nil")
+			}
+
+			return
+		}
+
+		mockTRRepo.EXPECT().
+			FindOperationRouteIDsByTransactionRouteIDs(gomock.Any(), gomock.Any()).
+			Return(junctionMap, nil)
+
+		// Build operation routes result based on opRoute miss rate
+		if len(allORIDs) > 0 {
+			var opRoutes []*mmodel.OperationRoute
+
+			for i, orID := range allORIDs {
+				// Deterministic miss: entries at indices < (omr% of total) are omitted
+				if len(allORIDs) > 0 && uint8(i*100/len(allORIDs)) < omr {
+					continue // Missing from FindByIDs result — simulates partial fetch
+				}
+
+				opRoutes = append(opRoutes, &mmodel.OperationRoute{
+					ID:             orID,
+					OrganizationID: orgID,
+					LedgerID:       ledgerID,
+					Title:          "fuzz-op",
+					OperationType:  "source",
+				})
+			}
+
+			if findByIDsError {
+				mockORRepo.EXPECT().
+					FindByIDs(gomock.Any(), orgID, ledgerID, gomock.Any()).
+					Return(nil, errors.New("fuzz findByIDs error"))
+
+				err := uc.enrichTransactionRoutesWithOperationRoutes(context.Background(), routes)
+				if err == nil {
+					t.Error("expected error from FindByIDs, got nil")
+				}
+
+				return
+			}
+
+			mockORRepo.EXPECT().
+				FindByIDs(gomock.Any(), orgID, ledgerID, gomock.Any()).
+				Return(opRoutes, nil)
+		}
+
+		// Primary property: the function must NEVER panic
+		err := uc.enrichTransactionRoutesWithOperationRoutes(context.Background(), routes)
+
+		// Secondary property: on success, every route must have a non-nil OperationRoutes slice
+		if err == nil {
+			for i, tr := range routes {
+				if tr.OperationRoutes == nil {
+					t.Errorf("route[%d] (%s) has nil OperationRoutes after successful enrichment", i, tr.ID)
+				}
+			}
+		}
+	})
+}
+
+// FuzzEnrichTransactionRoutes_JunctionMapShape exercises the enrichment function
+// with varying junction map shapes: routes pointing to many operation routes,
+// duplicate operation route IDs across transaction routes, and empty slices in
+// the junction map. The function must never panic and must always produce
+// non-nil OperationRoutes slices on success.
+//
+// Fuzz inputs:
+//   - numRoutes: number of transaction routes (bounded to 50)
+//   - opsPerRoute: number of operation route IDs per junction entry (bounded to 20)
+//   - sharedOps: whether all routes share the same set of operation route IDs
+//   - includeEmptySlices: whether some junction entries have empty []uuid.UUID
+func FuzzEnrichTransactionRoutes_JunctionMapShape(f *testing.F) {
+	// Seed 1: single route, single op (minimal valid case)
+	f.Add(uint8(1), uint8(1), false, false)
+
+	// Seed 2: many routes, many ops, no sharing (wide junction map)
+	f.Add(uint8(50), uint8(20), false, false)
+
+	// Seed 3: many routes sharing same ops (deduplication stress test)
+	f.Add(uint8(30), uint8(5), true, false)
+
+	// Seed 4: routes with empty junction slices mixed in
+	f.Add(uint8(20), uint8(3), false, true)
+
+	// Seed 5: single route, max ops per route (boundary)
+	f.Add(uint8(1), uint8(20), false, false)
+
+	// Seed 6: zero routes (boundary — empty slice)
+	f.Add(uint8(0), uint8(5), false, false)
+
+	// Seed 7: all routes share ops AND have empty slices mixed in
+	f.Add(uint8(15), uint8(10), true, true)
+
+	f.Fuzz(func(t *testing.T, numRoutes uint8, opsPerRoute uint8, sharedOps bool, includeEmptySlices bool) {
+		// Input bounding
+		if numRoutes > 50 {
+			numRoutes = 50
+		}
+
+		if opsPerRoute > 20 {
+			opsPerRoute = 20
+		}
+
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockTRRepo := transactionroute.NewMockRepository(ctrl)
+		mockORRepo := operationroute.NewMockRepository(ctrl)
+
+		uc := &UseCase{
+			TransactionRouteRepo: mockTRRepo,
+			OperationRouteRepo:   mockORRepo,
+		}
+
+		orgID := uuid.New()
+		ledgerID := uuid.New()
+
+		routes := make([]*mmodel.TransactionRoute, int(numRoutes))
+		for i := range routes {
+			routes[i] = &mmodel.TransactionRoute{
+				ID:             uuid.New(),
+				OrganizationID: orgID,
+				LedgerID:       ledgerID,
+				Title:          "fuzz-shape-route",
+			}
+		}
+
+		if numRoutes == 0 {
+			err := uc.enrichTransactionRoutesWithOperationRoutes(context.Background(), routes)
+			if err != nil {
+				t.Errorf("expected nil error for empty slice, got: %v", err)
+			}
+
+			return
+		}
+
+		// Build a shared pool of operation route IDs (used when sharedOps=true)
+		sharedORIDs := make([]uuid.UUID, int(opsPerRoute))
+		for i := range sharedORIDs {
+			sharedORIDs[i] = uuid.New()
+		}
+
+		// Build junction map
+		junctionMap := make(map[uuid.UUID][]uuid.UUID)
+		uniqueORIDs := make(map[uuid.UUID]struct{})
+
+		for i, tr := range routes {
+			// Mix in empty slices for even-indexed routes when includeEmptySlices=true
+			if includeEmptySlices && i%2 == 0 {
+				junctionMap[tr.ID] = []uuid.UUID{}
+
+				continue
+			}
+
+			var orIDs []uuid.UUID
+			if sharedOps {
+				orIDs = make([]uuid.UUID, len(sharedORIDs))
+				copy(orIDs, sharedORIDs)
+			} else {
+				orIDs = make([]uuid.UUID, int(opsPerRoute))
+				for j := range orIDs {
+					orIDs[j] = uuid.New()
+				}
+			}
+
+			junctionMap[tr.ID] = orIDs
+
+			for _, id := range orIDs {
+				uniqueORIDs[id] = struct{}{}
+			}
+		}
+
+		mockTRRepo.EXPECT().
+			FindOperationRouteIDsByTransactionRouteIDs(gomock.Any(), gomock.Any()).
+			Return(junctionMap, nil)
+
+		// Build the full set of operation routes matching all unique IDs
+		if len(uniqueORIDs) > 0 {
+			var opRoutes []*mmodel.OperationRoute
+			for orID := range uniqueORIDs {
+				opRoutes = append(opRoutes, &mmodel.OperationRoute{
+					ID:             orID,
+					OrganizationID: orgID,
+					LedgerID:       ledgerID,
+					Title:          "fuzz-shape-op",
+					OperationType:  "source",
+				})
+			}
+
+			mockORRepo.EXPECT().
+				FindByIDs(gomock.Any(), orgID, ledgerID, gomock.Any()).
+				Return(opRoutes, nil)
+		}
+
+		// Primary property: no panic
+		err := uc.enrichTransactionRoutesWithOperationRoutes(context.Background(), routes)
+
+		// Secondary properties on success:
+		if err == nil {
+			for i, tr := range routes {
+				// Non-nil OperationRoutes
+				if tr.OperationRoutes == nil {
+					t.Errorf("route[%d] (%s) has nil OperationRoutes after successful enrichment", i, tr.ID)
+				}
+
+				// Routes with empty junction entries should have 0 operation routes
+				jOrIDs := junctionMap[tr.ID]
+				if len(jOrIDs) == 0 && len(tr.OperationRoutes) != 0 {
+					t.Errorf("route[%d] (%s) expected 0 operation routes (empty junction), got %d",
+						i, tr.ID, len(tr.OperationRoutes))
+				}
+
+				// Routes with non-empty junction entries should have <= len(jOrIDs) operation routes
+				// (could be less if FindByIDs returned fewer, but never more)
+				if len(jOrIDs) > 0 && len(tr.OperationRoutes) > len(jOrIDs) {
+					t.Errorf("route[%d] (%s) has %d operation routes but junction only has %d entries",
+						i, tr.ID, len(tr.OperationRoutes), len(jOrIDs))
+				}
+			}
+		}
+	})
+}

--- a/components/ledger/internal/services/query/enrich-transaction-routes_property_test.go
+++ b/components/ledger/internal/services/query/enrich-transaction-routes_property_test.go
@@ -1,0 +1,373 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package query
+
+import (
+	"context"
+	"testing"
+	"testing/quick"
+
+	"github.com/LerianStudio/midaz/v3/components/ledger/internal/adapters/postgres/operationroute"
+	"github.com/LerianStudio/midaz/v3/components/ledger/internal/adapters/postgres/transactionroute"
+	"github.com/LerianStudio/midaz/v3/pkg/mmodel"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+// --- helpers -----------------------------------------------------------------
+
+// buildEnrichmentScenario constructs a deterministic test scenario from random seeds.
+// It builds N transaction routes (bounded to [0, maxRoutes]), a junction map where
+// each route maps to [0, maxOpsPerRoute] operation route IDs, and a full set of
+// operation route objects for all IDs in the junction map. This helper isolates
+// scenario construction from property assertions.
+type enrichmentScenario struct {
+	routes      []*mmodel.TransactionRoute
+	junctionMap map[uuid.UUID][]uuid.UUID
+	opRoutes    []*mmodel.OperationRoute
+	orgID       uuid.UUID
+	ledgerID    uuid.UUID
+}
+
+func buildEnrichmentScenario(numRoutes, maxOpsPerRoute uint8) enrichmentScenario {
+	const maxRoutes = 50
+
+	n := int(numRoutes % (maxRoutes + 1))
+	opsPerRoute := int(maxOpsPerRoute%10) + 1
+
+	orgID := uuid.New()
+	ledgerID := uuid.New()
+
+	routes := make([]*mmodel.TransactionRoute, n)
+	for i := range routes {
+		routes[i] = &mmodel.TransactionRoute{
+			ID:             uuid.New(),
+			OrganizationID: orgID,
+			LedgerID:       ledgerID,
+			Title:          "prop-route",
+		}
+	}
+
+	junctionMap := make(map[uuid.UUID][]uuid.UUID)
+	uniqueORIDs := make(map[uuid.UUID]struct{})
+
+	for _, tr := range routes {
+		orIDs := make([]uuid.UUID, opsPerRoute)
+		for j := range orIDs {
+			orIDs[j] = uuid.New()
+			uniqueORIDs[orIDs[j]] = struct{}{}
+		}
+
+		junctionMap[tr.ID] = orIDs
+	}
+
+	var opRoutes []*mmodel.OperationRoute
+	for orID := range uniqueORIDs {
+		opRoutes = append(opRoutes, &mmodel.OperationRoute{
+			ID:             orID,
+			OrganizationID: orgID,
+			LedgerID:       ledgerID,
+			Title:          "prop-op",
+			OperationType:  "source",
+		})
+	}
+
+	return enrichmentScenario{
+		routes:      routes,
+		junctionMap: junctionMap,
+		opRoutes:    opRoutes,
+		orgID:       orgID,
+		ledgerID:    ledgerID,
+	}
+}
+
+// setupMocksForScenario wires up gomock expectations for the standard happy-path
+// enrichment flow: junction query returns the scenario's junctionMap, FindByIDs
+// returns the scenario's opRoutes.
+func setupMocksForScenario(
+	ctrl *gomock.Controller,
+	s enrichmentScenario,
+) *UseCase {
+	mockTRRepo := transactionroute.NewMockRepository(ctrl)
+	mockORRepo := operationroute.NewMockRepository(ctrl)
+
+	if len(s.routes) > 0 {
+		mockTRRepo.EXPECT().
+			FindOperationRouteIDsByTransactionRouteIDs(gomock.Any(), gomock.Any()).
+			Return(s.junctionMap, nil)
+
+		if len(s.opRoutes) > 0 {
+			mockORRepo.EXPECT().
+				FindByIDs(gomock.Any(), s.orgID, s.ledgerID, gomock.Any()).
+				Return(s.opRoutes, nil)
+		}
+	}
+
+	return &UseCase{
+		TransactionRouteRepo: mockTRRepo,
+		OperationRouteRepo:   mockORRepo,
+	}
+}
+
+// --- property tests ----------------------------------------------------------
+
+// TestProperty_EnrichTransactionRoutes_Conservation verifies that enrichment never
+// adds or removes transaction routes. The output slice length must always equal the
+// input slice length, regardless of junction map contents.
+//
+// PROPERTY: len(routes_before) == len(routes_after)
+func TestProperty_EnrichTransactionRoutes_Conservation(t *testing.T) {
+	t.Parallel()
+
+	cfg := &quick.Config{MaxCount: 100}
+
+	property := func(numRoutes, maxOpsPerRoute uint8) bool {
+		s := buildEnrichmentScenario(numRoutes, maxOpsPerRoute)
+		countBefore := len(s.routes)
+
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		uc := setupMocksForScenario(ctrl, s)
+
+		err := uc.enrichTransactionRoutesWithOperationRoutes(context.Background(), s.routes)
+		if err != nil {
+			return false
+		}
+
+		// PROPERTY: enrichment preserves the number of transaction routes
+		return len(s.routes) == countBefore
+	}
+
+	err := quick.Check(property, cfg)
+	require.NoError(t, err)
+}
+
+// TestProperty_EnrichTransactionRoutes_NoNilOperationRoutes verifies that after
+// successful enrichment, every transaction route has a non-nil OperationRoutes slice.
+// Routes without junction entries get an empty slice ([]OperationRoute{}), never nil.
+//
+// PROPERTY: ∀ tr ∈ routes: tr.OperationRoutes != nil
+func TestProperty_EnrichTransactionRoutes_NoNilOperationRoutes(t *testing.T) {
+	t.Parallel()
+
+	cfg := &quick.Config{MaxCount: 100}
+
+	property := func(numRoutes, maxOpsPerRoute uint8) bool {
+		s := buildEnrichmentScenario(numRoutes, maxOpsPerRoute)
+
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		uc := setupMocksForScenario(ctrl, s)
+
+		err := uc.enrichTransactionRoutesWithOperationRoutes(context.Background(), s.routes)
+		if err != nil {
+			return false
+		}
+
+		// PROPERTY: every route has non-nil OperationRoutes after enrichment
+		for _, tr := range s.routes {
+			if tr.OperationRoutes == nil {
+				return false
+			}
+		}
+
+		return true
+	}
+
+	err := quick.Check(property, cfg)
+	require.NoError(t, err)
+}
+
+// TestProperty_EnrichTransactionRoutes_CorrectAssignment verifies that every
+// operation route assigned to a transaction route was present in the junction
+// mapping for that specific transaction route ID. No cross-contamination occurs.
+//
+// PROPERTY: ∀ tr: ∀ or ∈ tr.OperationRoutes: or.ID ∈ junctionMap[tr.ID]
+func TestProperty_EnrichTransactionRoutes_CorrectAssignment(t *testing.T) {
+	t.Parallel()
+
+	cfg := &quick.Config{MaxCount: 100}
+
+	property := func(numRoutes, maxOpsPerRoute uint8) bool {
+		s := buildEnrichmentScenario(numRoutes, maxOpsPerRoute)
+
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		uc := setupMocksForScenario(ctrl, s)
+
+		err := uc.enrichTransactionRoutesWithOperationRoutes(context.Background(), s.routes)
+		if err != nil {
+			return false
+		}
+
+		// Build a quick lookup: junctionMap[trID] → set of allowed orIDs
+		allowedByTR := make(map[uuid.UUID]map[uuid.UUID]struct{})
+		for trID, orIDs := range s.junctionMap {
+			set := make(map[uuid.UUID]struct{}, len(orIDs))
+			for _, orID := range orIDs {
+				set[orID] = struct{}{}
+			}
+
+			allowedByTR[trID] = set
+		}
+
+		// PROPERTY: every assigned operation route ID is in the junction set for its parent
+		for _, tr := range s.routes {
+			allowed := allowedByTR[tr.ID]
+			for _, or := range tr.OperationRoutes {
+				if _, ok := allowed[or.ID]; !ok {
+					return false
+				}
+			}
+		}
+
+		return true
+	}
+
+	err := quick.Check(property, cfg)
+	require.NoError(t, err)
+}
+
+// TestProperty_EnrichTransactionRoutes_NoOrphanOperationRoutes verifies that every
+// operation route returned from the batch FindByIDs ends up assigned to at least
+// one transaction route. No fetched operation route is wasted/orphaned.
+//
+// PROPERTY: ∀ or ∈ fetchedOpRoutes: ∃ tr: or.ID ∈ tr.OperationRoutes
+func TestProperty_EnrichTransactionRoutes_NoOrphanOperationRoutes(t *testing.T) {
+	t.Parallel()
+
+	cfg := &quick.Config{MaxCount: 100}
+
+	property := func(numRoutes, maxOpsPerRoute uint8) bool {
+		s := buildEnrichmentScenario(numRoutes, maxOpsPerRoute)
+
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		uc := setupMocksForScenario(ctrl, s)
+
+		err := uc.enrichTransactionRoutesWithOperationRoutes(context.Background(), s.routes)
+		if err != nil {
+			return false
+		}
+
+		if len(s.routes) == 0 {
+			return true // No routes → no operation routes → nothing to check
+		}
+
+		// Collect all assigned operation route IDs across all transaction routes
+		assignedIDs := make(map[uuid.UUID]struct{})
+		for _, tr := range s.routes {
+			for _, or := range tr.OperationRoutes {
+				assignedIDs[or.ID] = struct{}{}
+			}
+		}
+
+		// PROPERTY: every fetched operation route must appear in at least one assignment
+		for _, or := range s.opRoutes {
+			if _, assigned := assignedIDs[or.ID]; !assigned {
+				return false
+			}
+		}
+
+		return true
+	}
+
+	err := quick.Check(property, cfg)
+	require.NoError(t, err)
+}
+
+// TestProperty_EnrichTransactionRoutes_Idempotency verifies that running enrichment
+// twice on the same data produces the same result. After the first enrichment the
+// OperationRoutes field is populated; a second enrichment (with the same junction
+// data) must produce identical assignments.
+//
+// PROPERTY: enrich(enrich(routes)) == enrich(routes)
+func TestProperty_EnrichTransactionRoutes_Idempotency(t *testing.T) {
+	t.Parallel()
+
+	cfg := &quick.Config{MaxCount: 100}
+
+	property := func(numRoutes, maxOpsPerRoute uint8) bool {
+		s := buildEnrichmentScenario(numRoutes, maxOpsPerRoute)
+
+		// --- First enrichment ---
+		ctrl1 := gomock.NewController(t)
+		uc1 := setupMocksForScenario(ctrl1, s)
+
+		err := uc1.enrichTransactionRoutesWithOperationRoutes(context.Background(), s.routes)
+		ctrl1.Finish()
+
+		if err != nil {
+			return false
+		}
+
+		// Snapshot the first enrichment result
+		firstPass := make(map[uuid.UUID][]uuid.UUID, len(s.routes))
+		for _, tr := range s.routes {
+			ids := make([]uuid.UUID, len(tr.OperationRoutes))
+			for i, or := range tr.OperationRoutes {
+				ids[i] = or.ID
+			}
+
+			firstPass[tr.ID] = ids
+		}
+
+		// --- Second enrichment (same junction data, same opRoutes) ---
+		ctrl2 := gomock.NewController(t)
+		uc2 := setupMocksForScenario(ctrl2, s)
+
+		err = uc2.enrichTransactionRoutesWithOperationRoutes(context.Background(), s.routes)
+		ctrl2.Finish()
+
+		if err != nil {
+			return false
+		}
+
+		// Snapshot the second enrichment result
+		secondPass := make(map[uuid.UUID][]uuid.UUID, len(s.routes))
+		for _, tr := range s.routes {
+			ids := make([]uuid.UUID, len(tr.OperationRoutes))
+			for i, or := range tr.OperationRoutes {
+				ids[i] = or.ID
+			}
+
+			secondPass[tr.ID] = ids
+		}
+
+		// PROPERTY: first and second enrichment produce identical operation route ID sets
+		for trID, firstIDs := range firstPass {
+			secondIDs, exists := secondPass[trID]
+			if !exists {
+				return false
+			}
+
+			if len(firstIDs) != len(secondIDs) {
+				return false
+			}
+
+			// Compare as sets (order may vary due to map iteration in production code)
+			firstSet := make(map[uuid.UUID]struct{}, len(firstIDs))
+			for _, id := range firstIDs {
+				firstSet[id] = struct{}{}
+			}
+
+			for _, id := range secondIDs {
+				if _, ok := firstSet[id]; !ok {
+					return false
+				}
+			}
+		}
+
+		return true
+	}
+
+	err := quick.Check(property, cfg)
+	require.NoError(t, err)
+}

--- a/components/ledger/internal/services/query/get-all-metadata-transaction-routes-enrichment_test.go
+++ b/components/ledger/internal/services/query/get-all-metadata-transaction-routes-enrichment_test.go
@@ -1,0 +1,239 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package query
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+
+	libHTTP "github.com/LerianStudio/lib-commons/v4/commons/net/http"
+	mongodb "github.com/LerianStudio/midaz/v3/components/ledger/internal/adapters/mongodb/transaction"
+	"github.com/LerianStudio/midaz/v3/components/ledger/internal/adapters/postgres/operationroute"
+	"github.com/LerianStudio/midaz/v3/components/ledger/internal/adapters/postgres/transactionroute"
+	"github.com/LerianStudio/midaz/v3/pkg/mmodel"
+	"github.com/LerianStudio/midaz/v3/pkg/net/http"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.uber.org/mock/gomock"
+)
+
+// TestGetAllMetadataTransactionRoutes_OperationRoutesPopulated tests that the metadata
+// listing also returns operation routes populated.
+func TestGetAllMetadataTransactionRoutes_OperationRoutesPopulated(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	organizationID := uuid.New()
+	ledgerID := uuid.New()
+	trID1 := uuid.New()
+	orID1 := uuid.New()
+	orID2 := uuid.New()
+
+	mockTRRepo := transactionroute.NewMockRepository(ctrl)
+	mockORRepo := operationroute.NewMockRepository(ctrl)
+	mockMetadataRepo := mongodb.NewMockRepository(ctrl)
+
+	uc := &UseCase{
+		TransactionRouteRepo:    mockTRRepo,
+		OperationRouteRepo:      mockORRepo,
+		TransactionMetadataRepo: mockMetadataRepo,
+	}
+
+	filter := http.QueryHeader{
+		Limit:     10,
+		Page:      1,
+		SortOrder: "asc",
+		Metadata:  &bson.M{"key": "value"},
+	}
+
+	// Metadata with one matching route
+	expectedMetadata := []*mongodb.Metadata{
+		{
+			ID:       primitive.NewObjectID(),
+			EntityID: trID1.String(),
+			Data:     mongodb.JSON{"key": "value"},
+		},
+	}
+
+	allTransactionRoutes := []*mmodel.TransactionRoute{
+		{ID: trID1, OrganizationID: organizationID, LedgerID: ledgerID, Title: "route1"},
+		{ID: uuid.New(), OrganizationID: organizationID, LedgerID: ledgerID, Title: "route2"},
+	}
+
+	cursor := libHTTP.CursorPagination{Next: "next", Prev: "prev"}
+
+	mockMetadataRepo.EXPECT().
+		FindList(gomock.Any(), reflect.TypeOf(mmodel.TransactionRoute{}).Name(), gomock.Any()).
+		Return(expectedMetadata, nil)
+
+	mockTRRepo.EXPECT().
+		FindAll(gomock.Any(), organizationID, ledgerID, gomock.Any()).
+		Return(allTransactionRoutes, cursor, nil)
+
+	// Junction: trID1 -> [orID1, orID2]
+	junctionMap := map[uuid.UUID][]uuid.UUID{
+		trID1: {orID1, orID2},
+	}
+	mockTRRepo.EXPECT().
+		FindOperationRouteIDsByTransactionRouteIDs(gomock.Any(), []uuid.UUID{trID1}).
+		Return(junctionMap, nil)
+
+	opRoutes := []*mmodel.OperationRoute{
+		{ID: orID1, OrganizationID: organizationID, LedgerID: ledgerID, Title: "op1", OperationType: "source"},
+		{ID: orID2, OrganizationID: organizationID, LedgerID: ledgerID, Title: "op2", OperationType: "destination"},
+	}
+	mockORRepo.EXPECT().
+		FindByIDs(gomock.Any(), organizationID, ledgerID, gomock.Any()).
+		Return(opRoutes, nil)
+
+	result, curResult, err := uc.GetAllMetadataTransactionRoutes(context.Background(), organizationID, ledgerID, filter)
+
+	require.NoError(t, err)
+	assert.Equal(t, cursor, curResult)
+	require.Len(t, result, 1)
+
+	// The filtered route should have operation routes populated
+	assert.Len(t, result[0].OperationRoutes, 2)
+	assert.Equal(t, orID1, result[0].OperationRoutes[0].ID)
+	assert.Equal(t, orID2, result[0].OperationRoutes[1].ID)
+	assert.Equal(t, map[string]any{"key": "value"}, result[0].Metadata)
+}
+
+// TestGetAllMetadataTransactionRoutes_JunctionQueryError tests that when the junction
+// table query fails during metadata-filtered listing, the error propagates correctly.
+func TestGetAllMetadataTransactionRoutes_JunctionQueryError(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	organizationID := uuid.New()
+	ledgerID := uuid.New()
+	trID1 := uuid.New()
+
+	mockTRRepo := transactionroute.NewMockRepository(ctrl)
+	mockORRepo := operationroute.NewMockRepository(ctrl)
+	mockMetadataRepo := mongodb.NewMockRepository(ctrl)
+
+	uc := &UseCase{
+		TransactionRouteRepo:    mockTRRepo,
+		OperationRouteRepo:      mockORRepo,
+		TransactionMetadataRepo: mockMetadataRepo,
+	}
+
+	filter := http.QueryHeader{
+		Limit:     10,
+		Page:      1,
+		SortOrder: "asc",
+		Metadata:  &bson.M{"key": "value"},
+	}
+
+	expectedMetadata := []*mongodb.Metadata{
+		{
+			ID:       primitive.NewObjectID(),
+			EntityID: trID1.String(),
+			Data:     mongodb.JSON{"key": "value"},
+		},
+	}
+
+	allTransactionRoutes := []*mmodel.TransactionRoute{
+		{ID: trID1, OrganizationID: organizationID, LedgerID: ledgerID, Title: "route1"},
+	}
+
+	cursor := libHTTP.CursorPagination{Next: "next", Prev: "prev"}
+
+	mockMetadataRepo.EXPECT().
+		FindList(gomock.Any(), reflect.TypeOf(mmodel.TransactionRoute{}).Name(), gomock.Any()).
+		Return(expectedMetadata, nil)
+
+	mockTRRepo.EXPECT().
+		FindAll(gomock.Any(), organizationID, ledgerID, gomock.Any()).
+		Return(allTransactionRoutes, cursor, nil)
+
+	// Junction table query returns error
+	junctionErr := errors.New("junction table connection refused")
+	mockTRRepo.EXPECT().
+		FindOperationRouteIDsByTransactionRouteIDs(gomock.Any(), []uuid.UUID{trID1}).
+		Return(nil, junctionErr)
+
+	result, curResult, err := uc.GetAllMetadataTransactionRoutes(context.Background(), organizationID, ledgerID, filter)
+
+	assert.Nil(t, result)
+	assert.Equal(t, libHTTP.CursorPagination{}, curResult)
+	require.Error(t, err)
+	assert.Equal(t, junctionErr, err)
+}
+
+// TestGetAllMetadataTransactionRoutes_EmptyOperationRoutesNotNil tests that metadata-filtered
+// transaction routes with no linked operation routes return empty slice, not nil.
+func TestGetAllMetadataTransactionRoutes_EmptyOperationRoutesNotNil(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	organizationID := uuid.New()
+	ledgerID := uuid.New()
+	trID1 := uuid.New()
+
+	mockTRRepo := transactionroute.NewMockRepository(ctrl)
+	mockORRepo := operationroute.NewMockRepository(ctrl)
+	mockMetadataRepo := mongodb.NewMockRepository(ctrl)
+
+	uc := &UseCase{
+		TransactionRouteRepo:    mockTRRepo,
+		OperationRouteRepo:      mockORRepo,
+		TransactionMetadataRepo: mockMetadataRepo,
+	}
+
+	filter := http.QueryHeader{
+		Limit:     10,
+		Page:      1,
+		SortOrder: "asc",
+		Metadata:  &bson.M{"key": "value"},
+	}
+
+	expectedMetadata := []*mongodb.Metadata{
+		{
+			ID:       primitive.NewObjectID(),
+			EntityID: trID1.String(),
+			Data:     mongodb.JSON{"key": "value"},
+		},
+	}
+
+	allTransactionRoutes := []*mmodel.TransactionRoute{
+		{ID: trID1, OrganizationID: organizationID, LedgerID: ledgerID, Title: "route1"},
+	}
+
+	cursor := libHTTP.CursorPagination{Next: "next", Prev: "prev"}
+
+	mockMetadataRepo.EXPECT().
+		FindList(gomock.Any(), reflect.TypeOf(mmodel.TransactionRoute{}).Name(), gomock.Any()).
+		Return(expectedMetadata, nil)
+
+	mockTRRepo.EXPECT().
+		FindAll(gomock.Any(), organizationID, ledgerID, gomock.Any()).
+		Return(allTransactionRoutes, cursor, nil)
+
+	// Junction returns empty map — no linked operation routes
+	mockTRRepo.EXPECT().
+		FindOperationRouteIDsByTransactionRouteIDs(gomock.Any(), []uuid.UUID{trID1}).
+		Return(map[uuid.UUID][]uuid.UUID{}, nil)
+
+	result, curResult, err := uc.GetAllMetadataTransactionRoutes(context.Background(), organizationID, ledgerID, filter)
+
+	require.NoError(t, err)
+	assert.Equal(t, cursor, curResult)
+	require.Len(t, result, 1)
+
+	// Must be empty slice, NOT nil
+	require.NotNil(t, result[0].OperationRoutes, "operationRoutes must be empty slice, not nil")
+	assert.Empty(t, result[0].OperationRoutes)
+	assert.Equal(t, map[string]any{"key": "value"}, result[0].Metadata)
+}

--- a/components/ledger/internal/services/query/get-all-metadata-transaction-routes.go
+++ b/components/ledger/internal/services/query/get-all-metadata-transaction-routes.go
@@ -77,5 +77,15 @@ func (uc *UseCase) GetAllMetadataTransactionRoutes(ctx context.Context, organiza
 		}
 	}
 
+	if len(filteredTransactionRoutes) > 0 {
+		if err := uc.enrichTransactionRoutesWithOperationRoutes(ctx, filteredTransactionRoutes); err != nil {
+			libOpentelemetry.HandleSpanError(span, "Failed to enrich transaction routes with operation routes", err)
+
+			logger.Log(ctx, libLog.LevelError, fmt.Sprintf("Failed to enrich transaction routes with operation routes: %v", err))
+
+			return nil, libHTTP.CursorPagination{}, err
+		}
+	}
+
 	return filteredTransactionRoutes, cur, nil
 }

--- a/components/ledger/internal/services/query/get-all-metadata-transaction-routes_test.go
+++ b/components/ledger/internal/services/query/get-all-metadata-transaction-routes_test.go
@@ -12,6 +12,7 @@ import (
 
 	libHTTP "github.com/LerianStudio/lib-commons/v4/commons/net/http"
 	mongodb "github.com/LerianStudio/midaz/v3/components/ledger/internal/adapters/mongodb/transaction"
+	"github.com/LerianStudio/midaz/v3/components/ledger/internal/adapters/postgres/operationroute"
 	"github.com/LerianStudio/midaz/v3/components/ledger/internal/adapters/postgres/transactionroute"
 	"github.com/LerianStudio/midaz/v3/components/ledger/internal/services"
 	"github.com/LerianStudio/midaz/v3/pkg"
@@ -49,9 +50,11 @@ func TestGetAllMetadataTransactionRoutes(t *testing.T) {
 		defer ctrl.Finish()
 
 		mockTransactionRouteRepo := transactionroute.NewMockRepository(ctrl)
+		mockORRepo := operationroute.NewMockRepository(ctrl)
 		mockMetadataRepo := mongodb.NewMockRepository(ctrl)
 		uc := &UseCase{
 			TransactionRouteRepo:    mockTransactionRouteRepo,
+			OperationRouteRepo:      mockORRepo,
 			TransactionMetadataRepo: mockMetadataRepo,
 		}
 
@@ -100,6 +103,11 @@ func TestGetAllMetadataTransactionRoutes(t *testing.T) {
 		mockTransactionRouteRepo.EXPECT().
 			FindAll(gomock.Any(), organizationID, ledgerID, gomock.Any()).
 			Return(expectedTransactionRoutes, expectedCursor, nil)
+
+		// Enrichment: junction returns empty map (no links)
+		mockTransactionRouteRepo.EXPECT().
+			FindOperationRouteIDsByTransactionRouteIDs(gomock.Any(), gomock.Any()).
+			Return(map[uuid.UUID][]uuid.UUID{}, nil)
 
 		result, cursor, err := uc.GetAllMetadataTransactionRoutes(context.Background(), organizationID, ledgerID, filter)
 

--- a/components/ledger/internal/services/query/get-all-transaction-routes-enrichment_test.go
+++ b/components/ledger/internal/services/query/get-all-transaction-routes-enrichment_test.go
@@ -1,0 +1,456 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package query
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+
+	libHTTP "github.com/LerianStudio/lib-commons/v4/commons/net/http"
+	mongodb "github.com/LerianStudio/midaz/v3/components/ledger/internal/adapters/mongodb/transaction"
+	"github.com/LerianStudio/midaz/v3/components/ledger/internal/adapters/postgres/operationroute"
+	"github.com/LerianStudio/midaz/v3/components/ledger/internal/adapters/postgres/transactionroute"
+	"github.com/LerianStudio/midaz/v3/pkg/mmodel"
+	"github.com/LerianStudio/midaz/v3/pkg/net/http"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.uber.org/mock/gomock"
+)
+
+// TestGetAllTransactionRoutes_OperationRoutesPopulated tests that the list endpoint
+// returns each transaction route with its operationRoutes[] populated.
+func TestGetAllTransactionRoutes_OperationRoutesPopulated(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	organizationID := uuid.New()
+	ledgerID := uuid.New()
+	trID1 := uuid.New()
+	trID2 := uuid.New()
+	orID1 := uuid.New()
+	orID2 := uuid.New()
+	orID3 := uuid.New()
+
+	mockTRRepo := transactionroute.NewMockRepository(ctrl)
+	mockORRepo := operationroute.NewMockRepository(ctrl)
+	mockMetadataRepo := mongodb.NewMockRepository(ctrl)
+
+	uc := &UseCase{
+		TransactionRouteRepo:    mockTRRepo,
+		OperationRouteRepo:      mockORRepo,
+		TransactionMetadataRepo: mockMetadataRepo,
+	}
+
+	filter := http.QueryHeader{
+		Limit:     10,
+		Page:      1,
+		SortOrder: "asc",
+		Metadata:  &bson.M{},
+	}
+
+	transactionRoutes := []*mmodel.TransactionRoute{
+		{ID: trID1, OrganizationID: organizationID, LedgerID: ledgerID, Title: "route1"},
+		{ID: trID2, OrganizationID: organizationID, LedgerID: ledgerID, Title: "route2"},
+	}
+
+	cursor := libHTTP.CursorPagination{Next: "next", Prev: "prev"}
+
+	// FindAll returns transaction routes without operation routes
+	mockTRRepo.EXPECT().
+		FindAll(gomock.Any(), organizationID, ledgerID, gomock.Any()).
+		Return(transactionRoutes, cursor, nil)
+
+	// Metadata lookup
+	mockMetadataRepo.EXPECT().
+		FindList(gomock.Any(), reflect.TypeOf(mmodel.TransactionRoute{}).Name(), gomock.Any()).
+		Return([]*mongodb.Metadata{}, nil)
+
+	// Junction table query: trID1 -> [orID1, orID2], trID2 -> [orID3]
+	junctionMap := map[uuid.UUID][]uuid.UUID{
+		trID1: {orID1, orID2},
+		trID2: {orID3},
+	}
+	mockTRRepo.EXPECT().
+		FindOperationRouteIDsByTransactionRouteIDs(gomock.Any(), gomock.InAnyOrder([]uuid.UUID{trID1, trID2})).
+		Return(junctionMap, nil)
+
+	// Batch fetch operation routes
+	opRoutes := []*mmodel.OperationRoute{
+		{ID: orID1, OrganizationID: organizationID, LedgerID: ledgerID, Title: "op1", OperationType: "source"},
+		{ID: orID2, OrganizationID: organizationID, LedgerID: ledgerID, Title: "op2", OperationType: "destination"},
+		{ID: orID3, OrganizationID: organizationID, LedgerID: ledgerID, Title: "op3", OperationType: "source"},
+	}
+	mockORRepo.EXPECT().
+		FindByIDs(gomock.Any(), organizationID, ledgerID, gomock.Any()).
+		Return(opRoutes, nil)
+
+	result, curResult, err := uc.GetAllTransactionRoutes(context.Background(), organizationID, ledgerID, filter)
+
+	require.NoError(t, err)
+	assert.Equal(t, cursor, curResult)
+	require.Len(t, result, 2)
+
+	// trID1 should have 2 operation routes
+	assert.Len(t, result[0].OperationRoutes, 2)
+	assert.Equal(t, orID1, result[0].OperationRoutes[0].ID)
+	assert.Equal(t, orID2, result[0].OperationRoutes[1].ID)
+
+	// trID2 should have 1 operation route
+	assert.Len(t, result[1].OperationRoutes, 1)
+	assert.Equal(t, orID3, result[1].OperationRoutes[0].ID)
+}
+
+// TestGetAllTransactionRoutes_EmptyOperationRoutesNotNil tests that transaction routes
+// with no linked operation routes return an empty slice, not nil.
+func TestGetAllTransactionRoutes_EmptyOperationRoutesNotNil(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	organizationID := uuid.New()
+	ledgerID := uuid.New()
+	trID1 := uuid.New()
+
+	mockTRRepo := transactionroute.NewMockRepository(ctrl)
+	mockORRepo := operationroute.NewMockRepository(ctrl)
+	mockMetadataRepo := mongodb.NewMockRepository(ctrl)
+
+	uc := &UseCase{
+		TransactionRouteRepo:    mockTRRepo,
+		OperationRouteRepo:      mockORRepo,
+		TransactionMetadataRepo: mockMetadataRepo,
+	}
+
+	filter := http.QueryHeader{
+		Limit:     10,
+		Page:      1,
+		SortOrder: "asc",
+		Metadata:  &bson.M{},
+	}
+
+	transactionRoutes := []*mmodel.TransactionRoute{
+		{ID: trID1, OrganizationID: organizationID, LedgerID: ledgerID, Title: "route1"},
+	}
+
+	cursor := libHTTP.CursorPagination{Next: "next", Prev: "prev"}
+
+	mockTRRepo.EXPECT().
+		FindAll(gomock.Any(), organizationID, ledgerID, gomock.Any()).
+		Return(transactionRoutes, cursor, nil)
+
+	mockMetadataRepo.EXPECT().
+		FindList(gomock.Any(), reflect.TypeOf(mmodel.TransactionRoute{}).Name(), gomock.Any()).
+		Return([]*mongodb.Metadata{}, nil)
+
+	// Junction returns empty map — this route has no linked operation routes
+	mockTRRepo.EXPECT().
+		FindOperationRouteIDsByTransactionRouteIDs(gomock.Any(), []uuid.UUID{trID1}).
+		Return(map[uuid.UUID][]uuid.UUID{}, nil)
+
+	// FindByIDs should NOT be called when there are no operation route IDs
+	// (no expectation set — gomock will fail if it's called)
+
+	result, _, err := uc.GetAllTransactionRoutes(context.Background(), organizationID, ledgerID, filter)
+
+	require.NoError(t, err)
+	require.Len(t, result, 1)
+
+	// Must be empty slice, NOT nil
+	require.NotNil(t, result[0].OperationRoutes, "operationRoutes must be empty slice, not nil")
+	assert.Empty(t, result[0].OperationRoutes)
+}
+
+// TestGetAllTransactionRoutes_EmptyResultNoExtraDBCalls tests that when FindAll returns
+// an empty result set, no extra DB calls are made for operation route enrichment.
+func TestGetAllTransactionRoutes_EmptyResultNoExtraDBCalls(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	organizationID := uuid.New()
+	ledgerID := uuid.New()
+
+	mockTRRepo := transactionroute.NewMockRepository(ctrl)
+	mockMetadataRepo := mongodb.NewMockRepository(ctrl)
+
+	uc := &UseCase{
+		TransactionRouteRepo:    mockTRRepo,
+		TransactionMetadataRepo: mockMetadataRepo,
+	}
+
+	filter := http.QueryHeader{
+		Limit:     10,
+		Page:      1,
+		SortOrder: "asc",
+	}
+
+	cursor := libHTTP.CursorPagination{}
+
+	mockTRRepo.EXPECT().
+		FindAll(gomock.Any(), organizationID, ledgerID, gomock.Any()).
+		Return(nil, cursor, nil)
+
+	// No calls to FindOperationRouteIDsByTransactionRouteIDs or FindByIDs expected
+	// gomock will fail if they are called
+
+	result, _, err := uc.GetAllTransactionRoutes(context.Background(), organizationID, ledgerID, filter)
+
+	assert.NoError(t, err)
+	assert.Nil(t, result)
+}
+
+// TestGetAllTransactionRoutes_JunctionQueryError tests that when the junction table
+// query fails, the enrichment error propagates and the endpoint returns an error.
+func TestGetAllTransactionRoutes_JunctionQueryError(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	organizationID := uuid.New()
+	ledgerID := uuid.New()
+	trID1 := uuid.New()
+
+	mockTRRepo := transactionroute.NewMockRepository(ctrl)
+	mockMetadataRepo := mongodb.NewMockRepository(ctrl)
+
+	uc := &UseCase{
+		TransactionRouteRepo:    mockTRRepo,
+		TransactionMetadataRepo: mockMetadataRepo,
+	}
+
+	filter := http.QueryHeader{
+		Limit:     10,
+		Page:      1,
+		SortOrder: "asc",
+		Metadata:  &bson.M{},
+	}
+
+	transactionRoutes := []*mmodel.TransactionRoute{
+		{ID: trID1, OrganizationID: organizationID, LedgerID: ledgerID, Title: "route1"},
+	}
+
+	cursor := libHTTP.CursorPagination{Next: "next", Prev: "prev"}
+
+	mockTRRepo.EXPECT().
+		FindAll(gomock.Any(), organizationID, ledgerID, gomock.Any()).
+		Return(transactionRoutes, cursor, nil)
+
+	mockMetadataRepo.EXPECT().
+		FindList(gomock.Any(), reflect.TypeOf(mmodel.TransactionRoute{}).Name(), gomock.Any()).
+		Return([]*mongodb.Metadata{}, nil)
+
+	// Junction table query returns error
+	junctionErr := errors.New("junction table connection refused")
+	mockTRRepo.EXPECT().
+		FindOperationRouteIDsByTransactionRouteIDs(gomock.Any(), []uuid.UUID{trID1}).
+		Return(nil, junctionErr)
+
+	result, curResult, err := uc.GetAllTransactionRoutes(context.Background(), organizationID, ledgerID, filter)
+
+	assert.Nil(t, result)
+	assert.Equal(t, libHTTP.CursorPagination{}, curResult)
+	require.Error(t, err)
+	assert.Equal(t, junctionErr, err)
+}
+
+// TestGetAllTransactionRoutes_FindByIDsError tests that when the batch fetch of
+// operation routes fails, the enrichment error propagates correctly.
+func TestGetAllTransactionRoutes_FindByIDsError(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	organizationID := uuid.New()
+	ledgerID := uuid.New()
+	trID1 := uuid.New()
+	orID1 := uuid.New()
+
+	mockTRRepo := transactionroute.NewMockRepository(ctrl)
+	mockORRepo := operationroute.NewMockRepository(ctrl)
+	mockMetadataRepo := mongodb.NewMockRepository(ctrl)
+
+	uc := &UseCase{
+		TransactionRouteRepo:    mockTRRepo,
+		OperationRouteRepo:      mockORRepo,
+		TransactionMetadataRepo: mockMetadataRepo,
+	}
+
+	filter := http.QueryHeader{
+		Limit:     10,
+		Page:      1,
+		SortOrder: "asc",
+		Metadata:  &bson.M{},
+	}
+
+	transactionRoutes := []*mmodel.TransactionRoute{
+		{ID: trID1, OrganizationID: organizationID, LedgerID: ledgerID, Title: "route1"},
+	}
+
+	cursor := libHTTP.CursorPagination{Next: "next", Prev: "prev"}
+
+	mockTRRepo.EXPECT().
+		FindAll(gomock.Any(), organizationID, ledgerID, gomock.Any()).
+		Return(transactionRoutes, cursor, nil)
+
+	mockMetadataRepo.EXPECT().
+		FindList(gomock.Any(), reflect.TypeOf(mmodel.TransactionRoute{}).Name(), gomock.Any()).
+		Return([]*mongodb.Metadata{}, nil)
+
+	// Junction returns a valid mapping
+	junctionMap := map[uuid.UUID][]uuid.UUID{
+		trID1: {orID1},
+	}
+	mockTRRepo.EXPECT().
+		FindOperationRouteIDsByTransactionRouteIDs(gomock.Any(), []uuid.UUID{trID1}).
+		Return(junctionMap, nil)
+
+	// FindByIDs returns error
+	findByIDsErr := errors.New("operation route batch fetch timeout")
+	mockORRepo.EXPECT().
+		FindByIDs(gomock.Any(), organizationID, ledgerID, gomock.Any()).
+		Return(nil, findByIDsErr)
+
+	result, curResult, err := uc.GetAllTransactionRoutes(context.Background(), organizationID, ledgerID, filter)
+
+	assert.Nil(t, result)
+	assert.Equal(t, libHTTP.CursorPagination{}, curResult)
+	require.Error(t, err)
+	assert.Equal(t, findByIDsErr, err)
+}
+
+// TestGetAllTransactionRoutes_MixedLinksAndNoLinks tests that when some transaction
+// routes have linked operation routes and others don't, each gets the correct result:
+// populated []OperationRoute for those with links, empty []OperationRoute for those without.
+func TestGetAllTransactionRoutes_MixedLinksAndNoLinks(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	organizationID := uuid.New()
+	ledgerID := uuid.New()
+	trID1 := uuid.New()
+	trID2 := uuid.New()
+	trID3 := uuid.New()
+	orID1 := uuid.New()
+
+	mockTRRepo := transactionroute.NewMockRepository(ctrl)
+	mockORRepo := operationroute.NewMockRepository(ctrl)
+	mockMetadataRepo := mongodb.NewMockRepository(ctrl)
+
+	uc := &UseCase{
+		TransactionRouteRepo:    mockTRRepo,
+		OperationRouteRepo:      mockORRepo,
+		TransactionMetadataRepo: mockMetadataRepo,
+	}
+
+	filter := http.QueryHeader{
+		Limit:     10,
+		Page:      1,
+		SortOrder: "asc",
+		Metadata:  &bson.M{},
+	}
+
+	transactionRoutes := []*mmodel.TransactionRoute{
+		{ID: trID1, OrganizationID: organizationID, LedgerID: ledgerID, Title: "route-with-link"},
+		{ID: trID2, OrganizationID: organizationID, LedgerID: ledgerID, Title: "route-without-link"},
+		{ID: trID3, OrganizationID: organizationID, LedgerID: ledgerID, Title: "route-empty-link"},
+	}
+
+	cursor := libHTTP.CursorPagination{Next: "next", Prev: "prev"}
+
+	mockTRRepo.EXPECT().
+		FindAll(gomock.Any(), organizationID, ledgerID, gomock.Any()).
+		Return(transactionRoutes, cursor, nil)
+
+	mockMetadataRepo.EXPECT().
+		FindList(gomock.Any(), reflect.TypeOf(mmodel.TransactionRoute{}).Name(), gomock.Any()).
+		Return([]*mongodb.Metadata{}, nil)
+
+	// Junction: trID1 -> [orID1], trID2 not in map, trID3 -> empty slice
+	junctionMap := map[uuid.UUID][]uuid.UUID{
+		trID1: {orID1},
+		trID3: {},
+	}
+	mockTRRepo.EXPECT().
+		FindOperationRouteIDsByTransactionRouteIDs(gomock.Any(), gomock.Any()).
+		Return(junctionMap, nil)
+
+	opRoutes := []*mmodel.OperationRoute{
+		{ID: orID1, OrganizationID: organizationID, LedgerID: ledgerID, Title: "op1", OperationType: "source"},
+	}
+	mockORRepo.EXPECT().
+		FindByIDs(gomock.Any(), organizationID, ledgerID, gomock.Any()).
+		Return(opRoutes, nil)
+
+	result, _, err := uc.GetAllTransactionRoutes(context.Background(), organizationID, ledgerID, filter)
+
+	require.NoError(t, err)
+	require.Len(t, result, 3)
+
+	// trID1: has 1 operation route
+	assert.Len(t, result[0].OperationRoutes, 1)
+	assert.Equal(t, orID1, result[0].OperationRoutes[0].ID)
+
+	// trID2: not in junction map -> empty slice, not nil
+	require.NotNil(t, result[1].OperationRoutes)
+	assert.Empty(t, result[1].OperationRoutes)
+
+	// trID3: in junction map with empty slice -> empty slice, not nil
+	require.NotNil(t, result[2].OperationRoutes)
+	assert.Empty(t, result[2].OperationRoutes)
+}
+
+// TestGetAllTransactionRoutes_EmptyTransactionRoutesSlice tests that when FindAll returns
+// an empty (non-nil) slice, enrichment handles it without extra DB calls.
+// This exercises the len(transactionRoutes) == 0 early-return in enrichTransactionRoutesWithOperationRoutes.
+func TestGetAllTransactionRoutes_EmptyTransactionRoutesSlice(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	organizationID := uuid.New()
+	ledgerID := uuid.New()
+
+	mockTRRepo := transactionroute.NewMockRepository(ctrl)
+	mockMetadataRepo := mongodb.NewMockRepository(ctrl)
+
+	uc := &UseCase{
+		TransactionRouteRepo:    mockTRRepo,
+		TransactionMetadataRepo: mockMetadataRepo,
+	}
+
+	filter := http.QueryHeader{
+		Limit:     10,
+		Page:      1,
+		SortOrder: "asc",
+		Metadata:  &bson.M{},
+	}
+
+	// Return empty (non-nil) slice — this enters the transactionRoutes != nil branch
+	// but len == 0 triggers the early return in enrichTransactionRoutesWithOperationRoutes
+	emptySlice := []*mmodel.TransactionRoute{}
+	cursor := libHTTP.CursorPagination{}
+
+	mockTRRepo.EXPECT().
+		FindAll(gomock.Any(), organizationID, ledgerID, gomock.Any()).
+		Return(emptySlice, cursor, nil)
+
+	mockMetadataRepo.EXPECT().
+		FindList(gomock.Any(), reflect.TypeOf(mmodel.TransactionRoute{}).Name(), gomock.Any()).
+		Return([]*mongodb.Metadata{}, nil)
+
+	// No calls to FindOperationRouteIDsByTransactionRouteIDs or FindByIDs expected
+	// since the enrichment function returns early for an empty slice
+
+	result, _, err := uc.GetAllTransactionRoutes(context.Background(), organizationID, ledgerID, filter)
+
+	assert.NoError(t, err)
+	assert.Empty(t, result)
+}

--- a/components/ledger/internal/services/query/get-all-transaction-routes.go
+++ b/components/ledger/internal/services/query/get-all-transaction-routes.go
@@ -82,6 +82,14 @@ func (uc *UseCase) GetAllTransactionRoutes(ctx context.Context, organizationID, 
 				transactionRoutes[i].Metadata = data
 			}
 		}
+
+		if err := uc.enrichTransactionRoutesWithOperationRoutes(ctx, transactionRoutes); err != nil {
+			libOpentelemetry.HandleSpanError(span, "Failed to enrich transaction routes with operation routes", err)
+
+			logger.Log(ctx, libLog.LevelError, fmt.Sprintf("Failed to enrich transaction routes with operation routes: %v", err))
+
+			return nil, libHTTP.CursorPagination{}, err
+		}
 	}
 
 	return transactionRoutes, cur, nil

--- a/components/ledger/internal/services/query/get-all-transaction-routes_test.go
+++ b/components/ledger/internal/services/query/get-all-transaction-routes_test.go
@@ -12,6 +12,7 @@ import (
 
 	libHTTP "github.com/LerianStudio/lib-commons/v4/commons/net/http"
 	mongodb "github.com/LerianStudio/midaz/v3/components/ledger/internal/adapters/mongodb/transaction"
+	"github.com/LerianStudio/midaz/v3/components/ledger/internal/adapters/postgres/operationroute"
 	"github.com/LerianStudio/midaz/v3/components/ledger/internal/adapters/postgres/transactionroute"
 	"github.com/LerianStudio/midaz/v3/components/ledger/internal/services"
 	"github.com/LerianStudio/midaz/v3/pkg"
@@ -35,9 +36,11 @@ func TestGetAllTransactionRoutesSuccess(t *testing.T) {
 	transactionRouteID2 := uuid.New()
 
 	mockTransactionRouteRepo := transactionroute.NewMockRepository(ctrl)
+	mockORRepo := operationroute.NewMockRepository(ctrl)
 	mockMetadataRepo := mongodb.NewMockRepository(ctrl)
 	uc := &UseCase{
 		TransactionRouteRepo:    mockTransactionRouteRepo,
+		OperationRouteRepo:      mockORRepo,
 		TransactionMetadataRepo: mockMetadataRepo,
 	}
 
@@ -91,6 +94,11 @@ func TestGetAllTransactionRoutesSuccess(t *testing.T) {
 		FindList(gomock.Any(), reflect.TypeOf(mmodel.TransactionRoute{}).Name(), gomock.Any()).
 		Return(expectedMetadata, nil)
 
+	// Enrichment: junction returns empty map (no links)
+	mockTransactionRouteRepo.EXPECT().
+		FindOperationRouteIDsByTransactionRouteIDs(gomock.Any(), gomock.Any()).
+		Return(map[uuid.UUID][]uuid.UUID{}, nil)
+
 	result, cursor, err := uc.GetAllTransactionRoutes(context.Background(), organizationID, ledgerID, filter)
 
 	assert.NoError(t, err)
@@ -112,9 +120,11 @@ func TestGetAllTransactionRoutesSuccessWithoutMetadata(t *testing.T) {
 	transactionRouteID1 := uuid.New()
 
 	mockTransactionRouteRepo := transactionroute.NewMockRepository(ctrl)
+	mockORRepo := operationroute.NewMockRepository(ctrl)
 	mockMetadataRepo := mongodb.NewMockRepository(ctrl)
 	uc := &UseCase{
 		TransactionRouteRepo:    mockTransactionRouteRepo,
+		OperationRouteRepo:      mockORRepo,
 		TransactionMetadataRepo: mockMetadataRepo,
 	}
 
@@ -154,6 +164,11 @@ func TestGetAllTransactionRoutesSuccessWithoutMetadata(t *testing.T) {
 	mockMetadataRepo.EXPECT().
 		FindList(gomock.Any(), reflect.TypeOf(mmodel.TransactionRoute{}).Name(), gomock.Any()).
 		Return(expectedMetadata, nil)
+
+	// Enrichment: junction returns empty map (no links)
+	mockTransactionRouteRepo.EXPECT().
+		FindOperationRouteIDsByTransactionRouteIDs(gomock.Any(), gomock.Any()).
+		Return(map[uuid.UUID][]uuid.UUID{}, nil)
 
 	result, cursor, err := uc.GetAllTransactionRoutes(context.Background(), organizationID, ledgerID, filter)
 


### PR DESCRIPTION
The `GET /v1/organizations/{org}/ledgers/{ledger}/transaction-routes` listing endpoint was returning each transaction route without its `operationRoutes[]` field populated — unlike `GET .../transaction-routes/{id}`, which always returned the full objects. This forced clients to make N+1 requests (one list call + one GET-by-ID per item) to obtain the linked operation routes.

This PR fixes the asymmetry. The list endpoint (and its metadata-filtered variant) now returns `operationRoutes[]` populated on every item, consistent with the single-item endpoint.

## How

Post-query batch enrichment at the service layer, without touching FindAll SQL or cursor pagination:

1. After FindAll returns the paginated transaction routes, collect all their IDs
2. Query the junction table in one batch (FindOperationRouteIDsByTransactionRouteIDs) — with INNER JOIN operation_route to exclude orphaned references to soft-deleted operation routes
3. Batch-fetch the full operation route objects (FindByIDs) using the unique IDs from the mapping
4. Assign each operation route to its parent transaction route(s)

Total additional queries: 2 (constant, regardless of page size). No N+1.
This follows the existing metadata enrichment pattern already present in `get-all-transaction-routes.go`.

### Why not a JOIN in FindAll?

Cursor-based pagination uses LIMIT + WHERE id > cursor. Adding a LEFT JOIN through the junction table would cause row multiplication (one transaction route with 5 operation routes = 5 rows), breaking LIMIT semantics. The 2-query batch approach avoids this entirely.

## Changes

- `enrich-transaction-routes.go` — new enrichTransactionRoutesWithOperationRoutes method on the query UseCase
- `transactionroute.postgresql.go` — new FindOperationRouteIDsByTransactionRouteIDs repository method + interface
- `get-all-transaction-routes.go` / `get-all-metadata-transaction-routes.go` — call enrichment after existing metadata attachment