### PR TITLE
chore: force ledger image rebuild to pick up migration files

### DIFF
--- a/components/ledger/Dockerfile
+++ b/components/ledger/Dockerfile
@@ -1,5 +1,5 @@
 FROM --platform=$BUILDPLATFORM golang:1.25.8-alpine AS builder
-# Force rebuild for develop branch - 2026-04-01 (4)
+# Force rebuild for develop branch - 2026-04-03 (5)
 
 WORKDIR /ledger-app
 


### PR DESCRIPTION
## Context

midaz-ledger:3.6.0-rc.6 is in CrashLoopBackOff on staging (~22h, 261+ restarts).

**Root cause:** the Docker image was built with a cached layer that predates the migration files being moved to `components/ledger/migrations/transaction/`. The transaction migration directory doesn't exist in the final container image, causing `os.ErrNotExist` at startup:

```
ERROR postgres/postgres.go:907 no migration files found
ERROR app/main.go:47 Failed to initialize ledger service: failed to initialize transaction PostgreSQL: failed to run PostgreSQL migrations: postgres migrate_up: migration files not found: source directory missing or empty
```

Onboarding migrations load fine (directory exists, DB already migrated from rc.5). Transaction migrations fail because the cached `COPY . .` layer didn't include the new directory.

## Fix

Bumps the cache-bust comment in the Dockerfile to force a full rebuild, ensuring the `COPY . .` layer picks up `components/ledger/migrations/transaction/`.

## Post-merge note

After tagging rc.7 and before the pod starts, the `schema_migrations` table in the transaction DB on staging may need to be updated if migration version numbers were renumbered.