### PR TITLE
feat: Balance Overdraft: Persistence + Cache Layer Extension

### DIFF
--- a/components/ledger/internal/adapters/postgres/balance/balance.go
+++ b/components/ledger/internal/adapters/postgres/balance/balance.go
@@ -6,6 +6,7 @@ package balance
 
 import (
 	"database/sql"
+	"encoding/json"
 	"time"
 
 	libCommons "github.com/LerianStudio/lib-commons/v4/commons"
@@ -29,6 +30,9 @@ type BalancePostgreSQLModel struct {
 	AccountType    string
 	AllowSending   bool
 	AllowReceiving bool
+	Direction      string          `db:"direction"`
+	OverdraftUsed  decimal.Decimal `db:"overdraft_used"`
+	Settings       []byte          `db:"settings"`
 	CreatedAt      time.Time
 	UpdatedAt      time.Time
 	DeletedAt      sql.NullTime
@@ -49,8 +53,18 @@ func (b *BalancePostgreSQLModel) FromEntity(balance *mmodel.Balance) {
 		AccountType:    balance.AccountType,
 		AllowSending:   balance.AllowSending,
 		AllowReceiving: balance.AllowReceiving,
+		Direction:      balance.Direction,
+		OverdraftUsed:  balance.OverdraftUsed,
 		CreatedAt:      balance.CreatedAt,
 		UpdatedAt:      balance.UpdatedAt,
+	}
+
+	if balance.Settings != nil {
+		// json.Marshal cannot fail for BalanceSettings: it contains only
+		// JSON-safe primitives (string, bool, *string). We intentionally
+		// discard the error and leave b.Settings as nil on the (impossible)
+		// failure path, matching the existing behavior for a nil Settings.
+		b.Settings, _ = json.Marshal(balance.Settings)
 	}
 
 	if libCommons.IsNilOrEmpty(&balance.Key) {
@@ -86,8 +100,17 @@ func (b *BalancePostgreSQLModel) ToEntity() *mmodel.Balance {
 		AccountType:    b.AccountType,
 		AllowSending:   b.AllowSending,
 		AllowReceiving: b.AllowReceiving,
+		Direction:      b.Direction,
+		OverdraftUsed:  b.OverdraftUsed,
 		CreatedAt:      b.CreatedAt,
 		UpdatedAt:      b.UpdatedAt,
+	}
+
+	if len(b.Settings) > 0 {
+		var settings mmodel.BalanceSettings
+		if err := json.Unmarshal(b.Settings, &settings); err == nil {
+			balance.Settings = &settings
+		}
 	}
 
 	return balance

--- a/components/ledger/internal/adapters/postgres/balance/balance.postgresql.go
+++ b/components/ledger/internal/adapters/postgres/balance/balance.postgresql.go
@@ -48,6 +48,9 @@ var balanceColumnList = []string{
 	"updated_at",
 	"deleted_at",
 	"key",
+	"direction",
+	"overdraft_used",
+	"settings",
 }
 
 // Repository provides an interface for operations related to balance template entities.
@@ -156,6 +159,9 @@ func (r *BalancePostgreSQLRepository) Create(ctx context.Context, balance *mmode
 			record.UpdatedAt,
 			record.DeletedAt,
 			record.Key,
+			record.Direction,
+			record.OverdraftUsed,
+			record.Settings,
 		).
 		Suffix("RETURNING " + strings.Join(balanceColumnList, ", ")).
 		PlaceholderFormat(squirrel.Dollar)
@@ -191,6 +197,9 @@ func (r *BalancePostgreSQLRepository) Create(ctx context.Context, balance *mmode
 		&created.UpdatedAt,
 		&created.DeletedAt,
 		&created.Key,
+		&created.Direction,
+		&created.OverdraftUsed,
+		&created.Settings,
 	); err != nil {
 		libOpentelemetry.HandleSpanError(spanExec, "Failed to execute insert query", err)
 		logger.Log(ctx, libLog.LevelError, "Failed to execute insert query", libLog.Err(err))
@@ -268,6 +277,9 @@ func (r *BalancePostgreSQLRepository) ListByAccountIDs(ctx context.Context, orga
 			&balance.UpdatedAt,
 			&balance.DeletedAt,
 			&balance.Key,
+			&balance.Direction,
+			&balance.OverdraftUsed,
+			&balance.Settings,
 		); err != nil {
 			libOpentelemetry.HandleSpanError(span, "Failed to scan row", err)
 
@@ -363,6 +375,9 @@ func (r *BalancePostgreSQLRepository) ListByIDs(ctx context.Context, organizatio
 			&balance.UpdatedAt,
 			&balance.DeletedAt,
 			&balance.Key,
+			&balance.Direction,
+			&balance.OverdraftUsed,
+			&balance.Settings,
 		); err != nil {
 			libOpentelemetry.HandleSpanError(span, "Failed to scan row", err)
 			logger.Log(ctx, libLog.LevelError, fmt.Sprintf("Failed to scan row: %v", err))
@@ -473,6 +488,9 @@ func (r *BalancePostgreSQLRepository) ListAll(ctx context.Context, organizationI
 			&balance.UpdatedAt,
 			&balance.DeletedAt,
 			&balance.Key,
+			&balance.Direction,
+			&balance.OverdraftUsed,
+			&balance.Settings,
 		); err != nil {
 			libOpentelemetry.HandleSpanError(span, "Failed to scan row", err)
 
@@ -603,6 +621,9 @@ func (r *BalancePostgreSQLRepository) ListAllByAccountID(ctx context.Context, or
 			&balance.UpdatedAt,
 			&balance.DeletedAt,
 			&balance.Key,
+			&balance.Direction,
+			&balance.OverdraftUsed,
+			&balance.Settings,
 		); err != nil {
 			libOpentelemetry.HandleSpanError(span, "Failed to scan row", err)
 
@@ -711,6 +732,9 @@ func (r *BalancePostgreSQLRepository) ListByAliases(ctx context.Context, organiz
 			&balance.UpdatedAt,
 			&balance.DeletedAt,
 			&balance.Key,
+			&balance.Direction,
+			&balance.OverdraftUsed,
+			&balance.Settings,
 		); err != nil {
 			libOpentelemetry.HandleSpanError(span, "Failed to scan row", err)
 
@@ -821,6 +845,9 @@ func (r *BalancePostgreSQLRepository) ListByAliasesWithKeys(ctx context.Context,
 			&balance.UpdatedAt,
 			&balance.DeletedAt,
 			&balance.Key,
+			&balance.Direction,
+			&balance.OverdraftUsed,
+			&balance.Settings,
 		); err != nil {
 			libOpentelemetry.HandleSpanError(span, "Failed to scan row", err)
 			logger.Log(ctx, libLog.LevelError, "Failed to scan row", libLog.Err(err))
@@ -842,6 +869,11 @@ func (r *BalancePostgreSQLRepository) ListByAliasesWithKeys(ctx context.Context,
 }
 
 // BalancesUpdate updates the balances in the database.
+//
+// Note: this method intentionally persists only available, on_hold, and version.
+// overdraft_used is not synced here yet — it will be added once the cache script
+// is extended to track overdraft_used per balance. Until then, overdraft_used
+// remains whatever was last written by Create or a dedicated overdraft update path.
 func (r *BalancePostgreSQLRepository) BalancesUpdate(ctx context.Context, organizationID, ledgerID uuid.UUID, balances []*mmodel.Balance) error {
 	logger, tracer, _, _ := libCommons.NewTrackingFromContext(ctx)
 
@@ -994,6 +1026,9 @@ func (r *BalancePostgreSQLRepository) Find(ctx context.Context, organizationID, 
 		&balance.UpdatedAt,
 		&balance.DeletedAt,
 		&balance.Key,
+		&balance.Direction,
+		&balance.OverdraftUsed,
+		&balance.Settings,
 	); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			err := pkg.ValidateBusinessError(constant.ErrEntityNotFound, reflect.TypeOf(mmodel.Balance{}).Name())
@@ -1049,6 +1084,9 @@ func (r *BalancePostgreSQLRepository) FindByAccountIDAndKey(ctx context.Context,
 			   account_type,
 			   allow_sending,
 			   allow_receiving,
+			   direction,
+			   overdraft_used,
+			   settings,
 			   created_at,
 			   updated_at,
 			   deleted_at
@@ -1077,6 +1115,9 @@ func (r *BalancePostgreSQLRepository) FindByAccountIDAndKey(ctx context.Context,
 		&balance.AccountType,
 		&balance.AllowSending,
 		&balance.AllowReceiving,
+		&balance.Direction,
+		&balance.OverdraftUsed,
+		&balance.Settings,
 		&balance.CreatedAt,
 		&balance.UpdatedAt,
 		&balance.DeletedAt,
@@ -1348,7 +1389,7 @@ func (r *BalancePostgreSQLRepository) Update(ctx context.Context, organizationID
 		` AND ledger_id = $` + strconv.Itoa(len(args)-1) +
 		` AND id = $` + strconv.Itoa(len(args)) +
 		` AND deleted_at IS NULL` +
-		` RETURNING id, organization_id, ledger_id, account_id, alias, asset_code, available, on_hold, version, account_type, allow_sending, allow_receiving, created_at, updated_at, deleted_at, key`
+		` RETURNING id, organization_id, ledger_id, account_id, alias, asset_code, available, on_hold, version, account_type, allow_sending, allow_receiving, created_at, updated_at, deleted_at, key, direction, overdraft_used, settings`
 
 	record := &BalancePostgreSQLModel{}
 
@@ -1370,6 +1411,9 @@ func (r *BalancePostgreSQLRepository) Update(ctx context.Context, organizationID
 		&record.UpdatedAt,
 		&record.DeletedAt,
 		&record.Key,
+		&record.Direction,
+		&record.OverdraftUsed,
+		&record.Settings,
 	); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			err = pkg.ValidateBusinessError(constant.ErrEntityNotFound, reflect.TypeOf(mmodel.Balance{}).Name())
@@ -1402,6 +1446,11 @@ func (r *BalancePostgreSQLRepository) Update(ctx context.Context, organizationID
 // Note: this method uses raw SQL instead of Squirrel because UPDATE ... FROM (VALUES ...)
 // is a PostgreSQL-specific extension that Squirrel's Update builder does not support.
 // Wrapping it in squirrel.Expr would add complexity without benefit.
+//
+// Note: this method intentionally persists only available, on_hold, and version.
+// overdraft_used is not synced here yet — it will be added once the cache script
+// is extended to track overdraft_used per balance. Until then, overdraft_used
+// remains whatever was last written by Create or a dedicated overdraft update path.
 func (r *BalancePostgreSQLRepository) UpdateMany(ctx context.Context, organizationID, ledgerID uuid.UUID, balances []mmodel.BalanceRedis) (int64, error) {
 	if len(balances) == 0 {
 		return 0, nil
@@ -1651,6 +1700,9 @@ func (r *BalancePostgreSQLRepository) ListByAccountID(ctx context.Context, organ
 			&balance.UpdatedAt,
 			&balance.DeletedAt,
 			&balance.Key,
+			&balance.Direction,
+			&balance.OverdraftUsed,
+			&balance.Settings,
 		); err != nil {
 			libOpentelemetry.HandleSpanError(span, "Failed to scan row", err)
 			logger.Log(ctx, libLog.LevelError, fmt.Sprintf("Failed to scan row: %v", err))

--- a/components/ledger/internal/adapters/postgres/balance/balance.postgresql.go
+++ b/components/ledger/internal/adapters/postgres/balance/balance.postgresql.go
@@ -1070,26 +1070,7 @@ func (r *BalancePostgreSQLRepository) FindByAccountIDAndKey(ctx context.Context,
 
 	ctx, spanQuery := tracer.Start(ctx, "postgres.find.query")
 
-	query := `SELECT 
-			   id,
-			   organization_id,
-			   ledger_id,
-			   account_id,
-			   alias,
-			   key,
-			   asset_code,
-			   available,
-			   on_hold,
-			   version,
-			   account_type,
-			   allow_sending,
-			   allow_receiving,
-			   direction,
-			   overdraft_used,
-			   settings,
-			   created_at,
-			   updated_at,
-			   deleted_at
+	query := `SELECT ` + strings.Join(balanceColumnList, ", ") + `
 			FROM balance 
 			WHERE organization_id = $1 
 			   AND ledger_id = $2 
@@ -1107,7 +1088,6 @@ func (r *BalancePostgreSQLRepository) FindByAccountIDAndKey(ctx context.Context,
 		&balance.LedgerID,
 		&balance.AccountID,
 		&balance.Alias,
-		&balance.Key,
 		&balance.AssetCode,
 		&balance.Available,
 		&balance.OnHold,
@@ -1115,12 +1095,13 @@ func (r *BalancePostgreSQLRepository) FindByAccountIDAndKey(ctx context.Context,
 		&balance.AccountType,
 		&balance.AllowSending,
 		&balance.AllowReceiving,
-		&balance.Direction,
-		&balance.OverdraftUsed,
-		&balance.Settings,
 		&balance.CreatedAt,
 		&balance.UpdatedAt,
 		&balance.DeletedAt,
+		&balance.Key,
+		&balance.Direction,
+		&balance.OverdraftUsed,
+		&balance.Settings,
 	); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			err := pkg.ValidateBusinessError(constant.ErrEntityNotFound, reflect.TypeOf(mmodel.Balance{}).Name())
@@ -1389,7 +1370,7 @@ func (r *BalancePostgreSQLRepository) Update(ctx context.Context, organizationID
 		` AND ledger_id = $` + strconv.Itoa(len(args)-1) +
 		` AND id = $` + strconv.Itoa(len(args)) +
 		` AND deleted_at IS NULL` +
-		` RETURNING id, organization_id, ledger_id, account_id, alias, asset_code, available, on_hold, version, account_type, allow_sending, allow_receiving, created_at, updated_at, deleted_at, key, direction, overdraft_used, settings`
+		` RETURNING ` + strings.Join(balanceColumnList, ", ")
 
 	record := &BalancePostgreSQLModel{}
 

--- a/components/ledger/internal/adapters/postgres/balance/balance_overdraft_test.go
+++ b/components/ledger/internal/adapters/postgres/balance/balance_overdraft_test.go
@@ -1,0 +1,191 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package balance
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	"github.com/LerianStudio/midaz/v3/pkg/mmodel"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBalancePostgreSQLModel_HasOverdraftFields verifies via reflection that
+// BalancePostgreSQLModel exposes the overdraft fields with the expected types
+// and db struct tags required for repository persistence.
+func TestBalancePostgreSQLModel_HasOverdraftFields(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		fieldName    string
+		expectedType reflect.Type
+		expectedTag  string
+	}{
+		{
+			name:         "direction field",
+			fieldName:    "Direction",
+			expectedType: reflect.TypeOf(""),
+			expectedTag:  "direction",
+		},
+		{
+			name:         "overdraft_used field",
+			fieldName:    "OverdraftUsed",
+			expectedType: reflect.TypeOf(decimal.Decimal{}),
+			expectedTag:  "overdraft_used",
+		},
+		{
+			name:         "settings field",
+			fieldName:    "Settings",
+			expectedType: reflect.TypeOf([]byte(nil)),
+			expectedTag:  "settings",
+		},
+	}
+
+	modelType := reflect.TypeOf(BalancePostgreSQLModel{})
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			field, ok := modelType.FieldByName(tt.fieldName)
+			require.True(t, ok, "expected field %q on BalancePostgreSQLModel", tt.fieldName)
+			assert.Equal(t, tt.expectedType, field.Type, "field %q type mismatch", tt.fieldName)
+			assert.Equal(t, tt.expectedTag, field.Tag.Get("db"), "field %q db tag mismatch", tt.fieldName)
+		})
+	}
+}
+
+// TestBalancePostgreSQLModel_FromEntity_MapsOverdraftFields verifies that
+// FromEntity copies the scalar overdraft fields and marshals Settings as
+// valid JSON suitable for the JSONB column.
+func TestBalancePostgreSQLModel_FromEntity_MapsOverdraftFields(t *testing.T) {
+	t.Parallel()
+
+	limit := "500.00"
+	entity := &mmodel.Balance{
+		ID:            "00000000-0000-0000-0000-000000000001",
+		Direction:     "debit",
+		OverdraftUsed: decimal.NewFromFloat(50.00),
+		Settings: &mmodel.BalanceSettings{
+			AllowOverdraft:        true,
+			OverdraftLimitEnabled: true,
+			OverdraftLimit:        &limit,
+			BalanceScope:          mmodel.BalanceScopeTransactional,
+		},
+	}
+
+	var model BalancePostgreSQLModel
+	model.FromEntity(entity)
+
+	assert.Equal(t, "debit", model.Direction)
+	assert.True(t, model.OverdraftUsed.Equal(decimal.NewFromFloat(50.00)),
+		"expected overdraft_used=50.00, got %s", model.OverdraftUsed.String())
+
+	require.NotNil(t, model.Settings, "expected Settings to be marshaled to non-nil bytes")
+	assert.True(t, json.Valid(model.Settings), "expected Settings to be valid JSON")
+
+	var decoded mmodel.BalanceSettings
+	require.NoError(t, json.Unmarshal(model.Settings, &decoded))
+	assert.True(t, decoded.AllowOverdraft)
+	assert.True(t, decoded.OverdraftLimitEnabled)
+	require.NotNil(t, decoded.OverdraftLimit)
+	assert.Equal(t, "500.00", *decoded.OverdraftLimit)
+	assert.Equal(t, mmodel.BalanceScopeTransactional, decoded.BalanceScope)
+}
+
+// TestBalancePostgreSQLModel_ToEntity_MapsOverdraftFields verifies that
+// ToEntity round-trips the overdraft fields and unmarshals the Settings
+// JSON bytes back into a typed BalanceSettings on the entity.
+func TestBalancePostgreSQLModel_ToEntity_MapsOverdraftFields(t *testing.T) {
+	t.Parallel()
+
+	limit := "500.00"
+	settings := mmodel.BalanceSettings{
+		AllowOverdraft:        true,
+		OverdraftLimitEnabled: true,
+		OverdraftLimit:        &limit,
+		BalanceScope:          mmodel.BalanceScopeTransactional,
+	}
+	settingsBytes, err := json.Marshal(settings)
+	require.NoError(t, err)
+
+	model := BalancePostgreSQLModel{
+		ID:            "00000000-0000-0000-0000-000000000001",
+		Key:           "default",
+		Direction:     "debit",
+		OverdraftUsed: decimal.NewFromInt(50),
+		Settings:      settingsBytes,
+	}
+
+	entity := model.ToEntity()
+
+	assert.Equal(t, "debit", entity.Direction)
+	assert.True(t, entity.OverdraftUsed.Equal(decimal.NewFromInt(50)),
+		"expected overdraft_used=50, got %s", entity.OverdraftUsed.String())
+
+	require.NotNil(t, entity.Settings, "expected Settings unmarshaled onto entity")
+	assert.True(t, entity.Settings.AllowOverdraft)
+	assert.True(t, entity.Settings.OverdraftLimitEnabled)
+	require.NotNil(t, entity.Settings.OverdraftLimit)
+	assert.Equal(t, "500.00", *entity.Settings.OverdraftLimit)
+	assert.Equal(t, mmodel.BalanceScopeTransactional, entity.Settings.BalanceScope)
+}
+
+// TestBalancePostgreSQLModel_ToEntity_NilSettings ensures a model with nil
+// Settings bytes produces an entity with nil Settings (legacy-row
+// backwards compatibility).
+func TestBalancePostgreSQLModel_ToEntity_NilSettings(t *testing.T) {
+	t.Parallel()
+
+	model := BalancePostgreSQLModel{
+		ID:       "00000000-0000-0000-0000-000000000001",
+		Key:      "default",
+		Settings: nil,
+	}
+
+	entity := model.ToEntity()
+
+	assert.Nil(t, entity.Settings, "expected nil Settings on entity when model Settings is nil")
+}
+
+// TestBalancePostgreSQLModel_FromEntity_NilSettings ensures an entity with
+// nil Settings produces a model with nil Settings bytes, so the repository
+// writes SQL NULL rather than a JSON null literal.
+func TestBalancePostgreSQLModel_FromEntity_NilSettings(t *testing.T) {
+	t.Parallel()
+
+	entity := &mmodel.Balance{
+		ID:       "00000000-0000-0000-0000-000000000001",
+		Settings: nil,
+	}
+
+	var model BalancePostgreSQLModel
+	model.FromEntity(entity)
+
+	assert.Nil(t, model.Settings, "expected nil Settings bytes when entity Settings is nil")
+}
+
+// TestBalanceColumnList_IncludesOverdraftColumns ensures the column list used
+// by SELECT/INSERT/UPDATE statements references the overdraft columns, so
+// reads and writes stay in sync with the physical schema.
+func TestBalanceColumnList_IncludesOverdraftColumns(t *testing.T) {
+	t.Parallel()
+
+	expected := []string{"direction", "overdraft_used", "settings"}
+
+	for _, col := range expected {
+		col := col
+		t.Run(col, func(t *testing.T) {
+			t.Parallel()
+			assert.Contains(t, balanceColumnList, col,
+				"balanceColumnList must contain %q for repository round-trip", col)
+		})
+	}
+}

--- a/components/ledger/internal/services/command/create_balance_transaction_operations_async.go
+++ b/components/ledger/internal/services/command/create_balance_transaction_operations_async.go
@@ -293,6 +293,7 @@ func (uc *UseCase) RemoveTransactionFromRedisQueueIfStatus(ctx context.Context, 
 			expectedStatus,
 			queue.TransactionStatus,
 		))
+
 		return
 	}
 

--- a/pkg/mmodel/balance.go
+++ b/pkg/mmodel/balance.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/LerianStudio/midaz/v3/pkg/constant"
 	"github.com/LerianStudio/midaz/v3/pkg/mtransaction"
+	"github.com/LerianStudio/midaz/v3/pkg/utils"
 	"github.com/google/uuid"
 	"github.com/shopspring/decimal"
 )
@@ -572,7 +573,7 @@ func (b *BalanceRedis) UnmarshalJSON(data []byte) error {
 		b.OnHold = decimal.NewFromFloat(f)
 	}
 
-	b.OverdraftUsed = parseDecimalString(aux.OverdraftUsed, "0")
+	b.OverdraftUsed = utils.ParseDecimalString(aux.OverdraftUsed, "0")
 
 	if b.OverdraftLimit == "" {
 		b.OverdraftLimit = "0"
@@ -584,21 +585,6 @@ func (b *BalanceRedis) UnmarshalJSON(data []byte) error {
 	}
 
 	return nil
-}
-
-// parseDecimalString normalizes a value that may arrive as string, float64,
-// or json.Number into a plain decimal string. Returns defaultVal when v is nil.
-func parseDecimalString(v any, defaultVal string) string {
-	switch t := v.(type) {
-	case string:
-		return t
-	case float64:
-		return decimal.NewFromFloat(t).String()
-	case json.Number:
-		return t.String()
-	default:
-		return defaultVal
-	}
 }
 
 // BalanceErrorResponse represents an error response for balance operations.

--- a/pkg/mmodel/balance.go
+++ b/pkg/mmodel/balance.go
@@ -473,6 +473,24 @@ type BalanceRedis struct {
 
 	// Whether the account can receive funds (1=true, 0=false)
 	AllowReceiving int `json:"allowReceiving"`
+
+	// Accounting direction of the balance ("credit" or "debit")
+	Direction string `json:"direction"`
+
+	// Amount of overdraft currently consumed (decimal string for Lua)
+	OverdraftUsed string `json:"overdraftUsed"`
+
+	// Whether overdraft is allowed (1=true, 0=false for Lua)
+	AllowOverdraft int `json:"allowOverdraft"`
+
+	// Whether the overdraft limit is enabled (1=true, 0=false for Lua)
+	OverdraftLimitEnabled int `json:"overdraftLimitEnabled"`
+
+	// Maximum overdraft amount (decimal string for Lua)
+	OverdraftLimit string `json:"overdraftLimit"`
+
+	// Balance scope ("transactional" or "internal")
+	BalanceScope string `json:"balanceScope"`
 }
 
 // UnmarshalJSON is a custom unmarshal function for BalanceRedis
@@ -480,8 +498,9 @@ func (b *BalanceRedis) UnmarshalJSON(data []byte) error {
 	type Alias BalanceRedis
 
 	aux := struct {
-		Available any `json:"available"`
-		OnHold    any `json:"onHold"`
+		Available     any `json:"available"`
+		OnHold        any `json:"onHold"`
+		OverdraftUsed any `json:"overdraftUsed"`
 		*Alias
 	}{
 		Alias: (*Alias)(b),
@@ -553,12 +572,33 @@ func (b *BalanceRedis) UnmarshalJSON(data []byte) error {
 		b.OnHold = decimal.NewFromFloat(f)
 	}
 
+	b.OverdraftUsed = parseDecimalString(aux.OverdraftUsed, "0")
+
+	if b.OverdraftLimit == "" {
+		b.OverdraftLimit = "0"
+	}
+
 	// Set default value for Key if not provided (backwards compatibility)
 	if b.Key == "" {
 		b.Key = constant.DefaultBalanceKey
 	}
 
 	return nil
+}
+
+// parseDecimalString normalizes a value that may arrive as string, float64,
+// or json.Number into a plain decimal string. Returns defaultVal when v is nil.
+func parseDecimalString(v any, defaultVal string) string {
+	switch t := v.(type) {
+	case string:
+		return t
+	case float64:
+		return decimal.NewFromFloat(t).String()
+	case json.Number:
+		return t.String()
+	default:
+		return defaultVal
+	}
 }
 
 // BalanceErrorResponse represents an error response for balance operations.

--- a/pkg/mmodel/balance_redis_overdraft_test.go
+++ b/pkg/mmodel/balance_redis_overdraft_test.go
@@ -154,34 +154,6 @@ func TestBalanceRedis_UnmarshalJSON_OverdraftUsedFromFloat(t *testing.T) {
 	}
 }
 
-// TestBalanceRedis_UnmarshalJSON_OverdraftUsedFromNumber verifies that
-// the json.Number branch of parseDecimalString preserves the exact
-// textual representation supplied by the caller — the precision-safe
-// path for high-magnitude or high-precision decimals.
-func TestBalanceRedis_UnmarshalJSON_OverdraftUsedFromNumber(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name     string
-		input    json.Number
-		expected string
-	}{
-		{name: "high precision decimal", input: json.Number("123.456789012345"), expected: "123.456789012345"},
-		{name: "large integer", input: json.Number("9999999999999999"), expected: "9999999999999999"},
-		{name: "small fractional", input: json.Number("0.000001"), expected: "0.000001"},
-	}
-
-	for _, tt := range tests {
-		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			got := parseDecimalString(tt.input, "0")
-			assert.Equal(t, tt.expected, got)
-		})
-	}
-}
-
 // TestBalanceRedis_UnmarshalJSON_MissingOverdraftFields verifies legacy
 // payloads (written before the overdraft feature) still decode cleanly,
 // with sensible defaults applied to the overdraft fields.

--- a/pkg/mmodel/balance_redis_overdraft_test.go
+++ b/pkg/mmodel/balance_redis_overdraft_test.go
@@ -1,0 +1,213 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package mmodel
+
+import (
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBalanceRedis_HasOverdraftFields verifies via reflection that the
+// Redis cache projection exposes the overdraft fields with the right
+// types and json tags that the Lua scripts depend on.
+func TestBalanceRedis_HasOverdraftFields(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		fieldName    string
+		expectedType reflect.Type
+		expectedJSON string
+	}{
+		{
+			name:         "direction field",
+			fieldName:    "Direction",
+			expectedType: reflect.TypeOf(""),
+			expectedJSON: "direction",
+		},
+		{
+			name:         "overdraft_used field",
+			fieldName:    "OverdraftUsed",
+			expectedType: reflect.TypeOf(""),
+			expectedJSON: "overdraftUsed",
+		},
+		{
+			name:         "allow_overdraft field",
+			fieldName:    "AllowOverdraft",
+			expectedType: reflect.TypeOf(0),
+			expectedJSON: "allowOverdraft",
+		},
+		{
+			name:         "overdraft_limit_enabled field",
+			fieldName:    "OverdraftLimitEnabled",
+			expectedType: reflect.TypeOf(0),
+			expectedJSON: "overdraftLimitEnabled",
+		},
+		{
+			name:         "overdraft_limit field",
+			fieldName:    "OverdraftLimit",
+			expectedType: reflect.TypeOf(""),
+			expectedJSON: "overdraftLimit",
+		},
+		{
+			name:         "balance_scope field",
+			fieldName:    "BalanceScope",
+			expectedType: reflect.TypeOf(""),
+			expectedJSON: "balanceScope",
+		},
+	}
+
+	redisType := reflect.TypeOf(BalanceRedis{})
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			field, ok := redisType.FieldByName(tt.fieldName)
+			require.True(t, ok, "expected field %q on BalanceRedis", tt.fieldName)
+			assert.Equal(t, tt.expectedType, field.Type, "field %q type mismatch", tt.fieldName)
+
+			// JSON tag may have options (e.g. "name,omitempty"); take the name.
+			jsonTag := strings.Split(field.Tag.Get("json"), ",")[0]
+			assert.Equal(t, tt.expectedJSON, jsonTag, "field %q json tag mismatch", tt.fieldName)
+		})
+	}
+}
+
+// TestBalanceRedis_UnmarshalJSON_OverdraftFields verifies that a fully
+// populated JSON payload — matching what the Lua scripts write back — is
+// correctly deserialized, including the overdraft fields.
+func TestBalanceRedis_UnmarshalJSON_OverdraftFields(t *testing.T) {
+	t.Parallel()
+
+	payload := `{
+		"id": "00000000-0000-0000-0000-000000000001",
+		"alias": "@person1",
+		"key": "default",
+		"accountId": "00000000-0000-0000-0000-000000000002",
+		"assetCode": "USD",
+		"available": 1500,
+		"onHold": 500,
+		"version": 3,
+		"accountType": "deposit",
+		"allowSending": 1,
+		"allowReceiving": 1,
+		"direction": "debit",
+		"overdraftUsed": "50.00",
+		"allowOverdraft": 1,
+		"overdraftLimitEnabled": 1,
+		"overdraftLimit": "500.00",
+		"balanceScope": "transactional"
+	}`
+
+	var br BalanceRedis
+	require.NoError(t, json.Unmarshal([]byte(payload), &br))
+
+	assert.Equal(t, "debit", br.Direction)
+	assert.Equal(t, "50.00", br.OverdraftUsed)
+	assert.Equal(t, 1, br.AllowOverdraft)
+	assert.Equal(t, 1, br.OverdraftLimitEnabled)
+	assert.Equal(t, "500.00", br.OverdraftLimit)
+	assert.Equal(t, "transactional", br.BalanceScope)
+}
+
+// TestBalanceRedis_UnmarshalJSON_OverdraftUsedFromFloat verifies that
+// numeric OverdraftUsed values (common when Lua emits a plain number) are
+// normalized into a decimal string, preserving the integer/decimal value.
+func TestBalanceRedis_UnmarshalJSON_OverdraftUsedFromFloat(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{name: "decimal value", input: "50.5", expected: "50.5"},
+		{name: "zero value", input: "0", expected: "0"},
+		{name: "integer value", input: "100", expected: "100"},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			payload := `{
+				"available": 0,
+				"onHold": 0,
+				"overdraftUsed": ` + tt.input + `
+			}`
+
+			var br BalanceRedis
+			require.NoError(t, json.Unmarshal([]byte(payload), &br))
+
+			assert.Equal(t, tt.expected, br.OverdraftUsed)
+		})
+	}
+}
+
+// TestBalanceRedis_UnmarshalJSON_OverdraftUsedFromNumber verifies that
+// the json.Number branch of parseDecimalString preserves the exact
+// textual representation supplied by the caller — the precision-safe
+// path for high-magnitude or high-precision decimals.
+func TestBalanceRedis_UnmarshalJSON_OverdraftUsedFromNumber(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    json.Number
+		expected string
+	}{
+		{name: "high precision decimal", input: json.Number("123.456789012345"), expected: "123.456789012345"},
+		{name: "large integer", input: json.Number("9999999999999999"), expected: "9999999999999999"},
+		{name: "small fractional", input: json.Number("0.000001"), expected: "0.000001"},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := parseDecimalString(tt.input, "0")
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}
+
+// TestBalanceRedis_UnmarshalJSON_MissingOverdraftFields verifies legacy
+// payloads (written before the overdraft feature) still decode cleanly,
+// with sensible defaults applied to the overdraft fields.
+func TestBalanceRedis_UnmarshalJSON_MissingOverdraftFields(t *testing.T) {
+	t.Parallel()
+
+	payload := `{
+		"id": "00000000-0000-0000-0000-000000000001",
+		"alias": "@legacy",
+		"accountId": "00000000-0000-0000-0000-000000000002",
+		"assetCode": "USD",
+		"available": 100,
+		"onHold": 0,
+		"version": 1,
+		"accountType": "deposit",
+		"allowSending": 1,
+		"allowReceiving": 1
+	}`
+
+	var br BalanceRedis
+	require.NoError(t, json.Unmarshal([]byte(payload), &br))
+
+	assert.Equal(t, "", br.Direction, "legacy payload must leave Direction empty")
+	assert.Equal(t, "0", br.OverdraftUsed, "missing overdraftUsed must default to \"0\"")
+	assert.Equal(t, 0, br.AllowOverdraft)
+	assert.Equal(t, 0, br.OverdraftLimitEnabled)
+	assert.Equal(t, "0", br.OverdraftLimit, "missing overdraftLimit must default to \"0\"")
+	assert.Equal(t, "", br.BalanceScope)
+}

--- a/pkg/utils/decimal.go
+++ b/pkg/utils/decimal.go
@@ -1,0 +1,34 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package utils
+
+import (
+	"encoding/json"
+
+	"github.com/shopspring/decimal"
+)
+
+// ParseDecimalString normalizes a value that may arrive as string, float64,
+// or json.Number into a plain decimal string. Returns defaultVal when v is
+// nil or of an unsupported type.
+//
+// This helper is typically used inside custom JSON unmarshalers where the
+// same numeric field can be emitted as a string (e.g. by Lua/Redis), a
+// float64 (standard JSON number), or json.Number (when the decoder is
+// configured with UseNumber). It preserves the exact textual representation
+// for string and json.Number inputs, and converts float64 via
+// decimal.NewFromFloat to avoid binary-float surprises in the output.
+func ParseDecimalString(v any, defaultVal string) string {
+	switch t := v.(type) {
+	case string:
+		return t
+	case float64:
+		return decimal.NewFromFloat(t).String()
+	case json.Number:
+		return t.String()
+	default:
+		return defaultVal
+	}
+}

--- a/pkg/utils/decimal_test.go
+++ b/pkg/utils/decimal_test.go
@@ -1,0 +1,120 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package utils
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestParseDecimalString_FromNumber verifies that the json.Number branch of
+// ParseDecimalString preserves the exact textual representation supplied by
+// the caller — the precision-safe path for high-magnitude or high-precision
+// decimals.
+func TestParseDecimalString_FromNumber(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    json.Number
+		expected string
+	}{
+		{name: "high precision decimal", input: json.Number("123.456789012345"), expected: "123.456789012345"},
+		{name: "large integer", input: json.Number("9999999999999999"), expected: "9999999999999999"},
+		{name: "small fractional", input: json.Number("0.000001"), expected: "0.000001"},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := ParseDecimalString(tt.input, "0")
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}
+
+// TestParseDecimalString_FromString verifies that string inputs are returned
+// verbatim, preserving the exact representation provided by the caller.
+func TestParseDecimalString_FromString(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{name: "plain integer", input: "100", expected: "100"},
+		{name: "decimal value", input: "50.25", expected: "50.25"},
+		{name: "zero", input: "0", expected: "0"},
+		{name: "high precision", input: "123.456789012345", expected: "123.456789012345"},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := ParseDecimalString(tt.input, "default")
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}
+
+// TestParseDecimalString_FromFloat64 verifies that float64 inputs are
+// normalized into a decimal string via shopspring/decimal.
+func TestParseDecimalString_FromFloat64(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    float64
+		expected string
+	}{
+		{name: "whole number", input: 100, expected: "100"},
+		{name: "decimal", input: 50.5, expected: "50.5"},
+		{name: "zero", input: 0, expected: "0"},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := ParseDecimalString(tt.input, "default")
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}
+
+// TestParseDecimalString_DefaultValue verifies that unsupported or nil
+// inputs fall through to the caller-provided default.
+func TestParseDecimalString_DefaultValue(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    any
+		expected string
+	}{
+		{name: "nil input", input: nil, expected: "0"},
+		{name: "int input", input: 42, expected: "0"},
+		{name: "bool input", input: true, expected: "0"},
+		{name: "struct input", input: struct{}{}, expected: "0"},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := ParseDecimalString(tt.input, "0")
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}


### PR DESCRIPTION
**Summary**

Extends the PostgreSQL adapter and Redis cache projection to persist and retrieve the overdraft fields (direction, overdraft_used, settings) introduced by the schema foundation PR. After this PR, the new columns are fully round-tripped through all CRUD paths and the cache-aside layer.

**What changed**

**PostgreSQL adapter (components/ledger/internal/adapters/postgres/balance/)**
- BalancePostgreSQLModel: added Direction, OverdraftUsed, Settings fields with db: tags
- FromEntity: maps domain model to DB model, marshals *BalanceSettings to JSONB bytes (nil-safe, safe to discard marshal error since BalanceSettings contains only JSON-safe primitives)
- ToEntity: maps DB model back to domain model, unmarshals JSONB bytes to *BalanceSettings (nil/empty bytes produce nil Settings, not a parse error)
- balanceColumnList: expanded with 3 new columns
- All ~10 Scan sites updated consistently to include the new fields
- Create method Values() clause includes the 3 new fields
- FindByAccountIDAndKey hardcoded SQL updated to include new columns + scan
- Update RETURNING clause updated to include new columns + scan
- BalancesUpdate and UpdateMany intentionally NOT updated — they only sync available/on_hold/version; overdraft_used sync will be added when the cache script extension lands (documented in code comments)
Redis cache projection (pkg/mmodel/balance.go)
- BalanceRedis: added 6 flattened fields for Lua script consumption — Direction (string), OverdraftUsed (string), 
AllowOverdraft (int 1/0), OverdraftLimitEnabled (int 1/0), OverdraftLimit (string), BalanceScope (string)
- UnmarshalJSON: extended to handle OverdraftUsed from string/float64/json.Number using a new parseDecimalString helper (same multi-type pattern as Available/OnHold)
- Defaults for missing fields: OverdraftUsed and OverdraftLimit default to "0" for backwards compatibility with cached entries that predate the overdraft feature

**What's NOT included**

- HTTP handler changes (settings configuration, scope protection) — next PR
- Transaction enrichment (debit split, credit repayment)
- Cache script (Lua) changes
- UpdateMany/BalancesUpdate overdraft_used sync (lands with cache script extension)

**Testing**

- Unit tests for FromEntity/ToEntity mapping (both directions, nil/empty Settings, JSONB round-trip) — 100% coverage on new mapper code
- Unit tests for BalanceRedis overdraft fields, UnmarshalJSON from string/float/json.Number, missing field defaults
- balanceColumnList inclusion test for the 3 new columns
- Integration tests (from foundation PR) cover real PostgreSQL round-trip: schema defaults, JSONB persistence, direction persistence, batch update, nil settings, alias queries