### PR TITLE
feat: Balance Schema + Domain Model Foundation

### DIFF
--- a/components/ledger/internal/adapters/postgres/balance/balance_overdraft_integration_test.go
+++ b/components/ledger/internal/adapters/postgres/balance/balance_overdraft_integration_test.go
@@ -1,0 +1,280 @@
+//go:build integration
+
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package balance
+
+import (
+	"database/sql"
+	"encoding/json"
+	"testing"
+	"time"
+
+	libCommons "github.com/LerianStudio/lib-commons/v4/commons"
+	"github.com/LerianStudio/midaz/v3/pkg/mmodel"
+	pgtestutil "github.com/LerianStudio/midaz/v3/tests/utils/postgres"
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ============================================================================
+// Overdraft Column Integration Tests
+// ============================================================================
+
+func TestIntegration_BalanceOverdraft_DirectionPersisted(t *testing.T) {
+	// Arrange
+	container := pgtestutil.SetupContainer(t)
+
+	orgID := uuid.Must(libCommons.GenerateUUIDv7())
+	ledgerID := uuid.Must(libCommons.GenerateUUIDv7())
+	accountID := createTestAccountID()
+	balanceID := uuid.Must(libCommons.GenerateUUIDv7())
+	now := time.Now().Truncate(time.Microsecond)
+
+	_, err := container.DB.Exec(`
+		INSERT INTO balance (id, organization_id, ledger_id, account_id, alias, key,
+			asset_code, available, on_hold, version, account_type,
+			allow_sending, allow_receiving, created_at, updated_at, direction)
+		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16)`,
+		balanceID, orgID, ledgerID, accountID, "@dir-test", "default",
+		"USD", 1000, 0, 1, "deposit",
+		true, true, now, now, "debit",
+	)
+	require.NoError(t, err, "inserting balance with direction=debit")
+
+	// Act — read back via raw SQL to verify column value
+	var direction string
+
+	err = container.DB.QueryRow(
+		`SELECT direction FROM balance WHERE id = $1`, balanceID,
+	).Scan(&direction)
+
+	// Assert
+	require.NoError(t, err, "querying direction")
+	assert.Equal(t, "debit", direction, "direction should round-trip as debit")
+}
+
+func TestIntegration_BalanceOverdraft_SchemaDefaults(t *testing.T) {
+	// Arrange — insert a row WITHOUT specifying overdraft columns
+	container := pgtestutil.SetupContainer(t)
+
+	orgID := uuid.Must(libCommons.GenerateUUIDv7())
+	ledgerID := uuid.Must(libCommons.GenerateUUIDv7())
+	accountID := createTestAccountID()
+	balanceID := uuid.Must(libCommons.GenerateUUIDv7())
+	now := time.Now().Truncate(time.Microsecond)
+
+	_, err := container.DB.Exec(`
+		INSERT INTO balance (id, organization_id, ledger_id, account_id, alias, key,
+			asset_code, available, on_hold, version, account_type,
+			allow_sending, allow_receiving, created_at, updated_at)
+		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15)`,
+		balanceID, orgID, ledgerID, accountID, "@defaults-test", "default",
+		"USD", 500, 0, 0, "deposit",
+		true, true, now, now,
+	)
+	require.NoError(t, err, "inserting balance without overdraft columns")
+
+	// Act
+	var direction string
+	var overdraftUsed decimal.Decimal
+	var settingsRaw []byte
+
+	err = container.DB.QueryRow(`
+		SELECT direction, overdraft_used, settings
+		FROM balance WHERE id = $1`, balanceID,
+	).Scan(&direction, &overdraftUsed, &settingsRaw)
+
+	// Assert
+	require.NoError(t, err, "querying default overdraft columns")
+	assert.Equal(t, "credit", direction, "default direction should be credit")
+	assert.True(t, overdraftUsed.IsZero(), "default overdraft_used should be 0")
+	assert.Nil(t, settingsRaw, "default settings should be NULL")
+}
+
+func TestIntegration_BalanceOverdraft_SettingsJSONBRoundTrip(t *testing.T) {
+	// Arrange
+	container := pgtestutil.SetupContainer(t)
+
+	orgID := uuid.Must(libCommons.GenerateUUIDv7())
+	ledgerID := uuid.Must(libCommons.GenerateUUIDv7())
+	accountID := createTestAccountID()
+	balanceID := uuid.Must(libCommons.GenerateUUIDv7())
+	now := time.Now().Truncate(time.Microsecond)
+
+	limit := "500.00"
+	inputSettings := &mmodel.BalanceSettings{
+		AllowOverdraft:        true,
+		OverdraftLimitEnabled: true,
+		OverdraftLimit:        &limit,
+		BalanceScope:          "transactional",
+	}
+
+	settingsJSON, err := json.Marshal(inputSettings)
+	require.NoError(t, err, "marshalling settings to JSON")
+
+	_, err = container.DB.Exec(`
+		INSERT INTO balance (id, organization_id, ledger_id, account_id, alias, key,
+			asset_code, available, on_hold, version, account_type,
+			allow_sending, allow_receiving, created_at, updated_at,
+			direction, overdraft_used, settings)
+		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18)`,
+		balanceID, orgID, ledgerID, accountID, "@settings-test", "default",
+		"USD", 1000, 0, 1, "deposit",
+		true, true, now, now,
+		"credit", 0, settingsJSON,
+	)
+	require.NoError(t, err, "inserting balance with JSONB settings")
+
+	// Act — read settings back
+	var raw []byte
+
+	err = container.DB.QueryRow(
+		`SELECT settings FROM balance WHERE id = $1`, balanceID,
+	).Scan(&raw)
+	require.NoError(t, err, "querying settings JSONB")
+
+	var got mmodel.BalanceSettings
+	err = json.Unmarshal(raw, &got)
+
+	// Assert
+	require.NoError(t, err, "unmarshalling settings JSONB")
+	assert.True(t, got.AllowOverdraft, "allowOverdraft should be true")
+	assert.True(t, got.OverdraftLimitEnabled, "overdraftLimitEnabled should be true")
+	require.NotNil(t, got.OverdraftLimit, "overdraftLimit should not be nil")
+	assert.Equal(t, "500.00", *got.OverdraftLimit, "overdraftLimit should round-trip")
+	assert.Equal(t, "transactional", got.BalanceScope, "balanceScope should round-trip")
+}
+
+func TestIntegration_BalanceOverdraft_UpdateOverdraftUsedViaSQLBatch(t *testing.T) {
+	// Arrange — simulates the UpdateMany path (Redis→PG sync) at the SQL level.
+	// When the repository is updated to include overdraft_used in UpdateMany,
+	// this test verifies the column can be modified via a batch UPDATE.
+	container := pgtestutil.SetupContainer(t)
+
+	orgID := uuid.Must(libCommons.GenerateUUIDv7())
+	ledgerID := uuid.Must(libCommons.GenerateUUIDv7())
+	accountID := createTestAccountID()
+	balanceID := uuid.Must(libCommons.GenerateUUIDv7())
+	now := time.Now().Truncate(time.Microsecond)
+
+	_, err := container.DB.Exec(`
+		INSERT INTO balance (id, organization_id, ledger_id, account_id, alias, key,
+			asset_code, available, on_hold, version, account_type,
+			allow_sending, allow_receiving, created_at, updated_at,
+			direction, overdraft_used)
+		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17)`,
+		balanceID, orgID, ledgerID, accountID, "@update-od", "default",
+		"USD", 800, 0, 1, "deposit",
+		true, true, now, now,
+		"credit", 0,
+	)
+	require.NoError(t, err, "inserting initial balance")
+
+	// Act — update overdraft_used via batch-style UPDATE … FROM (VALUES …)
+	_, err = container.DB.Exec(`
+		UPDATE balance AS b
+		SET overdraft_used = v.overdraft_used,
+		    version = v.version,
+		    updated_at = $4
+		FROM (VALUES ($1::uuid, $2::numeric, $3::bigint)) AS v(id, overdraft_used, version)
+		WHERE b.id = v.id
+		  AND b.version < v.version
+		  AND b.deleted_at IS NULL`,
+		balanceID, decimal.NewFromInt(150), int64(2), time.Now(),
+	)
+	require.NoError(t, err, "updating overdraft_used via batch SQL")
+
+	// Assert
+	var overdraftUsed decimal.Decimal
+
+	err = container.DB.QueryRow(
+		`SELECT overdraft_used FROM balance WHERE id = $1`, balanceID,
+	).Scan(&overdraftUsed)
+
+	require.NoError(t, err, "querying updated overdraft_used")
+	assert.True(t, overdraftUsed.Equal(decimal.NewFromInt(150)),
+		"overdraft_used should be 150 after update, got %s", overdraftUsed)
+}
+
+func TestIntegration_BalanceOverdraft_NilSettingsDoesNotCauseParseError(t *testing.T) {
+	// Arrange — insert with NULL settings (legacy/no-overdraft balance)
+	container := pgtestutil.SetupContainer(t)
+
+	orgID := uuid.Must(libCommons.GenerateUUIDv7())
+	ledgerID := uuid.Must(libCommons.GenerateUUIDv7())
+	accountID := createTestAccountID()
+	balanceID := uuid.Must(libCommons.GenerateUUIDv7())
+	now := time.Now().Truncate(time.Microsecond)
+
+	_, err := container.DB.Exec(`
+		INSERT INTO balance (id, organization_id, ledger_id, account_id, alias, key,
+			asset_code, available, on_hold, version, account_type,
+			allow_sending, allow_receiving, created_at, updated_at)
+		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15)`,
+		balanceID, orgID, ledgerID, accountID, "@nil-settings", "default",
+		"BRL", 200, 0, 0, "deposit",
+		true, true, now, now,
+	)
+	require.NoError(t, err, "inserting balance without settings")
+
+	// Act — scan settings into a nullable byte slice
+	var raw sql.NullString
+
+	err = container.DB.QueryRow(
+		`SELECT settings FROM balance WHERE id = $1`, balanceID,
+	).Scan(&raw)
+
+	// Assert
+	require.NoError(t, err, "querying NULL settings should not error")
+	assert.False(t, raw.Valid, "settings should be SQL NULL for legacy balance")
+}
+
+func TestIntegration_BalanceOverdraft_ListByAliasesReturnsOverdraftColumns(t *testing.T) {
+	// Arrange
+	container := pgtestutil.SetupContainer(t)
+
+	orgID := uuid.Must(libCommons.GenerateUUIDv7())
+	ledgerID := uuid.Must(libCommons.GenerateUUIDv7())
+	accountID := createTestAccountID()
+	balanceID := uuid.Must(libCommons.GenerateUUIDv7())
+	now := time.Now().Truncate(time.Microsecond)
+	alias := "@list-od-test"
+
+	_, err := container.DB.Exec(`
+		INSERT INTO balance (id, organization_id, ledger_id, account_id, alias, key,
+			asset_code, available, on_hold, version, account_type,
+			allow_sending, allow_receiving, created_at, updated_at,
+			direction, overdraft_used)
+		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17)`,
+		balanceID, orgID, ledgerID, accountID, alias, "default",
+		"EUR", 300, 10, 1, "checking",
+		true, true, now, now,
+		"debit", 75,
+	)
+	require.NoError(t, err, "inserting balance with overdraft columns for list test")
+
+	// Act — read raw columns back via the alias to verify the data is present
+	var direction string
+	var overdraftUsed decimal.Decimal
+
+	err = container.DB.QueryRow(`
+		SELECT direction, overdraft_used
+		FROM balance
+		WHERE organization_id = $1
+		  AND ledger_id = $2
+		  AND alias = $3
+		  AND deleted_at IS NULL`,
+		orgID, ledgerID, alias,
+	).Scan(&direction, &overdraftUsed)
+
+	// Assert
+	require.NoError(t, err, "querying overdraft columns by alias")
+	assert.Equal(t, "debit", direction, "direction should be debit")
+	assert.True(t, overdraftUsed.Equal(decimal.NewFromInt(75)),
+		"overdraft_used should be 75, got %s", overdraftUsed)
+}

--- a/components/ledger/migrations/transaction/000031_add_overdraft_fields_to_balance.down.sql
+++ b/components/ledger/migrations/transaction/000031_add_overdraft_fields_to_balance.down.sql
@@ -1,0 +1,9 @@
+-- Rollback: remove the overdraft fields from the balance table.
+--
+-- Uses IF EXISTS so the rollback is safe to run against databases that
+-- never received the up migration.
+
+ALTER TABLE balance
+    DROP COLUMN IF EXISTS direction,
+    DROP COLUMN IF EXISTS overdraft_used,
+    DROP COLUMN IF EXISTS settings;

--- a/components/ledger/migrations/transaction/000031_add_overdraft_fields_to_balance.up.sql
+++ b/components/ledger/migrations/transaction/000031_add_overdraft_fields_to_balance.up.sql
@@ -1,0 +1,18 @@
+-- Add overdraft fields to the balance table.
+--
+-- Adds three columns required by the overdraft feature:
+--   * direction       — accounting direction of the balance ("credit"/"debit").
+--                        Defaults to 'credit' so legacy rows match the prior
+--                        implicit behavior.
+--   * overdraft_used  — amount of overdraft currently consumed. Non-negative.
+--   * settings        — optional per-balance configuration stored as JSONB
+--                        (allowOverdraft, overdraftLimitEnabled, overdraftLimit,
+--                        balanceScope).
+--
+-- All statements use IF NOT EXISTS for idempotent re-runs.
+
+ALTER TABLE balance
+    ADD COLUMN IF NOT EXISTS direction       VARCHAR(16)   NOT NULL DEFAULT 'credit'
+                                              CHECK (direction IN ('credit', 'debit')),
+    ADD COLUMN IF NOT EXISTS overdraft_used  DECIMAL        NOT NULL DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS settings        JSONB;

--- a/components/ledger/migrations/transaction/000031_add_overdraft_fields_to_balance.up.sql
+++ b/components/ledger/migrations/transaction/000031_add_overdraft_fields_to_balance.up.sql
@@ -14,5 +14,6 @@
 ALTER TABLE balance
     ADD COLUMN IF NOT EXISTS direction       VARCHAR(16)   NOT NULL DEFAULT 'credit'
                                               CHECK (direction IN ('credit', 'debit')),
-    ADD COLUMN IF NOT EXISTS overdraft_used  DECIMAL        NOT NULL DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS overdraft_used  DECIMAL        NOT NULL DEFAULT 0
+                                              CHECK (overdraft_used >= 0),
     ADD COLUMN IF NOT EXISTS settings        JSONB;

--- a/components/ledger/migrations/transaction/000031_add_overdraft_fields_to_balance_test.go
+++ b/components/ledger/migrations/transaction/000031_add_overdraft_fields_to_balance_test.go
@@ -1,0 +1,126 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package migrations
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestMigration000031_FilesExist verifies that migration 000031 ships both
+// up and down SQL files and that neither is empty.
+func TestMigration000031_FilesExist(t *testing.T) {
+	t.Parallel()
+
+	dir := migrationsDir(t)
+
+	tests := []struct {
+		name     string
+		filename string
+	}{
+		{
+			name:     "up migration file exists",
+			filename: "000031_add_overdraft_fields_to_balance.up.sql",
+		},
+		{
+			name:     "down migration file exists",
+			filename: "000031_add_overdraft_fields_to_balance.down.sql",
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			path := filepath.Join(dir, tc.filename)
+			_, err := os.Stat(path)
+			require.NoError(t, err, "migration file %s must exist", tc.filename)
+
+			content, err := os.ReadFile(path)
+			require.NoError(t, err, "migration file %s must be readable", tc.filename)
+			assert.NotEmpty(t, string(content), "migration file %s must not be empty", tc.filename)
+		})
+	}
+}
+
+// TestMigration000031_UpSQL_AddsOverdraftColumns verifies the up migration
+// adds the three columns required by the overdraft feature to the balance table.
+func TestMigration000031_UpSQL_AddsOverdraftColumns(t *testing.T) {
+	t.Parallel()
+
+	dir := migrationsDir(t)
+	path := filepath.Join(dir, "000031_add_overdraft_fields_to_balance.up.sql")
+
+	content, err := os.ReadFile(path)
+	require.NoError(t, err, "up migration file must be readable")
+
+	sql := strings.ToLower(string(content))
+
+	tests := []struct {
+		name        string
+		substring   string
+		description string
+	}{
+		{name: "targets balance table", substring: "alter table balance", description: "must alter the balance table"},
+		{name: "uses IF NOT EXISTS for idempotency", substring: "if not exists", description: "must use IF NOT EXISTS for idempotent re-runs"},
+		{name: "adds direction column", substring: "direction", description: "must add direction column"},
+		{name: "adds overdraft_used column", substring: "overdraft_used", description: "must add overdraft_used column"},
+		{name: "adds settings column", substring: "settings", description: "must add settings column"},
+		{name: "direction defaults to 'credit'", substring: "'credit'", description: "direction column must default to 'credit'"},
+		{name: "settings column is JSONB", substring: "jsonb", description: "settings column must use JSONB type"},
+		{name: "direction has CHECK constraint", substring: "check (direction in ('credit', 'debit'))", description: "direction column must have a CHECK constraint limiting values to credit/debit"},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Contains(t, sql, tc.substring, tc.description)
+		})
+	}
+}
+
+// TestMigration000031_DownSQL_DropsOverdraftColumns verifies the down migration
+// removes the three columns added by the up migration.
+func TestMigration000031_DownSQL_DropsOverdraftColumns(t *testing.T) {
+	t.Parallel()
+
+	dir := migrationsDir(t)
+	path := filepath.Join(dir, "000031_add_overdraft_fields_to_balance.down.sql")
+
+	content, err := os.ReadFile(path)
+	require.NoError(t, err, "down migration file must be readable")
+
+	sql := strings.ToLower(string(content))
+
+	tests := []struct {
+		name        string
+		substring   string
+		description string
+	}{
+		{name: "targets balance table", substring: "alter table balance", description: "must alter the balance table"},
+		{name: "uses IF EXISTS for idempotency", substring: "if exists", description: "must use IF EXISTS for idempotent rollback"},
+		{name: "drops direction column", substring: "direction", description: "must drop direction column"},
+		{name: "drops overdraft_used column", substring: "overdraft_used", description: "must drop overdraft_used column"},
+		{name: "drops settings column", substring: "settings", description: "must drop settings column"},
+		{name: "uses DROP COLUMN statements", substring: "drop column", description: "must DROP COLUMN the overdraft fields"},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Contains(t, sql, tc.substring, tc.description)
+		})
+	}
+}

--- a/components/ledger/migrations/transaction/000031_add_overdraft_fields_to_balance_test.go
+++ b/components/ledger/migrations/transaction/000031_add_overdraft_fields_to_balance_test.go
@@ -77,6 +77,7 @@ func TestMigration000031_UpSQL_AddsOverdraftColumns(t *testing.T) {
 		{name: "direction defaults to 'credit'", substring: "'credit'", description: "direction column must default to 'credit'"},
 		{name: "settings column is JSONB", substring: "jsonb", description: "settings column must use JSONB type"},
 		{name: "direction has CHECK constraint", substring: "check (direction in ('credit', 'debit'))", description: "direction column must have a CHECK constraint limiting values to credit/debit"},
+		{name: "overdraft_used has CHECK constraint", substring: "check (overdraft_used >= 0)", description: "overdraft_used column must have a non-negative CHECK constraint"},
 	}
 
 	for _, tc := range tests {

--- a/pkg/constant/errors.go
+++ b/pkg/constant/errors.go
@@ -179,6 +179,18 @@ var (
 	ErrDirectScenarioRequired         = errors.New("0164")
 	ErrRevertOnlyBidirectional        = errors.New("0165")
 	ErrAccountingEntryFieldRequired   = errors.New("0166")
+
+	// Overdraft Feature Errors
+	//
+	// ErrOverdraftLimitExceeded is returned when a transaction would drive a
+	// balance past its configured overdraft limit.
+	ErrOverdraftLimitExceeded = errors.New("0167")
+	// ErrDirectOperationOnInternalBalance is returned when a user-initiated
+	// operation targets a balance whose scope is "internal".
+	ErrDirectOperationOnInternalBalance = errors.New("0168")
+	// ErrDeletionOfInternalBalance is returned when a delete request targets
+	// a balance whose scope is "internal".
+	ErrDeletionOfInternalBalance = errors.New("0169")
 )
 
 // List of CRM errors.

--- a/pkg/constant/errors_overdraft_test.go
+++ b/pkg/constant/errors_overdraft_test.go
@@ -1,0 +1,56 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package constant
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestOverdraftErrorCodes_Registered verifies that the three overdraft
+// error codes are registered in the sentinel error table with the exact
+// numeric codes mandated by the TRD.
+func TestOverdraftErrorCodes_Registered(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		sentinel    error
+		expected    string
+		description string
+	}{
+		{
+			name:        "ErrOverdraftLimitExceeded is code 0167",
+			sentinel:    ErrOverdraftLimitExceeded,
+			expected:    "0167",
+			description: "transaction would exceed the balance's overdraft limit",
+		},
+		{
+			name:        "ErrDirectOperationOnInternalBalance is code 0168",
+			sentinel:    ErrDirectOperationOnInternalBalance,
+			expected:    "0168",
+			description: "direct operation attempted on an internal-scope balance",
+		},
+		{
+			name:        "ErrDeletionOfInternalBalance is code 0169",
+			sentinel:    ErrDeletionOfInternalBalance,
+			expected:    "0169",
+			description: "attempt to delete an internal-scope balance",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			require.NotNil(t, tt.sentinel, "%s: sentinel must be registered", tt.description)
+			assert.Equal(t, tt.expected, tt.sentinel.Error(),
+				"%s: sentinel error code must equal %s", tt.description, tt.expected)
+		})
+	}
+}

--- a/pkg/errors.go
+++ b/pkg/errors.go
@@ -449,6 +449,24 @@ func ValidateBusinessError(err error, entityType string, args ...any) error {
 			Title:      "Insufficient Funds Error",
 			Message:    "The transaction could not be completed due to insufficient funds in the account. Please add sufficient funds to your account and try again.",
 		},
+		constant.ErrOverdraftLimitExceeded: UnprocessableOperationError{
+			EntityType: entityType,
+			Code:       constant.ErrOverdraftLimitExceeded.Error(),
+			Title:      "Overdraft Limit Exceeded Error",
+			Message:    "The transaction could not be completed because it would exceed the configured overdraft limit for the balance. Please reduce the amount or increase the overdraft limit and try again.",
+		},
+		constant.ErrDirectOperationOnInternalBalance: UnprocessableOperationError{
+			EntityType: entityType,
+			Code:       constant.ErrDirectOperationOnInternalBalance.Error(),
+			Title:      "Direct Operation On Internal Balance Error",
+			Message:    "Direct operations on internal-scope balances are not permitted. Internal balances are managed exclusively by the system. Please target a transactional balance and try again.",
+		},
+		constant.ErrDeletionOfInternalBalance: UnprocessableOperationError{
+			EntityType: entityType,
+			Code:       constant.ErrDeletionOfInternalBalance.Error(),
+			Title:      "Deletion Of Internal Balance Error",
+			Message:    "Internal-scope balances cannot be deleted. They are managed by the system and must remain for accounting consistency.",
+		},
 		constant.ErrAccountIneligibility: UnprocessableOperationError{
 			EntityType: entityType,
 			Code:       constant.ErrAccountIneligibility.Error(),

--- a/pkg/errors_overdraft_test.go
+++ b/pkg/errors_overdraft_test.go
@@ -1,0 +1,71 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package pkg_test
+
+import (
+	"testing"
+
+	"github.com/LerianStudio/midaz/v3/pkg"
+	"github.com/LerianStudio/midaz/v3/pkg/constant"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestValidateBusinessError_OverdraftErrors verifies that ValidateBusinessError
+// maps the three overdraft sentinels (0167, 0168, 0169) to
+// UnprocessableOperationError (HTTP 422) with the correct codes, mirroring the
+// existing ErrInsufficientFunds mapping at pkg/errors.go:446.
+func TestValidateBusinessError_OverdraftErrors(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		sentinel   error
+		wantCode   string
+		entityType string
+	}{
+		{
+			name:       "ErrOverdraftLimitExceeded maps to UnprocessableOperationError (0167)",
+			sentinel:   constant.ErrOverdraftLimitExceeded,
+			wantCode:   "0167",
+			entityType: "Balance",
+		},
+		{
+			name:       "ErrDirectOperationOnInternalBalance maps to UnprocessableOperationError (0168)",
+			sentinel:   constant.ErrDirectOperationOnInternalBalance,
+			wantCode:   "0168",
+			entityType: "Balance",
+		},
+		{
+			name:       "ErrDeletionOfInternalBalance maps to UnprocessableOperationError (0169)",
+			sentinel:   constant.ErrDeletionOfInternalBalance,
+			wantCode:   "0169",
+			entityType: "Balance",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := pkg.ValidateBusinessError(tt.sentinel, tt.entityType)
+			require.Error(t, got, "ValidateBusinessError must return a mapped error for %s", tt.sentinel.Error())
+
+			mapped, ok := got.(pkg.UnprocessableOperationError)
+			require.True(t, ok,
+				"%s must map to UnprocessableOperationError (HTTP 422), got %T", tt.sentinel.Error(), got)
+
+			assert.Equal(t, tt.wantCode, mapped.Code,
+				"mapped error code must match sentinel error string")
+			assert.Equal(t, tt.entityType, mapped.EntityType,
+				"entityType must be propagated through ValidateBusinessError")
+			assert.NotEmpty(t, mapped.Title,
+				"mapped error must have a non-empty Title")
+			assert.NotEmpty(t, mapped.Message,
+				"mapped error must have a non-empty Message")
+		})
+	}
+}

--- a/pkg/mmodel/balance.go
+++ b/pkg/mmodel/balance.go
@@ -84,6 +84,21 @@ type Balance struct {
 	// example: true
 	AllowReceiving bool `json:"allowReceiving" example:"true"`
 
+	// Direction is the accounting direction of the balance. One of
+	// "credit" or "debit". Empty string denotes legacy rows predating the
+	// overdraft feature and is treated as "credit" by the engine.
+	// example: credit
+	Direction string `json:"direction,omitempty" example:"credit"`
+
+	// OverdraftUsed is the amount of overdraft currently consumed by this
+	// balance. Always non-negative; zero when the balance is in the black.
+	// example: 0
+	OverdraftUsed decimal.Decimal `json:"overdraftUsed" example:"0"`
+
+	// Settings carries optional per-balance configuration (overdraft,
+	// balance scope). Nil for legacy balances without custom settings.
+	Settings *BalanceSettings `json:"settings,omitempty"`
+
 	// Timestamp when the balance was created (RFC3339 format)
 	// example: 2021-01-01T00:00:00Z
 	// format: date-time
@@ -166,6 +181,21 @@ type BalanceHistory struct {
 	// maxLength: 50
 	AccountType string `json:"accountType" example:"creditCard" maxLength:"50"`
 
+	// Direction is the accounting direction of the balance at the time of
+	// the snapshot. One of "credit" or "debit". Empty string denotes
+	// legacy rows predating the overdraft feature.
+	// example: credit
+	Direction string `json:"direction,omitempty" example:"credit"`
+
+	// OverdraftUsed is the amount of overdraft consumed at the time of
+	// the snapshot. Always non-negative.
+	// example: 0
+	OverdraftUsed decimal.Decimal `json:"overdraftUsed" example:"0"`
+
+	// Settings is the per-balance configuration snapshot at the time the
+	// history row was recorded. Nil for legacy balances.
+	Settings *BalanceSettings `json:"settings,omitempty"`
+
 	// Timestamp when the balance was created (RFC3339 format)
 	// example: 2021-01-01T00:00:00Z
 	// format: date-time
@@ -177,7 +207,9 @@ type BalanceHistory struct {
 	UpdatedAt time.Time `json:"updatedAt" example:"2021-01-01T00:00:00Z" format:"date-time"`
 } // @name BalanceHistory
 
-// ToHistoryResponse converts a Balance to BalanceHistory (without permission flags)
+// ToHistoryResponse converts a Balance to BalanceHistory (without permission flags).
+// Settings are deep-copied so the history snapshot is fully independent of the
+// live balance — mutations on either side cannot affect the other.
 func (b *Balance) ToHistoryResponse() *BalanceHistory {
 	return &BalanceHistory{
 		ID:             b.ID,
@@ -191,14 +223,35 @@ func (b *Balance) ToHistoryResponse() *BalanceHistory {
 		OnHold:         b.OnHold,
 		Version:        b.Version,
 		AccountType:    b.AccountType,
+		Direction:      b.Direction,
+		OverdraftUsed:  b.OverdraftUsed,
+		Settings:       deepCopySettings(b.Settings),
 		CreatedAt:      b.CreatedAt,
 		UpdatedAt:      b.UpdatedAt,
 	}
 }
 
-// ToTransactionBalance converts mmodel.Balance to mtransaction.Balance
+// deepCopySettings returns an independent copy of the given BalanceSettings,
+// including the inner OverdraftLimit pointer. Returns nil when src is nil.
+func deepCopySettings(src *BalanceSettings) *BalanceSettings {
+	if src == nil {
+		return nil
+	}
+
+	cp := *src
+
+	if src.OverdraftLimit != nil {
+		v := *src.OverdraftLimit
+		cp.OverdraftLimit = &v
+	}
+
+	return &cp
+}
+
+// ToTransactionBalance converts mmodel.Balance to mtransaction.Balance,
+// flattening the optional Settings into individual fields.
 func (b *Balance) ToTransactionBalance() *mtransaction.Balance {
-	return &mtransaction.Balance{
+	result := &mtransaction.Balance{
 		ID:             b.ID,
 		OrganizationID: b.OrganizationID,
 		LedgerID:       b.LedgerID,
@@ -212,11 +265,28 @@ func (b *Balance) ToTransactionBalance() *mtransaction.Balance {
 		AccountType:    b.AccountType,
 		AllowSending:   b.AllowSending,
 		AllowReceiving: b.AllowReceiving,
+		Direction:      b.Direction,
+		OverdraftUsed:  b.OverdraftUsed,
 		CreatedAt:      b.CreatedAt,
 		UpdatedAt:      b.UpdatedAt,
 		DeletedAt:      b.DeletedAt,
 		Metadata:       b.Metadata,
 	}
+
+	if b.Settings != nil {
+		result.AllowOverdraft = b.Settings.AllowOverdraft
+		result.OverdraftLimitEnabled = b.Settings.OverdraftLimitEnabled
+		result.BalanceScope = b.Settings.BalanceScope
+
+		if b.Settings.OverdraftLimit != nil {
+			lim, err := decimal.NewFromString(*b.Settings.OverdraftLimit)
+			if err == nil {
+				result.OverdraftLimit = lim
+			}
+		}
+	}
+
+	return result
 }
 
 // CreateAdditionalBalance is a struct designed to encapsulate balance create request payload data.
@@ -238,6 +308,18 @@ type CreateAdditionalBalance struct {
 	// required: false
 	// example: true
 	AllowReceiving *bool `json:"allowReceiving" example:"true"`
+
+	// Direction is the accounting direction of the balance ("credit" or
+	// "debit"). Optional at creation; when omitted, defaults to the
+	// account's natural direction.
+	// required: false
+	// example: credit
+	Direction *string `json:"direction,omitempty" example:"credit"`
+
+	// Settings is the optional per-balance configuration (overdraft,
+	// balance scope). When omitted, platform defaults are applied.
+	// required: false
+	Settings *BalanceSettings `json:"settings,omitempty"`
 } // @name CreateAdditionalBalance
 
 // UpdateBalance is a struct designed to encapsulate balance update request payload data.
@@ -254,6 +336,12 @@ type UpdateBalance struct {
 	// required: false
 	// example: true
 	AllowReceiving *bool `json:"allowReceiving" example:"true"`
+
+	// Settings is the per-balance configuration (overdraft, balance
+	// scope). When provided, replaces the existing settings in full.
+	// Direction is intentionally absent: it is immutable after creation.
+	// required: false
+	Settings *BalanceSettings `json:"settings,omitempty"`
 } // @name UpdateBalance
 
 // CreateBalanceInput is the input model used by services to create a balance synchronously.

--- a/pkg/mmodel/balance.go
+++ b/pkg/mmodel/balance.go
@@ -283,6 +283,14 @@ func (b *Balance) ToTransactionBalance() *mtransaction.Balance {
 			if err == nil {
 				result.OverdraftLimit = lim
 			}
+			// If parsing fails, OverdraftLimit stays at zero while
+			// OverdraftLimitEnabled may be true. This is the conservative
+			// default: zero limit with enabled=true means "reject all
+			// overdraft", which is safer than silently allowing unlimited.
+			// Validate() guards creation, so this path only triggers on
+			// data corruption (manual DB edits, migration bugs). Proper
+			// error propagation requires changing this function's signature
+			// to return error — deferred to hardening.
 		}
 	}
 

--- a/pkg/mmodel/balance_overdraft_test.go
+++ b/pkg/mmodel/balance_overdraft_test.go
@@ -1,0 +1,220 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package mmodel
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/shopspring/decimal"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBalance_HasOverdraftFields verifies the Balance struct exposes the new
+// overdraft fields (Direction, OverdraftUsed, Settings) used by the overdraft
+// feature.
+func TestBalance_HasOverdraftFields(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		fieldName string
+		fieldType string
+	}{
+		{name: "Direction field is string", fieldName: "Direction", fieldType: "string"},
+		{name: "OverdraftUsed field is decimal.Decimal", fieldName: "OverdraftUsed", fieldType: "decimal.Decimal"},
+		{name: "Settings field is *BalanceSettings", fieldName: "Settings", fieldType: "*mmodel.BalanceSettings"},
+	}
+
+	bt := reflect.TypeOf(Balance{})
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			field, ok := bt.FieldByName(tt.fieldName)
+			require.True(t, ok, "Balance struct must have field %q", tt.fieldName)
+			assert.Equal(t, tt.fieldType, field.Type.String(),
+				"Balance.%s must be of type %s", tt.fieldName, tt.fieldType)
+		})
+	}
+}
+
+// TestBalanceHistory_HasOverdraftFields verifies BalanceHistory also carries
+// the new fields so historical snapshots preserve overdraft state.
+func TestBalanceHistory_HasOverdraftFields(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		fieldName string
+		fieldType string
+	}{
+		{name: "Direction field is string", fieldName: "Direction", fieldType: "string"},
+		{name: "OverdraftUsed field is decimal.Decimal", fieldName: "OverdraftUsed", fieldType: "decimal.Decimal"},
+		{name: "Settings field is *BalanceSettings", fieldName: "Settings", fieldType: "*mmodel.BalanceSettings"},
+	}
+
+	bt := reflect.TypeOf(BalanceHistory{})
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			field, ok := bt.FieldByName(tt.fieldName)
+			require.True(t, ok, "BalanceHistory struct must have field %q", tt.fieldName)
+			assert.Equal(t, tt.fieldType, field.Type.String(),
+				"BalanceHistory.%s must be of type %s", tt.fieldName, tt.fieldType)
+		})
+	}
+}
+
+// TestCreateAdditionalBalance_HasOverdraftFields verifies the create payload
+// accepts Direction (optional) and Settings (optional).
+func TestCreateAdditionalBalance_HasOverdraftFields(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		fieldName string
+		fieldType string
+	}{
+		{name: "Direction pointer is *string", fieldName: "Direction", fieldType: "*string"},
+		{name: "Settings is *BalanceSettings", fieldName: "Settings", fieldType: "*mmodel.BalanceSettings"},
+	}
+
+	bt := reflect.TypeOf(CreateAdditionalBalance{})
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			field, ok := bt.FieldByName(tt.fieldName)
+			require.True(t, ok, "CreateAdditionalBalance must have field %q", tt.fieldName)
+			assert.Equal(t, tt.fieldType, field.Type.String(),
+				"CreateAdditionalBalance.%s must be of type %s", tt.fieldName, tt.fieldType)
+		})
+	}
+}
+
+// TestUpdateBalance_HasSettingsField verifies the update payload exposes
+// Settings (optional). Direction is immutable after creation per PRD §4, so
+// UpdateBalance must NOT expose Direction.
+func TestUpdateBalance_HasSettingsField(t *testing.T) {
+	t.Parallel()
+
+	bt := reflect.TypeOf(UpdateBalance{})
+
+	field, ok := bt.FieldByName("Settings")
+	require.True(t, ok, "UpdateBalance must have field Settings")
+	assert.Equal(t, "*mmodel.BalanceSettings", field.Type.String(),
+		"UpdateBalance.Settings must be *BalanceSettings")
+
+	_, hasDirection := bt.FieldByName("Direction")
+	assert.False(t, hasDirection,
+		"UpdateBalance must NOT expose Direction - direction is immutable after creation")
+}
+
+// TestBalance_ToTransactionBalance_IncludesOverdraftFields ensures that
+// converting a Balance to mtransaction.Balance propagates the overdraft
+// fields Direction, OverdraftUsed, and the flattened settings fields.
+func TestBalance_ToTransactionBalance_IncludesOverdraftFields(t *testing.T) {
+	t.Parallel()
+
+	limit := "2500.00"
+	settings := &BalanceSettings{
+		BalanceScope:          "transactional",
+		AllowOverdraft:        true,
+		OverdraftLimitEnabled: true,
+		OverdraftLimit:        &limit,
+	}
+
+	tests := []struct {
+		name                      string
+		direction                 string
+		overdraftUsed             decimal.Decimal
+		settings                  *BalanceSettings
+		wantDirection             string
+		wantOverdraftUsed         decimal.Decimal
+		wantAllowOverdraft        bool
+		wantOverdraftLimitEnabled bool
+		wantOverdraftLimit        decimal.Decimal
+		wantBalanceScope          string
+	}{
+		{
+			name:                      "credit direction, zero used, full settings",
+			direction:                 "credit",
+			overdraftUsed:             decimal.Zero,
+			settings:                  settings,
+			wantDirection:             "credit",
+			wantOverdraftUsed:         decimal.Zero,
+			wantAllowOverdraft:        true,
+			wantOverdraftLimitEnabled: true,
+			wantOverdraftLimit:        decimal.RequireFromString("2500.00"),
+			wantBalanceScope:          "transactional",
+		},
+		{
+			name:                      "debit direction, non-zero used, nil settings",
+			direction:                 "debit",
+			overdraftUsed:             decimal.NewFromInt(250),
+			settings:                  nil,
+			wantDirection:             "debit",
+			wantOverdraftUsed:         decimal.NewFromInt(250),
+			wantAllowOverdraft:        false,
+			wantOverdraftLimitEnabled: false,
+			wantOverdraftLimit:        decimal.Zero,
+			wantBalanceScope:          "",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			b := &Balance{
+				ID:             "123e4567-e89b-12d3-a456-426614174000",
+				OrganizationID: "org-1",
+				LedgerID:       "ledger-1",
+				AccountID:      "account-1",
+				Alias:          "@acc",
+				Key:            "default",
+				AssetCode:      "USD",
+				Available:      decimal.NewFromInt(1000),
+				OnHold:         decimal.Zero,
+				Version:        1,
+				AccountType:    "deposit",
+				AllowSending:   true,
+				AllowReceiving: true,
+				Direction:      tt.direction,
+				OverdraftUsed:  tt.overdraftUsed,
+				Settings:       tt.settings,
+			}
+
+			got := b.ToTransactionBalance()
+			require.NotNil(t, got)
+
+			assert.Equal(t, tt.wantDirection, got.Direction,
+				"Direction must be propagated through ToTransactionBalance")
+			assert.True(t, tt.wantOverdraftUsed.Equal(got.OverdraftUsed),
+				"OverdraftUsed must be propagated: want %s got %s",
+				tt.wantOverdraftUsed, got.OverdraftUsed)
+			assert.Equal(t, tt.wantAllowOverdraft, got.AllowOverdraft,
+				"AllowOverdraft must be propagated")
+			assert.Equal(t, tt.wantOverdraftLimitEnabled, got.OverdraftLimitEnabled,
+				"OverdraftLimitEnabled must be propagated")
+			assert.True(t, tt.wantOverdraftLimit.Equal(got.OverdraftLimit),
+				"OverdraftLimit must be propagated: want %s got %s",
+				tt.wantOverdraftLimit, got.OverdraftLimit)
+			assert.Equal(t, tt.wantBalanceScope, got.BalanceScope,
+				"BalanceScope must be propagated")
+		})
+	}
+}

--- a/pkg/mmodel/balance_settings.go
+++ b/pkg/mmodel/balance_settings.go
@@ -1,0 +1,157 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package mmodel
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/shopspring/decimal"
+)
+
+// Balance scope constants for BalanceSettings.BalanceScope.
+const (
+	// BalanceScopeTransactional identifies a balance that can participate in
+	// user-initiated transactions. This is the default scope.
+	BalanceScopeTransactional = "transactional"
+
+	// BalanceScopeInternal identifies a balance managed exclusively by the
+	// system (e.g. overdraft reserves). Direct operations on internal-scope
+	// balances are rejected by the transaction engine.
+	BalanceScopeInternal = "internal"
+)
+
+// BalanceSettings captures the optional per-balance configuration introduced by
+// the overdraft feature. It is stored as a JSONB column on the balance row and
+// propagated through the transaction engine via Balance.Settings.
+//
+// swagger:model BalanceSettings
+// @Description Optional per-balance configuration controlling overdraft behavior and balance scope.
+type BalanceSettings struct {
+	// BalanceScope identifies how the balance participates in transactions.
+	// Allowed values: "transactional" (default), "internal". Empty string is
+	// treated as "transactional" for backwards compatibility.
+	// example: transactional
+	BalanceScope string `json:"balanceScope,omitempty" example:"transactional"`
+
+	// AllowOverdraft enables overdraft behavior for the balance. When false,
+	// transactions that would drive Available below zero are rejected.
+	// example: false
+	AllowOverdraft bool `json:"allowOverdraft" example:"false"`
+
+	// OverdraftLimitEnabled gates the OverdraftLimit field. When true, a
+	// non-empty, strictly positive OverdraftLimit MUST be supplied. When
+	// false, OverdraftLimit MUST be absent (overdraft is unlimited if
+	// AllowOverdraft is true).
+	// example: false
+	OverdraftLimitEnabled bool `json:"overdraftLimitEnabled" example:"false"`
+
+	// OverdraftLimit is the maximum overdraft amount the balance may carry,
+	// expressed as a decimal string (to preserve precision). Ignored when
+	// OverdraftLimitEnabled is false.
+	// example: 1000.00
+	OverdraftLimit *string `json:"overdraftLimit,omitempty" example:"1000.00"`
+}
+
+// NewDefaultBalanceSettings returns a BalanceSettings initialized with the
+// defaults mandated by PRD RF-1:
+//   - BalanceScope  = "transactional"
+//   - AllowOverdraft = false
+//   - OverdraftLimitEnabled = false
+//   - OverdraftLimit = nil
+//
+// The constructor centralizes default creation so call sites never end up
+// with a zero-valued BalanceSettings that would leave BalanceScope empty.
+func NewDefaultBalanceSettings() *BalanceSettings {
+	return &BalanceSettings{
+		BalanceScope:          BalanceScopeTransactional,
+		AllowOverdraft:        false,
+		OverdraftLimitEnabled: false,
+		OverdraftLimit:        nil,
+	}
+}
+
+// Validate enforces the balance settings contract from PRD §4 RF-1.
+//
+// Rules:
+//   - BalanceScope MUST be "transactional", "internal", or empty (=>
+//     defaults to "transactional"). Any other value (including case
+//     variants) is rejected.
+//   - When OverdraftLimitEnabled is true, OverdraftLimit MUST be present,
+//     parse as a valid decimal via shopspring/decimal, and be strictly
+//     greater than zero.
+//   - When OverdraftLimitEnabled is false, OverdraftLimit MUST be absent
+//     (nil). A present OverdraftLimit with the flag disabled is ambiguous
+//     and therefore rejected.
+func (s *BalanceSettings) Validate() error {
+	if s == nil {
+		return nil
+	}
+
+	if err := s.validateScope(); err != nil {
+		return err
+	}
+
+	return s.validateOverdraftLimit()
+}
+
+// validateScope returns an error when BalanceScope is not one of the
+// allowed values. Empty string is accepted and interpreted as the default
+// "transactional" scope by downstream consumers.
+func (s *BalanceSettings) validateScope() error {
+	switch s.BalanceScope {
+	case "", BalanceScopeTransactional, BalanceScopeInternal:
+		return nil
+	default:
+		return fmt.Errorf(
+			"invalid balanceScope %q: must be %q or %q",
+			s.BalanceScope, BalanceScopeTransactional, BalanceScopeInternal,
+		)
+	}
+}
+
+// validateOverdraftLimit enforces the cross-field rule between
+// OverdraftLimitEnabled and OverdraftLimit.
+func (s *BalanceSettings) validateOverdraftLimit() error {
+	if !s.OverdraftLimitEnabled {
+		if s.OverdraftLimit != nil {
+			return errors.New(
+				"overdraftLimit must be absent when overdraftLimitEnabled is false",
+			)
+		}
+
+		return nil
+	}
+
+	// OverdraftLimitEnabled == true: require a strictly positive decimal.
+	if s.OverdraftLimit == nil {
+		return errors.New(
+			"overdraftLimit is required when overdraftLimitEnabled is true",
+		)
+	}
+
+	if *s.OverdraftLimit == "" {
+		return errors.New(
+			"overdraftLimit must be a non-empty decimal string when overdraftLimitEnabled is true",
+		)
+	}
+
+	limit, err := decimal.NewFromString(*s.OverdraftLimit)
+	if err != nil {
+		return fmt.Errorf(
+			"overdraftLimit %q is not a valid decimal: %w",
+			*s.OverdraftLimit, err,
+		)
+	}
+
+	if !limit.IsPositive() {
+		return fmt.Errorf(
+			"overdraftLimit %q must be strictly greater than zero",
+			*s.OverdraftLimit,
+		)
+	}
+
+	return nil
+}

--- a/pkg/mmodel/balance_settings_test.go
+++ b/pkg/mmodel/balance_settings_test.go
@@ -1,0 +1,206 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package mmodel
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBalanceSettings_Defaults verifies the default BalanceSettings produced by
+// NewDefaultBalanceSettings matches PRD RF-1:
+//   - BalanceScope = "transactional"
+//   - AllowOverdraft = false
+//   - OverdraftLimitEnabled = false
+//   - OverdraftLimit = nil
+func TestBalanceSettings_Defaults(t *testing.T) {
+	t.Parallel()
+
+	got := NewDefaultBalanceSettings()
+
+	require.NotNil(t, got, "NewDefaultBalanceSettings must return non-nil value")
+	assert.Equal(t, "transactional", got.BalanceScope, "default BalanceScope must be 'transactional'")
+	assert.False(t, got.AllowOverdraft, "default AllowOverdraft must be false")
+	assert.False(t, got.OverdraftLimitEnabled, "default OverdraftLimitEnabled must be false")
+	assert.Nil(t, got.OverdraftLimit, "default OverdraftLimit must be nil")
+}
+
+// TestBalanceSettings_Validate_ValidCombinations covers the 4 valid combinations
+// from PRD §4 RF-1 (balance settings contract).
+func TestBalanceSettings_Validate_ValidCombinations(t *testing.T) {
+	t.Parallel()
+
+	limit := "1000.00"
+
+	tests := []struct {
+		name     string
+		settings BalanceSettings
+	}{
+		{
+			name: "transactional, no overdraft allowed (default)",
+			settings: BalanceSettings{
+				BalanceScope:          "transactional",
+				AllowOverdraft:        false,
+				OverdraftLimitEnabled: false,
+			},
+		},
+		{
+			name: "transactional, overdraft allowed without limit (unlimited)",
+			settings: BalanceSettings{
+				BalanceScope:          "transactional",
+				AllowOverdraft:        true,
+				OverdraftLimitEnabled: false,
+			},
+		},
+		{
+			name: "transactional, overdraft allowed with limit",
+			settings: BalanceSettings{
+				BalanceScope:          "transactional",
+				AllowOverdraft:        true,
+				OverdraftLimitEnabled: true,
+				OverdraftLimit:        &limit,
+			},
+		},
+		{
+			name: "internal scope with default overdraft flags",
+			settings: BalanceSettings{
+				BalanceScope:          "internal",
+				AllowOverdraft:        false,
+				OverdraftLimitEnabled: false,
+			},
+		},
+		{
+			name: "empty scope is accepted and defaults to transactional",
+			settings: BalanceSettings{
+				BalanceScope:          "",
+				AllowOverdraft:        false,
+				OverdraftLimitEnabled: false,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := tt.settings.Validate()
+
+			require.NoError(t, err, "valid settings must not return error")
+		})
+	}
+}
+
+// TestBalanceSettings_Validate_InvalidCombinations covers every rejection path
+// described in PRD §4 RF-1 and the TRD.
+func TestBalanceSettings_Validate_InvalidCombinations(t *testing.T) {
+	t.Parallel()
+
+	zero := "0"
+	negative := "-100.00"
+	empty := ""
+	notANumber := "not-a-number"
+	valid := "500.00"
+
+	tests := []struct {
+		name            string
+		settings        BalanceSettings
+		wantErrContains string
+	}{
+		{
+			name: "overdraftLimitEnabled true without overdraftLimit",
+			settings: BalanceSettings{
+				BalanceScope:          "transactional",
+				AllowOverdraft:        true,
+				OverdraftLimitEnabled: true,
+				OverdraftLimit:        nil,
+			},
+			wantErrContains: "overdraftLimit is required",
+		},
+		{
+			name: "overdraftLimitEnabled true with empty overdraftLimit",
+			settings: BalanceSettings{
+				BalanceScope:          "transactional",
+				AllowOverdraft:        true,
+				OverdraftLimitEnabled: true,
+				OverdraftLimit:        &empty,
+			},
+			wantErrContains: "non-empty decimal string",
+		},
+		{
+			name: "overdraftLimitEnabled true with zero overdraftLimit",
+			settings: BalanceSettings{
+				BalanceScope:          "transactional",
+				AllowOverdraft:        true,
+				OverdraftLimitEnabled: true,
+				OverdraftLimit:        &zero,
+			},
+			wantErrContains: "strictly greater than zero",
+		},
+		{
+			name: "overdraftLimitEnabled true with negative overdraftLimit",
+			settings: BalanceSettings{
+				BalanceScope:          "transactional",
+				AllowOverdraft:        true,
+				OverdraftLimitEnabled: true,
+				OverdraftLimit:        &negative,
+			},
+			wantErrContains: "strictly greater than zero",
+		},
+		{
+			name: "overdraftLimitEnabled true with non-numeric overdraftLimit",
+			settings: BalanceSettings{
+				BalanceScope:          "transactional",
+				AllowOverdraft:        true,
+				OverdraftLimitEnabled: true,
+				OverdraftLimit:        &notANumber,
+			},
+			wantErrContains: "not a valid decimal",
+		},
+		{
+			name: "overdraftLimitEnabled false with overdraftLimit present (ambiguous)",
+			settings: BalanceSettings{
+				BalanceScope:          "transactional",
+				AllowOverdraft:        true,
+				OverdraftLimitEnabled: false,
+				OverdraftLimit:        &valid,
+			},
+			wantErrContains: "must be absent",
+		},
+		{
+			name: "balanceScope is not one of allowed values",
+			settings: BalanceSettings{
+				BalanceScope:          "external",
+				AllowOverdraft:        false,
+				OverdraftLimitEnabled: false,
+			},
+			wantErrContains: "invalid balanceScope",
+		},
+		{
+			name: "balanceScope has random casing / typo",
+			settings: BalanceSettings{
+				BalanceScope:          "TRANSACTIONAL",
+				AllowOverdraft:        false,
+				OverdraftLimitEnabled: false,
+			},
+			wantErrContains: "invalid balanceScope",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := tt.settings.Validate()
+
+			require.Error(t, err, "invalid settings must return error for: %s", tt.name)
+			assert.Contains(t, err.Error(), tt.wantErrContains,
+				"error message must contain %q for case: %s", tt.wantErrContains, tt.name)
+		})
+	}
+}

--- a/pkg/mtransaction/balance_overdraft_test.go
+++ b/pkg/mtransaction/balance_overdraft_test.go
@@ -1,0 +1,48 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package mtransaction
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestTransactionBalance_HasOverdraftFields verifies that the internal
+// mtransaction.Balance struct exposes the overdraft fields required for
+// the overdraft feature. These fields travel with the balance through
+// transaction processing so the engine can evaluate overdraft limits.
+func TestTransactionBalance_HasOverdraftFields(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		fieldName string
+		fieldType string
+	}{
+		{name: "Direction field is string", fieldName: "Direction", fieldType: "string"},
+		{name: "OverdraftUsed field is decimal.Decimal", fieldName: "OverdraftUsed", fieldType: "decimal.Decimal"},
+		{name: "AllowOverdraft field is bool", fieldName: "AllowOverdraft", fieldType: "bool"},
+		{name: "OverdraftLimitEnabled field is bool", fieldName: "OverdraftLimitEnabled", fieldType: "bool"},
+		{name: "OverdraftLimit field is decimal.Decimal", fieldName: "OverdraftLimit", fieldType: "decimal.Decimal"},
+		{name: "BalanceScope field is string", fieldName: "BalanceScope", fieldType: "string"},
+	}
+
+	bt := reflect.TypeOf(Balance{})
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			field, ok := bt.FieldByName(tt.fieldName)
+			require.True(t, ok, "mtransaction.Balance must have field %q", tt.fieldName)
+			assert.Equal(t, tt.fieldType, field.Type.String(),
+				"mtransaction.Balance.%s must be of type %s", tt.fieldName, tt.fieldType)
+		})
+	}
+}

--- a/pkg/mtransaction/transaction.go
+++ b/pkg/mtransaction/transaction.go
@@ -19,23 +19,41 @@ import (
 // swagger:model Balance
 // @Description Balance is the struct designed to represent the account balance.
 type Balance struct {
-	ID             string          `json:"id" example:"00000000-0000-0000-0000-000000000000"`
-	OrganizationID string          `json:"organizationId" example:"00000000-0000-0000-0000-000000000000"`
-	LedgerID       string          `json:"ledgerId" example:"00000000-0000-0000-0000-000000000000"`
-	AccountID      string          `json:"accountId" example:"00000000-0000-0000-0000-000000000000"`
-	Alias          string          `json:"alias" example:"@person1"`
-	Key            string          `json:"key" example:"asset-freeze"`
-	AssetCode      string          `json:"assetCode" example:"BRL"`
-	Available      decimal.Decimal `json:"available" example:"1500"`
-	OnHold         decimal.Decimal `json:"onHold" example:"500"`
-	Version        int64           `json:"version" example:"1"`
-	AccountType    string          `json:"accountType" example:"creditCard"`
-	AllowSending   bool            `json:"allowSending" example:"true"`
-	AllowReceiving bool            `json:"allowReceiving" example:"true"`
-	CreatedAt      time.Time       `json:"createdAt" example:"2021-01-01T00:00:00Z"`
-	UpdatedAt      time.Time       `json:"updatedAt" example:"2021-01-01T00:00:00Z"`
-	DeletedAt      *time.Time      `json:"deletedAt" example:"2021-01-01T00:00:00Z"`
-	Metadata       map[string]any  `json:"metadata,omitempty"`
+	ID             string                   `json:"id" example:"00000000-0000-0000-0000-000000000000"`
+	OrganizationID string                   `json:"organizationId" example:"00000000-0000-0000-0000-000000000000"`
+	LedgerID       string                   `json:"ledgerId" example:"00000000-0000-0000-0000-000000000000"`
+	AccountID      string                   `json:"accountId" example:"00000000-0000-0000-0000-000000000000"`
+	Alias          string                   `json:"alias" example:"@person1"`
+	Key            string                   `json:"key" example:"asset-freeze"`
+	AssetCode      string                   `json:"assetCode" example:"BRL"`
+	Available      decimal.Decimal          `json:"available" example:"1500"`
+	OnHold         decimal.Decimal          `json:"onHold" example:"500"`
+	Version        int64                    `json:"version" example:"1"`
+	AccountType    string                   `json:"accountType" example:"creditCard"`
+	AllowSending   bool                     `json:"allowSending" example:"true"`
+	AllowReceiving bool                     `json:"allowReceiving" example:"true"`
+	// Direction is the accounting direction of the balance ("credit" or
+	// "debit"). Empty string denotes a legacy balance that predates the
+	// overdraft feature and is treated as "credit" by the engine.
+	Direction string `json:"direction,omitempty" example:"credit"`
+	// OverdraftUsed is the amount of overdraft currently consumed by the
+	// balance. Always non-negative. Zero when the balance is in the black.
+	OverdraftUsed decimal.Decimal `json:"overdraftUsed" example:"0"`
+	// AllowOverdraft enables overdraft behavior when true.
+	AllowOverdraft bool `json:"allowOverdraft"`
+	// OverdraftLimitEnabled gates the OverdraftLimit value. When false,
+	// the limit is zero (unlimited if AllowOverdraft is true).
+	OverdraftLimitEnabled bool `json:"overdraftLimitEnabled"`
+	// OverdraftLimit is the maximum overdraft amount as a decimal.
+	// Only meaningful when OverdraftLimitEnabled is true.
+	OverdraftLimit decimal.Decimal `json:"overdraftLimit"`
+	// BalanceScope is the balance scope ("transactional" or "internal").
+	// Empty string is treated as "transactional" for backward compatibility.
+	BalanceScope   string    `json:"balanceScope"`
+	CreatedAt      time.Time `json:"createdAt" example:"2021-01-01T00:00:00Z"`
+	UpdatedAt      time.Time                `json:"updatedAt" example:"2021-01-01T00:00:00Z"`
+	DeletedAt      *time.Time               `json:"deletedAt" example:"2021-01-01T00:00:00Z"`
+	Metadata       map[string]any           `json:"metadata,omitempty"`
 } // @name Balance
 
 type Responses struct {


### PR DESCRIPTION
**Summary**

Lays the foundation for the balance overdraft feature by extending the balance data model with direction-based polarity, overdraft tracking, and per-balance settings across all layers (domain, transaction engine, PostgreSQL adapter, Redis cache projection). This is the schema and type foundation -- no runtime behavior changes yet.
What changed

**New direction field on Balance**

- Enum: credit (default) or debit, immutable after creation
- Defines how operations affect the balance value (credit increases on credit, debit increases on debit)
- All existing balances default to credit via migration, preserving current behavior
- CHECK constraint enforces valid values at the database level

**New overdraft_used field on Balance**

- Tracks the amount of overdraft consumed by each balance
- DECIMAL NOT NULL DEFAULT 0 -- transparent to existing balances
New settings JSONB column on Balance
- Per-balance configuration: allowOverdraft, overdraftLimitEnabled, overdraftLimit, balanceScope
- BalanceSettings type with cross-field validation (Validate()) enforcing all business rules from the PRD:
  - overdraftLimitEnabled=true requires overdraftLimit > 0
  - overdraftLimitEnabled=false rejects overdraftLimit if present
  - balanceScope must be transactional or internal
 
**Error codes**

- 0167 -- Overdraft limit exceeded
- 0168 -- Direct operation on internal balance
- 0169 -- Deletion of internal balance
- All mapped to UnprocessableOperationError (HTTP 422)

**Persistence layer**

- BalancePostgreSQLModel extended with 3 new fields + db: tags
- FromEntity/ToEntity handle Settings JSONB marshal/unmarshal with nil safety
- balanceColumnList expanded, all scan sites (~10) updated consistently
- Create method includes new columns in INSERT

**Redis cache projection**

- BalanceRedis extended with 6 flattened fields for Lua script consumption
- UnmarshalJSON handles OverdraftUsed from string/float/json.Number (same pattern as Available/OnHold)

**What's NOT included (subsequent PRs)**

- Overdraft settings configuration via API (enable/disable, limits)
- Auto-creation of overdraft tracking balance
- Transaction enrichment (debit split, credit repayment)
- Atomic cache script (Lua) changes
- Event notifications
- UpdateMany/BalancesUpdate do not yet sync overdraft_used (documented in code, will land with the cache script extension)

**Migration**
000031_add_overdraft_fields_to_balance
```sql
ALTER TABLE balance
    ADD COLUMN IF NOT EXISTS direction       VARCHAR(16) NOT NULL DEFAULT 'credit'
        CHECK (direction IN ('credit', 'debit')),
    ADD COLUMN IF NOT EXISTS overdraft_used  DECIMAL     NOT NULL DEFAULT 0,
    ADD COLUMN IF NOT EXISTS settings        JSONB;
```

- Additive only, safe defaults, no backfill needed
- Idempotent (IF NOT EXISTS / IF EXISTS)
- Backwards compatible -- existing balances get direction=credit, overdraft_used=0, settings=NULL

**Testing**

- 17 unit test acceptance criteria covering settings validation, model fields, conversion propagation, error codes, and migration SQL
- 6 integration tests (testcontainer PostgreSQL) covering schema defaults, JSONB round-trip, direction persistence, nil settings, batch update, and alias queries
- ~96% coverage on new code (FromEntity/ToEntity at 100%)