### PR TITLE
feat: event-driven tenant discovery — consumer startup, error handling, and fixes

### DIFF
--- a/components/ledger/internal/bootstrap/config.go
+++ b/components/ledger/internal/bootstrap/config.go
@@ -462,6 +462,10 @@ func InitServersWithOptions(opts *Options) (*Service, error) {
 				}
 			}),
 			tmevent.WithOnTenantRemoved(func(ctx context.Context, tenantID string) {
+				if rmq != nil && rmq.multiTenantConsumer != nil {
+					rmq.multiTenantConsumer.StopConsumer(tenantID)
+				}
+
 				// Close ALL postgres managers (onboarding + transaction)
 				if onbPG.pgManager != nil {
 					if err := onbPG.pgManager.CloseConnection(ctx, tenantID); err != nil {

--- a/components/ledger/internal/bootstrap/config.go
+++ b/components/ledger/internal/bootstrap/config.go
@@ -457,6 +457,9 @@ func InitServersWithOptions(opts *Options) (*Service, error) {
 			tmevent.WithDispatcherLogger(logger),
 			tmevent.WithCacheTTL(cacheTTL),
 			tmevent.WithOnTenantAdded(func(ctx context.Context, tenantID string) {
+				if tenantClient != nil {
+					_ = tenantClient.InvalidateConfig(ctx, tenantID, tenantServiceName)
+				}
 				if rmq != nil && rmq.multiTenantConsumer != nil {
 					rmq.multiTenantConsumer.EnsureConsumerStarted(ctx, tenantID)
 				}

--- a/go.mod
+++ b/go.mod
@@ -100,7 +100,7 @@ require (
 )
 
 require (
-	github.com/LerianStudio/lib-commons/v4 v4.5.0-beta.14
+	github.com/LerianStudio/lib-commons/v4 v4.5.0-beta.15
 	github.com/Shopify/toxiproxy/v2 v2.12.0
 	github.com/docker/docker v28.5.2+incompatible
 	github.com/docker/go-connections v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -19,8 +19,8 @@ github.com/KyleBanks/depth v1.2.1 h1:5h8fQADFrWtarTdtDudMmGsC7GPbOAu6RVB3ffsVFHc
 github.com/KyleBanks/depth v1.2.1/go.mod h1:jzSb9d0L43HxTQfT+oSA1EEp2q+ne2uh6XgeJcm8brE=
 github.com/LerianStudio/lib-auth/v2 v2.6.0 h1:J0QvGXWoEbgd5HF5wtMznVfkho/aPihl6sAWn12bvZ4=
 github.com/LerianStudio/lib-auth/v2 v2.6.0/go.mod h1:AAbJCVaVokfO9bLa4aCIGzVMP6to/Ml5MC4X9B6jLZ0=
-github.com/LerianStudio/lib-commons/v4 v4.5.0-beta.14 h1:LvSYrbWWBgCNzeCYn+2kBDkHnRtacdBaPuMReIFYbhM=
-github.com/LerianStudio/lib-commons/v4 v4.5.0-beta.14/go.mod h1:/0EgYB6lT23afy/nmmeJiuoDnu3/tS56fXqW7fB0QMk=
+github.com/LerianStudio/lib-commons/v4 v4.5.0-beta.15 h1:UjFawOiXVeO4mwqkuQyICTsP9BvsLB7Ej6rFy/v/dDI=
+github.com/LerianStudio/lib-commons/v4 v4.5.0-beta.15/go.mod h1:/0EgYB6lT23afy/nmmeJiuoDnu3/tS56fXqW7fB0QMk=
 github.com/Masterminds/squirrel v1.5.4 h1:uUcX/aBc8O7Fg9kaISIUsHXdKuqehiXAMQTYX8afzqM=
 github.com/Masterminds/squirrel v1.5.4/go.mod h1:NNaOrjSoIDfDA40n7sr2tPNZRfjzjA400rg+riTZj10=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=


### PR DESCRIPTION
## Summary

Follow-up to #1989 with consumer lifecycle, error handling, and stability fixes.

## Changes

### Consumer Lifecycle
- `OnTenantAdded` → invalidates pmClient cache + starts RabbitMQ consumer goroutine
- `onTenantLoaded` → starts consumer on lazy-load (covers service restart)
- `OnTenantRemoved` → stops consumer goroutine + closes all connections + invalidates cache
- `EnsureConsumerStarted` / `StopConsumer` for on-demand goroutine management

### Error Handling
- `midazErrorMapper`: 403 (suspended/purged), 404 (not found), 422 (not provisioned), 503 (unavailable)
- Metadata helpers map tmcore errors to proper HTTP status codes
- Nil guards on all repository `getDB` methods

### Multi-Module Context
- `WithPG(manager, "module")` / `WithMB(manager, "module")` — one middleware, all modules
- `GetPG(ctx, module)` / `GetMB(ctx, module)` in repositories with generic fallback
- Module constants in `pkg/constant/module.go`

### Cleanup
- Removed deprecated ENVs (6 vars)
- Removed `GODEBUG=http2client=0` (fixed in lib-auth v2.6.0)
- CRM test fix for staging insecure HTTP
- Backward compat test coverage for all MULTI_TENANT_* fields

### Dependencies
- lib-commons: v4.5.0-beta.15
- lib-auth: v2.6.0

## Test plan
- [x] All ledger tests pass (24 packages)
- [x] All CRM tests pass (5 packages)
- [x] End-to-end: events, lazy-load, suspend, consumer startup
- [x] Single-tenant mode unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)