### PR TITLE
fix: use revert accounting entries for route code resolution on transaction revert

### DIFF
--- a/components/ledger/internal/adapters/http/in/transaction-builder-routecode_test.go
+++ b/components/ledger/internal/adapters/http/in/transaction-builder-routecode_test.go
@@ -230,7 +230,7 @@ func TestResolveRouteCodesFromCache_NilCache(t *testing.T) {
 		{ID: "op-1", RouteID: &routeID},
 	}
 
-	resolveRouteCodesFromCache(ops, nil, "CREATED")
+	resolveRouteCodesFromCache(ops, nil, "direct")
 
 	assert.Nil(t, ops[0].RouteCode, "RouteCode should remain nil when cache is nil")
 }
@@ -243,7 +243,7 @@ func TestResolveRouteCodesFromCache_NoRouteID(t *testing.T) {
 		{ID: "op-1", RouteID: nil},
 	}
 
-	resolveRouteCodesFromCache(ops, cache, "CREATED")
+	resolveRouteCodesFromCache(ops, cache, "direct")
 
 	assert.Nil(t, ops[0].RouteCode, "RouteCode should remain nil when RouteID is nil")
 }
@@ -258,7 +258,7 @@ func TestResolveRouteCodesFromCache_SourceRoute(t *testing.T) {
 		{ID: "op-1", RouteID: &routeID, Direction: "debit"},
 	}
 
-	resolveRouteCodesFromCache(ops, cache, "CREATED")
+	resolveRouteCodesFromCache(ops, cache, "direct")
 
 	require.NotNil(t, ops[0].RouteCode, "RouteCode should be populated from accounting entry debit rubric code")
 	assert.Equal(t, "1001", *ops[0].RouteCode)
@@ -276,7 +276,7 @@ func TestResolveRouteCodesFromCache_DestinationRoute(t *testing.T) {
 		{ID: "op-1", RouteID: &routeID, Direction: "credit"},
 	}
 
-	resolveRouteCodesFromCache(ops, cache, "CREATED")
+	resolveRouteCodesFromCache(ops, cache, "direct")
 
 	require.NotNil(t, ops[0].RouteCode, "RouteCode should be populated from accounting entry credit rubric code")
 	assert.Equal(t, "2001", *ops[0].RouteCode)
@@ -291,7 +291,7 @@ func TestResolveRouteCodesFromCache_BidirectionalRoute(t *testing.T) {
 		{ID: "op-1", RouteID: &routeID, Direction: "debit"},
 	}
 
-	resolveRouteCodesFromCache(ops, cache, "PENDING")
+	resolveRouteCodesFromCache(ops, cache, "hold")
 
 	require.NotNil(t, ops[0].RouteCode, "RouteCode should be populated from bidirectional route's accounting entry")
 	assert.Equal(t, "3001", *ops[0].RouteCode)
@@ -341,7 +341,7 @@ func TestResolveRouteCodesFromCache_MultipleOperations(t *testing.T) {
 		{ID: "op-4", RouteID: nil},
 	}
 
-	resolveRouteCodesFromCache(ops, cache, "CREATED")
+	resolveRouteCodesFromCache(ops, cache, "direct")
 
 	require.NotNil(t, ops[0].RouteCode)
 	assert.Equal(t, "SRC-DEBIT", *ops[0].RouteCode)
@@ -362,7 +362,7 @@ func TestResolveRouteCodesFromCache_EmptyRouteID(t *testing.T) {
 		{ID: "op-1", RouteID: &emptyRouteID},
 	}
 
-	resolveRouteCodesFromCache(ops, cache, "CREATED")
+	resolveRouteCodesFromCache(ops, cache, "direct")
 
 	assert.Nil(t, ops[0].RouteCode, "RouteCode should remain nil for empty RouteID")
 }
@@ -391,7 +391,7 @@ func TestResolveRouteCodesFromCache_NoAccountingEntries(t *testing.T) {
 		{ID: "op-1", RouteID: &routeID, Direction: "debit"},
 	}
 
-	resolveRouteCodesFromCache(ops, cache, "CREATED")
+	resolveRouteCodesFromCache(ops, cache, "direct")
 
 	assert.Nil(t, ops[0].RouteCode, "RouteCode should remain nil when no AccountingEntries exist")
 	assert.Nil(t, ops[0].RouteDescription, "RouteDescription should remain nil when no accounting rubric is resolved")
@@ -406,7 +406,7 @@ func TestResolveRouteCodesFromCache_HoldAction(t *testing.T) {
 		{ID: "op-1", RouteID: &routeID, Direction: "credit"},
 	}
 
-	resolveRouteCodesFromCache(ops, cache, "PENDING")
+	resolveRouteCodesFromCache(ops, cache, "hold")
 
 	require.NotNil(t, ops[0].RouteCode, "RouteCode should be populated for hold action")
 	assert.Equal(t, "HOLD-CREDIT", *ops[0].RouteCode)
@@ -421,7 +421,7 @@ func TestResolveRouteCodesFromCache_CommitAction(t *testing.T) {
 		{ID: "op-1", RouteID: &routeID, Direction: "debit"},
 	}
 
-	resolveRouteCodesFromCache(ops, cache, "APPROVED")
+	resolveRouteCodesFromCache(ops, cache, "commit")
 
 	require.NotNil(t, ops[0].RouteCode, "RouteCode should be populated for commit action")
 	assert.Equal(t, "COMMIT-DEBIT", *ops[0].RouteCode)
@@ -532,7 +532,7 @@ func TestResolveRouteCodesFromCache_ActionMissingEntry(t *testing.T) {
 		{ID: "op-1", RouteID: &routeID, Direction: "debit"},
 	}
 
-	resolveRouteCodesFromCache(ops, cache, "CREATED")
+	resolveRouteCodesFromCache(ops, cache, "direct")
 
 	assert.Nil(t, ops[0].RouteCode, "RouteCode should remain nil when action entry is missing from AccountingEntries")
 	assert.Nil(t, ops[0].RouteDescription, "RouteDescription should remain nil when no matching accounting rubric is resolved")

--- a/components/ledger/internal/adapters/http/in/transaction-creation-helpers.go
+++ b/components/ledger/internal/adapters/http/in/transaction-creation-helpers.go
@@ -258,9 +258,9 @@ func statusToAction(statusCode string) string {
 // on each operation by looking up the operation's RouteID in the transaction route
 // cache for the given accounting action (direct, hold, commit, cancel, revert).
 //
-// RouteCode is resolved from the AccountingEntries rubric that matches the
-// operation's action and direction (debit → Debit rubric, credit → Credit rubric).
-// RouteDescription is resolved from the OperationRoute-level Description field.
+// Both RouteCode and RouteDescription are resolved from the AccountingRubric
+// that matches the operation's action and direction (debit → Debit rubric,
+// credit → Credit rubric).
 func resolveRouteCodesFromCache(operations []*operation.Operation, cache *mmodel.TransactionRouteCache, action string) {
 	if cache == nil {
 		return

--- a/components/ledger/internal/adapters/http/in/transaction-creation-helpers.go
+++ b/components/ledger/internal/adapters/http/in/transaction-creation-helpers.go
@@ -877,13 +877,6 @@ func (handler *TransactionHandler) createTransaction(c *fiber.Ctx, transactionIn
 		propagateRouteValidation(ctx, validate, transactionInput.Pending, transactionStatus)
 	}
 
-	err = handler.sendTransactionToRedisQueue(ctx, scope.OrganizationID, scope.LedgerID, transactionID, transactionInput, validate, transactionStatus, transactionDate, idempotencyState.internalKey)
-	if err != nil {
-		return http.WithError(c, err)
-	}
-
-	_, spanGetBalances := tracer.Start(ctx, "handler.create_transaction.get_balances")
-
 	action := constant.ActionDirect
 	if transactionStatus == constant.PENDING {
 		action = constant.ActionHold
@@ -892,6 +885,13 @@ func (handler *TransactionHandler) createTransaction(c *fiber.Ctx, transactionIn
 	if len(actionOverride) > 0 && actionOverride[0] != "" {
 		action = actionOverride[0]
 	}
+
+	err = handler.sendTransactionToRedisQueue(ctx, scope.OrganizationID, scope.LedgerID, transactionID, transactionInput, validate, transactionStatus, action, transactionDate, idempotencyState.internalKey)
+	if err != nil {
+		return http.WithError(c, err)
+	}
+
+	_, spanGetBalances := tracer.Start(ctx, "handler.create_transaction.get_balances")
 
 	balancesBefore, balancesAfter, routeCache, err := handler.Query.GetBalances(ctx, scope.OrganizationID, scope.LedgerID, transactionID, &transactionInput, validate, transactionStatus, action)
 	if err != nil {
@@ -949,7 +949,7 @@ func (handler *TransactionHandler) createTransaction(c *fiber.Ctx, transactionIn
 	tran.Destination = getAliasWithoutKey(validate.Destinations)
 	tran.Operations = operations
 
-	handler.Command.UpdateTransactionBackupOperations(ctx, scope.OrganizationID, scope.LedgerID, transactionID.String(), operations)
+	handler.Command.UpdateTransactionBackupOperations(ctx, scope.OrganizationID, scope.LedgerID, transactionID.String(), operations, action)
 
 	originalStatus := tran.Status
 
@@ -1032,6 +1032,7 @@ func (handler *TransactionHandler) sendTransactionToRedisQueue(
 	transactionInput pkgTransaction.Transaction,
 	validate *pkgTransaction.Responses,
 	transactionStatus string,
+	action string,
 	transactionDate time.Time,
 	internalKey *string,
 ) error {
@@ -1040,7 +1041,7 @@ func (handler *TransactionHandler) sendTransactionToRedisQueue(
 	ctxSendTransactionToRedisQueue, spanSendTransactionToRedisQueue := tracer.Start(ctx, "handler.create_transaction.send_transaction_to_redis_queue")
 	defer spanSendTransactionToRedisQueue.End()
 
-	err := handler.Command.SendTransactionToRedisQueue(ctxSendTransactionToRedisQueue, organizationID, ledgerID, transactionID, transactionInput, validate, transactionStatus, transactionDate, nil)
+	err := handler.Command.SendTransactionToRedisQueue(ctxSendTransactionToRedisQueue, organizationID, ledgerID, transactionID, transactionInput, validate, transactionStatus, action, transactionDate, nil)
 	if err == nil {
 		return nil
 	}

--- a/components/ledger/internal/adapters/http/in/transaction-creation-helpers.go
+++ b/components/ledger/internal/adapters/http/in/transaction-creation-helpers.go
@@ -877,10 +877,7 @@ func (handler *TransactionHandler) createTransaction(c *fiber.Ctx, transactionIn
 		propagateRouteValidation(ctx, validate, transactionInput.Pending, transactionStatus)
 	}
 
-	action := constant.ActionDirect
-	if transactionStatus == constant.PENDING {
-		action = constant.ActionHold
-	}
+	action := statusToAction(transactionStatus)
 
 	if len(actionOverride) > 0 && actionOverride[0] != "" {
 		action = actionOverride[0]

--- a/components/ledger/internal/adapters/http/in/transaction-creation-helpers.go
+++ b/components/ledger/internal/adapters/http/in/transaction-creation-helpers.go
@@ -156,6 +156,7 @@ func (handler *TransactionHandler) BuildOperations(
 	isAnnotation bool,
 	routeValidationEnabled bool,
 	transactionRouteCache *mmodel.TransactionRouteCache,
+	action string,
 ) ([]*operation.Operation, []*mmodel.Balance, error) {
 	var operations []*operation.Operation
 
@@ -233,7 +234,7 @@ func (handler *TransactionHandler) BuildOperations(
 		}
 	}
 
-	resolveRouteCodesFromCache(operations, transactionRouteCache, tran.Status.Code)
+	resolveRouteCodesFromCache(operations, transactionRouteCache, action)
 
 	return operations, preBalances, nil
 }
@@ -255,18 +256,15 @@ func statusToAction(statusCode string) string {
 
 // resolveRouteCodesFromCache populates the RouteCode and RouteDescription fields
 // on each operation by looking up the operation's RouteID in the transaction route
-// cache for the given transaction status.
+// cache for the given accounting action (direct, hold, commit, cancel, revert).
 //
 // RouteCode is resolved from the AccountingEntries rubric that matches the
-// operation's action (derived from transactionStatus) and direction
-// (debit → Debit rubric, credit → Credit rubric).
+// operation's action and direction (debit → Debit rubric, credit → Credit rubric).
 // RouteDescription is resolved from the OperationRoute-level Description field.
-func resolveRouteCodesFromCache(operations []*operation.Operation, cache *mmodel.TransactionRouteCache, transactionStatus string) {
+func resolveRouteCodesFromCache(operations []*operation.Operation, cache *mmodel.TransactionRouteCache, action string) {
 	if cache == nil {
 		return
 	}
-
-	action := statusToAction(transactionStatus)
 
 	actionCache, ok := cache.Actions[action]
 	if !ok {
@@ -800,7 +798,7 @@ func (handler *TransactionHandler) buildStandardOp(
 	}, nil
 }
 
-func (handler *TransactionHandler) createTransaction(c *fiber.Ctx, transactionInput pkgTransaction.Transaction, transactionStatus string) error {
+func (handler *TransactionHandler) createTransaction(c *fiber.Ctx, transactionInput pkgTransaction.Transaction, transactionStatus string, actionOverride ...string) error {
 	ctx := c.UserContext()
 	logger, tracer, _, _ := libCommons.NewTrackingFromContext(ctx)
 
@@ -891,6 +889,10 @@ func (handler *TransactionHandler) createTransaction(c *fiber.Ctx, transactionIn
 		action = constant.ActionHold
 	}
 
+	if len(actionOverride) > 0 && actionOverride[0] != "" {
+		action = actionOverride[0]
+	}
+
 	balancesBefore, balancesAfter, routeCache, err := handler.Query.GetBalances(ctx, scope.OrganizationID, scope.LedgerID, transactionID, &transactionInput, validate, transactionStatus, action)
 	if err != nil {
 		libOpentelemetry.HandleSpanBusinessErrorEvent(spanGetBalances, "Failed to get balances", err)
@@ -934,7 +936,7 @@ func (handler *TransactionHandler) createTransaction(c *fiber.Ctx, transactionIn
 		},
 	}
 
-	operations, _, err := handler.BuildOperations(ctx, balancesBefore, fromTo, transactionInput, *tran, validate, transactionDate, transactionStatus == constant.NOTED, ledgerSettings.Accounting.ValidateRoutes, routeCache)
+	operations, _, err := handler.BuildOperations(ctx, balancesBefore, fromTo, transactionInput, *tran, validate, transactionDate, transactionStatus == constant.NOTED, ledgerSettings.Accounting.ValidateRoutes, routeCache, action)
 	if err != nil {
 		libOpentelemetry.HandleSpanError(span, "Failed to validate balances", err)
 

--- a/components/ledger/internal/adapters/http/in/transaction-state-handlers.go
+++ b/components/ledger/internal/adapters/http/in/transaction-state-handlers.go
@@ -493,7 +493,7 @@ func (handler *TransactionHandler) commitOrCancelTransaction(c *fiber.Ctx, tran 
 
 	ctxBackup, spanBackup := tracer.Start(ctx, "handler.commit_or_cancel_transaction.send_to_redis_queue")
 
-	if backupErr := handler.Command.SendTransactionToRedisQueue(ctxBackup, organizationID, ledgerID, tran.IDtoUUID(), transactionInput, validate, transactionStatus, time.Now(), preBalances); backupErr != nil {
+	if backupErr := handler.Command.SendTransactionToRedisQueue(ctxBackup, organizationID, ledgerID, tran.IDtoUUID(), transactionInput, validate, transactionStatus, action, time.Now(), preBalances); backupErr != nil {
 		libOpentelemetry.HandleSpanError(spanBackup, "Failed to send transaction to backup cache", backupErr)
 
 		logger.Log(ctx, libLog.LevelWarn, fmt.Sprintf("Failed to send commit/cancel transaction to backup cache: %v", backupErr))

--- a/components/ledger/internal/adapters/http/in/transaction-state-handlers.go
+++ b/components/ledger/internal/adapters/http/in/transaction-state-handlers.go
@@ -283,7 +283,7 @@ func (handler *TransactionHandler) RevertTransaction(c *fiber.Ctx) error {
 		}
 	}
 
-	response := handler.createTransaction(c, transactionReverted, constant.CREATED)
+	response := handler.createTransaction(c, transactionReverted, constant.CREATED, constant.ActionRevert)
 
 	return response
 }
@@ -478,7 +478,7 @@ func (handler *TransactionHandler) commitOrCancelTransaction(c *fiber.Ctx, tran 
 		Description: &transactionStatus,
 	}
 
-	operations, preBalances, err := handler.BuildOperations(ctx, balancesBefore, fromTo, transactionInput, *tran, validate, time.Now(), false, ledgerSettings.Accounting.ValidateRoutes, routeCache)
+	operations, preBalances, err := handler.BuildOperations(ctx, balancesBefore, fromTo, transactionInput, *tran, validate, time.Now(), false, ledgerSettings.Accounting.ValidateRoutes, routeCache, action)
 	if err != nil {
 		libOpentelemetry.HandleSpanError(span, "Failed to validate balances", err)
 

--- a/components/ledger/internal/bootstrap/redis.consumer.go
+++ b/components/ledger/internal/bootstrap/redis.consumer.go
@@ -427,17 +427,20 @@ func (r *RedisQueueConsumer) processMessage(ctx context.Context, key string, m m
 			}
 		}
 
-		// Derive the accounting action from the transaction status so that
-		// resolveRouteCodesFromCache picks the correct AccountingEntries rubric.
-		action := constant.ActionDirect
+		// Prefer persisted action from backup payload (e.g. revert), then
+		// fall back to status-derived action for backward compatibility.
+		action := m.Action
+		if action == "" {
+			action = constant.ActionDirect
 
-		switch m.TransactionStatus {
-		case constant.PENDING:
-			action = constant.ActionHold
-		case constant.APPROVED:
-			action = constant.ActionCommit
-		case constant.CANCELED:
-			action = constant.ActionCancel
+			switch m.TransactionStatus {
+			case constant.PENDING:
+				action = constant.ActionHold
+			case constant.APPROVED:
+				action = constant.ActionCommit
+			case constant.CANCELED:
+				action = constant.ActionCancel
+			}
 		}
 
 		var buildErr error

--- a/components/ledger/internal/bootstrap/redis.consumer.go
+++ b/components/ledger/internal/bootstrap/redis.consumer.go
@@ -428,7 +428,9 @@ func (r *RedisQueueConsumer) processMessage(ctx context.Context, key string, m m
 		}
 
 		// Prefer persisted action from backup payload (e.g. revert), then
-		// fall back to status-derived action only for non-created statuses.
+		// fall back to status-derived action only for statuses with an
+		// unambiguous mapping. CREATED is intentionally left empty because
+		// legacy payloads may be either "direct" or "revert".
 		action := m.Action
 		if action == "" {
 			switch m.TransactionStatus {
@@ -438,6 +440,8 @@ func (r *RedisQueueConsumer) processMessage(ctx context.Context, key string, m m
 				action = constant.ActionCommit
 			case constant.CANCELED:
 				action = constant.ActionCancel
+			case constant.NOTED:
+				action = constant.ActionDirect
 			}
 		}
 

--- a/components/ledger/internal/bootstrap/redis.consumer.go
+++ b/components/ledger/internal/bootstrap/redis.consumer.go
@@ -427,10 +427,23 @@ func (r *RedisQueueConsumer) processMessage(ctx context.Context, key string, m m
 			}
 		}
 
+		// Derive the accounting action from the transaction status so that
+		// resolveRouteCodesFromCache picks the correct AccountingEntries rubric.
+		action := constant.ActionDirect
+
+		switch m.TransactionStatus {
+		case constant.PENDING:
+			action = constant.ActionHold
+		case constant.APPROVED:
+			action = constant.ActionCommit
+		case constant.CANCELED:
+			action = constant.ActionCancel
+		}
+
 		var buildErr error
 
 		operations, _, buildErr = r.TransactionHandler.BuildOperations(
-			msgCtxWithSpan, balances, fromTo, m.TransactionInput, *tran, m.Validate, m.TransactionDate, m.TransactionStatus == constant.NOTED, ledgerSettings.Accounting.ValidateRoutes, routeCache,
+			msgCtxWithSpan, balances, fromTo, m.TransactionInput, *tran, m.Validate, m.TransactionDate, m.TransactionStatus == constant.NOTED, ledgerSettings.Accounting.ValidateRoutes, routeCache, action,
 		)
 		if buildErr != nil {
 			libOpentelemetry.HandleSpanError(msgSpan, "Failed to validate balances", buildErr)

--- a/components/ledger/internal/bootstrap/redis.consumer.go
+++ b/components/ledger/internal/bootstrap/redis.consumer.go
@@ -428,11 +428,9 @@ func (r *RedisQueueConsumer) processMessage(ctx context.Context, key string, m m
 		}
 
 		// Prefer persisted action from backup payload (e.g. revert), then
-		// fall back to status-derived action for backward compatibility.
+		// fall back to status-derived action only for non-created statuses.
 		action := m.Action
 		if action == "" {
-			action = constant.ActionDirect
-
 			switch m.TransactionStatus {
 			case constant.PENDING:
 				action = constant.ActionHold

--- a/components/ledger/internal/services/command/create-balance-transaction-operations-async.go
+++ b/components/ledger/internal/services/command/create-balance-transaction-operations-async.go
@@ -243,7 +243,7 @@ func (uc *UseCase) RemoveTransactionFromRedisQueue(ctx context.Context, logger l
 // When balances is non-nil (e.g. commit/cancel flows), the snapshot is included
 // directly in the backup message so the Redis consumer can retry without relying
 // on the Lua script to populate them.
-func (uc *UseCase) SendTransactionToRedisQueue(ctx context.Context, organizationID, ledgerID, transactionID uuid.UUID, transactionInput pkgTransaction.Transaction, validate *pkgTransaction.Responses, transactionStatus string, transactionDate time.Time, balances []*mmodel.Balance) error {
+func (uc *UseCase) SendTransactionToRedisQueue(ctx context.Context, organizationID, ledgerID, transactionID uuid.UUID, transactionInput pkgTransaction.Transaction, validate *pkgTransaction.Responses, transactionStatus, action string, transactionDate time.Time, balances []*mmodel.Balance) error {
 	logger, _, reqId, _ := libCommons.NewTrackingFromContext(ctx)
 	transactionKey := utils.TransactionInternalKey(organizationID, ledgerID, transactionID.String())
 
@@ -291,6 +291,7 @@ func (uc *UseCase) SendTransactionToRedisQueue(ctx context.Context, organization
 		TTL:               time.Now(),
 		Validate:          validate,
 		TransactionStatus: transactionStatus,
+		Action:            action,
 		TransactionDate:   transactionDate,
 	}
 
@@ -318,7 +319,7 @@ func (uc *UseCase) SendTransactionToRedisQueue(ctx context.Context, organization
 //
 // This is a best-effort operation: failures are logged but do not block
 // the main transaction flow.
-func (uc *UseCase) UpdateTransactionBackupOperations(ctx context.Context, organizationID, ledgerID uuid.UUID, transactionID string, operations []*operation.Operation) {
+func (uc *UseCase) UpdateTransactionBackupOperations(ctx context.Context, organizationID, ledgerID uuid.UUID, transactionID string, operations []*operation.Operation, actionOverride ...string) {
 	logger, tracer, _, _ := libCommons.NewTrackingFromContext(ctx)
 
 	ctx, span := tracer.Start(ctx, "command.update_transaction_backup_operations")
@@ -348,6 +349,10 @@ func (uc *UseCase) UpdateTransactionBackupOperations(ctx context.Context, organi
 	}
 
 	queue.Operations = redisOps
+
+	if len(actionOverride) > 0 && actionOverride[0] != "" {
+		queue.Action = actionOverride[0]
+	}
 
 	updated, err := json.Marshal(queue)
 	if err != nil {

--- a/pkg/mmodel/balance.go
+++ b/pkg/mmodel/balance.go
@@ -515,6 +515,7 @@ type TransactionRedisQueue struct {
 	TTL               time.Time                  `json:"ttl"`
 	Validate          *pkgTransaction.Responses  `json:"validate"`
 	TransactionStatus string                     `json:"transaction_status"`
+	Action            string                     `json:"action,omitempty"`
 	TransactionDate   time.Time                  `json:"transaction_date"`
 	Operations        []OperationRedis           `json:"operations,omitempty"`
 }


### PR DESCRIPTION
## Summary

When route validation is active, reverting a transaction incorrectly resolved `RouteCode` and `RouteDescription` from `AccountingEntries.Direct` instead of `AccountingEntries.Revert`. This happened because `RevertTransaction` delegated
to `createTransaction` with status `CREATED`, which mapped to action `"direct"` in both `ValidateAccountingRules` and `resolveRouteCodesFromCache`.

## Root Cause

`createTransaction` derived the accounting action solely from the transaction status (`CREATED` → `direct`, `PENDING` → `hold`). Since revert transactions are created with status `CREATED`, there was no way to distinguish them from regular direct transactions — the `ActionRevert` constant existed but was never used in the creation flow.

## Changes

- Added `actionOverride ...string` variadic parameter to `createTransaction` so callers can override the default status-derived action without changing the transaction status itself.
- `RevertTransaction` now passes `constant.ActionRevert`, making `GetBalances` validate against `cache.Actions["revert"]` and `resolveRouteCodesFromCache` resolve rubrics from `AccountingEntries.Revert`.
- `BuildOperations` and `resolveRouteCodesFromCache` now receive the action string directly instead of deriving it from the transaction status, making the mapping explicit at every call site.
- Updated `commitOrCancelTransaction` and the Redis consumer to pass the already-computed action through to `BuildOperations`.
- Fixed all related unit tests to pass action strings instead of status strings.