### PR TITLE
fix: split balance-sync keys and fix backup_queue cleanup backlog

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   build:
-    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/build.yml@v1.23.1
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/build.yml@v1.26.1
     with:
       runner_type: "blacksmith-4vcpu-ubuntu-2404"
       filter_paths: |-
@@ -46,7 +46,7 @@ jobs:
       !cancelled() &&
       needs.build.result == 'success' &&
       needs.build.outputs.has_builds == 'true'
-    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/gitops-update.yml@v1.23.1
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/gitops-update.yml@v1.26.1
     with:
       runner_type: "firmino-lxc-runners"
       gitops_repository: "LerianStudio/midaz-firmino-gitops"
@@ -66,7 +66,7 @@ jobs:
   upload-onboarding-migrations:
     needs: [build]
     if: needs.build.result == 'success'
-    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/s3-upload.yml@v1.23.1
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/s3-upload.yml@v1.26.1
     with:
       s3_bucket: "lerian-migration-files"
       file_pattern: "components/ledger/migrations/onboarding/*.sql"
@@ -79,7 +79,7 @@ jobs:
   upload-transaction-migrations:
     needs: [build]
     if: needs.build.result == 'success'
-    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/s3-upload.yml@v1.23.1
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/s3-upload.yml@v1.26.1
     with:
       s3_bucket: "lerian-migration-files"
       file_pattern: "components/ledger/migrations/transaction/*.sql"
@@ -95,7 +95,7 @@ jobs:
   api_dog_e2e_tests:
     needs: [update_gitops]
     if: needs.update_gitops.result == 'success'
-    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/api-dog-e2e-tests.yml@v1.23.1
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/api-dog-e2e-tests.yml@v1.26.1
     with:
       runner_type: "firmino-lxc-runners"
       auto_detect_environment: true

--- a/.github/workflows/go-combined-analysis.yml
+++ b/.github/workflows/go-combined-analysis.yml
@@ -25,7 +25,7 @@ on:
 jobs:
   go-analysis:
     name: Go Analysis
-    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/go-pr-analysis.yml@v1.23.1
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/go-pr-analysis.yml@v1.26.1
     with:
       runner_type: "blacksmith-4vcpu-ubuntu-2404"
       filter_paths: '["components/crm", "components/ledger"]'

--- a/.github/workflows/gptchangelog.yml
+++ b/.github/workflows/gptchangelog.yml
@@ -23,7 +23,7 @@ jobs:
   changelog:
     # Run if: manual trigger OR Release workflow succeeded
     if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
-    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/gptchangelog.yml@v1.23.1
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/gptchangelog.yml@v1.26.1
     with:
       runner_type: "blacksmith-4vcpu-ubuntu-2404"
       # No filter_paths = single app mode (non-monorepo)

--- a/.github/workflows/pr-security-scan.yml
+++ b/.github/workflows/pr-security-scan.yml
@@ -24,7 +24,7 @@ on:
 
 jobs:
   security-scan:
-    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/pr-security-scan.yml@v1.23.1
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/pr-security-scan.yml@v1.26.1
     with:
       runner_type: "blacksmith-4vcpu-ubuntu-2404"
       filter_paths: |-

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   validate:
-    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/pr-validation.yml@v1.23.1
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/pr-validation.yml@v1.26.1
     with:
       runner_type: "blacksmith-4vcpu-ubuntu-2404"
       pr_title_types: |

--- a/.github/workflows/release-notification.yml
+++ b/.github/workflows/release-notification.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   notify:
-    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/release-notification.yml@v1.23.1
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/release-notification.yml@v1.26.1
     with:
       product_name: "Midaz"
       slack_channel: "lerian-product-release"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
   # =========================
   release:
     name: Create Release
-    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/release.yml@v1.23.1
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/release.yml@v1.26.1
     with:
       runner_type: "blacksmith-4vcpu-ubuntu-2404"
     secrets: inherit

--- a/components/ledger/internal/adapters/redis/transaction/balance_schedule_test.go
+++ b/components/ledger/internal/adapters/redis/transaction/balance_schedule_test.go
@@ -35,7 +35,7 @@ func TestLuaScript_ContainsScheduleLogic(t *testing.T) {
 // TestScheduleKeyConstant verifies the schedule key constant matches
 // what the BalanceSyncWorker expects.
 func TestScheduleKeyConstant(t *testing.T) {
-	expectedKey := "schedule:{transactions}:balance-sync"
+	expectedKey := "schedule:{transactions}:balance-sync-v2"
 	assert.Equal(t, expectedKey, utils.BalanceSyncScheduleKey,
 		"Schedule key constant should match expected format")
 }

--- a/components/ledger/internal/adapters/redis/transaction/consumer.redis.go
+++ b/components/ledger/internal/adapters/redis/transaction/consumer.redis.go
@@ -98,6 +98,9 @@ type RedisRepository interface {
 	// Each claimed key gets a distributed lock (SET NX EX) to prevent concurrent processing.
 	// Returns the claimed keys with their scores for conditional removal later.
 	GetBalanceSyncKeys(ctx context.Context, limit int64) ([]SyncKey, error)
+	// GetBalanceSyncKeysLegacy claims due keys from the legacy ZSET (balance-sync, pre-v3.6.2).
+	// Used by the legacy drainer to process entries written by v3.5.x (seconds) or v3.6.0 (microseconds).
+	GetBalanceSyncKeysLegacy(ctx context.Context, limit int64) ([]SyncKey, error)
 	// ScheduleBalanceSyncBatch schedules multiple balance keys for sync using ZADD NX.
 	// Each member is a balance key with score = scheduled sync time (Unix timestamp).
 	// Uses NX mode: only adds new members, does not update scores of existing ones.
@@ -1069,6 +1072,68 @@ func (rr *RedisConsumerRepository) GetBalanceSyncKeys(ctx context.Context, limit
 
 	logger.Log(ctx, libLog.LevelInfo, "Claimed balance sync keys",
 		libLog.Int("count", len(out)))
+
+	return out, nil
+}
+
+// GetBalanceSyncKeysLegacy claims due keys from the legacy ZSET (balance-sync, pre-v3.6.2).
+// Reuses the same Lua claim script — the fractional-second `now` works with seconds-based
+// scores because both are in the ~1e9 range. Microsecond scores (~1e15) will never be
+// "due" and remain in the ZSET until TTL expiry or manual cleanup.
+func (rr *RedisConsumerRepository) GetBalanceSyncKeysLegacy(ctx context.Context, limit int64) ([]SyncKey, error) {
+	logger, tracer, _, _ := libCommons.NewTrackingFromContext(ctx)
+
+	ctx, span := tracer.Start(ctx, "redis.get_balance_sync_keys_legacy")
+	defer span.End()
+
+	rds, err := rr.conn.GetClient(ctx)
+	if err != nil {
+		libOpentelemetry.HandleSpanError(span, "Failed to get redis client", err)
+		logger.Log(ctx, libLog.LevelError, "Failed to get redis client", libLog.Err(err))
+
+		return nil, err
+	}
+
+	script := redis.NewScript(claimBalanceSyncKeysLua)
+
+	prefixedScheduleKey, err := tenantKeyFromContextOrError(ctx, utils.BalanceSyncScheduleKeyLegacy)
+	if err != nil {
+		libOpentelemetry.HandleSpanError(span, "Failed to namespace legacy schedule key", err)
+		logger.Log(ctx, libLog.LevelWarn, "Failed to namespace legacy schedule key", libLog.Err(err))
+
+		return nil, err
+	}
+
+	prefixedLockPrefix, err := tenantKeyFromContextOrError(ctx, utils.BalanceSyncLockPrefix)
+	if err != nil {
+		libOpentelemetry.HandleSpanError(span, "Failed to namespace lock prefix", err)
+		logger.Log(ctx, libLog.LevelWarn, "Failed to namespace lock prefix", libLog.Err(err))
+
+		return nil, err
+	}
+
+	const claimTTLSeconds int64 = 600
+
+	res, err := script.Run(ctx, rds, []string{prefixedScheduleKey}, limit, claimTTLSeconds, prefixedLockPrefix).Result()
+	if err != nil {
+		libOpentelemetry.HandleSpanError(span, "Failed to run claim_balance_sync_keys.lua (legacy)", err)
+		logger.Log(ctx, libLog.LevelError, "Failed to run claim_balance_sync_keys.lua (legacy)", libLog.Err(err))
+
+		return nil, err
+	}
+
+	out, err := parseSyncKeysFromLuaResult(res, logger, ctx)
+	if err != nil {
+		libOpentelemetry.HandleSpanError(span, "Failed to parse legacy claim script result", err)
+		logger.Log(ctx, libLog.LevelError, "Failed to parse legacy claim script result", libLog.Err(err))
+
+		return nil, err
+	}
+
+	if len(out) > 0 {
+		logger.Log(ctx, libLog.LevelInfo, "Claimed legacy balance sync keys",
+			libLog.Int("count", len(out)))
+	}
 
 	return out, nil
 }

--- a/components/ledger/internal/adapters/redis/transaction/consumer.redis_mock.go
+++ b/components/ledger/internal/adapters/redis/transaction/consumer.redis_mock.go
@@ -106,6 +106,21 @@ func (mr *MockRedisRepositoryMockRecorder) GetBalanceSyncKeys(ctx, limit any) *g
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBalanceSyncKeys", reflect.TypeOf((*MockRedisRepository)(nil).GetBalanceSyncKeys), ctx, limit)
 }
 
+// GetBalanceSyncKeysLegacy mocks base method.
+func (m *MockRedisRepository) GetBalanceSyncKeysLegacy(ctx context.Context, limit int64) ([]SyncKey, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetBalanceSyncKeysLegacy", ctx, limit)
+	ret0, _ := ret[0].([]SyncKey)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetBalanceSyncKeysLegacy indicates an expected call of GetBalanceSyncKeysLegacy.
+func (mr *MockRedisRepositoryMockRecorder) GetBalanceSyncKeysLegacy(ctx, limit any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBalanceSyncKeysLegacy", reflect.TypeOf((*MockRedisRepository)(nil).GetBalanceSyncKeysLegacy), ctx, limit)
+}
+
 // GetBalancesByKeys mocks base method.
 func (m *MockRedisRepository) GetBalancesByKeys(ctx context.Context, keys []string) (map[string]*mmodel.BalanceRedis, error) {
 	m.ctrl.T.Helper()

--- a/components/ledger/internal/adapters/redis/transaction/scripts/balance_atomic_operation.lua
+++ b/components/ledger/internal/adapters/redis/transaction/scripts/balance_atomic_operation.lua
@@ -244,10 +244,12 @@ local function main()
     -- before flushing to PostgreSQL, so immediate eligibility does not mean
     -- immediate DB write — the worker accumulates keys efficiently.
     --
-    -- Uses microsecond precision (seconds * 1e6 + microseconds) to prevent
+    -- Uses fractional-second precision (seconds + microseconds / 1e6) to prevent
     -- the conditional ZREM from removing entries re-scheduled in the same second.
+    -- Fractional seconds keep scores in the ~1e9 range (valid Unix timestamps),
+    -- ensuring rollback compatibility with versions that interpret scores as seconds.
     local timeNow = redis.call("TIME")
-    local dueAt = tonumber(timeNow[1]) * 1000000 + tonumber(timeNow[2])
+    local dueAt = tonumber(timeNow[1]) + tonumber(timeNow[2]) / 1000000
 
     for i = 1, #ARGV, groupSize do
         local redisBalanceKey = ARGV[i]

--- a/components/ledger/internal/adapters/redis/transaction/scripts/claim_balance_sync_keys.lua
+++ b/components/ledger/internal/adapters/redis/transaction/scripts/claim_balance_sync_keys.lua
@@ -1,15 +1,13 @@
 -- claim_balance_sync_keys.lua
 -- Fetches due balance sync keys from the ZSET schedule with distributed locking.
 --
--- The ZSET score is a microsecond timestamp set by balance_atomic_operation.lua
--- at mutation time (dueAt = now). With the dual-trigger collector (batch size OR
--- timeout), the score no longer controls *when* sync happens — the collector
--- flushes on its own schedule. However, the score still serves as an optimistic
--- concurrency token: if a newer mutation overwrites the score via ZADD between
--- claim and removal, remove_balance_sync_keys_batch.lua detects the mismatch
--- and skips ZREM, preserving the entry for the next sync cycle.
+-- The ZSET score is a fractional-second timestamp set by balance_atomic_operation.lua
+-- at mutation time (dueAt = seconds + microseconds/1e6). The score serves as an
+-- optimistic concurrency token: if a newer mutation overwrites the score via ZADD
+-- between claim and removal, remove_balance_sync_keys_batch.lua detects the
+-- mismatch and skips ZREM, preserving the entry for the next sync cycle.
 --
--- KEYS[1]: schedule sorted set (e.g., "schedule:{transactions}:balance-sync")
+-- KEYS[1]: schedule sorted set (e.g., "schedule:{transactions}:balance-sync-v2")
 -- ARGV[1]: max number of keys to return
 -- ARGV[2]: claim lock TTL in seconds (default 600)
 -- ARGV[3]: lock key prefix (default "lock:{transactions}:balance-sync:")
@@ -20,7 +18,7 @@ if not scheduleKey then
 end
 
 local t = redis.call('TIME')
-local now = tonumber(t[1]) * 1000000 + tonumber(t[2])
+local now = tonumber(t[1]) + tonumber(t[2]) / 1000000
 local limit = tonumber(ARGV[1]) or 25
 local claimTTL = tonumber(ARGV[2]) or 600
 local claimPrefix = ARGV[3] or "lock:{transactions}:balance-sync:"

--- a/components/ledger/internal/bootstrap/balance_sync.worker.go
+++ b/components/ledger/internal/bootstrap/balance_sync.worker.go
@@ -617,3 +617,71 @@ func (w *BalanceSyncWorker) extractIDsFromMember(member string) (organizationID 
 
 	return uuid.UUID{}, uuid.UUID{}, fmt.Errorf("balance sync key missing two UUIDs (orgID, ledgerID): %q", member)
 }
+
+// LegacyBalanceSyncDrainer drains entries from the legacy ZSET (balance-sync, pre-v3.6.2).
+// It reuses the same flush pipeline as the main worker but reads from the legacy key
+// with a longer idle wait. Once the legacy ZSET is fully drained, the drainer idles.
+type LegacyBalanceSyncDrainer struct {
+	logger   libLog.Logger
+	idleWait time.Duration
+	useCase  *command.UseCase
+	syncCfg  BalanceSyncConfig
+}
+
+// NewLegacyBalanceSyncDrainer creates a drainer for the pre-v3.6.2 balance-sync ZSET.
+func NewLegacyBalanceSyncDrainer(logger libLog.Logger, useCase *command.UseCase, syncCfg BalanceSyncConfig) *LegacyBalanceSyncDrainer {
+	if syncCfg.BatchSize <= 0 {
+		syncCfg.BatchSize = 50
+	}
+
+	if syncCfg.FlushTimeoutMs <= 0 {
+		syncCfg.FlushTimeoutMs = 2000
+	}
+
+	if syncCfg.PollIntervalMs <= 0 {
+		syncCfg.PollIntervalMs = 1000
+	}
+
+	return &LegacyBalanceSyncDrainer{
+		logger:   logger,
+		idleWait: 30 * time.Second, // long backoff — legacy ZSET drains to zero
+		useCase:  useCase,
+		syncCfg:  syncCfg,
+	}
+}
+
+// Run implements the Launcher interface for the legacy drainer.
+func (d *LegacyBalanceSyncDrainer) Run(_ *libCommons.Launcher) error {
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	d.logger.Log(ctx, libLog.LevelInfo, "LegacyBalanceSyncDrainer started — draining balance-sync (pre-v3.6.2)")
+
+	// Reuse the same collector/flush infrastructure as the main worker,
+	// but fetch from the legacy ZSET key via GetBalanceSyncKeysLegacy.
+	worker := NewBalanceSyncWorker(d.logger, d.useCase, d.syncCfg)
+	worker.idleWait = d.idleWait
+
+	collector := NewBalanceSyncCollector(
+		d.syncCfg.BatchSize,
+		d.syncCfg.FlushTimeout(),
+		d.syncCfg.PollInterval(),
+		d.logger,
+	)
+
+	collector.Run(ctx,
+		func(flushCtx context.Context, keys []redisTransaction.SyncKey) bool {
+			return worker.flushBatch(flushCtx, keys)
+		},
+		func(fetchCtx context.Context, limit int64) ([]redisTransaction.SyncKey, error) {
+			return d.useCase.TransactionRedisRepo.GetBalanceSyncKeysLegacy(fetchCtx, limit)
+		},
+		func(waitCtx context.Context) bool {
+			return waitOrDone(waitCtx, d.idleWait, d.logger)
+		},
+	)
+
+	d.logger.Log(ctx, libLog.LevelInfo, "LegacyBalanceSyncDrainer: shutting down...")
+
+	return nil
+}

--- a/components/ledger/internal/bootstrap/config.go
+++ b/components/ledger/internal/bootstrap/config.go
@@ -708,6 +708,14 @@ func InitServersWithOptions(opts *Options) (*Service, error) {
 	// BalanceSyncWorker: multi-tenant or single-tenant
 	balanceSyncWorker := initBalanceSyncWorker(internalOpts, cfg, logger, commandUseCase, txnPG.pgManager, tenantServiceName)
 
+	// Legacy drainer: drains pre-v3.6.2 ZSET entries (balance-sync key with seconds/microsecond scores).
+	// Uses relaxed timing (longer flush timeout, longer idle wait) since it only drains a finite backlog.
+	legacyDrainer := NewLegacyBalanceSyncDrainer(logger, commandUseCase, BalanceSyncConfig{
+		BatchSize:      cfg.BalanceSyncBatchSize,
+		FlushTimeoutMs: 2000,
+		PollIntervalMs: 1000,
+	})
+
 	logger.Log(context.Background(), libLog.LevelInfo, "Unified ledger component started successfully with single-port mode",
 		libLog.String("version", cfg.Version),
 		libLog.String("env", cfg.EnvName),
@@ -715,16 +723,17 @@ func InitServersWithOptions(opts *Options) (*Service, error) {
 	)
 
 	return &Service{
-		UnifiedServer:         unifiedServer,
-		MultiQueueConsumer:    rmq.multiQueueConsumer,
-		MultiTenantConsumer:   rmq.multiTenantConsumer,
-		RedisQueueConsumer:    redisConsumer,
-		BalanceSyncWorker:     balanceSyncWorker,
-		EventListener:         eventListener,
-		CircuitBreakerManager: rmq.circuitBreakerManager,
-		Logger:                logger,
-		Telemetry:             telemetry,
-		metricsFactory:        rmq.metricsFactory,
+		UnifiedServer:            unifiedServer,
+		MultiQueueConsumer:       rmq.multiQueueConsumer,
+		MultiTenantConsumer:      rmq.multiTenantConsumer,
+		RedisQueueConsumer:       redisConsumer,
+		BalanceSyncWorker:        balanceSyncWorker,
+		LegacyBalanceSyncDrainer: legacyDrainer,
+		EventListener:            eventListener,
+		CircuitBreakerManager:    rmq.circuitBreakerManager,
+		Logger:                   logger,
+		Telemetry:                telemetry,
+		metricsFactory:           rmq.metricsFactory,
 	}, nil
 }
 

--- a/components/ledger/internal/bootstrap/service.go
+++ b/components/ledger/internal/bootstrap/service.go
@@ -20,16 +20,17 @@ import (
 
 // Service is the unified ledger service that owns all infrastructure directly.
 type Service struct {
-	UnifiedServer         *UnifiedServer
-	MultiQueueConsumer    *MultiQueueConsumer
-	MultiTenantConsumer   *tmconsumer.MultiTenantConsumer
-	RedisQueueConsumer    *RedisQueueConsumer
-	BalanceSyncWorker     *BalanceSyncWorker
-	EventListener         *tmevent.TenantEventListener
-	CircuitBreakerManager *CircuitBreakerManager
-	Logger                libLog.Logger
-	Telemetry             *libOpentelemetry.Telemetry
-	metricsFactory        *metrics.MetricsFactory
+	UnifiedServer            *UnifiedServer
+	MultiQueueConsumer       *MultiQueueConsumer
+	MultiTenantConsumer      *tmconsumer.MultiTenantConsumer
+	RedisQueueConsumer       *RedisQueueConsumer
+	BalanceSyncWorker        *BalanceSyncWorker
+	LegacyBalanceSyncDrainer *LegacyBalanceSyncDrainer
+	EventListener            *tmevent.TenantEventListener
+	CircuitBreakerManager    *CircuitBreakerManager
+	Logger                   libLog.Logger
+	Telemetry                *libOpentelemetry.Telemetry
+	metricsFactory           *metrics.MetricsFactory
 }
 
 // Run starts the unified ledger service with all APIs on a single port.
@@ -60,6 +61,11 @@ func (s *Service) Run() {
 	// Balance sync worker (optional, started when configured)
 	if s.BalanceSyncWorker != nil {
 		launcherOpts = append(launcherOpts, libCommons.RunApp("Balance Sync Worker", s.BalanceSyncWorker))
+	}
+
+	// Legacy balance sync drainer — drains pre-v3.6.2 ZSET entries
+	if s.LegacyBalanceSyncDrainer != nil {
+		launcherOpts = append(launcherOpts, libCommons.RunApp("Legacy Balance Sync Drainer", s.LegacyBalanceSyncDrainer))
 	}
 
 	// Tenant event listener (Redis Pub/Sub)

--- a/components/ledger/internal/services/command/create_balance_transaction_operations_async.go
+++ b/components/ledger/internal/services/command/create_balance_transaction_operations_async.go
@@ -62,7 +62,7 @@ func (uc *UseCase) CreateBalanceTransactionOperationsAsync(ctx context.Context, 
 		return fmt.Errorf("transaction payload has nil Transaction field")
 	}
 
-	backupStatusForCleanup := t.Transaction.Status.Code
+	backupStatusForCleanup := utils.ExpectedBackupStatusForCleanup(t.Transaction.Status.Code, t.Validate)
 
 	// Legacy payload compatibility: messages from v3.5.x lack the Version field.
 	// Their balance persistence relied on UpdateBalances() in the consumer, which
@@ -152,7 +152,7 @@ func (uc *UseCase) CreateBalanceTransactionOperationsAsync(ctx context.Context, 
 
 	if strings.ToLower(os.Getenv("RABBITMQ_TRANSACTION_ASYNC")) == "true" {
 		if backupStatusForCleanup == "" {
-			backupStatusForCleanup = tran.Status.Code
+			backupStatusForCleanup = utils.ExpectedBackupStatusForCleanup(tran.Status.Code, t.Validate)
 		}
 
 		go uc.RemoveTransactionFromRedisQueueIfStatus(ctx, logger, data.OrganizationID, data.LedgerID, tran.ID, backupStatusForCleanup)

--- a/components/ledger/internal/services/command/create_bulk_transaction_operations_async.go
+++ b/components/ledger/internal/services/command/create_bulk_transaction_operations_async.go
@@ -22,6 +22,7 @@ import (
 	"github.com/LerianStudio/midaz/v3/pkg/mmodel"
 	"github.com/LerianStudio/midaz/v3/pkg/mtransaction"
 	"github.com/LerianStudio/midaz/v3/pkg/repository"
+	"github.com/LerianStudio/midaz/v3/pkg/utils"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/vmihailenco/msgpack/v5"
@@ -509,30 +510,12 @@ func (uc *UseCase) processMetadataAndEvents(
 
 		tx := payload.Transaction
 
-		// Skip if this transaction was not actually inserted (duplicate)
-		// If insertedTxIDs is empty, process all (fallback or status-update scenarios)
-		if len(insertedTxIDs) > 0 {
-			if _, wasInserted := insertedTxIDs[tx.ID]; !wasInserted {
-				logger.Log(ctx, libLog.LevelDebug, fmt.Sprintf(
-					"Skipping events for duplicate transaction %s", tx.ID))
-
-				continue
-			}
-		}
-
-		// Send events asynchronously with context that preserves trace but survives parent cancellation
-		go func() {
-			opCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), asyncOperationTimeout)
-			defer cancel()
-
-			uc.SendTransactionEvents(opCtx, tx)
-		}()
-
-		// Clean up backup queue with context that preserves trace but survives parent cancellation
+		// Clean up backup/write-behind entries for every payload that reached this stage,
+		// including duplicates ignored by INSERT ... ON CONFLICT DO NOTHING.
 		orgID, ledgerID, err := uc.extractOrgLedgerIDs(payload)
 		if err == nil {
 			useConditionalCleanup := strings.ToLower(os.Getenv("RABBITMQ_TRANSACTION_ASYNC")) == "true"
-			expectedStatus := tx.Status.Code
+			expectedStatus := utils.ExpectedBackupStatusForCleanup(tx.Status.Code, payload.Validate)
 
 			go func(orgID, ledgerID uuid.UUID, txID, status string) {
 				opCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), asyncOperationTimeout)
@@ -552,6 +535,25 @@ func (uc *UseCase) processMetadataAndEvents(
 				uc.DeleteWriteBehindTransaction(opCtx, orgID, ledgerID, txID)
 			}(orgID, ledgerID, tx.ID)
 		}
+
+		// Skip if this transaction was not actually inserted (duplicate)
+		// If insertedTxIDs is empty, process all (fallback or status-update scenarios)
+		if len(insertedTxIDs) > 0 {
+			if _, wasInserted := insertedTxIDs[tx.ID]; !wasInserted {
+				logger.Log(ctx, libLog.LevelDebug, fmt.Sprintf(
+					"Skipping events for duplicate transaction %s", tx.ID))
+
+				continue
+			}
+		}
+
+		// Send events asynchronously with context that preserves trace but survives parent cancellation
+		go func() {
+			opCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), asyncOperationTimeout)
+			defer cancel()
+
+			uc.SendTransactionEvents(opCtx, tx)
+		}()
 	}
 }
 

--- a/components/ledger/internal/services/command/create_bulk_transaction_operations_async_test.go
+++ b/components/ledger/internal/services/command/create_bulk_transaction_operations_async_test.go
@@ -7,8 +7,11 @@ package command
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"errors"
+	"sync"
 	"testing"
+	"time"
 
 	libLog "github.com/LerianStudio/lib-commons/v4/commons/log"
 	mongodb "github.com/LerianStudio/midaz/v3/components/ledger/internal/adapters/mongodb/transaction"
@@ -446,6 +449,150 @@ func TestCreateBulkTransactionOperationsAsync_StatusTransition_BelowThreshold(t 
 	assert.Equal(t, int64(0), result.TransactionsAttempted) // No inserts
 	assert.Equal(t, int64(1), result.TransactionsUpdateAttempted)
 	assert.Equal(t, int64(1), result.TransactionsUpdated)
+}
+
+func TestCreateBulkTransactionOperationsAsync_MixedInsertedAndDuplicate_CleansDuplicateBackup(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockTransactionRepo := transaction.NewMockRepository(ctrl)
+	mockOperationRepo := operation.NewMockRepository(ctrl)
+	mockMetadataRepo := mongodb.NewMockRepository(ctrl)
+	mockBalanceRepo := balance.NewMockRepository(ctrl)
+	mockRabbitMQRepo := rabbitmq.NewMockProducerRepository(ctrl)
+	mockRedisRepo := redis.NewMockRedisRepository(ctrl)
+
+	uc := &UseCase{
+		TransactionRepo:         mockTransactionRepo,
+		OperationRepo:           mockOperationRepo,
+		TransactionMetadataRepo: mockMetadataRepo,
+		BalanceRepo:             mockBalanceRepo,
+		RabbitMQRepo:            mockRabbitMQRepo,
+		TransactionRedisRepo:    mockRedisRepo,
+	}
+
+	orgID := uuid.New()
+	ledgerID := uuid.New()
+
+	insertedTxID := uuid.New().String()
+	duplicateTxID := uuid.New().String()
+
+	payloads := []transaction.TransactionProcessingPayload{
+		{
+			Transaction: &transaction.Transaction{
+				ID:             insertedTxID,
+				OrganizationID: orgID.String(),
+				LedgerID:       ledgerID.String(),
+				Status:         transaction.Status{Code: constant.APPROVED},
+				Operations: []*operation.Operation{
+					{ID: uuid.New().String(), TransactionID: insertedTxID},
+				},
+			},
+			Validate:      &mtransaction.Responses{Aliases: []string{"alias1"}},
+			Balances:      []*mmodel.Balance{{ID: uuid.New().String(), Alias: "alias1", Available: decimal.NewFromInt(100)}},
+			BalancesAfter: []*mmodel.Balance{{ID: uuid.New().String(), Alias: "alias1", Available: decimal.NewFromInt(50)}},
+			Version:       "v2",
+		},
+		{
+			Transaction: &transaction.Transaction{
+				ID:             duplicateTxID,
+				OrganizationID: orgID.String(),
+				LedgerID:       ledgerID.String(),
+				Status:         transaction.Status{Code: constant.APPROVED},
+				Operations: []*operation.Operation{
+					{ID: uuid.New().String(), TransactionID: duplicateTxID},
+				},
+			},
+			Validate:      &mtransaction.Responses{Aliases: []string{"alias2"}},
+			Balances:      []*mmodel.Balance{{ID: uuid.New().String(), Alias: "alias2", Available: decimal.NewFromInt(100)}},
+			BalancesAfter: []*mmodel.Balance{{ID: uuid.New().String(), Alias: "alias2", Available: decimal.NewFromInt(50)}},
+			Version:       "v2",
+		},
+	}
+
+	mockTx := &mockDBTransaction{}
+	mockTransactionRepo.EXPECT().
+		BeginTx(gomock.Any()).
+		Return(mockTx, nil).
+		Times(1)
+
+	mockTransactionRepo.EXPECT().
+		CreateBulkTx(gomock.Any(), mockTx, gomock.Any()).
+		Return(&repository.BulkInsertResult{
+			Attempted:   2,
+			Inserted:    1,
+			Ignored:     1,
+			InsertedIDs: []string{insertedTxID},
+		}, nil).
+		Times(1)
+
+	mockOperationRepo.EXPECT().
+		CreateBulkTx(gomock.Any(), mockTx, gomock.Any()).
+		Return(&repository.BulkInsertResult{
+			Attempted: 2,
+			Inserted:  1,
+			Ignored:   1,
+		}, nil).
+		Times(1)
+
+	mockMetadataRepo.EXPECT().Create(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	mockRabbitMQRepo.EXPECT().ProducerDefault(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+
+	rawQueue, err := json.Marshal(mmodel.TransactionRedisQueue{TransactionStatus: constant.CREATED})
+	require.NoError(t, err)
+
+	var removeWG sync.WaitGroup
+	removeWG.Add(2)
+
+	var delWG sync.WaitGroup
+	delWG.Add(2)
+
+	mockRedisRepo.EXPECT().
+		ReadMessageFromQueue(gomock.Any(), gomock.Any()).
+		Return(rawQueue, nil).
+		AnyTimes()
+
+	mockRedisRepo.EXPECT().
+		RemoveMessageFromQueue(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ string) error {
+			removeWG.Done()
+			return nil
+		}).
+		Times(2)
+
+	mockRedisRepo.EXPECT().
+		Del(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ string) error {
+			delWG.Done()
+			return nil
+		}).
+		Times(2)
+
+	result, err := uc.CreateBulkTransactionOperationsAsync(context.Background(), payloads)
+
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), result.TransactionsAttempted)
+	assert.Equal(t, int64(1), result.TransactionsInserted)
+	assert.Equal(t, int64(1), result.TransactionsIgnored)
+
+	waitWithTimeout := func(wg *sync.WaitGroup, what string) {
+		t.Helper()
+
+		done := make(chan struct{})
+		go func() {
+			wg.Wait()
+			close(done)
+		}()
+
+		select {
+		case <-done:
+		case <-time.After(2 * time.Second):
+			t.Fatalf("timed out waiting for %s", what)
+		}
+	}
+
+	waitWithTimeout(&removeWG, "backup queue cleanup")
+	waitWithTimeout(&delWG, "write-behind cleanup")
 }
 
 func TestCreateBulkTransactionOperationsAsync_NilTransaction_Skipped(t *testing.T) {

--- a/docs/PROJECT_RULES.md
+++ b/docs/PROJECT_RULES.md
@@ -959,7 +959,7 @@ Located in `.githooks/`:
 ### Balance Sync Worker (Transaction Component)
 
 Dual-trigger synchronization of balance keys from Redis to PostgreSQL. Each balance mutation
-atomically schedules a sync via ZADD into a Redis ZSET (`schedule:{transactions}:balance-sync`).
+atomically schedules a sync via ZADD into a Redis ZSET (`schedule:{transactions}:balance-sync-v2`).
 The worker collects due keys and flushes them in batches based on SIZE (batch full) or
 TIMEOUT (flush interval elapsed), whichever comes first.
 

--- a/pkg/utils/backup_queue.go
+++ b/pkg/utils/backup_queue.go
@@ -1,0 +1,25 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package utils
+
+import (
+	"github.com/LerianStudio/midaz/v3/pkg/constant"
+	"github.com/LerianStudio/midaz/v3/pkg/mtransaction"
+)
+
+// ExpectedBackupStatusForCleanup returns the status that should be used when
+// conditionally removing entries from backup_queue.
+//
+// CREATED transactions are promoted to APPROVED before async persistence, but
+// the backup_queue entry keeps TransactionStatus=CREATED (written earlier in
+// the HTTP flow). In this specific case, using APPROVED as expected status
+// would skip cleanup and leak entries.
+func ExpectedBackupStatusForCleanup(transactionStatus string, validate *mtransaction.Responses) string {
+	if transactionStatus == constant.APPROVED && validate != nil && !validate.Pending {
+		return constant.CREATED
+	}
+
+	return transactionStatus
+}

--- a/pkg/utils/backup_queue_test.go
+++ b/pkg/utils/backup_queue_test.go
@@ -1,0 +1,60 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package utils
+
+import (
+	"testing"
+
+	"github.com/LerianStudio/midaz/v3/pkg/constant"
+	"github.com/LerianStudio/midaz/v3/pkg/mtransaction"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExpectedBackupStatusForCleanup(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name              string
+		transactionStatus string
+		validate          *mtransaction.Responses
+		expected          string
+	}{
+		{
+			name:              "created promoted to approved maps back to CREATED",
+			transactionStatus: constant.APPROVED,
+			validate:          &mtransaction.Responses{Pending: false},
+			expected:          constant.CREATED,
+		},
+		{
+			name:              "pending transition keeps APPROVED",
+			transactionStatus: constant.APPROVED,
+			validate:          &mtransaction.Responses{Pending: true},
+			expected:          constant.APPROVED,
+		},
+		{
+			name:              "pending transition keeps CANCELED",
+			transactionStatus: constant.CANCELED,
+			validate:          &mtransaction.Responses{Pending: true},
+			expected:          constant.CANCELED,
+		},
+		{
+			name:              "nil validate keeps original status",
+			transactionStatus: constant.APPROVED,
+			validate:          nil,
+			expected:          constant.APPROVED,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := ExpectedBackupStatusForCleanup(tt.transactionStatus, tt.validate)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}

--- a/pkg/utils/cache.go
+++ b/pkg/utils/cache.go
@@ -11,8 +11,9 @@ import (
 )
 
 const (
-	BalanceSyncScheduleKey = "schedule:{transactions}:balance-sync"
-	BalanceSyncLockPrefix  = "lock:{transactions}:balance-sync:"
+	BalanceSyncScheduleKey       = "schedule:{transactions}:balance-sync-v2"
+	BalanceSyncScheduleKeyLegacy = "schedule:{transactions}:balance-sync"
+	BalanceSyncLockPrefix        = "lock:{transactions}:balance-sync:"
 )
 
 const (

--- a/pkg/utils/cache_test.go
+++ b/pkg/utils/cache_test.go
@@ -351,7 +351,8 @@ func TestCacheKeyConstants(t *testing.T) {
 	t.Run("BalanceSyncScheduleKey format", func(t *testing.T) {
 		t.Parallel()
 
-		assert.Equal(t, "schedule:{transactions}:balance-sync", BalanceSyncScheduleKey)
+		assert.Equal(t, "schedule:{transactions}:balance-sync-v2", BalanceSyncScheduleKey)
+		assert.Equal(t, "schedule:{transactions}:balance-sync", BalanceSyncScheduleKeyLegacy)
 	})
 
 	t.Run("BalanceSyncLockPrefix format", func(t *testing.T) {


### PR DESCRIPTION
## Summary

This hotfix updates the async recovery pipeline introduced in v3.6.x and targets two production-facing issues observed after v3.6.2.

### 1) Balance sync key separation with legacy draining

- Introduces a new schedule key: `schedule:{transactions}:balance-sync-v2`.
- Keeps the previous key as legacy: `schedule:{transactions}:balance-sync`.
- Adds `LegacyBalanceSyncDrainer` to continuously drain pre-v3.6.2 backlog.
- Adds repository support for legacy key claiming (`GetBalanceSyncKeysLegacy`).
- Updates Lua scheduling/claim scripts to use fractional-second scores for rollback-safe compatibility across versions.

### 2) backup_queue backlog cleanup fix

- Normalizes expected status used in conditional backup cleanup (shared helper in `pkg/utils`).
- Ensures backup/write-behind cleanup is executed even when a bulk payload is skipped as duplicate (`ON CONFLICT DO NOTHING`).
- Adds regression coverage for mixed inserted+duplicate bulk batches and cleanup behavior.

## Why
- Prevents safety-net drift/freeze caused by score/key compatibility during v3.6.x transitions.
- Eliminates artificial `backup_queue` growth where DB persistence succeeds but cleanup was being skipped.
- Improves operational stability under high-load async processing.

## Scope and impact

- No API contract changes.
- No DB migration required.
- Operational impact: temporary coexistence of `balance-sync` + `balance-sync-v2` until legacy backlog is fully drained.