### PR TITLE
refactor: update validation error handling in operation route

### DIFF
--- a/components/ledger/internal/adapters/http/in/operation-route-validation_test.go
+++ b/components/ledger/internal/adapters/http/in/operation-route-validation_test.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	pkg "github.com/LerianStudio/midaz/v3/pkg"
 	"github.com/LerianStudio/midaz/v3/pkg/constant"
 	"github.com/LerianStudio/midaz/v3/pkg/mmodel"
 	"github.com/stretchr/testify/assert"
@@ -444,7 +445,10 @@ func TestOperationRouteHandler_validateDirectionScenarioMatrix(t *testing.T) {
 
 			if tt.expectError {
 				require.Error(t, err, "expected validation error")
-				assert.Contains(t, err.Error(), tt.errorCode, "error should contain expected code")
+
+				var unprocessableErr pkg.UnprocessableOperationError
+				require.ErrorAs(t, err, &unprocessableErr, "expected UnprocessableOperationError")
+				assert.Equal(t, tt.errorCode, unprocessableErr.Code, "error code mismatch")
 			} else {
 				require.NoError(t, err, "expected no validation error")
 			}
@@ -689,7 +693,10 @@ func TestOperationRouteHandler_validateReserveGroupAtomicity(t *testing.T) {
 
 			if tt.expectError {
 				require.Error(t, err, "expected validation error")
-				assert.Contains(t, err.Error(), tt.errorCode, "error should contain expected code")
+
+				var unprocessableErr pkg.UnprocessableOperationError
+				require.ErrorAs(t, err, &unprocessableErr, "expected UnprocessableOperationError")
+				assert.Equal(t, tt.errorCode, unprocessableErr.Code, "error code mismatch")
 			} else {
 				require.NoError(t, err, "expected no validation error")
 			}
@@ -793,7 +800,10 @@ func TestOperationRouteHandler_validateDirectMandatory(t *testing.T) {
 
 			if tt.expectError {
 				require.Error(t, err, "expected validation error")
-				assert.Contains(t, err.Error(), tt.errorCode, "error should contain expected code")
+
+				var unprocessableErr pkg.UnprocessableOperationError
+				require.ErrorAs(t, err, &unprocessableErr, "expected UnprocessableOperationError")
+				assert.Equal(t, tt.errorCode, unprocessableErr.Code, "error code mismatch")
 			} else {
 				require.NoError(t, err, "expected no validation error")
 			}
@@ -1219,7 +1229,10 @@ func TestOperationRouteHandler_validateAccountingRulesMatrix(t *testing.T) {
 
 			if tt.expectError {
 				require.Error(t, err, "expected validation error")
-				assert.Contains(t, err.Error(), tt.errorCode, "error should contain expected code")
+
+				var unprocessableErr pkg.UnprocessableOperationError
+				require.ErrorAs(t, err, &unprocessableErr, "expected UnprocessableOperationError")
+				assert.Equal(t, tt.errorCode, unprocessableErr.Code, "error code mismatch")
 			} else {
 				require.NoError(t, err, "expected no validation error")
 			}
@@ -1499,9 +1512,13 @@ func TestOperationRouteHandler_validateEntryFieldRequirements(t *testing.T) {
 
 			if tt.expectError {
 				require.Error(t, err, "expected validation error")
-				assert.Contains(t, err.Error(), tt.errorCode, "error should contain expected code")
+
+				var unprocessableErr pkg.UnprocessableOperationError
+				require.ErrorAs(t, err, &unprocessableErr, "expected UnprocessableOperationError")
+				assert.Equal(t, tt.errorCode, unprocessableErr.Code, "error code mismatch")
+
 				if tt.errorField != "" {
-					assert.Contains(t, err.Error(), tt.errorField, "error should reference the missing field")
+					assert.Contains(t, unprocessableErr.Message, tt.errorField, "error should reference the missing field")
 				}
 			} else {
 				require.NoError(t, err, "expected no validation error")

--- a/components/ledger/internal/adapters/http/in/operation-route.go
+++ b/components/ledger/internal/adapters/http/in/operation-route.go
@@ -264,6 +264,7 @@ func (handler *OperationRouteHandler) UpdateOperationRoute(i any, c *fiber.Ctx) 
 
 		// Handle explicit top-level null for accountingEntries (RFC 7396: clear all)
 		var mergedEntries *mmodel.AccountingEntries
+
 		rawTrimmed := strings.TrimSpace(string(payload.AccountingEntriesRaw))
 		if rawTrimmed == "null" {
 			// Explicit null at top level - clear all entries

--- a/pkg/errors.go
+++ b/pkg/errors.go
@@ -1325,7 +1325,7 @@ func ValidateBusinessError(err error, entityType string, args ...any) error {
 		constant.ErrScenarioNotAllowedForDirection: UnprocessableOperationError{
 			EntityType: entityType,
 			Code:       constant.ErrScenarioNotAllowedForDirection.Error(),
-			Title:      "Scenario Not Allowed for Direction",
+			Title:      "Scenario Not Allowed For Direction",
 			Message:    fmt.Sprintf("The accounting scenario is not allowed for the specified operation direction. %v", args...),
 		},
 		constant.ErrReserveGroupIncomplete: UnprocessableOperationError{
@@ -1343,7 +1343,7 @@ func ValidateBusinessError(err error, entityType string, args ...any) error {
 		constant.ErrRevertOnlyBidirectional: UnprocessableOperationError{
 			EntityType: entityType,
 			Code:       constant.ErrRevertOnlyBidirectional.Error(),
-			Title:      "Revert Only for Bidirectional",
+			Title:      "Revert Only Bidirectional",
 			Message:    fmt.Sprintf("The revert scenario is only allowed for bidirectional operation routes. %v", args...),
 		},
 		constant.ErrAccountingEntryFieldRequired: UnprocessableOperationError{

--- a/pkg/errors.go
+++ b/pkg/errors.go
@@ -1322,31 +1322,31 @@ func ValidateBusinessError(err error, entityType string, args ...any) error {
 			Message:    "The number of operation routes exceeds the maximum allowed. Please reduce the number of operation routes and try again.",
 		},
 		// Accounting Rules Validation Errors (0162-0166)
-		constant.ErrScenarioNotAllowedForDirection: ValidationError{
+		constant.ErrScenarioNotAllowedForDirection: UnprocessableOperationError{
 			EntityType: entityType,
 			Code:       constant.ErrScenarioNotAllowedForDirection.Error(),
 			Title:      "Scenario Not Allowed for Direction",
 			Message:    fmt.Sprintf("The accounting scenario is not allowed for the specified operation direction. %v", args...),
 		},
-		constant.ErrReserveGroupIncomplete: ValidationError{
+		constant.ErrReserveGroupIncomplete: UnprocessableOperationError{
 			EntityType: entityType,
 			Code:       constant.ErrReserveGroupIncomplete.Error(),
 			Title:      "Reserve Group Incomplete",
 			Message:    fmt.Sprintf("The reserve group (hold, commit, cancel) must be complete. %v", args...),
 		},
-		constant.ErrDirectScenarioRequired: ValidationError{
+		constant.ErrDirectScenarioRequired: UnprocessableOperationError{
 			EntityType: entityType,
 			Code:       constant.ErrDirectScenarioRequired.Error(),
 			Title:      "Direct Scenario Required",
 			Message:    fmt.Sprintf("The direct scenario is required when other scenarios are present. %v", args...),
 		},
-		constant.ErrRevertOnlyBidirectional: ValidationError{
+		constant.ErrRevertOnlyBidirectional: UnprocessableOperationError{
 			EntityType: entityType,
 			Code:       constant.ErrRevertOnlyBidirectional.Error(),
 			Title:      "Revert Only for Bidirectional",
 			Message:    fmt.Sprintf("The revert scenario is only allowed for bidirectional operation routes. %v", args...),
 		},
-		constant.ErrAccountingEntryFieldRequired: ValidationError{
+		constant.ErrAccountingEntryFieldRequired: UnprocessableOperationError{
 			EntityType: entityType,
 			Code:       constant.ErrAccountingEntryFieldRequired.Error(),
 			Title:      "Accounting Entry Field Required",


### PR DESCRIPTION
## Summary

- Change HTTP response status code from 400 (Bad Request) to 422 (Unprocessable Entity) for accounting-rules matrix validation errors
- Update error type from `ValidationError` to `UnprocessableOperationError` for error codes 0162-0166
- Refactor tests to use type assertion (`ErrorAs`) instead of string parsing for more robust error validation

## Motivation

HTTP 422 (Unprocessable Entity) is semantically more appropriate for business rule violations where the request is syntactically valid but violates domain-specific rules. The accounting-rules matrix validation errors (0162-0166) represent scenarios where:

- A scenario is not allowed for a specific direction (e.g., `hold` for `destination`)
- The reserve group (hold/commit/cancel) is incomplete
- The `direct` scenario is missing when other scenarios are present
- The `revert` scenario is used outside bidirectional routes
- Required accounting entry fields (debit/credit) are missing based on direction+scenario matrix

These are not malformed requests (400), but valid requests that violate business rules (422).

## Semantic Decision

| Error Code | Error Name | Previous Status | New Status |
|------------|------------|-----------------|------------|
| 0162 | `ErrScenarioNotAllowedForDirection` | 400 | 422 |
| 0163 | `ErrReserveGroupIncomplete` | 400 | 422 |
| 0164 | `ErrDirectScenarioRequired` | 400 | 422 |
| 0165 | `ErrRevertOnlyBidirectional` | 400 | 422 |
| 0166 | `ErrAccountingEntryFieldRequired` | 400 | 422 |

## Changes

### Refactored Code

| Before | After |
|--------|-------|
| `ValidationError{}` for errors 0162-0166 | `UnprocessableOperationError{}` for errors 0162-0166 |
| `assert.Contains(t, err.Error(), tt.errorCode)` | `require.ErrorAs(t, err, &unprocessableErr)` + `assert.Equal(t, tt.errorCode, unprocessableErr.Code)` |

### Files Changed

| File | Purpose |
|------|---------|
| `pkg/errors.go` | Change error type from `ValidationError` to `UnprocessableOperationError` for 5 error codes |
| `components/ledger/internal/adapters/http/in/operation-route-validation_test.go` | Update tests to use `ErrorAs` type assertion for robust error validation |

## Test Plan

- [x] All existing validation tests pass (`TestOperationRouteHandler_validateDirectionScenarioMatrix`, `TestOperationRouteHandler_validateReserveGroupAtomicity`, `TestOperationRouteHandler_validateDirectMandatory`, `TestOperationRouteHandler_validateAccountingRulesMatrix`, `TestOperationRouteHandler_validateEntryFieldRequirements`)
- [x] `TestWithError_UnprocessableOperationError_Returns422` confirms HTTP 422 status code
- [x] golangci-lint passes with 0 issues
