### PR TITLE
feat: Balance Overdraft: Settings Configuration, Auto-Creation + Scope Protection

### DIFF
--- a/components/ledger/internal/services/command/create_balance_additional.go
+++ b/components/ledger/internal/services/command/create_balance_additional.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"reflect"
 	"strings"
 	"time"
 
@@ -34,9 +33,9 @@ func (uc *UseCase) CreateAdditionalBalance(ctx context.Context, organizationID, 
 	// repository call so a rejected request never touches persistence.
 	if strings.EqualFold(cbi.Key, constant.OverdraftBalanceKey) {
 		libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Reserved balance key", nil)
-		logger.Log(ctx, libLog.LevelWarn, fmt.Sprintf("Rejected reserved balance key: %v", cbi.Key))
+		logger.Log(ctx, libLog.LevelWarn, "Rejected reserved balance key", libLog.String("key", cbi.Key))
 
-		return nil, pkg.ValidateBusinessError(constant.ErrReservedBalanceKey, reflect.TypeOf(mmodel.Balance{}).Name(), cbi.Key)
+		return nil, pkg.ValidateBusinessError(constant.ErrReservedBalanceKey, constant.EntityBalance, cbi.Key)
 	}
 
 	// Direction validation runs before any repository call so invalid
@@ -48,9 +47,9 @@ func (uc *UseCase) CreateAdditionalBalance(ctx context.Context, organizationID, 
 			// valid
 		default:
 			libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Invalid balance direction", nil)
-			logger.Log(ctx, libLog.LevelWarn, fmt.Sprintf("Rejected invalid direction: %v", *cbi.Direction))
+			logger.Log(ctx, libLog.LevelWarn, "Rejected invalid balance direction", libLog.String("direction", *cbi.Direction))
 
-			return nil, pkg.ValidateBusinessError(constant.ErrInvalidBalanceDirection, reflect.TypeOf(mmodel.Balance{}).Name(), *cbi.Direction)
+			return nil, pkg.ValidateBusinessError(constant.ErrInvalidBalanceDirection, constant.EntityBalance, *cbi.Direction)
 		}
 	}
 
@@ -59,9 +58,9 @@ func (uc *UseCase) CreateAdditionalBalance(ctx context.Context, organizationID, 
 	if cbi.Settings != nil {
 		if err := cbi.Settings.Validate(); err != nil {
 			libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Invalid balance settings", err)
-			logger.Log(ctx, libLog.LevelWarn, fmt.Sprintf("Rejected invalid balance settings: %v", err))
+			logger.Log(ctx, libLog.LevelWarn, "Rejected invalid balance settings", libLog.Err(err))
 
-			return nil, pkg.ValidateBusinessError(constant.ErrInvalidBalanceSettings, reflect.TypeOf(mmodel.Balance{}).Name())
+			return nil, pkg.ValidateBusinessError(constant.ErrInvalidBalanceSettings, constant.EntityBalance)
 		}
 	}
 
@@ -71,9 +70,9 @@ func (uc *UseCase) CreateAdditionalBalance(ctx context.Context, organizationID, 
 	// those are permanently undeletable and bypass normal controls.
 	if cbi.Settings != nil && cbi.Settings.BalanceScope == mmodel.BalanceScopeInternal {
 		libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Reserved balance scope", nil)
-		logger.Log(ctx, libLog.LevelWarn, fmt.Sprintf("Rejected reserved balance scope: %v", cbi.Settings.BalanceScope))
+		logger.Log(ctx, libLog.LevelWarn, "Rejected reserved balance scope", libLog.String("scope", cbi.Settings.BalanceScope))
 
-		return nil, pkg.ValidateBusinessError(constant.ErrInvalidBalanceSettings, reflect.TypeOf(mmodel.Balance{}).Name())
+		return nil, pkg.ValidateBusinessError(constant.ErrInvalidBalanceSettings, constant.EntityBalance)
 	}
 
 	existingBalance, err := uc.BalanceRepo.FindByAccountIDAndKey(ctx, organizationID, ledgerID, accountID, strings.ToLower(cbi.Key))
@@ -93,7 +92,7 @@ func (uc *UseCase) CreateAdditionalBalance(ctx context.Context, organizationID, 
 
 		logger.Log(ctx, libLog.LevelInfo, fmt.Sprintf("Additional balance already exists: %v", cbi.Key))
 
-		return nil, pkg.ValidateBusinessError(constant.ErrDuplicatedAliasKeyValue, reflect.TypeOf(mmodel.Balance{}).Name(), cbi.Key)
+		return nil, pkg.ValidateBusinessError(constant.ErrDuplicatedAliasKeyValue, constant.EntityBalance, cbi.Key)
 	}
 
 	defaultBalance, err := uc.BalanceRepo.FindByAccountIDAndKey(ctx, organizationID, ledgerID, accountID, constant.DefaultBalanceKey)
@@ -108,7 +107,7 @@ func (uc *UseCase) CreateAdditionalBalance(ctx context.Context, organizationID, 
 	if defaultBalance.AccountType == constant.ExternalAccountType {
 		libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Additional balance not allowed for external account type", nil)
 
-		return nil, pkg.ValidateBusinessError(constant.ErrAdditionalBalanceNotAllowed, reflect.TypeOf(mmodel.Balance{}).Name(), defaultBalance.Alias)
+		return nil, pkg.ValidateBusinessError(constant.ErrAdditionalBalanceNotAllowed, constant.EntityBalance, defaultBalance.Alias)
 	}
 
 	// Direction defaults to "credit" when the caller omits it. Validation

--- a/components/ledger/internal/services/command/create_balance_additional.go
+++ b/components/ledger/internal/services/command/create_balance_additional.go
@@ -29,6 +29,53 @@ func (uc *UseCase) CreateAdditionalBalance(ctx context.Context, organizationID, 
 	ctx, span := tracer.Start(ctx, "command.create_additional_balance")
 	defer span.End()
 
+	// Reserved key guard: "overdraft" (any case) is system-managed and MUST
+	// not be created through the public API. This check runs BEFORE any
+	// repository call so a rejected request never touches persistence.
+	if strings.EqualFold(cbi.Key, constant.OverdraftBalanceKey) {
+		libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Reserved balance key", nil)
+		logger.Log(ctx, libLog.LevelWarn, fmt.Sprintf("Rejected reserved balance key: %v", cbi.Key))
+
+		return nil, pkg.ValidateBusinessError(constant.ErrReservedBalanceKey, reflect.TypeOf(mmodel.Balance{}).Name(), cbi.Key)
+	}
+
+	// Direction validation runs before any repository call so invalid
+	// payloads never touch persistence. Nil Direction is allowed and
+	// defaults to "credit" at construction time below.
+	if cbi.Direction != nil {
+		switch *cbi.Direction {
+		case constant.DirectionCredit, constant.DirectionDebit:
+			// valid
+		default:
+			libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Invalid balance direction", nil)
+			logger.Log(ctx, libLog.LevelWarn, fmt.Sprintf("Rejected invalid direction: %v", *cbi.Direction))
+
+			return nil, pkg.ValidateBusinessError(constant.ErrInvalidBalanceDirection, reflect.TypeOf(mmodel.Balance{}).Name(), *cbi.Direction)
+		}
+	}
+
+	// Settings validation also runs pre-persistence to keep the repository
+	// free of corrupt payloads.
+	if cbi.Settings != nil {
+		if err := cbi.Settings.Validate(); err != nil {
+			libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Invalid balance settings", err)
+			logger.Log(ctx, libLog.LevelWarn, fmt.Sprintf("Rejected invalid balance settings: %v", err))
+
+			return nil, pkg.ValidateBusinessError(constant.ErrInvalidBalanceSettings, reflect.TypeOf(mmodel.Balance{}).Name())
+		}
+	}
+
+	// Reserved scope guard: "internal" is reserved for system-managed
+	// balances (e.g., the auto-created overdraft balance). A client-facing
+	// request MUST NOT be able to create an internal-scoped balance —
+	// those are permanently undeletable and bypass normal controls.
+	if cbi.Settings != nil && cbi.Settings.BalanceScope == mmodel.BalanceScopeInternal {
+		libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Reserved balance scope", nil)
+		logger.Log(ctx, libLog.LevelWarn, fmt.Sprintf("Rejected reserved balance scope: %v", cbi.Settings.BalanceScope))
+
+		return nil, pkg.ValidateBusinessError(constant.ErrInvalidBalanceSettings, reflect.TypeOf(mmodel.Balance{}).Name())
+	}
+
 	existingBalance, err := uc.BalanceRepo.FindByAccountIDAndKey(ctx, organizationID, ledgerID, accountID, strings.ToLower(cbi.Key))
 	if err != nil {
 		var notFound pkg.EntityNotFoundError
@@ -64,6 +111,14 @@ func (uc *UseCase) CreateAdditionalBalance(ctx context.Context, organizationID, 
 		return nil, pkg.ValidateBusinessError(constant.ErrAdditionalBalanceNotAllowed, reflect.TypeOf(mmodel.Balance{}).Name(), defaultBalance.Alias)
 	}
 
+	// Direction defaults to "credit" when the caller omits it. Validation
+	// above guarantees that any provided value is one of the supported
+	// enum members.
+	direction := constant.DirectionCredit
+	if cbi.Direction != nil {
+		direction = *cbi.Direction
+	}
+
 	additionalBalance := &mmodel.Balance{
 		ID:             uuid.Must(libCommons.GenerateUUIDv7()).String(),
 		Alias:          defaultBalance.Alias,
@@ -75,6 +130,8 @@ func (uc *UseCase) CreateAdditionalBalance(ctx context.Context, organizationID, 
 		AccountType:    defaultBalance.AccountType,
 		AllowSending:   cbi.AllowSending == nil || *cbi.AllowSending,
 		AllowReceiving: cbi.AllowReceiving == nil || *cbi.AllowReceiving,
+		Direction:      direction,
+		Settings:       cbi.Settings,
 		CreatedAt:      time.Now(),
 		UpdatedAt:      time.Now(),
 	}

--- a/components/ledger/internal/services/command/create_balance_overdraft_test.go
+++ b/components/ledger/internal/services/command/create_balance_overdraft_test.go
@@ -1,0 +1,239 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package command
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/LerianStudio/midaz/v3/components/ledger/internal/adapters/postgres/balance"
+	"github.com/LerianStudio/midaz/v3/pkg"
+	"github.com/LerianStudio/midaz/v3/pkg/constant"
+	"github.com/LerianStudio/midaz/v3/pkg/mmodel"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+// defaultBalanceForOverdraft builds a default balance fixture used as the
+// reference account for additional-balance creation in these tests.
+func defaultBalanceForOverdraft(orgID, ledgerID, accountID uuid.UUID, alias string) *mmodel.Balance {
+	return &mmodel.Balance{
+		ID:             uuid.New().String(),
+		Alias:          alias,
+		Key:            constant.DefaultBalanceKey,
+		OrganizationID: orgID.String(),
+		LedgerID:       ledgerID.String(),
+		AccountID:      accountID.String(),
+		AssetCode:      "USD",
+		AccountType:    "deposit",
+		AllowSending:   true,
+		AllowReceiving: true,
+	}
+}
+
+// TestCreateAdditionalBalance_WithDirection verifies that when the caller
+// provides Direction="debit", the created balance carries that direction
+// instead of the default "credit".
+func TestCreateAdditionalBalance_WithDirection(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
+	ctx := context.Background()
+	orgID := uuid.New()
+	ledgerID := uuid.New()
+	accountID := uuid.New()
+	alias := "@debit-holder"
+
+	direction := constant.DirectionDebit
+	allow := true
+
+	cbi := &mmodel.CreateAdditionalBalance{
+		Key:            "savings",
+		AllowSending:   &allow,
+		AllowReceiving: &allow,
+		Direction:      &direction,
+	}
+
+	mockBalanceRepo := balance.NewMockRepository(ctrl)
+
+	mockBalanceRepo.EXPECT().
+		FindByAccountIDAndKey(gomock.Any(), orgID, ledgerID, accountID, "savings").
+		Return(nil, pkg.ValidateBusinessError(constant.ErrEntityNotFound, reflect.TypeOf(mmodel.Balance{}).Name())).
+		Times(1)
+
+	mockBalanceRepo.EXPECT().
+		FindByAccountIDAndKey(gomock.Any(), orgID, ledgerID, accountID, constant.DefaultBalanceKey).
+		Return(defaultBalanceForOverdraft(orgID, ledgerID, accountID, alias), nil).
+		Times(1)
+
+	mockBalanceRepo.EXPECT().
+		Create(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, b *mmodel.Balance) (*mmodel.Balance, error) {
+			assert.Equal(t, constant.DirectionDebit, b.Direction,
+				"created balance MUST carry the requested direction")
+			return b, nil
+		}).
+		Times(1)
+
+	uc := &UseCase{BalanceRepo: mockBalanceRepo}
+
+	result, err := uc.CreateAdditionalBalance(ctx, orgID, ledgerID, accountID, cbi)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, constant.DirectionDebit, result.Direction,
+		"returned balance MUST expose the requested direction")
+}
+
+// TestCreateAdditionalBalance_DefaultDirection verifies that when Direction
+// is omitted from the request, the created balance defaults to "credit".
+func TestCreateAdditionalBalance_DefaultDirection(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
+	ctx := context.Background()
+	orgID := uuid.New()
+	ledgerID := uuid.New()
+	accountID := uuid.New()
+	alias := "@default-direction"
+
+	allow := true
+
+	cbi := &mmodel.CreateAdditionalBalance{
+		Key:            "reserve",
+		AllowSending:   &allow,
+		AllowReceiving: &allow,
+		// Direction intentionally nil
+	}
+
+	mockBalanceRepo := balance.NewMockRepository(ctrl)
+
+	mockBalanceRepo.EXPECT().
+		FindByAccountIDAndKey(gomock.Any(), orgID, ledgerID, accountID, "reserve").
+		Return(nil, pkg.ValidateBusinessError(constant.ErrEntityNotFound, reflect.TypeOf(mmodel.Balance{}).Name())).
+		Times(1)
+
+	mockBalanceRepo.EXPECT().
+		FindByAccountIDAndKey(gomock.Any(), orgID, ledgerID, accountID, constant.DefaultBalanceKey).
+		Return(defaultBalanceForOverdraft(orgID, ledgerID, accountID, alias), nil).
+		Times(1)
+
+	mockBalanceRepo.EXPECT().
+		Create(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, b *mmodel.Balance) (*mmodel.Balance, error) {
+			assert.Equal(t, constant.DirectionCredit, b.Direction,
+				"missing direction MUST default to credit")
+			return b, nil
+		}).
+		Times(1)
+
+	uc := &UseCase{BalanceRepo: mockBalanceRepo}
+
+	result, err := uc.CreateAdditionalBalance(ctx, orgID, ledgerID, accountID, cbi)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, constant.DirectionCredit, result.Direction,
+		"returned balance MUST default to credit")
+}
+
+// TestCreateAdditionalBalance_InvalidDirection verifies that supplying an
+// unsupported direction returns a validation error before any persistence
+// is attempted.
+func TestCreateAdditionalBalance_InvalidDirection(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
+	ctx := context.Background()
+	orgID := uuid.New()
+	ledgerID := uuid.New()
+	accountID := uuid.New()
+
+	invalid := "sideways"
+	allow := true
+
+	cbi := &mmodel.CreateAdditionalBalance{
+		Key:            "weird",
+		AllowSending:   &allow,
+		AllowReceiving: &allow,
+		Direction:      &invalid,
+	}
+
+	mockBalanceRepo := balance.NewMockRepository(ctrl)
+
+	// Create MUST NOT be called when direction is invalid.
+	mockBalanceRepo.EXPECT().
+		Create(gomock.Any(), gomock.Any()).
+		Times(0)
+
+	uc := &UseCase{BalanceRepo: mockBalanceRepo}
+
+	result, err := uc.CreateAdditionalBalance(ctx, orgID, ledgerID, accountID, cbi)
+
+	require.Error(t, err, "invalid direction MUST return an error")
+	assert.Nil(t, result, "no balance should be returned on validation failure")
+}
+
+// TestCreateAdditionalBalance_ReservedKey verifies that the reserved
+// "overdraft" key cannot be created through the public API — it is
+// exclusively managed by the system when overdraft is enabled.
+func TestCreateAdditionalBalance_ReservedKey(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
+	ctx := context.Background()
+	orgID := uuid.New()
+	ledgerID := uuid.New()
+	accountID := uuid.New()
+
+	allow := true
+
+	cases := []struct {
+		name string
+		key  string
+	}{
+		{name: "lowercase", key: "overdraft"},
+		{name: "uppercase", key: "OVERDRAFT"},
+		{name: "mixed case", key: "Overdraft"},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			cbi := &mmodel.CreateAdditionalBalance{
+				Key:            tc.key,
+				AllowSending:   &allow,
+				AllowReceiving: &allow,
+			}
+
+			mockBalanceRepo := balance.NewMockRepository(ctrl)
+
+			// Create MUST NOT be invoked for the reserved key.
+			mockBalanceRepo.EXPECT().
+				Create(gomock.Any(), gomock.Any()).
+				Times(0)
+
+			uc := &UseCase{BalanceRepo: mockBalanceRepo}
+
+			result, err := uc.CreateAdditionalBalance(ctx, orgID, ledgerID, accountID, cbi)
+
+			require.Error(t, err, "reserved key MUST be rejected")
+			assert.Nil(t, result, "no balance should be returned when key is reserved")
+		})
+	}
+}

--- a/components/ledger/internal/services/command/create_balance_overdraft_test.go
+++ b/components/ledger/internal/services/command/create_balance_overdraft_test.go
@@ -6,7 +6,6 @@ package command
 
 import (
 	"context"
-	"reflect"
 	"testing"
 
 	"github.com/LerianStudio/midaz/v3/components/ledger/internal/adapters/postgres/balance"
@@ -65,7 +64,7 @@ func TestCreateAdditionalBalance_WithDirection(t *testing.T) {
 
 	mockBalanceRepo.EXPECT().
 		FindByAccountIDAndKey(gomock.Any(), orgID, ledgerID, accountID, "savings").
-		Return(nil, pkg.ValidateBusinessError(constant.ErrEntityNotFound, reflect.TypeOf(mmodel.Balance{}).Name())).
+		Return(nil, pkg.ValidateBusinessError(constant.ErrEntityNotFound, constant.EntityBalance)).
 		Times(1)
 
 	mockBalanceRepo.EXPECT().
@@ -119,7 +118,7 @@ func TestCreateAdditionalBalance_DefaultDirection(t *testing.T) {
 
 	mockBalanceRepo.EXPECT().
 		FindByAccountIDAndKey(gomock.Any(), orgID, ledgerID, accountID, "reserve").
-		Return(nil, pkg.ValidateBusinessError(constant.ErrEntityNotFound, reflect.TypeOf(mmodel.Balance{}).Name())).
+		Return(nil, pkg.ValidateBusinessError(constant.ErrEntityNotFound, constant.EntityBalance)).
 		Times(1)
 
 	mockBalanceRepo.EXPECT().
@@ -236,4 +235,36 @@ func TestCreateAdditionalBalance_ReservedKey(t *testing.T) {
 			assert.Nil(t, result, "no balance should be returned when key is reserved")
 		})
 	}
+}
+
+// TestCreateAdditionalBalance_RejectsInternalScope verifies that clients
+// cannot create balances with balanceScope="internal" through the public API.
+func TestCreateAdditionalBalance_RejectsInternalScope(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ctx := context.Background()
+	orgID := uuid.New()
+	ledgerID := uuid.New()
+	accountID := uuid.New()
+
+	mockBalanceRepo := balance.NewMockRepository(ctrl)
+
+	cbi := &mmodel.CreateAdditionalBalance{
+		Key: "savings",
+		Settings: &mmodel.BalanceSettings{
+			BalanceScope: mmodel.BalanceScopeInternal,
+		},
+	}
+
+	uc := &UseCase{BalanceRepo: mockBalanceRepo}
+
+	result, err := uc.CreateAdditionalBalance(ctx, orgID, ledgerID, accountID, cbi)
+
+	require.Error(t, err, "internal scope MUST be rejected on client creation")
+	assert.Nil(t, result, "no balance should be returned when scope is internal")
+	assert.Contains(t, err.Error(), constant.ErrInvalidBalanceSettings.Error(),
+		"error must reference the invalid-settings code")
 }

--- a/components/ledger/internal/services/command/create_balance_transaction_operations_async.go
+++ b/components/ledger/internal/services/command/create_balance_transaction_operations_async.go
@@ -20,6 +20,7 @@ import (
 	mongodb "github.com/LerianStudio/midaz/v3/components/ledger/internal/adapters/mongodb/transaction"
 	"github.com/LerianStudio/midaz/v3/components/ledger/internal/adapters/postgres/operation"
 	"github.com/LerianStudio/midaz/v3/components/ledger/internal/adapters/postgres/transaction"
+	"github.com/LerianStudio/midaz/v3/pkg"
 	"github.com/LerianStudio/midaz/v3/pkg/constant"
 	"github.com/LerianStudio/midaz/v3/pkg/mmodel"
 	"github.com/LerianStudio/midaz/v3/pkg/mtransaction"
@@ -307,6 +308,20 @@ func (uc *UseCase) RemoveTransactionFromRedisQueueIfStatus(ctx context.Context, 
 func (uc *UseCase) SendTransactionToRedisQueue(ctx context.Context, organizationID, ledgerID, transactionID uuid.UUID, transactionInput mtransaction.Transaction, validate *mtransaction.Responses, transactionStatus, action string, transactionDate time.Time, balances []*mmodel.Balance) error {
 	logger, _, reqId, _ := libCommons.NewTrackingFromContext(ctx)
 	transactionKey := utils.TransactionInternalKey(organizationID, ledgerID, transactionID.String())
+
+	// Scope protection: a transaction that targets any internal-scope
+	// balance (e.g. auto-created overdraft reserves) MUST be rejected
+	// BEFORE the transaction is published to the Redis queue. This keeps
+	// system-managed balances out of the user-initiated mutation path
+	// across every entry point (HTTP, gRPC, DSL).
+	for _, b := range balances {
+		if b != nil && b.Settings != nil && b.Settings.BalanceScope == mmodel.BalanceScopeInternal {
+			err := pkg.ValidateBusinessError(constant.ErrDirectOperationOnInternalBalance, reflect.TypeOf(mmodel.Balance{}).Name(), b.Alias)
+			logger.Log(ctx, libLog.LevelWarn, fmt.Sprintf("Rejected transaction targeting internal balance alias=%s key=%s", b.Alias, b.Key))
+
+			return err
+		}
+	}
 
 	utils.SanitizeAccountAliases(&transactionInput)
 

--- a/components/ledger/internal/services/command/create_balance_transaction_operations_async.go
+++ b/components/ledger/internal/services/command/create_balance_transaction_operations_async.go
@@ -316,7 +316,7 @@ func (uc *UseCase) SendTransactionToRedisQueue(ctx context.Context, organization
 	// across every entry point (HTTP, gRPC, DSL).
 	for _, b := range balances {
 		if b != nil && b.Settings != nil && b.Settings.BalanceScope == mmodel.BalanceScopeInternal {
-			err := pkg.ValidateBusinessError(constant.ErrDirectOperationOnInternalBalance, reflect.TypeOf(mmodel.Balance{}).Name(), b.Alias)
+			err := pkg.ValidateBusinessError(constant.ErrDirectOperationOnInternalBalance, constant.EntityBalance, b.Alias)
 			logger.Log(ctx, libLog.LevelWarn, fmt.Sprintf("Rejected transaction targeting internal balance alias=%s key=%s", b.Alias, b.Key))
 
 			return err

--- a/components/ledger/internal/services/command/delete_balance.go
+++ b/components/ledger/internal/services/command/delete_balance.go
@@ -12,6 +12,7 @@ import (
 	libOpentelemetry "github.com/LerianStudio/lib-commons/v4/commons/opentelemetry"
 	"github.com/LerianStudio/midaz/v3/pkg"
 	"github.com/LerianStudio/midaz/v3/pkg/constant"
+	"github.com/LerianStudio/midaz/v3/pkg/mmodel"
 	"github.com/google/uuid"
 
 	// DeleteBalance delete balance in the repository.
@@ -31,6 +32,18 @@ func (uc *UseCase) DeleteBalance(ctx context.Context, organizationID, ledgerID, 
 		libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Failed to get balance on repo by id", err)
 
 		logger.Log(ctx, libLog.LevelError, fmt.Sprintf("Error getting balance: %v", err))
+
+		return err
+	}
+
+	// Scope protection: internal-scope balances are managed exclusively by
+	// the system (e.g. overdraft reserves) and cannot be deleted via the
+	// public API. This guard runs BEFORE the funds-check so the caller
+	// receives the specific 0169 code instead of a generic validation.
+	if balance != nil && balance.Settings != nil && balance.Settings.BalanceScope == mmodel.BalanceScopeInternal {
+		err = pkg.ValidateBusinessError(constant.ErrDeletionOfInternalBalance, "DeleteBalance")
+		libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Internal-scope balance cannot be deleted", err)
+		logger.Log(ctx, libLog.LevelWarn, fmt.Sprintf("Error deleting internal balance: %v", err))
 
 		return err
 	}

--- a/components/ledger/internal/services/command/delete_balance.go
+++ b/components/ledger/internal/services/command/delete_balance.go
@@ -41,15 +41,15 @@ func (uc *UseCase) DeleteBalance(ctx context.Context, organizationID, ledgerID, 
 	// public API. This guard runs BEFORE the funds-check so the caller
 	// receives the specific 0169 code instead of a generic validation.
 	if balance != nil && balance.Settings != nil && balance.Settings.BalanceScope == mmodel.BalanceScopeInternal {
-		err = pkg.ValidateBusinessError(constant.ErrDeletionOfInternalBalance, "DeleteBalance")
+		err = pkg.ValidateBusinessError(constant.ErrDeletionOfInternalBalance, constant.EntityBalance)
 		libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Internal-scope balance cannot be deleted", err)
-		logger.Log(ctx, libLog.LevelWarn, fmt.Sprintf("Error deleting internal balance: %v", err))
+		logger.Log(ctx, libLog.LevelWarn, "Rejected deletion of internal-scope balance", libLog.Err(err))
 
 		return err
 	}
 
 	if balance != nil && (!balance.Available.IsZero() || !balance.OnHold.IsZero()) {
-		err = pkg.ValidateBusinessError(constant.ErrBalancesCantBeDeleted, "DeleteBalance")
+		err = pkg.ValidateBusinessError(constant.ErrBalancesCantBeDeleted, constant.EntityBalance)
 		libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Balance cannot be deleted because it still has funds in it.", err)
 		logger.Log(ctx, libLog.LevelWarn, fmt.Sprintf("Error deleting balance: %v", err))
 

--- a/components/ledger/internal/services/command/scope_protection_test.go
+++ b/components/ledger/internal/services/command/scope_protection_test.go
@@ -1,0 +1,169 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package command
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	libCommons "github.com/LerianStudio/lib-commons/v4/commons"
+	"github.com/LerianStudio/midaz/v3/components/ledger/internal/adapters/postgres/balance"
+	redis "github.com/LerianStudio/midaz/v3/components/ledger/internal/adapters/redis/transaction"
+	"github.com/LerianStudio/midaz/v3/pkg"
+	"github.com/LerianStudio/midaz/v3/pkg/constant"
+	"github.com/LerianStudio/midaz/v3/pkg/mmodel"
+	"github.com/LerianStudio/midaz/v3/pkg/mtransaction"
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+// TestTransactionCreate_RejectsInternalBalance verifies that a transaction
+// which targets a balance whose scope is "internal" is rejected with
+// ErrDirectOperationOnInternalBalance (0168) BEFORE it is published to the
+// Redis transaction queue.
+//
+// The scope guard protects system-managed balances (e.g. overdraft reserves)
+// from client-initiated operations. Enforcement lives in the transaction
+// command use case so that every entry point — HTTP, gRPC, DSL — benefits
+// from the same guarantee.
+func TestTransactionCreate_RejectsInternalBalance(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
+	orgID := uuid.Must(libCommons.GenerateUUIDv7())
+	ledgerID := uuid.Must(libCommons.GenerateUUIDv7())
+	transactionID := uuid.Must(libCommons.GenerateUUIDv7())
+
+	internalBalance := &mmodel.Balance{
+		ID:             uuid.New().String(),
+		OrganizationID: orgID.String(),
+		LedgerID:       ledgerID.String(),
+		AccountID:      uuid.New().String(),
+		Alias:          "@indebted",
+		Key:            "overdraft",
+		AssetCode:      "USD",
+		Direction:      constant.DirectionDebit,
+		Available:      decimal.NewFromInt(0),
+		OnHold:         decimal.NewFromInt(0),
+		Version:        1,
+		Settings: &mmodel.BalanceSettings{
+			BalanceScope: mmodel.BalanceScopeInternal,
+		},
+	}
+
+	mockBalanceRepo := balance.NewMockRepository(ctrl)
+	mockRedisRepo := redis.NewMockRedisRepository(ctrl)
+
+	// The scope guard MUST run BEFORE any Redis queue publishing.
+	mockRedisRepo.EXPECT().
+		AddMessageToQueue(gomock.Any(), gomock.Any(), gomock.Any()).
+		Times(0)
+
+	uc := UseCase{
+		BalanceRepo:          mockBalanceRepo,
+		TransactionRedisRepo: mockRedisRepo,
+	}
+
+	// Transaction targeting the overdraft (internal) balance.
+	validate := &mtransaction.Responses{
+		From: map[string]mtransaction.Amount{
+			"@indebted#overdraft": {
+				Value:           decimal.NewFromInt(100),
+				Operation:       "DEBIT",
+				TransactionType: "CREATED",
+			},
+		},
+	}
+
+	input := mtransaction.Transaction{
+		ChartOfAccountsGroupName: "test",
+	}
+
+	// When the resolved balance slice contains an internal-scope balance,
+	// the use case MUST refuse to enqueue the transaction and surface the
+	// 0168 error.
+	err := uc.SendTransactionToRedisQueue(
+		context.TODO(),
+		orgID,
+		ledgerID,
+		transactionID,
+		input,
+		validate,
+		constant.CREATED,
+		"CREATED",
+		time.Now(),
+		[]*mmodel.Balance{internalBalance},
+	)
+
+	require.Error(t, err, "transactions against an internal balance MUST be rejected")
+
+	var vErr pkg.UnprocessableOperationError
+	require.True(t, errors.As(err, &vErr),
+		"scope protection MUST surface an UnprocessableOperationError")
+	assert.Equal(t, constant.ErrDirectOperationOnInternalBalance.Error(), vErr.Code,
+		"error code MUST be 0168 (ErrDirectOperationOnInternalBalance)")
+}
+
+// TestBalanceDelete_RejectsInternalBalance verifies that attempting to delete
+// a balance whose scope is "internal" is rejected with
+// ErrDeletionOfInternalBalance (0169) BEFORE the repository Delete is called.
+func TestBalanceDelete_RejectsInternalBalance(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
+	orgID := uuid.Must(libCommons.GenerateUUIDv7())
+	ledgerID := uuid.Must(libCommons.GenerateUUIDv7())
+	balanceID := uuid.Must(libCommons.GenerateUUIDv7())
+
+	internalBalance := &mmodel.Balance{
+		ID:             balanceID.String(),
+		OrganizationID: orgID.String(),
+		LedgerID:       ledgerID.String(),
+		AccountID:      uuid.New().String(),
+		Alias:          "@indebted",
+		Key:            "overdraft",
+		Available:      decimal.Zero,
+		OnHold:         decimal.Zero,
+		Direction:      constant.DirectionDebit,
+		Settings: &mmodel.BalanceSettings{
+			BalanceScope: mmodel.BalanceScopeInternal,
+		},
+	}
+
+	mockBalanceRepo := balance.NewMockRepository(ctrl)
+
+	mockBalanceRepo.EXPECT().
+		Find(gomock.Any(), orgID, ledgerID, balanceID).
+		Return(internalBalance, nil).
+		Times(1)
+
+	// Delete MUST NOT be invoked for internal-scope balances.
+	mockBalanceRepo.EXPECT().
+		Delete(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Times(0)
+
+	uc := UseCase{
+		BalanceRepo: mockBalanceRepo,
+	}
+
+	err := uc.DeleteBalance(context.TODO(), orgID, ledgerID, balanceID)
+
+	require.Error(t, err, "deleting an internal-scope balance MUST be rejected")
+
+	var vErr pkg.UnprocessableOperationError
+	require.True(t, errors.As(err, &vErr),
+		"scope protection MUST surface an UnprocessableOperationError")
+	assert.Equal(t, constant.ErrDeletionOfInternalBalance.Error(), vErr.Code,
+		"error code MUST be 0169 (ErrDeletionOfInternalBalance)")
+}

--- a/components/ledger/internal/services/command/update_balance.go
+++ b/components/ledger/internal/services/command/update_balance.go
@@ -112,6 +112,17 @@ func (uc *UseCase) UpdateBalances(ctx context.Context, organizationID, ledgerID 
 
 // Update balance in the repository and returns the updated balance.
 // Overlays Redis cached values for Available, OnHold, and Version to ensure freshest data.
+//
+// When update.Settings is non-nil, the use case:
+//  1. Validates the Settings payload (HARD GATE — fails closed, no partial writes).
+//  2. Loads the current balance to enforce overdraft transition invariants:
+//     - disable-with-debt is rejected
+//     - reducing limit below current usage is rejected
+//  3. Auto-creates the system-managed "overdraft" balance on a false→true
+//     transition (idempotent — existing overdraft balances are reused).
+//
+// When update.Settings is nil, legacy behaviour is preserved: no Find call,
+// no settings validation, no auto-creation.
 func (uc *UseCase) Update(ctx context.Context, organizationID, ledgerID, balanceID uuid.UUID, update mmodel.UpdateBalance) (*mmodel.Balance, error) {
 	logger, tracer, _, _ := libCommons.NewTrackingFromContext(ctx)
 
@@ -119,6 +130,40 @@ func (uc *UseCase) Update(ctx context.Context, organizationID, ledgerID, balance
 	defer span.End()
 
 	logger.Log(ctx, libLog.LevelInfo, "Trying to update balance")
+
+	var current *mmodel.Balance
+
+	if update.Settings != nil {
+		if err := validateUpdateSettings(ctx, logger, span, update.Settings); err != nil {
+			return nil, err
+		}
+
+		existing, err := uc.BalanceRepo.Find(ctx, organizationID, ledgerID, balanceID)
+		if err != nil {
+			libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Failed to fetch current balance for settings update", err)
+			logger.Log(ctx, libLog.LevelError, fmt.Sprintf("Error fetching current balance: %v", err))
+
+			return nil, err
+		}
+
+		if err := enforceOverdraftTransition(ctx, logger, span, existing, update.Settings); err != nil {
+			return nil, err
+		}
+
+		current = existing
+	}
+
+	// Auto-create the system-managed overdraft balance BEFORE persisting
+	// the settings update. If auto-creation fails (e.g., Create returns a
+	// database error), the parent balance's settings MUST NOT have been
+	// mutated — this keeps the pair (parent.AllowOverdraft, overdraft
+	// balance) consistent on failure. Guarded so the path only runs when
+	// the caller actually provided new settings.
+	if update.Settings != nil {
+		if err := uc.ensureOverdraftBalance(ctx, logger, span, organizationID, ledgerID, current, update.Settings); err != nil {
+			return nil, err
+		}
+	}
 
 	balance, err := uc.BalanceRepo.Update(ctx, organizationID, ledgerID, balanceID, update)
 	if err != nil {

--- a/components/ledger/internal/services/command/update_balance_auto_overdraft_test.go
+++ b/components/ledger/internal/services/command/update_balance_auto_overdraft_test.go
@@ -1,0 +1,212 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package command
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	libCommons "github.com/LerianStudio/lib-commons/v4/commons"
+	"github.com/LerianStudio/midaz/v3/components/ledger/internal/adapters/postgres/balance"
+	redis "github.com/LerianStudio/midaz/v3/components/ledger/internal/adapters/redis/transaction"
+	"github.com/LerianStudio/midaz/v3/pkg"
+	"github.com/LerianStudio/midaz/v3/pkg/constant"
+	"github.com/LerianStudio/midaz/v3/pkg/mmodel"
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+// TestUpdateBalance_EnableOverdraft_AutoCreatesOverdraftBalance verifies that
+// flipping AllowOverdraft from false to true triggers the auto-creation of
+// a system-managed "overdraft" balance with direction=debit and scope=internal.
+func TestUpdateBalance_EnableOverdraft_AutoCreatesOverdraftBalance(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
+	orgID := uuid.Must(libCommons.GenerateUUIDv7())
+	ledgerID := uuid.Must(libCommons.GenerateUUIDv7())
+	balanceID := uuid.Must(libCommons.GenerateUUIDv7())
+	accountID := uuid.New()
+
+	current := &mmodel.Balance{
+		ID:             balanceID.String(),
+		OrganizationID: orgID.String(),
+		LedgerID:       ledgerID.String(),
+		AccountID:      accountID.String(),
+		Alias:          "@fresh",
+		Key:            "default",
+		AssetCode:      "USD",
+		Direction:      constant.DirectionCredit,
+		OverdraftUsed:  decimal.Zero,
+		Settings:       mmodel.NewDefaultBalanceSettings(),
+	}
+
+	update := mmodel.UpdateBalance{
+		Settings: &mmodel.BalanceSettings{
+			AllowOverdraft:        true,
+			OverdraftLimitEnabled: true,
+			OverdraftLimit:        strPtr("500.00"),
+		},
+	}
+
+	updated := *current
+	updated.Settings = update.Settings
+
+	mockBalanceRepo := balance.NewMockRepository(ctrl)
+	mockRedisRepo := redis.NewMockRedisRepository(ctrl)
+
+	mockBalanceRepo.EXPECT().
+		Find(gomock.Any(), orgID, ledgerID, balanceID).
+		Return(current, nil).
+		AnyTimes()
+
+	mockBalanceRepo.EXPECT().
+		Update(gomock.Any(), orgID, ledgerID, balanceID, update).
+		Return(&updated, nil).
+		Times(1)
+
+	// No existing overdraft balance yet. The repository signals "not
+	// found" by returning an EntityNotFoundError (mirroring the real
+	// PostgreSQL adapter which maps sql.ErrNoRows to this error), and
+	// the use case MUST treat it as the trigger for auto-creation.
+	mockBalanceRepo.EXPECT().
+		FindByAccountIDAndKey(gomock.Any(), orgID, ledgerID, accountID, "overdraft").
+		Return(nil, pkg.ValidateBusinessError(constant.ErrEntityNotFound, reflect.TypeOf(mmodel.Balance{}).Name())).
+		Times(1)
+
+	// Auto-creation MUST happen with direction=debit, scope=internal.
+	mockBalanceRepo.EXPECT().
+		Create(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, b *mmodel.Balance) (*mmodel.Balance, error) {
+			assert.Equal(t, "overdraft", b.Key,
+				"auto-created balance MUST use the overdraft key")
+			assert.Equal(t, constant.DirectionDebit, b.Direction,
+				"overdraft balance MUST have debit direction")
+			assert.Equal(t, accountID.String(), b.AccountID,
+				"overdraft balance MUST belong to the same account")
+			assert.Equal(t, current.AssetCode, b.AssetCode,
+				"overdraft balance MUST match the parent asset code")
+			require.NotNil(t, b.Settings,
+				"overdraft balance MUST carry settings")
+			assert.Equal(t, mmodel.BalanceScopeInternal, b.Settings.BalanceScope,
+				"overdraft balance MUST be scoped as internal")
+			return b, nil
+		}).
+		Times(1)
+
+	mockRedisRepo.EXPECT().
+		Get(gomock.Any(), gomock.Any()).
+		Return("", nil).
+		AnyTimes()
+
+	uc := UseCase{
+		BalanceRepo:          mockBalanceRepo,
+		TransactionRedisRepo: mockRedisRepo,
+	}
+
+	result, err := uc.Update(context.TODO(), orgID, ledgerID, balanceID, update)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+}
+
+// TestUpdateBalance_EnableOverdraft_Idempotent verifies that re-enabling
+// overdraft on a balance that already has a system overdraft balance does
+// NOT create a duplicate — the operation MUST be idempotent.
+func TestUpdateBalance_EnableOverdraft_Idempotent(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
+	orgID := uuid.Must(libCommons.GenerateUUIDv7())
+	ledgerID := uuid.Must(libCommons.GenerateUUIDv7())
+	balanceID := uuid.Must(libCommons.GenerateUUIDv7())
+	accountID := uuid.New()
+
+	current := &mmodel.Balance{
+		ID:             balanceID.String(),
+		OrganizationID: orgID.String(),
+		LedgerID:       ledgerID.String(),
+		AccountID:      accountID.String(),
+		Alias:          "@fresh",
+		Key:            "default",
+		AssetCode:      "USD",
+		Direction:      constant.DirectionCredit,
+		OverdraftUsed:  decimal.Zero,
+		Settings:       mmodel.NewDefaultBalanceSettings(),
+	}
+
+	existingOverdraft := &mmodel.Balance{
+		ID:             uuid.New().String(),
+		OrganizationID: orgID.String(),
+		LedgerID:       ledgerID.String(),
+		AccountID:      accountID.String(),
+		Alias:          "@fresh",
+		Key:            "overdraft",
+		AssetCode:      "USD",
+		Direction:      constant.DirectionDebit,
+		OverdraftUsed:  decimal.Zero,
+		Settings: &mmodel.BalanceSettings{
+			BalanceScope: mmodel.BalanceScopeInternal,
+		},
+	}
+
+	update := mmodel.UpdateBalance{
+		Settings: &mmodel.BalanceSettings{
+			AllowOverdraft:        true,
+			OverdraftLimitEnabled: true,
+			OverdraftLimit:        strPtr("500.00"),
+		},
+	}
+
+	updated := *current
+	updated.Settings = update.Settings
+
+	mockBalanceRepo := balance.NewMockRepository(ctrl)
+	mockRedisRepo := redis.NewMockRedisRepository(ctrl)
+
+	mockBalanceRepo.EXPECT().
+		Find(gomock.Any(), orgID, ledgerID, balanceID).
+		Return(current, nil).
+		AnyTimes()
+
+	mockBalanceRepo.EXPECT().
+		Update(gomock.Any(), orgID, ledgerID, balanceID, update).
+		Return(&updated, nil).
+		Times(1)
+
+	// Overdraft balance already exists — the use case MUST detect it.
+	mockBalanceRepo.EXPECT().
+		FindByAccountIDAndKey(gomock.Any(), orgID, ledgerID, accountID, "overdraft").
+		Return(existingOverdraft, nil).
+		Times(1)
+
+	// Create MUST NOT be called when the overdraft balance already exists.
+	mockBalanceRepo.EXPECT().
+		Create(gomock.Any(), gomock.Any()).
+		Times(0)
+
+	mockRedisRepo.EXPECT().
+		Get(gomock.Any(), gomock.Any()).
+		Return("", nil).
+		AnyTimes()
+
+	uc := UseCase{
+		BalanceRepo:          mockBalanceRepo,
+		TransactionRedisRepo: mockRedisRepo,
+	}
+
+	result, err := uc.Update(context.TODO(), orgID, ledgerID, balanceID, update)
+
+	require.NoError(t, err, "idempotent enable MUST succeed without errors")
+	require.NotNil(t, result)
+}

--- a/components/ledger/internal/services/command/update_balance_auto_overdraft_test.go
+++ b/components/ledger/internal/services/command/update_balance_auto_overdraft_test.go
@@ -6,7 +6,6 @@ package command
 
 import (
 	"context"
-	"reflect"
 	"testing"
 
 	libCommons "github.com/LerianStudio/lib-commons/v4/commons"
@@ -79,7 +78,7 @@ func TestUpdateBalance_EnableOverdraft_AutoCreatesOverdraftBalance(t *testing.T)
 	// the use case MUST treat it as the trigger for auto-creation.
 	mockBalanceRepo.EXPECT().
 		FindByAccountIDAndKey(gomock.Any(), orgID, ledgerID, accountID, "overdraft").
-		Return(nil, pkg.ValidateBusinessError(constant.ErrEntityNotFound, reflect.TypeOf(mmodel.Balance{}).Name())).
+		Return(nil, pkg.ValidateBusinessError(constant.ErrEntityNotFound, constant.EntityBalance)).
 		Times(1)
 
 	// Auto-creation MUST happen with direction=debit, scope=internal.

--- a/components/ledger/internal/services/command/update_balance_overdraft.go
+++ b/components/ledger/internal/services/command/update_balance_overdraft.go
@@ -16,6 +16,7 @@ import (
 	"github.com/LerianStudio/midaz/v3/pkg/constant"
 	"github.com/LerianStudio/midaz/v3/pkg/mmodel"
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/shopspring/decimal"
 	"go.opentelemetry.io/otel/trace"
 )
@@ -109,6 +110,22 @@ func enforceOverdraftTransition(ctx context.Context, logger libLog.Logger, span 
 //   - scope      = "internal" (protected from direct operations)
 //   - alias      = same as the parent balance
 //   - asset code = same as the parent balance
+//
+// Concurrency model:
+//
+// Two concurrent PATCH requests flipping AllowOverdraft from false→true on
+// the same account would each observe "no overdraft balance" in the initial
+// Find lookup and race to Create. Application-level locking cannot close
+// this window cleanly across replicas, so the invariant is enforced at the
+// storage layer: a partial UNIQUE index on
+// (organization_id, ledger_id, account_id, asset_code, key) rejects the
+// second insert with SQLSTATE 23505.
+//
+// When that happens we treat the race as benign — the peer request already
+// created the balance we were about to create — and re-fetch it so the
+// caller sees the same state it would have in the single-request case.
+// Any other Create failure (connectivity, constraint violations we did not
+// trigger, etc.) is propagated unchanged.
 func (uc *UseCase) ensureOverdraftBalance(ctx context.Context, logger libLog.Logger, span trace.Span, organizationID, ledgerID uuid.UUID, current *mmodel.Balance, nextSettings *mmodel.BalanceSettings) error {
 	if current == nil || nextSettings == nil {
 		return nil
@@ -186,6 +203,24 @@ func (uc *UseCase) ensureOverdraftBalance(ctx context.Context, logger libLog.Log
 	}
 
 	if _, cerr := uc.BalanceRepo.Create(ctx, overdraftBalance); cerr != nil {
+		// Benign race: a concurrent request won the Create. The partial
+		// UNIQUE index idx_unique_balance_account_key surfaces this as a
+		// PostgreSQL unique_violation (SQLSTATE 23505). Treat it as
+		// idempotent success — the peer request materialized the same row
+		// we were about to create. Verify with a follow-up Find so we
+		// never silently swallow a 23505 triggered by an unrelated index.
+		if isUniqueViolation(cerr) {
+			existing, reloadErr := uc.BalanceRepo.FindByAccountIDAndKey(ctx, organizationID, ledgerID, accountID, constant.OverdraftBalanceKey)
+			if reloadErr == nil && existing != nil {
+				logger.Log(ctx, libLog.LevelInfo, "Overdraft balance created concurrently by peer request, treating as idempotent success", libLog.String("accountID", current.AccountID))
+
+				return nil
+			}
+			// Fall through and surface the original Create error if the
+			// reload failed or still returned nil — that means the 23505
+			// did not come from our target tuple.
+		}
+
 		libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Failed to auto-create overdraft balance", cerr)
 		logger.Log(ctx, libLog.LevelError, "Failed to auto-create overdraft balance", libLog.Err(cerr))
 
@@ -195,4 +230,14 @@ func (uc *UseCase) ensureOverdraftBalance(ctx context.Context, logger libLog.Log
 	logger.Log(ctx, libLog.LevelInfo, "Auto-created overdraft balance", libLog.String("accountID", current.AccountID))
 
 	return nil
+}
+
+// isUniqueViolation reports whether err is a PostgreSQL unique_violation
+// (SQLSTATE 23505). Used by ensureOverdraftBalance to distinguish a benign
+// concurrent-insert race from real Create failures. Matches the pattern
+// already used in create_balance_transaction_operations_async.go.
+func isUniqueViolation(err error) bool {
+	var pgErr *pgconn.PgError
+
+	return errors.As(err, &pgErr) && pgErr.Code == constant.UniqueViolationCode
 }

--- a/components/ledger/internal/services/command/update_balance_overdraft.go
+++ b/components/ledger/internal/services/command/update_balance_overdraft.go
@@ -1,0 +1,199 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package command
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"reflect"
+	"time"
+
+	libCommons "github.com/LerianStudio/lib-commons/v4/commons"
+	libLog "github.com/LerianStudio/lib-commons/v4/commons/log"
+	libOpentelemetry "github.com/LerianStudio/lib-commons/v4/commons/opentelemetry"
+	"github.com/LerianStudio/midaz/v3/pkg"
+	"github.com/LerianStudio/midaz/v3/pkg/constant"
+	"github.com/LerianStudio/midaz/v3/pkg/mmodel"
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// validateUpdateSettings runs the BalanceSettings contract check before any
+// repository interaction. Failing closed here keeps corrupt payloads out of
+// PostgreSQL and guarantees no partial writes on validation failure.
+//
+// It also rejects any attempt to set BalanceScope="internal" via PATCH:
+// internal scope is reserved for system-managed balances (auto-created
+// overdraft balances) and MUST NOT be settable through the public API.
+func validateUpdateSettings(ctx context.Context, logger libLog.Logger, span trace.Span, settings *mmodel.BalanceSettings) error {
+	if err := settings.Validate(); err != nil {
+		libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Invalid balance settings payload", err)
+		logger.Log(ctx, libLog.LevelWarn, fmt.Sprintf("Rejected invalid balance settings: %v", err))
+
+		return pkg.ValidateBusinessError(constant.ErrInvalidBalanceSettings, reflect.TypeOf(mmodel.Balance{}).Name())
+	}
+
+	if settings.BalanceScope == mmodel.BalanceScopeInternal {
+		err := pkg.ValidateBusinessError(constant.ErrInvalidBalanceSettings, reflect.TypeOf(mmodel.Balance{}).Name())
+		libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Reserved balance scope", err)
+		logger.Log(ctx, libLog.LevelWarn, fmt.Sprintf("Rejected reserved balance scope on update: %v", settings.BalanceScope))
+
+		return err
+	}
+
+	return nil
+}
+
+// enforceOverdraftTransition protects balances that carry outstanding
+// overdraft usage. Two transitions are rejected:
+//
+//  1. disabling AllowOverdraft while OverdraftUsed > 0 — would orphan debt.
+//  2. reducing OverdraftLimit below OverdraftUsed — would leave the balance
+//     in a permanently over-limit state with no ability to recover.
+//
+// Both rules are enforced before the repository
+// Update is invoked.
+func enforceOverdraftTransition(ctx context.Context, logger libLog.Logger, span trace.Span, current *mmodel.Balance, next *mmodel.BalanceSettings) error {
+	if current == nil || next == nil {
+		return nil
+	}
+
+	usage := current.OverdraftUsed
+	if usage.IsZero() {
+		return nil
+	}
+
+	if !next.AllowOverdraft {
+		err := pkg.ValidateBusinessError(constant.ErrOverdraftDisableWithUsage, reflect.TypeOf(mmodel.Balance{}).Name())
+		libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Cannot disable overdraft while usage is non-zero", err)
+		logger.Log(ctx, libLog.LevelWarn, fmt.Sprintf("Rejected overdraft disable with usage=%s", usage.String()))
+
+		return err
+	}
+
+	if next.OverdraftLimitEnabled && next.OverdraftLimit != nil {
+		limit, perr := decimal.NewFromString(*next.OverdraftLimit)
+		if perr != nil {
+			// Should not happen — Validate() already parsed it. Treat as
+			// invalid payload to stay fail-closed.
+			wrapped := pkg.ValidateBusinessError(constant.ErrInvalidBalanceSettings, reflect.TypeOf(mmodel.Balance{}).Name())
+			libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Overdraft limit is not a valid decimal", perr)
+			logger.Log(ctx, libLog.LevelWarn, fmt.Sprintf("Invalid overdraft limit after validation: %v", perr))
+
+			return wrapped
+		}
+
+		if limit.LessThan(usage) {
+			err := pkg.ValidateBusinessError(constant.ErrOverdraftLimitBelowUsage, reflect.TypeOf(mmodel.Balance{}).Name())
+			libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Overdraft limit below current usage", err)
+			logger.Log(ctx, libLog.LevelWarn, fmt.Sprintf("Rejected overdraft limit=%s below usage=%s", limit.String(), usage.String()))
+
+			return err
+		}
+	}
+
+	return nil
+}
+
+// ensureOverdraftBalance auto-creates the system-managed overdraft balance
+// when AllowOverdraft transitions from false to true. The operation is
+// idempotent: if a balance with key="overdraft" already exists for the
+// account, no new row is created.
+//
+// The auto-created balance is:
+//   - key        = "overdraft"
+//   - direction  = "debit"
+//   - scope      = "internal" (protected from direct operations)
+//   - alias      = same as the parent balance
+//   - asset code = same as the parent balance
+func (uc *UseCase) ensureOverdraftBalance(ctx context.Context, logger libLog.Logger, span trace.Span, organizationID, ledgerID uuid.UUID, current *mmodel.Balance, nextSettings *mmodel.BalanceSettings) error {
+	if current == nil || nextSettings == nil {
+		return nil
+	}
+
+	if !nextSettings.AllowOverdraft {
+		return nil
+	}
+
+	// Only act on the false→true transition. Anything else is a no-op.
+	if current.Settings != nil && current.Settings.AllowOverdraft {
+		return nil
+	}
+
+	// An empty AccountID can only occur in tests that seed a minimal
+	// balance fixture. We fall back to uuid.Nil rather than failing the
+	// update because the overdraft auto-creation is a best-effort extension
+	// of the settings update — the parent balance has already been persisted.
+	var accountID uuid.UUID
+
+	if current.AccountID != "" {
+		parsed, perr := uuid.Parse(current.AccountID)
+		if perr != nil {
+			libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Invalid account id on current balance", perr)
+			logger.Log(ctx, libLog.LevelError, fmt.Sprintf("Failed to parse account id %q: %v", current.AccountID, perr))
+
+			return perr
+		}
+
+		accountID = parsed
+	}
+
+	existing, ferr := uc.BalanceRepo.FindByAccountIDAndKey(ctx, organizationID, ledgerID, accountID, constant.OverdraftBalanceKey)
+	if ferr != nil {
+		// The repository signals "not found" by returning an
+		// EntityNotFoundError (see FindByAccountIDAndKey in
+		// balance.postgresql.go — sql.ErrNoRows is mapped to
+		// pkg.ValidateBusinessError(constant.ErrEntityNotFound, ...)).
+		// Only propagate real infrastructure errors; a not-found result
+		// is the expected trigger for the auto-creation path below.
+		var notFound pkg.EntityNotFoundError
+		if !errors.As(ferr, &notFound) {
+			libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Failed to check for existing overdraft balance", ferr)
+			logger.Log(ctx, libLog.LevelError, fmt.Sprintf("Error checking overdraft balance: %v", ferr))
+
+			return ferr
+		}
+
+		existing = nil
+	}
+
+	if existing != nil {
+		// Idempotent: the overdraft balance already exists.
+		return nil
+	}
+
+	overdraftBalance := &mmodel.Balance{
+		ID:             uuid.Must(libCommons.GenerateUUIDv7()).String(),
+		OrganizationID: current.OrganizationID,
+		LedgerID:       current.LedgerID,
+		AccountID:      current.AccountID,
+		Alias:          current.Alias,
+		Key:            constant.OverdraftBalanceKey,
+		AssetCode:      current.AssetCode,
+		AccountType:    current.AccountType,
+		AllowSending:   false,
+		AllowReceiving: true,
+		Direction:      constant.DirectionDebit,
+		OverdraftUsed:  decimal.Zero,
+		Settings: &mmodel.BalanceSettings{
+			BalanceScope: mmodel.BalanceScopeInternal,
+		},
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+	}
+
+	if _, cerr := uc.BalanceRepo.Create(ctx, overdraftBalance); cerr != nil {
+		libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Failed to auto-create overdraft balance", cerr)
+		logger.Log(ctx, libLog.LevelError, fmt.Sprintf("Error auto-creating overdraft balance: %v", cerr))
+
+		return cerr
+	}
+
+	logger.Log(ctx, libLog.LevelInfo, fmt.Sprintf("Auto-created overdraft balance for account %s", current.AccountID))
+
+	return nil
+}

--- a/components/ledger/internal/services/command/update_balance_overdraft.go
+++ b/components/ledger/internal/services/command/update_balance_overdraft.go
@@ -7,8 +7,6 @@ package command
 import (
 	"context"
 	"errors"
-	"fmt"
-	"reflect"
 	"time"
 
 	libCommons "github.com/LerianStudio/lib-commons/v4/commons"
@@ -32,15 +30,15 @@ import (
 func validateUpdateSettings(ctx context.Context, logger libLog.Logger, span trace.Span, settings *mmodel.BalanceSettings) error {
 	if err := settings.Validate(); err != nil {
 		libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Invalid balance settings payload", err)
-		logger.Log(ctx, libLog.LevelWarn, fmt.Sprintf("Rejected invalid balance settings: %v", err))
+		logger.Log(ctx, libLog.LevelWarn, "Rejected invalid balance settings", libLog.Err(err))
 
-		return pkg.ValidateBusinessError(constant.ErrInvalidBalanceSettings, reflect.TypeOf(mmodel.Balance{}).Name())
+		return pkg.ValidateBusinessError(constant.ErrInvalidBalanceSettings, constant.EntityBalance)
 	}
 
 	if settings.BalanceScope == mmodel.BalanceScopeInternal {
-		err := pkg.ValidateBusinessError(constant.ErrInvalidBalanceSettings, reflect.TypeOf(mmodel.Balance{}).Name())
+		err := pkg.ValidateBusinessError(constant.ErrInvalidBalanceSettings, constant.EntityBalance)
 		libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Reserved balance scope", err)
-		logger.Log(ctx, libLog.LevelWarn, fmt.Sprintf("Rejected reserved balance scope on update: %v", settings.BalanceScope))
+		logger.Log(ctx, libLog.LevelWarn, "Rejected reserved balance scope on update", libLog.String("scope", settings.BalanceScope))
 
 		return err
 	}
@@ -68,9 +66,9 @@ func enforceOverdraftTransition(ctx context.Context, logger libLog.Logger, span 
 	}
 
 	if !next.AllowOverdraft {
-		err := pkg.ValidateBusinessError(constant.ErrOverdraftDisableWithUsage, reflect.TypeOf(mmodel.Balance{}).Name())
+		err := pkg.ValidateBusinessError(constant.ErrOverdraftDisableWithUsage, constant.EntityBalance)
 		libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Cannot disable overdraft while usage is non-zero", err)
-		logger.Log(ctx, libLog.LevelWarn, fmt.Sprintf("Rejected overdraft disable with usage=%s", usage.String()))
+		logger.Log(ctx, libLog.LevelWarn, "Rejected overdraft disable with active usage", libLog.String("overdraftUsed", usage.String()))
 
 		return err
 	}
@@ -80,17 +78,18 @@ func enforceOverdraftTransition(ctx context.Context, logger libLog.Logger, span 
 		if perr != nil {
 			// Should not happen — Validate() already parsed it. Treat as
 			// invalid payload to stay fail-closed.
-			wrapped := pkg.ValidateBusinessError(constant.ErrInvalidBalanceSettings, reflect.TypeOf(mmodel.Balance{}).Name())
+			wrapped := pkg.ValidateBusinessError(constant.ErrInvalidBalanceSettings, constant.EntityBalance)
+
 			libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Overdraft limit is not a valid decimal", perr)
-			logger.Log(ctx, libLog.LevelWarn, fmt.Sprintf("Invalid overdraft limit after validation: %v", perr))
+			logger.Log(ctx, libLog.LevelWarn, "Invalid overdraft limit after validation", libLog.Err(perr))
 
 			return wrapped
 		}
 
 		if limit.LessThan(usage) {
-			err := pkg.ValidateBusinessError(constant.ErrOverdraftLimitBelowUsage, reflect.TypeOf(mmodel.Balance{}).Name())
+			err := pkg.ValidateBusinessError(constant.ErrOverdraftLimitBelowUsage, constant.EntityBalance)
 			libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Overdraft limit below current usage", err)
-			logger.Log(ctx, libLog.LevelWarn, fmt.Sprintf("Rejected overdraft limit=%s below usage=%s", limit.String(), usage.String()))
+			logger.Log(ctx, libLog.LevelWarn, "Rejected overdraft limit below current usage", libLog.String("limit", limit.String()), libLog.String("overdraftUsed", usage.String()))
 
 			return err
 		}
@@ -134,7 +133,7 @@ func (uc *UseCase) ensureOverdraftBalance(ctx context.Context, logger libLog.Log
 		parsed, perr := uuid.Parse(current.AccountID)
 		if perr != nil {
 			libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Invalid account id on current balance", perr)
-			logger.Log(ctx, libLog.LevelError, fmt.Sprintf("Failed to parse account id %q: %v", current.AccountID, perr))
+			logger.Log(ctx, libLog.LevelError, "Failed to parse account ID", libLog.String("accountID", current.AccountID), libLog.Err(perr))
 
 			return perr
 		}
@@ -153,7 +152,7 @@ func (uc *UseCase) ensureOverdraftBalance(ctx context.Context, logger libLog.Log
 		var notFound pkg.EntityNotFoundError
 		if !errors.As(ferr, &notFound) {
 			libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Failed to check for existing overdraft balance", ferr)
-			logger.Log(ctx, libLog.LevelError, fmt.Sprintf("Error checking overdraft balance: %v", ferr))
+			logger.Log(ctx, libLog.LevelError, "Failed to check existing overdraft balance", libLog.Err(ferr))
 
 			return ferr
 		}
@@ -188,12 +187,12 @@ func (uc *UseCase) ensureOverdraftBalance(ctx context.Context, logger libLog.Log
 
 	if _, cerr := uc.BalanceRepo.Create(ctx, overdraftBalance); cerr != nil {
 		libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Failed to auto-create overdraft balance", cerr)
-		logger.Log(ctx, libLog.LevelError, fmt.Sprintf("Error auto-creating overdraft balance: %v", cerr))
+		logger.Log(ctx, libLog.LevelError, "Failed to auto-create overdraft balance", libLog.Err(cerr))
 
 		return cerr
 	}
 
-	logger.Log(ctx, libLog.LevelInfo, fmt.Sprintf("Auto-created overdraft balance for account %s", current.AccountID))
+	logger.Log(ctx, libLog.LevelInfo, "Auto-created overdraft balance", libLog.String("accountID", current.AccountID))
 
 	return nil
 }

--- a/components/ledger/internal/services/command/update_balance_overdraft_race_test.go
+++ b/components/ledger/internal/services/command/update_balance_overdraft_race_test.go
@@ -1,0 +1,275 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package command
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	libCommons "github.com/LerianStudio/lib-commons/v4/commons"
+	"github.com/LerianStudio/midaz/v3/components/ledger/internal/adapters/postgres/balance"
+	redis "github.com/LerianStudio/midaz/v3/components/ledger/internal/adapters/redis/transaction"
+	"github.com/LerianStudio/midaz/v3/pkg/constant"
+	"github.com/LerianStudio/midaz/v3/pkg/mmodel"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+// raceTestFixture returns a canonical (orgID, ledgerID, balanceID, current,
+// update) bundle driving the false→true AllowOverdraft transition. Centralised
+// so every race-handling test exercises the same initial state.
+func raceTestFixture(t *testing.T) (uuid.UUID, uuid.UUID, uuid.UUID, *mmodel.Balance, mmodel.UpdateBalance) {
+	t.Helper()
+
+	orgID := uuid.Must(libCommons.GenerateUUIDv7())
+	ledgerID := uuid.Must(libCommons.GenerateUUIDv7())
+	balanceID := uuid.Must(libCommons.GenerateUUIDv7())
+	accountID := uuid.Must(libCommons.GenerateUUIDv7())
+
+	newSettings := &mmodel.BalanceSettings{
+		BalanceScope:   mmodel.BalanceScopeTransactional,
+		AllowOverdraft: true,
+	}
+
+	current := &mmodel.Balance{
+		ID:             balanceID.String(),
+		OrganizationID: orgID.String(),
+		LedgerID:       ledgerID.String(),
+		AccountID:      accountID.String(),
+		Alias:          "@race",
+		Key:            "default",
+		AssetCode:      "USD",
+		Direction:      constant.DirectionCredit,
+		OverdraftUsed:  decimal.Zero,
+		Settings:       mmodel.NewDefaultBalanceSettings(),
+	}
+
+	return orgID, ledgerID, balanceID, current, mmodel.UpdateBalance{Settings: newSettings}
+}
+
+// TestEnsureOverdraftBalance_ConcurrentCreate_ReturnsBenignSuccess verifies
+// that when BalanceRepo.Create returns a PostgreSQL unique_violation
+// (SQLSTATE 23505), ensureOverdraftBalance treats it as idempotent success
+// as long as the second FindByAccountIDAndKey resolves the peer-created
+// row. This is the core race-condition guarantee: two concurrent PATCH
+// requests flipping AllowOverdraft MUST both succeed, with exactly one
+// overdraft balance materialised in the end.
+func TestEnsureOverdraftBalance_ConcurrentCreate_ReturnsBenignSuccess(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
+	orgID, ledgerID, balanceID, current, update := raceTestFixture(t)
+
+	expected := *current
+	expected.Settings = update.Settings
+
+	peerOverdraft := &mmodel.Balance{
+		ID:             uuid.Must(libCommons.GenerateUUIDv7()).String(),
+		OrganizationID: current.OrganizationID,
+		LedgerID:       current.LedgerID,
+		AccountID:      current.AccountID,
+		Alias:          current.Alias,
+		Key:            constant.OverdraftBalanceKey,
+		AssetCode:      current.AssetCode,
+		Direction:      constant.DirectionDebit,
+	}
+
+	mockBalanceRepo := balance.NewMockRepository(ctrl)
+	mockRedisRepo := redis.NewMockRedisRepository(ctrl)
+
+	mockBalanceRepo.EXPECT().
+		Find(gomock.Any(), orgID, ledgerID, balanceID).
+		Return(current, nil).
+		Times(1)
+
+	// First lookup: peer request has not yet committed → not found.
+	// Second lookup (after the 23505 from Create): peer's row is visible.
+	gomock.InOrder(
+		mockBalanceRepo.EXPECT().
+			FindByAccountIDAndKey(gomock.Any(), orgID, ledgerID, gomock.Any(), constant.OverdraftBalanceKey).
+			Return(nil, nil).
+			Times(1),
+		mockBalanceRepo.EXPECT().
+			FindByAccountIDAndKey(gomock.Any(), orgID, ledgerID, gomock.Any(), constant.OverdraftBalanceKey).
+			Return(peerOverdraft, nil).
+			Times(1),
+	)
+
+	// Simulate the partial UNIQUE index rejecting our insert.
+	mockBalanceRepo.EXPECT().
+		Create(gomock.Any(), gomock.Any()).
+		Return(nil, &pgconn.PgError{Code: constant.UniqueViolationCode}).
+		Times(1)
+
+	mockBalanceRepo.EXPECT().
+		Update(gomock.Any(), orgID, ledgerID, balanceID, update).
+		Return(&expected, nil).
+		Times(1)
+
+	mockRedisRepo.EXPECT().Get(gomock.Any(), gomock.Any()).Return("", nil).AnyTimes()
+
+	uc := UseCase{
+		BalanceRepo:          mockBalanceRepo,
+		TransactionRedisRepo: mockRedisRepo,
+	}
+
+	result, err := uc.Update(context.TODO(), orgID, ledgerID, balanceID, update)
+
+	require.NoError(t, err, "a benign 23505 race MUST NOT surface as an error to the caller")
+	require.NotNil(t, result)
+	require.NotNil(t, result.Settings)
+	assert.True(t, result.Settings.AllowOverdraft)
+}
+
+// TestEnsureOverdraftBalance_UniqueViolation_WithMissingRow_PropagatesError
+// covers the defensive branch: a 23505 was raised but the follow-up Find
+// still returns nil. That almost certainly means the unique violation came
+// from a DIFFERENT index than the one guarding our tuple, so we must NOT
+// silently swallow the error — the caller needs to see it.
+func TestEnsureOverdraftBalance_UniqueViolation_WithMissingRow_PropagatesError(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
+	orgID, ledgerID, balanceID, current, update := raceTestFixture(t)
+
+	mockBalanceRepo := balance.NewMockRepository(ctrl)
+	mockRedisRepo := redis.NewMockRedisRepository(ctrl)
+
+	mockBalanceRepo.EXPECT().
+		Find(gomock.Any(), orgID, ledgerID, balanceID).
+		Return(current, nil).
+		Times(1)
+
+	// Both lookups return nil — peer did not actually create the row, so
+	// the 23505 did not come from our target tuple.
+	mockBalanceRepo.EXPECT().
+		FindByAccountIDAndKey(gomock.Any(), orgID, ledgerID, gomock.Any(), constant.OverdraftBalanceKey).
+		Return(nil, nil).
+		Times(2)
+
+	pgErr := &pgconn.PgError{Code: constant.UniqueViolationCode}
+	mockBalanceRepo.EXPECT().
+		Create(gomock.Any(), gomock.Any()).
+		Return(nil, pgErr).
+		Times(1)
+
+	// Update MUST NOT be called when ensureOverdraftBalance fails — the
+	// parent balance's settings stay intact so the pair remains consistent.
+	mockBalanceRepo.EXPECT().
+		Update(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Times(0)
+
+	uc := UseCase{
+		BalanceRepo:          mockBalanceRepo,
+		TransactionRedisRepo: mockRedisRepo,
+	}
+
+	result, err := uc.Update(context.TODO(), orgID, ledgerID, balanceID, update)
+
+	require.Error(t, err, "unexplained 23505 MUST be surfaced to the caller")
+	assert.Nil(t, result)
+	assert.ErrorIs(t, err, pgErr, "the original Create error MUST be preserved")
+}
+
+// TestEnsureOverdraftBalance_NonUniqueViolation_PropagatesError verifies
+// that non-23505 errors from Create (connectivity failures, FK violations,
+// etc.) are propagated unchanged without touching the reload path.
+func TestEnsureOverdraftBalance_NonUniqueViolation_PropagatesError(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
+	orgID, ledgerID, balanceID, current, update := raceTestFixture(t)
+
+	mockBalanceRepo := balance.NewMockRepository(ctrl)
+	mockRedisRepo := redis.NewMockRedisRepository(ctrl)
+
+	mockBalanceRepo.EXPECT().
+		Find(gomock.Any(), orgID, ledgerID, balanceID).
+		Return(current, nil).
+		Times(1)
+
+	// Only the initial idempotency check runs. The reload path MUST NOT
+	// fire for non-unique-violation errors.
+	mockBalanceRepo.EXPECT().
+		FindByAccountIDAndKey(gomock.Any(), orgID, ledgerID, gomock.Any(), constant.OverdraftBalanceKey).
+		Return(nil, nil).
+		Times(1)
+
+	createErr := errors.New("connection reset by peer")
+	mockBalanceRepo.EXPECT().
+		Create(gomock.Any(), gomock.Any()).
+		Return(nil, createErr).
+		Times(1)
+
+	mockBalanceRepo.EXPECT().
+		Update(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Times(0)
+
+	uc := UseCase{
+		BalanceRepo:          mockBalanceRepo,
+		TransactionRedisRepo: mockRedisRepo,
+	}
+
+	result, err := uc.Update(context.TODO(), orgID, ledgerID, balanceID, update)
+
+	require.Error(t, err, "non-23505 Create errors MUST surface to the caller")
+	assert.Nil(t, result)
+	assert.ErrorIs(t, err, createErr, "the original Create error MUST be preserved")
+}
+
+// TestIsUniqueViolation_PgError_Code23505 asserts the helper that gates the
+// race-recovery branch. It MUST return true only for pgconn.PgError values
+// carrying SQLSTATE 23505 and false for every other error type (generic
+// errors, wrapped errors with a different code, nil).
+func TestIsUniqueViolation_PgError_Code23505(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "PgError with code 23505 is a unique violation",
+			err:  &pgconn.PgError{Code: constant.UniqueViolationCode},
+			want: true,
+		},
+		{
+			name: "PgError with another code is not a unique violation",
+			err:  &pgconn.PgError{Code: "23503"},
+			want: false,
+		},
+		{
+			name: "generic error is not a unique violation",
+			err:  errors.New("boom"),
+			want: false,
+		},
+		{
+			name: "nil error is not a unique violation",
+			err:  nil,
+			want: false,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tc.want, isUniqueViolation(tc.err))
+		})
+	}
+}

--- a/components/ledger/internal/services/command/update_balance_overdraft_test.go
+++ b/components/ledger/internal/services/command/update_balance_overdraft_test.go
@@ -1,0 +1,298 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package command
+
+import (
+	"context"
+	"testing"
+
+	libCommons "github.com/LerianStudio/lib-commons/v4/commons"
+	"github.com/LerianStudio/midaz/v3/components/ledger/internal/adapters/postgres/balance"
+	redis "github.com/LerianStudio/midaz/v3/components/ledger/internal/adapters/redis/transaction"
+	"github.com/LerianStudio/midaz/v3/pkg/constant"
+	"github.com/LerianStudio/midaz/v3/pkg/mmodel"
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+// strPtr returns a pointer to the given string, used for decimal string
+// literals carried by BalanceSettings.OverdraftLimit.
+func strPtr(s string) *string { return &s }
+
+// TestUpdateBalance_WithSettings verifies that a valid Settings payload is
+// forwarded to the repository and reflected on the returned balance.
+func TestUpdateBalance_WithSettings(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
+	orgID := uuid.Must(libCommons.GenerateUUIDv7())
+	ledgerID := uuid.Must(libCommons.GenerateUUIDv7())
+	balanceID := uuid.Must(libCommons.GenerateUUIDv7())
+
+	newSettings := &mmodel.BalanceSettings{
+		BalanceScope:          mmodel.BalanceScopeTransactional,
+		AllowOverdraft:        true,
+		OverdraftLimitEnabled: true,
+		OverdraftLimit:        strPtr("1000.00"),
+	}
+
+	update := mmodel.UpdateBalance{Settings: newSettings}
+
+	baseBalance := &mmodel.Balance{
+		ID:             balanceID.String(),
+		OrganizationID: orgID.String(),
+		LedgerID:       ledgerID.String(),
+		Alias:          "@alice",
+		Key:            "default",
+		Direction:      constant.DirectionCredit,
+		OverdraftUsed:  decimal.Zero,
+	}
+
+	existing := *baseBalance
+	existing.Settings = mmodel.NewDefaultBalanceSettings()
+
+	expected := *baseBalance
+	expected.Settings = newSettings
+
+	mockBalanceRepo := balance.NewMockRepository(ctrl)
+	mockRedisRepo := redis.NewMockRedisRepository(ctrl)
+
+	// The use case MUST read the current balance BEFORE applying the
+	// update so it can enforce transition invariants (usage vs. limit,
+	// disable-with-debt). Exactly one Find call is expected.
+	mockBalanceRepo.EXPECT().Find(gomock.Any(), orgID, ledgerID, balanceID).
+		Return(&existing, nil).Times(1)
+
+	// Idempotency check for the auto-managed overdraft balance.
+	mockBalanceRepo.EXPECT().
+		FindByAccountIDAndKey(gomock.Any(), orgID, ledgerID, gomock.Any(), "overdraft").
+		Return(nil, nil).AnyTimes()
+
+	mockBalanceRepo.EXPECT().Create(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, b *mmodel.Balance) (*mmodel.Balance, error) { return b, nil }).
+		AnyTimes()
+
+	mockBalanceRepo.EXPECT().
+		Update(gomock.Any(), orgID, ledgerID, balanceID, update).
+		Return(&expected, nil).Times(1)
+
+	mockRedisRepo.EXPECT().Get(gomock.Any(), gomock.Any()).Return("", nil).AnyTimes()
+
+	uc := UseCase{
+		BalanceRepo:          mockBalanceRepo,
+		TransactionRedisRepo: mockRedisRepo,
+	}
+
+	result, err := uc.Update(context.TODO(), orgID, ledgerID, balanceID, update)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.NotNil(t, result.Settings,
+		"Settings MUST be present on the updated balance")
+	assert.True(t, result.Settings.AllowOverdraft,
+		"AllowOverdraft MUST be persisted from the update payload")
+	assert.True(t, result.Settings.OverdraftLimitEnabled)
+	require.NotNil(t, result.Settings.OverdraftLimit)
+	assert.Equal(t, "1000.00", *result.Settings.OverdraftLimit)
+}
+
+// TestUpdateBalance_SettingsValidation verifies that invalid settings are
+// rejected before the repository is hit (HARD GATE — no partial writes).
+func TestUpdateBalance_SettingsValidation(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
+	orgID := uuid.Must(libCommons.GenerateUUIDv7())
+	ledgerID := uuid.Must(libCommons.GenerateUUIDv7())
+	balanceID := uuid.Must(libCommons.GenerateUUIDv7())
+
+	cases := []struct {
+		name     string
+		settings *mmodel.BalanceSettings
+	}{
+		{
+			name: "limit enabled without limit value",
+			settings: &mmodel.BalanceSettings{
+				AllowOverdraft: true, OverdraftLimitEnabled: true, OverdraftLimit: nil,
+			},
+		},
+		{
+			name: "limit disabled but limit value present",
+			settings: &mmodel.BalanceSettings{
+				AllowOverdraft: true, OverdraftLimitEnabled: false, OverdraftLimit: strPtr("100.00"),
+			},
+		},
+		{
+			name:     "invalid balance scope",
+			settings: &mmodel.BalanceSettings{BalanceScope: "galactic"},
+		},
+		{
+			name: "overdraft limit zero with flag enabled",
+			settings: &mmodel.BalanceSettings{
+				AllowOverdraft: true, OverdraftLimitEnabled: true, OverdraftLimit: strPtr("0"),
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			mockBalanceRepo := balance.NewMockRepository(ctrl)
+			mockRedisRepo := redis.NewMockRedisRepository(ctrl)
+
+			// Repository MUST NOT receive a corrupt settings payload.
+			mockBalanceRepo.EXPECT().
+				Update(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+				Times(0)
+
+			mockBalanceRepo.EXPECT().
+				Find(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+				AnyTimes().
+				Return(&mmodel.Balance{
+					ID:            balanceID.String(),
+					Direction:     constant.DirectionCredit,
+					OverdraftUsed: decimal.Zero,
+					Settings:      mmodel.NewDefaultBalanceSettings(),
+				}, nil)
+
+			uc := UseCase{
+				BalanceRepo:          mockBalanceRepo,
+				TransactionRedisRepo: mockRedisRepo,
+			}
+
+			update := mmodel.UpdateBalance{Settings: tc.settings}
+
+			result, err := uc.Update(context.TODO(), orgID, ledgerID, balanceID, update)
+
+			require.Error(t, err, "invalid settings MUST produce a validation error")
+			assert.Nil(t, result, "no balance should be returned when settings are invalid")
+		})
+	}
+}
+
+// TestUpdateBalance_CannotDisableOverdraftWithUsage verifies that overdraft
+// cannot be disabled while the balance is still carrying debt.
+func TestUpdateBalance_CannotDisableOverdraftWithUsage(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
+	orgID := uuid.Must(libCommons.GenerateUUIDv7())
+	ledgerID := uuid.Must(libCommons.GenerateUUIDv7())
+	balanceID := uuid.Must(libCommons.GenerateUUIDv7())
+
+	current := &mmodel.Balance{
+		ID:             balanceID.String(),
+		OrganizationID: orgID.String(),
+		LedgerID:       ledgerID.String(),
+		Alias:          "@indebted",
+		Key:            "default",
+		Direction:      constant.DirectionCredit,
+		OverdraftUsed:  decimal.NewFromInt(250),
+		Settings: &mmodel.BalanceSettings{
+			AllowOverdraft:        true,
+			OverdraftLimitEnabled: true,
+			OverdraftLimit:        strPtr("500.00"),
+		},
+	}
+
+	update := mmodel.UpdateBalance{
+		Settings: &mmodel.BalanceSettings{
+			AllowOverdraft:        false,
+			OverdraftLimitEnabled: false,
+		},
+	}
+
+	mockBalanceRepo := balance.NewMockRepository(ctrl)
+	mockRedisRepo := redis.NewMockRedisRepository(ctrl)
+
+	mockBalanceRepo.EXPECT().
+		Find(gomock.Any(), orgID, ledgerID, balanceID).
+		Return(current, nil).
+		Times(1)
+
+	// Must NOT persist a disable that would leave debt orphaned.
+	mockBalanceRepo.EXPECT().
+		Update(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Times(0)
+
+	uc := UseCase{
+		BalanceRepo:          mockBalanceRepo,
+		TransactionRedisRepo: mockRedisRepo,
+	}
+
+	result, err := uc.Update(context.TODO(), orgID, ledgerID, balanceID, update)
+
+	require.Error(t, err, "disabling overdraft with outstanding usage MUST fail")
+	assert.Nil(t, result)
+}
+
+// TestUpdateBalance_CannotReduceLimitBelowUsage verifies that the limit
+// cannot be reduced below the currently used overdraft amount.
+func TestUpdateBalance_CannotReduceLimitBelowUsage(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
+	orgID := uuid.Must(libCommons.GenerateUUIDv7())
+	ledgerID := uuid.Must(libCommons.GenerateUUIDv7())
+	balanceID := uuid.Must(libCommons.GenerateUUIDv7())
+
+	current := &mmodel.Balance{
+		ID:             balanceID.String(),
+		OrganizationID: orgID.String(),
+		LedgerID:       ledgerID.String(),
+		Alias:          "@indebted",
+		Key:            "default",
+		Direction:      constant.DirectionCredit,
+		OverdraftUsed:  decimal.NewFromInt(400),
+		Settings: &mmodel.BalanceSettings{
+			AllowOverdraft:        true,
+			OverdraftLimitEnabled: true,
+			OverdraftLimit:        strPtr("1000.00"),
+		},
+	}
+
+	update := mmodel.UpdateBalance{
+		Settings: &mmodel.BalanceSettings{
+			AllowOverdraft:        true,
+			OverdraftLimitEnabled: true,
+			OverdraftLimit:        strPtr("100.00"),
+		},
+	}
+
+	mockBalanceRepo := balance.NewMockRepository(ctrl)
+	mockRedisRepo := redis.NewMockRedisRepository(ctrl)
+
+	mockBalanceRepo.EXPECT().
+		Find(gomock.Any(), orgID, ledgerID, balanceID).
+		Return(current, nil).
+		Times(1)
+
+	mockBalanceRepo.EXPECT().
+		Update(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Times(0)
+
+	uc := UseCase{
+		BalanceRepo:          mockBalanceRepo,
+		TransactionRedisRepo: mockRedisRepo,
+	}
+
+	result, err := uc.Update(context.TODO(), orgID, ledgerID, balanceID, update)
+
+	require.Error(t, err, "reducing limit below current usage MUST fail")
+	assert.Nil(t, result)
+}

--- a/components/ledger/migrations/transaction/000032_add_unique_balance_account_key.down.sql
+++ b/components/ledger/migrations/transaction/000032_add_unique_balance_account_key.down.sql
@@ -1,0 +1,3 @@
+-- Roll back the partial unique index guarding (organization_id, ledger_id,
+-- account_id, asset_code, key) for live balance rows.
+DROP INDEX CONCURRENTLY IF EXISTS idx_unique_balance_account_key;

--- a/components/ledger/migrations/transaction/000032_add_unique_balance_account_key.up.sql
+++ b/components/ledger/migrations/transaction/000032_add_unique_balance_account_key.up.sql
@@ -1,0 +1,10 @@
+-- Prevent duplicate balances for the same account + key combination.
+-- Uses a partial index (WHERE deleted_at IS NULL) so soft-deleted rows
+-- do not block new balances with the same key.
+--
+-- CONCURRENTLY avoids long-lived ACCESS EXCLUSIVE locks on the balance
+-- table during deployment. Combined with IF NOT EXISTS, the migration
+-- is safe to re-run.
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS idx_unique_balance_account_key
+    ON balance (organization_id, ledger_id, account_id, asset_code, key)
+    WHERE deleted_at IS NULL;

--- a/components/ledger/migrations/transaction/000032_add_unique_balance_account_key_test.go
+++ b/components/ledger/migrations/transaction/000032_add_unique_balance_account_key_test.go
@@ -1,0 +1,131 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package migrations
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestMigration000032_FilesExist verifies that the migration ships both
+// up and down SQL files and that neither is empty.
+func TestMigration000032_FilesExist(t *testing.T) {
+	t.Parallel()
+
+	dir := migrationsDir(t)
+
+	tests := []struct {
+		name     string
+		filename string
+	}{
+		{
+			name:     "up migration file exists",
+			filename: "000032_add_unique_balance_account_key.up.sql",
+		},
+		{
+			name:     "down migration file exists",
+			filename: "000032_add_unique_balance_account_key.down.sql",
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			path := filepath.Join(dir, tc.filename)
+			_, err := os.Stat(path)
+			require.NoError(t, err, "migration file %s must exist", tc.filename)
+
+			content, err := os.ReadFile(path)
+			require.NoError(t, err, "migration file %s must be readable", tc.filename)
+			assert.NotEmpty(t, string(content), "migration file %s must not be empty", tc.filename)
+		})
+	}
+}
+
+// TestMigration000032_UpSQL_CreatesUniqueIndex verifies the up migration
+// creates the partial unique index that guards against duplicate balance
+// rows for the same (organization, ledger, account, asset, key) tuple.
+// The index MUST be UNIQUE (to enforce the invariant) and MUST use
+// CONCURRENTLY (to avoid table locks on live data).
+func TestMigration000032_UpSQL_CreatesUniqueIndex(t *testing.T) {
+	t.Parallel()
+
+	dir := migrationsDir(t)
+	path := filepath.Join(dir, "000032_add_unique_balance_account_key.up.sql")
+
+	content, err := os.ReadFile(path)
+	require.NoError(t, err, "up migration file must be readable")
+
+	sql := strings.ToLower(string(content))
+
+	tests := []struct {
+		name        string
+		substring   string
+		description string
+	}{
+		{name: "creates a UNIQUE index", substring: "create unique index", description: "must declare the index as UNIQUE so duplicates raise 23505"},
+		{name: "uses CONCURRENTLY", substring: "concurrently", description: "must build the index CONCURRENTLY to avoid table locks"},
+		{name: "uses IF NOT EXISTS for idempotency", substring: "if not exists", description: "must use IF NOT EXISTS for idempotent re-runs"},
+		{name: "names the index idx_unique_balance_account_key", substring: "idx_unique_balance_account_key", description: "must use the canonical index name"},
+		{name: "targets balance table", substring: "on balance", description: "must create the index on the balance table"},
+		{name: "includes organization_id column", substring: "organization_id", description: "index key must include organization_id"},
+		{name: "includes ledger_id column", substring: "ledger_id", description: "index key must include ledger_id"},
+		{name: "includes account_id column", substring: "account_id", description: "index key must include account_id"},
+		{name: "includes asset_code column", substring: "asset_code", description: "index key must include asset_code"},
+		{name: "includes key column", substring: "key", description: "index key must include the key column"},
+		{name: "is a partial index filtering soft-deleted rows", substring: "where deleted_at is null", description: "must be a partial index so soft-deleted rows do not block new balances"},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Contains(t, sql, tc.substring, tc.description)
+		})
+	}
+}
+
+// TestMigration000032_DownSQL_DropsUniqueIndex verifies the down migration
+// removes the index added by the up migration. DROP must also use
+// CONCURRENTLY to stay symmetric with the up migration and avoid locks.
+func TestMigration000032_DownSQL_DropsUniqueIndex(t *testing.T) {
+	t.Parallel()
+
+	dir := migrationsDir(t)
+	path := filepath.Join(dir, "000032_add_unique_balance_account_key.down.sql")
+
+	content, err := os.ReadFile(path)
+	require.NoError(t, err, "down migration file must be readable")
+
+	sql := strings.ToLower(string(content))
+
+	tests := []struct {
+		name        string
+		substring   string
+		description string
+	}{
+		{name: "drops the index", substring: "drop index", description: "must drop the index added by the up migration"},
+		{name: "uses CONCURRENTLY", substring: "concurrently", description: "must drop the index CONCURRENTLY to avoid table locks"},
+		{name: "uses IF EXISTS for idempotency", substring: "if exists", description: "must use IF EXISTS for idempotent rollback"},
+		{name: "targets idx_unique_balance_account_key", substring: "idx_unique_balance_account_key", description: "must drop the canonical index name"},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Contains(t, sql, tc.substring, tc.description)
+		})
+	}
+}

--- a/pkg/constant/balance.go
+++ b/pkg/constant/balance.go
@@ -5,5 +5,12 @@
 package constant
 
 const (
+	// DefaultBalanceKey identifies the primary balance automatically created
+	// for every account. It is the only balance key guaranteed to exist.
 	DefaultBalanceKey = "default"
+
+	// OverdraftBalanceKey identifies the system-managed balance that tracks
+	// overdraft usage. It is auto-created when overdraft is enabled on the
+	// parent balance and is protected from direct public operations.
+	OverdraftBalanceKey = "overdraft"
 )

--- a/pkg/constant/errors.go
+++ b/pkg/constant/errors.go
@@ -191,6 +191,21 @@ var (
 	// ErrDeletionOfInternalBalance is returned when a delete request targets
 	// a balance whose scope is "internal".
 	ErrDeletionOfInternalBalance = errors.New("0169")
+	// ErrReservedBalanceKey is returned when a public create-balance request
+	// uses a system-managed key (e.g. "overdraft").
+	ErrReservedBalanceKey = errors.New("0170")
+	// ErrInvalidBalanceDirection is returned when the supplied balance
+	// direction is not one of the supported enum members.
+	ErrInvalidBalanceDirection = errors.New("0171")
+	// ErrInvalidBalanceSettings is returned when a balance settings payload
+	// fails validation (e.g. limit enabled without a value, invalid scope).
+	ErrInvalidBalanceSettings = errors.New("0172")
+	// ErrOverdraftDisableWithUsage is returned when a caller attempts to
+	// disable overdraft on a balance that still carries outstanding debt.
+	ErrOverdraftDisableWithUsage = errors.New("0173")
+	// ErrOverdraftLimitBelowUsage is returned when a caller attempts to
+	// reduce the overdraft limit below the currently used amount.
+	ErrOverdraftLimitBelowUsage = errors.New("0174")
 )
 
 // List of CRM errors.

--- a/pkg/constant/errors_overdraft_test.go
+++ b/pkg/constant/errors_overdraft_test.go
@@ -13,7 +13,7 @@ import (
 
 // TestOverdraftErrorCodes_Registered verifies that the three overdraft
 // error codes are registered in the sentinel error table with the exact
-// numeric codes mandated by the TRD.
+// numeric codes for the overdraft feature.
 func TestOverdraftErrorCodes_Registered(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/errors.go
+++ b/pkg/errors.go
@@ -467,6 +467,36 @@ func ValidateBusinessError(err error, entityType string, args ...any) error {
 			Title:      "Deletion Of Internal Balance Error",
 			Message:    "Internal-scope balances cannot be deleted. They are managed by the system and must remain for accounting consistency.",
 		},
+		constant.ErrReservedBalanceKey: ValidationError{
+			EntityType: entityType,
+			Code:       constant.ErrReservedBalanceKey.Error(),
+			Title:      "Reserved Balance Key Error",
+			Message:    fmt.Sprintf("The balance key %v is reserved for system use and cannot be created through the public API. Please choose a different key and try again.", args...),
+		},
+		constant.ErrInvalidBalanceDirection: ValidationError{
+			EntityType: entityType,
+			Code:       constant.ErrInvalidBalanceDirection.Error(),
+			Title:      "Invalid Balance Direction Error",
+			Message:    fmt.Sprintf("The balance direction %v is not supported. Allowed values are \"credit\" and \"debit\".", args...),
+		},
+		constant.ErrInvalidBalanceSettings: ValidationError{
+			EntityType: entityType,
+			Code:       constant.ErrInvalidBalanceSettings.Error(),
+			Title:      "Invalid Balance Settings Error",
+			Message:    "The balance settings payload is invalid. Please review overdraft, limit, and scope fields and try again.",
+		},
+		constant.ErrOverdraftDisableWithUsage: UnprocessableOperationError{
+			EntityType: entityType,
+			Code:       constant.ErrOverdraftDisableWithUsage.Error(),
+			Title:      "Overdraft Disable With Usage Error",
+			Message:    "Overdraft cannot be disabled while the balance still carries outstanding overdraft usage. Repay the outstanding amount before disabling overdraft.",
+		},
+		constant.ErrOverdraftLimitBelowUsage: UnprocessableOperationError{
+			EntityType: entityType,
+			Code:       constant.ErrOverdraftLimitBelowUsage.Error(),
+			Title:      "Overdraft Limit Below Usage Error",
+			Message:    "The new overdraft limit is below the amount currently used. Raise the limit above the current usage or repay the outstanding amount before reducing the limit.",
+		},
 		constant.ErrAccountIneligibility: UnprocessableOperationError{
 			EntityType: entityType,
 			Code:       constant.ErrAccountIneligibility.Error(),

--- a/pkg/mmodel/balance_overdraft_test.go
+++ b/pkg/mmodel/balance_overdraft_test.go
@@ -105,7 +105,7 @@ func TestCreateAdditionalBalance_HasOverdraftFields(t *testing.T) {
 }
 
 // TestUpdateBalance_HasSettingsField verifies the update payload exposes
-// Settings (optional). Direction is immutable after creation per PRD §4, so
+// Settings (optional). Direction is immutable after creation, so
 // UpdateBalance must NOT expose Direction.
 func TestUpdateBalance_HasSettingsField(t *testing.T) {
 	t.Parallel()

--- a/pkg/mmodel/balance_settings.go
+++ b/pkg/mmodel/balance_settings.go
@@ -56,7 +56,7 @@ type BalanceSettings struct {
 }
 
 // NewDefaultBalanceSettings returns a BalanceSettings initialized with the
-// defaults mandated by PRD RF-1:
+// safe defaults for the overdraft feature:
 //   - BalanceScope  = "transactional"
 //   - AllowOverdraft = false
 //   - OverdraftLimitEnabled = false
@@ -73,7 +73,7 @@ func NewDefaultBalanceSettings() *BalanceSettings {
 	}
 }
 
-// Validate enforces the balance settings contract from PRD §4 RF-1.
+// Validate enforces the balance settings contract.
 //
 // Rules:
 //   - BalanceScope MUST be "transactional", "internal", or empty (=>

--- a/pkg/mmodel/balance_settings_test.go
+++ b/pkg/mmodel/balance_settings_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 // TestBalanceSettings_Defaults verifies the default BalanceSettings produced by
-// NewDefaultBalanceSettings matches PRD RF-1:
+// NewDefaultBalanceSettings returns safe defaults:
 //   - BalanceScope = "transactional"
 //   - AllowOverdraft = false
 //   - OverdraftLimitEnabled = false
@@ -30,7 +30,7 @@ func TestBalanceSettings_Defaults(t *testing.T) {
 }
 
 // TestBalanceSettings_Validate_ValidCombinations covers the 4 valid combinations
-// from PRD §4 RF-1 (balance settings contract).
+// from the balance settings contract.
 func TestBalanceSettings_Validate_ValidCombinations(t *testing.T) {
 	t.Parallel()
 
@@ -96,7 +96,7 @@ func TestBalanceSettings_Validate_ValidCombinations(t *testing.T) {
 }
 
 // TestBalanceSettings_Validate_InvalidCombinations covers every rejection path
-// described in PRD §4 RF-1 and the TRD.
+// described in the balance settings contract.
 func TestBalanceSettings_Validate_InvalidCombinations(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
**Summary**

Adds the runtime behavior for overdraft configuration: administrators can enable overdraft per balance with configurable limits, the system auto-provisions the overdraft tracking balance, and internal balances are protected from direct manipulation. This builds on the schema foundation (T-001 PR) and persistence layer (T-002 PR).

**What changed**

**Balance creation with direction**
- CreateAdditionalBalance accepts optional direction parameter (defaults to "credit")
- Enum validation: only "credit" or "debit" accepted, invalid values rejected
- Reserved key guard: balance key "overdraft" (case-insensitive) rejected from client creation
- Scope guard: clients cannot set balanceScope="internal" -- only the system can

**Overdraft settings on balance update**

- PATCH /balances/{id} accepts settings payload with cross-field validation:
  - overdraftLimitEnabled=true requires overdraftLimit > 0
  - overdraftLimitEnabled=false rejects overdraftLimit if present
  - Cannot disable overdraft when overdraft_used > 0
  - Cannot reduce overdraftLimit below current overdraft_used
  - balanceScope="internal" rejected from client updates
- All validation runs before any persistence -- invalid payloads never reach the database

**Overdraft balance auto-creation**

- When allowOverdraft transitions false → true, the system auto-creates a companion balance:
  - key="overdraft", direction="debit", balanceScope="internal"
  - Same account, asset, organization, ledger as the parent balance
- Idempotent: re-enabling overdraft does not create a duplicate
- Auto-creation runs before settings are persisted -- if it fails, settings remain unchanged (no inconsistent state)
- Uses errors.As(EntityNotFoundError) for correct repository contract matching

**Scope protection**

- Transactions targeting a balanceScope="internal" balance are rejected with error 0168
- Deleting a balanceScope="internal" balance is rejected with error 0169
- Internal balances remain visible via GET (read-only)

**Error codes**

- 0170 -- Reserved balance key (client tried to use "overdraft")
- 0171 -- Invalid balance direction
- 0172 -- Invalid balance settings
- 0173 -- Cannot disable overdraft with outstanding usage
- 0174 -- Cannot reduce overdraft limit below current usage

**Extracted helper file**

- update_balance_overdraft.go (178 lines) -- contains validateUpdateSettings, enforceOverdraftTransition, and ensureOverdraftBalance as single-responsibility helpers

**What's NOT included**

- Transaction enrichment (debit split, credit repayment) -- next PR
- Atomic cache script (Lua) changes
- Event notifications
- Redis write-through for settings (current balance-sync worker handles full hash refresh; sub-second settings freshness is not required)
- E2E tests (will land after transaction enrichment, when the full flow is testable end-to-end)

**Testing**

- 12 unit tests covering all acceptance criteria:
  - Direction: propagation, default, invalid enum, reserved key (4 tests)
  - Settings: validation, disable-with-usage, reduce-limit-below-usage, valid update (4 tests)
  - Auto-creation: enable triggers creation, idempotent re-enable (2 tests)
  - Scope protection: transaction rejection, delete rejection (2 tests)
- Package coverage: 85.7%
- validateUpdateSettings: 100% coverage
- DeleteBalance: 100% coverage
- All pre-existing tests pass (zero regressions)