### PR TITLE
chore(deps): upgrade lib-commons to v4.6.0 (stable)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -100,7 +100,7 @@ require (
 )
 
 require (
-	github.com/LerianStudio/lib-commons/v4 v4.6.0-beta.1
+	github.com/LerianStudio/lib-commons/v4 v4.6.0
 	github.com/Shopify/toxiproxy/v2 v2.12.0
 	github.com/docker/docker v28.5.2+incompatible
 	github.com/docker/go-connections v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -19,8 +19,8 @@ github.com/KyleBanks/depth v1.2.1 h1:5h8fQADFrWtarTdtDudMmGsC7GPbOAu6RVB3ffsVFHc
 github.com/KyleBanks/depth v1.2.1/go.mod h1:jzSb9d0L43HxTQfT+oSA1EEp2q+ne2uh6XgeJcm8brE=
 github.com/LerianStudio/lib-auth/v2 v2.6.0 h1:J0QvGXWoEbgd5HF5wtMznVfkho/aPihl6sAWn12bvZ4=
 github.com/LerianStudio/lib-auth/v2 v2.6.0/go.mod h1:AAbJCVaVokfO9bLa4aCIGzVMP6to/Ml5MC4X9B6jLZ0=
-github.com/LerianStudio/lib-commons/v4 v4.6.0-beta.1 h1:8GLwqYfykCKQjz/rj9/g+NqNxPDF10OR/FSnyioyRiM=
-github.com/LerianStudio/lib-commons/v4 v4.6.0-beta.1/go.mod h1:/0EgYB6lT23afy/nmmeJiuoDnu3/tS56fXqW7fB0QMk=
+github.com/LerianStudio/lib-commons/v4 v4.6.0 h1:O2XvuDhShNX3aaCaGAK4IM95Z8iM5TW1tjJkNKqIgKY=
+github.com/LerianStudio/lib-commons/v4 v4.6.0/go.mod h1:/0EgYB6lT23afy/nmmeJiuoDnu3/tS56fXqW7fB0QMk=
 github.com/Masterminds/squirrel v1.5.4 h1:uUcX/aBc8O7Fg9kaISIUsHXdKuqehiXAMQTYX8afzqM=
 github.com/Masterminds/squirrel v1.5.4/go.mod h1:NNaOrjSoIDfDA40n7sr2tPNZRfjzjA400rg+riTZj10=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=


### PR DESCRIPTION
## Summary
Upgrades lib-commons from `v4.6.0-beta.1` to `v4.6.0` (stable release).

## Changes
- `go.mod` / `go.sum` only — no code changes

## Test plan
- [x] `go build ./...` — passes