### PR TITLE
feat(ledger): add  readyz implementation and related tests

### DIFF
--- a/components/ledger/.env.example
+++ b/components/ledger/.env.example
@@ -9,6 +9,18 @@ ENV_NAME=development
 
 VERSION=v3.6.0
 
+# DEPLOYMENT MODE (controls TLS enforcement)
+# Valid values:
+#   - "saas": Lerian-hosted multi-tenant - TLS MANDATORY for all dependencies
+#             Service REFUSES TO START if any dependency lacks TLS
+#   - "byoc": Customer-hosted (Bring Your Own Cloud) - TLS recommended but not enforced
+#             Logs warnings for dependencies without TLS but allows startup
+#   - "local" (default): Developer workstation - TLS optional, no enforcement
+#
+# This setting controls the ValidateSaaSTLS() check at bootstrap.
+# Origin: Monetarie SaaS incident where MongoDB TLS mismatch caused silent failures.
+DEPLOYMENT_MODE=local
+
 # =============================================================================
 # UNIFIED LEDGER CONFIGURATION
 # =============================================================================

--- a/components/ledger/.env.example
+++ b/components/ledger/.env.example
@@ -18,7 +18,6 @@ VERSION=v3.6.0
 #   - "local" (default): Developer workstation - TLS optional, no enforcement
 #
 # This setting controls the ValidateSaaSTLS() check at bootstrap.
-# Origin: Monetarie SaaS incident where MongoDB TLS mismatch caused silent failures.
 DEPLOYMENT_MODE=local
 
 # =============================================================================

--- a/components/ledger/internal/bootstrap/config.go
+++ b/components/ledger/internal/bootstrap/config.go
@@ -50,6 +50,7 @@ type Config struct {
 	EnvName         string `env:"ENV_NAME"`
 	LogLevel        string `env:"LOG_LEVEL"`
 	Version         string `env:"VERSION"`
+	DeploymentMode  string `env:"DEPLOYMENT_MODE"`
 
 	// Server configuration - unified port for all APIs
 	ServerAddress string `env:"SERVER_ADDRESS" envDefault:":3002"`
@@ -684,12 +685,20 @@ func InitServersWithOptions(opts *Options) (*Service, error) {
 
 	logger.Log(context.Background(), libLog.LevelInfo, "Creating unified HTTP server on "+cfg.ServerAddress)
 
+	// === Readyz handler ===
+
+	readyzHandler, err := buildReadyzHandler(cfg, logger, redisConnection, onbPG, txnPG, onbMgo, txnMgo, rmq)
+	if err != nil {
+		return nil, fmt.Errorf("TLS enforcement failed: %w", err)
+	}
+
 	// === Unified server ===
 
 	unifiedServer := NewUnifiedServer(
 		cfg.ServerAddress,
 		logger,
 		telemetry,
+		readyzHandler,
 		onboardingRouteRegistrar,
 		transactionRouteRegistrar,
 		ledgerRouteRegistrar,

--- a/components/ledger/internal/bootstrap/config.go
+++ b/components/ledger/internal/bootstrap/config.go
@@ -18,6 +18,7 @@ import (
 	libCircuitBreaker "github.com/LerianStudio/lib-commons/v4/commons/circuitbreaker"
 	libLog "github.com/LerianStudio/lib-commons/v4/commons/log"
 	libOpentelemetry "github.com/LerianStudio/lib-commons/v4/commons/opentelemetry"
+	"github.com/LerianStudio/lib-commons/v4/commons/opentelemetry/metrics"
 	libRedis "github.com/LerianStudio/lib-commons/v4/commons/redis"
 	tmclient "github.com/LerianStudio/lib-commons/v4/commons/tenant-manager/client"
 	tmcore "github.com/LerianStudio/lib-commons/v4/commons/tenant-manager/core"
@@ -687,7 +688,13 @@ func InitServersWithOptions(opts *Options) (*Service, error) {
 
 	// === Readyz handler ===
 
-	readyzHandler, err := buildReadyzHandler(cfg, logger, redisConnection, onbPG, txnPG, onbMgo, txnMgo, rmq)
+	// Get metricsFactory from telemetry (nil-safe: checked inside handler)
+	var metricsFactory *metrics.MetricsFactory
+	if telemetry != nil {
+		metricsFactory = telemetry.MetricsFactory
+	}
+
+	readyzHandler, err := buildReadyzHandler(cfg, logger, redisConnection, onbPG, txnPG, onbMgo, txnMgo, rmq, metricsFactory)
 	if err != nil {
 		return nil, fmt.Errorf("TLS enforcement failed: %w", err)
 	}

--- a/components/ledger/internal/bootstrap/readyz.go
+++ b/components/ledger/internal/bootstrap/readyz.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"sync"
 	"sync/atomic"
 	"time"
 
@@ -231,133 +230,6 @@ func (h *ReadyzHandler) checkLifecycleState() (string, bool) {
 	return "", true
 }
 
-// runChecksConcurrently runs all checkers in parallel using goroutines.
-// Returns a map of checker name to DependencyCheck result.
-func (h *ReadyzHandler) runChecksConcurrently(ctx context.Context, checkers []DependencyChecker) map[string]DependencyCheck {
-	checks := make(map[string]DependencyCheck)
-
-	if len(checkers) == 0 {
-		return checks
-	}
-
-	type checkResult struct {
-		name  string
-		check DependencyCheck
-	}
-
-	results := make(chan checkResult, len(checkers))
-
-	var wg sync.WaitGroup
-
-	for _, checker := range checkers {
-		wg.Add(1)
-
-		go func(c DependencyChecker) {
-			defer wg.Done()
-
-			checkCtx, cancel := context.WithTimeout(ctx, h.timeoutForChecker(c))
-			defer cancel()
-
-			start := time.Now()
-			check := c.Check(checkCtx)
-			durationMs := time.Since(start).Milliseconds()
-
-			// Set TLS field
-			if c.TLSEnabled() {
-				tlsEnabled := true
-				check.TLS = &tlsEnabled
-			} else {
-				tlsDisabled := false
-				check.TLS = &tlsDisabled
-			}
-
-			// Record metrics
-			h.recordCheckMetrics(ctx, c.Name(), check.Status, durationMs)
-
-			// Log full error and sanitize for non-local modes
-			h.logAndSanitizeCheck(ctx, c.Name(), &check)
-
-			results <- checkResult{name: c.Name(), check: check}
-		}(checker)
-	}
-
-	// Close results channel when all goroutines complete
-	go func() {
-		wg.Wait()
-		close(results)
-	}()
-
-	// Collect results
-	for result := range results {
-		checks[result.name] = result.check
-	}
-
-	return checks
-}
-
-// runTenantChecksConcurrently runs tenant-aware checkers in parallel for a specific tenant.
-func (h *ReadyzHandler) runTenantChecksConcurrently(ctx context.Context, tenantID string, checkers []TenantAwareDependencyChecker) map[string]DependencyCheck {
-	checks := make(map[string]DependencyCheck)
-
-	if len(checkers) == 0 {
-		return checks
-	}
-
-	type checkResult struct {
-		name  string
-		check DependencyCheck
-	}
-
-	results := make(chan checkResult, len(checkers))
-
-	var wg sync.WaitGroup
-
-	for _, checker := range checkers {
-		wg.Add(1)
-
-		go func(c TenantAwareDependencyChecker) {
-			defer wg.Done()
-
-			checkCtx, cancel := context.WithTimeout(ctx, h.timeoutForChecker(c))
-			defer cancel()
-
-			start := time.Now()
-			check := c.CheckTenant(checkCtx, tenantID)
-			durationMs := time.Since(start).Milliseconds()
-
-			// Set TLS field
-			if c.TLSEnabled() {
-				tlsEnabled := true
-				check.TLS = &tlsEnabled
-			} else {
-				tlsDisabled := false
-				check.TLS = &tlsDisabled
-			}
-
-			// Record metrics
-			h.recordCheckMetrics(ctx, c.Name(), check.Status, durationMs)
-
-			// Log full error and sanitize for non-local modes
-			h.logAndSanitizeCheck(ctx, c.Name(), &check)
-
-			results <- checkResult{name: c.Name(), check: check}
-		}(checker)
-	}
-
-	// Close results channel when all goroutines complete
-	go func() {
-		wg.Wait()
-		close(results)
-	}()
-
-	// Collect results
-	for result := range results {
-		checks[result.name] = result.check
-	}
-
-	return checks
-}
-
 // HandleReadyz handles the /readyz endpoint for global health checks.
 // In multi-tenant mode, database checkers return "n/a" since connections are tenant-scoped.
 // Redis always returns actual status (shared infrastructure).
@@ -373,17 +245,38 @@ func (h *ReadyzHandler) HandleReadyz(c *fiber.Ctx) error {
 		})
 	}
 
-	// Run all checkers concurrently
-	checks := h.runChecksConcurrently(c.Context(), h.checkers)
-
-	// Determine overall health status
+	checks := make(map[string]DependencyCheck)
 	allHealthy := true
 
-	for _, check := range checks {
+	// Run all checkers sequentially
+	for _, checker := range h.checkers {
+		checkCtx, cancel := context.WithTimeout(c.Context(), h.timeoutForChecker(checker))
+
+		start := time.Now()
+		check := checker.Check(checkCtx)
+		durationMs := time.Since(start).Milliseconds()
+
+		cancel()
+
+		// Set TLS field
+		if checker.TLSEnabled() {
+			tlsEnabled := true
+			check.TLS = &tlsEnabled
+		} else {
+			tlsDisabled := false
+			check.TLS = &tlsDisabled
+		}
+
+		// Record metrics
+		h.recordCheckMetrics(c.Context(), checker.Name(), check.Status, durationMs)
+
+		// Log full error and sanitize for non-local modes
+		h.logAndSanitizeCheck(c.Context(), checker.Name(), &check)
+
+		checks[checker.Name()] = check
+
 		if check.Status == StatusDown || check.Status == StatusDegraded {
 			allHealthy = false
-
-			break
 		}
 	}
 
@@ -438,33 +331,75 @@ func (h *ReadyzHandler) HandleReadyzTenant(c *fiber.Ctx) error {
 	// Set tenant ID in context for downstream managers
 	ctx := tmcore.ContextWithTenantID(c.Context(), tenantID)
 
-	// Run tenant-aware checkers concurrently
-	tenantChecks := h.runTenantChecksConcurrently(ctx, tenantID, h.tenantCheckers)
-
-	// Get non-tenant-aware checkers (like Redis which is shared)
-	nonTenantCheckers := h.getNonTenantAwareCheckers()
-
-	// Run non-tenant-aware checkers concurrently
-	sharedChecks := h.runChecksConcurrently(ctx, nonTenantCheckers)
-
-	// Merge results
 	checks := make(map[string]DependencyCheck)
-	for name, check := range tenantChecks {
-		checks[name] = check
-	}
-
-	for name, check := range sharedChecks {
-		checks[name] = check
-	}
-
-	// Determine overall health status
 	allHealthy := true
 
-	for _, check := range checks {
+	// Run tenant-aware checkers sequentially
+	for _, checker := range h.tenantCheckers {
+		checkCtx, cancel := context.WithTimeout(ctx, h.timeoutForChecker(checker))
+
+		start := time.Now()
+		check := checker.CheckTenant(checkCtx, tenantID)
+		durationMs := time.Since(start).Milliseconds()
+
+		cancel()
+
+		// Set TLS field
+		if checker.TLSEnabled() {
+			tlsEnabled := true
+			check.TLS = &tlsEnabled
+		} else {
+			tlsDisabled := false
+			check.TLS = &tlsDisabled
+		}
+
+		// Record metrics
+		h.recordCheckMetrics(ctx, checker.Name(), check.Status, durationMs)
+
+		// Log full error and sanitize for non-local modes
+		h.logAndSanitizeCheck(ctx, checker.Name(), &check)
+
+		checks[checker.Name()] = check
+
 		if check.Status == StatusDown || check.Status == StatusDegraded {
 			allHealthy = false
+		}
+	}
 
-			break
+	// Run non-tenant-aware checkers (like Redis which is shared)
+	for _, checker := range h.checkers {
+		// Skip if we already have a tenant-aware version
+		if h.hasTenantChecker(checker.Name()) {
+			continue
+		}
+
+		checkCtx, cancel := context.WithTimeout(ctx, h.timeoutForChecker(checker))
+
+		start := time.Now()
+		check := checker.Check(checkCtx)
+		durationMs := time.Since(start).Milliseconds()
+
+		cancel()
+
+		// Set TLS field
+		if checker.TLSEnabled() {
+			tlsEnabled := true
+			check.TLS = &tlsEnabled
+		} else {
+			tlsDisabled := false
+			check.TLS = &tlsDisabled
+		}
+
+		// Record metrics
+		h.recordCheckMetrics(ctx, checker.Name(), check.Status, durationMs)
+
+		// Log full error and sanitize for non-local modes
+		h.logAndSanitizeCheck(ctx, checker.Name(), &check)
+
+		checks[checker.Name()] = check
+
+		if check.Status == StatusDown || check.Status == StatusDegraded {
+			allHealthy = false
 		}
 	}
 
@@ -487,20 +422,6 @@ func (h *ReadyzHandler) HandleReadyzTenant(c *fiber.Ctx) error {
 	}
 
 	return c.Status(httpStatus).JSON(response)
-}
-
-// getNonTenantAwareCheckers returns checkers that don't have a tenant-aware version.
-// These are shared infrastructure components like Redis.
-func (h *ReadyzHandler) getNonTenantAwareCheckers() []DependencyChecker {
-	var result []DependencyChecker
-
-	for _, checker := range h.checkers {
-		if !h.hasTenantChecker(checker.Name()) {
-			result = append(result, checker)
-		}
-	}
-
-	return result
 }
 
 // hasTenantChecker returns true if a tenant-aware checker with the given name exists.

--- a/components/ledger/internal/bootstrap/readyz.go
+++ b/components/ledger/internal/bootstrap/readyz.go
@@ -8,15 +8,20 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	libCircuitBreaker "github.com/LerianStudio/lib-commons/v4/commons/circuitbreaker"
 	libLog "github.com/LerianStudio/lib-commons/v4/commons/log"
+	"github.com/LerianStudio/lib-commons/v4/commons/opentelemetry/metrics"
 	libRedis "github.com/LerianStudio/lib-commons/v4/commons/redis"
 	tmcore "github.com/LerianStudio/lib-commons/v4/commons/tenant-manager/core"
 	tmmongo "github.com/LerianStudio/lib-commons/v4/commons/tenant-manager/mongo"
 	tmpostgres "github.com/LerianStudio/lib-commons/v4/commons/tenant-manager/postgres"
+	"github.com/LerianStudio/midaz/v3/pkg/utils"
 	"github.com/gofiber/fiber/v2"
+	"go.opentelemetry.io/otel/attribute"
 )
 
 // DependencyStatus represents the health status of a dependency.
@@ -49,6 +54,10 @@ const (
 
 	// DefaultRabbitMQTimeout is the default timeout for RabbitMQ health checks.
 	DefaultRabbitMQTimeout = 2 * time.Second
+
+	// DefaultDrainDelay is the time to wait after starting drain before fully shutting down.
+	// This gives load balancers time to stop sending traffic to the pod.
+	DefaultDrainDelay = 12 * time.Second
 )
 
 // DependencyCheck represents the health check result for a single dependency.
@@ -67,6 +76,7 @@ type ReadyzResponse struct {
 	Checks         map[string]DependencyCheck `json:"checks"`
 	Version        string                     `json:"version"`
 	DeploymentMode string                     `json:"deployment_mode"`
+	Reason         string                     `json:"reason,omitempty"`
 }
 
 // DependencyChecker is the interface for probing a dependency's health.
@@ -104,6 +114,13 @@ type ReadyzHandler struct {
 	txnPGManager       *tmpostgres.Manager
 	onbMongoManager    *tmmongo.Manager
 	txnMongoManager    *tmmongo.Manager
+
+	// Lifecycle state
+	serverReady atomic.Bool // true after HTTP server is listening
+	draining    atomic.Bool // true after SIGTERM received (graceful drain)
+
+	// OTel metrics (nil when telemetry disabled)
+	metricsFactory *metrics.MetricsFactory
 }
 
 // ReadyzHandlerConfig holds configuration for creating a ReadyzHandler.
@@ -118,6 +135,7 @@ type ReadyzHandlerConfig struct {
 	TxnPGManager       *tmpostgres.Manager
 	OnbMongoManager    *tmmongo.Manager
 	TxnMongoManager    *tmmongo.Manager
+	MetricsFactory     *metrics.MetricsFactory
 }
 
 // NewReadyzHandler creates a new ReadyzHandler with the given configuration.
@@ -133,39 +151,239 @@ func NewReadyzHandler(cfg ReadyzHandlerConfig) *ReadyzHandler {
 		txnPGManager:       cfg.TxnPGManager,
 		onbMongoManager:    cfg.OnbMongoManager,
 		txnMongoManager:    cfg.TxnMongoManager,
+		metricsFactory:     cfg.MetricsFactory,
 	}
+}
+
+// recordCheckMetrics records OTel metrics for a health check result.
+func (h *ReadyzHandler) recordCheckMetrics(ctx context.Context, checkerName string, status DependencyStatus, durationMs int64) {
+	if h.metricsFactory == nil {
+		return
+	}
+
+	attrs := []attribute.KeyValue{
+		attribute.String("checker", checkerName),
+		attribute.String("status", string(status)),
+	}
+
+	// Record check duration histogram
+	if histogram, err := h.metricsFactory.Histogram(utils.ReadyzCheckDuration); err == nil {
+		_ = histogram.WithAttributes(attrs...).Record(ctx, durationMs)
+	}
+
+	// Record check status counter
+	if counter, err := h.metricsFactory.Counter(utils.ReadyzCheckStatus); err == nil {
+		_ = counter.WithAttributes(attrs...).Add(ctx, 1)
+	}
+}
+
+// recordRequestMetrics records OTel metrics for a readyz request.
+func (h *ReadyzHandler) recordRequestMetrics(ctx context.Context, endpoint string, healthy bool) {
+	if h.metricsFactory == nil {
+		return
+	}
+
+	attrs := []attribute.KeyValue{
+		attribute.String("endpoint", endpoint),
+		attribute.Bool("healthy", healthy),
+	}
+
+	if counter, err := h.metricsFactory.Counter(utils.ReadyzRequestsTotal); err == nil {
+		_ = counter.WithAttributes(attrs...).Add(ctx, 1)
+	}
+}
+
+// SetServerReady marks the server as ready to accept traffic.
+// Call this after the HTTP server has started listening.
+func (h *ReadyzHandler) SetServerReady() {
+	h.serverReady.Store(true)
+	h.logger.Log(context.Background(), libLog.LevelInfo, "Readyz: server marked as ready")
+}
+
+// StartDrain initiates graceful drain mode.
+// After calling this, readyz will return 503 to signal load balancers to stop sending traffic.
+func (h *ReadyzHandler) StartDrain() {
+	h.draining.Store(true)
+	h.logger.Log(context.Background(), libLog.LevelInfo, "Readyz: graceful drain started")
+}
+
+// IsDraining returns true if the handler is in drain mode.
+func (h *ReadyzHandler) IsDraining() bool {
+	return h.draining.Load()
+}
+
+// IsServerReady returns true if the server is ready to accept traffic.
+func (h *ReadyzHandler) IsServerReady() bool {
+	return h.serverReady.Load()
+}
+
+// checkLifecycleState checks the server lifecycle state (self-probe and graceful drain).
+// Returns (reason, ok) where ok is false if the server should return 503.
+func (h *ReadyzHandler) checkLifecycleState() (string, bool) {
+	if !h.serverReady.Load() {
+		return "server not ready (startup in progress)", false
+	}
+
+	if h.draining.Load() {
+		return "server draining (shutdown in progress)", false
+	}
+
+	return "", true
+}
+
+// runChecksConcurrently runs all checkers in parallel using goroutines.
+// Returns a map of checker name to DependencyCheck result.
+func (h *ReadyzHandler) runChecksConcurrently(ctx context.Context, checkers []DependencyChecker) map[string]DependencyCheck {
+	checks := make(map[string]DependencyCheck)
+
+	if len(checkers) == 0 {
+		return checks
+	}
+
+	type checkResult struct {
+		name  string
+		check DependencyCheck
+	}
+
+	results := make(chan checkResult, len(checkers))
+
+	var wg sync.WaitGroup
+
+	for _, checker := range checkers {
+		wg.Add(1)
+
+		go func(c DependencyChecker) {
+			defer wg.Done()
+
+			checkCtx, cancel := context.WithTimeout(ctx, h.timeoutForChecker(c))
+			defer cancel()
+
+			start := time.Now()
+			check := c.Check(checkCtx)
+			durationMs := time.Since(start).Milliseconds()
+
+			// Set TLS field
+			if c.TLSEnabled() {
+				tlsEnabled := true
+				check.TLS = &tlsEnabled
+			} else {
+				tlsDisabled := false
+				check.TLS = &tlsDisabled
+			}
+
+			// Record metrics
+			h.recordCheckMetrics(ctx, c.Name(), check.Status, durationMs)
+
+			// Log full error and sanitize for non-local modes
+			h.logAndSanitizeCheck(ctx, c.Name(), &check)
+
+			results <- checkResult{name: c.Name(), check: check}
+		}(checker)
+	}
+
+	// Close results channel when all goroutines complete
+	go func() {
+		wg.Wait()
+		close(results)
+	}()
+
+	// Collect results
+	for result := range results {
+		checks[result.name] = result.check
+	}
+
+	return checks
+}
+
+// runTenantChecksConcurrently runs tenant-aware checkers in parallel for a specific tenant.
+func (h *ReadyzHandler) runTenantChecksConcurrently(ctx context.Context, tenantID string, checkers []TenantAwareDependencyChecker) map[string]DependencyCheck {
+	checks := make(map[string]DependencyCheck)
+
+	if len(checkers) == 0 {
+		return checks
+	}
+
+	type checkResult struct {
+		name  string
+		check DependencyCheck
+	}
+
+	results := make(chan checkResult, len(checkers))
+
+	var wg sync.WaitGroup
+
+	for _, checker := range checkers {
+		wg.Add(1)
+
+		go func(c TenantAwareDependencyChecker) {
+			defer wg.Done()
+
+			checkCtx, cancel := context.WithTimeout(ctx, h.timeoutForChecker(c))
+			defer cancel()
+
+			start := time.Now()
+			check := c.CheckTenant(checkCtx, tenantID)
+			durationMs := time.Since(start).Milliseconds()
+
+			// Set TLS field
+			if c.TLSEnabled() {
+				tlsEnabled := true
+				check.TLS = &tlsEnabled
+			} else {
+				tlsDisabled := false
+				check.TLS = &tlsDisabled
+			}
+
+			// Record metrics
+			h.recordCheckMetrics(ctx, c.Name(), check.Status, durationMs)
+
+			// Log full error and sanitize for non-local modes
+			h.logAndSanitizeCheck(ctx, c.Name(), &check)
+
+			results <- checkResult{name: c.Name(), check: check}
+		}(checker)
+	}
+
+	// Close results channel when all goroutines complete
+	go func() {
+		wg.Wait()
+		close(results)
+	}()
+
+	// Collect results
+	for result := range results {
+		checks[result.name] = result.check
+	}
+
+	return checks
 }
 
 // HandleReadyz handles the /readyz endpoint for global health checks.
 // In multi-tenant mode, database checkers return "n/a" since connections are tenant-scoped.
 // Redis always returns actual status (shared infrastructure).
 func (h *ReadyzHandler) HandleReadyz(c *fiber.Ctx) error {
-	checks := make(map[string]DependencyCheck)
+	// Check lifecycle state first (self-probe and graceful drain)
+	if reason, ok := h.checkLifecycleState(); !ok {
+		return c.Status(http.StatusServiceUnavailable).JSON(ReadyzResponse{
+			Status:         "unhealthy",
+			Checks:         map[string]DependencyCheck{},
+			Version:        h.version,
+			DeploymentMode: h.deploymentMode,
+			Reason:         reason,
+		})
+	}
+
+	// Run all checkers concurrently
+	checks := h.runChecksConcurrently(c.Context(), h.checkers)
+
+	// Determine overall health status
 	allHealthy := true
 
-	for _, checker := range h.checkers {
-		ctx, cancel := context.WithTimeout(c.Context(), h.timeoutForChecker(checker))
-
-		check := checker.Check(ctx)
-
-		cancel()
-
-		// Set TLS field if enabled
-		if checker.TLSEnabled() {
-			tlsEnabled := true
-			check.TLS = &tlsEnabled
-		} else {
-			tlsDisabled := false
-			check.TLS = &tlsDisabled
-		}
-
-		// Log full error and sanitize for non-local modes
-		h.logAndSanitizeCheck(c.Context(), checker.Name(), &check)
-
-		checks[checker.Name()] = check
-
+	for _, check := range checks {
 		if check.Status == StatusDown || check.Status == StatusDegraded {
 			allHealthy = false
+
+			break
 		}
 	}
 
@@ -176,6 +394,9 @@ func (h *ReadyzHandler) HandleReadyz(c *fiber.Ctx) error {
 		status = "unhealthy"
 		httpStatus = http.StatusServiceUnavailable
 	}
+
+	// Record request metrics
+	h.recordRequestMetrics(c.Context(), "/readyz", allHealthy)
 
 	response := ReadyzResponse{
 		Status:         status,
@@ -203,68 +424,47 @@ func (h *ReadyzHandler) HandleReadyzTenant(c *fiber.Ctx) error {
 		})
 	}
 
+	// Check lifecycle state first (self-probe and graceful drain)
+	if reason, ok := h.checkLifecycleState(); !ok {
+		return c.Status(http.StatusServiceUnavailable).JSON(ReadyzResponse{
+			Status:         "unhealthy",
+			Checks:         map[string]DependencyCheck{},
+			Version:        h.version,
+			DeploymentMode: h.deploymentMode,
+			Reason:         reason,
+		})
+	}
+
 	// Set tenant ID in context for downstream managers
 	ctx := tmcore.ContextWithTenantID(c.Context(), tenantID)
 
+	// Run tenant-aware checkers concurrently
+	tenantChecks := h.runTenantChecksConcurrently(ctx, tenantID, h.tenantCheckers)
+
+	// Get non-tenant-aware checkers (like Redis which is shared)
+	nonTenantCheckers := h.getNonTenantAwareCheckers()
+
+	// Run non-tenant-aware checkers concurrently
+	sharedChecks := h.runChecksConcurrently(ctx, nonTenantCheckers)
+
+	// Merge results
 	checks := make(map[string]DependencyCheck)
-	allHealthy := true
-
-	// Run tenant-aware checkers
-	for _, checker := range h.tenantCheckers {
-		checkCtx, cancel := context.WithTimeout(ctx, h.timeoutForChecker(checker))
-
-		check := checker.CheckTenant(checkCtx, tenantID)
-
-		cancel()
-
-		// Set TLS field if enabled
-		if checker.TLSEnabled() {
-			tlsEnabled := true
-			check.TLS = &tlsEnabled
-		} else {
-			tlsDisabled := false
-			check.TLS = &tlsDisabled
-		}
-
-		// Log full error and sanitize for non-local modes
-		h.logAndSanitizeCheck(ctx, checker.Name(), &check)
-
-		checks[checker.Name()] = check
-
-		if check.Status == StatusDown || check.Status == StatusDegraded {
-			allHealthy = false
-		}
+	for name, check := range tenantChecks {
+		checks[name] = check
 	}
 
-	// Run non-tenant-aware checkers (like Redis which is shared)
-	for _, checker := range h.checkers {
-		// Skip if we already have a tenant-aware version
-		if h.hasTenantChecker(checker.Name()) {
-			continue
-		}
+	for name, check := range sharedChecks {
+		checks[name] = check
+	}
 
-		checkCtx, cancel := context.WithTimeout(ctx, h.timeoutForChecker(checker))
+	// Determine overall health status
+	allHealthy := true
 
-		check := checker.Check(checkCtx)
-
-		cancel()
-
-		// Set TLS field if enabled
-		if checker.TLSEnabled() {
-			tlsEnabled := true
-			check.TLS = &tlsEnabled
-		} else {
-			tlsDisabled := false
-			check.TLS = &tlsDisabled
-		}
-
-		// Log full error and sanitize for non-local modes
-		h.logAndSanitizeCheck(ctx, checker.Name(), &check)
-
-		checks[checker.Name()] = check
-
+	for _, check := range checks {
 		if check.Status == StatusDown || check.Status == StatusDegraded {
 			allHealthy = false
+
+			break
 		}
 	}
 
@@ -276,6 +476,9 @@ func (h *ReadyzHandler) HandleReadyzTenant(c *fiber.Ctx) error {
 		httpStatus = http.StatusServiceUnavailable
 	}
 
+	// Record request metrics
+	h.recordRequestMetrics(ctx, "/readyz/tenant", allHealthy)
+
 	response := ReadyzResponse{
 		Status:         status,
 		Checks:         checks,
@@ -284,6 +487,20 @@ func (h *ReadyzHandler) HandleReadyzTenant(c *fiber.Ctx) error {
 	}
 
 	return c.Status(httpStatus).JSON(response)
+}
+
+// getNonTenantAwareCheckers returns checkers that don't have a tenant-aware version.
+// These are shared infrastructure components like Redis.
+func (h *ReadyzHandler) getNonTenantAwareCheckers() []DependencyChecker {
+	var result []DependencyChecker
+
+	for _, checker := range h.checkers {
+		if !h.hasTenantChecker(checker.Name()) {
+			result = append(result, checker)
+		}
+	}
+
+	return result
 }
 
 // hasTenantChecker returns true if a tenant-aware checker with the given name exists.
@@ -393,6 +610,7 @@ func buildReadyzHandler(
 	onbMgo *onboardingMongoComponents,
 	txnMgo *transactionMongoComponents,
 	rmq *rabbitMQComponents,
+	metricsFactory *metrics.MetricsFactory,
 ) (*ReadyzHandler, error) {
 	// Build DSN strings for TLS detection
 	onbPGDSN := fmt.Sprintf("host=%s user=%s password=%s dbname=%s port=%s sslmode=%s",
@@ -545,5 +763,6 @@ func buildReadyzHandler(
 		TxnPGManager:       txnPG.pgManager,
 		OnbMongoManager:    onbMgo.mongoManager,
 		TxnMongoManager:    txnMgo.mongoManager,
+		MetricsFactory:     metricsFactory,
 	}), nil
 }

--- a/components/ledger/internal/bootstrap/readyz.go
+++ b/components/ledger/internal/bootstrap/readyz.go
@@ -159,6 +159,9 @@ func (h *ReadyzHandler) HandleReadyz(c *fiber.Ctx) error {
 			check.TLS = &tlsDisabled
 		}
 
+		// Log full error and sanitize for non-local modes
+		h.logAndSanitizeCheck(c.Context(), checker.Name(), &check)
+
 		checks[checker.Name()] = check
 
 		if check.Status == StatusDown || check.Status == StatusDegraded {
@@ -223,6 +226,9 @@ func (h *ReadyzHandler) HandleReadyzTenant(c *fiber.Ctx) error {
 			check.TLS = &tlsDisabled
 		}
 
+		// Log full error and sanitize for non-local modes
+		h.logAndSanitizeCheck(ctx, checker.Name(), &check)
+
 		checks[checker.Name()] = check
 
 		if check.Status == StatusDown || check.Status == StatusDegraded {
@@ -251,6 +257,9 @@ func (h *ReadyzHandler) HandleReadyzTenant(c *fiber.Ctx) error {
 			tlsDisabled := false
 			check.TLS = &tlsDisabled
 		}
+
+		// Log full error and sanitize for non-local modes
+		h.logAndSanitizeCheck(ctx, checker.Name(), &check)
 
 		checks[checker.Name()] = check
 
@@ -342,6 +351,34 @@ func containsLower(s, substr string) bool {
 	}
 
 	return false
+}
+
+// sanitizeError returns a sanitized error message for non-local deployment modes.
+// In local mode, the full error is returned for debugging.
+// In saas/byoc modes, the error is sanitized to prevent leaking internal details.
+func (h *ReadyzHandler) sanitizeError(checkerName, originalError string) string {
+	if h.deploymentMode == DeploymentModeLocal {
+		return originalError
+	}
+
+	return fmt.Sprintf("%s check failed", checkerName)
+}
+
+// logAndSanitizeCheck logs the full error server-side and sanitizes it in the response.
+// This ensures operators can debug issues while preventing information disclosure to clients.
+func (h *ReadyzHandler) logAndSanitizeCheck(ctx context.Context, checkerName string, check *DependencyCheck) {
+	if check.Error == "" {
+		return
+	}
+
+	// Always log the full error server-side for debugging
+	h.logger.Log(ctx, libLog.LevelWarn, "Health check failed",
+		libLog.String("checker", checkerName),
+		libLog.String("status", string(check.Status)),
+		libLog.String("error", check.Error))
+
+	// Sanitize the error in the response for non-local modes
+	check.Error = h.sanitizeError(checkerName, check.Error)
 }
 
 // buildReadyzHandler creates the ReadyzHandler with appropriate checkers based on mode.
@@ -468,21 +505,15 @@ func buildReadyzHandler(
 	checkers = append(checkers,
 		NewRabbitMQChecker("rabbitmq", cfg.RabbitMQHealthCheckURL, rmqURI, cbManager))
 
-	// Validate TLS for all dependencies in non-local/development environments
-	onbPGTLS := detectPostgresTLS(onbPGDSN)
-	txnPGTLS := detectPostgresTLS(txnPGDSN)
-	onbMongoTLS, _ := detectMongoTLS(onbMongoURI)
-	txnMongoTLS, _ := detectMongoTLS(txnMongoURI)
-	redisTLS := detectRedisTLS(cfg.RedisHost, cfg.RedisTLS)
-	rmqTLS, _ := detectAMQPTLS(rmqURI)
-
-	tlsResults := []TLSValidationResult{
-		{Name: "postgres_onboarding", TLSEnabled: onbPGTLS},
-		{Name: "postgres_transaction", TLSEnabled: txnPGTLS},
-		{Name: "mongo_onboarding", TLSEnabled: onbMongoTLS},
-		{Name: "mongo_transaction", TLSEnabled: txnMongoTLS},
-		{Name: "redis", TLSEnabled: redisTLS},
-		{Name: "rabbitmq", TLSEnabled: rmqTLS},
+	// Build TLS validation results from already-created checkers.
+	// Each checker detected TLS during construction, so we reuse those results
+	// instead of calling detect*TLS() functions again.
+	tlsResults := make([]TLSValidationResult, 0, len(checkers))
+	for _, checker := range checkers {
+		tlsResults = append(tlsResults, TLSValidationResult{
+			Name:       checker.Name(),
+			TLSEnabled: checker.TLSEnabled(),
+		})
 	}
 
 	// ValidateSaaSTLS returns error ONLY for DEPLOYMENT_MODE=saas with insecure deps.

--- a/components/ledger/internal/bootstrap/readyz.go
+++ b/components/ledger/internal/bootstrap/readyz.go
@@ -1,0 +1,518 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package bootstrap
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+
+	libCircuitBreaker "github.com/LerianStudio/lib-commons/v4/commons/circuitbreaker"
+	libLog "github.com/LerianStudio/lib-commons/v4/commons/log"
+	libRedis "github.com/LerianStudio/lib-commons/v4/commons/redis"
+	tmcore "github.com/LerianStudio/lib-commons/v4/commons/tenant-manager/core"
+	tmmongo "github.com/LerianStudio/lib-commons/v4/commons/tenant-manager/mongo"
+	tmpostgres "github.com/LerianStudio/lib-commons/v4/commons/tenant-manager/postgres"
+	"github.com/gofiber/fiber/v2"
+)
+
+// DependencyStatus represents the health status of a dependency.
+// This is a closed vocabulary - only these values are valid.
+type DependencyStatus string
+
+const (
+	// StatusUp indicates the dependency probe succeeded.
+	StatusUp DependencyStatus = "up"
+
+	// StatusDown indicates the dependency probe failed.
+	StatusDown DependencyStatus = "down"
+
+	// StatusDegraded indicates the dependency is in a degraded state (e.g., circuit breaker half-open).
+	StatusDegraded DependencyStatus = "degraded"
+
+	// StatusSkipped indicates the dependency is optional and was not probed (e.g., disabled by config).
+	StatusSkipped DependencyStatus = "skipped"
+
+	// StatusNA indicates the dependency is not applicable in the current mode (e.g., tenant-scoped in MT mode).
+	StatusNA DependencyStatus = "n/a"
+)
+
+const (
+	// DefaultRedisTimeout is the default timeout for Redis health checks.
+	DefaultRedisTimeout = 1 * time.Second
+
+	// DefaultDatabaseTimeout is the default timeout for PostgreSQL and MongoDB health checks.
+	DefaultDatabaseTimeout = 2 * time.Second
+
+	// DefaultRabbitMQTimeout is the default timeout for RabbitMQ health checks.
+	DefaultRabbitMQTimeout = 2 * time.Second
+)
+
+// DependencyCheck represents the health check result for a single dependency.
+type DependencyCheck struct {
+	Status       DependencyStatus `json:"status"`
+	LatencyMs    *int64           `json:"latency_ms,omitempty"`
+	TLS          *bool            `json:"tls,omitempty"`
+	Error        string           `json:"error,omitempty"`
+	Reason       string           `json:"reason,omitempty"`
+	BreakerState string           `json:"breaker_state,omitempty"`
+}
+
+// ReadyzResponse is the response body for the /readyz endpoint.
+type ReadyzResponse struct {
+	Status         string                     `json:"status"`
+	Checks         map[string]DependencyCheck `json:"checks"`
+	Version        string                     `json:"version"`
+	DeploymentMode string                     `json:"deployment_mode"`
+}
+
+// DependencyChecker is the interface for probing a dependency's health.
+type DependencyChecker interface {
+	// Name returns the dependency identifier used as the key in the checks map.
+	Name() string
+
+	// Check probes the dependency and returns the health check result.
+	// The context should have a timeout applied by the caller.
+	Check(ctx context.Context) DependencyCheck
+
+	// TLSEnabled returns whether TLS is enabled for this dependency.
+	TLSEnabled() bool
+}
+
+// TenantAwareDependencyChecker extends DependencyChecker for tenant-scoped probes.
+// In multi-tenant mode, these checkers can resolve tenant-specific connections.
+type TenantAwareDependencyChecker interface {
+	DependencyChecker
+
+	// CheckTenant probes the dependency for a specific tenant.
+	// Returns StatusNA if the dependency doesn't support tenant-scoped checks.
+	CheckTenant(ctx context.Context, tenantID string) DependencyCheck
+}
+
+// ReadyzHandler handles /readyz and /readyz/tenant/:id requests.
+type ReadyzHandler struct {
+	logger             libLog.Logger
+	checkers           []DependencyChecker
+	tenantCheckers     []TenantAwareDependencyChecker
+	version            string
+	deploymentMode     string
+	multiTenantEnabled bool
+	onbPGManager       *tmpostgres.Manager
+	txnPGManager       *tmpostgres.Manager
+	onbMongoManager    *tmmongo.Manager
+	txnMongoManager    *tmmongo.Manager
+}
+
+// ReadyzHandlerConfig holds configuration for creating a ReadyzHandler.
+type ReadyzHandlerConfig struct {
+	Logger             libLog.Logger
+	Checkers           []DependencyChecker
+	TenantCheckers     []TenantAwareDependencyChecker
+	Version            string
+	DeploymentMode     string
+	MultiTenantEnabled bool
+	OnbPGManager       *tmpostgres.Manager
+	TxnPGManager       *tmpostgres.Manager
+	OnbMongoManager    *tmmongo.Manager
+	TxnMongoManager    *tmmongo.Manager
+}
+
+// NewReadyzHandler creates a new ReadyzHandler with the given configuration.
+func NewReadyzHandler(cfg ReadyzHandlerConfig) *ReadyzHandler {
+	return &ReadyzHandler{
+		logger:             cfg.Logger,
+		checkers:           cfg.Checkers,
+		tenantCheckers:     cfg.TenantCheckers,
+		version:            cfg.Version,
+		deploymentMode:     ResolveDeploymentMode(cfg.DeploymentMode),
+		multiTenantEnabled: cfg.MultiTenantEnabled,
+		onbPGManager:       cfg.OnbPGManager,
+		txnPGManager:       cfg.TxnPGManager,
+		onbMongoManager:    cfg.OnbMongoManager,
+		txnMongoManager:    cfg.TxnMongoManager,
+	}
+}
+
+// HandleReadyz handles the /readyz endpoint for global health checks.
+// In multi-tenant mode, database checkers return "n/a" since connections are tenant-scoped.
+// Redis always returns actual status (shared infrastructure).
+func (h *ReadyzHandler) HandleReadyz(c *fiber.Ctx) error {
+	checks := make(map[string]DependencyCheck)
+	allHealthy := true
+
+	for _, checker := range h.checkers {
+		ctx, cancel := context.WithTimeout(c.Context(), h.timeoutForChecker(checker))
+
+		check := checker.Check(ctx)
+
+		cancel()
+
+		// Set TLS field if enabled
+		if checker.TLSEnabled() {
+			tlsEnabled := true
+			check.TLS = &tlsEnabled
+		} else {
+			tlsDisabled := false
+			check.TLS = &tlsDisabled
+		}
+
+		checks[checker.Name()] = check
+
+		if check.Status == StatusDown || check.Status == StatusDegraded {
+			allHealthy = false
+		}
+	}
+
+	status := "healthy"
+	httpStatus := http.StatusOK
+
+	if !allHealthy {
+		status = "unhealthy"
+		httpStatus = http.StatusServiceUnavailable
+	}
+
+	response := ReadyzResponse{
+		Status:         status,
+		Checks:         checks,
+		Version:        h.version,
+		DeploymentMode: h.deploymentMode,
+	}
+
+	return c.Status(httpStatus).JSON(response)
+}
+
+// HandleReadyzTenant handles the /readyz/tenant/:id endpoint for tenant-specific health checks.
+// This endpoint resolves tenant-specific connections and probes them directly.
+func (h *ReadyzHandler) HandleReadyzTenant(c *fiber.Ctx) error {
+	tenantID := c.Params("id")
+	if tenantID == "" {
+		return c.Status(http.StatusBadRequest).JSON(fiber.Map{
+			"error": "tenant ID is required",
+		})
+	}
+
+	if !h.multiTenantEnabled {
+		return c.Status(http.StatusBadRequest).JSON(fiber.Map{
+			"error": "tenant-scoped readyz is only available in multi-tenant mode",
+		})
+	}
+
+	// Set tenant ID in context for downstream managers
+	ctx := tmcore.ContextWithTenantID(c.Context(), tenantID)
+
+	checks := make(map[string]DependencyCheck)
+	allHealthy := true
+
+	// Run tenant-aware checkers
+	for _, checker := range h.tenantCheckers {
+		checkCtx, cancel := context.WithTimeout(ctx, h.timeoutForChecker(checker))
+
+		check := checker.CheckTenant(checkCtx, tenantID)
+
+		cancel()
+
+		// Set TLS field if enabled
+		if checker.TLSEnabled() {
+			tlsEnabled := true
+			check.TLS = &tlsEnabled
+		} else {
+			tlsDisabled := false
+			check.TLS = &tlsDisabled
+		}
+
+		checks[checker.Name()] = check
+
+		if check.Status == StatusDown || check.Status == StatusDegraded {
+			allHealthy = false
+		}
+	}
+
+	// Run non-tenant-aware checkers (like Redis which is shared)
+	for _, checker := range h.checkers {
+		// Skip if we already have a tenant-aware version
+		if h.hasTenantChecker(checker.Name()) {
+			continue
+		}
+
+		checkCtx, cancel := context.WithTimeout(ctx, h.timeoutForChecker(checker))
+
+		check := checker.Check(checkCtx)
+
+		cancel()
+
+		// Set TLS field if enabled
+		if checker.TLSEnabled() {
+			tlsEnabled := true
+			check.TLS = &tlsEnabled
+		} else {
+			tlsDisabled := false
+			check.TLS = &tlsDisabled
+		}
+
+		checks[checker.Name()] = check
+
+		if check.Status == StatusDown || check.Status == StatusDegraded {
+			allHealthy = false
+		}
+	}
+
+	status := "healthy"
+	httpStatus := http.StatusOK
+
+	if !allHealthy {
+		status = "unhealthy"
+		httpStatus = http.StatusServiceUnavailable
+	}
+
+	response := ReadyzResponse{
+		Status:         status,
+		Checks:         checks,
+		Version:        h.version,
+		DeploymentMode: h.deploymentMode,
+	}
+
+	return c.Status(httpStatus).JSON(response)
+}
+
+// hasTenantChecker returns true if a tenant-aware checker with the given name exists.
+func (h *ReadyzHandler) hasTenantChecker(name string) bool {
+	for _, tc := range h.tenantCheckers {
+		if tc.Name() == name {
+			return true
+		}
+	}
+
+	return false
+}
+
+// timeoutForChecker returns the appropriate timeout for a checker based on its name.
+// Database probes (postgres, mongo) get DefaultDatabaseTimeout, Redis gets DefaultRedisTimeout,
+// RabbitMQ gets DefaultRabbitMQTimeout.
+func (h *ReadyzHandler) timeoutForChecker(checker DependencyChecker) time.Duration {
+	name := checker.Name()
+
+	switch {
+	case contains(name, "redis"):
+		return DefaultRedisTimeout
+	case contains(name, "postgres"), contains(name, "mongo"):
+		return DefaultDatabaseTimeout
+	case contains(name, "rabbitmq"):
+		return DefaultRabbitMQTimeout
+	default:
+		return DefaultDatabaseTimeout
+	}
+}
+
+// contains checks if substr is found in s (case-insensitive).
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(substr) == 0 ||
+		(len(s) > 0 && containsLower(s, substr)))
+}
+
+// containsLower performs a case-insensitive substring search.
+func containsLower(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		match := true
+
+		for j := range len(substr) {
+			sc := s[i+j]
+			uc := substr[j]
+
+			// Convert to lowercase for comparison
+			if sc >= 'A' && sc <= 'Z' {
+				sc += 'a' - 'A'
+			}
+
+			if uc >= 'A' && uc <= 'Z' {
+				uc += 'a' - 'A'
+			}
+
+			if sc != uc {
+				match = false
+				break
+			}
+		}
+
+		if match {
+			return true
+		}
+	}
+
+	return false
+}
+
+// buildReadyzHandler creates the ReadyzHandler with appropriate checkers based on mode.
+// In multi-tenant mode, database checkers return "n/a" globally; use /readyz/tenant/:id for tenant-specific checks.
+// Redis is shared infrastructure and always returns actual status.
+func buildReadyzHandler(
+	cfg *Config,
+	logger libLog.Logger,
+	redisConnection *libRedis.Client,
+	onbPG *onboardingPostgresComponents,
+	txnPG *transactionPostgresComponents,
+	onbMgo *onboardingMongoComponents,
+	txnMgo *transactionMongoComponents,
+	rmq *rabbitMQComponents,
+) (*ReadyzHandler, error) {
+	// Build DSN strings for TLS detection
+	onbPGDSN := fmt.Sprintf("host=%s user=%s password=%s dbname=%s port=%s sslmode=%s",
+		cfg.OnbPrefixedPrimaryDBHost, cfg.OnbPrefixedPrimaryDBUser, cfg.OnbPrefixedPrimaryDBPassword,
+		cfg.OnbPrefixedPrimaryDBName, cfg.OnbPrefixedPrimaryDBPort, cfg.OnbPrefixedPrimaryDBSSLMode)
+
+	txnPGDSN := fmt.Sprintf("host=%s user=%s password=%s dbname=%s port=%s sslmode=%s",
+		cfg.TxnPrefixedPrimaryDBHost, cfg.TxnPrefixedPrimaryDBUser, cfg.TxnPrefixedPrimaryDBPassword,
+		cfg.TxnPrefixedPrimaryDBName, cfg.TxnPrefixedPrimaryDBPort, cfg.TxnPrefixedPrimaryDBSSLMode)
+
+	// Build Mongo URIs for TLS detection
+	onbMongoURI := fmt.Sprintf("%s://%s:%s@%s:%s/%s?%s",
+		cfg.OnbPrefixedMongoURI, cfg.OnbPrefixedMongoDBUser, cfg.OnbPrefixedMongoDBPassword,
+		cfg.OnbPrefixedMongoDBHost, cfg.OnbPrefixedMongoDBPort, cfg.OnbPrefixedMongoDBName,
+		cfg.OnbPrefixedMongoDBParameters)
+
+	txnMongoURI := fmt.Sprintf("%s://%s:%s@%s:%s/%s?%s",
+		cfg.TxnPrefixedMongoURI, cfg.TxnPrefixedMongoDBUser, cfg.TxnPrefixedMongoDBPassword,
+		cfg.TxnPrefixedMongoDBHost, cfg.TxnPrefixedMongoDBPort, cfg.TxnPrefixedMongoDBName,
+		cfg.TxnPrefixedMongoDBParameters)
+
+	// Build RabbitMQ URI for TLS detection
+	rmqURI := buildRabbitMQConnectionString(
+		cfg.RabbitURI, cfg.RabbitMQUser, cfg.RabbitMQPass, cfg.RabbitMQHost, cfg.RabbitMQPortHost, cfg.RabbitMQVHost)
+
+	var checkers []DependencyChecker
+
+	var tenantCheckers []TenantAwareDependencyChecker
+
+	if cfg.MultiTenantEnabled {
+		// Multi-tenant mode: database checkers return n/a globally
+		// Tenant-specific checks are done via /readyz/tenant/:id
+
+		// PostgreSQL - n/a globally, tenant-aware checkers for /readyz/tenant/:id
+		onbPGTLSEnabled := detectPostgresTLS(onbPGDSN)
+		txnPGTLSEnabled := detectPostgresTLS(txnPGDSN)
+
+		checkers = append(checkers,
+			NewNAChecker("postgres_onboarding", "tenant-scoped; use /readyz/tenant/:id", onbPGTLSEnabled),
+			NewNAChecker("postgres_transaction", "tenant-scoped; use /readyz/tenant/:id", txnPGTLSEnabled),
+		)
+
+		if onbPG.pgManager != nil {
+			tenantCheckers = append(tenantCheckers,
+				NewTenantPostgresChecker("postgres_onboarding", onbPG.pgManager, onbPGDSN))
+		}
+
+		if txnPG.pgManager != nil {
+			tenantCheckers = append(tenantCheckers,
+				NewTenantPostgresChecker("postgres_transaction", txnPG.pgManager, txnPGDSN))
+		}
+
+		// MongoDB - n/a globally, tenant-aware checkers for /readyz/tenant/:id
+		onbMongoTLSEnabled, _ := detectMongoTLS(onbMongoURI)
+		txnMongoTLSEnabled, _ := detectMongoTLS(txnMongoURI)
+
+		checkers = append(checkers,
+			NewNAChecker("mongo_onboarding", "tenant-scoped; use /readyz/tenant/:id", onbMongoTLSEnabled),
+			NewNAChecker("mongo_transaction", "tenant-scoped; use /readyz/tenant/:id", txnMongoTLSEnabled),
+		)
+
+		if onbMgo.mongoManager != nil {
+			tenantCheckers = append(tenantCheckers,
+				NewTenantMongoChecker("mongo_onboarding", onbMgo.mongoManager, onbMongoURI))
+		}
+
+		if txnMgo.mongoManager != nil {
+			tenantCheckers = append(tenantCheckers,
+				NewTenantMongoChecker("mongo_transaction", txnMgo.mongoManager, txnMongoURI))
+		}
+	} else {
+		// Single-tenant mode: all checkers return actual status
+
+		// PostgreSQL checkers
+		if onbPG.connection != nil {
+			checkers = append(checkers,
+				NewPostgresChecker("postgres_onboarding", onbPG.connection, onbPGDSN))
+		}
+
+		if txnPG.connection != nil {
+			checkers = append(checkers,
+				NewPostgresChecker("postgres_transaction", txnPG.connection, txnPGDSN))
+		}
+
+		// MongoDB checkers
+		if onbMgo.connection != nil {
+			checkers = append(checkers,
+				NewMongoChecker("mongo_onboarding", onbMgo.connection, onbMongoURI))
+		}
+
+		if txnMgo.connection != nil {
+			checkers = append(checkers,
+				NewMongoChecker("mongo_transaction", txnMgo.connection, txnMongoURI))
+		}
+	}
+
+	// Redis - always returns actual status (shared infrastructure)
+	if redisConnection != nil {
+		checkers = append(checkers,
+			NewRedisChecker("redis", redisConnection, cfg.RedisHost, cfg.RedisTLS))
+	}
+
+	// RabbitMQ - check via health URL if configured
+	var cbManager libCircuitBreaker.Manager
+
+	if rmq != nil && rmq.circuitBreakerManager != nil {
+		cbManager = rmq.circuitBreakerManager.Manager
+	}
+
+	checkers = append(checkers,
+		NewRabbitMQChecker("rabbitmq", cfg.RabbitMQHealthCheckURL, rmqURI, cbManager))
+
+	// Validate TLS for all dependencies in non-local/development environments
+	onbPGTLS := detectPostgresTLS(onbPGDSN)
+	txnPGTLS := detectPostgresTLS(txnPGDSN)
+	onbMongoTLS, _ := detectMongoTLS(onbMongoURI)
+	txnMongoTLS, _ := detectMongoTLS(txnMongoURI)
+	redisTLS := detectRedisTLS(cfg.RedisHost, cfg.RedisTLS)
+	rmqTLS, _ := detectAMQPTLS(rmqURI)
+
+	tlsResults := []TLSValidationResult{
+		{Name: "postgres_onboarding", TLSEnabled: onbPGTLS},
+		{Name: "postgres_transaction", TLSEnabled: txnPGTLS},
+		{Name: "mongo_onboarding", TLSEnabled: onbMongoTLS},
+		{Name: "mongo_transaction", TLSEnabled: txnMongoTLS},
+		{Name: "redis", TLSEnabled: redisTLS},
+		{Name: "rabbitmq", TLSEnabled: rmqTLS},
+	}
+
+	// ValidateSaaSTLS returns error ONLY for DEPLOYMENT_MODE=saas with insecure deps.
+	// The error is returned to the caller to fail startup.
+	if err := ValidateSaaSTLS(cfg.DeploymentMode, tlsResults); err != nil {
+		return nil, err
+	}
+
+	// For BYOC mode, log a warning for insecure dependencies (recommended but not enforced)
+	if IsTLSRecommended(cfg.DeploymentMode) {
+		for _, result := range tlsResults {
+			if !result.TLSEnabled {
+				logger.Log(context.Background(), libLog.LevelWarn,
+					"TLS recommended but not configured for dependency",
+					libLog.String("dependency", result.Name),
+					libLog.String("deployment_mode", cfg.DeploymentMode))
+			}
+		}
+	}
+
+	return NewReadyzHandler(ReadyzHandlerConfig{
+		Logger:             logger,
+		Checkers:           checkers,
+		TenantCheckers:     tenantCheckers,
+		Version:            cfg.Version,
+		DeploymentMode:     cfg.DeploymentMode,
+		MultiTenantEnabled: cfg.MultiTenantEnabled,
+		OnbPGManager:       onbPG.pgManager,
+		TxnPGManager:       txnPG.pgManager,
+		OnbMongoManager:    onbMgo.mongoManager,
+		TxnMongoManager:    txnMgo.mongoManager,
+	}), nil
+}

--- a/components/ledger/internal/bootstrap/readyz_checkers.go
+++ b/components/ledger/internal/bootstrap/readyz_checkers.go
@@ -429,10 +429,8 @@ func NewRabbitMQChecker(name, healthCheckURL, uri string, cbManager libCircuitBr
 		healthCheckURL: healthCheckURL,
 		uri:            uri,
 		tlsEnabled:     tlsEnabled,
-		httpClient: &http.Client{
-			Timeout: 2 * time.Second,
-		},
-		cbManager: cbManager,
+		httpClient:     &http.Client{},
+		cbManager:      cbManager,
 	}
 }
 

--- a/components/ledger/internal/bootstrap/readyz_checkers.go
+++ b/components/ledger/internal/bootstrap/readyz_checkers.go
@@ -1,0 +1,721 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package bootstrap
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	libCircuitBreaker "github.com/LerianStudio/lib-commons/v4/commons/circuitbreaker"
+	libLog "github.com/LerianStudio/lib-commons/v4/commons/log"
+	libMongo "github.com/LerianStudio/lib-commons/v4/commons/mongo"
+	libPostgres "github.com/LerianStudio/lib-commons/v4/commons/postgres"
+	libRedis "github.com/LerianStudio/lib-commons/v4/commons/redis"
+	tmmongo "github.com/LerianStudio/lib-commons/v4/commons/tenant-manager/mongo"
+	tmpostgres "github.com/LerianStudio/lib-commons/v4/commons/tenant-manager/postgres"
+	"github.com/LerianStudio/midaz/v3/components/ledger/internal/adapters/rabbitmq"
+	"go.mongodb.org/mongo-driver/bson"
+)
+
+// PostgresChecker probes a PostgreSQL connection using SELECT 1.
+type PostgresChecker struct {
+	name       string
+	client     *libPostgres.Client
+	dsn        string
+	tlsEnabled bool
+}
+
+// NewPostgresChecker creates a new PostgreSQL health checker.
+func NewPostgresChecker(name string, client *libPostgres.Client, dsn string) *PostgresChecker {
+	tlsEnabled := detectPostgresTLS(dsn)
+
+	return &PostgresChecker{
+		name:       name,
+		client:     client,
+		dsn:        dsn,
+		tlsEnabled: tlsEnabled,
+	}
+}
+
+// Name returns the checker identifier.
+func (c *PostgresChecker) Name() string {
+	return c.name
+}
+
+// TLSEnabled returns whether TLS is enabled for this connection.
+func (c *PostgresChecker) TLSEnabled() bool {
+	return c.tlsEnabled
+}
+
+// Check probes the PostgreSQL connection.
+func (c *PostgresChecker) Check(ctx context.Context) DependencyCheck {
+	if c.client == nil {
+		return DependencyCheck{
+			Status: StatusSkipped,
+			Reason: "PostgreSQL client not configured",
+		}
+	}
+
+	start := time.Now()
+
+	db, err := c.client.Resolver(ctx)
+	if err != nil {
+		latencyMs := time.Since(start).Milliseconds()
+
+		return DependencyCheck{
+			Status:    StatusDown,
+			LatencyMs: &latencyMs,
+			Error:     fmt.Sprintf("failed to get database connection: %v", err),
+		}
+	}
+
+	var result int
+
+	err = db.QueryRowContext(ctx, "SELECT 1").Scan(&result)
+	latencyMs := time.Since(start).Milliseconds()
+
+	if err != nil {
+		return DependencyCheck{
+			Status:    StatusDown,
+			LatencyMs: &latencyMs,
+			Error:     fmt.Sprintf("SELECT 1 failed: %v", err),
+		}
+	}
+
+	return DependencyCheck{
+		Status:    StatusUp,
+		LatencyMs: &latencyMs,
+	}
+}
+
+// TenantPostgresChecker probes tenant-specific PostgreSQL connections.
+type TenantPostgresChecker struct {
+	name       string
+	manager    *tmpostgres.Manager
+	tlsEnabled bool
+}
+
+// NewTenantPostgresChecker creates a new tenant-aware PostgreSQL health checker.
+func NewTenantPostgresChecker(name string, manager *tmpostgres.Manager, dsn string) *TenantPostgresChecker {
+	tlsEnabled := detectPostgresTLS(dsn)
+
+	return &TenantPostgresChecker{
+		name:       name,
+		manager:    manager,
+		tlsEnabled: tlsEnabled,
+	}
+}
+
+// Name returns the checker identifier.
+func (c *TenantPostgresChecker) Name() string {
+	return c.name
+}
+
+// TLSEnabled returns whether TLS is enabled for this connection.
+func (c *TenantPostgresChecker) TLSEnabled() bool {
+	return c.tlsEnabled
+}
+
+// Check returns n/a for global checks since this is tenant-scoped.
+func (c *TenantPostgresChecker) Check(_ context.Context) DependencyCheck {
+	return DependencyCheck{
+		Status: StatusNA,
+		Reason: "tenant-scoped; use /readyz/tenant/:id",
+	}
+}
+
+// CheckTenant probes the PostgreSQL connection for a specific tenant.
+func (c *TenantPostgresChecker) CheckTenant(ctx context.Context, tenantID string) DependencyCheck {
+	if c.manager == nil {
+		return DependencyCheck{
+			Status: StatusSkipped,
+			Reason: "PostgreSQL manager not configured",
+		}
+	}
+
+	start := time.Now()
+
+	db, err := c.manager.GetDB(ctx, tenantID)
+	if err != nil {
+		latencyMs := time.Since(start).Milliseconds()
+
+		return DependencyCheck{
+			Status:    StatusDown,
+			LatencyMs: &latencyMs,
+			Error:     fmt.Sprintf("failed to get tenant connection: %v", err),
+		}
+	}
+
+	var result int
+
+	err = db.QueryRowContext(ctx, "SELECT 1").Scan(&result)
+	latencyMs := time.Since(start).Milliseconds()
+
+	if err != nil {
+		return DependencyCheck{
+			Status:    StatusDown,
+			LatencyMs: &latencyMs,
+			Error:     fmt.Sprintf("SELECT 1 failed: %v", err),
+		}
+	}
+
+	return DependencyCheck{
+		Status:    StatusUp,
+		LatencyMs: &latencyMs,
+	}
+}
+
+// MongoChecker probes a MongoDB connection using ping command.
+type MongoChecker struct {
+	name       string
+	client     *libMongo.Client
+	uri        string
+	tlsEnabled bool
+}
+
+// NewMongoChecker creates a new MongoDB health checker.
+func NewMongoChecker(name string, client *libMongo.Client, uri string) *MongoChecker {
+	tlsEnabled, _ := detectMongoTLS(uri)
+
+	return &MongoChecker{
+		name:       name,
+		client:     client,
+		uri:        uri,
+		tlsEnabled: tlsEnabled,
+	}
+}
+
+// NewMongoCheckerWithLogger creates a new MongoDB health checker that logs TLS detection errors.
+// If logger is nil, errors are silently ignored (same behavior as NewMongoChecker).
+func NewMongoCheckerWithLogger(name string, client *libMongo.Client, uri string, logger libLog.Logger) *MongoChecker {
+	tlsEnabled, err := detectMongoTLS(uri)
+	if err != nil && logger != nil {
+		logger.Log(context.Background(), libLog.LevelDebug,
+			"Failed to detect MongoDB TLS configuration",
+			libLog.String("checker", name),
+			libLog.Err(err))
+	}
+
+	return &MongoChecker{
+		name:       name,
+		client:     client,
+		uri:        uri,
+		tlsEnabled: tlsEnabled,
+	}
+}
+
+// Name returns the checker identifier.
+func (c *MongoChecker) Name() string {
+	return c.name
+}
+
+// TLSEnabled returns whether TLS is enabled for this connection.
+func (c *MongoChecker) TLSEnabled() bool {
+	return c.tlsEnabled
+}
+
+// Check probes the MongoDB connection.
+func (c *MongoChecker) Check(ctx context.Context) DependencyCheck {
+	if c.client == nil {
+		return DependencyCheck{
+			Status: StatusSkipped,
+			Reason: "MongoDB client not configured",
+		}
+	}
+
+	start := time.Now()
+
+	err := c.client.Ping(ctx)
+	latencyMs := time.Since(start).Milliseconds()
+
+	if err != nil {
+		return DependencyCheck{
+			Status:    StatusDown,
+			LatencyMs: &latencyMs,
+			Error:     fmt.Sprintf("ping failed: %v", err),
+		}
+	}
+
+	return DependencyCheck{
+		Status:    StatusUp,
+		LatencyMs: &latencyMs,
+	}
+}
+
+// TenantMongoChecker probes tenant-specific MongoDB connections.
+type TenantMongoChecker struct {
+	name       string
+	manager    *tmmongo.Manager
+	tlsEnabled bool
+}
+
+// NewTenantMongoChecker creates a new tenant-aware MongoDB health checker.
+func NewTenantMongoChecker(name string, manager *tmmongo.Manager, uri string) *TenantMongoChecker {
+	tlsEnabled, _ := detectMongoTLS(uri)
+
+	return &TenantMongoChecker{
+		name:       name,
+		manager:    manager,
+		tlsEnabled: tlsEnabled,
+	}
+}
+
+// NewTenantMongoCheckerWithLogger creates a new tenant-aware MongoDB health checker that logs TLS detection errors.
+// If logger is nil, errors are silently ignored (same behavior as NewTenantMongoChecker).
+func NewTenantMongoCheckerWithLogger(name string, manager *tmmongo.Manager, uri string, logger libLog.Logger) *TenantMongoChecker {
+	tlsEnabled, err := detectMongoTLS(uri)
+	if err != nil && logger != nil {
+		logger.Log(context.Background(), libLog.LevelDebug,
+			"Failed to detect MongoDB TLS configuration for tenant checker",
+			libLog.String("checker", name),
+			libLog.Err(err))
+	}
+
+	return &TenantMongoChecker{
+		name:       name,
+		manager:    manager,
+		tlsEnabled: tlsEnabled,
+	}
+}
+
+// Name returns the checker identifier.
+func (c *TenantMongoChecker) Name() string {
+	return c.name
+}
+
+// TLSEnabled returns whether TLS is enabled for this connection.
+func (c *TenantMongoChecker) TLSEnabled() bool {
+	return c.tlsEnabled
+}
+
+// Check returns n/a for global checks since this is tenant-scoped.
+func (c *TenantMongoChecker) Check(_ context.Context) DependencyCheck {
+	return DependencyCheck{
+		Status: StatusNA,
+		Reason: "tenant-scoped; use /readyz/tenant/:id",
+	}
+}
+
+// CheckTenant probes the MongoDB connection for a specific tenant.
+func (c *TenantMongoChecker) CheckTenant(ctx context.Context, tenantID string) DependencyCheck {
+	if c.manager == nil {
+		return DependencyCheck{
+			Status: StatusSkipped,
+			Reason: "MongoDB manager not configured",
+		}
+	}
+
+	start := time.Now()
+
+	db, err := c.manager.GetDatabaseForTenant(ctx, tenantID)
+	if err != nil {
+		latencyMs := time.Since(start).Milliseconds()
+
+		return DependencyCheck{
+			Status:    StatusDown,
+			LatencyMs: &latencyMs,
+			Error:     fmt.Sprintf("failed to get tenant database: %v", err),
+		}
+	}
+
+	// Run ping command on the database
+	err = db.Client().Ping(ctx, nil)
+	latencyMs := time.Since(start).Milliseconds()
+
+	if err != nil {
+		return DependencyCheck{
+			Status:    StatusDown,
+			LatencyMs: &latencyMs,
+			Error:     fmt.Sprintf("ping failed: %v", err),
+		}
+	}
+
+	return DependencyCheck{
+		Status:    StatusUp,
+		LatencyMs: &latencyMs,
+	}
+}
+
+// RedisChecker probes a Redis connection using PING command.
+type RedisChecker struct {
+	name       string
+	client     *libRedis.Client
+	host       string
+	tlsEnabled bool
+}
+
+// NewRedisChecker creates a new Redis health checker.
+func NewRedisChecker(name string, client *libRedis.Client, host string, tlsConfigEnabled bool) *RedisChecker {
+	return &RedisChecker{
+		name:       name,
+		client:     client,
+		host:       host,
+		tlsEnabled: detectRedisTLS(host, tlsConfigEnabled),
+	}
+}
+
+// Name returns the checker identifier.
+func (c *RedisChecker) Name() string {
+	return c.name
+}
+
+// TLSEnabled returns whether TLS is enabled for this connection.
+func (c *RedisChecker) TLSEnabled() bool {
+	return c.tlsEnabled
+}
+
+// Check probes the Redis connection.
+func (c *RedisChecker) Check(ctx context.Context) DependencyCheck {
+	if c.client == nil {
+		return DependencyCheck{
+			Status: StatusSkipped,
+			Reason: "Redis client not configured",
+		}
+	}
+
+	start := time.Now()
+
+	rds, err := c.client.GetClient(ctx)
+	if err != nil {
+		latencyMs := time.Since(start).Milliseconds()
+
+		return DependencyCheck{
+			Status:    StatusDown,
+			LatencyMs: &latencyMs,
+			Error:     fmt.Sprintf("failed to get Redis client: %v", err),
+		}
+	}
+
+	err = rds.Ping(ctx).Err()
+	latencyMs := time.Since(start).Milliseconds()
+
+	if err != nil {
+		return DependencyCheck{
+			Status:    StatusDown,
+			LatencyMs: &latencyMs,
+			Error:     fmt.Sprintf("PING failed: %v", err),
+		}
+	}
+
+	return DependencyCheck{
+		Status:    StatusUp,
+		LatencyMs: &latencyMs,
+	}
+}
+
+// RabbitMQChecker probes RabbitMQ using the health check URL.
+type RabbitMQChecker struct {
+	name           string
+	healthCheckURL string
+	uri            string
+	tlsEnabled     bool
+	httpClient     *http.Client
+	cbManager      libCircuitBreaker.Manager
+}
+
+// NewRabbitMQChecker creates a new RabbitMQ health checker.
+// If healthCheckURL is empty, the checker returns "skipped" status.
+func NewRabbitMQChecker(name, healthCheckURL, uri string, cbManager libCircuitBreaker.Manager) *RabbitMQChecker {
+	tlsEnabled, _ := detectAMQPTLS(uri)
+
+	return &RabbitMQChecker{
+		name:           name,
+		healthCheckURL: healthCheckURL,
+		uri:            uri,
+		tlsEnabled:     tlsEnabled,
+		httpClient: &http.Client{
+			Timeout: 2 * time.Second,
+		},
+		cbManager: cbManager,
+	}
+}
+
+// Name returns the checker identifier.
+func (c *RabbitMQChecker) Name() string {
+	return c.name
+}
+
+// TLSEnabled returns whether TLS is enabled for this connection.
+func (c *RabbitMQChecker) TLSEnabled() bool {
+	return c.tlsEnabled
+}
+
+// Check probes RabbitMQ via the health check URL.
+func (c *RabbitMQChecker) Check(ctx context.Context) DependencyCheck {
+	// Include circuit breaker state if available
+	var breakerState string
+
+	if c.cbManager != nil {
+		state := c.cbManager.GetState(rabbitmq.CircuitBreakerServiceName)
+		breakerState = mapCircuitBreakerState(state)
+
+		// If circuit breaker is open, report as degraded
+		if state == libCircuitBreaker.StateOpen {
+			return DependencyCheck{
+				Status:       StatusDegraded,
+				Reason:       "circuit breaker is open",
+				BreakerState: breakerState,
+			}
+		}
+
+		// If half-open, report as degraded
+		if state == libCircuitBreaker.StateHalfOpen {
+			return DependencyCheck{
+				Status:       StatusDegraded,
+				Reason:       "circuit breaker is half-open",
+				BreakerState: breakerState,
+			}
+		}
+	}
+
+	if c.healthCheckURL == "" {
+		check := DependencyCheck{
+			Status: StatusSkipped,
+			Reason: "RABBITMQ_HEALTH_CHECK_URL not configured",
+		}
+
+		if breakerState != "" {
+			check.BreakerState = breakerState
+		}
+
+		return check
+	}
+
+	start := time.Now()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.healthCheckURL, nil)
+	if err != nil {
+		latencyMs := time.Since(start).Milliseconds()
+
+		check := DependencyCheck{
+			Status:    StatusDown,
+			LatencyMs: &latencyMs,
+			Error:     fmt.Sprintf("failed to create request: %v", err),
+		}
+
+		if breakerState != "" {
+			check.BreakerState = breakerState
+		}
+
+		return check
+	}
+
+	resp, err := c.httpClient.Do(req)
+	latencyMs := time.Since(start).Milliseconds()
+
+	if err != nil {
+		check := DependencyCheck{
+			Status:    StatusDown,
+			LatencyMs: &latencyMs,
+			Error:     fmt.Sprintf("health check request failed: %v", err),
+		}
+
+		if breakerState != "" {
+			check.BreakerState = breakerState
+		}
+
+		return check
+	}
+
+	defer func() {
+		// Drain and close response body
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+	}()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		check := DependencyCheck{
+			Status:    StatusDown,
+			LatencyMs: &latencyMs,
+			Error:     fmt.Sprintf("health check returned status %d", resp.StatusCode),
+		}
+
+		if breakerState != "" {
+			check.BreakerState = breakerState
+		}
+
+		return check
+	}
+
+	check := DependencyCheck{
+		Status:    StatusUp,
+		LatencyMs: &latencyMs,
+	}
+
+	if breakerState != "" {
+		check.BreakerState = breakerState
+	}
+
+	return check
+}
+
+// mapCircuitBreakerState maps lib-commons circuit breaker state to string.
+func mapCircuitBreakerState(state libCircuitBreaker.State) string {
+	switch state {
+	case libCircuitBreaker.StateClosed:
+		return "closed"
+	case libCircuitBreaker.StateHalfOpen:
+		return "half-open"
+	case libCircuitBreaker.StateOpen:
+		return "open"
+	default:
+		return "unknown"
+	}
+}
+
+// NAChecker is a placeholder checker that always returns n/a status.
+// Used in multi-tenant mode for dependencies that are tenant-scoped.
+type NAChecker struct {
+	name       string
+	reason     string
+	tlsEnabled bool
+}
+
+// NewNAChecker creates a checker that always returns n/a status.
+func NewNAChecker(name, reason string, tlsEnabled bool) *NAChecker {
+	return &NAChecker{
+		name:       name,
+		reason:     reason,
+		tlsEnabled: tlsEnabled,
+	}
+}
+
+// Name returns the checker identifier.
+func (c *NAChecker) Name() string {
+	return c.name
+}
+
+// TLSEnabled returns whether TLS is enabled for this dependency.
+func (c *NAChecker) TLSEnabled() bool {
+	return c.tlsEnabled
+}
+
+// Check always returns n/a status.
+func (c *NAChecker) Check(_ context.Context) DependencyCheck {
+	return DependencyCheck{
+		Status: StatusNA,
+		Reason: c.reason,
+	}
+}
+
+// SQLDBChecker probes a raw *sql.DB connection.
+// This is useful for tenant-scoped connections where we get a raw *sql.DB.
+type SQLDBChecker struct {
+	name       string
+	db         *sql.DB
+	tlsEnabled bool
+}
+
+// NewSQLDBChecker creates a checker for a raw *sql.DB connection.
+func NewSQLDBChecker(name string, db *sql.DB, tlsEnabled bool) *SQLDBChecker {
+	return &SQLDBChecker{
+		name:       name,
+		db:         db,
+		tlsEnabled: tlsEnabled,
+	}
+}
+
+// Name returns the checker identifier.
+func (c *SQLDBChecker) Name() string {
+	return c.name
+}
+
+// TLSEnabled returns whether TLS is enabled.
+func (c *SQLDBChecker) TLSEnabled() bool {
+	return c.tlsEnabled
+}
+
+// Check probes the SQL database connection.
+func (c *SQLDBChecker) Check(ctx context.Context) DependencyCheck {
+	if c.db == nil {
+		return DependencyCheck{
+			Status: StatusSkipped,
+			Reason: "database not configured",
+		}
+	}
+
+	start := time.Now()
+
+	var result int
+
+	err := c.db.QueryRowContext(ctx, "SELECT 1").Scan(&result)
+	latencyMs := time.Since(start).Milliseconds()
+
+	if err != nil {
+		return DependencyCheck{
+			Status:    StatusDown,
+			LatencyMs: &latencyMs,
+			Error:     fmt.Sprintf("SELECT 1 failed: %v", err),
+		}
+	}
+
+	return DependencyCheck{
+		Status:    StatusUp,
+		LatencyMs: &latencyMs,
+	}
+}
+
+// MongoDatabaseChecker probes a MongoDB database using runCommand.
+type MongoDatabaseChecker struct {
+	name     string
+	database interface {
+		RunCommand(context.Context, any) error
+	}
+	tlsEnabled bool
+}
+
+// NewMongoDatabaseChecker creates a checker for a MongoDB database.
+func NewMongoDatabaseChecker(name string, database interface {
+	RunCommand(context.Context, any) error
+}, tlsEnabled bool,
+) *MongoDatabaseChecker {
+	return &MongoDatabaseChecker{
+		name:       name,
+		database:   database,
+		tlsEnabled: tlsEnabled,
+	}
+}
+
+// Name returns the checker identifier.
+func (c *MongoDatabaseChecker) Name() string {
+	return c.name
+}
+
+// TLSEnabled returns whether TLS is enabled.
+func (c *MongoDatabaseChecker) TLSEnabled() bool {
+	return c.tlsEnabled
+}
+
+// Check probes the MongoDB database.
+func (c *MongoDatabaseChecker) Check(ctx context.Context) DependencyCheck {
+	if c.database == nil {
+		return DependencyCheck{
+			Status: StatusSkipped,
+			Reason: "database not configured",
+		}
+	}
+
+	start := time.Now()
+
+	err := c.database.RunCommand(ctx, bson.D{{Key: "ping", Value: 1}})
+	latencyMs := time.Since(start).Milliseconds()
+
+	if err != nil {
+		return DependencyCheck{
+			Status:    StatusDown,
+			LatencyMs: &latencyMs,
+			Error:     fmt.Sprintf("ping failed: %v", err),
+		}
+	}
+
+	return DependencyCheck{
+		Status:    StatusUp,
+		LatencyMs: &latencyMs,
+	}
+}

--- a/components/ledger/internal/bootstrap/readyz_general_test.go
+++ b/components/ledger/internal/bootstrap/readyz_general_test.go
@@ -1,0 +1,628 @@
+//go:build !integration
+
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package bootstrap
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	libCircuitBreaker "github.com/LerianStudio/lib-commons/v4/commons/circuitbreaker"
+	libLog "github.com/LerianStudio/lib-commons/v4/commons/log"
+	"github.com/gofiber/fiber/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// =============================================================================
+// Mock Implementations
+// =============================================================================
+
+// mockCircuitBreakerManager implements libCircuitBreaker.Manager for testing.
+type mockCircuitBreakerManager struct {
+	state libCircuitBreaker.State
+}
+
+func (m *mockCircuitBreakerManager) GetOrCreate(_ string, _ libCircuitBreaker.Config) (libCircuitBreaker.CircuitBreaker, error) {
+	return nil, nil
+}
+
+func (m *mockCircuitBreakerManager) Execute(_ string, fn func() (any, error)) (any, error) {
+	return fn()
+}
+
+func (m *mockCircuitBreakerManager) GetState(_ string) libCircuitBreaker.State {
+	return m.state
+}
+
+func (m *mockCircuitBreakerManager) GetCounts(_ string) libCircuitBreaker.Counts {
+	return libCircuitBreaker.Counts{}
+}
+
+func (m *mockCircuitBreakerManager) IsHealthy(_ string) bool {
+	return m.state == libCircuitBreaker.StateClosed
+}
+
+func (m *mockCircuitBreakerManager) Reset(_ string) {}
+
+func (m *mockCircuitBreakerManager) RegisterStateChangeListener(_ libCircuitBreaker.StateChangeListener) {
+}
+
+// Verify mockCircuitBreakerManager implements the interface.
+var _ libCircuitBreaker.Manager = (*mockCircuitBreakerManager)(nil)
+
+// mockTenantCheckerWithError simulates tenant checker that returns errors.
+type mockTenantCheckerWithError struct {
+	name         string
+	tlsEnabled   bool
+	tenantError  error
+	tenantStatus DependencyStatus
+}
+
+func (m *mockTenantCheckerWithError) Name() string {
+	return m.name
+}
+
+func (m *mockTenantCheckerWithError) TLSEnabled() bool {
+	return m.tlsEnabled
+}
+
+func (m *mockTenantCheckerWithError) Check(_ context.Context) DependencyCheck {
+	return DependencyCheck{
+		Status: StatusNA,
+		Reason: "tenant-scoped; use /readyz/tenant/:id",
+	}
+}
+
+func (m *mockTenantCheckerWithError) CheckTenant(_ context.Context, _ string) DependencyCheck {
+	if m.tenantError != nil {
+		return DependencyCheck{
+			Status: m.tenantStatus,
+			Error:  m.tenantError.Error(),
+		}
+	}
+
+	latency := int64(5)
+
+	return DependencyCheck{
+		Status:    StatusUp,
+		LatencyMs: &latency,
+	}
+}
+
+// slowChecker simulates a checker with configurable delay.
+type slowChecker struct {
+	name       string
+	tlsEnabled bool
+	delay      time.Duration
+	callCount  atomic.Int64
+}
+
+func (c *slowChecker) Name() string {
+	return c.name
+}
+
+func (c *slowChecker) TLSEnabled() bool {
+	return c.tlsEnabled
+}
+
+func (c *slowChecker) Check(ctx context.Context) DependencyCheck {
+	c.callCount.Add(1)
+
+	select {
+	case <-time.After(c.delay):
+		latency := c.delay.Milliseconds()
+		return DependencyCheck{
+			Status:    StatusUp,
+			LatencyMs: &latency,
+		}
+	case <-ctx.Done():
+		return DependencyCheck{
+			Status: StatusDown,
+			Error:  "context deadline exceeded",
+		}
+	}
+}
+
+// =============================================================================
+// Circuit Breaker Tests
+// =============================================================================
+
+func TestRabbitMQChecker_CircuitBreakerClosed(t *testing.T) {
+	t.Parallel()
+
+	cbManager := &mockCircuitBreakerManager{state: libCircuitBreaker.StateClosed}
+	checker := NewRabbitMQChecker("rabbitmq", "", "", cbManager)
+
+	result := checker.Check(context.Background())
+
+	// With closed circuit breaker and no health URL, should be skipped (not degraded)
+	assert.Equal(t, StatusSkipped, result.Status)
+	assert.Equal(t, "closed", result.BreakerState)
+	assert.Contains(t, result.Reason, "RABBITMQ_HEALTH_CHECK_URL not configured")
+}
+
+func TestRabbitMQChecker_CircuitBreakerOpen(t *testing.T) {
+	t.Parallel()
+
+	cbManager := &mockCircuitBreakerManager{state: libCircuitBreaker.StateOpen}
+	checker := NewRabbitMQChecker("rabbitmq", "", "", cbManager)
+
+	result := checker.Check(context.Background())
+
+	assert.Equal(t, StatusDegraded, result.Status)
+	assert.Equal(t, "open", result.BreakerState)
+	assert.Equal(t, "circuit breaker is open", result.Reason)
+}
+
+func TestRabbitMQChecker_CircuitBreakerHalfOpen(t *testing.T) {
+	t.Parallel()
+
+	cbManager := &mockCircuitBreakerManager{state: libCircuitBreaker.StateHalfOpen}
+	checker := NewRabbitMQChecker("rabbitmq", "", "", cbManager)
+
+	result := checker.Check(context.Background())
+
+	assert.Equal(t, StatusDegraded, result.Status)
+	assert.Equal(t, "half-open", result.BreakerState)
+	assert.Equal(t, "circuit breaker is half-open", result.Reason)
+}
+
+func TestRabbitMQChecker_NilCircuitBreakerManager(t *testing.T) {
+	t.Parallel()
+
+	// When cbManager is nil, should not panic and should check health URL
+	checker := NewRabbitMQChecker("rabbitmq", "", "", nil)
+
+	result := checker.Check(context.Background())
+
+	// Without health URL and no circuit breaker, should be skipped
+	assert.Equal(t, StatusSkipped, result.Status)
+	assert.Empty(t, result.BreakerState)
+}
+
+func TestMapCircuitBreakerState(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		state libCircuitBreaker.State
+		want  string
+	}{
+		{"closed_state", libCircuitBreaker.StateClosed, "closed"},
+		{"open_state", libCircuitBreaker.StateOpen, "open"},
+		{"half_open_state", libCircuitBreaker.StateHalfOpen, "half-open"},
+		{"unknown_state", libCircuitBreaker.State("invalid"), "unknown"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := mapCircuitBreakerState(tt.state)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestRabbitMQChecker_DegradedAffectsGlobalHealth(t *testing.T) {
+	t.Parallel()
+
+	// Create a checker that will report degraded status
+	cbManager := &mockCircuitBreakerManager{state: libCircuitBreaker.StateOpen}
+	degradedChecker := NewRabbitMQChecker("rabbitmq", "", "", cbManager)
+
+	latency := int64(5)
+
+	// Healthy checker
+	healthyChecker := &mockChecker{
+		name:       "redis",
+		tlsEnabled: false,
+		check:      DependencyCheck{Status: StatusUp, LatencyMs: &latency},
+	}
+
+	handler := NewReadyzHandler(ReadyzHandlerConfig{
+		Logger:         libLog.NewNop(),
+		Checkers:       []DependencyChecker{healthyChecker, degradedChecker},
+		Version:        "1.0.0",
+		DeploymentMode: "local",
+	})
+
+	// Simulate handling the request
+	checks := make(map[string]DependencyCheck)
+	allHealthy := true
+
+	for _, checker := range handler.checkers {
+		check := checker.Check(context.Background())
+		checks[checker.Name()] = check
+
+		if check.Status == StatusDown || check.Status == StatusDegraded {
+			allHealthy = false
+		}
+	}
+
+	assert.False(t, allHealthy, "degraded should affect overall health")
+	assert.Equal(t, StatusDegraded, checks["rabbitmq"].Status)
+	assert.Equal(t, StatusUp, checks["redis"].Status)
+}
+
+// =============================================================================
+// Multi-Tenant Tests
+// =============================================================================
+
+func TestTenantPostgresChecker_TenantNotFound(t *testing.T) {
+	t.Parallel()
+
+	checker := &mockTenantCheckerWithError{
+		name:         "postgres_onboarding",
+		tlsEnabled:   false,
+		tenantError:  errors.New("tenant not found: unknown-tenant"),
+		tenantStatus: StatusDown,
+	}
+
+	result := checker.CheckTenant(context.Background(), "unknown-tenant")
+
+	assert.Equal(t, StatusDown, result.Status)
+	assert.Contains(t, result.Error, "tenant not found")
+}
+
+func TestTenantPostgresChecker_ConnectionFailure(t *testing.T) {
+	t.Parallel()
+
+	checker := &mockTenantCheckerWithError{
+		name:         "postgres_onboarding",
+		tlsEnabled:   true,
+		tenantError:  errors.New("connection refused: database unreachable"),
+		tenantStatus: StatusDown,
+	}
+
+	result := checker.CheckTenant(context.Background(), "tenant-123")
+
+	assert.Equal(t, StatusDown, result.Status)
+	assert.Contains(t, result.Error, "connection refused")
+}
+
+func TestTenantMongoChecker_PartialAvailability(t *testing.T) {
+	t.Parallel()
+
+	// Simulate scenario where PG is up but Mongo is down for a tenant
+	pgChecker := &mockTenantCheckerWithError{
+		name:         "postgres_onboarding",
+		tlsEnabled:   false,
+		tenantError:  nil, // healthy
+		tenantStatus: StatusUp,
+	}
+
+	mongoChecker := &mockTenantCheckerWithError{
+		name:         "mongo_onboarding",
+		tlsEnabled:   false,
+		tenantError:  errors.New("mongo connection timeout"),
+		tenantStatus: StatusDown,
+	}
+
+	// Both checks for a tenant
+	pgResult := pgChecker.CheckTenant(context.Background(), "tenant-456")
+	mongoResult := mongoChecker.CheckTenant(context.Background(), "tenant-456")
+
+	assert.Equal(t, StatusUp, pgResult.Status)
+	assert.Equal(t, StatusDown, mongoResult.Status)
+
+	// Overall health should be unhealthy (one down)
+	allHealthy := pgResult.Status != StatusDown && pgResult.Status != StatusDegraded &&
+		mongoResult.Status != StatusDown && mongoResult.Status != StatusDegraded
+
+	assert.False(t, allHealthy, "partial availability should result in unhealthy status")
+}
+
+func TestHandleReadyzTenant_AllTenantCheckersHealthy(t *testing.T) {
+	t.Parallel()
+
+	pgChecker := &mockTenantCheckerWithError{
+		name:       "postgres_onboarding",
+		tlsEnabled: false,
+	}
+
+	mongoChecker := &mockTenantCheckerWithError{
+		name:       "mongo_onboarding",
+		tlsEnabled: false,
+	}
+
+	handler := NewReadyzHandler(ReadyzHandlerConfig{
+		Logger:             libLog.NewNop(),
+		TenantCheckers:     []TenantAwareDependencyChecker{pgChecker, mongoChecker},
+		Version:            "1.0.0",
+		DeploymentMode:     "production",
+		MultiTenantEnabled: true,
+	})
+
+	// Verify handler is configured correctly
+	assert.True(t, handler.multiTenantEnabled)
+	assert.Len(t, handler.tenantCheckers, 2)
+}
+
+func TestHandleReadyzTenant_MixedHealthStatus(t *testing.T) {
+	t.Parallel()
+
+	// One healthy, one failing
+	healthyPG := &mockTenantCheckerWithError{
+		name:       "postgres_onboarding",
+		tlsEnabled: false,
+	}
+
+	failingMongo := &mockTenantCheckerWithError{
+		name:         "mongo_onboarding",
+		tlsEnabled:   false,
+		tenantError:  errors.New("replica set not available"),
+		tenantStatus: StatusDown,
+	}
+
+	// Shared redis (not tenant-scoped)
+	latency := int64(3)
+	redisChecker := &mockChecker{
+		name:       "redis",
+		tlsEnabled: false,
+		check:      DependencyCheck{Status: StatusUp, LatencyMs: &latency},
+	}
+
+	handler := NewReadyzHandler(ReadyzHandlerConfig{
+		Logger:             libLog.NewNop(),
+		Checkers:           []DependencyChecker{redisChecker},
+		TenantCheckers:     []TenantAwareDependencyChecker{healthyPG, failingMongo},
+		Version:            "1.0.0",
+		DeploymentMode:     "production",
+		MultiTenantEnabled: true,
+	})
+
+	// Simulate tenant health check aggregation
+	checks := make(map[string]DependencyCheck)
+	allHealthy := true
+
+	for _, tc := range handler.tenantCheckers {
+		result := tc.CheckTenant(context.Background(), "test-tenant")
+		checks[tc.Name()] = result
+
+		if result.Status == StatusDown || result.Status == StatusDegraded {
+			allHealthy = false
+		}
+	}
+
+	assert.False(t, allHealthy)
+	assert.Equal(t, StatusUp, checks["postgres_onboarding"].Status)
+	assert.Equal(t, StatusDown, checks["mongo_onboarding"].Status)
+}
+
+func TestTenantChecker_GlobalCheckReturnsNA(t *testing.T) {
+	t.Parallel()
+
+	checker := &mockTenantCheckerWithError{
+		name:       "postgres_transaction",
+		tlsEnabled: true,
+	}
+
+	// Global check should return n/a for tenant-scoped checkers
+	globalResult := checker.Check(context.Background())
+
+	assert.Equal(t, StatusNA, globalResult.Status)
+	assert.Contains(t, globalResult.Reason, "tenant-scoped")
+}
+
+// =============================================================================
+// Concurrent Access Tests
+// =============================================================================
+
+func TestReadyzHandler_ConcurrentRequests(t *testing.T) {
+	t.Parallel()
+
+	latency := int64(1)
+	checker := &mockChecker{
+		name:       "test_service",
+		tlsEnabled: false,
+		check:      DependencyCheck{Status: StatusUp, LatencyMs: &latency},
+	}
+
+	handler := NewReadyzHandler(ReadyzHandlerConfig{
+		Logger:         libLog.NewNop(),
+		Checkers:       []DependencyChecker{checker},
+		Version:        "1.0.0",
+		DeploymentMode: "local",
+	})
+
+	app := fiber.New()
+	app.Get("/readyz", handler.HandleReadyz)
+
+	const numRequests = 50
+	var wg sync.WaitGroup
+
+	results := make(chan int, numRequests)
+
+	for range numRequests {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+			resp, err := app.Test(req, -1)
+			if err != nil {
+				t.Logf("request error: %v", err)
+				results <- -1
+				return
+			}
+
+			results <- resp.StatusCode
+		}()
+	}
+
+	wg.Wait()
+	close(results)
+
+	var successCount, failCount int
+	for code := range results {
+		if code == http.StatusOK {
+			successCount++
+		} else {
+			failCount++
+		}
+	}
+
+	assert.Equal(t, numRequests, successCount, "all requests should succeed")
+	assert.Equal(t, 0, failCount, "no requests should fail")
+}
+
+func TestReadyzHandler_CheckerTimeoutRespected(t *testing.T) {
+	t.Parallel()
+
+	// Create a slow checker that takes longer than the timeout
+	slowCheck := &slowChecker{
+		name:  "slow_redis",
+		delay: 5 * time.Second, // Much longer than the 1s timeout for redis
+	}
+
+	handler := NewReadyzHandler(ReadyzHandlerConfig{
+		Logger:         libLog.NewNop(),
+		Checkers:       []DependencyChecker{slowCheck},
+		Version:        "1.0.0",
+		DeploymentMode: "local",
+	})
+
+	app := fiber.New()
+	app.Get("/readyz", handler.HandleReadyz)
+
+	start := time.Now()
+	req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+	resp, err := app.Test(req, 3000) // 3 second test timeout
+	elapsed := time.Since(start)
+
+	require.NoError(t, err)
+
+	// The handler should return within the checker timeout + overhead
+	assert.Less(t, elapsed, 3*time.Second, "handler should timeout and return quickly")
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	var response ReadyzResponse
+	err = json.Unmarshal(body, &response)
+	require.NoError(t, err)
+
+	// The slow checker should have timed out
+	slowCheckResult := response.Checks["slow_redis"]
+	assert.Equal(t, StatusDown, slowCheckResult.Status)
+	assert.Contains(t, slowCheckResult.Error, "context deadline exceeded")
+}
+
+func TestReadyzHandler_ParallelTenantChecks(t *testing.T) {
+	t.Parallel()
+
+	var pgCallCount, mongoCallCount atomic.Int64
+
+	pgChecker := &mockTenantChecker{
+		name:        "postgres_onboarding",
+		tlsEnabled:  false,
+		globalCheck: DependencyCheck{Status: StatusNA, Reason: "tenant-scoped"},
+		tenantCheck: DependencyCheck{Status: StatusUp, LatencyMs: ptrInt64(5)},
+	}
+
+	mongoChecker := &mockTenantChecker{
+		name:        "mongo_onboarding",
+		tlsEnabled:  false,
+		globalCheck: DependencyCheck{Status: StatusNA, Reason: "tenant-scoped"},
+		tenantCheck: DependencyCheck{Status: StatusUp, LatencyMs: ptrInt64(3)},
+	}
+
+	handler := NewReadyzHandler(ReadyzHandlerConfig{
+		Logger:             libLog.NewNop(),
+		TenantCheckers:     []TenantAwareDependencyChecker{pgChecker, mongoChecker},
+		Version:            "1.0.0",
+		DeploymentMode:     "production",
+		MultiTenantEnabled: true,
+	})
+
+	// Simulate concurrent tenant health checks
+	const numTenants = 10
+	var wg sync.WaitGroup
+
+	for i := range numTenants {
+		wg.Add(1)
+		go func(tenantNum int) {
+			defer wg.Done()
+
+			tenantID := string(rune('A' + tenantNum))
+			for _, checker := range handler.tenantCheckers {
+				result := checker.CheckTenant(context.Background(), "tenant-"+tenantID)
+				if checker.Name() == "postgres_onboarding" {
+					pgCallCount.Add(1)
+				} else {
+					mongoCallCount.Add(1)
+				}
+
+				assert.Equal(t, StatusUp, result.Status)
+			}
+		}(i)
+	}
+
+	wg.Wait()
+
+	assert.Equal(t, int64(numTenants), pgCallCount.Load())
+	assert.Equal(t, int64(numTenants), mongoCallCount.Load())
+}
+
+func TestReadyzHandler_RaceConditionSafety(t *testing.T) {
+	t.Parallel()
+
+	// This test verifies that concurrent access to the handler doesn't cause data races.
+	// Run with -race flag: go test -race -run TestReadyzHandler_RaceConditionSafety
+	latency := int64(1)
+	checker := &mockChecker{
+		name:       "test",
+		tlsEnabled: false,
+		check:      DependencyCheck{Status: StatusUp, LatencyMs: &latency},
+	}
+
+	handler := NewReadyzHandler(ReadyzHandlerConfig{
+		Logger:         libLog.NewNop(),
+		Checkers:       []DependencyChecker{checker},
+		Version:        "1.0.0",
+		DeploymentMode: "local",
+	})
+
+	app := fiber.New()
+	app.Get("/readyz", handler.HandleReadyz)
+
+	const goroutines = 20
+	var wg sync.WaitGroup
+
+	// Mix of read operations
+	for range goroutines {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			for range 10 {
+				req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+				resp, err := app.Test(req, -1)
+				if err == nil {
+					_, _ = io.Copy(io.Discard, resp.Body)
+					_ = resp.Body.Close()
+				}
+			}
+		}()
+	}
+
+	wg.Wait()
+	// If we reach here without race detector errors, the test passes
+}
+
+// ptrInt64 is a helper to create a pointer to int64.
+func ptrInt64(v int64) *int64 {
+	return &v
+}

--- a/components/ledger/internal/bootstrap/readyz_general_test.go
+++ b/components/ledger/internal/bootstrap/readyz_general_test.go
@@ -231,7 +231,7 @@ func TestRabbitMQChecker_DegradedAffectsGlobalHealth(t *testing.T) {
 		check:      DependencyCheck{Status: StatusUp, LatencyMs: &latency},
 	}
 
-	handler := NewReadyzHandler(ReadyzHandlerConfig{
+	handler := newReadyHandler(ReadyzHandlerConfig{
 		Logger:         libLog.NewNop(),
 		Checkers:       []DependencyChecker{healthyChecker, degradedChecker},
 		Version:        "1.0.0",
@@ -337,7 +337,7 @@ func TestHandleReadyzTenant_AllTenantCheckersHealthy(t *testing.T) {
 		tlsEnabled: false,
 	}
 
-	handler := NewReadyzHandler(ReadyzHandlerConfig{
+	handler := newReadyHandler(ReadyzHandlerConfig{
 		Logger:             libLog.NewNop(),
 		TenantCheckers:     []TenantAwareDependencyChecker{pgChecker, mongoChecker},
 		Version:            "1.0.0",
@@ -374,7 +374,7 @@ func TestHandleReadyzTenant_MixedHealthStatus(t *testing.T) {
 		check:      DependencyCheck{Status: StatusUp, LatencyMs: &latency},
 	}
 
-	handler := NewReadyzHandler(ReadyzHandlerConfig{
+	handler := newReadyHandler(ReadyzHandlerConfig{
 		Logger:             libLog.NewNop(),
 		Checkers:           []DependencyChecker{redisChecker},
 		TenantCheckers:     []TenantAwareDependencyChecker{healthyPG, failingMongo},
@@ -430,7 +430,7 @@ func TestReadyzHandler_ConcurrentRequests(t *testing.T) {
 		check:      DependencyCheck{Status: StatusUp, LatencyMs: &latency},
 	}
 
-	handler := NewReadyzHandler(ReadyzHandlerConfig{
+	handler := newReadyHandler(ReadyzHandlerConfig{
 		Logger:         libLog.NewNop(),
 		Checkers:       []DependencyChecker{checker},
 		Version:        "1.0.0",
@@ -487,7 +487,7 @@ func TestReadyzHandler_CheckerTimeoutRespected(t *testing.T) {
 		delay: 5 * time.Second, // Much longer than the 1s timeout for redis
 	}
 
-	handler := NewReadyzHandler(ReadyzHandlerConfig{
+	handler := newReadyHandler(ReadyzHandlerConfig{
 		Logger:         libLog.NewNop(),
 		Checkers:       []DependencyChecker{slowCheck},
 		Version:        "1.0.0",
@@ -539,7 +539,7 @@ func TestReadyzHandler_ParallelTenantChecks(t *testing.T) {
 		tenantCheck: DependencyCheck{Status: StatusUp, LatencyMs: ptrInt64(3)},
 	}
 
-	handler := NewReadyzHandler(ReadyzHandlerConfig{
+	handler := newReadyHandler(ReadyzHandlerConfig{
 		Logger:             libLog.NewNop(),
 		TenantCheckers:     []TenantAwareDependencyChecker{pgChecker, mongoChecker},
 		Version:            "1.0.0",
@@ -588,7 +588,7 @@ func TestReadyzHandler_RaceConditionSafety(t *testing.T) {
 		check:      DependencyCheck{Status: StatusUp, LatencyMs: &latency},
 	}
 
-	handler := NewReadyzHandler(ReadyzHandlerConfig{
+	handler := newReadyHandler(ReadyzHandlerConfig{
 		Logger:         libLog.NewNop(),
 		Checkers:       []DependencyChecker{checker},
 		Version:        "1.0.0",

--- a/components/ledger/internal/bootstrap/readyz_integration_test.go
+++ b/components/ledger/internal/bootstrap/readyz_integration_test.go
@@ -1,0 +1,370 @@
+//go:build integration
+
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package bootstrap
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	libLog "github.com/LerianStudio/lib-commons/v4/commons/log"
+	"github.com/gofiber/fiber/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	mongoContainer "github.com/LerianStudio/midaz/v3/tests/utils/mongodb"
+	pgContainer "github.com/LerianStudio/midaz/v3/tests/utils/postgres"
+	redisContainer "github.com/LerianStudio/midaz/v3/tests/utils/redis"
+)
+
+func TestReadyz_Integration_AllDependenciesHealthy(t *testing.T) {
+	t.Parallel()
+
+	// Start containers
+	pg := pgContainer.SetupContainer(t)
+	mongo := mongoContainer.SetupContainer(t)
+	redis := redisContainer.SetupContainer(t)
+
+	// Create lib-commons wrappers
+	mongoClient := mongoContainer.CreateConnection(t, mongo.URI, mongo.DBName)
+	redisClient := redisContainer.CreateConnection(t, redis.Addr)
+
+	// Create checkers using raw *sql.DB for PostgreSQL
+	// and lib-commons clients for MongoDB and Redis
+	checkers := []DependencyChecker{
+		NewSQLDBChecker("postgres_onboarding", pg.DB, false),
+		NewMongoChecker("mongo_onboarding", mongoClient, mongo.URI),
+		NewRedisChecker("redis", redisClient, redis.Addr, false),
+	}
+
+	handler := NewReadyzHandler(ReadyzHandlerConfig{
+		Logger:         libLog.NewNop(),
+		Checkers:       checkers,
+		Version:        "1.0.0-test",
+		DeploymentMode: "local",
+	})
+
+	app := fiber.New()
+	app.Get("/readyz", handler.HandleReadyz)
+
+	req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+	resp, err := app.Test(req, 10000) // 10s timeout for containers
+	require.NoError(t, err)
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	var response ReadyzResponse
+	err = json.Unmarshal(body, &response)
+	require.NoError(t, err)
+
+	assert.Equal(t, "healthy", response.Status)
+	assert.Equal(t, "1.0.0-test", response.Version)
+	assert.Equal(t, "local", response.DeploymentMode)
+
+	// All checkers should be up
+	assert.Equal(t, StatusUp, response.Checks["postgres_onboarding"].Status)
+	assert.Equal(t, StatusUp, response.Checks["mongo_onboarding"].Status)
+	assert.Equal(t, StatusUp, response.Checks["redis"].Status)
+
+	// Latencies should be populated
+	assert.NotNil(t, response.Checks["postgres_onboarding"].LatencyMs)
+	assert.NotNil(t, response.Checks["mongo_onboarding"].LatencyMs)
+	assert.NotNil(t, response.Checks["redis"].LatencyMs)
+}
+
+func TestReadyz_Integration_PostgresDown(t *testing.T) {
+	t.Parallel()
+
+	// Start only Redis and MongoDB
+	mongo := mongoContainer.SetupContainer(t)
+	redis := redisContainer.SetupContainer(t)
+
+	mongoClient := mongoContainer.CreateConnection(t, mongo.URI, mongo.DBName)
+	redisClient := redisContainer.CreateConnection(t, redis.Addr)
+
+	// Create a Postgres checker with nil db (simulating down)
+	checkers := []DependencyChecker{
+		NewSQLDBChecker("postgres_onboarding", nil, false), // nil = not configured/down
+		NewMongoChecker("mongo_onboarding", mongoClient, mongo.URI),
+		NewRedisChecker("redis", redisClient, redis.Addr, false),
+	}
+
+	handler := NewReadyzHandler(ReadyzHandlerConfig{
+		Logger:         libLog.NewNop(),
+		Checkers:       checkers,
+		Version:        "1.0.0-test",
+		DeploymentMode: "local",
+	})
+
+	app := fiber.New()
+	app.Get("/readyz", handler.HandleReadyz)
+
+	req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+	resp, err := app.Test(req, 10000)
+	require.NoError(t, err)
+
+	// Should return 200 since nil checker returns "skipped" not "down"
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	var response ReadyzResponse
+	err = json.Unmarshal(body, &response)
+	require.NoError(t, err)
+
+	assert.Equal(t, "healthy", response.Status)
+	assert.Equal(t, StatusSkipped, response.Checks["postgres_onboarding"].Status)
+
+	// Other checkers should still be healthy
+	assert.Equal(t, StatusUp, response.Checks["mongo_onboarding"].Status)
+	assert.Equal(t, StatusUp, response.Checks["redis"].Status)
+}
+
+func TestReadyz_Integration_TLSDetection(t *testing.T) {
+	t.Parallel()
+
+	// Test that TLS detection works correctly with real containers (all non-TLS)
+	pg := pgContainer.SetupContainer(t)
+	mongo := mongoContainer.SetupContainer(t)
+	redis := redisContainer.SetupContainer(t)
+
+	mongoClient := mongoContainer.CreateConnection(t, mongo.URI, mongo.DBName)
+	redisClient := redisContainer.CreateConnection(t, redis.Addr)
+
+	checkers := []DependencyChecker{
+		NewSQLDBChecker("postgres_onboarding", pg.DB, false),
+		NewMongoChecker("mongo_onboarding", mongoClient, mongo.URI),
+		NewRedisChecker("redis", redisClient, redis.Addr, false),
+	}
+
+	handler := NewReadyzHandler(ReadyzHandlerConfig{
+		Logger:         libLog.NewNop(),
+		Checkers:       checkers,
+		Version:        "1.0.0-test",
+		DeploymentMode: "local",
+	})
+
+	app := fiber.New()
+	app.Get("/readyz", handler.HandleReadyz)
+
+	req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+	resp, err := app.Test(req, 10000)
+	require.NoError(t, err)
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	var response ReadyzResponse
+	err = json.Unmarshal(body, &response)
+	require.NoError(t, err)
+
+	// All test containers use non-TLS connections
+	for name, check := range response.Checks {
+		require.NotNil(t, check.TLS, "TLS field should be set for %s", name)
+		assert.False(t, *check.TLS, "TLS should be false for test container %s", name)
+	}
+}
+
+func TestReadyz_Integration_LatencyMeasurement(t *testing.T) {
+	t.Parallel()
+
+	pg := pgContainer.SetupContainer(t)
+	redis := redisContainer.SetupContainer(t)
+
+	redisClient := redisContainer.CreateConnection(t, redis.Addr)
+
+	checkers := []DependencyChecker{
+		NewSQLDBChecker("postgres", pg.DB, false),
+		NewRedisChecker("redis", redisClient, redis.Addr, false),
+	}
+
+	handler := NewReadyzHandler(ReadyzHandlerConfig{
+		Logger:         libLog.NewNop(),
+		Checkers:       checkers,
+		Version:        "1.0.0",
+		DeploymentMode: "local",
+	})
+
+	app := fiber.New()
+	app.Get("/readyz", handler.HandleReadyz)
+
+	// Run multiple times to verify latency is measured each time
+	for i := range 3 {
+		req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+		resp, err := app.Test(req, 10000)
+		require.NoError(t, err, "iteration %d failed", i)
+
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+
+		var response ReadyzResponse
+		err = json.Unmarshal(body, &response)
+		require.NoError(t, err)
+
+		// Latency should be positive and reasonable (< 1 second for local containers)
+		pgLatency := response.Checks["postgres"].LatencyMs
+		redisLatency := response.Checks["redis"].LatencyMs
+
+		require.NotNil(t, pgLatency)
+		require.NotNil(t, redisLatency)
+
+		assert.Greater(t, *pgLatency, int64(0), "postgres latency should be positive")
+		assert.Less(t, *pgLatency, int64(1000), "postgres latency should be < 1s")
+
+		assert.Greater(t, *redisLatency, int64(0), "redis latency should be positive")
+		assert.Less(t, *redisLatency, int64(1000), "redis latency should be < 1s")
+	}
+}
+
+func TestReadyz_Integration_ConnectionTimeout(t *testing.T) {
+	t.Parallel()
+
+	// Test with only Redis to verify timeout behavior
+	redis := redisContainer.SetupContainer(t)
+	redisClient := redisContainer.CreateConnection(t, redis.Addr)
+
+	// Create a checker that will respond quickly
+	checkers := []DependencyChecker{
+		NewRedisChecker("redis", redisClient, redis.Addr, false),
+	}
+
+	handler := NewReadyzHandler(ReadyzHandlerConfig{
+		Logger:         libLog.NewNop(),
+		Checkers:       checkers,
+		Version:        "1.0.0",
+		DeploymentMode: "local",
+	})
+
+	app := fiber.New()
+	app.Get("/readyz", handler.HandleReadyz)
+
+	// Make multiple concurrent requests
+	const numRequests = 5
+	results := make(chan int, numRequests)
+
+	for range numRequests {
+		go func() {
+			req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+			resp, err := app.Test(req, 5000) // 5s timeout
+			if err != nil {
+				results <- -1
+				return
+			}
+			results <- resp.StatusCode
+		}()
+	}
+
+	// Collect results
+	successCount := 0
+	for range numRequests {
+		if <-results == http.StatusOK {
+			successCount++
+		}
+	}
+
+	assert.Equal(t, numRequests, successCount, "all concurrent requests should succeed")
+}
+
+func TestReadyz_Integration_MixedHealthStatus(t *testing.T) {
+	t.Parallel()
+
+	// Start only working containers
+	mongo := mongoContainer.SetupContainer(t)
+	redis := redisContainer.SetupContainer(t)
+
+	mongoClient := mongoContainer.CreateConnection(t, mongo.URI, mongo.DBName)
+	redisClient := redisContainer.CreateConnection(t, redis.Addr)
+
+	// Mix of healthy, skipped, and n/a checkers
+	checkers := []DependencyChecker{
+		NewSQLDBChecker("postgres_onboarding", nil, false), // skipped (nil)
+		NewMongoChecker("mongo_onboarding", mongoClient, mongo.URI),
+		NewRedisChecker("redis", redisClient, redis.Addr, false),
+		NewNAChecker("postgres_transaction", "tenant-scoped", false), // n/a
+	}
+
+	handler := NewReadyzHandler(ReadyzHandlerConfig{
+		Logger:         libLog.NewNop(),
+		Checkers:       checkers,
+		Version:        "1.0.0",
+		DeploymentMode: "local",
+	})
+
+	app := fiber.New()
+	app.Get("/readyz", handler.HandleReadyz)
+
+	req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+	resp, err := app.Test(req, 10000)
+	require.NoError(t, err)
+
+	// Should be healthy since skipped and n/a don't count as unhealthy
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	var response ReadyzResponse
+	err = json.Unmarshal(body, &response)
+	require.NoError(t, err)
+
+	assert.Equal(t, "healthy", response.Status)
+	assert.Equal(t, StatusSkipped, response.Checks["postgres_onboarding"].Status)
+	assert.Equal(t, StatusUp, response.Checks["mongo_onboarding"].Status)
+	assert.Equal(t, StatusUp, response.Checks["redis"].Status)
+	assert.Equal(t, StatusNA, response.Checks["postgres_transaction"].Status)
+}
+
+func TestReadyz_Integration_ClosedConnection(t *testing.T) {
+	t.Parallel()
+
+	// Start container
+	redis := redisContainer.SetupContainer(t)
+
+	// Create connection and then close it before using
+	conn, err := redis.Client.Ping(context.Background()).Result()
+	require.NoError(t, err)
+	require.NotEmpty(t, conn)
+
+	// Close the underlying client to simulate connection failure
+	// Note: we can't easily close lib-commons client, so we test with the checker
+	// that reports skipped when client is nil
+	checkers := []DependencyChecker{
+		NewRedisChecker("redis", nil, redis.Addr, false), // nil client = skipped
+	}
+
+	handler := NewReadyzHandler(ReadyzHandlerConfig{
+		Logger:         libLog.NewNop(),
+		Checkers:       checkers,
+		Version:        "1.0.0",
+		DeploymentMode: "local",
+	})
+
+	app := fiber.New()
+	app.Get("/readyz", handler.HandleReadyz)
+
+	req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+	resp, err := app.Test(req, 5000)
+	require.NoError(t, err)
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode) // skipped counts as healthy
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	var response ReadyzResponse
+	err = json.Unmarshal(body, &response)
+	require.NoError(t, err)
+
+	assert.Equal(t, StatusSkipped, response.Checks["redis"].Status)
+}

--- a/components/ledger/internal/bootstrap/readyz_integration_test.go
+++ b/components/ledger/internal/bootstrap/readyz_integration_test.go
@@ -24,6 +24,15 @@ import (
 	redisContainer "github.com/LerianStudio/midaz/v3/tests/utils/redis"
 )
 
+// newReadyHandler creates a ReadyzHandler and marks it as ready for testing.
+// This is needed because HandleReadyz now checks lifecycle state before running checks.
+func newReadyHandler(cfg ReadyzHandlerConfig) *ReadyzHandler {
+	handler := NewReadyzHandler(cfg)
+	handler.SetServerReady()
+
+	return handler
+}
+
 func TestReadyz_Integration_AllDependenciesHealthy(t *testing.T) {
 	t.Parallel()
 
@@ -44,7 +53,7 @@ func TestReadyz_Integration_AllDependenciesHealthy(t *testing.T) {
 		NewRedisChecker("redis", redisClient, redis.Addr, false),
 	}
 
-	handler := NewReadyzHandler(ReadyzHandlerConfig{
+	handler := newReadyHandler(ReadyzHandlerConfig{
 		Logger:         libLog.NewNop(),
 		Checkers:       checkers,
 		Version:        "1.0.0-test",
@@ -99,7 +108,7 @@ func TestReadyz_Integration_PostgresDown(t *testing.T) {
 		NewRedisChecker("redis", redisClient, redis.Addr, false),
 	}
 
-	handler := NewReadyzHandler(ReadyzHandlerConfig{
+	handler := newReadyHandler(ReadyzHandlerConfig{
 		Logger:         libLog.NewNop(),
 		Checkers:       checkers,
 		Version:        "1.0.0-test",
@@ -148,7 +157,7 @@ func TestReadyz_Integration_TLSDetection(t *testing.T) {
 		NewRedisChecker("redis", redisClient, redis.Addr, false),
 	}
 
-	handler := NewReadyzHandler(ReadyzHandlerConfig{
+	handler := newReadyHandler(ReadyzHandlerConfig{
 		Logger:         libLog.NewNop(),
 		Checkers:       checkers,
 		Version:        "1.0.0-test",
@@ -189,7 +198,7 @@ func TestReadyz_Integration_LatencyMeasurement(t *testing.T) {
 		NewRedisChecker("redis", redisClient, redis.Addr, false),
 	}
 
-	handler := NewReadyzHandler(ReadyzHandlerConfig{
+	handler := newReadyHandler(ReadyzHandlerConfig{
 		Logger:         libLog.NewNop(),
 		Checkers:       checkers,
 		Version:        "1.0.0",
@@ -239,7 +248,7 @@ func TestReadyz_Integration_ConnectionTimeout(t *testing.T) {
 		NewRedisChecker("redis", redisClient, redis.Addr, false),
 	}
 
-	handler := NewReadyzHandler(ReadyzHandlerConfig{
+	handler := newReadyHandler(ReadyzHandlerConfig{
 		Logger:         libLog.NewNop(),
 		Checkers:       checkers,
 		Version:        "1.0.0",
@@ -294,7 +303,7 @@ func TestReadyz_Integration_MixedHealthStatus(t *testing.T) {
 		NewNAChecker("postgres_transaction", "tenant-scoped", false), // n/a
 	}
 
-	handler := NewReadyzHandler(ReadyzHandlerConfig{
+	handler := newReadyHandler(ReadyzHandlerConfig{
 		Logger:         libLog.NewNop(),
 		Checkers:       checkers,
 		Version:        "1.0.0",
@@ -343,7 +352,7 @@ func TestReadyz_Integration_ClosedConnection(t *testing.T) {
 		NewRedisChecker("redis", nil, redis.Addr, false), // nil client = skipped
 	}
 
-	handler := NewReadyzHandler(ReadyzHandlerConfig{
+	handler := newReadyHandler(ReadyzHandlerConfig{
 		Logger:         libLog.NewNop(),
 		Checkers:       checkers,
 		Version:        "1.0.0",

--- a/components/ledger/internal/bootstrap/readyz_test.go
+++ b/components/ledger/internal/bootstrap/readyz_test.go
@@ -1,0 +1,624 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package bootstrap
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	libLog "github.com/LerianStudio/lib-commons/v4/commons/log"
+	"github.com/gofiber/fiber/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockChecker is a test implementation of DependencyChecker.
+type mockChecker struct {
+	name       string
+	tlsEnabled bool
+	check      DependencyCheck
+}
+
+func (m *mockChecker) Name() string {
+	return m.name
+}
+
+func (m *mockChecker) TLSEnabled() bool {
+	return m.tlsEnabled
+}
+
+func (m *mockChecker) Check(_ context.Context) DependencyCheck {
+	return m.check
+}
+
+// mockTenantChecker is a test implementation of TenantAwareDependencyChecker.
+type mockTenantChecker struct {
+	name        string
+	tlsEnabled  bool
+	globalCheck DependencyCheck
+	tenantCheck DependencyCheck
+}
+
+func (m *mockTenantChecker) Name() string {
+	return m.name
+}
+
+func (m *mockTenantChecker) TLSEnabled() bool {
+	return m.tlsEnabled
+}
+
+func (m *mockTenantChecker) Check(_ context.Context) DependencyCheck {
+	return m.globalCheck
+}
+
+func (m *mockTenantChecker) CheckTenant(_ context.Context, _ string) DependencyCheck {
+	return m.tenantCheck
+}
+
+func TestReadyzHandler_HandleReadyz(t *testing.T) {
+	t.Parallel()
+
+	latency := int64(5)
+
+	tests := []struct {
+		name           string
+		checkers       []DependencyChecker
+		version        string
+		deploymentMode string
+		wantStatus     int
+		wantHealthy    bool
+		wantChecks     map[string]DependencyStatus
+	}{
+		{
+			name: "all_healthy_returns_200",
+			checkers: []DependencyChecker{
+				&mockChecker{name: "postgres", tlsEnabled: false, check: DependencyCheck{Status: StatusUp, LatencyMs: &latency}},
+				&mockChecker{name: "redis", tlsEnabled: true, check: DependencyCheck{Status: StatusUp, LatencyMs: &latency}},
+			},
+			version:        "1.0.0",
+			deploymentMode: "production",
+			wantStatus:     http.StatusOK,
+			wantHealthy:    true,
+			wantChecks: map[string]DependencyStatus{
+				"postgres": StatusUp,
+				"redis":    StatusUp,
+			},
+		},
+		{
+			name: "one_down_returns_503",
+			checkers: []DependencyChecker{
+				&mockChecker{name: "postgres", tlsEnabled: false, check: DependencyCheck{Status: StatusUp, LatencyMs: &latency}},
+				&mockChecker{name: "redis", tlsEnabled: true, check: DependencyCheck{Status: StatusDown, Error: "connection refused"}},
+			},
+			version:        "1.0.0",
+			deploymentMode: "production",
+			wantStatus:     http.StatusServiceUnavailable,
+			wantHealthy:    false,
+			wantChecks: map[string]DependencyStatus{
+				"postgres": StatusUp,
+				"redis":    StatusDown,
+			},
+		},
+		{
+			name: "degraded_returns_503",
+			checkers: []DependencyChecker{
+				&mockChecker{name: "rabbitmq", tlsEnabled: false, check: DependencyCheck{Status: StatusDegraded, Reason: "circuit breaker half-open", BreakerState: "half-open"}},
+			},
+			version:        "1.0.0",
+			deploymentMode: "local",
+			wantStatus:     http.StatusServiceUnavailable,
+			wantHealthy:    false,
+			wantChecks: map[string]DependencyStatus{
+				"rabbitmq": StatusDegraded,
+			},
+		},
+		{
+			name: "skipped_and_na_count_as_healthy",
+			checkers: []DependencyChecker{
+				&mockChecker{name: "postgres", tlsEnabled: false, check: DependencyCheck{Status: StatusNA, Reason: "tenant-scoped"}},
+				&mockChecker{name: "redis", tlsEnabled: true, check: DependencyCheck{Status: StatusUp, LatencyMs: &latency}},
+				&mockChecker{name: "rabbitmq", tlsEnabled: false, check: DependencyCheck{Status: StatusSkipped, Reason: "not configured"}},
+			},
+			version:        "2.0.0",
+			deploymentMode: "staging",
+			wantStatus:     http.StatusOK,
+			wantHealthy:    true,
+			wantChecks: map[string]DependencyStatus{
+				"postgres": StatusNA,
+				"redis":    StatusUp,
+				"rabbitmq": StatusSkipped,
+			},
+		},
+		{
+			name:           "no_checkers_returns_healthy",
+			checkers:       []DependencyChecker{},
+			version:        "1.0.0",
+			deploymentMode: "local",
+			wantStatus:     http.StatusOK,
+			wantHealthy:    true,
+			wantChecks:     map[string]DependencyStatus{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			handler := NewReadyzHandler(ReadyzHandlerConfig{
+				Logger:         libLog.NewNop(),
+				Checkers:       tt.checkers,
+				Version:        tt.version,
+				DeploymentMode: tt.deploymentMode,
+			})
+
+			app := fiber.New()
+			app.Get("/readyz", handler.HandleReadyz)
+
+			req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+			resp, err := app.Test(req, -1)
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.wantStatus, resp.StatusCode)
+
+			body, err := io.ReadAll(resp.Body)
+			require.NoError(t, err)
+
+			var response ReadyzResponse
+			err = json.Unmarshal(body, &response)
+			require.NoError(t, err)
+
+			if tt.wantHealthy {
+				assert.Equal(t, "healthy", response.Status)
+			} else {
+				assert.Equal(t, "unhealthy", response.Status)
+			}
+
+			assert.Equal(t, tt.version, response.Version)
+			assert.Equal(t, tt.deploymentMode, response.DeploymentMode)
+
+			for name, wantStatus := range tt.wantChecks {
+				check, exists := response.Checks[name]
+				assert.True(t, exists, "check %s should exist", name)
+				assert.Equal(t, wantStatus, check.Status, "check %s status mismatch", name)
+			}
+		})
+	}
+}
+
+func TestReadyzHandler_HandleReadyzTenant(t *testing.T) {
+	t.Parallel()
+
+	latency := int64(10)
+
+	tests := []struct {
+		name               string
+		tenantID           string
+		multiTenantEnabled bool
+		tenantCheckers     []TenantAwareDependencyChecker
+		checkers           []DependencyChecker
+		wantStatus         int
+		wantHealthy        bool
+	}{
+		{
+			name:               "multi_tenant_enabled_all_healthy",
+			tenantID:           "tenant-123",
+			multiTenantEnabled: true,
+			tenantCheckers: []TenantAwareDependencyChecker{
+				&mockTenantChecker{
+					name:        "postgres",
+					tlsEnabled:  false,
+					globalCheck: DependencyCheck{Status: StatusNA, Reason: "tenant-scoped"},
+					tenantCheck: DependencyCheck{Status: StatusUp, LatencyMs: &latency},
+				},
+			},
+			checkers: []DependencyChecker{
+				&mockChecker{name: "redis", tlsEnabled: true, check: DependencyCheck{Status: StatusUp, LatencyMs: &latency}},
+			},
+			wantStatus:  http.StatusOK,
+			wantHealthy: true,
+		},
+		{
+			name:               "multi_tenant_disabled_returns_400",
+			tenantID:           "tenant-123",
+			multiTenantEnabled: false,
+			tenantCheckers:     nil,
+			checkers:           nil,
+			wantStatus:         http.StatusBadRequest,
+			wantHealthy:        false,
+		},
+		{
+			name:               "empty_tenant_id_returns_404",
+			tenantID:           "",
+			multiTenantEnabled: true,
+			tenantCheckers:     nil,
+			checkers:           nil,
+			wantStatus:         http.StatusNotFound, // Fiber returns 404 for missing path params
+			wantHealthy:        false,
+		},
+		{
+			name:               "tenant_db_down_returns_503",
+			tenantID:           "tenant-456",
+			multiTenantEnabled: true,
+			tenantCheckers: []TenantAwareDependencyChecker{
+				&mockTenantChecker{
+					name:        "postgres",
+					tlsEnabled:  true,
+					globalCheck: DependencyCheck{Status: StatusNA, Reason: "tenant-scoped"},
+					tenantCheck: DependencyCheck{Status: StatusDown, LatencyMs: &latency, Error: "connection failed"},
+				},
+			},
+			checkers: []DependencyChecker{
+				&mockChecker{name: "redis", tlsEnabled: true, check: DependencyCheck{Status: StatusUp, LatencyMs: &latency}},
+			},
+			wantStatus:  http.StatusServiceUnavailable,
+			wantHealthy: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			handler := NewReadyzHandler(ReadyzHandlerConfig{
+				Logger:             libLog.NewNop(),
+				Checkers:           tt.checkers,
+				TenantCheckers:     tt.tenantCheckers,
+				Version:            "1.0.0",
+				DeploymentMode:     "production",
+				MultiTenantEnabled: tt.multiTenantEnabled,
+			})
+
+			app := fiber.New()
+			app.Get("/readyz/tenant/:id", handler.HandleReadyzTenant)
+
+			path := "/readyz/tenant/" + tt.tenantID
+			if tt.tenantID == "" {
+				path = "/readyz/tenant/"
+			}
+
+			req := httptest.NewRequest(http.MethodGet, path, nil)
+			resp, err := app.Test(req, -1)
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.wantStatus, resp.StatusCode)
+
+			if tt.wantStatus == http.StatusOK || tt.wantStatus == http.StatusServiceUnavailable {
+				body, err := io.ReadAll(resp.Body)
+				require.NoError(t, err)
+
+				var response ReadyzResponse
+				err = json.Unmarshal(body, &response)
+				require.NoError(t, err)
+
+				if tt.wantHealthy {
+					assert.Equal(t, "healthy", response.Status)
+				} else {
+					assert.Equal(t, "unhealthy", response.Status)
+				}
+			}
+		})
+	}
+}
+
+func TestReadyzHandler_TLSField(t *testing.T) {
+	t.Parallel()
+
+	latency := int64(5)
+
+	handler := NewReadyzHandler(ReadyzHandlerConfig{
+		Logger: libLog.NewNop(),
+		Checkers: []DependencyChecker{
+			&mockChecker{name: "postgres_tls", tlsEnabled: true, check: DependencyCheck{Status: StatusUp, LatencyMs: &latency}},
+			&mockChecker{name: "redis_no_tls", tlsEnabled: false, check: DependencyCheck{Status: StatusUp, LatencyMs: &latency}},
+		},
+		Version:        "1.0.0",
+		DeploymentMode: "local",
+	})
+
+	app := fiber.New()
+	app.Get("/readyz", handler.HandleReadyz)
+
+	req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+	resp, err := app.Test(req, -1)
+	require.NoError(t, err)
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	var response ReadyzResponse
+	err = json.Unmarshal(body, &response)
+	require.NoError(t, err)
+
+	// Check TLS field for postgres_tls
+	pgCheck := response.Checks["postgres_tls"]
+	require.NotNil(t, pgCheck.TLS)
+	assert.True(t, *pgCheck.TLS, "postgres_tls should have TLS enabled")
+
+	// Check TLS field for redis_no_tls
+	redisCheck := response.Checks["redis_no_tls"]
+	require.NotNil(t, redisCheck.TLS)
+	assert.False(t, *redisCheck.TLS, "redis_no_tls should have TLS disabled")
+}
+
+func TestReadyzHandler_DeploymentModeDefault(t *testing.T) {
+	t.Parallel()
+
+	handler := NewReadyzHandler(ReadyzHandlerConfig{
+		Logger:         libLog.NewNop(),
+		Checkers:       []DependencyChecker{},
+		Version:        "1.0.0",
+		DeploymentMode: "", // Empty should default to "local"
+	})
+
+	app := fiber.New()
+	app.Get("/readyz", handler.HandleReadyz)
+
+	req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+	resp, err := app.Test(req, -1)
+	require.NoError(t, err)
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	var response ReadyzResponse
+	err = json.Unmarshal(body, &response)
+	require.NoError(t, err)
+
+	assert.Equal(t, "local", response.DeploymentMode)
+}
+
+func TestNAChecker(t *testing.T) {
+	t.Parallel()
+
+	checker := NewNAChecker("test_na", "tenant-scoped dependency", true)
+
+	assert.Equal(t, "test_na", checker.Name())
+	assert.True(t, checker.TLSEnabled())
+
+	check := checker.Check(context.Background())
+	assert.Equal(t, StatusNA, check.Status)
+	assert.Equal(t, "tenant-scoped dependency", check.Reason)
+}
+
+func TestTimeoutForChecker(t *testing.T) {
+	t.Parallel()
+
+	handler := &ReadyzHandler{}
+
+	tests := []struct {
+		name     string
+		checker  DependencyChecker
+		expected time.Duration
+	}{
+		{
+			name:     "redis_gets_1s_timeout",
+			checker:  &mockChecker{name: "redis"},
+			expected: 1 * time.Second,
+		},
+		{
+			name:     "postgres_gets_2s_timeout",
+			checker:  &mockChecker{name: "postgres_onboarding"},
+			expected: 2 * time.Second,
+		},
+		{
+			name:     "mongo_gets_2s_timeout",
+			checker:  &mockChecker{name: "mongo_transaction"},
+			expected: 2 * time.Second,
+		},
+		{
+			name:     "rabbitmq_gets_2s_timeout",
+			checker:  &mockChecker{name: "rabbitmq"},
+			expected: 2 * time.Second,
+		},
+		{
+			name:     "unknown_gets_2s_timeout",
+			checker:  &mockChecker{name: "unknown_service"},
+			expected: 2 * time.Second,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			timeout := handler.timeoutForChecker(tt.checker)
+			assert.Equal(t, tt.expected, timeout)
+		})
+	}
+}
+
+func TestContainsLower(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		s      string
+		substr string
+		want   bool
+	}{
+		{"empty_both", "", "", true},
+		{"empty_substr", "hello", "", true},
+		{"exact_match", "redis", "redis", true},
+		{"substring_match", "postgres_onboarding", "postgres", true},
+		{"case_insensitive", "PostgreSQL", "postgres", true},
+		{"case_insensitive_reverse", "postgres", "POSTGRES", true},
+		{"no_match", "redis", "postgres", false},
+		{"partial_no_match", "red", "redis", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := contains(tt.s, tt.substr)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestReadyzHandler_DegradedStateAggregation(t *testing.T) {
+	t.Parallel()
+
+	latency := int64(5)
+
+	tests := []struct {
+		name               string
+		checkers           []DependencyChecker
+		wantOverallHealthy bool
+		wantHTTPStatus     int
+	}{
+		{
+			name: "single_degraded_returns_503",
+			checkers: []DependencyChecker{
+				&mockChecker{name: "postgres", check: DependencyCheck{Status: StatusUp, LatencyMs: &latency}},
+				&mockChecker{name: "rabbitmq", check: DependencyCheck{Status: StatusDegraded, Reason: "circuit breaker half-open", BreakerState: "half-open"}},
+			},
+			wantOverallHealthy: false,
+			wantHTTPStatus:     http.StatusServiceUnavailable,
+		},
+		{
+			name: "multiple_degraded_returns_503",
+			checkers: []DependencyChecker{
+				&mockChecker{name: "postgres", check: DependencyCheck{Status: StatusDegraded, Reason: "high latency"}},
+				&mockChecker{name: "rabbitmq", check: DependencyCheck{Status: StatusDegraded, Reason: "circuit breaker open", BreakerState: "open"}},
+				&mockChecker{name: "redis", check: DependencyCheck{Status: StatusUp, LatencyMs: &latency}},
+			},
+			wantOverallHealthy: false,
+			wantHTTPStatus:     http.StatusServiceUnavailable,
+		},
+		{
+			name: "degraded_and_down_returns_503",
+			checkers: []DependencyChecker{
+				&mockChecker{name: "postgres", check: DependencyCheck{Status: StatusDown, Error: "connection refused"}},
+				&mockChecker{name: "rabbitmq", check: DependencyCheck{Status: StatusDegraded, Reason: "circuit breaker open"}},
+			},
+			wantOverallHealthy: false,
+			wantHTTPStatus:     http.StatusServiceUnavailable,
+		},
+		{
+			name: "all_up_with_skipped_returns_200",
+			checkers: []DependencyChecker{
+				&mockChecker{name: "postgres", check: DependencyCheck{Status: StatusUp, LatencyMs: &latency}},
+				&mockChecker{name: "redis", check: DependencyCheck{Status: StatusUp, LatencyMs: &latency}},
+				&mockChecker{name: "rabbitmq", check: DependencyCheck{Status: StatusSkipped, Reason: "not configured"}},
+			},
+			wantOverallHealthy: true,
+			wantHTTPStatus:     http.StatusOK,
+		},
+		{
+			name: "all_na_returns_200",
+			checkers: []DependencyChecker{
+				&mockChecker{name: "postgres_onboarding", check: DependencyCheck{Status: StatusNA, Reason: "tenant-scoped"}},
+				&mockChecker{name: "postgres_transaction", check: DependencyCheck{Status: StatusNA, Reason: "tenant-scoped"}},
+				&mockChecker{name: "mongo_onboarding", check: DependencyCheck{Status: StatusNA, Reason: "tenant-scoped"}},
+			},
+			wantOverallHealthy: true,
+			wantHTTPStatus:     http.StatusOK,
+		},
+		{
+			name: "mix_of_up_skipped_na_returns_200",
+			checkers: []DependencyChecker{
+				&mockChecker{name: "postgres", check: DependencyCheck{Status: StatusNA, Reason: "tenant-scoped"}},
+				&mockChecker{name: "redis", check: DependencyCheck{Status: StatusUp, LatencyMs: &latency}},
+				&mockChecker{name: "optional_service", check: DependencyCheck{Status: StatusSkipped, Reason: "disabled"}},
+			},
+			wantOverallHealthy: true,
+			wantHTTPStatus:     http.StatusOK,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			handler := NewReadyzHandler(ReadyzHandlerConfig{
+				Logger:         libLog.NewNop(),
+				Checkers:       tt.checkers,
+				Version:        "1.0.0",
+				DeploymentMode: "local",
+			})
+
+			app := fiber.New()
+			app.Get("/readyz", handler.HandleReadyz)
+
+			req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+			resp, err := app.Test(req, -1)
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.wantHTTPStatus, resp.StatusCode)
+
+			body, err := io.ReadAll(resp.Body)
+			require.NoError(t, err)
+
+			var response ReadyzResponse
+			err = json.Unmarshal(body, &response)
+			require.NoError(t, err)
+
+			if tt.wantOverallHealthy {
+				assert.Equal(t, "healthy", response.Status)
+			} else {
+				assert.Equal(t, "unhealthy", response.Status)
+			}
+		})
+	}
+}
+
+func TestReadyzHandler_AggregationLogic(t *testing.T) {
+	t.Parallel()
+
+	// Test that the aggregation logic correctly identifies unhealthy states
+	statusTests := []struct {
+		status    DependencyStatus
+		isHealthy bool
+	}{
+		{StatusUp, true},
+		{StatusDown, false},
+		{StatusDegraded, false},
+		{StatusSkipped, true},
+		{StatusNA, true},
+	}
+
+	for _, tt := range statusTests {
+		t.Run(string(tt.status), func(t *testing.T) {
+			t.Parallel()
+
+			isHealthy := tt.status != StatusDown && tt.status != StatusDegraded
+			assert.Equal(t, tt.isHealthy, isHealthy, "status %s health check", tt.status)
+		})
+	}
+}
+
+func TestDefaultTimeoutConstants(t *testing.T) {
+	t.Parallel()
+
+	// Verify default timeout constants are defined and have sensible values
+	assert.Equal(t, 1*time.Second, DefaultRedisTimeout, "Redis timeout should be 1s")
+	assert.Equal(t, 2*time.Second, DefaultDatabaseTimeout, "Database timeout should be 2s")
+	assert.Equal(t, 2*time.Second, DefaultRabbitMQTimeout, "RabbitMQ timeout should be 2s")
+}
+
+func TestTimeoutForCheckerUsesConstants(t *testing.T) {
+	t.Parallel()
+
+	handler := &ReadyzHandler{}
+
+	// Verify timeoutForChecker returns the constant values
+	redisChecker := &mockChecker{name: "redis"}
+	assert.Equal(t, DefaultRedisTimeout, handler.timeoutForChecker(redisChecker))
+
+	pgChecker := &mockChecker{name: "postgres_onboarding"}
+	assert.Equal(t, DefaultDatabaseTimeout, handler.timeoutForChecker(pgChecker))
+
+	mongoChecker := &mockChecker{name: "mongo_transaction"}
+	assert.Equal(t, DefaultDatabaseTimeout, handler.timeoutForChecker(mongoChecker))
+
+	rmqChecker := &mockChecker{name: "rabbitmq"}
+	assert.Equal(t, DefaultRabbitMQTimeout, handler.timeoutForChecker(rmqChecker))
+}

--- a/components/ledger/internal/bootstrap/readyz_test.go
+++ b/components/ledger/internal/bootstrap/readyz_test.go
@@ -62,6 +62,15 @@ func (m *mockTenantChecker) CheckTenant(_ context.Context, _ string) DependencyC
 	return m.tenantCheck
 }
 
+// newReadyHandler creates a ReadyzHandler and marks it as ready for testing.
+// This is needed because HandleReadyz now checks lifecycle state before running checks.
+func newReadyHandler(cfg ReadyzHandlerConfig) *ReadyzHandler {
+	handler := NewReadyzHandler(cfg)
+	handler.SetServerReady()
+
+	return handler
+}
+
 func TestReadyzHandler_HandleReadyz(t *testing.T) {
 	t.Parallel()
 
@@ -151,7 +160,7 @@ func TestReadyzHandler_HandleReadyz(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			handler := NewReadyzHandler(ReadyzHandlerConfig{
+			handler := newReadyHandler(ReadyzHandlerConfig{
 				Logger:         libLog.NewNop(),
 				Checkers:       tt.checkers,
 				Version:        tt.version,
@@ -266,7 +275,7 @@ func TestReadyzHandler_HandleReadyzTenant(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			handler := NewReadyzHandler(ReadyzHandlerConfig{
+			handler := newReadyHandler(ReadyzHandlerConfig{
 				Logger:             libLog.NewNop(),
 				Checkers:           tt.checkers,
 				TenantCheckers:     tt.tenantCheckers,
@@ -312,7 +321,7 @@ func TestReadyzHandler_TLSField(t *testing.T) {
 
 	latency := int64(5)
 
-	handler := NewReadyzHandler(ReadyzHandlerConfig{
+	handler := newReadyHandler(ReadyzHandlerConfig{
 		Logger: libLog.NewNop(),
 		Checkers: []DependencyChecker{
 			&mockChecker{name: "postgres_tls", tlsEnabled: true, check: DependencyCheck{Status: StatusUp, LatencyMs: &latency}},
@@ -350,7 +359,7 @@ func TestReadyzHandler_TLSField(t *testing.T) {
 func TestReadyzHandler_DeploymentModeDefault(t *testing.T) {
 	t.Parallel()
 
-	handler := NewReadyzHandler(ReadyzHandlerConfig{
+	handler := newReadyHandler(ReadyzHandlerConfig{
 		Logger:         libLog.NewNop(),
 		Checkers:       []DependencyChecker{},
 		Version:        "1.0.0",
@@ -538,7 +547,7 @@ func TestReadyzHandler_DegradedStateAggregation(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			handler := NewReadyzHandler(ReadyzHandlerConfig{
+			handler := newReadyHandler(ReadyzHandlerConfig{
 				Logger:         libLog.NewNop(),
 				Checkers:       tt.checkers,
 				Version:        "1.0.0",
@@ -716,7 +725,7 @@ func TestReadyzHandler_ErrorSanitization_InResponse(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			handler := NewReadyzHandler(ReadyzHandlerConfig{
+			handler := newReadyHandler(ReadyzHandlerConfig{
 				Logger: libLog.NewNop(),
 				Checkers: []DependencyChecker{
 					&mockChecker{
@@ -791,7 +800,7 @@ func TestReadyzHandler_ErrorSanitization_TenantEndpoint(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			handler := NewReadyzHandler(ReadyzHandlerConfig{
+			handler := newReadyHandler(ReadyzHandlerConfig{
 				Logger: libLog.NewNop(),
 				TenantCheckers: []TenantAwareDependencyChecker{
 					&mockTenantChecker{
@@ -835,4 +844,140 @@ func TestReadyzHandler_ErrorSanitization_TenantEndpoint(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestReadyzHandler_LifecycleState tests the self-probe and graceful drain functionality.
+func TestReadyzHandler_LifecycleState(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns_503_when_server_not_ready", func(t *testing.T) {
+		t.Parallel()
+
+		// Create handler WITHOUT calling SetServerReady()
+		handler := NewReadyzHandler(ReadyzHandlerConfig{
+			Logger:         libLog.NewNop(),
+			Checkers:       []DependencyChecker{},
+			Version:        "1.0.0",
+			DeploymentMode: "local",
+		})
+
+		app := fiber.New()
+		app.Get("/readyz", handler.HandleReadyz)
+
+		req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+		resp, err := app.Test(req)
+		require.NoError(t, err)
+
+		assert.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
+
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+
+		var response ReadyzResponse
+		err = json.Unmarshal(body, &response)
+		require.NoError(t, err)
+
+		assert.Equal(t, "unhealthy", response.Status)
+		assert.Contains(t, response.Reason, "server not ready")
+		assert.Empty(t, response.Checks, "no checks should run when server not ready")
+	})
+
+	t.Run("returns_200_after_server_ready", func(t *testing.T) {
+		t.Parallel()
+
+		handler := NewReadyzHandler(ReadyzHandlerConfig{
+			Logger:         libLog.NewNop(),
+			Checkers:       []DependencyChecker{},
+			Version:        "1.0.0",
+			DeploymentMode: "local",
+		})
+
+		// Initially not ready
+		assert.False(t, handler.IsServerReady())
+
+		// Mark as ready
+		handler.SetServerReady()
+		assert.True(t, handler.IsServerReady())
+
+		app := fiber.New()
+		app.Get("/readyz", handler.HandleReadyz)
+
+		req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+		resp, err := app.Test(req)
+		require.NoError(t, err)
+
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+	})
+
+	t.Run("returns_503_when_draining", func(t *testing.T) {
+		t.Parallel()
+
+		handler := NewReadyzHandler(ReadyzHandlerConfig{
+			Logger:         libLog.NewNop(),
+			Checkers:       []DependencyChecker{},
+			Version:        "1.0.0",
+			DeploymentMode: "local",
+		})
+
+		// Mark as ready first
+		handler.SetServerReady()
+		assert.False(t, handler.IsDraining())
+
+		// Start draining
+		handler.StartDrain()
+		assert.True(t, handler.IsDraining())
+
+		app := fiber.New()
+		app.Get("/readyz", handler.HandleReadyz)
+
+		req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+		resp, err := app.Test(req)
+		require.NoError(t, err)
+
+		assert.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
+
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+
+		var response ReadyzResponse
+		err = json.Unmarshal(body, &response)
+		require.NoError(t, err)
+
+		assert.Equal(t, "unhealthy", response.Status)
+		assert.Contains(t, response.Reason, "draining")
+		assert.Empty(t, response.Checks, "no checks should run when draining")
+	})
+
+	t.Run("tenant_endpoint_also_checks_lifecycle", func(t *testing.T) {
+		t.Parallel()
+
+		handler := NewReadyzHandler(ReadyzHandlerConfig{
+			Logger:             libLog.NewNop(),
+			Checkers:           []DependencyChecker{},
+			TenantCheckers:     []TenantAwareDependencyChecker{},
+			Version:            "1.0.0",
+			DeploymentMode:     "local",
+			MultiTenantEnabled: true,
+		})
+
+		// Don't set ready - should return 503
+
+		app := fiber.New()
+		app.Get("/readyz/tenant/:id", handler.HandleReadyzTenant)
+
+		req := httptest.NewRequest(http.MethodGet, "/readyz/tenant/test-tenant", nil)
+		resp, err := app.Test(req)
+		require.NoError(t, err)
+
+		assert.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
+
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+
+		var response ReadyzResponse
+		err = json.Unmarshal(body, &response)
+		require.NoError(t, err)
+
+		assert.Contains(t, response.Reason, "server not ready")
+	})
 }

--- a/components/ledger/internal/bootstrap/readyz_test.go
+++ b/components/ledger/internal/bootstrap/readyz_test.go
@@ -622,3 +622,217 @@ func TestTimeoutForCheckerUsesConstants(t *testing.T) {
 	rmqChecker := &mockChecker{name: "rabbitmq"}
 	assert.Equal(t, DefaultRabbitMQTimeout, handler.timeoutForChecker(rmqChecker))
 }
+
+func TestSanitizeError(t *testing.T) {
+	t.Parallel()
+
+	originalError := "failed to get database connection: dial tcp 203.0.113.50:5432: connection refused"
+
+	tests := []struct {
+		name           string
+		deploymentMode string
+		checkerName    string
+		wantError      string
+	}{
+		{
+			name:           "local_mode_returns_full_error",
+			deploymentMode: DeploymentModeLocal,
+			checkerName:    "postgres_onboarding",
+			wantError:      originalError,
+		},
+		{
+			name:           "saas_mode_returns_sanitized_error",
+			deploymentMode: DeploymentModeSaaS,
+			checkerName:    "postgres_onboarding",
+			wantError:      "postgres_onboarding check failed",
+		},
+		{
+			name:           "byoc_mode_returns_sanitized_error",
+			deploymentMode: DeploymentModeBYOC,
+			checkerName:    "postgres_onboarding",
+			wantError:      "postgres_onboarding check failed",
+		},
+		{
+			name:           "saas_mode_sanitizes_redis_error",
+			deploymentMode: DeploymentModeSaaS,
+			checkerName:    "redis",
+			wantError:      "redis check failed",
+		},
+		{
+			name:           "saas_mode_sanitizes_rabbitmq_error",
+			deploymentMode: DeploymentModeSaaS,
+			checkerName:    "rabbitmq",
+			wantError:      "rabbitmq check failed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			handler := &ReadyzHandler{
+				deploymentMode: tt.deploymentMode,
+			}
+
+			result := handler.sanitizeError(tt.checkerName, originalError)
+			assert.Equal(t, tt.wantError, result)
+		})
+	}
+}
+
+func TestReadyzHandler_ErrorSanitization_InResponse(t *testing.T) {
+	t.Parallel()
+
+	internalError := "SELECT 1 failed: dial tcp 999.999.9.999:9999: connect: connection refused"
+	latency := int64(50)
+
+	tests := []struct {
+		name              string
+		deploymentMode    string
+		wantErrorContains string
+		wantErrorExcludes string
+	}{
+		{
+			name:              "local_mode_exposes_full_error_in_response",
+			deploymentMode:    DeploymentModeLocal,
+			wantErrorContains: "999.999.9.999:999",
+			wantErrorExcludes: "",
+		},
+		{
+			name:              "saas_mode_sanitizes_error_in_response",
+			deploymentMode:    DeploymentModeSaaS,
+			wantErrorContains: "postgres_onboarding check failed",
+			wantErrorExcludes: "999.999.9.999",
+		},
+		{
+			name:              "byoc_mode_sanitizes_error_in_response",
+			deploymentMode:    DeploymentModeBYOC,
+			wantErrorContains: "postgres_onboarding check failed",
+			wantErrorExcludes: "999.999.9.999",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			handler := NewReadyzHandler(ReadyzHandlerConfig{
+				Logger: libLog.NewNop(),
+				Checkers: []DependencyChecker{
+					&mockChecker{
+						name: "postgres_onboarding",
+						check: DependencyCheck{
+							Status:    StatusDown,
+							LatencyMs: &latency,
+							Error:     internalError,
+						},
+					},
+				},
+				Version:        "1.0.0",
+				DeploymentMode: tt.deploymentMode,
+			})
+
+			app := fiber.New()
+			app.Get("/readyz", handler.HandleReadyz)
+
+			req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+			resp, err := app.Test(req)
+			require.NoError(t, err)
+			defer resp.Body.Close()
+
+			body, err := io.ReadAll(resp.Body)
+			require.NoError(t, err)
+
+			var response ReadyzResponse
+			err = json.Unmarshal(body, &response)
+			require.NoError(t, err)
+
+			check, exists := response.Checks["postgres_onboarding"]
+			require.True(t, exists, "postgres_onboarding check should exist")
+
+			assert.Contains(t, check.Error, tt.wantErrorContains,
+				"error should contain expected string")
+
+			if tt.wantErrorExcludes != "" {
+				assert.NotContains(t, check.Error, tt.wantErrorExcludes,
+					"error should not contain internal details")
+			}
+		})
+	}
+}
+
+func TestReadyzHandler_ErrorSanitization_TenantEndpoint(t *testing.T) {
+	t.Parallel()
+
+	internalError := "ping failed: server at db.example.invalid:27017 is not reachable"
+	latency := int64(100)
+
+	tests := []struct {
+		name              string
+		deploymentMode    string
+		wantErrorContains string
+		wantErrorExcludes string
+	}{
+		{
+			name:              "local_mode_exposes_full_error",
+			deploymentMode:    DeploymentModeLocal,
+			wantErrorContains: "db.example.invalid:27017",
+			wantErrorExcludes: "",
+		},
+		{
+			name:              "saas_mode_sanitizes_error",
+			deploymentMode:    DeploymentModeSaaS,
+			wantErrorContains: "mongo_onboarding check failed",
+			wantErrorExcludes: "db.example.invalid",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			handler := NewReadyzHandler(ReadyzHandlerConfig{
+				Logger: libLog.NewNop(),
+				TenantCheckers: []TenantAwareDependencyChecker{
+					&mockTenantChecker{
+						name: "mongo_onboarding",
+						tenantCheck: DependencyCheck{
+							Status:    StatusDown,
+							LatencyMs: &latency,
+							Error:     internalError,
+						},
+					},
+				},
+				Version:            "1.0.0",
+				DeploymentMode:     tt.deploymentMode,
+				MultiTenantEnabled: true,
+			})
+
+			app := fiber.New()
+			app.Get("/readyz/tenant/:id", handler.HandleReadyzTenant)
+
+			req := httptest.NewRequest(http.MethodGet, "/readyz/tenant/tenant-123", nil)
+			resp, err := app.Test(req)
+			require.NoError(t, err)
+			defer resp.Body.Close()
+
+			body, err := io.ReadAll(resp.Body)
+			require.NoError(t, err)
+
+			var response ReadyzResponse
+			err = json.Unmarshal(body, &response)
+			require.NoError(t, err)
+
+			check, exists := response.Checks["mongo_onboarding"]
+			require.True(t, exists, "mongo_onboarding check should exist")
+
+			assert.Contains(t, check.Error, tt.wantErrorContains,
+				"error should contain expected string")
+
+			if tt.wantErrorExcludes != "" {
+				assert.NotContains(t, check.Error, tt.wantErrorExcludes,
+					"error should not contain internal details")
+			}
+		})
+	}
+}

--- a/components/ledger/internal/bootstrap/service_test.go
+++ b/components/ledger/internal/bootstrap/service_test.go
@@ -243,11 +243,7 @@ func TestNewUnifiedServer_CreatesServer(t *testing.T) {
 	t.Run("creates_server_without_route_registrars", func(t *testing.T) {
 		t.Parallel()
 
-		server := NewUnifiedServer(
-			":0",
-			logger,
-			telemetry,
-		)
+		server := NewUnifiedServer(":0", logger, telemetry, nil)
 
 		require.NotNil(t, server, "NewUnifiedServer should return non-nil server")
 		assert.Equal(t, ":0", server.ServerAddress())
@@ -256,16 +252,13 @@ func TestNewUnifiedServer_CreatesServer(t *testing.T) {
 	t.Run("creates_server_with_route_registrar", func(t *testing.T) {
 		t.Parallel()
 
-		server := NewUnifiedServer(
-			":0",
-			logger,
-			telemetry,
-			func(router fiber.Router) {
-				router.Get("/test", func(c *fiber.Ctx) error {
-					return c.SendStatus(fiber.StatusNoContent)
-				})
-			},
-		)
+		registrar := func(router fiber.Router) {
+			router.Get("/test", func(c *fiber.Ctx) error {
+				return c.SendStatus(fiber.StatusNoContent)
+			})
+		}
+
+		server := NewUnifiedServer(":0", logger, telemetry, nil, registrar)
 
 		require.NotNil(t, server, "NewUnifiedServer should return non-nil server when a registrar is provided")
 		assert.Equal(t, ":0", server.ServerAddress())

--- a/components/ledger/internal/bootstrap/tls_detection.go
+++ b/components/ledger/internal/bootstrap/tls_detection.go
@@ -166,7 +166,7 @@ func ResolveDeploymentMode(mode string) string {
 func ValidateSaaSTLS(deploymentMode string, dependencies []TLSValidationResult) error {
 	lowerMode := strings.ToLower(deploymentMode)
 
-	// Only enforce TLS in SaaS mode - this is the Monetarie incident prevention
+	// Only enforce TLS in SaaS mode
 	if lowerMode != DeploymentModeSaaS {
 		return nil
 	}

--- a/components/ledger/internal/bootstrap/tls_detection.go
+++ b/components/ledger/internal/bootstrap/tls_detection.go
@@ -1,0 +1,199 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package bootstrap
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+// detectPostgresTLS returns true if the PostgreSQL DSN has TLS enabled.
+// PostgreSQL DSNs use key=value format with sslmode parameter.
+// Returns false if sslmode is "disable" or not set.
+func detectPostgresTLS(dsn string) bool {
+	if dsn == "" {
+		return false
+	}
+
+	// PostgreSQL DSN format: "host=x user=y password=z dbname=d port=p sslmode=s"
+	// Parse as space-separated key=value pairs
+	params := make(map[string]string)
+
+	for _, part := range strings.Fields(dsn) {
+		kv := strings.SplitN(part, "=", 2)
+		if len(kv) == 2 {
+			params[strings.ToLower(kv[0])] = kv[1]
+		}
+	}
+
+	sslmode, exists := params["sslmode"]
+	if !exists {
+		return false
+	}
+
+	// sslmode values that indicate TLS is enabled:
+	// require, verify-ca, verify-full
+	// sslmode=disable means no TLS
+	// sslmode=allow/prefer means TLS is optional (we report as false for determinism)
+	switch strings.ToLower(sslmode) {
+	case "require", "verify-ca", "verify-full":
+		return true
+	default:
+		return false
+	}
+}
+
+// detectMongoTLS returns true if the MongoDB URI has TLS enabled.
+// TLS is enabled when:
+//   - URI scheme is "mongodb+srv" (always uses TLS)
+//   - Query parameter "tls=true" is present (case-insensitive key and value)
+//   - Query parameter "ssl=true" is present (legacy, case-insensitive key and value)
+//
+// Returns error for malformed URI syntax.
+func detectMongoTLS(uri string) (bool, error) {
+	if uri == "" {
+		return false, nil
+	}
+
+	parsed, err := url.Parse(uri)
+	if err != nil {
+		return false, fmt.Errorf("invalid MongoDB URI: %w", err)
+	}
+
+	// mongodb+srv:// always uses TLS
+	if strings.ToLower(parsed.Scheme) == "mongodb+srv" {
+		return true, nil
+	}
+
+	// Check query parameters for tls=true or ssl=true (case-insensitive)
+	// url.Query() preserves original case, so we need to iterate all keys
+	query := parsed.Query()
+
+	for key, values := range query {
+		lowerKey := strings.ToLower(key)
+		if lowerKey == "tls" || lowerKey == "ssl" {
+			for _, v := range values {
+				if strings.EqualFold(v, "true") {
+					return true, nil
+				}
+			}
+		}
+	}
+
+	return false, nil
+}
+
+// detectRedisTLS returns true if Redis TLS is enabled.
+// TLS is enabled when:
+//   - tlsEnabled config flag is true
+//   - Host string uses "rediss://" scheme
+//
+// This function does not return an error as Redis host format is simpler.
+func detectRedisTLS(host string, tlsEnabled bool) bool {
+	if tlsEnabled {
+		return true
+	}
+
+	if host == "" {
+		return false
+	}
+
+	// Check for rediss:// scheme (note: double 's')
+	return strings.HasPrefix(strings.ToLower(host), "rediss://")
+}
+
+// detectAMQPTLS returns true if the AMQP URI uses TLS.
+// TLS is enabled when the URI scheme is "amqps" (instead of "amqp").
+// Returns error for malformed URI syntax.
+func detectAMQPTLS(uri string) (bool, error) {
+	if uri == "" {
+		return false, nil
+	}
+
+	parsed, err := url.Parse(uri)
+	if err != nil {
+		return false, fmt.Errorf("invalid AMQP URI: %w", err)
+	}
+
+	return strings.ToLower(parsed.Scheme) == "amqps", nil
+}
+
+// TLSValidationResult contains the TLS validation status for a dependency.
+type TLSValidationResult struct {
+	Name       string
+	TLSEnabled bool
+}
+
+// DeploymentMode constants define the valid deployment modes for TLS enforcement.
+const (
+	// DeploymentModeSaaS is the Lerian-hosted multi-tenant mode where TLS is MANDATORY.
+	DeploymentModeSaaS = "saas"
+	// DeploymentModeBYOC is the customer-hosted mode where TLS is recommended but not enforced.
+	DeploymentModeBYOC = "byoc"
+	// DeploymentModeLocal is the developer workstation mode where TLS is optional.
+	DeploymentModeLocal = "local"
+
+	// DefaultDeploymentMode is the deployment mode used when none is specified.
+	// Defaults to "local" for safe developer experience.
+	DefaultDeploymentMode = DeploymentModeLocal
+)
+
+// ResolveDeploymentMode normalizes the deployment mode string.
+// Returns DefaultDeploymentMode if input is empty or whitespace.
+// Otherwise returns the lowercased input for consistent comparison.
+func ResolveDeploymentMode(mode string) string {
+	trimmed := strings.TrimSpace(mode)
+	if trimmed == "" {
+		return DefaultDeploymentMode
+	}
+
+	return strings.ToLower(trimmed)
+}
+
+// ValidateSaaSTLS enforces TLS for all dependencies when DEPLOYMENT_MODE=saas.
+// This is a centralized function called from bootstrap BEFORE any connection is opened.
+//
+// Deployment mode semantics:
+//   - "saas": TLS MANDATORY for ALL dependencies - hard fail at startup if any lacks TLS
+//   - "byoc": TLS recommended but not hard-enforced (returns nil, caller may log warning)
+//   - "local" or unset: TLS optional - no enforcement
+//
+// Returns an error ONLY when DEPLOYMENT_MODE=saas and any dependency lacks TLS.
+// The error includes the specific dependency name(s) that failed validation.
+func ValidateSaaSTLS(deploymentMode string, dependencies []TLSValidationResult) error {
+	lowerMode := strings.ToLower(deploymentMode)
+
+	// Only enforce TLS in SaaS mode - this is the Monetarie incident prevention
+	if lowerMode != DeploymentModeSaaS {
+		return nil
+	}
+
+	// Collect all dependencies without TLS
+	var insecureDeps []string
+
+	for _, dep := range dependencies {
+		if !dep.TLSEnabled {
+			insecureDeps = append(insecureDeps, dep.Name)
+		}
+	}
+
+	if len(insecureDeps) > 0 {
+		return fmt.Errorf("DEPLOYMENT_MODE=saas: TLS required for %s but not configured",
+			strings.Join(insecureDeps, ", "))
+	}
+
+	return nil
+}
+
+// IsTLSEnforcementRequired returns true if the deployment mode requires TLS enforcement.
+func IsTLSEnforcementRequired(deploymentMode string) bool {
+	return strings.ToLower(deploymentMode) == DeploymentModeSaaS
+}
+
+// IsTLSRecommended returns true if TLS is recommended (but not required) for the deployment mode.
+func IsTLSRecommended(deploymentMode string) bool {
+	return strings.ToLower(deploymentMode) == DeploymentModeBYOC
+}

--- a/components/ledger/internal/bootstrap/tls_detection_test.go
+++ b/components/ledger/internal/bootstrap/tls_detection_test.go
@@ -1,0 +1,793 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package bootstrap
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDetectPostgresTLS(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		dsn  string
+		want bool
+	}{
+		{
+			name: "empty string returns false",
+			dsn:  "",
+			want: false,
+		},
+		{
+			name: "sslmode=disable returns false",
+			dsn:  "host=localhost user=midaz password=secret dbname=onboarding port=5432 sslmode=disable",
+			want: false,
+		},
+		{
+			name: "sslmode=require returns true",
+			dsn:  "host=localhost user=midaz password=secret dbname=onboarding port=5432 sslmode=require",
+			want: true,
+		},
+		{
+			name: "sslmode=verify-ca returns true",
+			dsn:  "host=localhost user=midaz password=secret dbname=onboarding port=5432 sslmode=verify-ca",
+			want: true,
+		},
+		{
+			name: "sslmode=verify-full returns true",
+			dsn:  "host=localhost user=midaz password=secret dbname=onboarding port=5432 sslmode=verify-full",
+			want: true,
+		},
+		{
+			name: "sslmode=allow returns false (optional TLS)",
+			dsn:  "host=localhost user=midaz password=secret dbname=onboarding port=5432 sslmode=allow",
+			want: false,
+		},
+		{
+			name: "sslmode=prefer returns false (optional TLS)",
+			dsn:  "host=localhost user=midaz password=secret dbname=onboarding port=5432 sslmode=prefer",
+			want: false,
+		},
+		{
+			name: "no sslmode parameter returns false",
+			dsn:  "host=localhost user=midaz password=secret dbname=onboarding port=5432",
+			want: false,
+		},
+		{
+			name: "sslmode uppercase returns true",
+			dsn:  "host=localhost user=midaz password=secret dbname=onboarding port=5432 SSLMODE=REQUIRE",
+			want: true,
+		},
+		{
+			name: "sslmode mixed case returns true",
+			dsn:  "host=localhost user=midaz password=secret dbname=onboarding port=5432 SslMode=Verify-Full",
+			want: true,
+		},
+		{
+			name: "sslmode with extra spaces",
+			dsn:  "host=localhost  user=midaz  password=secret  dbname=onboarding  port=5432  sslmode=require",
+			want: true,
+		},
+		{
+			name: "password with equals sign",
+			dsn:  "host=localhost user=midaz password=sec=ret dbname=onboarding port=5432 sslmode=require",
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := detectPostgresTLS(tt.dsn)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestDetectMongoTLS(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		uri     string
+		want    bool
+		wantErr bool
+	}{
+		{
+			name:    "empty string returns false",
+			uri:     "",
+			want:    false,
+			wantErr: false,
+		},
+		{
+			name:    "mongodb scheme without tls returns false",
+			uri:     "mongodb://user:pass@localhost:27017/dbname",
+			want:    false,
+			wantErr: false,
+		},
+		{
+			name:    "mongodb+srv scheme returns true (always TLS)",
+			uri:     "mongodb+srv://user:pass@cluster.mongodb.net/dbname",
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name:    "mongodb with tls=true returns true",
+			uri:     "mongodb://user:pass@localhost:27017/dbname?tls=true",
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name:    "mongodb with tls=false returns false",
+			uri:     "mongodb://user:pass@localhost:27017/dbname?tls=false",
+			want:    false,
+			wantErr: false,
+		},
+		{
+			name:    "mongodb with ssl=true returns true (legacy)",
+			uri:     "mongodb://user:pass@localhost:27017/dbname?ssl=true",
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name:    "mongodb with ssl=false returns false",
+			uri:     "mongodb://user:pass@localhost:27017/dbname?ssl=false",
+			want:    false,
+			wantErr: false,
+		},
+		{
+			name:    "mongodb with TLS=TRUE uppercase returns true",
+			uri:     "mongodb://user:pass@localhost:27017/dbname?TLS=TRUE",
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name:    "mongodb+srv uppercase scheme returns true",
+			uri:     "MONGODB+SRV://user:pass@cluster.mongodb.net/dbname",
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name:    "mongodb with multiple query params including tls",
+			uri:     "mongodb://user:pass@localhost:27017/dbname?retryWrites=true&tls=true&w=majority",
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name:    "mongodb with url-encoded params",
+			uri:     "mongodb://user:pass@localhost:27017/dbname?authSource=admin&tls=true",
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name:    "malformed URI returns error",
+			uri:     "://invalid-uri",
+			want:    false,
+			wantErr: true,
+		},
+		{
+			name:    "mongodb with replicaSet and tls",
+			uri:     "mongodb://user:pass@host1:27017,host2:27017/dbname?replicaSet=rs0&tls=true",
+			want:    true,
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := detectMongoTLS(tt.uri)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestDetectRedisTLS(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		host       string
+		tlsEnabled bool
+		want       bool
+	}{
+		{
+			name:       "empty host with tlsEnabled false returns false",
+			host:       "",
+			tlsEnabled: false,
+			want:       false,
+		},
+		{
+			name:       "empty host with tlsEnabled true returns true",
+			host:       "",
+			tlsEnabled: true,
+			want:       true,
+		},
+		{
+			name:       "plain host with tlsEnabled false returns false",
+			host:       "localhost:6379",
+			tlsEnabled: false,
+			want:       false,
+		},
+		{
+			name:       "plain host with tlsEnabled true returns true",
+			host:       "localhost:6379",
+			tlsEnabled: true,
+			want:       true,
+		},
+		{
+			name:       "rediss scheme returns true",
+			host:       "rediss://localhost:6379",
+			tlsEnabled: false,
+			want:       true,
+		},
+		{
+			name:       "rediss scheme uppercase returns true",
+			host:       "REDISS://localhost:6379",
+			tlsEnabled: false,
+			want:       true,
+		},
+		{
+			name:       "redis scheme (single s) returns false",
+			host:       "redis://localhost:6379",
+			tlsEnabled: false,
+			want:       false,
+		},
+		{
+			name:       "rediss scheme with tlsEnabled true returns true",
+			host:       "rediss://localhost:6379",
+			tlsEnabled: true,
+			want:       true,
+		},
+		{
+			name:       "sentinel hosts comma-separated without TLS",
+			host:       "sentinel1:26379,sentinel2:26379,sentinel3:26379",
+			tlsEnabled: false,
+			want:       false,
+		},
+		{
+			name:       "sentinel hosts with tlsEnabled true",
+			host:       "sentinel1:26379,sentinel2:26379,sentinel3:26379",
+			tlsEnabled: true,
+			want:       true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := detectRedisTLS(tt.host, tt.tlsEnabled)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestDetectAMQPTLS(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		uri     string
+		want    bool
+		wantErr bool
+	}{
+		{
+			name:    "empty string returns false",
+			uri:     "",
+			want:    false,
+			wantErr: false,
+		},
+		{
+			name:    "amqp scheme returns false",
+			uri:     "amqp://user:pass@localhost:5672/vhost",
+			want:    false,
+			wantErr: false,
+		},
+		{
+			name:    "amqps scheme returns true",
+			uri:     "amqps://user:pass@localhost:5671/vhost",
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name:    "AMQPS uppercase scheme returns true",
+			uri:     "AMQPS://user:pass@localhost:5671/vhost",
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name:    "amqp without vhost returns false",
+			uri:     "amqp://user:pass@localhost:5672",
+			want:    false,
+			wantErr: false,
+		},
+		{
+			name:    "amqps without vhost returns true",
+			uri:     "amqps://user:pass@localhost:5671",
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name:    "malformed URI returns error",
+			uri:     "://invalid-uri",
+			want:    false,
+			wantErr: true,
+		},
+		{
+			name:    "amqp with query params",
+			uri:     "amqp://user:pass@localhost:5672/vhost?heartbeat=30",
+			want:    false,
+			wantErr: false,
+		},
+		{
+			name:    "amqps with query params",
+			uri:     "amqps://user:pass@localhost:5671/vhost?heartbeat=30",
+			want:    true,
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := detectAMQPTLS(tt.uri)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestValidateSaaSTLS(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		deploymentMode string
+		dependencies   []TLSValidationResult
+		wantErr        bool
+		errContains    string
+	}{
+		{
+			name:           "local_mode_skips_validation",
+			deploymentMode: "local",
+			dependencies: []TLSValidationResult{
+				{Name: "postgres", TLSEnabled: false},
+				{Name: "redis", TLSEnabled: false},
+			},
+			wantErr: false,
+		},
+		{
+			name:           "LOCAL_uppercase_skips_validation",
+			deploymentMode: "LOCAL",
+			dependencies: []TLSValidationResult{
+				{Name: "rabbitmq", TLSEnabled: false},
+			},
+			wantErr: false,
+		},
+		{
+			name:           "byoc_mode_skips_validation",
+			deploymentMode: "byoc",
+			dependencies: []TLSValidationResult{
+				{Name: "postgres", TLSEnabled: false},
+				{Name: "mongo", TLSEnabled: false},
+			},
+			wantErr: false,
+		},
+		{
+			name:           "BYOC_uppercase_skips_validation",
+			deploymentMode: "BYOC",
+			dependencies: []TLSValidationResult{
+				{Name: "postgres", TLSEnabled: false},
+			},
+			wantErr: false,
+		},
+		{
+			name:           "empty_mode_defaults_to_no_enforcement",
+			deploymentMode: "",
+			dependencies: []TLSValidationResult{
+				{Name: "postgres", TLSEnabled: false},
+			},
+			wantErr: false,
+		},
+		{
+			name:           "saas_mode_all_tls_enabled_passes",
+			deploymentMode: "saas",
+			dependencies: []TLSValidationResult{
+				{Name: "postgres", TLSEnabled: true},
+				{Name: "mongo", TLSEnabled: true},
+				{Name: "redis", TLSEnabled: true},
+				{Name: "rabbitmq", TLSEnabled: true},
+			},
+			wantErr: false,
+		},
+		{
+			name:           "SAAS_uppercase_all_tls_enabled_passes",
+			deploymentMode: "SAAS",
+			dependencies: []TLSValidationResult{
+				{Name: "postgres", TLSEnabled: true},
+				{Name: "redis", TLSEnabled: true},
+			},
+			wantErr: false,
+		},
+		{
+			name:           "saas_mode_one_insecure_fails",
+			deploymentMode: "saas",
+			dependencies: []TLSValidationResult{
+				{Name: "postgres", TLSEnabled: true},
+				{Name: "redis", TLSEnabled: false},
+			},
+			wantErr:     true,
+			errContains: "redis",
+		},
+		{
+			name:           "saas_mode_multiple_insecure_fails",
+			deploymentMode: "saas",
+			dependencies: []TLSValidationResult{
+				{Name: "postgres", TLSEnabled: false},
+				{Name: "mongo", TLSEnabled: false},
+				{Name: "redis", TLSEnabled: true},
+			},
+			wantErr:     true,
+			errContains: "postgres",
+		},
+		{
+			name:           "saas_mode_empty_dependencies_passes",
+			deploymentMode: "saas",
+			dependencies:   []TLSValidationResult{},
+			wantErr:        false,
+		},
+		{
+			name:           "saas_mode_nil_dependencies_passes",
+			deploymentMode: "saas",
+			dependencies:   nil,
+			wantErr:        false,
+		},
+		{
+			name:           "unknown_mode_skips_validation",
+			deploymentMode: "production",
+			dependencies: []TLSValidationResult{
+				{Name: "postgres", TLSEnabled: false},
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := ValidateSaaSTLS(tt.deploymentMode, tt.dependencies)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errContains)
+				assert.Contains(t, err.Error(), "DEPLOYMENT_MODE=saas")
+
+				return
+			}
+
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestIsTLSEnforcementRequired(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		deploymentMode string
+		want           bool
+	}{
+		{"saas_requires_enforcement", "saas", true},
+		{"SAAS_uppercase_requires_enforcement", "SAAS", true},
+		{"byoc_no_enforcement", "byoc", false},
+		{"local_no_enforcement", "local", false},
+		{"empty_no_enforcement", "", false},
+		{"unknown_no_enforcement", "production", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := IsTLSEnforcementRequired(tt.deploymentMode)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestIsTLSRecommended(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		deploymentMode string
+		want           bool
+	}{
+		{"byoc_recommended", "byoc", true},
+		{"BYOC_uppercase_recommended", "BYOC", true},
+		{"saas_not_recommended_but_required", "saas", false},
+		{"local_not_recommended", "local", false},
+		{"empty_not_recommended", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := IsTLSRecommended(tt.deploymentMode)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestDefaultDeploymentMode(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "local", DefaultDeploymentMode, "default deployment mode should be 'local'")
+}
+
+func TestResolveDeploymentMode(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"empty_returns_default", "", DefaultDeploymentMode},
+		{"whitespace_returns_default", "   ", DefaultDeploymentMode},
+		{"saas_preserved", "saas", "saas"},
+		{"SAAS_lowercase", "SAAS", "saas"},
+		{"byoc_preserved", "byoc", "byoc"},
+		{"local_preserved", "local", "local"},
+		{"unknown_preserved_lowercase", "production", "production"},
+		{"leading_whitespace_trimmed", "  saas", "saas"},
+		{"trailing_whitespace_trimmed", "byoc  ", "byoc"},
+		{"mixed_case_lowercased", "SaaS", "saas"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := ResolveDeploymentMode(tt.input)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestDetectPostgresTLS_EdgeCases(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		dsn  string
+		want bool
+	}{
+		{
+			name: "sslmode_at_start",
+			dsn:  "sslmode=verify-full host=localhost user=midaz",
+			want: true,
+		},
+		{
+			name: "multiple_sslmode_last_wins",
+			dsn:  "host=localhost sslmode=require sslmode=disable",
+			want: false, // Last value wins with map
+		},
+		{
+			name: "sslmode_empty_value",
+			dsn:  "host=localhost sslmode= user=midaz",
+			want: false,
+		},
+		{
+			name: "sslmode_partial_match_sslmodex",
+			dsn:  "host=localhost sslmodex=require user=midaz",
+			want: false, // Should not match sslmodex
+		},
+		{
+			name: "unicode_in_password_before_sslmode",
+			dsn:  "host=localhost user=midaz password=pässwörd sslmode=require",
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := detectPostgresTLS(tt.dsn)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestDetectMongoTLS_EdgeCases(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		uri     string
+		want    bool
+		wantErr bool
+	}{
+		{
+			name:    "tls_value_with_whitespace",
+			uri:     "mongodb://user:pass@localhost:27017/db?tls= true",
+			want:    false, // " true" != "true"
+			wantErr: false,
+		},
+		{
+			name:    "multiple_tls_params",
+			uri:     "mongodb://user:pass@localhost:27017/db?tls=false&tls=true",
+			want:    true, // Should find at least one true
+			wantErr: false,
+		},
+		{
+			name:    "ssl_and_tls_mixed",
+			uri:     "mongodb://user:pass@localhost:27017/db?ssl=false&tls=true",
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name:    "fragment_with_tls",
+			uri:     "mongodb://user:pass@localhost:27017/db#tls=true",
+			want:    false, // Fragment is not a query param
+			wantErr: false,
+		},
+		{
+			name:    "ipv6_host_with_tls",
+			uri:     "mongodb://user:pass@[::1]:27017/db?tls=true",
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name:    "mongodb_plus_srv_mixed_case",
+			uri:     "MongoDb+SrV://user:pass@cluster.mongodb.net/db",
+			want:    true, // SRV always uses TLS
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := detectMongoTLS(tt.uri)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestDetectAMQPTLS_EdgeCases(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		uri     string
+		want    bool
+		wantErr bool
+	}{
+		{
+			name:    "amqps_with_ipv6",
+			uri:     "amqps://user:pass@[::1]:5671/vhost",
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name:    "amqp_uppercase_partial",
+			uri:     "AMqp://user:pass@localhost:5672/",
+			want:    false, // "amqp" not "amqps"
+			wantErr: false,
+		},
+		{
+			name:    "scheme_only",
+			uri:     "amqps://",
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name:    "amqps_with_query_and_fragment",
+			uri:     "amqps://user:pass@localhost:5671/vhost?heartbeat=30#section",
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name:    "empty_scheme",
+			uri:     "://localhost:5672/",
+			want:    false,
+			wantErr: true, // Parse error
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := detectAMQPTLS(tt.uri)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestDetectRedisTLS_EdgeCases(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		host       string
+		tlsEnabled bool
+		want       bool
+	}{
+		{
+			name:       "rediss_with_path",
+			host:       "rediss://localhost:6379/0",
+			tlsEnabled: false,
+			want:       true,
+		},
+		{
+			name:       "redis_scheme_not_rediss",
+			host:       "redis://localhost:6379",
+			tlsEnabled: false,
+			want:       false, // Single 's'
+		},
+		{
+			name:       "rediss_uppercase_mixed",
+			host:       "ReDiSs://localhost:6379",
+			tlsEnabled: false,
+			want:       true,
+		},
+		{
+			name:       "cluster_hosts_no_scheme",
+			host:       "node1:6379,node2:6379,node3:6379",
+			tlsEnabled: false,
+			want:       false,
+		},
+		{
+			name:       "sentinel_with_tls_flag",
+			host:       "sentinel1:26379,sentinel2:26379",
+			tlsEnabled: true,
+			want:       true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := detectRedisTLS(tt.host, tt.tlsEnabled)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/components/ledger/internal/bootstrap/unified-server.go
+++ b/components/ledger/internal/bootstrap/unified-server.go
@@ -7,6 +7,7 @@ package bootstrap
 import (
 	"context"
 	"fmt"
+	"time"
 
 	libCommons "github.com/LerianStudio/lib-commons/v4/commons"
 	libLog "github.com/LerianStudio/lib-commons/v4/commons/log"
@@ -84,6 +85,33 @@ func NewUnifiedServer(
 	// End tracing spans middleware (must be last)
 	app.Use(tlMid.EndTracingSpans)
 
+	// Register OnListen hook to mark server ready AFTER socket is bound.
+	// This avoids the race condition where readyz returns 200 before Fiber is listening.
+	if readyzHandler != nil {
+		app.Hooks().OnListen(func(ld fiber.ListenData) error {
+			readyzHandler.SetServerReady()
+			logger.Log(context.Background(), libLog.LevelInfo,
+				fmt.Sprintf("Server listening on %s:%s, readyz now returning healthy", ld.Host, ld.Port))
+
+			return nil
+		})
+
+		// Register OnShutdown hook to enable graceful drain.
+		// When SIGTERM is received, this hook:
+		// 1. Calls StartDrain() so readyz returns 503
+		// 2. Waits DefaultDrainDelay (12s) for load balancers to stop routing traffic
+		// 3. Returns, allowing Fiber to proceed with connection draining
+		app.Hooks().OnShutdown(func() error {
+			readyzHandler.StartDrain()
+			logger.Log(context.Background(), libLog.LevelInfo,
+				fmt.Sprintf("Graceful drain started, waiting %v for load balancers to update", DefaultDrainDelay))
+			time.Sleep(DefaultDrainDelay)
+			logger.Log(context.Background(), libLog.LevelInfo, "Drain delay complete, proceeding with shutdown")
+
+			return nil
+		})
+	}
+
 	return &UnifiedServer{
 		app:           app,
 		serverAddress: serverAddress,
@@ -98,20 +126,12 @@ func NewUnifiedServer(
 func (s *UnifiedServer) Run(l *libCommons.Launcher) error {
 	s.logger.Log(context.Background(), libLog.LevelInfo, fmt.Sprintf("Starting Unified HTTP Server on %s", s.serverAddress))
 
-	// Create server manager with graceful shutdown
-	serverManager := libCommonsServer.NewServerManager(nil, s.telemetry, s.logger).
-		WithHTTPServer(s.app, s.serverAddress)
-
-	// Mark server ready for readyz probe after Fiber starts listening.
-	// The WithHTTPServer call registers the server but doesn't start it yet.
-	// We mark ready right before StartWithGracefulShutdown which blocks until shutdown.
-	if s.readyzHandler != nil {
-		s.readyzHandler.SetServerReady()
-	}
-
-	// This blocks until SIGTERM/SIGINT is received.
-	// The server manager handles graceful shutdown internally.
-	serverManager.StartWithGracefulShutdown()
+	// Create server manager with graceful shutdown.
+	// The OnListen hook (registered in NewUnifiedServer) will call SetServerReady()
+	// after the socket is bound, ensuring readyz only returns 200 when truly ready.
+	libCommonsServer.NewServerManager(nil, s.telemetry, s.logger).
+		WithHTTPServer(s.app, s.serverAddress).
+		StartWithGracefulShutdown()
 
 	return nil
 }

--- a/components/ledger/internal/bootstrap/unified-server.go
+++ b/components/ledger/internal/bootstrap/unified-server.go
@@ -38,6 +38,7 @@ func NewUnifiedServer(
 	serverAddress string,
 	logger libLog.Logger,
 	telemetry *libOpentelemetry.Telemetry,
+	readyzHandler *ReadyzHandler,
 	routeRegistrars ...RouteRegistrar,
 ) *UnifiedServer {
 	app := fiber.New(fiber.Config{
@@ -53,11 +54,19 @@ func NewUnifiedServer(
 	app.Use(tlMid.WithTelemetry(telemetry))
 	app.Use(cors.New())
 	app.Use(libHTTP.WithHTTPLogging(libHTTP.WithCustomLogger(logger)))
+
 	// Health check for the unified server
 	app.Get("/health", libHTTP.Ping)
 
 	// Version endpoint
 	app.Get("/version", libHTTP.Version)
+
+	// Readyz endpoint - mounted BEFORE auth middleware (before route registrars)
+	// This endpoint is public and does not require authentication.
+	if readyzHandler != nil {
+		app.Get("/readyz", readyzHandler.HandleReadyz)
+		app.Get("/readyz/tenant/:id", readyzHandler.HandleReadyzTenant)
+	}
 
 	// Swagger documentation (unified onboarding + transaction)
 	app.Get("/swagger/*", WithSwaggerEnvConfig(), fiberSwagger.FiberWrapHandler(

--- a/components/ledger/internal/bootstrap/unified-server.go
+++ b/components/ledger/internal/bootstrap/unified-server.go
@@ -30,6 +30,7 @@ type UnifiedServer struct {
 	serverAddress string
 	logger        libLog.Logger
 	telemetry     *libOpentelemetry.Telemetry
+	readyzHandler *ReadyzHandler
 }
 
 // NewUnifiedServer creates a server that exposes all APIs on a single port.
@@ -88,6 +89,7 @@ func NewUnifiedServer(
 		serverAddress: serverAddress,
 		logger:        logger,
 		telemetry:     telemetry,
+		readyzHandler: readyzHandler,
 	}
 }
 
@@ -96,9 +98,20 @@ func NewUnifiedServer(
 func (s *UnifiedServer) Run(l *libCommons.Launcher) error {
 	s.logger.Log(context.Background(), libLog.LevelInfo, fmt.Sprintf("Starting Unified HTTP Server on %s", s.serverAddress))
 
-	libCommonsServer.NewServerManager(nil, s.telemetry, s.logger).
-		WithHTTPServer(s.app, s.serverAddress).
-		StartWithGracefulShutdown()
+	// Create server manager with graceful shutdown
+	serverManager := libCommonsServer.NewServerManager(nil, s.telemetry, s.logger).
+		WithHTTPServer(s.app, s.serverAddress)
+
+	// Mark server ready for readyz probe after Fiber starts listening.
+	// The WithHTTPServer call registers the server but doesn't start it yet.
+	// We mark ready right before StartWithGracefulShutdown which blocks until shutdown.
+	if s.readyzHandler != nil {
+		s.readyzHandler.SetServerReady()
+	}
+
+	// This blocks until SIGTERM/SIGINT is received.
+	// The server manager handles graceful shutdown internally.
+	serverManager.StartWithGracefulShutdown()
 
 	return nil
 }

--- a/components/ledger/internal/services/command/create_balance_transaction_operations_async.go
+++ b/components/ledger/internal/services/command/create_balance_transaction_operations_async.go
@@ -293,6 +293,7 @@ func (uc *UseCase) RemoveTransactionFromRedisQueueIfStatus(ctx context.Context, 
 			expectedStatus,
 			queue.TransactionStatus,
 		))
+
 		return
 	}
 

--- a/pkg/utils/metrics.go
+++ b/pkg/utils/metrics.go
@@ -129,4 +129,27 @@ var (
 		Unit:        "1",
 		Description: "Total fallback activations when bulk processing fails.",
 	}
+
+	// Readyz endpoint metrics
+
+	// ReadyzCheckDuration tracks the duration of individual health check probes.
+	ReadyzCheckDuration = metrics.Metric{
+		Name:        "readyz_check_duration_ms",
+		Unit:        "ms",
+		Description: "Duration of individual health check probes in milliseconds.",
+	}
+
+	// ReadyzCheckStatus counts health check outcomes by checker and status.
+	ReadyzCheckStatus = metrics.Metric{
+		Name:        "readyz_check_status_total",
+		Unit:        "1",
+		Description: "Count of health check outcomes by checker and status.",
+	}
+
+	// ReadyzRequestsTotal counts total readyz endpoint requests.
+	ReadyzRequestsTotal = metrics.Metric{
+		Name:        "readyz_requests_total",
+		Unit:        "1",
+		Description: "Total number of readyz endpoint requests.",
+	}
 )


### PR DESCRIPTION
## Summary

- Add comprehensive test coverage for `/readyz` endpoint implementation
- Implement timeout constants for health checkers (Redis: 1s, Database: 2s, RabbitMQ: 2s)
- Centralize deployment mode default resolution with `ResolveDeploymentMode()` function
- Add MongoDB checker variants with logger support for TLS detection error capture
- Add circuit breaker state tests for RabbitMQ health checks
- Add multi-tenant error path tests (tenant not found, connection failure, partial availability)
- Add TLS detection edge case tests for all supported protocols
- Add degraded state aggregation tests validating HTTP 503 behavior
- Add concurrent access and race condition safety tests
- Add integration tests with real containers (PostgreSQL, MongoDB, Redis)

## Motivation

The `/readyz` endpoint implementation required additional test coverage and minor improvements identified during code review:
1. Timeout values were inconsistent across checkers - now centralized as constants
2. Deployment mode defaulting was duplicated - now uses single `ResolveDeploymentMode()` function
3. MongoDB TLS detection errors were silently ignored - now logged at debug level
4. Missing test coverage for circuit breaker states, multi-tenant scenarios, and concurrent access
5. No integration tests with real infrastructure - now covered using testcontainers

## Semantic Decision

This is a **non-breaking enhancement** to the existing `/readyz` implementation. All changes are additive and maintain backward compatibility with the existing API contract.

## Changes

### New Files
| File | Purpose |
|------|---------|
| `components/ledger/internal/bootstrap/readyz.go` | Main readyz handler with `HandleReadyz` and `HandleReadyzTenant` endpoints |
| `components/ledger/internal/bootstrap/readyz_checkers.go` | Dependency checkers for PostgreSQL, MongoDB, Redis, RabbitMQ |
| `components/ledger/internal/bootstrap/readyz_test.go` | Core unit tests for handler behavior |
| `components/ledger/internal/bootstrap/readyz_general_test.go` | Circuit breaker, multi-tenant, and concurrent access tests |
| `components/ledger/internal/bootstrap/readyz_integration_test.go` | Integration tests with testcontainers |
| `components/ledger/internal/bootstrap/tls_detection.go` | TLS detection helpers and deployment mode utilities |
| `components/ledger/internal/bootstrap/tls_detection_test.go` | TLS detection and deployment mode tests |

### Environment Variables - Readyz Endpoint
| Variable | Type | Default | Description |
|----------|------|---------|-------------|
| `DEPLOYMENT_MODE` | string | `local` | Deployment mode: `saas`, `byoc`, or `local`. Controls TLS enforcement behavior. |

### Refactored Code
| Before | After |
|--------|-------|
| Timeout values hardcoded in checkers | Centralized constants: `DefaultRedisTimeout`, `DefaultDatabaseTimeout`, `DefaultRabbitMQTimeout` |
| Deployment mode defaulting in multiple places | Single `ResolveDeploymentMode()` function in `tls_detection.go` |
| `NewMongoChecker()` silently ignores TLS detection errors | `NewMongoCheckerWithLogger()` logs errors at debug level |
| Test files split across 4 separate files | Consolidated into 3 files: core tests, general tests, integration tests |

## Test Plan
- [x] Unit tests pass with race detection: `go test -race ./components/ledger/internal/bootstrap/...`
- [x] Integration tests pass: `go test -tags=integration ./components/ledger/internal/bootstrap/...`
- [x] Linting passes: `golangci-lint run ./components/ledger/internal/bootstrap/...`
- [x] All checkers return correct status vocabulary (up, down, degraded, skipped, n/a)
- [x] HTTP 503 returned when any checker reports `down` or `degraded`
- [x] HTTP 200 returned when all checkers report `up`, `skipped`, or `n/a`
- [x] TLS field populated correctly based on connection configuration
- [x] Deployment mode defaults to `local` when not specified
- [x] Circuit breaker states (open, half-open, closed) correctly map to health status
- [x] Concurrent requests handled without race conditions
- [x] Checker timeouts respected (slow checkers don't block response)
