### PR TITLE
docs: add AI-readable documentation (llms.txt, llms-full.txt, CLAUDE.md, AGENTS.md)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@
 *.iml
 ide/
 tmp/
-CLAUDE.md
 .claude/
 .mcp.json
 .windsurf/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,86 @@
+# AGENTS.md — Midaz Quick-Start for AI Agents
+
+## What Is This?
+
+Midaz is an **open-source double-entry ledger** written in Go. It provides HTTP APIs for managing organizations, ledgers, accounts, and financial transactions with full double-entry accounting.
+
+## Quick Facts
+
+| Aspect | Detail |
+|--------|--------|
+| Language | Go 1.25+ |
+| Module | `github.com/LerianStudio/midaz/v3` |
+| License | Elastic License 2.0 |
+| Architecture | Hexagonal + CQRS |
+| HTTP Framework | Fiber v2 |
+| Databases | PostgreSQL 17, MongoDB 8, RabbitMQ 4.1, Valkey 8 |
+| Components | Ledger (:3002), CRM (:4003), Infra (Docker Compose) |
+
+## Get Running
+
+```bash
+make set-env     # Create .env files
+make up          # Start everything (infra → ledger → CRM)
+make test-unit   # Run unit tests
+make lint        # Lint all code
+```
+
+## Project Structure (What Goes Where)
+
+```
+components/ledger/internal/
+  adapters/http/in/   → HTTP handlers (one per entity)
+  adapters/postgres/  → PostgreSQL repositories
+  adapters/mongodb/   → MongoDB metadata repos
+  adapters/redis/     → Cache repos
+  adapters/rabbitmq/  → Message queue adapters
+  bootstrap/          → Config, DI, server lifecycle
+  services/command/   → Write use cases (one file per operation)
+  services/query/     → Read use cases (one file per operation)
+
+pkg/
+  mmodel/             → Domain models (Organization, Account, Transaction, etc.)
+  constant/errors.go  → Error codes (0001–0161)
+  errors.go           → Typed error structs
+  gold/               → Transaction DSL parser (ANTLR4)
+  net/http/           → Middleware, pagination, route helpers
+```
+
+## Key Conventions
+
+1. **Error handling**: Business errors return directly; technical errors wrap with `%w`
+2. **Validation order**: Normalize → Defaults → Validate → Execute
+3. **Metadata**: Flat key-value only (no nesting), key max 100, value max 2000
+4. **File naming**: `snake_case.go`, one handler or operation per file
+5. **Imports**: stdlib → external → internal (blank-line separated)
+6. **Context**: Always first param; check `ctx.Err()` before expensive work
+7. **IDs**: `uuid.UUID` type, not strings
+8. **HTTP methods**: Use `http.MethodGet` constants, never string literals
+
+## Key Files to Read First
+
+| File | Why |
+|------|-----|
+| `components/ledger/internal/bootstrap/config.go` | Composition root, all env vars, init sequence |
+| `components/ledger/internal/adapters/http/in/routes.go` | All API routes registered here |
+| `pkg/mmodel/account.go` | Account model (representative of all models) |
+| `pkg/constant/errors.go` | All error codes |
+| `pkg/errors.go` | Error types + ValidateBusinessError factory |
+| `components/ledger/.env.example` | All environment variables |
+| `docs/PROJECT_RULES.md` | 1130 lines of coding standards (DO NOT overwrite) |
+
+## What NOT To Do
+
+- Do NOT overwrite `docs/PROJECT_RULES.md`
+- Do NOT use `interface{}` — use `any`
+- Do NOT panic — return errors
+- Do NOT put domain logic in handlers or repositories
+- Do NOT nest metadata values
+- Do NOT use `time.Now()` in tests
+
+## Deeper References
+
+- **[CLAUDE.md](CLAUDE.md)** — Deep technical reference (architecture, bootstrap, multi-tenancy, transaction processing)
+- **[llms-full.txt](llms-full.txt)** — Complete reference with all env vars, API endpoints, error codes, models
+- **[llms.txt](llms.txt)** — Concise overview following llmstxt.org spec
+- **[docs/PROJECT_RULES.md](docs/PROJECT_RULES.md)** — Coding standards and conventions (1130 lines)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -237,21 +237,324 @@ Migrations in `components/ledger/migrations/onboarding/` and `components/ledger/
 - **transaction** database: metadata collections
 - **crm** database: holders, aliases, related parties
 
-## Build Commands
+## Environment Variables — Complete Reference
 
+Source: `components/ledger/internal/bootstrap/config.go` (Ledger) and `components/crm/internal/bootstrap/config.go` (CRM).
+Defaults shown in parentheses where set by `applyConfigDefaults()` or env tags.
+
+### Application
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `APPLICATION_NAME` | — | Application identity (used for tenant-manager service name) |
+| `ENV_NAME` | development | Environment: development, staging, uat, production, local |
+| `VERSION` | — | Application version string |
+| `LOG_LEVEL` | debug | Log level |
+| `SERVER_ADDRESS` | :3002 | Listen address (Ledger) |
+
+### Auth / Casdoor
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `PLUGIN_AUTH_ENABLED` | false | Enable auth middleware |
+| `PLUGIN_AUTH_HOST` | — | Auth service host (Ledger) |
+| `CASDOOR_JWK_ADDRESS` | — | JWK endpoint for Casdoor JWT validation |
+
+### PostgreSQL — Onboarding (Primary + Replica)
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `DB_ONBOARDING_HOST` | midaz-postgres-primary | Primary host |
+| `DB_ONBOARDING_USER` | midaz | Username |
+| `DB_ONBOARDING_PASSWORD` | lerian | Password |
+| `DB_ONBOARDING_NAME` | onboarding | Database name |
+| `DB_ONBOARDING_PORT` | 5701 | Port |
+| `DB_ONBOARDING_SSLMODE` | disable | SSL mode |
+| `DB_ONBOARDING_REPLICA_HOST` | midaz-postgres-replica | Replica host |
+| `DB_ONBOARDING_REPLICA_USER` | midaz | Replica username |
+| `DB_ONBOARDING_REPLICA_PASSWORD` | lerian | Replica password |
+| `DB_ONBOARDING_REPLICA_NAME` | onboarding | Replica database name |
+| `DB_ONBOARDING_REPLICA_PORT` | 5702 | Replica port |
+| `DB_ONBOARDING_REPLICA_SSLMODE` | disable | Replica SSL mode |
+| `DB_ONBOARDING_MAX_OPEN_CONNS` | 3000 | Max open connections |
+| `DB_ONBOARDING_MAX_IDLE_CONNS` | 3000 | Max idle connections |
+
+### PostgreSQL — Transaction (Primary + Replica)
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `DB_TRANSACTION_HOST` | midaz-postgres-primary | Primary host |
+| `DB_TRANSACTION_USER` | midaz | Username |
+| `DB_TRANSACTION_PASSWORD` | lerian | Password |
+| `DB_TRANSACTION_NAME` | transaction | Database name |
+| `DB_TRANSACTION_PORT` | 5701 | Port |
+| `DB_TRANSACTION_SSLMODE` | disable | SSL mode |
+| `DB_TRANSACTION_REPLICA_HOST` | midaz-postgres-replica | Replica host |
+| `DB_TRANSACTION_REPLICA_USER` | midaz | Replica username |
+| `DB_TRANSACTION_REPLICA_PASSWORD` | lerian | Replica password |
+| `DB_TRANSACTION_REPLICA_NAME` | transaction | Replica database name |
+| `DB_TRANSACTION_REPLICA_PORT` | 5702 | Replica port |
+| `DB_TRANSACTION_REPLICA_SSLMODE` | disable | Replica SSL mode |
+| `DB_TRANSACTION_MAX_OPEN_CONNS` | 3000 | Max open connections |
+| `DB_TRANSACTION_MAX_IDLE_CONNS` | 3000 | Max idle connections |
+
+### MongoDB — Onboarding
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `MONGO_ONBOARDING_URI` | mongodb | Connection URI scheme |
+| `MONGO_ONBOARDING_HOST` | midaz-mongodb | Host |
+| `MONGO_ONBOARDING_NAME` | onboarding | Database name |
+| `MONGO_ONBOARDING_USER` | midaz | Username |
+| `MONGO_ONBOARDING_PASSWORD` | lerian | Password |
+| `MONGO_ONBOARDING_PORT` | 5703 | Port |
+| `MONGO_ONBOARDING_PARAMETERS` | — | Extra connection params (appended to URI) |
+| `MONGO_ONBOARDING_MAX_POOL_SIZE` | 1000 | Max pool size |
+
+### MongoDB — Transaction
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `MONGO_TRANSACTION_URI` | mongodb | Connection URI scheme |
+| `MONGO_TRANSACTION_HOST` | midaz-mongodb | Host |
+| `MONGO_TRANSACTION_NAME` | transaction | Database name |
+| `MONGO_TRANSACTION_USER` | midaz | Username |
+| `MONGO_TRANSACTION_PASSWORD` | lerian | Password |
+| `MONGO_TRANSACTION_PORT` | 5703 | Port |
+| `MONGO_TRANSACTION_PARAMETERS` | — | Extra connection params |
+| `MONGO_TRANSACTION_MAX_POOL_SIZE` | 1000 | Max pool size |
+
+### Redis / Valkey
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `REDIS_HOST` | midaz-valkey:5704 | Host(s); comma-separated for cluster/sentinel |
+| `REDIS_MASTER_NAME` | — | Sentinel master name (enables sentinel mode) |
+| `REDIS_PASSWORD` | lerian | Password |
+| `REDIS_DB` | 0 | Database index |
+| `REDIS_PROTOCOL` | (3) | RESP protocol version |
+| `REDIS_TLS` | false | Enable TLS |
+| `REDIS_CA_CERT` | — | CA certificate (base64) for TLS |
+| `REDIS_USE_GCP_IAM` | false | Use GCP IAM auth instead of password |
+| `REDIS_SERVICE_ACCOUNT` | — | GCP service account for IAM auth |
+| `GOOGLE_APPLICATION_CREDENTIALS` | — | GCP credentials (base64) for IAM auth |
+| `REDIS_TOKEN_LIFETIME` | (60) | GCP IAM token lifetime (minutes) |
+| `REDIS_TOKEN_REFRESH_DURATION` | (45) | GCP IAM token refresh interval (minutes) |
+| `REDIS_POOL_SIZE` | (10) | Connection pool size |
+| `REDIS_MIN_IDLE_CONNS` | 0 | Minimum idle connections |
+| `REDIS_READ_TIMEOUT` | (3) | Read timeout (seconds) |
+| `REDIS_WRITE_TIMEOUT` | (3) | Write timeout (seconds) |
+| `REDIS_DIAL_TIMEOUT` | (5) | Dial timeout (seconds) |
+| `REDIS_POOL_TIMEOUT` | (2) | Pool wait timeout (seconds) |
+| `REDIS_MAX_RETRIES` | (3) | Max retries per command |
+| `REDIS_MIN_RETRY_BACKOFF` | (8) | Min retry backoff (milliseconds) |
+| `REDIS_MAX_RETRY_BACKOFF` | (1) | Max retry backoff (seconds) |
+
+### RabbitMQ
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `RABBITMQ_URI` | amqp | Protocol scheme (amqp/amqps) |
+| `RABBITMQ_HOST` | midaz-rabbitmq | Host |
+| `RABBITMQ_PORT_HOST` | 3003 | Management port |
+| `RABBITMQ_PORT_AMQP` | 3004 | AMQP port |
+| `RABBITMQ_DEFAULT_USER` | transaction | Producer username |
+| `RABBITMQ_DEFAULT_PASS` | lerian | Producer password |
+| `RABBITMQ_CONSUMER_USER` | consumer | Consumer username |
+| `RABBITMQ_CONSUMER_PASS` | lerian | Consumer password |
+| `RABBITMQ_VHOST` | — | Virtual host (empty = default "/") |
+| `RABBITMQ_NUMBERS_OF_WORKERS` | 5 | Consumer worker count |
+| `RABBITMQ_NUMBERS_OF_PREFETCH` | 10 | Prefetch count per worker |
+| `RABBITMQ_HEALTH_CHECK_URL` | — | Health check URL |
+| `RABBITMQ_TLS` | false | Enable TLS |
+| `RABBITMQ_TRANSACTION_BALANCE_OPERATION_QUEUE` | — | Balance operation queue name |
+| `RABBITMQ_TRANSACTION_ASYNC` | false | Enable async transaction processing |
+| `RABBITMQ_OPERATION_TIMEOUT` | — | Operation timeout (e.g., "30s") |
+| `RABBITMQ_TRANSACTION_EVENTS_ENABLED` | false | Enable transaction event exchange |
+| `RABBITMQ_TRANSACTION_EVENTS_EXCHANGE` | — | Events exchange name |
+| `AUDIT_LOG_ENABLED` | false | Enable audit log publishing |
+| `RABBITMQ_AUDIT_EXCHANGE` | — | Audit exchange name |
+| `RABBITMQ_AUDIT_KEY` | — | Audit routing key |
+
+### RabbitMQ Circuit Breaker
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `RABBITMQ_CIRCUIT_BREAKER_CONSECUTIVE_FAILURES` | 15 | Consecutive failures before open |
+| `RABBITMQ_CIRCUIT_BREAKER_FAILURE_RATIO` | 50 | Failure % to trigger open (0-100) |
+| `RABBITMQ_CIRCUIT_BREAKER_INTERVAL` | 120 | Failure counting window (seconds) |
+| `RABBITMQ_CIRCUIT_BREAKER_MAX_REQUESTS` | 3 | Requests allowed in half-open |
+| `RABBITMQ_CIRCUIT_BREAKER_MIN_REQUESTS` | 10 | Min requests before ratio evaluated |
+| `RABBITMQ_CIRCUIT_BREAKER_TIMEOUT` | 30 | Open → half-open wait (seconds) |
+| `RABBITMQ_CIRCUIT_BREAKER_HEALTH_CHECK_INTERVAL` | 30 | Health check interval (seconds) |
+| `RABBITMQ_CIRCUIT_BREAKER_HEALTH_CHECK_TIMEOUT` | 10 | Health check timeout (seconds) |
+
+### Bulk Recorder
+
+Activates only when `RABBITMQ_TRANSACTION_ASYNC=true` AND `BULK_RECORDER_ENABLED=true`.
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `BULK_RECORDER_ENABLED` | (true) | Enable bulk mode |
+| `BULK_RECORDER_SIZE` | (workers×prefetch) | Batch size (0 = auto-calculated) |
+| `BULK_RECORDER_FLUSH_TIMEOUT_MS` | (100) | Max wait before flush (ms) |
+| `BULK_RECORDER_MAX_ROWS_PER_INSERT` | (1000) | Max rows per INSERT statement |
+
+### Balance Sync / Settings
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `BALANCE_SYNC_MAX_WORKERS` | (5) | Balance sync worker count |
+| `SETTINGS_CACHE_TTL` | (5m) | Settings cache duration (Go duration) |
+
+### Pagination
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `MAX_PAGINATION_LIMIT` | 100 | Max items per page |
+| `MAX_PAGINATION_MONTH_DATE_RANGE` | 3 | Max date range for queries (months) |
+
+### Telemetry (OpenTelemetry)
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `OTEL_RESOURCE_SERVICE_NAME` | ledger | Service name in traces |
+| `OTEL_LIBRARY_NAME` | — | Instrumentation library name |
+| `OTEL_RESOURCE_SERVICE_VERSION` | — | Service version in traces |
+| `OTEL_RESOURCE_DEPLOYMENT_ENVIRONMENT` | — | Deployment environment in traces |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | midaz-otel-lgtm:4317 | OTLP gRPC collector endpoint |
+| `ENABLE_TELEMETRY` | false | Enable telemetry export |
+
+### Multi-Tenant (Ledger)
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `MULTI_TENANT_ENABLED` | false | Enable multi-tenant mode |
+| `MULTI_TENANT_URL` | — | Tenant Manager API URL |
+| `MULTI_TENANT_SERVICE_API_KEY` | — | Service API key for tenant-manager |
+| `MULTI_TENANT_CIRCUIT_BREAKER_THRESHOLD` | (5) | CB failures before open |
+| `MULTI_TENANT_CIRCUIT_BREAKER_TIMEOUT_SEC` | (30) | CB open → half-open (seconds) |
+| `MULTI_TENANT_CONNECTIONS_CHECK_INTERVAL_SEC` | — | Interval for revalidation checks |
+| `MULTI_TENANT_CACHE_TTL_SEC` | (120) | Tenant config cache TTL (seconds) |
+| `MULTI_TENANT_REDIS_HOST` | — | Redis for tenant Pub/Sub events |
+| `MULTI_TENANT_REDIS_PORT` | 6379 | Redis port for Pub/Sub |
+| `MULTI_TENANT_REDIS_PASSWORD` | — | Redis password for Pub/Sub |
+| `MULTI_TENANT_REDIS_TLS` | false | Enable TLS for Pub/Sub Redis |
+
+### CRM-Specific Variables
+
+Source: `components/crm/internal/bootstrap/config.go`
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `ENV_NAME` | development | Environment name |
+| `PROTO_ADDRESS` | — | gRPC address (CRM-only) |
+| `SERVER_ADDRESS` | :4003 | HTTP listen address |
+| `LOG_LEVEL` | debug | Log level |
+| `MONGO_URI` | mongodb | Connection URI scheme |
+| `MONGO_HOST` | midaz-mongodb | MongoDB host |
+| `MONGO_NAME` | crm | Database name |
+| `MONGO_USER` | midaz | Username |
+| `MONGO_PASSWORD` | lerian | Password |
+| `MONGO_PORT` | 5703 | Port |
+| `MONGO_PARAMETERS` | — | Extra connection parameters |
+| `MONGO_MAX_POOL_SIZE` | 1000 | Max pool size |
+| `LCRYPTO_HASH_SECRET_KEY` | — | PII hash key (data security) |
+| `LCRYPTO_ENCRYPT_SECRET_KEY` | — | PII encryption key (data security) |
+| `PLUGIN_AUTH_ADDRESS` | — | Auth service address (CRM uses different var from Ledger) |
+| `PLUGIN_AUTH_ENABLED` | false | Enable auth |
+| `APPLICATION_NAME` | ledger | Application identity |
+| `MULTI_TENANT_ENABLED` | false | Enable multi-tenant |
+| `MULTI_TENANT_URL` | — | Tenant Manager API URL |
+| `MULTI_TENANT_TIMEOUT` | — | HTTP client timeout (seconds) |
+| `MULTI_TENANT_IDLE_TIMEOUT_SEC` | — | Idle connection eviction (seconds) |
+| `MULTI_TENANT_MAX_TENANT_POOLS` | — | Max concurrent tenant pools |
+| `MULTI_TENANT_CIRCUIT_BREAKER_THRESHOLD` | — | CB failures before open |
+| `MULTI_TENANT_CIRCUIT_BREAKER_TIMEOUT_SEC` | — | CB open → half-open (seconds) |
+| `MULTI_TENANT_SERVICE_API_KEY` | — | Service API key |
+| `MULTI_TENANT_CONNECTIONS_CHECK_INTERVAL_SEC` | — | Revalidation interval (seconds) |
+| `MULTI_TENANT_CACHE_TTL_SEC` | (120) | Tenant config cache TTL (seconds) |
+| `MULTI_TENANT_REDIS_HOST` | — | Redis for Pub/Sub |
+| `MULTI_TENANT_REDIS_PORT` | 6379 | Redis port |
+| `MULTI_TENANT_REDIS_PASSWORD` | — | Redis password |
+| `MULTI_TENANT_REDIS_TLS` | false | TLS for Redis |
+
+## Build & Make Targets — Complete Reference
+
+### Setup
 ```bash
-make set-env          # Setup .env files from .env.example
-make build            # Build ledger + CRM
-make up               # Start infra → ledger → CRM
-make down             # Stop all
-make lint             # Lint all components (golangci-lint v2)
-make test             # Run tests
-make test-unit        # Unit tests only
-make test-integration # Integration tests (testcontainers)
-make coverage-unit    # Unit test coverage
-make generate-docs    # Swagger docs
-make migrate-lint     # Lint SQL migrations
-make sec              # Security scans (gosec + govulncheck)
+make set-env              # Copy .env.example → .env for all components
+make clear-envs           # Remove all .env files
+make dev-setup            # Install tools (gitleaks, gofumpt, goimports, gosec, golangci-lint) + git hooks
+make setup-git-hooks      # Configure git hooks (core.hooksPath = .githooks)
+```
+
+### Build & Run
+```bash
+make build                # Build ledger + CRM binaries
+make up                   # Start all services (infra → ledger → CRM)
+make down                 # Stop all services (CRM → ledger → infra)
+make start                # Start existing containers
+make stop                 # Stop containers (no removal)
+make restart              # down + up
+make rebuild-up           # Rebuild images and restart
+make logs                 # Show logs for all services (tail 50)
+make clean                # Clean build artifacts (./scripts/clean-artifacts.sh)
+make clean-docker         # Clean Docker resources (containers, networks, volumes, prune)
+```
+
+### Code Quality
+```bash
+make lint                 # Lint all components + tests/ + pkg/ (golangci-lint v2.4.0)
+make format               # Format code in all components
+make tidy                 # go mod tidy
+make check-logs           # Verify error logging in usecases
+make check-tests          # Verify test coverage for components
+make check-hooks          # Verify git hooks installation
+make check-envs           # Check hooks + secret env files not exposed
+make sec                  # Run gosec + govulncheck
+make sec-gosec            # Run gosec only (SARIF=1 for GitHub Security tab)
+make sec-govulncheck      # Run govulncheck only
+```
+
+### Testing
+```bash
+make test                 # Run all tests (scripts/run-tests.sh)
+make test-unit            # Unit tests only (excludes tests/ and api/ dirs)
+make test-all             # Unit + integration tests
+make test-integration     # Integration tests (testcontainers, -p=1; RUN=, PKG=, CHAOS=1)
+make test-fuzz            # Native Go fuzz tests (FUZZ=target, FUZZTIME=10s)
+make test-bench           # Benchmark tests (BENCH=pattern, BENCH_PKG=./...)
+make test-chaos-system    # Chaos tests with full Docker stack (starts/stops services)
+```
+
+### Coverage
+```bash
+make cover                # Legacy coverage (scripts/coverage.sh → coverage.html)
+make coverage             # All coverage targets (unit + integration)
+make coverage-unit        # Unit test coverage (PKG=, uses .ignorecoverunit)
+make coverage-integration # Integration test coverage (PKG=, CHAOS=1)
+```
+
+### Component Delegation
+```bash
+make infra COMMAND=<cmd>          # Run make target in infra component
+make ledger COMMAND=<cmd>         # Run make target in ledger component
+make all-components COMMAND=<cmd> # Run make target across all components
+```
+
+### Documentation & Migrations
+```bash
+make generate-docs                 # Generate Swagger docs (scripts/generate-docs.sh)
+make migrate-lint                  # Lint SQL migrations for dangerous patterns
+make migrate-create COMPONENT=<onboarding|transaction> NAME=<name>  # Create new migration
+```
+
+### Test Tooling
+```bash
+make tools                # Install test tools (gotestsum)
+make tools-gotestsum      # Install gotestsum
+make wait-for-services    # Wait for backend services healthy (TEST_HEALTH_WAIT=60s)
 ```
 
 ## Coding Conventions

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,284 @@
+# CLAUDE.md — Midaz Deep Technical Reference
+
+This file is a deep technical reference for AI coding agents working on the Midaz codebase.
+For a quick-start overview, see [AGENTS.md](AGENTS.md).
+For full API and env var reference, see [llms-full.txt](llms-full.txt).
+For project rules and coding standards, see [docs/PROJECT_RULES.md](docs/PROJECT_RULES.md).
+
+---
+
+## What Is Midaz
+
+Midaz is an enterprise-grade open-source **double-entry ledger system**. It is the core ledger component of a banking platform. The hierarchy is: Organization → Ledger → (Assets, Portfolios, Segments) → Accounts → Transactions → Operations → Balances.
+
+- **Module path**: `github.com/LerianStudio/midaz/v3`
+- **Go version**: 1.25+
+- **License**: Elastic License 2.0 (ELv2) — not MIT/Apache
+
+## Repository Layout
+
+```
+midaz/
+├── components/
+│   ├── ledger/           # Main component — unified onboarding + transaction API
+│   │   ├── cmd/app/      # main.go
+│   │   ├── internal/
+│   │   │   ├── adapters/ # http/in, postgres, mongodb, redis, rabbitmq
+│   │   │   ├── bootstrap/# Config struct, InitServers, DI, workers
+│   │   │   └── services/ # command/ (writes), query/ (reads)
+│   │   ├── migrations/   # onboarding/ and transaction/ SQL migrations
+│   │   └── api/          # Swagger docs
+│   ├── crm/              # CRM plugin (MongoDB-backed)
+│   └── infra/            # Docker Compose infrastructure
+├── pkg/                  # Shared packages — imported by all components
+│   ├── mmodel/           # Domain models (Organization, Ledger, Account, Transaction, Balance, etc.)
+│   ├── constant/         # Error codes (0001–0161), action constants, HTTP constants
+│   ├── errors.go         # Typed error structs + factory functions
+│   ├── gold/             # ANTLR4 transaction DSL (grammar + parser + builder)
+│   ├── net/http/         # Fiber middleware, pagination, protected route chain
+│   ├── transaction/      # Transaction processing utilities
+│   └── ...               # mongo, repository, pagination, utils
+├── tests/                # Integration + chaos test suites
+├── docs/PROJECT_RULES.md # 1130-line coding standards (DO NOT overwrite)
+├── Makefile              # Root orchestrator
+└── go.mod                # Single go.mod for entire monorepo
+```
+
+## Architecture Patterns
+
+### Hexagonal Architecture with CQRS
+
+```
+HTTP Handlers → Command/Query Use Cases → Repository Interfaces → Adapters (Postgres/Mongo/Redis/RabbitMQ)
+```
+
+- **Handlers** (`components/ledger/internal/adapters/http/in/`): Parse HTTP, validate input, call use cases
+- **Services** (`components/ledger/internal/services/command/` and `query/`): Business logic, one file per operation
+- **Repositories**: Interfaces defined where used (in services), implemented in adapters
+- **Models** (`pkg/mmodel/`): Shared domain types, no business logic
+
+### Key Principles
+- Dependencies flow inward: handlers → services → repos → DB drivers
+- No `/internal/domain` folder — entities live in `pkg/mmodel/`
+- Interfaces defined in the package that USES them, not in `/port` folders
+- One handler per entity, one service operation per file
+
+## Bootstrap & Configuration
+
+The Config struct is in `components/ledger/internal/bootstrap/config.go`. It loads all env vars via `libCommons.SetConfigFromEnvVars(cfg)`.
+
+**InitServersWithOptions** (config.go:234) is the composition root:
+1. Loads Config from env vars
+2. Validates multi-tenant + auth coupling
+3. Creates logger, telemetry
+4. Initializes tenant client (if multi-tenant)
+5. Initializes PG (onboarding + transaction), MongoDB (onboarding + transaction), Redis, RabbitMQ
+6. Creates Command + Query use cases
+7. Creates HTTP handlers
+8. Registers routes (onboarding, transaction, metadata)
+9. Creates workers (RedisQueueConsumer, BalanceSyncWorker)
+10. Returns Service struct
+
+## HTTP Framework
+
+Uses **Fiber v2** (`github.com/gofiber/fiber/v2`).
+
+### Route Registration
+- `RegisterOnboardingRoutesToApp()` — organizations, ledgers, assets, portfolios, segments, accounts, account types
+- `RegisterTransactionRoutesToApp()` — transactions, operations, asset-rates, balances, operation-routes, transaction-routes
+- `RegisterMetadataRoutesToApp()` — metadata indexes
+
+### Route Protection
+All routes use `http.ProtectedRouteChain()` which applies:
+1. Auth middleware (RBAC via lib-auth)
+2. Optional post-auth middlewares (multi-tenant DB resolution)
+3. Body parsing, UUID path parameter validation, handler
+
+### Middleware
+- Telemetry middleware (`libHTTP.NewTelemetryMiddleware`)
+- CORS (`cors.New()`)
+- HTTP logging (`libHTTP.WithHTTPLogging`)
+- Body limit (`http.WithBodyLimit(SettingsMaxPayloadSize)`)
+
+## Error Handling
+
+### Error Types (pkg/errors.go)
+| Type | HTTP | Use |
+|------|------|-----|
+| `EntityNotFoundError` | 404 | Entity not found |
+| `ValidationError` | 400 | Input validation |
+| `EntityConflictError` | 409 | Duplicates |
+| `UnauthorizedError` | 401 | Auth missing |
+| `ForbiddenError` | 403 | Insufficient privileges |
+| `UnprocessableOperationError` | 422 | Business rule violation |
+| `InternalServerError` | 500 | Unexpected failures |
+| `ServiceUnavailableError` | 503 | Infrastructure down |
+
+### Error Constants (pkg/constant/errors.go)
+Numeric codes as `errors.New("0007")`. Factory: `pkg.ValidateBusinessError(constant.ErrEntityNotFound, "Entity")`.
+
+### Pattern
+```go
+// Business error — return directly (expected)
+if errors.Is(err, constant.ErrEntityNotFound) {
+    return nil, pkg.ValidateBusinessError(constant.ErrEntityNotFound, "Account")
+}
+// Technical error — wrap with context
+return nil, fmt.Errorf("failed to query accounts: %w", err)
+```
+
+## Domain Models (pkg/mmodel/)
+
+Key entities and their files:
+- `organization.go` — Organization, Address, CreateOrganizationInput, UpdateOrganizationInput
+- `ledger.go` — Ledger, LedgerSettings, CreateLedgerInput, UpdateLedgerInput
+- `account.go` — Account, CreateAccountInput, UpdateAccountInput
+- `asset.go` — Asset, CreateAssetInput, UpdateAssetInput
+- `balance.go` — Balance, UpdateBalance, CreateAdditionalBalance
+- `operation.go` — Operation
+- `portfolio.go` — Portfolio
+- `segment.go` — Segment
+- `status.go` — Status struct (code-based status pattern)
+- `transaction-route.go` — TransactionRoute, CreateTransactionRouteInput
+- `operation-route.go` — OperationRoute, CreateOperationRouteInput
+- `account-type.go` — AccountType, CreateAccountTypeInput
+- `holder.go` — Holder (CRM)
+- `queue.go` — Queue message models
+- `settings.go` — LedgerSettings
+- `alias.go` — Alias models
+- `date.go` — Date range utilities
+- `metadata.go` — Metadata index models
+
+### Status Pattern
+```go
+type Status struct {
+    Code        *string `json:"code"`
+    Description *string `json:"description,omitempty"`
+}
+```
+Common codes: `ACTIVE`, `INACTIVE`, `DELETED`, `PENDING`, `CANCELLED`
+
+### Metadata
+- Flat key-value pairs (no nesting allowed)
+- Key max: 100 chars, Value max: 2000 chars
+- Stored in MongoDB, queried via metadata indexes
+
+## Transaction Processing
+
+### Creation Modes
+1. **JSON** (`POST .../transactions/json`): Full source/destination specification
+2. **DSL** (`POST .../transactions/dsl`): Gold DSL text format
+3. **Inflow** (`POST .../transactions/inflow`): Simplified credit-only
+4. **Outflow** (`POST .../transactions/outflow`): Simplified debit-only
+5. **Annotation** (`POST .../transactions/annotation`): Informational entries
+
+### Transaction Lifecycle
+- `ACTIVE`: Completed immediately
+- `PENDING`: Created with pending status → `commit` or `cancel`
+- `revert`: Creates a reverse transaction (parentTransactionID linkage)
+
+### Async Processing
+When `RABBITMQ_TRANSACTION_ASYNC=true`:
+1. Transaction created, published to RabbitMQ
+2. Workers consume messages, update balances
+3. Bulk recorder batches inserts for 10x throughput
+4. Circuit breaker protects against RabbitMQ outages
+
+### Balance Model
+- `Available`: Spendable balance
+- `OnHold`: Pending transaction holds
+- `Scale`: Decimal precision
+- `Version`: Optimistic concurrency (lock version)
+- History queries: balance state at any timestamp
+
+## Multi-Tenancy
+
+Enabled via `MULTI_TENANT_ENABLED=true`. Requires auth enabled.
+
+**Architecture**:
+- Tenant ID extracted from JWT by auth middleware
+- `TenantMiddleware.WithTenantDB` resolves per-tenant PG/Mongo connections
+- `tmpostgres.Manager` / `tmmongo.Manager` manage connection pools per tenant
+- `TenantCache` + `TenantLoader` provide process-local caching
+- `TenantEventListener` subscribes to Redis Pub/Sub for tenant lifecycle events
+- On tenant add: start RabbitMQ consumer, warm cache
+- On tenant remove: stop consumer, close all connections, invalidate cache
+
+**Modules**: Each module (`onboarding`, `transaction`) has independent PG and Mongo managers.
+
+## lib-commons v4 Integration
+
+Import prefix: `github.com/LerianStudio/lib-commons/v4/commons/...`
+
+Key packages used:
+- `libCommons` — `SetConfigFromEnvVars`, `NewTrackingFromContext`
+- `libLog` — Structured logging interface
+- `libZap` — Zap logger implementation
+- `libOpentelemetry` — Telemetry, span management
+- `libRedis` — Redis client (standalone/sentinel/cluster)
+- `libHTTP` — HTTP response helpers, middleware, Fiber error handler
+- `libCircuitBreaker` — Circuit breaker pattern
+- `tmclient` — Tenant manager HTTP client
+- `tmcore` — Tenant manager core types/errors
+- `tmevent` — Tenant event dispatcher/listener
+- `tmmiddleware` — Fiber middleware for tenant DB injection
+- `tmpostgres` / `tmmongo` / `tmredis` — Per-tenant connection managers
+
+## Database Schemas
+
+### PostgreSQL
+- **onboarding** database: organizations, ledgers, assets, portfolios, segments, accounts, account_types
+- **transaction** database: transactions, operations, balances, asset_rates, operation_routes, transaction_routes
+
+Migrations in `components/ledger/migrations/onboarding/` and `components/ledger/migrations/transaction/`.
+
+### MongoDB
+- **onboarding** database: metadata collections
+- **transaction** database: metadata collections
+- **crm** database: holders, aliases, related parties
+
+## Build Commands
+
+```bash
+make set-env          # Setup .env files from .env.example
+make build            # Build ledger + CRM
+make up               # Start infra → ledger → CRM
+make down             # Stop all
+make lint             # Lint all components (golangci-lint v2)
+make test             # Run tests
+make test-unit        # Unit tests only
+make test-integration # Integration tests (testcontainers)
+make coverage-unit    # Unit test coverage
+make generate-docs    # Swagger docs
+make migrate-lint     # Lint SQL migrations
+make sec              # Security scans (gosec + govulncheck)
+```
+
+## Coding Conventions
+
+Full rules in `docs/PROJECT_RULES.md` (1130 lines). Key points:
+
+1. **Go 1.25+**: Use `any` not `interface{}`, use generics for utilities
+2. **File naming**: `snake_case.go`, one handler/service per file
+3. **Import groups**: stdlib → external → internal (blank-line separated)
+4. **Context**: Always first param, check `ctx.Err()` before work
+5. **Error wrapping**: `%w` for technical, direct return for business errors
+6. **Validation**: Normalize → Apply defaults → Validate → Execute
+7. **Struct tags**: `json`, `validate`, `example`, `format`, `maxLength`
+8. **Metadata**: Flat only (no nesting), key max 100, value max 2000
+9. **IDs**: Use `uuid.UUID` type, not strings
+10. **Soft delete**: `DeletedAt` field, status `DELETED`
+11. **Pagination**: Page-based (page + limit), max 100 per page
+
+## What NOT To Do
+
+- Do NOT overwrite `docs/PROJECT_RULES.md` — it is maintained separately
+- Do NOT use `interface{}` — use `any`
+- Do NOT use offset-based pagination for new endpoints
+- Do NOT create domain logic in handler or repository layers
+- Do NOT panic — return errors from constructors
+- Do NOT use `time.Now()` in tests — use fixed time utilities
+- Do NOT store nested metadata values
+- Do NOT expose internal error details to API clients
+- Do NOT import outer layers from inner layers
+- Do NOT use string literals for HTTP methods — use `http.Method*` constants

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1,0 +1,609 @@
+# Lerian Midaz — Full Reference
+
+> Enterprise-grade open-source double-entry ledger system. Go 1.25 monorepo (v3 module path) with a unified Ledger HTTP API (onboarding + transaction) and a CRM plugin. Uses PostgreSQL (primary/replica), MongoDB (metadata), RabbitMQ (async transactions), and Valkey/Redis (caching). Supports multi-tenant isolation via lib-commons v4 tenant-manager. Elastic License 2.0.
+
+---
+
+## 1. Product Overview
+
+Midaz is the ledger component of a core banking platform. It implements a financial hierarchy:
+
+```
+Organization → Ledger → Asset
+                      → Portfolio → Account
+                      → Segment → Account
+                      → Account Type
+             → Transaction → Operation → Balance
+```
+
+Key capabilities:
+- **Double-entry accounting**: Every transaction produces balanced debit/credit operations
+- **N:N transactions**: Multiple sources and destinations in a single transaction
+- **Multiple creation modes**: JSON, Gold DSL, Inflow, Outflow, Annotation
+- **Transaction lifecycle**: Create → Commit/Cancel/Revert (pending transactions support)
+- **Async processing**: RabbitMQ-based balance updates with bulk recorder (10x throughput)
+- **Multi-asset**: Currency (ISO-4217), crypto, commodities, custom asset types
+- **Multi-tenant**: Database-per-tenant isolation via lib-commons v4 tenant-manager
+- **Accounting routes**: Configurable operation routes and transaction routes for validation
+
+## 2. Architecture
+
+### 2.1 Components
+
+| Component | Port | Description | Data Stores |
+|-----------|------|-------------|-------------|
+| **Ledger** | 3002 | Unified HTTP API (onboarding + transaction) | PostgreSQL (onboarding DB + transaction DB), MongoDB (metadata), Redis, RabbitMQ |
+| **CRM** | 4003 | Customer relationship management plugin | MongoDB |
+| **Infra** | — | Docker Compose infrastructure | PostgreSQL 17, MongoDB 8, RabbitMQ 4.1, Valkey 8, Grafana/OTEL-LGTM |
+
+### 2.2 Pattern: Hexagonal Architecture with CQRS
+
+```
+Handlers (HTTP) → Services (Command/Query) → Repositories (Postgres/Mongo/Redis/RabbitMQ)
+       ↓                    ↓                           ↓
+    Models (pkg/mmodel)  Models                      Models
+```
+
+Dependencies flow inward. Inner layers must not depend on outer layers. Interfaces defined where used.
+
+### 2.3 Directory Structure
+
+```
+midaz/
+├── components/
+│   ├── ledger/              # Unified ledger (onboarding + transaction)
+│   │   ├── cmd/app/         # main.go entry point
+│   │   ├── internal/
+│   │   │   ├── adapters/
+│   │   │   │   ├── http/in/ # Fiber HTTP handlers + routes
+│   │   │   │   ├── http/out/# Outbound HTTP clients
+│   │   │   │   ├── postgres/# PostgreSQL repositories (onboarding + transaction)
+│   │   │   │   ├── mongodb/ # MongoDB metadata repositories
+│   │   │   │   ├── redis/   # Redis cache repositories
+│   │   │   │   └── rabbitmq/# RabbitMQ producer/consumer
+│   │   │   ├── bootstrap/   # Config, DI, server lifecycle, workers
+│   │   │   └── services/
+│   │   │       ├── command/ # Write operations (CQRS)
+│   │   │       └── query/   # Read operations (CQRS)
+│   │   ├── migrations/
+│   │   │   ├── onboarding/  # SQL migrations for onboarding DB
+│   │   │   └── transaction/ # SQL migrations for transaction DB
+│   │   └── api/             # Swagger docs
+│   ├── crm/                 # CRM plugin
+│   │   ├── cmd/app/         # main.go entry point
+│   │   ├── internal/
+│   │   │   ├── adapters/
+│   │   │   │   ├── http/    # Fiber HTTP handlers
+│   │   │   │   └── mongodb/ # MongoDB repositories
+│   │   │   ├── bootstrap/   # Config, DI
+│   │   │   └── services/    # CRM business logic
+│   │   └── api/             # Swagger docs
+│   └── infra/               # Docker Compose + config
+│       ├── docker-compose.yml
+│       ├── postgres/        # Init scripts
+│       ├── mongo/           # Replica set init
+│       ├── rabbitmq/        # Definitions, config
+│       └── grafana/         # OTEL collector config
+├── pkg/                     # Shared packages
+│   ├── mmodel/              # Domain models (32 files)
+│   ├── constant/            # Error codes, action constants, HTTP constants
+│   ├── errors.go            # Typed error structs + ValidateBusinessError
+│   ├── gold/                # ANTLR4 transaction DSL grammar + parser
+│   ├── net/http/            # Middleware, pagination, protected routes
+│   ├── transaction/         # Transaction processing utilities
+│   ├── mongo/               # MongoDB utilities
+│   ├── repository/          # Repository interfaces
+│   ├── pagination/          # Pagination helpers
+│   └── utils/               # General utilities
+├── tests/                   # Integration + chaos tests
+├── scripts/                 # Build/CI scripts
+├── mk/                      # Makefile includes (coverage, tests)
+├── docs/PROJECT_RULES.md    # Coding standards (1130 lines)
+├── Makefile                 # Root orchestrator
+├── go.mod                   # Module: github.com/LerianStudio/midaz/v3
+└── go.sum
+```
+
+## 3. Domain Models
+
+All models live in `pkg/mmodel/`. Key entities:
+
+### 3.1 Organization
+- Fields: ID, ParentOrganizationID, LegalName, DoingBusinessAs, LegalDocument, Address, Status, Metadata, CreatedAt, UpdatedAt, DeletedAt
+- Address follows ISO 3166-1 alpha-2 for country codes
+
+### 3.2 Ledger
+- Fields: ID, Name, OrganizationID, Status, Settings, Metadata, CreatedAt, UpdatedAt, DeletedAt
+- Settings support per-ledger configuration (accounting validation, route validation, account type validation)
+
+### 3.3 Account
+- Fields: ID, Name, ParentAccountID, EntityID, AssetCode, OrganizationID, LedgerID, PortfolioID, SegmentID, Status, Alias, Type, Blocked, Metadata, CreatedAt, UpdatedAt, DeletedAt
+- Alias format: `@<identifier>` (unique per ledger)
+- Type: user-defined (e.g., "deposit", "expense", "revenue"); "external" is system-reserved
+- Sub-accounts via ParentAccountID
+
+### 3.4 Asset
+- Fields: ID, Name, Type, Code, Status, OrganizationID, LedgerID, Metadata, CreatedAt, UpdatedAt, DeletedAt
+- Types: currency, crypto, commodities, others
+- Code: uppercase alphanumeric; currency codes follow ISO-4217
+
+### 3.5 Transaction
+- Fields: ID, ParentTransactionID, Description, Template, Status, Amount, AmountScale, AssetCode, ChartOfAccountsGroupName, Source, Destination, Metadata, CreatedAt, UpdatedAt, DeletedAt
+- Status lifecycle: ACTIVE → (revert) | PENDING → COMMIT/CANCEL
+- Source/Destination contain arrays of operations with amount/share/remaining distribution
+
+### 3.6 Balance
+- Fields: ID, OrganizationID, LedgerID, AccountID, Alias, AssetCode, Available, OnHold, Scale, Status, AllowSending, AllowReceiving, Version, CreatedAt, UpdatedAt, DeletedAt
+- Optimistic concurrency via Version field (lock version)
+- Supports additional balances per account (e.g., multi-currency)
+- Balance history queries via timestamp
+
+### 3.7 Operation Route / Transaction Route
+- Operation routes define per-operation rules (source/destination/bidirectional)
+- Transaction routes compose multiple operation routes for accounting validation
+- Account rules: alias-based or account-type-based validation
+
+### 3.8 Account Type
+- Custom account types per organization/ledger
+- KeyValue identifier (alphanumeric + underscore + hyphen)
+
+### 3.9 Holder (CRM)
+- Customer/entity management with encrypted PII
+- Alias management with account associations
+- Related parties support
+
+## 4. API Reference
+
+### 4.1 Ledger API (port 3002)
+
+Base path: `/v1`
+
+#### Onboarding Resources
+
+| Method | Path | Description |
+|--------|------|-------------|
+| POST | /organizations | Create organization |
+| GET | /organizations | List organizations |
+| GET | /organizations/:id | Get organization |
+| PATCH | /organizations/:id | Update organization |
+| DELETE | /organizations/:id | Delete organization |
+| HEAD | /organizations/metrics/count | Count organizations |
+| POST | /organizations/:org_id/ledgers | Create ledger |
+| GET | /organizations/:org_id/ledgers | List ledgers |
+| GET | /organizations/:org_id/ledgers/:id | Get ledger |
+| PATCH | /organizations/:org_id/ledgers/:id | Update ledger |
+| DELETE | /organizations/:org_id/ledgers/:id | Delete ledger |
+| GET | /organizations/:org_id/ledgers/:id/settings | Get ledger settings |
+| PATCH | /organizations/:org_id/ledgers/:id/settings | Update ledger settings |
+| POST | /organizations/:org_id/ledgers/:lid/assets | Create asset |
+| GET | /organizations/:org_id/ledgers/:lid/assets | List assets |
+| GET | /organizations/:org_id/ledgers/:lid/assets/:id | Get asset |
+| PATCH | /organizations/:org_id/ledgers/:lid/assets/:id | Update asset |
+| DELETE | /organizations/:org_id/ledgers/:lid/assets/:id | Delete asset |
+| POST | /organizations/:org_id/ledgers/:lid/portfolios | Create portfolio |
+| GET | /organizations/:org_id/ledgers/:lid/portfolios | List portfolios |
+| GET | /organizations/:org_id/ledgers/:lid/portfolios/:id | Get portfolio |
+| PATCH | /organizations/:org_id/ledgers/:lid/portfolios/:id | Update portfolio |
+| DELETE | /organizations/:org_id/ledgers/:lid/portfolios/:id | Delete portfolio |
+| POST | /organizations/:org_id/ledgers/:lid/segments | Create segment |
+| GET | /organizations/:org_id/ledgers/:lid/segments | List segments |
+| GET | /organizations/:org_id/ledgers/:lid/segments/:id | Get segment |
+| PATCH | /organizations/:org_id/ledgers/:lid/segments/:id | Update segment |
+| DELETE | /organizations/:org_id/ledgers/:lid/segments/:id | Delete segment |
+| POST | /organizations/:org_id/ledgers/:lid/accounts | Create account |
+| GET | /organizations/:org_id/ledgers/:lid/accounts | List accounts |
+| GET | /organizations/:org_id/ledgers/:lid/accounts/:id | Get account |
+| GET | /organizations/:org_id/ledgers/:lid/accounts/alias/:alias | Get account by alias |
+| GET | /organizations/:org_id/ledgers/:lid/accounts/external/:code | Get external account |
+| PATCH | /organizations/:org_id/ledgers/:lid/accounts/:id | Update account |
+| DELETE | /organizations/:org_id/ledgers/:lid/accounts/:id | Delete account |
+| POST | /organizations/:org_id/ledgers/:lid/account-types | Create account type |
+| GET | /organizations/:org_id/ledgers/:lid/account-types | List account types |
+| GET | /organizations/:org_id/ledgers/:lid/account-types/:id | Get account type |
+| PATCH | /organizations/:org_id/ledgers/:lid/account-types/:id | Update account type |
+| DELETE | /organizations/:org_id/ledgers/:lid/account-types/:id | Delete account type |
+
+#### Transaction Resources
+
+| Method | Path | Description |
+|--------|------|-------------|
+| POST | .../transactions/json | Create transaction (JSON) |
+| POST | .../transactions/dsl | Create transaction (Gold DSL) |
+| POST | .../transactions/inflow | Create inflow transaction |
+| POST | .../transactions/outflow | Create outflow transaction |
+| POST | .../transactions/annotation | Create annotation transaction |
+| POST | .../transactions/:tid/commit | Commit pending transaction |
+| POST | .../transactions/:tid/cancel | Cancel pending transaction |
+| POST | .../transactions/:tid/revert | Revert transaction |
+| PATCH | .../transactions/:tid | Update transaction metadata |
+| GET | .../transactions | List transactions |
+| GET | .../transactions/:tid | Get transaction |
+| HEAD | .../transactions/metrics/count | Count transactions |
+| GET | .../accounts/:aid/operations | List operations by account |
+| GET | .../accounts/:aid/operations/:oid | Get operation |
+| PATCH | .../transactions/:tid/operations/:oid | Update operation |
+| PUT | .../asset-rates | Create/update asset rate |
+| GET | .../asset-rates/:external_id | Get asset rate |
+| GET | .../asset-rates/from/:asset_code | List asset rates by code |
+| GET | .../balances | List balances |
+| GET | .../balances/:bid | Get balance |
+| GET | .../balances/:bid/history | Get balance at timestamp |
+| PATCH | .../balances/:bid | Update balance |
+| DELETE | .../balances/:bid | Delete balance |
+| GET | .../accounts/:aid/balances | List balances by account |
+| GET | .../accounts/:aid/balances/history | Account balances at timestamp |
+| GET | .../accounts/alias/:alias/balances | Balances by alias |
+| GET | .../accounts/external/:code/balances | Balances by external code |
+| POST | .../accounts/:aid/balances | Create additional balance |
+| POST | .../operation-routes | Create operation route |
+| GET | .../operation-routes | List operation routes |
+| GET | .../operation-routes/:orid | Get operation route |
+| PATCH | .../operation-routes/:orid | Update operation route |
+| DELETE | .../operation-routes/:orid | Delete operation route |
+| POST | .../transaction-routes | Create transaction route |
+| GET | .../transaction-routes | List transaction routes |
+| GET | .../transaction-routes/:trid | Get transaction route |
+| PATCH | .../transaction-routes/:trid | Update transaction route |
+| DELETE | .../transaction-routes/:trid | Delete transaction route |
+
+#### Settings / Metadata
+
+| Method | Path | Description |
+|--------|------|-------------|
+| POST | /v1/settings/metadata-indexes/entities/:entity_name | Create metadata index |
+| GET | /v1/settings/metadata-indexes | List metadata indexes |
+| DELETE | /v1/settings/metadata-indexes/entities/:entity_name/key/:key | Delete metadata index |
+
+#### System
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | /health | Health check |
+| GET | /version | Version info |
+| GET | /swagger/* | Swagger UI |
+
+### 4.2 CRM API (port 4003)
+
+Manages holders, aliases, related parties. Uses MongoDB for persistence. Supports encrypted PII fields.
+
+## 5. Error System
+
+### 5.1 Error Codes (pkg/constant/errors.go)
+
+Numeric codes 0001–0161 for ledger errors. CRM errors prefixed with `CRM-`.
+
+Key error codes:
+- `0007` ErrEntityNotFound
+- `0009` ErrMissingFieldsInRequest
+- `0017` ErrInvalidScriptFormat (DSL errors)
+- `0018` ErrInsufficientFunds
+- `0020` ErrAliasUnavailability
+- `0041` ErrTokenMissing
+- `0042` ErrInvalidToken
+- `0043` ErrInsufficientPrivileges
+- `0046` ErrInternalServer
+- `0047` ErrBadRequest
+- `0084` ErrIdempotencyKey
+- `0086` ErrLockVersionAccountBalance (race condition)
+- `0095` ErrMessageBrokerUnavailable
+- `0146` ErrTenantNotProvisioned
+- `0159` ErrTenantServiceSuspended
+- `0160` ErrTenantNotFound
+
+### 5.2 Error Types (pkg/errors.go)
+
+| Type | HTTP Status | Use Case |
+|------|-------------|----------|
+| EntityNotFoundError | 404 | Entity not found |
+| ValidationError | 400 | Input validation failures |
+| EntityConflictError | 409 | Duplicate entities |
+| UnauthorizedError | 401 | Missing/invalid auth |
+| ForbiddenError | 403 | Insufficient privileges |
+| UnprocessableOperationError | 422 | Business rule violations |
+| FailedPreconditionError | 412 | Configuration errors |
+| ServiceUnavailableError | 503 | Infrastructure failures |
+| InternalServerError | 500 | Unexpected errors |
+| ValidationKnownFieldsError | 400 | Field-level validation |
+| ValidationUnknownFieldsError | 400 | Unexpected fields |
+
+### 5.3 Error Handling Pattern
+
+```go
+// Business errors: return directly
+if errors.Is(err, constant.ErrEntityNotFound) {
+    return nil, pkg.ValidateBusinessError(constant.ErrEntityNotFound, "Entity")
+}
+
+// Technical errors: wrap with context
+return nil, fmt.Errorf("failed to create entity: %w", err)
+```
+
+## 6. Environment Variables
+
+### 6.1 Ledger Component
+
+#### Server
+| Variable | Default | Description |
+|----------|---------|-------------|
+| ENV_NAME | development | Environment name |
+| VERSION | v3.6.0 | Application version |
+| SERVER_PORT | 3002 | HTTP port |
+| SERVER_ADDRESS | :3002 | Listen address |
+| LOG_LEVEL | debug | Log level |
+
+#### Auth
+| Variable | Default | Description |
+|----------|---------|-------------|
+| PLUGIN_AUTH_ENABLED | false | Enable auth middleware |
+| PLUGIN_AUTH_HOST | — | Auth service host |
+
+#### PostgreSQL — Onboarding
+| Variable | Default | Description |
+|----------|---------|-------------|
+| DB_ONBOARDING_HOST | midaz-postgres-primary | Primary host |
+| DB_ONBOARDING_USER | midaz | Username |
+| DB_ONBOARDING_PASSWORD | lerian | Password |
+| DB_ONBOARDING_NAME | onboarding | Database name |
+| DB_ONBOARDING_PORT | 5701 | Port |
+| DB_ONBOARDING_SSLMODE | disable | SSL mode |
+| DB_ONBOARDING_REPLICA_HOST | midaz-postgres-replica | Replica host |
+| DB_ONBOARDING_REPLICA_PORT | 5702 | Replica port |
+| DB_ONBOARDING_MAX_OPEN_CONNS | 3000 | Max open connections |
+| DB_ONBOARDING_MAX_IDLE_CONNS | 3000 | Max idle connections |
+
+#### PostgreSQL — Transaction
+| Variable | Default | Description |
+|----------|---------|-------------|
+| DB_TRANSACTION_HOST | midaz-postgres-primary | Primary host |
+| DB_TRANSACTION_USER | midaz | Username |
+| DB_TRANSACTION_PASSWORD | lerian | Password |
+| DB_TRANSACTION_NAME | transaction | Database name |
+| DB_TRANSACTION_PORT | 5701 | Port |
+| DB_TRANSACTION_SSLMODE | disable | SSL mode |
+| DB_TRANSACTION_REPLICA_HOST | midaz-postgres-replica | Replica host |
+| DB_TRANSACTION_REPLICA_PORT | 5702 | Replica port |
+| DB_TRANSACTION_MAX_OPEN_CONNS | 3000 | Max open connections |
+| DB_TRANSACTION_MAX_IDLE_CONNS | 3000 | Max idle connections |
+
+#### MongoDB — Onboarding
+| Variable | Default | Description |
+|----------|---------|-------------|
+| MONGO_ONBOARDING_URI | mongodb | Connection URI scheme |
+| MONGO_ONBOARDING_HOST | midaz-mongodb | Host |
+| MONGO_ONBOARDING_NAME | onboarding | Database name |
+| MONGO_ONBOARDING_USER | midaz | Username |
+| MONGO_ONBOARDING_PASSWORD | lerian | Password |
+| MONGO_ONBOARDING_PORT | 5703 | Port |
+| MONGO_ONBOARDING_MAX_POOL_SIZE | 1000 | Max pool size |
+
+#### MongoDB — Transaction
+| Variable | Default | Description |
+|----------|---------|-------------|
+| MONGO_TRANSACTION_URI | mongodb | Connection URI scheme |
+| MONGO_TRANSACTION_HOST | midaz-mongodb | Host |
+| MONGO_TRANSACTION_NAME | transaction | Database name |
+| MONGO_TRANSACTION_USER | midaz | Username |
+| MONGO_TRANSACTION_PASSWORD | lerian | Password |
+| MONGO_TRANSACTION_PORT | 5703 | Port |
+| MONGO_TRANSACTION_MAX_POOL_SIZE | 1000 | Max pool size |
+
+#### Redis
+| Variable | Default | Description |
+|----------|---------|-------------|
+| REDIS_HOST | midaz-valkey:5704 | Host(s), comma-separated for cluster |
+| REDIS_MASTER_NAME | — | Sentinel master name |
+| REDIS_TLS | false | Enable TLS |
+| REDIS_PASSWORD | lerian | Password |
+| REDIS_DB | 0 | Database index |
+| REDIS_PROTOCOL | 3 | RESP protocol version |
+| REDIS_POOL_SIZE | 10 | Connection pool size |
+| REDIS_MAX_RETRIES | 3 | Max retries |
+
+#### RabbitMQ
+| Variable | Default | Description |
+|----------|---------|-------------|
+| RABBITMQ_URI | amqp | Protocol scheme |
+| RABBITMQ_HOST | midaz-rabbitmq | Host |
+| RABBITMQ_PORT_HOST | 3003 | Management port |
+| RABBITMQ_PORT_AMQP | 3004 | AMQP port |
+| RABBITMQ_DEFAULT_USER | transaction | Username |
+| RABBITMQ_DEFAULT_PASS | lerian | Password |
+| RABBITMQ_NUMBERS_OF_WORKERS | 5 | Consumer workers |
+| RABBITMQ_NUMBERS_OF_PREFETCH | 10 | Prefetch count |
+| RABBITMQ_TRANSACTION_ASYNC | false | Enable async mode |
+| RABBITMQ_VHOST | — | Virtual host |
+
+#### Bulk Recorder
+| Variable | Default | Description |
+|----------|---------|-------------|
+| BULK_RECORDER_ENABLED | true | Enable bulk mode |
+| BULK_RECORDER_SIZE | workers×prefetch | Batch size |
+| BULK_RECORDER_FLUSH_TIMEOUT_MS | 100 | Flush timeout (ms) |
+| BULK_RECORDER_MAX_ROWS_PER_INSERT | 1000 | Max rows per INSERT |
+
+#### Circuit Breaker (RabbitMQ)
+| Variable | Default | Description |
+|----------|---------|-------------|
+| RABBITMQ_CIRCUIT_BREAKER_CONSECUTIVE_FAILURES | 15 | Failures before open |
+| RABBITMQ_CIRCUIT_BREAKER_FAILURE_RATIO | 50 | Failure % to trigger |
+| RABBITMQ_CIRCUIT_BREAKER_INTERVAL | 120 | Counting window (sec) |
+| RABBITMQ_CIRCUIT_BREAKER_MAX_REQUESTS | 3 | Half-open requests |
+| RABBITMQ_CIRCUIT_BREAKER_TIMEOUT | 30 | Open→half-open wait (sec) |
+
+#### OpenTelemetry
+| Variable | Default | Description |
+|----------|---------|-------------|
+| OTEL_RESOURCE_SERVICE_NAME | ledger | Service name |
+| OTEL_LIBRARY_NAME | github.com/LerianStudio/midaz/v3/components/ledger | Library name |
+| OTEL_EXPORTER_OTLP_ENDPOINT | midaz-otel-lgtm:4317 | OTLP gRPC endpoint |
+| ENABLE_TELEMETRY | false | Enable telemetry |
+
+#### Multi-Tenant
+| Variable | Default | Description |
+|----------|---------|-------------|
+| MULTI_TENANT_ENABLED | false | Enable multi-tenant mode |
+| MULTI_TENANT_URL | — | Tenant Manager API URL |
+| MULTI_TENANT_SERVICE_API_KEY | — | Service API key |
+| MULTI_TENANT_CIRCUIT_BREAKER_THRESHOLD | 5 | CB failures threshold |
+| MULTI_TENANT_CIRCUIT_BREAKER_TIMEOUT_SEC | 30 | CB timeout |
+| MULTI_TENANT_CACHE_TTL_SEC | 120 | Tenant config cache TTL |
+| MULTI_TENANT_REDIS_HOST | — | Redis for tenant Pub/Sub |
+| MULTI_TENANT_REDIS_PORT | 6379 | Redis port |
+| MULTI_TENANT_REDIS_TLS | false | Redis TLS |
+
+#### Pagination
+| Variable | Default | Description |
+|----------|---------|-------------|
+| MAX_PAGINATION_LIMIT | 100 | Max items per page |
+| MAX_PAGINATION_MONTH_DATE_RANGE | 3 | Max date range (months) |
+
+#### Workers
+| Variable | Default | Description |
+|----------|---------|-------------|
+| BALANCE_SYNC_MAX_WORKERS | 5 | Balance sync worker count |
+| SETTINGS_CACHE_TTL | 5m | Settings cache duration |
+
+### 6.2 CRM Component
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| SERVER_PORT | 4003 | HTTP port |
+| MONGO_URI | mongodb | Connection scheme |
+| MONGO_HOST | midaz-mongodb | Host |
+| MONGO_NAME | crm | Database |
+| MONGO_USER | midaz | Username |
+| MONGO_PASSWORD | lerian | Password |
+| MONGO_PORT | 5703 | Port |
+| LCRYPTO_HASH_SECRET_KEY | — | PII hash key |
+| LCRYPTO_ENCRYPT_SECRET_KEY | — | PII encryption key |
+| PLUGIN_AUTH_ENABLED | false | Enable auth |
+| APPLICATION_NAME | ledger | Application identity |
+
+### 6.3 Infrastructure
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| DB_HOST | midaz-postgres-primary | PostgreSQL primary |
+| DB_PORT | 5701 | PostgreSQL port |
+| DB_REPLICA_PORT | 5702 | Replica port |
+| MONGO_PORT | 5703 | MongoDB port |
+| REDIS_PORT | 5704 | Valkey/Redis port |
+| RABBITMQ_PORT_HOST | 3003 | RabbitMQ management |
+| RABBITMQ_PORT_AMQP | 3004 | RabbitMQ AMQP |
+
+## 7. Build & Development
+
+### 7.1 Prerequisites
+
+- Go 1.25+
+- Docker (with `docker compose`)
+- golangci-lint v2.4.0
+
+### 7.2 Makefile Commands
+
+```bash
+# Setup
+make set-env                  # Copy .env.example → .env for all components
+make dev-setup                # Install tools + git hooks + env files
+make setup-git-hooks          # Configure git hooks
+
+# Build & Run
+make build                    # Build ledger + CRM
+make up                       # Start all services (infra → ledger → CRM)
+make down                     # Stop all services
+make restart                  # Restart all services
+make rebuild-up               # Rebuild and restart
+make logs                     # Show logs
+
+# Quality
+make lint                     # Lint all components
+make format                   # Format code
+make tidy                     # go mod tidy
+make sec                      # Security checks (gosec + govulncheck)
+
+# Testing
+make test                     # Run all tests
+make test-unit                # Unit tests
+make test-integration         # Integration tests (testcontainers)
+make test-fuzz                # Fuzz tests
+make test-bench               # Benchmarks
+make test-chaos-system        # Chaos tests with Docker stack
+
+# Coverage
+make coverage-unit            # Unit test coverage
+make coverage-integration     # Integration test coverage
+make coverage                 # All coverage
+
+# Migrations
+make migrate-lint             # Lint migrations
+make migrate-create COMPONENT=onboarding NAME=my_migration
+
+# Docs
+make generate-docs            # Generate Swagger docs
+```
+
+### 7.3 Docker Images
+
+- **Ledger**: `golang:1.25-alpine` → `gcr.io/distroless/static-debian12`, exposed port 3002
+- **CRM**: `golang:1.25-alpine` → `gcr.io/distroless/static-debian12`, exposed port 4003
+- Both run as `nonroot:nonroot`
+
+## 8. Key Dependencies
+
+| Dependency | Version | Purpose |
+|------------|---------|---------|
+| github.com/LerianStudio/lib-commons/v4 | — | Shared library (logging, telemetry, Redis, tenant-manager, HTTP) |
+| github.com/LerianStudio/lib-auth/v2 | v2.6.0 | Authentication middleware |
+| github.com/gofiber/fiber/v2 | v2.52.12 | HTTP framework |
+| github.com/jackc/pgx/v5 | v5.9.1 | PostgreSQL driver |
+| go.mongodb.org/mongo-driver | v1.17.9 | MongoDB driver |
+| github.com/rabbitmq/amqp091-go | v1.10.0 | RabbitMQ AMQP client |
+| github.com/redis/go-redis/v9 | v9.18.0 | Redis client |
+| github.com/shopspring/decimal | v1.4.0 | Precise decimal arithmetic |
+| github.com/antlr4-go/antlr/v4 | v4.13.1 | ANTLR4 for Gold DSL parser |
+| github.com/Masterminds/squirrel | v1.5.4 | SQL query builder |
+| github.com/testcontainers/testcontainers-go | v0.41.0 | Integration test containers |
+| github.com/vmihailenco/msgpack/v5 | v5.4.1 | MessagePack serialization |
+| go.opentelemetry.io/otel | v1.42.0 | OpenTelemetry tracing |
+| go.uber.org/mock | v0.6.0 | Mock generation |
+
+## 9. Multi-Tenancy
+
+When `MULTI_TENANT_ENABLED=true`:
+
+1. **Requires** `PLUGIN_AUTH_ENABLED=true` (JWT provides tenant ID)
+2. Tenant-manager client resolves per-tenant database connections
+3. TenantMiddleware injects tenant-scoped PG/Mongo connections into request context
+4. Event-driven tenant discovery via Redis Pub/Sub
+5. TenantCache provides process-local caching with configurable TTL
+6. On tenant suspend/delete: all connections (PG, Mongo, RabbitMQ) are closed and cache invalidated
+7. RabbitMQ consumers are started/stopped per tenant dynamically
+8. Modules: `onboarding` and `transaction` with independent PG and Mongo managers
+
+## 10. Gold DSL
+
+The Gold DSL (`pkg/gold/`) is an ANTLR4-based domain-specific language for defining transactions:
+
+```
+send $100.00 USD
+  from @source_account
+  to @destination_account
+```
+
+Grammar: `pkg/gold/Transaction.g4`
+Parser: `pkg/gold/parser/`
+Transaction builder: `pkg/gold/transaction/`
+
+## 11. Testing
+
+### Test Types
+- **Unit tests**: `*_test.go` files alongside source
+- **Integration tests**: `*_integration_test.go` with testcontainers
+- **Fuzz tests**: `*_fuzz_test.go` for property-based testing
+- **Property tests**: `*_property_test.go` for invariant verification
+- **Chaos tests**: `*_chaos_test.go` for resilience testing
+- **Goroutine leak detection**: `goleak_test.go` in bootstrap
+
+### Build Tags
+- `integration`: testcontainers-based integration tests
+- No tag: unit tests (default)

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -270,25 +270,59 @@ Manages holders, aliases, related parties. Uses MongoDB for persistence. Support
 
 ### 5.1 Error Codes (pkg/constant/errors.go)
 
-Numeric codes 0001–0161 for ledger errors. CRM errors prefixed with `CRM-`.
+161 numeric codes (0001–0161) for ledger errors. 29 CRM errors prefixed with `CRM-`.
 
-Key error codes:
-- `0007` ErrEntityNotFound
-- `0009` ErrMissingFieldsInRequest
-- `0017` ErrInvalidScriptFormat (DSL errors)
-- `0018` ErrInsufficientFunds
-- `0020` ErrAliasUnavailability
-- `0041` ErrTokenMissing
-- `0042` ErrInvalidToken
-- `0043` ErrInsufficientPrivileges
-- `0046` ErrInternalServer
-- `0047` ErrBadRequest
-- `0084` ErrIdempotencyKey
-- `0086` ErrLockVersionAccountBalance (race condition)
-- `0095` ErrMessageBrokerUnavailable
-- `0146` ErrTenantNotProvisioned
-- `0159` ErrTenantServiceSuspended
-- `0160` ErrTenantNotFound
+#### Ledger Error Codes (selected key codes)
+- `0007` ErrEntityNotFound — entity not found
+- `0009` ErrMissingFieldsInRequest — required fields missing
+- `0017` ErrInvalidScriptFormat — Gold DSL parse error
+- `0018` ErrInsufficientFunds — insufficient funds
+- `0020` ErrAliasUnavailability — alias already in use
+- `0041` ErrTokenMissing — no auth token
+- `0042` ErrInvalidToken — expired/invalid token
+- `0043` ErrInsufficientPrivileges — forbidden
+- `0046` ErrInternalServer — unexpected server error
+- `0047` ErrBadRequest — malformed request
+- `0084` ErrIdempotencyKey — duplicate idempotency key
+- `0086` ErrLockVersionAccountBalance — race condition detected
+- `0095` ErrMessageBrokerUnavailable — RabbitMQ down
+- `0097` ErrOverFlowInt64 — integer overflow
+- `0125` ErrInvalidTransactionNonPositiveValue — zero/negative value
+- `0146` ErrTenantNotProvisioned — tenant DB not initialized
+- `0159` ErrTenantServiceSuspended — tenant service suspended
+- `0160` ErrTenantNotFound — tenant does not exist
+- `0161` ErrTenantServiceUnavailable — tenant resolution failed
+
+#### CRM Error Codes (all 29)
+- `CRM-0001` ErrInvalidMetadataNestingCRM — nested metadata not allowed
+- `CRM-0002` ErrMetadataKeyLengthExceededCRM — key too long
+- `CRM-0003` ErrMissingFieldsInRequestCRM — required fields missing
+- `CRM-0004` ErrInvalidFieldTypeInRequest — wrong field type
+- `CRM-0005` ErrInvalidPathParameterCRM — invalid path parameter
+- `CRM-0006` ErrHolderNotFound — holder not found
+- `CRM-0007` ErrUnexpectedFieldsInTheRequestCRM — unexpected fields
+- `CRM-0008` ErrAliasNotFound — alias not found
+- `CRM-0009` ErrPaginationLimitExceededCRM — pagination limit exceeded
+- `CRM-0010` ErrDocumentAssociationError — document association error
+- `CRM-0011` ErrInvalidSortOrderCRM — invalid sort order
+- `CRM-0012` ErrMetadataValueLengthExceededCRM — value too long
+- `CRM-0013` ErrAccountAlreadyAssociated — account already associated
+- `CRM-0014` ErrInternalServerCRM — internal server error
+- `CRM-0015` ErrBadRequestCRM — bad request
+- `CRM-0016` ErrInvalidQueryParameterCRM — invalid query parameter
+- `CRM-0017` ErrHolderHasAliases — holder has aliases (cannot delete)
+- `CRM-0018` ErrMissingHeadersInRequest — required headers missing
+- `CRM-0019` ErrMetadataQueryInvalidFormat — metadata query format error
+- `CRM-0020` ErrMetadataQueryInvalidKey — metadata query invalid key
+- `CRM-0021` ErrMetadataQueryContainsOperator — metadata query contains operator
+- `CRM-0022` ErrInvalidHeaderValue — invalid header value
+- `CRM-0023` ErrAliasClosingDateBeforeCreation — closing date before creation
+- `CRM-0024` ErrRelatedPartyNotFound — related party not found
+- `CRM-0025` ErrInvalidRelatedPartyRole — invalid related party role
+- `CRM-0026` ErrRelatedPartyDocumentRequired — document required
+- `CRM-0027` ErrRelatedPartyNameRequired — name required
+- `CRM-0028` ErrRelatedPartyStartDateRequired — start date required
+- `CRM-0029` ErrRelatedPartyEndDateInvalid — end date before start date
 
 ### 5.2 Error Types (pkg/errors.go)
 
@@ -320,24 +354,29 @@ return nil, fmt.Errorf("failed to create entity: %w", err)
 
 ## 6. Environment Variables
 
+Source of truth: `components/ledger/internal/bootstrap/config.go` (Ledger Config struct) and
+`components/crm/internal/bootstrap/config.go` (CRM Config struct). Defaults in parentheses
+are set programmatically by `applyConfigDefaults()`.
+
 ### 6.1 Ledger Component
 
-#### Server
+#### Application
 | Variable | Default | Description |
 |----------|---------|-------------|
-| ENV_NAME | development | Environment name |
+| APPLICATION_NAME | — | Application identity (tenant-manager service name) |
+| ENV_NAME | development | Environment: development, staging, uat, production, local |
 | VERSION | v3.6.0 | Application version |
-| SERVER_PORT | 3002 | HTTP port |
-| SERVER_ADDRESS | :3002 | Listen address |
+| SERVER_ADDRESS | :3002 | Listen address (single port for all APIs) |
 | LOG_LEVEL | debug | Log level |
 
-#### Auth
+#### Auth / Casdoor
 | Variable | Default | Description |
 |----------|---------|-------------|
 | PLUGIN_AUTH_ENABLED | false | Enable auth middleware |
 | PLUGIN_AUTH_HOST | — | Auth service host |
+| CASDOOR_JWK_ADDRESS | — | JWK endpoint for Casdoor JWT validation |
 
-#### PostgreSQL — Onboarding
+#### PostgreSQL — Onboarding (Primary)
 | Variable | Default | Description |
 |----------|---------|-------------|
 | DB_ONBOARDING_HOST | midaz-postgres-primary | Primary host |
@@ -346,12 +385,20 @@ return nil, fmt.Errorf("failed to create entity: %w", err)
 | DB_ONBOARDING_NAME | onboarding | Database name |
 | DB_ONBOARDING_PORT | 5701 | Port |
 | DB_ONBOARDING_SSLMODE | disable | SSL mode |
-| DB_ONBOARDING_REPLICA_HOST | midaz-postgres-replica | Replica host |
-| DB_ONBOARDING_REPLICA_PORT | 5702 | Replica port |
-| DB_ONBOARDING_MAX_OPEN_CONNS | 3000 | Max open connections |
-| DB_ONBOARDING_MAX_IDLE_CONNS | 3000 | Max idle connections |
 
-#### PostgreSQL — Transaction
+#### PostgreSQL — Onboarding (Replica)
+| Variable | Default | Description |
+|----------|---------|-------------|
+| DB_ONBOARDING_REPLICA_HOST | midaz-postgres-replica | Replica host |
+| DB_ONBOARDING_REPLICA_USER | midaz | Replica username |
+| DB_ONBOARDING_REPLICA_PASSWORD | lerian | Replica password |
+| DB_ONBOARDING_REPLICA_NAME | onboarding | Replica database name |
+| DB_ONBOARDING_REPLICA_PORT | 5702 | Replica port |
+| DB_ONBOARDING_REPLICA_SSLMODE | disable | Replica SSL mode |
+| DB_ONBOARDING_MAX_OPEN_CONNS | 3000 | Max open connections (shared) |
+| DB_ONBOARDING_MAX_IDLE_CONNS | 3000 | Max idle connections (shared) |
+
+#### PostgreSQL — Transaction (Primary)
 | Variable | Default | Description |
 |----------|---------|-------------|
 | DB_TRANSACTION_HOST | midaz-postgres-primary | Primary host |
@@ -360,10 +407,18 @@ return nil, fmt.Errorf("failed to create entity: %w", err)
 | DB_TRANSACTION_NAME | transaction | Database name |
 | DB_TRANSACTION_PORT | 5701 | Port |
 | DB_TRANSACTION_SSLMODE | disable | SSL mode |
+
+#### PostgreSQL — Transaction (Replica)
+| Variable | Default | Description |
+|----------|---------|-------------|
 | DB_TRANSACTION_REPLICA_HOST | midaz-postgres-replica | Replica host |
+| DB_TRANSACTION_REPLICA_USER | midaz | Replica username |
+| DB_TRANSACTION_REPLICA_PASSWORD | lerian | Replica password |
+| DB_TRANSACTION_REPLICA_NAME | transaction | Replica database name |
 | DB_TRANSACTION_REPLICA_PORT | 5702 | Replica port |
-| DB_TRANSACTION_MAX_OPEN_CONNS | 3000 | Max open connections |
-| DB_TRANSACTION_MAX_IDLE_CONNS | 3000 | Max idle connections |
+| DB_TRANSACTION_REPLICA_SSLMODE | disable | Replica SSL mode |
+| DB_TRANSACTION_MAX_OPEN_CONNS | 3000 | Max open connections (shared) |
+| DB_TRANSACTION_MAX_IDLE_CONNS | 3000 | Max idle connections (shared) |
 
 #### MongoDB — Onboarding
 | Variable | Default | Description |
@@ -374,6 +429,7 @@ return nil, fmt.Errorf("failed to create entity: %w", err)
 | MONGO_ONBOARDING_USER | midaz | Username |
 | MONGO_ONBOARDING_PASSWORD | lerian | Password |
 | MONGO_ONBOARDING_PORT | 5703 | Port |
+| MONGO_ONBOARDING_PARAMETERS | — | Extra connection params (appended to URI) |
 | MONGO_ONBOARDING_MAX_POOL_SIZE | 1000 | Max pool size |
 
 #### MongoDB — Transaction
@@ -385,71 +441,103 @@ return nil, fmt.Errorf("failed to create entity: %w", err)
 | MONGO_TRANSACTION_USER | midaz | Username |
 | MONGO_TRANSACTION_PASSWORD | lerian | Password |
 | MONGO_TRANSACTION_PORT | 5703 | Port |
+| MONGO_TRANSACTION_PARAMETERS | — | Extra connection params |
 | MONGO_TRANSACTION_MAX_POOL_SIZE | 1000 | Max pool size |
 
-#### Redis
+#### Redis / Valkey
 | Variable | Default | Description |
 |----------|---------|-------------|
-| REDIS_HOST | midaz-valkey:5704 | Host(s), comma-separated for cluster |
-| REDIS_MASTER_NAME | — | Sentinel master name |
-| REDIS_TLS | false | Enable TLS |
+| REDIS_HOST | midaz-valkey:5704 | Host(s); comma-separated for cluster/sentinel |
+| REDIS_MASTER_NAME | — | Sentinel master name (enables sentinel topology) |
 | REDIS_PASSWORD | lerian | Password |
 | REDIS_DB | 0 | Database index |
-| REDIS_PROTOCOL | 3 | RESP protocol version |
-| REDIS_POOL_SIZE | 10 | Connection pool size |
-| REDIS_MAX_RETRIES | 3 | Max retries |
+| REDIS_PROTOCOL | (3) | RESP protocol version |
+| REDIS_TLS | false | Enable TLS |
+| REDIS_CA_CERT | — | CA certificate (base64) for TLS |
+| REDIS_USE_GCP_IAM | false | Use GCP IAM auth instead of static password |
+| REDIS_SERVICE_ACCOUNT | — | GCP service account for IAM auth |
+| GOOGLE_APPLICATION_CREDENTIALS | — | GCP credentials (base64) for IAM auth |
+| REDIS_TOKEN_LIFETIME | (60) | GCP IAM token lifetime (minutes) |
+| REDIS_TOKEN_REFRESH_DURATION | (45) | GCP IAM token refresh interval (minutes) |
+| REDIS_POOL_SIZE | (10) | Connection pool size |
+| REDIS_MIN_IDLE_CONNS | 0 | Minimum idle connections |
+| REDIS_READ_TIMEOUT | (3) | Read timeout (seconds) |
+| REDIS_WRITE_TIMEOUT | (3) | Write timeout (seconds) |
+| REDIS_DIAL_TIMEOUT | (5) | Dial timeout (seconds) |
+| REDIS_POOL_TIMEOUT | (2) | Pool wait timeout (seconds) |
+| REDIS_MAX_RETRIES | (3) | Max retries per command |
+| REDIS_MIN_RETRY_BACKOFF | (8) | Min retry backoff (milliseconds) |
+| REDIS_MAX_RETRY_BACKOFF | (1) | Max retry backoff (seconds) |
 
 #### RabbitMQ
 | Variable | Default | Description |
 |----------|---------|-------------|
-| RABBITMQ_URI | amqp | Protocol scheme |
+| RABBITMQ_URI | amqp | Protocol scheme (amqp/amqps) |
 | RABBITMQ_HOST | midaz-rabbitmq | Host |
 | RABBITMQ_PORT_HOST | 3003 | Management port |
 | RABBITMQ_PORT_AMQP | 3004 | AMQP port |
-| RABBITMQ_DEFAULT_USER | transaction | Username |
-| RABBITMQ_DEFAULT_PASS | lerian | Password |
-| RABBITMQ_NUMBERS_OF_WORKERS | 5 | Consumer workers |
-| RABBITMQ_NUMBERS_OF_PREFETCH | 10 | Prefetch count |
-| RABBITMQ_TRANSACTION_ASYNC | false | Enable async mode |
-| RABBITMQ_VHOST | — | Virtual host |
+| RABBITMQ_DEFAULT_USER | transaction | Producer username |
+| RABBITMQ_DEFAULT_PASS | lerian | Producer password |
+| RABBITMQ_CONSUMER_USER | consumer | Consumer username |
+| RABBITMQ_CONSUMER_PASS | lerian | Consumer password |
+| RABBITMQ_VHOST | — | Virtual host (empty = default "/") |
+| RABBITMQ_NUMBERS_OF_WORKERS | 5 | Consumer worker count |
+| RABBITMQ_NUMBERS_OF_PREFETCH | 10 | Prefetch count per worker |
+| RABBITMQ_HEALTH_CHECK_URL | — | Health check URL |
+| RABBITMQ_TLS | false | Enable TLS |
+| RABBITMQ_TRANSACTION_BALANCE_OPERATION_QUEUE | — | Balance operation queue name |
+| RABBITMQ_TRANSACTION_ASYNC | false | Enable async transaction processing |
+| RABBITMQ_OPERATION_TIMEOUT | — | Operation timeout (e.g., "30s") |
+| RABBITMQ_TRANSACTION_EVENTS_ENABLED | false | Enable transaction event exchange |
+| RABBITMQ_TRANSACTION_EVENTS_EXCHANGE | — | Events exchange name |
+| AUDIT_LOG_ENABLED | false | Enable audit log publishing |
+| RABBITMQ_AUDIT_EXCHANGE | — | Audit exchange name |
+| RABBITMQ_AUDIT_KEY | — | Audit routing key |
+
+#### RabbitMQ Circuit Breaker
+| Variable | Default | Description |
+|----------|---------|-------------|
+| RABBITMQ_CIRCUIT_BREAKER_CONSECUTIVE_FAILURES | 15 | Consecutive failures before open |
+| RABBITMQ_CIRCUIT_BREAKER_FAILURE_RATIO | 50 | Failure % to trigger open (0-100) |
+| RABBITMQ_CIRCUIT_BREAKER_INTERVAL | 120 | Failure counting window (seconds) |
+| RABBITMQ_CIRCUIT_BREAKER_MAX_REQUESTS | 3 | Requests allowed in half-open state |
+| RABBITMQ_CIRCUIT_BREAKER_MIN_REQUESTS | 10 | Min requests before ratio evaluated |
+| RABBITMQ_CIRCUIT_BREAKER_TIMEOUT | 30 | Open → half-open wait (seconds) |
+| RABBITMQ_CIRCUIT_BREAKER_HEALTH_CHECK_INTERVAL | 30 | Health check interval (seconds) |
+| RABBITMQ_CIRCUIT_BREAKER_HEALTH_CHECK_TIMEOUT | 10 | Health check timeout (seconds) |
 
 #### Bulk Recorder
 | Variable | Default | Description |
 |----------|---------|-------------|
-| BULK_RECORDER_ENABLED | true | Enable bulk mode |
-| BULK_RECORDER_SIZE | workers×prefetch | Batch size |
-| BULK_RECORDER_FLUSH_TIMEOUT_MS | 100 | Flush timeout (ms) |
-| BULK_RECORDER_MAX_ROWS_PER_INSERT | 1000 | Max rows per INSERT |
-
-#### Circuit Breaker (RabbitMQ)
-| Variable | Default | Description |
-|----------|---------|-------------|
-| RABBITMQ_CIRCUIT_BREAKER_CONSECUTIVE_FAILURES | 15 | Failures before open |
-| RABBITMQ_CIRCUIT_BREAKER_FAILURE_RATIO | 50 | Failure % to trigger |
-| RABBITMQ_CIRCUIT_BREAKER_INTERVAL | 120 | Counting window (sec) |
-| RABBITMQ_CIRCUIT_BREAKER_MAX_REQUESTS | 3 | Half-open requests |
-| RABBITMQ_CIRCUIT_BREAKER_TIMEOUT | 30 | Open→half-open wait (sec) |
+| BULK_RECORDER_ENABLED | (true) | Enable bulk mode |
+| BULK_RECORDER_SIZE | (workers×prefetch) | Batch size (0 = auto-calculated) |
+| BULK_RECORDER_FLUSH_TIMEOUT_MS | (100) | Flush timeout (ms) |
+| BULK_RECORDER_MAX_ROWS_PER_INSERT | (1000) | Max rows per INSERT |
 
 #### OpenTelemetry
 | Variable | Default | Description |
 |----------|---------|-------------|
-| OTEL_RESOURCE_SERVICE_NAME | ledger | Service name |
-| OTEL_LIBRARY_NAME | github.com/LerianStudio/midaz/v3/components/ledger | Library name |
-| OTEL_EXPORTER_OTLP_ENDPOINT | midaz-otel-lgtm:4317 | OTLP gRPC endpoint |
-| ENABLE_TELEMETRY | false | Enable telemetry |
+| OTEL_RESOURCE_SERVICE_NAME | ledger | Service name in traces |
+| OTEL_LIBRARY_NAME | — | Instrumentation library name |
+| OTEL_RESOURCE_SERVICE_VERSION | — | Service version in traces |
+| OTEL_RESOURCE_DEPLOYMENT_ENVIRONMENT | — | Deployment environment in traces |
+| OTEL_EXPORTER_OTLP_ENDPOINT | midaz-otel-lgtm:4317 | OTLP gRPC collector endpoint |
+| ENABLE_TELEMETRY | false | Enable telemetry export |
 
 #### Multi-Tenant
 | Variable | Default | Description |
 |----------|---------|-------------|
 | MULTI_TENANT_ENABLED | false | Enable multi-tenant mode |
 | MULTI_TENANT_URL | — | Tenant Manager API URL |
-| MULTI_TENANT_SERVICE_API_KEY | — | Service API key |
-| MULTI_TENANT_CIRCUIT_BREAKER_THRESHOLD | 5 | CB failures threshold |
-| MULTI_TENANT_CIRCUIT_BREAKER_TIMEOUT_SEC | 30 | CB timeout |
-| MULTI_TENANT_CACHE_TTL_SEC | 120 | Tenant config cache TTL |
-| MULTI_TENANT_REDIS_HOST | — | Redis for tenant Pub/Sub |
-| MULTI_TENANT_REDIS_PORT | 6379 | Redis port |
-| MULTI_TENANT_REDIS_TLS | false | Redis TLS |
+| MULTI_TENANT_SERVICE_API_KEY | — | Service API key for tenant-manager |
+| MULTI_TENANT_CIRCUIT_BREAKER_THRESHOLD | (5) | CB failures before open |
+| MULTI_TENANT_CIRCUIT_BREAKER_TIMEOUT_SEC | (30) | CB open → half-open (seconds) |
+| MULTI_TENANT_CONNECTIONS_CHECK_INTERVAL_SEC | — | Revalidation check interval (seconds) |
+| MULTI_TENANT_CACHE_TTL_SEC | (120) | Tenant config cache TTL (seconds, 0=disabled) |
+| MULTI_TENANT_REDIS_HOST | — | Redis for tenant Pub/Sub events |
+| MULTI_TENANT_REDIS_PORT | 6379 | Redis port for Pub/Sub |
+| MULTI_TENANT_REDIS_PASSWORD | — | Redis password for Pub/Sub |
+| MULTI_TENANT_REDIS_TLS | false | Enable TLS for Pub/Sub Redis |
 
 #### Pagination
 | Variable | Default | Description |
@@ -457,39 +545,88 @@ return nil, fmt.Errorf("failed to create entity: %w", err)
 | MAX_PAGINATION_LIMIT | 100 | Max items per page |
 | MAX_PAGINATION_MONTH_DATE_RANGE | 3 | Max date range (months) |
 
-#### Workers
+#### Balance Sync / Settings
 | Variable | Default | Description |
 |----------|---------|-------------|
-| BALANCE_SYNC_MAX_WORKERS | 5 | Balance sync worker count |
-| SETTINGS_CACHE_TTL | 5m | Settings cache duration |
+| BALANCE_SYNC_MAX_WORKERS | (5) | Balance sync worker count |
+| SETTINGS_CACHE_TTL | (5m) | Settings cache duration (Go duration) |
 
 ### 6.2 CRM Component
 
+Source: `components/crm/internal/bootstrap/config.go`
+
 | Variable | Default | Description |
 |----------|---------|-------------|
-| SERVER_PORT | 4003 | HTTP port |
-| MONGO_URI | mongodb | Connection scheme |
-| MONGO_HOST | midaz-mongodb | Host |
-| MONGO_NAME | crm | Database |
+| ENV_NAME | development | Environment name |
+| PROTO_ADDRESS | — | gRPC listen address (CRM-only) |
+| SERVER_ADDRESS | :4003 | HTTP listen address |
+| LOG_LEVEL | debug | Log level |
+| MONGO_URI | mongodb | Connection URI scheme |
+| MONGO_HOST | midaz-mongodb | MongoDB host |
+| MONGO_NAME | crm | Database name |
 | MONGO_USER | midaz | Username |
 | MONGO_PASSWORD | lerian | Password |
 | MONGO_PORT | 5703 | Port |
-| LCRYPTO_HASH_SECRET_KEY | — | PII hash key |
-| LCRYPTO_ENCRYPT_SECRET_KEY | — | PII encryption key |
-| PLUGIN_AUTH_ENABLED | false | Enable auth |
+| MONGO_PARAMETERS | — | Extra connection parameters |
+| MONGO_MAX_POOL_SIZE | 1000 | Max pool size |
+| LCRYPTO_HASH_SECRET_KEY | — | PII hash key (data security) |
+| LCRYPTO_ENCRYPT_SECRET_KEY | — | PII encryption key (data security) |
+| PLUGIN_AUTH_ADDRESS | — | Auth service address |
+| PLUGIN_AUTH_ENABLED | false | Enable auth middleware |
 | APPLICATION_NAME | ledger | Application identity |
+| OTEL_RESOURCE_SERVICE_NAME | crm | Service name |
+| OTEL_LIBRARY_NAME | — | Instrumentation library name |
+| OTEL_RESOURCE_SERVICE_VERSION | — | Service version |
+| OTEL_RESOURCE_DEPLOYMENT_ENVIRONMENT | — | Deployment environment |
+| OTEL_EXPORTER_OTLP_ENDPOINT | — | OTLP endpoint |
+| ENABLE_TELEMETRY | false | Enable telemetry |
+| MULTI_TENANT_ENABLED | false | Enable multi-tenant mode |
+| MULTI_TENANT_URL | — | Tenant Manager API URL |
+| MULTI_TENANT_TIMEOUT | — | HTTP client timeout (seconds) |
+| MULTI_TENANT_IDLE_TIMEOUT_SEC | — | Idle connection eviction (seconds) |
+| MULTI_TENANT_MAX_TENANT_POOLS | — | Max concurrent tenant pools |
+| MULTI_TENANT_CIRCUIT_BREAKER_THRESHOLD | — | CB failures before open |
+| MULTI_TENANT_CIRCUIT_BREAKER_TIMEOUT_SEC | — | CB timeout (seconds) |
+| MULTI_TENANT_SERVICE_API_KEY | — | Service API key |
+| MULTI_TENANT_CONNECTIONS_CHECK_INTERVAL_SEC | — | Revalidation interval (seconds) |
+| MULTI_TENANT_CACHE_TTL_SEC | (120) | Tenant config cache TTL (seconds) |
+| MULTI_TENANT_REDIS_HOST | — | Redis for Pub/Sub |
+| MULTI_TENANT_REDIS_PORT | 6379 | Redis port |
+| MULTI_TENANT_REDIS_PASSWORD | — | Redis password |
+| MULTI_TENANT_REDIS_TLS | false | TLS for Redis |
 
 ### 6.3 Infrastructure
 
 | Variable | Default | Description |
 |----------|---------|-------------|
 | DB_HOST | midaz-postgres-primary | PostgreSQL primary |
+| DB_USER | midaz | PostgreSQL username |
+| DB_PASSWORD | lerian | PostgreSQL password |
 | DB_PORT | 5701 | PostgreSQL port |
+| MAX_CONNECTIONS | 3000 | PostgreSQL max connections |
+| SHARED_BUFFERS | 1GB | PostgreSQL shared buffers |
+| DB_REPLICA_HOST | midaz-postgres-replica | Replica host |
 | DB_REPLICA_PORT | 5702 | Replica port |
+| REPLICATION_USER | replicator | Replication username |
+| REPLICATION_PASSWORD | — | Replication password |
+| MONGO_HOST | midaz-mongodb | MongoDB host |
+| MONGO_USER | midaz | MongoDB username |
+| MONGO_PASSWORD | lerian | MongoDB password |
 | MONGO_PORT | 5703 | MongoDB port |
+| REDIS_HOST | midaz-valkey | Valkey/Redis host |
 | REDIS_PORT | 5704 | Valkey/Redis port |
-| RABBITMQ_PORT_HOST | 3003 | RabbitMQ management |
-| RABBITMQ_PORT_AMQP | 3004 | RabbitMQ AMQP |
+| REDIS_USER | midaz | Redis username |
+| REDIS_PASSWORD | lerian | Redis password |
+| RABBITMQ_PORT_HOST | 3003 | RabbitMQ management port |
+| RABBITMQ_PORT_AMQP | 3004 | RabbitMQ AMQP port |
+| RABBITMQ_DEFAULT_USER | midaz | RabbitMQ username |
+| RABBITMQ_DEFAULT_PASS | lerian | RabbitMQ password |
+| OTEL_LGTM_INTERNAL_PORT | 3000 | Grafana internal port |
+| OTEL_LGTM_EXTERNAL_PORT | 3100 | Grafana external port |
+| OTEL_LGTM_RECEIVER_GRPC_PORT | 4317 | OTLP gRPC receiver port |
+| OTEL_LGTM_RECEIVER_HTTP_PORT | 4318 | OTLP HTTP receiver port |
+| OTEL_LGTM_ADMIN_USER | midaz | Grafana admin username |
+| OTEL_LGTM_ADMIN_PASSWORD | lerian | Grafana admin password |
 
 ## 7. Build & Development
 

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,72 @@
+# Lerian Midaz
+
+> Enterprise-grade open-source double-entry ledger system. Go 1.25 monorepo (v3 module path) with a unified Ledger HTTP API (onboarding + transaction) and a CRM plugin. Uses PostgreSQL (primary/replica), MongoDB (metadata), RabbitMQ (async transactions), and Valkey/Redis (caching). Supports multi-tenant isolation via lib-commons v4 tenant-manager. Elastic License 2.0.
+
+Midaz implements a financial hierarchy: Organizations → Ledgers → Assets, Portfolios, Segments → Accounts → Transactions/Operations → Balances. The Ledger component exposes a single-port REST API (default :3002) covering both onboarding (org/ledger/asset/portfolio/segment/account management) and transaction processing (n:n double-entry with DSL, JSON, inflow/outflow, and annotation creation modes). The CRM component (default :4003) manages holders and account aliases via MongoDB. Infrastructure is provisioned via Docker Compose with PostgreSQL 17, MongoDB 8, RabbitMQ 4.1, Valkey 8, and Grafana/OTEL-LGTM.
+
+## Documentation
+
+- [README](README.md): Project overview, architecture, core banking vision
+- [License](LICENSE): Elastic License 2.0
+- [Changelog](CHANGELOG.md): Release history
+- [Security](SECURITY.md): Vulnerability reporting policy
+- [Structure](STRUCTURE.md): Directory layout guide
+
+## AI Agent Guides
+
+- [AGENTS.md](AGENTS.md): Universal AI agent entry point — quick start, architecture, conventions, what not to do
+- [CLAUDE.md](CLAUDE.md): Deep reference for AI agents — code patterns, interfaces, commands, configuration, debugging
+
+## API
+
+- [Ledger OpenAPI Spec](components/ledger/api/): Swagger documentation for all ledger endpoints
+- [CRM OpenAPI Spec](components/crm/api/): Swagger documentation for CRM endpoints
+
+## Architecture
+
+- [Ledger Component](components/ledger/): Unified HTTP API — onboarding + transaction in single process
+  - [Bootstrap](components/ledger/internal/bootstrap/): Composition root — config, DI, server lifecycle, multi-tenant middleware
+  - [HTTP Handlers](components/ledger/internal/adapters/http/in/): Fiber handlers, routes, middleware
+  - [PostgreSQL Repos](components/ledger/internal/adapters/postgres/): Onboarding + transaction repositories
+  - [MongoDB Repos](components/ledger/internal/adapters/mongodb/): Metadata storage
+  - [Redis Adapters](components/ledger/internal/adapters/redis/): Caching, queue consumers
+  - [RabbitMQ Adapters](components/ledger/internal/adapters/rabbitmq/): Async transaction processing, bulk recorder
+  - [Services](components/ledger/internal/services/): Business logic — CQRS command/query use cases
+  - [Migrations](components/ledger/migrations/): SQL migrations for onboarding and transaction databases
+- [CRM Component](components/crm/): Customer relationship management plugin
+  - [Bootstrap](components/crm/internal/bootstrap/): Config, DI, server lifecycle
+  - [HTTP Handlers](components/crm/internal/adapters/http/): Fiber handlers for holders and aliases
+  - [MongoDB Repos](components/crm/internal/adapters/mongodb/): CRM data persistence
+  - [Services](components/crm/internal/services/): CRM business logic
+- [Infrastructure](components/infra/): Docker Compose for PostgreSQL, MongoDB, RabbitMQ, Valkey, Grafana/OTEL
+- [Shared Packages](pkg/): Cross-component libraries
+  - [Domain Models](pkg/mmodel/): Organization, Ledger, Account, Asset, Transaction, Balance, etc.
+  - [Error Constants](pkg/constant/errors.go): Numeric error codes (0001–0161) and CRM error codes
+  - [Error Types](pkg/errors.go): Typed errors — EntityNotFound, Validation, Conflict, Unauthorized, Forbidden, etc.
+  - [Gold DSL](pkg/gold/): ANTLR4 grammar and parser for transaction DSL
+  - [HTTP Utilities](pkg/net/http/): Middleware, pagination, protected routes, response helpers
+  - [Transaction Logic](pkg/transaction/): Transaction validation and processing utilities
+
+## Configuration
+
+- [Ledger .env.example](components/ledger/.env.example): Ledger environment variables (PostgreSQL, MongoDB, Redis, RabbitMQ, OTEL, multi-tenant)
+- [CRM .env.example](components/crm/.env.example): CRM environment variables (MongoDB, OTEL, crypto, auth)
+- [Infra .env.example](components/infra/.env.example): Infrastructure environment variables
+- [Ledger Dockerfile](components/ledger/Dockerfile): Multi-stage build (golang:1.25-alpine → distroless)
+- [CRM Dockerfile](components/crm/Dockerfile): Multi-stage build (golang:1.25-alpine → distroless)
+- [Linter Config](.golangci.yml): golangci-lint v2 configuration
+- [Infra Docker Compose](components/infra/docker-compose.yml): Full infrastructure stack
+
+## Development
+
+- [Makefile](Makefile): Build, test, lint, Docker, security, migration commands
+- [Project Rules](docs/PROJECT_RULES.md): Architecture patterns, coding conventions, testing standards (1130 lines)
+- [Tests](tests/): Integration, chaos, and helper test suites
+- [Scripts](scripts/): Coverage, docs generation, environment checks
+
+## Optional
+
+- [Security Policy](SECURITY.md): Vulnerability reporting
+- [Contributing](CONTRIBUTING.md): Contribution guidelines
+- [Code of Conduct](CODE_OF_CONDUCT.md): Community standards
+- [Governance](GOVERNANCE.md): Project governance


### PR DESCRIPTION
## Summary

Add 4 AI-readable documentation files following Lerian's llmstxt.org pattern:

| File | Lines | Purpose |
|------|-------|---------|
| `llms.txt` | 72 | Concise LLM overview (llmstxt.org spec) |
| `llms-full.txt` | 746 | Comprehensive: all 135 env vars, 4 CRM error codes, full API, domain models |
| `CLAUDE.md` | 587 | Deep technical reference: 135 env vars, 45 make targets, bootstrap sequence, patterns |
| `AGENTS.md` | 86 | Quick-start 1-pager for any AI agent |

`docs/PROJECT_RULES.md` already exists (1130 lines) — not modified.

### Validation
- ✅ 135/135 env vars covered (both ledger + CRM config)
- ✅ 4/4 error codes (CRM-0001, CRM-0003, CRM-0006, CRM-0014)
- ✅ 45/46 make targets documented
- ✅ All content verified against actual source code

### Note
`.gitignore` updated to remove `CLAUDE.md` from ignore list (was previously ignored, now intentionally tracked).