### PR TITLE
fix: rewrite migration 021 to remove NOT NULL and use safe PG 12+ CHECK pattern

### DIFF
--- a/components/ledger/Dockerfile
+++ b/components/ledger/Dockerfile
@@ -1,5 +1,4 @@
 FROM --platform=$BUILDPLATFORM golang:1.26.2-alpine AS builder
-# Force rebuild for develop branch - 2026-04-03 (5)
 
 WORKDIR /ledger-app
 

--- a/components/ledger/migrations/transaction/000021_backfill_direction.down.sql
+++ b/components/ledger/migrations/transaction/000021_backfill_direction.down.sql
@@ -1,2 +1,1 @@
 ALTER TABLE operation DROP CONSTRAINT IF EXISTS chk_operation_direction;
-ALTER TABLE operation ALTER COLUMN direction DROP NOT NULL;

--- a/components/ledger/migrations/transaction/000021_backfill_direction.up.sql
+++ b/components/ledger/migrations/transaction/000021_backfill_direction.up.sql
@@ -1,3 +1,4 @@
+-- Backfill direction from type for existing operations
 UPDATE operation SET direction = CASE
     WHEN UPPER(type) = 'DEBIT' THEN 'debit'
     WHEN UPPER(type) = 'CREDIT' THEN 'credit'
@@ -6,7 +7,13 @@ UPDATE operation SET direction = CASE
     ELSE 'debit'
 END WHERE direction IS NULL;
 
-ALTER TABLE operation ALTER COLUMN direction SET NOT NULL;
-
+-- Domain CHECK with NOT VALID: registers the constraint without scanning the table.
+-- ACCESS EXCLUSIVE lock for milliseconds only. New INSERTs/UPDATEs are validated
+-- against the CHECK from this point on.
 ALTER TABLE operation DROP CONSTRAINT IF EXISTS chk_operation_direction;
-ALTER TABLE operation ADD CONSTRAINT chk_operation_direction CHECK (LOWER(direction) IN ('debit', 'credit'));
+ALTER TABLE operation ADD CONSTRAINT chk_operation_direction
+    CHECK (LOWER(direction) IN ('debit', 'credit')) NOT VALID;
+
+-- VALIDATE performs the full scan to verify existing rows satisfy the CHECK.
+-- Uses SHARE UPDATE EXCLUSIVE lock — reads and writes continue normally.
+ALTER TABLE operation VALIDATE CONSTRAINT chk_operation_direction;


### PR DESCRIPTION
## Summary

- Removes `SET NOT NULL` from the `direction` column in migration 021 to allow safe rollback to v3.5.3
- Rewrites CHECK constraint using `NOT VALID` + `VALIDATE` to avoid prolonged ACCESS EXCLUSIVE lock on large tables

## Context
The previous migration blocked rollback to v3.5.3 because v3.5.3 INSERTs to the `operation` table omit the `direction` column. With `NOT NULL` and no `DEFAULT`, PostgreSQL rejects every INSERT — breaking all transaction creation. Additionally, the inline CHECK held an ACCESS EXCLUSIVE lock for the full table scan duration, which can block reads and writes for minutes on tables with >1M rows.

## Changes

**`000021_backfill_direction.up.sql`**
- Removed `ALTER TABLE operation ALTER COLUMN direction SET NOT NULL`
- Split CHECK into `ADD CONSTRAINT ... NOT VALID` (millisecond lock) + `VALIDATE CONSTRAINT` (scan under SHARE UPDATE EXCLUSIVE — reads/writes continue)

**`000021_backfill_direction.down.sql`**
- Removed `ALTER COLUMN direction DROP NOT NULL` (no longer applies)