### PR TITLE
refactor: standardize context API, env naming, and lib-commons v4.5.0-beta.19

### DIFF
--- a/components/crm/internal/bootstrap/config.go
+++ b/components/crm/internal/bootstrap/config.go
@@ -56,7 +56,7 @@ type Config struct {
 	MultiTenantCircuitBreakerThreshold  int    `env:"MULTI_TENANT_CIRCUIT_BREAKER_THRESHOLD"`   // failures before circuit opens
 	MultiTenantCircuitBreakerTimeoutSec int    `env:"MULTI_TENANT_CIRCUIT_BREAKER_TIMEOUT_SEC"` // seconds before circuit resets
 	MultiTenantServiceAPIKey            string `env:"MULTI_TENANT_SERVICE_API_KEY"`
-	MultiTenantSettingsCheckIntervalSec int    `env:"MULTI_TENANT_SETTINGS_CHECK_INTERVAL_SEC"` // seconds between tenant config revalidation checks
+	MultiTenantConnectionsIntervalSec int    `env:"MULTI_TENANT_CONNECTIONS_INTERVAL_SEC"` // seconds between tenant config revalidation checks
 	MultiTenantCacheTTLSec              int    `env:"MULTI_TENANT_CACHE_TTL_SEC" default:"120"` // seconds for tenant config cache TTL (0 = disabled)
 	MultiTenantRedisHost                string `env:"MULTI_TENANT_REDIS_HOST"`
 	MultiTenantRedisPort                string `env:"MULTI_TENANT_REDIS_PORT"`

--- a/components/crm/internal/bootstrap/config.go
+++ b/components/crm/internal/bootstrap/config.go
@@ -56,7 +56,7 @@ type Config struct {
 	MultiTenantCircuitBreakerThreshold  int    `env:"MULTI_TENANT_CIRCUIT_BREAKER_THRESHOLD"`   // failures before circuit opens
 	MultiTenantCircuitBreakerTimeoutSec int    `env:"MULTI_TENANT_CIRCUIT_BREAKER_TIMEOUT_SEC"` // seconds before circuit resets
 	MultiTenantServiceAPIKey            string `env:"MULTI_TENANT_SERVICE_API_KEY"`
-	MultiTenantConnectionsIntervalSec int    `env:"MULTI_TENANT_CONNECTIONS_INTERVAL_SEC"` // seconds between tenant config revalidation checks
+	MultiTenantConnectionsCheckIntervalSec int    `env:"MULTI_TENANT_CONNECTIONS_CHECK_INTERVAL_SEC"` // seconds between tenant config revalidation checks
 	MultiTenantCacheTTLSec              int    `env:"MULTI_TENANT_CACHE_TTL_SEC" default:"120"` // seconds for tenant config cache TTL (0 = disabled)
 	MultiTenantRedisHost                string `env:"MULTI_TENANT_REDIS_HOST"`
 	MultiTenantRedisPort                string `env:"MULTI_TENANT_REDIS_PORT"`

--- a/components/crm/internal/bootstrap/config.tenant.go
+++ b/components/crm/internal/bootstrap/config.tenant.go
@@ -277,9 +277,9 @@ func buildMongoManagerOptions(cfg *Config, logger libLog.Logger) []tmmongo.Optio
 		mongoOpts = append(mongoOpts, tmmongo.WithIdleTimeout(time.Duration(cfg.MultiTenantIdleTimeoutSec)*time.Second))
 	}
 
-	if cfg.MultiTenantConnectionsIntervalSec > 0 {
-		mongoOpts = append(mongoOpts, tmmongo.WithSettingsCheckInterval(
-			time.Duration(cfg.MultiTenantConnectionsIntervalSec)*time.Second,
+	if cfg.MultiTenantConnectionsCheckIntervalSec > 0 {
+		mongoOpts = append(mongoOpts, tmmongo.WithConnectionsCheckInterval(
+			time.Duration(cfg.MultiTenantConnectionsCheckIntervalSec)*time.Second,
 		))
 	}
 

--- a/components/crm/internal/bootstrap/config.tenant.go
+++ b/components/crm/internal/bootstrap/config.tenant.go
@@ -277,9 +277,9 @@ func buildMongoManagerOptions(cfg *Config, logger libLog.Logger) []tmmongo.Optio
 		mongoOpts = append(mongoOpts, tmmongo.WithIdleTimeout(time.Duration(cfg.MultiTenantIdleTimeoutSec)*time.Second))
 	}
 
-	if cfg.MultiTenantSettingsCheckIntervalSec > 0 {
+	if cfg.MultiTenantConnectionsIntervalSec > 0 {
 		mongoOpts = append(mongoOpts, tmmongo.WithSettingsCheckInterval(
-			time.Duration(cfg.MultiTenantSettingsCheckIntervalSec)*time.Second,
+			time.Duration(cfg.MultiTenantConnectionsIntervalSec)*time.Second,
 		))
 	}
 

--- a/components/ledger/internal/bootstrap/backward_compat_test.go
+++ b/components/ledger/internal/bootstrap/backward_compat_test.go
@@ -83,7 +83,7 @@ func TestMultiTenant_BackwardCompatibility(t *testing.T) {
 			"MultiTenantCircuitBreakerThreshold":  "MULTI_TENANT_CIRCUIT_BREAKER_THRESHOLD",
 			"MultiTenantCircuitBreakerTimeoutSec": "MULTI_TENANT_CIRCUIT_BREAKER_TIMEOUT_SEC",
 			"MultiTenantServiceAPIKey":            "MULTI_TENANT_SERVICE_API_KEY",
-			"MultiTenantConnectionsIntervalSec": "MULTI_TENANT_CONNECTIONS_INTERVAL_SEC",
+			"MultiTenantConnectionsCheckIntervalSec": "MULTI_TENANT_CONNECTIONS_CHECK_INTERVAL_SEC",
 			"MultiTenantCacheTTLSec":              "MULTI_TENANT_CACHE_TTL_SEC",
 			"MultiTenantRedisHost":                "MULTI_TENANT_REDIS_HOST",
 			"MultiTenantRedisPort":                "MULTI_TENANT_REDIS_PORT",

--- a/components/ledger/internal/bootstrap/backward_compat_test.go
+++ b/components/ledger/internal/bootstrap/backward_compat_test.go
@@ -83,7 +83,7 @@ func TestMultiTenant_BackwardCompatibility(t *testing.T) {
 			"MultiTenantCircuitBreakerThreshold":  "MULTI_TENANT_CIRCUIT_BREAKER_THRESHOLD",
 			"MultiTenantCircuitBreakerTimeoutSec": "MULTI_TENANT_CIRCUIT_BREAKER_TIMEOUT_SEC",
 			"MultiTenantServiceAPIKey":            "MULTI_TENANT_SERVICE_API_KEY",
-			"MultiTenantSettingsCheckIntervalSec": "MULTI_TENANT_SETTINGS_CHECK_INTERVAL_SEC",
+			"MultiTenantConnectionsIntervalSec": "MULTI_TENANT_CONNECTIONS_INTERVAL_SEC",
 			"MultiTenantCacheTTLSec":              "MULTI_TENANT_CACHE_TTL_SEC",
 			"MultiTenantRedisHost":                "MULTI_TENANT_REDIS_HOST",
 			"MultiTenantRedisPort":                "MULTI_TENANT_REDIS_PORT",

--- a/components/ledger/internal/bootstrap/config.go
+++ b/components/ledger/internal/bootstrap/config.go
@@ -96,7 +96,7 @@ type Config struct {
 	MultiTenantCircuitBreakerThreshold  int    `env:"MULTI_TENANT_CIRCUIT_BREAKER_THRESHOLD"`
 	MultiTenantCircuitBreakerTimeoutSec int    `env:"MULTI_TENANT_CIRCUIT_BREAKER_TIMEOUT_SEC"`
 	MultiTenantServiceAPIKey            string `env:"MULTI_TENANT_SERVICE_API_KEY"`
-	MultiTenantConnectionsIntervalSec int    `env:"MULTI_TENANT_CONNECTIONS_INTERVAL_SEC"`
+	MultiTenantConnectionsCheckIntervalSec int    `env:"MULTI_TENANT_CONNECTIONS_CHECK_INTERVAL_SEC"`
 	MultiTenantCacheTTLSec              int    `env:"MULTI_TENANT_CACHE_TTL_SEC" default:"120"` // seconds for tenant config cache TTL (0 = disabled)
 	MultiTenantRedisHost                string `env:"MULTI_TENANT_REDIS_HOST"`
 	MultiTenantRedisPort                string `env:"MULTI_TENANT_REDIS_PORT"`

--- a/components/ledger/internal/bootstrap/config.go
+++ b/components/ledger/internal/bootstrap/config.go
@@ -96,7 +96,7 @@ type Config struct {
 	MultiTenantCircuitBreakerThreshold  int    `env:"MULTI_TENANT_CIRCUIT_BREAKER_THRESHOLD"`
 	MultiTenantCircuitBreakerTimeoutSec int    `env:"MULTI_TENANT_CIRCUIT_BREAKER_TIMEOUT_SEC"`
 	MultiTenantServiceAPIKey            string `env:"MULTI_TENANT_SERVICE_API_KEY"`
-	MultiTenantSettingsCheckIntervalSec int    `env:"MULTI_TENANT_SETTINGS_CHECK_INTERVAL_SEC"`
+	MultiTenantConnectionsIntervalSec int    `env:"MULTI_TENANT_CONNECTIONS_INTERVAL_SEC"`
 	MultiTenantCacheTTLSec              int    `env:"MULTI_TENANT_CACHE_TTL_SEC" default:"120"` // seconds for tenant config cache TTL (0 = disabled)
 	MultiTenantRedisHost                string `env:"MULTI_TENANT_REDIS_HOST"`
 	MultiTenantRedisPort                string `env:"MULTI_TENANT_REDIS_PORT"`

--- a/components/ledger/internal/bootstrap/config.mongo.onboarding.go
+++ b/components/ledger/internal/bootstrap/config.mongo.onboarding.go
@@ -51,9 +51,9 @@ func initOnboardingMultiTenantMongo(opts *Options, cfg *Config, logger libLog.Lo
 		tmmongo.WithLogger(logger),
 	}
 
-	if cfg.MultiTenantSettingsCheckIntervalSec > 0 {
+	if cfg.MultiTenantConnectionsIntervalSec > 0 {
 		mongoOpts = append(mongoOpts, tmmongo.WithSettingsCheckInterval(
-			time.Duration(cfg.MultiTenantSettingsCheckIntervalSec)*time.Second,
+			time.Duration(cfg.MultiTenantConnectionsIntervalSec)*time.Second,
 		))
 	}
 

--- a/components/ledger/internal/bootstrap/config.mongo.onboarding.go
+++ b/components/ledger/internal/bootstrap/config.mongo.onboarding.go
@@ -51,9 +51,9 @@ func initOnboardingMultiTenantMongo(opts *Options, cfg *Config, logger libLog.Lo
 		tmmongo.WithLogger(logger),
 	}
 
-	if cfg.MultiTenantConnectionsIntervalSec > 0 {
-		mongoOpts = append(mongoOpts, tmmongo.WithSettingsCheckInterval(
-			time.Duration(cfg.MultiTenantConnectionsIntervalSec)*time.Second,
+	if cfg.MultiTenantConnectionsCheckIntervalSec > 0 {
+		mongoOpts = append(mongoOpts, tmmongo.WithConnectionsCheckInterval(
+			time.Duration(cfg.MultiTenantConnectionsCheckIntervalSec)*time.Second,
 		))
 	}
 

--- a/components/ledger/internal/bootstrap/config.mongo.onboarding_test.go
+++ b/components/ledger/internal/bootstrap/config.mongo.onboarding_test.go
@@ -131,7 +131,7 @@ func TestInitOnboardingMultiTenantMongo_NilTenantClient_ReturnsError(t *testing.
 	assert.Contains(t, err.Error(), "TenantClient is required")
 }
 
-func TestInitOnboardingMultiTenantMongo_WithSettingsCheckInterval(t *testing.T) {
+func TestInitOnboardingMultiTenantMongo_WithConnectionsInterval(t *testing.T) {
 	t.Parallel()
 
 	logger := libLog.NewNop()
@@ -142,11 +142,11 @@ func TestInitOnboardingMultiTenantMongo_WithSettingsCheckInterval(t *testing.T) 
 		interval int
 	}{
 		{
-			name:     "positive interval applies WithSettingsCheckInterval option",
+			name:     "positive interval applies WithConnectionsInterval option",
 			interval: 60,
 		},
 		{
-			name:     "zero interval skips WithSettingsCheckInterval option",
+			name:     "zero interval skips WithConnectionsInterval option",
 			interval: 0,
 		},
 	}
@@ -162,7 +162,7 @@ func TestInitOnboardingMultiTenantMongo_WithSettingsCheckInterval(t *testing.T) 
 			}
 
 			cfg := &Config{
-				MultiTenantSettingsCheckIntervalSec: tt.interval,
+				MultiTenantConnectionsIntervalSec: tt.interval,
 			}
 
 			result, err := initOnboardingMultiTenantMongo(opts, cfg, logger)

--- a/components/ledger/internal/bootstrap/config.mongo.onboarding_test.go
+++ b/components/ledger/internal/bootstrap/config.mongo.onboarding_test.go
@@ -131,7 +131,7 @@ func TestInitOnboardingMultiTenantMongo_NilTenantClient_ReturnsError(t *testing.
 	assert.Contains(t, err.Error(), "TenantClient is required")
 }
 
-func TestInitOnboardingMultiTenantMongo_WithConnectionsInterval(t *testing.T) {
+func TestInitOnboardingMultiTenantMongo_WithConnectionsCheckInterval(t *testing.T) {
 	t.Parallel()
 
 	logger := libLog.NewNop()
@@ -142,11 +142,11 @@ func TestInitOnboardingMultiTenantMongo_WithConnectionsInterval(t *testing.T) {
 		interval int
 	}{
 		{
-			name:     "positive interval applies WithConnectionsInterval option",
+			name:     "positive interval applies WithConnectionsCheckInterval option",
 			interval: 60,
 		},
 		{
-			name:     "zero interval skips WithConnectionsInterval option",
+			name:     "zero interval skips WithConnectionsCheckInterval option",
 			interval: 0,
 		},
 	}
@@ -162,7 +162,7 @@ func TestInitOnboardingMultiTenantMongo_WithConnectionsInterval(t *testing.T) {
 			}
 
 			cfg := &Config{
-				MultiTenantConnectionsIntervalSec: tt.interval,
+				MultiTenantConnectionsCheckIntervalSec: tt.interval,
 			}
 
 			result, err := initOnboardingMultiTenantMongo(opts, cfg, logger)

--- a/components/ledger/internal/bootstrap/config.mongo.transaction.go
+++ b/components/ledger/internal/bootstrap/config.mongo.transaction.go
@@ -51,9 +51,9 @@ func initTransactionMultiTenantMongo(opts *Options, cfg *Config, logger libLog.L
 		tmmongo.WithLogger(logger),
 	}
 
-	if cfg.MultiTenantConnectionsIntervalSec > 0 {
-		mongoOpts = append(mongoOpts, tmmongo.WithSettingsCheckInterval(
-			time.Duration(cfg.MultiTenantConnectionsIntervalSec)*time.Second,
+	if cfg.MultiTenantConnectionsCheckIntervalSec > 0 {
+		mongoOpts = append(mongoOpts, tmmongo.WithConnectionsCheckInterval(
+			time.Duration(cfg.MultiTenantConnectionsCheckIntervalSec)*time.Second,
 		))
 	}
 

--- a/components/ledger/internal/bootstrap/config.mongo.transaction.go
+++ b/components/ledger/internal/bootstrap/config.mongo.transaction.go
@@ -51,9 +51,9 @@ func initTransactionMultiTenantMongo(opts *Options, cfg *Config, logger libLog.L
 		tmmongo.WithLogger(logger),
 	}
 
-	if cfg.MultiTenantSettingsCheckIntervalSec > 0 {
+	if cfg.MultiTenantConnectionsIntervalSec > 0 {
 		mongoOpts = append(mongoOpts, tmmongo.WithSettingsCheckInterval(
-			time.Duration(cfg.MultiTenantSettingsCheckIntervalSec)*time.Second,
+			time.Duration(cfg.MultiTenantConnectionsIntervalSec)*time.Second,
 		))
 	}
 

--- a/components/ledger/internal/bootstrap/config.mongo.transaction_test.go
+++ b/components/ledger/internal/bootstrap/config.mongo.transaction_test.go
@@ -130,7 +130,7 @@ func TestInitTransactionMultiTenantMongo_NilTenantClient_ReturnsError(t *testing
 	assert.Contains(t, err.Error(), "TenantClient is required")
 }
 
-func TestInitTransactionMultiTenantMongo_WithSettingsCheckInterval(t *testing.T) {
+func TestInitTransactionMultiTenantMongo_WithConnectionsInterval(t *testing.T) {
 	t.Parallel()
 
 	logger := libLog.NewNop()
@@ -141,11 +141,11 @@ func TestInitTransactionMultiTenantMongo_WithSettingsCheckInterval(t *testing.T)
 		interval int
 	}{
 		{
-			name:     "positive interval applies WithSettingsCheckInterval option",
+			name:     "positive interval applies WithConnectionsInterval option",
 			interval: 60,
 		},
 		{
-			name:     "zero interval skips WithSettingsCheckInterval option",
+			name:     "zero interval skips WithConnectionsInterval option",
 			interval: 0,
 		},
 	}
@@ -161,7 +161,7 @@ func TestInitTransactionMultiTenantMongo_WithSettingsCheckInterval(t *testing.T)
 			}
 
 			cfg := &Config{
-				MultiTenantSettingsCheckIntervalSec: tt.interval,
+				MultiTenantConnectionsIntervalSec: tt.interval,
 			}
 
 			result, err := initTransactionMultiTenantMongo(opts, cfg, logger)

--- a/components/ledger/internal/bootstrap/config.mongo.transaction_test.go
+++ b/components/ledger/internal/bootstrap/config.mongo.transaction_test.go
@@ -130,7 +130,7 @@ func TestInitTransactionMultiTenantMongo_NilTenantClient_ReturnsError(t *testing
 	assert.Contains(t, err.Error(), "TenantClient is required")
 }
 
-func TestInitTransactionMultiTenantMongo_WithConnectionsInterval(t *testing.T) {
+func TestInitTransactionMultiTenantMongo_WithConnectionsCheckInterval(t *testing.T) {
 	t.Parallel()
 
 	logger := libLog.NewNop()
@@ -141,11 +141,11 @@ func TestInitTransactionMultiTenantMongo_WithConnectionsInterval(t *testing.T) {
 		interval int
 	}{
 		{
-			name:     "positive interval applies WithConnectionsInterval option",
+			name:     "positive interval applies WithConnectionsCheckInterval option",
 			interval: 60,
 		},
 		{
-			name:     "zero interval skips WithConnectionsInterval option",
+			name:     "zero interval skips WithConnectionsCheckInterval option",
 			interval: 0,
 		},
 	}
@@ -161,7 +161,7 @@ func TestInitTransactionMultiTenantMongo_WithConnectionsInterval(t *testing.T) {
 			}
 
 			cfg := &Config{
-				MultiTenantConnectionsIntervalSec: tt.interval,
+				MultiTenantConnectionsCheckIntervalSec: tt.interval,
 			}
 
 			result, err := initTransactionMultiTenantMongo(opts, cfg, logger)

--- a/components/ledger/internal/bootstrap/config.postgres.onboarding.go
+++ b/components/ledger/internal/bootstrap/config.postgres.onboarding.go
@@ -58,8 +58,8 @@ func initOnboardingMultiTenantPostgres(opts *Options, cfg *Config, logger libLog
 		tmpostgres.WithLogger(logger),
 	}
 
-	if cfg.MultiTenantSettingsCheckIntervalSec > 0 {
-		pgOpts = append(pgOpts, tmpostgres.WithSettingsCheckInterval(time.Duration(cfg.MultiTenantSettingsCheckIntervalSec)*time.Second))
+	if cfg.MultiTenantConnectionsIntervalSec > 0 {
+		pgOpts = append(pgOpts, tmpostgres.WithSettingsCheckInterval(time.Duration(cfg.MultiTenantConnectionsIntervalSec)*time.Second))
 	}
 
 	pgMgr := tmpostgres.NewManager(

--- a/components/ledger/internal/bootstrap/config.postgres.onboarding.go
+++ b/components/ledger/internal/bootstrap/config.postgres.onboarding.go
@@ -58,8 +58,8 @@ func initOnboardingMultiTenantPostgres(opts *Options, cfg *Config, logger libLog
 		tmpostgres.WithLogger(logger),
 	}
 
-	if cfg.MultiTenantConnectionsIntervalSec > 0 {
-		pgOpts = append(pgOpts, tmpostgres.WithSettingsCheckInterval(time.Duration(cfg.MultiTenantConnectionsIntervalSec)*time.Second))
+	if cfg.MultiTenantConnectionsCheckIntervalSec > 0 {
+		pgOpts = append(pgOpts, tmpostgres.WithConnectionsCheckInterval(time.Duration(cfg.MultiTenantConnectionsCheckIntervalSec)*time.Second))
 	}
 
 	pgMgr := tmpostgres.NewManager(

--- a/components/ledger/internal/bootstrap/config.postgres.transaction.go
+++ b/components/ledger/internal/bootstrap/config.postgres.transaction.go
@@ -56,8 +56,8 @@ func initTransactionMultiTenantPostgres(opts *Options, cfg *Config, logger libLo
 		tmpostgres.WithLogger(logger),
 	}
 
-	if cfg.MultiTenantSettingsCheckIntervalSec > 0 {
-		pgOpts = append(pgOpts, tmpostgres.WithSettingsCheckInterval(time.Duration(cfg.MultiTenantSettingsCheckIntervalSec)*time.Second))
+	if cfg.MultiTenantConnectionsIntervalSec > 0 {
+		pgOpts = append(pgOpts, tmpostgres.WithSettingsCheckInterval(time.Duration(cfg.MultiTenantConnectionsIntervalSec)*time.Second))
 	}
 
 	pgMgr := tmpostgres.NewManager(

--- a/components/ledger/internal/bootstrap/config.postgres.transaction.go
+++ b/components/ledger/internal/bootstrap/config.postgres.transaction.go
@@ -56,8 +56,8 @@ func initTransactionMultiTenantPostgres(opts *Options, cfg *Config, logger libLo
 		tmpostgres.WithLogger(logger),
 	}
 
-	if cfg.MultiTenantConnectionsIntervalSec > 0 {
-		pgOpts = append(pgOpts, tmpostgres.WithSettingsCheckInterval(time.Duration(cfg.MultiTenantConnectionsIntervalSec)*time.Second))
+	if cfg.MultiTenantConnectionsCheckIntervalSec > 0 {
+		pgOpts = append(pgOpts, tmpostgres.WithConnectionsCheckInterval(time.Duration(cfg.MultiTenantConnectionsCheckIntervalSec)*time.Second))
 	}
 
 	pgMgr := tmpostgres.NewManager(

--- a/go.mod
+++ b/go.mod
@@ -100,7 +100,7 @@ require (
 )
 
 require (
-	github.com/LerianStudio/lib-commons/v4 v4.5.0-beta.17
+	github.com/LerianStudio/lib-commons/v4 v4.5.0-beta.19
 	github.com/Shopify/toxiproxy/v2 v2.12.0
 	github.com/docker/docker v28.5.2+incompatible
 	github.com/docker/go-connections v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -19,8 +19,8 @@ github.com/KyleBanks/depth v1.2.1 h1:5h8fQADFrWtarTdtDudMmGsC7GPbOAu6RVB3ffsVFHc
 github.com/KyleBanks/depth v1.2.1/go.mod h1:jzSb9d0L43HxTQfT+oSA1EEp2q+ne2uh6XgeJcm8brE=
 github.com/LerianStudio/lib-auth/v2 v2.6.0 h1:J0QvGXWoEbgd5HF5wtMznVfkho/aPihl6sAWn12bvZ4=
 github.com/LerianStudio/lib-auth/v2 v2.6.0/go.mod h1:AAbJCVaVokfO9bLa4aCIGzVMP6to/Ml5MC4X9B6jLZ0=
-github.com/LerianStudio/lib-commons/v4 v4.5.0-beta.17 h1:2wm6uRV+9N0Cce0jV9ruZAJa4dJCZ3TH0sS0pryreOA=
-github.com/LerianStudio/lib-commons/v4 v4.5.0-beta.17/go.mod h1:/0EgYB6lT23afy/nmmeJiuoDnu3/tS56fXqW7fB0QMk=
+github.com/LerianStudio/lib-commons/v4 v4.5.0-beta.19 h1:Njl99MR9FocEfp4GjA3nBJLTFcemY9SAUegBIikVxbI=
+github.com/LerianStudio/lib-commons/v4 v4.5.0-beta.19/go.mod h1:/0EgYB6lT23afy/nmmeJiuoDnu3/tS56fXqW7fB0QMk=
 github.com/Masterminds/squirrel v1.5.4 h1:uUcX/aBc8O7Fg9kaISIUsHXdKuqehiXAMQTYX8afzqM=
 github.com/Masterminds/squirrel v1.5.4/go.mod h1:NNaOrjSoIDfDA40n7sr2tPNZRfjzjA400rg+riTZj10=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=


### PR DESCRIPTION
## Summary

Standardize context API naming, ENV naming, and upgrade lib-commons.

## Changes

### Context API (lib-commons v4.5.0-beta.19)
Merged 10 functions into 5 variadic:
- `ContextWithPG(ctx, db, module...)` / `GetPGContext(ctx, module...)`
- `ContextWithMB(ctx, db, module...)` / `GetMBContext(ctx, module...)`
- `valkey.GetKeyContext(ctx, key)`

### ENV renames
- `MULTI_TENANT_SETTINGS_CHECK_INTERVAL_SEC` → `MULTI_TENANT_CONNECTIONS_CHECK_INTERVAL_SEC`
- Removed legacy: `SetTenantIDInContext`, `GetTenantID`, `GetPostgresForTenant`, `GetMongoForTenant`

### Cleanup
- Removed unused watcher package from lib-commons
- lib-auth v2.6.0 (HTTP/2 hpack fix)
- Consumer lifecycle: OnTenantAdded, StopConsumer, onTenantLoaded
- Cache invalidation on add and remove

## Test plan
- [x] All ledger tests pass
- [x] All CRM tests pass
- [x] All pkg tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)