### PR TITLE
fix: add explicit sort tiebreaker to account balance history query

### DIFF
--- a/components/ledger/internal/adapters/postgres/balance/balance.postgresql.go
+++ b/components/ledger/internal/adapters/postgres/balance/balance.postgresql.go
@@ -1750,7 +1750,7 @@ func (r *BalancePostgreSQLRepository) ListByAccountIDAtTimestamp(ctx context.Con
 		Where(squirrel.Eq{"account_id": accountID}).
 		Where(squirrel.LtOrEq{"created_at": timestamp}).
 		Where(squirrel.Eq{"deleted_at": nil}).
-		OrderBy("balance_id", "created_at DESC")
+		OrderBy("balance_id", "created_at DESC", "balance_version_after DESC", "id DESC")
 
 	latestOpsSql, latestOpsArgs, err := latestOpsSubquery.ToSql()
 	if err != nil {


### PR DESCRIPTION
## Summary

- Add `balance_version_after DESC, id DESC` to the ORDER BY in `ListByAccountIDAtTimestamp`

## Why

DISTINCT ON used `ORDER BY balance_id, created_at DESC` — only 2 columns. When multiple operations share the same `(balance_id, created_at)` (which happens in bulk inserts and pending transactions), DISTINCT ON would pick the correct row only by coincidence of the index scan order, not by an explicit guarantee.

Adding `balance_version_after DESC` makes the selection explicit: the operation with the highest version wins. Adding `id DESC` provides a deterministic tiebreaker for annotation operations, which zero out `balance_version_after` (consistent with ORDER BY in `FindLastOperationsForAccountBeforeTimestamp`).

## What Changed

- **`balance.postgresql.go`**: added `"balance_version_after DESC", "id DESC"` to the `OrderBy` clause in the `latestOpsSubquery` of `ListByAccountIDAtTimestamp`