### PR TITLE
feat(bootstrap): pass CacheTTL to multi-tenant consumer config

### DIFF
--- a/components/ledger/internal/bootstrap/config.go
+++ b/components/ledger/internal/bootstrap/config.go
@@ -23,6 +23,7 @@ import (
 	tmmiddleware "github.com/LerianStudio/lib-commons/v4/commons/tenant-manager/middleware"
 	tmmongo "github.com/LerianStudio/lib-commons/v4/commons/tenant-manager/mongo"
 	tmpostgres "github.com/LerianStudio/lib-commons/v4/commons/tenant-manager/postgres"
+	tmwatcher "github.com/LerianStudio/lib-commons/v4/commons/tenant-manager/watcher"
 	libZap "github.com/LerianStudio/lib-commons/v4/commons/zap"
 	httpin "github.com/LerianStudio/midaz/v3/components/ledger/internal/adapters/http/in"
 	onbRedis "github.com/LerianStudio/midaz/v3/components/ledger/internal/adapters/redis/onboarding"
@@ -417,6 +418,32 @@ func InitServersWithOptions(opts *Options) (*Service, error) {
 		rmq.mongoManager = txnMgo.mongoManager
 	}
 
+	// 7. SettingsWatcher — revalidates PG pool settings independently of the RabbitMQ consumer
+	var settingsWatcher *tmwatcher.SettingsWatcher
+
+	if cfg.MultiTenantEnabled && tenantClient != nil {
+		watcherOpts := []tmwatcher.Option{
+			tmwatcher.WithLogger(logger),
+		}
+
+		settingsCheckInterval := time.Duration(cfg.MultiTenantSettingsCheckIntervalSec) * time.Second
+		if settingsCheckInterval > 0 {
+			watcherOpts = append(watcherOpts, tmwatcher.WithInterval(settingsCheckInterval))
+		}
+
+		if onbPG.pgManager != nil {
+			watcherOpts = append(watcherOpts, tmwatcher.WithPostgresManager(onbPG.pgManager))
+		}
+
+		if txnPG.pgManager != nil {
+			watcherOpts = append(watcherOpts, tmwatcher.WithPostgresManager(txnPG.pgManager))
+		}
+
+		settingsWatcher = tmwatcher.NewSettingsWatcher(tenantClient, tenantServiceName, watcherOpts...)
+
+		logger.Log(context.Background(), libLog.LevelInfo, "SettingsWatcher created for PostgreSQL pool settings revalidation")
+	}
+
 	// === Use cases ===
 
 	settingsCacheTTL := resolveSettingsCacheTTL(cfg, logger)
@@ -568,6 +595,7 @@ func InitServersWithOptions(opts *Options) (*Service, error) {
 		MultiTenantConsumer:   rmq.multiTenantConsumer,
 		RedisQueueConsumer:    redisConsumer,
 		BalanceSyncWorker:     balanceSyncWorker,
+		SettingsWatcher:       settingsWatcher,
 		CircuitBreakerManager: rmq.circuitBreakerManager,
 		Logger:                logger,
 		Telemetry:             telemetry,

--- a/components/ledger/internal/bootstrap/config.rabbitmq.go
+++ b/components/ledger/internal/bootstrap/config.rabbitmq.go
@@ -111,6 +111,7 @@ func initMultiTenantRabbitMQ(
 		Service:          opts.TenantServiceName,
 		Environment:      opts.TenantEnvironment,
 		DiscoveryTimeout: discoveryTimeout,
+		CacheTTL:         time.Duration(cfg.MultiTenantCacheTTLSec) * time.Second,
 	}
 
 	consumer, err := tmconsumer.NewMultiTenantConsumerWithError(tenantRabbitMQ, mtConfig, logger)

--- a/components/ledger/internal/bootstrap/service.go
+++ b/components/ledger/internal/bootstrap/service.go
@@ -6,12 +6,16 @@ package bootstrap
 
 import (
 	"context"
+	"os"
+	"os/signal"
+	"syscall"
 
 	libCommons "github.com/LerianStudio/lib-commons/v4/commons"
 	libLog "github.com/LerianStudio/lib-commons/v4/commons/log"
 	libOpentelemetry "github.com/LerianStudio/lib-commons/v4/commons/opentelemetry"
 	"github.com/LerianStudio/lib-commons/v4/commons/opentelemetry/metrics"
 	tmconsumer "github.com/LerianStudio/lib-commons/v4/commons/tenant-manager/consumer"
+	tmwatcher "github.com/LerianStudio/lib-commons/v4/commons/tenant-manager/watcher"
 )
 
 // Service is the unified ledger service that owns all infrastructure directly.
@@ -21,6 +25,7 @@ type Service struct {
 	MultiTenantConsumer   *tmconsumer.MultiTenantConsumer
 	RedisQueueConsumer    *RedisQueueConsumer
 	BalanceSyncWorker     *BalanceSyncWorker
+	SettingsWatcher       *tmwatcher.SettingsWatcher
 	CircuitBreakerManager *CircuitBreakerManager
 	Logger                libLog.Logger
 	Telemetry             *libOpentelemetry.Telemetry
@@ -57,6 +62,12 @@ func (s *Service) Run() {
 		launcherOpts = append(launcherOpts, libCommons.RunApp("Balance Sync Worker", s.BalanceSyncWorker))
 	}
 
+	// Settings watcher (multi-tenant only: revalidates PG pool settings periodically)
+	if s.SettingsWatcher != nil {
+		launcherOpts = append(launcherOpts, libCommons.RunApp("Settings Watcher",
+			&settingsWatcherRunnable{watcher: s.SettingsWatcher, logger: s.Logger}))
+	}
+
 	// Circuit breaker health checker
 	if s.CircuitBreakerManager != nil {
 		launcherOpts = append(launcherOpts, libCommons.RunApp("Circuit Breaker Health Checker",
@@ -64,4 +75,39 @@ func (s *Service) Run() {
 	}
 
 	libCommons.NewLauncher(launcherOpts...).Run()
+}
+
+// settingsWatcherRunnable adapts *tmwatcher.SettingsWatcher to the
+// mbootstrap.Runnable interface so the Launcher can manage its lifecycle.
+// It starts the watcher in the foreground and stops it gracefully on
+// SIGINT/SIGTERM, matching the shutdown pattern of other runnables in
+// this package (multiTenantConsumerRunnable, RedisQueueConsumer).
+type settingsWatcherRunnable struct {
+	watcher *tmwatcher.SettingsWatcher
+	logger  libLog.Logger
+}
+
+// Run implements mbootstrap.Runnable.
+// It starts the SettingsWatcher which periodically revalidates PostgreSQL
+// connection pool settings for all registered managers. The watcher is
+// stopped gracefully on SIGINT/SIGTERM.
+func (r *settingsWatcherRunnable) Run(_ *libCommons.Launcher) error {
+	if r.watcher == nil {
+		return nil
+	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+
+	r.watcher.Start(ctx)
+
+	r.logger.Log(ctx, libLog.LevelInfo, "SettingsWatcher started for PostgreSQL pool settings revalidation")
+
+	<-ctx.Done()
+	stop()
+
+	r.watcher.Stop()
+
+	r.logger.Log(context.Background(), libLog.LevelInfo, "SettingsWatcher stopped")
+
+	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -100,7 +100,7 @@ require (
 )
 
 require (
-	github.com/LerianStudio/lib-commons/v4 v4.4.0-beta.4
+	github.com/LerianStudio/lib-commons/v4 v4.4.0-beta.6
 	github.com/Shopify/toxiproxy/v2 v2.12.0
 	github.com/docker/docker v28.5.2+incompatible
 	github.com/docker/go-connections v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -19,8 +19,8 @@ github.com/KyleBanks/depth v1.2.1 h1:5h8fQADFrWtarTdtDudMmGsC7GPbOAu6RVB3ffsVFHc
 github.com/KyleBanks/depth v1.2.1/go.mod h1:jzSb9d0L43HxTQfT+oSA1EEp2q+ne2uh6XgeJcm8brE=
 github.com/LerianStudio/lib-auth/v2 v2.5.0 h1:PUchYPGgqaOQwbC6Bcv7WKwjarZl7fgrw6O427iuP8k=
 github.com/LerianStudio/lib-auth/v2 v2.5.0/go.mod h1:AAbJCVaVokfO9bLa4aCIGzVMP6to/Ml5MC4X9B6jLZ0=
-github.com/LerianStudio/lib-commons/v4 v4.4.0-beta.4 h1:2qsdloyXg+dC70S01mFa42CRUYSV+n3HBUwYZLzkvxo=
-github.com/LerianStudio/lib-commons/v4 v4.4.0-beta.4/go.mod h1:/0EgYB6lT23afy/nmmeJiuoDnu3/tS56fXqW7fB0QMk=
+github.com/LerianStudio/lib-commons/v4 v4.4.0-beta.6 h1:FcUVAh+tQSZWFkAekWH5MJL6uqDBabgPfTjjPZXqyck=
+github.com/LerianStudio/lib-commons/v4 v4.4.0-beta.6/go.mod h1:/0EgYB6lT23afy/nmmeJiuoDnu3/tS56fXqW7fB0QMk=
 github.com/Masterminds/squirrel v1.5.4 h1:uUcX/aBc8O7Fg9kaISIUsHXdKuqehiXAMQTYX8afzqM=
 github.com/Masterminds/squirrel v1.5.4/go.mod h1:NNaOrjSoIDfDA40n7sr2tPNZRfjzjA400rg+riTZj10=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=


### PR DESCRIPTION
## Summary

- **CacheTTL**: Passes `MULTI_TENANT_CACHE_TTL_SEC` (default 120s) to the consumer's internal HTTP client (was using lib-commons 1h default)
- **SettingsWatcher**: Wires standalone PostgreSQL pool settings revalidation — independent of RabbitMQ consumer. Both PG managers (onboarding + transaction) are registered.

## Changes

| File | Change |
|------|--------|
| `config.rabbitmq.go` | Pass `CacheTTL` to consumer's `MultiTenantConfig` |
| `config.go` | Create `SettingsWatcher` with both PG managers (onboarding + transaction), guarded by multi-tenant mode |
| `service.go` | Add `SettingsWatcher` field, `settingsWatcherRunnable` adapter for graceful lifecycle |

## Architecture

```
Bootstrap (multi-tenant):
  ├─ PG Managers (onboarding + transaction)
  ├─ Mongo Manager
  ├─ MultiTenantConsumer (RabbitMQ)
  │    └─ syncTenants only (no more settings revalidation)
  └─ SettingsWatcher (NEW — standalone goroutine)
       ├─ onboarding PG Manager → revalidate pool settings
       └─ transaction PG Manager → revalidate pool settings
```

## Dependencies

- [lib-commons #394](https://github.com/LerianStudio/lib-commons/pull/394) — CacheTTL + StatementTimeout (merged)
- [lib-commons #395](https://github.com/LerianStudio/lib-commons/pull/395) — SettingsWatcher component (open)

## Test plan

- [ ] After lib-commons bump: `go build ./...` compiles
- [ ] Change pool settings in tenant-manager → reflected in Midaz logs within ~120s
- [ ] Change statementTimeout → `SET statement_timeout` executed on PG
- [ ] No RabbitMQ dependency for settings revalidation
- [ ] Graceful shutdown: watcher stops cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)