### PR TITLE
feat: dual-trigger balance sync with conditional ZREM and backup queue fix

### DIFF
--- a/components/ledger/.env.example
+++ b/components/ledger/.env.example
@@ -243,8 +243,11 @@ RABBITMQ_AUDIT_KEY=audit.append_log.key
 MAX_PAGINATION_LIMIT=100
 MAX_PAGINATION_MONTH_DATE_RANGE=3
 
-# BALANCE SYNC WORKER
+# BALANCE SYNC WORKER (dual-trigger: flushes on SIZE or TIMEOUT, whichever comes first)
 BALANCE_SYNC_MAX_WORKERS=5
+# BALANCE_SYNC_BATCH_SIZE=50          # Keys accumulated before flush (SIZE trigger)
+# BALANCE_SYNC_FLUSH_TIMEOUT_MS=500   # Max ms before flush (TIMEOUT trigger)
+# BALANCE_SYNC_POLL_INTERVAL_MS=50    # ZSET polling interval ms when draining
 
 # =============================================================================
 # SWAGGER CONFIGURATION (optional overrides)

--- a/components/ledger/internal/adapters/http/in/transaction-state-handlers.go
+++ b/components/ledger/internal/adapters/http/in/transaction-state-handlers.go
@@ -501,6 +501,11 @@ func (handler *TransactionHandler) commitOrCancelTransaction(c *fiber.Ctx, tran 
 
 	spanBackup.End()
 
+	// Materialize operation IDs in the backup entry to prevent duplicate
+	// operations if the Redis backup consumer replays this transaction.
+	// Without this, BuildOperations() generates new UUIDs on replay.
+	handler.Command.UpdateTransactionBackupOperations(ctx, organizationID, ledgerID, tran.IDtoUUID().String(), operations, action)
+
 	if strings.ToLower(os.Getenv("RABBITMQ_TRANSACTION_ASYNC")) == "true" {
 		_, err = handler.Command.UpdateTransactionStatus(ctx, tran)
 		if err != nil {

--- a/components/ledger/internal/adapters/redis/transaction/consumer.redis.go
+++ b/components/ledger/internal/adapters/redis/transaction/consumer.redis.go
@@ -75,6 +75,15 @@ func tenantKeysFromContext(ctx context.Context, keys []string) ([]string, error)
 // Callers MUST check for empty string to detect cache miss. Do not store
 // empty strings as values; use JSON or another format that is never empty.
 //
+// SyncKey holds a balance schedule member together with the ZADD score it had
+// when the worker claimed it.  The score is passed back to
+// RemoveBalanceSyncKeysBatch so the Lua script can skip removal when a newer
+// mutation re-scheduled the same member (conditional ZREM).
+type SyncKey struct {
+	Key   string
+	Score float64
+}
+
 //go:generate mockgen --destination=consumer.redis_mock.go --package=redis . RedisRepository
 type RedisRepository interface {
 	Set(ctx context.Context, key, value string, ttl time.Duration) error
@@ -92,7 +101,7 @@ type RedisRepository interface {
 	ReadMessageFromQueue(ctx context.Context, key string) ([]byte, error)
 	ReadAllMessagesFromQueue(ctx context.Context) (map[string]string, error)
 	RemoveMessageFromQueue(ctx context.Context, key string) error
-	GetBalanceSyncKeys(ctx context.Context, limit int64) ([]string, error)
+	GetBalanceSyncKeys(ctx context.Context, limit int64) ([]SyncKey, error)
 	RemoveBalanceSyncKey(ctx context.Context, member string) error
 	// ScheduleBalanceSyncBatch schedules multiple balance keys for sync using ZADD NX.
 	// Each member is a balance key with score = scheduled sync time (Unix timestamp).
@@ -104,9 +113,11 @@ type RedisRepository interface {
 	// Returns a map of key -> *mmodel.BalanceRedis (nil if key does not exist).
 	// This enables batch retrieval for the aggregation engine.
 	GetBalancesByKeys(ctx context.Context, keys []string) (map[string]*mmodel.BalanceRedis, error)
-	// RemoveBalanceSyncKeysBatch removes multiple keys from the sync schedule and their locks.
+	// RemoveBalanceSyncKeysBatch conditionally removes keys from the sync schedule.
+	// Only removes a member if its current ZSET score matches the claimed score,
+	// preventing removal of entries re-scheduled by newer mutations.
 	// Returns the number of keys actually removed from the schedule.
-	RemoveBalanceSyncKeysBatch(ctx context.Context, keys []string) (int64, error)
+	RemoveBalanceSyncKeysBatch(ctx context.Context, keys []SyncKey) (int64, error)
 }
 
 // RedisConsumerRepository is a Redis implementation of the Redis consumer.
@@ -956,7 +967,7 @@ func (rr *RedisConsumerRepository) RemoveMessageFromQueue(ctx context.Context, k
 }
 
 // GetBalanceSyncKeys returns due scheduled balance keys limited by 'limit'.
-func (rr *RedisConsumerRepository) GetBalanceSyncKeys(ctx context.Context, limit int64) ([]string, error) {
+func (rr *RedisConsumerRepository) GetBalanceSyncKeys(ctx context.Context, limit int64) ([]SyncKey, error) {
 	logger, tracer, _, _ := libCommons.NewTrackingFromContext(ctx)
 
 	ctx, span := tracer.Start(ctx, "redis.get_balance_sync_keys")
@@ -988,29 +999,41 @@ func (rr *RedisConsumerRepository) GetBalanceSyncKeys(ctx context.Context, limit
 		return nil, err
 	}
 
-	var out []string
+	// Parse alternating [member, score, member, score, ...] from Lua result
+	var raw []string
 
 	switch vv := res.(type) {
 	case []any:
-		out = make([]string, 0, len(vv))
+		raw = make([]string, 0, len(vv))
 		for _, it := range vv {
 			switch s := it.(type) {
 			case string:
-				out = append(out, s)
+				raw = append(raw, s)
 			case []byte:
-				out = append(out, string(s))
+				raw = append(raw, string(s))
 			default:
-				out = append(out, fmt.Sprint(it))
+				raw = append(raw, fmt.Sprint(it))
 			}
 		}
 	case []string:
-		out = vv
+		raw = vv
 	default:
 		err = fmt.Errorf("unexpected result type from Redis script: %T", res)
 
 		logger.Log(ctx, libLog.LevelWarn, fmt.Sprintf("Warning: %v", err))
 
 		return nil, err
+	}
+
+	out := make([]SyncKey, 0, len(raw)/2)
+	for i := 0; i+1 < len(raw); i += 2 {
+		score, parseErr := strconv.ParseFloat(raw[i+1], 64)
+		if parseErr != nil {
+			logger.Log(ctx, libLog.LevelWarn, fmt.Sprintf("Failed to parse score for %s: %v", raw[i], parseErr))
+			continue
+		}
+
+		out = append(out, SyncKey{Key: raw[i], Score: score})
 	}
 
 	logger.Log(ctx, libLog.LevelInfo, fmt.Sprintf("fetch_due returned %d keys", len(out)))
@@ -1281,10 +1304,12 @@ func (rr *RedisConsumerRepository) GetBalancesByKeys(ctx context.Context, keys [
 	return result, nil
 }
 
-// RemoveBalanceSyncKeysBatch removes multiple keys from the balance sync schedule.
-// Also removes associated lock keys. Returns count of removed schedule entries.
+// RemoveBalanceSyncKeysBatch conditionally removes keys from the balance sync schedule.
+// Only removes a member if its current ZSET score matches the claimed score,
+// preventing removal of entries re-scheduled by newer mutations.
+// Also removes associated lock keys unconditionally.
 // Large inputs are processed in chunks of maxRedisBatchSize to prevent oversized payloads.
-func (rr *RedisConsumerRepository) RemoveBalanceSyncKeysBatch(ctx context.Context, keys []string) (int64, error) {
+func (rr *RedisConsumerRepository) RemoveBalanceSyncKeysBatch(ctx context.Context, keys []SyncKey) (int64, error) {
 	if len(keys) == 0 {
 		return 0, nil
 	}
@@ -1326,12 +1351,12 @@ func (rr *RedisConsumerRepository) RemoveBalanceSyncKeysBatch(ctx context.Contex
 		end := min(start+maxRedisBatchSize, len(keys))
 		chunk := keys[start:end]
 
-		// Build args: [lockPrefix, member1, member2, ...]
-		args := make([]any, 0, len(chunk)+1)
+		// Build args: [lockPrefix, member1, score1, member2, score2, ...]
+		args := make([]any, 0, len(chunk)*2+1)
 		args = append(args, prefixedLockPrefix)
 
-		for _, key := range chunk {
-			args = append(args, key)
+		for _, sk := range chunk {
+			args = append(args, sk.Key, strconv.FormatFloat(sk.Score, 'f', -1, 64))
 		}
 
 		result, err := client.Eval(ctx, removeBalanceSyncKeysBatchScript, []string{prefixedScheduleKey}, args...).Result()

--- a/components/ledger/internal/adapters/redis/transaction/consumer.redis_atomic_state_test.go
+++ b/components/ledger/internal/adapters/redis/transaction/consumer.redis_atomic_state_test.go
@@ -159,7 +159,7 @@ func TestKeyNamespacing_MalformedTenantID_FailsClosedBatchScheduleAndRemove(t *t
 			conn: newMockEvalConnection(mockClient),
 		}
 
-		_, err := repo.RemoveBalanceSyncKeysBatch(ctx, []string{"balance:key"})
+		_, err := repo.RemoveBalanceSyncKeysBatch(ctx, []SyncKey{{Key: "balance:key", Score: 0}})
 		require.Error(t, err)
 	})
 }

--- a/components/ledger/internal/adapters/redis/transaction/consumer.redis_mock.go
+++ b/components/ledger/internal/adapters/redis/transaction/consumer.redis_mock.go
@@ -92,10 +92,10 @@ func (mr *MockRedisRepositoryMockRecorder) Get(ctx, key any) *gomock.Call {
 }
 
 // GetBalanceSyncKeys mocks base method.
-func (m *MockRedisRepository) GetBalanceSyncKeys(ctx context.Context, limit int64) ([]string, error) {
+func (m *MockRedisRepository) GetBalanceSyncKeys(ctx context.Context, limit int64) ([]SyncKey, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetBalanceSyncKeys", ctx, limit)
-	ret0, _ := ret[0].([]string)
+	ret0, _ := ret[0].([]SyncKey)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -240,7 +240,7 @@ func (mr *MockRedisRepositoryMockRecorder) RemoveBalanceSyncKey(ctx, member any)
 }
 
 // RemoveBalanceSyncKeysBatch mocks base method.
-func (m *MockRedisRepository) RemoveBalanceSyncKeysBatch(ctx context.Context, keys []string) (int64, error) {
+func (m *MockRedisRepository) RemoveBalanceSyncKeysBatch(ctx context.Context, keys []SyncKey) (int64, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RemoveBalanceSyncKeysBatch", ctx, keys)
 	ret0, _ := ret[0].(int64)

--- a/components/ledger/internal/adapters/redis/transaction/consumer.redis_test.go
+++ b/components/ledger/internal/adapters/redis/transaction/consumer.redis_test.go
@@ -737,13 +737,18 @@ func TestRemoveBalanceSyncKeysBatch_SingleKey(t *testing.T) {
 		conn: newMockEvalConnection(mockClient),
 	}
 
-	count, err := repo.RemoveBalanceSyncKeysBatch(context.Background(), []SyncKey{{Key: "balance:key1", Score: 0}})
+	count, err := repo.RemoveBalanceSyncKeysBatch(context.Background(), []SyncKey{{Key: "balance:key1", Score: 100}})
 
 	require.NoError(t, err)
 	assert.Equal(t, int64(1), count)
 	assert.NotEmpty(t, capturedScript, "Lua script should be passed")
-	assert.Len(t, capturedKeys, 1, "Should have 1 key (schedule key)")
-	assert.Len(t, capturedArgs, 3, "Should have lock prefix + 1 member + 1 score")
+	assert.Equal(t, []string{utils.BalanceSyncScheduleKey}, capturedKeys, "KEYS[1] should be the schedule key")
+	// ARGV contract: [lockPrefix, member1, score1]
+	assert.Equal(t, []any{
+		utils.BalanceSyncLockPrefix,
+		"balance:key1",
+		"100",
+	}, capturedArgs, "ARGV should be [lockPrefix, member, score_as_string]")
 }
 
 func TestRemoveBalanceSyncKeysBatch_MultipleKeys(t *testing.T) {
@@ -764,12 +769,21 @@ func TestRemoveBalanceSyncKeysBatch_MultipleKeys(t *testing.T) {
 		conn: newMockEvalConnection(mockClient),
 	}
 
-	count, err := repo.RemoveBalanceSyncKeysBatch(context.Background(), []SyncKey{{Key: "key1", Score: 0}, {Key: "key2", Score: 0}, {Key: "key3", Score: 0}})
+	count, err := repo.RemoveBalanceSyncKeysBatch(context.Background(), []SyncKey{
+		{Key: "key1", Score: 100},
+		{Key: "key2", Score: 200},
+		{Key: "key3", Score: 300},
+	})
 
 	require.NoError(t, err)
 	assert.Equal(t, int64(3), count)
-	// Args should be: [lockPrefix, key1, score1, key2, score2, key3, score3]
-	assert.Len(t, capturedArgs, 7, "Should have lock prefix + 3 members + 3 scores")
+	// ARGV contract: [lockPrefix, member1, score1, member2, score2, member3, score3]
+	assert.Equal(t, []any{
+		utils.BalanceSyncLockPrefix,
+		"key1", "100",
+		"key2", "200",
+		"key3", "300",
+	}, capturedArgs, "ARGV should alternate member/score pairs after lock prefix")
 }
 
 func TestRemoveBalanceSyncKeysBatch_PartialRemoval(t *testing.T) {
@@ -788,7 +802,11 @@ func TestRemoveBalanceSyncKeysBatch_PartialRemoval(t *testing.T) {
 		conn: newMockEvalConnection(mockClient),
 	}
 
-	count, err := repo.RemoveBalanceSyncKeysBatch(context.Background(), []SyncKey{{Key: "key1", Score: 0}, {Key: "key2", Score: 0}, {Key: "key3", Score: 0}})
+	count, err := repo.RemoveBalanceSyncKeysBatch(context.Background(), []SyncKey{
+		{Key: "key1", Score: 100},
+		{Key: "key2", Score: 200},
+		{Key: "key3", Score: 300},
+	})
 
 	require.NoError(t, err)
 	assert.Equal(t, int64(2), count, "Should return actual count of removed keys")

--- a/components/ledger/internal/adapters/redis/transaction/consumer.redis_test.go
+++ b/components/ledger/internal/adapters/redis/transaction/consumer.redis_test.go
@@ -687,7 +687,7 @@ func TestRemoveBalanceSyncKeysBatch_EmptyInput(t *testing.T) {
 	}
 
 	// Empty input should return 0 without any Redis call
-	count, err := repo.RemoveBalanceSyncKeysBatch(context.Background(), []string{})
+	count, err := repo.RemoveBalanceSyncKeysBatch(context.Background(), []SyncKey{})
 
 	assert.NoError(t, err, "Empty keys should return nil error")
 	assert.Equal(t, int64(0), count, "Empty keys should return 0 count")
@@ -707,7 +707,7 @@ func TestRemoveBalanceSyncKeysBatch_EmptyInput_NoRedisCall(t *testing.T) {
 		conn: newMockEvalConnection(mockClient),
 	}
 
-	count, err := repo.RemoveBalanceSyncKeysBatch(context.Background(), []string{})
+	count, err := repo.RemoveBalanceSyncKeysBatch(context.Background(), []SyncKey{})
 
 	assert.NoError(t, err)
 	assert.Equal(t, int64(0), count)
@@ -737,13 +737,13 @@ func TestRemoveBalanceSyncKeysBatch_SingleKey(t *testing.T) {
 		conn: newMockEvalConnection(mockClient),
 	}
 
-	count, err := repo.RemoveBalanceSyncKeysBatch(context.Background(), []string{"balance:key1"})
+	count, err := repo.RemoveBalanceSyncKeysBatch(context.Background(), []SyncKey{{Key: "balance:key1", Score: 0}})
 
 	require.NoError(t, err)
 	assert.Equal(t, int64(1), count)
 	assert.NotEmpty(t, capturedScript, "Lua script should be passed")
 	assert.Len(t, capturedKeys, 1, "Should have 1 key (schedule key)")
-	assert.Len(t, capturedArgs, 2, "Should have lock prefix + 1 member")
+	assert.Len(t, capturedArgs, 3, "Should have lock prefix + 1 member + 1 score")
 }
 
 func TestRemoveBalanceSyncKeysBatch_MultipleKeys(t *testing.T) {
@@ -764,12 +764,12 @@ func TestRemoveBalanceSyncKeysBatch_MultipleKeys(t *testing.T) {
 		conn: newMockEvalConnection(mockClient),
 	}
 
-	count, err := repo.RemoveBalanceSyncKeysBatch(context.Background(), []string{"key1", "key2", "key3"})
+	count, err := repo.RemoveBalanceSyncKeysBatch(context.Background(), []SyncKey{{Key: "key1", Score: 0}, {Key: "key2", Score: 0}, {Key: "key3", Score: 0}})
 
 	require.NoError(t, err)
 	assert.Equal(t, int64(3), count)
-	// Args should be: [lockPrefix, key1, key2, key3]
-	assert.Len(t, capturedArgs, 4, "Should have lock prefix + 3 members")
+	// Args should be: [lockPrefix, key1, score1, key2, score2, key3, score3]
+	assert.Len(t, capturedArgs, 7, "Should have lock prefix + 3 members + 3 scores")
 }
 
 func TestRemoveBalanceSyncKeysBatch_PartialRemoval(t *testing.T) {
@@ -788,7 +788,7 @@ func TestRemoveBalanceSyncKeysBatch_PartialRemoval(t *testing.T) {
 		conn: newMockEvalConnection(mockClient),
 	}
 
-	count, err := repo.RemoveBalanceSyncKeysBatch(context.Background(), []string{"key1", "key2", "key3"})
+	count, err := repo.RemoveBalanceSyncKeysBatch(context.Background(), []SyncKey{{Key: "key1", Score: 0}, {Key: "key2", Score: 0}, {Key: "key3", Score: 0}})
 
 	require.NoError(t, err)
 	assert.Equal(t, int64(2), count, "Should return actual count of removed keys")
@@ -810,7 +810,7 @@ func TestRemoveBalanceSyncKeysBatch_RedisError(t *testing.T) {
 		conn: newMockEvalConnection(mockClient),
 	}
 
-	count, err := repo.RemoveBalanceSyncKeysBatch(context.Background(), []string{"balance:key1"})
+	count, err := repo.RemoveBalanceSyncKeysBatch(context.Background(), []SyncKey{{Key: "balance:key1", Score: 0}})
 
 	require.Error(t, err)
 	assert.ErrorIs(t, err, expectedError)
@@ -832,7 +832,7 @@ func TestRemoveBalanceSyncKeysBatch_UnexpectedResultType(t *testing.T) {
 		conn: newMockEvalConnection(mockClient),
 	}
 
-	count, err := repo.RemoveBalanceSyncKeysBatch(context.Background(), []string{"balance:key1"})
+	count, err := repo.RemoveBalanceSyncKeysBatch(context.Background(), []SyncKey{{Key: "balance:key1", Score: 0}})
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unexpected result type")
@@ -875,7 +875,7 @@ func TestRemoveBalanceSyncKeysBatch_ScriptUsesCorrectPattern(t *testing.T) {
 		conn: newMockEvalConnection(mockClient),
 	}
 
-	_, err := repo.RemoveBalanceSyncKeysBatch(context.Background(), []string{"balance:key1"})
+	_, err := repo.RemoveBalanceSyncKeysBatch(context.Background(), []SyncKey{{Key: "balance:key1", Score: 0}})
 
 	require.NoError(t, err)
 
@@ -899,7 +899,7 @@ func TestRemoveBalanceSyncKeysBatch_ZeroKeysRemoved(t *testing.T) {
 		conn: newMockEvalConnection(mockClient),
 	}
 
-	count, err := repo.RemoveBalanceSyncKeysBatch(context.Background(), []string{"nonexistent:key1", "nonexistent:key2"})
+	count, err := repo.RemoveBalanceSyncKeysBatch(context.Background(), []SyncKey{{Key: "nonexistent:key1", Score: 0}, {Key: "nonexistent:key2", Score: 0}})
 
 	require.NoError(t, err)
 	assert.Equal(t, int64(0), count, "Should return 0 when no keys were removed")
@@ -907,7 +907,7 @@ func TestRemoveBalanceSyncKeysBatch_ZeroKeysRemoved(t *testing.T) {
 
 func TestRemoveBalanceSyncKeysBatch_InterfaceCompliance(t *testing.T) {
 	type BatchRemover interface {
-		RemoveBalanceSyncKeysBatch(ctx context.Context, keys []string) (int64, error)
+		RemoveBalanceSyncKeysBatch(ctx context.Context, keys []SyncKey) (int64, error)
 	}
 
 	var _ BatchRemover = (*RedisConsumerRepository)(nil)

--- a/components/ledger/internal/adapters/redis/transaction/scripts/balance_atomic_operation.lua
+++ b/components/ledger/internal/adapters/redis/transaction/scripts/balance_atomic_operation.lua
@@ -242,11 +242,13 @@ local function main()
     -- First argument: whether to schedule balance sync (1 = enabled, 0 = disabled)
     local scheduleSync = tonumber(ARGV[1]) or 1
 
-    -- schedule a pre-expire warning 10 minutes before the TTL
-    local warnBefore = 600 -- 10 minutes
+    -- Schedule balance sync immediately (eligible for worker pickup right away).
+    -- The worker uses a dual-trigger (size OR timeout) to batch multiple keys
+    -- before flushing to PostgreSQL, so immediate eligibility does not mean
+    -- immediate DB write — the worker accumulates keys efficiently.
     local timeNow = redis.call("TIME")
     local nowSec = tonumber(timeNow[1])
-    local dueAt = nowSec + (ttl - warnBefore)
+    local dueAt = nowSec
 
     -- Start from index 2 since ARGV[1] is the scheduleSync flag
     for i = 2, #ARGV, groupSize do

--- a/components/ledger/internal/adapters/redis/transaction/scripts/balance_atomic_operation.lua
+++ b/components/ledger/internal/adapters/redis/transaction/scripts/balance_atomic_operation.lua
@@ -246,9 +246,11 @@ local function main()
     -- The worker uses a dual-trigger (size OR timeout) to batch multiple keys
     -- before flushing to PostgreSQL, so immediate eligibility does not mean
     -- immediate DB write — the worker accumulates keys efficiently.
+    --
+    -- Uses microsecond precision (seconds * 1e6 + microseconds) to prevent
+    -- the conditional ZREM from removing entries re-scheduled in the same second.
     local timeNow = redis.call("TIME")
-    local nowSec = tonumber(timeNow[1])
-    local dueAt = nowSec
+    local dueAt = tonumber(timeNow[1]) * 1000000 + tonumber(timeNow[2])
 
     -- Start from index 2 since ARGV[1] is the scheduleSync flag
     for i = 2, #ARGV, groupSize do

--- a/components/ledger/internal/adapters/redis/transaction/scripts/get_balances_near_expiration.lua
+++ b/components/ledger/internal/adapters/redis/transaction/scripts/get_balances_near_expiration.lua
@@ -4,21 +4,26 @@ if not scheduleKey then
 end
 
 local t = redis.call('TIME')
-local now = tonumber(t[1])
+local now = tonumber(t[1]) * 1000000 + tonumber(t[2])
 local limit = tonumber(ARGV[1]) or 25
 local claimTTL = tonumber(ARGV[2]) or 600
 local claimPrefix = ARGV[3] or "lock:{transactions}:balance-sync:"
 
--- Return due members up to 'now' that we can claim (SET NX EX)
-local due = redis.call('ZRANGEBYSCORE', scheduleKey, '-inf', now, 'LIMIT', 0, limit)
+-- Return due members up to 'now' that we can claim (SET NX EX).
+-- Returns alternating [member, score, member, score, ...] so the caller
+-- can later do a conditional ZREM (only remove if score hasn't changed).
+local due = redis.call('ZRANGEBYSCORE', scheduleKey, '-inf', now, 'WITHSCORES', 'LIMIT', 0, limit)
 local claimed = {}
 
-for i = 1, #due do
+-- 'due' is now [member1, score1, member2, score2, ...]
+for i = 1, #due, 2 do
   local member = due[i]
+  local score  = due[i + 1]
   local lockKey = claimPrefix .. member
   local ok = redis.call('SET', lockKey, '1', 'NX', 'EX', claimTTL)
   if ok then
     table.insert(claimed, member)
+    table.insert(claimed, score)
   end
 end
 

--- a/components/ledger/internal/adapters/redis/transaction/scripts/remove_balance_sync_keys_batch.lua
+++ b/components/ledger/internal/adapters/redis/transaction/scripts/remove_balance_sync_keys_batch.lua
@@ -1,21 +1,34 @@
 -- remove_balance_sync_keys_batch.lua
--- Removes multiple members from the balance sync schedule and their associated locks.
+-- Conditionally removes members from the balance sync schedule and their locks.
+-- Only removes a member if its current ZSET score matches the claimed score,
+-- preventing removal of entries re-scheduled by newer balance mutations.
+--
 -- KEYS[1]: schedule key (e.g., "schedule:{transactions}:balance-sync")
 -- ARGV[1]: lock prefix (e.g., "lock:{transactions}:balance-sync:")
--- ARGV[2..N]: members to remove
+-- ARGV[2..N]: alternating pairs of [member, claimedScore, member, claimedScore, ...]
 
 local scheduleKey = KEYS[1]
 local lockPrefix = ARGV[1]
 local removed = 0
 
-for i = 2, #ARGV do
+for i = 2, #ARGV, 2 do
     local member = ARGV[i]
+    local claimedScore = tonumber(ARGV[i + 1])
 
-    -- Remove from sorted set
-    local zremResult = redis.call('ZREM', scheduleKey, member)
-    removed = removed + zremResult
+    -- Only remove if the score has NOT been updated by a newer mutation.
+    -- If a new ZADD happened after our claim, currentScore > claimedScore
+    -- and we must NOT remove (the newer mutation needs to be synced).
+    local currentScore = redis.call('ZSCORE', scheduleKey, member)
 
-    -- Remove associated lock if exists
+    if currentScore then
+        currentScore = tonumber(currentScore)
+        if currentScore <= claimedScore then
+            redis.call('ZREM', scheduleKey, member)
+            removed = removed + 1
+        end
+    end
+
+    -- Always remove the lock (it's ours regardless of ZREM outcome)
     local lockKey = lockPrefix .. member
     redis.call('DEL', lockKey)
 end

--- a/components/ledger/internal/adapters/redis/transaction/scripts/remove_balance_sync_keys_batch.lua
+++ b/components/ledger/internal/adapters/redis/transaction/scripts/remove_balance_sync_keys_batch.lua
@@ -15,14 +15,13 @@ for i = 2, #ARGV, 2 do
     local member = ARGV[i]
     local claimedScore = tonumber(ARGV[i + 1])
 
-    -- Only remove if the score has NOT been updated by a newer mutation.
-    -- If a new ZADD happened after our claim, currentScore > claimedScore
-    -- and we must NOT remove (the newer mutation needs to be synced).
+    -- Only remove if the score is exactly what we claimed.
+    -- Any change (higher from a newer mutation, or lower from clock drift)
+    -- means this entry should survive for the next sync cycle.
     local currentScore = redis.call('ZSCORE', scheduleKey, member)
 
     if currentScore then
-        currentScore = tonumber(currentScore)
-        if currentScore <= claimedScore then
+        if tonumber(currentScore) == claimedScore then
             redis.call('ZREM', scheduleKey, member)
             removed = removed + 1
         end

--- a/components/ledger/internal/bootstrap/balance.worker.go
+++ b/components/ledger/internal/bootstrap/balance.worker.go
@@ -21,6 +21,7 @@ import (
 	tmcore "github.com/LerianStudio/lib-commons/v4/commons/tenant-manager/core"
 	tmpostgres "github.com/LerianStudio/lib-commons/v4/commons/tenant-manager/postgres"
 	"github.com/LerianStudio/lib-commons/v4/commons/tenant-manager/tenantcache"
+	redisTransaction "github.com/LerianStudio/midaz/v3/components/ledger/internal/adapters/redis/transaction"
 	"github.com/LerianStudio/midaz/v3/components/ledger/internal/services/command"
 	"github.com/LerianStudio/midaz/v3/pkg/constant"
 	"github.com/LerianStudio/midaz/v3/pkg/mmodel"
@@ -160,12 +161,12 @@ func (w *BalanceSyncWorker) runSingleTenant() error {
 		w.logger,
 	)
 
-	collector.SetFlushCallback(func(flushCtx context.Context, keys []string) bool {
+	collector.SetFlushCallback(func(flushCtx context.Context, keys []redisTransaction.SyncKey) bool {
 		return w.flushBatch(flushCtx, keys)
 	})
 
 	collector.Run(ctx,
-		func(fetchCtx context.Context, limit int64) ([]string, error) {
+		func(fetchCtx context.Context, limit int64) ([]redisTransaction.SyncKey, error) {
 			return w.useCase.TransactionRedisRepo.GetBalanceSyncKeys(fetchCtx, limit)
 		},
 		func(waitCtx context.Context) bool {
@@ -295,12 +296,12 @@ func (w *BalanceSyncWorker) shouldShutdown(ctx context.Context) bool {
 type orgLedgerGroup struct {
 	orgID    uuid.UUID
 	ledgerID uuid.UUID
-	keys     []string
+	keys     []redisTransaction.SyncKey
 }
 
 // flushBatch groups keys by (orgID, ledgerID) and processes each group via SyncBalancesBatch.
 // This is the flush callback used by the BalanceSyncCollector.
-func (w *BalanceSyncWorker) flushBatch(ctx context.Context, keys []string) bool {
+func (w *BalanceSyncWorker) flushBatch(ctx context.Context, keys []redisTransaction.SyncKey) bool {
 	if len(keys) == 0 {
 		return false
 	}
@@ -323,18 +324,18 @@ func (w *BalanceSyncWorker) flushBatch(ctx context.Context, keys []string) bool 
 
 // groupKeysByOrgLedger groups Redis balance keys by their (organizationID, ledgerID) pair.
 // Keys that cannot be parsed are logged and skipped.
-func (w *BalanceSyncWorker) groupKeysByOrgLedger(keys []string) []orgLedgerGroup {
+func (w *BalanceSyncWorker) groupKeysByOrgLedger(keys []redisTransaction.SyncKey) []orgLedgerGroup {
 	type groupKey struct {
 		orgID    uuid.UUID
 		ledgerID uuid.UUID
 	}
 
-	grouped := make(map[groupKey][]string, 1) // typically 1 group in single-tenant
+	grouped := make(map[groupKey][]redisTransaction.SyncKey, 1) // typically 1 group in single-tenant
 
 	for _, key := range keys {
-		orgID, ledgerID, err := w.extractIDsFromMember(key)
+		orgID, ledgerID, err := w.extractIDsFromMember(key.Key)
 		if err != nil {
-			w.logger.Log(context.Background(), libLog.LevelWarn, fmt.Sprintf("BalanceSyncWorker: failed to extract IDs from key %s: %v", key, err))
+			w.logger.Log(context.Background(), libLog.LevelWarn, fmt.Sprintf("BalanceSyncWorker: failed to extract IDs from key %s: %v", key.Key, err))
 
 			continue
 		}
@@ -378,7 +379,7 @@ func (w *BalanceSyncWorker) processBalancesToExpire(ctx context.Context, rds red
 	// This is guaranteed by the worker's scheduling mechanism which fetches keys
 	// from a single ZSET scoped per tenant context. In multi-tenant mode,
 	// processTenantBalances is called per-tenant, ensuring batch homogeneity.
-	orgID, ledgerID, extractErr := w.extractIDsFromMember(members[0])
+	orgID, ledgerID, extractErr := w.extractIDsFromMember(members[0].Key)
 	if extractErr == nil {
 		return w.processBalancesToExpireBatch(ctx, orgID, ledgerID, members)
 	}
@@ -406,7 +407,7 @@ func (w *BalanceSyncWorker) processBalancesToExpire(ctx context.Context, rds red
 			return true
 		}
 
-		member := m
+		member := m.Key
 
 		sem <- struct{}{}
 
@@ -444,7 +445,7 @@ func (w *BalanceSyncWorker) processBalancesToExpire(ctx context.Context, rds red
 //  4. Removes all processed keys in batch
 //
 // Returns true if any balances were processed.
-func (w *BalanceSyncWorker) processBalancesToExpireBatch(ctx context.Context, organizationID, ledgerID uuid.UUID, keys []string) bool {
+func (w *BalanceSyncWorker) processBalancesToExpireBatch(ctx context.Context, organizationID, ledgerID uuid.UUID, keys []redisTransaction.SyncKey) bool {
 	if len(keys) == 0 {
 		return false
 	}

--- a/components/ledger/internal/bootstrap/balance.worker.go
+++ b/components/ledger/internal/bootstrap/balance.worker.go
@@ -335,7 +335,14 @@ func (w *BalanceSyncWorker) groupKeysByOrgLedger(keys []redisTransaction.SyncKey
 	for _, key := range keys {
 		orgID, ledgerID, err := w.extractIDsFromMember(key.Key)
 		if err != nil {
-			w.logger.Log(context.Background(), libLog.LevelWarn, fmt.Sprintf("BalanceSyncWorker: failed to extract IDs from key %s: %v", key.Key, err))
+			w.logger.Log(context.Background(), libLog.LevelWarn, fmt.Sprintf("BalanceSyncWorker: failed to extract IDs from key %s: %v — removing from schedule", key.Key, err))
+
+			// Clean up the claimed entry to prevent it from becoming a poison record.
+			// Uses the batch variant with a single element so the conditional ZREM
+			// and lock cleanup run through the same Lua script path.
+			if _, remErr := w.useCase.TransactionRedisRepo.RemoveBalanceSyncKeysBatch(context.Background(), []redisTransaction.SyncKey{key}); remErr != nil {
+				w.logger.Log(context.Background(), libLog.LevelWarn, fmt.Sprintf("BalanceSyncWorker: failed to remove unparseable key %s: %v", key.Key, remErr))
+			}
 
 			continue
 		}

--- a/components/ledger/internal/bootstrap/balance.worker.go
+++ b/components/ledger/internal/bootstrap/balance.worker.go
@@ -29,14 +29,26 @@ import (
 	"github.com/redis/go-redis/v9"
 )
 
-// BalanceSyncWorker continuously processes keys scheduled for pre-expiry actions.
-// Ensures that the balance is synced before the key expires.
+// BalanceSyncConfig holds configuration for the balance sync dual-trigger.
+type BalanceSyncConfig struct {
+	// BatchSize is the number of keys to accumulate before flushing (SIZE trigger).
+	BatchSize int
+	// FlushTimeoutMs is the max time in milliseconds before flushing an incomplete batch (TIMEOUT trigger).
+	FlushTimeoutMs int
+	// PollIntervalMs is the ZSET polling interval in milliseconds when buffer has items but no new keys.
+	PollIntervalMs int
+}
+
+// BalanceSyncWorker continuously processes balance keys using a dual-trigger collector.
+// Keys become eligible immediately after balance mutation (Lua ZADD with dueAt=now).
+// The worker accumulates keys and flushes based on batch size OR timeout, whichever comes first.
 type BalanceSyncWorker struct {
 	redisConn          *libRedis.Client
 	logger             libLog.Logger
 	idleWait           time.Duration
 	batchSize          int64
 	maxWorkers         int
+	syncConfig         BalanceSyncConfig
 	useCase            *command.UseCase
 	multiTenantEnabled bool
 	tenantCache        *tenantcache.TenantCache
@@ -44,17 +56,40 @@ type BalanceSyncWorker struct {
 	serviceName        string
 }
 
-func NewBalanceSyncWorker(conn *libRedis.Client, logger libLog.Logger, useCase *command.UseCase, maxWorkers int) *BalanceSyncWorker {
+func NewBalanceSyncWorker(conn *libRedis.Client, logger libLog.Logger, useCase *command.UseCase, maxWorkers int, syncCfg BalanceSyncConfig) *BalanceSyncWorker {
 	if maxWorkers <= 0 {
 		maxWorkers = 5
+	}
+
+	// Apply safe defaults for zero-value config (e.g., in tests)
+	if syncCfg.BatchSize <= 0 {
+		syncCfg.BatchSize = 50
+	}
+
+	if syncCfg.FlushTimeoutMs <= 0 {
+		syncCfg.FlushTimeoutMs = 500
+	}
+
+	if syncCfg.PollIntervalMs <= 0 {
+		syncCfg.PollIntervalMs = 50
+	}
+
+	// Idle wait defaults to 2x the flush timeout. With dual-trigger and dueAt=now,
+	// a long idle backoff (e.g. 10 min) would delay pickup of new keys. Using a short
+	// idle wait ensures the worker re-checks the ZSET frequently when transitioning
+	// from idle to busy mode.
+	idleWait := time.Duration(syncCfg.FlushTimeoutMs*2) * time.Millisecond
+	if idleWait < 1*time.Second {
+		idleWait = 1 * time.Second
 	}
 
 	return &BalanceSyncWorker{
 		redisConn:  conn,
 		logger:     logger,
-		idleWait:   600 * time.Second,
-		batchSize:  int64(maxWorkers),
+		idleWait:   idleWait,
+		batchSize:  int64(syncCfg.BatchSize),
 		maxWorkers: maxWorkers,
+		syncConfig: syncCfg,
 		useCase:    useCase,
 	}
 }
@@ -70,12 +105,13 @@ func NewBalanceSyncWorkerMultiTenant(
 	logger libLog.Logger,
 	useCase *command.UseCase,
 	maxWorkers int,
+	syncCfg BalanceSyncConfig,
 	multiTenantEnabled bool,
 	cache *tenantcache.TenantCache,
 	pgManager *tmpostgres.Manager,
 	serviceName string,
 ) *BalanceSyncWorker {
-	w := NewBalanceSyncWorker(conn, logger, useCase, maxWorkers)
+	w := NewBalanceSyncWorker(conn, logger, useCase, maxWorkers, syncCfg)
 	w.multiTenantEnabled = multiTenantEnabled
 	w.tenantCache = cache
 	w.pgManager = pgManager
@@ -101,12 +137,13 @@ func (w *BalanceSyncWorker) Run(_ *libCommons.Launcher) error {
 }
 
 // runSingleTenant runs the balance sync loop using the default (shared) database connection.
-// This is the original Run() behavior preserved for backward compatibility.
+// Uses the dual-trigger collector (size OR timeout) for near-real-time balance persistence.
 func (w *BalanceSyncWorker) runSingleTenant() error {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
-	w.logger.Log(ctx, libLog.LevelInfo, "BalanceSyncWorker started (single-tenant mode)")
+	w.logger.Log(ctx, libLog.LevelInfo, fmt.Sprintf("BalanceSyncWorker started (single-tenant, dual-trigger: batch_size=%d, flush_timeout=%dms, poll_interval=%dms)",
+		w.syncConfig.BatchSize, w.syncConfig.FlushTimeoutMs, w.syncConfig.PollIntervalMs))
 
 	rds, err := w.redisConn.GetClient(ctx)
 	if err != nil {
@@ -115,34 +152,41 @@ func (w *BalanceSyncWorker) runSingleTenant() error {
 		return err
 	}
 
-	for {
-		if w.shouldShutdown(ctx) {
-			w.logger.Log(ctx, libLog.LevelInfo, "BalanceSyncWorker: shutting down...")
+	collector := NewBalanceSyncCollector(
+		w.syncConfig.BatchSize,
+		time.Duration(w.syncConfig.FlushTimeoutMs)*time.Millisecond,
+		time.Duration(w.syncConfig.PollIntervalMs)*time.Millisecond,
+		w.idleWait,
+		w.logger,
+	)
 
-			return nil
-		}
+	collector.SetFlushCallback(func(flushCtx context.Context, keys []string) bool {
+		return w.flushBatch(flushCtx, keys)
+	})
 
-		if w.processBalancesToExpire(ctx, rds) {
-			continue
-		}
+	collector.Run(ctx,
+		func(fetchCtx context.Context, limit int64) ([]string, error) {
+			return w.useCase.TransactionRedisRepo.GetBalanceSyncKeys(fetchCtx, limit)
+		},
+		func(waitCtx context.Context) bool {
+			return w.waitForNextOrBackoff(waitCtx, rds)
+		},
+	)
 
-		if w.waitForNextOrBackoff(ctx, rds) {
-			w.logger.Log(ctx, libLog.LevelInfo, "BalanceSyncWorker: shutting down...")
+	w.logger.Log(ctx, libLog.LevelInfo, "BalanceSyncWorker: shutting down...")
 
-			return nil
-		}
-	}
+	return nil
 }
 
 // runMultiTenant runs the balance sync loop iterating over all active tenants.
-// For each tenant, it resolves a per-tenant PostgreSQL connection and injects it
-// into the context before processing. If a tenant's connection fails, it logs and
-// skips that tenant without affecting others.
+// Each tenant gets its own dual-trigger collector for independent batch accumulation.
+// If a tenant's connection fails, it logs and skips that tenant without affecting others.
 func (w *BalanceSyncWorker) runMultiTenant() error {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
-	w.logger.Log(ctx, libLog.LevelInfo, "BalanceSyncWorker started (multi-tenant mode)")
+	w.logger.Log(ctx, libLog.LevelInfo, fmt.Sprintf("BalanceSyncWorker started (multi-tenant, dual-trigger: batch_size=%d, flush_timeout=%dms, poll_interval=%dms)",
+		w.syncConfig.BatchSize, w.syncConfig.FlushTimeoutMs, w.syncConfig.PollIntervalMs))
 
 	rds, err := w.redisConn.GetClient(ctx)
 	if err != nil {
@@ -245,6 +289,70 @@ func (w *BalanceSyncWorker) shouldShutdown(ctx context.Context) bool {
 	default:
 		return false
 	}
+}
+
+// orgLedgerGroup holds keys grouped by organization and ledger for batch processing.
+type orgLedgerGroup struct {
+	orgID    uuid.UUID
+	ledgerID uuid.UUID
+	keys     []string
+}
+
+// flushBatch groups keys by (orgID, ledgerID) and processes each group via SyncBalancesBatch.
+// This is the flush callback used by the BalanceSyncCollector.
+func (w *BalanceSyncWorker) flushBatch(ctx context.Context, keys []string) bool {
+	if len(keys) == 0 {
+		return false
+	}
+
+	w.logger.Log(ctx, libLog.LevelInfo, fmt.Sprintf("BalanceSyncWorker: flushBatch called with %d keys", len(keys)))
+
+	groups := w.groupKeysByOrgLedger(keys)
+	processed := false
+
+	for _, group := range groups {
+		w.logger.Log(ctx, libLog.LevelInfo, fmt.Sprintf("BalanceSyncWorker: syncing group org=%s ledger=%s with %d keys", group.orgID, group.ledgerID, len(group.keys)))
+
+		if w.processBalancesToExpireBatch(ctx, group.orgID, group.ledgerID, group.keys) {
+			processed = true
+		}
+	}
+
+	return processed
+}
+
+// groupKeysByOrgLedger groups Redis balance keys by their (organizationID, ledgerID) pair.
+// Keys that cannot be parsed are logged and skipped.
+func (w *BalanceSyncWorker) groupKeysByOrgLedger(keys []string) []orgLedgerGroup {
+	type groupKey struct {
+		orgID    uuid.UUID
+		ledgerID uuid.UUID
+	}
+
+	grouped := make(map[groupKey][]string, 1) // typically 1 group in single-tenant
+
+	for _, key := range keys {
+		orgID, ledgerID, err := w.extractIDsFromMember(key)
+		if err != nil {
+			w.logger.Log(context.Background(), libLog.LevelWarn, fmt.Sprintf("BalanceSyncWorker: failed to extract IDs from key %s: %v", key, err))
+
+			continue
+		}
+
+		gk := groupKey{orgID: orgID, ledgerID: ledgerID}
+		grouped[gk] = append(grouped[gk], key)
+	}
+
+	result := make([]orgLedgerGroup, 0, len(grouped))
+	for gk, groupKeys := range grouped {
+		result = append(result, orgLedgerGroup{
+			orgID:    gk.orgID,
+			ledgerID: gk.ledgerID,
+			keys:     groupKeys,
+		})
+	}
+
+	return result
 }
 
 func (w *BalanceSyncWorker) processBalancesToExpire(ctx context.Context, rds redis.UniversalClient) bool {

--- a/components/ledger/internal/bootstrap/balance.worker.go
+++ b/components/ledger/internal/bootstrap/balance.worker.go
@@ -643,11 +643,13 @@ func waitOrDone(ctx context.Context, d time.Duration, logger libLog.Logger) bool
 	}
 }
 
-// waitUntilDue waits until the given dueAtUnix time.
+// waitUntilDue waits until the given dueAt score time.
+// The score uses microsecond precision (seconds*1e6 + microseconds) to match
+// the ZADD scores set by the Lua balance_atomic_operation script.
 // Returns true if the context was cancelled while waiting.
-func (w *BalanceSyncWorker) waitUntilDue(ctx context.Context, dueAtUnix int64, logger libLog.Logger) bool {
-	nowUnix := time.Now().Unix()
-	if dueAtUnix <= nowUnix {
+func (w *BalanceSyncWorker) waitUntilDue(ctx context.Context, dueAtScore int64, logger libLog.Logger) bool {
+	nowMicro := time.Now().UnixMicro()
+	if dueAtScore <= nowMicro {
 		// Due time already passed but item not processed (ZSET/sync-queue desync).
 		// Apply minimal backoff to prevent busy loop when:
 		// - ZSET has entry with expired score
@@ -656,7 +658,7 @@ func (w *BalanceSyncWorker) waitUntilDue(ctx context.Context, dueAtUnix int64, l
 		return waitOrDone(ctx, 500*time.Millisecond, logger)
 	}
 
-	waitFor := time.Duration(dueAtUnix-nowUnix) * time.Second
+	waitFor := time.Duration(dueAtScore-nowMicro) * time.Microsecond
 	if waitFor <= 0 {
 		return waitOrDone(ctx, 500*time.Millisecond, logger)
 	}

--- a/components/ledger/internal/bootstrap/balance.worker_test.go
+++ b/components/ledger/internal/bootstrap/balance.worker_test.go
@@ -373,7 +373,7 @@ func TestProcessBalancesToExpire_NoMembers(t *testing.T) {
 	mockRedisRepo := redis.NewMockRedisRepository(ctrl)
 	mockRedisRepo.EXPECT().
 		GetBalanceSyncKeys(gomock.Any(), int64(50)).
-		Return([]string{}, nil).
+		Return([]redis.SyncKey{}, nil).
 		Times(1)
 
 	useCase := &command.UseCase{
@@ -464,7 +464,7 @@ func TestProcessBalancesToExpire_ShutdownDuringProcessing(t *testing.T) {
 	mockRedisRepo := redis.NewMockRedisRepository(ctrl)
 	mockRedisRepo.EXPECT().
 		GetBalanceSyncKeys(gomock.Any(), int64(50)).
-		Return([]string{member}, nil).
+		Return([]redis.SyncKey{{Key: member, Score: 1000}}, nil).
 		Times(1)
 
 	useCase := &command.UseCase{

--- a/components/ledger/internal/bootstrap/balance.worker_test.go
+++ b/components/ledger/internal/bootstrap/balance.worker_test.go
@@ -66,12 +66,12 @@ func TestNewBalanceSyncWorker(t *testing.T) {
 			logger := newTestLogger()
 			useCase := &command.UseCase{}
 
-			worker := NewBalanceSyncWorker(conn, logger, useCase, tt.maxWorkers)
+			worker := NewBalanceSyncWorker(conn, logger, useCase, tt.maxWorkers, BalanceSyncConfig{})
 
 			require.NotNil(t, worker)
 			assert.Equal(t, tt.expectedMaxWorkers, worker.maxWorkers)
-			assert.Equal(t, int64(tt.expectedMaxWorkers), worker.batchSize)
-			assert.Equal(t, 600*time.Second, worker.idleWait)
+			assert.Equal(t, int64(50), worker.batchSize)
+			assert.Equal(t, 1*time.Second, worker.idleWait) // 2 * FlushTimeoutMs(500) = 1000ms, clamped to 1s
 			assert.Same(t, conn, worker.redisConn)
 			assert.Same(t, useCase, worker.useCase)
 		})
@@ -372,7 +372,7 @@ func TestProcessBalancesToExpire_NoMembers(t *testing.T) {
 
 	mockRedisRepo := redis.NewMockRedisRepository(ctrl)
 	mockRedisRepo.EXPECT().
-		GetBalanceSyncKeys(gomock.Any(), int64(5)).
+		GetBalanceSyncKeys(gomock.Any(), int64(50)).
 		Return([]string{}, nil).
 		Times(1)
 
@@ -382,7 +382,7 @@ func TestProcessBalancesToExpire_NoMembers(t *testing.T) {
 
 	worker := &BalanceSyncWorker{
 		logger:     newTestLogger(),
-		batchSize:  5,
+		batchSize:  50,
 		maxWorkers: 5,
 		useCase:    useCase,
 	}
@@ -401,7 +401,7 @@ func TestProcessBalancesToExpire_ErrorGettingKeys(t *testing.T) {
 
 	mockRedisRepo := redis.NewMockRedisRepository(ctrl)
 	mockRedisRepo.EXPECT().
-		GetBalanceSyncKeys(gomock.Any(), int64(5)).
+		GetBalanceSyncKeys(gomock.Any(), int64(50)).
 		Return(nil, errors.New("redis connection error")).
 		Times(1)
 
@@ -411,7 +411,7 @@ func TestProcessBalancesToExpire_ErrorGettingKeys(t *testing.T) {
 
 	worker := &BalanceSyncWorker{
 		logger:     newTestLogger(),
-		batchSize:  5,
+		batchSize:  50,
 		maxWorkers: 5,
 		useCase:    useCase,
 	}
@@ -430,7 +430,7 @@ func TestProcessBalancesToExpire_RedisNilError(t *testing.T) {
 
 	mockRedisRepo := redis.NewMockRedisRepository(ctrl)
 	mockRedisRepo.EXPECT().
-		GetBalanceSyncKeys(gomock.Any(), int64(5)).
+		GetBalanceSyncKeys(gomock.Any(), int64(50)).
 		Return(nil, goredis.Nil).
 		Times(1)
 
@@ -440,7 +440,7 @@ func TestProcessBalancesToExpire_RedisNilError(t *testing.T) {
 
 	worker := &BalanceSyncWorker{
 		logger:     newTestLogger(),
-		batchSize:  5,
+		batchSize:  50,
 		maxWorkers: 5,
 		useCase:    useCase,
 	}
@@ -463,7 +463,7 @@ func TestProcessBalancesToExpire_ShutdownDuringProcessing(t *testing.T) {
 
 	mockRedisRepo := redis.NewMockRedisRepository(ctrl)
 	mockRedisRepo.EXPECT().
-		GetBalanceSyncKeys(gomock.Any(), int64(5)).
+		GetBalanceSyncKeys(gomock.Any(), int64(50)).
 		Return([]string{member}, nil).
 		Times(1)
 
@@ -473,7 +473,7 @@ func TestProcessBalancesToExpire_ShutdownDuringProcessing(t *testing.T) {
 
 	worker := &BalanceSyncWorker{
 		logger:     newTestLogger(),
-		batchSize:  5,
+		batchSize:  50,
 		maxWorkers: 5,
 		useCase:    useCase,
 	}

--- a/components/ledger/internal/bootstrap/balance_sync_collector.go
+++ b/components/ledger/internal/bootstrap/balance_sync_collector.go
@@ -140,7 +140,9 @@ func (c *BalanceSyncCollector) Run(ctx context.Context, fetchKeys FetchKeysFunc,
 			continue
 		}
 
-		c.handleIdleMode(ctx, timer, waitForNext)
+		if c.handleIdleMode(ctx, timer, waitForNext) {
+			return // shutdown requested
+		}
 	}
 }
 
@@ -188,16 +190,19 @@ func (c *BalanceSyncCollector) handleDrainingMode(ctx context.Context, bufLen in
 }
 
 // handleIdleMode stops the timer and waits for the next scheduled key or shutdown.
-func (c *BalanceSyncCollector) handleIdleMode(ctx context.Context, timer *time.Timer, waitForNext WaitForNextFunc) {
+// Returns true if shutdown was requested.
+func (c *BalanceSyncCollector) handleIdleMode(ctx context.Context, timer *time.Timer, waitForNext WaitForNextFunc) bool {
 	c.logger.Log(ctx, libLog.LevelInfo, "BalanceSyncCollector: idle mode — no keys in ZSET, waiting for next scheduled key")
 	timer.Stop()
 
 	if waitForNext(ctx) {
-		return
+		return true
 	}
 
 	c.logger.Log(ctx, libLog.LevelInfo, "BalanceSyncCollector: woke up from idle, resuming polling")
 	timer.Reset(c.flushTimeout)
+
+	return false
 }
 
 // flushRemaining drains any leftover buffer on shutdown.

--- a/components/ledger/internal/bootstrap/balance_sync_collector.go
+++ b/components/ledger/internal/bootstrap/balance_sync_collector.go
@@ -117,6 +117,17 @@ func (c *BalanceSyncCollector) Run(ctx context.Context, fetchKeys FetchKeysFunc,
 		if err != nil {
 			c.logger.Log(ctx, libLog.LevelWarn, "BalanceSyncCollector: fetch keys error: "+err.Error())
 
+			// If the buffer already has items, skip the sleep and re-enter the
+			// draining path so the timeout trigger can still flush on time.
+			// Only sleep when the buffer is empty to avoid a tight error loop.
+			c.mu.Lock()
+			hasItems := len(c.buffer) > 0
+			c.mu.Unlock()
+
+			if hasItems {
+				continue
+			}
+
 			if waitOrShutdown(ctx, c.pollInterval) {
 				return
 			}

--- a/components/ledger/internal/bootstrap/balance_sync_collector.go
+++ b/components/ledger/internal/bootstrap/balance_sync_collector.go
@@ -1,0 +1,264 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package bootstrap
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	libLog "github.com/LerianStudio/lib-commons/v4/commons/log"
+)
+
+// BalanceSyncCollector accumulates Redis ZSET keys for batch processing.
+// It triggers a flush when the batch size is reached or a timeout elapses,
+// whichever comes first (dual-trigger pattern).
+//
+// Unlike the RabbitMQ BulkCollector which receives messages via a Go channel (push),
+// this collector polls a Redis ZSET for eligible keys (pull). It adapts the same
+// dual-trigger concept to a polling-based data source.
+//
+// Lifecycle: continuous loop with idle backoff (not single-use like BulkCollector).
+type BalanceSyncCollector struct {
+	mu           sync.Mutex
+	batchSize    int
+	flushTimeout time.Duration
+	pollInterval time.Duration
+	idleBackoff  time.Duration
+	buffer       []string
+	flushFn      FlushFunc
+	logger       libLog.Logger
+}
+
+// FlushFunc is called when the collector flushes accumulated keys.
+// It receives the batch of keys and returns true if any processing occurred.
+type FlushFunc func(ctx context.Context, keys []string) bool
+
+// FetchKeysFunc fetches eligible keys from the ZSET schedule.
+// limit is the maximum number of keys to return.
+type FetchKeysFunc func(ctx context.Context, limit int64) ([]string, error)
+
+// WaitForNextFunc waits until the next scheduled key is due or a backoff period elapses.
+// Returns true if shutdown was requested during the wait.
+type WaitForNextFunc func(ctx context.Context) bool
+
+// NewBalanceSyncCollector creates a new collector with the given configuration.
+func NewBalanceSyncCollector(
+	batchSize int,
+	flushTimeout time.Duration,
+	pollInterval time.Duration,
+	idleBackoff time.Duration,
+	logger libLog.Logger,
+) *BalanceSyncCollector {
+	if batchSize <= 0 {
+		batchSize = 50
+	}
+
+	if flushTimeout <= 0 {
+		flushTimeout = 500 * time.Millisecond
+	}
+
+	if pollInterval <= 0 {
+		pollInterval = 50 * time.Millisecond
+	}
+
+	if idleBackoff <= 0 {
+		idleBackoff = 10 * time.Second
+	}
+
+	return &BalanceSyncCollector{
+		batchSize:    batchSize,
+		flushTimeout: flushTimeout,
+		pollInterval: pollInterval,
+		idleBackoff:  idleBackoff,
+		buffer:       make([]string, 0, batchSize),
+		logger:       logger,
+	}
+}
+
+// SetFlushCallback sets the function called when the collector flushes accumulated keys.
+func (c *BalanceSyncCollector) SetFlushCallback(fn FlushFunc) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.flushFn = fn
+}
+
+// Run starts the collector's main loop. It polls for eligible keys and flushes
+// based on the dual-trigger (size OR timeout). Blocks until context is cancelled.
+//
+// The loop has three modes:
+//   - Busy mode: keys are available, tight poll loop to accumulate quickly
+//   - Draining mode: buffer has items but no new keys, wait for timeout or poll
+//   - Idle mode: nothing to do, sleep until next scheduled key
+func (c *BalanceSyncCollector) Run(ctx context.Context, fetchKeys FetchKeysFunc, waitForNext WaitForNextFunc) {
+	timer := time.NewTimer(c.flushTimeout)
+	timerActive := true
+
+	defer func() {
+		timer.Stop()
+
+		// Final flush on shutdown
+		c.mu.Lock()
+		remaining := c.buffer
+		c.buffer = make([]string, 0, c.batchSize)
+		c.mu.Unlock()
+
+		if len(remaining) > 0 && c.flushFn != nil {
+			c.logger.Log(context.Background(), libLog.LevelInfo, fmt.Sprintf("BalanceSyncCollector: shutdown — final flush of %d remaining keys", len(remaining)))
+
+			// Use a short timeout context for final flush
+			flushCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+
+			c.flushFn(flushCtx, remaining)
+		}
+	}()
+
+	for {
+		if ctx.Err() != nil {
+			return
+		}
+
+		// 1. Poll: fetch eligible keys from ZSET
+		c.mu.Lock()
+		remaining := c.batchSize - len(c.buffer)
+		c.mu.Unlock()
+
+		keys, err := fetchKeys(ctx, int64(remaining))
+		if err != nil {
+			// Log but don't exit — transient Redis errors should not kill the worker
+			c.logger.Log(ctx, libLog.LevelWarn, "BalanceSyncCollector: fetch keys error: "+err.Error())
+
+			// Brief pause before retry to avoid tight error loop
+			if waitOrShutdown(ctx, c.pollInterval) {
+				return
+			}
+
+			continue
+		}
+
+		if len(keys) > 0 {
+			c.mu.Lock()
+			c.buffer = append(c.buffer, keys...)
+			bufLen := len(c.buffer)
+			c.mu.Unlock()
+
+			c.logger.Log(ctx, libLog.LevelInfo, fmt.Sprintf("BalanceSyncCollector: fetched %d keys, buffer=%d/%d", len(keys), bufLen, c.batchSize))
+
+			// Reset timer when first key arrives in an empty buffer
+			if bufLen == len(keys) && timerActive {
+				if !timer.Stop() {
+					select {
+					case <-timer.C:
+					default:
+					}
+				}
+
+				timer.Reset(c.flushTimeout)
+			}
+
+			// 2. SIZE trigger: buffer full → flush immediately
+			if bufLen >= c.batchSize {
+				c.logger.Log(ctx, libLog.LevelInfo, fmt.Sprintf("BalanceSyncCollector: SIZE trigger fired (buffer=%d >= batch_size=%d), flushing now", bufLen, c.batchSize))
+				c.flush(ctx)
+
+				if !timer.Stop() {
+					select {
+					case <-timer.C:
+					default:
+					}
+				}
+
+				timer.Reset(c.flushTimeout)
+				timerActive = true
+
+				continue // tight loop — fetch more immediately
+			}
+
+			// 3. Got keys but not enough yet — tight loop (busy mode)
+			continue
+		}
+
+		// No keys fetched from ZSET
+
+		// 4. Draining mode: buffer has items but no new keys arriving
+		c.mu.Lock()
+		bufLen := len(c.buffer)
+		c.mu.Unlock()
+
+		if bufLen > 0 {
+			select {
+			case <-ctx.Done():
+				return
+			case <-timer.C:
+				// TIMEOUT trigger: flush what we have
+				c.logger.Log(ctx, libLog.LevelInfo, fmt.Sprintf("BalanceSyncCollector: TIMEOUT trigger fired (%v elapsed, buffer=%d), flushing now", c.flushTimeout, bufLen))
+				c.flush(ctx)
+
+				timer.Reset(c.flushTimeout)
+				timerActive = true
+			case <-time.After(c.pollInterval):
+				// Poll again to check for new keys
+			}
+
+			continue
+		}
+
+		// 5. Idle mode: buffer empty and nothing in ZSET
+		c.logger.Log(ctx, libLog.LevelInfo, "BalanceSyncCollector: idle mode — no keys in ZSET, waiting for next scheduled key")
+		timer.Stop()
+		timerActive = false
+
+		if waitForNext(ctx) {
+			return // shutdown requested
+		}
+
+		c.logger.Log(ctx, libLog.LevelInfo, "BalanceSyncCollector: woke up from idle, resuming polling")
+
+		// Re-arm timer for next accumulation cycle
+		timer.Reset(c.flushTimeout)
+		timerActive = true
+	}
+}
+
+// flush drains the buffer and calls the flush callback.
+func (c *BalanceSyncCollector) flush(ctx context.Context) {
+	c.mu.Lock()
+	if len(c.buffer) == 0 {
+		c.mu.Unlock()
+		return
+	}
+
+	keys := c.buffer
+	c.buffer = make([]string, 0, c.batchSize)
+	c.mu.Unlock()
+
+	if c.flushFn != nil {
+		c.flushFn(ctx, keys)
+	}
+}
+
+// Size returns the current number of accumulated keys.
+func (c *BalanceSyncCollector) Size() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	return len(c.buffer)
+}
+
+// waitOrShutdown waits for duration d or returns true if ctx is cancelled.
+func waitOrShutdown(ctx context.Context, d time.Duration) bool {
+	t := time.NewTimer(d)
+	defer t.Stop()
+
+	select {
+	case <-ctx.Done():
+		return true
+	case <-t.C:
+		return false
+	}
+}

--- a/components/ledger/internal/bootstrap/balance_sync_collector.go
+++ b/components/ledger/internal/bootstrap/balance_sync_collector.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	libLog "github.com/LerianStudio/lib-commons/v4/commons/log"
+	redisTransaction "github.com/LerianStudio/midaz/v3/components/ledger/internal/adapters/redis/transaction"
 )
 
 // BalanceSyncCollector accumulates Redis ZSET keys for batch processing.
@@ -28,18 +29,18 @@ type BalanceSyncCollector struct {
 	flushTimeout time.Duration
 	pollInterval time.Duration
 	idleBackoff  time.Duration
-	buffer       []string
+	buffer       []redisTransaction.SyncKey
 	flushFn      FlushFunc
 	logger       libLog.Logger
 }
 
 // FlushFunc is called when the collector flushes accumulated keys.
 // It receives the batch of keys and returns true if any processing occurred.
-type FlushFunc func(ctx context.Context, keys []string) bool
+type FlushFunc func(ctx context.Context, keys []redisTransaction.SyncKey) bool
 
 // FetchKeysFunc fetches eligible keys from the ZSET schedule.
 // limit is the maximum number of keys to return.
-type FetchKeysFunc func(ctx context.Context, limit int64) ([]string, error)
+type FetchKeysFunc func(ctx context.Context, limit int64) ([]redisTransaction.SyncKey, error)
 
 // WaitForNextFunc waits until the next scheduled key is due or a backoff period elapses.
 // Returns true if shutdown was requested during the wait.
@@ -74,7 +75,7 @@ func NewBalanceSyncCollector(
 		flushTimeout: flushTimeout,
 		pollInterval: pollInterval,
 		idleBackoff:  idleBackoff,
-		buffer:       make([]string, 0, batchSize),
+		buffer:       make([]redisTransaction.SyncKey, 0, batchSize),
 		logger:       logger,
 	}
 }
@@ -104,7 +105,7 @@ func (c *BalanceSyncCollector) Run(ctx context.Context, fetchKeys FetchKeysFunc,
 		// Final flush on shutdown
 		c.mu.Lock()
 		remaining := c.buffer
-		c.buffer = make([]string, 0, c.batchSize)
+		c.buffer = make([]redisTransaction.SyncKey, 0, c.batchSize)
 		c.mu.Unlock()
 
 		if len(remaining) > 0 && c.flushFn != nil {
@@ -174,6 +175,7 @@ func (c *BalanceSyncCollector) Run(ctx context.Context, fetchKeys FetchKeysFunc,
 				}
 
 				timer.Reset(c.flushTimeout)
+
 				timerActive = true
 
 				continue // tight loop — fetch more immediately
@@ -200,6 +202,7 @@ func (c *BalanceSyncCollector) Run(ctx context.Context, fetchKeys FetchKeysFunc,
 				c.flush(ctx)
 
 				timer.Reset(c.flushTimeout)
+
 				timerActive = true
 			case <-time.After(c.pollInterval):
 				// Poll again to check for new keys
@@ -211,6 +214,7 @@ func (c *BalanceSyncCollector) Run(ctx context.Context, fetchKeys FetchKeysFunc,
 		// 5. Idle mode: buffer empty and nothing in ZSET
 		c.logger.Log(ctx, libLog.LevelInfo, "BalanceSyncCollector: idle mode — no keys in ZSET, waiting for next scheduled key")
 		timer.Stop()
+
 		timerActive = false
 
 		if waitForNext(ctx) {
@@ -221,6 +225,7 @@ func (c *BalanceSyncCollector) Run(ctx context.Context, fetchKeys FetchKeysFunc,
 
 		// Re-arm timer for next accumulation cycle
 		timer.Reset(c.flushTimeout)
+
 		timerActive = true
 	}
 }
@@ -228,13 +233,14 @@ func (c *BalanceSyncCollector) Run(ctx context.Context, fetchKeys FetchKeysFunc,
 // flush drains the buffer and calls the flush callback.
 func (c *BalanceSyncCollector) flush(ctx context.Context) {
 	c.mu.Lock()
+
 	if len(c.buffer) == 0 {
 		c.mu.Unlock()
 		return
 	}
 
 	keys := c.buffer
-	c.buffer = make([]string, 0, c.batchSize)
+	c.buffer = make([]redisTransaction.SyncKey, 0, c.batchSize)
 	c.mu.Unlock()
 
 	if c.flushFn != nil {

--- a/components/ledger/internal/bootstrap/balance_sync_collector.go
+++ b/components/ledger/internal/bootstrap/balance_sync_collector.go
@@ -97,9 +97,11 @@ func (c *BalanceSyncCollector) SetFlushCallback(fn FlushFunc) {
 //   - Idle mode: nothing to do, sleep until next scheduled key
 func (c *BalanceSyncCollector) Run(ctx context.Context, fetchKeys FetchKeysFunc, waitForNext WaitForNextFunc) {
 	timer := time.NewTimer(c.flushTimeout)
+	pollTimer := time.NewTimer(c.pollInterval)
 
 	defer func() {
 		timer.Stop()
+		pollTimer.Stop()
 		c.flushRemaining()
 	}()
 
@@ -147,7 +149,7 @@ func (c *BalanceSyncCollector) Run(ctx context.Context, fetchKeys FetchKeysFunc,
 		c.mu.Unlock()
 
 		if bufLen > 0 {
-			c.handleDrainingMode(ctx, bufLen, timer)
+			c.handleDrainingMode(ctx, bufLen, timer, pollTimer)
 			continue
 		}
 
@@ -187,7 +189,11 @@ func (c *BalanceSyncCollector) handleBusyMode(ctx context.Context, keys []redisT
 
 // handleDrainingMode waits for either the TIMEOUT trigger or the poll interval
 // when the buffer has items but no new keys are arriving.
-func (c *BalanceSyncCollector) handleDrainingMode(ctx context.Context, bufLen int, timer *time.Timer) {
+// pollTimer is a reusable timer for the poll interval (avoids time.After allocation leak).
+func (c *BalanceSyncCollector) handleDrainingMode(ctx context.Context, bufLen int, timer *time.Timer, pollTimer *time.Timer) {
+	stopAndDrain(pollTimer)
+	pollTimer.Reset(c.pollInterval)
+
 	select {
 	case <-ctx.Done():
 		return
@@ -195,7 +201,7 @@ func (c *BalanceSyncCollector) handleDrainingMode(ctx context.Context, bufLen in
 		c.logger.Log(ctx, libLog.LevelInfo, fmt.Sprintf("BalanceSyncCollector: TIMEOUT trigger fired (%v elapsed, buffer=%d), flushing now", c.flushTimeout, bufLen))
 		c.flush(ctx)
 		timer.Reset(c.flushTimeout)
-	case <-time.After(c.pollInterval):
+	case <-pollTimer.C:
 		// Poll again to check for new keys
 	}
 }
@@ -204,7 +210,7 @@ func (c *BalanceSyncCollector) handleDrainingMode(ctx context.Context, bufLen in
 // Returns true if shutdown was requested.
 func (c *BalanceSyncCollector) handleIdleMode(ctx context.Context, timer *time.Timer, waitForNext WaitForNextFunc) bool {
 	c.logger.Log(ctx, libLog.LevelInfo, "BalanceSyncCollector: idle mode — no keys in ZSET, waiting for next scheduled key")
-	timer.Stop()
+	stopAndDrain(timer)
 
 	if waitForNext(ctx) {
 		return true

--- a/components/ledger/internal/bootstrap/balance_sync_collector.go
+++ b/components/ledger/internal/bootstrap/balance_sync_collector.go
@@ -97,26 +97,10 @@ func (c *BalanceSyncCollector) SetFlushCallback(fn FlushFunc) {
 //   - Idle mode: nothing to do, sleep until next scheduled key
 func (c *BalanceSyncCollector) Run(ctx context.Context, fetchKeys FetchKeysFunc, waitForNext WaitForNextFunc) {
 	timer := time.NewTimer(c.flushTimeout)
-	timerActive := true
 
 	defer func() {
 		timer.Stop()
-
-		// Final flush on shutdown
-		c.mu.Lock()
-		remaining := c.buffer
-		c.buffer = make([]redisTransaction.SyncKey, 0, c.batchSize)
-		c.mu.Unlock()
-
-		if len(remaining) > 0 && c.flushFn != nil {
-			c.logger.Log(context.Background(), libLog.LevelInfo, fmt.Sprintf("BalanceSyncCollector: shutdown — final flush of %d remaining keys", len(remaining)))
-
-			// Use a short timeout context for final flush
-			flushCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-			defer cancel()
-
-			c.flushFn(flushCtx, remaining)
-		}
+		c.flushRemaining()
 	}()
 
 	for {
@@ -124,17 +108,15 @@ func (c *BalanceSyncCollector) Run(ctx context.Context, fetchKeys FetchKeysFunc,
 			return
 		}
 
-		// 1. Poll: fetch eligible keys from ZSET
+		// Poll: fetch eligible keys from ZSET
 		c.mu.Lock()
 		remaining := c.batchSize - len(c.buffer)
 		c.mu.Unlock()
 
 		keys, err := fetchKeys(ctx, int64(remaining))
 		if err != nil {
-			// Log but don't exit — transient Redis errors should not kill the worker
 			c.logger.Log(ctx, libLog.LevelWarn, "BalanceSyncCollector: fetch keys error: "+err.Error())
 
-			// Brief pause before retry to avoid tight error loop
 			if waitOrShutdown(ctx, c.pollInterval) {
 				return
 			}
@@ -143,90 +125,95 @@ func (c *BalanceSyncCollector) Run(ctx context.Context, fetchKeys FetchKeysFunc,
 		}
 
 		if len(keys) > 0 {
-			c.mu.Lock()
-			c.buffer = append(c.buffer, keys...)
-			bufLen := len(c.buffer)
-			c.mu.Unlock()
-
-			c.logger.Log(ctx, libLog.LevelInfo, fmt.Sprintf("BalanceSyncCollector: fetched %d keys, buffer=%d/%d", len(keys), bufLen, c.batchSize))
-
-			// Reset timer when first key arrives in an empty buffer
-			if bufLen == len(keys) && timerActive {
-				if !timer.Stop() {
-					select {
-					case <-timer.C:
-					default:
-					}
-				}
-
-				timer.Reset(c.flushTimeout)
+			if c.handleBusyMode(ctx, keys, timer) {
+				continue
 			}
-
-			// 2. SIZE trigger: buffer full → flush immediately
-			if bufLen >= c.batchSize {
-				c.logger.Log(ctx, libLog.LevelInfo, fmt.Sprintf("BalanceSyncCollector: SIZE trigger fired (buffer=%d >= batch_size=%d), flushing now", bufLen, c.batchSize))
-				c.flush(ctx)
-
-				if !timer.Stop() {
-					select {
-					case <-timer.C:
-					default:
-					}
-				}
-
-				timer.Reset(c.flushTimeout)
-
-				timerActive = true
-
-				continue // tight loop — fetch more immediately
-			}
-
-			// 3. Got keys but not enough yet — tight loop (busy mode)
-			continue
 		}
 
 		// No keys fetched from ZSET
-
-		// 4. Draining mode: buffer has items but no new keys arriving
 		c.mu.Lock()
 		bufLen := len(c.buffer)
 		c.mu.Unlock()
 
 		if bufLen > 0 {
-			select {
-			case <-ctx.Done():
-				return
-			case <-timer.C:
-				// TIMEOUT trigger: flush what we have
-				c.logger.Log(ctx, libLog.LevelInfo, fmt.Sprintf("BalanceSyncCollector: TIMEOUT trigger fired (%v elapsed, buffer=%d), flushing now", c.flushTimeout, bufLen))
-				c.flush(ctx)
-
-				timer.Reset(c.flushTimeout)
-
-				timerActive = true
-			case <-time.After(c.pollInterval):
-				// Poll again to check for new keys
-			}
-
+			c.handleDrainingMode(ctx, bufLen, timer)
 			continue
 		}
 
-		// 5. Idle mode: buffer empty and nothing in ZSET
-		c.logger.Log(ctx, libLog.LevelInfo, "BalanceSyncCollector: idle mode — no keys in ZSET, waiting for next scheduled key")
-		timer.Stop()
+		c.handleIdleMode(ctx, timer, waitForNext)
+	}
+}
 
-		timerActive = false
+// handleBusyMode processes newly fetched keys: appends to buffer, flushes on SIZE trigger,
+// or continues the tight poll loop. Returns true if the main loop should continue immediately.
+func (c *BalanceSyncCollector) handleBusyMode(ctx context.Context, keys []redisTransaction.SyncKey, timer *time.Timer) bool {
+	c.mu.Lock()
+	wasEmpty := len(c.buffer) == 0
+	c.buffer = append(c.buffer, keys...)
+	bufLen := len(c.buffer)
+	c.mu.Unlock()
 
-		if waitForNext(ctx) {
-			return // shutdown requested
-		}
+	c.logger.Log(ctx, libLog.LevelInfo, fmt.Sprintf("BalanceSyncCollector: fetched %d keys, buffer=%d/%d", len(keys), bufLen, c.batchSize))
 
-		c.logger.Log(ctx, libLog.LevelInfo, "BalanceSyncCollector: woke up from idle, resuming polling")
-
-		// Re-arm timer for next accumulation cycle
+	// Reset timer when first keys arrive in a previously empty buffer
+	if wasEmpty {
+		stopAndDrain(timer)
 		timer.Reset(c.flushTimeout)
+	}
 
-		timerActive = true
+	// SIZE trigger: buffer full → flush immediately
+	if bufLen >= c.batchSize {
+		c.logger.Log(ctx, libLog.LevelInfo, fmt.Sprintf("BalanceSyncCollector: SIZE trigger fired (buffer=%d >= batch_size=%d), flushing now", bufLen, c.batchSize))
+		c.flush(ctx)
+		stopAndDrain(timer)
+		timer.Reset(c.flushTimeout)
+	}
+
+	return true // always continue tight loop after fetching keys
+}
+
+// handleDrainingMode waits for either the TIMEOUT trigger or the poll interval
+// when the buffer has items but no new keys are arriving.
+func (c *BalanceSyncCollector) handleDrainingMode(ctx context.Context, bufLen int, timer *time.Timer) {
+	select {
+	case <-ctx.Done():
+		return
+	case <-timer.C:
+		c.logger.Log(ctx, libLog.LevelInfo, fmt.Sprintf("BalanceSyncCollector: TIMEOUT trigger fired (%v elapsed, buffer=%d), flushing now", c.flushTimeout, bufLen))
+		c.flush(ctx)
+		timer.Reset(c.flushTimeout)
+	case <-time.After(c.pollInterval):
+		// Poll again to check for new keys
+	}
+}
+
+// handleIdleMode stops the timer and waits for the next scheduled key or shutdown.
+func (c *BalanceSyncCollector) handleIdleMode(ctx context.Context, timer *time.Timer, waitForNext WaitForNextFunc) {
+	c.logger.Log(ctx, libLog.LevelInfo, "BalanceSyncCollector: idle mode — no keys in ZSET, waiting for next scheduled key")
+	timer.Stop()
+
+	if waitForNext(ctx) {
+		return
+	}
+
+	c.logger.Log(ctx, libLog.LevelInfo, "BalanceSyncCollector: woke up from idle, resuming polling")
+	timer.Reset(c.flushTimeout)
+}
+
+// flushRemaining drains any leftover buffer on shutdown.
+func (c *BalanceSyncCollector) flushRemaining() {
+	c.mu.Lock()
+	remaining := c.buffer
+	c.buffer = make([]redisTransaction.SyncKey, 0, c.batchSize)
+	c.mu.Unlock()
+
+	if len(remaining) > 0 && c.flushFn != nil {
+		c.logger.Log(context.Background(), libLog.LevelInfo, fmt.Sprintf("BalanceSyncCollector: shutdown — final flush of %d remaining keys", len(remaining)))
+
+		flushCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
+		c.flushFn(flushCtx, remaining)
 	}
 }
 
@@ -254,6 +241,16 @@ func (c *BalanceSyncCollector) Size() int {
 	defer c.mu.Unlock()
 
 	return len(c.buffer)
+}
+
+// stopAndDrain stops a timer and drains its channel if needed.
+func stopAndDrain(t *time.Timer) {
+	if !t.Stop() {
+		select {
+		case <-t.C:
+		default:
+		}
+	}
 }
 
 // waitOrShutdown waits for duration d or returns true if ctx is cancelled.

--- a/components/ledger/internal/bootstrap/balance_sync_collector_test.go
+++ b/components/ledger/internal/bootstrap/balance_sync_collector_test.go
@@ -1,0 +1,1124 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package bootstrap
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	libLog "github.com/LerianStudio/lib-commons/v4/commons/log"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --------------------------------------------------------------------
+// Helpers
+// --------------------------------------------------------------------
+
+// flushedBatch records a single flush invocation for assertion.
+type flushedBatch struct {
+	keys []string
+	at   time.Time
+}
+
+// flushRecorder is a concurrency-safe recorder for flush calls.
+type flushRecorder struct {
+	mu      sync.Mutex
+	batches []flushedBatch
+}
+
+func (r *flushRecorder) record(_ context.Context, keys []string) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	cp := make([]string, len(keys))
+	copy(cp, keys)
+
+	r.batches = append(r.batches, flushedBatch{keys: cp, at: time.Now()})
+
+	return true
+}
+
+func (r *flushRecorder) count() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	return len(r.batches)
+}
+
+func (r *flushRecorder) allKeys() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	var all []string
+	for _, b := range r.batches {
+		all = append(all, b.keys...)
+	}
+
+	return all
+}
+
+func (r *flushRecorder) getBatches() []flushedBatch {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	cp := make([]flushedBatch, len(r.batches))
+	copy(cp, r.batches)
+
+	return cp
+}
+
+// fetchFunc builds a FetchKeysFunc that reads from a channel of key-slices.
+// When the channel is empty it blocks until a value arrives or the context is cancelled.
+// On context cancellation it returns nil, ctx.Err().
+func fetchFunc(ch <-chan []string) FetchKeysFunc {
+	return func(ctx context.Context, _ int64) ([]string, error) {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case keys, ok := <-ch:
+			if !ok {
+				// Channel closed — return empty from now on
+				return nil, nil
+			}
+
+			return keys, nil
+		}
+	}
+}
+
+// fetchFuncImmediate returns a FetchKeysFunc that pulls the next value
+// from a channel without blocking (returns empty slice if nothing ready).
+func fetchFuncImmediate(ch <-chan []string) FetchKeysFunc {
+	return func(ctx context.Context, _ int64) ([]string, error) {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+
+		select {
+		case keys := <-ch:
+			return keys, nil
+		default:
+			return nil, nil
+		}
+	}
+}
+
+// waitForNextShutdown returns a WaitForNextFunc that always returns true (shutdown).
+func waitForNextShutdown() WaitForNextFunc {
+	return func(_ context.Context) bool {
+		return true
+	}
+}
+
+// waitForNextResume returns a WaitForNextFunc that blocks on a channel.
+// Send to the channel to unblock (returns false = continue).
+// If ctx is cancelled it returns true.
+func waitForNextResume(ch <-chan struct{}) WaitForNextFunc {
+	return func(ctx context.Context) bool {
+		select {
+		case <-ctx.Done():
+			return true
+		case <-ch:
+			return false
+		}
+	}
+}
+
+// nopLogger returns a no-op logger for tests.
+func nopLogger() libLog.Logger {
+	return libLog.NewNop()
+}
+
+// --------------------------------------------------------------------
+// Constructor defaults
+// --------------------------------------------------------------------
+
+func TestNewBalanceSyncCollector_Defaults(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name             string
+		batchSize        int
+		flushTimeout     time.Duration
+		pollInterval     time.Duration
+		idleBackoff      time.Duration
+		wantBatchSize    int
+		wantFlushTimeout time.Duration
+		wantPollInterval time.Duration
+		wantIdleBackoff  time.Duration
+	}{
+		{
+			name:             "all zero values get safe defaults",
+			batchSize:        0,
+			flushTimeout:     0,
+			pollInterval:     0,
+			idleBackoff:      0,
+			wantBatchSize:    50,
+			wantFlushTimeout: 500 * time.Millisecond,
+			wantPollInterval: 50 * time.Millisecond,
+			wantIdleBackoff:  10 * time.Second,
+		},
+		{
+			name:             "all negative values get safe defaults",
+			batchSize:        -1,
+			flushTimeout:     -1,
+			pollInterval:     -1,
+			idleBackoff:      -1,
+			wantBatchSize:    50,
+			wantFlushTimeout: 500 * time.Millisecond,
+			wantPollInterval: 50 * time.Millisecond,
+			wantIdleBackoff:  10 * time.Second,
+		},
+		{
+			name:             "positive values are preserved",
+			batchSize:        10,
+			flushTimeout:     2 * time.Second,
+			pollInterval:     100 * time.Millisecond,
+			idleBackoff:      5 * time.Second,
+			wantBatchSize:    10,
+			wantFlushTimeout: 2 * time.Second,
+			wantPollInterval: 100 * time.Millisecond,
+			wantIdleBackoff:  5 * time.Second,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			c := NewBalanceSyncCollector(tt.batchSize, tt.flushTimeout, tt.pollInterval, tt.idleBackoff, nopLogger())
+
+			require.NotNil(t, c)
+			assert.Equal(t, tt.wantBatchSize, c.batchSize)
+			assert.Equal(t, tt.wantFlushTimeout, c.flushTimeout)
+			assert.Equal(t, tt.wantPollInterval, c.pollInterval)
+			assert.Equal(t, tt.wantIdleBackoff, c.idleBackoff)
+			assert.NotNil(t, c.buffer)
+			assert.Equal(t, 0, len(c.buffer))
+		})
+	}
+}
+
+func TestNewBalanceSyncCollector_BufferCapacity(t *testing.T) {
+	t.Parallel()
+
+	c := NewBalanceSyncCollector(25, time.Second, time.Second, time.Second, nopLogger())
+
+	assert.Equal(t, 25, cap(c.buffer), "buffer capacity should equal batchSize")
+}
+
+// --------------------------------------------------------------------
+// SetFlushCallback
+// --------------------------------------------------------------------
+
+func TestSetFlushCallback(t *testing.T) {
+	t.Parallel()
+
+	c := NewBalanceSyncCollector(10, time.Second, time.Second, time.Second, nopLogger())
+
+	assert.Nil(t, c.flushFn, "flushFn should be nil before SetFlushCallback")
+
+	called := false
+	c.SetFlushCallback(func(_ context.Context, _ []string) bool {
+		called = true
+		return true
+	})
+
+	require.NotNil(t, c.flushFn)
+
+	c.flushFn(context.Background(), []string{"k"})
+	assert.True(t, called)
+}
+
+// --------------------------------------------------------------------
+// Size
+// --------------------------------------------------------------------
+
+func TestSize_ReflectsBuffer(t *testing.T) {
+	t.Parallel()
+
+	c := NewBalanceSyncCollector(10, time.Second, time.Second, time.Second, nopLogger())
+
+	assert.Equal(t, 0, c.Size())
+
+	c.mu.Lock()
+	c.buffer = append(c.buffer, "a", "b", "c")
+	c.mu.Unlock()
+
+	assert.Equal(t, 3, c.Size())
+}
+
+// --------------------------------------------------------------------
+// flush (internal)
+// --------------------------------------------------------------------
+
+func TestFlush_EmptyBuffer(t *testing.T) {
+	t.Parallel()
+
+	rec := &flushRecorder{}
+
+	c := NewBalanceSyncCollector(10, time.Second, time.Second, time.Second, nopLogger())
+	c.SetFlushCallback(rec.record)
+
+	c.flush(context.Background())
+
+	assert.Equal(t, 0, rec.count(), "should not call flushFn when buffer is empty")
+}
+
+func TestFlush_WithItems(t *testing.T) {
+	t.Parallel()
+
+	rec := &flushRecorder{}
+
+	c := NewBalanceSyncCollector(10, time.Second, time.Second, time.Second, nopLogger())
+	c.SetFlushCallback(rec.record)
+
+	c.mu.Lock()
+	c.buffer = append(c.buffer, "key1", "key2")
+	c.mu.Unlock()
+
+	c.flush(context.Background())
+
+	assert.Equal(t, 1, rec.count())
+	assert.Equal(t, []string{"key1", "key2"}, rec.allKeys())
+	assert.Equal(t, 0, c.Size(), "buffer should be empty after flush")
+}
+
+func TestFlush_NilCallback(t *testing.T) {
+	t.Parallel()
+
+	c := NewBalanceSyncCollector(10, time.Second, time.Second, time.Second, nopLogger())
+	// Deliberately do NOT set a callback.
+
+	c.mu.Lock()
+	c.buffer = append(c.buffer, "k")
+	c.mu.Unlock()
+
+	// Should not panic.
+	c.flush(context.Background())
+
+	assert.Equal(t, 0, c.Size(), "buffer should be drained even without callback")
+}
+
+// --------------------------------------------------------------------
+// waitOrShutdown (package-level helper)
+// --------------------------------------------------------------------
+
+func TestWaitOrShutdown_TimerExpires(t *testing.T) {
+	t.Parallel()
+
+	result := waitOrShutdown(context.Background(), 1*time.Millisecond)
+
+	assert.False(t, result, "should return false when timer fires")
+}
+
+func TestWaitOrShutdown_ContextCancelled(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	result := waitOrShutdown(ctx, time.Hour)
+
+	assert.True(t, result, "should return true when context is cancelled")
+}
+
+// --------------------------------------------------------------------
+// Run — Size trigger
+// --------------------------------------------------------------------
+
+func TestRun_SizeTrigger_FlushesWhenBatchFull(t *testing.T) {
+	t.Parallel()
+
+	const batchSize = 3
+	rec := &flushRecorder{}
+
+	c := NewBalanceSyncCollector(
+		batchSize,
+		10*time.Second, // large timeout so only size triggers
+		50*time.Millisecond,
+		10*time.Second,
+		nopLogger(),
+	)
+	c.SetFlushCallback(rec.record)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	keyCh := make(chan []string, 10)
+
+	// Feed exactly batchSize keys in one shot
+	keyCh <- []string{"a", "b", "c"}
+
+	done := make(chan struct{})
+
+	go func() {
+		c.Run(ctx, fetchFuncImmediate(keyCh), waitForNextShutdown())
+		close(done)
+	}()
+
+	// Wait for the flush to happen
+	require.Eventually(t, func() bool {
+		return rec.count() >= 1
+	}, 3*time.Second, 10*time.Millisecond, "expected size-triggered flush")
+
+	cancel()
+	<-done
+
+	batches := rec.getBatches()
+	require.GreaterOrEqual(t, len(batches), 1)
+	assert.Equal(t, []string{"a", "b", "c"}, batches[0].keys)
+}
+
+func TestRun_SizeTrigger_AccumulatesAcrossPolls(t *testing.T) {
+	t.Parallel()
+
+	const batchSize = 4
+	rec := &flushRecorder{}
+
+	c := NewBalanceSyncCollector(
+		batchSize,
+		10*time.Second, // large timeout
+		50*time.Millisecond,
+		10*time.Second,
+		nopLogger(),
+	)
+	c.SetFlushCallback(rec.record)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	keyCh := make(chan []string, 10)
+
+	// Feed keys in two separate polls that together reach batchSize
+	keyCh <- []string{"a", "b"}
+	keyCh <- []string{"c", "d"}
+
+	done := make(chan struct{})
+
+	go func() {
+		c.Run(ctx, fetchFuncImmediate(keyCh), waitForNextShutdown())
+		close(done)
+	}()
+
+	require.Eventually(t, func() bool {
+		return rec.count() >= 1
+	}, 3*time.Second, 10*time.Millisecond, "expected size-triggered flush after accumulation")
+
+	cancel()
+	<-done
+
+	allKeys := rec.allKeys()
+	assert.Contains(t, allKeys, "a")
+	assert.Contains(t, allKeys, "b")
+	assert.Contains(t, allKeys, "c")
+	assert.Contains(t, allKeys, "d")
+}
+
+// --------------------------------------------------------------------
+// Run — Timeout trigger
+// --------------------------------------------------------------------
+
+func TestRun_TimeoutTrigger_FlushesPartialBatch(t *testing.T) {
+	t.Parallel()
+
+	const batchSize = 100 // large so size trigger never fires
+	rec := &flushRecorder{}
+
+	c := NewBalanceSyncCollector(
+		batchSize,
+		200*time.Millisecond, // short timeout to trigger quickly
+		50*time.Millisecond,
+		10*time.Second,
+		nopLogger(),
+	)
+	c.SetFlushCallback(rec.record)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	keyCh := make(chan []string, 10)
+
+	// Feed a partial batch, then nothing — timeout should flush
+	keyCh <- []string{"x", "y"}
+
+	done := make(chan struct{})
+
+	go func() {
+		c.Run(ctx, fetchFuncImmediate(keyCh), waitForNextShutdown())
+		close(done)
+	}()
+
+	require.Eventually(t, func() bool {
+		return rec.count() >= 1
+	}, 3*time.Second, 10*time.Millisecond, "expected timeout-triggered flush")
+
+	cancel()
+	<-done
+
+	assert.Equal(t, []string{"x", "y"}, rec.getBatches()[0].keys)
+}
+
+// --------------------------------------------------------------------
+// Run — Empty buffer does NOT flush on timeout
+// --------------------------------------------------------------------
+
+func TestRun_EmptyBuffer_NoFlushOnTimeout(t *testing.T) {
+	t.Parallel()
+
+	rec := &flushRecorder{}
+
+	c := NewBalanceSyncCollector(
+		10,
+		100*time.Millisecond,
+		50*time.Millisecond,
+		10*time.Second,
+		nopLogger(),
+	)
+	c.SetFlushCallback(rec.record)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+
+	// fetchKeys always returns empty — collector enters idle mode,
+	// waitForNext sees cancellation.
+	emptyFetch := func(_ context.Context, _ int64) ([]string, error) {
+		return nil, nil
+	}
+
+	c.Run(ctx, emptyFetch, func(ctx context.Context) bool {
+		// Block until context is cancelled
+		<-ctx.Done()
+		return true
+	})
+
+	assert.Equal(t, 0, rec.count(), "should never flush when buffer is always empty")
+}
+
+// --------------------------------------------------------------------
+// Run — Idle mode enters waitForNext
+// --------------------------------------------------------------------
+
+func TestRun_IdleMode_CallsWaitForNext(t *testing.T) {
+	t.Parallel()
+
+	var waitCalled atomic.Int32
+
+	c := NewBalanceSyncCollector(10, time.Second, 50*time.Millisecond, 10*time.Second, nopLogger())
+	c.SetFlushCallback(func(_ context.Context, _ []string) bool { return true })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	emptyFetch := func(ctx context.Context, _ int64) ([]string, error) {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+
+		return nil, nil
+	}
+
+	done := make(chan struct{})
+
+	go func() {
+		c.Run(ctx, emptyFetch, func(ctx context.Context) bool {
+			waitCalled.Add(1)
+			// First call: return false (continue loop) to verify re-entry
+			if waitCalled.Load() <= 1 {
+				return false
+			}
+			// Second call: signal shutdown
+			return true
+		})
+		close(done)
+	}()
+
+	<-done
+
+	assert.GreaterOrEqual(t, int(waitCalled.Load()), 2, "waitForNext should be called at least twice")
+}
+
+// --------------------------------------------------------------------
+// Run — Context cancellation → final flush
+// --------------------------------------------------------------------
+
+func TestRun_ContextCancellation_FinalFlush(t *testing.T) {
+	t.Parallel()
+
+	const batchSize = 100 // large so size trigger doesn't fire
+	rec := &flushRecorder{}
+
+	c := NewBalanceSyncCollector(
+		batchSize,
+		10*time.Second, // long timeout
+		50*time.Millisecond,
+		10*time.Second,
+		nopLogger(),
+	)
+	c.SetFlushCallback(rec.record)
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	keyCh := make(chan []string, 10)
+
+	// Feed keys that won't fill the batch
+	keyCh <- []string{"final1", "final2"}
+
+	done := make(chan struct{})
+
+	go func() {
+		c.Run(ctx, fetchFuncImmediate(keyCh), waitForNextShutdown())
+		close(done)
+	}()
+
+	// Wait for the keys to be consumed into the buffer
+	require.Eventually(t, func() bool {
+		return c.Size() >= 2
+	}, 3*time.Second, 10*time.Millisecond, "keys should be accumulated in buffer")
+
+	// Now cancel — the deferred final flush should fire
+	cancel()
+	<-done
+
+	allKeys := rec.allKeys()
+	assert.Contains(t, allKeys, "final1")
+	assert.Contains(t, allKeys, "final2")
+}
+
+// --------------------------------------------------------------------
+// Run — Error handling: transient fetch errors don't kill the loop
+// --------------------------------------------------------------------
+
+func TestRun_TransientFetchError_ContinuesLoop(t *testing.T) {
+	t.Parallel()
+
+	rec := &flushRecorder{}
+
+	c := NewBalanceSyncCollector(
+		3,
+		10*time.Second,
+		10*time.Millisecond,
+		10*time.Second,
+		nopLogger(),
+	)
+	c.SetFlushCallback(rec.record)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var callCount atomic.Int32
+
+	fetchFn := func(ctx context.Context, limit int64) ([]string, error) {
+		n := callCount.Add(1)
+		switch {
+		case n <= 2:
+			// First two calls: transient error
+			return nil, errors.New("redis timeout")
+		case n == 3:
+			// Third call: success
+			return []string{"a", "b", "c"}, nil
+		default:
+			if ctx.Err() != nil {
+				return nil, ctx.Err()
+			}
+
+			return nil, nil
+		}
+	}
+
+	done := make(chan struct{})
+
+	go func() {
+		c.Run(ctx, fetchFn, waitForNextShutdown())
+		close(done)
+	}()
+
+	require.Eventually(t, func() bool {
+		return rec.count() >= 1
+	}, 5*time.Second, 10*time.Millisecond, "should flush despite earlier transient errors")
+
+	cancel()
+	<-done
+
+	assert.Equal(t, []string{"a", "b", "c"}, rec.getBatches()[0].keys)
+	assert.GreaterOrEqual(t, int(callCount.Load()), 3, "fetch should have been called at least 3 times (2 errors + 1 success)")
+}
+
+// --------------------------------------------------------------------
+// Run — Busy mode: continuous key flow
+// --------------------------------------------------------------------
+
+func TestRun_BusyMode_MultipleBatches(t *testing.T) {
+	t.Parallel()
+
+	const batchSize = 2
+	rec := &flushRecorder{}
+
+	c := NewBalanceSyncCollector(
+		batchSize,
+		10*time.Second,
+		50*time.Millisecond,
+		10*time.Second,
+		nopLogger(),
+	)
+	c.SetFlushCallback(rec.record)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	keyCh := make(chan []string, 10)
+
+	// Feed multiple full batches back-to-back
+	keyCh <- []string{"a1", "a2"}
+	keyCh <- []string{"b1", "b2"}
+	keyCh <- []string{"c1", "c2"}
+
+	done := make(chan struct{})
+
+	go func() {
+		c.Run(ctx, fetchFuncImmediate(keyCh), waitForNextShutdown())
+		close(done)
+	}()
+
+	require.Eventually(t, func() bool {
+		return rec.count() >= 3
+	}, 5*time.Second, 10*time.Millisecond, "expected 3 size-triggered flushes")
+
+	cancel()
+	<-done
+
+	allKeys := rec.allKeys()
+	assert.Len(t, allKeys, 6)
+}
+
+// --------------------------------------------------------------------
+// Run — Mixed trigger: partial batch flushed by timeout,
+// then new keys arrive and fill a batch by size.
+// --------------------------------------------------------------------
+
+func TestRun_MixedTrigger_TimeoutThenSize(t *testing.T) {
+	t.Parallel()
+
+	const batchSize = 3
+	rec := &flushRecorder{}
+
+	c := NewBalanceSyncCollector(
+		batchSize,
+		200*time.Millisecond, // short timeout
+		50*time.Millisecond,
+		10*time.Second,
+		nopLogger(),
+	)
+	c.SetFlushCallback(rec.record)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	keyCh := make(chan []string, 10)
+	waitCh := make(chan struct{}, 5)
+
+	// Phase 1: partial batch — should trigger timeout flush
+	keyCh <- []string{"p1"}
+
+	done := make(chan struct{})
+
+	go func() {
+		c.Run(ctx, fetchFuncImmediate(keyCh), waitForNextResume(waitCh))
+		close(done)
+	}()
+
+	// Wait for the timeout-triggered flush of the partial batch
+	require.Eventually(t, func() bool {
+		return rec.count() >= 1
+	}, 3*time.Second, 10*time.Millisecond, "expected timeout-triggered flush of partial batch")
+
+	// Phase 2: full batch — load keys then resume from idle
+	keyCh <- []string{"s1", "s2", "s3"}
+	waitCh <- struct{}{}
+
+	require.Eventually(t, func() bool {
+		return rec.count() >= 2
+	}, 3*time.Second, 10*time.Millisecond, "expected size-triggered flush of full batch")
+
+	cancel()
+	<-done
+
+	batches := rec.getBatches()
+	require.GreaterOrEqual(t, len(batches), 2)
+	assert.Equal(t, []string{"p1"}, batches[0].keys, "first flush should be the partial batch")
+	assert.Equal(t, []string{"s1", "s2", "s3"}, batches[1].keys, "second flush should be the full batch")
+}
+
+// --------------------------------------------------------------------
+// Run — waitForNext resumes polling after idle
+// --------------------------------------------------------------------
+
+func TestRun_IdleResumeAfterWaitForNext(t *testing.T) {
+	t.Parallel()
+
+	const batchSize = 2
+	rec := &flushRecorder{}
+
+	c := NewBalanceSyncCollector(
+		batchSize,
+		200*time.Millisecond,
+		50*time.Millisecond,
+		10*time.Second,
+		nopLogger(),
+	)
+	c.SetFlushCallback(rec.record)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	keyCh := make(chan []string, 10)
+	waitCh := make(chan struct{}, 5)
+
+	var fetchCallCount atomic.Int32
+
+	fetchFn := func(ctx context.Context, limit int64) ([]string, error) {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+
+		n := fetchCallCount.Add(1)
+		if n == 1 {
+			// First round: nothing — will enter idle
+			return nil, nil
+		}
+
+		// After resume: check channel for keys
+		select {
+		case keys := <-keyCh:
+			return keys, nil
+		default:
+			return nil, nil
+		}
+	}
+
+	done := make(chan struct{})
+
+	go func() {
+		c.Run(ctx, fetchFn, waitForNextResume(waitCh))
+		close(done)
+	}()
+
+	// Wait for collector to reach idle and call waitForNext
+	time.Sleep(200 * time.Millisecond)
+
+	// Now push keys and resume from idle
+	keyCh <- []string{"k1", "k2"}
+	waitCh <- struct{}{}
+
+	require.Eventually(t, func() bool {
+		return rec.count() >= 1
+	}, 3*time.Second, 10*time.Millisecond, "should flush after resuming from idle")
+
+	cancel()
+	<-done
+
+	assert.Contains(t, rec.allKeys(), "k1")
+	assert.Contains(t, rec.allKeys(), "k2")
+}
+
+// --------------------------------------------------------------------
+// Run — No flushFn set: Run should not panic
+// --------------------------------------------------------------------
+
+func TestRun_NilFlushCallback_NoPanic(t *testing.T) {
+	t.Parallel()
+
+	c := NewBalanceSyncCollector(2, 100*time.Millisecond, 50*time.Millisecond, 10*time.Second, nopLogger())
+	// Deliberately do NOT call SetFlushCallback.
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	keyCh := make(chan []string, 10)
+	keyCh <- []string{"a", "b"} // will trigger size flush with nil callback
+
+	done := make(chan struct{})
+
+	go func() {
+		c.Run(ctx, fetchFuncImmediate(keyCh), waitForNextShutdown())
+		close(done)
+	}()
+
+	// Let it run a bit to hit the flush path
+	time.Sleep(200 * time.Millisecond)
+	cancel()
+	<-done
+
+	// No panic = test passed.
+}
+
+// --------------------------------------------------------------------
+// Run — Context cancelled before first iteration
+// --------------------------------------------------------------------
+
+func TestRun_ImmediateCancel_ExitsCleanly(t *testing.T) {
+	t.Parallel()
+
+	rec := &flushRecorder{}
+
+	c := NewBalanceSyncCollector(10, time.Second, 50*time.Millisecond, 10*time.Second, nopLogger())
+	c.SetFlushCallback(rec.record)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Cancel immediately
+
+	// Pre-load buffer to verify final flush
+	c.mu.Lock()
+	c.buffer = append(c.buffer, "leftover")
+	c.mu.Unlock()
+
+	c.Run(ctx, func(_ context.Context, _ int64) ([]string, error) {
+		return nil, nil
+	}, waitForNextShutdown())
+
+	// Final flush should have drained the buffer
+	assert.Equal(t, 1, rec.count(), "final flush should fire for pre-loaded buffer")
+	assert.Equal(t, []string{"leftover"}, rec.allKeys())
+}
+
+// --------------------------------------------------------------------
+// Run — Final flush on shutdown with empty buffer: no flush
+// --------------------------------------------------------------------
+
+func TestRun_FinalFlush_EmptyBuffer_NoFlush(t *testing.T) {
+	t.Parallel()
+
+	rec := &flushRecorder{}
+
+	c := NewBalanceSyncCollector(10, time.Second, 50*time.Millisecond, 10*time.Second, nopLogger())
+	c.SetFlushCallback(rec.record)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	c.Run(ctx, func(_ context.Context, _ int64) ([]string, error) {
+		return nil, nil
+	}, waitForNextShutdown())
+
+	assert.Equal(t, 0, rec.count(), "no flush when buffer is empty at shutdown")
+}
+
+// --------------------------------------------------------------------
+// Run — Timer reset: first keys in empty buffer reset the timer
+// --------------------------------------------------------------------
+
+func TestRun_TimerResetOnFirstKeys(t *testing.T) {
+	t.Parallel()
+
+	const batchSize = 100 // large so size never triggers
+	rec := &flushRecorder{}
+
+	c := NewBalanceSyncCollector(
+		batchSize,
+		300*time.Millisecond,
+		50*time.Millisecond,
+		10*time.Second,
+		nopLogger(),
+	)
+	c.SetFlushCallback(rec.record)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	keyCh := make(chan []string, 10)
+	waitCh := make(chan struct{}, 5)
+
+	done := make(chan struct{})
+
+	go func() {
+		c.Run(ctx, fetchFuncImmediate(keyCh), waitForNextResume(waitCh))
+		close(done)
+	}()
+
+	// The collector starts, polls empty, enters idle, blocks on waitForNext.
+	// Delay before sending keys — the flush should happen ~300ms after
+	// the keys arrive, not ~300ms after Run started.
+	time.Sleep(200 * time.Millisecond)
+	keyCh <- []string{"late-key"}
+	waitCh <- struct{}{} // resume from idle
+	sendTime := time.Now()
+
+	require.Eventually(t, func() bool {
+		return rec.count() >= 1
+	}, 3*time.Second, 10*time.Millisecond, "expected timeout flush")
+
+	batches := rec.getBatches()
+	flushDelay := batches[0].at.Sub(sendTime)
+
+	// The flush should happen approximately flushTimeout after the keys arrived.
+	// Allow generous tolerance for CI environments.
+	assert.Greater(t, flushDelay, 100*time.Millisecond, "flush should not happen immediately")
+	assert.Less(t, flushDelay, 2*time.Second, "flush should happen within reasonable timeout window")
+
+	cancel()
+	<-done
+}
+
+// --------------------------------------------------------------------
+// Run — Concurrent safety: multiple goroutines checking Size()
+// --------------------------------------------------------------------
+
+func TestRun_ConcurrentSizeAccess(t *testing.T) {
+	t.Parallel()
+
+	c := NewBalanceSyncCollector(100, 200*time.Millisecond, 20*time.Millisecond, 10*time.Second, nopLogger())
+	c.SetFlushCallback(func(_ context.Context, _ []string) bool { return true })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	keyCh := make(chan []string, 100)
+
+	// Feed keys continuously
+	go func() {
+		for i := 0; i < 50; i++ {
+			select {
+			case keyCh <- []string{"k"}:
+			case <-ctx.Done():
+				return
+			}
+
+			time.Sleep(5 * time.Millisecond)
+		}
+	}()
+
+	done := make(chan struct{})
+
+	go func() {
+		c.Run(ctx, fetchFuncImmediate(keyCh), waitForNextShutdown())
+		close(done)
+	}()
+
+	// Concurrently read Size() while Run is active
+	var wg sync.WaitGroup
+
+	for range 5 {
+		wg.Add(1)
+
+		go func() {
+			defer wg.Done()
+
+			for range 20 {
+				_ = c.Size()
+				time.Sleep(2 * time.Millisecond)
+			}
+		}()
+	}
+
+	wg.Wait()
+	cancel()
+	<-done
+	// No race condition = test passed.
+}
+
+// --------------------------------------------------------------------
+// Run — fetchKeys blocking: uses channel-based fetchFunc
+// (verifies that a blocking fetch properly yields on ctx cancellation)
+// --------------------------------------------------------------------
+
+func TestRun_BlockingFetch_ContextCancellation(t *testing.T) {
+	t.Parallel()
+
+	c := NewBalanceSyncCollector(10, time.Second, 50*time.Millisecond, 10*time.Second, nopLogger())
+	c.SetFlushCallback(func(_ context.Context, _ []string) bool { return true })
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// fetchFunc blocks waiting on channel
+	keyCh := make(chan []string)
+
+	done := make(chan struct{})
+
+	go func() {
+		c.Run(ctx, fetchFunc(keyCh), waitForNextShutdown())
+		close(done)
+	}()
+
+	// Cancel while fetch is blocked
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+
+	select {
+	case <-done:
+		// Clean exit
+	case <-time.After(3 * time.Second):
+		t.Fatal("Run did not exit within timeout after context cancellation")
+	}
+}
+
+// --------------------------------------------------------------------
+// Run — Multiple flush cycles
+// --------------------------------------------------------------------
+
+func TestRun_MultipleFlushCycles(t *testing.T) {
+	t.Parallel()
+
+	const batchSize = 2
+	rec := &flushRecorder{}
+
+	c := NewBalanceSyncCollector(
+		batchSize,
+		150*time.Millisecond,
+		20*time.Millisecond,
+		10*time.Second,
+		nopLogger(),
+	)
+	c.SetFlushCallback(rec.record)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	keyCh := make(chan []string, 20)
+	waitCh := make(chan struct{}, 10)
+
+	done := make(chan struct{})
+
+	go func() {
+		c.Run(ctx, fetchFuncImmediate(keyCh), waitForNextResume(waitCh))
+		close(done)
+	}()
+
+	// Cycle 1: size trigger
+	keyCh <- []string{"c1a", "c1b"}
+
+	require.Eventually(t, func() bool {
+		return rec.count() >= 1
+	}, 3*time.Second, 10*time.Millisecond)
+
+	// Cycle 2: timeout trigger (partial batch)
+	// Load keys then resume from idle
+	keyCh <- []string{"c2a"}
+	waitCh <- struct{}{}
+
+	require.Eventually(t, func() bool {
+		return rec.count() >= 2
+	}, 3*time.Second, 10*time.Millisecond)
+
+	// Cycle 3: size trigger again
+	keyCh <- []string{"c3a", "c3b"}
+	waitCh <- struct{}{}
+
+	require.Eventually(t, func() bool {
+		return rec.count() >= 3
+	}, 3*time.Second, 10*time.Millisecond)
+
+	cancel()
+	<-done
+
+	batches := rec.getBatches()
+	require.GreaterOrEqual(t, len(batches), 3)
+	assert.Equal(t, []string{"c1a", "c1b"}, batches[0].keys)
+	assert.Equal(t, []string{"c2a"}, batches[1].keys)
+	assert.Equal(t, []string{"c3a", "c3b"}, batches[2].keys)
+}

--- a/components/ledger/internal/bootstrap/balance_sync_collector_test.go
+++ b/components/ledger/internal/bootstrap/balance_sync_collector_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	libLog "github.com/LerianStudio/lib-commons/v4/commons/log"
+	redisTransaction "github.com/LerianStudio/midaz/v3/components/ledger/internal/adapters/redis/transaction"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -33,12 +34,14 @@ type flushRecorder struct {
 	batches []flushedBatch
 }
 
-func (r *flushRecorder) record(_ context.Context, keys []string) bool {
+func (r *flushRecorder) record(_ context.Context, keys []redisTransaction.SyncKey) bool {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
 	cp := make([]string, len(keys))
-	copy(cp, keys)
+	for i, k := range keys {
+		cp[i] = k.Key
+	}
 
 	r.batches = append(r.batches, flushedBatch{keys: cp, at: time.Now()})
 
@@ -78,7 +81,7 @@ func (r *flushRecorder) getBatches() []flushedBatch {
 // When the channel is empty it blocks until a value arrives or the context is cancelled.
 // On context cancellation it returns nil, ctx.Err().
 func fetchFunc(ch <-chan []string) FetchKeysFunc {
-	return func(ctx context.Context, _ int64) ([]string, error) {
+	return func(ctx context.Context, _ int64) ([]redisTransaction.SyncKey, error) {
 		select {
 		case <-ctx.Done():
 			return nil, ctx.Err()
@@ -88,7 +91,12 @@ func fetchFunc(ch <-chan []string) FetchKeysFunc {
 				return nil, nil
 			}
 
-			return keys, nil
+			syncKeys := make([]redisTransaction.SyncKey, len(keys))
+			for i, k := range keys {
+				syncKeys[i] = redisTransaction.SyncKey{Key: k}
+			}
+
+			return syncKeys, nil
 		}
 	}
 }
@@ -96,14 +104,19 @@ func fetchFunc(ch <-chan []string) FetchKeysFunc {
 // fetchFuncImmediate returns a FetchKeysFunc that pulls the next value
 // from a channel without blocking (returns empty slice if nothing ready).
 func fetchFuncImmediate(ch <-chan []string) FetchKeysFunc {
-	return func(ctx context.Context, _ int64) ([]string, error) {
+	return func(ctx context.Context, _ int64) ([]redisTransaction.SyncKey, error) {
 		if ctx.Err() != nil {
 			return nil, ctx.Err()
 		}
 
 		select {
 		case keys := <-ch:
-			return keys, nil
+			syncKeys := make([]redisTransaction.SyncKey, len(keys))
+			for i, k := range keys {
+				syncKeys[i] = redisTransaction.SyncKey{Key: k}
+			}
+
+			return syncKeys, nil
 		default:
 			return nil, nil
 		}
@@ -226,14 +239,14 @@ func TestSetFlushCallback(t *testing.T) {
 	assert.Nil(t, c.flushFn, "flushFn should be nil before SetFlushCallback")
 
 	called := false
-	c.SetFlushCallback(func(_ context.Context, _ []string) bool {
+	c.SetFlushCallback(func(_ context.Context, _ []redisTransaction.SyncKey) bool {
 		called = true
 		return true
 	})
 
 	require.NotNil(t, c.flushFn)
 
-	c.flushFn(context.Background(), []string{"k"})
+	c.flushFn(context.Background(), []redisTransaction.SyncKey{{Key: "k"}})
 	assert.True(t, called)
 }
 
@@ -249,7 +262,7 @@ func TestSize_ReflectsBuffer(t *testing.T) {
 	assert.Equal(t, 0, c.Size())
 
 	c.mu.Lock()
-	c.buffer = append(c.buffer, "a", "b", "c")
+	c.buffer = append(c.buffer, redisTransaction.SyncKey{Key: "a"}, redisTransaction.SyncKey{Key: "b"}, redisTransaction.SyncKey{Key: "c"})
 	c.mu.Unlock()
 
 	assert.Equal(t, 3, c.Size())
@@ -281,7 +294,7 @@ func TestFlush_WithItems(t *testing.T) {
 	c.SetFlushCallback(rec.record)
 
 	c.mu.Lock()
-	c.buffer = append(c.buffer, "key1", "key2")
+	c.buffer = append(c.buffer, redisTransaction.SyncKey{Key: "key1"}, redisTransaction.SyncKey{Key: "key2"})
 	c.mu.Unlock()
 
 	c.flush(context.Background())
@@ -298,7 +311,7 @@ func TestFlush_NilCallback(t *testing.T) {
 	// Deliberately do NOT set a callback.
 
 	c.mu.Lock()
-	c.buffer = append(c.buffer, "k")
+	c.buffer = append(c.buffer, redisTransaction.SyncKey{Key: "k"})
 	c.mu.Unlock()
 
 	// Should not panic.
@@ -489,7 +502,7 @@ func TestRun_EmptyBuffer_NoFlushOnTimeout(t *testing.T) {
 
 	// fetchKeys always returns empty — collector enters idle mode,
 	// waitForNext sees cancellation.
-	emptyFetch := func(_ context.Context, _ int64) ([]string, error) {
+	emptyFetch := func(_ context.Context, _ int64) ([]redisTransaction.SyncKey, error) {
 		return nil, nil
 	}
 
@@ -512,12 +525,12 @@ func TestRun_IdleMode_CallsWaitForNext(t *testing.T) {
 	var waitCalled atomic.Int32
 
 	c := NewBalanceSyncCollector(10, time.Second, 50*time.Millisecond, 10*time.Second, nopLogger())
-	c.SetFlushCallback(func(_ context.Context, _ []string) bool { return true })
+	c.SetFlushCallback(func(_ context.Context, _ []redisTransaction.SyncKey) bool { return true })
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	emptyFetch := func(ctx context.Context, _ int64) ([]string, error) {
+	emptyFetch := func(ctx context.Context, _ int64) ([]redisTransaction.SyncKey, error) {
 		if ctx.Err() != nil {
 			return nil, ctx.Err()
 		}
@@ -615,7 +628,7 @@ func TestRun_TransientFetchError_ContinuesLoop(t *testing.T) {
 
 	var callCount atomic.Int32
 
-	fetchFn := func(ctx context.Context, limit int64) ([]string, error) {
+	fetchFn := func(ctx context.Context, limit int64) ([]redisTransaction.SyncKey, error) {
 		n := callCount.Add(1)
 		switch {
 		case n <= 2:
@@ -623,7 +636,7 @@ func TestRun_TransientFetchError_ContinuesLoop(t *testing.T) {
 			return nil, errors.New("redis timeout")
 		case n == 3:
 			// Third call: success
-			return []string{"a", "b", "c"}, nil
+			return []redisTransaction.SyncKey{{Key: "a"}, {Key: "b"}, {Key: "c"}}, nil
 		default:
 			if ctx.Err() != nil {
 				return nil, ctx.Err()
@@ -783,7 +796,7 @@ func TestRun_IdleResumeAfterWaitForNext(t *testing.T) {
 
 	var fetchCallCount atomic.Int32
 
-	fetchFn := func(ctx context.Context, limit int64) ([]string, error) {
+	fetchFn := func(ctx context.Context, limit int64) ([]redisTransaction.SyncKey, error) {
 		if ctx.Err() != nil {
 			return nil, ctx.Err()
 		}
@@ -797,7 +810,12 @@ func TestRun_IdleResumeAfterWaitForNext(t *testing.T) {
 		// After resume: check channel for keys
 		select {
 		case keys := <-keyCh:
-			return keys, nil
+			syncKeys := make([]redisTransaction.SyncKey, len(keys))
+			for i, k := range keys {
+				syncKeys[i] = redisTransaction.SyncKey{Key: k}
+			}
+
+			return syncKeys, nil
 		default:
 			return nil, nil
 		}
@@ -875,10 +893,10 @@ func TestRun_ImmediateCancel_ExitsCleanly(t *testing.T) {
 
 	// Pre-load buffer to verify final flush
 	c.mu.Lock()
-	c.buffer = append(c.buffer, "leftover")
+	c.buffer = append(c.buffer, redisTransaction.SyncKey{Key: "leftover"})
 	c.mu.Unlock()
 
-	c.Run(ctx, func(_ context.Context, _ int64) ([]string, error) {
+	c.Run(ctx, func(_ context.Context, _ int64) ([]redisTransaction.SyncKey, error) {
 		return nil, nil
 	}, waitForNextShutdown())
 
@@ -902,7 +920,7 @@ func TestRun_FinalFlush_EmptyBuffer_NoFlush(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	c.Run(ctx, func(_ context.Context, _ int64) ([]string, error) {
+	c.Run(ctx, func(_ context.Context, _ int64) ([]redisTransaction.SyncKey, error) {
 		return nil, nil
 	}, waitForNextShutdown())
 
@@ -973,7 +991,7 @@ func TestRun_ConcurrentSizeAccess(t *testing.T) {
 	t.Parallel()
 
 	c := NewBalanceSyncCollector(100, 200*time.Millisecond, 20*time.Millisecond, 10*time.Second, nopLogger())
-	c.SetFlushCallback(func(_ context.Context, _ []string) bool { return true })
+	c.SetFlushCallback(func(_ context.Context, _ []redisTransaction.SyncKey) bool { return true })
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -1031,7 +1049,7 @@ func TestRun_BlockingFetch_ContextCancellation(t *testing.T) {
 	t.Parallel()
 
 	c := NewBalanceSyncCollector(10, time.Second, 50*time.Millisecond, 10*time.Second, nopLogger())
-	c.SetFlushCallback(func(_ context.Context, _ []string) bool { return true })
+	c.SetFlushCallback(func(_ context.Context, _ []redisTransaction.SyncKey) bool { return true })
 
 	ctx, cancel := context.WithCancel(context.Background())
 

--- a/components/ledger/internal/bootstrap/config.go
+++ b/components/ledger/internal/bootstrap/config.go
@@ -196,7 +196,10 @@ type Config struct {
 	BulkRecorderMaxRowsPerInsert int  `env:"BULK_RECORDER_MAX_ROWS_PER_INSERT"`
 
 	// --- Balance/Worker fields ---
-	BalanceSyncMaxWorkers int `env:"BALANCE_SYNC_MAX_WORKERS"`
+	BalanceSyncMaxWorkers     int `env:"BALANCE_SYNC_MAX_WORKERS"`
+	BalanceSyncBatchSize      int `env:"BALANCE_SYNC_BATCH_SIZE"`
+	BalanceSyncFlushTimeoutMs int `env:"BALANCE_SYNC_FLUSH_TIMEOUT_MS"`
+	BalanceSyncPollIntervalMs int `env:"BALANCE_SYNC_POLL_INTERVAL_MS"`
 
 	// --- Settings ---
 	SettingsCacheTTL string `env:"SETTINGS_CACHE_TTL"`
@@ -842,15 +845,22 @@ func initBalanceSyncWorker(opts *Options, cfg *Config, logger libLog.Logger, com
 		logger.Log(context.Background(), libLog.LevelInfo, fmt.Sprintf("BalanceSyncWorker using default: BALANCE_SYNC_MAX_WORKERS=%d", defaultBalanceSyncMaxWorkers))
 	}
 
+	syncCfg := BalanceSyncConfig{
+		BatchSize:      cfg.BalanceSyncBatchSize,
+		FlushTimeoutMs: cfg.BalanceSyncFlushTimeoutMs,
+		PollIntervalMs: cfg.BalanceSyncPollIntervalMs,
+	}
+
 	var balanceSyncWorker *BalanceSyncWorker
 
 	if opts != nil && opts.MultiTenantEnabled && opts.TenantCache != nil {
-		balanceSyncWorker = NewBalanceSyncWorkerMultiTenant(redisConn, logger, commandUC, balanceSyncMaxWorkers, true, opts.TenantCache, pgManager, tenantServiceName)
+		balanceSyncWorker = NewBalanceSyncWorkerMultiTenant(redisConn, logger, commandUC, balanceSyncMaxWorkers, syncCfg, true, opts.TenantCache, pgManager, tenantServiceName)
 	} else {
-		balanceSyncWorker = NewBalanceSyncWorker(redisConn, logger, commandUC, balanceSyncMaxWorkers)
+		balanceSyncWorker = NewBalanceSyncWorker(redisConn, logger, commandUC, balanceSyncMaxWorkers, syncCfg)
 	}
 
-	logger.Log(context.Background(), libLog.LevelInfo, fmt.Sprintf("BalanceSyncWorker enabled with %d max workers.", balanceSyncMaxWorkers))
+	logger.Log(context.Background(), libLog.LevelInfo, fmt.Sprintf("BalanceSyncWorker enabled: max_workers=%d, batch_size=%d, flush_timeout_ms=%d, poll_interval_ms=%d",
+		balanceSyncMaxWorkers, syncCfg.BatchSize, syncCfg.FlushTimeoutMs, syncCfg.PollIntervalMs))
 
 	return balanceSyncWorker
 }
@@ -1101,4 +1111,9 @@ func applyConfigDefaults(cfg *Config) {
 
 		cfg.BulkRecorderSize = workers * prefetch
 	}
+
+	// Balance Sync Worker defaults (dual-trigger)
+	intDefault(&cfg.BalanceSyncBatchSize, 50)
+	intDefault(&cfg.BalanceSyncFlushTimeoutMs, 500)
+	intDefault(&cfg.BalanceSyncPollIntervalMs, 50)
 }

--- a/components/ledger/internal/bootstrap/workers_multitenant_fuzz_test.go
+++ b/components/ledger/internal/bootstrap/workers_multitenant_fuzz_test.go
@@ -76,7 +76,7 @@ func FuzzNewBalanceSyncWorkerMultiTenant_MaxWorkers(f *testing.F) {
 
 	f.Fuzz(func(t *testing.T, maxWorkers int, multiTenantEnabled bool, serviceName string) {
 		// Property: constructor must never panic (enforced by test execution).
-		worker := NewBalanceSyncWorkerMultiTenant(conn, logger, useCase, maxWorkers, multiTenantEnabled, cache, pgMgr, serviceName)
+		worker := NewBalanceSyncWorkerMultiTenant(conn, logger, useCase, maxWorkers, BalanceSyncConfig{}, multiTenantEnabled, cache, pgMgr, serviceName)
 
 		// Property: returned worker is never nil.
 		if worker == nil {
@@ -108,9 +108,9 @@ func FuzzNewBalanceSyncWorkerMultiTenant_MaxWorkers(f *testing.F) {
 			t.Fatal("isMultiTenantReady() should be false when multiTenantEnabled is false")
 		}
 
-		// Property: batchSize equals maxWorkers (post-default).
-		if worker.batchSize != int64(worker.maxWorkers) {
-			t.Fatalf("batchSize (%d) should equal maxWorkers (%d)", worker.batchSize, worker.maxWorkers)
+		// Property: batchSize equals default BatchSize (50) when BalanceSyncConfig{} is used.
+		if worker.batchSize != int64(50) {
+			t.Fatalf("batchSize (%d) should equal default BatchSize (50)", worker.batchSize)
 		}
 	})
 }
@@ -216,7 +216,7 @@ func FuzzIsMultiTenantReady_FieldCombinations(f *testing.F) {
 
 	f.Fuzz(func(t *testing.T, workerEnabled bool, workerHasPGMgr bool, consumerEnabled bool, consumerHasPGMgr bool) {
 		// --- BalanceSyncWorker predicate ---
-		worker := NewBalanceSyncWorker(conn, logger, useCase, 5)
+		worker := NewBalanceSyncWorker(conn, logger, useCase, 5, BalanceSyncConfig{})
 		worker.multiTenantEnabled = workerEnabled
 
 		if workerHasPGMgr {

--- a/components/ledger/internal/bootstrap/workers_multitenant_property_test.go
+++ b/components/ledger/internal/bootstrap/workers_multitenant_property_test.go
@@ -62,7 +62,7 @@ func TestProperty_BalanceSyncWorker_PredicateEqualsEnabledAndPGManagerNonNil(t *
 	cache := tenantcache.NewTenantCache()
 
 	property := func(enabled bool, hasPGManager bool, hasTenantCache bool) bool {
-		worker := NewBalanceSyncWorker(conn, logger, useCase, 5)
+		worker := NewBalanceSyncWorker(conn, logger, useCase, 5, BalanceSyncConfig{})
 		worker.multiTenantEnabled = enabled
 
 		if hasPGManager {
@@ -151,7 +151,7 @@ func TestProperty_RedisQueueConsumer_PredicateEqualsEnabledAndPGManagerNonNil(t 
 //   - redisConn, logger, useCase are the same instances passed in
 //   - idleWait is the base default (600s)
 //   - maxWorkers > 0 always (clamped to 5 if input <= 0, preserved otherwise)
-//   - batchSize == int64(maxWorkers) after clamping
+//   - batchSize == int64(50) (default from BalanceSyncConfig{})
 //   - multiTenantEnabled matches the input bool
 //   - tenantClient and pgManager are the exact instances passed in
 func TestProperty_NewBalanceSyncWorkerMultiTenant_PreservesBaseFields(t *testing.T) {
@@ -178,7 +178,7 @@ func TestProperty_NewBalanceSyncWorkerMultiTenant_PreservesBaseFields(t *testing
 			maxWorkers = -maxBound
 		}
 
-		worker := NewBalanceSyncWorkerMultiTenant(conn, logger, useCase, maxWorkers, enabled, cache, pgMgr, "transaction")
+		worker := NewBalanceSyncWorkerMultiTenant(conn, logger, useCase, maxWorkers, BalanceSyncConfig{}, enabled, cache, pgMgr, "transaction")
 
 		// Property: constructor never returns nil.
 		if worker == nil {
@@ -194,8 +194,8 @@ func TestProperty_NewBalanceSyncWorkerMultiTenant_PreservesBaseFields(t *testing
 			return false
 		}
 
-		// Property: idleWait is the base default.
-		if worker.idleWait != 600*time.Second {
+		// Property: idleWait is 2x flushTimeout (default 500ms = 1s), clamped to min 1s.
+		if worker.idleWait != 1*time.Second {
 			return false
 		}
 
@@ -214,8 +214,8 @@ func TestProperty_NewBalanceSyncWorkerMultiTenant_PreservesBaseFields(t *testing
 			return false
 		}
 
-		// Property: batchSize == int64(maxWorkers) after clamping.
-		if worker.batchSize != int64(worker.maxWorkers) {
+		// Property: batchSize == int64(50) (default from BalanceSyncConfig{}).
+		if worker.batchSize != int64(50) {
 			return false
 		}
 
@@ -360,7 +360,7 @@ func TestProperty_MultiTenantConstructors_NeverPanic(t *testing.T) {
 		// Note: logger is always non-nil because the base constructor calls
 		// logger methods; passing nil logger would panic in production too,
 		// but that is a caller contract, not a multi-tenant invariant.
-		worker := NewBalanceSyncWorkerMultiTenant(wConn, logger, wUseCase, 0, workerEnabled, wTenantCache, wPGManager, "transaction")
+		worker := NewBalanceSyncWorkerMultiTenant(wConn, logger, wUseCase, 0, BalanceSyncConfig{}, workerEnabled, wTenantCache, wPGManager, "transaction")
 		if worker == nil {
 			return false
 		}

--- a/components/ledger/internal/bootstrap/workers_multitenant_test.go
+++ b/components/ledger/internal/bootstrap/workers_multitenant_test.go
@@ -68,7 +68,7 @@ func TestBalanceSyncWorker_MultiTenantFields(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			worker := NewBalanceSyncWorker(conn, logger, useCase, 5)
+			worker := NewBalanceSyncWorker(conn, logger, useCase, 5, BalanceSyncConfig{})
 
 			// These fields must exist on the struct for multi-tenant support.
 			// The test will fail to compile until the fields are added.
@@ -104,7 +104,7 @@ func TestBalanceSyncWorker_FallbackWhenPGManagerNil(t *testing.T) {
 	conn := &libRedis.Client{}
 	useCase := &command.UseCase{}
 
-	worker := NewBalanceSyncWorker(conn, logger, useCase, 5)
+	worker := NewBalanceSyncWorker(conn, logger, useCase, 5, BalanceSyncConfig{})
 
 	// Set multiTenantEnabled = true but leave pgManager nil
 	worker.multiTenantEnabled = true
@@ -224,7 +224,7 @@ func TestNewBalanceSyncWorkerMultiTenant(t *testing.T) {
 	pgMgr := tmpostgres.NewManager(tenantClient, "transaction", tmpostgres.WithLogger(logger))
 	cache := tenantcache.NewTenantCache()
 
-	worker := NewBalanceSyncWorkerMultiTenant(conn, logger, useCase, 5, true, cache, pgMgr, "transaction")
+	worker := NewBalanceSyncWorkerMultiTenant(conn, logger, useCase, 5, BalanceSyncConfig{}, true, cache, pgMgr, "transaction")
 
 	require.NotNil(t, worker, "worker should not be nil")
 	assert.True(t, worker.multiTenantEnabled,
@@ -359,7 +359,7 @@ func TestBalanceSyncWorker_IsMultiTenantReady(t *testing.T) {
 			if tt.name == "false_for_zero_value_struct" {
 				worker = &BalanceSyncWorker{}
 			} else {
-				worker = NewBalanceSyncWorker(conn, logger, useCase, 5)
+				worker = NewBalanceSyncWorker(conn, logger, useCase, 5, BalanceSyncConfig{})
 				worker.multiTenantEnabled = tt.multiTenantEnabled
 				worker.pgManager = tt.pgManager
 				worker.tenantCache = tt.tenantCache
@@ -509,7 +509,7 @@ func TestNewBalanceSyncWorkerMultiTenant_EdgeCases(t *testing.T) {
 			t.Parallel()
 
 			worker := NewBalanceSyncWorkerMultiTenant(
-				conn, logger, useCase, 5,
+				conn, logger, useCase, 5, BalanceSyncConfig{},
 				tt.multiTenantEnabled, tt.tenantCache, tt.pgManager, "transaction",
 			)
 
@@ -632,7 +632,7 @@ func TestNewBalanceSyncWorker_ZeroValueMultiTenantFields(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			worker := NewBalanceSyncWorker(conn, logger, useCase, tt.maxWorkers)
+			worker := NewBalanceSyncWorker(conn, logger, useCase, tt.maxWorkers, BalanceSyncConfig{})
 
 			require.NotNil(t, worker, "base constructor must return non-nil")
 			assert.Equal(t, tt.wantMaxWorkers, worker.maxWorkers,
@@ -766,7 +766,7 @@ func TestBalanceSyncWorker_RunDispatchesBasedOnMultiTenantReady(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			worker := NewBalanceSyncWorker(conn, logger, useCase, 5)
+			worker := NewBalanceSyncWorker(conn, logger, useCase, 5, BalanceSyncConfig{})
 			worker.multiTenantEnabled = tt.multiTenantEnabled
 			worker.pgManager = tt.pgManager
 			worker.tenantCache = tt.tenantCache
@@ -922,7 +922,7 @@ func TestBalanceSyncWorker_MultiTenantConstructorPreservesRunBehavior(t *testing
 			t.Parallel()
 
 			worker := NewBalanceSyncWorkerMultiTenant(
-				conn, logger, useCase, 5,
+				conn, logger, useCase, 5, BalanceSyncConfig{},
 				tt.multiTenantEnabled, cache, tt.pgManager, "transaction",
 			)
 

--- a/components/ledger/internal/services/command/sync-balances-batch.go
+++ b/components/ledger/internal/services/command/sync-balances-batch.go
@@ -11,6 +11,7 @@ import (
 	libCommons "github.com/LerianStudio/lib-commons/v4/commons"
 	libLog "github.com/LerianStudio/lib-commons/v4/commons/log"
 	libOpentelemetry "github.com/LerianStudio/lib-commons/v4/commons/opentelemetry"
+	redisTransaction "github.com/LerianStudio/midaz/v3/components/ledger/internal/adapters/redis/transaction"
 	redisBalance "github.com/LerianStudio/midaz/v3/components/ledger/internal/adapters/redis/transaction/balance"
 	"github.com/LerianStudio/midaz/v3/pkg/constant"
 	"github.com/LerianStudio/midaz/v3/pkg/mmodel"
@@ -42,7 +43,7 @@ type SyncBalancesBatchResult struct {
 //   - Missing keys (already expired): skipped in aggregation
 //   - Version conflicts: optimistic locking in DB update
 //   - Partial failures: keys only removed after successful DB write
-func (uc *UseCase) SyncBalancesBatch(ctx context.Context, organizationID, ledgerID uuid.UUID, keys []string) (*SyncBalancesBatchResult, error) {
+func (uc *UseCase) SyncBalancesBatch(ctx context.Context, organizationID, ledgerID uuid.UUID, keys []redisTransaction.SyncKey) (*SyncBalancesBatchResult, error) {
 	logger, tracer, _, metricFactory := libCommons.NewTrackingFromContext(ctx)
 
 	ctx, span := tracer.Start(ctx, "command.sync_balances_batch")
@@ -56,7 +57,16 @@ func (uc *UseCase) SyncBalancesBatch(ctx context.Context, organizationID, ledger
 		return result, nil
 	}
 
-	balanceMap, err := uc.TransactionRedisRepo.GetBalancesByKeys(ctx, keys)
+	// Build a map from plain key string to its claimed score, and extract plain keys for MGET.
+	scoreMap := make(map[string]float64, len(keys))
+	plainKeys := make([]string, 0, len(keys))
+
+	for _, sk := range keys {
+		scoreMap[sk.Key] = sk.Score
+		plainKeys = append(plainKeys, sk.Key)
+	}
+
+	balanceMap, err := uc.TransactionRedisRepo.GetBalancesByKeys(ctx, plainKeys)
 	if err != nil {
 		libOpentelemetry.HandleSpanError(span, "Failed to get balances by keys", err)
 		logger.Log(ctx, libLog.LevelError, fmt.Sprintf("Failed to get balances by keys: %v", err))
@@ -65,13 +75,13 @@ func (uc *UseCase) SyncBalancesBatch(ctx context.Context, organizationID, ledger
 	}
 
 	aggregatedBalances := make([]*redisBalance.AggregatedBalance, 0, len(keys))
-	orphanedKeys := make([]string, 0)
+	orphanedKeys := make([]redisTransaction.SyncKey, 0)
 
-	for _, key := range keys {
+	for _, key := range plainKeys {
 		balance := balanceMap[key]
 		if balance == nil {
 			logger.Log(ctx, libLog.LevelDebug, fmt.Sprintf("Balance key %s has no data (expired), marking as orphaned", key))
-			orphanedKeys = append(orphanedKeys, key)
+			orphanedKeys = append(orphanedKeys, redisTransaction.SyncKey{Key: key, Score: scoreMap[key]})
 
 			continue
 		}
@@ -79,7 +89,7 @@ func (uc *UseCase) SyncBalancesBatch(ctx context.Context, organizationID, ledger
 		compositeKey, parseErr := redisBalance.BalanceCompositeKeyFromRedisKey(key)
 		if parseErr != nil {
 			logger.Log(ctx, libLog.LevelWarn, fmt.Sprintf("Failed to parse composite key from %s: %v", key, parseErr))
-			orphanedKeys = append(orphanedKeys, key)
+			orphanedKeys = append(orphanedKeys, redisTransaction.SyncKey{Key: key, Score: scoreMap[key]})
 
 			continue
 		}
@@ -137,14 +147,14 @@ func (uc *UseCase) SyncBalancesBatch(ctx context.Context, organizationID, ledger
 	}
 
 	balancesToSync := make([]mmodel.BalanceRedis, 0, len(deduplicated))
-	keysToRemove := make([]string, 0, len(deduplicated)+len(orphanedKeys))
+	keysToRemove := make([]redisTransaction.SyncKey, 0, len(deduplicated)+len(orphanedKeys))
 
 	// Add orphaned keys first (they need cleanup regardless of DB sync outcome)
 	keysToRemove = append(keysToRemove, orphanedKeys...)
 
 	for _, ab := range deduplicated {
 		balancesToSync = append(balancesToSync, *ab.Balance)
-		keysToRemove = append(keysToRemove, ab.RedisKey)
+		keysToRemove = append(keysToRemove, redisTransaction.SyncKey{Key: ab.RedisKey, Score: scoreMap[ab.RedisKey]})
 	}
 
 	synced, err := uc.BalanceRepo.SyncBatch(ctx, organizationID, ledgerID, balancesToSync)

--- a/components/ledger/internal/services/command/sync-balances-batch.go
+++ b/components/ledger/internal/services/command/sync-balances-batch.go
@@ -157,12 +157,25 @@ func (uc *UseCase) SyncBalancesBatch(ctx context.Context, organizationID, ledger
 		keysToRemove = append(keysToRemove, redisTransaction.SyncKey{Key: ab.RedisKey, Score: scoreMap[ab.RedisKey]})
 	}
 
-	synced, err := uc.BalanceRepo.SyncBatch(ctx, organizationID, ledgerID, balancesToSync)
-	if err != nil {
-		libOpentelemetry.HandleSpanError(span, "Failed to sync batch to database", err)
-		logger.Log(ctx, libLog.LevelError, fmt.Sprintf("Failed to sync batch to database: %v", err))
+	synced, syncErr := uc.BalanceRepo.SyncBatch(ctx, organizationID, ledgerID, balancesToSync)
+	if syncErr != nil {
+		libOpentelemetry.HandleSpanError(span, "Failed to sync batch to database", syncErr)
+		logger.Log(ctx, libLog.LevelError, fmt.Sprintf("Failed to sync batch to database: %v", syncErr))
 
-		return nil, err
+		// Still clean up orphaned keys even though DB failed — these are expired/unparseable
+		// entries that would otherwise become permanent poison records in the ZSET.
+		// Only skip removing the valid-balance keys (those need to be retried on next cycle).
+		if len(orphanedKeys) > 0 {
+			removed, cleanupErr := uc.TransactionRedisRepo.RemoveBalanceSyncKeysBatch(ctx, orphanedKeys)
+			if cleanupErr != nil {
+				logger.Log(ctx, libLog.LevelWarn, fmt.Sprintf("Failed to remove orphaned keys after DB error: %v", cleanupErr))
+			} else {
+				result.KeysRemoved = removed
+				logger.Log(ctx, libLog.LevelInfo, fmt.Sprintf("Cleaned up %d orphaned keys despite DB error", removed))
+			}
+		}
+
+		return result, syncErr
 	}
 
 	result.BalancesSynced = synced

--- a/components/ledger/internal/services/command/sync-balances-batch.go
+++ b/components/ledger/internal/services/command/sync-balances-batch.go
@@ -77,6 +77,10 @@ func (uc *UseCase) SyncBalancesBatch(ctx context.Context, organizationID, ledger
 	aggregatedBalances := make([]*redisBalance.AggregatedBalance, 0, len(keys))
 	orphanedKeys := make([]redisTransaction.SyncKey, 0)
 
+	// Track all Redis keys that map to each composite key so dedup losers
+	// are also removed from the ZSET schedule (not just the winner).
+	compositeToRedisKeys := make(map[string][]string)
+
 	for _, key := range plainKeys {
 		balance := balanceMap[key]
 		if balance == nil {
@@ -104,6 +108,9 @@ func (uc *UseCase) SyncBalancesBatch(ctx context.Context, organizationID, ledger
 		if parsedIsGeneric && balanceHasSpecificKey {
 			compositeKey.PartitionKey = balance.Key
 		}
+
+		keyStr := compositeKey.String()
+		compositeToRedisKeys[keyStr] = append(compositeToRedisKeys[keyStr], key)
 
 		aggregatedBalances = append(aggregatedBalances, &redisBalance.AggregatedBalance{
 			RedisKey: key,
@@ -147,14 +154,22 @@ func (uc *UseCase) SyncBalancesBatch(ctx context.Context, organizationID, ledger
 	}
 
 	balancesToSync := make([]mmodel.BalanceRedis, 0, len(deduplicated))
-	keysToRemove := make([]redisTransaction.SyncKey, 0, len(deduplicated)+len(orphanedKeys))
+	keysToRemove := make([]redisTransaction.SyncKey, 0, len(plainKeys))
 
 	// Add orphaned keys first (they need cleanup regardless of DB sync outcome)
 	keysToRemove = append(keysToRemove, orphanedKeys...)
 
 	for _, ab := range deduplicated {
 		balancesToSync = append(balancesToSync, *ab.Balance)
-		keysToRemove = append(keysToRemove, redisTransaction.SyncKey{Key: ab.RedisKey, Score: scoreMap[ab.RedisKey]})
+
+		// Remove ALL Redis keys that mapped to this composite key, not just the
+		// dedup winner. Loser keys point to the same balance and were already
+		// superseded by the winner's version — leaving them would cause
+		// unnecessary re-processing on the next sync cycle.
+		compositeStr := ab.Key.String()
+		for _, redisKey := range compositeToRedisKeys[compositeStr] {
+			keysToRemove = append(keysToRemove, redisTransaction.SyncKey{Key: redisKey, Score: scoreMap[redisKey]})
+		}
 	}
 
 	synced, syncErr := uc.BalanceRepo.SyncBatch(ctx, organizationID, ledgerID, balancesToSync)

--- a/components/ledger/internal/services/command/sync-balances-batch_test.go
+++ b/components/ledger/internal/services/command/sync-balances-batch_test.go
@@ -19,6 +19,16 @@ import (
 	"go.uber.org/mock/gomock"
 )
 
+// toSyncKeys converts a string slice to SyncKey slice for test convenience.
+func toSyncKeys(keys []string) []redis.SyncKey {
+	syncKeys := make([]redis.SyncKey, len(keys))
+	for i, k := range keys {
+		syncKeys[i] = redis.SyncKey{Key: k, Score: 1000}
+	}
+
+	return syncKeys
+}
+
 // TestSyncBalancesBatch_EmptyKeys verifies that when given empty keys,
 // the use case returns immediately with zero synced and no error.
 func TestSyncBalancesBatch_EmptyKeys(t *testing.T) {
@@ -27,7 +37,7 @@ func TestSyncBalancesBatch_EmptyKeys(t *testing.T) {
 
 	uc := UseCase{}
 
-	result, err := uc.SyncBalancesBatch(context.TODO(), organizationID, ledgerID, []string{})
+	result, err := uc.SyncBalancesBatch(context.TODO(), organizationID, ledgerID, []redis.SyncKey{})
 
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
@@ -63,7 +73,7 @@ func TestSyncBalancesBatch_AllKeysExpired(t *testing.T) {
 	// With the fix: orphaned keys are cleaned up even when no valid balances exist
 	mockRedis.EXPECT().
 		RemoveBalanceSyncKeysBatch(gomock.Any(), gomock.Any()).
-		DoAndReturn(func(_ context.Context, keysToRemove []string) (int64, error) {
+		DoAndReturn(func(_ context.Context, keysToRemove []redis.SyncKey) (int64, error) {
 			assert.Len(t, keysToRemove, 2, "Both expired keys should be removed")
 			return 2, nil
 		}).
@@ -73,7 +83,7 @@ func TestSyncBalancesBatch_AllKeysExpired(t *testing.T) {
 		TransactionRedisRepo: mockRedis,
 	}
 
-	result, err := uc.SyncBalancesBatch(context.TODO(), organizationID, ledgerID, keys)
+	result, err := uc.SyncBalancesBatch(context.TODO(), organizationID, ledgerID, toSyncKeys(keys))
 
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
@@ -145,7 +155,7 @@ func TestSyncBalancesBatch_SuccessWithAggregation(t *testing.T) {
 		BalanceRepo:          mockBalance,
 	}
 
-	result, err := uc.SyncBalancesBatch(context.TODO(), organizationID, ledgerID, keys)
+	result, err := uc.SyncBalancesBatch(context.TODO(), organizationID, ledgerID, toSyncKeys(keys))
 
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
@@ -208,7 +218,7 @@ func TestSyncBalancesBatch_PartialData(t *testing.T) {
 		BalanceRepo:          mockBalance,
 	}
 
-	result, err := uc.SyncBalancesBatch(context.TODO(), organizationID, ledgerID, keys)
+	result, err := uc.SyncBalancesBatch(context.TODO(), organizationID, ledgerID, toSyncKeys(keys))
 
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
@@ -241,7 +251,7 @@ func TestSyncBalancesBatch_RedisError(t *testing.T) {
 		TransactionRedisRepo: mockRedis,
 	}
 
-	result, err := uc.SyncBalancesBatch(context.TODO(), organizationID, ledgerID, keys)
+	result, err := uc.SyncBalancesBatch(context.TODO(), organizationID, ledgerID, toSyncKeys(keys))
 
 	assert.Error(t, err)
 	assert.Nil(t, result)
@@ -291,7 +301,7 @@ func TestSyncBalancesBatch_DBError(t *testing.T) {
 		BalanceRepo:          mockBalance,
 	}
 
-	result, err := uc.SyncBalancesBatch(context.TODO(), organizationID, ledgerID, keys)
+	result, err := uc.SyncBalancesBatch(context.TODO(), organizationID, ledgerID, toSyncKeys(keys))
 
 	assert.Error(t, err)
 	assert.Nil(t, result)
@@ -345,7 +355,7 @@ func TestSyncBalancesBatch_ScheduleCleanupFailure(t *testing.T) {
 	}
 
 	// Should succeed despite cleanup failure
-	result, err := uc.SyncBalancesBatch(context.TODO(), organizationID, ledgerID, keys)
+	result, err := uc.SyncBalancesBatch(context.TODO(), organizationID, ledgerID, toSyncKeys(keys))
 
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
@@ -422,7 +432,7 @@ func TestSyncBalancesBatch_AggregationKeepsHighestVersion(t *testing.T) {
 		BalanceRepo:          mockBalance,
 	}
 
-	result, err := uc.SyncBalancesBatch(context.TODO(), organizationID, ledgerID, keys)
+	result, err := uc.SyncBalancesBatch(context.TODO(), organizationID, ledgerID, toSyncKeys(keys))
 
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
@@ -498,12 +508,16 @@ func TestSyncBalancesBatch_InvalidKeyFormat(t *testing.T) {
 	// All 4 keys removed: 1 valid + 3 invalid (orphaned due to parse errors)
 	mockRedis.EXPECT().
 		RemoveBalanceSyncKeysBatch(gomock.Any(), gomock.Any()).
-		DoAndReturn(func(_ context.Context, keysToRemove []string) (int64, error) {
+		DoAndReturn(func(_ context.Context, keysToRemove []redis.SyncKey) (int64, error) {
 			assert.Len(t, keysToRemove, 4, "All keys should be removed (valid + invalid)")
-			assert.Contains(t, keysToRemove, validKey, "valid key should be removed")
-			assert.Contains(t, keysToRemove, invalidKey1, "invalid key 1 should be removed")
-			assert.Contains(t, keysToRemove, invalidKey2, "invalid key 2 should be removed")
-			assert.Contains(t, keysToRemove, invalidKey3, "invalid key 3 should be removed")
+			removedStrs := make([]string, len(keysToRemove))
+			for i, k := range keysToRemove {
+				removedStrs[i] = k.Key
+			}
+			assert.Contains(t, removedStrs, validKey, "valid key should be removed")
+			assert.Contains(t, removedStrs, invalidKey1, "invalid key 1 should be removed")
+			assert.Contains(t, removedStrs, invalidKey2, "invalid key 2 should be removed")
+			assert.Contains(t, removedStrs, invalidKey3, "invalid key 3 should be removed")
 			return 4, nil
 		}).
 		Times(1)
@@ -513,7 +527,7 @@ func TestSyncBalancesBatch_InvalidKeyFormat(t *testing.T) {
 		BalanceRepo:          mockBalance,
 	}
 
-	result, err := uc.SyncBalancesBatch(context.TODO(), organizationID, ledgerID, keys)
+	result, err := uc.SyncBalancesBatch(context.TODO(), organizationID, ledgerID, toSyncKeys(keys))
 
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
@@ -572,11 +586,15 @@ func TestSyncBalancesBatch_ExactKeysRemoved(t *testing.T) {
 	// Verify ALL keys are removed: key1, key2 (orphaned), and key3
 	mockRedis.EXPECT().
 		RemoveBalanceSyncKeysBatch(gomock.Any(), gomock.Any()).
-		DoAndReturn(func(_ context.Context, keysToRemove []string) (int64, error) {
+		DoAndReturn(func(_ context.Context, keysToRemove []redis.SyncKey) (int64, error) {
 			assert.Len(t, keysToRemove, 3, "Expected all 3 keys to be removed")
-			assert.Contains(t, keysToRemove, key1, "key1 should be in removal list")
-			assert.Contains(t, keysToRemove, key2, "key2 (orphaned) MUST be in removal list")
-			assert.Contains(t, keysToRemove, key3, "key3 should be in removal list")
+			removedStrs := make([]string, len(keysToRemove))
+			for i, k := range keysToRemove {
+				removedStrs[i] = k.Key
+			}
+			assert.Contains(t, removedStrs, key1, "key1 should be in removal list")
+			assert.Contains(t, removedStrs, key2, "key2 (orphaned) MUST be in removal list")
+			assert.Contains(t, removedStrs, key3, "key3 should be in removal list")
 			return 3, nil
 		}).
 		Times(1)
@@ -586,7 +604,7 @@ func TestSyncBalancesBatch_ExactKeysRemoved(t *testing.T) {
 		BalanceRepo:          mockBalance,
 	}
 
-	result, err := uc.SyncBalancesBatch(context.TODO(), organizationID, ledgerID, keys)
+	result, err := uc.SyncBalancesBatch(context.TODO(), organizationID, ledgerID, toSyncKeys(keys))
 
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
@@ -625,7 +643,7 @@ func TestSyncBalancesBatch_ContextCancellation(t *testing.T) {
 		TransactionRedisRepo: mockRedis,
 	}
 
-	result, err := uc.SyncBalancesBatch(ctx, organizationID, ledgerID, keys)
+	result, err := uc.SyncBalancesBatch(ctx, organizationID, ledgerID, toSyncKeys(keys))
 
 	assert.Error(t, err)
 	assert.Nil(t, result)
@@ -683,11 +701,15 @@ func TestSyncBalancesBatch_OrphanedKeysCleanedUp(t *testing.T) {
 	// This is the bug fix: orphaned keys MUST be in removal list
 	mockRedis.EXPECT().
 		RemoveBalanceSyncKeysBatch(gomock.Any(), gomock.Any()).
-		DoAndReturn(func(_ context.Context, keysToRemove []string) (int64, error) {
+		DoAndReturn(func(_ context.Context, keysToRemove []redis.SyncKey) (int64, error) {
 			assert.Len(t, keysToRemove, 3, "Expected 3 keys to be removed (1 valid + 2 orphaned)")
-			assert.Contains(t, keysToRemove, validKey, "valid key should be in removal list")
-			assert.Contains(t, keysToRemove, orphanedKey1, "orphaned key 1 should be in removal list")
-			assert.Contains(t, keysToRemove, orphanedKey2, "orphaned key 2 should be in removal list")
+			removedStrs := make([]string, len(keysToRemove))
+			for i, k := range keysToRemove {
+				removedStrs[i] = k.Key
+			}
+			assert.Contains(t, removedStrs, validKey, "valid key should be in removal list")
+			assert.Contains(t, removedStrs, orphanedKey1, "orphaned key 1 should be in removal list")
+			assert.Contains(t, removedStrs, orphanedKey2, "orphaned key 2 should be in removal list")
 			return 3, nil
 		}).
 		Times(1)
@@ -697,7 +719,7 @@ func TestSyncBalancesBatch_OrphanedKeysCleanedUp(t *testing.T) {
 		BalanceRepo:          mockBalance,
 	}
 
-	result, err := uc.SyncBalancesBatch(context.TODO(), organizationID, ledgerID, keys)
+	result, err := uc.SyncBalancesBatch(context.TODO(), organizationID, ledgerID, toSyncKeys(keys))
 
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
@@ -756,8 +778,12 @@ func TestSyncBalancesBatch_MalformedKeyWithTrailingHash(t *testing.T) {
 	// Before this fix, the key would remain in the schedule and be reprocessed indefinitely.
 	mockRedis.EXPECT().
 		RemoveBalanceSyncKeysBatch(gomock.Any(), gomock.Any()).
-		DoAndReturn(func(_ context.Context, keysToRemove []string) (int64, error) {
-			assert.Contains(t, keysToRemove, malformedKey, "Malformed key MUST be removed from schedule to prevent infinite loop")
+		DoAndReturn(func(_ context.Context, keysToRemove []redis.SyncKey) (int64, error) {
+			removedStrs := make([]string, len(keysToRemove))
+			for i, k := range keysToRemove {
+				removedStrs[i] = k.Key
+			}
+			assert.Contains(t, removedStrs, malformedKey, "Malformed key MUST be removed from schedule to prevent infinite loop")
 			return int64(len(keysToRemove)), nil
 		}).
 		Times(1)
@@ -767,7 +793,7 @@ func TestSyncBalancesBatch_MalformedKeyWithTrailingHash(t *testing.T) {
 		BalanceRepo:          mockBalance,
 	}
 
-	result, err := uc.SyncBalancesBatch(context.TODO(), organizationID, ledgerID, keys)
+	result, err := uc.SyncBalancesBatch(context.TODO(), organizationID, ledgerID, toSyncKeys(keys))
 
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
@@ -831,7 +857,7 @@ func TestSyncBalancesBatch_MalformedKeyFallbackToDefault(t *testing.T) {
 		BalanceRepo:          mockBalance,
 	}
 
-	result, err := uc.SyncBalancesBatch(context.TODO(), organizationID, ledgerID, keys)
+	result, err := uc.SyncBalancesBatch(context.TODO(), organizationID, ledgerID, toSyncKeys(keys))
 
 	assert.NoError(t, err)
 	assert.NotNil(t, result)

--- a/components/ledger/internal/services/command/sync-balances-batch_test.go
+++ b/components/ledger/internal/services/command/sync-balances-batch_test.go
@@ -20,13 +20,20 @@ import (
 )
 
 // toSyncKeys converts a string slice to SyncKey slice for test convenience.
+// Each key gets a distinct score (1001, 1002, ...) so tests can detect if
+// SyncBalancesBatch or RemoveBalanceSyncKeysBatch drops, rewrites, or reorders scores.
 func toSyncKeys(keys []string) []redis.SyncKey {
 	syncKeys := make([]redis.SyncKey, len(keys))
 	for i, k := range keys {
-		syncKeys[i] = redis.SyncKey{Key: k, Score: 1000}
+		syncKeys[i] = redis.SyncKey{Key: k, Score: float64(1001 + i)}
 	}
 
 	return syncKeys
+}
+
+// syncKeyScore returns the score that toSyncKeys assigns to the i-th key (0-indexed).
+func syncKeyScore(i int) float64 {
+	return float64(1001 + i)
 }
 
 // TestSyncBalancesBatch_EmptyKeys verifies that when given empty keys,
@@ -75,6 +82,11 @@ func TestSyncBalancesBatch_AllKeysExpired(t *testing.T) {
 		RemoveBalanceSyncKeysBatch(gomock.Any(), gomock.Any()).
 		DoAndReturn(func(_ context.Context, keysToRemove []redis.SyncKey) (int64, error) {
 			assert.Len(t, keysToRemove, 2, "Both expired keys should be removed")
+			for i, sk := range keysToRemove {
+				assert.Equal(t, keys[i], sk.Key, "Key mismatch at index %d", i)
+				assert.Equal(t, syncKeyScore(i), sk.Score, "Score mismatch at index %d — claimed score must be preserved", i)
+			}
+
 			return 2, nil
 		}).
 		Times(1)
@@ -304,7 +316,9 @@ func TestSyncBalancesBatch_DBError(t *testing.T) {
 	result, err := uc.SyncBalancesBatch(context.TODO(), organizationID, ledgerID, toSyncKeys(keys))
 
 	assert.Error(t, err)
-	assert.Nil(t, result)
+	assert.NotNil(t, result, "Result should be returned even on DB error (contains partial metrics)")
+	assert.Equal(t, int64(0), result.BalancesSynced, "No balances should be synced on DB error")
+	assert.Equal(t, int64(0), result.KeysRemoved, "No keys removed (no orphaned keys in this test)")
 	assert.Contains(t, err.Error(), "database connection error")
 }
 
@@ -506,6 +520,13 @@ func TestSyncBalancesBatch_InvalidKeyFormat(t *testing.T) {
 		Times(1)
 
 	// All 4 keys removed: 1 valid + 3 invalid (orphaned due to parse errors)
+	// Build expected score map from input so we can verify scores are preserved through the pipeline
+	inputSyncKeys := toSyncKeys(keys)
+	expectedScores := make(map[string]float64, len(inputSyncKeys))
+	for _, sk := range inputSyncKeys {
+		expectedScores[sk.Key] = sk.Score
+	}
+
 	mockRedis.EXPECT().
 		RemoveBalanceSyncKeysBatch(gomock.Any(), gomock.Any()).
 		DoAndReturn(func(_ context.Context, keysToRemove []redis.SyncKey) (int64, error) {
@@ -513,6 +534,7 @@ func TestSyncBalancesBatch_InvalidKeyFormat(t *testing.T) {
 			removedStrs := make([]string, len(keysToRemove))
 			for i, k := range keysToRemove {
 				removedStrs[i] = k.Key
+				assert.Equal(t, expectedScores[k.Key], k.Score, "Score for %s must be preserved from input", k.Key)
 			}
 			assert.Contains(t, removedStrs, validKey, "valid key should be removed")
 			assert.Contains(t, removedStrs, invalidKey1, "invalid key 1 should be removed")
@@ -584,6 +606,12 @@ func TestSyncBalancesBatch_ExactKeysRemoved(t *testing.T) {
 		Times(1)
 
 	// Verify ALL keys are removed: key1, key2 (orphaned), and key3
+	inputSyncKeys := toSyncKeys(keys)
+	expectedScores := make(map[string]float64, len(inputSyncKeys))
+	for _, sk := range inputSyncKeys {
+		expectedScores[sk.Key] = sk.Score
+	}
+
 	mockRedis.EXPECT().
 		RemoveBalanceSyncKeysBatch(gomock.Any(), gomock.Any()).
 		DoAndReturn(func(_ context.Context, keysToRemove []redis.SyncKey) (int64, error) {
@@ -591,6 +619,7 @@ func TestSyncBalancesBatch_ExactKeysRemoved(t *testing.T) {
 			removedStrs := make([]string, len(keysToRemove))
 			for i, k := range keysToRemove {
 				removedStrs[i] = k.Key
+				assert.Equal(t, expectedScores[k.Key], k.Score, "Score for %s must be preserved", k.Key)
 			}
 			assert.Contains(t, removedStrs, key1, "key1 should be in removal list")
 			assert.Contains(t, removedStrs, key2, "key2 (orphaned) MUST be in removal list")
@@ -699,6 +728,12 @@ func TestSyncBalancesBatch_OrphanedKeysCleanedUp(t *testing.T) {
 
 	// KEY ASSERTION: ALL 3 keys should be removed (1 valid + 2 orphaned)
 	// This is the bug fix: orphaned keys MUST be in removal list
+	inputSyncKeys := toSyncKeys(keys)
+	expectedScores := make(map[string]float64, len(inputSyncKeys))
+	for _, sk := range inputSyncKeys {
+		expectedScores[sk.Key] = sk.Score
+	}
+
 	mockRedis.EXPECT().
 		RemoveBalanceSyncKeysBatch(gomock.Any(), gomock.Any()).
 		DoAndReturn(func(_ context.Context, keysToRemove []redis.SyncKey) (int64, error) {
@@ -706,6 +741,7 @@ func TestSyncBalancesBatch_OrphanedKeysCleanedUp(t *testing.T) {
 			removedStrs := make([]string, len(keysToRemove))
 			for i, k := range keysToRemove {
 				removedStrs[i] = k.Key
+				assert.Equal(t, expectedScores[k.Key], k.Score, "Score for %s must be preserved", k.Key)
 			}
 			assert.Contains(t, removedStrs, validKey, "valid key should be in removal list")
 			assert.Contains(t, removedStrs, orphanedKey1, "orphaned key 1 should be in removal list")
@@ -776,12 +812,19 @@ func TestSyncBalancesBatch_MalformedKeyWithTrailingHash(t *testing.T) {
 
 	// KEY ASSERTION: Verify malformed key is removed from schedule to break the infinite loop.
 	// Before this fix, the key would remain in the schedule and be reprocessed indefinitely.
+	inputSyncKeys := toSyncKeys(keys)
+	expectedScores := make(map[string]float64, len(inputSyncKeys))
+	for _, sk := range inputSyncKeys {
+		expectedScores[sk.Key] = sk.Score
+	}
+
 	mockRedis.EXPECT().
 		RemoveBalanceSyncKeysBatch(gomock.Any(), gomock.Any()).
 		DoAndReturn(func(_ context.Context, keysToRemove []redis.SyncKey) (int64, error) {
 			removedStrs := make([]string, len(keysToRemove))
 			for i, k := range keysToRemove {
 				removedStrs[i] = k.Key
+				assert.Equal(t, expectedScores[k.Key], k.Score, "Score for %s must be preserved", k.Key)
 			}
 			assert.Contains(t, removedStrs, malformedKey, "Malformed key MUST be removed from schedule to prevent infinite loop")
 			return int64(len(keysToRemove)), nil

--- a/components/ledger/migrations/transaction/000019_add_route_id_to_operation.up.sql
+++ b/components/ledger/migrations/transaction/000019_add_route_id_to_operation.up.sql
@@ -1,3 +1,3 @@
 ALTER TABLE operation ADD COLUMN IF NOT EXISTS route_id UUID;
 ALTER TABLE operation DROP CONSTRAINT IF EXISTS fk_operation_route_id;
-ALTER TABLE operation ADD CONSTRAINT fk_operation_route_id FOREIGN KEY (route_id) REFERENCES operation_route(id);
+ALTER TABLE operation ADD CONSTRAINT fk_operation_route_id FOREIGN KEY (route_id) REFERENCES operation_route(id) NOT VALID;

--- a/mk/coverage-unit.mk
+++ b/mk/coverage-unit.mk
@@ -33,17 +33,8 @@ GOTESTSUM        := $(shell command -v gotestsum 2>/dev/null)
 _COVERAGE_OUT := $(abspath $(TEST_REPORTS_DIR))/unit_coverage.out
 _CALLER_DIR   := $(CURDIR)
 
-# macOS ld64 workaround: suppress LC_DYSYMTAB warnings when using -race
-UNAME_S := $(shell uname -s)
-ifeq ($(UNAME_S),Darwin)
-  ifneq ($(DISABLE_OSX_LINKER_WORKAROUND),1)
-    GO_TEST_LDFLAGS := -ldflags="-linkmode=external -extldflags=-ld_classic"
-  else
-    GO_TEST_LDFLAGS :=
-  endif
-else
-  GO_TEST_LDFLAGS :=
-endif
+# macOS ld64 workaround removed: -ld_classic is deprecated.
+GO_TEST_LDFLAGS :=
 
 .PHONY: coverage-unit
 coverage-unit:

--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -47,20 +47,10 @@ else
   LOW_RES_RACE_FLAG := -race
 endif
 
-# macOS ld64 workaround: newer ld emits noisy LC_DYSYMTAB warnings when linking test binaries with -race.
-# If available, prefer Apple's classic linker to silence them.
-UNAME_S := $(shell uname -s)
-ifeq ($(UNAME_S),Darwin)
-  # Prefer classic mode to suppress LC_DYSYMTAB warnings on macOS.
-  # Set DISABLE_OSX_LINKER_WORKAROUND=1 to disable this behavior.
-  ifneq ($(DISABLE_OSX_LINKER_WORKAROUND),1)
-    GO_TEST_LDFLAGS := -ldflags="-linkmode=external -extldflags=-ld_classic"
-  else
-    GO_TEST_LDFLAGS :=
-  endif
-else
-  GO_TEST_LDFLAGS :=
-endif
+# macOS ld64 workaround removed: -ld_classic is deprecated and produces warnings
+# on modern Xcode toolchains. The original LC_DYSYMTAB warnings it suppressed
+# are no longer emitted by recent Go + linker versions.
+GO_TEST_LDFLAGS :=
 
 define wait_for_services
 	echo "Waiting for services to become healthy..."


### PR DESCRIPTION
## Summary

Replace the pre-TTL scheduled balance sync (~50 min delay) with a dual-trigger collector that flushes to PostgreSQL on batch size OR timeout, whichever comes first. Fix ZADD/ZREM race condition with microsecond-precision scores and conditional removal. Fix duplicate operations on Redis backup queue replay for pending transaction commit/cancel.

## Changes

### Balance Sync Dual-Trigger

- New `BalanceSyncCollector` component with SIZE and TIMEOUT triggers (configurable via `BALANCE_SYNC_BATCH_SIZE`, `BALANCE_SYNC_FLUSH_TIMEOUT_MS`, `BALANCE_SYNC_POLL_INTERVAL_MS`)
- Lua `balance_atomic_operation.lua`: immediate eligibility (`dueAt = now`) with microsecond-precision ZADD scores
- Lua `get_balances_near_expiration.lua`: returns `WITHSCORES` pairs, microsecond `now` comparison
- Lua `remove_balance_sync_keys_batch.lua`: conditional ZREM (only removes if score unchanged since claim)
- New `SyncKey` type propagated through full pipeline for score-aware removal
- `waitUntilDue` uses `UnixMicro()` to match microsecond scores
- Idle backoff reduced from 10 min to 2× flush timeout
- Keys grouped by org/ledger in flush callback

### Backup Queue Fix

- Add `UpdateTransactionBackupOperations` to commit/cancel flow (`transaction-state-handlers.go`) to materialize operation IDs in backup entry, preventing duplicate operations on replay