### PR TITLE
fix: harden async transaction durability and backup-consumer reliability

### DIFF
--- a/components/ledger/internal/adapters/http/in/transaction_state_handlers.go
+++ b/components/ledger/internal/adapters/http/in/transaction_state_handlers.go
@@ -483,6 +483,22 @@ func (handler *TransactionHandler) commitOrCancelTransaction(c *fiber.Ctx, tran 
 		return http.WithError(c, err)
 	}
 
+	ctxBackupSeed, spanBackupSeed := tracer.Start(ctx, "handler.commit_or_cancel_transaction.pre_seed_backup")
+
+	if backupErr := handler.Command.SendTransactionToRedisQueue(ctxBackupSeed, organizationID, ledgerID, tran.IDtoUUID(), transactionInput, validate, transactionStatus, action, time.Now(), nil); backupErr != nil {
+		libOpentelemetry.HandleSpanError(spanBackupSeed, "Failed to pre-seed transaction backup cache", backupErr)
+
+		logger.Log(ctx, libLog.LevelError, fmt.Sprintf("Failed to pre-seed commit/cancel transaction backup cache: %v", backupErr))
+
+		spanBackupSeed.End()
+
+		deleteLockOnError()
+
+		return http.WithError(c, pkg.ValidateBusinessError(backupErr, constant.EntityTransaction))
+	}
+
+	spanBackupSeed.End()
+
 	result, err := handler.Command.ProcessBalanceOperations(ctx, command.ProcessBalanceOperationsInput{
 		OrganizationID:    organizationID,
 		LedgerID:          ledgerID,
@@ -495,6 +511,8 @@ func (handler *TransactionHandler) commitOrCancelTransaction(c *fiber.Ctx, tran 
 	if err != nil {
 		libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Failed to process balance operations", err)
 		logger.Log(ctx, libLog.LevelError, "Failed to process balance operations", libLog.Err(err))
+
+		handler.Command.RemoveTransactionFromRedisQueue(ctx, logger, organizationID, ledgerID, tran.IDtoUUID().String())
 
 		deleteLockOnError()
 

--- a/components/ledger/internal/adapters/postgres/transaction/transaction.go
+++ b/components/ledger/internal/adapters/postgres/transaction/transaction.go
@@ -380,6 +380,12 @@ type TransactionProcessingPayload struct {
 
 	// Input transaction data (renamed from ParseDSL for clarity)
 	Input *mtransaction.Transaction `json:"input" msgpack:"ParseDSL"`
+
+	// Version discriminates the payload format for rolling-update compatibility.
+	// "v2": produced by v3.6.2+ — balance persistence is handled by BalanceSyncWorker.
+	// ""  : produced by v3.5.x  — consumer must call UpdateBalances() directly,
+	//       because the sync worker may not have ZSET entries for these transactions.
+	Version string `json:"version,omitempty" msgpack:"Version,omitempty"`
 }
 
 // TransactionResponse represents a success response containing a single transaction.

--- a/components/ledger/internal/adapters/rabbitmq/producer.rabbitmq.go
+++ b/components/ledger/internal/adapters/rabbitmq/producer.rabbitmq.go
@@ -91,7 +91,19 @@ func (prmq *ProducerRabbitMQRepository) ProducerDefault(ctx context.Context, exc
 		return nil, err
 	}
 
-	err := prmq.conn.Channel.Publish(
+	// Use ChannelSnapshot to get a consistent channel reference under lock,
+	// avoiding a TOCTOU race where another goroutine's reconnection could
+	// replace the channel between EnsureChannel and Publish.
+	ch := prmq.conn.ChannelSnapshot()
+	if ch == nil {
+		err := fmt.Errorf("rabbitmq channel unavailable after ensure")
+		logger.Log(ctx, libLog.LevelError, "Channel snapshot returned nil", libLog.Err(err))
+		libOpentelemetry.HandleSpanError(spanProducer, "Channel snapshot returned nil", err)
+
+		return nil, err
+	}
+
+	err := ch.Publish(
 		exchange,
 		key,
 		false,
@@ -138,7 +150,19 @@ func (prmq *ProducerRabbitMQRepository) ProducerDefaultWithContext(ctx context.C
 		return nil, err
 	}
 
-	err := prmq.conn.Channel.Publish(
+	// Use ChannelSnapshot to get a consistent channel reference under lock,
+	// avoiding a TOCTOU race where another goroutine's reconnection could
+	// replace the channel between EnsureChannelContext and Publish.
+	ch := prmq.conn.ChannelSnapshot()
+	if ch == nil {
+		err := fmt.Errorf("rabbitmq channel unavailable after ensure")
+		logger.Log(ctx, libLog.LevelError, "Channel snapshot returned nil", libLog.Err(err))
+		libOpentelemetry.HandleSpanError(spanProducer, "Channel snapshot returned nil", err)
+
+		return nil, err
+	}
+
+	err := ch.Publish(
 		exchange,
 		key,
 		false,

--- a/components/ledger/internal/bootstrap/redis.consumer.go
+++ b/components/ledger/internal/bootstrap/redis.consumer.go
@@ -32,14 +32,10 @@ import (
 )
 
 const (
-	// CronTimeToRun     = 30 * time.Minute
-	// MessageTimeOfLife = 30
-	// MaxWorkers        = 100
-	// CycleLockTTL      = 1800 // 30 minutes in seconds — matches CronTimeToRun
-	CronTimeToRun     = 3 * time.Minute
-	MessageTimeOfLife = 3
+	CronTimeToRun     = 30 * time.Minute
+	MessageTimeOfLife = 30
 	MaxWorkers        = 100
-	CycleLockTTL      = 60 // seconds
+	CycleLockTTL      = 1800 // 30 minutes in seconds — matches CronTimeToRun
 )
 
 type RedisQueueConsumer struct {

--- a/components/ledger/internal/bootstrap/redis.consumer.go
+++ b/components/ledger/internal/bootstrap/redis.consumer.go
@@ -32,10 +32,14 @@ import (
 )
 
 const (
-	CronTimeToRun     = 30 * time.Minute
-	MessageTimeOfLife = 30
+	// CronTimeToRun     = 30 * time.Minute
+	// MessageTimeOfLife = 30
+	// MaxWorkers        = 100
+	// CycleLockTTL      = 1800 // 30 minutes in seconds — matches CronTimeToRun
+	CronTimeToRun     = 3 * time.Minute
+	MessageTimeOfLife = 3
 	MaxWorkers        = 100
-	ConsumerLockTTL   = 1500 // 25 minutes in seconds
+	CycleLockTTL      = 60 // seconds
 )
 
 type RedisQueueConsumer struct {
@@ -111,9 +115,24 @@ func (r *RedisQueueConsumer) runSingleTenant() error {
 			return nil
 
 		case <-ticker.C:
-			r.readMessagesAndProcess(ctx)
+			r.executeCycle(ctx)
 		}
 	}
+}
+
+// executeCycle acquires the cycle-level distributed lock and, if this pod is the
+// leader, processes all backup queue messages. Extracted from the ticker case to
+// scope the defer-based lock release correctly (defer inside a for-select does not
+// run at the end of each iteration).
+func (r *RedisQueueConsumer) executeCycle(ctx context.Context) {
+	acquired, release := r.acquireCycleLock(ctx)
+	if !acquired {
+		return
+	}
+
+	defer release()
+
+	r.readMessagesAndProcess(ctx)
 }
 
 // runMultiTenant runs the Redis queue consumer iterating over all active tenants.
@@ -136,42 +155,100 @@ func (r *RedisQueueConsumer) runMultiTenant() error {
 			return nil
 
 		case <-ticker.C:
-			tenantIDs := r.tenantCache.TenantIDs()
-			if len(tenantIDs) == 0 {
-				r.Logger.Log(ctx, libLog.LevelInfo, "RedisQueueConsumer: no tenants in cache, skipping cycle")
-
-				continue
-			}
-
-			for _, tenantID := range tenantIDs {
-				if ctx.Err() != nil {
-					r.Logger.Log(ctx, libLog.LevelInfo, "RedisQueueConsumer: shutting down...")
-					return nil
-				}
-
-				tenantCtx := tmcore.ContextWithTenantID(ctx, tenantID)
-
-				conn, err := r.pgManager.GetConnection(tenantCtx, tenantID)
-				if err != nil {
-					r.Logger.Log(ctx, libLog.LevelError, fmt.Sprintf("RedisQueueConsumer: failed to get PG connection for tenant %s: %v", tenantID, err))
-
-					continue
-				}
-
-				db, err := conn.GetDB()
-				if err != nil {
-					r.Logger.Log(ctx, libLog.LevelError, fmt.Sprintf("RedisQueueConsumer: failed to get DB for tenant %s: %v", tenantID, err))
-
-					continue
-				}
-
-				tenantCtx = tmcore.ContextWithPG(tenantCtx, db)
-				tenantCtx = tmcore.ContextWithPG(tenantCtx, db, constant.ModuleTransaction)
-
-				r.readMessagesAndProcess(tenantCtx)
-			}
+			r.executeMultiTenantCycle(ctx)
 		}
 	}
+}
+
+// executeMultiTenantCycle acquires the cycle-level distributed lock and, if this
+// pod is the leader, processes backup queue messages for every active tenant.
+// Extracted from the ticker case to scope the defer-based lock release correctly.
+func (r *RedisQueueConsumer) executeMultiTenantCycle(ctx context.Context) {
+	acquired, release := r.acquireCycleLock(ctx)
+	if !acquired {
+		return
+	}
+
+	defer release()
+
+	tenantIDs := r.tenantCache.TenantIDs()
+	if len(tenantIDs) == 0 {
+		r.Logger.Log(ctx, libLog.LevelInfo, "RedisQueueConsumer: no tenants in cache, skipping cycle")
+
+		return
+	}
+
+	for _, tenantID := range tenantIDs {
+		if ctx.Err() != nil {
+			r.Logger.Log(ctx, libLog.LevelInfo, "RedisQueueConsumer: context cancelled, stopping tenant iteration")
+
+			return
+		}
+
+		tenantCtx := tmcore.ContextWithTenantID(ctx, tenantID)
+
+		conn, err := r.pgManager.GetConnection(tenantCtx, tenantID)
+		if err != nil {
+			r.Logger.Log(ctx, libLog.LevelError, fmt.Sprintf("RedisQueueConsumer: failed to get PG connection for tenant %s: %v", tenantID, err))
+
+			continue
+		}
+
+		db, err := conn.GetDB()
+		if err != nil {
+			r.Logger.Log(ctx, libLog.LevelError, fmt.Sprintf("RedisQueueConsumer: failed to get DB for tenant %s: %v", tenantID, err))
+
+			continue
+		}
+
+		tenantCtx = tmcore.ContextWithPG(tenantCtx, db)
+		tenantCtx = tmcore.ContextWithPG(tenantCtx, db, constant.ModuleTransaction)
+
+		r.readMessagesAndProcess(tenantCtx)
+	}
+}
+
+// acquireCycleLock attempts to acquire the cycle-level distributed lock via SetNX.
+// Returns (true, releaseFunc) if the lock was acquired, or (false, nil) if another
+// pod already holds it or an error occurred.
+// The release function deletes the lock key; callers should defer it.
+func (r *RedisQueueConsumer) acquireCycleLock(ctx context.Context) (bool, func()) {
+	cycleLockKey := utils.RedisConsumerCycleLockKey()
+	podID := podIdentifier()
+
+	success, err := r.TransactionHandler.Command.TransactionRedisRepo.SetNX(ctx, cycleLockKey, podID, CycleLockTTL)
+	if err != nil {
+		r.Logger.Log(ctx, libLog.LevelWarn, fmt.Sprintf("Failed to acquire backup consumer cycle lock: %v", err))
+
+		return false, nil
+	}
+
+	if !success {
+		r.Logger.Log(ctx, libLog.LevelInfo, "Another pod holds the backup consumer lock, skipping cycle")
+
+		return false, nil
+	}
+
+	r.Logger.Log(ctx, libLog.LevelInfo, fmt.Sprintf("Cycle lock acquired by pod %s", podID))
+
+	release := func() {
+		if delErr := r.TransactionHandler.Command.TransactionRedisRepo.Del(ctx, cycleLockKey); delErr != nil {
+			r.Logger.Log(ctx, libLog.LevelWarn, fmt.Sprintf("Failed to release backup consumer cycle lock: %v", delErr))
+		}
+	}
+
+	return true, release
+}
+
+// podIdentifier returns a stable identifier for the current pod, used as the
+// value stored in the cycle lock for debugging and observability.
+func podIdentifier() string {
+	hostname, err := os.Hostname()
+	if err != nil {
+		return "unknown"
+	}
+
+	return hostname
 }
 
 func (r *RedisQueueConsumer) readMessagesAndProcess(ctx context.Context) {
@@ -242,8 +319,10 @@ Outer:
 	r.Logger.Log(ctx, libLog.LevelInfo, fmt.Sprintf("Finished processing total of %d eligible messages", len(messages)-totalMessagesLessThanOneHour))
 }
 
-// processMessage handles a single Redis backup queue message: acquires a distributed lock,
-// rebuilds balances and operations, and writes the transaction via the async path.
+// processMessage handles a single Redis backup queue message: rebuilds balances
+// and operations, and writes the transaction via the async path.
+// Duplicate-processing prevention is handled at the cycle level by acquireCycleLock;
+// only the leader pod reaches this method.
 func (r *RedisQueueConsumer) processMessage(ctx context.Context, key string, m mmodel.TransactionRedisQueue) {
 	_, tracer, _, _ := libCommons.NewTrackingFromContext(ctx) //nolint:dogsled
 
@@ -267,32 +346,6 @@ func (r *RedisQueueConsumer) processMessage(ctx context.Context, key string, m m
 		return
 	default:
 	}
-
-	// Acquire distributed lock to prevent duplicate processing across pods
-	lockKey := utils.RedisConsumerLockKey(m.OrganizationID, m.LedgerID, m.TransactionID.String())
-
-	_, spanLock := tracer.Start(msgCtxWithSpan, "redis.consumer.acquire_lock")
-
-	success, err := r.TransactionHandler.Command.TransactionRedisRepo.SetNX(msgCtxWithSpan, lockKey, "", ConsumerLockTTL)
-	if err != nil {
-		libOpentelemetry.HandleSpanError(spanLock, "Failed to acquire lock", err)
-		spanLock.End()
-
-		logger.Log(ctx, libLog.LevelWarn, fmt.Sprintf("Failed to acquire lock for message %s: %v", key, err))
-
-		return
-	}
-
-	if !success {
-		libOpentelemetry.HandleSpanEvent(spanLock, "Lock already held by another pod")
-		spanLock.End()
-
-		logger.Log(ctx, libLog.LevelInfo, fmt.Sprintf("Message %s already being processed by another pod, skipping", key))
-
-		return
-	}
-
-	spanLock.End()
 
 	if m.Validate == nil {
 		logger.Log(ctx, libLog.LevelWarn, fmt.Sprintf("Message (key: %s) has nil Validate field, skipping. Message will remain in queue.", key))

--- a/components/ledger/internal/services/command/create_balance_transaction_operations_async.go
+++ b/components/ledger/internal/services/command/create_balance_transaction_operations_async.go
@@ -64,6 +64,20 @@ func (uc *UseCase) CreateBalanceTransactionOperationsAsync(ctx context.Context, 
 
 	backupStatusForCleanup := t.Transaction.Status.Code
 
+	// Legacy payload compatibility: messages from v3.5.x lack the Version field.
+	// Their balance persistence relied on UpdateBalances() in the consumer, which
+	// was removed in v3.6.x (replaced by BalanceSyncWorker). Without this fallback,
+	// balances for in-flight v3.5.x messages would never reach PostgreSQL.
+	if t.Version == "" && t.Transaction.Status.Code != constant.NOTED {
+		logger.Log(ctx, libLog.LevelWarn, "Legacy payload detected (no Version field), calling UpdateBalances for backward compatibility")
+
+		if err := uc.UpdateBalances(ctx, data.OrganizationID, data.LedgerID, *t.Validate, t.Balances, t.BalancesAfter); err != nil {
+			logger.Log(ctx, libLog.LevelError, fmt.Sprintf("Failed to update balances for legacy payload: %v", err))
+
+			return err
+		}
+	}
+
 	// Note: Balance updates are handled by BalanceSyncWorker asynchronously.
 	// Hot balance was already updated atomically by Lua script during validation.
 	// Cold balance persistence is scheduled via ZADD to schedule:balance-sync.
@@ -98,8 +112,8 @@ func (uc *UseCase) CreateBalanceTransactionOperationsAsync(ctx context.Context, 
 	logger.Log(ctx, libLog.LevelInfo, "Trying to create new operations")
 
 	for _, oper := range tran.Operations {
-		if oper.Direction == "" {
-			logger.Log(ctx, libLog.LevelWarn, fmt.Sprintf("Operation %s has empty direction, may be from pre-migration message", oper.ID))
+		if err := validateOperationDirection(oper, logger, ctx); err != nil {
+			return err
 		}
 
 		_, err = uc.OperationRepo.Create(ctxProcessOperation, oper)
@@ -411,5 +425,24 @@ func (uc *UseCase) UpdateTransactionBackupOperations(ctx context.Context, organi
 	if err := uc.TransactionRedisRepo.AddMessageToQueue(ctx, transactionKey, updated); err != nil {
 		libOpentelemetry.HandleSpanError(span, "Failed to write updated transaction backup with operations", err)
 		logger.Log(ctx, libLog.LevelWarn, fmt.Sprintf("Failed to write updated transaction backup with operations: %v", err))
+	}
+}
+
+// validateOperationDirection checks the direction field of an operation.
+// Empty direction is allowed with a warning (v3.5.3 messages lack this field).
+// Non-empty direction must be one of the valid values ("debit", "credit").
+func validateOperationDirection(oper *operation.Operation, logger libLog.Logger, ctx context.Context) error {
+	if oper.Direction == "" {
+		logger.Log(ctx, libLog.LevelWarn, fmt.Sprintf(
+			"Operation %s has empty direction, may be from pre-migration message", oper.ID))
+
+		return nil
+	}
+
+	switch strings.ToLower(oper.Direction) {
+	case "debit", "credit":
+		return nil
+	default:
+		return fmt.Errorf("operation %s has invalid direction %q: must be 'debit' or 'credit'", oper.ID, oper.Direction)
 	}
 }

--- a/components/ledger/internal/services/command/create_balance_transaction_operations_async.go
+++ b/components/ledger/internal/services/command/create_balance_transaction_operations_async.go
@@ -9,7 +9,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 	"reflect"
+	"strings"
 	"time"
 
 	libCommons "github.com/LerianStudio/lib-commons/v4/commons"
@@ -59,6 +61,8 @@ func (uc *UseCase) CreateBalanceTransactionOperationsAsync(ctx context.Context, 
 
 		return fmt.Errorf("transaction payload has nil Transaction field")
 	}
+
+	backupStatusForCleanup := t.Transaction.Status.Code
 
 	// Note: Balance updates are handled by BalanceSyncWorker asynchronously.
 	// Hot balance was already updated atomically by Lua script during validation.
@@ -132,7 +136,15 @@ func (uc *UseCase) CreateBalanceTransactionOperationsAsync(ctx context.Context, 
 
 	logger.Log(ctx, libLog.LevelInfo, fmt.Sprintf("Backup queue: cleaning up transaction %s after successful processing", tran.ID))
 
-	go uc.RemoveTransactionFromRedisQueue(ctx, logger, data.OrganizationID, data.LedgerID, tran.ID)
+	if strings.ToLower(os.Getenv("RABBITMQ_TRANSACTION_ASYNC")) == "true" {
+		if backupStatusForCleanup == "" {
+			backupStatusForCleanup = tran.Status.Code
+		}
+
+		go uc.RemoveTransactionFromRedisQueueIfStatus(ctx, logger, data.OrganizationID, data.LedgerID, tran.ID, backupStatusForCleanup)
+	} else {
+		go uc.RemoveTransactionFromRedisQueue(ctx, logger, data.OrganizationID, data.LedgerID, tran.ID)
+	}
 
 	uc.DeleteWriteBehindTransaction(ctx, data.OrganizationID, data.LedgerID, tran.ID)
 
@@ -237,6 +249,40 @@ func (uc *UseCase) RemoveTransactionFromRedisQueue(ctx context.Context, logger l
 	} else {
 		logger.Log(ctx, libLog.LevelInfo, fmt.Sprintf("Backup queue: transaction removed successfully from backup_queue:{transactions} with key %s", transactionKey))
 	}
+}
+
+// RemoveTransactionFromRedisQueueIfStatus removes a backup entry only when the
+// current queue payload still matches the expected transaction status.
+//
+// This prevents stale consumers from deleting a newer backup stage for the
+// same transaction ID (e.g. late PENDING-create worker removing a newer
+// APPROVED/CANCELED backup written by commit/cancel flow).
+func (uc *UseCase) RemoveTransactionFromRedisQueueIfStatus(ctx context.Context, logger libLog.Logger, organizationID, ledgerID uuid.UUID, transactionID, expectedStatus string) {
+	transactionKey := utils.TransactionInternalKey(organizationID, ledgerID, transactionID)
+
+	raw, err := uc.TransactionRedisRepo.ReadMessageFromQueue(ctx, transactionKey)
+	if err != nil {
+		logger.Log(ctx, libLog.LevelWarn, fmt.Sprintf("Backup queue: failed to read transaction %s before conditional cleanup: %v", transactionKey, err))
+		return
+	}
+
+	var queue mmodel.TransactionRedisQueue
+	if err := json.Unmarshal(raw, &queue); err != nil {
+		logger.Log(ctx, libLog.LevelWarn, fmt.Sprintf("Backup queue: failed to decode transaction %s before conditional cleanup: %v", transactionKey, err))
+		return
+	}
+
+	if !strings.EqualFold(queue.TransactionStatus, expectedStatus) {
+		logger.Log(ctx, libLog.LevelInfo, fmt.Sprintf(
+			"Backup queue: skip cleanup for transaction %s because status changed (expected=%s current=%s)",
+			transactionKey,
+			expectedStatus,
+			queue.TransactionStatus,
+		))
+		return
+	}
+
+	uc.RemoveTransactionFromRedisQueue(ctx, logger, organizationID, ledgerID, transactionID)
 }
 
 // SendTransactionToRedisQueue func that send transaction to redis queue.

--- a/components/ledger/internal/services/command/create_balance_transaction_operations_async.go
+++ b/components/ledger/internal/services/command/create_balance_transaction_operations_async.go
@@ -112,7 +112,7 @@ func (uc *UseCase) CreateBalanceTransactionOperationsAsync(ctx context.Context, 
 	logger.Log(ctx, libLog.LevelInfo, "Trying to create new operations")
 
 	for _, oper := range tran.Operations {
-		if err := validateOperationDirection(oper, logger, ctx); err != nil {
+		if err := validateOperationDirection(ctx, logger, oper); err != nil {
 			return err
 		}
 
@@ -431,7 +431,7 @@ func (uc *UseCase) UpdateTransactionBackupOperations(ctx context.Context, organi
 // validateOperationDirection checks the direction field of an operation.
 // Empty direction is allowed with a warning (v3.5.3 messages lack this field).
 // Non-empty direction must be one of the valid values ("debit", "credit").
-func validateOperationDirection(oper *operation.Operation, logger libLog.Logger, ctx context.Context) error {
+func validateOperationDirection(ctx context.Context, logger libLog.Logger, oper *operation.Operation) error {
 	if oper.Direction == "" {
 		logger.Log(ctx, libLog.LevelWarn, fmt.Sprintf(
 			"Operation %s has empty direction, may be from pre-migration message", oper.ID))

--- a/components/ledger/internal/services/command/create_balance_transaction_operations_async_test.go
+++ b/components/ledger/internal/services/command/create_balance_transaction_operations_async_test.go
@@ -133,6 +133,7 @@ func TestCreateBalanceTransactionOperationsAsync(t *testing.T) {
 			Validate:    validate,
 			Balances:    balances,
 			Input:       transactionInput,
+			Version:     "v2",
 		}
 
 		transactionBytes, marshalErr := msgpack.Marshal(transactionQueue)
@@ -257,6 +258,7 @@ func TestCreateBalanceTransactionOperationsAsync(t *testing.T) {
 			Validate:    validate,
 			Balances:    balances,
 			Input:       transactionInput,
+			Version:     "v2",
 		}
 
 		transactionBytes, marshalErr := msgpack.Marshal(transactionQueue)
@@ -445,6 +447,7 @@ func TestCreateBalanceTransactionOperationsAsync(t *testing.T) {
 			Validate:    validate,
 			Balances:    balances,
 			Input:       transactionInput,
+			Version:     "v2",
 		}
 
 		transactionBytes, marshalErr := msgpack.Marshal(transactionQueue)
@@ -630,6 +633,7 @@ func TestCreateBalanceTransactionOperationsAsync(t *testing.T) {
 			Validate:    validate,
 			Balances:    balances,
 			Input:       transactionInput,
+			Version:     "v2",
 		}
 
 		transactionBytes, marshalErr := msgpack.Marshal(transactionQueue)
@@ -782,6 +786,7 @@ func TestCreateBalanceTransactionOperationsAsync(t *testing.T) {
 			Validate:    validate,
 			Balances:    balances,
 			Input:       transactionInput,
+			Version:     "v2",
 		}
 
 		transactionBytes, marshalErr := msgpack.Marshal(transactionQueue)
@@ -942,6 +947,7 @@ func TestCreateBalanceTransactionOperationsAsync(t *testing.T) {
 			Validate:    validate,
 			Balances:    balances,
 			Input:       transactionInput,
+			Version:     "v2",
 		}
 
 		transactionBytes, marshalErr := msgpack.Marshal(transactionQueue)
@@ -1106,6 +1112,7 @@ func TestCreateBTOAsync(t *testing.T) {
 		Validate:    validate,
 		Balances:    balances,
 		Input:       transactionInput,
+		Version:     "v2",
 	}
 
 	transactionBytes, marshalErr := msgpack.Marshal(transactionQueue)

--- a/components/ledger/internal/services/command/create_bulk_transaction_operations_async.go
+++ b/components/ledger/internal/services/command/create_bulk_transaction_operations_async.go
@@ -90,6 +90,30 @@ func (uc *UseCase) CreateBulkTransactionOperationsAsync(
 		return result, nil
 	}
 
+	// Legacy payload compatibility: messages from v3.5.x lack the Version field.
+	// Their balance persistence relied on UpdateBalances() in the consumer, which
+	// was removed in v3.6.x. Call UpdateBalances() for each legacy payload before
+	// bulk insert to ensure balances reach PostgreSQL.
+	for i := range payloads {
+		p := &payloads[i]
+		if p.Version == "" && p.Transaction != nil && p.Validate != nil && p.Transaction.Status.Code != constant.NOTED {
+			orgID, ledgerID, err := uc.extractOrgLedgerIDs(*p)
+			if err != nil {
+				logger.Log(ctx, libLog.LevelWarn, fmt.Sprintf("Legacy payload: failed to extract IDs: %v", err))
+
+				continue
+			}
+
+			logger.Log(ctx, libLog.LevelWarn, fmt.Sprintf(
+				"Legacy payload detected (no Version field) for transaction %s, calling UpdateBalances",
+				p.Transaction.ID))
+
+			if err := uc.UpdateBalances(ctx, orgID, ledgerID, *p.Validate, p.Balances, p.BalancesAfter); err != nil {
+				logger.Log(ctx, libLog.LevelError, fmt.Sprintf("Failed to update balances for legacy payload %s: %v", p.Transaction.ID, err))
+			}
+		}
+	}
+
 	// Classify payloads into inserts and updates
 	toInsert, toUpdate := uc.classifyAndExtractEntities(payloads)
 
@@ -358,6 +382,15 @@ func (uc *UseCase) bulkInsertOperationsTx(
 	operations []*operation.Operation,
 	result *BulkResult,
 ) error {
+	// Validate direction on all operations before bulk insert.
+	for _, op := range operations {
+		if op != nil {
+			if err := validateOperationDirection(op, logger, ctx); err != nil {
+				return err
+			}
+		}
+	}
+
 	result.OperationsAttempted = int64(len(operations))
 
 	insertResult, err := uc.OperationRepo.CreateBulkTx(ctx, dbTx, operations)

--- a/components/ledger/internal/services/command/create_bulk_transaction_operations_async.go
+++ b/components/ledger/internal/services/command/create_bulk_transaction_operations_async.go
@@ -8,7 +8,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"sort"
+	"strings"
 	"time"
 
 	libCommons "github.com/LerianStudio/lib-commons/v4/commons"
@@ -496,12 +498,19 @@ func (uc *UseCase) processMetadataAndEvents(
 		// Clean up backup queue with context that preserves trace but survives parent cancellation
 		orgID, ledgerID, err := uc.extractOrgLedgerIDs(payload)
 		if err == nil {
-			go func(orgID, ledgerID uuid.UUID, txID string) {
+			useConditionalCleanup := strings.ToLower(os.Getenv("RABBITMQ_TRANSACTION_ASYNC")) == "true"
+			expectedStatus := tx.Status.Code
+
+			go func(orgID, ledgerID uuid.UUID, txID, status string) {
 				opCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), asyncOperationTimeout)
 				defer cancel()
 
-				uc.RemoveTransactionFromRedisQueue(opCtx, logger, orgID, ledgerID, txID)
-			}(orgID, ledgerID, tx.ID)
+				if useConditionalCleanup {
+					uc.RemoveTransactionFromRedisQueueIfStatus(opCtx, logger, orgID, ledgerID, txID, status)
+				} else {
+					uc.RemoveTransactionFromRedisQueue(opCtx, logger, orgID, ledgerID, txID)
+				}
+			}(orgID, ledgerID, tx.ID, expectedStatus)
 
 			go func(orgID, ledgerID uuid.UUID, txID string) {
 				opCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), asyncOperationTimeout)

--- a/components/ledger/internal/services/command/create_bulk_transaction_operations_async.go
+++ b/components/ledger/internal/services/command/create_bulk_transaction_operations_async.go
@@ -385,7 +385,7 @@ func (uc *UseCase) bulkInsertOperationsTx(
 	// Validate direction on all operations before bulk insert.
 	for _, op := range operations {
 		if op != nil {
-			if err := validateOperationDirection(op, logger, ctx); err != nil {
+			if err := validateOperationDirection(ctx, logger, op); err != nil {
 				return err
 			}
 		}

--- a/components/ledger/internal/services/command/create_bulk_transaction_operations_async_test.go
+++ b/components/ledger/internal/services/command/create_bulk_transaction_operations_async_test.go
@@ -135,6 +135,7 @@ func TestCreateBulkTransactionOperationsAsync_SingleTransaction_Success(t *testi
 				Available: decimal.NewFromInt(50),
 			},
 		},
+		Version: "v2",
 	}
 
 	// Mock DB transaction for atomic inserts
@@ -250,6 +251,7 @@ func TestCreateBulkTransactionOperationsAsync_MultipleTransactions_Success(t *te
 			BalancesAfter: []*mmodel.Balance{
 				{ID: uuid.New().String(), Alias: "alias1", Available: decimal.NewFromInt(50)},
 			},
+			Version: "v2",
 		}
 	}
 
@@ -336,6 +338,7 @@ func TestCreateBulkTransactionOperationsAsync_WithDuplicates(t *testing.T) {
 		Validate:      &mtransaction.Responses{Aliases: []string{"alias1"}},
 		Balances:      []*mmodel.Balance{{ID: uuid.New().String(), Alias: "alias1", Available: decimal.NewFromInt(100)}},
 		BalancesAfter: []*mmodel.Balance{{ID: uuid.New().String(), Alias: "alias1", Available: decimal.NewFromInt(50)}},
+		Version:       "v2",
 	}
 
 	// Mock DB transaction for atomic inserts
@@ -420,6 +423,7 @@ func TestCreateBulkTransactionOperationsAsync_StatusTransition_BelowThreshold(t 
 		},
 		Balances:      []*mmodel.Balance{{ID: uuid.New().String(), Alias: "alias1", Available: decimal.NewFromInt(100)}},
 		BalancesAfter: []*mmodel.Balance{{ID: uuid.New().String(), Alias: "alias1", Available: decimal.NewFromInt(50)}},
+		Version:       "v2",
 	}
 
 	// Note: Balance updates are handled by BalanceSyncWorker, not in this flow
@@ -500,6 +504,7 @@ func TestCreateBulkTransactionOperationsAsync_BulkInsertFails_UsesFallback(t *te
 		Validate:      &mtransaction.Responses{Aliases: []string{"alias1"}},
 		Balances:      []*mmodel.Balance{{ID: uuid.New().String(), Alias: "alias1", Available: decimal.NewFromInt(100)}},
 		BalancesAfter: []*mmodel.Balance{{ID: uuid.New().String(), Alias: "alias1", Available: decimal.NewFromInt(50)}},
+		Version:       "v2",
 	}
 
 	// Mock DB transaction for atomic inserts - will fail and rollback
@@ -598,6 +603,7 @@ func TestClassifyAndExtractEntities_SeparatesInsertsAndUpdates(t *testing.T) {
 				Status: transaction.Status{Code: constant.APPROVED},
 			},
 			Validate: &mtransaction.Responses{Pending: true},
+			Version:  "v2",
 		},
 		// Update: pending -> canceled
 		{
@@ -606,6 +612,7 @@ func TestClassifyAndExtractEntities_SeparatesInsertsAndUpdates(t *testing.T) {
 				Status: transaction.Status{Code: constant.CANCELED},
 			},
 			Validate: &mtransaction.Responses{Pending: true},
+			Version:  "v2",
 		},
 	}
 
@@ -632,6 +639,7 @@ func TestIsStatusTransition(t *testing.T) {
 					Status: transaction.Status{Code: constant.APPROVED},
 				},
 				Validate: &mtransaction.Responses{Pending: true},
+				Version:  "v2",
 			},
 			expected: true,
 		},
@@ -642,6 +650,7 @@ func TestIsStatusTransition(t *testing.T) {
 					Status: transaction.Status{Code: constant.CANCELED},
 				},
 				Validate: &mtransaction.Responses{Pending: true},
+				Version:  "v2",
 			},
 			expected: true,
 		},
@@ -671,6 +680,7 @@ func TestIsStatusTransition(t *testing.T) {
 					Status: transaction.Status{Code: constant.APPROVED},
 				},
 				Validate: &mtransaction.Responses{Pending: false},
+				Version:  "v2",
 			},
 			expected: false,
 		},
@@ -848,6 +858,7 @@ func TestCreateBulkTransactionOperationsAsync_BalanceUpdateFails_UsesFallback(t 
 		Validate:      &mtransaction.Responses{Aliases: []string{"alias1"}},
 		Balances:      []*mmodel.Balance{{ID: uuid.New().String(), Alias: "alias1", Available: decimal.NewFromInt(100)}},
 		BalancesAfter: []*mmodel.Balance{{ID: uuid.New().String(), Alias: "alias1", Available: decimal.NewFromInt(50)}},
+		Version:       "v2",
 	}
 
 	// Mock DB transaction for atomic inserts
@@ -938,6 +949,7 @@ func TestCreateBulkTransactionOperationsAsync_StatusTransition_AboveThreshold_Us
 			},
 			Balances:      []*mmodel.Balance{{ID: uuid.New().String(), Alias: "alias1", Available: decimal.NewFromInt(100)}},
 			BalancesAfter: []*mmodel.Balance{{ID: uuid.New().String(), Alias: "alias1", Available: decimal.NewFromInt(50)}},
+			Version:       "v2",
 		}
 	}
 
@@ -1109,6 +1121,7 @@ func TestClassifyAndExtractEntities_CollectsOperationsForStatusTransitions(t *te
 				},
 			},
 			Validate: &mtransaction.Responses{Pending: true},
+			Version:  "v2",
 		},
 	}
 
@@ -1169,6 +1182,7 @@ func TestClassifyAndExtractEntities_MixedBatch_CollectsAllOperations(t *testing.
 				},
 			},
 			Validate: &mtransaction.Responses{Pending: true},
+			Version:  "v2",
 		},
 	}
 

--- a/components/ledger/internal/services/command/write_transaction.go
+++ b/components/ledger/internal/services/command/write_transaction.go
@@ -47,6 +47,7 @@ func (uc *UseCase) WriteTransactionAsync(ctx context.Context, organizationID, le
 		BalancesAfter: blcAfter,
 		Transaction:   tran,
 		Input:         transactionInput,
+		Version:       "v2",
 	}
 
 	marshal, err := msgpack.Marshal(value)
@@ -127,6 +128,7 @@ func (uc *UseCase) WriteTransactionSync(ctx context.Context, organizationID, led
 		BalancesAfter: blcAfter,
 		Transaction:   tran,
 		Input:         transactionInput,
+		Version:       "v2",
 	}
 
 	marshal, err := msgpack.Marshal(value)

--- a/components/ledger/migrations/transaction/000021_backfill_direction.down.sql
+++ b/components/ledger/migrations/transaction/000021_backfill_direction.down.sql
@@ -1,1 +1,2 @@
-ALTER TABLE operation DROP CONSTRAINT IF EXISTS chk_operation_direction;
+-- No constraint to drop — direction validation is at the application layer.
+-- Backfilled values remain in place (no data rollback needed).

--- a/components/ledger/migrations/transaction/000021_backfill_direction.up.sql
+++ b/components/ledger/migrations/transaction/000021_backfill_direction.up.sql
@@ -7,13 +7,7 @@ UPDATE operation SET direction = CASE
     ELSE 'debit'
 END WHERE direction IS NULL;
 
--- Domain CHECK with NOT VALID: registers the constraint without scanning the table.
--- ACCESS EXCLUSIVE lock for milliseconds only. New INSERTs/UPDATEs are validated
--- against the CHECK from this point on.
+-- Direction validation is enforced at the application layer (not via CHECK constraint)
+-- to avoid blocking INSERTs during rolling updates when v3.5.3 messages arrive
+-- without a direction field. See inferDirectionFromType in the Go service layer.
 ALTER TABLE operation DROP CONSTRAINT IF EXISTS chk_operation_direction;
-ALTER TABLE operation ADD CONSTRAINT chk_operation_direction
-    CHECK (LOWER(direction) IN ('debit', 'credit')) NOT VALID;
-
--- VALIDATE performs the full scan to verify existing rows satisfy the CHECK.
--- Uses SHARE UPDATE EXCLUSIVE lock — reads and writes continue normally.
-ALTER TABLE operation VALIDATE CONSTRAINT chk_operation_direction;

--- a/go.mod
+++ b/go.mod
@@ -102,7 +102,7 @@ require (
 )
 
 require (
-	github.com/LerianStudio/lib-commons/v4 v4.6.1-0.20260416134329-1da10dd5a7ed
+	github.com/LerianStudio/lib-commons/v4 v4.6.1
 	github.com/Shopify/toxiproxy/v2 v2.12.0
 	github.com/docker/docker v28.5.2+incompatible
 	github.com/docker/go-connections v0.6.0

--- a/go.mod
+++ b/go.mod
@@ -102,7 +102,7 @@ require (
 )
 
 require (
-	github.com/LerianStudio/lib-commons/v4 v4.6.0
+	github.com/LerianStudio/lib-commons/v4 v4.6.1-0.20260416134329-1da10dd5a7ed
 	github.com/Shopify/toxiproxy/v2 v2.12.0
 	github.com/docker/docker v28.5.2+incompatible
 	github.com/docker/go-connections v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -19,8 +19,8 @@ github.com/KyleBanks/depth v1.2.1 h1:5h8fQADFrWtarTdtDudMmGsC7GPbOAu6RVB3ffsVFHc
 github.com/KyleBanks/depth v1.2.1/go.mod h1:jzSb9d0L43HxTQfT+oSA1EEp2q+ne2uh6XgeJcm8brE=
 github.com/LerianStudio/lib-auth/v2 v2.6.0 h1:J0QvGXWoEbgd5HF5wtMznVfkho/aPihl6sAWn12bvZ4=
 github.com/LerianStudio/lib-auth/v2 v2.6.0/go.mod h1:AAbJCVaVokfO9bLa4aCIGzVMP6to/Ml5MC4X9B6jLZ0=
-github.com/LerianStudio/lib-commons/v4 v4.6.1-0.20260416134329-1da10dd5a7ed h1:GRHhCpy2gE0rxL5JswgTHhXcxd9CtdFlrmWRDPsO7i8=
-github.com/LerianStudio/lib-commons/v4 v4.6.1-0.20260416134329-1da10dd5a7ed/go.mod h1:/0EgYB6lT23afy/nmmeJiuoDnu3/tS56fXqW7fB0QMk=
+github.com/LerianStudio/lib-commons/v4 v4.6.1 h1:vNMulad4GUjBbX9ArgfvHG0Dj7IXO6lzFFzuxrh21c8=
+github.com/LerianStudio/lib-commons/v4 v4.6.1/go.mod h1:/0EgYB6lT23afy/nmmeJiuoDnu3/tS56fXqW7fB0QMk=
 github.com/Masterminds/squirrel v1.5.4 h1:uUcX/aBc8O7Fg9kaISIUsHXdKuqehiXAMQTYX8afzqM=
 github.com/Masterminds/squirrel v1.5.4/go.mod h1:NNaOrjSoIDfDA40n7sr2tPNZRfjzjA400rg+riTZj10=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=

--- a/go.sum
+++ b/go.sum
@@ -19,8 +19,8 @@ github.com/KyleBanks/depth v1.2.1 h1:5h8fQADFrWtarTdtDudMmGsC7GPbOAu6RVB3ffsVFHc
 github.com/KyleBanks/depth v1.2.1/go.mod h1:jzSb9d0L43HxTQfT+oSA1EEp2q+ne2uh6XgeJcm8brE=
 github.com/LerianStudio/lib-auth/v2 v2.6.0 h1:J0QvGXWoEbgd5HF5wtMznVfkho/aPihl6sAWn12bvZ4=
 github.com/LerianStudio/lib-auth/v2 v2.6.0/go.mod h1:AAbJCVaVokfO9bLa4aCIGzVMP6to/Ml5MC4X9B6jLZ0=
-github.com/LerianStudio/lib-commons/v4 v4.6.0 h1:O2XvuDhShNX3aaCaGAK4IM95Z8iM5TW1tjJkNKqIgKY=
-github.com/LerianStudio/lib-commons/v4 v4.6.0/go.mod h1:/0EgYB6lT23afy/nmmeJiuoDnu3/tS56fXqW7fB0QMk=
+github.com/LerianStudio/lib-commons/v4 v4.6.1-0.20260416134329-1da10dd5a7ed h1:GRHhCpy2gE0rxL5JswgTHhXcxd9CtdFlrmWRDPsO7i8=
+github.com/LerianStudio/lib-commons/v4 v4.6.1-0.20260416134329-1da10dd5a7ed/go.mod h1:/0EgYB6lT23afy/nmmeJiuoDnu3/tS56fXqW7fB0QMk=
 github.com/Masterminds/squirrel v1.5.4 h1:uUcX/aBc8O7Fg9kaISIUsHXdKuqehiXAMQTYX8afzqM=
 github.com/Masterminds/squirrel v1.5.4/go.mod h1:NNaOrjSoIDfDA40n7sr2tPNZRfjzjA400rg+riTZj10=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=

--- a/pkg/utils/cache.go
+++ b/pkg/utils/cache.go
@@ -151,7 +151,10 @@ func PendingTransactionLockKey(organizationID, ledgerID uuid.UUID, transactionID
 
 // RedisConsumerLockKey returns a key with the following format to be used on redis cluster:
 // "redis_consumer_lock:{organizationID:ledgerID}:transactionID"
-// This key is used to prevent duplicate processing of the same transaction across multiple pods.
+//
+// Deprecated: This per-transaction lock has been replaced by the cycle-level lock
+// (RedisConsumerCycleLockKey). Retained for reference during rolling deployments
+// where old pods may still hold per-transaction locks.
 func RedisConsumerLockKey(organizationID, ledgerID uuid.UUID, transactionID string) string {
 	var builder strings.Builder
 
@@ -168,6 +171,15 @@ func RedisConsumerLockKey(organizationID, ledgerID uuid.UUID, transactionID stri
 	builder.WriteString(transactionID)
 
 	return builder.String()
+}
+
+// RedisConsumerCycleLockKey returns the distributed lock key used for leader election
+// in the Redis backup queue consumer. Only one pod acquires this lock per processing
+// cycle, eliminating N×M SetNX calls (N pods × M messages) in favor of N×1.
+// Format: "lock:{transactions}:backup-consumer-cycle"
+// The {transactions} hash tag ensures the key routes to the correct Redis Cluster slot.
+func RedisConsumerCycleLockKey() string {
+	return "lock:{transactions}:backup-consumer-cycle"
 }
 
 // LedgerSettingsInternalKey returns a key with the following format to be used on redis cluster:

--- a/pkg/utils/cache_test.go
+++ b/pkg/utils/cache_test.go
@@ -332,6 +332,19 @@ func TestLedgerSettingsInternalKey(t *testing.T) {
 	}
 }
 
+func TestRedisConsumerCycleLockKey(t *testing.T) {
+	t.Parallel()
+
+	result := RedisConsumerCycleLockKey()
+
+	assert.Equal(t, "lock:{transactions}:backup-consumer-cycle", result,
+		"cycle lock key must use {transactions} hash tag for Redis Cluster routing")
+
+	// Call twice to ensure deterministic output (no randomness).
+	assert.Equal(t, result, RedisConsumerCycleLockKey(),
+		"cycle lock key must be deterministic across calls")
+}
+
 func TestCacheKeyConstants(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Context

Chaos tests with RabbitMQ outages/reconnects exposed edge cases where balance updates could succeed while transaction persistence/recovery paths were still vulnerable.

## What changed

- Added conditional Redis backup cleanup by transaction status, preventing stale workers from deleting newer backup snapshots for the same transaction.
- Moved operation `direction` enforcement from DB CHECK constraint to application validation (plus migration updates).
- Added async payload `Version` and a legacy fallback (`UpdateBalances`) for pre-version messages still in queue during rolling upgrades.
- Prevented RabbitMQ publish TOCTOU race by using channel snapshot semantics before publish.
- Replaced per-transaction Redis backup lock with cycle-level leader election lock (`lock:{transactions}:backup-consumer-cycle`) to reduce lock churn and improve processing stability.

## Why

These changes make the async pipeline safer under broker instability, preserve backward compatibility for in-flight legacy messages, and reduce Redis contention in backup processing.

## Validation

- `go test ./components/ledger/internal/services/command -count=1`
- `go test ./components/ledger/internal/adapters/rabbitmq -count=1`
- `go test ./components/ledger/internal/bootstrap -count=1`
- `go test ./pkg/utils -count=1`
- Chaos replay run showed backup queue draining correctly and no balance/operation inconsistencies.