### PR TITLE
feat: add Accounting Rules Validation for Operation Routes

### DIFF
--- a/components/ledger/internal/adapters/http/in/operation-route-validation_test.go
+++ b/components/ledger/internal/adapters/http/in/operation-route-validation_test.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/LerianStudio/midaz/v3/pkg/constant"
 	"github.com/LerianStudio/midaz/v3/pkg/mmodel"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -232,6 +233,865 @@ func TestFindUnknownAccountingEntryKeys(t *testing.T) {
 				}
 
 				assert.ElementsMatch(t, tt.expectKeys, actualKeys, "unexpected keys mismatch")
+			}
+		})
+	}
+}
+
+func TestOperationRouteHandler_validateDirectionScenarioMatrix(t *testing.T) {
+	t.Parallel()
+
+	handler := &OperationRouteHandler{}
+
+	tests := []struct {
+		name          string
+		operationType string
+		entries       *mmodel.AccountingEntries
+		expectError   bool
+		errorCode     string
+	}{
+		// Source direction tests
+		{
+			name:          "source with direct only - valid",
+			operationType: constant.OperationRouteTypeSource,
+			entries: &mmodel.AccountingEntries{
+				Direct: &mmodel.AccountingEntry{
+					Debit:  &mmodel.AccountingRubric{Code: "1001", Description: "Debit"},
+					Credit: &mmodel.AccountingRubric{Code: "2001", Description: "Credit"},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name:          "source with hold, commit, cancel - valid",
+			operationType: constant.OperationRouteTypeSource,
+			entries: &mmodel.AccountingEntries{
+				Direct: &mmodel.AccountingEntry{
+					Debit:  &mmodel.AccountingRubric{Code: "1001", Description: "Debit"},
+					Credit: &mmodel.AccountingRubric{Code: "2001", Description: "Credit"},
+				},
+				Hold: &mmodel.AccountingEntry{
+					Debit:  &mmodel.AccountingRubric{Code: "1002", Description: "Hold Debit"},
+					Credit: &mmodel.AccountingRubric{Code: "2002", Description: "Hold Credit"},
+				},
+				Commit: &mmodel.AccountingEntry{
+					Debit:  &mmodel.AccountingRubric{Code: "1003", Description: "Commit Debit"},
+					Credit: &mmodel.AccountingRubric{Code: "2003", Description: "Commit Credit"},
+				},
+				Cancel: &mmodel.AccountingEntry{
+					Debit:  &mmodel.AccountingRubric{Code: "1004", Description: "Cancel Debit"},
+					Credit: &mmodel.AccountingRubric{Code: "2004", Description: "Cancel Credit"},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name:          "source with revert - invalid",
+			operationType: constant.OperationRouteTypeSource,
+			entries: &mmodel.AccountingEntries{
+				Direct: &mmodel.AccountingEntry{
+					Debit:  &mmodel.AccountingRubric{Code: "1001", Description: "Debit"},
+					Credit: &mmodel.AccountingRubric{Code: "2001", Description: "Credit"},
+				},
+				Revert: &mmodel.AccountingEntry{
+					Debit:  &mmodel.AccountingRubric{Code: "1005", Description: "Revert Debit"},
+					Credit: &mmodel.AccountingRubric{Code: "2005", Description: "Revert Credit"},
+				},
+			},
+			expectError: true,
+			errorCode:   "0165",
+		},
+
+		// Destination direction tests
+		{
+			name:          "destination with direct only - valid",
+			operationType: constant.OperationRouteTypeDestination,
+			entries: &mmodel.AccountingEntries{
+				Direct: &mmodel.AccountingEntry{
+					Debit:  &mmodel.AccountingRubric{Code: "1001", Description: "Debit"},
+					Credit: &mmodel.AccountingRubric{Code: "2001", Description: "Credit"},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name:          "destination with direct and commit - valid",
+			operationType: constant.OperationRouteTypeDestination,
+			entries: &mmodel.AccountingEntries{
+				Direct: &mmodel.AccountingEntry{
+					Debit:  &mmodel.AccountingRubric{Code: "1001", Description: "Debit"},
+					Credit: &mmodel.AccountingRubric{Code: "2001", Description: "Credit"},
+				},
+				Commit: &mmodel.AccountingEntry{
+					Debit:  &mmodel.AccountingRubric{Code: "1003", Description: "Commit Debit"},
+					Credit: &mmodel.AccountingRubric{Code: "2003", Description: "Commit Credit"},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name:          "destination with hold - invalid",
+			operationType: constant.OperationRouteTypeDestination,
+			entries: &mmodel.AccountingEntries{
+				Direct: &mmodel.AccountingEntry{
+					Debit:  &mmodel.AccountingRubric{Code: "1001", Description: "Debit"},
+					Credit: &mmodel.AccountingRubric{Code: "2001", Description: "Credit"},
+				},
+				Hold: &mmodel.AccountingEntry{
+					Debit:  &mmodel.AccountingRubric{Code: "1002", Description: "Hold Debit"},
+					Credit: &mmodel.AccountingRubric{Code: "2002", Description: "Hold Credit"},
+				},
+			},
+			expectError: true,
+			errorCode:   "0162",
+		},
+		{
+			name:          "destination with cancel - invalid",
+			operationType: constant.OperationRouteTypeDestination,
+			entries: &mmodel.AccountingEntries{
+				Direct: &mmodel.AccountingEntry{
+					Debit:  &mmodel.AccountingRubric{Code: "1001", Description: "Debit"},
+					Credit: &mmodel.AccountingRubric{Code: "2001", Description: "Credit"},
+				},
+				Cancel: &mmodel.AccountingEntry{
+					Debit:  &mmodel.AccountingRubric{Code: "1004", Description: "Cancel Debit"},
+					Credit: &mmodel.AccountingRubric{Code: "2004", Description: "Cancel Credit"},
+				},
+			},
+			expectError: true,
+			errorCode:   "0162",
+		},
+		{
+			name:          "destination with revert - invalid",
+			operationType: constant.OperationRouteTypeDestination,
+			entries: &mmodel.AccountingEntries{
+				Direct: &mmodel.AccountingEntry{
+					Debit:  &mmodel.AccountingRubric{Code: "1001", Description: "Debit"},
+					Credit: &mmodel.AccountingRubric{Code: "2001", Description: "Credit"},
+				},
+				Revert: &mmodel.AccountingEntry{
+					Debit:  &mmodel.AccountingRubric{Code: "1005", Description: "Revert Debit"},
+					Credit: &mmodel.AccountingRubric{Code: "2005", Description: "Revert Credit"},
+				},
+			},
+			expectError: true,
+			errorCode:   "0162",
+		},
+
+		// Bidirectional direction tests
+		{
+			name:          "bidirectional with all scenarios - valid",
+			operationType: constant.OperationRouteTypeBidirectional,
+			entries: &mmodel.AccountingEntries{
+				Direct: &mmodel.AccountingEntry{
+					Debit:  &mmodel.AccountingRubric{Code: "1001", Description: "Debit"},
+					Credit: &mmodel.AccountingRubric{Code: "2001", Description: "Credit"},
+				},
+				Hold: &mmodel.AccountingEntry{
+					Debit:  &mmodel.AccountingRubric{Code: "1002", Description: "Hold Debit"},
+					Credit: &mmodel.AccountingRubric{Code: "2002", Description: "Hold Credit"},
+				},
+				Commit: &mmodel.AccountingEntry{
+					Debit:  &mmodel.AccountingRubric{Code: "1003", Description: "Commit Debit"},
+					Credit: &mmodel.AccountingRubric{Code: "2003", Description: "Commit Credit"},
+				},
+				Cancel: &mmodel.AccountingEntry{
+					Debit:  &mmodel.AccountingRubric{Code: "1004", Description: "Cancel Debit"},
+					Credit: &mmodel.AccountingRubric{Code: "2004", Description: "Cancel Credit"},
+				},
+				Revert: &mmodel.AccountingEntry{
+					Debit:  &mmodel.AccountingRubric{Code: "1005", Description: "Revert Debit"},
+					Credit: &mmodel.AccountingRubric{Code: "2005", Description: "Revert Credit"},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name:          "bidirectional with revert only - valid for direction check",
+			operationType: constant.OperationRouteTypeBidirectional,
+			entries: &mmodel.AccountingEntries{
+				Direct: &mmodel.AccountingEntry{
+					Debit:  &mmodel.AccountingRubric{Code: "1001", Description: "Debit"},
+					Credit: &mmodel.AccountingRubric{Code: "2001", Description: "Credit"},
+				},
+				Revert: &mmodel.AccountingEntry{
+					Debit:  &mmodel.AccountingRubric{Code: "1005", Description: "Revert Debit"},
+					Credit: &mmodel.AccountingRubric{Code: "2005", Description: "Revert Credit"},
+				},
+			},
+			expectError: false,
+		},
+
+		// Edge case: invalid operation type
+		{
+			name:          "invalid operation type - no validation error (falls through default)",
+			operationType: "invalid_type",
+			entries: &mmodel.AccountingEntries{
+				Direct: &mmodel.AccountingEntry{
+					Debit:  &mmodel.AccountingRubric{Code: "1001", Description: "Debit"},
+					Credit: &mmodel.AccountingRubric{Code: "2001", Description: "Credit"},
+				},
+			},
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := context.Background()
+
+			err := handler.validateDirectionScenarioMatrix(ctx, tt.operationType, tt.entries, "operation_route")
+
+			if tt.expectError {
+				require.Error(t, err, "expected validation error")
+				assert.Contains(t, err.Error(), tt.errorCode, "error should contain expected code")
+			} else {
+				require.NoError(t, err, "expected no validation error")
+			}
+		})
+	}
+}
+
+func TestOperationRouteHandler_validateReserveGroupAtomicity(t *testing.T) {
+	t.Parallel()
+
+	handler := &OperationRouteHandler{}
+
+	tests := []struct {
+		name          string
+		operationType string
+		entries       *mmodel.AccountingEntries
+		expectError   bool
+		errorCode     string
+	}{
+		// Complete reserve group
+		{
+			name:          "source with complete reserve group - valid",
+			operationType: constant.OperationRouteTypeSource,
+			entries: &mmodel.AccountingEntries{
+				Direct: &mmodel.AccountingEntry{
+					Debit:  &mmodel.AccountingRubric{Code: "1001", Description: "Debit"},
+					Credit: &mmodel.AccountingRubric{Code: "2001", Description: "Credit"},
+				},
+				Hold: &mmodel.AccountingEntry{
+					Debit:  &mmodel.AccountingRubric{Code: "1002", Description: "Hold Debit"},
+					Credit: &mmodel.AccountingRubric{Code: "2002", Description: "Hold Credit"},
+				},
+				Commit: &mmodel.AccountingEntry{
+					Debit:  &mmodel.AccountingRubric{Code: "1003", Description: "Commit Debit"},
+					Credit: &mmodel.AccountingRubric{Code: "2003", Description: "Commit Credit"},
+				},
+				Cancel: &mmodel.AccountingEntry{
+					Debit:  &mmodel.AccountingRubric{Code: "1004", Description: "Cancel Debit"},
+					Credit: &mmodel.AccountingRubric{Code: "2004", Description: "Cancel Credit"},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name:          "source with no reserve group - valid",
+			operationType: constant.OperationRouteTypeSource,
+			entries: &mmodel.AccountingEntries{
+				Direct: &mmodel.AccountingEntry{
+					Debit:  &mmodel.AccountingRubric{Code: "1001", Description: "Debit"},
+					Credit: &mmodel.AccountingRubric{Code: "2001", Description: "Credit"},
+				},
+			},
+			expectError: false,
+		},
+
+		// Incomplete reserve group - missing commit
+		{
+			name:          "source with hold and cancel but missing commit - invalid",
+			operationType: constant.OperationRouteTypeSource,
+			entries: &mmodel.AccountingEntries{
+				Direct: &mmodel.AccountingEntry{
+					Debit:  &mmodel.AccountingRubric{Code: "1001", Description: "Debit"},
+					Credit: &mmodel.AccountingRubric{Code: "2001", Description: "Credit"},
+				},
+				Hold: &mmodel.AccountingEntry{
+					Debit:  &mmodel.AccountingRubric{Code: "1002", Description: "Hold Debit"},
+					Credit: &mmodel.AccountingRubric{Code: "2002", Description: "Hold Credit"},
+				},
+				Cancel: &mmodel.AccountingEntry{
+					Debit:  &mmodel.AccountingRubric{Code: "1004", Description: "Cancel Debit"},
+					Credit: &mmodel.AccountingRubric{Code: "2004", Description: "Cancel Credit"},
+				},
+			},
+			expectError: true,
+			errorCode:   "0163",
+		},
+
+		// Incomplete reserve group - missing cancel
+		{
+			name:          "source with hold and commit but missing cancel - invalid",
+			operationType: constant.OperationRouteTypeSource,
+			entries: &mmodel.AccountingEntries{
+				Direct: &mmodel.AccountingEntry{
+					Debit:  &mmodel.AccountingRubric{Code: "1001", Description: "Debit"},
+					Credit: &mmodel.AccountingRubric{Code: "2001", Description: "Credit"},
+				},
+				Hold: &mmodel.AccountingEntry{
+					Debit:  &mmodel.AccountingRubric{Code: "1002", Description: "Hold Debit"},
+					Credit: &mmodel.AccountingRubric{Code: "2002", Description: "Hold Credit"},
+				},
+				Commit: &mmodel.AccountingEntry{
+					Debit:  &mmodel.AccountingRubric{Code: "1003", Description: "Commit Debit"},
+					Credit: &mmodel.AccountingRubric{Code: "2003", Description: "Commit Credit"},
+				},
+			},
+			expectError: true,
+			errorCode:   "0163",
+		},
+
+		// Incomplete reserve group - hold only
+		{
+			name:          "source with hold only - invalid",
+			operationType: constant.OperationRouteTypeSource,
+			entries: &mmodel.AccountingEntries{
+				Direct: &mmodel.AccountingEntry{
+					Debit:  &mmodel.AccountingRubric{Code: "1001", Description: "Debit"},
+					Credit: &mmodel.AccountingRubric{Code: "2001", Description: "Credit"},
+				},
+				Hold: &mmodel.AccountingEntry{
+					Debit:  &mmodel.AccountingRubric{Code: "1002", Description: "Hold Debit"},
+					Credit: &mmodel.AccountingRubric{Code: "2002", Description: "Hold Credit"},
+				},
+			},
+			expectError: true,
+			errorCode:   "0163",
+		},
+
+		// Commit/cancel without hold
+		{
+			name:          "source with commit only (no hold) - invalid",
+			operationType: constant.OperationRouteTypeSource,
+			entries: &mmodel.AccountingEntries{
+				Direct: &mmodel.AccountingEntry{
+					Debit:  &mmodel.AccountingRubric{Code: "1001", Description: "Debit"},
+					Credit: &mmodel.AccountingRubric{Code: "2001", Description: "Credit"},
+				},
+				Commit: &mmodel.AccountingEntry{
+					Debit:  &mmodel.AccountingRubric{Code: "1003", Description: "Commit Debit"},
+					Credit: &mmodel.AccountingRubric{Code: "2003", Description: "Commit Credit"},
+				},
+			},
+			expectError: true,
+			errorCode:   "0163",
+		},
+
+		// Destination skips reserve group validation
+		{
+			name:          "destination with commit only - valid (reserve group not applicable)",
+			operationType: constant.OperationRouteTypeDestination,
+			entries: &mmodel.AccountingEntries{
+				Direct: &mmodel.AccountingEntry{
+					Debit:  &mmodel.AccountingRubric{Code: "1001", Description: "Debit"},
+					Credit: &mmodel.AccountingRubric{Code: "2001", Description: "Credit"},
+				},
+				Commit: &mmodel.AccountingEntry{
+					Debit:  &mmodel.AccountingRubric{Code: "1003", Description: "Commit Debit"},
+					Credit: &mmodel.AccountingRubric{Code: "2003", Description: "Commit Credit"},
+				},
+			},
+			expectError: false,
+		},
+
+		// Bidirectional with reserve group
+		{
+			name:          "bidirectional with complete reserve group - valid",
+			operationType: constant.OperationRouteTypeBidirectional,
+			entries: &mmodel.AccountingEntries{
+				Direct: &mmodel.AccountingEntry{
+					Debit:  &mmodel.AccountingRubric{Code: "1001", Description: "Debit"},
+					Credit: &mmodel.AccountingRubric{Code: "2001", Description: "Credit"},
+				},
+				Hold: &mmodel.AccountingEntry{
+					Debit:  &mmodel.AccountingRubric{Code: "1002", Description: "Hold Debit"},
+					Credit: &mmodel.AccountingRubric{Code: "2002", Description: "Hold Credit"},
+				},
+				Commit: &mmodel.AccountingEntry{
+					Debit:  &mmodel.AccountingRubric{Code: "1003", Description: "Commit Debit"},
+					Credit: &mmodel.AccountingRubric{Code: "2003", Description: "Commit Credit"},
+				},
+				Cancel: &mmodel.AccountingEntry{
+					Debit:  &mmodel.AccountingRubric{Code: "1004", Description: "Cancel Debit"},
+					Credit: &mmodel.AccountingRubric{Code: "2004", Description: "Cancel Credit"},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name:          "bidirectional with hold only - invalid",
+			operationType: constant.OperationRouteTypeBidirectional,
+			entries: &mmodel.AccountingEntries{
+				Direct: &mmodel.AccountingEntry{
+					Debit:  &mmodel.AccountingRubric{Code: "1001", Description: "Debit"},
+					Credit: &mmodel.AccountingRubric{Code: "2001", Description: "Credit"},
+				},
+				Hold: &mmodel.AccountingEntry{
+					Debit:  &mmodel.AccountingRubric{Code: "1002", Description: "Hold Debit"},
+					Credit: &mmodel.AccountingRubric{Code: "2002", Description: "Hold Credit"},
+				},
+			},
+			expectError: true,
+			errorCode:   "0163",
+		},
+
+		// Edge case: cancel only without hold
+		{
+			name:          "source with cancel only (no hold) - invalid",
+			operationType: constant.OperationRouteTypeSource,
+			entries: &mmodel.AccountingEntries{
+				Direct: &mmodel.AccountingEntry{
+					Debit:  &mmodel.AccountingRubric{Code: "1001", Description: "Debit"},
+					Credit: &mmodel.AccountingRubric{Code: "2001", Description: "Credit"},
+				},
+				Cancel: &mmodel.AccountingEntry{
+					Debit:  &mmodel.AccountingRubric{Code: "1004", Description: "Cancel Debit"},
+					Credit: &mmodel.AccountingRubric{Code: "2004", Description: "Cancel Credit"},
+				},
+			},
+			expectError: true,
+			errorCode:   "0163",
+		},
+
+		// Edge case: bidirectional with partial reserve group (hold + commit, missing cancel)
+		{
+			name:          "bidirectional with hold and commit but missing cancel - invalid",
+			operationType: constant.OperationRouteTypeBidirectional,
+			entries: &mmodel.AccountingEntries{
+				Direct: &mmodel.AccountingEntry{
+					Debit:  &mmodel.AccountingRubric{Code: "1001", Description: "Debit"},
+					Credit: &mmodel.AccountingRubric{Code: "2001", Description: "Credit"},
+				},
+				Hold: &mmodel.AccountingEntry{
+					Debit:  &mmodel.AccountingRubric{Code: "1002", Description: "Hold Debit"},
+					Credit: &mmodel.AccountingRubric{Code: "2002", Description: "Hold Credit"},
+				},
+				Commit: &mmodel.AccountingEntry{
+					Debit:  &mmodel.AccountingRubric{Code: "1003", Description: "Commit Debit"},
+					Credit: &mmodel.AccountingRubric{Code: "2003", Description: "Commit Credit"},
+				},
+			},
+			expectError: true,
+			errorCode:   "0163",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := context.Background()
+
+			err := handler.validateReserveGroupAtomicity(ctx, tt.operationType, tt.entries, "operation_route")
+
+			if tt.expectError {
+				require.Error(t, err, "expected validation error")
+				assert.Contains(t, err.Error(), tt.errorCode, "error should contain expected code")
+			} else {
+				require.NoError(t, err, "expected no validation error")
+			}
+		})
+	}
+}
+
+func TestOperationRouteHandler_validateDirectMandatory(t *testing.T) {
+	t.Parallel()
+
+	handler := &OperationRouteHandler{}
+
+	tests := []struct {
+		name        string
+		entries     *mmodel.AccountingEntries
+		expectError bool
+		errorCode   string
+	}{
+		{
+			name: "direct only - valid",
+			entries: &mmodel.AccountingEntries{
+				Direct: &mmodel.AccountingEntry{
+					Debit:  &mmodel.AccountingRubric{Code: "1001", Description: "Debit"},
+					Credit: &mmodel.AccountingRubric{Code: "2001", Description: "Credit"},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "direct with other scenarios - valid",
+			entries: &mmodel.AccountingEntries{
+				Direct: &mmodel.AccountingEntry{
+					Debit:  &mmodel.AccountingRubric{Code: "1001", Description: "Debit"},
+					Credit: &mmodel.AccountingRubric{Code: "2001", Description: "Credit"},
+				},
+				Hold: &mmodel.AccountingEntry{
+					Debit:  &mmodel.AccountingRubric{Code: "1002", Description: "Hold Debit"},
+					Credit: &mmodel.AccountingRubric{Code: "2002", Description: "Hold Credit"},
+				},
+				Commit: &mmodel.AccountingEntry{
+					Debit:  &mmodel.AccountingRubric{Code: "1003", Description: "Commit Debit"},
+					Credit: &mmodel.AccountingRubric{Code: "2003", Description: "Commit Credit"},
+				},
+				Cancel: &mmodel.AccountingEntry{
+					Debit:  &mmodel.AccountingRubric{Code: "1004", Description: "Cancel Debit"},
+					Credit: &mmodel.AccountingRubric{Code: "2004", Description: "Cancel Credit"},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "hold without direct - invalid",
+			entries: &mmodel.AccountingEntries{
+				Hold: &mmodel.AccountingEntry{
+					Debit:  &mmodel.AccountingRubric{Code: "1002", Description: "Hold Debit"},
+					Credit: &mmodel.AccountingRubric{Code: "2002", Description: "Hold Credit"},
+				},
+				Commit: &mmodel.AccountingEntry{
+					Debit:  &mmodel.AccountingRubric{Code: "1003", Description: "Commit Debit"},
+					Credit: &mmodel.AccountingRubric{Code: "2003", Description: "Commit Credit"},
+				},
+				Cancel: &mmodel.AccountingEntry{
+					Debit:  &mmodel.AccountingRubric{Code: "1004", Description: "Cancel Debit"},
+					Credit: &mmodel.AccountingRubric{Code: "2004", Description: "Cancel Credit"},
+				},
+			},
+			expectError: true,
+			errorCode:   "0164",
+		},
+		{
+			name: "revert without direct - invalid",
+			entries: &mmodel.AccountingEntries{
+				Revert: &mmodel.AccountingEntry{
+					Debit:  &mmodel.AccountingRubric{Code: "1005", Description: "Revert Debit"},
+					Credit: &mmodel.AccountingRubric{Code: "2005", Description: "Revert Credit"},
+				},
+			},
+			expectError: true,
+			errorCode:   "0164",
+		},
+		{
+			name: "commit without direct - invalid",
+			entries: &mmodel.AccountingEntries{
+				Commit: &mmodel.AccountingEntry{
+					Debit:  &mmodel.AccountingRubric{Code: "1003", Description: "Commit Debit"},
+					Credit: &mmodel.AccountingRubric{Code: "2003", Description: "Commit Credit"},
+				},
+			},
+			expectError: true,
+			errorCode:   "0164",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := context.Background()
+
+			err := handler.validateDirectMandatory(ctx, tt.entries, "operation_route")
+
+			if tt.expectError {
+				require.Error(t, err, "expected validation error")
+				assert.Contains(t, err.Error(), tt.errorCode, "error should contain expected code")
+			} else {
+				require.NoError(t, err, "expected no validation error")
+			}
+		})
+	}
+}
+
+func TestMergeAccountingEntries(t *testing.T) {
+	t.Parallel()
+
+	directEntry := &mmodel.AccountingEntry{
+		Debit:  &mmodel.AccountingRubric{Code: "1001", Description: "Direct Debit"},
+		Credit: &mmodel.AccountingRubric{Code: "2001", Description: "Direct Credit"},
+	}
+	holdEntry := &mmodel.AccountingEntry{
+		Debit:  &mmodel.AccountingRubric{Code: "1002", Description: "Hold Debit"},
+		Credit: &mmodel.AccountingRubric{Code: "2002", Description: "Hold Credit"},
+	}
+	commitEntry := &mmodel.AccountingEntry{
+		Debit:  &mmodel.AccountingRubric{Code: "1003", Description: "Commit Debit"},
+		Credit: &mmodel.AccountingRubric{Code: "2003", Description: "Commit Credit"},
+	}
+	cancelEntry := &mmodel.AccountingEntry{
+		Debit:  &mmodel.AccountingRubric{Code: "1004", Description: "Cancel Debit"},
+		Credit: &mmodel.AccountingRubric{Code: "2004", Description: "Cancel Credit"},
+	}
+	revertEntry := &mmodel.AccountingEntry{
+		Debit:  &mmodel.AccountingRubric{Code: "1005", Description: "Revert Debit"},
+		Credit: &mmodel.AccountingRubric{Code: "2005", Description: "Revert Credit"},
+	}
+
+	newDirectEntry := &mmodel.AccountingEntry{
+		Debit:  &mmodel.AccountingRubric{Code: "NEW1", Description: "New Direct Debit"},
+		Credit: &mmodel.AccountingRubric{Code: "NEW2", Description: "New Direct Credit"},
+	}
+
+	tests := []struct {
+		name     string
+		existing *mmodel.AccountingEntries
+		incoming *mmodel.AccountingEntries
+		expected *mmodel.AccountingEntries
+	}{
+		{
+			name:     "both nil returns nil",
+			existing: nil,
+			incoming: nil,
+			expected: nil,
+		},
+		{
+			name:     "existing nil returns incoming",
+			existing: nil,
+			incoming: &mmodel.AccountingEntries{Direct: directEntry},
+			expected: &mmodel.AccountingEntries{Direct: directEntry},
+		},
+		{
+			name:     "incoming nil returns existing",
+			existing: &mmodel.AccountingEntries{Direct: directEntry},
+			incoming: nil,
+			expected: &mmodel.AccountingEntries{Direct: directEntry},
+		},
+		{
+			name:     "incoming overwrites existing direct",
+			existing: &mmodel.AccountingEntries{Direct: directEntry},
+			incoming: &mmodel.AccountingEntries{Direct: newDirectEntry},
+			expected: &mmodel.AccountingEntries{Direct: newDirectEntry},
+		},
+		{
+			name: "incoming adds to existing",
+			existing: &mmodel.AccountingEntries{
+				Direct: directEntry,
+			},
+			incoming: &mmodel.AccountingEntries{
+				Hold:   holdEntry,
+				Commit: commitEntry,
+				Cancel: cancelEntry,
+			},
+			expected: &mmodel.AccountingEntries{
+				Direct: directEntry,
+				Hold:   holdEntry,
+				Commit: commitEntry,
+				Cancel: cancelEntry,
+			},
+		},
+		{
+			name: "existing preserved when incoming is partial",
+			existing: &mmodel.AccountingEntries{
+				Direct: directEntry,
+				Hold:   holdEntry,
+				Commit: commitEntry,
+				Cancel: cancelEntry,
+				Revert: revertEntry,
+			},
+			incoming: &mmodel.AccountingEntries{
+				Direct: newDirectEntry,
+			},
+			expected: &mmodel.AccountingEntries{
+				Direct: newDirectEntry,
+				Hold:   holdEntry,
+				Commit: commitEntry,
+				Cancel: cancelEntry,
+				Revert: revertEntry,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			result := mergeAccountingEntries(tt.existing, tt.incoming)
+
+			if tt.expected == nil {
+				assert.Nil(t, result)
+				return
+			}
+
+			require.NotNil(t, result)
+			assert.Equal(t, tt.expected.Direct, result.Direct)
+			assert.Equal(t, tt.expected.Hold, result.Hold)
+			assert.Equal(t, tt.expected.Commit, result.Commit)
+			assert.Equal(t, tt.expected.Cancel, result.Cancel)
+			assert.Equal(t, tt.expected.Revert, result.Revert)
+		})
+	}
+}
+
+func TestOperationRouteHandler_validateAccountingRulesMatrix(t *testing.T) {
+	t.Parallel()
+
+	handler := &OperationRouteHandler{}
+
+	tests := []struct {
+		name          string
+		operationType string
+		entries       *mmodel.AccountingEntries
+		expectError   bool
+		errorCode     string
+	}{
+		{
+			name:          "nil entries returns no error",
+			operationType: constant.OperationRouteTypeSource,
+			entries:       nil,
+			expectError:   false,
+		},
+		{
+			name:          "valid source with direct only",
+			operationType: constant.OperationRouteTypeSource,
+			entries: &mmodel.AccountingEntries{
+				Direct: &mmodel.AccountingEntry{
+					Debit:  &mmodel.AccountingRubric{Code: "1001", Description: "Debit"},
+					Credit: &mmodel.AccountingRubric{Code: "2001", Description: "Credit"},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name:          "valid source with complete reserve group",
+			operationType: constant.OperationRouteTypeSource,
+			entries: &mmodel.AccountingEntries{
+				Direct: &mmodel.AccountingEntry{
+					Debit:  &mmodel.AccountingRubric{Code: "1001", Description: "Debit"},
+					Credit: &mmodel.AccountingRubric{Code: "2001", Description: "Credit"},
+				},
+				Hold: &mmodel.AccountingEntry{
+					Debit:  &mmodel.AccountingRubric{Code: "1002", Description: "Hold Debit"},
+					Credit: &mmodel.AccountingRubric{Code: "2002", Description: "Hold Credit"},
+				},
+				Commit: &mmodel.AccountingEntry{
+					Debit:  &mmodel.AccountingRubric{Code: "1003", Description: "Commit Debit"},
+					Credit: &mmodel.AccountingRubric{Code: "2003", Description: "Commit Credit"},
+				},
+				Cancel: &mmodel.AccountingEntry{
+					Debit:  &mmodel.AccountingRubric{Code: "1004", Description: "Cancel Debit"},
+					Credit: &mmodel.AccountingRubric{Code: "2004", Description: "Cancel Credit"},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name:          "source with revert fails direction check",
+			operationType: constant.OperationRouteTypeSource,
+			entries: &mmodel.AccountingEntries{
+				Direct: &mmodel.AccountingEntry{
+					Debit:  &mmodel.AccountingRubric{Code: "1001", Description: "Debit"},
+					Credit: &mmodel.AccountingRubric{Code: "2001", Description: "Credit"},
+				},
+				Revert: &mmodel.AccountingEntry{
+					Debit:  &mmodel.AccountingRubric{Code: "1005", Description: "Revert Debit"},
+					Credit: &mmodel.AccountingRubric{Code: "2005", Description: "Revert Credit"},
+				},
+			},
+			expectError: true,
+			errorCode:   "0165",
+		},
+		{
+			name:          "source with incomplete reserve group fails",
+			operationType: constant.OperationRouteTypeSource,
+			entries: &mmodel.AccountingEntries{
+				Direct: &mmodel.AccountingEntry{
+					Debit:  &mmodel.AccountingRubric{Code: "1001", Description: "Debit"},
+					Credit: &mmodel.AccountingRubric{Code: "2001", Description: "Credit"},
+				},
+				Hold: &mmodel.AccountingEntry{
+					Debit:  &mmodel.AccountingRubric{Code: "1002", Description: "Hold Debit"},
+					Credit: &mmodel.AccountingRubric{Code: "2002", Description: "Hold Credit"},
+				},
+			},
+			expectError: true,
+			errorCode:   "0163",
+		},
+		{
+			name:          "missing direct with other scenarios fails",
+			operationType: constant.OperationRouteTypeSource,
+			entries: &mmodel.AccountingEntries{
+				Hold: &mmodel.AccountingEntry{
+					Debit:  &mmodel.AccountingRubric{Code: "1002", Description: "Hold Debit"},
+					Credit: &mmodel.AccountingRubric{Code: "2002", Description: "Hold Credit"},
+				},
+				Commit: &mmodel.AccountingEntry{
+					Debit:  &mmodel.AccountingRubric{Code: "1003", Description: "Commit Debit"},
+					Credit: &mmodel.AccountingRubric{Code: "2003", Description: "Commit Credit"},
+				},
+				Cancel: &mmodel.AccountingEntry{
+					Debit:  &mmodel.AccountingRubric{Code: "1004", Description: "Cancel Debit"},
+					Credit: &mmodel.AccountingRubric{Code: "2004", Description: "Cancel Credit"},
+				},
+			},
+			expectError: true,
+			errorCode:   "0164",
+		},
+		{
+			name:          "valid bidirectional with all scenarios",
+			operationType: constant.OperationRouteTypeBidirectional,
+			entries: &mmodel.AccountingEntries{
+				Direct: &mmodel.AccountingEntry{
+					Debit:  &mmodel.AccountingRubric{Code: "1001", Description: "Debit"},
+					Credit: &mmodel.AccountingRubric{Code: "2001", Description: "Credit"},
+				},
+				Hold: &mmodel.AccountingEntry{
+					Debit:  &mmodel.AccountingRubric{Code: "1002", Description: "Hold Debit"},
+					Credit: &mmodel.AccountingRubric{Code: "2002", Description: "Hold Credit"},
+				},
+				Commit: &mmodel.AccountingEntry{
+					Debit:  &mmodel.AccountingRubric{Code: "1003", Description: "Commit Debit"},
+					Credit: &mmodel.AccountingRubric{Code: "2003", Description: "Commit Credit"},
+				},
+				Cancel: &mmodel.AccountingEntry{
+					Debit:  &mmodel.AccountingRubric{Code: "1004", Description: "Cancel Debit"},
+					Credit: &mmodel.AccountingRubric{Code: "2004", Description: "Cancel Credit"},
+				},
+				Revert: &mmodel.AccountingEntry{
+					Debit:  &mmodel.AccountingRubric{Code: "1005", Description: "Revert Debit"},
+					Credit: &mmodel.AccountingRubric{Code: "2005", Description: "Revert Credit"},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name:          "destination with hold fails direction check",
+			operationType: constant.OperationRouteTypeDestination,
+			entries: &mmodel.AccountingEntries{
+				Direct: &mmodel.AccountingEntry{
+					Debit:  &mmodel.AccountingRubric{Code: "1001", Description: "Debit"},
+					Credit: &mmodel.AccountingRubric{Code: "2001", Description: "Credit"},
+				},
+				Hold: &mmodel.AccountingEntry{
+					Debit:  &mmodel.AccountingRubric{Code: "1002", Description: "Hold Debit"},
+					Credit: &mmodel.AccountingRubric{Code: "2002", Description: "Hold Credit"},
+				},
+			},
+			expectError: true,
+			errorCode:   "0162",
+		},
+
+		// Edge case: empty AccountingEntries struct (all fields nil)
+		{
+			name:          "empty entries struct with all nil fields - valid",
+			operationType: constant.OperationRouteTypeSource,
+			entries:       &mmodel.AccountingEntries{},
+			expectError:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := context.Background()
+
+			err := handler.validateAccountingRulesMatrix(ctx, tt.operationType, tt.entries)
+
+			if tt.expectError {
+				require.Error(t, err, "expected validation error")
+				assert.Contains(t, err.Error(), tt.errorCode, "error should contain expected code")
+			} else {
+				require.NoError(t, err, "expected no validation error")
 			}
 		})
 	}

--- a/components/ledger/internal/adapters/http/in/operation-route-validation_test.go
+++ b/components/ledger/internal/adapters/http/in/operation-route-validation_test.go
@@ -905,7 +905,8 @@ func TestMergeAccountingEntries(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			result := mergeAccountingEntries(tt.existing, tt.incoming)
+			// Pass nil for rawUpdates to use simple merge (backward compatible behavior)
+			result := mergeAccountingEntries(tt.existing, tt.incoming, nil)
 
 			if tt.expected == nil {
 				assert.Nil(t, result)
@@ -918,6 +919,137 @@ func TestMergeAccountingEntries(t *testing.T) {
 			assert.Equal(t, tt.expected.Commit, result.Commit)
 			assert.Equal(t, tt.expected.Cancel, result.Cancel)
 			assert.Equal(t, tt.expected.Revert, result.Revert)
+		})
+	}
+}
+
+func TestMergeAccountingEntries_ExplicitNullRemoval(t *testing.T) {
+	t.Parallel()
+
+	directEntry := &mmodel.AccountingEntry{
+		Debit:  &mmodel.AccountingRubric{Code: "1001", Description: "Direct Debit"},
+		Credit: &mmodel.AccountingRubric{Code: "2001", Description: "Direct Credit"},
+	}
+	holdEntry := &mmodel.AccountingEntry{
+		Debit:  &mmodel.AccountingRubric{Code: "1002", Description: "Hold Debit"},
+		Credit: &mmodel.AccountingRubric{Code: "2002", Description: "Hold Credit"},
+	}
+	commitEntry := &mmodel.AccountingEntry{
+		Debit:  &mmodel.AccountingRubric{Code: "1003", Description: "Commit Debit"},
+		Credit: &mmodel.AccountingRubric{Code: "2003", Description: "Commit Credit"},
+	}
+	cancelEntry := &mmodel.AccountingEntry{
+		Debit:  &mmodel.AccountingRubric{Code: "1004", Description: "Cancel Debit"},
+		Credit: &mmodel.AccountingRubric{Code: "2004", Description: "Cancel Credit"},
+	}
+
+	tests := []struct {
+		name       string
+		existing   *mmodel.AccountingEntries
+		incoming   *mmodel.AccountingEntries
+		rawUpdates string // JSON to simulate raw request body
+		expected   *mmodel.AccountingEntries
+	}{
+		{
+			name: "explicit null removes hold entry",
+			existing: &mmodel.AccountingEntries{
+				Direct: directEntry,
+				Hold:   holdEntry,
+				Commit: commitEntry,
+				Cancel: cancelEntry,
+			},
+			incoming:   &mmodel.AccountingEntries{}, // unmarshaled result when hold: null
+			rawUpdates: `{"hold": null}`,
+			expected: &mmodel.AccountingEntries{
+				Direct: directEntry,
+				Hold:   nil, // explicitly removed
+				Commit: commitEntry,
+				Cancel: cancelEntry,
+			},
+		},
+		{
+			name: "explicit null removes entire reserve group",
+			existing: &mmodel.AccountingEntries{
+				Direct: directEntry,
+				Hold:   holdEntry,
+				Commit: commitEntry,
+				Cancel: cancelEntry,
+			},
+			incoming:   &mmodel.AccountingEntries{},
+			rawUpdates: `{"hold": null, "commit": null, "cancel": null}`,
+			expected: &mmodel.AccountingEntries{
+				Direct: directEntry,
+				Hold:   nil,
+				Commit: nil,
+				Cancel: nil,
+			},
+		},
+		{
+			name: "absent field keeps existing value",
+			existing: &mmodel.AccountingEntries{
+				Direct: directEntry,
+				Hold:   holdEntry,
+			},
+			incoming:   &mmodel.AccountingEntries{},
+			rawUpdates: `{}`, // empty object means keep all existing
+			expected: &mmodel.AccountingEntries{
+				Direct: directEntry,
+				Hold:   holdEntry,
+			},
+		},
+		{
+			name: "explicit null removes all entries returns nil",
+			existing: &mmodel.AccountingEntries{
+				Direct: directEntry,
+			},
+			incoming:   &mmodel.AccountingEntries{},
+			rawUpdates: `{"direct": null}`,
+			expected:   nil,
+		},
+		{
+			name: "mixed: update one, remove another, keep rest",
+			existing: &mmodel.AccountingEntries{
+				Direct: directEntry,
+				Hold:   holdEntry,
+				Commit: commitEntry,
+				Cancel: cancelEntry,
+			},
+			incoming: &mmodel.AccountingEntries{
+				Direct: &mmodel.AccountingEntry{
+					Debit:  &mmodel.AccountingRubric{Code: "NEW1", Description: "Updated"},
+					Credit: &mmodel.AccountingRubric{Code: "NEW2", Description: "Updated"},
+				},
+			},
+			rawUpdates: `{"direct": {"debit": {"code": "NEW1", "description": "Updated"}, "credit": {"code": "NEW2", "description": "Updated"}}, "hold": null}`,
+			expected: &mmodel.AccountingEntries{
+				Direct: &mmodel.AccountingEntry{
+					Debit:  &mmodel.AccountingRubric{Code: "NEW1", Description: "Updated"},
+					Credit: &mmodel.AccountingRubric{Code: "NEW2", Description: "Updated"},
+				},
+				Hold:   nil, // explicitly removed
+				Commit: commitEntry,
+				Cancel: cancelEntry,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			result := mergeAccountingEntries(tt.existing, tt.incoming, []byte(tt.rawUpdates))
+
+			if tt.expected == nil {
+				assert.Nil(t, result)
+				return
+			}
+
+			require.NotNil(t, result)
+			assert.Equal(t, tt.expected.Direct, result.Direct, "Direct mismatch")
+			assert.Equal(t, tt.expected.Hold, result.Hold, "Hold mismatch")
+			assert.Equal(t, tt.expected.Commit, result.Commit, "Commit mismatch")
+			assert.Equal(t, tt.expected.Cancel, result.Cancel, "Cancel mismatch")
+			assert.Equal(t, tt.expected.Revert, result.Revert, "Revert mismatch")
 		})
 	}
 }

--- a/components/ledger/internal/adapters/http/in/operation-route-validation_test.go
+++ b/components/ledger/internal/adapters/http/in/operation-route-validation_test.go
@@ -68,24 +68,22 @@ func TestOperationRouteHandler_validateAccountingEntries(t *testing.T) {
 			expectError: false,
 		},
 		{
-			name: "direct entry missing debit returns error",
+			name: "direct entry with only credit passes structure validation",
 			entries: &mmodel.AccountingEntries{
 				Direct: &mmodel.AccountingEntry{
 					Credit: &mmodel.AccountingRubric{Code: "2001", Description: "Revenue"},
 				},
 			},
-			expectError: true,
-			errorField:  "accountingEntries.direct.debit",
+			expectError: false, // Structure is valid; field requirements validated separately
 		},
 		{
-			name: "hold entry missing credit returns error",
+			name: "hold entry with only debit passes structure validation",
 			entries: &mmodel.AccountingEntries{
 				Hold: &mmodel.AccountingEntry{
 					Debit: &mmodel.AccountingRubric{Code: "1002", Description: "Held Funds"},
 				},
 			},
-			expectError: true,
-			errorField:  "accountingEntries.hold.credit",
+			expectError: false, // Structure is valid; field requirements validated separately
 		},
 		{
 			name: "debit with empty code returns error",
@@ -362,7 +360,7 @@ func TestOperationRouteHandler_validateDirectionScenarioMatrix(t *testing.T) {
 			errorCode:   "0162",
 		},
 		{
-			name:          "destination with revert - invalid",
+			name:          "destination with revert - invalid (uses 0165 same as source)",
 			operationType: constant.OperationRouteTypeDestination,
 			entries: &mmodel.AccountingEntries{
 				Direct: &mmodel.AccountingEntry{
@@ -375,7 +373,7 @@ func TestOperationRouteHandler_validateDirectionScenarioMatrix(t *testing.T) {
 				},
 			},
 			expectError: true,
-			errorCode:   "0162",
+			errorCode:   "0165",
 		},
 
 		// Bidirectional direction tests
@@ -1222,6 +1220,289 @@ func TestOperationRouteHandler_validateAccountingRulesMatrix(t *testing.T) {
 			if tt.expectError {
 				require.Error(t, err, "expected validation error")
 				assert.Contains(t, err.Error(), tt.errorCode, "error should contain expected code")
+			} else {
+				require.NoError(t, err, "expected no validation error")
+			}
+		})
+	}
+}
+
+func TestGetFieldRequirements(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		operationType string
+		scenario      string
+		expectDebit   bool
+		expectCredit  bool
+	}{
+		// Source direction
+		{
+			name:          "source/direct requires only debit",
+			operationType: constant.OperationRouteTypeSource,
+			scenario:      constant.ActionDirect,
+			expectDebit:   true,
+			expectCredit:  false,
+		},
+		{
+			name:          "source/hold requires both",
+			operationType: constant.OperationRouteTypeSource,
+			scenario:      constant.ActionHold,
+			expectDebit:   true,
+			expectCredit:  true,
+		},
+		{
+			name:          "source/commit requires only debit",
+			operationType: constant.OperationRouteTypeSource,
+			scenario:      constant.ActionCommit,
+			expectDebit:   true,
+			expectCredit:  false,
+		},
+		{
+			name:          "source/cancel requires both",
+			operationType: constant.OperationRouteTypeSource,
+			scenario:      constant.ActionCancel,
+			expectDebit:   true,
+			expectCredit:  true,
+		},
+		// Destination direction
+		{
+			name:          "destination/direct requires only credit",
+			operationType: constant.OperationRouteTypeDestination,
+			scenario:      constant.ActionDirect,
+			expectDebit:   false,
+			expectCredit:  true,
+		},
+		{
+			name:          "destination/commit requires only credit",
+			operationType: constant.OperationRouteTypeDestination,
+			scenario:      constant.ActionCommit,
+			expectDebit:   false,
+			expectCredit:  true,
+		},
+		// Bidirectional direction
+		{
+			name:          "bidirectional/direct requires both",
+			operationType: constant.OperationRouteTypeBidirectional,
+			scenario:      constant.ActionDirect,
+			expectDebit:   true,
+			expectCredit:  true,
+		},
+		{
+			name:          "bidirectional/hold requires both",
+			operationType: constant.OperationRouteTypeBidirectional,
+			scenario:      constant.ActionHold,
+			expectDebit:   true,
+			expectCredit:  true,
+		},
+		{
+			name:          "bidirectional/revert requires both",
+			operationType: constant.OperationRouteTypeBidirectional,
+			scenario:      constant.ActionRevert,
+			expectDebit:   true,
+			expectCredit:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			req := getFieldRequirements(tt.operationType, tt.scenario)
+
+			assert.Equal(t, tt.expectDebit, req.debitRequired, "debit requirement mismatch")
+			assert.Equal(t, tt.expectCredit, req.creditRequired, "credit requirement mismatch")
+		})
+	}
+}
+
+func TestOperationRouteHandler_validateEntryFieldRequirements(t *testing.T) {
+	t.Parallel()
+
+	handler := &OperationRouteHandler{}
+
+	tests := []struct {
+		name          string
+		operationType string
+		entries       *mmodel.AccountingEntries
+		expectError   bool
+		errorCode     string
+		errorField    string
+	}{
+		// Source direction - direct requires only debit
+		{
+			name:          "source/direct with only debit - valid",
+			operationType: constant.OperationRouteTypeSource,
+			entries: &mmodel.AccountingEntries{
+				Direct: &mmodel.AccountingEntry{
+					Debit: &mmodel.AccountingRubric{Code: "1001", Description: "Debit"},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name:          "source/direct with both debit and credit - valid (permissive)",
+			operationType: constant.OperationRouteTypeSource,
+			entries: &mmodel.AccountingEntries{
+				Direct: &mmodel.AccountingEntry{
+					Debit:  &mmodel.AccountingRubric{Code: "1001", Description: "Debit"},
+					Credit: &mmodel.AccountingRubric{Code: "2001", Description: "Credit"},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name:          "source/direct with only credit - invalid (debit required)",
+			operationType: constant.OperationRouteTypeSource,
+			entries: &mmodel.AccountingEntries{
+				Direct: &mmodel.AccountingEntry{
+					Credit: &mmodel.AccountingRubric{Code: "2001", Description: "Credit"},
+				},
+			},
+			expectError: true,
+			errorCode:   "0166",
+			errorField:  "debit",
+		},
+		// Source direction - hold requires both
+		{
+			name:          "source/hold with both - valid",
+			operationType: constant.OperationRouteTypeSource,
+			entries: &mmodel.AccountingEntries{
+				Direct: &mmodel.AccountingEntry{
+					Debit: &mmodel.AccountingRubric{Code: "1001", Description: "Debit"},
+				},
+				Hold: &mmodel.AccountingEntry{
+					Debit:  &mmodel.AccountingRubric{Code: "1002", Description: "Hold Debit"},
+					Credit: &mmodel.AccountingRubric{Code: "2002", Description: "Hold Credit"},
+				},
+				Commit: &mmodel.AccountingEntry{
+					Debit: &mmodel.AccountingRubric{Code: "1003", Description: "Commit Debit"},
+				},
+				Cancel: &mmodel.AccountingEntry{
+					Debit:  &mmodel.AccountingRubric{Code: "1004", Description: "Cancel Debit"},
+					Credit: &mmodel.AccountingRubric{Code: "2004", Description: "Cancel Credit"},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name:          "source/hold missing credit - invalid",
+			operationType: constant.OperationRouteTypeSource,
+			entries: &mmodel.AccountingEntries{
+				Direct: &mmodel.AccountingEntry{
+					Debit: &mmodel.AccountingRubric{Code: "1001", Description: "Debit"},
+				},
+				Hold: &mmodel.AccountingEntry{
+					Debit: &mmodel.AccountingRubric{Code: "1002", Description: "Hold Debit"},
+				},
+				Commit: &mmodel.AccountingEntry{
+					Debit: &mmodel.AccountingRubric{Code: "1003", Description: "Commit Debit"},
+				},
+				Cancel: &mmodel.AccountingEntry{
+					Debit:  &mmodel.AccountingRubric{Code: "1004", Description: "Cancel Debit"},
+					Credit: &mmodel.AccountingRubric{Code: "2004", Description: "Cancel Credit"},
+				},
+			},
+			expectError: true,
+			errorCode:   "0166",
+			errorField:  "credit",
+		},
+		// Destination direction - direct requires only credit
+		{
+			name:          "destination/direct with only credit - valid",
+			operationType: constant.OperationRouteTypeDestination,
+			entries: &mmodel.AccountingEntries{
+				Direct: &mmodel.AccountingEntry{
+					Credit: &mmodel.AccountingRubric{Code: "2001", Description: "Credit"},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name:          "destination/direct with only debit - invalid (credit required)",
+			operationType: constant.OperationRouteTypeDestination,
+			entries: &mmodel.AccountingEntries{
+				Direct: &mmodel.AccountingEntry{
+					Debit: &mmodel.AccountingRubric{Code: "1001", Description: "Debit"},
+				},
+			},
+			expectError: true,
+			errorCode:   "0166",
+			errorField:  "credit",
+		},
+		{
+			name:          "destination/direct and commit with only credit - valid",
+			operationType: constant.OperationRouteTypeDestination,
+			entries: &mmodel.AccountingEntries{
+				Direct: &mmodel.AccountingEntry{
+					Credit: &mmodel.AccountingRubric{Code: "2001", Description: "Credit"},
+				},
+				Commit: &mmodel.AccountingEntry{
+					Credit: &mmodel.AccountingRubric{Code: "2003", Description: "Commit Credit"},
+				},
+			},
+			expectError: false,
+		},
+		// Bidirectional direction - all scenarios require both
+		{
+			name:          "bidirectional/direct with both - valid",
+			operationType: constant.OperationRouteTypeBidirectional,
+			entries: &mmodel.AccountingEntries{
+				Direct: &mmodel.AccountingEntry{
+					Debit:  &mmodel.AccountingRubric{Code: "1001", Description: "Debit"},
+					Credit: &mmodel.AccountingRubric{Code: "2001", Description: "Credit"},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name:          "bidirectional/direct missing debit - invalid",
+			operationType: constant.OperationRouteTypeBidirectional,
+			entries: &mmodel.AccountingEntries{
+				Direct: &mmodel.AccountingEntry{
+					Credit: &mmodel.AccountingRubric{Code: "2001", Description: "Credit"},
+				},
+			},
+			expectError: true,
+			errorCode:   "0166",
+			errorField:  "debit",
+		},
+		{
+			name:          "bidirectional/direct missing credit - invalid",
+			operationType: constant.OperationRouteTypeBidirectional,
+			entries: &mmodel.AccountingEntries{
+				Direct: &mmodel.AccountingEntry{
+					Debit: &mmodel.AccountingRubric{Code: "1001", Description: "Debit"},
+				},
+			},
+			expectError: true,
+			errorCode:   "0166",
+			errorField:  "credit",
+		},
+		// Nil entries - valid
+		{
+			name:          "nil entries - valid",
+			operationType: constant.OperationRouteTypeSource,
+			entries:       nil,
+			expectError:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := context.Background()
+
+			err := handler.validateEntryFieldRequirements(ctx, tt.operationType, tt.entries, "OperationRoute")
+
+			if tt.expectError {
+				require.Error(t, err, "expected validation error")
+				assert.Contains(t, err.Error(), tt.errorCode, "error should contain expected code")
+				if tt.errorField != "" {
+					assert.Contains(t, err.Error(), tt.errorField, "error should reference the missing field")
+				}
 			} else {
 				require.NoError(t, err, "expected no validation error")
 			}

--- a/components/ledger/internal/adapters/http/in/operation-route.go
+++ b/components/ledger/internal/adapters/http/in/operation-route.go
@@ -262,9 +262,17 @@ func (handler *OperationRouteHandler) UpdateOperationRoute(i any, c *fiber.Ctx) 
 			return http.WithError(c, err)
 		}
 
-		// Merge incoming entries with existing to get final state
-		// Pass raw JSON to properly handle explicit null removals (RFC 7396)
-		mergedEntries := mergeAccountingEntries(existingRoute.AccountingEntries, payload.AccountingEntries, payload.AccountingEntriesRaw)
+		// Handle explicit top-level null for accountingEntries (RFC 7396: clear all)
+		var mergedEntries *mmodel.AccountingEntries
+		rawTrimmed := strings.TrimSpace(string(payload.AccountingEntriesRaw))
+		if rawTrimmed == "null" {
+			// Explicit null at top level - clear all entries
+			mergedEntries = nil
+		} else {
+			// Merge incoming entries with existing to get final state
+			// Pass raw JSON to properly handle explicit null removals (RFC 7396)
+			mergedEntries = mergeAccountingEntries(existingRoute.AccountingEntries, payload.AccountingEntries, payload.AccountingEntriesRaw)
+		}
 
 		// Validate the merged entries against the direction×scenario matrix
 		if err := handler.validateAccountingRulesMatrix(ctx, existingRoute.OperationType, mergedEntries); err != nil {

--- a/components/ledger/internal/adapters/http/in/operation-route.go
+++ b/components/ledger/internal/adapters/http/in/operation-route.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	libCommons "github.com/LerianStudio/lib-commons/v4/commons"
+	libLog "github.com/LerianStudio/lib-commons/v4/commons/log"
 	libOpentelemetry "github.com/LerianStudio/lib-commons/v4/commons/opentelemetry"
 	"github.com/LerianStudio/midaz/v3/components/ledger/internal/services/command"
 	"github.com/LerianStudio/midaz/v3/components/ledger/internal/services/query"
@@ -22,9 +23,7 @@ import (
 	"github.com/gofiber/fiber/v2"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.opentelemetry.io/otel/attribute"
-
-	// OperationRouteHandler is a struct that contains the command and query use cases.
-	libLog "github.com/LerianStudio/lib-commons/v4/commons/log"
+	"go.opentelemetry.io/otel/trace"
 )
 
 type OperationRouteHandler struct {
@@ -539,8 +538,10 @@ func (handler *OperationRouteHandler) validateAccountRule(ctx context.Context, a
 	return nil
 }
 
-// validateAccountingEntries validates accounting entries configuration for operation routes.
-// It ensures each action entry has both debit and credit rubrics with non-empty code and description.
+// validateAccountingEntries validates the structure of accounting entries.
+// It ensures that any present rubric (debit/credit) has non-empty code and description.
+// Note: This function validates STRUCTURE only. Field REQUIREMENTS (which fields are mandatory
+// based on direction+scenario) are validated by validateAccountingRulesMatrix.
 func (handler *OperationRouteHandler) validateAccountingEntries(ctx context.Context, entries *mmodel.AccountingEntries) error {
 	logger, tracer, _, _ := libCommons.NewTrackingFromContext(ctx)
 
@@ -571,6 +572,7 @@ func (handler *OperationRouteHandler) validateAccountingEntries(ctx context.Cont
 			continue
 		}
 
+		// An entry with neither debit nor credit is invalid structure
 		if action.entry.Debit == nil && action.entry.Credit == nil {
 			fieldPath := "accountingEntries." + action.name + ".debit, accountingEntries." + action.name + ".credit"
 
@@ -583,63 +585,54 @@ func (handler *OperationRouteHandler) validateAccountingEntries(ctx context.Cont
 			return err
 		}
 
-		if action.entry.Debit == nil {
-			fieldPath := "accountingEntries." + action.name + ".debit"
-
-			err := pkg.ValidateBusinessError(constant.ErrMissingFieldsInRequest, entityName, fieldPath)
-
-			libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Accounting entry missing debit", err)
-
-			logger.Log(ctx, libLog.LevelWarn, fmt.Sprintf("Accounting entry %s missing debit, Error: %s", action.name, err.Error()))
-
-			return err
-		}
-
-		if action.entry.Credit == nil {
-			fieldPath := "accountingEntries." + action.name + ".credit"
-
-			err := pkg.ValidateBusinessError(constant.ErrMissingFieldsInRequest, entityName, fieldPath)
-
-			libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Accounting entry missing credit", err)
-
-			logger.Log(ctx, libLog.LevelWarn, fmt.Sprintf("Accounting entry %s missing credit, Error: %s", action.name, err.Error()))
-
-			return err
-		}
-
-		rubrics := []struct {
-			side   string
-			rubric *mmodel.AccountingRubric
-		}{
-			{"debit", action.entry.Debit},
-			{"credit", action.entry.Credit},
-		}
-
-		for _, r := range rubrics {
-			if strings.TrimSpace(r.rubric.Code) == "" {
-				fieldPath := "accountingEntries." + action.name + "." + r.side + ".code"
-
-				err := pkg.ValidateBusinessError(constant.ErrMissingFieldsInRequest, entityName, fieldPath)
-
-				libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Accounting rubric code is empty", err)
-
-				logger.Log(ctx, libLog.LevelWarn, fmt.Sprintf("Accounting entry %s %s code is empty, Error: %s", action.name, r.side, err.Error()))
-
-				return err
-			}
-
-			if strings.TrimSpace(r.rubric.Description) == "" {
-				fieldPath := "accountingEntries." + action.name + "." + r.side + ".description"
-
-				err := pkg.ValidateBusinessError(constant.ErrMissingFieldsInRequest, entityName, fieldPath)
-
-				libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Accounting rubric description is empty", err)
-
-				logger.Log(ctx, libLog.LevelWarn, fmt.Sprintf("Accounting entry %s %s description is empty, Error: %s", action.name, r.side, err.Error()))
-
+		// Validate debit rubric if present
+		if action.entry.Debit != nil {
+			if err := handler.validateRubricStructure(ctx, span, logger, entityName, action.name, "debit", action.entry.Debit); err != nil {
 				return err
 			}
 		}
+
+		// Validate credit rubric if present
+		if action.entry.Credit != nil {
+			if err := handler.validateRubricStructure(ctx, span, logger, entityName, action.name, "credit", action.entry.Credit); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// validateRubricStructure validates that a rubric has non-empty code and description.
+func (handler *OperationRouteHandler) validateRubricStructure(
+	ctx context.Context,
+	span trace.Span,
+	logger libLog.Logger,
+	entityName, actionName, side string,
+	rubric *mmodel.AccountingRubric,
+) error {
+	if strings.TrimSpace(rubric.Code) == "" {
+		fieldPath := "accountingEntries." + actionName + "." + side + ".code"
+
+		err := pkg.ValidateBusinessError(constant.ErrMissingFieldsInRequest, entityName, fieldPath)
+
+		libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Accounting rubric code is empty", err)
+
+		logger.Log(ctx, libLog.LevelWarn, fmt.Sprintf("Accounting entry %s %s code is empty, Error: %s", actionName, side, err.Error()))
+
+		return err
+	}
+
+	if strings.TrimSpace(rubric.Description) == "" {
+		fieldPath := "accountingEntries." + actionName + "." + side + ".description"
+
+		err := pkg.ValidateBusinessError(constant.ErrMissingFieldsInRequest, entityName, fieldPath)
+
+		libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Accounting rubric description is empty", err)
+
+		logger.Log(ctx, libLog.LevelWarn, fmt.Sprintf("Accounting entry %s %s description is empty, Error: %s", actionName, side, err.Error()))
+
+		return err
 	}
 
 	return nil
@@ -679,6 +672,53 @@ func findUnknownAccountingEntryKeys(raw json.RawMessage) map[string]any {
 	return unknowns
 }
 
+// fieldRequirement defines which fields (debit/credit) are required for a direction+scenario.
+type fieldRequirement struct {
+	debitRequired  bool
+	creditRequired bool
+}
+
+// getFieldRequirements returns the field requirements based on operationType and scenario.
+// This implements the direction × scenario matrix from accounting-rules.md:
+//
+//	source:      direct[D], hold[D][C], commit[D], cancel[D][C]
+//	destination: direct[C], commit[C]
+//	bidirectional: all scenarios require [D][C]
+//
+// Note: Blocked scenarios (source/revert, destination/hold, etc.) are validated
+// separately by validateDirectionScenarioMatrix. This function assumes the
+// scenario is allowed for the direction.
+func getFieldRequirements(operationType, scenario string) fieldRequirement {
+	// Bidirectional always requires both
+	if operationType == constant.OperationRouteTypeBidirectional {
+		return fieldRequirement{debitRequired: true, creditRequired: true}
+	}
+
+	// Source direction requirements
+	if operationType == constant.OperationRouteTypeSource {
+		switch scenario {
+		case constant.ActionDirect, constant.ActionCommit:
+			// Unilateral operations at origin - only debit
+			return fieldRequirement{debitRequired: true, creditRequired: false}
+		case constant.ActionHold, constant.ActionCancel:
+			// Move between available ↔ on_hold in same account - both required
+			return fieldRequirement{debitRequired: true, creditRequired: true}
+		}
+	}
+
+	// Destination direction requirements
+	if operationType == constant.OperationRouteTypeDestination {
+		switch scenario {
+		case constant.ActionDirect, constant.ActionCommit:
+			// Unilateral operations at destination - only credit
+			return fieldRequirement{debitRequired: false, creditRequired: true}
+		}
+	}
+
+	// Default: require both (safe fallback)
+	return fieldRequirement{debitRequired: true, creditRequired: true}
+}
+
 // validateAccountingRulesMatrix validates that the accounting entries comply with
 // the direction × scenario matrix defined in accounting-rules.md.
 //
@@ -708,8 +748,13 @@ func (handler *OperationRouteHandler) validateAccountingRulesMatrix(
 
 	entityName := reflect.TypeOf(mmodel.OperationRoute{}).Name()
 
-	// Check direction × scenario matrix
+	// Check direction × scenario matrix (which scenarios are allowed)
 	if err := handler.validateDirectionScenarioMatrix(ctx, operationType, entries, entityName); err != nil {
+		return err
+	}
+
+	// Check field requirements per direction+scenario (which debit/credit are required)
+	if err := handler.validateEntryFieldRequirements(ctx, operationType, entries, entityName); err != nil {
 		return err
 	}
 
@@ -757,14 +802,13 @@ func (handler *OperationRouteHandler) validateDirectionScenarioMatrix(
 		}
 
 	case constant.OperationRouteTypeDestination:
-		// destination: hold, cancel, revert are NOT allowed
+		// destination: hold, cancel are NOT allowed (return 0162)
 		invalidScenarios := []struct {
 			name  string
 			entry *mmodel.AccountingEntry
 		}{
 			{constant.ActionHold, entries.Hold},
 			{constant.ActionCancel, entries.Cancel},
-			{constant.ActionRevert, entries.Revert},
 		}
 
 		for _, scenario := range invalidScenarios {
@@ -780,6 +824,20 @@ func (handler *OperationRouteHandler) validateDirectionScenarioMatrix(
 
 				return err
 			}
+		}
+
+		// destination: revert is NOT allowed (return 0165 - same as source)
+		if entries.Revert != nil {
+			err := pkg.ValidateBusinessError(
+				constant.ErrRevertOnlyBidirectional,
+				entityName,
+				"revert is only allowed for bidirectional operation routes",
+			)
+
+			libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Revert not allowed for destination direction", err)
+			logger.Log(ctx, libLog.LevelWarn, "Revert scenario not allowed for destination direction")
+
+			return err
 		}
 
 	case constant.OperationRouteTypeBidirectional:
@@ -886,6 +944,82 @@ func (handler *OperationRouteHandler) validateDirectMandatory(
 
 		return err
 	}
+
+	return nil
+}
+
+// validateEntryFieldRequirements validates that required fields (debit/credit) are present
+// based on the direction × scenario matrix. This is a permissive validation:
+// - Required fields MUST be present
+// - Non-required fields MAY be present (accepted but not enforced)
+func (handler *OperationRouteHandler) validateEntryFieldRequirements(
+	ctx context.Context,
+	operationType string,
+	entries *mmodel.AccountingEntries,
+	entityName string,
+) error {
+	logger, tracer, _, _ := libCommons.NewTrackingFromContext(ctx)
+
+	_, span := tracer.Start(ctx, "handler.validate_entry_field_requirements")
+	defer span.End()
+
+	// If no entries, nothing to validate
+	if entries == nil {
+		return nil
+	}
+
+	actions := []struct {
+		name  string
+		entry *mmodel.AccountingEntry
+	}{
+		{constant.ActionDirect, entries.Direct},
+		{constant.ActionHold, entries.Hold},
+		{constant.ActionCommit, entries.Commit},
+		{constant.ActionCancel, entries.Cancel},
+		{constant.ActionRevert, entries.Revert},
+	}
+
+	for _, action := range actions {
+		if action.entry == nil {
+			continue
+		}
+
+		req := getFieldRequirements(operationType, action.name)
+
+		// Check debit requirement
+		if req.debitRequired && action.entry.Debit == nil {
+			fieldPath := fmt.Sprintf("accountingEntries.%s.debit", action.name)
+
+			err := pkg.ValidateBusinessError(
+				constant.ErrAccountingEntryFieldRequired,
+				entityName,
+				fmt.Sprintf("%s is required for %s/%s", "debit", operationType, action.name),
+			)
+
+			libOpentelemetry.HandleSpanBusinessErrorEvent(span, fmt.Sprintf("Debit required for %s/%s", operationType, action.name), err)
+			logger.Log(ctx, libLog.LevelWarn, fmt.Sprintf("Missing required field %s, Error: %s", fieldPath, err.Error()))
+
+			return err
+		}
+
+		// Check credit requirement
+		if req.creditRequired && action.entry.Credit == nil {
+			fieldPath := fmt.Sprintf("accountingEntries.%s.credit", action.name)
+
+			err := pkg.ValidateBusinessError(
+				constant.ErrAccountingEntryFieldRequired,
+				entityName,
+				fmt.Sprintf("%s is required for %s/%s", "credit", operationType, action.name),
+			)
+
+			libOpentelemetry.HandleSpanBusinessErrorEvent(span, fmt.Sprintf("Credit required for %s/%s", operationType, action.name), err)
+			logger.Log(ctx, libLog.LevelWarn, fmt.Sprintf("Missing required field %s, Error: %s", fieldPath, err.Error()))
+
+			return err
+		}
+	}
+
+	logger.Log(ctx, libLog.LevelDebug, "Entry field requirements validation passed")
 
 	return nil
 }

--- a/components/ledger/internal/adapters/http/in/operation-route.go
+++ b/components/ledger/internal/adapters/http/in/operation-route.go
@@ -255,7 +255,8 @@ func (handler *OperationRouteHandler) UpdateOperationRoute(i any, c *fiber.Ctx) 
 
 	// Validate accounting rules matrix for PATCH operations
 	// We need to fetch the existing route to get operation type and merge entries
-	if payload.AccountingEntries != nil {
+	// Validation runs when accountingEntries is present (even if removing entries via explicit null)
+	if payload.AccountingEntries != nil || len(payload.AccountingEntriesRaw) > 0 {
 		existingRoute, err := handler.Query.GetOperationRouteByID(ctx, organizationID, ledgerID, nil, id)
 		if err != nil {
 			libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Failed to retrieve existing Operation Route for validation", err)
@@ -263,7 +264,8 @@ func (handler *OperationRouteHandler) UpdateOperationRoute(i any, c *fiber.Ctx) 
 		}
 
 		// Merge incoming entries with existing to get final state
-		mergedEntries := mergeAccountingEntries(existingRoute.AccountingEntries, payload.AccountingEntries)
+		// Pass raw JSON to properly handle explicit null removals (RFC 7396)
+		mergedEntries := mergeAccountingEntries(existingRoute.AccountingEntries, payload.AccountingEntries, payload.AccountingEntriesRaw)
 
 		// Validate the merged entries against the direction×scenario matrix
 		if err := handler.validateAccountingRulesMatrix(ctx, existingRoute.OperationType, mergedEntries); err != nil {
@@ -890,9 +892,15 @@ func (handler *OperationRouteHandler) validateDirectMandatory(
 
 // mergeAccountingEntries creates a merged view of existing and incoming accounting entries.
 // Used for PATCH operations where only partial updates are provided.
-// For each scenario, if incoming has a value, use it; otherwise, use existing.
-// Note: This does NOT handle explicit null (removal) - that's handled by AccountingEntriesRaw.
-func mergeAccountingEntries(existing, incoming *mmodel.AccountingEntries) *mmodel.AccountingEntries {
+//
+// This function implements RFC 7396 JSON Merge Patch semantics:
+//   - Field absent in rawUpdates: keep existing value
+//   - Field explicitly set to null in rawUpdates: remove entry (set to nil)
+//   - Field set to a value in rawUpdates: use new value
+//
+// The rawUpdates parameter is required to distinguish between "field omitted" and
+// "field: null" since Go's json.Unmarshal sets both to nil.
+func mergeAccountingEntries(existing, incoming *mmodel.AccountingEntries, rawUpdates json.RawMessage) *mmodel.AccountingEntries {
 	if existing == nil && incoming == nil {
 		return nil
 	}
@@ -901,40 +909,103 @@ func mergeAccountingEntries(existing, incoming *mmodel.AccountingEntries) *mmode
 		return incoming
 	}
 
+	// If no raw updates provided, fall back to simple merge (incoming wins if non-nil)
+	if len(rawUpdates) == 0 {
+		return mergeAccountingEntriesSimple(existing, incoming)
+	}
+
+	// Parse raw JSON to detect which fields are explicitly present
+	var rawFields map[string]json.RawMessage
+	if err := json.Unmarshal(rawUpdates, &rawFields); err != nil {
+		// If parsing fails, fall back to simple merge
+		return mergeAccountingEntriesSimple(existing, incoming)
+	}
+
+	merged := &mmodel.AccountingEntries{}
+
+	// Helper to apply merge logic for each field
+	applyMerge := func(fieldName string, existingEntry, incomingEntry *mmodel.AccountingEntry) *mmodel.AccountingEntry {
+		raw, fieldPresent := rawFields[fieldName]
+		if !fieldPresent {
+			// Field not in update - keep existing
+			return existingEntry
+		}
+
+		// Field is present in raw update
+		if string(raw) == "null" {
+			// Explicit null - remove entry
+			return nil
+		}
+
+		// Field has a value - use incoming (which was unmarshaled from the same JSON)
+		if incomingEntry != nil {
+			return incomingEntry
+		}
+
+		// Incoming is nil but raw wasn't null - keep existing as fallback
+		return existingEntry
+	}
+
+	var incomingDirect, incomingHold, incomingCommit, incomingCancel, incomingRevert *mmodel.AccountingEntry
+	if incoming != nil {
+		incomingDirect = incoming.Direct
+		incomingHold = incoming.Hold
+		incomingCommit = incoming.Commit
+		incomingCancel = incoming.Cancel
+		incomingRevert = incoming.Revert
+	}
+
+	merged.Direct = applyMerge("direct", existing.Direct, incomingDirect)
+	merged.Hold = applyMerge("hold", existing.Hold, incomingHold)
+	merged.Commit = applyMerge("commit", existing.Commit, incomingCommit)
+	merged.Cancel = applyMerge("cancel", existing.Cancel, incomingCancel)
+	merged.Revert = applyMerge("revert", existing.Revert, incomingRevert)
+
+	// Check if all entries are nil - return nil instead of empty struct
+	if merged.Direct == nil && merged.Hold == nil && merged.Commit == nil &&
+		merged.Cancel == nil && merged.Revert == nil {
+		return nil
+	}
+
+	return merged
+}
+
+// mergeAccountingEntriesSimple performs a simple merge where incoming non-nil values win.
+// Used as fallback when raw JSON is not available.
+func mergeAccountingEntriesSimple(existing, incoming *mmodel.AccountingEntries) *mmodel.AccountingEntries {
 	if incoming == nil {
 		return existing
 	}
 
 	merged := &mmodel.AccountingEntries{}
 
-	// For each scenario: incoming wins if present, otherwise keep existing
 	if incoming.Direct != nil {
 		merged.Direct = incoming.Direct
-	} else {
+	} else if existing != nil {
 		merged.Direct = existing.Direct
 	}
 
 	if incoming.Hold != nil {
 		merged.Hold = incoming.Hold
-	} else {
+	} else if existing != nil {
 		merged.Hold = existing.Hold
 	}
 
 	if incoming.Commit != nil {
 		merged.Commit = incoming.Commit
-	} else {
+	} else if existing != nil {
 		merged.Commit = existing.Commit
 	}
 
 	if incoming.Cancel != nil {
 		merged.Cancel = incoming.Cancel
-	} else {
+	} else if existing != nil {
 		merged.Cancel = existing.Cancel
 	}
 
 	if incoming.Revert != nil {
 		merged.Revert = incoming.Revert
-	} else {
+	} else if existing != nil {
 		merged.Revert = existing.Revert
 	}
 

--- a/components/ledger/internal/adapters/http/in/operation-route.go
+++ b/components/ledger/internal/adapters/http/in/operation-route.go
@@ -81,6 +81,10 @@ func (handler *OperationRouteHandler) CreateOperationRoute(i any, c *fiber.Ctx) 
 		return http.WithError(c, err)
 	}
 
+	if err := handler.validateAccountingRulesMatrix(ctx, payload.OperationType, payload.AccountingEntries); err != nil {
+		return http.WithError(c, err)
+	}
+
 	// Reject unknown keys inside accountingEntries (e.g., "foobar") that Go's
 	// json.Unmarshal silently ignores but could confuse clients into thinking
 	// their data was accepted.
@@ -246,6 +250,24 @@ func (handler *OperationRouteHandler) UpdateOperationRoute(i any, c *fiber.Ctx) 
 
 				payload.AccountingEntriesRaw = raw
 			}
+		}
+	}
+
+	// Validate accounting rules matrix for PATCH operations
+	// We need to fetch the existing route to get operation type and merge entries
+	if payload.AccountingEntries != nil {
+		existingRoute, err := handler.Query.GetOperationRouteByID(ctx, organizationID, ledgerID, nil, id)
+		if err != nil {
+			libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Failed to retrieve existing Operation Route for validation", err)
+			return http.WithError(c, err)
+		}
+
+		// Merge incoming entries with existing to get final state
+		mergedEntries := mergeAccountingEntries(existingRoute.AccountingEntries, payload.AccountingEntries)
+
+		// Validate the merged entries against the direction×scenario matrix
+		if err := handler.validateAccountingRulesMatrix(ctx, existingRoute.OperationType, mergedEntries); err != nil {
+			return http.WithError(c, err)
 		}
 	}
 
@@ -653,4 +675,268 @@ func findUnknownAccountingEntryKeys(raw json.RawMessage) map[string]any {
 	}
 
 	return unknowns
+}
+
+// validateAccountingRulesMatrix validates that the accounting entries comply with
+// the direction × scenario matrix defined in accounting-rules.md.
+//
+// Matrix rules:
+//   - source: direct[D], hold[D][C], commit[D], cancel[D][C], revert[✗]
+//   - destination: direct[C], hold[✗], commit[C], cancel[✗], revert[✗]
+//   - bidirectional: all scenarios allowed with [D][C]
+//
+// Additional rules:
+//   - Reserve group (hold, commit, cancel) must be atomic for source/bidirectional
+//   - direct is mandatory when any other scenario is present
+//   - revert is only allowed for bidirectional
+func (handler *OperationRouteHandler) validateAccountingRulesMatrix(
+	ctx context.Context,
+	operationType string,
+	entries *mmodel.AccountingEntries,
+) error {
+	logger, tracer, _, _ := libCommons.NewTrackingFromContext(ctx)
+
+	_, span := tracer.Start(ctx, "handler.validate_accounting_rules_matrix")
+	defer span.End()
+
+	// If no entries, nothing to validate
+	if entries == nil {
+		return nil
+	}
+
+	entityName := reflect.TypeOf(mmodel.OperationRoute{}).Name()
+
+	// Check direction × scenario matrix
+	if err := handler.validateDirectionScenarioMatrix(ctx, operationType, entries, entityName); err != nil {
+		return err
+	}
+
+	// Check reserve group atomicity (hold requires commit and cancel)
+	if err := handler.validateReserveGroupAtomicity(ctx, operationType, entries, entityName); err != nil {
+		return err
+	}
+
+	// Check direct is mandatory when other scenarios exist
+	if err := handler.validateDirectMandatory(ctx, entries, entityName); err != nil {
+		return err
+	}
+
+	logger.Log(ctx, libLog.LevelDebug, "Accounting rules matrix validation passed")
+
+	return nil
+}
+
+// validateDirectionScenarioMatrix checks that scenarios are valid for the given direction.
+func (handler *OperationRouteHandler) validateDirectionScenarioMatrix(
+	ctx context.Context,
+	operationType string,
+	entries *mmodel.AccountingEntries,
+	entityName string,
+) error {
+	logger, tracer, _, _ := libCommons.NewTrackingFromContext(ctx)
+
+	_, span := tracer.Start(ctx, "handler.validate_direction_scenario_matrix")
+	defer span.End()
+
+	switch operationType {
+	case constant.OperationRouteTypeSource:
+		// source: revert is NOT allowed
+		if entries.Revert != nil {
+			err := pkg.ValidateBusinessError(
+				constant.ErrRevertOnlyBidirectional,
+				entityName,
+				"revert is only allowed for bidirectional operation routes",
+			)
+
+			libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Revert not allowed for source direction", err)
+			logger.Log(ctx, libLog.LevelWarn, "Revert scenario not allowed for source direction")
+
+			return err
+		}
+
+	case constant.OperationRouteTypeDestination:
+		// destination: hold, cancel, revert are NOT allowed
+		invalidScenarios := []struct {
+			name  string
+			entry *mmodel.AccountingEntry
+		}{
+			{constant.ActionHold, entries.Hold},
+			{constant.ActionCancel, entries.Cancel},
+			{constant.ActionRevert, entries.Revert},
+		}
+
+		for _, scenario := range invalidScenarios {
+			if scenario.entry != nil {
+				err := pkg.ValidateBusinessError(
+					constant.ErrScenarioNotAllowedForDirection,
+					entityName,
+					fmt.Sprintf("%s scenario is not allowed for destination direction", scenario.name),
+				)
+
+				libOpentelemetry.HandleSpanBusinessErrorEvent(span, fmt.Sprintf("%s not allowed for destination", scenario.name), err)
+				logger.Log(ctx, libLog.LevelWarn, fmt.Sprintf("%s scenario not allowed for destination direction", scenario.name))
+
+				return err
+			}
+		}
+
+	case constant.OperationRouteTypeBidirectional:
+		// bidirectional: all scenarios allowed - no restrictions
+
+	default:
+		// Invalid operation type - should be caught by struct validation
+	}
+
+	return nil
+}
+
+// validateReserveGroupAtomicity ensures that hold, commit, and cancel form an atomic group.
+// For source/bidirectional: if hold exists, commit AND cancel must also exist.
+// For destination: reserve group is not applicable (hold/cancel not allowed).
+func (handler *OperationRouteHandler) validateReserveGroupAtomicity(
+	ctx context.Context,
+	operationType string,
+	entries *mmodel.AccountingEntries,
+	entityName string,
+) error {
+	logger, tracer, _, _ := libCommons.NewTrackingFromContext(ctx)
+
+	_, span := tracer.Start(ctx, "handler.validate_reserve_group_atomicity")
+	defer span.End()
+
+	// Reserve group only applies to source and bidirectional
+	if operationType == constant.OperationRouteTypeDestination {
+		return nil
+	}
+
+	hasHold := entries.Hold != nil
+	hasCommit := entries.Commit != nil
+	hasCancel := entries.Cancel != nil
+
+	// If hold exists, both commit and cancel must exist
+	if hasHold {
+		var missing []string
+
+		if !hasCommit {
+			missing = append(missing, "commit")
+		}
+
+		if !hasCancel {
+			missing = append(missing, "cancel")
+		}
+
+		if len(missing) > 0 {
+			err := pkg.ValidateBusinessError(
+				constant.ErrReserveGroupIncomplete,
+				entityName,
+				fmt.Sprintf("reserve group incomplete: hold requires %s", strings.Join(missing, " and ")),
+			)
+
+			libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Reserve group incomplete", err)
+			logger.Log(ctx, libLog.LevelWarn, fmt.Sprintf("Reserve group incomplete: missing %v", missing))
+
+			return err
+		}
+	}
+
+	// If commit or cancel exists without hold, that's also incomplete
+	if (hasCommit || hasCancel) && !hasHold {
+		err := pkg.ValidateBusinessError(
+			constant.ErrReserveGroupIncomplete,
+			entityName,
+			"reserve group incomplete: commit and cancel require hold",
+		)
+
+		libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Reserve group incomplete - missing hold", err)
+		logger.Log(ctx, libLog.LevelWarn, "Reserve group incomplete: commit/cancel without hold")
+
+		return err
+	}
+
+	return nil
+}
+
+// validateDirectMandatory ensures that direct scenario is present when other scenarios exist.
+func (handler *OperationRouteHandler) validateDirectMandatory(
+	ctx context.Context,
+	entries *mmodel.AccountingEntries,
+	entityName string,
+) error {
+	logger, tracer, _, _ := libCommons.NewTrackingFromContext(ctx)
+
+	_, span := tracer.Start(ctx, "handler.validate_direct_mandatory")
+	defer span.End()
+
+	hasDirect := entries.Direct != nil
+	hasOtherScenarios := entries.Hold != nil || entries.Commit != nil ||
+		entries.Cancel != nil || entries.Revert != nil
+
+	// If any other scenario exists, direct must also exist
+	if hasOtherScenarios && !hasDirect {
+		err := pkg.ValidateBusinessError(
+			constant.ErrDirectScenarioRequired,
+			entityName,
+			"direct scenario is required when other scenarios are present",
+		)
+
+		libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Direct scenario required", err)
+		logger.Log(ctx, libLog.LevelWarn, "Direct scenario is required when other scenarios are present")
+
+		return err
+	}
+
+	return nil
+}
+
+// mergeAccountingEntries creates a merged view of existing and incoming accounting entries.
+// Used for PATCH operations where only partial updates are provided.
+// For each scenario, if incoming has a value, use it; otherwise, use existing.
+// Note: This does NOT handle explicit null (removal) - that's handled by AccountingEntriesRaw.
+func mergeAccountingEntries(existing, incoming *mmodel.AccountingEntries) *mmodel.AccountingEntries {
+	if existing == nil && incoming == nil {
+		return nil
+	}
+
+	if existing == nil {
+		return incoming
+	}
+
+	if incoming == nil {
+		return existing
+	}
+
+	merged := &mmodel.AccountingEntries{}
+
+	// For each scenario: incoming wins if present, otherwise keep existing
+	if incoming.Direct != nil {
+		merged.Direct = incoming.Direct
+	} else {
+		merged.Direct = existing.Direct
+	}
+
+	if incoming.Hold != nil {
+		merged.Hold = incoming.Hold
+	} else {
+		merged.Hold = existing.Hold
+	}
+
+	if incoming.Commit != nil {
+		merged.Commit = incoming.Commit
+	} else {
+		merged.Commit = existing.Commit
+	}
+
+	if incoming.Cancel != nil {
+		merged.Cancel = incoming.Cancel
+	} else {
+		merged.Cancel = existing.Cancel
+	}
+
+	if incoming.Revert != nil {
+		merged.Revert = incoming.Revert
+	} else {
+		merged.Revert = existing.Revert
+	}
+
+	return merged
 }

--- a/pkg/constant/errors.go
+++ b/pkg/constant/errors.go
@@ -179,6 +179,7 @@ var (
 	ErrReserveGroupIncomplete         = errors.New("0163")
 	ErrDirectScenarioRequired         = errors.New("0164")
 	ErrRevertOnlyBidirectional        = errors.New("0165")
+	ErrAccountingEntryFieldRequired   = errors.New("0166")
 )
 
 // List of CRM errors.

--- a/pkg/constant/errors.go
+++ b/pkg/constant/errors.go
@@ -173,6 +173,12 @@ var (
 	ErrTenantServiceSuspended                   = errors.New("0159")
 	ErrTenantNotFound                           = errors.New("0160")
 	ErrTenantServiceUnavailable                 = errors.New("0161")
+
+	// Accounting Rules Validation Errors
+	ErrScenarioNotAllowedForDirection = errors.New("0162")
+	ErrReserveGroupIncomplete         = errors.New("0163")
+	ErrDirectScenarioRequired         = errors.New("0164")
+	ErrRevertOnlyBidirectional        = errors.New("0165")
 )
 
 // List of CRM errors.

--- a/pkg/constant/operation-route.go
+++ b/pkg/constant/operation-route.go
@@ -9,3 +9,10 @@ const (
 	AccountRuleTypeAlias       = "alias"
 	AccountRuleTypeAccountType = "account_type"
 )
+
+// Operation Route Types (Directions)
+const (
+	OperationRouteTypeSource        = "source"
+	OperationRouteTypeDestination   = "destination"
+	OperationRouteTypeBidirectional = "bidirectional"
+)

--- a/pkg/errors.go
+++ b/pkg/errors.go
@@ -1346,6 +1346,12 @@ func ValidateBusinessError(err error, entityType string, args ...any) error {
 			Title:      "Revert Only for Bidirectional",
 			Message:    fmt.Sprintf("The revert scenario is only allowed for bidirectional operation routes. %v", args...),
 		},
+		constant.ErrAccountingEntryFieldRequired: ValidationError{
+			EntityType: entityType,
+			Code:       constant.ErrAccountingEntryFieldRequired.Error(),
+			Title:      "Accounting Entry Field Required",
+			Message:    fmt.Sprintf("A required field is missing in the accounting entry. %v", args...),
+		},
 	}
 
 	if mappedError, found := errorMap[err]; found {

--- a/pkg/errors.go
+++ b/pkg/errors.go
@@ -1321,6 +1321,31 @@ func ValidateBusinessError(err error, entityType string, args ...any) error {
 			Title:      "Too Many Operation Routes",
 			Message:    "The number of operation routes exceeds the maximum allowed. Please reduce the number of operation routes and try again.",
 		},
+		// Accounting Rules Validation Errors (0162-0165)
+		constant.ErrScenarioNotAllowedForDirection: ValidationError{
+			EntityType: entityType,
+			Code:       constant.ErrScenarioNotAllowedForDirection.Error(),
+			Title:      "Scenario Not Allowed for Direction",
+			Message:    fmt.Sprintf("The accounting scenario is not allowed for the specified operation direction. %v", args...),
+		},
+		constant.ErrReserveGroupIncomplete: ValidationError{
+			EntityType: entityType,
+			Code:       constant.ErrReserveGroupIncomplete.Error(),
+			Title:      "Reserve Group Incomplete",
+			Message:    fmt.Sprintf("The reserve group (hold, commit, cancel) must be complete. %v", args...),
+		},
+		constant.ErrDirectScenarioRequired: ValidationError{
+			EntityType: entityType,
+			Code:       constant.ErrDirectScenarioRequired.Error(),
+			Title:      "Direct Scenario Required",
+			Message:    fmt.Sprintf("The direct scenario is required when other scenarios are present. %v", args...),
+		},
+		constant.ErrRevertOnlyBidirectional: ValidationError{
+			EntityType: entityType,
+			Code:       constant.ErrRevertOnlyBidirectional.Error(),
+			Title:      "Revert Only for Bidirectional",
+			Message:    fmt.Sprintf("The revert scenario is only allowed for bidirectional operation routes. %v", args...),
+		},
 	}
 
 	if mappedError, found := errorMap[err]; found {

--- a/pkg/errors.go
+++ b/pkg/errors.go
@@ -1321,7 +1321,7 @@ func ValidateBusinessError(err error, entityType string, args ...any) error {
 			Title:      "Too Many Operation Routes",
 			Message:    "The number of operation routes exceeds the maximum allowed. Please reduce the number of operation routes and try again.",
 		},
-		// Accounting Rules Validation Errors (0162-0165)
+		// Accounting Rules Validation Errors (0162-0166)
 		constant.ErrScenarioNotAllowedForDirection: ValidationError{
 			EntityType: entityType,
 			Code:       constant.ErrScenarioNotAllowedForDirection.Error(),

--- a/pkg/mmodel/operation-route.go
+++ b/pkg/mmodel/operation-route.go
@@ -24,11 +24,12 @@ type AccountingRubric struct {
 // AccountingEntry represents a single accounting entry with debit and credit rubrics.
 //
 // @Description AccountingEntry object containing debit and credit rubrics for a specific action.
+// Field requirements depend on operationType and scenario - validated by validateEntryFieldRequirements.
 type AccountingEntry struct {
-	// The debit rubric for this entry.
-	Debit *AccountingRubric `json:"debit" validate:"required" msgpack:"debit"`
-	// The credit rubric for this entry.
-	Credit *AccountingRubric `json:"credit" validate:"required" msgpack:"credit"`
+	// The debit rubric for this entry. Required based on operationType/scenario matrix.
+	Debit *AccountingRubric `json:"debit" validate:"omitempty" msgpack:"debit"`
+	// The credit rubric for this entry. Required based on operationType/scenario matrix.
+	Credit *AccountingRubric `json:"credit" validate:"omitempty" msgpack:"credit"`
 } // @name AccountingEntry
 
 // AccountingEntries groups accounting entries by transaction action type.


### PR DESCRIPTION
## Summary

Implements comprehensive accounting rules validation for Operation Routes based on the direction × scenario matrix. This ensures that accounting entries comply with business rules that define which scenarios are valid for each operation direction (`source`, `destination`, `bidirectional`) and which fields (`debit`, `credit`) are required per combination.

## Motivation

Operation Routes define how accounting entries are structured for different transaction scenarios. Without proper validation, clients could create invalid configurations (e.g., a `revert` scenario for `source` direction, or missing `credit` field for `destination/direct`). This implementation enforces the accounting matrix rules at the API level, preventing invalid data from entering the system and providing clear, actionable error messages.

Key business rules enforced:
- `source` direction: `revert` is blocked; `hold`/`cancel` require both D+C (balance moves between `available` ↔ `on_hold`)
- `destination` direction: `hold`/`cancel`/`revert` are blocked
- `bidirectional`: all scenarios allowed, all require D+C
- Reserve group atomicity: `hold`, `commit`, `cancel` must be defined together
- Direct is mandatory when other scenarios are present

## Semantic Decision

**Non-breaking addition** - Adds validation to existing endpoint. Previously accepted invalid payloads will now receive clear validation errors. This is considered a bug fix, not a breaking change.

## Changes

### New Files
| File | Purpose |
|------|---------|
| N/A | All changes are modifications to existing files |

### New Error Codes
| Code | Constant | Title | Trigger |
|------|----------|-------|---------|
| 0162 | `ErrScenarioNotAllowedForDirection` | Scenario Not Allowed for Direction | `hold`/`cancel` for destination, blocked scenarios |
| 0163 | `ErrReserveGroupIncomplete` | Reserve Group Incomplete | `hold` without `commit`/`cancel`, or vice-versa |
| 0164 | `ErrDirectScenarioRequired` | Direct Scenario Required | Other scenarios exist but `direct` is missing |
| 0165 | `ErrRevertOnlyBidirectional` | Revert Only for Bidirectional | `revert` used with `source` or `destination` |
| 0166 | `ErrAccountingEntryFieldRequired` | Accounting Entry Field Required | Missing required `debit` or `credit` per matrix |

### New Constants
| Constant | Value | Purpose |
|----------|-------|---------|
| `OperationRouteTypeSource` | `"source"` | Direction constant for validation |
| `OperationRouteTypeDestination` | `"destination"` | Direction constant for validation |
| `OperationRouteTypeBidirectional` | `"bidirectional"` | Direction constant for validation |

### Refactored Code
| Before | After |
|--------|-------|
| No accounting rules validation | Full direction × scenario matrix validation |
| Unconditional `debit`/`credit` required | Direction-aware field requirements |
| No reserve group validation | Atomic validation of `hold`/`commit`/`cancel` |

### New Functions
| Function | Location | Purpose |
|----------|----------|---------|
| `validateAccountingRulesMatrix` | operation-route.go:734 | Entry point for matrix validation |
| `validateDirectionScenarioMatrix` | operation-route.go:776 | Validates allowed scenarios per direction |
| `validateReserveGroupAtomicity` | operation-route.go:856 | Ensures hold/commit/cancel are atomic |
| `validateDirectMandatory` | operation-route.go:920 | Ensures direct is present when required |
| `validateEntryFieldRequirements` | operation-route.go:955 | Validates required debit/credit per matrix |
| `getFieldRequirements` | operation-route.go:691 | Returns field requirements for direction+scenario |
| `mergeAccountingEntries` | operation-route.go:1037 | RFC 7396 merge for PATCH operations |

### Validation Matrix Implemented

```
                 source          destination      bidirectional
═══════════════════════════════════════════════════════════════════
direct           D ✔  C ✘        D ✘  C ✔        D ✔  C ✔
hold             D ✔  C ✔        ── ✗ ──         D ✔  C ✔
commit           D ✔  C ✘        D ✘  C ✔        D ✔  C ✔
cancel           D ✔  C ✔        ── ✗ ──         D ✔  C ✔
revert           ── ✗ ──         ── ✗ ──         D ✔  C ✔

Legend:
  D = Debit required    C = Credit required
  ✔ = field required    ✘ = field not required    ✗ = scenario blocked
```

## Test Plan
- [x] Unit tests for `getFieldRequirements` (9 test cases covering all direction×scenario combinations)
- [x] Unit tests for `validateEntryFieldRequirements` (13 test cases)
- [x] Unit tests for `validateDirectionScenarioMatrix` (blocked scenario detection)
- [x] Unit tests for `validateReserveGroupAtomicity` (complete/incomplete groups)
- [x] Unit tests for `validateDirectMandatory` (direct presence check)
- [x] Unit tests for `mergeAccountingEntries` (RFC 7396 merge behavior)
- [x] All existing tests pass
- [x] No race conditions detected
- [x] No linter issues
