### PR TITLE
refactor: standardize context getter names and lib-commons v4.5.0-beta.16

### DIFF
--- a/components/crm/internal/adapters/mongodb/alias/alias.mongodb.go
+++ b/components/crm/internal/adapters/mongodb/alias/alias.mongodb.go
@@ -70,14 +70,14 @@ func NewMongoDBRepository(connection *libMongo.Client, dataSecurity *libCrypto.C
 func (am *MongoDBRepository) getDatabase(ctx context.Context) (*mongo.Database, error) {
 	if am.connection == nil {
 		// Check tenant context when static connection is nil (multi-tenant mode without static fallback)
-		if db := tmcore.GetMongoFromContext(ctx); db != nil {
+		if db := tmcore.GetMongoContext(ctx); db != nil {
 			return db, nil
 		}
 
 		return nil, fmt.Errorf("no database connection available: multi-tenant context required but not present, and no static connection configured")
 	}
 
-	if db := tmcore.GetMongoFromContext(ctx); db != nil {
+	if db := tmcore.GetMongoContext(ctx); db != nil {
 		return db, nil
 	}
 

--- a/components/crm/internal/adapters/mongodb/alias/alias.mongodb.go
+++ b/components/crm/internal/adapters/mongodb/alias/alias.mongodb.go
@@ -70,14 +70,14 @@ func NewMongoDBRepository(connection *libMongo.Client, dataSecurity *libCrypto.C
 func (am *MongoDBRepository) getDatabase(ctx context.Context) (*mongo.Database, error) {
 	if am.connection == nil {
 		// Check tenant context when static connection is nil (multi-tenant mode without static fallback)
-		if db := tmcore.GetMongoContext(ctx); db != nil {
+		if db := tmcore.GetMBContext(ctx); db != nil {
 			return db, nil
 		}
 
 		return nil, fmt.Errorf("no database connection available: multi-tenant context required but not present, and no static connection configured")
 	}
 
-	if db := tmcore.GetMongoContext(ctx); db != nil {
+	if db := tmcore.GetMBContext(ctx); db != nil {
 		return db, nil
 	}
 

--- a/components/crm/internal/adapters/mongodb/alias/alias.mongodb_tenant_test.go
+++ b/components/crm/internal/adapters/mongodb/alias/alias.mongodb_tenant_test.go
@@ -100,7 +100,7 @@ func TestGetDatabase_ReturnsTenantDB_WhenContextHasTenantMongo(t *testing.T) {
 			repo := &MongoDBRepository{
 				connection: newPlaceholderConnection("static-db"),
 			}
-			ctx := tmcore.ContextWithMongo(context.Background(), tt.tenantDB)
+			ctx := tmcore.ContextWithMB(context.Background(), tt.tenantDB)
 
 			// Act
 			db, err := repo.getDatabase(ctx)
@@ -122,7 +122,7 @@ func TestGetDatabase_TenantDB_TakesPrecedence_OverStaticConnection(t *testing.T)
 	}
 
 	tenantDB := newDisconnectedDatabase(t, "tenant-priority")
-	ctx := tmcore.ContextWithMongo(context.Background(), tenantDB)
+	ctx := tmcore.ContextWithMB(context.Background(), tenantDB)
 
 	// Act
 	db, dbErr := repo.getDatabase(ctx)
@@ -181,7 +181,7 @@ func TestGetDatabase_FallsBackToStaticConnection_WhenNoTenantContext(t *testing.
 func TestGetDatabase_FallsBack_WhenTenantDBIsNilInContext(t *testing.T) {
 	t.Parallel()
 
-	ctx := tmcore.ContextWithMongo(context.Background(), nil)
+	ctx := tmcore.ContextWithMB(context.Background(), nil)
 
 	repo := &MongoDBRepository{
 		connection: newPlaceholderConnection("fallback-nil-db"),
@@ -210,8 +210,8 @@ func TestGetDatabase_TwoTenants_ResolveToDifferentDatabases(t *testing.T) {
 		connection: newPlaceholderConnection("static-db"),
 	}
 
-	ctxTenantA := tmcore.ContextWithMongo(context.Background(), tenantAcmeDB)
-	ctxTenantB := tmcore.ContextWithMongo(context.Background(), tenantGlobexDB)
+	ctxTenantA := tmcore.ContextWithMB(context.Background(), tenantAcmeDB)
+	ctxTenantB := tmcore.ContextWithMB(context.Background(), tenantGlobexDB)
 
 	// Act — resolve database for each tenant
 	dbA, errA := repo.getDatabase(ctxTenantA)
@@ -239,8 +239,8 @@ func TestGetDatabase_SameTenant_ReturnsSameDatabase(t *testing.T) {
 		connection: newPlaceholderConnection("static-db"),
 	}
 
-	ctx1 := tmcore.ContextWithMongo(context.Background(), tenantDB)
-	ctx2 := tmcore.ContextWithMongo(context.Background(), tenantDB)
+	ctx1 := tmcore.ContextWithMB(context.Background(), tenantDB)
+	ctx2 := tmcore.ContextWithMB(context.Background(), tenantDB)
 
 	// Act
 	db1, err1 := repo.getDatabase(ctx1)
@@ -286,7 +286,7 @@ func TestGetDatabase_NilConnection_WithTenantContext_Succeeds(t *testing.T) {
 		connection: nil,
 	}
 
-	ctx := tmcore.ContextWithMongo(context.Background(), tenantDB)
+	ctx := tmcore.ContextWithMB(context.Background(), tenantDB)
 
 	// Act
 	db, err := repo.getDatabase(ctx)

--- a/components/crm/internal/adapters/mongodb/holder/holder.mongodb.go
+++ b/components/crm/internal/adapters/mongodb/holder/holder.mongodb.go
@@ -72,14 +72,14 @@ func NewMongoDBRepository(connection *libMongo.Client, dataSecurity *libCrypto.C
 func (hm *MongoDBRepository) getDatabase(ctx context.Context) (*mongo.Database, error) {
 	if hm.connection == nil {
 		// Check tenant context when static connection is nil (multi-tenant mode without static fallback)
-		if db := tmcore.GetMongoFromContext(ctx); db != nil {
+		if db := tmcore.GetMongoContext(ctx); db != nil {
 			return db, nil
 		}
 
 		return nil, fmt.Errorf("no database connection available: multi-tenant context required but not present, and no static connection configured")
 	}
 
-	if db := tmcore.GetMongoFromContext(ctx); db != nil {
+	if db := tmcore.GetMongoContext(ctx); db != nil {
 		return db, nil
 	}
 

--- a/components/crm/internal/adapters/mongodb/holder/holder.mongodb.go
+++ b/components/crm/internal/adapters/mongodb/holder/holder.mongodb.go
@@ -72,14 +72,14 @@ func NewMongoDBRepository(connection *libMongo.Client, dataSecurity *libCrypto.C
 func (hm *MongoDBRepository) getDatabase(ctx context.Context) (*mongo.Database, error) {
 	if hm.connection == nil {
 		// Check tenant context when static connection is nil (multi-tenant mode without static fallback)
-		if db := tmcore.GetMongoContext(ctx); db != nil {
+		if db := tmcore.GetMBContext(ctx); db != nil {
 			return db, nil
 		}
 
 		return nil, fmt.Errorf("no database connection available: multi-tenant context required but not present, and no static connection configured")
 	}
 
-	if db := tmcore.GetMongoContext(ctx); db != nil {
+	if db := tmcore.GetMBContext(ctx); db != nil {
 		return db, nil
 	}
 

--- a/components/crm/internal/adapters/mongodb/holder/holder.mongodb_tenant_test.go
+++ b/components/crm/internal/adapters/mongodb/holder/holder.mongodb_tenant_test.go
@@ -80,7 +80,7 @@ func TestGetDatabase_ReturnsTenantDB_WhenContextHasTenantMongo(t *testing.T) {
 			t.Parallel()
 
 			repo := &MongoDBRepository{connection: newPlaceholderConnection("static-db")}
-			ctx := tmcore.ContextWithMongo(context.Background(), tt.tenantDB)
+			ctx := tmcore.ContextWithMB(context.Background(), tt.tenantDB)
 
 			db, err := repo.getDatabase(ctx)
 
@@ -98,7 +98,7 @@ func TestGetDatabase_TenantDB_TakesPrecedence_OverStaticConnection(t *testing.T)
 	repo := &MongoDBRepository{connection: newPlaceholderConnection("static-db")}
 
 	tenantDB := newDisconnectedDatabase(t, "tenant-priority")
-	ctx := tmcore.ContextWithMongo(context.Background(), tenantDB)
+	ctx := tmcore.ContextWithMB(context.Background(), tenantDB)
 
 	db, dbErr := repo.getDatabase(ctx)
 
@@ -139,7 +139,7 @@ func TestGetDatabase_FallsBackToStaticConnection_WhenNoTenantContext(t *testing.
 func TestGetDatabase_FallsBack_WhenTenantDBIsNilInContext(t *testing.T) {
 	t.Parallel()
 
-	ctx := tmcore.ContextWithMongo(context.Background(), nil)
+	ctx := tmcore.ContextWithMB(context.Background(), nil)
 
 	repo := &MongoDBRepository{connection: newPlaceholderConnection("fallback-nil-db")}
 
@@ -157,8 +157,8 @@ func TestGetDatabase_TwoTenants_ResolveToDifferentDatabases(t *testing.T) {
 
 	repo := &MongoDBRepository{connection: newPlaceholderConnection("static-db")}
 
-	ctxTenantA := tmcore.ContextWithMongo(context.Background(), tenantAcmeDB)
-	ctxTenantB := tmcore.ContextWithMongo(context.Background(), tenantGlobexDB)
+	ctxTenantA := tmcore.ContextWithMB(context.Background(), tenantAcmeDB)
+	ctxTenantB := tmcore.ContextWithMB(context.Background(), tenantGlobexDB)
 
 	dbA, errA := repo.getDatabase(ctxTenantA)
 	dbB, errB := repo.getDatabase(ctxTenantB)
@@ -181,8 +181,8 @@ func TestGetDatabase_SameTenant_ReturnsSameDatabase(t *testing.T) {
 
 	repo := &MongoDBRepository{connection: newPlaceholderConnection("static-db")}
 
-	ctx1 := tmcore.ContextWithMongo(context.Background(), tenantDB)
-	ctx2 := tmcore.ContextWithMongo(context.Background(), tenantDB)
+	ctx1 := tmcore.ContextWithMB(context.Background(), tenantDB)
+	ctx2 := tmcore.ContextWithMB(context.Background(), tenantDB)
 
 	db1, err1 := repo.getDatabase(ctx1)
 	db2, err2 := repo.getDatabase(ctx2)
@@ -211,7 +211,7 @@ func TestGetDatabase_NilConnection_WithTenantContext_Succeeds(t *testing.T) {
 
 	repo := &MongoDBRepository{connection: nil}
 
-	ctx := tmcore.ContextWithMongo(context.Background(), tenantDB)
+	ctx := tmcore.ContextWithMB(context.Background(), tenantDB)
 
 	db, err := repo.getDatabase(ctx)
 

--- a/components/ledger/internal/adapters/http/in/metadata.go
+++ b/components/ledger/internal/adapters/http/in/metadata.go
@@ -99,13 +99,13 @@ func (handler *MetadataIndexHandler) contextForEntity(ctx context.Context, entit
 	}
 
 	// Store in both generic and module-specific context keys.
-	ctx = tmcore.ContextWithMongo(ctx, tenantDB)
+	ctx = tmcore.ContextWithMB(ctx, tenantDB)
 
 	// Determine module name based on entity type for module-specific injection.
 	if _, ok := onboardingEntities[entityName]; ok {
-		ctx = tmcore.ContextWithMB(ctx, constant.ModuleOnboarding, tenantDB)
+		ctx = tmcore.ContextWithMB(ctx, tenantDB, constant.ModuleOnboarding)
 	} else {
-		ctx = tmcore.ContextWithMB(ctx, constant.ModuleTransaction, tenantDB)
+		ctx = tmcore.ContextWithMB(ctx, tenantDB, constant.ModuleTransaction)
 	}
 
 	return ctx, nil
@@ -139,8 +139,8 @@ func (handler *MetadataIndexHandler) contextForRepoGroup(ctx context.Context, on
 	}
 
 	// Store in both generic and module-specific context keys.
-	ctx = tmcore.ContextWithMongo(ctx, tenantDB)
-	ctx = tmcore.ContextWithMB(ctx, groupName, tenantDB)
+	ctx = tmcore.ContextWithMB(ctx, tenantDB)
+	ctx = tmcore.ContextWithMB(ctx, tenantDB, groupName)
 
 	return ctx, nil
 }

--- a/components/ledger/internal/adapters/http/in/metadata.go
+++ b/components/ledger/internal/adapters/http/in/metadata.go
@@ -78,7 +78,7 @@ func (handler *MetadataIndexHandler) getMongoManager(entityName string) *tmmongo
 }
 
 func (handler *MetadataIndexHandler) contextForEntity(ctx context.Context, entityName string) (context.Context, error) {
-	tenantID := tmcore.GetTenantID(ctx)
+	tenantID := tmcore.GetTenantIDContext(ctx)
 
 	mongoManager := handler.getMongoManager(entityName)
 	if tenantID == "" {
@@ -112,7 +112,7 @@ func (handler *MetadataIndexHandler) contextForEntity(ctx context.Context, entit
 }
 
 func (handler *MetadataIndexHandler) contextForRepoGroup(ctx context.Context, onboardingRepo bool) (context.Context, error) {
-	tenantID := tmcore.GetTenantID(ctx)
+	tenantID := tmcore.GetTenantIDContext(ctx)
 	mongoManager := handler.TransactionMongoManager
 	groupName := constant.ModuleTransaction
 

--- a/components/ledger/internal/adapters/http/in/transaction-state-handlers.go
+++ b/components/ledger/internal/adapters/http/in/transaction-state-handlers.go
@@ -521,7 +521,7 @@ func (handler *TransactionHandler) commitOrCancelTransaction(c *fiber.Ctx, tran 
 		return http.WithError(c, err)
 	}
 
-	tenantCtx := tmcore.ContextWithTenantID(context.Background(), tmcore.GetTenantIDFromContext(ctx))
+	tenantCtx := tmcore.ContextWithTenantID(context.Background(), tmcore.GetTenantIDContext(ctx))
 
 	go handler.Command.SendLogTransactionAuditQueue(tenantCtx, operations, organizationID, ledgerID, tran.IDtoUUID())
 

--- a/components/ledger/internal/adapters/mongodb/onboarding/metadata.mongodb.go
+++ b/components/ledger/internal/adapters/mongodb/onboarding/metadata.mongodb.go
@@ -70,12 +70,12 @@ func NewMetadataMongoDBRepository(mc *libMongo.Client) *MetadataMongoDBRepositor
 // In single-tenant mode (or when no tenant context exists), falls back to the static connection.
 func (mmr *MetadataMongoDBRepository) getDatabase(ctx context.Context) (*mongo.Database, error) {
 	// Module-specific database (from middleware WithModule)
-	if db := tmcore.GetMB(ctx, constant.ModuleOnboarding); db != nil {
+	if db := tmcore.GetMBContext(ctx, constant.ModuleOnboarding); db != nil {
 		return db, nil
 	}
 
 	// Generic database fallback (single-module services)
-	if db := tmcore.GetMongoFromContext(ctx); db != nil {
+	if db := tmcore.GetMongoContext(ctx); db != nil {
 		return db, nil
 	}
 

--- a/components/ledger/internal/adapters/mongodb/onboarding/metadata.mongodb.go
+++ b/components/ledger/internal/adapters/mongodb/onboarding/metadata.mongodb.go
@@ -75,7 +75,7 @@ func (mmr *MetadataMongoDBRepository) getDatabase(ctx context.Context) (*mongo.D
 	}
 
 	// Generic database fallback (single-module services)
-	if db := tmcore.GetMongoContext(ctx); db != nil {
+	if db := tmcore.GetMBContext(ctx); db != nil {
 		return db, nil
 	}
 

--- a/components/ledger/internal/adapters/mongodb/onboarding/metadata.mongodb_integration_test.go
+++ b/components/ledger/internal/adapters/mongodb/onboarding/metadata.mongodb_integration_test.go
@@ -1195,8 +1195,8 @@ func setupTenantIsolation(t *testing.T) *tenantIsolationInfra {
 	placeholderConn := &libMongo.Client{}
 	repo := NewMetadataMongoDBRepository(placeholderConn)
 
-	ctxA := tmcore.ContextWithMongo(context.Background(), tenantADatabase)
-	ctxB := tmcore.ContextWithMongo(context.Background(), tenantBDatabase)
+	ctxA := tmcore.ContextWithMB(context.Background(), tenantADatabase)
+	ctxB := tmcore.ContextWithMB(context.Background(), tenantBDatabase)
 
 	return &tenantIsolationInfra{
 		container: container,
@@ -1423,7 +1423,7 @@ func TestIntegration_MetadataRepository_TenantContext_TakesPrecedence_OverStatic
 
 	// -- Query with a tenant context pointing to a DIFFERENT database --
 	tenantDB := container.Client.Database("tenant_isolated_db")
-	tenantCtx := tmcore.ContextWithMongo(context.Background(), tenantDB)
+	tenantCtx := tmcore.ContextWithMB(context.Background(), tenantDB)
 
 	tenantResult, err := repo.FindByEntity(tenantCtx, collection, "precedence-entity")
 	require.NoError(t, err)

--- a/components/ledger/internal/adapters/mongodb/onboarding/metadata.mongodb_tenant_test.go
+++ b/components/ledger/internal/adapters/mongodb/onboarding/metadata.mongodb_tenant_test.go
@@ -117,7 +117,7 @@ func TestGetDatabase_ReturnsTenantDB_WhenContextHasTenantMongo(t *testing.T) {
 				connection: newPlaceholderConnection("static-db"),
 				Database:   "static-db",
 			}
-			ctx := tmcore.ContextWithMongo(context.Background(), tt.tenantDB)
+			ctx := tmcore.ContextWithMB(context.Background(), tt.tenantDB)
 
 			// Act
 			db, err := repo.getDatabase(ctx)
@@ -140,7 +140,7 @@ func TestGetDatabase_TenantDB_TakesPrecedence_OverStaticConnection(t *testing.T)
 	}
 
 	tenantDB := newDisconnectedDatabase(t, "tenant-priority")
-	ctx := tmcore.ContextWithMongo(context.Background(), tenantDB)
+	ctx := tmcore.ContextWithMB(context.Background(), tenantDB)
 
 	// Act
 	db, dbErr := repo.getDatabase(ctx)
@@ -203,10 +203,10 @@ func TestGetDatabase_FallsBackToStaticConnection_WhenNoTenantContext(t *testing.
 func TestGetDatabase_FallsBack_WhenTenantDBIsNilInContext(t *testing.T) {
 	t.Parallel()
 
-	// Arrange — inject a nil *mongo.Database into context via ContextWithMongo.
-	// GetMongoFromContext checks db != nil, so it should return nil,
+	// Arrange — inject a nil *mongo.Database into context via ContextWithMB.
+	// GetMBContext checks db != nil, so it should return nil,
 	// which causes getDatabase to fall through to the static connection path.
-	ctx := tmcore.ContextWithMongo(context.Background(), nil)
+	ctx := tmcore.ContextWithMB(context.Background(), nil)
 
 	repo := &MetadataMongoDBRepository{
 		connection: newPlaceholderConnection("fallback-nil-db"),

--- a/components/ledger/internal/adapters/mongodb/transaction/metadata.mongodb.go
+++ b/components/ledger/internal/adapters/mongodb/transaction/metadata.mongodb.go
@@ -70,7 +70,7 @@ func (mmr *MetadataMongoDBRepository) getDatabase(ctx context.Context) (*mongo.D
 	}
 
 	// Generic database fallback (single-module services)
-	if db := tmcore.GetMongoContext(ctx); db != nil {
+	if db := tmcore.GetMBContext(ctx); db != nil {
 		return db, nil
 	}
 

--- a/components/ledger/internal/adapters/mongodb/transaction/metadata.mongodb.go
+++ b/components/ledger/internal/adapters/mongodb/transaction/metadata.mongodb.go
@@ -65,12 +65,12 @@ func NewMetadataMongoDBRepository(mc *libMongo.Client, requireTenant ...bool) *M
 // In single-tenant mode (or when no tenant context exists), falls back to the static connection.
 func (mmr *MetadataMongoDBRepository) getDatabase(ctx context.Context) (*mongo.Database, error) {
 	// Module-specific database (from middleware WithModule)
-	if db := tmcore.GetMB(ctx, constant.ModuleTransaction); db != nil {
+	if db := tmcore.GetMBContext(ctx, constant.ModuleTransaction); db != nil {
 		return db, nil
 	}
 
 	// Generic database fallback (single-module services)
-	if db := tmcore.GetMongoFromContext(ctx); db != nil {
+	if db := tmcore.GetMongoContext(ctx); db != nil {
 		return db, nil
 	}
 

--- a/components/ledger/internal/adapters/mongodb/transaction/metadata.mongodb_integration_test.go
+++ b/components/ledger/internal/adapters/mongodb/transaction/metadata.mongodb_integration_test.go
@@ -1163,8 +1163,8 @@ func TestIntegration_MetadataRepository_TenantIsolation_CreateAndFind(t *testing
 
 	collection := "operation"
 
-	ctxA := tmcore.ContextWithMongo(context.Background(), tenantADB)
-	ctxB := tmcore.ContextWithMongo(context.Background(), tenantBDB)
+	ctxA := tmcore.ContextWithMB(context.Background(), tenantADB)
+	ctxB := tmcore.ContextWithMB(context.Background(), tenantBDB)
 
 	metaA := &Metadata{
 		EntityID:   "iso-entity-1",
@@ -1232,8 +1232,8 @@ func TestIntegration_MetadataRepository_TenantIsolation_UpdateDoesNotCrossTenant
 
 	collection := "operation"
 
-	ctxA := tmcore.ContextWithMongo(context.Background(), tenantADB)
-	ctxB := tmcore.ContextWithMongo(context.Background(), tenantBDB)
+	ctxA := tmcore.ContextWithMB(context.Background(), tenantADB)
+	ctxB := tmcore.ContextWithMB(context.Background(), tenantBDB)
 
 	// Insert same entity_id into both tenants with different data
 	metaA := &Metadata{
@@ -1285,8 +1285,8 @@ func TestIntegration_MetadataRepository_TenantIsolation_DeleteDoesNotCrossTenant
 
 	collection := "operation"
 
-	ctxA := tmcore.ContextWithMongo(context.Background(), tenantADB)
-	ctxB := tmcore.ContextWithMongo(context.Background(), tenantBDB)
+	ctxA := tmcore.ContextWithMB(context.Background(), tenantADB)
+	ctxB := tmcore.ContextWithMB(context.Background(), tenantBDB)
 
 	// Insert same entity_id into both tenants
 	metaA := &Metadata{
@@ -1381,7 +1381,7 @@ func TestIntegration_MetadataRepository_TenantContext_TakesPrecedence_OverStatic
 
 	collection := "operation"
 
-	ctxWithTenant := tmcore.ContextWithMongo(context.Background(), tenantDB)
+	ctxWithTenant := tmcore.ContextWithMB(context.Background(), tenantDB)
 
 	metadata := &Metadata{
 		EntityID:   "precedence-entity-1",

--- a/components/ledger/internal/adapters/mongodb/transaction/metadata.mongodb_tenant_test.go
+++ b/components/ledger/internal/adapters/mongodb/transaction/metadata.mongodb_tenant_test.go
@@ -112,7 +112,7 @@ func TestGetDatabase_ReturnsTenantDB_WhenContextHasTenantMongo(t *testing.T) {
 			repo := &MetadataMongoDBRepository{
 				connection: newPlaceholderConnection(),
 			}
-			ctx := tmcore.ContextWithMongo(context.Background(), tt.tenantDB)
+			ctx := tmcore.ContextWithMB(context.Background(), tt.tenantDB)
 
 			// Act
 			db, err := repo.getDatabase(ctx)
@@ -134,7 +134,7 @@ func TestGetDatabase_TenantDB_TakesPrecedence_OverStaticConnection(t *testing.T)
 	}
 
 	tenantDB := newDisconnectedDatabase(t, "tenant-priority")
-	ctx := tmcore.ContextWithMongo(context.Background(), tenantDB)
+	ctx := tmcore.ContextWithMB(context.Background(), tenantDB)
 
 	// Act
 	db, dbErr := repo.getDatabase(ctx)
@@ -196,10 +196,10 @@ func TestGetDatabase_FallsBackToStaticConnection_WhenNoTenantContext(t *testing.
 func TestGetDatabase_FallsBack_WhenTenantDBIsNilInContext(t *testing.T) {
 	t.Parallel()
 
-	// Arrange — inject a nil *mongo.Database into context via ContextWithMongo.
-	// GetMongoFromContext checks db != nil, so it should return nil,
+	// Arrange — inject a nil *mongo.Database into context via ContextWithMB.
+	// GetMBContext checks db != nil, so it should return nil,
 	// which causes getDatabase to fall through to the static connection path.
-	ctx := tmcore.ContextWithMongo(context.Background(), nil)
+	ctx := tmcore.ContextWithMB(context.Background(), nil)
 
 	repo := &MetadataMongoDBRepository{
 		connection: newPlaceholderConnection(),

--- a/components/ledger/internal/adapters/postgres/account/account.postgresql.go
+++ b/components/ledger/internal/adapters/postgres/account/account.postgresql.go
@@ -100,7 +100,7 @@ func (r *AccountPostgreSQLRepository) getDB(ctx context.Context) (dbresolver.DB,
 	}
 
 	// Generic connection fallback (single-module services)
-	if db := tmcore.GetPGConnectionContext(ctx); db != nil {
+	if db := tmcore.GetPGContext(ctx); db != nil {
 		return db, nil
 	}
 

--- a/components/ledger/internal/adapters/postgres/account/account.postgresql.go
+++ b/components/ledger/internal/adapters/postgres/account/account.postgresql.go
@@ -95,12 +95,12 @@ func NewAccountPostgreSQLRepository(pc *libPostgres.Client, requireTenant ...boo
 // In single-tenant mode (or when no tenant context exists), falls back to the static connection.
 func (r *AccountPostgreSQLRepository) getDB(ctx context.Context) (dbresolver.DB, error) {
 	// Module-specific connection (from middleware WithModule)
-	if db := tmcore.GetPG(ctx, constant.ModuleOnboarding); db != nil {
+	if db := tmcore.GetPGContext(ctx, constant.ModuleOnboarding); db != nil {
 		return db, nil
 	}
 
 	// Generic connection fallback (single-module services)
-	if db := tmcore.GetPGConnectionFromContext(ctx); db != nil {
+	if db := tmcore.GetPGConnectionContext(ctx); db != nil {
 		return db, nil
 	}
 

--- a/components/ledger/internal/adapters/postgres/accounttype/accounttype.postgresql.go
+++ b/components/ledger/internal/adapters/postgres/accounttype/accounttype.postgresql.go
@@ -88,7 +88,7 @@ func (r *AccountTypePostgreSQLRepository) getDB(ctx context.Context) (dbresolver
 	}
 
 	// Generic connection fallback (single-module services)
-	if db := tmcore.GetPGConnectionContext(ctx); db != nil {
+	if db := tmcore.GetPGContext(ctx); db != nil {
 		return db, nil
 	}
 

--- a/components/ledger/internal/adapters/postgres/accounttype/accounttype.postgresql.go
+++ b/components/ledger/internal/adapters/postgres/accounttype/accounttype.postgresql.go
@@ -83,12 +83,12 @@ func NewAccountTypePostgreSQLRepository(pc *libPostgres.Client, requireTenant ..
 // In single-tenant mode (or when no tenant context exists), falls back to the static connection.
 func (r *AccountTypePostgreSQLRepository) getDB(ctx context.Context) (dbresolver.DB, error) {
 	// Module-specific connection (from middleware WithModule)
-	if db := tmcore.GetPG(ctx, constant.ModuleOnboarding); db != nil {
+	if db := tmcore.GetPGContext(ctx, constant.ModuleOnboarding); db != nil {
 		return db, nil
 	}
 
 	// Generic connection fallback (single-module services)
-	if db := tmcore.GetPGConnectionFromContext(ctx); db != nil {
+	if db := tmcore.GetPGConnectionContext(ctx); db != nil {
 		return db, nil
 	}
 

--- a/components/ledger/internal/adapters/postgres/asset/asset.postgresql.go
+++ b/components/ledger/internal/adapters/postgres/asset/asset.postgresql.go
@@ -84,12 +84,12 @@ func NewAssetPostgreSQLRepository(pc *libPostgres.Client, requireTenant ...bool)
 // In single-tenant mode (or when no tenant context exists), falls back to the static connection.
 func (r *AssetPostgreSQLRepository) getDB(ctx context.Context) (dbresolver.DB, error) {
 	// Module-specific connection (from middleware WithModule)
-	if db := tmcore.GetPG(ctx, constant.ModuleOnboarding); db != nil {
+	if db := tmcore.GetPGContext(ctx, constant.ModuleOnboarding); db != nil {
 		return db, nil
 	}
 
 	// Generic connection fallback (single-module services)
-	if db := tmcore.GetPGConnectionFromContext(ctx); db != nil {
+	if db := tmcore.GetPGConnectionContext(ctx); db != nil {
 		return db, nil
 	}
 

--- a/components/ledger/internal/adapters/postgres/asset/asset.postgresql.go
+++ b/components/ledger/internal/adapters/postgres/asset/asset.postgresql.go
@@ -89,7 +89,7 @@ func (r *AssetPostgreSQLRepository) getDB(ctx context.Context) (dbresolver.DB, e
 	}
 
 	// Generic connection fallback (single-module services)
-	if db := tmcore.GetPGConnectionContext(ctx); db != nil {
+	if db := tmcore.GetPGContext(ctx); db != nil {
 		return db, nil
 	}
 

--- a/components/ledger/internal/adapters/postgres/assetrate/assetrate.postgresql.go
+++ b/components/ledger/internal/adapters/postgres/assetrate/assetrate.postgresql.go
@@ -84,7 +84,7 @@ func (r *AssetRatePostgreSQLRepository) getDB(ctx context.Context) (dbresolver.D
 	}
 
 	// Generic connection fallback (single-module services)
-	if db := tmcore.GetPGConnectionContext(ctx); db != nil {
+	if db := tmcore.GetPGContext(ctx); db != nil {
 		return db, nil
 	}
 

--- a/components/ledger/internal/adapters/postgres/assetrate/assetrate.postgresql.go
+++ b/components/ledger/internal/adapters/postgres/assetrate/assetrate.postgresql.go
@@ -79,12 +79,12 @@ func NewAssetRatePostgreSQLRepository(pc *libPostgres.Client, requireTenant ...b
 // In single-tenant mode (or when no tenant context exists), falls back to the static connection.
 func (r *AssetRatePostgreSQLRepository) getDB(ctx context.Context) (dbresolver.DB, error) {
 	// Module-specific connection (from middleware WithModule)
-	if db := tmcore.GetPG(ctx, constant.ModuleTransaction); db != nil {
+	if db := tmcore.GetPGContext(ctx, constant.ModuleTransaction); db != nil {
 		return db, nil
 	}
 
 	// Generic connection fallback (single-module services)
-	if db := tmcore.GetPGConnectionFromContext(ctx); db != nil {
+	if db := tmcore.GetPGConnectionContext(ctx); db != nil {
 		return db, nil
 	}
 

--- a/components/ledger/internal/adapters/postgres/balance/balance.postgresql.go
+++ b/components/ledger/internal/adapters/postgres/balance/balance.postgresql.go
@@ -106,7 +106,7 @@ func (r *BalancePostgreSQLRepository) getDB(ctx context.Context) (dbresolver.DB,
 	}
 
 	// Generic connection fallback (single-module services)
-	if db := tmcore.GetPGConnectionContext(ctx); db != nil {
+	if db := tmcore.GetPGContext(ctx); db != nil {
 		return db, nil
 	}
 

--- a/components/ledger/internal/adapters/postgres/balance/balance.postgresql.go
+++ b/components/ledger/internal/adapters/postgres/balance/balance.postgresql.go
@@ -101,12 +101,12 @@ func NewBalancePostgreSQLRepository(pc *libPostgres.Client, requireTenant ...boo
 // In single-tenant mode (or when no tenant context exists), falls back to the static connection.
 func (r *BalancePostgreSQLRepository) getDB(ctx context.Context) (dbresolver.DB, error) {
 	// Module-specific connection (from middleware WithModule)
-	if db := tmcore.GetPG(ctx, constant.ModuleTransaction); db != nil {
+	if db := tmcore.GetPGContext(ctx, constant.ModuleTransaction); db != nil {
 		return db, nil
 	}
 
 	// Generic connection fallback (single-module services)
-	if db := tmcore.GetPGConnectionFromContext(ctx); db != nil {
+	if db := tmcore.GetPGConnectionContext(ctx); db != nil {
 		return db, nil
 	}
 

--- a/components/ledger/internal/adapters/postgres/ledger/ledger.postgresql.go
+++ b/components/ledger/internal/adapters/postgres/ledger/ledger.postgresql.go
@@ -92,7 +92,7 @@ func (r *LedgerPostgreSQLRepository) getDB(ctx context.Context) (dbresolver.DB, 
 	}
 
 	// Generic connection fallback (single-module services)
-	if db := tmcore.GetPGConnectionContext(ctx); db != nil {
+	if db := tmcore.GetPGContext(ctx); db != nil {
 		return db, nil
 	}
 

--- a/components/ledger/internal/adapters/postgres/ledger/ledger.postgresql.go
+++ b/components/ledger/internal/adapters/postgres/ledger/ledger.postgresql.go
@@ -87,12 +87,12 @@ func NewLedgerPostgreSQLRepository(pc *libPostgres.Client, requireTenant ...bool
 // In single-tenant mode (or when no tenant context exists), falls back to the static connection.
 func (r *LedgerPostgreSQLRepository) getDB(ctx context.Context) (dbresolver.DB, error) {
 	// Module-specific connection (from middleware WithModule)
-	if db := tmcore.GetPG(ctx, constant.ModuleOnboarding); db != nil {
+	if db := tmcore.GetPGContext(ctx, constant.ModuleOnboarding); db != nil {
 		return db, nil
 	}
 
 	// Generic connection fallback (single-module services)
-	if db := tmcore.GetPGConnectionFromContext(ctx); db != nil {
+	if db := tmcore.GetPGConnectionContext(ctx); db != nil {
 		return db, nil
 	}
 

--- a/components/ledger/internal/adapters/postgres/operation/operation.postgresql.go
+++ b/components/ledger/internal/adapters/postgres/operation/operation.postgresql.go
@@ -142,7 +142,7 @@ func (r *OperationPostgreSQLRepository) getDB(ctx context.Context) (dbresolver.D
 	}
 
 	// Generic connection fallback (single-module services)
-	if db := tmcore.GetPGConnectionContext(ctx); db != nil {
+	if db := tmcore.GetPGContext(ctx); db != nil {
 		return db, nil
 	}
 

--- a/components/ledger/internal/adapters/postgres/operation/operation.postgresql.go
+++ b/components/ledger/internal/adapters/postgres/operation/operation.postgresql.go
@@ -137,12 +137,12 @@ func NewOperationPostgreSQLRepository(pc *libPostgres.Client, requireTenant ...b
 // In single-tenant mode (or when no tenant context exists), falls back to the static connection.
 func (r *OperationPostgreSQLRepository) getDB(ctx context.Context) (dbresolver.DB, error) {
 	// Module-specific connection (from middleware WithModule)
-	if db := tmcore.GetPG(ctx, constant.ModuleTransaction); db != nil {
+	if db := tmcore.GetPGContext(ctx, constant.ModuleTransaction); db != nil {
 		return db, nil
 	}
 
 	// Generic connection fallback (single-module services)
-	if db := tmcore.GetPGConnectionFromContext(ctx); db != nil {
+	if db := tmcore.GetPGConnectionContext(ctx); db != nil {
 		return db, nil
 	}
 

--- a/components/ledger/internal/adapters/postgres/operation/operation_createbulk_test.go
+++ b/components/ledger/internal/adapters/postgres/operation/operation_createbulk_test.go
@@ -96,7 +96,7 @@ func TestOperationCreateBulk_NilElementInSlice(t *testing.T) {
 	t.Parallel()
 
 	mockDB := &mockOperationDB{}
-	ctx := tmcore.ContextWithPGConnection(context.Background(), mockDB)
+	ctx := tmcore.ContextWithPG(context.Background(), mockDB)
 
 	repo := &OperationPostgreSQLRepository{
 		connection:    nil,
@@ -121,7 +121,7 @@ func TestOperationCreateBulk_NilElementAtStart(t *testing.T) {
 	t.Parallel()
 
 	mockDB := &mockOperationDB{}
-	ctx := tmcore.ContextWithPGConnection(context.Background(), mockDB)
+	ctx := tmcore.ContextWithPG(context.Background(), mockDB)
 
 	repo := &OperationPostgreSQLRepository{
 		connection:    nil,
@@ -145,7 +145,7 @@ func TestOperationCreateBulk_NilElementAtEnd(t *testing.T) {
 	t.Parallel()
 
 	mockDB := &mockOperationDB{}
-	ctx := tmcore.ContextWithPGConnection(context.Background(), mockDB)
+	ctx := tmcore.ContextWithPG(context.Background(), mockDB)
 
 	repo := &OperationPostgreSQLRepository{
 		connection:    nil,
@@ -189,7 +189,7 @@ func TestOperationCreateBulk_SortsInputByID(t *testing.T) {
 	}
 
 	// Inject mock DB into context using tenant manager
-	ctx := tmcore.ContextWithPGConnection(context.Background(), mockDB)
+	ctx := tmcore.ContextWithPG(context.Background(), mockDB)
 
 	repo := &OperationPostgreSQLRepository{
 		connection:    nil,
@@ -527,7 +527,7 @@ func TestOperationCreateBulk_AllNilElements(t *testing.T) {
 	t.Parallel()
 
 	mockDB := &mockOperationDB{}
-	ctx := tmcore.ContextWithPGConnection(context.Background(), mockDB)
+	ctx := tmcore.ContextWithPG(context.Background(), mockDB)
 
 	repo := &OperationPostgreSQLRepository{
 		connection:    nil,
@@ -548,7 +548,7 @@ func TestOperationCreateBulk_MultipleNilElements(t *testing.T) {
 	t.Parallel()
 
 	mockDB := &mockOperationDB{}
-	ctx := tmcore.ContextWithPGConnection(context.Background(), mockDB)
+	ctx := tmcore.ContextWithPG(context.Background(), mockDB)
 
 	repo := &OperationPostgreSQLRepository{
 		connection:    nil,
@@ -633,7 +633,7 @@ func TestOperationCreateBulk_ChunkFailure_PartialResult(t *testing.T) {
 		},
 	}
 
-	ctx := tmcore.ContextWithPGConnection(context.Background(), mockDB)
+	ctx := tmcore.ContextWithPG(context.Background(), mockDB)
 
 	repo := &OperationPostgreSQLRepository{
 		connection:    nil,
@@ -667,7 +667,7 @@ func TestOperationCreateBulk_FirstChunkFailure(t *testing.T) {
 		},
 	}
 
-	ctx := tmcore.ContextWithPGConnection(context.Background(), mockDB)
+	ctx := tmcore.ContextWithPG(context.Background(), mockDB)
 
 	repo := &OperationPostgreSQLRepository{
 		connection:    nil,
@@ -701,7 +701,7 @@ func TestOperationCreateBulk_ContextCancellation(t *testing.T) {
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
-	ctx = tmcore.ContextWithPGConnection(ctx, mockDB)
+	ctx = tmcore.ContextWithPG(ctx, mockDB)
 
 	repo := &OperationPostgreSQLRepository{
 		connection:    nil,

--- a/components/ledger/internal/adapters/postgres/operationroute/operationroute.postgresql.go
+++ b/components/ledger/internal/adapters/postgres/operationroute/operationroute.postgresql.go
@@ -80,7 +80,7 @@ func (r *OperationRoutePostgreSQLRepository) getDB(ctx context.Context) (dbresol
 	}
 
 	// Generic connection fallback (single-module services)
-	if db := tmcore.GetPGConnectionContext(ctx); db != nil {
+	if db := tmcore.GetPGContext(ctx); db != nil {
 		return db, nil
 	}
 

--- a/components/ledger/internal/adapters/postgres/operationroute/operationroute.postgresql.go
+++ b/components/ledger/internal/adapters/postgres/operationroute/operationroute.postgresql.go
@@ -75,12 +75,12 @@ func NewOperationRoutePostgreSQLRepository(pc *libPostgres.Client, requireTenant
 // In single-tenant mode (or when no tenant context exists), falls back to the static connection.
 func (r *OperationRoutePostgreSQLRepository) getDB(ctx context.Context) (dbresolver.DB, error) {
 	// Module-specific connection (from middleware WithModule)
-	if db := tmcore.GetPG(ctx, constant.ModuleTransaction); db != nil {
+	if db := tmcore.GetPGContext(ctx, constant.ModuleTransaction); db != nil {
 		return db, nil
 	}
 
 	// Generic connection fallback (single-module services)
-	if db := tmcore.GetPGConnectionFromContext(ctx); db != nil {
+	if db := tmcore.GetPGConnectionContext(ctx); db != nil {
 		return db, nil
 	}
 

--- a/components/ledger/internal/adapters/postgres/organization/organization.postgresql.go
+++ b/components/ledger/internal/adapters/postgres/organization/organization.postgresql.go
@@ -89,7 +89,7 @@ func (r *OrganizationPostgreSQLRepository) getDB(ctx context.Context) (dbresolve
 	}
 
 	// Generic connection fallback (single-module services)
-	if db := tmcore.GetPGConnectionContext(ctx); db != nil {
+	if db := tmcore.GetPGContext(ctx); db != nil {
 		return db, nil
 	}
 

--- a/components/ledger/internal/adapters/postgres/organization/organization.postgresql.go
+++ b/components/ledger/internal/adapters/postgres/organization/organization.postgresql.go
@@ -84,12 +84,12 @@ func NewOrganizationPostgreSQLRepository(pc *libPostgres.Client, requireTenant .
 // In single-tenant mode (or when no tenant context exists), falls back to the static connection.
 func (r *OrganizationPostgreSQLRepository) getDB(ctx context.Context) (dbresolver.DB, error) {
 	// Module-specific connection (from middleware WithModule)
-	if db := tmcore.GetPG(ctx, constant.ModuleOnboarding); db != nil {
+	if db := tmcore.GetPGContext(ctx, constant.ModuleOnboarding); db != nil {
 		return db, nil
 	}
 
 	// Generic connection fallback (single-module services)
-	if db := tmcore.GetPGConnectionFromContext(ctx); db != nil {
+	if db := tmcore.GetPGConnectionContext(ctx); db != nil {
 		return db, nil
 	}
 

--- a/components/ledger/internal/adapters/postgres/organization/organization.postgresql_chaos_test.go
+++ b/components/ledger/internal/adapters/postgres/organization/organization.postgresql_chaos_test.go
@@ -404,7 +404,7 @@ func TestIntegration_Chaos_Organization_NetworkPartition(t *testing.T) {
 	tenantDB, err := infra.conn.Resolver(context.Background())
 	require.NoError(t, err, "setup: must be able to get DB from proxied connection")
 
-	tenantCtx := tmcore.ContextWithPGConnection(ctx, tenantDB)
+	tenantCtx := tmcore.ContextWithPG(ctx, tenantDB)
 
 	// --- Phase 1: Normal ---
 	// Verify operations work both with plain context (static path) and with

--- a/components/ledger/internal/adapters/postgres/organization/organization.postgresql_fuzz_test.go
+++ b/components/ledger/internal/adapters/postgres/organization/organization.postgresql_fuzz_test.go
@@ -18,7 +18,7 @@ import (
 // FUZZ TESTS -- getDB Context Tenant PG Connection Resolution
 //
 // This fuzz test exercises getDB with arbitrary context values alongside
-// the generic tenant PG connection via tmcore.ContextWithPGConnection
+// the generic tenant PG connection via tmcore.ContextWithPG
 // to verify:
 //  1. No panic under any context content (including Unicode, null bytes, very
 //     long strings, empty strings, and security payloads).
@@ -74,7 +74,7 @@ func FuzzGetDB_TenantPGConnection(f *testing.F) {
 
 		ctx := context.WithValue(context.Background(), ctxKey{name: "fuzz"}, contextValue)
 		if hasTenant {
-			ctx = tmcore.ContextWithPGConnection(ctx, tenantDB)
+			ctx = tmcore.ContextWithPG(ctx, tenantDB)
 		}
 
 		repo := &OrganizationPostgreSQLRepository{

--- a/components/ledger/internal/adapters/postgres/organization/organization.postgresql_integration_test.go
+++ b/components/ledger/internal/adapters/postgres/organization/organization.postgresql_integration_test.go
@@ -933,7 +933,7 @@ func TestIntegration_GetDB_CreateAndFindRoundTrip(t *testing.T) {
 // ============================================================================
 //
 // These tests verify that when a tenant-specific dbresolver.DB is injected into
-// context via tmcore.ContextWithPGConnection(tenantDB),
+// context via tmcore.ContextWithPG(tenantDB),
 // the getDB method returns that tenant DB instead of the static connection.
 //
 // Strategy: Two separate PostgreSQL containers.
@@ -985,7 +985,7 @@ func TestIntegration_GetDB_TenantContext_ReturnsValidHandle(t *testing.T) {
 	repo := createRepository(t, staticContainer)
 
 	_, tenantDB := setupTenantContainer(t)
-	ctx := tmcore.ContextWithPGConnection(context.Background(), tenantDB)
+	ctx := tmcore.ContextWithPG(context.Background(), tenantDB)
 
 	// Act
 	db, err := repo.getDB(ctx)
@@ -1001,7 +1001,7 @@ func TestIntegration_GetDB_TenantContext_CanExecuteQueries(t *testing.T) {
 	repo := createRepository(t, staticContainer)
 
 	_, tenantDB := setupTenantContainer(t)
-	ctx := tmcore.ContextWithPGConnection(context.Background(), tenantDB)
+	ctx := tmcore.ContextWithPG(context.Background(), tenantDB)
 
 	// Act -- getDB should return the tenant DB, which should support queries.
 	db, err := repo.getDB(ctx)
@@ -1029,7 +1029,7 @@ func TestIntegration_GetDB_TenantContext_RoutesToTenantDatabase(t *testing.T) {
 	tenantOrgID := pgtestutil.CreateTestOrganizationWithParams(t, tenantContainer.DB, params)
 
 	// Act -- use tenant context: getDB should route to the tenant database.
-	tenantCtx := tmcore.ContextWithPGConnection(context.Background(), tenantDB)
+	tenantCtx := tmcore.ContextWithPG(context.Background(), tenantDB)
 	found, err := repo.Find(tenantCtx, tenantOrgID)
 
 	// Assert -- data exists only in tenant container, so Find succeeds only
@@ -1054,7 +1054,7 @@ func TestIntegration_GetDB_TenantContext_CreateAndFind(t *testing.T) {
 	repo := createRepository(t, staticContainer)
 
 	_, tenantDB := setupTenantContainer(t)
-	tenantCtx := tmcore.ContextWithPGConnection(context.Background(), tenantDB)
+	tenantCtx := tmcore.ContextWithPG(context.Background(), tenantDB)
 
 	// Act -- Create through tenant context.
 	org := &mmodel.Organization{
@@ -1092,7 +1092,7 @@ func TestIntegration_GetDB_TenantContext_CountIsolation(t *testing.T) {
 	repo := createRepository(t, staticContainer)
 
 	tenantContainer, tenantDB := setupTenantContainer(t)
-	tenantCtx := tmcore.ContextWithPGConnection(context.Background(), tenantDB)
+	tenantCtx := tmcore.ContextWithPG(context.Background(), tenantDB)
 
 	// Get initial counts.
 	staticCount, err := repo.Count(context.Background())
@@ -1130,7 +1130,7 @@ func TestIntegration_GetDB_TenantContext_AlwaysReturnsTenantDB(t *testing.T) {
 	tenantContainer, tenantDB := setupTenantContainer(t)
 
 	// Inject tenant DB via generic tenant PG connection.
-	tenantCtx := tmcore.ContextWithPGConnection(context.Background(), tenantDB)
+	tenantCtx := tmcore.ContextWithPG(context.Background(), tenantDB)
 
 	// Insert data into tenant container so we can verify the tenant path is used.
 	params := pgtestutil.DefaultOrganizationParams()
@@ -1153,7 +1153,7 @@ func TestIntegration_GetDB_TenantContext_UpdateAndDeleteThroughTenantPath(t *tes
 	repo := createRepository(t, staticContainer)
 
 	tenantContainer, tenantDB := setupTenantContainer(t)
-	tenantCtx := tmcore.ContextWithPGConnection(context.Background(), tenantDB)
+	tenantCtx := tmcore.ContextWithPG(context.Background(), tenantDB)
 
 	// Insert directly into tenant container.
 	params := pgtestutil.DefaultOrganizationParams()
@@ -1200,7 +1200,7 @@ func TestIntegration_GetDB_TenantContext_FindAllThroughTenantPath(t *testing.T) 
 	repo := createRepository(t, staticContainer)
 
 	tenantContainer, tenantDB := setupTenantContainer(t)
-	tenantCtx := tmcore.ContextWithPGConnection(context.Background(), tenantDB)
+	tenantCtx := tmcore.ContextWithPG(context.Background(), tenantDB)
 
 	// Insert 3 organizations into tenant container only.
 	for i := 0; i < 3; i++ {
@@ -1229,7 +1229,7 @@ func TestIntegration_GetDB_TenantContext_ListByIDsThroughTenantPath(t *testing.T
 	repo := createRepository(t, staticContainer)
 
 	tenantContainer, tenantDB := setupTenantContainer(t)
-	tenantCtx := tmcore.ContextWithPGConnection(context.Background(), tenantDB)
+	tenantCtx := tmcore.ContextWithPG(context.Background(), tenantDB)
 
 	// Insert 2 organizations into tenant container.
 	params1 := pgtestutil.DefaultOrganizationParams()

--- a/components/ledger/internal/adapters/postgres/organization/organization.postgresql_property_test.go
+++ b/components/ledger/internal/adapters/postgres/organization/organization.postgresql_property_test.go
@@ -70,7 +70,7 @@ func TestProperty_GetDB_NeverReturnsNilWithoutError(t *testing.T) {
 	repo := newPropertyRepo()
 
 	property := func(_ string) bool {
-		ctx := tmcore.ContextWithPGConnection(
+		ctx := tmcore.ContextWithPG(
 			context.Background(), &mockDB{},
 		)
 
@@ -96,7 +96,7 @@ func TestProperty_GetDB_TenantConnectionReturned(t *testing.T) {
 
 	property := func(_ string) bool {
 		injectedDB := &mockDB{}
-		ctx := tmcore.ContextWithPGConnection(
+		ctx := tmcore.ContextWithPG(
 			context.Background(), injectedDB,
 		)
 
@@ -126,7 +126,7 @@ func TestProperty_GetDB_Determinism(t *testing.T) {
 	repo := newPropertyRepo()
 
 	property := func(_ string) bool {
-		ctx := tmcore.ContextWithPGConnection(
+		ctx := tmcore.ContextWithPG(
 			context.Background(), &mockDB{},
 		)
 
@@ -166,7 +166,7 @@ func TestProperty_GetDB_FallbackGuarantee(t *testing.T) {
 	property := func(_ string) bool {
 		// Inject the tenant DB -- this is what the middleware does
 		// in production multi-tenant mode.
-		ctx := tmcore.ContextWithPGConnection(context.Background(), tenantDB)
+		ctx := tmcore.ContextWithPG(context.Background(), tenantDB)
 
 		db, err := repo.getDB(ctx)
 		// getDB must always succeed and return the tenant DB.
@@ -200,7 +200,7 @@ func TestProperty_GetDB_FallbackGuarantee_WithContextValues(t *testing.T) {
 		ctx := context.WithValue(context.Background(), ctxKey{name: keyName}, value)
 
 		// Layer the tenant DB on top.
-		ctx = tmcore.ContextWithPGConnection(ctx, tenantDB)
+		ctx = tmcore.ContextWithPG(ctx, tenantDB)
 
 		db, err := repo.getDB(ctx)
 		if err != nil {

--- a/components/ledger/internal/adapters/postgres/organization/organization.postgresql_tenant_test.go
+++ b/components/ledger/internal/adapters/postgres/organization/organization.postgresql_tenant_test.go
@@ -59,7 +59,7 @@ func TestGetDB_ReturnsTenantDB_WhenContextHasTenantPGConnection(t *testing.T) {
 				connection: newPlaceholderPostgresConnection(),
 				tableName:  "organization",
 			}
-			ctx := tmcore.ContextWithPGConnection(context.Background(), tt.tenantDB)
+			ctx := tmcore.ContextWithPG(context.Background(), tt.tenantDB)
 
 			// Act
 			db, err := repo.getDB(ctx)

--- a/components/ledger/internal/adapters/postgres/portfolio/portfolio.postgresql.go
+++ b/components/ledger/internal/adapters/postgres/portfolio/portfolio.postgresql.go
@@ -83,12 +83,12 @@ func NewPortfolioPostgreSQLRepository(pc *libPostgres.Client, requireTenant ...b
 // In single-tenant mode (or when no tenant context exists), falls back to the static connection.
 func (r *PortfolioPostgreSQLRepository) getDB(ctx context.Context) (dbresolver.DB, error) {
 	// Module-specific connection (from middleware WithModule)
-	if db := tmcore.GetPG(ctx, constant.ModuleOnboarding); db != nil {
+	if db := tmcore.GetPGContext(ctx, constant.ModuleOnboarding); db != nil {
 		return db, nil
 	}
 
 	// Generic connection fallback (single-module services)
-	if db := tmcore.GetPGConnectionFromContext(ctx); db != nil {
+	if db := tmcore.GetPGConnectionContext(ctx); db != nil {
 		return db, nil
 	}
 

--- a/components/ledger/internal/adapters/postgres/portfolio/portfolio.postgresql.go
+++ b/components/ledger/internal/adapters/postgres/portfolio/portfolio.postgresql.go
@@ -88,7 +88,7 @@ func (r *PortfolioPostgreSQLRepository) getDB(ctx context.Context) (dbresolver.D
 	}
 
 	// Generic connection fallback (single-module services)
-	if db := tmcore.GetPGConnectionContext(ctx); db != nil {
+	if db := tmcore.GetPGContext(ctx); db != nil {
 		return db, nil
 	}
 

--- a/components/ledger/internal/adapters/postgres/segment/segment.postgresql.go
+++ b/components/ledger/internal/adapters/postgres/segment/segment.postgresql.go
@@ -87,7 +87,7 @@ func (p *SegmentPostgreSQLRepository) getDB(ctx context.Context) (dbresolver.DB,
 	}
 
 	// Generic connection fallback (single-module services)
-	if db := tmcore.GetPGConnectionContext(ctx); db != nil {
+	if db := tmcore.GetPGContext(ctx); db != nil {
 		return db, nil
 	}
 

--- a/components/ledger/internal/adapters/postgres/segment/segment.postgresql.go
+++ b/components/ledger/internal/adapters/postgres/segment/segment.postgresql.go
@@ -82,12 +82,12 @@ func NewSegmentPostgreSQLRepository(pc *libPostgres.Client, requireTenant ...boo
 // In single-tenant mode (or when no tenant context exists), falls back to the static connection.
 func (p *SegmentPostgreSQLRepository) getDB(ctx context.Context) (dbresolver.DB, error) {
 	// Module-specific connection (from middleware WithModule)
-	if db := tmcore.GetPG(ctx, constant.ModuleOnboarding); db != nil {
+	if db := tmcore.GetPGContext(ctx, constant.ModuleOnboarding); db != nil {
 		return db, nil
 	}
 
 	// Generic connection fallback (single-module services)
-	if db := tmcore.GetPGConnectionFromContext(ctx); db != nil {
+	if db := tmcore.GetPGConnectionContext(ctx); db != nil {
 		return db, nil
 	}
 

--- a/components/ledger/internal/adapters/postgres/transaction/transaction.postgresql.go
+++ b/components/ledger/internal/adapters/postgres/transaction/transaction.postgresql.go
@@ -127,7 +127,7 @@ func (r *TransactionPostgreSQLRepository) getDB(ctx context.Context) (dbresolver
 	}
 
 	// Generic connection fallback (single-module services)
-	if db := tmcore.GetPGConnectionContext(ctx); db != nil {
+	if db := tmcore.GetPGContext(ctx); db != nil {
 		return db, nil
 	}
 

--- a/components/ledger/internal/adapters/postgres/transaction/transaction.postgresql.go
+++ b/components/ledger/internal/adapters/postgres/transaction/transaction.postgresql.go
@@ -122,12 +122,12 @@ func NewTransactionPostgreSQLRepository(pc *libPostgres.Client, requireTenant ..
 // In single-tenant mode (or when no tenant context exists), falls back to the static connection.
 func (r *TransactionPostgreSQLRepository) getDB(ctx context.Context) (dbresolver.DB, error) {
 	// Module-specific connection (from middleware WithModule)
-	if db := tmcore.GetPG(ctx, constant.ModuleTransaction); db != nil {
+	if db := tmcore.GetPGContext(ctx, constant.ModuleTransaction); db != nil {
 		return db, nil
 	}
 
 	// Generic connection fallback (single-module services)
-	if db := tmcore.GetPGConnectionFromContext(ctx); db != nil {
+	if db := tmcore.GetPGConnectionContext(ctx); db != nil {
 		return db, nil
 	}
 

--- a/components/ledger/internal/adapters/postgres/transaction/transaction.postgresql_chaos_test.go
+++ b/components/ledger/internal/adapters/postgres/transaction/transaction.postgresql_chaos_test.go
@@ -416,7 +416,7 @@ func TestIntegration_Chaos_Transaction_GetDB_NetworkPartition(t *testing.T) {
 	tenantDB, err := infra.conn.Resolver(context.Background())
 	require.NoError(t, err, "setup: must be able to get DB from proxied connection")
 
-	tenantCtx := tmcore.ContextWithPGConnection(ctx, tenantDB)
+	tenantCtx := tmcore.ContextWithPG(ctx, tenantDB)
 
 	// --- Phase 1: Normal ---
 	// Verify operations work both with plain context (static path) and with

--- a/components/ledger/internal/adapters/postgres/transaction/transaction.postgresql_fuzz_test.go
+++ b/components/ledger/internal/adapters/postgres/transaction/transaction.postgresql_fuzz_test.go
@@ -18,7 +18,7 @@ import (
 // FUZZ TESTS -- getDB Context Tenant PG Connection Resolution
 //
 // This fuzz test exercises getDB with arbitrary context values alongside
-// the generic tenant PG connection via tmcore.ContextWithPGConnection
+// the generic tenant PG connection via tmcore.ContextWithPG
 // to verify:
 //  1. No panic under any context content (including Unicode, null bytes, very
 //     long strings, empty strings, and security payloads).
@@ -74,7 +74,7 @@ func FuzzGetDB_TenantPGConnection(f *testing.F) {
 
 		ctx := context.WithValue(context.Background(), ctxKey{name: "fuzz"}, contextValue)
 		if hasTenant {
-			ctx = tmcore.ContextWithPGConnection(ctx, tenantDB)
+			ctx = tmcore.ContextWithPG(ctx, tenantDB)
 		}
 
 		repo := &TransactionPostgreSQLRepository{

--- a/components/ledger/internal/adapters/postgres/transaction/transaction.postgresql_integration_test.go
+++ b/components/ledger/internal/adapters/postgres/transaction/transaction.postgresql_integration_test.go
@@ -1483,7 +1483,7 @@ func TestIntegration_GetDB_CreateAndFindRoundTrip(t *testing.T) {
 // =============================================================================
 //
 // These tests verify that when a tenant-specific dbresolver.DB is injected into
-// context via tmcore.ContextWithPGConnection(tenantDB),
+// context via tmcore.ContextWithPG(tenantDB),
 // the getDB method returns that tenant DB instead of the static connection.
 //
 // Strategy: Two separate PostgreSQL containers.
@@ -1537,7 +1537,7 @@ func TestIntegration_GetDB_TenantContext_ReturnsValidHandle(t *testing.T) {
 	// Arrange -- static container for constructor, tenant container for context.
 	infra := setupIntegrationInfra(t)
 	_, tenantDB := setupTenantContainer(t)
-	ctx := tmcore.ContextWithPGConnection(context.Background(), tenantDB)
+	ctx := tmcore.ContextWithPG(context.Background(), tenantDB)
 
 	// Act
 	db, err := infra.repo.getDB(ctx)
@@ -1557,7 +1557,7 @@ func TestIntegration_GetDB_TenantContext_CanExecuteQueries(t *testing.T) {
 	// Arrange
 	infra := setupIntegrationInfra(t)
 	_, tenantDB := setupTenantContainer(t)
-	ctx := tmcore.ContextWithPGConnection(context.Background(), tenantDB)
+	ctx := tmcore.ContextWithPG(context.Background(), tenantDB)
 
 	// Act -- getDB should return the tenant DB, which should support queries.
 	db, err := infra.repo.getDB(ctx)
@@ -1587,7 +1587,7 @@ func TestIntegration_GetDB_TenantContext_RoutesToTenantDatabase(t *testing.T) {
 	ledgerID := infra.ledgerID
 
 	// Create a transaction ONLY in the tenant database via tenant context.
-	tenantCtx := tmcore.ContextWithPGConnection(context.Background(), tenantDB)
+	tenantCtx := tmcore.ContextWithPG(context.Background(), tenantDB)
 
 	tx := &Transaction{
 		ID:             uuid.New().String(),
@@ -1631,7 +1631,7 @@ func TestIntegration_GetDB_TenantContext_CreateAndFind(t *testing.T) {
 	// Arrange
 	infra := setupIntegrationInfra(t)
 	_, tenantDB := setupTenantContainer(t)
-	tenantCtx := tmcore.ContextWithPGConnection(context.Background(), tenantDB)
+	tenantCtx := tmcore.ContextWithPG(context.Background(), tenantDB)
 
 	orgID := infra.orgID
 	ledgerID := infra.ledgerID
@@ -1675,7 +1675,7 @@ func TestIntegration_GetDB_TenantContext_FindAllIsolation(t *testing.T) {
 	// Arrange
 	infra := setupIntegrationInfra(t)
 	_, tenantDB := setupTenantContainer(t)
-	tenantCtx := tmcore.ContextWithPGConnection(context.Background(), tenantDB)
+	tenantCtx := tmcore.ContextWithPG(context.Background(), tenantDB)
 
 	orgID := infra.orgID
 	ledgerID := infra.ledgerID
@@ -1728,7 +1728,7 @@ func TestIntegration_GetDB_TenantContext_AlwaysReturnsTenantDB(t *testing.T) {
 	_, tenantDB := setupTenantContainer(t)
 
 	// Inject tenant DB via generic tenant PG connection.
-	tenantCtx := tmcore.ContextWithPGConnection(context.Background(), tenantDB)
+	tenantCtx := tmcore.ContextWithPG(context.Background(), tenantDB)
 
 	// Act -- getDB should return the tenant DB handle.
 	db, err := infra.repo.getDB(tenantCtx)
@@ -1748,7 +1748,7 @@ func TestIntegration_GetDB_TenantContext_UpdateAndDeleteThroughTenantPath(t *tes
 	// Arrange
 	infra := setupIntegrationInfra(t)
 	_, tenantDB := setupTenantContainer(t)
-	tenantCtx := tmcore.ContextWithPGConnection(context.Background(), tenantDB)
+	tenantCtx := tmcore.ContextWithPG(context.Background(), tenantDB)
 
 	orgID := infra.orgID
 	ledgerID := infra.ledgerID

--- a/components/ledger/internal/adapters/postgres/transaction/transaction.postgresql_property_test.go
+++ b/components/ledger/internal/adapters/postgres/transaction/transaction.postgresql_property_test.go
@@ -72,7 +72,7 @@ func TestProperty_GetDB_NeverReturnsNilWithoutError(t *testing.T) {
 	repo := newPropertyRepo()
 
 	property := func(_ string) bool {
-		ctx := tmcore.ContextWithPGConnection(
+		ctx := tmcore.ContextWithPG(
 			context.Background(), &mockDB{},
 		)
 
@@ -100,7 +100,7 @@ func TestProperty_GetDB_TenantConnectionReturned(t *testing.T) {
 
 	property := func(_ string) bool {
 		injectedDB := &mockDB{}
-		ctx := tmcore.ContextWithPGConnection(
+		ctx := tmcore.ContextWithPG(
 			context.Background(), injectedDB,
 		)
 
@@ -132,7 +132,7 @@ func TestProperty_GetDB_Determinism(t *testing.T) {
 	repo := newPropertyRepo()
 
 	property := func(_ string) bool {
-		ctx := tmcore.ContextWithPGConnection(
+		ctx := tmcore.ContextWithPG(
 			context.Background(), &mockDB{},
 		)
 
@@ -174,7 +174,7 @@ func TestProperty_GetDB_FallbackGuarantee(t *testing.T) {
 	property := func(_ string) bool {
 		// Inject the tenant DB -- this is what the middleware does
 		// in production multi-tenant mode.
-		ctx := tmcore.ContextWithPGConnection(context.Background(), tenantDB)
+		ctx := tmcore.ContextWithPG(context.Background(), tenantDB)
 
 		db, err := repo.getDB(ctx)
 		// getDB must always succeed and return the tenant DB.
@@ -210,7 +210,7 @@ func TestProperty_GetDB_FallbackGuarantee_WithContextValues(t *testing.T) {
 		ctx := context.WithValue(context.Background(), ctxKey{name: keyName}, value)
 
 		// Layer the tenant DB on top.
-		ctx = tmcore.ContextWithPGConnection(ctx, tenantDB)
+		ctx = tmcore.ContextWithPG(ctx, tenantDB)
 
 		db, err := repo.getDB(ctx)
 		if err != nil {

--- a/components/ledger/internal/adapters/postgres/transaction/transaction.postgresql_tenant_test.go
+++ b/components/ledger/internal/adapters/postgres/transaction/transaction.postgresql_tenant_test.go
@@ -59,7 +59,7 @@ func TestGetDB_ReturnsTenantDB_WhenContextHasTenantPGConnection(t *testing.T) {
 				connection: newPlaceholderPostgresConnection(),
 				tableName:  "transaction",
 			}
-			ctx := tmcore.ContextWithPGConnection(context.Background(), tt.tenantDB)
+			ctx := tmcore.ContextWithPG(context.Background(), tt.tenantDB)
 
 			// Act
 			db, err := repo.getDB(ctx)

--- a/components/ledger/internal/adapters/postgres/transaction/transaction_createbulk_test.go
+++ b/components/ledger/internal/adapters/postgres/transaction/transaction_createbulk_test.go
@@ -87,7 +87,7 @@ func TestCreateBulk_NilElementInSlice(t *testing.T) {
 	t.Parallel()
 
 	mockDB := &bulkMockDB{}
-	ctx := tmcore.ContextWithPGConnection(context.Background(), mockDB)
+	ctx := tmcore.ContextWithPG(context.Background(), mockDB)
 
 	repo := &TransactionPostgreSQLRepository{
 		connection:    nil,
@@ -112,7 +112,7 @@ func TestCreateBulk_NilElementAtStart(t *testing.T) {
 	t.Parallel()
 
 	mockDB := &bulkMockDB{}
-	ctx := tmcore.ContextWithPGConnection(context.Background(), mockDB)
+	ctx := tmcore.ContextWithPG(context.Background(), mockDB)
 
 	repo := &TransactionPostgreSQLRepository{
 		connection:    nil,
@@ -136,7 +136,7 @@ func TestCreateBulk_NilElementAtEnd(t *testing.T) {
 	t.Parallel()
 
 	mockDB := &bulkMockDB{}
-	ctx := tmcore.ContextWithPGConnection(context.Background(), mockDB)
+	ctx := tmcore.ContextWithPG(context.Background(), mockDB)
 
 	repo := &TransactionPostgreSQLRepository{
 		connection:    nil,
@@ -180,7 +180,7 @@ func TestCreateBulk_SortsInputByID(t *testing.T) {
 	}
 
 	// Inject mock DB into context using tenant manager
-	ctx := tmcore.ContextWithPGConnection(context.Background(), mockDB)
+	ctx := tmcore.ContextWithPG(context.Background(), mockDB)
 
 	repo := &TransactionPostgreSQLRepository{
 		connection:    nil,
@@ -577,7 +577,7 @@ func TestCreateBulk_ChunkFailure_PartialResult(t *testing.T) {
 		},
 	}
 
-	ctx := tmcore.ContextWithPGConnection(context.Background(), mockDB)
+	ctx := tmcore.ContextWithPG(context.Background(), mockDB)
 
 	repo := &TransactionPostgreSQLRepository{
 		connection:    nil,
@@ -611,7 +611,7 @@ func TestCreateBulk_FirstChunkFailure(t *testing.T) {
 		},
 	}
 
-	ctx := tmcore.ContextWithPGConnection(context.Background(), mockDB)
+	ctx := tmcore.ContextWithPG(context.Background(), mockDB)
 
 	repo := &TransactionPostgreSQLRepository{
 		connection:    nil,
@@ -644,7 +644,7 @@ func TestCreateBulk_ContextCancellation(t *testing.T) {
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
-	ctx = tmcore.ContextWithPGConnection(ctx, mockDB)
+	ctx = tmcore.ContextWithPG(ctx, mockDB)
 
 	repo := &TransactionPostgreSQLRepository{
 		connection:    nil,

--- a/components/ledger/internal/adapters/postgres/transaction/transaction_updatebulk_test.go
+++ b/components/ledger/internal/adapters/postgres/transaction/transaction_updatebulk_test.go
@@ -52,7 +52,7 @@ func TestUpdateBulk_NilElementInSlice(t *testing.T) {
 	t.Parallel()
 
 	mockDB := &bulkMockDB{}
-	ctx := tmcore.ContextWithPGConnection(context.Background(), mockDB)
+	ctx := tmcore.ContextWithPG(context.Background(), mockDB)
 
 	repo := &TransactionPostgreSQLRepository{
 		connection:    nil,
@@ -77,7 +77,7 @@ func TestUpdateBulk_NilElementAtStart(t *testing.T) {
 	t.Parallel()
 
 	mockDB := &bulkMockDB{}
-	ctx := tmcore.ContextWithPGConnection(context.Background(), mockDB)
+	ctx := tmcore.ContextWithPG(context.Background(), mockDB)
 
 	repo := &TransactionPostgreSQLRepository{
 		connection:    nil,
@@ -103,7 +103,7 @@ func TestUpdateBulk_SingleTransaction_AllUpdated(t *testing.T) {
 	// With batched update, a single transaction results in a single ExecContext call
 	// rowsAffected = 1 means the transaction was updated
 	mockDB := &bulkMockDB{rowsAffected: 1}
-	ctx := tmcore.ContextWithPGConnection(context.Background(), mockDB)
+	ctx := tmcore.ContextWithPG(context.Background(), mockDB)
 
 	repo := &TransactionPostgreSQLRepository{
 		connection:    nil,
@@ -129,7 +129,7 @@ func TestUpdateBulk_SingleTransaction_Unchanged(t *testing.T) {
 
 	// rowsAffected = 0 means status already matches (no update needed)
 	mockDB := &bulkMockDB{rowsAffected: 0}
-	ctx := tmcore.ContextWithPGConnection(context.Background(), mockDB)
+	ctx := tmcore.ContextWithPG(context.Background(), mockDB)
 
 	repo := &TransactionPostgreSQLRepository{
 		connection:    nil,
@@ -156,7 +156,7 @@ func TestUpdateBulk_MultipleTransactions_MixedResults(t *testing.T) {
 	// The rowsAffected reflects how many rows were actually updated (status changed).
 	// For 3 transactions where 2 have status changes and 1 doesn't, rowsAffected = 2.
 	mockDB := &bulkMockDB{rowsAffected: 2}
-	ctx := tmcore.ContextWithPGConnection(context.Background(), mockDB)
+	ctx := tmcore.ContextWithPG(context.Background(), mockDB)
 
 	repo := &TransactionPostgreSQLRepository{
 		connection:    nil,
@@ -178,7 +178,7 @@ func TestUpdateBulk_SortsByID(t *testing.T) {
 	t.Parallel()
 
 	mockDB := &bulkMockDB{rowsAffected: 1}
-	ctx := tmcore.ContextWithPGConnection(context.Background(), mockDB)
+	ctx := tmcore.ContextWithPG(context.Background(), mockDB)
 
 	repo := &TransactionPostgreSQLRepository{
 		connection:    nil,
@@ -207,7 +207,7 @@ func TestUpdateBulk_DatabaseError(t *testing.T) {
 
 	dbErr := errors.New("database connection lost")
 	mockDB := &bulkMockDB{execErr: dbErr}
-	ctx := tmcore.ContextWithPGConnection(context.Background(), mockDB)
+	ctx := tmcore.ContextWithPG(context.Background(), mockDB)
 
 	repo := &TransactionPostgreSQLRepository{
 		connection:    nil,
@@ -294,7 +294,7 @@ func TestUpdateBulk_ContextCancellation(t *testing.T) {
 	cancel() // Cancel immediately
 
 	mockDB := &bulkMockDB{rowsAffected: 1}
-	ctx = tmcore.ContextWithPGConnection(ctx, mockDB)
+	ctx = tmcore.ContextWithPG(ctx, mockDB)
 
 	repo := &TransactionPostgreSQLRepository{
 		connection:    nil,
@@ -315,7 +315,7 @@ func TestUpdateBulk_StatusTransition_PendingToApproved(t *testing.T) {
 	t.Parallel()
 
 	mockDB := &bulkMockDB{rowsAffected: 1}
-	ctx := tmcore.ContextWithPGConnection(context.Background(), mockDB)
+	ctx := tmcore.ContextWithPG(context.Background(), mockDB)
 
 	repo := &TransactionPostgreSQLRepository{
 		connection:    nil,
@@ -340,7 +340,7 @@ func TestUpdateBulk_StatusTransition_PendingToCanceled(t *testing.T) {
 	t.Parallel()
 
 	mockDB := &bulkMockDB{rowsAffected: 1}
-	ctx := tmcore.ContextWithPGConnection(context.Background(), mockDB)
+	ctx := tmcore.ContextWithPG(context.Background(), mockDB)
 
 	repo := &TransactionPostgreSQLRepository{
 		connection:    nil,
@@ -388,7 +388,7 @@ func TestUpdateBulk_BatchedQuery_SingleExecPerChunk(t *testing.T) {
 	mockDB := &updateBulkQueryCaptureMock{
 		bulkMockDB: bulkMockDB{rowsAffected: 5},
 	}
-	ctx := tmcore.ContextWithPGConnection(context.Background(), mockDB)
+	ctx := tmcore.ContextWithPG(context.Background(), mockDB)
 
 	repo := &TransactionPostgreSQLRepository{
 		connection:    nil,
@@ -431,7 +431,7 @@ func TestUpdateBulk_BatchedQuery_ParameterStructure(t *testing.T) {
 	mockDB := &updateBulkQueryCaptureMock{
 		bulkMockDB: bulkMockDB{rowsAffected: 2},
 	}
-	ctx := tmcore.ContextWithPGConnection(context.Background(), mockDB)
+	ctx := tmcore.ContextWithPG(context.Background(), mockDB)
 
 	repo := &TransactionPostgreSQLRepository{
 		connection:    nil,
@@ -485,7 +485,7 @@ func TestUpdateBulk_BatchedQuery_MultipleChunks(t *testing.T) {
 			{rowsAffected: 1},   // Third chunk (1 transaction)
 		},
 	}
-	ctx := tmcore.ContextWithPGConnection(context.Background(), sequenceMock)
+	ctx := tmcore.ContextWithPG(context.Background(), sequenceMock)
 
 	repo := &TransactionPostgreSQLRepository{
 		connection:    nil,
@@ -513,7 +513,7 @@ func TestUpdateBulk_BatchedQuery_EmptyChunk(t *testing.T) {
 	mockDB := &updateBulkQueryCaptureMock{
 		bulkMockDB: bulkMockDB{rowsAffected: 0},
 	}
-	ctx := tmcore.ContextWithPGConnection(context.Background(), mockDB)
+	ctx := tmcore.ContextWithPG(context.Background(), mockDB)
 
 	repo := &TransactionPostgreSQLRepository{
 		connection:    nil,
@@ -556,7 +556,7 @@ func TestUpdateBulk_CrossTenantIsolation(t *testing.T) {
 	mockDB := &updateBulkQueryCaptureMock{
 		bulkMockDB: bulkMockDB{rowsAffected: 0}, // No rows updated due to WHERE mismatch
 	}
-	ctx := tmcore.ContextWithPGConnection(context.Background(), mockDB)
+	ctx := tmcore.ContextWithPG(context.Background(), mockDB)
 
 	repo := &TransactionPostgreSQLRepository{
 		connection:    nil,

--- a/components/ledger/internal/adapters/postgres/transactionroute/transactionroute.postgresql.go
+++ b/components/ledger/internal/adapters/postgres/transactionroute/transactionroute.postgresql.go
@@ -76,7 +76,7 @@ func (r *TransactionRoutePostgreSQLRepository) getDB(ctx context.Context) (dbres
 	}
 
 	// Generic connection fallback (single-module services)
-	if db := tmcore.GetPGConnectionContext(ctx); db != nil {
+	if db := tmcore.GetPGContext(ctx); db != nil {
 		return db, nil
 	}
 

--- a/components/ledger/internal/adapters/postgres/transactionroute/transactionroute.postgresql.go
+++ b/components/ledger/internal/adapters/postgres/transactionroute/transactionroute.postgresql.go
@@ -71,12 +71,12 @@ func NewTransactionRoutePostgreSQLRepository(pc *libPostgres.Client, requireTena
 // In single-tenant mode (or when no tenant context exists), falls back to the static connection.
 func (r *TransactionRoutePostgreSQLRepository) getDB(ctx context.Context) (dbresolver.DB, error) {
 	// Module-specific connection (from middleware WithModule)
-	if db := tmcore.GetPG(ctx, constant.ModuleTransaction); db != nil {
+	if db := tmcore.GetPGContext(ctx, constant.ModuleTransaction); db != nil {
 		return db, nil
 	}
 
 	// Generic connection fallback (single-module services)
-	if db := tmcore.GetPGConnectionFromContext(ctx); db != nil {
+	if db := tmcore.GetPGConnectionContext(ctx); db != nil {
 		return db, nil
 	}
 

--- a/components/ledger/internal/adapters/postgres/transactionroute/transactionroute.postgresql_chaos_test.go
+++ b/components/ledger/internal/adapters/postgres/transactionroute/transactionroute.postgresql_chaos_test.go
@@ -438,7 +438,7 @@ func TestIntegration_Chaos_TransactionRoute_NetworkPartition(t *testing.T) {
 	tenantDB, err := infra.conn.Resolver(context.Background())
 	require.NoError(t, err, "setup: must be able to get DB from proxied connection")
 
-	tenantCtx := tmcore.ContextWithPGConnection(ctx, tenantDB)
+	tenantCtx := tmcore.ContextWithPG(ctx, tenantDB)
 
 	// --- Phase 1: Normal ---
 	// Verify operations work both with plain context (static path) and with

--- a/components/ledger/internal/adapters/rabbitmq/producer.multitenant.go
+++ b/components/ledger/internal/adapters/rabbitmq/producer.multitenant.go
@@ -121,7 +121,7 @@ func (p *MultiTenantProducerRepository) publish(ctx context.Context, exchange, k
 	ctx, span := tracer.Start(ctx, spanName)
 	defer span.End()
 
-	tenantID := tmcore.GetTenantIDFromContext(ctx)
+	tenantID := tmcore.GetTenantIDContext(ctx)
 	if tenantID == "" {
 		err := fmt.Errorf("tenant ID is required in context for multi-tenant producer")
 		libOpentelemetry.HandleSpanError(span, "Missing tenant ID in context", err)

--- a/components/ledger/internal/adapters/rabbitmq/producer.multitenant_integration_test.go
+++ b/components/ledger/internal/adapters/rabbitmq/producer.multitenant_integration_test.go
@@ -304,7 +304,7 @@ func TestIntegration_MultiTenantProducer_MessageIsolation(t *testing.T) {
 	// Publish 3 messages as tenant A
 	for i := 0; i < 3; i++ {
 		msg := fmt.Sprintf(`{"tenant":"%s","seq":%d}`, tenantA, i)
-		ctxA := tmcore.SetTenantIDInContext(ctx, tenantA)
+		ctxA := tmcore.ContextWithTenantID(ctx, tenantA)
 
 		_, err := infra.producer.ProducerDefault(ctxA, infra.exchange, infra.routingKey, []byte(msg))
 		require.NoError(t, err, "tenant-a publish %d should succeed", i)
@@ -313,7 +313,7 @@ func TestIntegration_MultiTenantProducer_MessageIsolation(t *testing.T) {
 	// Publish 2 messages as tenant B
 	for i := 0; i < 2; i++ {
 		msg := fmt.Sprintf(`{"tenant":"%s","seq":%d}`, tenantB, i)
-		ctxB := tmcore.SetTenantIDInContext(ctx, tenantB)
+		ctxB := tmcore.ContextWithTenantID(ctx, tenantB)
 
 		_, err := infra.producer.ProducerDefault(ctxB, infra.exchange, infra.routingKey, []byte(msg))
 		require.NoError(t, err, "tenant-b publish %d should succeed", i)
@@ -367,7 +367,7 @@ func TestIntegration_MultiTenantProducer_WithContext(t *testing.T) {
 	tenantID := "tenant-ctx"
 	infra := setupMultiTenantInfra(t, []string{tenantID})
 
-	ctx := tmcore.SetTenantIDInContext(context.Background(), tenantID)
+	ctx := tmcore.ContextWithTenantID(context.Background(), tenantID)
 	msg := []byte(`{"method":"with-context"}`)
 
 	_, err := infra.producer.ProducerDefaultWithContext(ctx, infra.exchange, infra.routingKey, msg)
@@ -391,7 +391,7 @@ func TestIntegration_MultiTenantProducer_ConnectionReuse(t *testing.T) {
 	tenantID := "tenant-reuse"
 	infra := setupMultiTenantInfra(t, []string{tenantID})
 
-	ctx := tmcore.SetTenantIDInContext(context.Background(), tenantID)
+	ctx := tmcore.ContextWithTenantID(context.Background(), tenantID)
 
 	// Publish 10 messages rapidly
 	for i := 0; i < 10; i++ {
@@ -433,7 +433,7 @@ func TestIntegration_MultiTenantProducer_PersistentDelivery(t *testing.T) {
 	tenantID := "tenant-persist"
 	infra := setupMultiTenantInfra(t, []string{tenantID})
 
-	ctx := tmcore.SetTenantIDInContext(context.Background(), tenantID)
+	ctx := tmcore.ContextWithTenantID(context.Background(), tenantID)
 	msg := []byte(`{"persist":true}`)
 
 	_, err := infra.producer.ProducerDefault(ctx, infra.exchange, infra.routingKey, msg)

--- a/components/ledger/internal/adapters/rabbitmq/producer.multitenant_test.go
+++ b/components/ledger/internal/adapters/rabbitmq/producer.multitenant_test.go
@@ -275,7 +275,7 @@ func TestMultiTenantProducer_ProducerDefault(t *testing.T) {
 			// Build context with or without tenant ID
 			ctx := context.Background()
 			if tt.tenantID != "" {
-				ctx = tmcore.SetTenantIDInContext(ctx, tt.tenantID)
+				ctx = tmcore.ContextWithTenantID(ctx, tt.tenantID)
 			}
 
 			// Only set up GetChannel expectation when tenant ID is present
@@ -397,7 +397,7 @@ func TestMultiTenantProducer_ProducerDefaultWithContext(t *testing.T) {
 
 			ctx := context.Background()
 			if tt.tenantID != "" {
-				ctx = tmcore.SetTenantIDInContext(ctx, tt.tenantID)
+				ctx = tmcore.ContextWithTenantID(ctx, tt.tenantID)
 			}
 
 			if tt.tenantID != "" {
@@ -472,7 +472,7 @@ func TestMultiTenantProducer_BothMethodsDelegateToPublish(t *testing.T) {
 			producer := NewMultiTenantProducerWithProvider(provider, logger)
 
 			tenantID := "tenant-delegate-test"
-			ctx := tmcore.SetTenantIDInContext(context.Background(), tenantID)
+			ctx := tmcore.ContextWithTenantID(context.Background(), tenantID)
 			exchange := "test-exchange"
 			key := "test.key"
 			message := []byte(`{"verify":"delegate"}`)
@@ -651,7 +651,7 @@ func TestMultiTenantProducer_PublishMessageParameters(t *testing.T) {
 			producer := NewMultiTenantProducerWithProvider(provider, logger)
 
 			tenantID := "tenant-params"
-			ctx := tmcore.SetTenantIDInContext(context.Background(), tenantID)
+			ctx := tmcore.ContextWithTenantID(context.Background(), tenantID)
 			exchange := "test-exchange"
 			key := "test.key"
 
@@ -715,7 +715,7 @@ func TestMultiTenantProducer_ProducerDefault_EmptyStringTenantID(t *testing.T) {
 			producer := NewMultiTenantProducerWithProvider(provider, logger)
 
 			// SetTenantIDInContext with empty string is equivalent to no tenant
-			ctx := tmcore.SetTenantIDInContext(context.Background(), tt.tenantID)
+			ctx := tmcore.ContextWithTenantID(context.Background(), tt.tenantID)
 
 			_, err := producer.ProducerDefault(ctx, "exchange", "key", []byte("msg"))
 
@@ -763,7 +763,7 @@ func TestMultiTenantProducer_ProducerDefault_GetChannelErrorWrapping(t *testing.
 
 			producer := NewMultiTenantProducerWithProvider(provider, logger)
 
-			ctx := tmcore.SetTenantIDInContext(context.Background(), tt.tenantID)
+			ctx := tmcore.ContextWithTenantID(context.Background(), tt.tenantID)
 
 			provider.EXPECT().
 				GetChannel(gomock.Any(), tt.tenantID).
@@ -907,7 +907,7 @@ func TestMultiTenantProducer_ProducerDefault_CanceledContext(t *testing.T) {
 			producer := NewMultiTenantProducerWithProvider(provider, logger)
 
 			ctx, cancel := context.WithCancel(context.Background())
-			ctx = tmcore.SetTenantIDInContext(ctx, "tenant-cancel")
+			ctx = tmcore.ContextWithTenantID(ctx, "tenant-cancel")
 
 			if tt.cancelContext {
 				cancel()

--- a/components/ledger/internal/adapters/redis/onboarding/consumer.redis.go
+++ b/components/ledger/internal/adapters/redis/onboarding/consumer.redis.go
@@ -60,7 +60,7 @@ func (rr *RedisConsumerRepository) Set(ctx context.Context, key, value string, t
 	ctx, span := tracer.Start(ctx, "redis.set")
 	defer span.End()
 
-	key, err := tmvalkey.GetKeyFromContext(ctx, key)
+	key, err := tmvalkey.GetKeyContext(ctx, key)
 	if err != nil {
 		libOpentelemetry.HandleSpanError(span, "Failed to build tenant key", err)
 
@@ -96,7 +96,7 @@ func (rr *RedisConsumerRepository) Get(ctx context.Context, key string) (string,
 	ctx, span := tracer.Start(ctx, "redis.get")
 	defer span.End()
 
-	key, err := tmvalkey.GetKeyFromContext(ctx, key)
+	key, err := tmvalkey.GetKeyContext(ctx, key)
 	if err != nil {
 		libOpentelemetry.HandleSpanError(span, "Failed to build tenant key", err)
 
@@ -130,7 +130,7 @@ func (rr *RedisConsumerRepository) Del(ctx context.Context, key string) error {
 	ctx, span := tracer.Start(ctx, "redis.del")
 	defer span.End()
 
-	key, err := tmvalkey.GetKeyFromContext(ctx, key)
+	key, err := tmvalkey.GetKeyContext(ctx, key)
 	if err != nil {
 		libOpentelemetry.HandleSpanError(span, "Failed to build tenant key", err)
 

--- a/components/ledger/internal/adapters/redis/onboarding/consumer.redis_chaos_test.go
+++ b/components/ledger/internal/adapters/redis/onboarding/consumer.redis_chaos_test.go
@@ -125,7 +125,7 @@ func TestIntegration_Chaos_RedisNamespacing_ConnectionLossOnSet(t *testing.T) {
 	infra := setupOnboardingRedisChaosNetworkInfra(t)
 
 	tenantID := "chaos-set-tenant-" + uuid.New().String()
-	ctx := tmcore.SetTenantIDInContext(context.Background(), tenantID)
+	ctx := tmcore.ContextWithTenantID(context.Background(), tenantID)
 	key := "chaos-set-key:" + uuid.New().String()
 	value := "chaos-set-value-" + uuid.New().String()
 	ttl := 5 * time.Minute
@@ -234,7 +234,7 @@ func TestIntegration_Chaos_RedisNamespacing_RecoveryAfterReconnect(t *testing.T)
 	infra := setupOnboardingRedisChaosNetworkInfra(t)
 
 	tenantID := "chaos-recovery-tenant-" + uuid.New().String()
-	ctx := tmcore.SetTenantIDInContext(context.Background(), tenantID)
+	ctx := tmcore.ContextWithTenantID(context.Background(), tenantID)
 	key := "chaos-recovery-key:" + uuid.New().String()
 	value := "chaos-recovery-value-" + uuid.New().String()
 	ttl := 5 * time.Minute

--- a/components/ledger/internal/adapters/redis/onboarding/consumer.redis_fuzz_test.go
+++ b/components/ledger/internal/adapters/redis/onboarding/consumer.redis_fuzz_test.go
@@ -72,7 +72,7 @@ func FuzzKeyNamespacing_SimpleKey(f *testing.F) {
 		// Build context with or without a tenant ID.
 		var ctx context.Context
 		if tenantID != "" {
-			ctx = tmcore.SetTenantIDInContext(context.Background(), tenantID)
+			ctx = tmcore.ContextWithTenantID(context.Background(), tenantID)
 		} else {
 			ctx = context.Background()
 		}

--- a/components/ledger/internal/adapters/redis/onboarding/consumer.redis_fuzz_test.go
+++ b/components/ledger/internal/adapters/redis/onboarding/consumer.redis_fuzz_test.go
@@ -14,7 +14,7 @@ import (
 	// =============================================================================
 	// FUZZ TESTS — Redis Key Namespacing (T-002)
 	//
-	// These fuzz tests exercise tmvalkey.GetKeyFromContext with arbitrary key and
+	// These fuzz tests exercise tmvalkey.GetKeyContext with arbitrary key and
 	// tenantID inputs to verify:
 	//   1. No panic under any input (including Unicode, null bytes, very long strings,
 	//      colons, empty strings, and strings that already look like namespaced keys).
@@ -78,9 +78,9 @@ func FuzzKeyNamespacing_SimpleKey(f *testing.F) {
 		}
 
 		// Call the function under test — must not panic.
-		result, err := tmvalkey.GetKeyFromContext(ctx, key)
+		result, err := tmvalkey.GetKeyContext(ctx, key)
 		if err != nil {
-			t.Fatalf("GetKeyFromContext should not fail for generated inputs: %v", err)
+			t.Fatalf("GetKeyContext should not fail for generated inputs: %v", err)
 		}
 
 		// Invariant 1: non-empty tenantID → prefix is applied.
@@ -100,9 +100,9 @@ func FuzzKeyNamespacing_SimpleKey(f *testing.F) {
 
 		// Invariant 3: determinism — calling again with the same context and key
 		// must return the same value.
-		result2, err := tmvalkey.GetKeyFromContext(ctx, key)
+		result2, err := tmvalkey.GetKeyContext(ctx, key)
 		if err != nil {
-			t.Fatalf("GetKeyFromContext should be deterministic without errors: %v", err)
+			t.Fatalf("GetKeyContext should be deterministic without errors: %v", err)
 		}
 		if result != result2 {
 			t.Errorf("FuzzKeyNamespacing_SimpleKey: non-deterministic result: first=%q second=%q (key=%q, tenantID=%q)",

--- a/components/ledger/internal/adapters/redis/onboarding/consumer.redis_integration_test.go
+++ b/components/ledger/internal/adapters/redis/onboarding/consumer.redis_integration_test.go
@@ -74,7 +74,7 @@ func TestIntegration_RedisNamespacing_SetGetWithTenant(t *testing.T) {
 	infra := setupOnboardingRedisIntegrationInfra(t)
 
 	tenantID := "int-tenant-" + uuid.New().String()
-	ctx := tmcore.SetTenantIDInContext(context.Background(), tenantID)
+	ctx := tmcore.ContextWithTenantID(context.Background(), tenantID)
 
 	logicalKey := "session:token:" + uuid.New().String()
 	value := "integration-value-" + uuid.New().String()
@@ -191,8 +191,8 @@ func TestIntegration_RedisNamespacing_TwoTenantsNoCollision(t *testing.T) {
 	tenantA := "tenant-a-" + uuid.New().String()
 	tenantB := "tenant-b-" + uuid.New().String()
 
-	ctxA := tmcore.SetTenantIDInContext(context.Background(), tenantA)
-	ctxB := tmcore.SetTenantIDInContext(context.Background(), tenantB)
+	ctxA := tmcore.ContextWithTenantID(context.Background(), tenantA)
+	ctxB := tmcore.ContextWithTenantID(context.Background(), tenantB)
 
 	// Both tenants use the exact same logical key.
 	sharedLogicalKey := "shared:session:token"
@@ -280,8 +280,8 @@ func TestIntegration_RedisNamespacing_DelWithTenant(t *testing.T) {
 	tenantA := "del-tenant-a-" + uuid.New().String()
 	tenantB := "del-tenant-b-" + uuid.New().String()
 
-	ctxA := tmcore.SetTenantIDInContext(context.Background(), tenantA)
-	ctxB := tmcore.SetTenantIDInContext(context.Background(), tenantB)
+	ctxA := tmcore.ContextWithTenantID(context.Background(), tenantA)
+	ctxB := tmcore.ContextWithTenantID(context.Background(), tenantB)
 
 	logicalKey := "profile:settings:" + uuid.New().String()
 	valueA := "settings-a-" + uuid.New().String()
@@ -342,7 +342,7 @@ func TestIntegration_RedisNamespacing_TTLIsRespected(t *testing.T) {
 	infra := setupOnboardingRedisIntegrationInfra(t)
 
 	tenantID := "ttl-tenant-" + uuid.New().String()
-	ctx := tmcore.SetTenantIDInContext(context.Background(), tenantID)
+	ctx := tmcore.ContextWithTenantID(context.Background(), tenantID)
 
 	logicalKey := "ephemeral:key:" + uuid.New().String()
 	value := "ephemeral-value"

--- a/components/ledger/internal/adapters/redis/onboarding/consumer.redis_test.go
+++ b/components/ledger/internal/adapters/redis/onboarding/consumer.redis_test.go
@@ -113,7 +113,7 @@ func TestKeyNamespacing_SimpleKeyMethods(t *testing.T) {
 
 			ctx := context.Background()
 			if tc.tenantID != "" {
-				ctx = tmcore.SetTenantIDInContext(ctx, tc.tenantID)
+				ctx = tmcore.ContextWithTenantID(ctx, tc.tenantID)
 			}
 
 			// Test Set

--- a/components/ledger/internal/adapters/redis/transaction/consumer.redis.go
+++ b/components/ledger/internal/adapters/redis/transaction/consumer.redis.go
@@ -51,7 +51,7 @@ type redisClientProvider interface {
 }
 
 func tenantKeyFromContextOrError(ctx context.Context, key string) (string, error) {
-	return tmvalkey.GetKeyFromContext(ctx, key)
+	return tmvalkey.GetKeyContext(ctx, key)
 }
 
 func tenantKeysFromContext(ctx context.Context, keys []string) ([]string, error) {

--- a/components/ledger/internal/adapters/redis/transaction/consumer.redis_atomic_state_test.go
+++ b/components/ledger/internal/adapters/redis/transaction/consumer.redis_atomic_state_test.go
@@ -74,7 +74,7 @@ func redisDecimalFromString(t *testing.T, value string) decimal.Decimal {
 func TestKeyNamespacing_MalformedTenantID_FailsClosedBalanceSyncScripts(t *testing.T) {
 	t.Parallel()
 
-	ctx := tmcore.SetTenantIDInContext(context.Background(), "tenant:invalid")
+	ctx := tmcore.ContextWithTenantID(context.Background(), "tenant:invalid")
 
 	t.Run("get balance sync keys", func(t *testing.T) {
 		t.Parallel()
@@ -116,14 +116,14 @@ func TestKeyNamespacing_MalformedTenantID_FailsClosedGetBalancesByKeys(t *testin
 		conn: newMockMGetConnection(mockClient),
 	}
 
-	_, err := repo.GetBalancesByKeys(tmcore.SetTenantIDInContext(context.Background(), "tenant:invalid"), []string{"key1", "key2"})
+	_, err := repo.GetBalancesByKeys(tmcore.ContextWithTenantID(context.Background(), "tenant:invalid"), []string{"key1", "key2"})
 	require.Error(t, err)
 }
 
 func TestKeyNamespacing_MalformedTenantID_FailsClosedBatchScheduleAndRemove(t *testing.T) {
 	t.Parallel()
 
-	ctx := tmcore.SetTenantIDInContext(context.Background(), "tenant:invalid")
+	ctx := tmcore.ContextWithTenantID(context.Background(), "tenant:invalid")
 
 	t.Run("schedule balance sync batch", func(t *testing.T) {
 		t.Parallel()

--- a/components/ledger/internal/adapters/redis/transaction/consumer.redis_chaos_test.go
+++ b/components/ledger/internal/adapters/redis/transaction/consumer.redis_chaos_test.go
@@ -135,7 +135,7 @@ func TestIntegration_Chaos_RedisNamespacing_ConnectionLossOnSet(t *testing.T) {
 	infra := setupRedisChaosNetworkInfra(t)
 
 	tenantID := "chaos-tenant-" + uuid.New().String()
-	ctx := tmcore.SetTenantIDInContext(context.Background(), tenantID)
+	ctx := tmcore.ContextWithTenantID(context.Background(), tenantID)
 	key := "chaos-set-key:" + uuid.New().String()
 	value := "chaos-set-value-" + uuid.New().String()
 
@@ -216,7 +216,7 @@ func TestIntegration_Chaos_RedisNamespacing_HighLatencyOnGet(t *testing.T) {
 	infra := setupRedisChaosNetworkInfra(t)
 
 	tenantID := "chaos-latency-tenant-" + uuid.New().String()
-	ctx := tmcore.SetTenantIDInContext(context.Background(), tenantID)
+	ctx := tmcore.ContextWithTenantID(context.Background(), tenantID)
 	key := "chaos-latency-key:" + uuid.New().String()
 	value := "chaos-latency-value"
 
@@ -327,7 +327,7 @@ func TestIntegration_Chaos_RedisNamespacing_ConnectionLossOnMGet(t *testing.T) {
 	infra := setupRedisChaosNetworkInfra(t)
 
 	tenantID := "chaos-mget-tenant-" + uuid.New().String()
-	ctx := tmcore.SetTenantIDInContext(context.Background(), tenantID)
+	ctx := tmcore.ContextWithTenantID(context.Background(), tenantID)
 
 	// Pre-populate several keys.
 	keys := []string{
@@ -439,7 +439,7 @@ func TestIntegration_Chaos_RedisNamespacing_ConnectionLossOnQueueOp(t *testing.T
 	infra := setupRedisChaosNetworkInfra(t)
 
 	tenantID := "chaos-queue-tenant-" + uuid.New().String()
-	ctx := tmcore.SetTenantIDInContext(context.Background(), tenantID)
+	ctx := tmcore.ContextWithTenantID(context.Background(), tenantID)
 
 	msgKey := "chaos-queue-msg:" + uuid.New().String()
 	msgPayload := []byte(`{"chaos":"test","ts":"` + time.Now().Format(time.RFC3339) + `"}`)
@@ -524,7 +524,7 @@ func TestIntegration_Chaos_RedisNamespacing_RecoveryAfterReconnect(t *testing.T)
 	infra := setupRedisChaosNetworkInfra(t)
 
 	tenantID := "chaos-recovery-tenant-" + uuid.New().String()
-	ctx := tmcore.SetTenantIDInContext(context.Background(), tenantID)
+	ctx := tmcore.ContextWithTenantID(context.Background(), tenantID)
 	key := "chaos-recovery-key:" + uuid.New().String()
 	value := "chaos-recovery-value-" + uuid.New().String()
 

--- a/components/ledger/internal/adapters/redis/transaction/consumer.redis_fuzz_test.go
+++ b/components/ledger/internal/adapters/redis/transaction/consumer.redis_fuzz_test.go
@@ -68,7 +68,7 @@ func FuzzKeyNamespacing_SimpleKey(f *testing.F) {
 		// Build context with or without a tenant ID.
 		var ctx context.Context
 		if tenantID != "" {
-			ctx = tmcore.SetTenantIDInContext(context.Background(), tenantID)
+			ctx = tmcore.ContextWithTenantID(context.Background(), tenantID)
 		} else {
 			ctx = context.Background()
 		}
@@ -163,7 +163,7 @@ func FuzzKeyNamespacing_MGet(f *testing.F) {
 		// Build context.
 		var ctx context.Context
 		if tenantID != "" {
-			ctx = tmcore.SetTenantIDInContext(context.Background(), tenantID)
+			ctx = tmcore.ContextWithTenantID(context.Background(), tenantID)
 		} else {
 			ctx = context.Background()
 		}
@@ -294,7 +294,7 @@ func FuzzKeyNamespacing_QueueKey(f *testing.F) {
 		// Build context.
 		var ctx context.Context
 		if tenantID != "" {
-			ctx = tmcore.SetTenantIDInContext(context.Background(), tenantID)
+			ctx = tmcore.ContextWithTenantID(context.Background(), tenantID)
 		} else {
 			ctx = context.Background()
 		}

--- a/components/ledger/internal/adapters/redis/transaction/consumer.redis_fuzz_test.go
+++ b/components/ledger/internal/adapters/redis/transaction/consumer.redis_fuzz_test.go
@@ -14,7 +14,7 @@ import (
 	// =============================================================================
 	// FUZZ TESTS — Redis Key Namespacing (T-001)
 	//
-	// These fuzz tests exercise tmvalkey.GetKeyFromContext with arbitrary key and
+	// These fuzz tests exercise tmvalkey.GetKeyContext with arbitrary key and
 	// tenantID inputs to verify:
 	//   1. No panic under any input (including Unicode, null bytes, very long strings,
 	//      colons, empty strings, and strings that already look like namespaced keys).
@@ -74,7 +74,7 @@ func FuzzKeyNamespacing_SimpleKey(f *testing.F) {
 		}
 
 		// Call the function under test — must not panic.
-		result, err := tmvalkey.GetKeyFromContext(ctx, key)
+		result, err := tmvalkey.GetKeyContext(ctx, key)
 		if err != nil {
 			t.Fatalf("unexpected namespacing error: %v", err)
 		}
@@ -96,7 +96,7 @@ func FuzzKeyNamespacing_SimpleKey(f *testing.F) {
 
 		// Invariant 3: determinism — calling again with the same context and key
 		// must return the same value.
-		result2, err := tmvalkey.GetKeyFromContext(ctx, key)
+		result2, err := tmvalkey.GetKeyContext(ctx, key)
 		if err != nil {
 			t.Fatalf("unexpected namespacing error in second call: %v", err)
 		}

--- a/components/ledger/internal/adapters/redis/transaction/consumer.redis_integration_test.go
+++ b/components/ledger/internal/adapters/redis/transaction/consumer.redis_integration_test.go
@@ -1842,7 +1842,7 @@ func TestIntegration_RedisNamespacing_SetGetWithTenant(t *testing.T) {
 	infra := setupRedisIntegrationInfra(t)
 
 	tenantID := "tenant-" + uuid.New().String()
-	ctx := tmcore.SetTenantIDInContext(context.Background(), tenantID)
+	ctx := tmcore.ContextWithTenantID(context.Background(), tenantID)
 
 	originalKey := "balance:" + uuid.New().String()
 	expectedStoredKey := "tenant:" + tenantID + ":" + originalKey
@@ -1918,8 +1918,8 @@ func TestIntegration_RedisNamespacing_TwoTenantsNoCollision(t *testing.T) {
 	tenantA := "tenant-A-" + uuid.New().String()
 	tenantB := "tenant-B-" + uuid.New().String()
 
-	ctxA := tmcore.SetTenantIDInContext(context.Background(), tenantA)
-	ctxB := tmcore.SetTenantIDInContext(context.Background(), tenantB)
+	ctxA := tmcore.ContextWithTenantID(context.Background(), tenantA)
+	ctxB := tmcore.ContextWithTenantID(context.Background(), tenantB)
 
 	// Both tenants use the SAME logical key
 	sharedKey := "balance:123"
@@ -1968,7 +1968,7 @@ func TestIntegration_RedisNamespacing_MGetWithTenantReturnsOriginalKeys(t *testi
 	infra := setupRedisIntegrationInfra(t)
 
 	tenantID := "mget-tenant-" + uuid.New().String()
-	ctx := tmcore.SetTenantIDInContext(context.Background(), tenantID)
+	ctx := tmcore.ContextWithTenantID(context.Background(), tenantID)
 
 	// Store values for multiple keys under this tenant
 	keys := []string{
@@ -2025,8 +2025,8 @@ func TestIntegration_RedisNamespacing_QueueTenantIsolation(t *testing.T) {
 	tenantA := "queue-tenant-A-" + uuid.New().String()
 	tenantB := "queue-tenant-B-" + uuid.New().String()
 
-	ctxA := tmcore.SetTenantIDInContext(context.Background(), tenantA)
-	ctxB := tmcore.SetTenantIDInContext(context.Background(), tenantB)
+	ctxA := tmcore.ContextWithTenantID(context.Background(), tenantA)
+	ctxB := tmcore.ContextWithTenantID(context.Background(), tenantB)
 
 	msgKeyA := "tx-msg-A-" + uuid.New().String()
 	msgKeyB := "tx-msg-B-" + uuid.New().String()

--- a/components/ledger/internal/adapters/redis/transaction/consumer.redis_property_test.go
+++ b/components/ledger/internal/adapters/redis/transaction/consumer.redis_property_test.go
@@ -188,7 +188,7 @@ func TestProperty_MGet_OutputKeysMatchOriginal(t *testing.T) {
 
 		ctx := context.Background()
 		if tenantID != "" {
-			ctx = tmcore.SetTenantIDInContext(ctx, tenantID)
+			ctx = tmcore.ContextWithTenantID(ctx, tenantID)
 		}
 
 		result, err := repo.MGet(ctx, originalKeys)

--- a/components/ledger/internal/adapters/redis/transaction/consumer.redis_test.go
+++ b/components/ledger/internal/adapters/redis/transaction/consumer.redis_test.go
@@ -952,7 +952,7 @@ func TestKeyNamespacing_SimpleKeyMethods(t *testing.T) {
 
 			ctx := context.Background()
 			if tc.tenantID != "" {
-				ctx = tmcore.SetTenantIDInContext(ctx, tc.tenantID)
+				ctx = tmcore.ContextWithTenantID(ctx, tc.tenantID)
 			}
 
 			// Test Set
@@ -1047,7 +1047,7 @@ func TestKeyNamespacing_MGet(t *testing.T) {
 
 			ctx := context.Background()
 			if tc.tenantID != "" {
-				ctx = tmcore.SetTenantIDInContext(ctx, tc.tenantID)
+				ctx = tmcore.ContextWithTenantID(ctx, tc.tenantID)
 			}
 
 			result, err := repo.MGet(ctx, tc.originalKeys)
@@ -1114,7 +1114,7 @@ func TestKeyNamespacing_QueueOperations(t *testing.T) {
 
 			ctx := context.Background()
 			if tc.tenantID != "" {
-				ctx = tmcore.SetTenantIDInContext(ctx, tc.tenantID)
+				ctx = tmcore.ContextWithTenantID(ctx, tc.tenantID)
 			}
 
 			// Test AddMessageToQueue
@@ -1208,7 +1208,7 @@ func TestKeyNamespacing_ListBalanceByKey(t *testing.T) {
 
 			ctx := context.Background()
 			if tc.tenantID != "" {
-				ctx = tmcore.SetTenantIDInContext(ctx, tc.tenantID)
+				ctx = tmcore.ContextWithTenantID(ctx, tc.tenantID)
 			}
 
 			_, err := repo.ListBalanceByKey(ctx, organizationID, ledgerID, balanceKey)
@@ -1273,7 +1273,7 @@ func TestKeyNamespacing_ProcessBalanceAtomicOperation(t *testing.T) {
 
 			ctx := context.Background()
 			if tc.tenantID != "" {
-				ctx = tmcore.SetTenantIDInContext(ctx, tc.tenantID)
+				ctx = tmcore.ContextWithTenantID(ctx, tc.tenantID)
 			}
 
 			balanceOp := mmodel.BalanceOperation{
@@ -1373,7 +1373,7 @@ func TestKeyNamespacing_GetBalanceSyncKeys(t *testing.T) {
 
 			ctx := context.Background()
 			if tc.tenantID != "" {
-				ctx = tmcore.SetTenantIDInContext(ctx, tc.tenantID)
+				ctx = tmcore.ContextWithTenantID(ctx, tc.tenantID)
 			}
 
 			// The script result will be empty []any — that is the expected fallback from the stub.
@@ -1431,7 +1431,7 @@ func TestKeyNamespacing_RemoveBalanceSyncKey(t *testing.T) {
 
 			ctx := context.Background()
 			if tc.tenantID != "" {
-				ctx = tmcore.SetTenantIDInContext(ctx, tc.tenantID)
+				ctx = tmcore.ContextWithTenantID(ctx, tc.tenantID)
 			}
 
 			member := "balance:{transactions}:org:ledger:default"

--- a/components/ledger/internal/bootstrap/balance.worker.go
+++ b/components/ledger/internal/bootstrap/balance.worker.go
@@ -232,8 +232,8 @@ func (w *BalanceSyncWorker) processTenantBalances(ctx context.Context, tenantID 
 		return false
 	}
 
-	tenantCtx = tmcore.ContextWithPGConnection(tenantCtx, db)
-	tenantCtx = tmcore.ContextWithPG(tenantCtx, constant.ModuleTransaction, db)
+	tenantCtx = tmcore.ContextWithPG(tenantCtx, db)
+	tenantCtx = tmcore.ContextWithPG(tenantCtx, db, constant.ModuleTransaction)
 
 	return w.processBalancesToExpire(tenantCtx, rds)
 }

--- a/components/ledger/internal/bootstrap/config.rabbitmq.go
+++ b/components/ledger/internal/bootstrap/config.rabbitmq.go
@@ -249,8 +249,8 @@ func resolveTenantConnections(ctx context.Context, rmq *rabbitMQComponents) (con
 
 		// Store the tenant PG connection in both generic and module-specific context keys.
 		// Generic key provides backward compatibility; module key enables cross-module resolution.
-		ctx = tmcore.ContextWithPGConnection(ctx, db)
-		ctx = tmcore.ContextWithPG(ctx, constant.ModuleTransaction, db)
+		ctx = tmcore.ContextWithPG(ctx, db)
+		ctx = tmcore.ContextWithPG(ctx, db, constant.ModuleTransaction)
 	}
 
 	if rmq.mongoManager != nil {
@@ -263,8 +263,8 @@ func resolveTenantConnections(ctx context.Context, rmq *rabbitMQComponents) (con
 
 		emitTenantCounter(ctx, rmq.metricsFactory, utils.TenantConnectionsTotal, tenantID, "mongodb")
 
-		ctx = tmcore.ContextWithMongo(ctx, mongoDB)
-		ctx = tmcore.ContextWithMB(ctx, constant.ModuleTransaction, mongoDB)
+		ctx = tmcore.ContextWithMB(ctx, mongoDB)
+		ctx = tmcore.ContextWithMB(ctx, mongoDB, constant.ModuleTransaction)
 	}
 
 	return ctx, nil

--- a/components/ledger/internal/bootstrap/config.rabbitmq.go
+++ b/components/ledger/internal/bootstrap/config.rabbitmq.go
@@ -199,7 +199,7 @@ func initMultiTenantRabbitMQ(
 				}
 
 				// Emit message processed metric after successful handler execution
-				tenantID := tmcore.GetTenantIDFromContext(ctx)
+				tenantID := tmcore.GetTenantIDContext(ctx)
 				if rmqComponents.metricsFactory != nil && tenantID != "" {
 					counter, counterErr := rmqComponents.metricsFactory.Counter(utils.TenantMessagesProcessedTotal)
 					if counterErr == nil {
@@ -232,7 +232,7 @@ func initMultiTenantRabbitMQ(
 //   - Nil pgManager/mongoManager: skips that resolution (not configured).
 //   - Connection error: returns error so the message is nacked and retried.
 func resolveTenantConnections(ctx context.Context, rmq *rabbitMQComponents) (context.Context, error) {
-	tenantID := tmcore.GetTenantIDFromContext(ctx)
+	tenantID := tmcore.GetTenantIDContext(ctx)
 	if tenantID == "" {
 		return ctx, fmt.Errorf("missing tenant context in multi-tenant consumer")
 	}

--- a/components/ledger/internal/bootstrap/config.rabbitmq_test.go
+++ b/components/ledger/internal/bootstrap/config.rabbitmq_test.go
@@ -84,7 +84,7 @@ func TestResolveTenantConnections_EmitsMetrics_OnNilManagersNoError(t *testing.T
 	// skip resolution without error and without emitting metrics.
 	result, err := resolveTenantConnections(ctx, rmq)
 	require.NoError(t, err, "should not error with nil managers")
-	assert.Equal(t, "tenant-001", tmcore.GetTenantIDFromContext(result),
+	assert.Equal(t, "tenant-001", tmcore.GetTenantIDContext(result),
 		"tenant ID should be preserved")
 }
 

--- a/components/ledger/internal/bootstrap/redis.consumer.go
+++ b/components/ledger/internal/bootstrap/redis.consumer.go
@@ -165,8 +165,8 @@ func (r *RedisQueueConsumer) runMultiTenant() error {
 					continue
 				}
 
-				tenantCtx = tmcore.ContextWithPGConnection(tenantCtx, db)
-				tenantCtx = tmcore.ContextWithPG(tenantCtx, constant.ModuleTransaction, db)
+				tenantCtx = tmcore.ContextWithPG(tenantCtx, db)
+				tenantCtx = tmcore.ContextWithPG(tenantCtx, db, constant.ModuleTransaction)
 
 				r.readMessagesAndProcess(tenantCtx)
 			}

--- a/components/ledger/internal/bootstrap/workers_multitenant_test.go
+++ b/components/ledger/internal/bootstrap/workers_multitenant_test.go
@@ -875,7 +875,7 @@ func TestResolveTenantConnections_NilManagers(t *testing.T) {
 			require.NotPanics(t, func() {
 				result, err := resolveTenantConnections(ctx, rmq)
 				require.NoError(t, err)
-				assert.Equal(t, tt.tenantID, tmcore.GetTenantIDFromContext(result),
+				assert.Equal(t, tt.tenantID, tmcore.GetTenantIDContext(result),
 					"tenant ID should be preserved with nil managers")
 			}, "resolveTenantConnections must not panic with nil managers")
 		})

--- a/components/ledger/internal/services/command/create-write-behind-transaction.go
+++ b/components/ledger/internal/services/command/create-write-behind-transaction.go
@@ -30,7 +30,7 @@ func (uc *UseCase) CreateWriteBehindTransaction(ctx context.Context, organizatio
 	ctx, span := tracer.Start(ctx, "command.create_write_behind_transaction")
 	defer span.End()
 
-	tenantID := tmcore.GetTenantIDFromContext(ctx)
+	tenantID := tmcore.GetTenantIDContext(ctx)
 
 	logger.Log(ctx, libLog.LevelInfo, fmt.Sprintf("[DEBUG] CreateWriteBehindTransaction: tenantID=%q", tenantID))
 

--- a/components/ledger/internal/services/command/delete-write-behind-transaction.go
+++ b/components/ledger/internal/services/command/delete-write-behind-transaction.go
@@ -26,7 +26,7 @@ func (uc *UseCase) DeleteWriteBehindTransaction(ctx context.Context, organizatio
 	ctx, span := tracer.Start(ctx, "command.delete_write_behind_transaction")
 	defer span.End()
 
-	tenantID := tmcore.GetTenantIDFromContext(ctx)
+	tenantID := tmcore.GetTenantIDContext(ctx)
 
 	key := utils.WriteBehindTransactionKey(organizationID, ledgerID, transactionID)
 

--- a/go.mod
+++ b/go.mod
@@ -100,7 +100,7 @@ require (
 )
 
 require (
-	github.com/LerianStudio/lib-commons/v4 v4.5.0-beta.15
+	github.com/LerianStudio/lib-commons/v4 v4.5.0-beta.16
 	github.com/Shopify/toxiproxy/v2 v2.12.0
 	github.com/docker/docker v28.5.2+incompatible
 	github.com/docker/go-connections v0.6.0

--- a/go.mod
+++ b/go.mod
@@ -100,7 +100,7 @@ require (
 )
 
 require (
-	github.com/LerianStudio/lib-commons/v4 v4.5.0-beta.16
+	github.com/LerianStudio/lib-commons/v4 v4.5.0-beta.17
 	github.com/Shopify/toxiproxy/v2 v2.12.0
 	github.com/docker/docker v28.5.2+incompatible
 	github.com/docker/go-connections v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -19,8 +19,8 @@ github.com/KyleBanks/depth v1.2.1 h1:5h8fQADFrWtarTdtDudMmGsC7GPbOAu6RVB3ffsVFHc
 github.com/KyleBanks/depth v1.2.1/go.mod h1:jzSb9d0L43HxTQfT+oSA1EEp2q+ne2uh6XgeJcm8brE=
 github.com/LerianStudio/lib-auth/v2 v2.6.0 h1:J0QvGXWoEbgd5HF5wtMznVfkho/aPihl6sAWn12bvZ4=
 github.com/LerianStudio/lib-auth/v2 v2.6.0/go.mod h1:AAbJCVaVokfO9bLa4aCIGzVMP6to/Ml5MC4X9B6jLZ0=
-github.com/LerianStudio/lib-commons/v4 v4.5.0-beta.16 h1:dqKkHWKY9qGj1n5NW5B+o9zvN6T8xO4gb1oPoBakA/w=
-github.com/LerianStudio/lib-commons/v4 v4.5.0-beta.16/go.mod h1:/0EgYB6lT23afy/nmmeJiuoDnu3/tS56fXqW7fB0QMk=
+github.com/LerianStudio/lib-commons/v4 v4.5.0-beta.17 h1:2wm6uRV+9N0Cce0jV9ruZAJa4dJCZ3TH0sS0pryreOA=
+github.com/LerianStudio/lib-commons/v4 v4.5.0-beta.17/go.mod h1:/0EgYB6lT23afy/nmmeJiuoDnu3/tS56fXqW7fB0QMk=
 github.com/Masterminds/squirrel v1.5.4 h1:uUcX/aBc8O7Fg9kaISIUsHXdKuqehiXAMQTYX8afzqM=
 github.com/Masterminds/squirrel v1.5.4/go.mod h1:NNaOrjSoIDfDA40n7sr2tPNZRfjzjA400rg+riTZj10=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=

--- a/go.sum
+++ b/go.sum
@@ -19,8 +19,8 @@ github.com/KyleBanks/depth v1.2.1 h1:5h8fQADFrWtarTdtDudMmGsC7GPbOAu6RVB3ffsVFHc
 github.com/KyleBanks/depth v1.2.1/go.mod h1:jzSb9d0L43HxTQfT+oSA1EEp2q+ne2uh6XgeJcm8brE=
 github.com/LerianStudio/lib-auth/v2 v2.6.0 h1:J0QvGXWoEbgd5HF5wtMznVfkho/aPihl6sAWn12bvZ4=
 github.com/LerianStudio/lib-auth/v2 v2.6.0/go.mod h1:AAbJCVaVokfO9bLa4aCIGzVMP6to/Ml5MC4X9B6jLZ0=
-github.com/LerianStudio/lib-commons/v4 v4.5.0-beta.15 h1:UjFawOiXVeO4mwqkuQyICTsP9BvsLB7Ej6rFy/v/dDI=
-github.com/LerianStudio/lib-commons/v4 v4.5.0-beta.15/go.mod h1:/0EgYB6lT23afy/nmmeJiuoDnu3/tS56fXqW7fB0QMk=
+github.com/LerianStudio/lib-commons/v4 v4.5.0-beta.16 h1:dqKkHWKY9qGj1n5NW5B+o9zvN6T8xO4gb1oPoBakA/w=
+github.com/LerianStudio/lib-commons/v4 v4.5.0-beta.16/go.mod h1:/0EgYB6lT23afy/nmmeJiuoDnu3/tS56fXqW7fB0QMk=
 github.com/Masterminds/squirrel v1.5.4 h1:uUcX/aBc8O7Fg9kaISIUsHXdKuqehiXAMQTYX8afzqM=
 github.com/Masterminds/squirrel v1.5.4/go.mod h1:NNaOrjSoIDfDA40n7sr2tPNZRfjzjA400rg+riTZj10=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=

--- a/pkg/net/http/protected_routes_test.go
+++ b/pkg/net/http/protected_routes_test.go
@@ -54,7 +54,7 @@ func TestMarkTrustedAuthAssertion_SetsTrustedLocalsAndTenantContext(t *testing.T
 	app.Get("/test", func(c *fiber.Ctx) error {
 		return c.JSON(fiber.Map{
 			"userID":   c.Locals("user_id"),
-			"tenantID": tmcore.GetTenantID(c.UserContext()),
+			"tenantID": tmcore.GetTenantIDContext(c.UserContext()),
 		})
 	})
 


### PR DESCRIPTION
## Summary

Standardize all context getter function names to `Get{X}Context` pattern. Upgrade lib-commons to v4.5.0-beta.16.

## Renames

| Old | New |
|-----|-----|
| `GetTenantIDFromContext` | `GetTenantIDContext` |
| `GetPG` | `GetPGContext` |
| `GetPGConnectionFromContext` | `GetPGConnectionContext` |
| `GetMB` | `GetMBContext` |
| `GetMongoFromContext` | `GetMongoContext` |
| `SetTenantIDInContext` | `ContextWithTenantID` |

## Also includes
- Consumer lifecycle fixes (OnTenantAdded, StopConsumer, onTenantLoaded)
- Cache invalidation on tenant add/remove
- lib-auth v2.6.0 (HTTP/2 hpack fix)

## Test plan
- [x] All ledger tests pass
- [x] All CRM tests pass
- [x] All pkg tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)