### PR TITLE
fix: correct migration COPY destination paths in ledger Dockerfile

### DIFF
--- a/components/ledger/Dockerfile
+++ b/components/ledger/Dockerfile
@@ -18,8 +18,8 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-amd64} \
 FROM gcr.io/distroless/static-debian12
 
 COPY --from=builder /app /app
-COPY --from=builder /ledger-app/components/ledger/migrations/onboarding /components/ledger/migrations/onboarding
-COPY --from=builder /ledger-app/components/ledger/migrations/transaction /components/ledger/migrations/transaction
+COPY --from=builder /ledger-app/components/ledger/migrations/onboarding /components/onboarding/migrations
+COPY --from=builder /ledger-app/components/ledger/migrations/transaction /components/transaction/migrations
 
 EXPOSE 3002
 


### PR DESCRIPTION
## Problem

midaz-ledger:3.6.0-rc.6 is in CrashLoopBackOff on Firmino staging (~22h, 261+ restarts) because the Dockerfile copies migrations to wrong destination paths.

The lib-commons `PostgresConnection` uses `Component="onboarding"` and `Component="transaction"` to resolve migration paths as `/components/onboarding/migrations` and `/components/transaction/migrations`.

But the Dockerfile was copying to `/components/ledger/migrations/onboarding` and `/components/ledger/migrations/transaction` — paths that lib-commons never looks at.

## Fix

Changed the COPY destination paths to match what lib-commons expects:
- `/components/onboarding/migrations`
- `/components/transaction/migrations`

Source paths in the build stage unchanged.

Fixes DSINT-1024.