### PR TITLE
fix: add accountID to FindLastOperationBeforeTimestamp for point-in-time index alignment

### DIFF
--- a/components/ledger/internal/adapters/http/in/balance_test.go
+++ b/components/ledger/internal/adapters/http/in/balance_test.go
@@ -1416,7 +1416,7 @@ func TestBalanceHandler_GetBalanceAtTimestamp(t *testing.T) {
 
 				// Then find last operation before date
 				operationRepo.EXPECT().
-					FindLastOperationBeforeTimestamp(gomock.Any(), orgID, ledgerID, balanceID, gomock.Any()).
+					FindLastOperationBeforeTimestamp(gomock.Any(), orgID, ledgerID, accountID, balanceID, gomock.Any()).
 					Return(&operation.Operation{
 						ID:         uuid.New().String(),
 						AccountID:  accountID.String(),
@@ -1542,7 +1542,7 @@ func TestBalanceHandler_GetBalanceAtTimestamp(t *testing.T) {
 
 				// No operation found before date (implementation checks this before CreatedAt)
 				operationRepo.EXPECT().
-					FindLastOperationBeforeTimestamp(gomock.Any(), orgID, ledgerID, balanceID, gomock.Any()).
+					FindLastOperationBeforeTimestamp(gomock.Any(), orgID, ledgerID, gomock.Any(), balanceID, gomock.Any()).
 					Return(nil, nil).
 					Times(1)
 			},

--- a/components/ledger/internal/adapters/http/in/balance_test.go
+++ b/components/ledger/internal/adapters/http/in/balance_test.go
@@ -1525,6 +1525,8 @@ func TestBalanceHandler_GetBalanceAtTimestamp(t *testing.T) {
 			name: "no balance data at date returns 404",
 			date: "2024-01-15 10:30:00",
 			setupMocks: func(balanceRepo *balance.MockRepository, operationRepo *operation.MockRepository, orgID, ledgerID, balanceID uuid.UUID, date time.Time) {
+				accountID := uuid.New()
+
 				// Balance exists but was created AFTER the query date
 				balanceRepo.EXPECT().
 					Find(gomock.Any(), orgID, ledgerID, balanceID).
@@ -1532,7 +1534,7 @@ func TestBalanceHandler_GetBalanceAtTimestamp(t *testing.T) {
 						ID:             balanceID.String(),
 						OrganizationID: orgID.String(),
 						LedgerID:       ledgerID.String(),
-						AccountID:      uuid.New().String(),
+						AccountID:      accountID.String(),
 						Alias:          "@user1",
 						Key:            "default",
 						AssetCode:      "USD",
@@ -1542,7 +1544,7 @@ func TestBalanceHandler_GetBalanceAtTimestamp(t *testing.T) {
 
 				// No operation found before date (implementation checks this before CreatedAt)
 				operationRepo.EXPECT().
-					FindLastOperationBeforeTimestamp(gomock.Any(), orgID, ledgerID, gomock.Any(), balanceID, gomock.Any()).
+					FindLastOperationBeforeTimestamp(gomock.Any(), orgID, ledgerID, accountID, balanceID, gomock.Any()).
 					Return(nil, nil).
 					Times(1)
 			},

--- a/components/ledger/internal/adapters/postgres/operation/operation.postgresql.go
+++ b/components/ledger/internal/adapters/postgres/operation/operation.postgresql.go
@@ -56,7 +56,7 @@ type Repository interface {
 	Update(ctx context.Context, organizationID, ledgerID, transactionID, id uuid.UUID, operation *Operation) (*Operation, error)
 	Delete(ctx context.Context, organizationID, ledgerID, id uuid.UUID) error
 	// Point-in-time balance queries
-	FindLastOperationBeforeTimestamp(ctx context.Context, organizationID, ledgerID, balanceID uuid.UUID, timestamp time.Time) (*Operation, error)
+	FindLastOperationBeforeTimestamp(ctx context.Context, organizationID, ledgerID, accountID, balanceID uuid.UUID, timestamp time.Time) (*Operation, error)
 	FindLastOperationsForAccountBeforeTimestamp(ctx context.Context, organizationID, ledgerID, accountID uuid.UUID, timestamp time.Time, filter http.Pagination) ([]*Operation, libHTTP.CursorPagination, error)
 }
 
@@ -1240,7 +1240,7 @@ func (r *OperationPostgreSQLRepository) FindAllByAccount(ctx context.Context, or
 
 // FindLastOperationBeforeTimestamp finds the last operation for a specific balance before a given timestamp.
 // This is used for point-in-time balance queries to determine the balance state at a specific moment.
-func (r *OperationPostgreSQLRepository) FindLastOperationBeforeTimestamp(ctx context.Context, organizationID, ledgerID, balanceID uuid.UUID, timestamp time.Time) (*Operation, error) {
+func (r *OperationPostgreSQLRepository) FindLastOperationBeforeTimestamp(ctx context.Context, organizationID, ledgerID, accountID, balanceID uuid.UUID, timestamp time.Time) (*Operation, error) {
 	logger, tracer, _, _ := libCommons.NewTrackingFromContext(ctx)
 
 	ctx, span := tracer.Start(ctx, "postgres.find_last_operation_before_timestamp")
@@ -1255,11 +1255,12 @@ func (r *OperationPostgreSQLRepository) FindLastOperationBeforeTimestamp(ctx con
 	}
 
 	// Build query to find the last operation for this balance before the timestamp
-	// Uses optimized column list (9 columns vs 26) to enable Index-Only Scan with covering index
+	// Uses optimized column list (9 columns vs 26) to match idx_operation_account_balance_pit
 	findQuery := squirrel.Select(operationPointInTimeColumns...).
 		From(r.tableName).
 		Where(squirrel.Eq{"organization_id": organizationID}).
 		Where(squirrel.Eq{"ledger_id": ledgerID}).
+		Where(squirrel.Eq{"account_id": accountID}).
 		Where(squirrel.Eq{"balance_id": balanceID}).
 		Where(squirrel.LtOrEq{"created_at": timestamp}).
 		Where(squirrel.Eq{"deleted_at": nil}).

--- a/components/ledger/internal/adapters/postgres/operation/operation.postgresql_mock.go
+++ b/components/ledger/internal/adapters/postgres/operation/operation.postgresql_mock.go
@@ -167,18 +167,18 @@ func (mr *MockRepositoryMockRecorder) FindByAccount(ctx, organizationID, ledgerI
 }
 
 // FindLastOperationBeforeTimestamp mocks base method.
-func (m *MockRepository) FindLastOperationBeforeTimestamp(ctx context.Context, organizationID, ledgerID, balanceID uuid.UUID, timestamp time.Time) (*Operation, error) {
+func (m *MockRepository) FindLastOperationBeforeTimestamp(ctx context.Context, organizationID, ledgerID, accountID, balanceID uuid.UUID, timestamp time.Time) (*Operation, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "FindLastOperationBeforeTimestamp", ctx, organizationID, ledgerID, balanceID, timestamp)
+	ret := m.ctrl.Call(m, "FindLastOperationBeforeTimestamp", ctx, organizationID, ledgerID, accountID, balanceID, timestamp)
 	ret0, _ := ret[0].(*Operation)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // FindLastOperationBeforeTimestamp indicates an expected call of FindLastOperationBeforeTimestamp.
-func (mr *MockRepositoryMockRecorder) FindLastOperationBeforeTimestamp(ctx, organizationID, ledgerID, balanceID, timestamp any) *gomock.Call {
+func (mr *MockRepositoryMockRecorder) FindLastOperationBeforeTimestamp(ctx, organizationID, ledgerID, accountID, balanceID, timestamp any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindLastOperationBeforeTimestamp", reflect.TypeOf((*MockRepository)(nil).FindLastOperationBeforeTimestamp), ctx, organizationID, ledgerID, balanceID, timestamp)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindLastOperationBeforeTimestamp", reflect.TypeOf((*MockRepository)(nil).FindLastOperationBeforeTimestamp), ctx, organizationID, ledgerID, accountID, balanceID, timestamp)
 }
 
 // FindLastOperationsForAccountBeforeTimestamp mocks base method.

--- a/components/ledger/internal/services/query/get-balance-at-timestamp.go
+++ b/components/ledger/internal/services/query/get-balance-at-timestamp.go
@@ -49,8 +49,17 @@ func (uc *UseCase) GetBalanceAtTimestamp(ctx context.Context, organizationID, le
 		return nil, err
 	}
 
+	// Parse account ID from the balance for the index-optimized query
+	accountID, err := uuid.Parse(currentBalance.AccountID)
+	if err != nil {
+		libOpentelemetry.HandleSpanError(span, "Failed to parse account ID from balance", err)
+		logger.Log(ctx, libLog.LevelError, fmt.Sprintf("Failed to parse account ID from balance: %v", err))
+
+		return nil, err
+	}
+
 	// Find the last operation before the timestamp
-	operation, err := uc.OperationRepo.FindLastOperationBeforeTimestamp(ctx, organizationID, ledgerID, balanceID, timestamp)
+	operation, err := uc.OperationRepo.FindLastOperationBeforeTimestamp(ctx, organizationID, ledgerID, accountID, balanceID, timestamp)
 	if err != nil {
 		libOpentelemetry.HandleSpanError(span, "Failed to get operation before timestamp", err)
 		logger.Log(ctx, libLog.LevelError, fmt.Sprintf("Error getting operation before timestamp: %v", err))

--- a/components/ledger/internal/services/query/get-balance-at-timestamp_test.go
+++ b/components/ledger/internal/services/query/get-balance-at-timestamp_test.go
@@ -77,7 +77,7 @@ func TestGetBalanceAtTimestamp(t *testing.T) {
 			Return(currentBalance, nil)
 
 		operationRepo.EXPECT().
-			FindLastOperationBeforeTimestamp(gomock.Any(), orgID, ledgerID, balanceID, timestamp).
+			FindLastOperationBeforeTimestamp(gomock.Any(), orgID, ledgerID, accountID, balanceID, timestamp).
 			Return(lastOperation, nil)
 
 		result, err := uc.GetBalanceAtTimestamp(context.Background(), orgID, ledgerID, balanceID, timestamp)
@@ -174,6 +174,7 @@ func TestGetBalanceAtTimestamp(t *testing.T) {
 
 				orgID := uuid.Must(libCommons.GenerateUUIDv7())
 				ledgerID := uuid.Must(libCommons.GenerateUUIDv7())
+				accountID := uuid.Must(libCommons.GenerateUUIDv7())
 				balanceID := uuid.Must(libCommons.GenerateUUIDv7())
 				timestamp := time.Now().Add(-time.Hour)
 
@@ -181,6 +182,7 @@ func TestGetBalanceAtTimestamp(t *testing.T) {
 					ID:             balanceID.String(),
 					OrganizationID: orgID.String(),
 					LedgerID:       ledgerID.String(),
+					AccountID:      accountID.String(),
 				}
 
 				balanceRepo := balance.NewMockRepository(ctrl)
@@ -200,7 +202,7 @@ func TestGetBalanceAtTimestamp(t *testing.T) {
 
 				if tt.setupOperationExp {
 					operationRepo.EXPECT().
-						FindLastOperationBeforeTimestamp(gomock.Any(), orgID, ledgerID, balanceID, timestamp).
+						FindLastOperationBeforeTimestamp(gomock.Any(), orgID, ledgerID, accountID, balanceID, timestamp).
 						Return(nil, tt.operationRepoErr)
 				}
 
@@ -246,7 +248,7 @@ func TestGetBalanceAtTimestamp(t *testing.T) {
 			Return(currentBalance, nil)
 
 		operationRepo.EXPECT().
-			FindLastOperationBeforeTimestamp(gomock.Any(), orgID, ledgerID, balanceID, timestamp).
+			FindLastOperationBeforeTimestamp(gomock.Any(), orgID, ledgerID, accountID, balanceID, timestamp).
 			Return(nil, nil)
 
 		result, err := uc.GetBalanceAtTimestamp(context.Background(), orgID, ledgerID, balanceID, timestamp)
@@ -270,6 +272,7 @@ func TestGetBalanceAtTimestamp(t *testing.T) {
 
 		orgID := uuid.Must(libCommons.GenerateUUIDv7())
 		ledgerID := uuid.Must(libCommons.GenerateUUIDv7())
+		accountID := uuid.Must(libCommons.GenerateUUIDv7())
 		balanceID := uuid.Must(libCommons.GenerateUUIDv7())
 		timestamp := time.Now().Add(-24 * time.Hour)
 		// Balance was created AFTER the timestamp
@@ -279,6 +282,7 @@ func TestGetBalanceAtTimestamp(t *testing.T) {
 			ID:             balanceID.String(),
 			OrganizationID: orgID.String(),
 			LedgerID:       ledgerID.String(),
+			AccountID:      accountID.String(),
 			CreatedAt:      balanceCreatedAt,
 		}
 
@@ -292,7 +296,7 @@ func TestGetBalanceAtTimestamp(t *testing.T) {
 			Return(currentBalance, nil)
 
 		operationRepo.EXPECT().
-			FindLastOperationBeforeTimestamp(gomock.Any(), orgID, ledgerID, balanceID, timestamp).
+			FindLastOperationBeforeTimestamp(gomock.Any(), orgID, ledgerID, accountID, balanceID, timestamp).
 			Return(nil, nil)
 
 		result, err := uc.GetBalanceAtTimestamp(context.Background(), orgID, ledgerID, balanceID, timestamp)
@@ -347,7 +351,7 @@ func TestGetBalanceAtTimestamp(t *testing.T) {
 			Return(currentBalance, nil)
 
 		operationRepo.EXPECT().
-			FindLastOperationBeforeTimestamp(gomock.Any(), orgID, ledgerID, balanceID, timestamp).
+			FindLastOperationBeforeTimestamp(gomock.Any(), orgID, ledgerID, accountID, balanceID, timestamp).
 			Return(lastOperation, nil)
 
 		result, err := uc.GetBalanceAtTimestamp(context.Background(), orgID, ledgerID, balanceID, timestamp)


### PR DESCRIPTION
## Summary

- Add `accountID` parameter to `FindLastOperationBeforeTimestamp` so the query provides all leading key columns to the new unified point-in-time index (`idx_operation_account_balance_pit`)
- Parse `accountID` from the already-fetched `currentBalance` in the service layer — no additional database call needed

## Why

The new index key is `(organization_id, ledger_id, account_id, balance_id, created_at DESC, balance_version_after DESC)`. Without `account_id` in the WHERE clause, PostgreSQL can only use the first 2 key columns due to the B-tree leftmost prefix rule — it cannot skip `account_id` to reach `balance_id`. Adding the parameter enables a full key match, reducing the scan from 24 rows to 2 rows (validated on dev).

## What Changed

- **Repository interface** (`operation.postgresql.go`): added `accountID uuid.UUID` to the `FindLastOperationBeforeTimestamp` signature
- **Implementation** (`operation.postgresql.go`): added `WHERE account_id = ?` clause
- **Mock** (`operation.postgresql_mock.go`): regenerated via `mockgen`
- **Service layer** (`get-balance-at-timestamp.go`): parses `currentBalance.AccountID` (string → uuid) and passes it to the repository call
- **Tests**: updated all mock expectations in service tests and HTTP handler tests to include the new parameter

## Follow-Up PRs

- PR 3: remove dead `id DESC` tiebreaker from Query 2 ORDER BY
- PR 4: add explicit `balance_version_after DESC` tiebreaker to Query 3 ORDER BY