### PR TITLE
feat: add segment_id and portfolio_id query filters to account listing

### DIFF
--- a/components/ledger/api/docs.go
+++ b/components/ledger/api/docs.go
@@ -5,7 +5,7 @@ import "github.com/swaggo/swag"
 
 // SwaggerInfo holds exported Swagger Info so clients can modify it
 var SwaggerInfo = &swag.Spec{
-	Version:          "v3.5.2",
+	Version:          "v3.6.0",
 	Host:             "localhost:3002",
 	BasePath:         "/",
 	Schemes:          []string{"http", "https"},
@@ -36,7 +36,7 @@ const docTemplate = `
       "name": "Apache 2.0",
       "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
     },
-    "version": "v3.5.2"
+    "version": "v3.6.0"
   },
   "host": "localhost:3002",
   "basePath": "/",
@@ -1735,6 +1735,18 @@ const docTemplate = `
             "type": "string",
             "description": "Sort direction for results based on creation date",
             "name": "sort_order",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "description": "Filter accounts by portfolio ID (UUID format)",
+            "name": "portfolio_id",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "description": "Filter accounts by segment ID (UUID format)",
+            "name": "segment_id",
             "in": "query"
           }
         ],
@@ -6707,7 +6719,7 @@ const docTemplate = `
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/github_com_LerianStudio_midaz_v3_components_ledger_adapters_postgres_transaction.CreateTransactionSwaggerModel"
+              "$ref": "#/definitions/github_com_LerianStudio_midaz_v3_components_ledger_internal_adapters_postgres_transaction.CreateTransactionSwaggerModel"
             }
           }
         ],
@@ -6978,7 +6990,7 @@ const docTemplate = `
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/github_com_LerianStudio_midaz_v3_components_ledger_adapters_postgres_transaction.CreateTransactionSwaggerModel"
+              "$ref": "#/definitions/github_com_LerianStudio_midaz_v3_components_ledger_internal_adapters_postgres_transaction.CreateTransactionSwaggerModel"
             }
           }
         ],
@@ -10436,7 +10448,7 @@ const docTemplate = `
         }
       }
     },
-    "github_com_LerianStudio_midaz_v3_components_ledger_adapters_postgres_transaction.CreateTransactionSwaggerModel": {
+    "github_com_LerianStudio_midaz_v3_components_ledger_internal_adapters_postgres_transaction.CreateTransactionSwaggerModel": {
       "description": "Schema for creating transaction with the complete Send operation structure defined inline",
       "type": "object",
       "properties": {

--- a/components/ledger/api/docs.go
+++ b/components/ledger/api/docs.go
@@ -1739,13 +1739,13 @@ const docTemplate = `
           },
           {
             "type": "string",
-            "description": "Filter accounts by portfolio ID (UUID format)",
+            "description": "Filter accounts by portfolio ID (UUID format). If both portfolio_id and segment_id are provided, both filters are applied (AND semantics).",
             "name": "portfolio_id",
             "in": "query"
           },
           {
             "type": "string",
-            "description": "Filter accounts by segment ID (UUID format)",
+            "description": "Filter accounts by segment ID (UUID format). If both portfolio_id and segment_id are provided, both filters are applied (AND semantics).",
             "name": "segment_id",
             "in": "query"
           }

--- a/components/ledger/api/docs.go
+++ b/components/ledger/api/docs.go
@@ -1739,12 +1739,14 @@ const docTemplate = `
           },
           {
             "type": "string",
+            "format": "uuid",
             "description": "Filter accounts by portfolio ID (UUID format). If both portfolio_id and segment_id are provided, both filters are applied (AND semantics).",
             "name": "portfolio_id",
             "in": "query"
           },
           {
             "type": "string",
+            "format": "uuid",
             "description": "Filter accounts by segment ID (UUID format). If both portfolio_id and segment_id are provided, both filters are applied (AND semantics).",
             "name": "segment_id",
             "in": "query"

--- a/components/ledger/api/openapi.yaml
+++ b/components/ledger/api/openapi.yaml
@@ -1435,12 +1435,14 @@ paths:
         in: query
         name: portfolio_id
         schema:
+          format: uuid
           type: string
       - description: Filter accounts by segment ID (UUID format). If both portfolio_id
           and segment_id are provided, both filters are applied (AND semantics).
         in: query
         name: segment_id
         schema:
+          format: uuid
           type: string
       responses:
         "200":

--- a/components/ledger/api/openapi.yaml
+++ b/components/ledger/api/openapi.yaml
@@ -1430,6 +1430,16 @@ paths:
           - asc
           - desc
           type: string
+      - description: Filter accounts by portfolio ID (UUID format)
+        in: query
+        name: portfolio_id
+        schema:
+          type: string
+      - description: Filter accounts by segment ID (UUID format)
+        in: query
+        name: segment_id
+        schema:
+          type: string
       responses:
         "200":
           content:
@@ -5494,7 +5504,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/github_com_LerianStudio_midaz_v3_components_ledger_adapters_postgres_transaction.CreateTransactionSwaggerModel'
+              $ref: '#/components/schemas/github_com_LerianStudio_midaz_v3_components_ledger_internal_adapters_postgres_transaction.CreateTransactionSwaggerModel'
         description: Transaction Input
         required: true
       responses:
@@ -5723,7 +5733,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/github_com_LerianStudio_midaz_v3_components_ledger_adapters_postgres_transaction.CreateTransactionSwaggerModel'
+              $ref: '#/components/schemas/github_com_LerianStudio_midaz_v3_components_ledger_internal_adapters_postgres_transaction.CreateTransactionSwaggerModel'
         description: Transaction Input
         required: true
       responses:
@@ -9599,7 +9609,7 @@ components:
           maxLength: 50
           type: string
       type: object
-    github_com_LerianStudio_midaz_v3_components_ledger_adapters_postgres_transaction.CreateTransactionSwaggerModel:
+    github_com_LerianStudio_midaz_v3_components_ledger_internal_adapters_postgres_transaction.CreateTransactionSwaggerModel:
       description: Schema for creating transaction with the complete Send operation
         structure defined inline
       properties:
@@ -9654,7 +9664,7 @@ components:
           format: uuid
           type: string
         send:
-          $ref: '#/components/schemas/github_com_LerianStudio_midaz_v3_components_ledger_adapters_postgres_transaction_CreateTransactionSwaggerModel_send'
+          $ref: '#/components/schemas/github_com_LerianStudio_midaz_v3_components_ledger_internal_adapters_postgres_transaction_CreateTransactionSwaggerModel_send'
         transactionDate:
           description: |-
             TransactionDate Period from transaction creation date until now
@@ -10884,8 +10894,8 @@ components:
             required: true
           type: string
       type: object
-    github_com_LerianStudio_midaz_v3_components_ledger_adapters_postgres_transaction_CreateTransactionSwaggerModel_send_source_from:
-      properties:
+    ? github_com_LerianStudio_midaz_v3_components_ledger_internal_adapters_postgres_transaction_CreateTransactionSwaggerModel_send_source_from
+    : properties:
         accountAlias:
           description: |-
             Account identifier or alias
@@ -10912,8 +10922,8 @@ components:
             example: {"operation": "funding", "type": "external"}
           type: object
       type: object
-    github_com_LerianStudio_midaz_v3_components_ledger_adapters_postgres_transaction_CreateTransactionSwaggerModel_send_source:
-      description: |-
+    ? github_com_LerianStudio_midaz_v3_components_ledger_internal_adapters_postgres_transaction_CreateTransactionSwaggerModel_send_source
+    : description: |-
         Source accounts and amounts for the transaction
         required: true
       properties:
@@ -10922,10 +10932,10 @@ components:
             List of source operations
             required: true
           items:
-            $ref: '#/components/schemas/github_com_LerianStudio_midaz_v3_components_ledger_adapters_postgres_transaction_CreateTransactionSwaggerModel_send_source_from'
+            $ref: '#/components/schemas/github_com_LerianStudio_midaz_v3_components_ledger_internal_adapters_postgres_transaction_CreateTransactionSwaggerModel_send_source_from'
           type: array
       type: object
-    github_com_LerianStudio_midaz_v3_components_ledger_adapters_postgres_transaction_CreateTransactionSwaggerModel_send:
+    github_com_LerianStudio_midaz_v3_components_ledger_internal_adapters_postgres_transaction_CreateTransactionSwaggerModel_send:
       description: |-
         Send operation details including source and distribution
         required: true
@@ -10939,7 +10949,7 @@ components:
         distribute:
           $ref: '#/components/schemas/CreateTransactionInflowSwaggerModel_send_distribute'
         source:
-          $ref: '#/components/schemas/github_com_LerianStudio_midaz_v3_components_ledger_adapters_postgres_transaction_CreateTransactionSwaggerModel_send_source'
+          $ref: '#/components/schemas/github_com_LerianStudio_midaz_v3_components_ledger_internal_adapters_postgres_transaction_CreateTransactionSwaggerModel_send_source'
         value:
           description: |-
             Transaction amount value in the smallest unit of the asset

--- a/components/ledger/api/openapi.yaml
+++ b/components/ledger/api/openapi.yaml
@@ -1430,12 +1430,14 @@ paths:
           - asc
           - desc
           type: string
-      - description: Filter accounts by portfolio ID (UUID format)
+      - description: Filter accounts by portfolio ID (UUID format). If both portfolio_id
+          and segment_id are provided, both filters are applied (AND semantics).
         in: query
         name: portfolio_id
         schema:
           type: string
-      - description: Filter accounts by segment ID (UUID format)
+      - description: Filter accounts by segment ID (UUID format). If both portfolio_id
+          and segment_id are provided, both filters are applied (AND semantics).
         in: query
         name: segment_id
         schema:

--- a/components/ledger/api/swagger.json
+++ b/components/ledger/api/swagger.json
@@ -1715,13 +1715,13 @@
           },
           {
             "type": "string",
-            "description": "Filter accounts by portfolio ID (UUID format)",
+            "description": "Filter accounts by portfolio ID (UUID format). If both portfolio_id and segment_id are provided, both filters are applied (AND semantics).",
             "name": "portfolio_id",
             "in": "query"
           },
           {
             "type": "string",
-            "description": "Filter accounts by segment ID (UUID format)",
+            "description": "Filter accounts by segment ID (UUID format). If both portfolio_id and segment_id are provided, both filters are applied (AND semantics).",
             "name": "segment_id",
             "in": "query"
           }

--- a/components/ledger/api/swagger.json
+++ b/components/ledger/api/swagger.json
@@ -12,7 +12,7 @@
       "name": "Apache 2.0",
       "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
     },
-    "version": "v3.5.2"
+    "version": "v3.6.0"
   },
   "host": "localhost:3002",
   "basePath": "/",
@@ -1711,6 +1711,18 @@
             "type": "string",
             "description": "Sort direction for results based on creation date",
             "name": "sort_order",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "description": "Filter accounts by portfolio ID (UUID format)",
+            "name": "portfolio_id",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "description": "Filter accounts by segment ID (UUID format)",
+            "name": "segment_id",
             "in": "query"
           }
         ],
@@ -6683,7 +6695,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/github_com_LerianStudio_midaz_v3_components_ledger_adapters_postgres_transaction.CreateTransactionSwaggerModel"
+              "$ref": "#/definitions/github_com_LerianStudio_midaz_v3_components_ledger_internal_adapters_postgres_transaction.CreateTransactionSwaggerModel"
             }
           }
         ],
@@ -6954,7 +6966,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/github_com_LerianStudio_midaz_v3_components_ledger_adapters_postgres_transaction.CreateTransactionSwaggerModel"
+              "$ref": "#/definitions/github_com_LerianStudio_midaz_v3_components_ledger_internal_adapters_postgres_transaction.CreateTransactionSwaggerModel"
             }
           }
         ],
@@ -10412,7 +10424,7 @@
         }
       }
     },
-    "github_com_LerianStudio_midaz_v3_components_ledger_adapters_postgres_transaction.CreateTransactionSwaggerModel": {
+    "github_com_LerianStudio_midaz_v3_components_ledger_internal_adapters_postgres_transaction.CreateTransactionSwaggerModel": {
       "description": "Schema for creating transaction with the complete Send operation structure defined inline",
       "type": "object",
       "properties": {

--- a/components/ledger/api/swagger.json
+++ b/components/ledger/api/swagger.json
@@ -1715,12 +1715,14 @@
           },
           {
             "type": "string",
+            "format": "uuid",
             "description": "Filter accounts by portfolio ID (UUID format). If both portfolio_id and segment_id are provided, both filters are applied (AND semantics).",
             "name": "portfolio_id",
             "in": "query"
           },
           {
             "type": "string",
+            "format": "uuid",
             "description": "Filter accounts by segment ID (UUID format). If both portfolio_id and segment_id are provided, both filters are applied (AND semantics).",
             "name": "segment_id",
             "in": "query"

--- a/components/ledger/api/swagger.yaml
+++ b/components/ledger/api/swagger.yaml
@@ -12,7 +12,7 @@ info:
   license:
     name: Apache 2.0
     url: http://www.apache.org/licenses/LICENSE-2.0.html
-  version: v3.5.2
+  version: v3.6.0
 host: localhost:3002
 basePath: /
 paths:
@@ -1185,6 +1185,14 @@ paths:
         type: string
         description: Sort direction for results based on creation date
         name: sort_order
+        in: query
+      - type: string
+        description: Filter accounts by portfolio ID (UUID format)
+        name: portfolio_id
+        in: query
+      - type: string
+        description: Filter accounts by segment ID (UUID format)
+        name: segment_id
         in: query
       responses:
         '200':
@@ -4557,7 +4565,7 @@ paths:
         in: body
         required: true
         schema:
-          $ref: '#/definitions/github_com_LerianStudio_midaz_v3_components_ledger_adapters_postgres_transaction.CreateTransactionSwaggerModel'
+          $ref: '#/definitions/github_com_LerianStudio_midaz_v3_components_ledger_internal_adapters_postgres_transaction.CreateTransactionSwaggerModel'
       responses:
         '201':
           description: Created
@@ -4739,7 +4747,7 @@ paths:
         in: body
         required: true
         schema:
-          $ref: '#/definitions/github_com_LerianStudio_midaz_v3_components_ledger_adapters_postgres_transaction.CreateTransactionSwaggerModel'
+          $ref: '#/definitions/github_com_LerianStudio_midaz_v3_components_ledger_internal_adapters_postgres_transaction.CreateTransactionSwaggerModel'
       responses:
         '201':
           description: Created
@@ -8244,7 +8252,7 @@ definitions:
         type: string
         maxLength: 50
         example: Charge Settlement
-  github_com_LerianStudio_midaz_v3_components_ledger_adapters_postgres_transaction.CreateTransactionSwaggerModel:
+  github_com_LerianStudio_midaz_v3_components_ledger_internal_adapters_postgres_transaction.CreateTransactionSwaggerModel:
     description: Schema for creating transaction with the complete Send operation
       structure defined inline
     type: object

--- a/components/ledger/api/swagger.yaml
+++ b/components/ledger/api/swagger.yaml
@@ -1187,11 +1187,13 @@ paths:
         name: sort_order
         in: query
       - type: string
+        format: uuid
         description: Filter accounts by portfolio ID (UUID format). If both portfolio_id
           and segment_id are provided, both filters are applied (AND semantics).
         name: portfolio_id
         in: query
       - type: string
+        format: uuid
         description: Filter accounts by segment ID (UUID format). If both portfolio_id
           and segment_id are provided, both filters are applied (AND semantics).
         name: segment_id

--- a/components/ledger/api/swagger.yaml
+++ b/components/ledger/api/swagger.yaml
@@ -1187,11 +1187,13 @@ paths:
         name: sort_order
         in: query
       - type: string
-        description: Filter accounts by portfolio ID (UUID format)
+        description: Filter accounts by portfolio ID (UUID format). If both portfolio_id
+          and segment_id are provided, both filters are applied (AND semantics).
         name: portfolio_id
         in: query
       - type: string
-        description: Filter accounts by segment ID (UUID format)
+        description: Filter accounts by segment ID (UUID format). If both portfolio_id
+          and segment_id are provided, both filters are applied (AND semantics).
         name: segment_id
         in: query
       responses:

--- a/components/ledger/internal/adapters/http/in/account.go
+++ b/components/ledger/internal/adapters/http/in/account.go
@@ -126,8 +126,10 @@ func (handler *AccountHandler) GetAllAccounts(c *fiber.Ctx) error {
 	organizationID := c.Locals("organization_id").(uuid.UUID)
 	ledgerID := c.Locals("ledger_id").(uuid.UUID)
 
-	var portfolioID *uuid.UUID
-	var segmentID *uuid.UUID
+	var (
+		portfolioID *uuid.UUID
+		segmentID   *uuid.UUID
+	)
 
 	headerParams, err := http.ValidateParameters(c.Queries())
 	if err != nil {

--- a/components/ledger/internal/adapters/http/in/account.go
+++ b/components/ledger/internal/adapters/http/in/account.go
@@ -106,8 +106,8 @@ func (handler *AccountHandler) CreateAccount(i any, c *fiber.Ctx) error {
 //	@Param			start_date		query		string																false	"Filter accounts created on or after this date (format: YYYY-MM-DD)"
 //	@Param			end_date		query		string																false	"Filter accounts created on or before this date (format: YYYY-MM-DD)"
 //	@Param			sort_order		query		string																false	"Sort direction for results based on creation date"	Enums(asc,desc)
-//	@Param			portfolio_id	query		string																false	"Filter accounts by portfolio ID (UUID format)"
-//	@Param			segment_id		query		string																false	"Filter accounts by segment ID (UUID format)"
+//	@Param			portfolio_id	query		string																false	"Filter accounts by portfolio ID (UUID format). If both portfolio_id and segment_id are provided, both filters are applied (AND semantics)."
+//	@Param			segment_id		query		string																false	"Filter accounts by segment ID (UUID format). If both portfolio_id and segment_id are provided, both filters are applied (AND semantics)."
 //	@Success		200				{object}	http.Pagination{items=[]mmodel.Account}	"Successfully retrieved accounts list"
 //	@Failure		400				{object}	mmodel.Error														"Invalid query parameters"
 //	@Failure		401				{object}	mmodel.Error														"Unauthorized access"

--- a/components/ledger/internal/adapters/http/in/account.go
+++ b/components/ledger/internal/adapters/http/in/account.go
@@ -106,6 +106,8 @@ func (handler *AccountHandler) CreateAccount(i any, c *fiber.Ctx) error {
 //	@Param			start_date		query		string																false	"Filter accounts created on or after this date (format: YYYY-MM-DD)"
 //	@Param			end_date		query		string																false	"Filter accounts created on or before this date (format: YYYY-MM-DD)"
 //	@Param			sort_order		query		string																false	"Sort direction for results based on creation date"	Enums(asc,desc)
+//	@Param			portfolio_id	query		string																false	"Filter accounts by portfolio ID (UUID format)"
+//	@Param			segment_id		query		string																false	"Filter accounts by segment ID (UUID format)"
 //	@Success		200				{object}	http.Pagination{items=[]mmodel.Account}	"Successfully retrieved accounts list"
 //	@Failure		400				{object}	mmodel.Error														"Invalid query parameters"
 //	@Failure		401				{object}	mmodel.Error														"Unauthorized access"
@@ -125,6 +127,7 @@ func (handler *AccountHandler) GetAllAccounts(c *fiber.Ctx) error {
 	ledgerID := c.Locals("ledger_id").(uuid.UUID)
 
 	var portfolioID *uuid.UUID
+	var segmentID *uuid.UUID
 
 	headerParams, err := http.ValidateParameters(c.Queries())
 	if err != nil {
@@ -151,10 +154,17 @@ func (handler *AccountHandler) GetAllAccounts(c *fiber.Ctx) error {
 		logger.Log(ctx, libLog.LevelInfo, fmt.Sprintf("Search of all Accounts with Portfolio ID: %s", portfolioID))
 	}
 
+	if !libCommons.IsNilOrEmpty(&headerParams.SegmentID) {
+		parsedID := uuid.MustParse(headerParams.SegmentID)
+		segmentID = &parsedID
+
+		logger.Log(ctx, libLog.LevelInfo, fmt.Sprintf("Search of all Accounts with Segment ID: %s", segmentID))
+	}
+
 	if headerParams.Metadata != nil {
 		logger.Log(ctx, libLog.LevelInfo, "Initiating retrieval of all Accounts by metadata")
 
-		accounts, err := handler.Query.GetAllMetadataAccounts(ctx, organizationID, ledgerID, portfolioID, *headerParams)
+		accounts, err := handler.Query.GetAllMetadataAccounts(ctx, organizationID, ledgerID, portfolioID, segmentID, *headerParams)
 		if err != nil {
 			libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Failed to retrieve all Accounts on query", err)
 
@@ -174,7 +184,7 @@ func (handler *AccountHandler) GetAllAccounts(c *fiber.Ctx) error {
 
 	headerParams.Metadata = &bson.M{}
 
-	accounts, err := handler.Query.GetAllAccount(ctx, organizationID, ledgerID, portfolioID, *headerParams)
+	accounts, err := handler.Query.GetAllAccount(ctx, organizationID, ledgerID, portfolioID, segmentID, *headerParams)
 	if err != nil {
 		libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Failed to retrieve all Accounts on query", err)
 

--- a/components/ledger/internal/adapters/http/in/account.go
+++ b/components/ledger/internal/adapters/http/in/account.go
@@ -106,8 +106,8 @@ func (handler *AccountHandler) CreateAccount(i any, c *fiber.Ctx) error {
 //	@Param			start_date		query		string																false	"Filter accounts created on or after this date (format: YYYY-MM-DD)"
 //	@Param			end_date		query		string																false	"Filter accounts created on or before this date (format: YYYY-MM-DD)"
 //	@Param			sort_order		query		string																false	"Sort direction for results based on creation date"	Enums(asc,desc)
-//	@Param			portfolio_id	query		string																false	"Filter accounts by portfolio ID (UUID format). If both portfolio_id and segment_id are provided, both filters are applied (AND semantics)."
-//	@Param			segment_id		query		string																false	"Filter accounts by segment ID (UUID format). If both portfolio_id and segment_id are provided, both filters are applied (AND semantics)."
+//	@Param			portfolio_id	query		string																false	"Filter accounts by portfolio ID (UUID format). If both portfolio_id and segment_id are provided, both filters are applied (AND semantics)."	format(uuid)
+//	@Param			segment_id		query		string																false	"Filter accounts by segment ID (UUID format). If both portfolio_id and segment_id are provided, both filters are applied (AND semantics)."	format(uuid)
 //	@Success		200				{object}	http.Pagination{items=[]mmodel.Account}	"Successfully retrieved accounts list"
 //	@Failure		400				{object}	mmodel.Error														"Invalid query parameters"
 //	@Failure		401				{object}	mmodel.Error														"Unauthorized access"

--- a/components/ledger/internal/adapters/http/in/account_test.go
+++ b/components/ledger/internal/adapters/http/in/account_test.go
@@ -219,7 +219,7 @@ func TestAccountHandler_GetAllAccounts(t *testing.T) {
 			queryParams: "",
 			setupMocks: func(accountRepo *account.MockRepository, metadataRepo *mongodb.MockRepository, orgID, ledgerID uuid.UUID) {
 				accountRepo.EXPECT().
-					FindAll(gomock.Any(), orgID, ledgerID, gomock.Nil(), gomock.Any()).
+					FindAll(gomock.Any(), orgID, ledgerID, gomock.Nil(), gomock.Nil(), gomock.Any()).
 					Return([]*mmodel.Account{}, nil).
 					Times(1)
 			},
@@ -247,7 +247,7 @@ func TestAccountHandler_GetAllAccounts(t *testing.T) {
 				account2ID := uuid.New().String()
 
 				accountRepo.EXPECT().
-					FindAll(gomock.Any(), orgID, ledgerID, gomock.Nil(), gomock.Any()).
+					FindAll(gomock.Any(), orgID, ledgerID, gomock.Nil(), gomock.Nil(), gomock.Any()).
 					Return([]*mmodel.Account{
 						{
 							ID:             account1ID,
@@ -327,7 +327,7 @@ func TestAccountHandler_GetAllAccounts(t *testing.T) {
 
 				// AccountRepo.ListByIDs returns the accounts
 				accountRepo.EXPECT().
-					ListByIDs(gomock.Any(), orgID, ledgerID, gomock.Nil(), gomock.Any()).
+					ListByIDs(gomock.Any(), orgID, ledgerID, gomock.Nil(), gomock.Nil(), gomock.Any()).
 					Return([]*mmodel.Account{
 						{
 							ID:             account1ID,
@@ -408,7 +408,7 @@ func TestAccountHandler_GetAllAccounts(t *testing.T) {
 
 				// AccountRepo.ListByIDs returns not found error
 				accountRepo.EXPECT().
-					ListByIDs(gomock.Any(), orgID, ledgerID, gomock.Nil(), gomock.Any()).
+					ListByIDs(gomock.Any(), orgID, ledgerID, gomock.Nil(), gomock.Nil(), gomock.Any()).
 					Return(nil, pkg.ValidateBusinessError(cn.ErrNoAccountsFound, reflect.TypeOf(mmodel.Account{}).Name())).
 					Times(1)
 			},
@@ -426,7 +426,7 @@ func TestAccountHandler_GetAllAccounts(t *testing.T) {
 			queryParams: "",
 			setupMocks: func(accountRepo *account.MockRepository, metadataRepo *mongodb.MockRepository, orgID, ledgerID uuid.UUID) {
 				accountRepo.EXPECT().
-					FindAll(gomock.Any(), orgID, ledgerID, gomock.Nil(), gomock.Any()).
+					FindAll(gomock.Any(), orgID, ledgerID, gomock.Nil(), gomock.Nil(), gomock.Any()).
 					Return(nil, pkg.InternalServerError{
 						Code:    "0046",
 						Title:   "Internal Server Error",

--- a/components/ledger/internal/adapters/postgres/account/account.postgresql.go
+++ b/components/ledger/internal/adapters/postgres/account/account.postgresql.go
@@ -56,12 +56,12 @@ var accountColumnList = []string{
 // It defines methods for creating, retrieving, updating, and deleting accounts in the database.
 type Repository interface {
 	Create(ctx context.Context, acc *mmodel.Account) (*mmodel.Account, error)
-	FindAll(ctx context.Context, organizationID, ledgerID uuid.UUID, portfolioID *uuid.UUID, filter http.Pagination) ([]*mmodel.Account, error)
+	FindAll(ctx context.Context, organizationID, ledgerID uuid.UUID, portfolioID, segmentID *uuid.UUID, filter http.Pagination) ([]*mmodel.Account, error)
 	Find(ctx context.Context, organizationID, ledgerID uuid.UUID, portfolioID *uuid.UUID, id uuid.UUID) (*mmodel.Account, error)
 	FindWithDeleted(ctx context.Context, organizationID, ledgerID uuid.UUID, portfolioID *uuid.UUID, id uuid.UUID) (*mmodel.Account, error)
 	FindAlias(ctx context.Context, organizationID, ledgerID uuid.UUID, portfolioID *uuid.UUID, alias string) (*mmodel.Account, error)
 	FindByAlias(ctx context.Context, organizationID, ledgerID uuid.UUID, alias string) (bool, error)
-	ListByIDs(ctx context.Context, organizationID, ledgerID uuid.UUID, portfolioID *uuid.UUID, ids []uuid.UUID) ([]*mmodel.Account, error)
+	ListByIDs(ctx context.Context, organizationID, ledgerID uuid.UUID, portfolioID, segmentID *uuid.UUID, ids []uuid.UUID) ([]*mmodel.Account, error)
 	ListByAlias(ctx context.Context, organizationID, ledgerID, portfolioID uuid.UUID, alias []string) ([]*mmodel.Account, error)
 	Update(ctx context.Context, organizationID, ledgerID uuid.UUID, portfolioID *uuid.UUID, id uuid.UUID, acc *mmodel.Account) (*mmodel.Account, error)
 	Delete(ctx context.Context, organizationID, ledgerID uuid.UUID, portfolioID *uuid.UUID, id uuid.UUID) error
@@ -221,7 +221,7 @@ func (r *AccountPostgreSQLRepository) Create(ctx context.Context, acc *mmodel.Ac
 }
 
 // FindAll retrieves an Account entities from the database (including soft-deleted ones) with pagination.
-func (r *AccountPostgreSQLRepository) FindAll(ctx context.Context, organizationID, ledgerID uuid.UUID, portfolioID *uuid.UUID, filter http.Pagination) ([]*mmodel.Account, error) {
+func (r *AccountPostgreSQLRepository) FindAll(ctx context.Context, organizationID, ledgerID uuid.UUID, portfolioID, segmentID *uuid.UUID, filter http.Pagination) ([]*mmodel.Account, error) {
 	logger, tracer, _, _ := libCommons.NewTrackingFromContext(ctx)
 
 	ctx, span := tracer.Start(ctx, "postgres.find_all_accounts")
@@ -246,6 +246,10 @@ func (r *AccountPostgreSQLRepository) FindAll(ctx context.Context, organizationI
 
 	if portfolioID != nil && *portfolioID != uuid.Nil {
 		findAll = findAll.Where(squirrel.Expr("portfolio_id = ?", *portfolioID))
+	}
+
+	if segmentID != nil && *segmentID != uuid.Nil {
+		findAll = findAll.Where(squirrel.Expr("segment_id = ?", *segmentID))
 	}
 
 	findAll = findAll.OrderBy("created_at " + strings.ToUpper(filter.SortOrder)).
@@ -641,7 +645,7 @@ func (r *AccountPostgreSQLRepository) FindByAlias(ctx context.Context, organizat
 }
 
 // ListByIDs retrieves Accounts entities from the database using the provided IDs.
-func (r *AccountPostgreSQLRepository) ListByIDs(ctx context.Context, organizationID, ledgerID uuid.UUID, portfolioID *uuid.UUID, ids []uuid.UUID) ([]*mmodel.Account, error) {
+func (r *AccountPostgreSQLRepository) ListByIDs(ctx context.Context, organizationID, ledgerID uuid.UUID, portfolioID, segmentID *uuid.UUID, ids []uuid.UUID) ([]*mmodel.Account, error) {
 	logger, tracer, _, _ := libCommons.NewTrackingFromContext(ctx)
 
 	ctx, span := tracer.Start(ctx, "postgres.list_accounts_by_ids")
@@ -669,6 +673,10 @@ func (r *AccountPostgreSQLRepository) ListByIDs(ctx context.Context, organizatio
 
 	if portfolioID != nil && *portfolioID != uuid.Nil {
 		findAll = findAll.Where(squirrel.Expr("portfolio_id = ?", *portfolioID))
+	}
+
+	if segmentID != nil && *segmentID != uuid.Nil {
+		findAll = findAll.Where(squirrel.Expr("segment_id = ?", *segmentID))
 	}
 
 	query, args, err := findAll.ToSql()

--- a/components/ledger/internal/adapters/postgres/account/account.postgresql_integration_test.go
+++ b/components/ledger/internal/adapters/postgres/account/account.postgresql_integration_test.go
@@ -1043,6 +1043,39 @@ func TestIntegration_AccountRepository_ListByIDs_ReturnsMatchingAccounts(t *test
 	assert.True(t, ids[id2.String()])
 }
 
+func TestIntegration_AccountRepository_ListByIDs_FiltersBySegment(t *testing.T) {
+	// Arrange
+	container := pgtestutil.SetupContainer(t)
+
+	repo := createRepository(t, container)
+
+	orgID := pgtestutil.CreateTestOrganization(t, container.DB)
+	ledgerID := pgtestutil.CreateTestLedger(t, container.DB, orgID)
+	segmentID := pgtestutil.CreateTestSegmentWithParams(t, container.DB, orgID, ledgerID, pgtestutil.DefaultSegmentParams())
+
+	// Create 3 accounts, assign segment to 2 of them.
+	id1 := pgtestutil.CreateTestAccount(t, container.DB, orgID, ledgerID, nil, "In Segment 1", "@listsg1", "USD", nil)
+	id2 := pgtestutil.CreateTestAccount(t, container.DB, orgID, ledgerID, nil, "In Segment 2", "@listsg2", "USD", nil)
+	id3 := pgtestutil.CreateTestAccount(t, container.DB, orgID, ledgerID, nil, "No Segment", "@listsg3", "USD", nil)
+
+	_, err := container.DB.Exec("UPDATE account SET segment_id = $1 WHERE id IN ($2, $3)", segmentID, id1, id2)
+	require.NoError(t, err, "failed to assign segment_id to test accounts")
+
+	ctx := context.Background()
+
+	// Act: ListByIDs with all 3 IDs but segment filter should exclude id3.
+	accounts, err := repo.ListByIDs(ctx, orgID, ledgerID, nil, &segmentID, []uuid.UUID{id1, id2, id3})
+
+	// Assert
+	require.NoError(t, err)
+	assert.Len(t, accounts, 2, "should only return accounts matching the segment")
+
+	for _, acc := range accounts {
+		assert.NotNil(t, acc.SegmentID)
+		assert.Equal(t, segmentID.String(), *acc.SegmentID)
+	}
+}
+
 func TestIntegration_AccountRepository_ListByIDs_ExcludesSoftDeleted(t *testing.T) {
 	// Arrange
 	container := pgtestutil.SetupContainer(t)

--- a/components/ledger/internal/adapters/postgres/account/account.postgresql_integration_test.go
+++ b/components/ledger/internal/adapters/postgres/account/account.postgresql_integration_test.go
@@ -522,6 +522,47 @@ func TestIntegration_AccountRepository_FindAll_FiltersByPortfolio(t *testing.T) 
 	}
 }
 
+func TestIntegration_AccountRepository_FindAll_FiltersBySegment(t *testing.T) {
+	// Arrange
+	container := pgtestutil.SetupContainer(t)
+
+	repo := createRepository(t, container)
+
+	orgID := pgtestutil.CreateTestOrganization(t, container.DB)
+	ledgerID := pgtestutil.CreateTestLedger(t, container.DB, orgID)
+	segmentID := pgtestutil.CreateTestSegmentWithParams(t, container.DB, orgID, ledgerID, pgtestutil.DefaultSegmentParams())
+
+	// Insert 2 accounts with segment, 1 without.
+	acc1 := pgtestutil.CreateTestAccount(t, container.DB, orgID, ledgerID, nil, "In Segment 1", "@insegment1", "USD", nil)
+	acc2 := pgtestutil.CreateTestAccount(t, container.DB, orgID, ledgerID, nil, "In Segment 2", "@insegment2", "USD", nil)
+	pgtestutil.CreateTestAccount(t, container.DB, orgID, ledgerID, nil, "No Segment", "@nosegment", "USD", nil)
+
+	// Assign segment_id directly via SQL since CreateTestAccount doesn't support it.
+	_, err := container.DB.Exec("UPDATE account SET segment_id = $1 WHERE id IN ($2, $3)", segmentID, acc1, acc2)
+	require.NoError(t, err, "failed to assign segment_id to test accounts")
+
+	ctx := context.Background()
+	filter := http.Pagination{
+		Limit:     10,
+		Page:      1,
+		SortOrder: "asc",
+		StartDate: time.Now().Add(-24 * time.Hour),
+		EndDate:   time.Now().Add(24 * time.Hour),
+	}
+
+	// Act
+	accounts, err := repo.FindAll(ctx, orgID, ledgerID, nil, &segmentID, filter)
+
+	// Assert
+	require.NoError(t, err)
+	assert.Len(t, accounts, 2, "should only return accounts in the segment")
+
+	for _, acc := range accounts {
+		assert.NotNil(t, acc.SegmentID)
+		assert.Equal(t, segmentID.String(), *acc.SegmentID)
+	}
+}
+
 // ============================================================================
 // FindWithDeleted Tests
 // ============================================================================

--- a/components/ledger/internal/adapters/postgres/account/account.postgresql_integration_test.go
+++ b/components/ledger/internal/adapters/postgres/account/account.postgresql_integration_test.go
@@ -382,7 +382,7 @@ func TestIntegration_AccountRepository_FindAll_ReturnsPaginatedAccounts(t *testi
 	}
 
 	// Act
-	accounts, err := repo.FindAll(ctx, orgID, ledgerID, nil, filter)
+	accounts, err := repo.FindAll(ctx, orgID, ledgerID, nil, nil, filter)
 
 	// Assert
 	require.NoError(t, err, "FindAll should not return error")
@@ -420,15 +420,15 @@ func TestIntegration_AccountRepository_FindAll_PaginatesWithoutDuplicates(t *tes
 
 	// Act - Get all 3 pages
 	baseFilter.Page = 1
-	page1, err := repo.FindAll(ctx, orgID, ledgerID, nil, baseFilter)
+	page1, err := repo.FindAll(ctx, orgID, ledgerID, nil, nil, baseFilter)
 	require.NoError(t, err)
 
 	baseFilter.Page = 2
-	page2, err := repo.FindAll(ctx, orgID, ledgerID, nil, baseFilter)
+	page2, err := repo.FindAll(ctx, orgID, ledgerID, nil, nil, baseFilter)
 	require.NoError(t, err)
 
 	baseFilter.Page = 3
-	page3, err := repo.FindAll(ctx, orgID, ledgerID, nil, baseFilter)
+	page3, err := repo.FindAll(ctx, orgID, ledgerID, nil, nil, baseFilter)
 	require.NoError(t, err)
 
 	// Assert - Correct counts per page
@@ -474,7 +474,7 @@ func TestIntegration_AccountRepository_FindAll_ExcludesSoftDeleted(t *testing.T)
 	}
 
 	// Act
-	accounts, err := repo.FindAll(ctx, orgID, ledgerID, nil, filter)
+	accounts, err := repo.FindAll(ctx, orgID, ledgerID, nil, nil, filter)
 
 	// Assert
 	require.NoError(t, err)
@@ -510,7 +510,7 @@ func TestIntegration_AccountRepository_FindAll_FiltersByPortfolio(t *testing.T) 
 	}
 
 	// Act
-	accounts, err := repo.FindAll(ctx, orgID, ledgerID, &portfolioID, filter)
+	accounts, err := repo.FindAll(ctx, orgID, ledgerID, &portfolioID, nil, filter)
 
 	// Assert
 	require.NoError(t, err)
@@ -988,7 +988,7 @@ func TestIntegration_AccountRepository_ListByIDs_ReturnsMatchingAccounts(t *test
 	ctx := context.Background()
 
 	// Act
-	accounts, err := repo.ListByIDs(ctx, orgID, ledgerID, nil, []uuid.UUID{id1, id2})
+	accounts, err := repo.ListByIDs(ctx, orgID, ledgerID, nil, nil, []uuid.UUID{id1, id2})
 
 	// Assert
 	require.NoError(t, err)
@@ -1018,7 +1018,7 @@ func TestIntegration_AccountRepository_ListByIDs_ExcludesSoftDeleted(t *testing.
 	ctx := context.Background()
 
 	// Act
-	accounts, err := repo.ListByIDs(ctx, orgID, ledgerID, nil, []uuid.UUID{id1, id2})
+	accounts, err := repo.ListByIDs(ctx, orgID, ledgerID, nil, nil, []uuid.UUID{id1, id2})
 
 	// Assert
 	require.NoError(t, err)
@@ -1038,7 +1038,7 @@ func TestIntegration_AccountRepository_ListByIDs_ReturnsEmptyForNoMatch(t *testi
 	ctx := context.Background()
 
 	// Act
-	accounts, err := repo.ListByIDs(ctx, orgID, ledgerID, nil, []uuid.UUID{uuid.Must(libCommons.GenerateUUIDv7())})
+	accounts, err := repo.ListByIDs(ctx, orgID, ledgerID, nil, nil, []uuid.UUID{uuid.Must(libCommons.GenerateUUIDv7())})
 
 	// Assert
 	require.NoError(t, err)

--- a/components/ledger/internal/adapters/postgres/account/account.postgresql_mock.go
+++ b/components/ledger/internal/adapters/postgres/account/account.postgresql_mock.go
@@ -103,18 +103,18 @@ func (mr *MockRepositoryMockRecorder) FindAlias(ctx, organizationID, ledgerID, p
 }
 
 // FindAll mocks base method.
-func (m *MockRepository) FindAll(ctx context.Context, organizationID, ledgerID uuid.UUID, portfolioID *uuid.UUID, filter http.Pagination) ([]*mmodel.Account, error) {
+func (m *MockRepository) FindAll(ctx context.Context, organizationID, ledgerID uuid.UUID, portfolioID, segmentID *uuid.UUID, filter http.Pagination) ([]*mmodel.Account, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "FindAll", ctx, organizationID, ledgerID, portfolioID, filter)
+	ret := m.ctrl.Call(m, "FindAll", ctx, organizationID, ledgerID, portfolioID, segmentID, filter)
 	ret0, _ := ret[0].([]*mmodel.Account)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // FindAll indicates an expected call of FindAll.
-func (mr *MockRepositoryMockRecorder) FindAll(ctx, organizationID, ledgerID, portfolioID, filter any) *gomock.Call {
+func (mr *MockRepositoryMockRecorder) FindAll(ctx, organizationID, ledgerID, portfolioID, segmentID, filter any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindAll", reflect.TypeOf((*MockRepository)(nil).FindAll), ctx, organizationID, ledgerID, portfolioID, filter)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindAll", reflect.TypeOf((*MockRepository)(nil).FindAll), ctx, organizationID, ledgerID, portfolioID, segmentID, filter)
 }
 
 // FindByAlias mocks base method.
@@ -193,18 +193,18 @@ func (mr *MockRepositoryMockRecorder) ListByAlias(ctx, organizationID, ledgerID,
 }
 
 // ListByIDs mocks base method.
-func (m *MockRepository) ListByIDs(ctx context.Context, organizationID, ledgerID uuid.UUID, portfolioID *uuid.UUID, ids []uuid.UUID) ([]*mmodel.Account, error) {
+func (m *MockRepository) ListByIDs(ctx context.Context, organizationID, ledgerID uuid.UUID, portfolioID, segmentID *uuid.UUID, ids []uuid.UUID) ([]*mmodel.Account, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListByIDs", ctx, organizationID, ledgerID, portfolioID, ids)
+	ret := m.ctrl.Call(m, "ListByIDs", ctx, organizationID, ledgerID, portfolioID, segmentID, ids)
 	ret0, _ := ret[0].([]*mmodel.Account)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ListByIDs indicates an expected call of ListByIDs.
-func (mr *MockRepositoryMockRecorder) ListByIDs(ctx, organizationID, ledgerID, portfolioID, ids any) *gomock.Call {
+func (mr *MockRepositoryMockRecorder) ListByIDs(ctx, organizationID, ledgerID, portfolioID, segmentID, ids any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListByIDs", reflect.TypeOf((*MockRepository)(nil).ListByIDs), ctx, organizationID, ledgerID, portfolioID, ids)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListByIDs", reflect.TypeOf((*MockRepository)(nil).ListByIDs), ctx, organizationID, ledgerID, portfolioID, segmentID, ids)
 }
 
 // Update mocks base method.

--- a/components/ledger/internal/services/query/get-all-accounts.go
+++ b/components/ledger/internal/services/query/get-all-accounts.go
@@ -22,7 +22,7 @@ import (
 )
 
 // GetAllAccount fetches all accounts from the repository.
-func (uc *UseCase) GetAllAccount(ctx context.Context, organizationID, ledgerID uuid.UUID, portfolioID *uuid.UUID, filter http.QueryHeader) ([]*mmodel.Account, error) {
+func (uc *UseCase) GetAllAccount(ctx context.Context, organizationID, ledgerID uuid.UUID, portfolioID, segmentID *uuid.UUID, filter http.QueryHeader) ([]*mmodel.Account, error) {
 	logger, tracer, _, _ := libCommons.NewTrackingFromContext(ctx)
 
 	ctx, span := tracer.Start(ctx, "query.get_all_account")
@@ -30,7 +30,7 @@ func (uc *UseCase) GetAllAccount(ctx context.Context, organizationID, ledgerID u
 
 	logger.Log(ctx, libLog.LevelInfo, "Retrieving accounts")
 
-	accounts, err := uc.AccountRepo.FindAll(ctx, organizationID, ledgerID, portfolioID, filter.ToOffsetPagination())
+	accounts, err := uc.AccountRepo.FindAll(ctx, organizationID, ledgerID, portfolioID, segmentID, filter.ToOffsetPagination())
 	if err != nil {
 		logger.Log(ctx, libLog.LevelError, fmt.Sprintf("Error getting accounts on repo: %v", err))
 

--- a/components/ledger/internal/services/query/get-all-accounts_integration_test.go
+++ b/components/ledger/internal/services/query/get-all-accounts_integration_test.go
@@ -4,10 +4,6 @@
 
 //go:build integration
 
-// Copyright (c) 2026 Lerian Studio. All rights reserved.
-// Use of this source code is governed by the Elastic License 2.0
-// that can be found in the LICENSE file.
-
 package query
 
 import (

--- a/components/ledger/internal/services/query/get-all-accounts_integration_test.go
+++ b/components/ledger/internal/services/query/get-all-accounts_integration_test.go
@@ -78,7 +78,7 @@ func TestIntegration_GetAllAccount_PaginationUnion(t *testing.T) {
 			EndDate:   time.Now().Add(24 * time.Hour),
 		}
 
-		accounts, err := uc.GetAllAccount(ctx, orgID, ledgerID, nil, filter)
+		accounts, err := uc.GetAllAccount(ctx, orgID, ledgerID, nil, nil, filter)
 		require.NoError(t, err, "GetAllAccount page %d should succeed", page)
 
 		for _, acc := range accounts {
@@ -148,11 +148,11 @@ func TestIntegration_GetAllAccount_PaginationStableOrder(t *testing.T) {
 	}
 
 	// First read
-	accounts1, err := uc.GetAllAccount(ctx, orgID, ledgerID, nil, filter)
+	accounts1, err := uc.GetAllAccount(ctx, orgID, ledgerID, nil, nil, filter)
 	require.NoError(t, err, "first GetAllAccount should succeed")
 
 	// Second read
-	accounts2, err := uc.GetAllAccount(ctx, orgID, ledgerID, nil, filter)
+	accounts2, err := uc.GetAllAccount(ctx, orgID, ledgerID, nil, nil, filter)
 	require.NoError(t, err, "second GetAllAccount should succeed")
 
 	// Assert: same length

--- a/components/ledger/internal/services/query/get-all-accounts_test.go
+++ b/components/ledger/internal/services/query/get-all-accounts_test.go
@@ -35,6 +35,7 @@ func TestGetAllAccount(t *testing.T) {
 	organizationID := uuid.New()
 	ledgerID := uuid.New()
 	portfolioID := uuid.New()
+	segmentID := uuid.New()
 
 	filter := http.QueryHeader{
 		Limit: 10,
@@ -43,12 +44,16 @@ func TestGetAllAccount(t *testing.T) {
 
 	tests := []struct {
 		name             string
+		portfolioID      *uuid.UUID
+		segmentID        *uuid.UUID
 		setupMocks       func()
 		expectedErr      error
 		expectedAccounts []*mmodel.Account
 	}{
 		{
-			name: "success - accounts retrieved with metadata",
+			name:        "success - accounts retrieved with metadata",
+			portfolioID: &portfolioID,
+			segmentID:   nil,
 			setupMocks: func() {
 				bFalse := false
 				bTrue := true
@@ -81,7 +86,33 @@ func TestGetAllAccount(t *testing.T) {
 			},
 		},
 		{
-			name: "failure - accounts not found",
+			name:        "success - accounts filtered by segmentID",
+			portfolioID: &portfolioID,
+			segmentID:   &segmentID,
+			setupMocks: func() {
+				mockAccountRepo.EXPECT().
+					FindAll(gomock.Any(), organizationID, ledgerID, &portfolioID, &segmentID, filter.ToOffsetPagination()).
+					Return([]*mmodel.Account{
+						{ID: "acc1"},
+					}, nil).
+					Times(1)
+
+				mockMetadataRepo.EXPECT().
+					FindByEntityIDs(gomock.Any(), "Account", []string{"acc1"}).
+					Return([]*mongodb.Metadata{
+						{EntityID: "acc1", Data: map[string]any{"key1": "value1"}},
+					}, nil).
+					Times(1)
+			},
+			expectedErr: nil,
+			expectedAccounts: []*mmodel.Account{
+				{ID: "acc1", Metadata: map[string]any{"key1": "value1"}},
+			},
+		},
+		{
+			name:        "failure - accounts not found",
+			portfolioID: &portfolioID,
+			segmentID:   nil,
 			setupMocks: func() {
 				mockAccountRepo.EXPECT().
 					FindAll(gomock.Any(), organizationID, ledgerID, &portfolioID, gomock.Nil(), filter.ToOffsetPagination()).
@@ -92,7 +123,9 @@ func TestGetAllAccount(t *testing.T) {
 			expectedAccounts: nil,
 		},
 		{
-			name: "failure - error retrieving accounts",
+			name:        "failure - error retrieving accounts",
+			portfolioID: &portfolioID,
+			segmentID:   nil,
 			setupMocks: func() {
 				mockAccountRepo.EXPECT().
 					FindAll(gomock.Any(), organizationID, ledgerID, &portfolioID, gomock.Nil(), filter.ToOffsetPagination()).
@@ -103,7 +136,9 @@ func TestGetAllAccount(t *testing.T) {
 			expectedAccounts: nil,
 		},
 		{
-			name: "failure - metadata retrieval error",
+			name:        "failure - metadata retrieval error",
+			portfolioID: &portfolioID,
+			segmentID:   nil,
 			setupMocks: func() {
 				mockAccountRepo.EXPECT().
 					FindAll(gomock.Any(), organizationID, ledgerID, &portfolioID, gomock.Nil(), filter.ToOffsetPagination()).
@@ -127,7 +162,7 @@ func TestGetAllAccount(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			tt.setupMocks()
 
-			result, err := uc.GetAllAccount(ctx, organizationID, ledgerID, &portfolioID, nil, filter)
+			result, err := uc.GetAllAccount(ctx, organizationID, ledgerID, tt.portfolioID, tt.segmentID, filter)
 
 			if tt.expectedErr != nil {
 				assert.Error(t, err)

--- a/components/ledger/internal/services/query/get-all-accounts_test.go
+++ b/components/ledger/internal/services/query/get-all-accounts_test.go
@@ -53,7 +53,7 @@ func TestGetAllAccount(t *testing.T) {
 				bFalse := false
 				bTrue := true
 				mockAccountRepo.EXPECT().
-					FindAll(gomock.Any(), organizationID, ledgerID, &portfolioID, filter.ToOffsetPagination()).
+					FindAll(gomock.Any(), organizationID, ledgerID, &portfolioID, gomock.Nil(), filter.ToOffsetPagination()).
 					Return([]*mmodel.Account{
 						{ID: "acc1", Blocked: &bFalse},
 						{ID: "acc2", Blocked: &bTrue},
@@ -84,7 +84,7 @@ func TestGetAllAccount(t *testing.T) {
 			name: "failure - accounts not found",
 			setupMocks: func() {
 				mockAccountRepo.EXPECT().
-					FindAll(gomock.Any(), organizationID, ledgerID, &portfolioID, filter.ToOffsetPagination()).
+					FindAll(gomock.Any(), organizationID, ledgerID, &portfolioID, gomock.Nil(), filter.ToOffsetPagination()).
 					Return(nil, services.ErrDatabaseItemNotFound).
 					Times(1)
 			},
@@ -95,7 +95,7 @@ func TestGetAllAccount(t *testing.T) {
 			name: "failure - error retrieving accounts",
 			setupMocks: func() {
 				mockAccountRepo.EXPECT().
-					FindAll(gomock.Any(), organizationID, ledgerID, &portfolioID, filter.ToOffsetPagination()).
+					FindAll(gomock.Any(), organizationID, ledgerID, &portfolioID, gomock.Nil(), filter.ToOffsetPagination()).
 					Return(nil, errors.New("failed to retrieve accounts")).
 					Times(1)
 			},
@@ -106,7 +106,7 @@ func TestGetAllAccount(t *testing.T) {
 			name: "failure - metadata retrieval error",
 			setupMocks: func() {
 				mockAccountRepo.EXPECT().
-					FindAll(gomock.Any(), organizationID, ledgerID, &portfolioID, filter.ToOffsetPagination()).
+					FindAll(gomock.Any(), organizationID, ledgerID, &portfolioID, gomock.Nil(), filter.ToOffsetPagination()).
 					Return([]*mmodel.Account{
 						{ID: "acc1"},
 						{ID: "acc2"},
@@ -127,7 +127,7 @@ func TestGetAllAccount(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			tt.setupMocks()
 
-			result, err := uc.GetAllAccount(ctx, organizationID, ledgerID, &portfolioID, filter)
+			result, err := uc.GetAllAccount(ctx, organizationID, ledgerID, &portfolioID, nil, filter)
 
 			if tt.expectedErr != nil {
 				assert.Error(t, err)

--- a/components/ledger/internal/services/query/get-all-metadata-accounts.go
+++ b/components/ledger/internal/services/query/get-all-metadata-accounts.go
@@ -21,7 +21,7 @@ import (
 )
 
 // GetAllMetadataAccounts fetches all accounts from the repository.
-func (uc *UseCase) GetAllMetadataAccounts(ctx context.Context, organizationID, ledgerID uuid.UUID, portfolioID *uuid.UUID, filter http.QueryHeader) ([]*mmodel.Account, error) {
+func (uc *UseCase) GetAllMetadataAccounts(ctx context.Context, organizationID, ledgerID uuid.UUID, portfolioID, segmentID *uuid.UUID, filter http.QueryHeader) ([]*mmodel.Account, error) {
 	logger, tracer, _, _ := libCommons.NewTrackingFromContext(ctx)
 
 	ctx, span := tracer.Start(ctx, "query.get_all_metadata_accounts")
@@ -55,7 +55,7 @@ func (uc *UseCase) GetAllMetadataAccounts(ctx context.Context, organizationID, l
 		metadataMap[meta.EntityID] = meta.Data
 	}
 
-	accounts, err := uc.AccountRepo.ListByIDs(ctx, organizationID, ledgerID, portfolioID, uuids)
+	accounts, err := uc.AccountRepo.ListByIDs(ctx, organizationID, ledgerID, portfolioID, segmentID, uuids)
 	if err != nil {
 		if errors.Is(err, services.ErrDatabaseItemNotFound) {
 			err := pkg.ValidateBusinessError(constant.ErrNoAccountsFound, reflect.TypeOf(mmodel.Account{}).Name())

--- a/components/ledger/internal/services/query/get-all-metadata-accounts_test.go
+++ b/components/ledger/internal/services/query/get-all-metadata-accounts_test.go
@@ -60,7 +60,7 @@ func TestGetAllMetadataAccounts(t *testing.T) {
 						{EntityID: acc2ID.String(), Data: map[string]any{"group": "ops"}},
 					}, nil)
 				mockAccountRepo.EXPECT().
-					ListByIDs(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Eq([]uuid.UUID{acc1ID, acc2ID})).
+					ListByIDs(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Eq([]uuid.UUID{acc1ID, acc2ID})).
 					Return([]*mmodel.Account{
 						{ID: acc1ID.String(), Name: "Account 1", Status: mmodel.Status{Code: "ACTIVE"}},
 						{ID: acc2ID.String(), Name: "Account 2", Status: mmodel.Status{Code: "ACTIVE"}},
@@ -98,7 +98,7 @@ func TestGetAllMetadataAccounts(t *testing.T) {
 						},
 					}, nil)
 				mockAccountRepo.EXPECT().
-					ListByIDs(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					ListByIDs(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 					Return([]*mmodel.Account{
 						{ID: acc1ID.String(), Name: "Admin Account"},
 					}, nil)
@@ -121,7 +121,7 @@ func TestGetAllMetadataAccounts(t *testing.T) {
 						{EntityID: acc1ID.String(), Data: map[string]any{"key": "value"}},
 					}, nil)
 				mockAccountRepo.EXPECT().
-					ListByIDs(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Not(gomock.Nil()), gomock.Any()).
+					ListByIDs(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Not(gomock.Nil()), gomock.Any(), gomock.Any()).
 					Return([]*mmodel.Account{
 						{ID: acc1ID.String(), Name: "Portfolio Account"},
 					}, nil)
@@ -171,7 +171,7 @@ func TestGetAllMetadataAccounts(t *testing.T) {
 						{EntityID: acc1ID.String(), Data: map[string]any{"key": "value"}},
 					}, nil)
 				mockAccountRepo.EXPECT().
-					ListByIDs(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					ListByIDs(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(nil, services.ErrDatabaseItemNotFound)
 			},
 			expectErr:   true,
@@ -189,7 +189,7 @@ func TestGetAllMetadataAccounts(t *testing.T) {
 						{EntityID: acc1ID.String(), Data: map[string]any{"key": "value"}},
 					}, nil)
 				mockAccountRepo.EXPECT().
-					ListByIDs(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					ListByIDs(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(nil, errors.New("database connection timeout"))
 			},
 			expectErr:   true,
@@ -209,7 +209,7 @@ func TestGetAllMetadataAccounts(t *testing.T) {
 						{EntityID: acc2ID.String(), Data: map[string]any{"found": true}},
 					}, nil)
 				mockAccountRepo.EXPECT().
-					ListByIDs(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					ListByIDs(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 					Return([]*mmodel.Account{
 						{ID: acc1ID.String(), Name: "Only This One"},
 					}, nil)
@@ -228,7 +228,7 @@ func TestGetAllMetadataAccounts(t *testing.T) {
 			tt.mockSetup()
 
 			ctx := context.Background()
-			result, err := uc.GetAllMetadataAccounts(ctx, tt.organizationID, tt.ledgerID, tt.portfolioID, tt.filter)
+			result, err := uc.GetAllMetadataAccounts(ctx, tt.organizationID, tt.ledgerID, tt.portfolioID, nil, tt.filter)
 
 			if tt.expectErr {
 				require.Error(t, err)

--- a/components/ledger/internal/services/query/get-all-metadata-accounts_test.go
+++ b/components/ledger/internal/services/query/get-all-metadata-accounts_test.go
@@ -160,6 +160,31 @@ func TestGetAllMetadataAccounts(t *testing.T) {
 			},
 		},
 		{
+			name:           "success - filters by both portfolio and segment when provided",
+			organizationID: uuid.New(),
+			ledgerID:       uuid.New(),
+			portfolioID:    func() *uuid.UUID { id := uuid.New(); return &id }(),
+			segmentID:      func() *uuid.UUID { id := uuid.New(); return &id }(),
+			mockSetup: func() {
+				mockMetadataRepo.EXPECT().
+					FindList(gomock.Any(), "Account", gomock.Any()).
+					Return([]*mongodb.Metadata{
+						{EntityID: acc1ID.String(), Data: map[string]any{"key": "both-value"}},
+					}, nil)
+				mockAccountRepo.EXPECT().
+					ListByIDs(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Not(gomock.Nil()), gomock.Not(gomock.Nil()), gomock.Any()).
+					Return([]*mmodel.Account{
+						{ID: acc1ID.String(), Name: "Both Filters Account"},
+					}, nil)
+			},
+			expectErr: false,
+			validate: func(t *testing.T, result []*mmodel.Account) {
+				require.Len(t, result, 1)
+				assert.Equal(t, acc1ID.String(), result[0].ID)
+				assert.Equal(t, "both-value", result[0].Metadata["key"])
+			},
+		},
+		{
 			name:           "error - metadata not found returns nil",
 			organizationID: uuid.New(),
 			ledgerID:       uuid.New(),

--- a/components/ledger/internal/services/query/get-all-metadata-accounts_test.go
+++ b/components/ledger/internal/services/query/get-all-metadata-accounts_test.go
@@ -41,6 +41,7 @@ func TestGetAllMetadataAccounts(t *testing.T) {
 		organizationID uuid.UUID
 		ledgerID       uuid.UUID
 		portfolioID    *uuid.UUID
+		segmentID      *uuid.UUID
 		filter         http.QueryHeader
 		mockSetup      func()
 		expectErr      bool
@@ -131,6 +132,31 @@ func TestGetAllMetadataAccounts(t *testing.T) {
 				require.Len(t, result, 1)
 				assert.Equal(t, acc1ID.String(), result[0].ID)
 				assert.Equal(t, "value", result[0].Metadata["key"])
+			},
+		},
+		{
+			name:           "success - filters by segment when provided",
+			organizationID: uuid.New(),
+			ledgerID:       uuid.New(),
+			portfolioID:    nil,
+			segmentID:      func() *uuid.UUID { id := uuid.New(); return &id }(),
+			mockSetup: func() {
+				mockMetadataRepo.EXPECT().
+					FindList(gomock.Any(), "Account", gomock.Any()).
+					Return([]*mongodb.Metadata{
+						{EntityID: acc1ID.String(), Data: map[string]any{"key": "seg-value"}},
+					}, nil)
+				mockAccountRepo.EXPECT().
+					ListByIDs(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Not(gomock.Nil()), gomock.Any()).
+					Return([]*mmodel.Account{
+						{ID: acc1ID.String(), Name: "Segment Account"},
+					}, nil)
+			},
+			expectErr: false,
+			validate: func(t *testing.T, result []*mmodel.Account) {
+				require.Len(t, result, 1)
+				assert.Equal(t, acc1ID.String(), result[0].ID)
+				assert.Equal(t, "seg-value", result[0].Metadata["key"])
 			},
 		},
 		{
@@ -228,7 +254,7 @@ func TestGetAllMetadataAccounts(t *testing.T) {
 			tt.mockSetup()
 
 			ctx := context.Background()
-			result, err := uc.GetAllMetadataAccounts(ctx, tt.organizationID, tt.ledgerID, tt.portfolioID, nil, tt.filter)
+			result, err := uc.GetAllMetadataAccounts(ctx, tt.organizationID, tt.ledgerID, tt.portfolioID, tt.segmentID, tt.filter)
 
 			if tt.expectErr {
 				require.Error(t, err)

--- a/components/ledger/migrations/onboarding/000009_create_idx_account_segment.down.sql
+++ b/components/ledger/migrations/onboarding/000009_create_idx_account_segment.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX CONCURRENTLY IF EXISTS idx_account_segment;

--- a/components/ledger/migrations/onboarding/000009_create_idx_account_segment.up.sql
+++ b/components/ledger/migrations/onboarding/000009_create_idx_account_segment.up.sql
@@ -1,0 +1,3 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_account_segment
+    ON account (organization_id, ledger_id, segment_id)
+    WHERE deleted_at IS NULL;

--- a/components/ledger/migrations/onboarding/000010_create_idx_account_portfolio.down.sql
+++ b/components/ledger/migrations/onboarding/000010_create_idx_account_portfolio.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX CONCURRENTLY IF EXISTS idx_account_portfolio;

--- a/components/ledger/migrations/onboarding/000010_create_idx_account_portfolio.up.sql
+++ b/components/ledger/migrations/onboarding/000010_create_idx_account_portfolio.up.sql
@@ -1,0 +1,3 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_account_portfolio
+    ON account (organization_id, ledger_id, portfolio_id)
+    WHERE deleted_at IS NULL;

--- a/pkg/net/http/httputils.go
+++ b/pkg/net/http/httputils.go
@@ -36,6 +36,7 @@ type QueryHeader struct {
 	EndDate                             time.Time
 	UseMetadata                         bool
 	PortfolioID                         string
+	SegmentID                           string
 	OperationType                       string
 	Direction                           *string
 	RouteID                             *string
@@ -96,6 +97,7 @@ func ValidateParameters(params map[string]string) (*QueryHeader, error) {
 	var (
 		metadata                            *bson.M
 		portfolioID                         string
+		segmentID                           string
 		operationType                       string
 		direction                           *string
 		routeID                             *string
@@ -153,6 +155,8 @@ func ValidateParameters(params map[string]string) (*QueryHeader, error) {
 			endDate = parsedDate
 		case strings.Contains(key, "portfolio_id"):
 			portfolioID = value
+		case strings.Contains(key, "segment_id"):
+			segmentID = value
 		case strings.Contains(strings.ToLower(key), "type"):
 			operationType = strings.ToUpper(value)
 		case key == "direction":
@@ -224,6 +228,13 @@ func ValidateParameters(params map[string]string) (*QueryHeader, error) {
 		}
 	}
 
+	if !libCommons.IsNilOrEmpty(&segmentID) {
+		_, err := uuid.Parse(segmentID)
+		if err != nil {
+			return nil, pkg.ValidateBusinessError(constant.ErrInvalidQueryParameter, "", "segment_id")
+		}
+	}
+
 	if direction != nil && *direction != constant.DirectionDebit && *direction != constant.DirectionCredit {
 		return nil, pkg.ValidateBusinessError(constant.ErrInvalidQueryParameter, "", "direction")
 	}
@@ -244,6 +255,7 @@ func ValidateParameters(params map[string]string) (*QueryHeader, error) {
 		EndDate:                             endDate,
 		UseMetadata:                         useMetadata,
 		PortfolioID:                         portfolioID,
+		SegmentID:                           segmentID,
 		OperationType:                       operationType,
 		Direction:                           direction,
 		RouteID:                             routeID,

--- a/pkg/net/http/httputils_test.go
+++ b/pkg/net/http/httputils_test.go
@@ -184,6 +184,29 @@ func TestValidateParameters_WithInvalidPortfolioID(t *testing.T) {
 	assert.Nil(t, result)
 }
 
+func TestValidateParameters_WithSegmentID(t *testing.T) {
+	validUUID := "123e4567-e89b-12d3-a456-426614174000"
+	params := map[string]string{
+		"segment_id": validUUID,
+	}
+
+	result, err := ValidateParameters(params)
+
+	require.NoError(t, err)
+	assert.Equal(t, validUUID, result.SegmentID)
+}
+
+func TestValidateParameters_WithInvalidSegmentID(t *testing.T) {
+	params := map[string]string{
+		"segment_id": "invalid-uuid",
+	}
+
+	result, err := ValidateParameters(params)
+
+	assert.Error(t, err)
+	assert.Nil(t, result)
+}
+
 func TestValidateParameters_WithOperationType(t *testing.T) {
 	params := map[string]string{
 		"type": "credit",

--- a/postman/MIDAZ.postman_collection.json
+++ b/postman/MIDAZ.postman_collection.json
@@ -24,7 +24,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "afd5934a-0c89-4990-baed-eb66efe3423d",
+                "id": "fd9ff3f4-285d-4404-891b-29689e0cafbe",
                 "exec": [
                   "// Request not found in collection for: POST /v1/organizations",
                   "// Variables to extract: [\"organizationId\"]"
@@ -47,7 +47,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "fa3cd0ee-6776-44ca-998c-08d02c7d6810",
+                "id": "30b0f877-9459-4e60-bb99-cb3bf6213883",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}",
                   "// Variables to extract: []"
@@ -70,7 +70,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "628614a7-0e46-4917-b741-5ab2d8efbaf5",
+                "id": "44e7ca79-2d22-454a-af92-aa9bc84b7e98",
                 "exec": [
                   "// Request not found in collection for: PATCH /v1/organizations/{organizationId}",
                   "// Variables to extract: []"
@@ -93,7 +93,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "8defd71d-05ec-4bd8-ad36-90d224e0edab",
+                "id": "83cf2fc7-1e80-4aed-87d9-81175c3e9f19",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations",
                   "// Variables to extract: []"
@@ -116,7 +116,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "c576f53e-728f-4a34-85af-639f63c3ac9a",
+                "id": "edfaa65e-366f-40ab-a22f-45799193f5ac",
                 "exec": [
                   "// Request not found in collection for: POST /v1/organizations/{organizationId}/ledgers",
                   "// Variables to extract: [\"ledgerId\"]"
@@ -139,7 +139,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "297a1f60-4d4f-4005-8bc4-e44b8a70207d",
+                "id": "1515b4e3-7fd1-40f1-8740-ae27380411f4",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}",
                   "// Variables to extract: []"
@@ -162,7 +162,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "8a4c8182-770d-45ca-8c10-2b00f400e977",
+                "id": "1442d442-0da1-4e97-b1d4-8a05f9a111a4",
                 "exec": [
                   "// Request not found in collection for: PATCH /v1/organizations/{organizationId}/ledgers/{ledgerId}",
                   "// Variables to extract: []"
@@ -185,7 +185,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "2beeee75-5a86-4d91-9f3a-83b039da55bd",
+                "id": "dd172487-bae4-4c02-962a-34e3099a24ac",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers",
                   "// Variables to extract: []"
@@ -208,7 +208,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "3c29949e-05b0-4b85-81d4-d0fd5856c5d8",
+                "id": "895b0089-038d-4be5-8784-8da068f9c0fb",
                 "exec": [
                   "// Request not found in collection for: POST /v1/organizations/{organizationId}/ledgers/{ledgerId}/assets",
                   "// Variables to extract: [\"assetId\"]"
@@ -231,7 +231,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "3a84b2b9-6080-4a7d-8645-5360f5606b3a",
+                "id": "336522b8-1432-47bc-96fe-6371c86ad33e",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/assets/{assetId}",
                   "// Variables to extract: []"
@@ -254,7 +254,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "208b5816-bc98-4dd0-b2df-ed773ea61063",
+                "id": "5b174d23-aea2-4f0b-be24-32028d19d4ad",
                 "exec": [
                   "// Request not found in collection for: PATCH /v1/organizations/{organizationId}/ledgers/{ledgerId}/assets/{assetId}",
                   "// Variables to extract: []"
@@ -277,7 +277,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "68002d81-8dfd-4dd9-aacd-bd5e1aa53d82",
+                "id": "b79f0bb9-be74-4699-87bc-28f46773e70f",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/assets",
                   "// Variables to extract: []"
@@ -300,7 +300,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "54a53a1e-e0ea-4c9b-9ef8-46cfe8acb693",
+                "id": "8814cfa1-743d-41d2-8e25-7d092a689ada",
                 "exec": [
                   "// Request not found in collection for: POST /v1/organizations/{organizationId}/ledgers/{ledgerId}/accounts",
                   "// Variables to extract: [\"accountId\",\"accountAlias\"]"
@@ -323,7 +323,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "ff208bf0-b3c4-4017-8489-2192b64fded4",
+                "id": "a6f74201-2338-4053-a9f8-a314ba7d6e13",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/accounts/{accountId}",
                   "// Variables to extract: []"
@@ -346,7 +346,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "f3de0982-ca7f-4fe9-9fbf-4a82446eab79",
+                "id": "f4d708b3-9fc1-4ee3-a400-bdf145c35e74",
                 "exec": [
                   "// Request not found in collection for: PATCH /v1/organizations/{organizationId}/ledgers/{ledgerId}/accounts/{accountId}",
                   "// Variables to extract: []"
@@ -369,7 +369,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "8b09e9e9-bd2e-4f3e-b5f4-8c6dc470473b",
+                "id": "16d4688b-31e3-4abd-b9b1-bbdc944ca356",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/accounts",
                   "// Variables to extract: []"
@@ -392,7 +392,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "a4e884a5-4121-4b9f-84e7-1391218d43ac",
+                "id": "881e8297-08b8-49a2-900c-2fc99c24eb30",
                 "exec": [
                   "// Request not found in collection for: POST /v1/organizations/{organizationId}/ledgers/{ledgerId}/portfolios",
                   "// Variables to extract: [\"portfolioId\"]"
@@ -415,7 +415,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "8c49d433-2817-47d5-8c29-00cb13114a44",
+                "id": "78948416-f8dc-4468-a510-411dee55ed69",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/portfolios/{portfolioId}",
                   "// Variables to extract: []"
@@ -438,7 +438,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "e17b78be-16b5-41f7-8bf2-e89ab1bfca0c",
+                "id": "4c831148-4edd-43ba-8c62-ed2b8363e9f6",
                 "exec": [
                   "// Request not found in collection for: PATCH /v1/organizations/{organizationId}/ledgers/{ledgerId}/portfolios/{portfolioId}",
                   "// Variables to extract: []"
@@ -461,7 +461,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "0a162718-4f77-4bf8-89eb-dc7034a4bc8a",
+                "id": "231c6c1c-1e66-4212-be89-d0d2970d1f98",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/portfolios",
                   "// Variables to extract: []"
@@ -484,7 +484,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "87be162b-5da5-4309-aa45-95acb950977f",
+                "id": "55215994-cec6-4e76-8af3-2370dea7b00f",
                 "exec": [
                   "// Request not found in collection for: POST /v1/organizations/{organizationId}/ledgers/{ledgerId}/segments",
                   "// Variables to extract: [\"segmentId\"]"
@@ -507,7 +507,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "0f632521-8ada-43d4-9592-f2fafddc3e52",
+                "id": "f733d666-89e0-4d3e-b196-8613e21d62fd",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/segments/{segmentId}",
                   "// Variables to extract: []"
@@ -530,7 +530,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "b92fef6f-911b-4c6c-a029-dff089219016",
+                "id": "d98b8bbf-8f39-4dd7-9d67-0a885be94e6c",
                 "exec": [
                   "// Request not found in collection for: PATCH /v1/organizations/{organizationId}/ledgers/{ledgerId}/segments/{segmentId}",
                   "// Variables to extract: []"
@@ -553,7 +553,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "b1c136bd-3a1f-4b7d-b275-62b3e1740a35",
+                "id": "b751b575-7dd4-4eae-ba22-c6681b202b67",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/segments",
                   "// Variables to extract: []"
@@ -576,7 +576,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "d6e82483-7db6-4b8c-a57a-b359c03d9cdd",
+                "id": "fe9012d4-911a-48b0-93f5-394c9e50f89b",
                 "exec": [
                   "// Request not found in collection for: HEAD /v1/organizations/metrics/count",
                   "// Variables to extract: []"
@@ -599,7 +599,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "4a38d838-6088-4b2e-bd3a-2c2cc0e2e772",
+                "id": "991087dc-48dc-4da1-a875-c80f26edf812",
                 "exec": [
                   "// Request not found in collection for: HEAD /v1/organizations/{organizationId}/ledgers/metrics/count",
                   "// Variables to extract: []"
@@ -622,7 +622,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "fdfd9d2c-ca35-4672-be4d-ef9ca28558f6",
+                "id": "e5c2774c-45e9-40db-8e40-118ac133465f",
                 "exec": [
                   "// Request not found in collection for: HEAD /v1/organizations/{organizationId}/ledgers/{ledgerId}/accounts/metrics/count",
                   "// Variables to extract: []"
@@ -645,7 +645,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "f66a3e30-660f-4e06-b908-5b88fc45e289",
+                "id": "31a02646-b93f-4760-93e8-3709609355e7",
                 "exec": [
                   "// Request not found in collection for: HEAD /v1/organizations/{organizationId}/ledgers/{ledgerId}/assets/metrics/count",
                   "// Variables to extract: []"
@@ -668,7 +668,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "7a08a3fc-f424-44cc-b6cd-2eed21beb4b8",
+                "id": "6e8ec72f-106d-4037-811e-14dd3dcd3c50",
                 "exec": [
                   "// Request not found in collection for: HEAD /v1/organizations/{organizationId}/ledgers/{ledgerId}/portfolios/metrics/count",
                   "// Variables to extract: []"
@@ -691,7 +691,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "5715a8de-0eec-44ba-9056-c2a88b1ba408",
+                "id": "cec76374-4f5b-4234-bfe4-e1e5298fb2c1",
                 "exec": [
                   "// Request not found in collection for: HEAD /v1/organizations/{organizationId}/ledgers/{ledgerId}/segments/metrics/count",
                   "// Variables to extract: []"
@@ -714,7 +714,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "f3ab3b6d-bda9-43d6-bf15-8087f00bc70a",
+                "id": "a769f832-3549-4e6c-ad63-9bf0a13a60ff",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/accounts/alias/{alias}",
                   "// Variables to extract: []"
@@ -737,7 +737,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "53ef0816-ae32-457b-a92a-3ba1774fe8c2",
+                "id": "bdf0ec21-e52c-40ca-a323-32723320b9cc",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/accounts/external/{code}",
                   "// Variables to extract: []"
@@ -760,7 +760,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "a0ec6133-aa16-42c0-b0ab-9bfc9036bc8b",
+                "id": "edfcb661-aad5-4015-8479-eda07bfc9bd9",
                 "exec": [
                   "// Request not found in collection for: POST /v1/organizations/{organizationId}/ledgers/{ledgerId}/transactions/json",
                   "// Variables to extract: [\"transactionId\",\"balanceId\",\"operationId\"]"
@@ -783,7 +783,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "45d51df6-c0e6-4a6e-adb8-1b1be35d48a6",
+                "id": "b1da07bb-ff97-44f6-bc09-c04ceb02ac08",
                 "exec": [
                   "// Request not found in collection for: POST /v1/organizations/{organizationId}/ledgers/{ledgerId}/transactions/inflow",
                   "// Variables to extract: [\"inflowTransactionId\"]"
@@ -806,7 +806,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "84666ef3-3beb-45aa-a692-9b142957e552",
+                "id": "77790456-cd5a-4dd0-8024-5b7c10a5021d",
                 "exec": [
                   "// Request not found in collection for: POST /v1/organizations/{organizationId}/ledgers/{ledgerId}/transactions/outflow",
                   "// Variables to extract: [\"outflowTransactionId\"]"
@@ -829,7 +829,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "d34d23a3-0a17-4056-9245-c5b64d71399e",
+                "id": "4c9c3d3e-d1e0-4897-b4af-a4e9f61f9061",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/transactions/{transactionId}",
                   "// Variables to extract: []"
@@ -852,7 +852,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "744af5c5-0a55-418f-b581-52336cc89c44",
+                "id": "4411c1ca-a610-4574-9eef-3e02770fbc11",
                 "exec": [
                   "// Request not found in collection for: PATCH /v1/organizations/{organizationId}/ledgers/{ledgerId}/transactions/{transactionId}",
                   "// Variables to extract: []"
@@ -875,7 +875,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "f38934c0-b14b-4752-80a0-fcd4a127805d",
+                "id": "5e1ea043-f9e4-4e21-b9d5-2a358c101927",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/transactions",
                   "// Variables to extract: []"
@@ -898,7 +898,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "979da0d7-b722-463b-8d90-4f7c77e46bee",
+                "id": "2c384933-5861-48c0-b3d4-5098a748c336",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/accounts/{accountId}/operations/{operationId}",
                   "// Variables to extract: []"
@@ -921,7 +921,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "26c53d3f-f629-4345-a98a-968a552d4374",
+                "id": "676b713b-aed6-401b-8b5e-795863252b8c",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/accounts/{accountId}/operations",
                   "// Variables to extract: []"
@@ -944,7 +944,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "3a581b48-d75b-4e5e-92d2-a4a7873d6c0d",
+                "id": "803ea19d-aae8-45c8-8e7c-38e9b5207596",
                 "exec": [
                   "// Request not found in collection for: PATCH /v1/organizations/{organizationId}/ledgers/{ledgerId}/transactions/{transactionId}/operations/{operationId}",
                   "// Variables to extract: []"
@@ -967,7 +967,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "378c255d-4fb4-44df-80da-40c4220a53ff",
+                "id": "b6d4deaa-ece6-4653-a083-3b28eb311c90",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/balances/{balanceId}",
                   "// Variables to extract: []"
@@ -990,7 +990,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "dc85b2ce-f2d5-4bd8-aea6-4ee5da6c641b",
+                "id": "74da317c-b950-4c25-9d09-1af5ad7337a9",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/accounts/{accountId}/balances",
                   "// Variables to extract: []"
@@ -1013,7 +1013,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "d4b693ec-52ef-4a1d-b91d-bdd56ea4cf25",
+                "id": "a331a7de-e2ee-4a26-a555-45638a7a7fa2",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/accounts/alias/{alias}/balances",
                   "// Variables to extract: []"
@@ -1036,7 +1036,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "936c76ac-7010-456c-a1f1-11efb0370fbe",
+                "id": "db85d6c8-3a90-41c5-8b2e-fb57a43b4c86",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/accounts/external/{code}/balances",
                   "// Variables to extract: []"
@@ -1059,7 +1059,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "7bba600b-1ba7-4925-aeaf-35a93d8c05f4",
+                "id": "f63c980c-1a2c-4e08-a0ac-7d374af261be",
                 "exec": [
                   "// Request not found in collection for: PATCH /v1/organizations/{organizationId}/ledgers/{ledgerId}/balances/{balanceId}",
                   "// Variables to extract: []"
@@ -1082,7 +1082,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "034ff5b6-908b-4d9b-a9f1-bfb52d6ef23c",
+                "id": "27bdef99-a120-4fac-997d-a4b5aa3046d7",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/balances",
                   "// Variables to extract: []"
@@ -1105,7 +1105,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "f6858755-a169-4369-a48b-b7337657da6b",
+                "id": "282d8639-71e5-4571-935a-7eae6b970f50",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/accounts/alias/{alias}/balances",
                   "// Variables to extract: [\"currentBalanceAmount\"]"
@@ -1128,7 +1128,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "115468b9-20c1-46c3-a7a8-cb5a51eae029",
+                "id": "fde9df8b-ec1f-44f9-a7c7-f15bd7d221c6",
                 "exec": [
                   "// Request not found in collection for: POST /v1/organizations/{organizationId}/ledgers/{ledgerId}/transactions/json",
                   "// Variables to extract: []"
@@ -1151,7 +1151,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "3c442296-2cb1-4dff-ab7c-c2d2d91464f5",
+                "id": "8a6e2dba-f8c2-4157-8d28-c4e7cf09f420",
                 "exec": [
                   "// Request not found in collection for: DELETE /v1/organizations/{organizationId}/ledgers/{ledgerId}/balances/{balanceId}",
                   "// Variables to extract: []"
@@ -1174,7 +1174,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "45060aad-c7d5-4e19-9358-c2ce56d11cf7",
+                "id": "d995d696-e368-4883-98f6-87fd8e000ce5",
                 "exec": [
                   "// Request not found in collection for: DELETE /v1/organizations/{organizationId}/ledgers/{ledgerId}/segments/{segmentId}",
                   "// Variables to extract: []"
@@ -1197,7 +1197,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "77cc80ba-4ecc-463c-9e90-36060b87ea0f",
+                "id": "542f39ec-a3d4-4e37-bf50-d175c45638a0",
                 "exec": [
                   "// Request not found in collection for: DELETE /v1/organizations/{organizationId}/ledgers/{ledgerId}/portfolios/{portfolioId}",
                   "// Variables to extract: []"
@@ -1220,7 +1220,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "ab0548e2-6cc9-49af-bc26-94c6e5b3de9f",
+                "id": "1ae62ead-1be0-473d-b208-52466709aead",
                 "exec": [
                   "// Request not found in collection for: DELETE /v1/organizations/{organizationId}/ledgers/{ledgerId}/accounts/{accountId}",
                   "// Variables to extract: []"
@@ -1243,7 +1243,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "54c464eb-9d72-457e-aeac-73b37343ca7c",
+                "id": "3e78751d-cf12-4f37-a87d-e715efce7112",
                 "exec": [
                   "// Request not found in collection for: DELETE /v1/organizations/{organizationId}/ledgers/{ledgerId}/assets/{assetId}",
                   "// Variables to extract: []"
@@ -1266,7 +1266,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "0b482655-b974-4322-907c-978aea8051bd",
+                "id": "cb5ef441-f334-49d2-a372-ee6729e9d3b3",
                 "exec": [
                   "// Request not found in collection for: DELETE /v1/organizations/{organizationId}/ledgers/{ledgerId}",
                   "// Variables to extract: []"
@@ -1289,7 +1289,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "481aa55b-804c-4428-b6c0-924850eefc7b",
+                "id": "1fba5dbd-7f58-4a41-9f83-6b34bc54b233",
                 "exec": [
                   "// Request not found in collection for: DELETE /v1/organizations/{organizationId}",
                   "// Variables to extract: []"
@@ -1318,7 +1318,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "d2c87b70-174f-4734-91a0-0151ba05291a",
+                "id": "c43395ab-549b-4bae-ac2a-4e81a05b4993",
                 "exec": [
                   "\n// ===== WORKFLOW SUMMARY =====\nconsole.log(\"📊 Workflow Execution Summary\");\nconsole.log(\"Total Steps: 56\");\n\n// Calculate total execution time\nconst startTime = pm.globals.get(\"workflow_start_time\");\nif (startTime) {\n    const totalTime = Date.now() - startTime;\n    console.log(\"⏱️ Total Execution Time: \" + totalTime + \"ms\");\n    pm.globals.set(\"workflow_total_time\", totalTime);\n}\n\n// Summary of step performance\nconsole.log(\"📈 Performance Summary:\");\nfor (let i = 1; i <= 56; i++) {\n    const stepTime = pm.environment.get(\"perf_step_\" + i);\n    if (stepTime) {\n        console.log(\"  Step \" + i + \": \" + stepTime + \"ms\");\n    }\n}\n\nconsole.log(\"✅ Workflow completed successfully\");\n"
                 ],
@@ -1328,7 +1328,7 @@
           ]
         }
       ],
-      "_postman_id": "25c581f2-07a3-4ac2-9fa3-54dd45434185",
+      "_postman_id": "d08a6e96-aba8-49f2-a0f6-88a69cc7149c",
       "event": []
     },
     {

--- a/postman/MIDAZ.postman_collection.json
+++ b/postman/MIDAZ.postman_collection.json
@@ -24,7 +24,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "96d5a548-ef08-40a5-93b0-f9c5fdb40fdf",
+                "id": "afd5934a-0c89-4990-baed-eb66efe3423d",
                 "exec": [
                   "// Request not found in collection for: POST /v1/organizations",
                   "// Variables to extract: [\"organizationId\"]"
@@ -47,7 +47,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "d77da4c0-4ebe-4a74-8910-3ae5cd9028b8",
+                "id": "fa3cd0ee-6776-44ca-998c-08d02c7d6810",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}",
                   "// Variables to extract: []"
@@ -70,7 +70,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "8c8b3055-d80c-4c1e-96a4-59e3191db0d8",
+                "id": "628614a7-0e46-4917-b741-5ab2d8efbaf5",
                 "exec": [
                   "// Request not found in collection for: PATCH /v1/organizations/{organizationId}",
                   "// Variables to extract: []"
@@ -93,7 +93,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "45b513d0-66cb-492f-92aa-bf06e3ef32d3",
+                "id": "8defd71d-05ec-4bd8-ad36-90d224e0edab",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations",
                   "// Variables to extract: []"
@@ -116,7 +116,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "3c83548d-2171-482b-b09f-67d533d31c2e",
+                "id": "c576f53e-728f-4a34-85af-639f63c3ac9a",
                 "exec": [
                   "// Request not found in collection for: POST /v1/organizations/{organizationId}/ledgers",
                   "// Variables to extract: [\"ledgerId\"]"
@@ -139,7 +139,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "a2f46716-f659-4872-9aea-c19e6b9e1297",
+                "id": "297a1f60-4d4f-4005-8bc4-e44b8a70207d",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}",
                   "// Variables to extract: []"
@@ -162,7 +162,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "f7e3c422-ed95-4650-ade1-2d14cab66308",
+                "id": "8a4c8182-770d-45ca-8c10-2b00f400e977",
                 "exec": [
                   "// Request not found in collection for: PATCH /v1/organizations/{organizationId}/ledgers/{ledgerId}",
                   "// Variables to extract: []"
@@ -185,7 +185,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "a6b93f8f-2afb-43f7-af01-a92520a09ee0",
+                "id": "2beeee75-5a86-4d91-9f3a-83b039da55bd",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers",
                   "// Variables to extract: []"
@@ -208,7 +208,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "0c83e970-0263-4c9d-922f-bcac22729ad7",
+                "id": "3c29949e-05b0-4b85-81d4-d0fd5856c5d8",
                 "exec": [
                   "// Request not found in collection for: POST /v1/organizations/{organizationId}/ledgers/{ledgerId}/assets",
                   "// Variables to extract: [\"assetId\"]"
@@ -231,7 +231,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "c4141dc5-6700-41f1-9f19-4da3ef0d2ec0",
+                "id": "3a84b2b9-6080-4a7d-8645-5360f5606b3a",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/assets/{assetId}",
                   "// Variables to extract: []"
@@ -254,7 +254,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "971d6fe0-bea7-42b0-a416-dcb1636e6edc",
+                "id": "208b5816-bc98-4dd0-b2df-ed773ea61063",
                 "exec": [
                   "// Request not found in collection for: PATCH /v1/organizations/{organizationId}/ledgers/{ledgerId}/assets/{assetId}",
                   "// Variables to extract: []"
@@ -277,7 +277,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "a76ef310-5853-464d-bc43-8af8ecaa39c3",
+                "id": "68002d81-8dfd-4dd9-aacd-bd5e1aa53d82",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/assets",
                   "// Variables to extract: []"
@@ -300,7 +300,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "3d5fa682-4ae1-4a96-a51b-5cb6d521139c",
+                "id": "54a53a1e-e0ea-4c9b-9ef8-46cfe8acb693",
                 "exec": [
                   "// Request not found in collection for: POST /v1/organizations/{organizationId}/ledgers/{ledgerId}/accounts",
                   "// Variables to extract: [\"accountId\",\"accountAlias\"]"
@@ -323,7 +323,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "9850610e-1274-421d-bc44-535217dc7f02",
+                "id": "ff208bf0-b3c4-4017-8489-2192b64fded4",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/accounts/{accountId}",
                   "// Variables to extract: []"
@@ -346,7 +346,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "be097e54-da48-434a-88a5-f7ecb2cb4357",
+                "id": "f3de0982-ca7f-4fe9-9fbf-4a82446eab79",
                 "exec": [
                   "// Request not found in collection for: PATCH /v1/organizations/{organizationId}/ledgers/{ledgerId}/accounts/{accountId}",
                   "// Variables to extract: []"
@@ -369,7 +369,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "a7c7f753-5708-4379-9b94-b38044c54893",
+                "id": "8b09e9e9-bd2e-4f3e-b5f4-8c6dc470473b",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/accounts",
                   "// Variables to extract: []"
@@ -392,7 +392,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "541eabf4-5058-42d5-ae26-169e703375fa",
+                "id": "a4e884a5-4121-4b9f-84e7-1391218d43ac",
                 "exec": [
                   "// Request not found in collection for: POST /v1/organizations/{organizationId}/ledgers/{ledgerId}/portfolios",
                   "// Variables to extract: [\"portfolioId\"]"
@@ -415,7 +415,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "282ba0ed-4279-49d2-b8e3-f7b87ef3bd28",
+                "id": "8c49d433-2817-47d5-8c29-00cb13114a44",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/portfolios/{portfolioId}",
                   "// Variables to extract: []"
@@ -438,7 +438,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "cc9ff7f8-a4db-4db3-94f6-34383c7f451a",
+                "id": "e17b78be-16b5-41f7-8bf2-e89ab1bfca0c",
                 "exec": [
                   "// Request not found in collection for: PATCH /v1/organizations/{organizationId}/ledgers/{ledgerId}/portfolios/{portfolioId}",
                   "// Variables to extract: []"
@@ -461,7 +461,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "39b7d39c-021f-4fc6-a86a-b8d6672155f0",
+                "id": "0a162718-4f77-4bf8-89eb-dc7034a4bc8a",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/portfolios",
                   "// Variables to extract: []"
@@ -484,7 +484,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "06f89a9d-860b-41f8-8745-a1dd4b894501",
+                "id": "87be162b-5da5-4309-aa45-95acb950977f",
                 "exec": [
                   "// Request not found in collection for: POST /v1/organizations/{organizationId}/ledgers/{ledgerId}/segments",
                   "// Variables to extract: [\"segmentId\"]"
@@ -507,7 +507,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "504f88f0-b72f-416a-96bd-a18cc5cd3d64",
+                "id": "0f632521-8ada-43d4-9592-f2fafddc3e52",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/segments/{segmentId}",
                   "// Variables to extract: []"
@@ -530,7 +530,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "4ddfb6ce-0a1b-423e-803b-bbf973e8883d",
+                "id": "b92fef6f-911b-4c6c-a029-dff089219016",
                 "exec": [
                   "// Request not found in collection for: PATCH /v1/organizations/{organizationId}/ledgers/{ledgerId}/segments/{segmentId}",
                   "// Variables to extract: []"
@@ -553,7 +553,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "7487bd87-d1cd-40ff-abf4-922611a82d85",
+                "id": "b1c136bd-3a1f-4b7d-b275-62b3e1740a35",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/segments",
                   "// Variables to extract: []"
@@ -576,7 +576,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "a8d66dbc-a9b6-4736-92bd-2c01aef5b74c",
+                "id": "d6e82483-7db6-4b8c-a57a-b359c03d9cdd",
                 "exec": [
                   "// Request not found in collection for: HEAD /v1/organizations/metrics/count",
                   "// Variables to extract: []"
@@ -599,7 +599,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "57175637-b50e-4f90-b45f-19e06c24eb9d",
+                "id": "4a38d838-6088-4b2e-bd3a-2c2cc0e2e772",
                 "exec": [
                   "// Request not found in collection for: HEAD /v1/organizations/{organizationId}/ledgers/metrics/count",
                   "// Variables to extract: []"
@@ -622,7 +622,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "049d5001-4842-4d12-9b8e-605def675408",
+                "id": "fdfd9d2c-ca35-4672-be4d-ef9ca28558f6",
                 "exec": [
                   "// Request not found in collection for: HEAD /v1/organizations/{organizationId}/ledgers/{ledgerId}/accounts/metrics/count",
                   "// Variables to extract: []"
@@ -645,7 +645,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "2239062b-9623-4b6e-800c-bffe2573404a",
+                "id": "f66a3e30-660f-4e06-b908-5b88fc45e289",
                 "exec": [
                   "// Request not found in collection for: HEAD /v1/organizations/{organizationId}/ledgers/{ledgerId}/assets/metrics/count",
                   "// Variables to extract: []"
@@ -668,7 +668,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "af5cfb75-88a0-4f8a-94f3-2e9bdcd01874",
+                "id": "7a08a3fc-f424-44cc-b6cd-2eed21beb4b8",
                 "exec": [
                   "// Request not found in collection for: HEAD /v1/organizations/{organizationId}/ledgers/{ledgerId}/portfolios/metrics/count",
                   "// Variables to extract: []"
@@ -691,7 +691,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "15dd7c6e-0e72-4e2e-81d5-633615cdd350",
+                "id": "5715a8de-0eec-44ba-9056-c2a88b1ba408",
                 "exec": [
                   "// Request not found in collection for: HEAD /v1/organizations/{organizationId}/ledgers/{ledgerId}/segments/metrics/count",
                   "// Variables to extract: []"
@@ -714,7 +714,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "7cea62ad-e5e0-48c1-b82d-e72f0025130e",
+                "id": "f3ab3b6d-bda9-43d6-bf15-8087f00bc70a",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/accounts/alias/{alias}",
                   "// Variables to extract: []"
@@ -737,7 +737,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "ee1d906f-fa36-499e-89ac-7ef7da3ca091",
+                "id": "53ef0816-ae32-457b-a92a-3ba1774fe8c2",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/accounts/external/{code}",
                   "// Variables to extract: []"
@@ -760,7 +760,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "ff99830b-0f61-4ac8-9185-0bf8b9af853e",
+                "id": "a0ec6133-aa16-42c0-b0ab-9bfc9036bc8b",
                 "exec": [
                   "// Request not found in collection for: POST /v1/organizations/{organizationId}/ledgers/{ledgerId}/transactions/json",
                   "// Variables to extract: [\"transactionId\",\"balanceId\",\"operationId\"]"
@@ -783,7 +783,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "d4e5be3c-ac46-4749-ab2c-c7b37a6296e5",
+                "id": "45d51df6-c0e6-4a6e-adb8-1b1be35d48a6",
                 "exec": [
                   "// Request not found in collection for: POST /v1/organizations/{organizationId}/ledgers/{ledgerId}/transactions/inflow",
                   "// Variables to extract: [\"inflowTransactionId\"]"
@@ -806,7 +806,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "e842a5ef-0697-427e-9d32-7c68bcba531b",
+                "id": "84666ef3-3beb-45aa-a692-9b142957e552",
                 "exec": [
                   "// Request not found in collection for: POST /v1/organizations/{organizationId}/ledgers/{ledgerId}/transactions/outflow",
                   "// Variables to extract: [\"outflowTransactionId\"]"
@@ -829,7 +829,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "6f7a5d89-f075-4134-bd32-f66fdfbaaa5a",
+                "id": "d34d23a3-0a17-4056-9245-c5b64d71399e",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/transactions/{transactionId}",
                   "// Variables to extract: []"
@@ -852,7 +852,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "2d5ce333-ca40-4a57-ae41-2f477b52bbc0",
+                "id": "744af5c5-0a55-418f-b581-52336cc89c44",
                 "exec": [
                   "// Request not found in collection for: PATCH /v1/organizations/{organizationId}/ledgers/{ledgerId}/transactions/{transactionId}",
                   "// Variables to extract: []"
@@ -875,7 +875,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "d78f1946-2ddb-431b-a76a-b62752fd70ad",
+                "id": "f38934c0-b14b-4752-80a0-fcd4a127805d",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/transactions",
                   "// Variables to extract: []"
@@ -898,7 +898,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "ffaefe6d-a6df-452a-8664-9d6c6164ac2a",
+                "id": "979da0d7-b722-463b-8d90-4f7c77e46bee",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/accounts/{accountId}/operations/{operationId}",
                   "// Variables to extract: []"
@@ -921,7 +921,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "45d26c92-dc2e-4042-add5-75184408d592",
+                "id": "26c53d3f-f629-4345-a98a-968a552d4374",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/accounts/{accountId}/operations",
                   "// Variables to extract: []"
@@ -944,7 +944,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "f3a1d20a-650c-4af3-a101-8fa00ce423f7",
+                "id": "3a581b48-d75b-4e5e-92d2-a4a7873d6c0d",
                 "exec": [
                   "// Request not found in collection for: PATCH /v1/organizations/{organizationId}/ledgers/{ledgerId}/transactions/{transactionId}/operations/{operationId}",
                   "// Variables to extract: []"
@@ -967,7 +967,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "c4b98f2d-4a88-4c7b-976a-8acbfe5a943a",
+                "id": "378c255d-4fb4-44df-80da-40c4220a53ff",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/balances/{balanceId}",
                   "// Variables to extract: []"
@@ -990,7 +990,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "d8459f6f-6ec8-4ac3-8c49-5250407a504d",
+                "id": "dc85b2ce-f2d5-4bd8-aea6-4ee5da6c641b",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/accounts/{accountId}/balances",
                   "// Variables to extract: []"
@@ -1013,7 +1013,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "570c36fb-38cd-4e03-9ef6-398652883832",
+                "id": "d4b693ec-52ef-4a1d-b91d-bdd56ea4cf25",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/accounts/alias/{alias}/balances",
                   "// Variables to extract: []"
@@ -1036,7 +1036,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "70ae56e6-f1a1-4726-a9f9-5221f38e3328",
+                "id": "936c76ac-7010-456c-a1f1-11efb0370fbe",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/accounts/external/{code}/balances",
                   "// Variables to extract: []"
@@ -1059,7 +1059,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "7842e8a8-4ab8-42ad-85cb-3455f11a5f7b",
+                "id": "7bba600b-1ba7-4925-aeaf-35a93d8c05f4",
                 "exec": [
                   "// Request not found in collection for: PATCH /v1/organizations/{organizationId}/ledgers/{ledgerId}/balances/{balanceId}",
                   "// Variables to extract: []"
@@ -1082,7 +1082,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "b7769b32-682f-45cc-9f38-770a1d5f6139",
+                "id": "034ff5b6-908b-4d9b-a9f1-bfb52d6ef23c",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/balances",
                   "// Variables to extract: []"
@@ -1105,7 +1105,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "c76de465-ca68-46fd-a14e-ad1e8873b17b",
+                "id": "f6858755-a169-4369-a48b-b7337657da6b",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/accounts/alias/{alias}/balances",
                   "// Variables to extract: [\"currentBalanceAmount\"]"
@@ -1128,7 +1128,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "ec83f6f9-a3a7-41b9-b83c-40e525c4c24f",
+                "id": "115468b9-20c1-46c3-a7a8-cb5a51eae029",
                 "exec": [
                   "// Request not found in collection for: POST /v1/organizations/{organizationId}/ledgers/{ledgerId}/transactions/json",
                   "// Variables to extract: []"
@@ -1151,7 +1151,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "65609484-d0cb-44cd-b1bb-00c1eddc5478",
+                "id": "3c442296-2cb1-4dff-ab7c-c2d2d91464f5",
                 "exec": [
                   "// Request not found in collection for: DELETE /v1/organizations/{organizationId}/ledgers/{ledgerId}/balances/{balanceId}",
                   "// Variables to extract: []"
@@ -1174,7 +1174,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "1b1a6e26-9518-40ed-af13-8b10bb872311",
+                "id": "45060aad-c7d5-4e19-9358-c2ce56d11cf7",
                 "exec": [
                   "// Request not found in collection for: DELETE /v1/organizations/{organizationId}/ledgers/{ledgerId}/segments/{segmentId}",
                   "// Variables to extract: []"
@@ -1197,7 +1197,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "366f24dd-1886-4173-a823-af226150b035",
+                "id": "77cc80ba-4ecc-463c-9e90-36060b87ea0f",
                 "exec": [
                   "// Request not found in collection for: DELETE /v1/organizations/{organizationId}/ledgers/{ledgerId}/portfolios/{portfolioId}",
                   "// Variables to extract: []"
@@ -1220,7 +1220,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "95daaa4d-f851-4eb9-8877-4fbb76d3f034",
+                "id": "ab0548e2-6cc9-49af-bc26-94c6e5b3de9f",
                 "exec": [
                   "// Request not found in collection for: DELETE /v1/organizations/{organizationId}/ledgers/{ledgerId}/accounts/{accountId}",
                   "// Variables to extract: []"
@@ -1243,7 +1243,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "bf8114a2-9aef-4f43-81f3-488838b3731a",
+                "id": "54c464eb-9d72-457e-aeac-73b37343ca7c",
                 "exec": [
                   "// Request not found in collection for: DELETE /v1/organizations/{organizationId}/ledgers/{ledgerId}/assets/{assetId}",
                   "// Variables to extract: []"
@@ -1266,7 +1266,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "96764cbf-de08-448a-9f34-735de4e78646",
+                "id": "0b482655-b974-4322-907c-978aea8051bd",
                 "exec": [
                   "// Request not found in collection for: DELETE /v1/organizations/{organizationId}/ledgers/{ledgerId}",
                   "// Variables to extract: []"
@@ -1289,7 +1289,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "a712bbe2-c4c2-4b4f-ae0f-7be2c2d9c605",
+                "id": "481aa55b-804c-4428-b6c0-924850eefc7b",
                 "exec": [
                   "// Request not found in collection for: DELETE /v1/organizations/{organizationId}",
                   "// Variables to extract: []"
@@ -1318,7 +1318,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "e90787db-09a0-4f1e-a788-a33b9faf3d9a",
+                "id": "d2c87b70-174f-4734-91a0-0151ba05291a",
                 "exec": [
                   "\n// ===== WORKFLOW SUMMARY =====\nconsole.log(\"📊 Workflow Execution Summary\");\nconsole.log(\"Total Steps: 56\");\n\n// Calculate total execution time\nconst startTime = pm.globals.get(\"workflow_start_time\");\nif (startTime) {\n    const totalTime = Date.now() - startTime;\n    console.log(\"⏱️ Total Execution Time: \" + totalTime + \"ms\");\n    pm.globals.set(\"workflow_total_time\", totalTime);\n}\n\n// Summary of step performance\nconsole.log(\"📈 Performance Summary:\");\nfor (let i = 1; i <= 56; i++) {\n    const stepTime = pm.environment.get(\"perf_step_\" + i);\n    if (stepTime) {\n        console.log(\"  Step \" + i + \": \" + stepTime + \"ms\");\n    }\n}\n\nconsole.log(\"✅ Workflow completed successfully\");\n"
                 ],
@@ -1328,7 +1328,7 @@
           ]
         }
       ],
-      "_postman_id": "591d8609-ab5e-4ecf-a105-5d9e7db3e2b5",
+      "_postman_id": "25c581f2-07a3-4ac2-9fa3-54dd45434185",
       "event": []
     },
     {

--- a/postman/MIDAZ.postman_collection.json
+++ b/postman/MIDAZ.postman_collection.json
@@ -24,7 +24,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "fd9ff3f4-285d-4404-891b-29689e0cafbe",
+                "id": "f5039840-943b-46c8-9943-b3f055fe1d5a",
                 "exec": [
                   "// Request not found in collection for: POST /v1/organizations",
                   "// Variables to extract: [\"organizationId\"]"
@@ -47,7 +47,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "30b0f877-9459-4e60-bb99-cb3bf6213883",
+                "id": "59ea6511-61a0-4970-94e3-49489b7413be",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}",
                   "// Variables to extract: []"
@@ -70,7 +70,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "44e7ca79-2d22-454a-af92-aa9bc84b7e98",
+                "id": "07a019f5-f727-4be0-b3a5-6e94093a9228",
                 "exec": [
                   "// Request not found in collection for: PATCH /v1/organizations/{organizationId}",
                   "// Variables to extract: []"
@@ -93,7 +93,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "83cf2fc7-1e80-4aed-87d9-81175c3e9f19",
+                "id": "9d262169-3ee0-4c1c-abdb-051ce9a6e5ee",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations",
                   "// Variables to extract: []"
@@ -116,7 +116,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "edfaa65e-366f-40ab-a22f-45799193f5ac",
+                "id": "9b5b2c81-5afd-4b7f-81e6-c31db3445302",
                 "exec": [
                   "// Request not found in collection for: POST /v1/organizations/{organizationId}/ledgers",
                   "// Variables to extract: [\"ledgerId\"]"
@@ -139,7 +139,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "1515b4e3-7fd1-40f1-8740-ae27380411f4",
+                "id": "8a275b85-4303-470a-bd5a-6532193a2cd7",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}",
                   "// Variables to extract: []"
@@ -162,7 +162,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "1442d442-0da1-4e97-b1d4-8a05f9a111a4",
+                "id": "284ff8a3-4c78-478d-a6e9-884eff64e9d4",
                 "exec": [
                   "// Request not found in collection for: PATCH /v1/organizations/{organizationId}/ledgers/{ledgerId}",
                   "// Variables to extract: []"
@@ -185,7 +185,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "dd172487-bae4-4c02-962a-34e3099a24ac",
+                "id": "a785bc28-f31f-493e-941a-72d9a1ec7ebb",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers",
                   "// Variables to extract: []"
@@ -208,7 +208,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "895b0089-038d-4be5-8784-8da068f9c0fb",
+                "id": "7c2d58a6-3582-4e00-86f0-dd0c3a5125dc",
                 "exec": [
                   "// Request not found in collection for: POST /v1/organizations/{organizationId}/ledgers/{ledgerId}/assets",
                   "// Variables to extract: [\"assetId\"]"
@@ -231,7 +231,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "336522b8-1432-47bc-96fe-6371c86ad33e",
+                "id": "60ebc7c5-f159-4f22-8cdf-c9b4c4b32e6c",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/assets/{assetId}",
                   "// Variables to extract: []"
@@ -254,7 +254,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "5b174d23-aea2-4f0b-be24-32028d19d4ad",
+                "id": "04133824-0647-4fd1-9307-4801e00efc97",
                 "exec": [
                   "// Request not found in collection for: PATCH /v1/organizations/{organizationId}/ledgers/{ledgerId}/assets/{assetId}",
                   "// Variables to extract: []"
@@ -277,7 +277,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "b79f0bb9-be74-4699-87bc-28f46773e70f",
+                "id": "5023d23c-dee8-4921-8b57-19f74f34d284",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/assets",
                   "// Variables to extract: []"
@@ -300,7 +300,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "8814cfa1-743d-41d2-8e25-7d092a689ada",
+                "id": "c1c0b0ae-206d-446c-bb9f-f284e513eeb6",
                 "exec": [
                   "// Request not found in collection for: POST /v1/organizations/{organizationId}/ledgers/{ledgerId}/accounts",
                   "// Variables to extract: [\"accountId\",\"accountAlias\"]"
@@ -323,7 +323,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "a6f74201-2338-4053-a9f8-a314ba7d6e13",
+                "id": "0ced5321-1af1-4abd-8181-b2df142caf2a",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/accounts/{accountId}",
                   "// Variables to extract: []"
@@ -346,7 +346,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "f4d708b3-9fc1-4ee3-a400-bdf145c35e74",
+                "id": "1615eef4-6f57-4a92-bed2-cd1c5ecda1b1",
                 "exec": [
                   "// Request not found in collection for: PATCH /v1/organizations/{organizationId}/ledgers/{ledgerId}/accounts/{accountId}",
                   "// Variables to extract: []"
@@ -369,7 +369,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "16d4688b-31e3-4abd-b9b1-bbdc944ca356",
+                "id": "03f12609-50c6-47e5-8f1b-bcb3db05f3e2",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/accounts",
                   "// Variables to extract: []"
@@ -392,7 +392,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "881e8297-08b8-49a2-900c-2fc99c24eb30",
+                "id": "4f3bc5b7-aa04-4592-a8f5-ed362945c22a",
                 "exec": [
                   "// Request not found in collection for: POST /v1/organizations/{organizationId}/ledgers/{ledgerId}/portfolios",
                   "// Variables to extract: [\"portfolioId\"]"
@@ -415,7 +415,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "78948416-f8dc-4468-a510-411dee55ed69",
+                "id": "0baae00c-a79c-4dbc-b7e6-7e73a995c0fb",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/portfolios/{portfolioId}",
                   "// Variables to extract: []"
@@ -438,7 +438,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "4c831148-4edd-43ba-8c62-ed2b8363e9f6",
+                "id": "fe2f17af-9bf1-43e2-8d5d-2dfdc266688d",
                 "exec": [
                   "// Request not found in collection for: PATCH /v1/organizations/{organizationId}/ledgers/{ledgerId}/portfolios/{portfolioId}",
                   "// Variables to extract: []"
@@ -461,7 +461,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "231c6c1c-1e66-4212-be89-d0d2970d1f98",
+                "id": "49743102-6a7e-473a-add4-d02a6869c9c3",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/portfolios",
                   "// Variables to extract: []"
@@ -484,7 +484,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "55215994-cec6-4e76-8af3-2370dea7b00f",
+                "id": "b29665c4-0e7c-4f2a-b81e-1f39626d2b02",
                 "exec": [
                   "// Request not found in collection for: POST /v1/organizations/{organizationId}/ledgers/{ledgerId}/segments",
                   "// Variables to extract: [\"segmentId\"]"
@@ -507,7 +507,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "f733d666-89e0-4d3e-b196-8613e21d62fd",
+                "id": "21ebc37f-2b1b-4639-a716-dc75e2f3cb25",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/segments/{segmentId}",
                   "// Variables to extract: []"
@@ -530,7 +530,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "d98b8bbf-8f39-4dd7-9d67-0a885be94e6c",
+                "id": "94661e20-ff39-4425-bd75-eff0d1458c8c",
                 "exec": [
                   "// Request not found in collection for: PATCH /v1/organizations/{organizationId}/ledgers/{ledgerId}/segments/{segmentId}",
                   "// Variables to extract: []"
@@ -553,7 +553,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "b751b575-7dd4-4eae-ba22-c6681b202b67",
+                "id": "97041564-9052-4a98-8f6d-3a9788ce8e46",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/segments",
                   "// Variables to extract: []"
@@ -576,7 +576,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "fe9012d4-911a-48b0-93f5-394c9e50f89b",
+                "id": "af8316fb-7c2a-4083-8644-6d316882974b",
                 "exec": [
                   "// Request not found in collection for: HEAD /v1/organizations/metrics/count",
                   "// Variables to extract: []"
@@ -599,7 +599,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "991087dc-48dc-4da1-a875-c80f26edf812",
+                "id": "f41004d4-cf82-4b00-a8fd-edb51edb3981",
                 "exec": [
                   "// Request not found in collection for: HEAD /v1/organizations/{organizationId}/ledgers/metrics/count",
                   "// Variables to extract: []"
@@ -622,7 +622,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "e5c2774c-45e9-40db-8e40-118ac133465f",
+                "id": "67009c49-58fa-40f6-a5ba-e434429f182a",
                 "exec": [
                   "// Request not found in collection for: HEAD /v1/organizations/{organizationId}/ledgers/{ledgerId}/accounts/metrics/count",
                   "// Variables to extract: []"
@@ -645,7 +645,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "31a02646-b93f-4760-93e8-3709609355e7",
+                "id": "ba4aa803-761c-4f16-a78c-20136bc6b47e",
                 "exec": [
                   "// Request not found in collection for: HEAD /v1/organizations/{organizationId}/ledgers/{ledgerId}/assets/metrics/count",
                   "// Variables to extract: []"
@@ -668,7 +668,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "6e8ec72f-106d-4037-811e-14dd3dcd3c50",
+                "id": "9903b1b3-d965-440a-bc4a-5ee4dfd8570e",
                 "exec": [
                   "// Request not found in collection for: HEAD /v1/organizations/{organizationId}/ledgers/{ledgerId}/portfolios/metrics/count",
                   "// Variables to extract: []"
@@ -691,7 +691,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "cec76374-4f5b-4234-bfe4-e1e5298fb2c1",
+                "id": "6edb80c7-56ed-40e0-b219-1e52390588e7",
                 "exec": [
                   "// Request not found in collection for: HEAD /v1/organizations/{organizationId}/ledgers/{ledgerId}/segments/metrics/count",
                   "// Variables to extract: []"
@@ -714,7 +714,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "a769f832-3549-4e6c-ad63-9bf0a13a60ff",
+                "id": "d8c6df84-29dd-48b0-a5f7-3ef011ce79a0",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/accounts/alias/{alias}",
                   "// Variables to extract: []"
@@ -737,7 +737,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "bdf0ec21-e52c-40ca-a323-32723320b9cc",
+                "id": "68b66a7c-f2e3-4dee-96fb-4508e273ee30",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/accounts/external/{code}",
                   "// Variables to extract: []"
@@ -760,7 +760,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "edfcb661-aad5-4015-8479-eda07bfc9bd9",
+                "id": "e141e986-e2ed-42a3-bc38-d95caaadcc15",
                 "exec": [
                   "// Request not found in collection for: POST /v1/organizations/{organizationId}/ledgers/{ledgerId}/transactions/json",
                   "// Variables to extract: [\"transactionId\",\"balanceId\",\"operationId\"]"
@@ -783,7 +783,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "b1da07bb-ff97-44f6-bc09-c04ceb02ac08",
+                "id": "6d0473cd-cccd-43b7-b8b2-b423d6f49508",
                 "exec": [
                   "// Request not found in collection for: POST /v1/organizations/{organizationId}/ledgers/{ledgerId}/transactions/inflow",
                   "// Variables to extract: [\"inflowTransactionId\"]"
@@ -806,7 +806,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "77790456-cd5a-4dd0-8024-5b7c10a5021d",
+                "id": "1eecf505-58e0-4025-82b7-0070604168e5",
                 "exec": [
                   "// Request not found in collection for: POST /v1/organizations/{organizationId}/ledgers/{ledgerId}/transactions/outflow",
                   "// Variables to extract: [\"outflowTransactionId\"]"
@@ -829,7 +829,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "4c9c3d3e-d1e0-4897-b4af-a4e9f61f9061",
+                "id": "a6dbce3b-71c4-427f-a0e8-65d01b9f4169",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/transactions/{transactionId}",
                   "// Variables to extract: []"
@@ -852,7 +852,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "4411c1ca-a610-4574-9eef-3e02770fbc11",
+                "id": "a02bd9ab-5e7a-44d1-9fca-ca7d8f3ecb75",
                 "exec": [
                   "// Request not found in collection for: PATCH /v1/organizations/{organizationId}/ledgers/{ledgerId}/transactions/{transactionId}",
                   "// Variables to extract: []"
@@ -875,7 +875,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "5e1ea043-f9e4-4e21-b9d5-2a358c101927",
+                "id": "c934410b-faaf-49bb-b9e7-90e7d532889b",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/transactions",
                   "// Variables to extract: []"
@@ -898,7 +898,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "2c384933-5861-48c0-b3d4-5098a748c336",
+                "id": "5270fa87-10b0-4f0e-9b8d-074ac8f04433",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/accounts/{accountId}/operations/{operationId}",
                   "// Variables to extract: []"
@@ -921,7 +921,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "676b713b-aed6-401b-8b5e-795863252b8c",
+                "id": "d8213cdf-e732-4d00-8160-0cb73d9d0bbb",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/accounts/{accountId}/operations",
                   "// Variables to extract: []"
@@ -944,7 +944,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "803ea19d-aae8-45c8-8e7c-38e9b5207596",
+                "id": "3bd2e184-b87a-4a8f-b137-96f7ad538668",
                 "exec": [
                   "// Request not found in collection for: PATCH /v1/organizations/{organizationId}/ledgers/{ledgerId}/transactions/{transactionId}/operations/{operationId}",
                   "// Variables to extract: []"
@@ -967,7 +967,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "b6d4deaa-ece6-4653-a083-3b28eb311c90",
+                "id": "1308fb2d-f7f6-40a5-ba27-4f28eac137a6",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/balances/{balanceId}",
                   "// Variables to extract: []"
@@ -990,7 +990,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "74da317c-b950-4c25-9d09-1af5ad7337a9",
+                "id": "da3e5c2c-2f57-437e-afaa-3fa304668216",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/accounts/{accountId}/balances",
                   "// Variables to extract: []"
@@ -1013,7 +1013,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "a331a7de-e2ee-4a26-a555-45638a7a7fa2",
+                "id": "d145dfd7-3a0b-4aa6-bdd2-17ec2e57320b",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/accounts/alias/{alias}/balances",
                   "// Variables to extract: []"
@@ -1036,7 +1036,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "db85d6c8-3a90-41c5-8b2e-fb57a43b4c86",
+                "id": "05f4d628-97de-4705-93ee-a0c7415f9095",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/accounts/external/{code}/balances",
                   "// Variables to extract: []"
@@ -1059,7 +1059,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "f63c980c-1a2c-4e08-a0ac-7d374af261be",
+                "id": "64498de6-7689-4c79-9f98-fc44d6986fe5",
                 "exec": [
                   "// Request not found in collection for: PATCH /v1/organizations/{organizationId}/ledgers/{ledgerId}/balances/{balanceId}",
                   "// Variables to extract: []"
@@ -1082,7 +1082,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "27bdef99-a120-4fac-997d-a4b5aa3046d7",
+                "id": "ab6abab0-4492-4132-98b2-761714f37e65",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/balances",
                   "// Variables to extract: []"
@@ -1105,7 +1105,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "282d8639-71e5-4571-935a-7eae6b970f50",
+                "id": "88a77b78-e681-48f0-82f6-3e255c0031e6",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/accounts/alias/{alias}/balances",
                   "// Variables to extract: [\"currentBalanceAmount\"]"
@@ -1128,7 +1128,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "fde9df8b-ec1f-44f9-a7c7-f15bd7d221c6",
+                "id": "a516761e-aa4a-4c52-98bf-4a222892e3bd",
                 "exec": [
                   "// Request not found in collection for: POST /v1/organizations/{organizationId}/ledgers/{ledgerId}/transactions/json",
                   "// Variables to extract: []"
@@ -1151,7 +1151,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "8a6e2dba-f8c2-4157-8d28-c4e7cf09f420",
+                "id": "24cc33ca-af56-4d7e-a97a-99d7832f9aac",
                 "exec": [
                   "// Request not found in collection for: DELETE /v1/organizations/{organizationId}/ledgers/{ledgerId}/balances/{balanceId}",
                   "// Variables to extract: []"
@@ -1174,7 +1174,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "d995d696-e368-4883-98f6-87fd8e000ce5",
+                "id": "c7e80110-c7bc-4609-b08c-aca8c5daeba9",
                 "exec": [
                   "// Request not found in collection for: DELETE /v1/organizations/{organizationId}/ledgers/{ledgerId}/segments/{segmentId}",
                   "// Variables to extract: []"
@@ -1197,7 +1197,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "542f39ec-a3d4-4e37-bf50-d175c45638a0",
+                "id": "6dc4c33a-c3b8-4871-ada5-1f72cf0921e0",
                 "exec": [
                   "// Request not found in collection for: DELETE /v1/organizations/{organizationId}/ledgers/{ledgerId}/portfolios/{portfolioId}",
                   "// Variables to extract: []"
@@ -1220,7 +1220,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "1ae62ead-1be0-473d-b208-52466709aead",
+                "id": "fb9f18da-ed2c-4105-a648-5989a57699a1",
                 "exec": [
                   "// Request not found in collection for: DELETE /v1/organizations/{organizationId}/ledgers/{ledgerId}/accounts/{accountId}",
                   "// Variables to extract: []"
@@ -1243,7 +1243,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "3e78751d-cf12-4f37-a87d-e715efce7112",
+                "id": "5a9da716-fe93-4c52-b788-f43a54f79297",
                 "exec": [
                   "// Request not found in collection for: DELETE /v1/organizations/{organizationId}/ledgers/{ledgerId}/assets/{assetId}",
                   "// Variables to extract: []"
@@ -1266,7 +1266,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "cb5ef441-f334-49d2-a372-ee6729e9d3b3",
+                "id": "90773970-6774-4687-bdf0-4f1447df787c",
                 "exec": [
                   "// Request not found in collection for: DELETE /v1/organizations/{organizationId}/ledgers/{ledgerId}",
                   "// Variables to extract: []"
@@ -1289,7 +1289,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "1fba5dbd-7f58-4a41-9f83-6b34bc54b233",
+                "id": "a8c53692-87cc-4f62-a956-efdbcad84d92",
                 "exec": [
                   "// Request not found in collection for: DELETE /v1/organizations/{organizationId}",
                   "// Variables to extract: []"
@@ -1318,7 +1318,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "c43395ab-549b-4bae-ac2a-4e81a05b4993",
+                "id": "fa532ba7-98e4-41af-9d61-0f9984d4a397",
                 "exec": [
                   "\n// ===== WORKFLOW SUMMARY =====\nconsole.log(\"📊 Workflow Execution Summary\");\nconsole.log(\"Total Steps: 56\");\n\n// Calculate total execution time\nconst startTime = pm.globals.get(\"workflow_start_time\");\nif (startTime) {\n    const totalTime = Date.now() - startTime;\n    console.log(\"⏱️ Total Execution Time: \" + totalTime + \"ms\");\n    pm.globals.set(\"workflow_total_time\", totalTime);\n}\n\n// Summary of step performance\nconsole.log(\"📈 Performance Summary:\");\nfor (let i = 1; i <= 56; i++) {\n    const stepTime = pm.environment.get(\"perf_step_\" + i);\n    if (stepTime) {\n        console.log(\"  Step \" + i + \": \" + stepTime + \"ms\");\n    }\n}\n\nconsole.log(\"✅ Workflow completed successfully\");\n"
                 ],
@@ -1328,7 +1328,7 @@
           ]
         }
       ],
-      "_postman_id": "d08a6e96-aba8-49f2-a0f6-88a69cc7149c",
+      "_postman_id": "0a4cad66-9170-427f-8e0a-ddd3cce0ece6",
       "event": []
     },
     {


### PR DESCRIPTION
## Summary
- Adds optional `segment_id` query parameter to `GET /accounts`, enabling server-side filtering by segment
- Adds database indexes on `segment_id` and `portfolio_id` for efficient filtered queries
- The existing `portfolio_id` parameter is unchanged; both filters compose with AND logic

## Motivation
API consumers currently must fetch all accounts and filter client-side to find accounts belonging to a specific segment or portfolio. This is inefficient for ledgers with thousands of accounts and prevents segment-scoped dashboards or portfolio-scoped reports from being built with a single API call.

## Changes

### Query parameter parsing (`pkg/net/http/httputils.go`)
- Added `SegmentID` field to `QueryHeader` struct
- Added `segment_id` case in `ValidateParameters` with UUID validation

### HTTP handler (`components/ledger/internal/adapters/http/in/account.go`)
- `GetAllAccounts` parses `segmentID` from validated query params
- Passes `segmentID` to both the direct query and metadata query service paths
- Swagger annotations document both `portfolio_id` and `segment_id` parameters

### Service layer
- `GetAllAccount` and `GetAllMetadataAccounts` accept and forward `segmentID *uuid.UUID`

### Repository layer (`components/ledger/internal/adapters/postgres/account/`)
- `FindAll` and `ListByIDs` interface methods accept `segmentID *uuid.UUID`
- Implementations add conditional `WHERE segment_id = ?` clause using the established nil-pointer pattern

### Database migrations
- `000009` — Partial index on `(organization_id, ledger_id, segment_id) WHERE deleted_at IS NULL`
- `000010` — Partial index on `(organization_id, ledger_id, portfolio_id) WHERE deleted_at IS NULL`
- Split into separate files because `CREATE INDEX CONCURRENTLY` cannot run inside a transaction block

### Tests
- Unit tests for `segment_id` query parameter parsing (valid, invalid UUID)
- Updated all existing mock expectations across handler, service, and integration test files

## Backward compatibility
Fully backward compatible. Omitting both parameters returns all accounts (unchanged behavior). No breaking changes to the API contract — only additive optional query parameters.