### PR TITLE
feat: add filtered transaction count endpoint

### DIFF
--- a/components/ledger/api/docs.go
+++ b/components/ledger/api/docs.go
@@ -6765,105 +6765,6 @@ const docTemplate = `
         }
       }
     },
-    "/v1/organizations/{organization_id}/ledgers/{ledger_id}/transactions/count": {
-      "head": {
-        "description": "Count transactions matching optional filters (route, status, date range)",
-        "tags": [
-          "Transactions"
-        ],
-        "summary": "Count Transactions by Filters",
-        "parameters": [
-          {
-            "type": "string",
-            "description": "Authorization Bearer Token",
-            "name": "Authorization",
-            "in": "header",
-            "required": true
-          },
-          {
-            "type": "string",
-            "description": "Request ID",
-            "name": "X-Request-Id",
-            "in": "header"
-          },
-          {
-            "type": "string",
-            "format": "uuid",
-            "description": "Organization ID",
-            "name": "organization_id",
-            "in": "path",
-            "required": true
-          },
-          {
-            "type": "string",
-            "format": "uuid",
-            "description": "Ledger ID",
-            "name": "ledger_id",
-            "in": "path",
-            "required": true
-          },
-          {
-            "type": "string",
-            "description": "Filter by transaction route",
-            "name": "route",
-            "in": "query"
-          },
-          {
-            "type": "string",
-            "description": "Filter by transaction status (CREATED, APPROVED, PENDING, CANCELED, NOTED)",
-            "name": "status",
-            "in": "query"
-          },
-          {
-            "type": "string",
-            "description": "Start of date range (RFC 3339, defaults to today 00:00:00 UTC)",
-            "name": "start_date",
-            "in": "query"
-          },
-          {
-            "type": "string",
-            "description": "End of date range (RFC 3339, defaults to today 23:59:59 UTC)",
-            "name": "end_date",
-            "in": "query"
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "No Content",
-            "headers": {
-              "X-Total-Count": {
-                "type": "integer",
-                "description": "Total count of matching transactions"
-              }
-            }
-          },
-          "400": {
-            "description": "Bad Request",
-            "schema": {
-              "$ref": "#/definitions/Error"
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "schema": {
-              "$ref": "#/definitions/Error"
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "schema": {
-              "$ref": "#/definitions/Error"
-            }
-          },
-          "500": {
-            "description": "Internal Server Error",
-            "schema": {
-              "$ref": "#/definitions/Error"
-            }
-          }
-        }
-      }
-    },
     "/v1/organizations/{organization_id}/ledgers/{ledger_id}/transactions/dsl": {
       "post": {
         "description": "Create a Transaction with the input DSL file",
@@ -7128,6 +7029,105 @@ const docTemplate = `
           },
           "500": {
             "description": "Internal server error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/v1/organizations/{organization_id}/ledgers/{ledger_id}/transactions/metrics/count": {
+      "head": {
+        "description": "Count transactions matching optional filters (route, status, date range)",
+        "tags": [
+          "Transactions"
+        ],
+        "summary": "Count Transactions by Filters",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "Authorization Bearer Token",
+            "name": "Authorization",
+            "in": "header",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "Request ID",
+            "name": "X-Request-Id",
+            "in": "header"
+          },
+          {
+            "type": "string",
+            "format": "uuid",
+            "description": "Organization ID",
+            "name": "organization_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "format": "uuid",
+            "description": "Ledger ID",
+            "name": "ledger_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "Filter by transaction route",
+            "name": "route",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "description": "Filter by transaction status (CREATED, APPROVED, PENDING, CANCELED, NOTED)",
+            "name": "status",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "description": "Start of date range (RFC 3339, defaults to today 00:00:00 UTC)",
+            "name": "start_date",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "description": "End of date range (RFC 3339, defaults to today 23:59:59 UTC)",
+            "name": "end_date",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content",
+            "headers": {
+              "X-Total-Count": {
+                "type": "integer",
+                "description": "Total count of matching transactions"
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
             "schema": {
               "$ref": "#/definitions/Error"
             }

--- a/components/ledger/api/docs.go
+++ b/components/ledger/api/docs.go
@@ -7080,19 +7080,28 @@ const docTemplate = `
             "in": "query"
           },
           {
+            "enum": [
+              "CREATED",
+              "APPROVED",
+              "PENDING",
+              "CANCELED",
+              "NOTED"
+            ],
             "type": "string",
-            "description": "Filter by transaction status (CREATED, APPROVED, PENDING, CANCELED, NOTED)",
+            "description": "Filter by transaction status",
             "name": "status",
             "in": "query"
           },
           {
             "type": "string",
+            "format": "date-time",
             "description": "Start of date range (RFC 3339, defaults to today 00:00:00 UTC)",
             "name": "start_date",
             "in": "query"
           },
           {
             "type": "string",
+            "format": "date-time",
             "description": "End of date range (RFC 3339, defaults to today 23:59:59 UTC)",
             "name": "end_date",
             "in": "query"

--- a/components/ledger/api/docs.go
+++ b/components/ledger/api/docs.go
@@ -6765,6 +6765,105 @@ const docTemplate = `
         }
       }
     },
+    "/v1/organizations/{organization_id}/ledgers/{ledger_id}/transactions/count": {
+      "head": {
+        "description": "Count transactions matching optional filters (route, status, date range)",
+        "tags": [
+          "Transactions"
+        ],
+        "summary": "Count Transactions by Filters",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "Authorization Bearer Token",
+            "name": "Authorization",
+            "in": "header",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "Request ID",
+            "name": "X-Request-Id",
+            "in": "header"
+          },
+          {
+            "type": "string",
+            "format": "uuid",
+            "description": "Organization ID",
+            "name": "organization_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "format": "uuid",
+            "description": "Ledger ID",
+            "name": "ledger_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "Filter by transaction route",
+            "name": "route",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "description": "Filter by transaction status (CREATED, APPROVED, PENDING, CANCELED, NOTED)",
+            "name": "status",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "description": "Start of date range (RFC 3339, defaults to today 00:00:00 UTC)",
+            "name": "start_date",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "description": "End of date range (RFC 3339, defaults to today 23:59:59 UTC)",
+            "name": "end_date",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content",
+            "headers": {
+              "X-Total-Count": {
+                "type": "integer",
+                "description": "Total count of matching transactions"
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
     "/v1/organizations/{organization_id}/ledgers/{ledger_id}/transactions/dsl": {
       "post": {
         "description": "Create a Transaction with the input DSL file",

--- a/components/ledger/api/openapi.yaml
+++ b/components/ledger/api/openapi.yaml
@@ -5552,6 +5552,93 @@ paths:
       tags:
       - Transactions
       x-codegen-request-body-name: transaction
+  /v1/organizations/{organization_id}/ledgers/{ledger_id}/transactions/count:
+    head:
+      description: Count transactions matching optional filters (route, status, date
+        range)
+      parameters:
+      - description: Authorization Bearer Token
+        in: header
+        name: Authorization
+        required: true
+        schema:
+          type: string
+      - description: Request ID
+        in: header
+        name: X-Request-Id
+        schema:
+          type: string
+      - description: Organization ID
+        in: path
+        name: organization_id
+        required: true
+        schema:
+          format: uuid
+          type: string
+      - description: Ledger ID
+        in: path
+        name: ledger_id
+        required: true
+        schema:
+          format: uuid
+          type: string
+      - description: Filter by transaction route
+        in: query
+        name: route
+        schema:
+          type: string
+      - description: Filter by transaction status (CREATED, APPROVED, PENDING, CANCELED,
+          NOTED)
+        in: query
+        name: status
+        schema:
+          type: string
+      - description: Start of date range (RFC 3339, defaults to today 00:00:00 UTC)
+        in: query
+        name: start_date
+        schema:
+          type: string
+      - description: End of date range (RFC 3339, defaults to today 23:59:59 UTC)
+        in: query
+        name: end_date
+        schema:
+          type: string
+      responses:
+        "204":
+          content: {}
+          description: No Content
+          headers:
+            X-Total-Count:
+              description: Total count of matching transactions
+              schema:
+                type: integer
+        "400":
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Bad Request
+        "401":
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unauthorized
+        "403":
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Forbidden
+        "500":
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
+      summary: Count Transactions by Filters
+      tags:
+      - Transactions
   /v1/organizations/{organization_id}/ledgers/{ledger_id}/transactions/dsl:
     post:
       description: Create a Transaction with the input DSL file

--- a/components/ledger/api/openapi.yaml
+++ b/components/ledger/api/openapi.yaml
@@ -5552,93 +5552,6 @@ paths:
       tags:
       - Transactions
       x-codegen-request-body-name: transaction
-  /v1/organizations/{organization_id}/ledgers/{ledger_id}/transactions/count:
-    head:
-      description: Count transactions matching optional filters (route, status, date
-        range)
-      parameters:
-      - description: Authorization Bearer Token
-        in: header
-        name: Authorization
-        required: true
-        schema:
-          type: string
-      - description: Request ID
-        in: header
-        name: X-Request-Id
-        schema:
-          type: string
-      - description: Organization ID
-        in: path
-        name: organization_id
-        required: true
-        schema:
-          format: uuid
-          type: string
-      - description: Ledger ID
-        in: path
-        name: ledger_id
-        required: true
-        schema:
-          format: uuid
-          type: string
-      - description: Filter by transaction route
-        in: query
-        name: route
-        schema:
-          type: string
-      - description: Filter by transaction status (CREATED, APPROVED, PENDING, CANCELED,
-          NOTED)
-        in: query
-        name: status
-        schema:
-          type: string
-      - description: Start of date range (RFC 3339, defaults to today 00:00:00 UTC)
-        in: query
-        name: start_date
-        schema:
-          type: string
-      - description: End of date range (RFC 3339, defaults to today 23:59:59 UTC)
-        in: query
-        name: end_date
-        schema:
-          type: string
-      responses:
-        "204":
-          content: {}
-          description: No Content
-          headers:
-            X-Total-Count:
-              description: Total count of matching transactions
-              schema:
-                type: integer
-        "400":
-          content:
-            '*/*':
-              schema:
-                $ref: '#/components/schemas/Error'
-          description: Bad Request
-        "401":
-          content:
-            '*/*':
-              schema:
-                $ref: '#/components/schemas/Error'
-          description: Unauthorized
-        "403":
-          content:
-            '*/*':
-              schema:
-                $ref: '#/components/schemas/Error'
-          description: Forbidden
-        "500":
-          content:
-            '*/*':
-              schema:
-                $ref: '#/components/schemas/Error'
-          description: Internal Server Error
-      summary: Count Transactions by Filters
-      tags:
-      - Transactions
   /v1/organizations/{organization_id}/ledgers/{ledger_id}/transactions/dsl:
     post:
       description: Create a Transaction with the input DSL file
@@ -5868,6 +5781,100 @@ paths:
       tags:
       - Transactions
       x-codegen-request-body-name: transaction
+  /v1/organizations/{organization_id}/ledgers/{ledger_id}/transactions/metrics/count:
+    head:
+      description: Count transactions matching optional filters (route, status, date
+        range)
+      parameters:
+      - description: Authorization Bearer Token
+        in: header
+        name: Authorization
+        required: true
+        schema:
+          type: string
+      - description: Request ID
+        in: header
+        name: X-Request-Id
+        schema:
+          type: string
+      - description: Organization ID
+        in: path
+        name: organization_id
+        required: true
+        schema:
+          format: uuid
+          type: string
+      - description: Ledger ID
+        in: path
+        name: ledger_id
+        required: true
+        schema:
+          format: uuid
+          type: string
+      - description: Filter by transaction route
+        in: query
+        name: route
+        schema:
+          type: string
+      - description: Filter by transaction status
+        in: query
+        name: status
+        schema:
+          enum:
+          - CREATED
+          - APPROVED
+          - PENDING
+          - CANCELED
+          - NOTED
+          type: string
+      - description: Start of date range (RFC 3339, defaults to today 00:00:00 UTC)
+        in: query
+        name: start_date
+        schema:
+          format: date-time
+          type: string
+      - description: End of date range (RFC 3339, defaults to today 23:59:59 UTC)
+        in: query
+        name: end_date
+        schema:
+          format: date-time
+          type: string
+      responses:
+        "204":
+          content: {}
+          description: No Content
+          headers:
+            X-Total-Count:
+              description: Total count of matching transactions
+              schema:
+                type: integer
+        "400":
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Bad Request
+        "401":
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unauthorized
+        "403":
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Forbidden
+        "500":
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
+      summary: Count Transactions by Filters
+      tags:
+      - Transactions
   /v1/organizations/{organization_id}/ledgers/{ledger_id}/transactions/outflow:
     post:
       description: Create a Transaction with the input payload

--- a/components/ledger/api/swagger.json
+++ b/components/ledger/api/swagger.json
@@ -6741,6 +6741,105 @@
         }
       }
     },
+    "/v1/organizations/{organization_id}/ledgers/{ledger_id}/transactions/count": {
+      "head": {
+        "description": "Count transactions matching optional filters (route, status, date range)",
+        "tags": [
+          "Transactions"
+        ],
+        "summary": "Count Transactions by Filters",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "Authorization Bearer Token",
+            "name": "Authorization",
+            "in": "header",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "Request ID",
+            "name": "X-Request-Id",
+            "in": "header"
+          },
+          {
+            "type": "string",
+            "format": "uuid",
+            "description": "Organization ID",
+            "name": "organization_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "format": "uuid",
+            "description": "Ledger ID",
+            "name": "ledger_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "Filter by transaction route",
+            "name": "route",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "description": "Filter by transaction status (CREATED, APPROVED, PENDING, CANCELED, NOTED)",
+            "name": "status",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "description": "Start of date range (RFC 3339, defaults to today 00:00:00 UTC)",
+            "name": "start_date",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "description": "End of date range (RFC 3339, defaults to today 23:59:59 UTC)",
+            "name": "end_date",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content",
+            "headers": {
+              "X-Total-Count": {
+                "type": "integer",
+                "description": "Total count of matching transactions"
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
     "/v1/organizations/{organization_id}/ledgers/{ledger_id}/transactions/dsl": {
       "post": {
         "description": "Create a Transaction with the input DSL file",

--- a/components/ledger/api/swagger.json
+++ b/components/ledger/api/swagger.json
@@ -7056,19 +7056,28 @@
             "in": "query"
           },
           {
+            "enum": [
+              "CREATED",
+              "APPROVED",
+              "PENDING",
+              "CANCELED",
+              "NOTED"
+            ],
             "type": "string",
-            "description": "Filter by transaction status (CREATED, APPROVED, PENDING, CANCELED, NOTED)",
+            "description": "Filter by transaction status",
             "name": "status",
             "in": "query"
           },
           {
             "type": "string",
+            "format": "date-time",
             "description": "Start of date range (RFC 3339, defaults to today 00:00:00 UTC)",
             "name": "start_date",
             "in": "query"
           },
           {
             "type": "string",
+            "format": "date-time",
             "description": "End of date range (RFC 3339, defaults to today 23:59:59 UTC)",
             "name": "end_date",
             "in": "query"

--- a/components/ledger/api/swagger.json
+++ b/components/ledger/api/swagger.json
@@ -6741,105 +6741,6 @@
         }
       }
     },
-    "/v1/organizations/{organization_id}/ledgers/{ledger_id}/transactions/count": {
-      "head": {
-        "description": "Count transactions matching optional filters (route, status, date range)",
-        "tags": [
-          "Transactions"
-        ],
-        "summary": "Count Transactions by Filters",
-        "parameters": [
-          {
-            "type": "string",
-            "description": "Authorization Bearer Token",
-            "name": "Authorization",
-            "in": "header",
-            "required": true
-          },
-          {
-            "type": "string",
-            "description": "Request ID",
-            "name": "X-Request-Id",
-            "in": "header"
-          },
-          {
-            "type": "string",
-            "format": "uuid",
-            "description": "Organization ID",
-            "name": "organization_id",
-            "in": "path",
-            "required": true
-          },
-          {
-            "type": "string",
-            "format": "uuid",
-            "description": "Ledger ID",
-            "name": "ledger_id",
-            "in": "path",
-            "required": true
-          },
-          {
-            "type": "string",
-            "description": "Filter by transaction route",
-            "name": "route",
-            "in": "query"
-          },
-          {
-            "type": "string",
-            "description": "Filter by transaction status (CREATED, APPROVED, PENDING, CANCELED, NOTED)",
-            "name": "status",
-            "in": "query"
-          },
-          {
-            "type": "string",
-            "description": "Start of date range (RFC 3339, defaults to today 00:00:00 UTC)",
-            "name": "start_date",
-            "in": "query"
-          },
-          {
-            "type": "string",
-            "description": "End of date range (RFC 3339, defaults to today 23:59:59 UTC)",
-            "name": "end_date",
-            "in": "query"
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "No Content",
-            "headers": {
-              "X-Total-Count": {
-                "type": "integer",
-                "description": "Total count of matching transactions"
-              }
-            }
-          },
-          "400": {
-            "description": "Bad Request",
-            "schema": {
-              "$ref": "#/definitions/Error"
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "schema": {
-              "$ref": "#/definitions/Error"
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "schema": {
-              "$ref": "#/definitions/Error"
-            }
-          },
-          "500": {
-            "description": "Internal Server Error",
-            "schema": {
-              "$ref": "#/definitions/Error"
-            }
-          }
-        }
-      }
-    },
     "/v1/organizations/{organization_id}/ledgers/{ledger_id}/transactions/dsl": {
       "post": {
         "description": "Create a Transaction with the input DSL file",
@@ -7104,6 +7005,105 @@
           },
           "500": {
             "description": "Internal server error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/v1/organizations/{organization_id}/ledgers/{ledger_id}/transactions/metrics/count": {
+      "head": {
+        "description": "Count transactions matching optional filters (route, status, date range)",
+        "tags": [
+          "Transactions"
+        ],
+        "summary": "Count Transactions by Filters",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "Authorization Bearer Token",
+            "name": "Authorization",
+            "in": "header",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "Request ID",
+            "name": "X-Request-Id",
+            "in": "header"
+          },
+          {
+            "type": "string",
+            "format": "uuid",
+            "description": "Organization ID",
+            "name": "organization_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "format": "uuid",
+            "description": "Ledger ID",
+            "name": "ledger_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "Filter by transaction route",
+            "name": "route",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "description": "Filter by transaction status (CREATED, APPROVED, PENDING, CANCELED, NOTED)",
+            "name": "status",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "description": "Start of date range (RFC 3339, defaults to today 00:00:00 UTC)",
+            "name": "start_date",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "description": "End of date range (RFC 3339, defaults to today 23:59:59 UTC)",
+            "name": "end_date",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content",
+            "headers": {
+              "X-Total-Count": {
+                "type": "integer",
+                "description": "Total count of matching transactions"
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
             "schema": {
               "$ref": "#/definitions/Error"
             }

--- a/components/ledger/api/swagger.yaml
+++ b/components/ledger/api/swagger.yaml
@@ -4810,16 +4810,23 @@ paths:
         description: Filter by transaction route
         name: route
         in: query
-      - type: string
-        description: Filter by transaction status (CREATED, APPROVED, PENDING, CANCELED,
-          NOTED)
+      - enum:
+        - CREATED
+        - APPROVED
+        - PENDING
+        - CANCELED
+        - NOTED
+        type: string
+        description: Filter by transaction status
         name: status
         in: query
       - type: string
+        format: date-time
         description: Start of date range (RFC 3339, defaults to today 00:00:00 UTC)
         name: start_date
         in: query
       - type: string
+        format: date-time
         description: End of date range (RFC 3339, defaults to today 23:59:59 UTC)
         name: end_date
         in: query

--- a/components/ledger/api/swagger.yaml
+++ b/components/ledger/api/swagger.yaml
@@ -4595,75 +4595,6 @@ paths:
           description: Internal server error
           schema:
             $ref: '#/definitions/Error'
-  /v1/organizations/{organization_id}/ledgers/{ledger_id}/transactions/count:
-    head:
-      description: Count transactions matching optional filters (route, status, date
-        range)
-      tags:
-      - Transactions
-      summary: Count Transactions by Filters
-      parameters:
-      - type: string
-        description: Authorization Bearer Token
-        name: Authorization
-        in: header
-        required: true
-      - type: string
-        description: Request ID
-        name: X-Request-Id
-        in: header
-      - type: string
-        format: uuid
-        description: Organization ID
-        name: organization_id
-        in: path
-        required: true
-      - type: string
-        format: uuid
-        description: Ledger ID
-        name: ledger_id
-        in: path
-        required: true
-      - type: string
-        description: Filter by transaction route
-        name: route
-        in: query
-      - type: string
-        description: Filter by transaction status (CREATED, APPROVED, PENDING, CANCELED,
-          NOTED)
-        name: status
-        in: query
-      - type: string
-        description: Start of date range (RFC 3339, defaults to today 00:00:00 UTC)
-        name: start_date
-        in: query
-      - type: string
-        description: End of date range (RFC 3339, defaults to today 23:59:59 UTC)
-        name: end_date
-        in: query
-      responses:
-        '204':
-          description: No Content
-          headers:
-            X-Total-Count:
-              type: integer
-              description: Total count of matching transactions
-        '400':
-          description: Bad Request
-          schema:
-            $ref: '#/definitions/Error'
-        '401':
-          description: Unauthorized
-          schema:
-            $ref: '#/definitions/Error'
-        '403':
-          description: Forbidden
-          schema:
-            $ref: '#/definitions/Error'
-        '500':
-          description: Internal Server Error
-          schema:
-            $ref: '#/definitions/Error'
   /v1/organizations/{organization_id}/ledgers/{ledger_id}/transactions/dsl:
     post:
       description: Create a Transaction with the input DSL file
@@ -4844,6 +4775,75 @@ paths:
             $ref: '#/definitions/Error'
         '500':
           description: Internal server error
+          schema:
+            $ref: '#/definitions/Error'
+  /v1/organizations/{organization_id}/ledgers/{ledger_id}/transactions/metrics/count:
+    head:
+      description: Count transactions matching optional filters (route, status, date
+        range)
+      tags:
+      - Transactions
+      summary: Count Transactions by Filters
+      parameters:
+      - type: string
+        description: Authorization Bearer Token
+        name: Authorization
+        in: header
+        required: true
+      - type: string
+        description: Request ID
+        name: X-Request-Id
+        in: header
+      - type: string
+        format: uuid
+        description: Organization ID
+        name: organization_id
+        in: path
+        required: true
+      - type: string
+        format: uuid
+        description: Ledger ID
+        name: ledger_id
+        in: path
+        required: true
+      - type: string
+        description: Filter by transaction route
+        name: route
+        in: query
+      - type: string
+        description: Filter by transaction status (CREATED, APPROVED, PENDING, CANCELED,
+          NOTED)
+        name: status
+        in: query
+      - type: string
+        description: Start of date range (RFC 3339, defaults to today 00:00:00 UTC)
+        name: start_date
+        in: query
+      - type: string
+        description: End of date range (RFC 3339, defaults to today 23:59:59 UTC)
+        name: end_date
+        in: query
+      responses:
+        '204':
+          description: No Content
+          headers:
+            X-Total-Count:
+              type: integer
+              description: Total count of matching transactions
+        '400':
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/Error'
+        '401':
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/Error'
+        '403':
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/Error'
+        '500':
+          description: Internal Server Error
           schema:
             $ref: '#/definitions/Error'
   /v1/organizations/{organization_id}/ledgers/{ledger_id}/transactions/outflow:

--- a/components/ledger/api/swagger.yaml
+++ b/components/ledger/api/swagger.yaml
@@ -4595,6 +4595,75 @@ paths:
           description: Internal server error
           schema:
             $ref: '#/definitions/Error'
+  /v1/organizations/{organization_id}/ledgers/{ledger_id}/transactions/count:
+    head:
+      description: Count transactions matching optional filters (route, status, date
+        range)
+      tags:
+      - Transactions
+      summary: Count Transactions by Filters
+      parameters:
+      - type: string
+        description: Authorization Bearer Token
+        name: Authorization
+        in: header
+        required: true
+      - type: string
+        description: Request ID
+        name: X-Request-Id
+        in: header
+      - type: string
+        format: uuid
+        description: Organization ID
+        name: organization_id
+        in: path
+        required: true
+      - type: string
+        format: uuid
+        description: Ledger ID
+        name: ledger_id
+        in: path
+        required: true
+      - type: string
+        description: Filter by transaction route
+        name: route
+        in: query
+      - type: string
+        description: Filter by transaction status (CREATED, APPROVED, PENDING, CANCELED,
+          NOTED)
+        name: status
+        in: query
+      - type: string
+        description: Start of date range (RFC 3339, defaults to today 00:00:00 UTC)
+        name: start_date
+        in: query
+      - type: string
+        description: End of date range (RFC 3339, defaults to today 23:59:59 UTC)
+        name: end_date
+        in: query
+      responses:
+        '204':
+          description: No Content
+          headers:
+            X-Total-Count:
+              type: integer
+              description: Total count of matching transactions
+        '400':
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/Error'
+        '401':
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/Error'
+        '403':
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/Error'
+        '500':
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/Error'
   /v1/organizations/{organization_id}/ledgers/{ledger_id}/transactions/dsl:
     post:
       description: Create a Transaction with the input DSL file

--- a/components/ledger/internal/adapters/http/in/count-transactions-by-filters.go
+++ b/components/ledger/internal/adapters/http/in/count-transactions-by-filters.go
@@ -38,9 +38,9 @@ var validTransactionStatuses = map[string]bool{
 //	@Param			organization_id	path		string	true	"Organization ID"	format(uuid)
 //	@Param			ledger_id		path		string	true	"Ledger ID"			format(uuid)
 //	@Param			route			query		string	false	"Filter by transaction route"
-//	@Param			status			query		string	false	"Filter by transaction status (CREATED, APPROVED, PENDING, CANCELED, NOTED)"
-//	@Param			start_date		query		string	false	"Start of date range (RFC 3339, defaults to today 00:00:00 UTC)"
-//	@Param			end_date		query		string	false	"End of date range (RFC 3339, defaults to today 23:59:59 UTC)"
+//	@Param			status			query		string	false	"Filter by transaction status"	Enums(CREATED, APPROVED, PENDING, CANCELED, NOTED)
+//	@Param			start_date		query		string	false	"Start of date range (RFC 3339, defaults to today 00:00:00 UTC)"	format(date-time)
+//	@Param			end_date		query		string	false	"End of date range (RFC 3339, defaults to today 23:59:59 UTC)"	format(date-time)
 //	@Success		204
 //	@Header			204	{integer}	X-Total-Count	"Total count of matching transactions"
 //	@Failure		400	{object}	mmodel.Error

--- a/components/ledger/internal/adapters/http/in/count-transactions-by-filters.go
+++ b/components/ledger/internal/adapters/http/in/count-transactions-by-filters.go
@@ -1,0 +1,150 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package in
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	libCommons "github.com/LerianStudio/lib-commons/v4/commons"
+	libLog "github.com/LerianStudio/lib-commons/v4/commons/log"
+	libOpentelemetry "github.com/LerianStudio/lib-commons/v4/commons/opentelemetry"
+	"github.com/LerianStudio/midaz/v3/components/ledger/internal/adapters/postgres/transaction"
+	"github.com/LerianStudio/midaz/v3/pkg"
+	"github.com/LerianStudio/midaz/v3/pkg/constant"
+	"github.com/LerianStudio/midaz/v3/pkg/net/http"
+	"github.com/gofiber/fiber/v2"
+)
+
+// validTransactionStatuses contains the allowlist of valid transaction statuses for filtering.
+var validTransactionStatuses = map[string]bool{
+	constant.CREATED:  true,
+	constant.APPROVED: true,
+	constant.PENDING:  true,
+	constant.CANCELED: true,
+	constant.NOTED:    true,
+}
+
+// CountTransactionsByFilters counts transactions matching optional filters.
+//
+//	@Summary		Count Transactions by Filters
+//	@Description	Count transactions matching optional filters (route, status, date range)
+//	@Tags			Transactions
+//	@Param			Authorization	header		string	true	"Authorization Bearer Token"
+//	@Param			X-Request-Id	header		string	false	"Request ID"
+//	@Param			organization_id	path		string	true	"Organization ID"	format(uuid)
+//	@Param			ledger_id		path		string	true	"Ledger ID"			format(uuid)
+//	@Param			route			query		string	false	"Filter by transaction route"
+//	@Param			status			query		string	false	"Filter by transaction status (CREATED, APPROVED, PENDING, CANCELED, NOTED)"
+//	@Param			start_date		query		string	false	"Start of date range (RFC 3339, defaults to today 00:00:00 UTC)"
+//	@Param			end_date		query		string	false	"End of date range (RFC 3339, defaults to today 23:59:59 UTC)"
+//	@Success		204
+//	@Header			204	{integer}	X-Total-Count	"Total count of matching transactions"
+//	@Failure		400	{object}	mmodel.Error
+//	@Failure		401	{object}	mmodel.Error
+//	@Failure		403	{object}	mmodel.Error
+//	@Failure		500	{object}	mmodel.Error
+//	@Router			/v1/organizations/{organization_id}/ledgers/{ledger_id}/transactions/count [head]
+func (handler *TransactionHandler) CountTransactionsByFilters(c *fiber.Ctx) error {
+	ctx := c.UserContext()
+
+	logger, tracer, _, _ := libCommons.NewTrackingFromContext(ctx)
+
+	ctx, span := tracer.Start(ctx, "handler.count_transactions_by_filters")
+	defer span.End()
+
+	organizationID, err := http.GetUUIDFromLocals(c, "organization_id")
+	if err != nil {
+		return http.WithError(c, err)
+	}
+
+	ledgerID, err := http.GetUUIDFromLocals(c, "ledger_id")
+	if err != nil {
+		return http.WithError(c, err)
+	}
+
+	filter, err := parseCountFilter(c)
+	if err != nil {
+		libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Invalid query parameters", err)
+
+		logger.Log(ctx, libLog.LevelError, fmt.Sprintf("Invalid query parameters: %v", err))
+
+		return http.WithError(c, err)
+	}
+
+	logger.Log(ctx, libLog.LevelInfo, fmt.Sprintf(
+		"Counting transactions for organization %s and ledger %s with filters: route=%s, status=%s",
+		organizationID, ledgerID, filter.Route, filter.Status,
+	))
+
+	count, err := handler.Query.CountTransactionsByFilters(ctx, organizationID, ledgerID, filter)
+	if err != nil {
+		libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Failed to count transactions by filters", err)
+
+		logger.Log(ctx, libLog.LevelError, fmt.Sprintf("Error counting transactions: %v", err))
+
+		return http.WithError(c, err)
+	}
+
+	logger.Log(ctx, libLog.LevelInfo, fmt.Sprintf(
+		"Successfully counted transactions for organization %s and ledger %s: %d",
+		organizationID, ledgerID, count,
+	))
+
+	c.Set(constant.XTotalCount, fmt.Sprintf("%d", count))
+	c.Set(constant.ContentLength, "0")
+
+	return http.NoContent(c)
+}
+
+// parseCountFilter extracts and validates optional query parameters for the count endpoint.
+func parseCountFilter(c *fiber.Ctx) (transaction.CountFilter, error) {
+	var filter transaction.CountFilter
+
+	filter.Route = strings.TrimSpace(c.Query("route"))
+
+	status := strings.TrimSpace(c.Query("status"))
+	if status != "" {
+		upper := strings.ToUpper(status)
+		if !validTransactionStatuses[upper] {
+			return filter, pkg.ValidateBusinessError(constant.ErrInvalidQueryParameter, "", "status")
+		}
+
+		filter.Status = upper
+	}
+
+	now := time.Now().UTC()
+
+	startDateStr := strings.TrimSpace(c.Query("start_date"))
+	if startDateStr != "" {
+		parsed, err := time.Parse(time.RFC3339, startDateStr)
+		if err != nil {
+			return filter, pkg.ValidateBusinessError(constant.ErrInvalidDatetimeFormat, "", "start_date", "RFC 3339 (e.g. 2025-01-01T00:00:00Z)")
+		}
+
+		filter.StartDate = parsed
+	} else {
+		filter.StartDate = time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC)
+	}
+
+	endDateStr := strings.TrimSpace(c.Query("end_date"))
+	if endDateStr != "" {
+		parsed, err := time.Parse(time.RFC3339, endDateStr)
+		if err != nil {
+			return filter, pkg.ValidateBusinessError(constant.ErrInvalidDatetimeFormat, "", "end_date", "RFC 3339 (e.g. 2025-01-01T23:59:59Z)")
+		}
+
+		filter.EndDate = parsed
+	} else {
+		filter.EndDate = time.Date(now.Year(), now.Month(), now.Day(), 23, 59, 59, 999999999, time.UTC)
+	}
+
+	if filter.StartDate.After(filter.EndDate) {
+		return filter, pkg.ValidateBusinessError(constant.ErrInvalidFinalDate, "")
+	}
+
+	return filter, nil
+}

--- a/components/ledger/internal/adapters/http/in/count-transactions-by-filters.go
+++ b/components/ledger/internal/adapters/http/in/count-transactions-by-filters.go
@@ -47,7 +47,7 @@ var validTransactionStatuses = map[string]bool{
 //	@Failure		401	{object}	mmodel.Error
 //	@Failure		403	{object}	mmodel.Error
 //	@Failure		500	{object}	mmodel.Error
-//	@Router			/v1/organizations/{organization_id}/ledgers/{ledger_id}/transactions/count [head]
+//	@Router			/v1/organizations/{organization_id}/ledgers/{ledger_id}/transactions/metrics/count [head]
 func (handler *TransactionHandler) CountTransactionsByFilters(c *fiber.Ctx) error {
 	ctx := c.UserContext()
 

--- a/components/ledger/internal/adapters/http/in/count-transactions-by-filters_fuzz_test.go
+++ b/components/ledger/internal/adapters/http/in/count-transactions-by-filters_fuzz_test.go
@@ -224,11 +224,19 @@ func FuzzParseCountFilter_Dates(f *testing.F) {
 			}
 		}
 
-		// Both parseable or empty - check date order
-		if err != nil {
-			// Could be start > end
-			t.Logf("Error (possibly start > end): %v", err)
+		// Both parseable or empty — enforce start <= end invariant
+		if trimmedStart != "" && trimmedEnd != "" {
+			startT, startErr := time.Parse(time.RFC3339, trimmedStart)
+			endT, endErr := time.Parse(time.RFC3339, trimmedEnd)
+
+			if startErr == nil && endErr == nil && startT.After(endT) {
+				assert.Error(t, err, "start_date > end_date should produce error")
+				return
+			}
 		}
+
+		// If we reach here, inputs are valid — no error expected
+		assert.NoError(t, err, "valid inputs should not produce error: route=%q status=%q start=%q end=%q", "", "", startDate, endDate)
 	})
 }
 

--- a/components/ledger/internal/adapters/http/in/count-transactions-by-filters_fuzz_test.go
+++ b/components/ledger/internal/adapters/http/in/count-transactions-by-filters_fuzz_test.go
@@ -1,0 +1,277 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package in
+
+// =============================================================================
+// FUZZ TESTS — parseCountFilter Input Parsing
+//
+// These tests exercise the parseCountFilter function with fuzzer-generated
+// inputs to verify:
+//   1. No panics on any combination of route, status, start_date, end_date.
+//   2. Validation errors are returned correctly for invalid inputs.
+//   3. No SQL injection vectors pass through validation.
+//
+// Run with:
+//
+//	go test -run=^$ -fuzz=Fuzz -fuzztime=30s \
+//	    ./components/ledger/internal/adapters/http/in/
+//
+// =============================================================================
+
+import (
+	"fmt"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/stretchr/testify/assert"
+)
+
+// fuzzParseCountFilter is a test helper that creates a Fiber context with the
+// given query parameters and calls parseCountFilter. It returns the error (if
+// any) and a boolean indicating whether the function panicked.
+func fuzzParseCountFilter(t *testing.T, route, status, startDate, endDate string) (err error, panicked bool) {
+	t.Helper()
+
+	defer func() {
+		if r := recover(); r != nil {
+			panicked = true
+			err = fmt.Errorf("panic: %v", r)
+		}
+	}()
+
+	app := fiber.New()
+
+	var capturedErr error
+
+	app.Get("/test", func(c *fiber.Ctx) error {
+		_, capturedErr = parseCountFilter(c)
+		return c.SendStatus(200)
+	})
+
+	qv := url.Values{}
+	if route != "" {
+		qv.Set("route", route)
+	}
+
+	if status != "" {
+		qv.Set("status", status)
+	}
+
+	if startDate != "" {
+		qv.Set("start_date", startDate)
+	}
+
+	if endDate != "" {
+		qv.Set("end_date", endDate)
+	}
+
+	target := "/test"
+	if len(qv) > 0 {
+		target += "?" + qv.Encode()
+	}
+
+	req := httptest.NewRequest("GET", target, nil)
+	_, _ = app.Test(req)
+
+	return capturedErr, false
+}
+
+// FuzzParseCountFilter_Route fuzzes the route query parameter to verify
+// parseCountFilter never panics regardless of input.
+//
+// Invariants verified:
+//   - No panic on any input
+//   - Route value is accepted (no validation error on route alone)
+func FuzzParseCountFilter_Route(f *testing.F) {
+	// Seed corpus: 5+ entries covering required categories.
+	f.Add("")                          // Empty
+	f.Add("PIX")                       // Valid: typical route
+	f.Add("TED")                       // Valid: another route
+	f.Add(strings.Repeat("A", 1000))   // Boundary: very long string
+	f.Add("route'; DROP TABLE t;--")   // Security: SQL injection
+	f.Add("\x00\x01\x02null-bytes")    // Security: null bytes
+	f.Add("日本語テスト")                    // Unicode: non-ASCII
+	f.Add("route with spaces & chars") // Special characters
+
+	f.Fuzz(func(t *testing.T, route string) {
+		// Bound input to prevent OOM
+		if len(route) > 1024 {
+			route = route[:1024]
+		}
+
+		err, panicked := fuzzParseCountFilter(t, route, "", "", "")
+		assert.False(t, panicked, "parseCountFilter must not panic for route=%q", route)
+
+		// Route has no validation (any string is accepted).
+		// The only error source is date parsing, and we provide no dates.
+		assert.NoError(t, err, "route-only filter should not error for route=%q", route)
+	})
+}
+
+// FuzzParseCountFilter_Status fuzzes the status query parameter.
+//
+// Invariants verified:
+//   - No panic on any input
+//   - Only allowlisted statuses are accepted (CREATED, APPROVED, PENDING, CANCELED, NOTED)
+//   - All other strings produce a validation error
+func FuzzParseCountFilter_Status(f *testing.F) {
+	// Seed corpus
+	f.Add("")                             // Empty: no filter
+	f.Add("APPROVED")                     // Valid
+	f.Add("CREATED")                      // Valid
+	f.Add("PENDING")                      // Valid
+	f.Add("CANCELED")                     // Valid
+	f.Add("NOTED")                        // Valid
+	f.Add("approved")                     // Boundary: lowercase (should be normalized)
+	f.Add("INVALID_STATUS")               // Invalid
+	f.Add("'; DROP TABLE transaction;--") // Security: SQL injection
+	f.Add(strings.Repeat("STATUS", 200))  // Boundary: very long
+	f.Add("\x00")                         // Security: null byte
+	f.Add("日本語")                          // Unicode: non-ASCII
+
+	f.Fuzz(func(t *testing.T, status string) {
+		if len(status) > 1024 {
+			status = status[:1024]
+		}
+
+		err, panicked := fuzzParseCountFilter(t, "", status, "", "")
+		assert.False(t, panicked, "parseCountFilter must not panic for status=%q", status)
+
+		// parseCountFilter trims the status before checking.
+		// If the trimmed result is empty, no filter is applied (valid).
+		trimmed := strings.TrimSpace(status)
+		if trimmed == "" {
+			assert.NoError(t, err, "empty/whitespace-only status should not error")
+			return
+		}
+
+		upper := strings.ToUpper(trimmed)
+		validStatuses := map[string]bool{
+			"CREATED": true, "APPROVED": true, "PENDING": true,
+			"CANCELED": true, "NOTED": true,
+		}
+
+		if validStatuses[upper] {
+			assert.NoError(t, err, "valid status %q should not error", status)
+		} else {
+			assert.Error(t, err, "invalid status %q should produce error", status)
+		}
+	})
+}
+
+// FuzzParseCountFilter_Dates fuzzes the start_date and end_date query parameters.
+//
+// Invariants verified:
+//   - No panic on any input
+//   - Valid RFC 3339 dates are accepted
+//   - Invalid date formats produce validation errors
+//   - start_date > end_date produces validation error
+func FuzzParseCountFilter_Dates(f *testing.F) {
+	now := time.Now().UTC()
+	today := now.Format(time.RFC3339)
+	yesterday := now.Add(-24 * time.Hour).Format(time.RFC3339)
+	tomorrow := now.Add(24 * time.Hour).Format(time.RFC3339)
+
+	// Seed corpus
+	f.Add("", "")                                                   // Empty: use defaults
+	f.Add(today, today)                                             // Valid: same day
+	f.Add(yesterday, tomorrow)                                      // Valid: range
+	f.Add("not-a-date", "")                                         // Invalid: bad format
+	f.Add("", "not-a-date")                                         // Invalid: bad end_date
+	f.Add(tomorrow, yesterday)                                      // Invalid: start > end
+	f.Add("2025-01-01T00:00:00Z", "2025-12-31T23:59:59Z")           // Valid: explicit range
+	f.Add("2025-01-01", "2025-12-31")                               // Invalid: not RFC 3339
+	f.Add("'; DROP TABLE t;--", "")                                 // Security: SQL injection
+	f.Add(strings.Repeat("2", 500), "")                             // Boundary: very long
+	f.Add("0001-01-01T00:00:00Z", "9999-12-31T23:59:59Z")           // Boundary: extreme dates
+	f.Add("2025-01-01T00:00:00+05:30", "2025-01-02T00:00:00-03:00") // Valid: with timezone
+
+	f.Fuzz(func(t *testing.T, startDate, endDate string) {
+		if len(startDate) > 512 {
+			startDate = startDate[:512]
+		}
+		if len(endDate) > 512 {
+			endDate = endDate[:512]
+		}
+
+		err, panicked := fuzzParseCountFilter(t, "", "", startDate, endDate)
+		assert.False(t, panicked, "parseCountFilter must not panic for dates start=%q end=%q", startDate, endDate)
+
+		// parseCountFilter trims whitespace from both dates.
+		// If the trimmed result is empty, defaults are used (valid).
+		trimmedStart := strings.TrimSpace(startDate)
+		trimmedEnd := strings.TrimSpace(endDate)
+
+		// If trimmed start is non-empty and not valid RFC 3339, should error
+		if trimmedStart != "" {
+			if _, parseErr := time.Parse(time.RFC3339, trimmedStart); parseErr != nil {
+				assert.Error(t, err, "invalid start_date format should produce error")
+				return
+			}
+		}
+
+		// If trimmed end is non-empty and not valid RFC 3339, should error
+		if trimmedEnd != "" {
+			if _, parseErr := time.Parse(time.RFC3339, trimmedEnd); parseErr != nil {
+				assert.Error(t, err, "invalid end_date format should produce error")
+				return
+			}
+		}
+
+		// Both parseable or empty - check date order
+		if err != nil {
+			// Could be start > end
+			t.Logf("Error (possibly start > end): %v", err)
+		}
+	})
+}
+
+// FuzzParseCountFilter_AllParams fuzzes all four query parameters simultaneously.
+//
+// Invariants verified:
+//   - No panic on any combination of inputs
+//   - Function is deterministic (same input → same result)
+func FuzzParseCountFilter_AllParams(f *testing.F) {
+	// Seed corpus: combined scenarios
+	f.Add("PIX", "APPROVED", "2025-01-01T00:00:00Z", "2025-12-31T23:59:59Z") // All valid
+	f.Add("", "", "", "")                                                    // All empty
+	f.Add("TED", "INVALID", "", "")                                          // Invalid status
+	f.Add("", "", "not-a-date", "2025-01-01T00:00:00Z")                      // Invalid start
+	f.Add("route'; DROP TABLE t;--", "'; DROP TABLE t;--", "'; DROP TABLE t;--", "")
+	f.Add(strings.Repeat("X", 500), strings.Repeat("Y", 500), "", "") // Long strings
+
+	f.Fuzz(func(t *testing.T, route, status, startDate, endDate string) {
+		// Bound all inputs
+		if len(route) > 1024 {
+			route = route[:1024]
+		}
+		if len(status) > 1024 {
+			status = status[:1024]
+		}
+		if len(startDate) > 512 {
+			startDate = startDate[:512]
+		}
+		if len(endDate) > 512 {
+			endDate = endDate[:512]
+		}
+
+		err1, panicked := fuzzParseCountFilter(t, route, status, startDate, endDate)
+		assert.False(t, panicked, "parseCountFilter must not panic")
+
+		// Determinism: same input must produce same result
+		err2, panicked2 := fuzzParseCountFilter(t, route, status, startDate, endDate)
+		assert.False(t, panicked2, "determinism check must not panic")
+
+		if err1 == nil {
+			assert.NoError(t, err2, "determinism: second call must also succeed")
+		} else {
+			assert.Error(t, err2, "determinism: second call must also fail")
+		}
+	})
+}

--- a/components/ledger/internal/adapters/http/in/count-transactions-by-filters_fuzz_test.go
+++ b/components/ledger/internal/adapters/http/in/count-transactions-by-filters_fuzz_test.go
@@ -224,19 +224,31 @@ func FuzzParseCountFilter_Dates(f *testing.F) {
 			}
 		}
 
-		// Both parseable or empty — enforce start <= end invariant
-		if trimmedStart != "" && trimmedEnd != "" {
-			startT, startErr := time.Parse(time.RFC3339, trimmedStart)
-			endT, endErr := time.Parse(time.RFC3339, trimmedEnd)
+		// Both parseable or empty — enforce start <= end invariant.
+		// parseCountFilter defaults missing dates to today's UTC range,
+		// so we must compute the effective dates the same way.
+		now := time.Now().UTC()
+		var effectiveStart, effectiveEnd time.Time
 
-			if startErr == nil && endErr == nil && startT.After(endT) {
-				assert.Error(t, err, "start_date > end_date should produce error")
-				return
-			}
+		if trimmedStart != "" {
+			effectiveStart, _ = time.Parse(time.RFC3339, trimmedStart)
+		} else {
+			effectiveStart = time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC)
+		}
+
+		if trimmedEnd != "" {
+			effectiveEnd, _ = time.Parse(time.RFC3339, trimmedEnd)
+		} else {
+			effectiveEnd = time.Date(now.Year(), now.Month(), now.Day(), 23, 59, 59, 999999999, time.UTC)
+		}
+
+		if effectiveStart.After(effectiveEnd) {
+			assert.Error(t, err, "start_date > end_date should produce error (effective start=%v end=%v)", effectiveStart, effectiveEnd)
+			return
 		}
 
 		// If we reach here, inputs are valid — no error expected
-		assert.NoError(t, err, "valid inputs should not produce error: route=%q status=%q start=%q end=%q", "", "", startDate, endDate)
+		assert.NoError(t, err, "valid inputs should not produce error: start=%q end=%q (effective start=%v end=%v)", startDate, endDate, effectiveStart, effectiveEnd)
 	})
 }
 

--- a/components/ledger/internal/adapters/http/in/count-transactions-by-filters_property_test.go
+++ b/components/ledger/internal/adapters/http/in/count-transactions-by-filters_property_test.go
@@ -1,0 +1,250 @@
+//go:build integration
+
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package in
+
+// =============================================================================
+// PROPERTY-BASED TESTS — CountTransactionsByFilters Domain Invariants
+//
+// These tests verify that domain invariants of the count filter parsing hold
+// across hundreds of automatically-generated inputs. They use testing/quick.
+//
+// Invariants verified:
+//   1. Count is non-negative: parseCountFilter never produces a filter that
+//      could yield a negative count.
+//   2. Date range validity: start_date > end_date always returns an error.
+//   3. Status allowlist: only CREATED, APPROVED, PENDING, CANCELED, NOTED are
+//      accepted; all other strings are rejected.
+//   4. Filter determinism: same input always produces the same output.
+//
+// Run with:
+//
+//	go test -tags integration -run TestProperty -v -count=1 \
+//	    ./components/ledger/internal/adapters/http/in/
+//
+// =============================================================================
+
+import (
+	"fmt"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"testing/quick"
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// boundString trims a generated string to a maximum length for property tests.
+func boundString(s string, maxLen int) string {
+	if len(s) > maxLen {
+		return s[:maxLen]
+	}
+
+	return s
+}
+
+// callParseCountFilter creates a Fiber context with given query params and calls
+// parseCountFilter, returning the result.
+func callParseCountFilter(route, status, startDate, endDate string) (errResult error) {
+	app := fiber.New()
+
+	app.Get("/prop", func(c *fiber.Ctx) error {
+		_, errResult = parseCountFilter(c)
+		return c.SendStatus(200)
+	})
+
+	qv := url.Values{}
+	if route != "" {
+		qv.Set("route", route)
+	}
+
+	if status != "" {
+		qv.Set("status", status)
+	}
+
+	if startDate != "" {
+		qv.Set("start_date", startDate)
+	}
+
+	if endDate != "" {
+		qv.Set("end_date", endDate)
+	}
+
+	target := "/prop"
+	if len(qv) > 0 {
+		target += "?" + qv.Encode()
+	}
+
+	req := httptest.NewRequest("GET", target, nil)
+	_, _ = app.Test(req)
+
+	return errResult
+}
+
+// TestProperty_ParseCountFilter_DateRangeInvalidity verifies that whenever
+// start_date is strictly after end_date, parseCountFilter always returns an error.
+// This property must hold for ANY pair of valid RFC 3339 timestamps.
+func TestProperty_ParseCountFilter_DateRangeInvalidity(t *testing.T) {
+	t.Parallel()
+
+	cfg := &quick.Config{MaxCount: 100}
+
+	// Property: for any gap > 0, startDate = base+gap and endDate = base
+	// must always produce an error (start > end).
+	f := func(baseUnix int64, gapSeconds uint32) bool {
+		// Bound inputs to reasonable range to avoid overflow
+		if baseUnix < 0 {
+			baseUnix = -baseUnix
+		}
+
+		baseUnix = baseUnix % (365 * 24 * 3600 * 100) // ~100 years from epoch
+
+		base := time.Unix(baseUnix, 0).UTC()
+
+		// Ensure gap is at least 1 second
+		gap := time.Duration(gapSeconds%86400+1) * time.Second
+		start := base.Add(gap)
+		end := base
+
+		startStr := start.Format(time.RFC3339)
+		endStr := end.Format(time.RFC3339)
+
+		err := callParseCountFilter("", "", startStr, endStr)
+
+		return err != nil // must always error when start > end
+	}
+
+	err := quick.Check(f, cfg)
+	require.NoError(t, err, "property violated: start_date > end_date must always return error")
+}
+
+// TestProperty_ParseCountFilter_StatusAllowlist verifies that any status string
+// NOT in the valid set {CREATED, APPROVED, PENDING, CANCELED, NOTED} always
+// produces a validation error.
+func TestProperty_ParseCountFilter_StatusAllowlist(t *testing.T) {
+	t.Parallel()
+
+	cfg := &quick.Config{MaxCount: 100}
+
+	validStatuses := map[string]bool{
+		"CREATED": true, "APPROVED": true, "PENDING": true,
+		"CANCELED": true, "NOTED": true,
+	}
+
+	f := func(status string) bool {
+		status = boundString(status, 256)
+		if status == "" {
+			return true // empty is valid (no filter)
+		}
+
+		err := callParseCountFilter("", status, "", "")
+		upper := strings.ToUpper(strings.TrimSpace(status))
+
+		if validStatuses[upper] {
+			// Valid status: must NOT error
+			return err == nil
+		}
+
+		// Invalid status: MUST error
+		return err != nil
+	}
+
+	err := quick.Check(f, cfg)
+	require.NoError(t, err, "property violated: invalid status must always produce error")
+}
+
+// TestProperty_ParseCountFilter_Determinism verifies that calling parseCountFilter
+// twice with the same input always produces the same result (error or success).
+func TestProperty_ParseCountFilter_Determinism(t *testing.T) {
+	t.Parallel()
+
+	cfg := &quick.Config{MaxCount: 100}
+
+	f := func(route, status, startDate, endDate string) bool {
+		route = boundString(route, 256)
+		status = boundString(status, 256)
+		startDate = boundString(startDate, 256)
+		endDate = boundString(endDate, 256)
+
+		err1 := callParseCountFilter(route, status, startDate, endDate)
+		err2 := callParseCountFilter(route, status, startDate, endDate)
+
+		if err1 == nil {
+			return err2 == nil
+		}
+
+		return err2 != nil
+	}
+
+	err := quick.Check(f, cfg)
+	require.NoError(t, err, "property violated: parseCountFilter must be deterministic")
+}
+
+// TestProperty_ParseCountFilter_ValidDateRangeAccepted verifies that when both
+// dates are valid RFC 3339 and start <= end, and status is empty, parseCountFilter
+// always succeeds (returns no error).
+func TestProperty_ParseCountFilter_ValidDateRangeAccepted(t *testing.T) {
+	t.Parallel()
+
+	cfg := &quick.Config{MaxCount: 100}
+
+	f := func(baseUnix int64, gapSeconds uint32) bool {
+		if baseUnix < 0 {
+			baseUnix = -baseUnix
+		}
+
+		baseUnix = baseUnix % (365 * 24 * 3600 * 100)
+
+		base := time.Unix(baseUnix, 0).UTC()
+		gap := time.Duration(gapSeconds%86400) * time.Second
+
+		start := base
+		end := base.Add(gap)
+
+		startStr := start.Format(time.RFC3339)
+		endStr := end.Format(time.RFC3339)
+
+		err := callParseCountFilter("", "", startStr, endStr)
+
+		return err == nil
+	}
+
+	err := quick.Check(f, cfg)
+	require.NoError(t, err, "property violated: valid date range (start <= end) must always succeed")
+}
+
+// TestProperty_ParseCountFilter_ValidStatusAlwaysAccepted verifies that any
+// valid status string is always accepted regardless of casing.
+func TestProperty_ParseCountFilter_ValidStatusAlwaysAccepted(t *testing.T) {
+	t.Parallel()
+
+	validStatuses := []string{"CREATED", "APPROVED", "PENDING", "CANCELED", "NOTED"}
+
+	for _, status := range validStatuses {
+		status := status
+
+		t.Run(fmt.Sprintf("status_%s", status), func(t *testing.T) {
+			t.Parallel()
+
+			// Test with exact case
+			err := callParseCountFilter("", status, "", "")
+			assert.NoError(t, err, "valid status %s should be accepted", status)
+
+			// Test with lowercase
+			err = callParseCountFilter("", strings.ToLower(status), "", "")
+			assert.NoError(t, err, "lowercase status %s should be accepted", strings.ToLower(status))
+
+			// Test with mixed case
+			mixed := strings.ToLower(status[:1]) + status[1:]
+			err = callParseCountFilter("", mixed, "", "")
+			assert.NoError(t, err, "mixed case status %s should be accepted", mixed)
+		})
+	}
+}

--- a/components/ledger/internal/adapters/http/in/count-transactions-by-filters_test.go
+++ b/components/ledger/internal/adapters/http/in/count-transactions-by-filters_test.go
@@ -1,0 +1,177 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package in
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"github.com/LerianStudio/midaz/v3/components/ledger/internal/adapters/postgres/transaction"
+	"github.com/LerianStudio/midaz/v3/components/ledger/internal/services/query"
+	"github.com/LerianStudio/midaz/v3/pkg"
+	cn "github.com/LerianStudio/midaz/v3/pkg/constant"
+	"github.com/gofiber/fiber/v2"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func TestTransactionHandler_CountTransactionsByFilters(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		queryParams    string
+		setupMocks     func(transactionRepo *transaction.MockRepository, orgID, ledgerID uuid.UUID)
+		expectedStatus int
+		expectedCount  string
+	}{
+		{
+			name:        "success with all filters",
+			queryParams: "route=payment&status=APPROVED&start_date=2025-01-01T00:00:00Z&end_date=2025-01-31T23:59:59Z",
+			setupMocks: func(transactionRepo *transaction.MockRepository, orgID, ledgerID uuid.UUID) {
+				transactionRepo.EXPECT().
+					CountByFilters(gomock.Any(), orgID, ledgerID, gomock.Any()).
+					Return(int64(100), nil).
+					Times(1)
+			},
+			expectedStatus: 204,
+			expectedCount:  "100",
+		},
+		{
+			name:        "success with no filters (defaults)",
+			queryParams: "",
+			setupMocks: func(transactionRepo *transaction.MockRepository, orgID, ledgerID uuid.UUID) {
+				transactionRepo.EXPECT().
+					CountByFilters(gomock.Any(), orgID, ledgerID, gomock.Any()).
+					Return(int64(5), nil).
+					Times(1)
+			},
+			expectedStatus: 204,
+			expectedCount:  "5",
+		},
+		{
+			name:        "success with route only",
+			queryParams: "route=transfer",
+			setupMocks: func(transactionRepo *transaction.MockRepository, orgID, ledgerID uuid.UUID) {
+				transactionRepo.EXPECT().
+					CountByFilters(gomock.Any(), orgID, ledgerID, gomock.Any()).
+					Return(int64(7), nil).
+					Times(1)
+			},
+			expectedStatus: 204,
+			expectedCount:  "7",
+		},
+		{
+			name:        "success with status only",
+			queryParams: "status=PENDING",
+			setupMocks: func(transactionRepo *transaction.MockRepository, orgID, ledgerID uuid.UUID) {
+				transactionRepo.EXPECT().
+					CountByFilters(gomock.Any(), orgID, ledgerID, gomock.Any()).
+					Return(int64(3), nil).
+					Times(1)
+			},
+			expectedStatus: 204,
+			expectedCount:  "3",
+		},
+		{
+			name:        "invalid status returns 400",
+			queryParams: "status=INVALID",
+			setupMocks: func(_ *transaction.MockRepository, _, _ uuid.UUID) {
+				// No repo call expected
+			},
+			expectedStatus: 400,
+		},
+		{
+			name:        "invalid start_date returns 400",
+			queryParams: "start_date=not-a-date",
+			setupMocks: func(_ *transaction.MockRepository, _, _ uuid.UUID) {
+				// No repo call expected
+			},
+			expectedStatus: 400,
+		},
+		{
+			name:        "invalid end_date returns 400",
+			queryParams: "end_date=not-a-date",
+			setupMocks: func(_ *transaction.MockRepository, _, _ uuid.UUID) {
+				// No repo call expected
+			},
+			expectedStatus: 400,
+		},
+		{
+			name:        "start_date after end_date returns 400",
+			queryParams: "start_date=2025-12-31T00:00:00Z&end_date=2025-01-01T00:00:00Z",
+			setupMocks: func(_ *transaction.MockRepository, _, _ uuid.UUID) {
+				// No repo call expected
+			},
+			expectedStatus: 400,
+		},
+		{
+			name:        "service error returns 500",
+			queryParams: "",
+			setupMocks: func(transactionRepo *transaction.MockRepository, orgID, ledgerID uuid.UUID) {
+				transactionRepo.EXPECT().
+					CountByFilters(gomock.Any(), orgID, ledgerID, gomock.Any()).
+					Return(int64(0), pkg.InternalServerError{
+						Code:    "0046",
+						Title:   "Internal Server Error",
+						Message: "Database connection failed",
+					}).
+					Times(1)
+			},
+			expectedStatus: 500,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctrl := gomock.NewController(t)
+			t.Cleanup(ctrl.Finish)
+
+			orgID := uuid.New()
+			ledgerID := uuid.New()
+
+			mockTransactionRepo := transaction.NewMockRepository(ctrl)
+			tt.setupMocks(mockTransactionRepo, orgID, ledgerID)
+
+			queryUC := &query.UseCase{
+				TransactionRepo: mockTransactionRepo,
+			}
+			handler := &TransactionHandler{Query: queryUC}
+
+			app := fiber.New()
+			app.Head("/v1/organizations/:organization_id/ledgers/:ledger_id/transactions/count",
+				func(c *fiber.Ctx) error {
+					c.Locals("organization_id", orgID)
+					c.Locals("ledger_id", ledgerID)
+					return c.Next()
+				},
+				handler.CountTransactionsByFilters,
+			)
+
+			url := "/v1/organizations/" + orgID.String() + "/ledgers/" + ledgerID.String() + "/transactions/count"
+			if tt.queryParams != "" {
+				url += "?" + tt.queryParams
+			}
+
+			req := httptest.NewRequest("HEAD", url, nil)
+			resp, err := app.Test(req)
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectedStatus, resp.StatusCode)
+
+			if tt.expectedStatus == 204 {
+				totalCount := resp.Header.Get(cn.XTotalCount)
+				assert.Equal(t, tt.expectedCount, totalCount, "X-Total-Count header should contain the count")
+
+				contentLength := resp.Header.Get(cn.ContentLength)
+				assert.Equal(t, "0", contentLength, "Content-Length should be 0")
+			}
+		})
+	}
+}

--- a/components/ledger/internal/adapters/http/in/count-transactions-by-filters_test.go
+++ b/components/ledger/internal/adapters/http/in/count-transactions-by-filters_test.go
@@ -145,7 +145,7 @@ func TestTransactionHandler_CountTransactionsByFilters(t *testing.T) {
 			handler := &TransactionHandler{Query: queryUC}
 
 			app := fiber.New()
-			app.Head("/v1/organizations/:organization_id/ledgers/:ledger_id/transactions/count",
+			app.Head("/v1/organizations/:organization_id/ledgers/:ledger_id/transactions/metrics/count",
 				func(c *fiber.Ctx) error {
 					c.Locals("organization_id", orgID)
 					c.Locals("ledger_id", ledgerID)
@@ -154,7 +154,7 @@ func TestTransactionHandler_CountTransactionsByFilters(t *testing.T) {
 				handler.CountTransactionsByFilters,
 			)
 
-			url := "/v1/organizations/" + orgID.String() + "/ledgers/" + ledgerID.String() + "/transactions/count"
+			url := "/v1/organizations/" + orgID.String() + "/ledgers/" + ledgerID.String() + "/transactions/metrics/count"
 			if tt.queryParams != "" {
 				url += "?" + tt.queryParams
 			}

--- a/components/ledger/internal/adapters/http/in/routes.go
+++ b/components/ledger/internal/adapters/http/in/routes.go
@@ -176,7 +176,7 @@ func RegisterTransactionRoutesToApp(f fiber.Router, auth *middleware.AuthClient,
 
 	f.Patch("/v1/organizations/:organization_id/ledgers/:ledger_id/transactions/:transaction_id", protectedMidaz(auth, "transactions", "patch", routeOptions, http.ParseUUIDPathParameters("transaction"), http.WithBody(new(transaction.UpdateTransactionInput), th.UpdateTransaction))...)
 
-	f.Head("/v1/organizations/:organization_id/ledgers/:ledger_id/transactions/count", protectedMidaz(auth, "transactions", "head", routeOptions, http.ParseUUIDPathParameters("transaction"), th.CountTransactionsByFilters)...)
+	f.Head("/v1/organizations/:organization_id/ledgers/:ledger_id/transactions/metrics/count", protectedMidaz(auth, "transactions", "head", routeOptions, http.ParseUUIDPathParameters("transaction"), th.CountTransactionsByFilters)...)
 
 	f.Get("/v1/organizations/:organization_id/ledgers/:ledger_id/transactions/:transaction_id", protectedMidaz(auth, "transactions", "get", routeOptions, http.ParseUUIDPathParameters("transaction"), th.GetTransaction)...)
 	f.Get("/v1/organizations/:organization_id/ledgers/:ledger_id/transactions", protectedMidaz(auth, "transactions", "get", routeOptions, http.ParseUUIDPathParameters("transaction"), th.GetAllTransactions)...)

--- a/components/ledger/internal/adapters/http/in/routes.go
+++ b/components/ledger/internal/adapters/http/in/routes.go
@@ -176,6 +176,8 @@ func RegisterTransactionRoutesToApp(f fiber.Router, auth *middleware.AuthClient,
 
 	f.Patch("/v1/organizations/:organization_id/ledgers/:ledger_id/transactions/:transaction_id", protectedMidaz(auth, "transactions", "patch", routeOptions, http.ParseUUIDPathParameters("transaction"), http.WithBody(new(transaction.UpdateTransactionInput), th.UpdateTransaction))...)
 
+	f.Head("/v1/organizations/:organization_id/ledgers/:ledger_id/transactions/count", protectedMidaz(auth, "transactions", "head", routeOptions, http.ParseUUIDPathParameters("transaction"), th.CountTransactionsByFilters)...)
+
 	f.Get("/v1/organizations/:organization_id/ledgers/:ledger_id/transactions/:transaction_id", protectedMidaz(auth, "transactions", "get", routeOptions, http.ParseUUIDPathParameters("transaction"), th.GetTransaction)...)
 	f.Get("/v1/organizations/:organization_id/ledgers/:ledger_id/transactions", protectedMidaz(auth, "transactions", "get", routeOptions, http.ParseUUIDPathParameters("transaction"), th.GetAllTransactions)...)
 

--- a/components/ledger/internal/adapters/postgres/transaction/count-by-filters_chaos_test.go
+++ b/components/ledger/internal/adapters/postgres/transaction/count-by-filters_chaos_test.go
@@ -235,12 +235,8 @@ func TestIntegration_Chaos_CountByFilters_HighLatency(t *testing.T) {
 	_, err = infra.repo.CountByFilters(ctxTimeout, infra.orgID, infra.ledgerID, filter)
 	elapsed := time.Since(start)
 
-	if err != nil {
-		t.Logf("Phase 3 (Verify): count timed out as expected after %v: %v", elapsed, err)
-	} else {
-		t.Logf("Phase 3 (Verify): count succeeded despite latency in %v", elapsed)
-	}
-	// Key invariant: no panic occurred
+	require.Error(t, err, "Phase 3 (Verify): CountByFilters should timeout with 5s latency and 3s context deadline")
+	t.Logf("Phase 3 (Verify): count timed out as expected after %v: %v", elapsed, err)
 
 	// Phase 4: Restore — remove latency toxic
 	t.Log("Phase 4 (Restore): removing latency")
@@ -262,8 +258,9 @@ func TestIntegration_Chaos_CountByFilters_HighLatency(t *testing.T) {
 }
 
 // TestIntegration_Chaos_CountByFilters_ConnectionPoolExhaustion tests that
-// CountByFilters returns an error instead of hanging when the connection pool
-// is exhausted (via Toxiproxy bandwidth limit to slow all connections).
+// CountByFilters returns errors instead of hanging when the connection pool
+// is exhausted. Uses a severe bandwidth throttle (1 KB/s) with high concurrency
+// (20 goroutines) to create real connection pool contention.
 //
 // 5-phase structure: Normal → Inject → Verify → Restore → Recovery
 func TestIntegration_Chaos_CountByFilters_ConnectionPoolExhaustion(t *testing.T) {
@@ -294,15 +291,17 @@ func TestIntegration_Chaos_CountByFilters_ConnectionPoolExhaustion(t *testing.T)
 	assert.Equal(t, int64(5), count)
 	t.Logf("Phase 1 (Normal): count = %d", count)
 
-	// Phase 2: Inject — disconnect proxy to simulate pool exhaustion
-	// When the connection is severed, existing pool connections become stale
-	// and new connections cannot be established, simulating pool exhaustion.
-	t.Log("Phase 2 (Inject): disconnecting proxy to simulate connection pool exhaustion")
-	err = infra.proxy.Disconnect()
-	require.NoError(t, err, "failed to disconnect proxy")
+	// Phase 2: Inject — severely throttle bandwidth to create connection contention.
+	// A 1 KB/s limit forces all queries to take several seconds, exhausting the
+	// connection pool when many concurrent requests compete for connections.
+	t.Log("Phase 2 (Inject): adding severe bandwidth throttle (1 KB/s)")
+	err = infra.proxy.AddBandwidthLimit(1)
+	require.NoError(t, err, "failed to add bandwidth limit")
 
-	// Phase 3: Verify — concurrent queries should fail gracefully (no panic, no hang)
-	const concurrency = 10
+	// Phase 3: Verify — flood with concurrent queries to exhaust the pool.
+	// 20 goroutines competing for connections through a 1 KB/s pipe should
+	// cause timeouts and contention.
+	const concurrency = 20
 	var wg sync.WaitGroup
 	var errCount int64
 
@@ -312,7 +311,7 @@ func TestIntegration_Chaos_CountByFilters_ConnectionPoolExhaustion(t *testing.T)
 		go func() {
 			defer wg.Done()
 
-			ctxTimeout, cancel := context.WithTimeout(ctx, 3*time.Second)
+			ctxTimeout, cancel := context.WithTimeout(ctx, 5*time.Second)
 			defer cancel()
 
 			_, queryErr := infra.repo.CountByFilters(ctxTimeout, infra.orgID, infra.ledgerID, filter)
@@ -325,12 +324,12 @@ func TestIntegration_Chaos_CountByFilters_ConnectionPoolExhaustion(t *testing.T)
 	wg.Wait()
 
 	t.Logf("Phase 3 (Verify): %d/%d concurrent queries failed during pool exhaustion", errCount, concurrency)
-	require.Greater(t, errCount, int64(0), "at least some concurrent queries should fail during pool exhaustion")
+	require.Greater(t, errCount, int64(0), "at least some concurrent queries should fail or timeout during bandwidth throttle")
 
-	// Phase 4: Restore — reconnect
-	t.Log("Phase 4 (Restore): reconnecting proxy")
-	err = infra.proxy.Reconnect()
-	require.NoError(t, err, "failed to reconnect proxy")
+	// Phase 4: Restore — remove bandwidth throttle
+	t.Log("Phase 4 (Restore): removing bandwidth throttle")
+	err = infra.proxy.RemoveAllToxics()
+	require.NoError(t, err, "failed to remove toxics")
 
 	// Phase 5: Recovery — verify normal operation resumes
 	chaos.AssertRecoveryWithin(t, func() error {

--- a/components/ledger/internal/adapters/postgres/transaction/count-by-filters_chaos_test.go
+++ b/components/ledger/internal/adapters/postgres/transaction/count-by-filters_chaos_test.go
@@ -1,0 +1,337 @@
+//go:build integration
+
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+// Chaos tests for CountByFilters in the transaction PostgreSQL repository.
+//
+// These tests exercise fault-tolerance of CountByFilters when the underlying
+// PostgreSQL connection experiences failures (connection loss, latency,
+// network partition). They use Toxiproxy for network fault injection.
+//
+// Run with:
+//
+//	CHAOS=1 go test -tags integration -v -run TestIntegration_Chaos_CountByFilters \
+//	    ./components/ledger/internal/adapters/postgres/transaction/...
+package transaction
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"testing"
+	"time"
+
+	libCommons "github.com/LerianStudio/lib-commons/v4/commons"
+	libPostgres "github.com/LerianStudio/lib-commons/v4/commons/postgres"
+	"github.com/LerianStudio/midaz/v3/tests/utils/chaos"
+	pgtestutil "github.com/LerianStudio/midaz/v3/tests/utils/postgres"
+
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// =============================================================================
+// CHAOS TEST INFRASTRUCTURE FOR CountByFilters
+// =============================================================================
+
+// countByFiltersChaosInfra holds resources for CountByFilters chaos tests.
+type countByFiltersChaosInfra struct {
+	pgResult   *pgtestutil.ContainerResult
+	chaosInfra *chaos.Infrastructure
+	repo       *TransactionPostgreSQLRepository
+	conn       *libPostgres.Client
+	proxy      *chaos.Proxy
+	orgID      uuid.UUID
+	ledgerID   uuid.UUID
+}
+
+// setupCountByFiltersChaosInfra creates the chaos test infrastructure:
+//  1. Creates Docker network + Toxiproxy container
+//  2. Starts PostgreSQL container
+//  3. Creates Toxiproxy proxy forwarding to PostgreSQL
+//  4. Runs migrations and inserts test data
+//  5. Builds repository connected through the proxy
+func setupCountByFiltersChaosInfra(t *testing.T) *countByFiltersChaosInfra {
+	t.Helper()
+
+	chaosInfra := chaos.NewInfrastructure(t)
+
+	pgResult := pgtestutil.SetupContainer(t)
+
+	_, err := chaosInfra.RegisterContainerWithPort("postgres", pgResult.Container, "5432/tcp")
+	require.NoError(t, err, "failed to register PostgreSQL container")
+
+	proxy, err := chaosInfra.CreateProxyFor("postgres", "8668/tcp")
+	require.NoError(t, err, "failed to create Toxiproxy proxy for PostgreSQL")
+
+	containerInfo, ok := chaosInfra.GetContainer("postgres")
+	require.True(t, ok, "PostgreSQL container should be registered")
+	require.NotEmpty(t, containerInfo.ProxyListen, "proxy address should be set")
+
+	migrationsPath := pgtestutil.FindMigrationsPath(t, "transaction")
+	proxyConnStr := pgtestutil.BuildConnectionStringWithHost(containerInfo.ProxyListen, pgResult.Config)
+
+	conn := pgtestutil.CreatePostgresClient(t, proxyConnStr, proxyConnStr, pgResult.Config.DBName, migrationsPath)
+
+	repo := NewTransactionPostgreSQLRepository(conn)
+
+	orgID := uuid.Must(libCommons.GenerateUUIDv7())
+	ledgerID := uuid.Must(libCommons.GenerateUUIDv7())
+
+	// Insert test data directly through the container (bypassing proxy)
+	// so data exists before chaos injection.
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	body := `{"send":{"asset":"USD","value":"100"}}`
+
+	for i := 0; i < 5; i++ {
+		insertCountChaosTransaction(t, pgResult.DB, orgID, ledgerID, "PIX", "APPROVED", &body, now, nil)
+	}
+
+	return &countByFiltersChaosInfra{
+		pgResult:   pgResult,
+		chaosInfra: chaosInfra,
+		repo:       repo,
+		conn:       conn,
+		proxy:      proxy,
+		orgID:      orgID,
+		ledgerID:   ledgerID,
+	}
+}
+
+// insertCountChaosTransaction inserts a transaction with precise control.
+func insertCountChaosTransaction(t *testing.T, db *sql.DB, orgID, ledgerID uuid.UUID, route, status string, body *string, createdAt time.Time, deletedAt *time.Time) {
+	t.Helper()
+
+	id := uuid.Must(libCommons.GenerateUUIDv7())
+	amount := decimal.NewFromInt(100)
+
+	_, err := db.Exec(`
+		INSERT INTO transaction (id, parent_transaction_id, description, status, status_description, amount, asset_code, chart_of_accounts_group_name, route, organization_id, ledger_id, body, created_at, updated_at, deleted_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)
+	`, id, nil, "Chaos test transaction", status, nil, amount, "USD", "default", route, orgID, ledgerID, body, createdAt, createdAt, deletedAt)
+	require.NoError(t, err, "failed to insert chaos test transaction")
+}
+
+// =============================================================================
+// CHAOS TESTS
+// =============================================================================
+
+// TestIntegration_Chaos_CountByFilters_ConnectionLoss tests that CountByFilters
+// returns an error gracefully (no panic) when the database connection is severed.
+//
+// 5-phase structure: Normal → Inject → Verify → Restore → Recovery
+func TestIntegration_Chaos_CountByFilters_ConnectionLoss(t *testing.T) {
+	if os.Getenv("CHAOS") != "1" {
+		t.Skip("skipping chaos test (set CHAOS=1 to run)")
+	}
+
+	if testing.Short() {
+		t.Skip("skipping chaos test in short mode")
+	}
+
+	infra := setupCountByFiltersChaosInfra(t)
+	ctx := context.Background()
+
+	todayStart := time.Date(time.Now().Year(), time.Now().Month(), time.Now().Day(), 0, 0, 0, 0, time.UTC)
+	todayEnd := time.Date(time.Now().Year(), time.Now().Month(), time.Now().Day(), 23, 59, 59, 999999999, time.UTC)
+
+	filter := CountFilter{
+		Route:     "PIX",
+		Status:    "APPROVED",
+		StartDate: todayStart,
+		EndDate:   todayEnd,
+	}
+
+	// Phase 1: Normal — verify count works before chaos
+	count, err := infra.repo.CountByFilters(ctx, infra.orgID, infra.ledgerID, filter)
+	require.NoError(t, err, "count should work before chaos")
+	assert.Equal(t, int64(5), count, "expected 5 transactions before chaos")
+	t.Logf("Phase 1 (Normal): count = %d", count)
+
+	// Phase 2: Inject — disconnect the proxy (simulate connection loss)
+	t.Log("Phase 2 (Inject): disconnecting network")
+	err = infra.proxy.Disconnect()
+	require.NoError(t, err, "failed to disconnect proxy")
+
+	// Phase 3: Verify — CountByFilters should fail gracefully (no panic)
+	ctxTimeout, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	_, err = infra.repo.CountByFilters(ctxTimeout, infra.orgID, infra.ledgerID, filter)
+	if err != nil {
+		t.Logf("Phase 3 (Verify): count during connection loss returned error (expected): %v", err)
+	} else {
+		t.Log("Phase 3 (Verify): count succeeded during connection loss (connection pool cached)")
+	}
+	// Key invariant: no panic occurred (test would have crashed)
+
+	// Phase 4: Restore — reconnect the proxy
+	t.Log("Phase 4 (Restore): reconnecting network")
+	err = infra.proxy.Reconnect()
+	require.NoError(t, err, "failed to reconnect proxy")
+
+	// Phase 5: Recovery — verify count works again
+	chaos.AssertRecoveryWithin(t, func() error {
+		_, err := infra.repo.CountByFilters(ctx, infra.orgID, infra.ledgerID, filter)
+		return err
+	}, 30*time.Second, "CountByFilters should recover after network reconnection")
+
+	count, err = infra.repo.CountByFilters(ctx, infra.orgID, infra.ledgerID, filter)
+	require.NoError(t, err, "count should work after recovery")
+	assert.Equal(t, int64(5), count, "data should be intact after chaos")
+	t.Logf("Phase 5 (Recovery): count = %d", count)
+
+	t.Log("Chaos test passed: CountByFilters connection loss handled gracefully")
+}
+
+// TestIntegration_Chaos_CountByFilters_HighLatency tests that CountByFilters
+// handles high network latency gracefully (query completes or times out).
+//
+// 5-phase structure: Normal → Inject → Verify → Restore → Recovery
+func TestIntegration_Chaos_CountByFilters_HighLatency(t *testing.T) {
+	if os.Getenv("CHAOS") != "1" {
+		t.Skip("skipping chaos test (set CHAOS=1 to run)")
+	}
+
+	if testing.Short() {
+		t.Skip("skipping chaos test in short mode")
+	}
+
+	infra := setupCountByFiltersChaosInfra(t)
+	ctx := context.Background()
+
+	todayStart := time.Date(time.Now().Year(), time.Now().Month(), time.Now().Day(), 0, 0, 0, 0, time.UTC)
+	todayEnd := time.Date(time.Now().Year(), time.Now().Month(), time.Now().Day(), 23, 59, 59, 999999999, time.UTC)
+
+	filter := CountFilter{
+		Route:     "PIX",
+		Status:    "APPROVED",
+		StartDate: todayStart,
+		EndDate:   todayEnd,
+	}
+
+	// Phase 1: Normal — verify baseline works
+	start := time.Now()
+	count, err := infra.repo.CountByFilters(ctx, infra.orgID, infra.ledgerID, filter)
+	baselineLatency := time.Since(start)
+	require.NoError(t, err, "count should work before chaos")
+	assert.Equal(t, int64(5), count)
+	t.Logf("Phase 1 (Normal): count = %d, latency = %v", count, baselineLatency)
+
+	// Phase 2: Inject — add 5-second latency
+	t.Log("Phase 2 (Inject): adding 5s network latency")
+	err = infra.proxy.AddLatency(5*time.Second, 500*time.Millisecond)
+	require.NoError(t, err, "failed to add latency")
+
+	// Phase 3: Verify — query with timeout to verify graceful timeout
+	ctxTimeout, cancel := context.WithTimeout(ctx, 3*time.Second)
+	defer cancel()
+
+	start = time.Now()
+	_, err = infra.repo.CountByFilters(ctxTimeout, infra.orgID, infra.ledgerID, filter)
+	elapsed := time.Since(start)
+
+	if err != nil {
+		t.Logf("Phase 3 (Verify): count timed out as expected after %v: %v", elapsed, err)
+	} else {
+		t.Logf("Phase 3 (Verify): count succeeded despite latency in %v", elapsed)
+	}
+	// Key invariant: no panic occurred
+
+	// Phase 4: Restore — remove latency toxic
+	t.Log("Phase 4 (Restore): removing latency")
+	err = infra.proxy.RemoveAllToxics()
+	require.NoError(t, err, "failed to remove toxics")
+
+	// Phase 5: Recovery — verify normal operation resumes
+	chaos.AssertRecoveryWithin(t, func() error {
+		_, err := infra.repo.CountByFilters(ctx, infra.orgID, infra.ledgerID, filter)
+		return err
+	}, 30*time.Second, "CountByFilters should recover after latency removal")
+
+	count, err = infra.repo.CountByFilters(ctx, infra.orgID, infra.ledgerID, filter)
+	require.NoError(t, err, "count should work after recovery")
+	assert.Equal(t, int64(5), count, "data should be intact after chaos")
+	t.Logf("Phase 5 (Recovery): count = %d", count)
+
+	t.Log("Chaos test passed: CountByFilters high latency handled gracefully")
+}
+
+// TestIntegration_Chaos_CountByFilters_ConnectionPoolExhaustion tests that
+// CountByFilters returns an error instead of hanging when the connection pool
+// is exhausted (via Toxiproxy bandwidth limit to slow all connections).
+//
+// 5-phase structure: Normal → Inject → Verify → Restore → Recovery
+func TestIntegration_Chaos_CountByFilters_ConnectionPoolExhaustion(t *testing.T) {
+	if os.Getenv("CHAOS") != "1" {
+		t.Skip("skipping chaos test (set CHAOS=1 to run)")
+	}
+
+	if testing.Short() {
+		t.Skip("skipping chaos test in short mode")
+	}
+
+	infra := setupCountByFiltersChaosInfra(t)
+	ctx := context.Background()
+
+	todayStart := time.Date(time.Now().Year(), time.Now().Month(), time.Now().Day(), 0, 0, 0, 0, time.UTC)
+	todayEnd := time.Date(time.Now().Year(), time.Now().Month(), time.Now().Day(), 23, 59, 59, 999999999, time.UTC)
+
+	filter := CountFilter{
+		Route:     "PIX",
+		Status:    "APPROVED",
+		StartDate: todayStart,
+		EndDate:   todayEnd,
+	}
+
+	// Phase 1: Normal — verify baseline works
+	count, err := infra.repo.CountByFilters(ctx, infra.orgID, infra.ledgerID, filter)
+	require.NoError(t, err, "count should work before chaos")
+	assert.Equal(t, int64(5), count)
+	t.Logf("Phase 1 (Normal): count = %d", count)
+
+	// Phase 2: Inject — disconnect proxy to simulate pool exhaustion
+	// When the connection is severed, existing pool connections become stale
+	// and new connections cannot be established, simulating pool exhaustion.
+	t.Log("Phase 2 (Inject): disconnecting proxy to simulate connection pool exhaustion")
+	err = infra.proxy.Disconnect()
+	require.NoError(t, err, "failed to disconnect proxy")
+
+	// Phase 3: Verify — multiple concurrent queries should all fail gracefully
+	errCount := 0
+	for i := 0; i < 5; i++ {
+		ctxTimeout, cancel := context.WithTimeout(ctx, 3*time.Second)
+
+		_, queryErr := infra.repo.CountByFilters(ctxTimeout, infra.orgID, infra.ledgerID, filter)
+		cancel()
+
+		if queryErr != nil {
+			errCount++
+		}
+	}
+
+	t.Logf("Phase 3 (Verify): %d/5 queries failed during pool exhaustion", errCount)
+	// Key invariant: no panic, no hang (timeout worked)
+
+	// Phase 4: Restore — reconnect
+	t.Log("Phase 4 (Restore): reconnecting proxy")
+	err = infra.proxy.Reconnect()
+	require.NoError(t, err, "failed to reconnect proxy")
+
+	// Phase 5: Recovery — verify normal operation resumes
+	chaos.AssertRecoveryWithin(t, func() error {
+		_, err := infra.repo.CountByFilters(ctx, infra.orgID, infra.ledgerID, filter)
+		return err
+	}, 30*time.Second, "CountByFilters should recover after reconnection")
+
+	count, err = infra.repo.CountByFilters(ctx, infra.orgID, infra.ledgerID, filter)
+	require.NoError(t, err, "count should work after recovery")
+	assert.Equal(t, int64(5), count, "data should be intact after chaos")
+	t.Logf("Phase 5 (Recovery): count = %d", count)
+
+	t.Log("Chaos test passed: CountByFilters connection pool exhaustion handled gracefully")
+}

--- a/components/ledger/internal/adapters/postgres/transaction/count-by-filters_chaos_test.go
+++ b/components/ledger/internal/adapters/postgres/transaction/count-by-filters_chaos_test.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"database/sql"
 	"os"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -47,6 +49,7 @@ type countByFiltersChaosInfra struct {
 	proxy      *chaos.Proxy
 	orgID      uuid.UUID
 	ledgerID   uuid.UUID
+	seededAt   time.Time
 }
 
 // setupCountByFiltersChaosInfra creates the chaos test infrastructure:
@@ -99,6 +102,7 @@ func setupCountByFiltersChaosInfra(t *testing.T) *countByFiltersChaosInfra {
 		proxy:      proxy,
 		orgID:      orgID,
 		ledgerID:   ledgerID,
+		seededAt:   now,
 	}
 }
 
@@ -136,8 +140,8 @@ func TestIntegration_Chaos_CountByFilters_ConnectionLoss(t *testing.T) {
 	infra := setupCountByFiltersChaosInfra(t)
 	ctx := context.Background()
 
-	todayStart := time.Date(time.Now().Year(), time.Now().Month(), time.Now().Day(), 0, 0, 0, 0, time.UTC)
-	todayEnd := time.Date(time.Now().Year(), time.Now().Month(), time.Now().Day(), 23, 59, 59, 999999999, time.UTC)
+	todayStart := time.Date(infra.seededAt.Year(), infra.seededAt.Month(), infra.seededAt.Day(), 0, 0, 0, 0, time.UTC)
+	todayEnd := time.Date(infra.seededAt.Year(), infra.seededAt.Month(), infra.seededAt.Day(), 23, 59, 59, 999999999, time.UTC)
 
 	filter := CountFilter{
 		Route:     "PIX",
@@ -162,12 +166,8 @@ func TestIntegration_Chaos_CountByFilters_ConnectionLoss(t *testing.T) {
 	defer cancel()
 
 	_, err = infra.repo.CountByFilters(ctxTimeout, infra.orgID, infra.ledgerID, filter)
-	if err != nil {
-		t.Logf("Phase 3 (Verify): count during connection loss returned error (expected): %v", err)
-	} else {
-		t.Log("Phase 3 (Verify): count succeeded during connection loss (connection pool cached)")
-	}
-	// Key invariant: no panic occurred (test would have crashed)
+	require.Error(t, err, "Phase 3 (Verify): CountByFilters should fail during connection loss")
+	t.Logf("Phase 3 (Verify): count during connection loss returned error (expected): %v", err)
 
 	// Phase 4: Restore — reconnect the proxy
 	t.Log("Phase 4 (Restore): reconnecting network")
@@ -204,8 +204,8 @@ func TestIntegration_Chaos_CountByFilters_HighLatency(t *testing.T) {
 	infra := setupCountByFiltersChaosInfra(t)
 	ctx := context.Background()
 
-	todayStart := time.Date(time.Now().Year(), time.Now().Month(), time.Now().Day(), 0, 0, 0, 0, time.UTC)
-	todayEnd := time.Date(time.Now().Year(), time.Now().Month(), time.Now().Day(), 23, 59, 59, 999999999, time.UTC)
+	todayStart := time.Date(infra.seededAt.Year(), infra.seededAt.Month(), infra.seededAt.Day(), 0, 0, 0, 0, time.UTC)
+	todayEnd := time.Date(infra.seededAt.Year(), infra.seededAt.Month(), infra.seededAt.Day(), 23, 59, 59, 999999999, time.UTC)
 
 	filter := CountFilter{
 		Route:     "PIX",
@@ -278,8 +278,8 @@ func TestIntegration_Chaos_CountByFilters_ConnectionPoolExhaustion(t *testing.T)
 	infra := setupCountByFiltersChaosInfra(t)
 	ctx := context.Background()
 
-	todayStart := time.Date(time.Now().Year(), time.Now().Month(), time.Now().Day(), 0, 0, 0, 0, time.UTC)
-	todayEnd := time.Date(time.Now().Year(), time.Now().Month(), time.Now().Day(), 23, 59, 59, 999999999, time.UTC)
+	todayStart := time.Date(infra.seededAt.Year(), infra.seededAt.Month(), infra.seededAt.Day(), 0, 0, 0, 0, time.UTC)
+	todayEnd := time.Date(infra.seededAt.Year(), infra.seededAt.Month(), infra.seededAt.Day(), 23, 59, 59, 999999999, time.UTC)
 
 	filter := CountFilter{
 		Route:     "PIX",
@@ -301,21 +301,31 @@ func TestIntegration_Chaos_CountByFilters_ConnectionPoolExhaustion(t *testing.T)
 	err = infra.proxy.Disconnect()
 	require.NoError(t, err, "failed to disconnect proxy")
 
-	// Phase 3: Verify — multiple concurrent queries should all fail gracefully
-	errCount := 0
-	for i := 0; i < 5; i++ {
-		ctxTimeout, cancel := context.WithTimeout(ctx, 3*time.Second)
+	// Phase 3: Verify — concurrent queries should fail gracefully (no panic, no hang)
+	const concurrency = 10
+	var wg sync.WaitGroup
+	var errCount int64
 
-		_, queryErr := infra.repo.CountByFilters(ctxTimeout, infra.orgID, infra.ledgerID, filter)
-		cancel()
+	for i := 0; i < concurrency; i++ {
+		wg.Add(1)
 
-		if queryErr != nil {
-			errCount++
-		}
+		go func() {
+			defer wg.Done()
+
+			ctxTimeout, cancel := context.WithTimeout(ctx, 3*time.Second)
+			defer cancel()
+
+			_, queryErr := infra.repo.CountByFilters(ctxTimeout, infra.orgID, infra.ledgerID, filter)
+			if queryErr != nil {
+				atomic.AddInt64(&errCount, 1)
+			}
+		}()
 	}
 
-	t.Logf("Phase 3 (Verify): %d/5 queries failed during pool exhaustion", errCount)
-	// Key invariant: no panic, no hang (timeout worked)
+	wg.Wait()
+
+	t.Logf("Phase 3 (Verify): %d/%d concurrent queries failed during pool exhaustion", errCount, concurrency)
+	require.Greater(t, errCount, int64(0), "at least some concurrent queries should fail during pool exhaustion")
 
 	// Phase 4: Restore — reconnect
 	t.Log("Phase 4 (Restore): reconnecting proxy")

--- a/components/ledger/internal/adapters/postgres/transaction/count-by-filters_integration_test.go
+++ b/components/ledger/internal/adapters/postgres/transaction/count-by-filters_integration_test.go
@@ -1,0 +1,405 @@
+//go:build integration
+
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package transaction
+
+// =============================================================================
+// INTEGRATION TESTS — CountByFilters Repository Method
+//
+// These tests verify CountByFilters against a real PostgreSQL container with
+// known test data. They use testcontainers for isolation and the project's
+// standard fixture helpers.
+//
+// Test data layout:
+//   - 5 transactions: route="PIX", status="APPROVED", created_at=today
+//   - 3 transactions: route="PIX", status="PENDING",  created_at=today
+//   - 2 transactions: route="TED", status="APPROVED", created_at=today
+//   - 1 transaction:  route="PIX", status="APPROVED", deleted_at=now (soft-deleted)
+//   - 2 transactions: route="PIX", status="APPROVED", created_at=yesterday
+//
+// Run with:
+//
+//	go test -tags integration -run TestIntegration_CountByFilters -v -count=1 \
+//	    ./components/ledger/internal/adapters/postgres/transaction/
+//
+// =============================================================================
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+
+	libCommons "github.com/LerianStudio/lib-commons/v4/commons"
+	pgtestutil "github.com/LerianStudio/midaz/v3/tests/utils/postgres"
+
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// countByFiltersInfra holds infrastructure for CountByFilters integration tests.
+type countByFiltersInfra struct {
+	pgContainer *pgtestutil.ContainerResult
+	repo        *TransactionPostgreSQLRepository
+	orgID       uuid.UUID
+	ledgerID    uuid.UUID
+}
+
+// setupCountByFiltersInfra creates infrastructure and inserts the standard
+// test data set for CountByFilters tests.
+func setupCountByFiltersInfra(t *testing.T) *countByFiltersInfra {
+	t.Helper()
+
+	pgContainer := pgtestutil.SetupContainer(t)
+
+	migrationsPath := pgtestutil.FindMigrationsPath(t, "transaction")
+	connStr := pgtestutil.BuildConnectionString(pgContainer.Host, pgContainer.Port, pgContainer.Config)
+
+	conn := pgtestutil.CreatePostgresClient(t, connStr, connStr, pgContainer.Config.DBName, migrationsPath)
+
+	repo := NewTransactionPostgreSQLRepository(conn)
+
+	orgID := uuid.Must(libCommons.GenerateUUIDv7())
+	ledgerID := uuid.Must(libCommons.GenerateUUIDv7())
+
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	yesterday := now.Add(-24 * time.Hour)
+
+	body := `{"send":{"asset":"USD","value":"100"}}`
+
+	// 5 transactions: route="PIX", status="APPROVED", created_at=today
+	for i := 0; i < 5; i++ {
+		insertTransaction(t, pgContainer.DB, orgID, ledgerID, "PIX", "APPROVED", &body, now, nil)
+	}
+
+	// 3 transactions: route="PIX", status="PENDING", created_at=today
+	for i := 0; i < 3; i++ {
+		insertTransaction(t, pgContainer.DB, orgID, ledgerID, "PIX", "PENDING", &body, now, nil)
+	}
+
+	// 2 transactions: route="TED", status="APPROVED", created_at=today
+	for i := 0; i < 2; i++ {
+		insertTransaction(t, pgContainer.DB, orgID, ledgerID, "TED", "APPROVED", &body, now, nil)
+	}
+
+	// 1 soft-deleted transaction: route="PIX", status="APPROVED", deleted_at=now
+	deletedAt := now
+	insertTransaction(t, pgContainer.DB, orgID, ledgerID, "PIX", "APPROVED", &body, now, &deletedAt)
+
+	// 2 transactions: route="PIX", status="APPROVED", created_at=yesterday
+	for i := 0; i < 2; i++ {
+		insertTransaction(t, pgContainer.DB, orgID, ledgerID, "PIX", "APPROVED", &body, yesterday, nil)
+	}
+
+	return &countByFiltersInfra{
+		pgContainer: pgContainer,
+		repo:        repo,
+		orgID:       orgID,
+		ledgerID:    ledgerID,
+	}
+}
+
+// insertTransaction inserts a transaction row with precise control over route,
+// status, created_at, and deleted_at timestamps.
+func insertTransaction(t *testing.T, db *sql.DB, orgID, ledgerID uuid.UUID, route, status string, body *string, createdAt time.Time, deletedAt *time.Time) uuid.UUID {
+	t.Helper()
+
+	id := uuid.Must(libCommons.GenerateUUIDv7())
+	amount := decimal.NewFromInt(100)
+
+	_, err := db.Exec(`
+		INSERT INTO transaction (id, parent_transaction_id, description, status, status_description, amount, asset_code, chart_of_accounts_group_name, route, organization_id, ledger_id, body, created_at, updated_at, deleted_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)
+	`, id, nil, "Test transaction", status, nil, amount, "USD", "default", route, orgID, ledgerID, body, createdAt, createdAt, deletedAt)
+	require.NoError(t, err, "failed to insert test transaction")
+
+	return id
+}
+
+// todayRange returns the start and end of today in UTC.
+func todayRange() (time.Time, time.Time) {
+	now := time.Now().UTC()
+	start := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC)
+	end := time.Date(now.Year(), now.Month(), now.Day(), 23, 59, 59, 999999999, time.UTC)
+
+	return start, end
+}
+
+// fullRange returns a 48-hour range covering yesterday through today.
+func fullRange() (time.Time, time.Time) {
+	now := time.Now().UTC()
+	start := time.Date(now.Year(), now.Month(), now.Day()-1, 0, 0, 0, 0, time.UTC)
+	end := time.Date(now.Year(), now.Month(), now.Day(), 23, 59, 59, 999999999, time.UTC)
+
+	return start, end
+}
+
+// =============================================================================
+// INTEGRATION TESTS
+// =============================================================================
+
+// TestIntegration_CountByFilters_NoFilters counts all non-deleted transactions
+// created today (default date range).
+func TestIntegration_CountByFilters_NoFilters(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	infra := setupCountByFiltersInfra(t)
+	ctx := context.Background()
+
+	todayStart, todayEnd := todayRange()
+
+	count, err := infra.repo.CountByFilters(ctx, infra.orgID, infra.ledgerID, CountFilter{
+		StartDate: todayStart,
+		EndDate:   todayEnd,
+	})
+	require.NoError(t, err)
+
+	// Today's non-deleted: 5 PIX/APPROVED + 3 PIX/PENDING + 2 TED/APPROVED = 10
+	assert.Equal(t, int64(10), count, "count all today (no filters) should be 10")
+}
+
+// TestIntegration_CountByFilters_ByRoute counts transactions filtered by route="PIX".
+func TestIntegration_CountByFilters_ByRoute(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	infra := setupCountByFiltersInfra(t)
+	ctx := context.Background()
+
+	todayStart, todayEnd := todayRange()
+
+	count, err := infra.repo.CountByFilters(ctx, infra.orgID, infra.ledgerID, CountFilter{
+		Route:     "PIX",
+		StartDate: todayStart,
+		EndDate:   todayEnd,
+	})
+	require.NoError(t, err)
+
+	// Today's PIX non-deleted: 5 APPROVED + 3 PENDING = 8
+	assert.Equal(t, int64(8), count, "count by route=PIX today should be 8")
+}
+
+// TestIntegration_CountByFilters_ByStatus counts transactions filtered by status="APPROVED".
+func TestIntegration_CountByFilters_ByStatus(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	infra := setupCountByFiltersInfra(t)
+	ctx := context.Background()
+
+	todayStart, todayEnd := todayRange()
+
+	count, err := infra.repo.CountByFilters(ctx, infra.orgID, infra.ledgerID, CountFilter{
+		Status:    "APPROVED",
+		StartDate: todayStart,
+		EndDate:   todayEnd,
+	})
+	require.NoError(t, err)
+
+	// Today's APPROVED non-deleted: 5 PIX + 2 TED = 7
+	assert.Equal(t, int64(7), count, "count by status=APPROVED today should be 7")
+}
+
+// TestIntegration_CountByFilters_ByRouteAndStatus counts with both route and status.
+func TestIntegration_CountByFilters_ByRouteAndStatus(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	infra := setupCountByFiltersInfra(t)
+	ctx := context.Background()
+
+	todayStart, todayEnd := todayRange()
+
+	count, err := infra.repo.CountByFilters(ctx, infra.orgID, infra.ledgerID, CountFilter{
+		Route:     "PIX",
+		Status:    "APPROVED",
+		StartDate: todayStart,
+		EndDate:   todayEnd,
+	})
+	require.NoError(t, err)
+
+	// Today's PIX/APPROVED non-deleted: 5
+	assert.Equal(t, int64(5), count, "count by route=PIX status=APPROVED today should be 5")
+}
+
+// TestIntegration_CountByFilters_ExplicitDateRange counts with a date range
+// spanning yesterday through today (includes the 2 yesterday transactions).
+func TestIntegration_CountByFilters_ExplicitDateRange(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	infra := setupCountByFiltersInfra(t)
+	ctx := context.Background()
+
+	start, end := fullRange()
+
+	count, err := infra.repo.CountByFilters(ctx, infra.orgID, infra.ledgerID, CountFilter{
+		StartDate: start,
+		EndDate:   end,
+	})
+	require.NoError(t, err)
+
+	// All non-deleted: 10 today + 2 yesterday = 12
+	assert.Equal(t, int64(12), count, "count with full date range should be 12")
+}
+
+// TestIntegration_CountByFilters_NonExistentRoute returns 0 for a route with no transactions.
+func TestIntegration_CountByFilters_NonExistentRoute(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	infra := setupCountByFiltersInfra(t)
+	ctx := context.Background()
+
+	start, end := fullRange()
+
+	count, err := infra.repo.CountByFilters(ctx, infra.orgID, infra.ledgerID, CountFilter{
+		Route:     "NONEXISTENT",
+		StartDate: start,
+		EndDate:   end,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), count, "count for non-existent route should be 0")
+}
+
+// TestIntegration_CountByFilters_SoftDeletedExcluded verifies that soft-deleted
+// transactions are never counted.
+func TestIntegration_CountByFilters_SoftDeletedExcluded(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	infra := setupCountByFiltersInfra(t)
+	ctx := context.Background()
+
+	start, end := fullRange()
+
+	// Count all PIX/APPROVED across full range
+	count, err := infra.repo.CountByFilters(ctx, infra.orgID, infra.ledgerID, CountFilter{
+		Route:     "PIX",
+		Status:    "APPROVED",
+		StartDate: start,
+		EndDate:   end,
+	})
+	require.NoError(t, err)
+
+	// 5 today + 2 yesterday = 7 (soft-deleted excluded)
+	assert.Equal(t, int64(7), count, "soft-deleted PIX/APPROVED should be excluded")
+}
+
+// TestIntegration_CountByFilters_EmptyOrg returns 0 for an org with no transactions.
+func TestIntegration_CountByFilters_EmptyOrg(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	infra := setupCountByFiltersInfra(t)
+	ctx := context.Background()
+
+	start, end := fullRange()
+
+	// Use a different org ID that has no transactions
+	emptyOrgID := uuid.Must(libCommons.GenerateUUIDv7())
+
+	count, err := infra.repo.CountByFilters(ctx, emptyOrgID, infra.ledgerID, CountFilter{
+		StartDate: start,
+		EndDate:   end,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), count, "count for org with no transactions should be 0")
+}
+
+// TestIntegration_CountByFilters_FilterNarrowing verifies that adding a filter
+// never increases the count (monotonic decrease property).
+func TestIntegration_CountByFilters_FilterNarrowing(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	infra := setupCountByFiltersInfra(t)
+	ctx := context.Background()
+
+	todayStart, todayEnd := todayRange()
+
+	// Count with no filters
+	countAll, err := infra.repo.CountByFilters(ctx, infra.orgID, infra.ledgerID, CountFilter{
+		StartDate: todayStart,
+		EndDate:   todayEnd,
+	})
+	require.NoError(t, err)
+
+	// Count with route filter
+	countRoute, err := infra.repo.CountByFilters(ctx, infra.orgID, infra.ledgerID, CountFilter{
+		Route:     "PIX",
+		StartDate: todayStart,
+		EndDate:   todayEnd,
+	})
+	require.NoError(t, err)
+
+	// Count with route + status filter
+	countRouteStatus, err := infra.repo.CountByFilters(ctx, infra.orgID, infra.ledgerID, CountFilter{
+		Route:     "PIX",
+		Status:    "APPROVED",
+		StartDate: todayStart,
+		EndDate:   todayEnd,
+	})
+	require.NoError(t, err)
+
+	// Narrowing: all >= route >= route+status
+	assert.GreaterOrEqual(t, countAll, countRoute,
+		"adding route filter should not increase count (%d >= %d)", countAll, countRoute)
+	assert.GreaterOrEqual(t, countRoute, countRouteStatus,
+		"adding status filter should not increase count (%d >= %d)", countRoute, countRouteStatus)
+}
+
+// TestIntegration_CountByFilters_FutureDateRange returns 0 for a future date range.
+func TestIntegration_CountByFilters_FutureDateRange(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	infra := setupCountByFiltersInfra(t)
+	ctx := context.Background()
+
+	futureStart := time.Now().UTC().Add(48 * time.Hour)
+	futureEnd := futureStart.Add(24 * time.Hour)
+
+	count, err := infra.repo.CountByFilters(ctx, infra.orgID, infra.ledgerID, CountFilter{
+		StartDate: futureStart,
+		EndDate:   futureEnd,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), count, "count for future date range should be 0")
+}
+
+// TestIntegration_CountByFilters_CancelledContext returns error on cancelled context.
+func TestIntegration_CountByFilters_CancelledContext(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	infra := setupCountByFiltersInfra(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Cancel immediately
+
+	todayStart, todayEnd := todayRange()
+
+	_, err := infra.repo.CountByFilters(ctx, infra.orgID, infra.ledgerID, CountFilter{
+		StartDate: todayStart,
+		EndDate:   todayEnd,
+	})
+	assert.Error(t, err, "cancelled context should produce error")
+}

--- a/components/ledger/internal/adapters/postgres/transaction/count-by-filters_integration_test.go
+++ b/components/ledger/internal/adapters/postgres/transaction/count-by-filters_integration_test.go
@@ -48,6 +48,7 @@ type countByFiltersInfra struct {
 	repo        *TransactionPostgreSQLRepository
 	orgID       uuid.UUID
 	ledgerID    uuid.UUID
+	seededAt    time.Time
 }
 
 // setupCountByFiltersInfra creates infrastructure and inserts the standard
@@ -101,6 +102,7 @@ func setupCountByFiltersInfra(t *testing.T) *countByFiltersInfra {
 		repo:        repo,
 		orgID:       orgID,
 		ledgerID:    ledgerID,
+		seededAt:    now,
 	}
 }
 
@@ -121,21 +123,17 @@ func insertTransaction(t *testing.T, db *sql.DB, orgID, ledgerID uuid.UUID, rout
 	return id
 }
 
-// todayRange returns the start and end of today in UTC.
-func todayRange() (time.Time, time.Time) {
-	now := time.Now().UTC()
-	start := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC)
-	end := time.Date(now.Year(), now.Month(), now.Day(), 23, 59, 59, 999999999, time.UTC)
-
+// todayRange returns the start and end of the given reference day in UTC.
+func todayRange(ref time.Time) (time.Time, time.Time) {
+	start := time.Date(ref.Year(), ref.Month(), ref.Day(), 0, 0, 0, 0, time.UTC)
+	end := time.Date(ref.Year(), ref.Month(), ref.Day(), 23, 59, 59, 999999999, time.UTC)
 	return start, end
 }
 
-// fullRange returns a 48-hour range covering yesterday through today.
-func fullRange() (time.Time, time.Time) {
-	now := time.Now().UTC()
-	start := time.Date(now.Year(), now.Month(), now.Day()-1, 0, 0, 0, 0, time.UTC)
-	end := time.Date(now.Year(), now.Month(), now.Day(), 23, 59, 59, 999999999, time.UTC)
-
+// fullRange returns a 48-hour range covering the day before ref through ref day.
+func fullRange(ref time.Time) (time.Time, time.Time) {
+	start := time.Date(ref.Year(), ref.Month(), ref.Day()-1, 0, 0, 0, 0, time.UTC)
+	end := time.Date(ref.Year(), ref.Month(), ref.Day(), 23, 59, 59, 999999999, time.UTC)
 	return start, end
 }
 
@@ -153,7 +151,7 @@ func TestIntegration_CountByFilters_NoFilters(t *testing.T) {
 	infra := setupCountByFiltersInfra(t)
 	ctx := context.Background()
 
-	todayStart, todayEnd := todayRange()
+	todayStart, todayEnd := todayRange(infra.seededAt)
 
 	count, err := infra.repo.CountByFilters(ctx, infra.orgID, infra.ledgerID, CountFilter{
 		StartDate: todayStart,
@@ -174,7 +172,7 @@ func TestIntegration_CountByFilters_ByRoute(t *testing.T) {
 	infra := setupCountByFiltersInfra(t)
 	ctx := context.Background()
 
-	todayStart, todayEnd := todayRange()
+	todayStart, todayEnd := todayRange(infra.seededAt)
 
 	count, err := infra.repo.CountByFilters(ctx, infra.orgID, infra.ledgerID, CountFilter{
 		Route:     "PIX",
@@ -196,7 +194,7 @@ func TestIntegration_CountByFilters_ByStatus(t *testing.T) {
 	infra := setupCountByFiltersInfra(t)
 	ctx := context.Background()
 
-	todayStart, todayEnd := todayRange()
+	todayStart, todayEnd := todayRange(infra.seededAt)
 
 	count, err := infra.repo.CountByFilters(ctx, infra.orgID, infra.ledgerID, CountFilter{
 		Status:    "APPROVED",
@@ -218,7 +216,7 @@ func TestIntegration_CountByFilters_ByRouteAndStatus(t *testing.T) {
 	infra := setupCountByFiltersInfra(t)
 	ctx := context.Background()
 
-	todayStart, todayEnd := todayRange()
+	todayStart, todayEnd := todayRange(infra.seededAt)
 
 	count, err := infra.repo.CountByFilters(ctx, infra.orgID, infra.ledgerID, CountFilter{
 		Route:     "PIX",
@@ -242,7 +240,7 @@ func TestIntegration_CountByFilters_ExplicitDateRange(t *testing.T) {
 	infra := setupCountByFiltersInfra(t)
 	ctx := context.Background()
 
-	start, end := fullRange()
+	start, end := fullRange(infra.seededAt)
 
 	count, err := infra.repo.CountByFilters(ctx, infra.orgID, infra.ledgerID, CountFilter{
 		StartDate: start,
@@ -263,7 +261,7 @@ func TestIntegration_CountByFilters_NonExistentRoute(t *testing.T) {
 	infra := setupCountByFiltersInfra(t)
 	ctx := context.Background()
 
-	start, end := fullRange()
+	start, end := fullRange(infra.seededAt)
 
 	count, err := infra.repo.CountByFilters(ctx, infra.orgID, infra.ledgerID, CountFilter{
 		Route:     "NONEXISTENT",
@@ -284,7 +282,7 @@ func TestIntegration_CountByFilters_SoftDeletedExcluded(t *testing.T) {
 	infra := setupCountByFiltersInfra(t)
 	ctx := context.Background()
 
-	start, end := fullRange()
+	start, end := fullRange(infra.seededAt)
 
 	// Count all PIX/APPROVED across full range
 	count, err := infra.repo.CountByFilters(ctx, infra.orgID, infra.ledgerID, CountFilter{
@@ -308,7 +306,7 @@ func TestIntegration_CountByFilters_EmptyOrg(t *testing.T) {
 	infra := setupCountByFiltersInfra(t)
 	ctx := context.Background()
 
-	start, end := fullRange()
+	start, end := fullRange(infra.seededAt)
 
 	// Use a different org ID that has no transactions
 	emptyOrgID := uuid.Must(libCommons.GenerateUUIDv7())
@@ -331,7 +329,7 @@ func TestIntegration_CountByFilters_FilterNarrowing(t *testing.T) {
 	infra := setupCountByFiltersInfra(t)
 	ctx := context.Background()
 
-	todayStart, todayEnd := todayRange()
+	todayStart, todayEnd := todayRange(infra.seededAt)
 
 	// Count with no filters
 	countAll, err := infra.repo.CountByFilters(ctx, infra.orgID, infra.ledgerID, CountFilter{
@@ -395,7 +393,7 @@ func TestIntegration_CountByFilters_CancelledContext(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // Cancel immediately
 
-	todayStart, todayEnd := todayRange()
+	todayStart, todayEnd := todayRange(infra.seededAt)
 
 	_, err := infra.repo.CountByFilters(ctx, infra.orgID, infra.ledgerID, CountFilter{
 		StartDate: todayStart,

--- a/components/ledger/internal/adapters/postgres/transaction/transaction.go
+++ b/components/ledger/internal/adapters/postgres/transaction/transaction.go
@@ -19,6 +19,14 @@ import (
 	"github.com/google/uuid"
 )
 
+// CountFilter holds optional filters for counting transactions.
+type CountFilter struct {
+	Route     string    // Empty means include all routes
+	Status    string    // Empty means include all statuses
+	StartDate time.Time // Mandatory lower bound on created_at
+	EndDate   time.Time // Mandatory upper bound on created_at
+}
+
 // TransactionPostgreSQLModel represents the entity TransactionPostgreSQLModel into SQL context in Database
 //
 // @Description Database model for storing transaction information in PostgreSQL

--- a/components/ledger/internal/adapters/postgres/transaction/transaction.postgresql.go
+++ b/components/ledger/internal/adapters/postgres/transaction/transaction.postgresql.go
@@ -88,6 +88,7 @@ type Repository interface {
 	Delete(ctx context.Context, organizationID, ledgerID, id uuid.UUID) error
 	FindWithOperations(ctx context.Context, organizationID, ledgerID, id uuid.UUID) (*Transaction, error)
 	FindOrListAllWithOperations(ctx context.Context, organizationID, ledgerID uuid.UUID, ids []uuid.UUID, filter http.Pagination) ([]*Transaction, libHTTP.CursorPagination, error)
+	CountByFilters(ctx context.Context, organizationID, ledgerID uuid.UUID, filter CountFilter) (int64, error)
 }
 
 // transactionColumns is derived from transactionColumnList for use with squirrel.Select.
@@ -1375,6 +1376,65 @@ func (r *TransactionPostgreSQLRepository) FindOrListAllWithOperations(ctx contex
 	}
 
 	return transactions, cur, nil
+}
+
+// CountByFilters returns the number of transactions matching the given filters.
+func (r *TransactionPostgreSQLRepository) CountByFilters(ctx context.Context, organizationID, ledgerID uuid.UUID, filter CountFilter) (int64, error) {
+	logger, tracer, _, _ := libCommons.NewTrackingFromContext(ctx)
+
+	ctx, span := tracer.Start(ctx, "postgres.count_transactions_by_filters")
+	defer span.End()
+
+	db, err := r.getDB(ctx)
+	if err != nil {
+		libOpentelemetry.HandleSpanError(span, "Failed to get database connection", err)
+
+		logger.Log(ctx, libLog.LevelError, fmt.Sprintf("Failed to get database connection: %v", err))
+
+		return 0, err
+	}
+
+	countQuery := squirrel.Select("COUNT(*)").
+		From(r.tableName).
+		Where(squirrel.Expr("organization_id = ?", organizationID)).
+		Where(squirrel.Expr("ledger_id = ?", ledgerID)).
+		Where(squirrel.GtOrEq{"created_at": filter.StartDate}).
+		Where(squirrel.LtOrEq{"created_at": filter.EndDate}).
+		Where(squirrel.Eq{"deleted_at": nil}).
+		PlaceholderFormat(squirrel.Dollar)
+
+	if filter.Route != "" {
+		countQuery = countQuery.Where(squirrel.Eq{"route": filter.Route})
+	}
+
+	if filter.Status != "" {
+		countQuery = countQuery.Where(squirrel.Eq{"status": filter.Status})
+	}
+
+	query, args, err := countQuery.ToSql()
+	if err != nil {
+		libOpentelemetry.HandleSpanError(span, "Failed to build query", err)
+
+		logger.Log(ctx, libLog.LevelError, fmt.Sprintf("Failed to build query: %v", err))
+
+		return 0, err
+	}
+
+	ctx, spanQuery := tracer.Start(ctx, "postgres.count_transactions_by_filters.query")
+	defer spanQuery.End()
+
+	var count int64
+
+	err = db.QueryRowContext(ctx, query, args...).Scan(&count)
+	if err != nil {
+		libOpentelemetry.HandleSpanError(spanQuery, "Failed to execute count query", err)
+
+		logger.Log(ctx, libLog.LevelError, fmt.Sprintf("Failed to execute count query: %v", err))
+
+		return 0, err
+	}
+
+	return count, nil
 }
 
 // derefString safely dereferences a *string, returning "" if nil.

--- a/components/ledger/internal/adapters/postgres/transaction/transaction.postgresql_mock.go
+++ b/components/ledger/internal/adapters/postgres/transaction/transaction.postgresql_mock.go
@@ -44,6 +44,21 @@ func (m *MockRepository) EXPECT() *MockRepositoryMockRecorder {
 	return m.recorder
 }
 
+// CountByFilters mocks base method.
+func (m *MockRepository) CountByFilters(ctx context.Context, organizationID, ledgerID uuid.UUID, filter CountFilter) (int64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CountByFilters", ctx, organizationID, ledgerID, filter)
+	ret0, _ := ret[0].(int64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CountByFilters indicates an expected call of CountByFilters.
+func (mr *MockRepositoryMockRecorder) CountByFilters(ctx, organizationID, ledgerID, filter any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CountByFilters", reflect.TypeOf((*MockRepository)(nil).CountByFilters), ctx, organizationID, ledgerID, filter)
+}
+
 // Create mocks base method.
 func (m *MockRepository) Create(ctx context.Context, transaction *Transaction) (*Transaction, error) {
 	m.ctrl.T.Helper()

--- a/components/ledger/internal/services/query/count-transactions-by-filters.go
+++ b/components/ledger/internal/services/query/count-transactions-by-filters.go
@@ -1,0 +1,42 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package query
+
+import (
+	"context"
+	"fmt"
+
+	libCommons "github.com/LerianStudio/lib-commons/v4/commons"
+	libLog "github.com/LerianStudio/lib-commons/v4/commons/log"
+	libOpentelemetry "github.com/LerianStudio/lib-commons/v4/commons/opentelemetry"
+	"github.com/LerianStudio/midaz/v3/components/ledger/internal/adapters/postgres/transaction"
+	"github.com/google/uuid"
+)
+
+// CountTransactionsByFilters returns the number of transactions matching the given filters.
+func (uc *UseCase) CountTransactionsByFilters(ctx context.Context, organizationID, ledgerID uuid.UUID, filter transaction.CountFilter) (int64, error) {
+	logger, tracer, _, _ := libCommons.NewTrackingFromContext(ctx)
+
+	ctx, span := tracer.Start(ctx, "query.count_transactions_by_filters")
+	defer span.End()
+
+	logger.Log(ctx, libLog.LevelInfo, fmt.Sprintf(
+		"Counting transactions with filters: organizationID=%s, ledgerID=%s, route=%s, status=%s, startDate=%s, endDate=%s",
+		organizationID, ledgerID, filter.Route, filter.Status, filter.StartDate, filter.EndDate,
+	))
+
+	count, err := uc.TransactionRepo.CountByFilters(ctx, organizationID, ledgerID, filter)
+	if err != nil {
+		libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Failed to count transactions by filters", err)
+
+		logger.Log(ctx, libLog.LevelError, fmt.Sprintf("Failed to count transactions by filters: %v", err))
+
+		return 0, err
+	}
+
+	logger.Log(ctx, libLog.LevelInfo, fmt.Sprintf("Transaction count result: %d", count))
+
+	return count, nil
+}

--- a/components/ledger/internal/services/query/count-transactions-by-filters_test.go
+++ b/components/ledger/internal/services/query/count-transactions-by-filters_test.go
@@ -1,0 +1,101 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package query
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/LerianStudio/midaz/v3/components/ledger/internal/adapters/postgres/transaction"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+)
+
+func TestCountTransactionsByFilters(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name           string
+		setupMock      func(mockRepo *transaction.MockRepository)
+		organizationID uuid.UUID
+		ledgerID       uuid.UUID
+		filter         transaction.CountFilter
+		expectedCount  int64
+		expectedError  bool
+	}{
+		{
+			name: "success with filters",
+			setupMock: func(mockRepo *transaction.MockRepository) {
+				mockRepo.EXPECT().
+					CountByFilters(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(int64(42), nil)
+			},
+			organizationID: uuid.New(),
+			ledgerID:       uuid.New(),
+			filter: transaction.CountFilter{
+				Route:     "payment",
+				Status:    "APPROVED",
+				StartDate: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+				EndDate:   time.Date(2025, 1, 31, 23, 59, 59, 0, time.UTC),
+			},
+			expectedCount: 42,
+			expectedError: false,
+		},
+		{
+			name: "success with zero count",
+			setupMock: func(mockRepo *transaction.MockRepository) {
+				mockRepo.EXPECT().
+					CountByFilters(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(int64(0), nil)
+			},
+			organizationID: uuid.New(),
+			ledgerID:       uuid.New(),
+			filter:         transaction.CountFilter{},
+			expectedCount:  0,
+			expectedError:  false,
+		},
+		{
+			name: "repository error",
+			setupMock: func(mockRepo *transaction.MockRepository) {
+				mockRepo.EXPECT().
+					CountByFilters(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(int64(0), errors.New("database error"))
+			},
+			organizationID: uuid.New(),
+			ledgerID:       uuid.New(),
+			filter:         transaction.CountFilter{},
+			expectedCount:  0,
+			expectedError:  true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockRepo := transaction.NewMockRepository(ctrl)
+			tc.setupMock(mockRepo)
+
+			uc := &UseCase{
+				TransactionRepo: mockRepo,
+			}
+
+			count, err := uc.CountTransactionsByFilters(context.Background(), tc.organizationID, tc.ledgerID, tc.filter)
+
+			if tc.expectedError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tc.expectedCount, count)
+			}
+		})
+	}
+}

--- a/components/ledger/internal/services/query/count-transactions-by-filters_test.go
+++ b/components/ledger/internal/services/query/count-transactions-by-filters_test.go
@@ -21,7 +21,7 @@ func TestCountTransactionsByFilters(t *testing.T) {
 
 	testCases := []struct {
 		name           string
-		setupMock      func(mockRepo *transaction.MockRepository)
+		setupMock      func(mockRepo *transaction.MockRepository, orgID uuid.UUID, ledgerID uuid.UUID, filter transaction.CountFilter)
 		organizationID uuid.UUID
 		ledgerID       uuid.UUID
 		filter         transaction.CountFilter
@@ -30,9 +30,9 @@ func TestCountTransactionsByFilters(t *testing.T) {
 	}{
 		{
 			name: "success with filters",
-			setupMock: func(mockRepo *transaction.MockRepository) {
+			setupMock: func(mockRepo *transaction.MockRepository, orgID uuid.UUID, ledgerID uuid.UUID, filter transaction.CountFilter) {
 				mockRepo.EXPECT().
-					CountByFilters(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					CountByFilters(gomock.Any(), gomock.Eq(orgID), gomock.Eq(ledgerID), gomock.Eq(filter)).
 					Return(int64(42), nil)
 			},
 			organizationID: uuid.New(),
@@ -48,9 +48,9 @@ func TestCountTransactionsByFilters(t *testing.T) {
 		},
 		{
 			name: "success with zero count",
-			setupMock: func(mockRepo *transaction.MockRepository) {
+			setupMock: func(mockRepo *transaction.MockRepository, orgID uuid.UUID, ledgerID uuid.UUID, filter transaction.CountFilter) {
 				mockRepo.EXPECT().
-					CountByFilters(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					CountByFilters(gomock.Any(), gomock.Eq(orgID), gomock.Eq(ledgerID), gomock.Eq(filter)).
 					Return(int64(0), nil)
 			},
 			organizationID: uuid.New(),
@@ -61,9 +61,9 @@ func TestCountTransactionsByFilters(t *testing.T) {
 		},
 		{
 			name: "repository error",
-			setupMock: func(mockRepo *transaction.MockRepository) {
+			setupMock: func(mockRepo *transaction.MockRepository, orgID uuid.UUID, ledgerID uuid.UUID, filter transaction.CountFilter) {
 				mockRepo.EXPECT().
-					CountByFilters(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					CountByFilters(gomock.Any(), gomock.Eq(orgID), gomock.Eq(ledgerID), gomock.Eq(filter)).
 					Return(int64(0), errors.New("database error"))
 			},
 			organizationID: uuid.New(),
@@ -82,7 +82,7 @@ func TestCountTransactionsByFilters(t *testing.T) {
 			defer ctrl.Finish()
 
 			mockRepo := transaction.NewMockRepository(ctrl)
-			tc.setupMock(mockRepo)
+			tc.setupMock(mockRepo, tc.organizationID, tc.ledgerID, tc.filter)
 
 			uc := &UseCase{
 				TransactionRepo: mockRepo,

--- a/components/ledger/migrations/transaction/000030_create_idx_transaction_route_status.down.sql
+++ b/components/ledger/migrations/transaction/000030_create_idx_transaction_route_status.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX CONCURRENTLY IF EXISTS idx_transaction_route_status;

--- a/components/ledger/migrations/transaction/000030_create_idx_transaction_route_status.up.sql
+++ b/components/ledger/migrations/transaction/000030_create_idx_transaction_route_status.up.sql
@@ -1,0 +1,3 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_transaction_route_status
+ON "transaction" (organization_id, ledger_id, route, status, created_at)
+WHERE deleted_at IS NULL;

--- a/components/ledger/migrations/transaction/000031_create_idx_transaction_date_range.down.sql
+++ b/components/ledger/migrations/transaction/000031_create_idx_transaction_date_range.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX CONCURRENTLY IF EXISTS idx_transaction_date_range;

--- a/components/ledger/migrations/transaction/000031_create_idx_transaction_date_range.up.sql
+++ b/components/ledger/migrations/transaction/000031_create_idx_transaction_date_range.up.sql
@@ -1,0 +1,3 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_transaction_date_range
+ON "transaction" (organization_id, ledger_id, created_at)
+WHERE deleted_at IS NULL;

--- a/postman/MIDAZ.postman_collection.json
+++ b/postman/MIDAZ.postman_collection.json
@@ -24,7 +24,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "f5039840-943b-46c8-9943-b3f055fe1d5a",
+                "id": "513db7f5-a8f8-4ecd-8342-e7310cfbd64d",
                 "exec": [
                   "// Request not found in collection for: POST /v1/organizations",
                   "// Variables to extract: [\"organizationId\"]"
@@ -47,7 +47,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "59ea6511-61a0-4970-94e3-49489b7413be",
+                "id": "b5980d5e-7454-42c8-b561-83d5674de8f9",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}",
                   "// Variables to extract: []"
@@ -70,7 +70,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "07a019f5-f727-4be0-b3a5-6e94093a9228",
+                "id": "d38b05ea-3021-4219-a84b-976b495f9d61",
                 "exec": [
                   "// Request not found in collection for: PATCH /v1/organizations/{organizationId}",
                   "// Variables to extract: []"
@@ -93,7 +93,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "9d262169-3ee0-4c1c-abdb-051ce9a6e5ee",
+                "id": "4d47f5e2-00d9-4fe5-bd37-78924567ecbb",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations",
                   "// Variables to extract: []"
@@ -116,7 +116,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "9b5b2c81-5afd-4b7f-81e6-c31db3445302",
+                "id": "114baa22-e6a0-4b5e-9271-9641d2185c23",
                 "exec": [
                   "// Request not found in collection for: POST /v1/organizations/{organizationId}/ledgers",
                   "// Variables to extract: [\"ledgerId\"]"
@@ -139,7 +139,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "8a275b85-4303-470a-bd5a-6532193a2cd7",
+                "id": "613fbfe1-de59-4f45-903c-4b57a14f3242",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}",
                   "// Variables to extract: []"
@@ -162,7 +162,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "284ff8a3-4c78-478d-a6e9-884eff64e9d4",
+                "id": "ac947644-03c7-4fc4-a4db-18ef90a9df96",
                 "exec": [
                   "// Request not found in collection for: PATCH /v1/organizations/{organizationId}/ledgers/{ledgerId}",
                   "// Variables to extract: []"
@@ -185,7 +185,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "a785bc28-f31f-493e-941a-72d9a1ec7ebb",
+                "id": "6296ab40-c5ea-4436-8028-8b68805af818",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers",
                   "// Variables to extract: []"
@@ -208,7 +208,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "7c2d58a6-3582-4e00-86f0-dd0c3a5125dc",
+                "id": "b4757746-fdfe-4bb8-a7ea-5572d841a22f",
                 "exec": [
                   "// Request not found in collection for: POST /v1/organizations/{organizationId}/ledgers/{ledgerId}/assets",
                   "// Variables to extract: [\"assetId\"]"
@@ -231,7 +231,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "60ebc7c5-f159-4f22-8cdf-c9b4c4b32e6c",
+                "id": "fd1d6dd2-075a-4f9a-827b-02306e905fd4",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/assets/{assetId}",
                   "// Variables to extract: []"
@@ -254,7 +254,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "04133824-0647-4fd1-9307-4801e00efc97",
+                "id": "375853b7-3049-4698-8b99-0df6de8524a4",
                 "exec": [
                   "// Request not found in collection for: PATCH /v1/organizations/{organizationId}/ledgers/{ledgerId}/assets/{assetId}",
                   "// Variables to extract: []"
@@ -277,7 +277,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "5023d23c-dee8-4921-8b57-19f74f34d284",
+                "id": "2aa98651-1655-45ce-a140-73fc42596f88",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/assets",
                   "// Variables to extract: []"
@@ -300,7 +300,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "c1c0b0ae-206d-446c-bb9f-f284e513eeb6",
+                "id": "0427c331-1c1a-4694-a47a-10b0ca96f60f",
                 "exec": [
                   "// Request not found in collection for: POST /v1/organizations/{organizationId}/ledgers/{ledgerId}/accounts",
                   "// Variables to extract: [\"accountId\",\"accountAlias\"]"
@@ -323,7 +323,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "0ced5321-1af1-4abd-8181-b2df142caf2a",
+                "id": "015f18d3-31e8-4b7f-b23f-465c4293dc06",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/accounts/{accountId}",
                   "// Variables to extract: []"
@@ -346,7 +346,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "1615eef4-6f57-4a92-bed2-cd1c5ecda1b1",
+                "id": "eea6ce3b-5324-4265-a1a0-eae614642d76",
                 "exec": [
                   "// Request not found in collection for: PATCH /v1/organizations/{organizationId}/ledgers/{ledgerId}/accounts/{accountId}",
                   "// Variables to extract: []"
@@ -369,7 +369,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "03f12609-50c6-47e5-8f1b-bcb3db05f3e2",
+                "id": "f8a50bf0-0610-4bc9-9c95-b5f7296ef539",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/accounts",
                   "// Variables to extract: []"
@@ -392,7 +392,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "4f3bc5b7-aa04-4592-a8f5-ed362945c22a",
+                "id": "b656fd1b-3ed6-44a4-85a5-99248ee77dc2",
                 "exec": [
                   "// Request not found in collection for: POST /v1/organizations/{organizationId}/ledgers/{ledgerId}/portfolios",
                   "// Variables to extract: [\"portfolioId\"]"
@@ -415,7 +415,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "0baae00c-a79c-4dbc-b7e6-7e73a995c0fb",
+                "id": "2b54801b-0d4f-4fe9-8697-656290be21db",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/portfolios/{portfolioId}",
                   "// Variables to extract: []"
@@ -438,7 +438,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "fe2f17af-9bf1-43e2-8d5d-2dfdc266688d",
+                "id": "4b5302e5-6c01-4d41-9fcb-58e7478dbbd7",
                 "exec": [
                   "// Request not found in collection for: PATCH /v1/organizations/{organizationId}/ledgers/{ledgerId}/portfolios/{portfolioId}",
                   "// Variables to extract: []"
@@ -461,7 +461,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "49743102-6a7e-473a-add4-d02a6869c9c3",
+                "id": "5bf58df8-df99-42fa-b419-7b97738a87aa",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/portfolios",
                   "// Variables to extract: []"
@@ -484,7 +484,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "b29665c4-0e7c-4f2a-b81e-1f39626d2b02",
+                "id": "413e3764-4831-465f-a933-3790b9c8f323",
                 "exec": [
                   "// Request not found in collection for: POST /v1/organizations/{organizationId}/ledgers/{ledgerId}/segments",
                   "// Variables to extract: [\"segmentId\"]"
@@ -507,7 +507,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "21ebc37f-2b1b-4639-a716-dc75e2f3cb25",
+                "id": "0fa68eb2-3350-4461-875b-9b667b0c438d",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/segments/{segmentId}",
                   "// Variables to extract: []"
@@ -530,7 +530,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "94661e20-ff39-4425-bd75-eff0d1458c8c",
+                "id": "6c7a249b-6e36-4704-bd5c-e64db0610823",
                 "exec": [
                   "// Request not found in collection for: PATCH /v1/organizations/{organizationId}/ledgers/{ledgerId}/segments/{segmentId}",
                   "// Variables to extract: []"
@@ -553,7 +553,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "97041564-9052-4a98-8f6d-3a9788ce8e46",
+                "id": "14124ed1-84b1-440a-a0ce-3db7dccde699",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/segments",
                   "// Variables to extract: []"
@@ -576,7 +576,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "af8316fb-7c2a-4083-8644-6d316882974b",
+                "id": "034b05b5-1e08-4288-ac79-b74b4a067b1a",
                 "exec": [
                   "// Request not found in collection for: HEAD /v1/organizations/metrics/count",
                   "// Variables to extract: []"
@@ -599,7 +599,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "f41004d4-cf82-4b00-a8fd-edb51edb3981",
+                "id": "0ed43600-7c96-4be0-a8ef-7b47c0f2ed57",
                 "exec": [
                   "// Request not found in collection for: HEAD /v1/organizations/{organizationId}/ledgers/metrics/count",
                   "// Variables to extract: []"
@@ -622,7 +622,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "67009c49-58fa-40f6-a5ba-e434429f182a",
+                "id": "65e7b66e-5cfe-460b-8d32-c151b4e05f34",
                 "exec": [
                   "// Request not found in collection for: HEAD /v1/organizations/{organizationId}/ledgers/{ledgerId}/accounts/metrics/count",
                   "// Variables to extract: []"
@@ -645,7 +645,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "ba4aa803-761c-4f16-a78c-20136bc6b47e",
+                "id": "45c9eda9-6f01-4c76-ba68-0ab97820cf18",
                 "exec": [
                   "// Request not found in collection for: HEAD /v1/organizations/{organizationId}/ledgers/{ledgerId}/assets/metrics/count",
                   "// Variables to extract: []"
@@ -668,7 +668,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "9903b1b3-d965-440a-bc4a-5ee4dfd8570e",
+                "id": "3b42cecf-5050-4e69-ba3e-abb9fc64208f",
                 "exec": [
                   "// Request not found in collection for: HEAD /v1/organizations/{organizationId}/ledgers/{ledgerId}/portfolios/metrics/count",
                   "// Variables to extract: []"
@@ -691,7 +691,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "6edb80c7-56ed-40e0-b219-1e52390588e7",
+                "id": "51d6a6ee-da12-46a6-b1fe-2b062af3e8c9",
                 "exec": [
                   "// Request not found in collection for: HEAD /v1/organizations/{organizationId}/ledgers/{ledgerId}/segments/metrics/count",
                   "// Variables to extract: []"
@@ -714,7 +714,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "d8c6df84-29dd-48b0-a5f7-3ef011ce79a0",
+                "id": "caf00974-d93b-4afe-bf4c-0c508b0c0d03",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/accounts/alias/{alias}",
                   "// Variables to extract: []"
@@ -737,7 +737,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "68b66a7c-f2e3-4dee-96fb-4508e273ee30",
+                "id": "4d50340a-d2c3-48bc-bad8-41e94819a3b5",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/accounts/external/{code}",
                   "// Variables to extract: []"
@@ -760,7 +760,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "e141e986-e2ed-42a3-bc38-d95caaadcc15",
+                "id": "1d322333-3c77-43a6-87e3-4b077f8198d4",
                 "exec": [
                   "// Request not found in collection for: POST /v1/organizations/{organizationId}/ledgers/{ledgerId}/transactions/json",
                   "// Variables to extract: [\"transactionId\",\"balanceId\",\"operationId\"]"
@@ -783,7 +783,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "6d0473cd-cccd-43b7-b8b2-b423d6f49508",
+                "id": "16283805-ee9f-407a-a88f-017f732c4fdf",
                 "exec": [
                   "// Request not found in collection for: POST /v1/organizations/{organizationId}/ledgers/{ledgerId}/transactions/inflow",
                   "// Variables to extract: [\"inflowTransactionId\"]"
@@ -806,7 +806,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "1eecf505-58e0-4025-82b7-0070604168e5",
+                "id": "8708bef0-4e6f-4aa7-8b1d-01c5619ec4b7",
                 "exec": [
                   "// Request not found in collection for: POST /v1/organizations/{organizationId}/ledgers/{ledgerId}/transactions/outflow",
                   "// Variables to extract: [\"outflowTransactionId\"]"
@@ -829,7 +829,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "a6dbce3b-71c4-427f-a0e8-65d01b9f4169",
+                "id": "751c7cb9-0a7a-4bab-8723-115fbfa21f36",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/transactions/{transactionId}",
                   "// Variables to extract: []"
@@ -852,7 +852,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "a02bd9ab-5e7a-44d1-9fca-ca7d8f3ecb75",
+                "id": "83905245-5545-4045-9ec4-081833bd3cc4",
                 "exec": [
                   "// Request not found in collection for: PATCH /v1/organizations/{organizationId}/ledgers/{ledgerId}/transactions/{transactionId}",
                   "// Variables to extract: []"
@@ -875,7 +875,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "c934410b-faaf-49bb-b9e7-90e7d532889b",
+                "id": "b179cb92-1290-4755-bedb-3d61580dd3b5",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/transactions",
                   "// Variables to extract: []"
@@ -898,7 +898,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "5270fa87-10b0-4f0e-9b8d-074ac8f04433",
+                "id": "83007b91-630f-4859-b70f-6cd3da97cb17",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/accounts/{accountId}/operations/{operationId}",
                   "// Variables to extract: []"
@@ -921,7 +921,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "d8213cdf-e732-4d00-8160-0cb73d9d0bbb",
+                "id": "5d2218c0-af31-426a-9d4d-f8f52fde3631",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/accounts/{accountId}/operations",
                   "// Variables to extract: []"
@@ -944,7 +944,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "3bd2e184-b87a-4a8f-b137-96f7ad538668",
+                "id": "65d31e26-2fa9-4c50-91b3-ef3d0c42a337",
                 "exec": [
                   "// Request not found in collection for: PATCH /v1/organizations/{organizationId}/ledgers/{ledgerId}/transactions/{transactionId}/operations/{operationId}",
                   "// Variables to extract: []"
@@ -967,7 +967,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "1308fb2d-f7f6-40a5-ba27-4f28eac137a6",
+                "id": "ac0b291c-d0d6-4533-9f58-edfdca818870",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/balances/{balanceId}",
                   "// Variables to extract: []"
@@ -990,7 +990,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "da3e5c2c-2f57-437e-afaa-3fa304668216",
+                "id": "11a8c6d5-e278-4e2d-975d-ce05fa598a64",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/accounts/{accountId}/balances",
                   "// Variables to extract: []"
@@ -1013,7 +1013,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "d145dfd7-3a0b-4aa6-bdd2-17ec2e57320b",
+                "id": "e4353678-df66-44f3-8577-bb169e9ea7c7",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/accounts/alias/{alias}/balances",
                   "// Variables to extract: []"
@@ -1036,7 +1036,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "05f4d628-97de-4705-93ee-a0c7415f9095",
+                "id": "493c8e76-c85a-422e-8611-c4c1c19495d9",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/accounts/external/{code}/balances",
                   "// Variables to extract: []"
@@ -1059,7 +1059,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "64498de6-7689-4c79-9f98-fc44d6986fe5",
+                "id": "2f4a66c1-7f8d-4ab5-9578-f312d62f4245",
                 "exec": [
                   "// Request not found in collection for: PATCH /v1/organizations/{organizationId}/ledgers/{ledgerId}/balances/{balanceId}",
                   "// Variables to extract: []"
@@ -1082,7 +1082,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "ab6abab0-4492-4132-98b2-761714f37e65",
+                "id": "1df83a8a-464a-433b-a3f9-1ea72401234e",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/balances",
                   "// Variables to extract: []"
@@ -1105,7 +1105,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "88a77b78-e681-48f0-82f6-3e255c0031e6",
+                "id": "31b401c4-db22-48ab-9e53-b78f712487ed",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/accounts/alias/{alias}/balances",
                   "// Variables to extract: [\"currentBalanceAmount\"]"
@@ -1128,7 +1128,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "a516761e-aa4a-4c52-98bf-4a222892e3bd",
+                "id": "d109b65c-0844-40da-b2eb-1e2307543cf7",
                 "exec": [
                   "// Request not found in collection for: POST /v1/organizations/{organizationId}/ledgers/{ledgerId}/transactions/json",
                   "// Variables to extract: []"
@@ -1151,7 +1151,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "24cc33ca-af56-4d7e-a97a-99d7832f9aac",
+                "id": "33d237e3-ddb2-45c0-8b49-69dce26ecb09",
                 "exec": [
                   "// Request not found in collection for: DELETE /v1/organizations/{organizationId}/ledgers/{ledgerId}/balances/{balanceId}",
                   "// Variables to extract: []"
@@ -1174,7 +1174,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "c7e80110-c7bc-4609-b08c-aca8c5daeba9",
+                "id": "17bc85eb-8a5d-4df3-a693-6ff5f2dd228e",
                 "exec": [
                   "// Request not found in collection for: DELETE /v1/organizations/{organizationId}/ledgers/{ledgerId}/segments/{segmentId}",
                   "// Variables to extract: []"
@@ -1197,7 +1197,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "6dc4c33a-c3b8-4871-ada5-1f72cf0921e0",
+                "id": "fecaae40-c32e-40a1-8370-5561c8ecfdc3",
                 "exec": [
                   "// Request not found in collection for: DELETE /v1/organizations/{organizationId}/ledgers/{ledgerId}/portfolios/{portfolioId}",
                   "// Variables to extract: []"
@@ -1220,7 +1220,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "fb9f18da-ed2c-4105-a648-5989a57699a1",
+                "id": "3d56ae3c-7be3-4aae-b498-287bdf617b7d",
                 "exec": [
                   "// Request not found in collection for: DELETE /v1/organizations/{organizationId}/ledgers/{ledgerId}/accounts/{accountId}",
                   "// Variables to extract: []"
@@ -1243,7 +1243,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "5a9da716-fe93-4c52-b788-f43a54f79297",
+                "id": "8d6c2974-f574-4752-bc00-c4b70e090188",
                 "exec": [
                   "// Request not found in collection for: DELETE /v1/organizations/{organizationId}/ledgers/{ledgerId}/assets/{assetId}",
                   "// Variables to extract: []"
@@ -1266,7 +1266,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "90773970-6774-4687-bdf0-4f1447df787c",
+                "id": "67201b23-d96b-488d-9aca-1b235fb06e85",
                 "exec": [
                   "// Request not found in collection for: DELETE /v1/organizations/{organizationId}/ledgers/{ledgerId}",
                   "// Variables to extract: []"
@@ -1289,7 +1289,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "a8c53692-87cc-4f62-a956-efdbcad84d92",
+                "id": "e664162c-360c-4b75-853e-465355463b9c",
                 "exec": [
                   "// Request not found in collection for: DELETE /v1/organizations/{organizationId}",
                   "// Variables to extract: []"
@@ -1318,7 +1318,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "fa532ba7-98e4-41af-9d61-0f9984d4a397",
+                "id": "0e237f3f-1eea-4579-b1c1-842d1136cea8",
                 "exec": [
                   "\n// ===== WORKFLOW SUMMARY =====\nconsole.log(\"📊 Workflow Execution Summary\");\nconsole.log(\"Total Steps: 56\");\n\n// Calculate total execution time\nconst startTime = pm.globals.get(\"workflow_start_time\");\nif (startTime) {\n    const totalTime = Date.now() - startTime;\n    console.log(\"⏱️ Total Execution Time: \" + totalTime + \"ms\");\n    pm.globals.set(\"workflow_total_time\", totalTime);\n}\n\n// Summary of step performance\nconsole.log(\"📈 Performance Summary:\");\nfor (let i = 1; i <= 56; i++) {\n    const stepTime = pm.environment.get(\"perf_step_\" + i);\n    if (stepTime) {\n        console.log(\"  Step \" + i + \": \" + stepTime + \"ms\");\n    }\n}\n\nconsole.log(\"✅ Workflow completed successfully\");\n"
                 ],
@@ -1328,7 +1328,7 @@
           ]
         }
       ],
-      "_postman_id": "0a4cad66-9170-427f-8e0a-ddd3cce0ece6",
+      "_postman_id": "04db9705-e44b-425e-bd0c-09e9e49b2044",
       "event": []
     },
     {

--- a/postman/MIDAZ.postman_collection.json
+++ b/postman/MIDAZ.postman_collection.json
@@ -24,7 +24,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "513db7f5-a8f8-4ecd-8342-e7310cfbd64d",
+                "id": "7446001e-f641-4dc5-baa1-600804773bd1",
                 "exec": [
                   "// Request not found in collection for: POST /v1/organizations",
                   "// Variables to extract: [\"organizationId\"]"
@@ -47,7 +47,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "b5980d5e-7454-42c8-b561-83d5674de8f9",
+                "id": "d1c3b492-5bca-462d-b386-8a042b421764",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}",
                   "// Variables to extract: []"
@@ -70,7 +70,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "d38b05ea-3021-4219-a84b-976b495f9d61",
+                "id": "2f141a0d-7e94-4a0b-bd43-71876b4a7a6d",
                 "exec": [
                   "// Request not found in collection for: PATCH /v1/organizations/{organizationId}",
                   "// Variables to extract: []"
@@ -93,7 +93,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "4d47f5e2-00d9-4fe5-bd37-78924567ecbb",
+                "id": "f5072cb5-26b4-4df1-ad81-231907bee592",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations",
                   "// Variables to extract: []"
@@ -116,7 +116,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "114baa22-e6a0-4b5e-9271-9641d2185c23",
+                "id": "5bd0d46a-eb91-4442-9e9d-2477fb8f70f7",
                 "exec": [
                   "// Request not found in collection for: POST /v1/organizations/{organizationId}/ledgers",
                   "// Variables to extract: [\"ledgerId\"]"
@@ -139,7 +139,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "613fbfe1-de59-4f45-903c-4b57a14f3242",
+                "id": "a316125d-34e6-4758-b03d-ee2bba94b0db",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}",
                   "// Variables to extract: []"
@@ -162,7 +162,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "ac947644-03c7-4fc4-a4db-18ef90a9df96",
+                "id": "06fc4cc8-cef1-4f28-8488-b38916ccef7b",
                 "exec": [
                   "// Request not found in collection for: PATCH /v1/organizations/{organizationId}/ledgers/{ledgerId}",
                   "// Variables to extract: []"
@@ -185,7 +185,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "6296ab40-c5ea-4436-8028-8b68805af818",
+                "id": "b46df80a-e7b0-4b01-b206-9728af9dfd00",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers",
                   "// Variables to extract: []"
@@ -208,7 +208,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "b4757746-fdfe-4bb8-a7ea-5572d841a22f",
+                "id": "6c2454d4-5da2-4a7b-b94f-5f6f68d98c41",
                 "exec": [
                   "// Request not found in collection for: POST /v1/organizations/{organizationId}/ledgers/{ledgerId}/assets",
                   "// Variables to extract: [\"assetId\"]"
@@ -231,7 +231,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "fd1d6dd2-075a-4f9a-827b-02306e905fd4",
+                "id": "8246518e-b3c9-4ebe-9bf2-44601325a135",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/assets/{assetId}",
                   "// Variables to extract: []"
@@ -254,7 +254,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "375853b7-3049-4698-8b99-0df6de8524a4",
+                "id": "21152243-8adc-4ed2-a2cc-d7be763679c5",
                 "exec": [
                   "// Request not found in collection for: PATCH /v1/organizations/{organizationId}/ledgers/{ledgerId}/assets/{assetId}",
                   "// Variables to extract: []"
@@ -277,7 +277,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "2aa98651-1655-45ce-a140-73fc42596f88",
+                "id": "3be2bb3b-c2cc-40f6-98f4-298facf64afb",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/assets",
                   "// Variables to extract: []"
@@ -300,7 +300,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "0427c331-1c1a-4694-a47a-10b0ca96f60f",
+                "id": "88f11ac5-46bf-4c88-b327-642a4f673e94",
                 "exec": [
                   "// Request not found in collection for: POST /v1/organizations/{organizationId}/ledgers/{ledgerId}/accounts",
                   "// Variables to extract: [\"accountId\",\"accountAlias\"]"
@@ -323,7 +323,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "015f18d3-31e8-4b7f-b23f-465c4293dc06",
+                "id": "d2d65f8d-98e8-4f9a-942f-2b7c783cc2d7",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/accounts/{accountId}",
                   "// Variables to extract: []"
@@ -346,7 +346,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "eea6ce3b-5324-4265-a1a0-eae614642d76",
+                "id": "eb35d0d0-c98f-4186-ab30-581d8fa71dc8",
                 "exec": [
                   "// Request not found in collection for: PATCH /v1/organizations/{organizationId}/ledgers/{ledgerId}/accounts/{accountId}",
                   "// Variables to extract: []"
@@ -369,7 +369,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "f8a50bf0-0610-4bc9-9c95-b5f7296ef539",
+                "id": "fd5d1de3-050f-4eb7-bde9-6658b23e3565",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/accounts",
                   "// Variables to extract: []"
@@ -392,7 +392,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "b656fd1b-3ed6-44a4-85a5-99248ee77dc2",
+                "id": "d053df71-3aa9-4c5a-9d6f-08043aac4c12",
                 "exec": [
                   "// Request not found in collection for: POST /v1/organizations/{organizationId}/ledgers/{ledgerId}/portfolios",
                   "// Variables to extract: [\"portfolioId\"]"
@@ -415,7 +415,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "2b54801b-0d4f-4fe9-8697-656290be21db",
+                "id": "50dc19e7-7bd8-4ebd-b18d-9bf929c0aa64",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/portfolios/{portfolioId}",
                   "// Variables to extract: []"
@@ -438,7 +438,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "4b5302e5-6c01-4d41-9fcb-58e7478dbbd7",
+                "id": "614adb03-8a2b-458e-b08d-de85390063d6",
                 "exec": [
                   "// Request not found in collection for: PATCH /v1/organizations/{organizationId}/ledgers/{ledgerId}/portfolios/{portfolioId}",
                   "// Variables to extract: []"
@@ -461,7 +461,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "5bf58df8-df99-42fa-b419-7b97738a87aa",
+                "id": "db6082d5-6302-40cf-bc84-09ab2c123df8",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/portfolios",
                   "// Variables to extract: []"
@@ -484,7 +484,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "413e3764-4831-465f-a933-3790b9c8f323",
+                "id": "7f75c3a2-0057-4959-9f16-4c6a7ccb9f32",
                 "exec": [
                   "// Request not found in collection for: POST /v1/organizations/{organizationId}/ledgers/{ledgerId}/segments",
                   "// Variables to extract: [\"segmentId\"]"
@@ -507,7 +507,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "0fa68eb2-3350-4461-875b-9b667b0c438d",
+                "id": "b7014911-28b0-4ed4-a635-9a72db32897c",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/segments/{segmentId}",
                   "// Variables to extract: []"
@@ -530,7 +530,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "6c7a249b-6e36-4704-bd5c-e64db0610823",
+                "id": "a35a376b-13f3-403e-9a98-647f11d5ff55",
                 "exec": [
                   "// Request not found in collection for: PATCH /v1/organizations/{organizationId}/ledgers/{ledgerId}/segments/{segmentId}",
                   "// Variables to extract: []"
@@ -553,7 +553,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "14124ed1-84b1-440a-a0ce-3db7dccde699",
+                "id": "41b209b4-d01a-4b00-92f6-93fb99e4224f",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/segments",
                   "// Variables to extract: []"
@@ -576,7 +576,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "034b05b5-1e08-4288-ac79-b74b4a067b1a",
+                "id": "3864d25a-cc24-4967-b630-2eb1cffba07e",
                 "exec": [
                   "// Request not found in collection for: HEAD /v1/organizations/metrics/count",
                   "// Variables to extract: []"
@@ -599,7 +599,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "0ed43600-7c96-4be0-a8ef-7b47c0f2ed57",
+                "id": "3184a8ba-5963-4821-81cd-073220f0b51c",
                 "exec": [
                   "// Request not found in collection for: HEAD /v1/organizations/{organizationId}/ledgers/metrics/count",
                   "// Variables to extract: []"
@@ -622,7 +622,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "65e7b66e-5cfe-460b-8d32-c151b4e05f34",
+                "id": "4ee34762-8bb4-4dd2-97af-e85528bedfcd",
                 "exec": [
                   "// Request not found in collection for: HEAD /v1/organizations/{organizationId}/ledgers/{ledgerId}/accounts/metrics/count",
                   "// Variables to extract: []"
@@ -645,7 +645,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "45c9eda9-6f01-4c76-ba68-0ab97820cf18",
+                "id": "7e94ea1b-d8bb-410f-b1ac-46527d19040d",
                 "exec": [
                   "// Request not found in collection for: HEAD /v1/organizations/{organizationId}/ledgers/{ledgerId}/assets/metrics/count",
                   "// Variables to extract: []"
@@ -668,7 +668,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "3b42cecf-5050-4e69-ba3e-abb9fc64208f",
+                "id": "2216e7a0-b7b8-4b97-b196-231e509c5388",
                 "exec": [
                   "// Request not found in collection for: HEAD /v1/organizations/{organizationId}/ledgers/{ledgerId}/portfolios/metrics/count",
                   "// Variables to extract: []"
@@ -691,7 +691,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "51d6a6ee-da12-46a6-b1fe-2b062af3e8c9",
+                "id": "f66df5e4-e72b-4448-a680-904c101bb635",
                 "exec": [
                   "// Request not found in collection for: HEAD /v1/organizations/{organizationId}/ledgers/{ledgerId}/segments/metrics/count",
                   "// Variables to extract: []"
@@ -714,7 +714,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "caf00974-d93b-4afe-bf4c-0c508b0c0d03",
+                "id": "91faca67-815b-4e5b-a72c-3ef27edaa50e",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/accounts/alias/{alias}",
                   "// Variables to extract: []"
@@ -737,7 +737,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "4d50340a-d2c3-48bc-bad8-41e94819a3b5",
+                "id": "b3f09bcd-d610-41eb-b619-0aff47e5fa0d",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/accounts/external/{code}",
                   "// Variables to extract: []"
@@ -760,7 +760,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "1d322333-3c77-43a6-87e3-4b077f8198d4",
+                "id": "144cacc5-e611-45ca-b952-cee501e8986a",
                 "exec": [
                   "// Request not found in collection for: POST /v1/organizations/{organizationId}/ledgers/{ledgerId}/transactions/json",
                   "// Variables to extract: [\"transactionId\",\"balanceId\",\"operationId\"]"
@@ -783,7 +783,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "16283805-ee9f-407a-a88f-017f732c4fdf",
+                "id": "096b563b-2fb3-4b78-8aac-a415131223eb",
                 "exec": [
                   "// Request not found in collection for: POST /v1/organizations/{organizationId}/ledgers/{ledgerId}/transactions/inflow",
                   "// Variables to extract: [\"inflowTransactionId\"]"
@@ -806,7 +806,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "8708bef0-4e6f-4aa7-8b1d-01c5619ec4b7",
+                "id": "5b455007-9b31-4d13-835b-28a1977ec581",
                 "exec": [
                   "// Request not found in collection for: POST /v1/organizations/{organizationId}/ledgers/{ledgerId}/transactions/outflow",
                   "// Variables to extract: [\"outflowTransactionId\"]"
@@ -829,7 +829,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "751c7cb9-0a7a-4bab-8723-115fbfa21f36",
+                "id": "92bfd169-fb28-4e5f-b261-9c61cb8bb0b6",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/transactions/{transactionId}",
                   "// Variables to extract: []"
@@ -852,7 +852,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "83905245-5545-4045-9ec4-081833bd3cc4",
+                "id": "7285d6d8-1dab-4d86-b752-4d4052837e9b",
                 "exec": [
                   "// Request not found in collection for: PATCH /v1/organizations/{organizationId}/ledgers/{ledgerId}/transactions/{transactionId}",
                   "// Variables to extract: []"
@@ -875,7 +875,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "b179cb92-1290-4755-bedb-3d61580dd3b5",
+                "id": "fdf8bd9a-c65f-4ed9-852c-bdacaffd4aeb",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/transactions",
                   "// Variables to extract: []"
@@ -898,7 +898,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "83007b91-630f-4859-b70f-6cd3da97cb17",
+                "id": "8756361e-3c5e-4cde-b8f9-c287172a379f",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/accounts/{accountId}/operations/{operationId}",
                   "// Variables to extract: []"
@@ -921,7 +921,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "5d2218c0-af31-426a-9d4d-f8f52fde3631",
+                "id": "c9020a2a-aa52-4759-892c-e9d451e1820b",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/accounts/{accountId}/operations",
                   "// Variables to extract: []"
@@ -944,7 +944,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "65d31e26-2fa9-4c50-91b3-ef3d0c42a337",
+                "id": "25728d79-97b4-4320-bddc-0a3720cc710e",
                 "exec": [
                   "// Request not found in collection for: PATCH /v1/organizations/{organizationId}/ledgers/{ledgerId}/transactions/{transactionId}/operations/{operationId}",
                   "// Variables to extract: []"
@@ -967,7 +967,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "ac0b291c-d0d6-4533-9f58-edfdca818870",
+                "id": "1ec9605d-ed04-4d1e-91a8-eeefbaebe2ff",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/balances/{balanceId}",
                   "// Variables to extract: []"
@@ -990,7 +990,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "11a8c6d5-e278-4e2d-975d-ce05fa598a64",
+                "id": "8669f1ac-a07a-4266-b178-f55293b35d12",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/accounts/{accountId}/balances",
                   "// Variables to extract: []"
@@ -1013,7 +1013,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "e4353678-df66-44f3-8577-bb169e9ea7c7",
+                "id": "2da1f75d-98a4-4d37-9d5e-e4c7e7c157bc",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/accounts/alias/{alias}/balances",
                   "// Variables to extract: []"
@@ -1036,7 +1036,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "493c8e76-c85a-422e-8611-c4c1c19495d9",
+                "id": "3433f84b-6683-481c-865d-286bb626b967",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/accounts/external/{code}/balances",
                   "// Variables to extract: []"
@@ -1059,7 +1059,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "2f4a66c1-7f8d-4ab5-9578-f312d62f4245",
+                "id": "27ee7efa-2198-45ff-a25b-783ebbb174c9",
                 "exec": [
                   "// Request not found in collection for: PATCH /v1/organizations/{organizationId}/ledgers/{ledgerId}/balances/{balanceId}",
                   "// Variables to extract: []"
@@ -1082,7 +1082,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "1df83a8a-464a-433b-a3f9-1ea72401234e",
+                "id": "95ae3808-ad2c-4674-a68c-4004b7b00332",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/balances",
                   "// Variables to extract: []"
@@ -1105,7 +1105,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "31b401c4-db22-48ab-9e53-b78f712487ed",
+                "id": "0f90ac59-b461-409c-a364-ccd93e8c71c0",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/accounts/alias/{alias}/balances",
                   "// Variables to extract: [\"currentBalanceAmount\"]"
@@ -1128,7 +1128,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "d109b65c-0844-40da-b2eb-1e2307543cf7",
+                "id": "430eb79d-ab95-4ede-9df4-a52d7ba9a25d",
                 "exec": [
                   "// Request not found in collection for: POST /v1/organizations/{organizationId}/ledgers/{ledgerId}/transactions/json",
                   "// Variables to extract: []"
@@ -1151,7 +1151,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "33d237e3-ddb2-45c0-8b49-69dce26ecb09",
+                "id": "7de8a1c5-b5be-4429-8b9f-835e2a27481e",
                 "exec": [
                   "// Request not found in collection for: DELETE /v1/organizations/{organizationId}/ledgers/{ledgerId}/balances/{balanceId}",
                   "// Variables to extract: []"
@@ -1174,7 +1174,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "17bc85eb-8a5d-4df3-a693-6ff5f2dd228e",
+                "id": "56f30ea1-f50a-4659-959f-3b959ed85bae",
                 "exec": [
                   "// Request not found in collection for: DELETE /v1/organizations/{organizationId}/ledgers/{ledgerId}/segments/{segmentId}",
                   "// Variables to extract: []"
@@ -1197,7 +1197,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "fecaae40-c32e-40a1-8370-5561c8ecfdc3",
+                "id": "d1a0b964-345a-4210-9b09-53e4ae087802",
                 "exec": [
                   "// Request not found in collection for: DELETE /v1/organizations/{organizationId}/ledgers/{ledgerId}/portfolios/{portfolioId}",
                   "// Variables to extract: []"
@@ -1220,7 +1220,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "3d56ae3c-7be3-4aae-b498-287bdf617b7d",
+                "id": "b3f8c64b-1e1b-4ad5-8bf5-0b99598fd056",
                 "exec": [
                   "// Request not found in collection for: DELETE /v1/organizations/{organizationId}/ledgers/{ledgerId}/accounts/{accountId}",
                   "// Variables to extract: []"
@@ -1243,7 +1243,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "8d6c2974-f574-4752-bc00-c4b70e090188",
+                "id": "bfc31907-1c68-43de-b2a6-fae5ab156b83",
                 "exec": [
                   "// Request not found in collection for: DELETE /v1/organizations/{organizationId}/ledgers/{ledgerId}/assets/{assetId}",
                   "// Variables to extract: []"
@@ -1266,7 +1266,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "67201b23-d96b-488d-9aca-1b235fb06e85",
+                "id": "5fa70176-6495-4edc-b67b-155fe09fa885",
                 "exec": [
                   "// Request not found in collection for: DELETE /v1/organizations/{organizationId}/ledgers/{ledgerId}",
                   "// Variables to extract: []"
@@ -1289,7 +1289,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "e664162c-360c-4b75-853e-465355463b9c",
+                "id": "d5f67a12-6364-4541-a2d2-6b9bb81f8238",
                 "exec": [
                   "// Request not found in collection for: DELETE /v1/organizations/{organizationId}",
                   "// Variables to extract: []"
@@ -1318,7 +1318,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "0e237f3f-1eea-4579-b1c1-842d1136cea8",
+                "id": "9101c542-ec4b-4c9a-a826-a5762973ff1a",
                 "exec": [
                   "\n// ===== WORKFLOW SUMMARY =====\nconsole.log(\"📊 Workflow Execution Summary\");\nconsole.log(\"Total Steps: 56\");\n\n// Calculate total execution time\nconst startTime = pm.globals.get(\"workflow_start_time\");\nif (startTime) {\n    const totalTime = Date.now() - startTime;\n    console.log(\"⏱️ Total Execution Time: \" + totalTime + \"ms\");\n    pm.globals.set(\"workflow_total_time\", totalTime);\n}\n\n// Summary of step performance\nconsole.log(\"📈 Performance Summary:\");\nfor (let i = 1; i <= 56; i++) {\n    const stepTime = pm.environment.get(\"perf_step_\" + i);\n    if (stepTime) {\n        console.log(\"  Step \" + i + \": \" + stepTime + \"ms\");\n    }\n}\n\nconsole.log(\"✅ Workflow completed successfully\");\n"
                 ],
@@ -1328,7 +1328,7 @@
           ]
         }
       ],
-      "_postman_id": "04db9705-e44b-425e-bd0c-09e9e49b2044",
+      "_postman_id": "0d950094-e115-41b1-8df5-37f43a5dee6e",
       "event": []
     },
     {


### PR DESCRIPTION
## What

Adds a `HEAD /v1/organizations/{organization_id}/ledgers/{ledger_id}/transactions/metrics/count` endpoint that returns the total number of transactions matching optional filters via the `X-Total-Count` response header.

Follows the same pattern as existing count endpoints across the platform (`HEAD .../metrics/count`).

## Filters

| Parameter | Type | Default |
|-----------|------|---------|
| `route` | string | — (all routes) |
| `status` | enum: CREATED, APPROVED, PENDING, CANCELED, NOTED | — (all statuses) |
| `start_date` | RFC 3339 datetime | start of current UTC day |
| `end_date` | RFC 3339 datetime | end of current UTC day |

All filters are optional and combined with AND logic.

## Why

Billing and fees systems need to count transactions matching specific criteria (route, status, date range) without paginating through the full transaction list. This endpoint returns the count in a single sub-second request.

## Changes

- `000030`, `000031`: Two partial composite B-tree indexes on `transaction (organization_id, ledger_id, route, status, created_at)` and `(organization_id, ledger_id, created_at)` — both created with `CONCURRENTLY` for non-blocking production deployment
- Repository: `CountByFilters` method with conditional squirrel WHERE clauses
- Service: `CountTransactionsByFilters` query method
- Handler: `CountTransactionsByFilters` with input validation, date defaulting, HEAD response
- Route: registered before `/:transaction_id` to avoid path collision
- Tests: unit (handler + service + repository), fuzz, property, integration, chaos
- Swagger: regenerated with new endpoint