### PR TITLE
feat(crm): implement Readyz handler

### DIFF
--- a/components/crm/.env.example
+++ b/components/crm/.env.example
@@ -2,6 +2,16 @@ ENV_NAME=development
 
 # APP
 VERSION=v3.6.0
+# DEPLOYMENT MODE (controls TLS enforcement)
+# Valid values:
+#   - "saas": Lerian-hosted multi-tenant - TLS MANDATORY for all dependencies
+#             Service REFUSES TO START if any dependency lacks TLS
+#   - "byoc": Customer-hosted (Bring Your Own Cloud) - TLS recommended but not enforced
+#             Logs warnings for dependencies without TLS but allows startup
+#   - "local" (default): Developer workstation - TLS optional, no enforcement
+#
+# This setting controls the ValidateSaaSTLS() check at bootstrap.
+DEPLOYMENT_MODE=local
 SERVER_PORT=4003
 SERVER_ADDRESS=:${SERVER_PORT}
 

--- a/components/crm/internal/adapters/http/in/routes.go
+++ b/components/crm/internal/adapters/http/in/routes.go
@@ -19,7 +19,13 @@ import (
 
 const ApplicationName = "plugin-crm"
 
-func NewRouter(lg libLog.Logger, tl *libOpenTelemetry.Telemetry, auth *middleware.AuthClient, tenantMw fiber.Handler, hh *HolderHandler, ah *AliasHandler) *fiber.App {
+// ReadyzHandler is the interface for the readyz endpoint handler.
+// This interface is defined here to avoid circular imports with the bootstrap package.
+type ReadyzHandler interface {
+	HandleReadyz(c *fiber.Ctx) error
+}
+
+func NewRouter(lg libLog.Logger, tl *libOpenTelemetry.Telemetry, auth *middleware.AuthClient, tenantMw fiber.Handler, readyzHandler ReadyzHandler, hh *HolderHandler, ah *AliasHandler) *fiber.App {
 	f := fiber.New(fiber.Config{
 		DisableStartupMessage: true,
 		ErrorHandler: func(ctx *fiber.Ctx, err error) error {
@@ -39,6 +45,12 @@ func NewRouter(lg libLog.Logger, tl *libOpenTelemetry.Telemetry, auth *middlewar
 	f.Get("/health", libHTTP.Ping)
 	f.Get("/version", libHTTP.Version)
 	f.Get("/swagger/*", WithSwaggerEnvConfig(), fiberSwagger.WrapHandler)
+
+	// Readyz endpoint: registered BEFORE auth/tenant middleware for K8s readiness probes.
+	// K8s probes do not authenticate, so this endpoint MUST NOT require auth.
+	if readyzHandler != nil {
+		f.Get("/readyz", readyzHandler.HandleReadyz)
+	}
 
 	// Tenant middleware: registered only when multi-tenant mode is enabled.
 	// When tenantMw is nil (single-tenant mode), this block is skipped entirely.

--- a/components/crm/internal/bootstrap/backward_compat_test.go
+++ b/components/crm/internal/bootstrap/backward_compat_test.go
@@ -119,20 +119,20 @@ func TestMultiTenant_BackwardCompatibility(t *testing.T) {
 		// This ensures backward compat: all fields must be optional (no envDefault
 		// that forces multi-tenant on).
 		expectedFields := map[string]string{
-			"MultiTenantEnabled":                  "MULTI_TENANT_ENABLED",
-			"MultiTenantURL":                      "MULTI_TENANT_URL",
-			"MultiTenantTimeout":                  "MULTI_TENANT_TIMEOUT",
-			"MultiTenantIdleTimeoutSec":           "MULTI_TENANT_IDLE_TIMEOUT_SEC",
-			"MultiTenantMaxTenantPools":           "MULTI_TENANT_MAX_TENANT_POOLS",
-			"MultiTenantCircuitBreakerThreshold":  "MULTI_TENANT_CIRCUIT_BREAKER_THRESHOLD",
-			"MultiTenantCircuitBreakerTimeoutSec": "MULTI_TENANT_CIRCUIT_BREAKER_TIMEOUT_SEC",
-			"MultiTenantServiceAPIKey":            "MULTI_TENANT_SERVICE_API_KEY",
+			"MultiTenantEnabled":                     "MULTI_TENANT_ENABLED",
+			"MultiTenantURL":                         "MULTI_TENANT_URL",
+			"MultiTenantTimeout":                     "MULTI_TENANT_TIMEOUT",
+			"MultiTenantIdleTimeoutSec":              "MULTI_TENANT_IDLE_TIMEOUT_SEC",
+			"MultiTenantMaxTenantPools":              "MULTI_TENANT_MAX_TENANT_POOLS",
+			"MultiTenantCircuitBreakerThreshold":     "MULTI_TENANT_CIRCUIT_BREAKER_THRESHOLD",
+			"MultiTenantCircuitBreakerTimeoutSec":    "MULTI_TENANT_CIRCUIT_BREAKER_TIMEOUT_SEC",
+			"MultiTenantServiceAPIKey":               "MULTI_TENANT_SERVICE_API_KEY",
 			"MultiTenantConnectionsCheckIntervalSec": "MULTI_TENANT_CONNECTIONS_CHECK_INTERVAL_SEC",
-			"MultiTenantCacheTTLSec":              "MULTI_TENANT_CACHE_TTL_SEC",
-			"MultiTenantRedisHost":                "MULTI_TENANT_REDIS_HOST",
-			"MultiTenantRedisPort":                "MULTI_TENANT_REDIS_PORT",
-			"MultiTenantRedisPassword":            "MULTI_TENANT_REDIS_PASSWORD",
-			"MultiTenantRedisTLS":                 "MULTI_TENANT_REDIS_TLS",
+			"MultiTenantCacheTTLSec":                 "MULTI_TENANT_CACHE_TTL_SEC",
+			"MultiTenantRedisHost":                   "MULTI_TENANT_REDIS_HOST",
+			"MultiTenantRedisPort":                   "MULTI_TENANT_REDIS_PORT",
+			"MultiTenantRedisPassword":               "MULTI_TENANT_REDIS_PASSWORD",
+			"MultiTenantRedisTLS":                    "MULTI_TENANT_REDIS_TLS",
 		}
 
 		cfg := &Config{}

--- a/components/crm/internal/bootstrap/config.go
+++ b/components/crm/internal/bootstrap/config.go
@@ -16,6 +16,7 @@ import (
 	libLog "github.com/LerianStudio/lib-commons/v4/commons/log"
 	libMongo "github.com/LerianStudio/lib-commons/v4/commons/mongo"
 	libOpentelemetry "github.com/LerianStudio/lib-commons/v4/commons/opentelemetry"
+	"github.com/LerianStudio/lib-commons/v4/commons/opentelemetry/metrics"
 	libZap "github.com/LerianStudio/lib-commons/v4/commons/zap"
 	"github.com/LerianStudio/midaz/v3/components/crm/internal/adapters/http/in"
 	"github.com/LerianStudio/midaz/v3/components/crm/internal/adapters/mongodb/alias"
@@ -63,6 +64,8 @@ type Config struct {
 	MultiTenantRedisPassword               string `env:"MULTI_TENANT_REDIS_PASSWORD"`
 	MultiTenantRedisTLS                    bool   `env:"MULTI_TENANT_REDIS_TLS"`
 	ApplicationName                        string `env:"APPLICATION_NAME"`
+	DeploymentMode                         string `env:"DEPLOYMENT_MODE"`
+	Version                                string `env:"VERSION"`
 }
 
 // Options contains optional dependencies that can be injected by callers.
@@ -175,8 +178,20 @@ func InitServersWithOptions(opts *Options) (*Service, error) {
 		return nil, fmt.Errorf("failed to initialize tenant middleware: %w", err)
 	}
 
-	httpApp := in.NewRouter(logger, telemetry, auth, tenantMiddleware, holderHandler, aliasHandler)
-	serverAPI := NewServer(cfg, httpApp, logger, telemetry)
+	// Get metrics factory from telemetry for readyz metrics emission
+	var metricsFactory *metrics.MetricsFactory
+	if telemetry != nil {
+		metricsFactory = telemetry.MetricsFactory
+	}
+
+	// Build readyz handler with MongoDB checker
+	readyzHandler, err := buildReadyzHandler(cfg, logger, mongoConnection, metricsFactory)
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize readyz handler: %w", err)
+	}
+
+	httpApp := in.NewRouter(logger, telemetry, auth, tenantMiddleware, readyzHandler, holderHandler, aliasHandler)
+	serverAPI := NewServer(cfg, httpApp, logger, telemetry, readyzHandler)
 
 	return &Service{
 		Server:        serverAPI,
@@ -276,4 +291,69 @@ func resolveLoggerEnvironment(env string) libZap.Environment {
 	default:
 		return libZap.EnvironmentDevelopment
 	}
+}
+
+// buildReadyzHandler creates the ReadyzHandler with appropriate checkers based on configuration.
+// In single-tenant mode, the MongoDB checker returns actual status.
+// In multi-tenant mode (future), database checkers would return "n/a" globally.
+func buildReadyzHandler(
+	cfg *Config,
+	logger libLog.Logger,
+	mongoConnection *libMongo.Client,
+	metricsFactory *metrics.MetricsFactory,
+) (*ReadyzHandler, error) {
+	// Build Mongo URI for TLS detection
+	mongoPort, mongoParameters := pkgMongo.ExtractMongoPortAndParameters(cfg.MongoDBPort, cfg.MongoDBParameters, logger)
+
+	mongoURI, err := resolveMongoURI(cfg, mongoPort, mongoParameters)
+	if err != nil {
+		// If we can't resolve the URI, use empty string (TLS detection will return false)
+		mongoURI = ""
+	}
+
+	var checkers []DependencyChecker
+
+	// MongoDB checker - returns actual status in single-tenant mode
+	if mongoConnection != nil {
+		checkers = append(checkers, NewMongoChecker("mongo", mongoConnection, mongoURI))
+	} else {
+		// If no connection, add a skipped checker
+		tlsEnabled, _ := detectMongoTLS(mongoURI)
+		checkers = append(checkers, NewNAChecker("mongo", "MongoDB client not configured", tlsEnabled))
+	}
+
+	// Build TLS validation results from already-created checkers
+	tlsResults := make([]TLSValidationResult, 0, len(checkers))
+	for _, checker := range checkers {
+		tlsResults = append(tlsResults, TLSValidationResult{
+			Name:       checker.Name(),
+			TLSEnabled: checker.TLSEnabled(),
+		})
+	}
+
+	// ValidateSaaSTLS returns error ONLY for DEPLOYMENT_MODE=saas with insecure deps.
+	// The error is returned to the caller to fail startup.
+	if err := ValidateSaaSTLS(cfg.DeploymentMode, tlsResults); err != nil {
+		return nil, err
+	}
+
+	// For BYOC mode, log a warning for insecure dependencies (recommended but not enforced)
+	if IsTLSRecommended(cfg.DeploymentMode) {
+		for _, result := range tlsResults {
+			if !result.TLSEnabled {
+				logger.Log(context.Background(), libLog.LevelWarn,
+					"TLS recommended but not configured for dependency",
+					libLog.String("dependency", result.Name),
+					libLog.String("deployment_mode", cfg.DeploymentMode))
+			}
+		}
+	}
+
+	return NewReadyzHandler(ReadyzHandlerConfig{
+		Logger:         logger,
+		Checkers:       checkers,
+		Version:        cfg.Version,
+		DeploymentMode: cfg.DeploymentMode,
+		MetricsFactory: metricsFactory,
+	}), nil
 }

--- a/components/crm/internal/bootstrap/readyz.go
+++ b/components/crm/internal/bootstrap/readyz.go
@@ -1,0 +1,289 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package bootstrap
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"sync/atomic"
+	"time"
+
+	libLog "github.com/LerianStudio/lib-commons/v4/commons/log"
+	"github.com/LerianStudio/lib-commons/v4/commons/opentelemetry/metrics"
+	"github.com/LerianStudio/midaz/v3/pkg/utils"
+	"github.com/gofiber/fiber/v2"
+	"go.opentelemetry.io/otel/attribute"
+)
+
+// DependencyStatus represents the health status of a dependency.
+// This is a closed vocabulary - only these values are valid.
+type DependencyStatus string
+
+const (
+	// StatusUp indicates the dependency probe succeeded.
+	StatusUp DependencyStatus = "up"
+
+	// StatusDown indicates the dependency probe failed.
+	StatusDown DependencyStatus = "down"
+
+	// StatusDegraded indicates the dependency is in a degraded state (e.g., circuit breaker half-open).
+	StatusDegraded DependencyStatus = "degraded"
+
+	// StatusSkipped indicates the dependency is optional and was not probed (e.g., disabled by config).
+	StatusSkipped DependencyStatus = "skipped"
+
+	// StatusNA indicates the dependency is not applicable in the current mode (e.g., tenant-scoped in MT mode).
+	StatusNA DependencyStatus = "n/a"
+)
+
+const (
+	// DefaultDatabaseTimeout is the default timeout for MongoDB health checks.
+	DefaultDatabaseTimeout = 2 * time.Second
+
+	// DefaultDrainDelay is the time to wait after starting drain before fully shutting down.
+	// This gives load balancers time to stop sending traffic to the pod.
+	DefaultDrainDelay = 12 * time.Second
+)
+
+// DependencyCheck represents the health check result for a single dependency.
+type DependencyCheck struct {
+	Status       DependencyStatus `json:"status"`
+	LatencyMs    *int64           `json:"latency_ms,omitempty"`
+	TLS          *bool            `json:"tls,omitempty"`
+	Error        string           `json:"error,omitempty"`
+	Reason       string           `json:"reason,omitempty"`
+	BreakerState string           `json:"breaker_state,omitempty"`
+}
+
+// ReadyzResponse is the response body for the /readyz endpoint.
+type ReadyzResponse struct {
+	Status         string                     `json:"status"`
+	Checks         map[string]DependencyCheck `json:"checks"`
+	Version        string                     `json:"version"`
+	DeploymentMode string                     `json:"deployment_mode"`
+	Reason         string                     `json:"reason,omitempty"`
+}
+
+// DependencyChecker is the interface for probing a dependency's health.
+type DependencyChecker interface {
+	// Name returns the dependency identifier used as the key in the checks map.
+	Name() string
+
+	// Check probes the dependency and returns the health check result.
+	// The context should have a timeout applied by the caller.
+	Check(ctx context.Context) DependencyCheck
+
+	// TLSEnabled returns whether TLS is enabled for this dependency.
+	TLSEnabled() bool
+}
+
+// ReadyzHandler handles /readyz requests.
+type ReadyzHandler struct {
+	logger         libLog.Logger
+	checkers       []DependencyChecker
+	version        string
+	deploymentMode string
+
+	// Lifecycle state
+	serverReady atomic.Bool // true after HTTP server is listening
+	draining    atomic.Bool // true after SIGTERM received (graceful drain)
+
+	// OTel metrics (nil when telemetry disabled)
+	metricsFactory *metrics.MetricsFactory
+}
+
+// ReadyzHandlerConfig holds configuration for creating a ReadyzHandler.
+type ReadyzHandlerConfig struct {
+	Logger         libLog.Logger
+	Checkers       []DependencyChecker
+	Version        string
+	DeploymentMode string
+	MetricsFactory *metrics.MetricsFactory
+}
+
+// NewReadyzHandler creates a new ReadyzHandler with the given configuration.
+func NewReadyzHandler(cfg ReadyzHandlerConfig) *ReadyzHandler {
+	return &ReadyzHandler{
+		logger:         cfg.Logger,
+		checkers:       cfg.Checkers,
+		version:        cfg.Version,
+		deploymentMode: ResolveDeploymentMode(cfg.DeploymentMode),
+		metricsFactory: cfg.MetricsFactory,
+	}
+}
+
+// recordCheckMetrics records OTel metrics for a health check result.
+func (h *ReadyzHandler) recordCheckMetrics(ctx context.Context, checkerName string, status DependencyStatus, durationMs int64) {
+	if h.metricsFactory == nil {
+		return
+	}
+
+	attrs := []attribute.KeyValue{
+		attribute.String("checker", checkerName),
+		attribute.String("status", string(status)),
+	}
+
+	// Record check duration histogram
+	if histogram, err := h.metricsFactory.Histogram(utils.ReadyzCheckDuration); err == nil {
+		_ = histogram.WithAttributes(attrs...).Record(ctx, durationMs)
+	}
+
+	// Record check status counter
+	if counter, err := h.metricsFactory.Counter(utils.ReadyzCheckStatus); err == nil {
+		_ = counter.WithAttributes(attrs...).Add(ctx, 1)
+	}
+}
+
+// recordRequestMetrics records OTel metrics for a readyz request.
+func (h *ReadyzHandler) recordRequestMetrics(ctx context.Context, endpoint string, healthy bool) {
+	if h.metricsFactory == nil {
+		return
+	}
+
+	attrs := []attribute.KeyValue{
+		attribute.String("endpoint", endpoint),
+		attribute.Bool("healthy", healthy),
+	}
+
+	if counter, err := h.metricsFactory.Counter(utils.ReadyzRequestsTotal); err == nil {
+		_ = counter.WithAttributes(attrs...).Add(ctx, 1)
+	}
+}
+
+// SetServerReady marks the server as ready to accept traffic.
+// Call this after the HTTP server has started listening.
+func (h *ReadyzHandler) SetServerReady() {
+	h.serverReady.Store(true)
+	h.logger.Log(context.Background(), libLog.LevelInfo, "Readyz: server marked as ready")
+}
+
+// StartDrain initiates graceful drain mode.
+// After calling this, readyz will return 503 to signal load balancers to stop sending traffic.
+func (h *ReadyzHandler) StartDrain() {
+	h.draining.Store(true)
+	h.logger.Log(context.Background(), libLog.LevelInfo, "Readyz: graceful drain started")
+}
+
+// IsDraining returns true if the handler is in drain mode.
+func (h *ReadyzHandler) IsDraining() bool {
+	return h.draining.Load()
+}
+
+// IsServerReady returns true if the server is ready to accept traffic.
+func (h *ReadyzHandler) IsServerReady() bool {
+	return h.serverReady.Load()
+}
+
+// checkLifecycleState checks the server lifecycle state (self-probe and graceful drain).
+// Returns (reason, ok) where ok is false if the server should return 503.
+func (h *ReadyzHandler) checkLifecycleState() (string, bool) {
+	if !h.serverReady.Load() {
+		return "server not ready (startup in progress)", false
+	}
+
+	if h.draining.Load() {
+		return "server draining (shutdown in progress)", false
+	}
+
+	return "", true
+}
+
+// HandleReadyz handles the /readyz endpoint for global health checks.
+func (h *ReadyzHandler) HandleReadyz(c *fiber.Ctx) error {
+	// Check lifecycle state first (self-probe and graceful drain)
+	if reason, ok := h.checkLifecycleState(); !ok {
+		return c.Status(http.StatusServiceUnavailable).JSON(ReadyzResponse{
+			Status:         "unhealthy",
+			Checks:         map[string]DependencyCheck{},
+			Version:        h.version,
+			DeploymentMode: h.deploymentMode,
+			Reason:         reason,
+		})
+	}
+
+	checks := make(map[string]DependencyCheck)
+	allHealthy := true
+
+	// Run all checkers sequentially
+	for _, checker := range h.checkers {
+		checkCtx, cancel := context.WithTimeout(c.Context(), DefaultDatabaseTimeout)
+
+		start := time.Now()
+		check := checker.Check(checkCtx)
+		durationMs := time.Since(start).Milliseconds()
+
+		cancel()
+
+		// Set TLS field
+		if checker.TLSEnabled() {
+			tlsEnabled := true
+			check.TLS = &tlsEnabled
+		} else {
+			tlsDisabled := false
+			check.TLS = &tlsDisabled
+		}
+
+		// Record metrics
+		h.recordCheckMetrics(c.Context(), checker.Name(), check.Status, durationMs)
+
+		// Log full error and sanitize for non-local modes
+		h.logAndSanitizeCheck(c.Context(), checker.Name(), &check)
+
+		checks[checker.Name()] = check
+
+		if check.Status == StatusDown || check.Status == StatusDegraded {
+			allHealthy = false
+		}
+	}
+
+	status := "healthy"
+	httpStatus := http.StatusOK
+
+	if !allHealthy {
+		status = "unhealthy"
+		httpStatus = http.StatusServiceUnavailable
+	}
+
+	// Record request metrics
+	h.recordRequestMetrics(c.Context(), "/readyz", allHealthy)
+
+	response := ReadyzResponse{
+		Status:         status,
+		Checks:         checks,
+		Version:        h.version,
+		DeploymentMode: h.deploymentMode,
+	}
+
+	return c.Status(httpStatus).JSON(response)
+}
+
+// sanitizeError returns a sanitized error message for non-local deployment modes.
+// In local mode, the full error is returned for debugging.
+// In saas/byoc modes, the error is sanitized to prevent leaking internal details.
+func (h *ReadyzHandler) sanitizeError(checkerName, originalError string) string {
+	if h.deploymentMode == DeploymentModeLocal {
+		return originalError
+	}
+
+	return fmt.Sprintf("%s check failed", checkerName)
+}
+
+// logAndSanitizeCheck logs the full error server-side and sanitizes it in the response.
+// This ensures operators can debug issues while preventing information disclosure to clients.
+func (h *ReadyzHandler) logAndSanitizeCheck(ctx context.Context, checkerName string, check *DependencyCheck) {
+	if check.Error == "" {
+		return
+	}
+
+	// Always log the full error server-side for debugging
+	h.logger.Log(ctx, libLog.LevelWarn, "Health check failed",
+		libLog.String("checker", checkerName),
+		libLog.String("status", string(check.Status)),
+		libLog.String("error", check.Error))
+
+	// Sanitize the error in the response for non-local modes
+	check.Error = h.sanitizeError(checkerName, check.Error)
+}

--- a/components/crm/internal/bootstrap/readyz_checkers.go
+++ b/components/crm/internal/bootstrap/readyz_checkers.go
@@ -1,0 +1,106 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package bootstrap
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	libMongo "github.com/LerianStudio/lib-commons/v4/commons/mongo"
+)
+
+// MongoChecker probes a MongoDB connection using ping command.
+type MongoChecker struct {
+	name       string
+	client     *libMongo.Client
+	uri        string
+	tlsEnabled bool
+}
+
+// NewMongoChecker creates a new MongoDB health checker.
+func NewMongoChecker(name string, client *libMongo.Client, uri string) *MongoChecker {
+	tlsEnabled, _ := detectMongoTLS(uri)
+
+	return &MongoChecker{
+		name:       name,
+		client:     client,
+		uri:        uri,
+		tlsEnabled: tlsEnabled,
+	}
+}
+
+// Name returns the checker identifier.
+func (c *MongoChecker) Name() string {
+	return c.name
+}
+
+// TLSEnabled returns whether TLS is enabled for this connection.
+func (c *MongoChecker) TLSEnabled() bool {
+	return c.tlsEnabled
+}
+
+// Check probes the MongoDB connection.
+func (c *MongoChecker) Check(ctx context.Context) DependencyCheck {
+	if c.client == nil {
+		return DependencyCheck{
+			Status: StatusSkipped,
+			Reason: "MongoDB client not configured",
+		}
+	}
+
+	start := time.Now()
+
+	err := c.client.Ping(ctx)
+	latencyMs := time.Since(start).Milliseconds()
+
+	if err != nil {
+		return DependencyCheck{
+			Status:    StatusDown,
+			LatencyMs: &latencyMs,
+			Error:     fmt.Sprintf("ping failed: %v", err),
+		}
+	}
+
+	return DependencyCheck{
+		Status:    StatusUp,
+		LatencyMs: &latencyMs,
+	}
+}
+
+// NAChecker is a placeholder checker that always returns n/a status.
+// Used in multi-tenant mode for dependencies that are tenant-scoped.
+type NAChecker struct {
+	name       string
+	reason     string
+	tlsEnabled bool
+}
+
+// NewNAChecker creates a checker that always returns n/a status.
+func NewNAChecker(name, reason string, tlsEnabled bool) *NAChecker {
+	return &NAChecker{
+		name:       name,
+		reason:     reason,
+		tlsEnabled: tlsEnabled,
+	}
+}
+
+// Name returns the checker identifier.
+func (c *NAChecker) Name() string {
+	return c.name
+}
+
+// TLSEnabled returns whether TLS is enabled for this dependency.
+func (c *NAChecker) TLSEnabled() bool {
+	return c.tlsEnabled
+}
+
+// Check always returns n/a status.
+func (c *NAChecker) Check(_ context.Context) DependencyCheck {
+	return DependencyCheck{
+		Status: StatusNA,
+		Reason: c.reason,
+	}
+}

--- a/components/crm/internal/bootstrap/readyz_integration_test.go
+++ b/components/crm/internal/bootstrap/readyz_integration_test.go
@@ -1,0 +1,348 @@
+//go:build integration
+
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package bootstrap
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	libLog "github.com/LerianStudio/lib-commons/v4/commons/log"
+	"github.com/gofiber/fiber/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	mongoContainer "github.com/LerianStudio/midaz/v3/tests/utils/mongodb"
+)
+
+// newReadyHandler creates a ReadyzHandler and marks it as ready for testing.
+// This is needed because HandleReadyz checks lifecycle state before running checks.
+func newReadyHandler(cfg ReadyzHandlerConfig) *ReadyzHandler {
+	handler := NewReadyzHandler(cfg)
+	handler.SetServerReady()
+
+	return handler
+}
+
+func TestReadyz_Integration_AllDependenciesHealthy(t *testing.T) {
+	t.Parallel()
+
+	// Start MongoDB container
+	mongo := mongoContainer.SetupContainer(t)
+
+	// Create lib-commons wrapper
+	mongoClient := mongoContainer.CreateConnection(t, mongo.URI, mongo.DBName)
+
+	// Create checker using lib-commons client for MongoDB
+	checkers := []DependencyChecker{
+		NewMongoChecker("mongo", mongoClient, mongo.URI),
+	}
+
+	handler := newReadyHandler(ReadyzHandlerConfig{
+		Logger:         libLog.NewNop(),
+		Checkers:       checkers,
+		Version:        "1.0.0-test",
+		DeploymentMode: "local",
+	})
+
+	app := fiber.New()
+	app.Get("/readyz", handler.HandleReadyz)
+
+	req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+	resp, err := app.Test(req, 10000) // 10s timeout for containers
+	require.NoError(t, err)
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	var response ReadyzResponse
+	err = json.Unmarshal(body, &response)
+	require.NoError(t, err)
+
+	assert.Equal(t, "healthy", response.Status)
+	assert.Equal(t, "1.0.0-test", response.Version)
+	assert.Equal(t, "local", response.DeploymentMode)
+
+	// MongoDB checker should be up
+	assert.Equal(t, StatusUp, response.Checks["mongo"].Status)
+
+	// Latency should be populated
+	assert.NotNil(t, response.Checks["mongo"].LatencyMs)
+}
+
+func TestReadyz_Integration_MongoSkipped(t *testing.T) {
+	t.Parallel()
+
+	// Create a Mongo checker with nil client (simulating not configured)
+	checkers := []DependencyChecker{
+		NewMongoChecker("mongo", nil, ""), // nil = not configured
+	}
+
+	handler := newReadyHandler(ReadyzHandlerConfig{
+		Logger:         libLog.NewNop(),
+		Checkers:       checkers,
+		Version:        "1.0.0-test",
+		DeploymentMode: "local",
+	})
+
+	app := fiber.New()
+	app.Get("/readyz", handler.HandleReadyz)
+
+	req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+	resp, err := app.Test(req, 5000)
+	require.NoError(t, err)
+
+	// Should return 200 since nil checker returns "skipped" not "down"
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	var response ReadyzResponse
+	err = json.Unmarshal(body, &response)
+	require.NoError(t, err)
+
+	assert.Equal(t, "healthy", response.Status)
+	assert.Equal(t, StatusSkipped, response.Checks["mongo"].Status)
+}
+
+func TestReadyz_Integration_TLSDetection(t *testing.T) {
+	t.Parallel()
+
+	// Test that TLS detection works correctly with real containers (non-TLS)
+	mongo := mongoContainer.SetupContainer(t)
+	mongoClient := mongoContainer.CreateConnection(t, mongo.URI, mongo.DBName)
+
+	checkers := []DependencyChecker{
+		NewMongoChecker("mongo", mongoClient, mongo.URI),
+	}
+
+	handler := newReadyHandler(ReadyzHandlerConfig{
+		Logger:         libLog.NewNop(),
+		Checkers:       checkers,
+		Version:        "1.0.0-test",
+		DeploymentMode: "local",
+	})
+
+	app := fiber.New()
+	app.Get("/readyz", handler.HandleReadyz)
+
+	req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+	resp, err := app.Test(req, 10000)
+	require.NoError(t, err)
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	var response ReadyzResponse
+	err = json.Unmarshal(body, &response)
+	require.NoError(t, err)
+
+	// Test container uses non-TLS connection
+	for name, check := range response.Checks {
+		require.NotNil(t, check.TLS, "TLS field should be set for %s", name)
+		assert.False(t, *check.TLS, "TLS should be false for test container %s", name)
+	}
+}
+
+func TestReadyz_Integration_LatencyMeasurement(t *testing.T) {
+	t.Parallel()
+
+	mongo := mongoContainer.SetupContainer(t)
+	mongoClient := mongoContainer.CreateConnection(t, mongo.URI, mongo.DBName)
+
+	checkers := []DependencyChecker{
+		NewMongoChecker("mongo", mongoClient, mongo.URI),
+	}
+
+	handler := newReadyHandler(ReadyzHandlerConfig{
+		Logger:         libLog.NewNop(),
+		Checkers:       checkers,
+		Version:        "1.0.0",
+		DeploymentMode: "local",
+	})
+
+	app := fiber.New()
+	app.Get("/readyz", handler.HandleReadyz)
+
+	// Run multiple times to verify latency is measured each time
+	for i := range 3 {
+		req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+		resp, err := app.Test(req, 10000)
+		require.NoError(t, err, "iteration %d failed", i)
+
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+
+		var response ReadyzResponse
+		err = json.Unmarshal(body, &response)
+		require.NoError(t, err)
+
+		// Latency should be non-negative and reasonable (< 1 second for local containers)
+		// Note: Very fast pings may return 0ms at millisecond precision
+		mongoLatency := response.Checks["mongo"].LatencyMs
+
+		require.NotNil(t, mongoLatency)
+
+		assert.GreaterOrEqual(t, *mongoLatency, int64(0), "mongo latency should be non-negative")
+		assert.Less(t, *mongoLatency, int64(1000), "mongo latency should be < 1s")
+	}
+}
+
+func TestReadyz_Integration_ConcurrentRequests(t *testing.T) {
+	t.Parallel()
+
+	mongo := mongoContainer.SetupContainer(t)
+	mongoClient := mongoContainer.CreateConnection(t, mongo.URI, mongo.DBName)
+
+	checkers := []DependencyChecker{
+		NewMongoChecker("mongo", mongoClient, mongo.URI),
+	}
+
+	handler := newReadyHandler(ReadyzHandlerConfig{
+		Logger:         libLog.NewNop(),
+		Checkers:       checkers,
+		Version:        "1.0.0",
+		DeploymentMode: "local",
+	})
+
+	app := fiber.New()
+	app.Get("/readyz", handler.HandleReadyz)
+
+	// Make multiple concurrent requests
+	const numRequests = 5
+	results := make(chan int, numRequests)
+
+	for range numRequests {
+		go func() {
+			req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+			resp, err := app.Test(req, 5000) // 5s timeout
+			if err != nil {
+				results <- -1
+				return
+			}
+			results <- resp.StatusCode
+		}()
+	}
+
+	// Collect results
+	successCount := 0
+	for range numRequests {
+		if <-results == http.StatusOK {
+			successCount++
+		}
+	}
+
+	assert.Equal(t, numRequests, successCount, "all concurrent requests should succeed")
+}
+
+func TestReadyz_Integration_MixedHealthStatus(t *testing.T) {
+	t.Parallel()
+
+	// Start only working container
+	mongo := mongoContainer.SetupContainer(t)
+	mongoClient := mongoContainer.CreateConnection(t, mongo.URI, mongo.DBName)
+
+	// Mix of healthy and n/a checkers
+	checkers := []DependencyChecker{
+		NewMongoChecker("mongo", mongoClient, mongo.URI),
+		NewNAChecker("mongo_tenant", "tenant-scoped", false), // n/a
+	}
+
+	handler := newReadyHandler(ReadyzHandlerConfig{
+		Logger:         libLog.NewNop(),
+		Checkers:       checkers,
+		Version:        "1.0.0",
+		DeploymentMode: "local",
+	})
+
+	app := fiber.New()
+	app.Get("/readyz", handler.HandleReadyz)
+
+	req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+	resp, err := app.Test(req, 10000)
+	require.NoError(t, err)
+
+	// Should be healthy since n/a doesn't count as unhealthy
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	var response ReadyzResponse
+	err = json.Unmarshal(body, &response)
+	require.NoError(t, err)
+
+	assert.Equal(t, "healthy", response.Status)
+	assert.Equal(t, StatusUp, response.Checks["mongo"].Status)
+	assert.Equal(t, StatusNA, response.Checks["mongo_tenant"].Status)
+}
+
+func TestReadyz_Integration_LifecycleState(t *testing.T) {
+	t.Parallel()
+
+	mongo := mongoContainer.SetupContainer(t)
+	mongoClient := mongoContainer.CreateConnection(t, mongo.URI, mongo.DBName)
+
+	checkers := []DependencyChecker{
+		NewMongoChecker("mongo", mongoClient, mongo.URI),
+	}
+
+	// Create handler but do NOT mark as ready
+	handler := NewReadyzHandler(ReadyzHandlerConfig{
+		Logger:         libLog.NewNop(),
+		Checkers:       checkers,
+		Version:        "1.0.0",
+		DeploymentMode: "local",
+	})
+
+	app := fiber.New()
+	app.Get("/readyz", handler.HandleReadyz)
+
+	// Test 1: Server not ready should return 503
+	req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+	resp, err := app.Test(req, 5000)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	var response ReadyzResponse
+	err = json.Unmarshal(body, &response)
+	require.NoError(t, err)
+	assert.Equal(t, "unhealthy", response.Status)
+	assert.Contains(t, response.Reason, "server not ready")
+
+	// Test 2: Mark as ready, should return 200
+	handler.SetServerReady()
+
+	req = httptest.NewRequest(http.MethodGet, "/readyz", nil)
+	resp, err = app.Test(req, 5000)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	// Test 3: Start drain, should return 503
+	handler.StartDrain()
+
+	req = httptest.NewRequest(http.MethodGet, "/readyz", nil)
+	resp, err = app.Test(req, 5000)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
+
+	body, err = io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	err = json.Unmarshal(body, &response)
+	require.NoError(t, err)
+	assert.Equal(t, "unhealthy", response.Status)
+	assert.Contains(t, response.Reason, "server draining")
+}

--- a/components/crm/internal/bootstrap/readyz_test.go
+++ b/components/crm/internal/bootstrap/readyz_test.go
@@ -1,0 +1,633 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package bootstrap
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	libLog "github.com/LerianStudio/lib-commons/v4/commons/log"
+	"github.com/gofiber/fiber/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// readyzMockLogger is a no-op logger for readyz testing.
+type readyzMockLogger struct{}
+
+func (m *readyzMockLogger) Log(_ context.Context, _ libLog.Level, _ string, _ ...libLog.Field) {}
+func (m *readyzMockLogger) With(_ ...libLog.Field) libLog.Logger                               { return m }
+func (m *readyzMockLogger) WithGroup(_ string) libLog.Logger                                   { return m }
+func (m *readyzMockLogger) Enabled(_ libLog.Level) bool                                        { return true }
+func (m *readyzMockLogger) Sync(_ context.Context) error                                       { return nil }
+
+func newReadyzMockLogger() libLog.Logger {
+	return &readyzMockLogger{}
+}
+
+// mockChecker implements DependencyChecker for testing.
+type mockChecker struct {
+	name       string
+	tlsEnabled bool
+	checkFn    func(ctx context.Context) DependencyCheck
+}
+
+func newMockChecker(name string, tlsEnabled bool, status DependencyStatus) *mockChecker {
+	return &mockChecker{
+		name:       name,
+		tlsEnabled: tlsEnabled,
+		checkFn: func(_ context.Context) DependencyCheck {
+			latency := int64(1)
+			return DependencyCheck{
+				Status:    status,
+				LatencyMs: &latency,
+			}
+		},
+	}
+}
+
+func newMockCheckerWithError(name string, tlsEnabled bool, status DependencyStatus, errMsg string) *mockChecker {
+	return &mockChecker{
+		name:       name,
+		tlsEnabled: tlsEnabled,
+		checkFn: func(_ context.Context) DependencyCheck {
+			latency := int64(1)
+			return DependencyCheck{
+				Status:    status,
+				LatencyMs: &latency,
+				Error:     errMsg,
+			}
+		},
+	}
+}
+
+func newMockCheckerWithReason(name string, tlsEnabled bool, status DependencyStatus, reason string) *mockChecker {
+	return &mockChecker{
+		name:       name,
+		tlsEnabled: tlsEnabled,
+		checkFn: func(_ context.Context) DependencyCheck {
+			return DependencyCheck{
+				Status: status,
+				Reason: reason,
+			}
+		},
+	}
+}
+
+func (m *mockChecker) Name() string {
+	return m.name
+}
+
+func (m *mockChecker) TLSEnabled() bool {
+	return m.tlsEnabled
+}
+
+func (m *mockChecker) Check(ctx context.Context) DependencyCheck {
+	return m.checkFn(ctx)
+}
+
+// createTestApp creates a Fiber app with the readyz handler for testing.
+func createTestApp(handler *ReadyzHandler) *fiber.App {
+	app := fiber.New()
+	app.Get("/readyz", handler.HandleReadyz)
+
+	return app
+}
+
+func TestReadyzHandler_HandleReadyz_AllHealthy(t *testing.T) {
+	t.Parallel()
+
+	handler := NewReadyzHandler(ReadyzHandlerConfig{
+		Logger:         newReadyzMockLogger(),
+		Version:        "1.0.0",
+		DeploymentMode: "local",
+		Checkers: []DependencyChecker{
+			newMockChecker("mongo", true, StatusUp),
+		},
+	})
+	handler.SetServerReady()
+
+	app := createTestApp(handler)
+
+	req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+	resp, err := app.Test(req, -1)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	var response ReadyzResponse
+	err = json.Unmarshal(body, &response)
+	require.NoError(t, err)
+
+	assert.Equal(t, "healthy", response.Status)
+	assert.Equal(t, "1.0.0", response.Version)
+	assert.Equal(t, "local", response.DeploymentMode)
+	assert.Contains(t, response.Checks, "mongo")
+	assert.Equal(t, StatusUp, response.Checks["mongo"].Status)
+}
+
+func TestReadyzHandler_HandleReadyz_OneDown(t *testing.T) {
+	t.Parallel()
+
+	handler := NewReadyzHandler(ReadyzHandlerConfig{
+		Logger:         newReadyzMockLogger(),
+		Version:        "1.0.0",
+		DeploymentMode: "local",
+		Checkers: []DependencyChecker{
+			newMockChecker("mongo", true, StatusDown),
+		},
+	})
+	handler.SetServerReady()
+
+	app := createTestApp(handler)
+
+	req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+	resp, err := app.Test(req, -1)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	var response ReadyzResponse
+	err = json.Unmarshal(body, &response)
+	require.NoError(t, err)
+
+	assert.Equal(t, "unhealthy", response.Status)
+	assert.Equal(t, StatusDown, response.Checks["mongo"].Status)
+}
+
+func TestReadyzHandler_HandleReadyz_OneDegraded(t *testing.T) {
+	t.Parallel()
+
+	handler := NewReadyzHandler(ReadyzHandlerConfig{
+		Logger:         newReadyzMockLogger(),
+		Version:        "1.0.0",
+		DeploymentMode: "local",
+		Checkers: []DependencyChecker{
+			newMockChecker("mongo", true, StatusDegraded),
+		},
+	})
+	handler.SetServerReady()
+
+	app := createTestApp(handler)
+
+	req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+	resp, err := app.Test(req, -1)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	var response ReadyzResponse
+	err = json.Unmarshal(body, &response)
+	require.NoError(t, err)
+
+	assert.Equal(t, "unhealthy", response.Status)
+	assert.Equal(t, StatusDegraded, response.Checks["mongo"].Status)
+}
+
+func TestReadyzHandler_HandleReadyz_SkippedCountsAsHealthy(t *testing.T) {
+	t.Parallel()
+
+	handler := NewReadyzHandler(ReadyzHandlerConfig{
+		Logger:         newReadyzMockLogger(),
+		Version:        "1.0.0",
+		DeploymentMode: "local",
+		Checkers: []DependencyChecker{
+			newMockCheckerWithReason("mongo", true, StatusSkipped, "MONGO_ENABLED=false"),
+		},
+	})
+	handler.SetServerReady()
+
+	app := createTestApp(handler)
+
+	req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+	resp, err := app.Test(req, -1)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	var response ReadyzResponse
+	err = json.Unmarshal(body, &response)
+	require.NoError(t, err)
+
+	assert.Equal(t, "healthy", response.Status)
+	assert.Equal(t, StatusSkipped, response.Checks["mongo"].Status)
+	assert.Equal(t, "MONGO_ENABLED=false", response.Checks["mongo"].Reason)
+}
+
+func TestReadyzHandler_HandleReadyz_NACountsAsHealthy(t *testing.T) {
+	t.Parallel()
+
+	handler := NewReadyzHandler(ReadyzHandlerConfig{
+		Logger:         newReadyzMockLogger(),
+		Version:        "1.0.0",
+		DeploymentMode: "local",
+		Checkers: []DependencyChecker{
+			newMockCheckerWithReason("mongo", true, StatusNA, "tenant-scoped; use /readyz/tenant/:id"),
+		},
+	})
+	handler.SetServerReady()
+
+	app := createTestApp(handler)
+
+	req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+	resp, err := app.Test(req, -1)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	var response ReadyzResponse
+	err = json.Unmarshal(body, &response)
+	require.NoError(t, err)
+
+	assert.Equal(t, "healthy", response.Status)
+	assert.Equal(t, StatusNA, response.Checks["mongo"].Status)
+}
+
+func TestReadyzHandler_HandleReadyz_NoCheckers(t *testing.T) {
+	t.Parallel()
+
+	handler := NewReadyzHandler(ReadyzHandlerConfig{
+		Logger:         newReadyzMockLogger(),
+		Version:        "1.0.0",
+		DeploymentMode: "local",
+		Checkers:       []DependencyChecker{},
+	})
+	handler.SetServerReady()
+
+	app := createTestApp(handler)
+
+	req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+	resp, err := app.Test(req, -1)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	var response ReadyzResponse
+	err = json.Unmarshal(body, &response)
+	require.NoError(t, err)
+
+	assert.Equal(t, "healthy", response.Status)
+	assert.Empty(t, response.Checks)
+}
+
+func TestReadyzHandler_LifecycleState_ServerNotReady(t *testing.T) {
+	t.Parallel()
+
+	handler := NewReadyzHandler(ReadyzHandlerConfig{
+		Logger:         newReadyzMockLogger(),
+		Version:        "1.0.0",
+		DeploymentMode: "local",
+		Checkers: []DependencyChecker{
+			newMockChecker("mongo", true, StatusUp),
+		},
+	})
+	// Do NOT call SetServerReady() - server is not ready
+
+	app := createTestApp(handler)
+
+	req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+	resp, err := app.Test(req, -1)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	var response ReadyzResponse
+	err = json.Unmarshal(body, &response)
+	require.NoError(t, err)
+
+	assert.Equal(t, "unhealthy", response.Status)
+	assert.Contains(t, response.Reason, "server not ready")
+}
+
+func TestReadyzHandler_LifecycleState_Draining(t *testing.T) {
+	t.Parallel()
+
+	handler := NewReadyzHandler(ReadyzHandlerConfig{
+		Logger:         newReadyzMockLogger(),
+		Version:        "1.0.0",
+		DeploymentMode: "local",
+		Checkers: []DependencyChecker{
+			newMockChecker("mongo", true, StatusUp),
+		},
+	})
+	handler.SetServerReady()
+	handler.StartDrain()
+
+	app := createTestApp(handler)
+
+	req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+	resp, err := app.Test(req, -1)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	var response ReadyzResponse
+	err = json.Unmarshal(body, &response)
+	require.NoError(t, err)
+
+	assert.Equal(t, "unhealthy", response.Status)
+	assert.Contains(t, response.Reason, "draining")
+}
+
+func TestReadyzHandler_ErrorSanitization_LocalMode(t *testing.T) {
+	t.Parallel()
+
+	handler := NewReadyzHandler(ReadyzHandlerConfig{
+		Logger:         newReadyzMockLogger(),
+		Version:        "1.0.0",
+		DeploymentMode: "local",
+		Checkers: []DependencyChecker{
+			newMockCheckerWithError("mongo", true, StatusDown, "connection refused to 192.168.1.100:27017"),
+		},
+	})
+	handler.SetServerReady()
+
+	app := createTestApp(handler)
+
+	req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+	resp, err := app.Test(req, -1)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	var response ReadyzResponse
+	err = json.Unmarshal(body, &response)
+	require.NoError(t, err)
+
+	// In local mode, full error is exposed
+	assert.Contains(t, response.Checks["mongo"].Error, "192.168.1.100")
+}
+
+func TestReadyzHandler_ErrorSanitization_SaaSMode(t *testing.T) {
+	t.Parallel()
+
+	handler := NewReadyzHandler(ReadyzHandlerConfig{
+		Logger:         newReadyzMockLogger(),
+		Version:        "1.0.0",
+		DeploymentMode: "saas",
+		Checkers: []DependencyChecker{
+			newMockCheckerWithError("mongo", true, StatusDown, "connection refused to 192.168.1.100:27017"),
+		},
+	})
+	handler.SetServerReady()
+
+	app := createTestApp(handler)
+
+	req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+	resp, err := app.Test(req, -1)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	var response ReadyzResponse
+	err = json.Unmarshal(body, &response)
+	require.NoError(t, err)
+
+	// In saas mode, error is sanitized (should not contain internal IP)
+	assert.NotContains(t, response.Checks["mongo"].Error, "192.168.1.100")
+	assert.Contains(t, response.Checks["mongo"].Error, "mongo check failed")
+}
+
+func TestReadyzHandler_ErrorSanitization_BYOCMode(t *testing.T) {
+	t.Parallel()
+
+	handler := NewReadyzHandler(ReadyzHandlerConfig{
+		Logger:         newReadyzMockLogger(),
+		Version:        "1.0.0",
+		DeploymentMode: "byoc",
+		Checkers: []DependencyChecker{
+			newMockCheckerWithError("mongo", true, StatusDown, "connection refused to 192.168.1.100:27017"),
+		},
+	})
+	handler.SetServerReady()
+
+	app := createTestApp(handler)
+
+	req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+	resp, err := app.Test(req, -1)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	var response ReadyzResponse
+	err = json.Unmarshal(body, &response)
+	require.NoError(t, err)
+
+	// In byoc mode, error is sanitized (should not contain internal IP)
+	assert.NotContains(t, response.Checks["mongo"].Error, "192.168.1.100")
+	assert.Contains(t, response.Checks["mongo"].Error, "mongo check failed")
+}
+
+func TestReadyzHandler_TLSFieldSet(t *testing.T) {
+	t.Parallel()
+
+	handler := NewReadyzHandler(ReadyzHandlerConfig{
+		Logger:         newReadyzMockLogger(),
+		Version:        "1.0.0",
+		DeploymentMode: "local",
+		Checkers: []DependencyChecker{
+			newMockChecker("mongo_tls", true, StatusUp),
+			newMockChecker("mongo_notls", false, StatusUp),
+		},
+	})
+	handler.SetServerReady()
+
+	app := createTestApp(handler)
+
+	req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+	resp, err := app.Test(req, -1)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	var response ReadyzResponse
+	err = json.Unmarshal(body, &response)
+	require.NoError(t, err)
+
+	// Check TLS field is set correctly
+	require.NotNil(t, response.Checks["mongo_tls"].TLS)
+	assert.True(t, *response.Checks["mongo_tls"].TLS)
+
+	require.NotNil(t, response.Checks["mongo_notls"].TLS)
+	assert.False(t, *response.Checks["mongo_notls"].TLS)
+}
+
+func TestReadyzHandler_SetServerReady(t *testing.T) {
+	t.Parallel()
+
+	handler := NewReadyzHandler(ReadyzHandlerConfig{
+		Logger:         newReadyzMockLogger(),
+		Version:        "1.0.0",
+		DeploymentMode: "local",
+	})
+
+	assert.False(t, handler.IsServerReady())
+
+	handler.SetServerReady()
+
+	assert.True(t, handler.IsServerReady())
+}
+
+func TestReadyzHandler_StartDrain(t *testing.T) {
+	t.Parallel()
+
+	handler := NewReadyzHandler(ReadyzHandlerConfig{
+		Logger:         newReadyzMockLogger(),
+		Version:        "1.0.0",
+		DeploymentMode: "local",
+	})
+
+	assert.False(t, handler.IsDraining())
+
+	handler.StartDrain()
+
+	assert.True(t, handler.IsDraining())
+}
+
+func TestReadyzHandler_MultipleCheckers(t *testing.T) {
+	t.Parallel()
+
+	handler := NewReadyzHandler(ReadyzHandlerConfig{
+		Logger:         newReadyzMockLogger(),
+		Version:        "1.0.0",
+		DeploymentMode: "local",
+		Checkers: []DependencyChecker{
+			newMockChecker("mongo", true, StatusUp),
+			newMockChecker("upstream_api", true, StatusUp),
+		},
+	})
+	handler.SetServerReady()
+
+	app := createTestApp(handler)
+
+	req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+	resp, err := app.Test(req, -1)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	var response ReadyzResponse
+	err = json.Unmarshal(body, &response)
+	require.NoError(t, err)
+
+	assert.Equal(t, "healthy", response.Status)
+	assert.Len(t, response.Checks, 2)
+	assert.Contains(t, response.Checks, "mongo")
+	assert.Contains(t, response.Checks, "upstream_api")
+}
+
+func TestReadyzHandler_MixedStatusWithDownFails(t *testing.T) {
+	t.Parallel()
+
+	handler := NewReadyzHandler(ReadyzHandlerConfig{
+		Logger:         newReadyzMockLogger(),
+		Version:        "1.0.0",
+		DeploymentMode: "local",
+		Checkers: []DependencyChecker{
+			newMockChecker("mongo", true, StatusUp),
+			newMockChecker("upstream_api", true, StatusDown),
+		},
+	})
+	handler.SetServerReady()
+
+	app := createTestApp(handler)
+
+	req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+	resp, err := app.Test(req, -1)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	var response ReadyzResponse
+	err = json.Unmarshal(body, &response)
+	require.NoError(t, err)
+
+	assert.Equal(t, "unhealthy", response.Status)
+}
+
+func TestNAChecker(t *testing.T) {
+	t.Parallel()
+
+	checker := NewNAChecker("mongo", "tenant-scoped; use /readyz/tenant/:id", true)
+
+	assert.Equal(t, "mongo", checker.Name())
+	assert.True(t, checker.TLSEnabled())
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	check := checker.Check(ctx)
+
+	assert.Equal(t, StatusNA, check.Status)
+	assert.Equal(t, "tenant-scoped; use /readyz/tenant/:id", check.Reason)
+}
+
+func TestNAChecker_TLSDisabled(t *testing.T) {
+	t.Parallel()
+
+	checker := NewNAChecker("mongo", "some reason", false)
+
+	assert.Equal(t, "mongo", checker.Name())
+	assert.False(t, checker.TLSEnabled())
+
+	ctx := context.Background()
+	check := checker.Check(ctx)
+
+	assert.Equal(t, StatusNA, check.Status)
+	assert.Equal(t, "some reason", check.Reason)
+}

--- a/components/crm/internal/bootstrap/server.go
+++ b/components/crm/internal/bootstrap/server.go
@@ -5,6 +5,10 @@
 package bootstrap
 
 import (
+	"context"
+	"fmt"
+	"time"
+
 	libCommons "github.com/LerianStudio/lib-commons/v4/commons"
 	libCommonsLog "github.com/LerianStudio/lib-commons/v4/commons/log"
 	libCommonsOtel "github.com/LerianStudio/lib-commons/v4/commons/opentelemetry"
@@ -12,12 +16,13 @@ import (
 	"github.com/gofiber/fiber/v2"
 )
 
-// Server represents the http server for Ledger services.
+// Server represents the http server for CRM services.
 type Server struct {
 	app           *fiber.App
 	serverAddress string
 	logger        libCommonsLog.Logger
 	telemetry     libCommonsOtel.Telemetry
+	readyzHandler *ReadyzHandler
 }
 
 // ServerAddress returns is a convenience method to return the server address.
@@ -26,17 +31,39 @@ func (s *Server) ServerAddress() string {
 }
 
 // NewServer creates an instance of Server.
-func NewServer(cfg *Config, app *fiber.App, logger libCommonsLog.Logger, telemetry *libCommonsOtel.Telemetry) *Server {
+func NewServer(cfg *Config, app *fiber.App, logger libCommonsLog.Logger, telemetry *libCommonsOtel.Telemetry, readyzHandler *ReadyzHandler) *Server {
 	return &Server{
 		app:           app,
 		serverAddress: cfg.ServerAddress,
 		logger:        logger,
 		telemetry:     *telemetry,
+		readyzHandler: readyzHandler,
 	}
 }
 
 // Run runs the server.
 func (s *Server) Run(l *libCommons.Launcher) error {
+	// Register lifecycle hooks for readyz
+	s.app.Hooks().OnListen(func(_ fiber.ListenData) error {
+		if s.readyzHandler != nil {
+			s.readyzHandler.SetServerReady()
+		}
+
+		return nil
+	})
+
+	s.app.Hooks().OnShutdown(func() error {
+		if s.readyzHandler != nil {
+			s.readyzHandler.StartDrain()
+			// Wait for drain delay to allow load balancers to stop sending traffic
+			s.logger.Log(context.Background(), libCommonsLog.LevelInfo,
+				fmt.Sprintf("Waiting %v for graceful drain before shutdown", DefaultDrainDelay))
+			time.Sleep(DefaultDrainDelay)
+		}
+
+		return nil
+	})
+
 	libCommonsServer.NewServerManager(nil, &s.telemetry, s.logger).
 		WithHTTPServer(s.app, s.serverAddress).
 		StartWithGracefulShutdown()

--- a/components/crm/internal/bootstrap/tls_detection.go
+++ b/components/crm/internal/bootstrap/tls_detection.go
@@ -1,0 +1,128 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package bootstrap
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+// detectMongoTLS returns true if the MongoDB URI has TLS enabled.
+// TLS is enabled when:
+//   - URI scheme is "mongodb+srv" (always uses TLS)
+//   - Query parameter "tls=true" is present (case-insensitive key and value)
+//   - Query parameter "ssl=true" is present (legacy, case-insensitive key and value)
+//
+// Returns error for malformed URI syntax.
+func detectMongoTLS(uri string) (bool, error) {
+	if uri == "" {
+		return false, nil
+	}
+
+	parsed, err := url.Parse(uri)
+	if err != nil {
+		return false, fmt.Errorf("invalid MongoDB URI: %w", err)
+	}
+
+	// mongodb+srv:// always uses TLS
+	if strings.ToLower(parsed.Scheme) == "mongodb+srv" {
+		return true, nil
+	}
+
+	// Check query parameters for tls=true or ssl=true (case-insensitive)
+	// url.Query() preserves original case, so we need to iterate all keys
+	query := parsed.Query()
+
+	for key, values := range query {
+		lowerKey := strings.ToLower(key)
+		if lowerKey == "tls" || lowerKey == "ssl" {
+			for _, v := range values {
+				if strings.EqualFold(v, "true") {
+					return true, nil
+				}
+			}
+		}
+	}
+
+	return false, nil
+}
+
+// TLSValidationResult contains the TLS validation status for a dependency.
+type TLSValidationResult struct {
+	Name       string
+	TLSEnabled bool
+}
+
+// DeploymentMode constants define the valid deployment modes for TLS enforcement.
+const (
+	// DeploymentModeSaaS is the Lerian-hosted multi-tenant mode where TLS is MANDATORY.
+	DeploymentModeSaaS = "saas"
+	// DeploymentModeBYOC is the customer-hosted mode where TLS is recommended but not enforced.
+	DeploymentModeBYOC = "byoc"
+	// DeploymentModeLocal is the developer workstation mode where TLS is optional.
+	DeploymentModeLocal = "local"
+
+	// DefaultDeploymentMode is the deployment mode used when none is specified.
+	// Defaults to "local" for safe developer experience.
+	DefaultDeploymentMode = DeploymentModeLocal
+)
+
+// ResolveDeploymentMode normalizes the deployment mode string.
+// Returns DefaultDeploymentMode if input is empty or whitespace.
+// Otherwise returns the lowercased input for consistent comparison.
+func ResolveDeploymentMode(mode string) string {
+	trimmed := strings.TrimSpace(mode)
+	if trimmed == "" {
+		return DefaultDeploymentMode
+	}
+
+	return strings.ToLower(trimmed)
+}
+
+// ValidateSaaSTLS enforces TLS for all dependencies when DEPLOYMENT_MODE=saas.
+// This is a centralized function called from bootstrap BEFORE any connection is opened.
+//
+// Deployment mode semantics:
+//   - "saas": TLS MANDATORY for ALL dependencies - hard fail at startup if any lacks TLS
+//   - "byoc": TLS recommended but not hard-enforced (returns nil, caller may log warning)
+//   - "local" or unset: TLS optional - no enforcement
+//
+// Returns an error ONLY when DEPLOYMENT_MODE=saas and any dependency lacks TLS.
+// The error includes the specific dependency name(s) that failed validation.
+func ValidateSaaSTLS(deploymentMode string, dependencies []TLSValidationResult) error {
+	lowerMode := strings.ToLower(deploymentMode)
+
+	// Only enforce TLS in SaaS mode
+	if lowerMode != DeploymentModeSaaS {
+		return nil
+	}
+
+	// Collect all dependencies without TLS
+	var insecureDeps []string
+
+	for _, dep := range dependencies {
+		if !dep.TLSEnabled {
+			insecureDeps = append(insecureDeps, dep.Name)
+		}
+	}
+
+	if len(insecureDeps) > 0 {
+		return fmt.Errorf("DEPLOYMENT_MODE=saas: TLS required for %s but not configured",
+			strings.Join(insecureDeps, ", "))
+	}
+
+	return nil
+}
+
+// IsTLSEnforcementRequired returns true if the deployment mode requires TLS enforcement.
+func IsTLSEnforcementRequired(deploymentMode string) bool {
+	return strings.ToLower(deploymentMode) == DeploymentModeSaaS
+}
+
+// IsTLSRecommended returns true if TLS is recommended (but not required) for the deployment mode.
+func IsTLSRecommended(deploymentMode string) bool {
+	return strings.ToLower(deploymentMode) == DeploymentModeBYOC
+}

--- a/components/crm/internal/bootstrap/tls_detection_test.go
+++ b/components/crm/internal/bootstrap/tls_detection_test.go
@@ -1,0 +1,394 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package bootstrap
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDetectMongoTLS(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		uri     string
+		want    bool
+		wantErr bool
+	}{
+		{
+			name:    "empty string returns false",
+			uri:     "",
+			want:    false,
+			wantErr: false,
+		},
+		{
+			name:    "mongodb scheme without tls returns false",
+			uri:     "mongodb://user:pass@localhost:27017/dbname",
+			want:    false,
+			wantErr: false,
+		},
+		{
+			name:    "mongodb+srv scheme returns true (always TLS)",
+			uri:     "mongodb+srv://user:pass@cluster.mongodb.net/dbname",
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name:    "mongodb with tls=true returns true",
+			uri:     "mongodb://user:pass@localhost:27017/dbname?tls=true",
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name:    "mongodb with tls=false returns false",
+			uri:     "mongodb://user:pass@localhost:27017/dbname?tls=false",
+			want:    false,
+			wantErr: false,
+		},
+		{
+			name:    "mongodb with ssl=true returns true (legacy)",
+			uri:     "mongodb://user:pass@localhost:27017/dbname?ssl=true",
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name:    "mongodb with ssl=false returns false",
+			uri:     "mongodb://user:pass@localhost:27017/dbname?ssl=false",
+			want:    false,
+			wantErr: false,
+		},
+		{
+			name:    "mongodb with TLS=TRUE uppercase returns true",
+			uri:     "mongodb://user:pass@localhost:27017/dbname?TLS=TRUE",
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name:    "mongodb+srv uppercase scheme returns true",
+			uri:     "MONGODB+SRV://user:pass@cluster.mongodb.net/dbname",
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name:    "mongodb with multiple query params including tls",
+			uri:     "mongodb://user:pass@localhost:27017/dbname?retryWrites=true&tls=true&w=majority",
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name:    "mongodb with url-encoded params",
+			uri:     "mongodb://user:pass@localhost:27017/dbname?authSource=admin&tls=true",
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name:    "malformed URI returns error",
+			uri:     "://invalid-uri",
+			want:    false,
+			wantErr: true,
+		},
+		{
+			name:    "mongodb with replicaSet and tls",
+			uri:     "mongodb://user:pass@host1:27017,host2:27017/dbname?replicaSet=rs0&tls=true",
+			want:    true,
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := detectMongoTLS(tt.uri)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestDetectMongoTLS_EdgeCases(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		uri     string
+		want    bool
+		wantErr bool
+	}{
+		{
+			name:    "tls_value_with_whitespace",
+			uri:     "mongodb://user:pass@localhost:27017/db?tls= true",
+			want:    false, // " true" != "true"
+			wantErr: false,
+		},
+		{
+			name:    "multiple_tls_params",
+			uri:     "mongodb://user:pass@localhost:27017/db?tls=false&tls=true",
+			want:    true, // Should find at least one true
+			wantErr: false,
+		},
+		{
+			name:    "ssl_and_tls_mixed",
+			uri:     "mongodb://user:pass@localhost:27017/db?ssl=false&tls=true",
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name:    "fragment_with_tls",
+			uri:     "mongodb://user:pass@localhost:27017/db#tls=true",
+			want:    false, // Fragment is not a query param
+			wantErr: false,
+		},
+		{
+			name:    "ipv6_host_with_tls",
+			uri:     "mongodb://user:pass@[::1]:27017/db?tls=true",
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name:    "mongodb_plus_srv_mixed_case",
+			uri:     "MongoDb+SrV://user:pass@cluster.mongodb.net/db",
+			want:    true, // SRV always uses TLS
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := detectMongoTLS(tt.uri)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestResolveDeploymentMode(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"empty_returns_default", "", DefaultDeploymentMode},
+		{"whitespace_returns_default", "   ", DefaultDeploymentMode},
+		{"saas_preserved", "saas", "saas"},
+		{"SAAS_lowercase", "SAAS", "saas"},
+		{"byoc_preserved", "byoc", "byoc"},
+		{"BYOC_lowercase", "BYOC", "byoc"},
+		{"local_preserved", "local", "local"},
+		{"LOCAL_lowercase", "LOCAL", "local"},
+		{"unknown_preserved_lowercase", "production", "production"},
+		{"leading_whitespace_trimmed", "  saas", "saas"},
+		{"trailing_whitespace_trimmed", "byoc  ", "byoc"},
+		{"mixed_case_lowercased", "SaaS", "saas"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := ResolveDeploymentMode(tt.input)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestValidateSaaSTLS(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		deploymentMode string
+		dependencies   []TLSValidationResult
+		wantErr        bool
+		errContains    string
+	}{
+		{
+			name:           "local_mode_skips_validation",
+			deploymentMode: "local",
+			dependencies: []TLSValidationResult{
+				{Name: "mongo", TLSEnabled: false},
+			},
+			wantErr: false,
+		},
+		{
+			name:           "LOCAL_uppercase_skips_validation",
+			deploymentMode: "LOCAL",
+			dependencies: []TLSValidationResult{
+				{Name: "mongo", TLSEnabled: false},
+			},
+			wantErr: false,
+		},
+		{
+			name:           "byoc_mode_skips_validation",
+			deploymentMode: "byoc",
+			dependencies: []TLSValidationResult{
+				{Name: "mongo", TLSEnabled: false},
+			},
+			wantErr: false,
+		},
+		{
+			name:           "BYOC_uppercase_skips_validation",
+			deploymentMode: "BYOC",
+			dependencies: []TLSValidationResult{
+				{Name: "mongo", TLSEnabled: false},
+			},
+			wantErr: false,
+		},
+		{
+			name:           "empty_mode_defaults_to_no_enforcement",
+			deploymentMode: "",
+			dependencies: []TLSValidationResult{
+				{Name: "mongo", TLSEnabled: false},
+			},
+			wantErr: false,
+		},
+		{
+			name:           "saas_mode_all_tls_enabled_passes",
+			deploymentMode: "saas",
+			dependencies: []TLSValidationResult{
+				{Name: "mongo", TLSEnabled: true},
+			},
+			wantErr: false,
+		},
+		{
+			name:           "SAAS_uppercase_all_tls_enabled_passes",
+			deploymentMode: "SAAS",
+			dependencies: []TLSValidationResult{
+				{Name: "mongo", TLSEnabled: true},
+			},
+			wantErr: false,
+		},
+		{
+			name:           "saas_mode_one_insecure_fails",
+			deploymentMode: "saas",
+			dependencies: []TLSValidationResult{
+				{Name: "mongo", TLSEnabled: false},
+			},
+			wantErr:     true,
+			errContains: "mongo",
+		},
+		{
+			name:           "saas_mode_multiple_insecure_fails",
+			deploymentMode: "saas",
+			dependencies: []TLSValidationResult{
+				{Name: "mongo", TLSEnabled: false},
+				{Name: "upstream", TLSEnabled: false},
+			},
+			wantErr:     true,
+			errContains: "mongo",
+		},
+		{
+			name:           "saas_mode_empty_dependencies_passes",
+			deploymentMode: "saas",
+			dependencies:   []TLSValidationResult{},
+			wantErr:        false,
+		},
+		{
+			name:           "saas_mode_nil_dependencies_passes",
+			deploymentMode: "saas",
+			dependencies:   nil,
+			wantErr:        false,
+		},
+		{
+			name:           "unknown_mode_skips_validation",
+			deploymentMode: "production",
+			dependencies: []TLSValidationResult{
+				{Name: "mongo", TLSEnabled: false},
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := ValidateSaaSTLS(tt.deploymentMode, tt.dependencies)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errContains)
+				assert.Contains(t, err.Error(), "DEPLOYMENT_MODE=saas")
+
+				return
+			}
+
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestIsTLSEnforcementRequired(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		deploymentMode string
+		want           bool
+	}{
+		{"saas_requires_enforcement", "saas", true},
+		{"SAAS_uppercase_requires_enforcement", "SAAS", true},
+		{"byoc_no_enforcement", "byoc", false},
+		{"local_no_enforcement", "local", false},
+		{"empty_no_enforcement", "", false},
+		{"unknown_no_enforcement", "production", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := IsTLSEnforcementRequired(tt.deploymentMode)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestIsTLSRecommended(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		deploymentMode string
+		want           bool
+	}{
+		{"byoc_recommended", "byoc", true},
+		{"BYOC_uppercase_recommended", "BYOC", true},
+		{"saas_not_recommended_but_required", "saas", false},
+		{"local_not_recommended", "local", false},
+		{"empty_not_recommended", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := IsTLSRecommended(tt.deploymentMode)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestDefaultDeploymentMode(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "local", DefaultDeploymentMode, "default deployment mode should be 'local'")
+}


### PR DESCRIPTION
## Summary

Add production-grade `/readyz` health check endpoint to the CRM component for Kubernetes readiness probes, implementing MongoDB dependency checking, TLS detection, lifecycle management (startup/draining states), error sanitization, and OpenTelemetry metrics integration.

## Motivation

Kubernetes readiness probes require a dedicated endpoint that accurately reflects the service's ability to handle traffic. The existing `/health` endpoint (liveness probe) does not check dependencies or lifecycle state, which can lead to traffic being routed to pods that are not ready to serve requests or are in the process of shutting down.

This implementation enables:
- Zero-downtime deployments via proper readiness signaling
- Graceful shutdown with 12s drain delay for load balancer convergence
- Dependency health visibility for operations teams
- TLS enforcement for SaaS deployments

## Semantic Decision

This is a **feature addition** (non-breaking). The `/readyz` endpoint is new and does not modify existing behavior. All existing endpoints continue to work unchanged.

## Changes

### New Files
| File | Purpose |
|------|---------|
| `components/crm/internal/bootstrap/readyz.go` | Core ReadyzHandler with lifecycle management, error sanitization, and OTel metrics |
| `components/crm/internal/bootstrap/readyz_checkers.go` | MongoChecker and NAChecker implementations of DependencyChecker interface |
| `components/crm/internal/bootstrap/tls_detection.go` | TLS detection utilities, deployment mode handling, SaaS TLS enforcement |
| `components/crm/internal/bootstrap/readyz_test.go` | Unit tests for ReadyzHandler (633 lines) |
| `components/crm/internal/bootstrap/readyz_integration_test.go` | Integration tests with testcontainers (348 lines) |
| `components/crm/internal/bootstrap/tls_detection_test.go` | TLS detection and validation tests (394 lines) |

### Environment Variables - Readyz
| Variable | Type | Default | Description |
|----------|------|---------|-------------|
| `DEPLOYMENT_MODE` | string | `local` | Deployment mode: `saas` (TLS enforced), `byoc` (TLS recommended), `local` (no enforcement) |
| `VERSION` | string | - | Application version string (reported in readyz response) |

### Refactored Code
| Before | After |
|--------|-------|
| `NewRouter(lg, tl, auth, tenantMw, hh, ah)` | `NewRouter(lg, tl, auth, tenantMw, readyzHandler, hh, ah)` |
| `NewServer(cfg, app, logger, telemetry)` | `NewServer(cfg, app, logger, telemetry, readyzHandler)` |
| Server struct with 4 fields | Server struct with 5 fields (added `readyzHandler`) |

### OpenTelemetry Metrics
| Metric | Type | Description |
|--------|------|-------------|
| `readyz_check_duration_ms` | Histogram | Per-checker probe latency in milliseconds |
| `readyz_check_status` | Counter | Health check outcomes by checker name and status |
| `readyz_requests_total` | Counter | Total readyz endpoint requests by endpoint and health result |

## Test Plan
- [x] Unit tests pass (`go test ./components/crm/internal/bootstrap/... -v`)
- [x] Integration tests pass with testcontainers (`go test -tags=integration ./components/crm/internal/bootstrap/...`)
- [x] Race detector passes (`go test -race ./components/crm/internal/bootstrap/...`)
- [x] Linter passes (`golangci-lint run ./components/crm/...`)
- [x] Build succeeds (`go build ./components/crm/...`)
- [x] All 5 DependencyStatus values tested (up, down, degraded, skipped, n/a)
- [x] Lifecycle states tested (startup not ready, ready, draining)
- [x] Error sanitization tested for local/saas/byoc modes
- [x] TLS detection edge cases tested (mongodb+srv, ssl=true, case variations)
- [x] Concurrent request safety verified with race detector
