### PR TITLE
feat: balance overdraft with direction-based balance model

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,22 +3,22 @@
 <div align="center">
 
 [![Latest Release](https://img.shields.io/github/v/release/LerianStudio/midaz?include_prereleases)](https://github.com/LerianStudio/midaz/v3/releases)
-[![License: Apache-2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://github.com/LerianStudio/midaz/v3/blob/main/LICENSE)
+[![License: Elastic-2.0](https://img.shields.io/badge/License-Elastic_2.0-blue.svg)](https://github.com/LerianStudio/midaz/v3/blob/main/LICENSE)
 [![Go Report](https://goreportcard.com/badge/github.com/lerianstudio/midaz)](https://goreportcard.com/report/github.com/lerianstudio/midaz)
 [![Discord](https://img.shields.io/badge/Discord-Lerian%20Studio-%237289da.svg?logo=discord)](https://discord.gg/DnhqKwkGv3)
 
 </div>
 
-# Lerian Midaz: Enterprise-Grade Open-Source Ledger System
+# Lerian Midaz: Enterprise-Grade Source-Available Ledger System
 
-Lerian Midaz is a modern, open-source ledger system for building financial infrastructure. It scales from fintech startups to enterprise banking solutions. The robust architecture empowers developers to create sophisticated financial applications that handle complex transactional requirements.
+Lerian Midaz is a modern, source-available ledger system for building financial infrastructure. It scales from fintech startups to enterprise banking solutions. The robust architecture empowers developers to create sophisticated financial applications that handle complex transactional requirements.
 
 ## Why Midaz?
 
 - **Enterprise-Ready**: Built with the reliability, scalability, and security needed for mission-critical financial systems
 - **Developer-Friendly**: Clean architecture and comprehensive API documentation for rapid integration and development
 - **Future-Proof Design**: Multi-asset and multi-currency support to handle both traditional and digital assets in a single system
-- **Community-Backed**: Growing open-source community with commercial support options available from Lerian
+- **Community-Backed**: Growing developer community with commercial support options available from Lerian
 
 ## Core Banking
 
@@ -31,7 +31,7 @@ At Lerian, we view a core banking system as a comprehensive platform consisting 
 2. **Transactional Messaging Integrations**: These are responsible for integrating with external systems to generate debits and credits in the ledger. Examples include instant payments (like PIX in Brazil), card transactions, and wire transfers.
 3. **Governance Integrations**: These are responsible for enhancing the core banking capabilities with KYC, anti-fraud/AML measures, management reporting, regulatory compliance, and accounting reporting.
 
-Our open-source approach allows for the integration of Midaz with other components, like transactional messaging and governance, creating a complete core banking solution tailored to your specific needs. We also provide a marketplace with different plugins that streamline the integration of these messaging systems and governance players. These plugins are built by both Lerian and the community/partners.
+Our source-available approach allows for the integration of Midaz with other components, like transactional messaging and governance, creating a complete core banking solution tailored to your specific needs. We also provide a marketplace with different plugins that streamline the integration of these messaging systems and governance players. These plugins are built by both Lerian and the community/partners.
 
 Interested in contributing to plugin development? Reach out in the Discussions tab or at [contact@lerian.studio](mailto:contact@lerian.studio).
 
@@ -123,7 +123,7 @@ Follow our [Getting Started Guide](https://docs.lerian.studio/en/midaz/midaz-get
 
 ## Contributing & License
 
-We welcome contributions from the community. Read our [Contributing Guidelines](CONTRIBUTING.md) to get started. Lerian Midaz is released under the Apache License 2.0. See [LICENSE](LICENSE) for details. You can use, modify, and distribute Midaz as long as you include the original copyright and license notice.
+We welcome contributions from the community. Read our [Contributing Guidelines](CONTRIBUTING.md) to get started. Lerian Midaz is released under the [Elastic License 2.0 (ELv2)](LICENSE) — a source-available license that allows you to use, copy, modify, and redistribute Midaz, with three primary limitations: you may not provide it to others as a managed/hosted service, circumvent its license key functionality, or remove/obscure license notices.
 
 ## About Lerian
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <div align="center">
 
 [![Latest Release](https://img.shields.io/github/v/release/LerianStudio/midaz?include_prereleases)](https://github.com/LerianStudio/midaz/v3/releases)
-[![License: Elastic-2.0](https://img.shields.io/badge/License-Elastic_2.0-blue.svg)](https://github.com/LerianStudio/midaz/v3/blob/main/LICENSE)
+[![License: Elastic-2.0](https://img.shields.io/badge/License-Elastic_2.0-blue.svg)](https://github.com/LerianStudio/midaz/blob/main/LICENSE)
 [![Go Report](https://goreportcard.com/badge/github.com/lerianstudio/midaz)](https://goreportcard.com/report/github.com/lerianstudio/midaz)
 [![Discord](https://img.shields.io/badge/Discord-Lerian%20Studio-%237289da.svg?logo=discord)](https://discord.gg/DnhqKwkGv3)
 

--- a/components/crm/.env.example
+++ b/components/crm/.env.example
@@ -11,7 +11,7 @@ ENV_NAME=development
 #
 # This setting controls the ValidateSaaSTLS() check at bootstrap.
 DEPLOYMENT_MODE=local
-VERSION=v3.6.0
+VERSION=v3.7.0
 SERVER_PORT=4003
 SERVER_ADDRESS=:${SERVER_PORT}
 

--- a/components/crm/api/crm_docs.go
+++ b/components/crm/api/crm_docs.go
@@ -1596,7 +1596,7 @@ const docTemplatecrm = `{
 
 // SwaggerInfocrm holds exported Swagger Info so clients can modify it
 var SwaggerInfocrm = &swag.Spec{
-	Version:          "1.0.0",
+	Version:          "v3.7.0",
 	Host:             "localhost:4003",
 	BasePath:         "/",
 	Schemes:          []string{},

--- a/components/crm/api/crm_swagger.json
+++ b/components/crm/api/crm_swagger.json
@@ -4,7 +4,7 @@
         "description": "The CRM API provides a set of endpoints for managing holder data, including information related to their ledger accounts.",
         "title": "CRM API",
         "contact": {},
-        "version": "1.0.0"
+        "version": "v3.7.0"
     },
     "host": "localhost:4003",
     "basePath": "/",

--- a/components/crm/api/crm_swagger.yaml
+++ b/components/crm/api/crm_swagger.yaml
@@ -531,7 +531,7 @@ info:
   description: The CRM API provides a set of endpoints for managing holder data, including
     information related to their ledger accounts.
   title: CRM API
-  version: 1.0.0
+  version: v3.7.0
 paths:
   /v1/aliases:
     get:

--- a/components/crm/api/openapi.yaml
+++ b/components/crm/api/openapi.yaml
@@ -4,7 +4,7 @@ info:
   description: The CRM API provides a set of endpoints for managing holder data, including
     information related to their ledger accounts.
   title: CRM API
-  version: 1.0.0
+  version: v3.7.0
 servers:
 - url: //localhost:4003/
 paths:

--- a/components/crm/cmd/app/main.go
+++ b/components/crm/cmd/app/main.go
@@ -17,7 +17,7 @@ import (
 )
 
 // @title						CRM API
-// @version					1.0.0
+// @version					v3.7.0
 // @description				The CRM API provides a set of endpoints for managing holder data, including information related to their ledger accounts.
 // @host						localhost:4003
 // @BasePath					/

--- a/components/crm/internal/adapters/http/in/alias.go
+++ b/components/crm/internal/adapters/http/in/alias.go
@@ -102,7 +102,7 @@ func (handler *AliasHandler) GetAliasByID(c *fiber.Ctx) error {
 	ctx, span := tracer.Start(ctx, "handler.get_alias_by_id")
 	defer span.End()
 
-	id, err := http.GetUUIDFromLocals(c, "id")
+	id, err := http.GetUUIDFromLocals(c, "alias_id")
 	if err != nil {
 		return http.WithError(c, err)
 	}
@@ -162,7 +162,7 @@ func (handler *AliasHandler) UpdateAlias(p any, c *fiber.Ctx) error {
 	ctx, span := tracer.Start(ctx, "handler.update_alias")
 	defer span.End()
 
-	id, err := http.GetUUIDFromLocals(c, "id")
+	id, err := http.GetUUIDFromLocals(c, "alias_id")
 	if err != nil {
 		return http.WithError(c, err)
 	}
@@ -237,7 +237,7 @@ func (handler *AliasHandler) DeleteAliasByID(c *fiber.Ctx) error {
 	ctx, span := tracer.Start(ctx, "handler.remove_alias_by_id")
 	defer span.End()
 
-	id, err := http.GetUUIDFromLocals(c, "id")
+	id, err := http.GetUUIDFromLocals(c, "alias_id")
 	if err != nil {
 		return http.WithError(c, err)
 	}

--- a/components/crm/internal/adapters/http/in/alias_test.go
+++ b/components/crm/internal/adapters/http/in/alias_test.go
@@ -480,10 +480,10 @@ func TestAliasHandler_GetAliasByID(t *testing.T) {
 			handler := &AliasHandler{Service: uc}
 
 			app := fiber.New()
-			app.Get("/v1/holders/:holder_id/aliases/:id",
+			app.Get("/v1/holders/:holder_id/aliases/:alias_id",
 				func(c *fiber.Ctx) error {
 					c.Locals("holder_id", holderID)
-					c.Locals("id", aliasID)
+					c.Locals("alias_id", aliasID)
 					c.Request().Header.Set("X-Organization-Id", orgID)
 					return c.Next()
 				},
@@ -738,10 +738,10 @@ func TestAliasHandler_UpdateAlias(t *testing.T) {
 			handler := &AliasHandler{Service: uc}
 
 			app := fiber.New()
-			app.Patch("/v1/holders/:holder_id/aliases/:id",
+			app.Patch("/v1/holders/:holder_id/aliases/:alias_id",
 				func(c *fiber.Ctx) error {
 					c.Locals("holder_id", holderID)
-					c.Locals("id", aliasID)
+					c.Locals("alias_id", aliasID)
 					c.Request().Header.Set("X-Organization-Id", orgID)
 					return c.Next()
 				},
@@ -859,10 +859,10 @@ func TestAliasHandler_DeleteAliasByID(t *testing.T) {
 			handler := &AliasHandler{Service: uc}
 
 			app := fiber.New()
-			app.Delete("/v1/holders/:holder_id/aliases/:id",
+			app.Delete("/v1/holders/:holder_id/aliases/:alias_id",
 				func(c *fiber.Ctx) error {
 					c.Locals("holder_id", holderID)
-					c.Locals("id", aliasID)
+					c.Locals("alias_id", aliasID)
 					c.Request().Header.Set("X-Organization-Id", orgID)
 					return c.Next()
 				},

--- a/components/crm/internal/adapters/http/in/routes.go
+++ b/components/crm/internal/adapters/http/in/routes.go
@@ -68,9 +68,9 @@ func NewRouter(lg libLog.Logger, tl *libOpenTelemetry.Telemetry, auth *middlewar
 	// Aliases
 	f.Get("/v1/aliases", auth.Authorize(ApplicationName, "aliases", "get"), ah.GetAllAliases)
 	f.Post("/v1/holders/:holder_id/aliases", auth.Authorize(ApplicationName, "aliases", "post"), http.ParseUUIDPathParameters("aliases"), http.WithBody(new(mmodel.CreateAliasInput), ah.CreateAlias))
-	f.Get("/v1/holders/:holder_id/aliases/:id", auth.Authorize(ApplicationName, "aliases", "get"), http.ParseUUIDPathParameters("aliases"), ah.GetAliasByID)
-	f.Patch("/v1/holders/:holder_id/aliases/:id", auth.Authorize(ApplicationName, "aliases", "patch"), http.ParseUUIDPathParameters("aliases"), http.WithBody(new(mmodel.UpdateAliasInput), ah.UpdateAlias))
-	f.Delete("/v1/holders/:holder_id/aliases/:id", auth.Authorize(ApplicationName, "aliases", "delete"), http.ParseUUIDPathParameters("aliases"), ah.DeleteAliasByID)
+	f.Get("/v1/holders/:holder_id/aliases/:alias_id", auth.Authorize(ApplicationName, "aliases", "get"), http.ParseUUIDPathParameters("aliases"), ah.GetAliasByID)
+	f.Patch("/v1/holders/:holder_id/aliases/:alias_id", auth.Authorize(ApplicationName, "aliases", "patch"), http.ParseUUIDPathParameters("aliases"), http.WithBody(new(mmodel.UpdateAliasInput), ah.UpdateAlias))
+	f.Delete("/v1/holders/:holder_id/aliases/:alias_id", auth.Authorize(ApplicationName, "aliases", "delete"), http.ParseUUIDPathParameters("aliases"), ah.DeleteAliasByID)
 	f.Delete("/v1/holders/:holder_id/aliases/:alias_id/related-parties/:related_party_id", auth.Authorize(ApplicationName, "aliases", "delete"), http.ParseUUIDPathParameters("related-parties"), ah.DeleteRelatedParty)
 
 	f.Use(tlMid.EndTracingSpans)

--- a/components/infra/rabbitmq/etc/definitions.json
+++ b/components/infra/rabbitmq/etc/definitions.json
@@ -79,6 +79,15 @@
       "vhost": "/",
       "type": "topic",
       "durable": true
+    },
+    {
+      "name": "transaction.overdraft_events.exchange",
+      "vhost": "/",
+      "type": "topic",
+      "durable": true,
+      "auto_delete": false,
+      "internal": false,
+      "arguments": {}
     }
   ],
   "bindings": [

--- a/components/ledger/.env.example
+++ b/components/ledger/.env.example
@@ -7,7 +7,7 @@
 # DEFAULT local
 ENV_NAME=development
 
-VERSION=v3.6.0
+VERSION=v3.7.0
 
 # DEPLOYMENT MODE (controls TLS enforcement)
 # Valid values:

--- a/components/ledger/.env.example
+++ b/components/ledger/.env.example
@@ -244,6 +244,12 @@ RABBITMQ_CIRCUIT_BREAKER_HEALTH_CHECK_TIMEOUT=10
 RABBITMQ_TRANSACTION_EVENTS_ENABLED=false
 RABBITMQ_TRANSACTION_EVENTS_EXCHANGE=transaction.transaction_events.exchange
 
+# OVERDRAFT EXCHANGE EVENTS
+# Events emitted when overdraft is used (drawn), repaid, or fully cleared.
+# Routing key pattern: midaz.balance.<action> (e.g. midaz.balance.overdraft.drawn)
+RABBITMQ_OVERDRAFT_EVENTS_ENABLED=false
+RABBITMQ_OVERDRAFT_EVENTS_EXCHANGE=transaction.overdraft_events.exchange
+
 # AUDIT
 AUDIT_LOG_ENABLED=false
 RABBITMQ_AUDIT_EXCHANGE=audit.append_log.exchange

--- a/components/ledger/api/docs.go
+++ b/components/ledger/api/docs.go
@@ -5,7 +5,7 @@ import "github.com/swaggo/swag"
 
 // SwaggerInfo holds exported Swagger Info so clients can modify it
 var SwaggerInfo = &swag.Spec{
-	Version:          "v3.6.0",
+	Version:          "v3.7.0",
 	Host:             "localhost:3002",
 	BasePath:         "/",
 	Schemes:          []string{"http", "https"},
@@ -33,10 +33,10 @@ const docTemplate = `
       "url": "https://discord.gg/DnhqKwkGv3"
     },
     "license": {
-      "name": "Apache 2.0",
-      "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
+      "name": "Elastic License 2.0",
+      "url": "https://www.elastic.co/licensing/elastic-license"
     },
-    "version": "v3.6.0"
+    "version": "v3.7.0"
   },
   "host": "localhost:3002",
   "basePath": "/",
@@ -296,7 +296,7 @@ const docTemplate = `
         }
       }
     },
-    "/v1/organizations/{id}": {
+    "/v1/organizations/{organization_id}": {
       "get": {
         "description": "Returns detailed information about an organization identified by its UUID",
         "produces": [
@@ -323,7 +323,7 @@ const docTemplate = `
           {
             "type": "string",
             "description": "Organization ID in UUID format",
-            "name": "id",
+            "name": "organization_id",
             "in": "path",
             "required": true
           }
@@ -384,7 +384,7 @@ const docTemplate = `
           {
             "type": "string",
             "description": "Organization ID in UUID format",
-            "name": "id",
+            "name": "organization_id",
             "in": "path",
             "required": true
           }
@@ -454,7 +454,7 @@ const docTemplate = `
           {
             "type": "string",
             "description": "Organization ID in UUID format",
-            "name": "id",
+            "name": "organization_id",
             "in": "path",
             "required": true
           },
@@ -789,7 +789,7 @@ const docTemplate = `
         }
       }
     },
-    "/v1/organizations/{organization_id}/ledgers/{id}": {
+    "/v1/organizations/{organization_id}/ledgers/{ledger_id}": {
       "get": {
         "description": "Returns detailed information about a ledger identified by its UUID within the specified organization",
         "produces": [
@@ -823,7 +823,7 @@ const docTemplate = `
           {
             "type": "string",
             "description": "Ledger ID in UUID format",
-            "name": "id",
+            "name": "ledger_id",
             "in": "path",
             "required": true
           }
@@ -891,7 +891,7 @@ const docTemplate = `
           {
             "type": "string",
             "description": "Ledger ID in UUID format",
-            "name": "id",
+            "name": "ledger_id",
             "in": "path",
             "required": true
           }
@@ -968,7 +968,7 @@ const docTemplate = `
           {
             "type": "string",
             "description": "Ledger ID in UUID format",
-            "name": "id",
+            "name": "ledger_id",
             "in": "path",
             "required": true
           },
@@ -1009,168 +1009,6 @@ const docTemplate = `
           },
           "404": {
             "description": "Ledger or organization not found",
-            "schema": {
-              "$ref": "#/definitions/Error"
-            }
-          },
-          "500": {
-            "description": "Internal server error",
-            "schema": {
-              "$ref": "#/definitions/Error"
-            }
-          }
-        }
-      }
-    },
-    "/v1/organizations/{organization_id}/ledgers/{id}/settings": {
-      "get": {
-        "description": "Returns the current configuration settings for a specific ledger. If no settings have been persisted, returns the default settings object.",
-        "produces": [
-          "application/json"
-        ],
-        "tags": [
-          "Ledgers"
-        ],
-        "summary": "Get ledger settings",
-        "parameters": [
-          {
-            "type": "string",
-            "description": "Authorization Bearer Token with format: Bearer {token}",
-            "name": "Authorization",
-            "in": "header",
-            "required": true
-          },
-          {
-            "type": "string",
-            "description": "Request ID for tracing",
-            "name": "X-Request-Id",
-            "in": "header"
-          },
-          {
-            "type": "string",
-            "description": "Organization ID in UUID format",
-            "name": "organization_id",
-            "in": "path",
-            "required": true
-          },
-          {
-            "type": "string",
-            "description": "Ledger ID in UUID format",
-            "name": "id",
-            "in": "path",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successfully retrieved ledger settings",
-            "schema": {
-              "$ref": "#/definitions/mmodel.LedgerSettings"
-            }
-          },
-          "401": {
-            "description": "Unauthorized access",
-            "schema": {
-              "$ref": "#/definitions/Error"
-            }
-          },
-          "403": {
-            "description": "Forbidden access",
-            "schema": {
-              "$ref": "#/definitions/Error"
-            }
-          },
-          "404": {
-            "description": "Ledger not found",
-            "schema": {
-              "$ref": "#/definitions/Error"
-            }
-          },
-          "500": {
-            "description": "Internal server error",
-            "schema": {
-              "$ref": "#/definitions/Error"
-            }
-          }
-        }
-      },
-      "patch": {
-        "description": "Updates the configuration settings for a specific ledger using schema-aware deep merge. Only known settings fields are allowed - unknown fields return error 0147 (ErrUnknownSettingsField). Type validation is enforced - incorrect types return error 0148 (ErrInvalidSettingsFieldType). Nested objects (like 'accounting') are deep-merged, preserving existing properties not specified in the update. Example: updating only 'accounting.validateRoutes' preserves the existing 'accounting.validateAccountType' value. Allowed fields: accounting.validateAccountType (boolean), accounting.validateRoutes (boolean).",
-        "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/json"
-        ],
-        "tags": [
-          "Ledgers"
-        ],
-        "summary": "Update ledger settings",
-        "parameters": [
-          {
-            "type": "string",
-            "description": "Authorization Bearer Token with format: Bearer {token}",
-            "name": "Authorization",
-            "in": "header",
-            "required": true
-          },
-          {
-            "type": "string",
-            "description": "Request ID for tracing",
-            "name": "X-Request-Id",
-            "in": "header"
-          },
-          {
-            "type": "string",
-            "description": "Organization ID in UUID format",
-            "name": "organization_id",
-            "in": "path",
-            "required": true
-          },
-          {
-            "type": "string",
-            "description": "Ledger ID in UUID format",
-            "name": "id",
-            "in": "path",
-            "required": true
-          },
-          {
-            "description": "Settings to merge with existing settings. Only known fields allowed: accounting.validateAccountType (bool), accounting.validateRoutes (bool)",
-            "name": "settings",
-            "in": "body",
-            "required": true,
-            "schema": {
-              "type": "object"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successfully updated ledger settings",
-            "schema": {
-              "$ref": "#/definitions/mmodel.LedgerSettings"
-            }
-          },
-          "400": {
-            "description": "Invalid request body, unknown field (0147), or invalid field type (0148)",
-            "schema": {
-              "$ref": "#/definitions/Error"
-            }
-          },
-          "401": {
-            "description": "Unauthorized access",
-            "schema": {
-              "$ref": "#/definitions/Error"
-            }
-          },
-          "403": {
-            "description": "Forbidden access",
-            "schema": {
-              "$ref": "#/definitions/Error"
-            }
-          },
-          "404": {
-            "description": "Ledger not found",
             "schema": {
               "$ref": "#/definitions/Error"
             }
@@ -1409,7 +1247,7 @@ const docTemplate = `
         }
       }
     },
-    "/v1/organizations/{organization_id}/ledgers/{ledger_id}/account-types/{id}": {
+    "/v1/organizations/{organization_id}/ledgers/{ledger_id}/account-types/{account_type_id}": {
       "get": {
         "description": "Returns detailed information about an account type identified by its UUID within the specified ledger",
         "produces": [
@@ -1450,7 +1288,7 @@ const docTemplate = `
           {
             "type": "string",
             "description": "Account Type ID in UUID format",
-            "name": "id",
+            "name": "account_type_id",
             "in": "path",
             "required": true
           }
@@ -1528,7 +1366,7 @@ const docTemplate = `
           {
             "type": "string",
             "description": "Account Type ID in UUID format",
-            "name": "id",
+            "name": "account_type_id",
             "in": "path",
             "required": true
           }
@@ -1600,7 +1438,7 @@ const docTemplate = `
           {
             "type": "string",
             "description": "Account Type ID in UUID format",
-            "name": "id",
+            "name": "account_type_id",
             "in": "path",
             "required": true
           },
@@ -2319,6 +2157,266 @@ const docTemplate = `
         }
       }
     },
+    "/v1/organizations/{organization_id}/ledgers/{ledger_id}/accounts/{account_id}": {
+      "get": {
+        "description": "Returns detailed information about an account identified by its UUID within the specified ledger",
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "Accounts"
+        ],
+        "summary": "Retrieve a specific account",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "Authorization Bearer Token with format: Bearer {token}",
+            "name": "Authorization",
+            "in": "header",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "Request ID for tracing",
+            "name": "X-Request-Id",
+            "in": "header"
+          },
+          {
+            "type": "string",
+            "description": "Organization ID in UUID format",
+            "name": "organization_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "Ledger ID in UUID format",
+            "name": "ledger_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "Account ID in UUID format",
+            "name": "account_id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully retrieved account",
+            "schema": {
+              "$ref": "#/definitions/Account"
+            }
+          },
+          "401": {
+            "description": "Unauthorized access",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "403": {
+            "description": "Forbidden access",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "404": {
+            "description": "Account, ledger, or organization not found",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      },
+      "delete": {
+        "description": "Permanently removes an account from the specified ledger. This operation cannot be undone.",
+        "tags": [
+          "Accounts"
+        ],
+        "summary": "Delete an account",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "Authorization Bearer Token with format: Bearer {token}",
+            "name": "Authorization",
+            "in": "header",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "Request ID for tracing",
+            "name": "X-Request-Id",
+            "in": "header"
+          },
+          {
+            "type": "string",
+            "description": "Organization ID in UUID format",
+            "name": "organization_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "Ledger ID in UUID format",
+            "name": "ledger_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "Account ID in UUID format",
+            "name": "account_id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Account successfully deleted"
+          },
+          "401": {
+            "description": "Unauthorized access",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "403": {
+            "description": "Forbidden access",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "404": {
+            "description": "Account, ledger, or organization not found",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "409": {
+            "description": "Conflict: Account cannot be deleted due to existing dependencies",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      },
+      "patch": {
+        "description": "Updates an existing account's properties such as name, status, portfolio, segment, and metadata within the specified ledger",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "Accounts"
+        ],
+        "summary": "Update an account",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "Authorization Bearer Token with format: Bearer {token}",
+            "name": "Authorization",
+            "in": "header",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "Request ID for tracing",
+            "name": "X-Request-Id",
+            "in": "header"
+          },
+          {
+            "type": "string",
+            "description": "Organization ID in UUID format",
+            "name": "organization_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "Ledger ID in UUID format",
+            "name": "ledger_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "Account ID in UUID format",
+            "name": "account_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "description": "Account properties to update including name, status, portfolio, segment, and optional metadata",
+            "name": "account",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/UpdateAccountInput"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully updated account",
+            "schema": {
+              "$ref": "#/definitions/Account"
+            }
+          },
+          "400": {
+            "description": "Invalid input, validation errors",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "401": {
+            "description": "Unauthorized access",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "403": {
+            "description": "Forbidden access",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "404": {
+            "description": "Account, ledger, organization, portfolio, or segment not found",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "409": {
+            "description": "Conflict: Account with the same name already exists",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
     "/v1/organizations/{organization_id}/ledgers/{ledger_id}/accounts/{account_id}/balances": {
       "get": {
         "description": "Get all balances by account id",
@@ -2886,266 +2984,6 @@ const docTemplate = `
           },
           "404": {
             "description": "Operation not found",
-            "schema": {
-              "$ref": "#/definitions/Error"
-            }
-          },
-          "500": {
-            "description": "Internal server error",
-            "schema": {
-              "$ref": "#/definitions/Error"
-            }
-          }
-        }
-      }
-    },
-    "/v1/organizations/{organization_id}/ledgers/{ledger_id}/accounts/{id}": {
-      "get": {
-        "description": "Returns detailed information about an account identified by its UUID within the specified ledger",
-        "produces": [
-          "application/json"
-        ],
-        "tags": [
-          "Accounts"
-        ],
-        "summary": "Retrieve a specific account",
-        "parameters": [
-          {
-            "type": "string",
-            "description": "Authorization Bearer Token with format: Bearer {token}",
-            "name": "Authorization",
-            "in": "header",
-            "required": true
-          },
-          {
-            "type": "string",
-            "description": "Request ID for tracing",
-            "name": "X-Request-Id",
-            "in": "header"
-          },
-          {
-            "type": "string",
-            "description": "Organization ID in UUID format",
-            "name": "organization_id",
-            "in": "path",
-            "required": true
-          },
-          {
-            "type": "string",
-            "description": "Ledger ID in UUID format",
-            "name": "ledger_id",
-            "in": "path",
-            "required": true
-          },
-          {
-            "type": "string",
-            "description": "Account ID in UUID format",
-            "name": "id",
-            "in": "path",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successfully retrieved account",
-            "schema": {
-              "$ref": "#/definitions/Account"
-            }
-          },
-          "401": {
-            "description": "Unauthorized access",
-            "schema": {
-              "$ref": "#/definitions/Error"
-            }
-          },
-          "403": {
-            "description": "Forbidden access",
-            "schema": {
-              "$ref": "#/definitions/Error"
-            }
-          },
-          "404": {
-            "description": "Account, ledger, or organization not found",
-            "schema": {
-              "$ref": "#/definitions/Error"
-            }
-          },
-          "500": {
-            "description": "Internal server error",
-            "schema": {
-              "$ref": "#/definitions/Error"
-            }
-          }
-        }
-      },
-      "delete": {
-        "description": "Permanently removes an account from the specified ledger. This operation cannot be undone.",
-        "tags": [
-          "Accounts"
-        ],
-        "summary": "Delete an account",
-        "parameters": [
-          {
-            "type": "string",
-            "description": "Authorization Bearer Token with format: Bearer {token}",
-            "name": "Authorization",
-            "in": "header",
-            "required": true
-          },
-          {
-            "type": "string",
-            "description": "Request ID for tracing",
-            "name": "X-Request-Id",
-            "in": "header"
-          },
-          {
-            "type": "string",
-            "description": "Organization ID in UUID format",
-            "name": "organization_id",
-            "in": "path",
-            "required": true
-          },
-          {
-            "type": "string",
-            "description": "Ledger ID in UUID format",
-            "name": "ledger_id",
-            "in": "path",
-            "required": true
-          },
-          {
-            "type": "string",
-            "description": "Account ID in UUID format",
-            "name": "id",
-            "in": "path",
-            "required": true
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "Account successfully deleted"
-          },
-          "401": {
-            "description": "Unauthorized access",
-            "schema": {
-              "$ref": "#/definitions/Error"
-            }
-          },
-          "403": {
-            "description": "Forbidden access",
-            "schema": {
-              "$ref": "#/definitions/Error"
-            }
-          },
-          "404": {
-            "description": "Account, ledger, or organization not found",
-            "schema": {
-              "$ref": "#/definitions/Error"
-            }
-          },
-          "409": {
-            "description": "Conflict: Account cannot be deleted due to existing dependencies",
-            "schema": {
-              "$ref": "#/definitions/Error"
-            }
-          },
-          "500": {
-            "description": "Internal server error",
-            "schema": {
-              "$ref": "#/definitions/Error"
-            }
-          }
-        }
-      },
-      "patch": {
-        "description": "Updates an existing account's properties such as name, status, portfolio, segment, and metadata within the specified ledger",
-        "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/json"
-        ],
-        "tags": [
-          "Accounts"
-        ],
-        "summary": "Update an account",
-        "parameters": [
-          {
-            "type": "string",
-            "description": "Authorization Bearer Token with format: Bearer {token}",
-            "name": "Authorization",
-            "in": "header",
-            "required": true
-          },
-          {
-            "type": "string",
-            "description": "Request ID for tracing",
-            "name": "X-Request-Id",
-            "in": "header"
-          },
-          {
-            "type": "string",
-            "description": "Organization ID in UUID format",
-            "name": "organization_id",
-            "in": "path",
-            "required": true
-          },
-          {
-            "type": "string",
-            "description": "Ledger ID in UUID format",
-            "name": "ledger_id",
-            "in": "path",
-            "required": true
-          },
-          {
-            "type": "string",
-            "description": "Account ID in UUID format",
-            "name": "id",
-            "in": "path",
-            "required": true
-          },
-          {
-            "description": "Account properties to update including name, status, portfolio, segment, and optional metadata",
-            "name": "account",
-            "in": "body",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/UpdateAccountInput"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successfully updated account",
-            "schema": {
-              "$ref": "#/definitions/Account"
-            }
-          },
-          "400": {
-            "description": "Invalid input, validation errors",
-            "schema": {
-              "$ref": "#/definitions/Error"
-            }
-          },
-          "401": {
-            "description": "Unauthorized access",
-            "schema": {
-              "$ref": "#/definitions/Error"
-            }
-          },
-          "403": {
-            "description": "Forbidden access",
-            "schema": {
-              "$ref": "#/definitions/Error"
-            }
-          },
-          "404": {
-            "description": "Account, ledger, organization, portfolio, or segment not found",
-            "schema": {
-              "$ref": "#/definitions/Error"
-            }
-          },
-          "409": {
-            "description": "Conflict: Account with the same name already exists",
             "schema": {
               "$ref": "#/definitions/Error"
             }
@@ -3777,7 +3615,7 @@ const docTemplate = `
         }
       }
     },
-    "/v1/organizations/{organization_id}/ledgers/{ledger_id}/assets/{id}": {
+    "/v1/organizations/{organization_id}/ledgers/{ledger_id}/assets/{asset_id}": {
       "get": {
         "description": "Returns detailed information about an asset identified by its UUID within the specified ledger",
         "produces": [
@@ -3818,7 +3656,7 @@ const docTemplate = `
           {
             "type": "string",
             "description": "Asset ID in UUID format",
-            "name": "id",
+            "name": "asset_id",
             "in": "path",
             "required": true
           }
@@ -3893,7 +3731,7 @@ const docTemplate = `
           {
             "type": "string",
             "description": "Asset ID in UUID format",
-            "name": "id",
+            "name": "asset_id",
             "in": "path",
             "required": true
           }
@@ -3977,7 +3815,7 @@ const docTemplate = `
           {
             "type": "string",
             "description": "Asset ID in UUID format",
-            "name": "id",
+            "name": "asset_id",
             "in": "path",
             "required": true
           },
@@ -4722,7 +4560,7 @@ const docTemplate = `
         }
       }
     },
-    "/v1/organizations/{organization_id}/ledgers/{ledger_id}/operation-routes/{id}": {
+    "/v1/organizations/{organization_id}/ledgers/{ledger_id}/operation-routes/{operation_route_id}": {
       "get": {
         "description": "Returns detailed information about an operation route identified by its UUID within the specified ledger",
         "produces": [
@@ -4763,7 +4601,7 @@ const docTemplate = `
           {
             "type": "string",
             "description": "Operation Route ID in UUID format",
-            "name": "id",
+            "name": "operation_route_id",
             "in": "path",
             "required": true
           }
@@ -4782,9 +4620,7 @@ const docTemplate = `
             }
           }
         }
-      }
-    },
-    "/v1/organizations/{organization_id}/ledgers/{ledger_id}/operation-routes/{operation_route_id}": {
+      },
       "delete": {
         "description": "Deletes an existing operation route identified by its UUID within the specified ledger",
         "produces": [
@@ -5264,7 +5100,7 @@ const docTemplate = `
         }
       }
     },
-    "/v1/organizations/{organization_id}/ledgers/{ledger_id}/portfolios/{id}": {
+    "/v1/organizations/{organization_id}/ledgers/{ledger_id}/portfolios/{portfolio_id}": {
       "get": {
         "description": "Returns detailed information about a portfolio identified by its UUID within the specified ledger",
         "produces": [
@@ -5305,7 +5141,7 @@ const docTemplate = `
           {
             "type": "string",
             "description": "Portfolio ID in UUID format",
-            "name": "id",
+            "name": "portfolio_id",
             "in": "path",
             "required": true
           }
@@ -5380,7 +5216,7 @@ const docTemplate = `
           {
             "type": "string",
             "description": "Portfolio ID in UUID format",
-            "name": "id",
+            "name": "portfolio_id",
             "in": "path",
             "required": true
           }
@@ -5464,7 +5300,7 @@ const docTemplate = `
           {
             "type": "string",
             "description": "Portfolio ID in UUID format",
-            "name": "id",
+            "name": "portfolio_id",
             "in": "path",
             "required": true
           },
@@ -5825,7 +5661,7 @@ const docTemplate = `
         }
       }
     },
-    "/v1/organizations/{organization_id}/ledgers/{ledger_id}/segments/{id}": {
+    "/v1/organizations/{organization_id}/ledgers/{ledger_id}/segments/{segment_id}": {
       "get": {
         "description": "Returns detailed information about a segment identified by its UUID within the specified ledger",
         "produces": [
@@ -5866,7 +5702,7 @@ const docTemplate = `
           {
             "type": "string",
             "description": "Segment ID in UUID format",
-            "name": "id",
+            "name": "segment_id",
             "in": "path",
             "required": true
           }
@@ -5941,7 +5777,7 @@ const docTemplate = `
           {
             "type": "string",
             "description": "Segment ID in UUID format",
-            "name": "id",
+            "name": "segment_id",
             "in": "path",
             "required": true
           }
@@ -6025,7 +5861,7 @@ const docTemplate = `
           {
             "type": "string",
             "description": "Segment ID in UUID format",
-            "name": "id",
+            "name": "segment_id",
             "in": "path",
             "required": true
           },
@@ -6072,6 +5908,168 @@ const docTemplate = `
           },
           "409": {
             "description": "Conflict: Segment with the same name already exists",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/v1/organizations/{organization_id}/ledgers/{ledger_id}/settings": {
+      "get": {
+        "description": "Returns the current configuration settings for a specific ledger. If no settings have been persisted, returns the default settings object.",
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "Ledgers"
+        ],
+        "summary": "Get ledger settings",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "Authorization Bearer Token with format: Bearer {token}",
+            "name": "Authorization",
+            "in": "header",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "Request ID for tracing",
+            "name": "X-Request-Id",
+            "in": "header"
+          },
+          {
+            "type": "string",
+            "description": "Organization ID in UUID format",
+            "name": "organization_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "Ledger ID in UUID format",
+            "name": "ledger_id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully retrieved ledger settings",
+            "schema": {
+              "$ref": "#/definitions/mmodel.LedgerSettings"
+            }
+          },
+          "401": {
+            "description": "Unauthorized access",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "403": {
+            "description": "Forbidden access",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "404": {
+            "description": "Ledger not found",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      },
+      "patch": {
+        "description": "Updates the configuration settings for a specific ledger using schema-aware deep merge. Only known settings fields are allowed - unknown fields return error 0147 (ErrUnknownSettingsField). Type validation is enforced - incorrect types return error 0148 (ErrInvalidSettingsFieldType). Nested objects (like 'accounting') are deep-merged, preserving existing properties not specified in the update. Example: updating only 'accounting.validateRoutes' preserves the existing 'accounting.validateAccountType' value. Allowed fields: accounting.validateAccountType (boolean), accounting.validateRoutes (boolean).",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "Ledgers"
+        ],
+        "summary": "Update ledger settings",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "Authorization Bearer Token with format: Bearer {token}",
+            "name": "Authorization",
+            "in": "header",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "Request ID for tracing",
+            "name": "X-Request-Id",
+            "in": "header"
+          },
+          {
+            "type": "string",
+            "description": "Organization ID in UUID format",
+            "name": "organization_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "Ledger ID in UUID format",
+            "name": "ledger_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "description": "Settings to merge with existing settings. Only known fields allowed: accounting.validateAccountType (bool), accounting.validateRoutes (bool)",
+            "name": "settings",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully updated ledger settings",
+            "schema": {
+              "$ref": "#/definitions/mmodel.LedgerSettings"
+            }
+          },
+          "400": {
+            "description": "Invalid request body, unknown field (0147), or invalid field type (0148)",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "401": {
+            "description": "Unauthorized access",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "403": {
+            "description": "Forbidden access",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "404": {
+            "description": "Ledger not found",
             "schema": {
               "$ref": "#/definitions/Error"
             }

--- a/components/ledger/api/docs.go
+++ b/components/ledger/api/docs.go
@@ -8268,7 +8268,7 @@ const docTemplate = `
       }
     },
     "AccountingEntries": {
-      "description": "AccountingEntries object containing optional accounting entries for each action type (direct, hold, commit, cancel, revert).",
+      "description": "AccountingEntries object containing optional accounting entries for each action type (direct, hold, commit, cancel, revert, overdraft, refund).",
       "type": "object",
       "properties": {
         "cancel": {
@@ -8297,6 +8297,14 @@ const docTemplate = `
         },
         "hold": {
           "description": "The accounting entry for the hold action.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/AccountingEntry"
+            }
+          ]
+        },
+        "overdraft": {
+          "description": "The accounting entry for the overdraft lifecycle. Debit rubric classifies\noverdraft usage (deficit grows); credit rubric classifies overdraft\nrepayment (deficit shrinks). Both rubrics are REQUIRED when this entry\nis present.",
           "allOf": [
             {
               "$ref": "#/definitions/AccountingEntry"
@@ -8596,6 +8604,12 @@ const docTemplate = `
           "minimum": 0,
           "example": 500
         },
+        "overdraftUsed": {
+          "description": "OverdraftUsed is populated from OperationSnapshot.OverdraftUsedBefore when this Balance\nrepresents the state BEFORE the operation, or from OperationSnapshot.OverdraftUsedAfter\nwhen it represents the state AFTER. Parsed from the snapshot's string-encoded decimal.\nAlways present under the always-populated wire-shape contract — non-overdraft\noperations carry decimal.Zero. Parse errors on malformed historical rows also\nfall back to decimal.Zero (read-only audit context, never a correctness gate).\nexample: 130\nminimum: 0",
+          "type": "number",
+          "minimum": 0,
+          "example": 130
+        },
         "version": {
           "description": "Balance version after the operation\nexample: 2\nminimum: 0",
           "type": "integer",
@@ -8645,6 +8659,11 @@ const docTemplate = `
           "format": "date-time",
           "example": "2021-01-01T00:00:00Z"
         },
+        "direction": {
+          "description": "Direction is the accounting direction of the balance at the time of\nthe snapshot. One of \"credit\" or \"debit\". Empty string denotes\nlegacy rows predating the overdraft feature.\nexample: credit",
+          "type": "string",
+          "example": "credit"
+        },
         "id": {
           "description": "Unique identifier for the balance (UUID format)\nexample: 00000000-0000-0000-0000-000000000000\nformat: uuid",
           "type": "string",
@@ -8674,6 +8693,19 @@ const docTemplate = `
           "type": "string",
           "format": "uuid",
           "example": "00000000-0000-0000-0000-000000000000"
+        },
+        "overdraftUsed": {
+          "description": "OverdraftUsed is the amount of overdraft consumed at the time of\nthe snapshot. Always non-negative.\nexample: 0",
+          "type": "number",
+          "example": 0
+        },
+        "settings": {
+          "description": "Settings is the per-balance configuration snapshot at the time the\nhistory row was recorded. Nil for legacy balances.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/mmodel.BalanceSettings"
+            }
+          ]
         },
         "updatedAt": {
           "description": "Timestamp when the balance was last updated (RFC3339 format)\nexample: 2021-01-01T00:00:00Z\nformat: date-time",
@@ -8811,11 +8843,24 @@ const docTemplate = `
           "type": "boolean",
           "example": true
         },
+        "direction": {
+          "description": "Direction is the accounting direction of the balance (\"credit\" or\n\"debit\"). Optional at creation; when omitted, defaults to the\naccount's natural direction.\nrequired: false\nexample: credit",
+          "type": "string",
+          "example": "credit"
+        },
         "key": {
           "description": "Unique key for the balance\nrequired: true\nmaxLength: 100\nexample: asset-freeze",
           "type": "string",
           "maxLength": 100,
           "example": "asset-freeze"
+        },
+        "settings": {
+          "description": "Settings is the optional per-balance configuration (overdraft,\nbalance scope). When omitted, platform defaults are applied.\nrequired: false",
+          "allOf": [
+            {
+              "$ref": "#/definitions/mmodel.BalanceSettings"
+            }
+          ]
         }
       }
     },
@@ -9150,7 +9195,7 @@ const docTemplate = `
       }
     },
     "CreateTransactionInflowInput": {
-      "description": "CreateTransactionInflowInput is the input payload to create an inflow transaction. Contains all necessary fields to create a financial transaction without source information, only destination.",
+      "description": "CreateTransactionInflowInput is the input payload to create an inflow transaction. Contains all necessary fields to create a financial transaction without source information, only destination. Pending is not supported for inflows because the auto-filled external source account cannot hold funds.",
       "type": "object",
       "required": [
         "send"
@@ -10499,6 +10544,14 @@ const docTemplate = `
           "description": "Whether the account should be allowed to send funds from this balance\nrequired: false\nexample: true",
           "type": "boolean",
           "example": true
+        },
+        "settings": {
+          "description": "Settings is the per-balance configuration (overdraft, balance\nscope). When provided, replaces the existing settings in full.\nDirection is intentionally absent: it is immutable after creation.\nrequired: false",
+          "allOf": [
+            {
+              "$ref": "#/definitions/mmodel.BalanceSettings"
+            }
+          ]
         }
       }
     },
@@ -10825,6 +10878,11 @@ const docTemplate = `
           "format": "date-time",
           "example": "2021-01-01T00:00:00Z"
         },
+        "direction": {
+          "description": "Direction is the accounting direction of the balance. One of\n\"credit\" or \"debit\". Empty string denotes legacy rows predating the\noverdraft feature and is treated as \"credit\" by the engine.\nexample: credit",
+          "type": "string",
+          "example": "credit"
+        },
         "id": {
           "description": "Unique identifier for the balance (UUID format)\nexample: 00000000-0000-0000-0000-000000000000\nformat: uuid",
           "type": "string",
@@ -10860,6 +10918,19 @@ const docTemplate = `
           "format": "uuid",
           "example": "00000000-0000-0000-0000-000000000000"
         },
+        "overdraftUsed": {
+          "description": "OverdraftUsed is the amount of overdraft currently consumed by this\nbalance. Always non-negative; zero when the balance is in the black.\nexample: 0",
+          "type": "number",
+          "example": 0
+        },
+        "settings": {
+          "description": "Settings carries optional per-balance configuration (overdraft,\nbalance scope). Nil for legacy balances without custom settings.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/mmodel.BalanceSettings"
+            }
+          ]
+        },
         "updatedAt": {
           "description": "Timestamp when the balance was last updated (RFC3339 format)\nexample: 2021-01-01T00:00:00Z\nformat: date-time",
           "type": "string",
@@ -10871,6 +10942,32 @@ const docTemplate = `
           "type": "integer",
           "minimum": 1,
           "example": 1
+        }
+      }
+    },
+    "mmodel.BalanceSettings": {
+      "description": "Optional per-balance configuration controlling overdraft behavior and balance scope.",
+      "type": "object",
+      "properties": {
+        "allowOverdraft": {
+          "description": "AllowOverdraft enables overdraft behavior for the balance. When false,\ntransactions that would drive Available below zero are rejected.\nexample: false",
+          "type": "boolean",
+          "example": false
+        },
+        "balanceScope": {
+          "description": "BalanceScope identifies how the balance participates in transactions.\nAllowed values: \"transactional\" (default), \"internal\". Empty string is\ntreated as \"transactional\" for backwards compatibility.\nexample: transactional",
+          "type": "string",
+          "example": "transactional"
+        },
+        "overdraftLimit": {
+          "description": "OverdraftLimit is the maximum overdraft amount the balance may carry,\nexpressed as a decimal string (to preserve precision). Ignored when\nOverdraftLimitEnabled is false.\nexample: 1000.00",
+          "type": "string",
+          "example": "1000.00"
+        },
+        "overdraftLimitEnabled": {
+          "description": "OverdraftLimitEnabled gates the OverdraftLimit field. When true, a\nnon-empty, strictly positive OverdraftLimit MUST be supplied. When\nfalse, OverdraftLimit MUST be absent (overdraft is unlimited if\nAllowOverdraft is true).\nexample: false",
+          "type": "boolean",
+          "example": false
         }
       }
     },

--- a/components/ledger/api/openapi.yaml
+++ b/components/ledger/api/openapi.yaml
@@ -6894,7 +6894,7 @@ components:
       type: object
     AccountingEntries:
       description: AccountingEntries object containing optional accounting entries
-        for each action type (direct, hold, commit, cancel, revert).
+        for each action type (direct, hold, commit, cancel, revert, overdraft, refund).
       properties:
         cancel:
           allOf:
@@ -6915,6 +6915,15 @@ components:
           allOf:
           - $ref: '#/components/schemas/AccountingEntry'
           description: The accounting entry for the hold action.
+          type: object
+        overdraft:
+          allOf:
+          - $ref: '#/components/schemas/AccountingEntry'
+          description: |-
+            The accounting entry for the overdraft lifecycle. Debit rubric classifies
+            overdraft usage (deficit grows); credit rubric classifies overdraft
+            repayment (deficit shrinks). Both rubrics are REQUIRED when this entry
+            is present.
           type: object
         revert:
           allOf:
@@ -7261,6 +7270,19 @@ components:
           example: 500.0
           minimum: 0
           type: number
+        overdraftUsed:
+          description: |-
+            OverdraftUsed is populated from OperationSnapshot.OverdraftUsedBefore when this Balance
+            represents the state BEFORE the operation, or from OperationSnapshot.OverdraftUsedAfter
+            when it represents the state AFTER. Parsed from the snapshot's string-encoded decimal.
+            Always present under the always-populated wire-shape contract — non-overdraft
+            operations carry decimal.Zero. Parse errors on malformed historical rows also
+            fall back to decimal.Zero (read-only audit context, never a correctness gate).
+            example: 130
+            minimum: 0
+          example: 130.0
+          minimum: 0
+          type: number
         version:
           description: |-
             Balance version after the operation
@@ -7275,6 +7297,7 @@ components:
         include permission flags (allowSending/allowReceiving) as these are not tracked
         historically.
       example:
+        settings: '{}'
         assetCode: USD
         onHold: 500.0
         accountType: creditCard
@@ -7284,9 +7307,11 @@ components:
         organizationId: 00000000-0000-0000-0000-000000000000
         accountId: 00000000-0000-0000-0000-000000000000
         createdAt: 2021-01-01T00:00:00Z
+        overdraftUsed: 0.0
         alias: '@person1'
         id: 00000000-0000-0000-0000-000000000000
         key: asset-freeze
+        direction: credit
         updatedAt: 2021-01-01T00:00:00Z
       properties:
         accountId:
@@ -7339,6 +7364,14 @@ components:
           example: 2021-01-01T00:00:00Z
           format: date-time
           type: string
+        direction:
+          description: |-
+            Direction is the accounting direction of the balance at the time of
+            the snapshot. One of "credit" or "debit". Empty string denotes
+            legacy rows predating the overdraft feature.
+            example: credit
+          example: credit
+          type: string
         id:
           description: |-
             Unique identifier for the balance (UUID format)
@@ -7379,6 +7412,20 @@ components:
           example: 00000000-0000-0000-0000-000000000000
           format: uuid
           type: string
+        overdraftUsed:
+          description: |-
+            OverdraftUsed is the amount of overdraft consumed at the time of
+            the snapshot. Always non-negative.
+            example: 0
+          example: 0.0
+          type: number
+        settings:
+          allOf:
+          - $ref: '#/components/schemas/mmodel.BalanceSettings'
+          description: |-
+            Settings is the per-balance configuration snapshot at the time the
+            history row was recorded. Nil for legacy balances.
+          type: object
         updatedAt:
           description: |-
             Timestamp when the balance was last updated (RFC3339 format)
@@ -7547,9 +7594,11 @@ components:
       description: Request payload for creating a new balance with specified permissions
         and custom key.
       example:
+        settings: '{}'
         allowReceiving: true
         allowSending: true
         key: asset-freeze
+        direction: credit
       properties:
         allowReceiving:
           description: |-
@@ -7565,6 +7614,15 @@ components:
             example: true
           example: true
           type: boolean
+        direction:
+          description: |-
+            Direction is the accounting direction of the balance ("credit" or
+            "debit"). Optional at creation; when omitted, defaults to the
+            account's natural direction.
+            required: false
+            example: credit
+          example: credit
+          type: string
         key:
           description: |-
             Unique key for the balance
@@ -7574,6 +7632,14 @@ components:
           example: asset-freeze
           maxLength: 100
           type: string
+        settings:
+          allOf:
+          - $ref: '#/components/schemas/mmodel.BalanceSettings'
+          description: |-
+            Settings is the optional per-balance configuration (overdraft,
+            balance scope). When omitted, platform defaults are applied.
+            required: false
+          type: object
       required:
       - key
       type: object
@@ -7988,7 +8054,8 @@ components:
     CreateTransactionInflowInput:
       description: CreateTransactionInflowInput is the input payload to create an
         inflow transaction. Contains all necessary fields to create a financial transaction
-        without source information, only destination.
+        without source information, only destination. Pending is not supported for
+        inflows because the auto-filled external source account cannot hold funds.
       example:
         metadata:
           key: '{}'
@@ -9639,6 +9706,7 @@ components:
         All fields are optional - only specified fields will be updated. Omitted fields
         will remain unchanged.
       example:
+        settings: '{}'
         allowReceiving: true
         allowSending: true
       properties:
@@ -9656,6 +9724,15 @@ components:
             example: true
           example: true
           type: boolean
+        settings:
+          allOf:
+          - $ref: '#/components/schemas/mmodel.BalanceSettings'
+          description: |-
+            Settings is the per-balance configuration (overdraft, balance
+            scope). When provided, replaces the existing settings in full.
+            Direction is intentionally absent: it is immutable after creation.
+            required: false
+          type: object
       type: object
     UpdateLedgerInput:
       description: Request payload for updating an existing ledger. All fields are
@@ -9988,6 +10065,7 @@ components:
         for balance operations. Balances represent the amount of a specific asset
         held in an account, including available and on-hold amounts.
       example:
+        settings: '{}'
         metadata:
           key: '{}'
         assetCode: USD
@@ -10002,9 +10080,11 @@ components:
         accountId: 00000000-0000-0000-0000-000000000000
         createdAt: 2021-01-01T00:00:00Z
         deletedAt: 2021-01-01T00:00:00Z
+        overdraftUsed: 0.0
         alias: '@person1'
         id: 00000000-0000-0000-0000-000000000000
         key: asset-freeze
+        direction: credit
         updatedAt: 2021-01-01T00:00:00Z
       properties:
         accountId:
@@ -10077,6 +10157,14 @@ components:
           example: 2021-01-01T00:00:00Z
           format: date-time
           type: string
+        direction:
+          description: |-
+            Direction is the accounting direction of the balance. One of
+            "credit" or "debit". Empty string denotes legacy rows predating the
+            overdraft feature and is treated as "credit" by the engine.
+            example: credit
+          example: credit
+          type: string
         id:
           description: |-
             Unique identifier for the balance (UUID format)
@@ -10124,6 +10212,20 @@ components:
           example: 00000000-0000-0000-0000-000000000000
           format: uuid
           type: string
+        overdraftUsed:
+          description: |-
+            OverdraftUsed is the amount of overdraft currently consumed by this
+            balance. Always non-negative; zero when the balance is in the black.
+            example: 0
+          example: 0.0
+          type: number
+        settings:
+          allOf:
+          - $ref: '#/components/schemas/mmodel.BalanceSettings'
+          description: |-
+            Settings carries optional per-balance configuration (overdraft,
+            balance scope). Nil for legacy balances without custom settings.
+          type: object
         updatedAt:
           description: |-
             Timestamp when the balance was last updated (RFC3339 format)
@@ -10140,6 +10242,43 @@ components:
           example: 1
           minimum: 1
           type: integer
+      type: object
+    mmodel.BalanceSettings:
+      description: Optional per-balance configuration controlling overdraft behavior
+        and balance scope.
+      properties:
+        allowOverdraft:
+          description: |-
+            AllowOverdraft enables overdraft behavior for the balance. When false,
+            transactions that would drive Available below zero are rejected.
+            example: false
+          example: false
+          type: boolean
+        balanceScope:
+          description: |-
+            BalanceScope identifies how the balance participates in transactions.
+            Allowed values: "transactional" (default), "internal". Empty string is
+            treated as "transactional" for backwards compatibility.
+            example: transactional
+          example: transactional
+          type: string
+        overdraftLimit:
+          description: |-
+            OverdraftLimit is the maximum overdraft amount the balance may carry,
+            expressed as a decimal string (to preserve precision). Ignored when
+            OverdraftLimitEnabled is false.
+            example: 1000.00
+          example: "1000.00"
+          type: string
+        overdraftLimitEnabled:
+          description: |-
+            OverdraftLimitEnabled gates the OverdraftLimit field. When true, a
+            non-empty, strictly positive OverdraftLimit MUST be supplied. When
+            false, OverdraftLimit MUST be absent (overdraft is unlimited if
+            AllowOverdraft is true).
+            example: false
+          example: false
+          type: boolean
       type: object
     mmodel.LedgerSettings:
       example:
@@ -10332,7 +10471,8 @@ components:
           page: 6
           items: '{}'
         items:
-        - metadata:
+        - settings: '{}'
+          metadata:
             key: '{}'
           assetCode: USD
           onHold: 500.0
@@ -10346,11 +10486,14 @@ components:
           accountId: 00000000-0000-0000-0000-000000000000
           createdAt: 2021-01-01T00:00:00Z
           deletedAt: 2021-01-01T00:00:00Z
+          overdraftUsed: 0.0
           alias: '@person1'
           id: 00000000-0000-0000-0000-000000000000
           key: asset-freeze
+          direction: credit
           updatedAt: 2021-01-01T00:00:00Z
-        - metadata:
+        - settings: '{}'
+          metadata:
             key: '{}'
           assetCode: USD
           onHold: 500.0
@@ -10364,9 +10507,11 @@ components:
           accountId: 00000000-0000-0000-0000-000000000000
           createdAt: 2021-01-01T00:00:00Z
           deletedAt: 2021-01-01T00:00:00Z
+          overdraftUsed: 0.0
           alias: '@person1'
           id: 00000000-0000-0000-0000-000000000000
           key: asset-freeze
+          direction: credit
           updatedAt: 2021-01-01T00:00:00Z
       properties:
         http.Pagination:

--- a/components/ledger/api/openapi.yaml
+++ b/components/ledger/api/openapi.yaml
@@ -6,11 +6,11 @@ info:
   description: This is a swagger documentation for the Midaz Ledger API (unified onboarding
     + transaction)
   license:
-    name: Apache 2.0
-    url: http://www.apache.org/licenses/LICENSE-2.0.html
+    name: Elastic License 2.0
+    url: https://www.elastic.co/licensing/elastic-license
   termsOfService: http://swagger.io/terms/
   title: Midaz Ledger API
-  version: v1.48.0
+  version: v3.7.0
 servers:
 - url: //localhost:3000/
 paths:
@@ -223,7 +223,7 @@ paths:
       summary: Count total organizations
       tags:
       - Organizations
-  /v1/organizations/{id}:
+  /v1/organizations/{organization_id}:
     delete:
       description: 'Permanently removes an organization identified by its UUID. Note:
         This operation is not available in production environments.'
@@ -241,7 +241,7 @@ paths:
           type: string
       - description: Organization ID in UUID format
         in: path
-        name: id
+        name: organization_id
         required: true
         schema:
           type: string
@@ -299,7 +299,7 @@ paths:
           type: string
       - description: Organization ID in UUID format
         in: path
-        name: id
+        name: organization_id
         required: true
         schema:
           type: string
@@ -354,7 +354,7 @@ paths:
           type: string
       - description: Organization ID in UUID format
         in: path
-        name: id
+        name: organization_id
         required: true
         schema:
           type: string
@@ -634,7 +634,7 @@ paths:
       summary: Count total ledgers
       tags:
       - Ledgers
-  /v1/organizations/{organization_id}/ledgers/{id}:
+  /v1/organizations/{organization_id}/ledgers/{ledger_id}:
     delete:
       description: 'Permanently removes a ledger identified by its UUID. Note: This
         operation is not available in production environments.'
@@ -658,7 +658,7 @@ paths:
           type: string
       - description: Ledger ID in UUID format
         in: path
-        name: id
+        name: ledger_id
         required: true
         schema:
           type: string
@@ -722,7 +722,7 @@ paths:
           type: string
       - description: Ledger ID in UUID format
         in: path
-        name: id
+        name: ledger_id
         required: true
         schema:
           type: string
@@ -783,7 +783,7 @@ paths:
           type: string
       - description: Ledger ID in UUID format
         in: path
-        name: id
+        name: ledger_id
         required: true
         schema:
           type: string
@@ -835,152 +835,6 @@ paths:
       tags:
       - Ledgers
       x-codegen-request-body-name: ledger
-  /v1/organizations/{organization_id}/ledgers/{id}/settings:
-    get:
-      description: Returns the current configuration settings for a specific ledger.
-        If no settings have been persisted, returns the default settings object.
-      parameters:
-      - description: 'Authorization Bearer Token with format: Bearer {token}'
-        in: header
-        name: Authorization
-        required: true
-        schema:
-          type: string
-      - description: Request ID for tracing
-        in: header
-        name: X-Request-Id
-        schema:
-          type: string
-      - description: Organization ID in UUID format
-        in: path
-        name: organization_id
-        required: true
-        schema:
-          type: string
-      - description: Ledger ID in UUID format
-        in: path
-        name: id
-        required: true
-        schema:
-          type: string
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/mmodel.LedgerSettings'
-          description: Successfully retrieved ledger settings
-        "401":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-          description: Unauthorized access
-        "403":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-          description: Forbidden access
-        "404":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-          description: Ledger not found
-        "500":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-          description: Internal server error
-      summary: Get ledger settings
-      tags:
-      - Ledgers
-    patch:
-      description: 'Updates the configuration settings for a specific ledger using
-        schema-aware deep merge. Only known settings fields are allowed - unknown
-        fields return error 0147 (ErrUnknownSettingsField). Type validation is enforced
-        - incorrect types return error 0148 (ErrInvalidSettingsFieldType). Nested
-        objects (like ''accounting'') are deep-merged, preserving existing properties
-        not specified in the update. Example: updating only ''accounting.validateRoutes''
-        preserves the existing ''accounting.validateAccountType'' value. Allowed fields:
-        accounting.validateAccountType (boolean), accounting.validateRoutes (boolean).'
-      parameters:
-      - description: 'Authorization Bearer Token with format: Bearer {token}'
-        in: header
-        name: Authorization
-        required: true
-        schema:
-          type: string
-      - description: Request ID for tracing
-        in: header
-        name: X-Request-Id
-        schema:
-          type: string
-      - description: Organization ID in UUID format
-        in: path
-        name: organization_id
-        required: true
-        schema:
-          type: string
-      - description: Ledger ID in UUID format
-        in: path
-        name: id
-        required: true
-        schema:
-          type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-        description: 'Settings to merge with existing settings. Only known fields
-          allowed: accounting.validateAccountType (bool), accounting.validateRoutes
-          (bool)'
-        required: true
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/mmodel.LedgerSettings'
-          description: Successfully updated ledger settings
-        "400":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-          description: Invalid request body, unknown field (0147), or invalid field
-            type (0148)
-        "401":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-          description: Unauthorized access
-        "403":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-          description: Forbidden access
-        "404":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-          description: Ledger not found
-        "500":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-          description: Internal server error
-      summary: Update ledger settings
-      tags:
-      - Ledgers
-      x-codegen-request-body-name: settings
   /v1/organizations/{organization_id}/ledgers/{ledger_id}/account-types:
     get:
       description: Returns a paginated list of all account types for the specified
@@ -1158,7 +1012,7 @@ paths:
       tags:
       - Account Types
       x-codegen-request-body-name: accountType
-  /v1/organizations/{organization_id}/ledgers/{ledger_id}/account-types/{id}:
+  /v1/organizations/{organization_id}/ledgers/{ledger_id}/account-types/{account_type_id}:
     delete:
       description: Deletes an existing account type identified by its UUID within
         the specified ledger
@@ -1188,7 +1042,7 @@ paths:
           type: string
       - description: Account Type ID in UUID format
         in: path
-        name: id
+        name: account_type_id
         required: true
         schema:
           type: string
@@ -1246,7 +1100,7 @@ paths:
           type: string
       - description: Account Type ID in UUID format
         in: path
-        name: id
+        name: account_type_id
         required: true
         schema:
           type: string
@@ -1312,7 +1166,7 @@ paths:
           type: string
       - description: Account Type ID in UUID format
         in: path
-        name: id
+        name: account_type_id
         required: true
         schema:
           type: string
@@ -1899,6 +1753,232 @@ paths:
       summary: Count accounts
       tags:
       - Accounts
+  /v1/organizations/{organization_id}/ledgers/{ledger_id}/accounts/{account_id}:
+    delete:
+      description: Permanently removes an account from the specified ledger. This
+        operation cannot be undone.
+      parameters:
+      - description: 'Authorization Bearer Token with format: Bearer {token}'
+        in: header
+        name: Authorization
+        required: true
+        schema:
+          type: string
+      - description: Request ID for tracing
+        in: header
+        name: X-Request-Id
+        schema:
+          type: string
+      - description: Organization ID in UUID format
+        in: path
+        name: organization_id
+        required: true
+        schema:
+          type: string
+      - description: Ledger ID in UUID format
+        in: path
+        name: ledger_id
+        required: true
+        schema:
+          type: string
+      - description: Account ID in UUID format
+        in: path
+        name: account_id
+        required: true
+        schema:
+          type: string
+      responses:
+        "204":
+          content: {}
+          description: Account successfully deleted
+        "401":
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unauthorized access
+        "403":
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Forbidden access
+        "404":
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Account, ledger, or organization not found
+        "409":
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: 'Conflict: Account cannot be deleted due to existing dependencies'
+        "500":
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal server error
+      summary: Delete an account
+      tags:
+      - Accounts
+    get:
+      description: Returns detailed information about an account identified by its
+        UUID within the specified ledger
+      parameters:
+      - description: 'Authorization Bearer Token with format: Bearer {token}'
+        in: header
+        name: Authorization
+        required: true
+        schema:
+          type: string
+      - description: Request ID for tracing
+        in: header
+        name: X-Request-Id
+        schema:
+          type: string
+      - description: Organization ID in UUID format
+        in: path
+        name: organization_id
+        required: true
+        schema:
+          type: string
+      - description: Ledger ID in UUID format
+        in: path
+        name: ledger_id
+        required: true
+        schema:
+          type: string
+      - description: Account ID in UUID format
+        in: path
+        name: account_id
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Account'
+          description: Successfully retrieved account
+        "401":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unauthorized access
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Forbidden access
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Account, ledger, or organization not found
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal server error
+      summary: Retrieve a specific account
+      tags:
+      - Accounts
+    patch:
+      description: Updates an existing account's properties such as name, status,
+        portfolio, segment, and metadata within the specified ledger
+      parameters:
+      - description: 'Authorization Bearer Token with format: Bearer {token}'
+        in: header
+        name: Authorization
+        required: true
+        schema:
+          type: string
+      - description: Request ID for tracing
+        in: header
+        name: X-Request-Id
+        schema:
+          type: string
+      - description: Organization ID in UUID format
+        in: path
+        name: organization_id
+        required: true
+        schema:
+          type: string
+      - description: Ledger ID in UUID format
+        in: path
+        name: ledger_id
+        required: true
+        schema:
+          type: string
+      - description: Account ID in UUID format
+        in: path
+        name: account_id
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateAccountInput'
+        description: Account properties to update including name, status, portfolio,
+          segment, and optional metadata
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Account'
+          description: Successfully updated account
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Invalid input, validation errors
+        "401":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unauthorized access
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Forbidden access
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Account, ledger, organization, portfolio, or segment not found
+        "409":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: 'Conflict: Account with the same name already exists'
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal server error
+      summary: Update an account
+      tags:
+      - Accounts
+      x-codegen-request-body-name: account
   /v1/organizations/{organization_id}/ledgers/{ledger_id}/accounts/{account_id}/balances:
     get:
       description: Get all balances by account id
@@ -2363,232 +2443,6 @@ paths:
       summary: Get Operation
       tags:
       - Operations
-  /v1/organizations/{organization_id}/ledgers/{ledger_id}/accounts/{id}:
-    delete:
-      description: Permanently removes an account from the specified ledger. This
-        operation cannot be undone.
-      parameters:
-      - description: 'Authorization Bearer Token with format: Bearer {token}'
-        in: header
-        name: Authorization
-        required: true
-        schema:
-          type: string
-      - description: Request ID for tracing
-        in: header
-        name: X-Request-Id
-        schema:
-          type: string
-      - description: Organization ID in UUID format
-        in: path
-        name: organization_id
-        required: true
-        schema:
-          type: string
-      - description: Ledger ID in UUID format
-        in: path
-        name: ledger_id
-        required: true
-        schema:
-          type: string
-      - description: Account ID in UUID format
-        in: path
-        name: id
-        required: true
-        schema:
-          type: string
-      responses:
-        "204":
-          content: {}
-          description: Account successfully deleted
-        "401":
-          content:
-            '*/*':
-              schema:
-                $ref: '#/components/schemas/Error'
-          description: Unauthorized access
-        "403":
-          content:
-            '*/*':
-              schema:
-                $ref: '#/components/schemas/Error'
-          description: Forbidden access
-        "404":
-          content:
-            '*/*':
-              schema:
-                $ref: '#/components/schemas/Error'
-          description: Account, ledger, or organization not found
-        "409":
-          content:
-            '*/*':
-              schema:
-                $ref: '#/components/schemas/Error'
-          description: 'Conflict: Account cannot be deleted due to existing dependencies'
-        "500":
-          content:
-            '*/*':
-              schema:
-                $ref: '#/components/schemas/Error'
-          description: Internal server error
-      summary: Delete an account
-      tags:
-      - Accounts
-    get:
-      description: Returns detailed information about an account identified by its
-        UUID within the specified ledger
-      parameters:
-      - description: 'Authorization Bearer Token with format: Bearer {token}'
-        in: header
-        name: Authorization
-        required: true
-        schema:
-          type: string
-      - description: Request ID for tracing
-        in: header
-        name: X-Request-Id
-        schema:
-          type: string
-      - description: Organization ID in UUID format
-        in: path
-        name: organization_id
-        required: true
-        schema:
-          type: string
-      - description: Ledger ID in UUID format
-        in: path
-        name: ledger_id
-        required: true
-        schema:
-          type: string
-      - description: Account ID in UUID format
-        in: path
-        name: id
-        required: true
-        schema:
-          type: string
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Account'
-          description: Successfully retrieved account
-        "401":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-          description: Unauthorized access
-        "403":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-          description: Forbidden access
-        "404":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-          description: Account, ledger, or organization not found
-        "500":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-          description: Internal server error
-      summary: Retrieve a specific account
-      tags:
-      - Accounts
-    patch:
-      description: Updates an existing account's properties such as name, status,
-        portfolio, segment, and metadata within the specified ledger
-      parameters:
-      - description: 'Authorization Bearer Token with format: Bearer {token}'
-        in: header
-        name: Authorization
-        required: true
-        schema:
-          type: string
-      - description: Request ID for tracing
-        in: header
-        name: X-Request-Id
-        schema:
-          type: string
-      - description: Organization ID in UUID format
-        in: path
-        name: organization_id
-        required: true
-        schema:
-          type: string
-      - description: Ledger ID in UUID format
-        in: path
-        name: ledger_id
-        required: true
-        schema:
-          type: string
-      - description: Account ID in UUID format
-        in: path
-        name: id
-        required: true
-        schema:
-          type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/UpdateAccountInput'
-        description: Account properties to update including name, status, portfolio,
-          segment, and optional metadata
-        required: true
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Account'
-          description: Successfully updated account
-        "400":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-          description: Invalid input, validation errors
-        "401":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-          description: Unauthorized access
-        "403":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-          description: Forbidden access
-        "404":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-          description: Account, ledger, organization, portfolio, or segment not found
-        "409":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-          description: 'Conflict: Account with the same name already exists'
-        "500":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-          description: Internal server error
-      summary: Update an account
-      tags:
-      - Accounts
-      x-codegen-request-body-name: account
   /v1/organizations/{organization_id}/ledgers/{ledger_id}/asset-rates:
     put:
       description: Create or Update an AssetRate with the input details
@@ -3090,7 +2944,7 @@ paths:
       summary: Count total assets
       tags:
       - Assets
-  /v1/organizations/{organization_id}/ledgers/{ledger_id}/assets/{id}:
+  /v1/organizations/{organization_id}/ledgers/{ledger_id}/assets/{asset_id}:
     delete:
       description: Permanently removes an asset from the specified ledger. This operation
         cannot be undone.
@@ -3120,7 +2974,7 @@ paths:
           type: string
       - description: Asset ID in UUID format
         in: path
-        name: id
+        name: asset_id
         required: true
         schema:
           type: string
@@ -3190,7 +3044,7 @@ paths:
           type: string
       - description: Asset ID in UUID format
         in: path
-        name: id
+        name: asset_id
         required: true
         schema:
           type: string
@@ -3257,7 +3111,7 @@ paths:
           type: string
       - description: Asset ID in UUID format
         in: path
-        name: id
+        name: asset_id
         required: true
         schema:
           type: string
@@ -3868,56 +3722,6 @@ paths:
       tags:
       - Operation Route
       x-codegen-request-body-name: operation-route
-  /v1/organizations/{organization_id}/ledgers/{ledger_id}/operation-routes/{id}:
-    get:
-      description: Returns detailed information about an operation route identified
-        by its UUID within the specified ledger
-      parameters:
-      - description: 'Authorization Bearer Token with format: Bearer {token}'
-        in: header
-        name: Authorization
-        required: true
-        schema:
-          type: string
-      - description: Request ID for tracing
-        in: header
-        name: X-Request-Id
-        schema:
-          type: string
-      - description: Organization ID in UUID format
-        in: path
-        name: organization_id
-        required: true
-        schema:
-          type: string
-      - description: Ledger ID in UUID format
-        in: path
-        name: ledger_id
-        required: true
-        schema:
-          type: string
-      - description: Operation Route ID in UUID format
-        in: path
-        name: id
-        required: true
-        schema:
-          type: string
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/OperationRoute'
-          description: Successfully retrieved operation route
-        "401":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-          description: Unauthorized access
-      summary: Retrieve a specific operation route
-      tags:
-      - Operation Route
   /v1/organizations/{organization_id}/ledgers/{ledger_id}/operation-routes/{operation_route_id}:
     delete:
       description: Deletes an existing operation route identified by its UUID within
@@ -3975,6 +3779,55 @@ paths:
                 $ref: '#/components/schemas/Error'
           description: Internal server error
       summary: Delete an operation route
+      tags:
+      - Operation Route
+    get:
+      description: Returns detailed information about an operation route identified
+        by its UUID within the specified ledger
+      parameters:
+      - description: 'Authorization Bearer Token with format: Bearer {token}'
+        in: header
+        name: Authorization
+        required: true
+        schema:
+          type: string
+      - description: Request ID for tracing
+        in: header
+        name: X-Request-Id
+        schema:
+          type: string
+      - description: Organization ID in UUID format
+        in: path
+        name: organization_id
+        required: true
+        schema:
+          type: string
+      - description: Ledger ID in UUID format
+        in: path
+        name: ledger_id
+        required: true
+        schema:
+          type: string
+      - description: Operation Route ID in UUID format
+        in: path
+        name: operation_route_id
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OperationRoute'
+          description: Successfully retrieved operation route
+        "401":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unauthorized access
+      summary: Retrieve a specific operation route
       tags:
       - Operation Route
     patch:
@@ -4319,7 +4172,7 @@ paths:
       summary: Count total portfolios
       tags:
       - Portfolios
-  /v1/organizations/{organization_id}/ledgers/{ledger_id}/portfolios/{id}:
+  /v1/organizations/{organization_id}/ledgers/{ledger_id}/portfolios/{portfolio_id}:
     delete:
       description: Permanently removes a portfolio from the specified ledger. This
         operation cannot be undone.
@@ -4349,7 +4202,7 @@ paths:
           type: string
       - description: Portfolio ID in UUID format
         in: path
-        name: id
+        name: portfolio_id
         required: true
         schema:
           type: string
@@ -4419,7 +4272,7 @@ paths:
           type: string
       - description: Portfolio ID in UUID format
         in: path
-        name: id
+        name: portfolio_id
         required: true
         schema:
           type: string
@@ -4486,7 +4339,7 @@ paths:
           type: string
       - description: Portfolio ID in UUID format
         in: path
-        name: id
+        name: portfolio_id
         required: true
         schema:
           type: string
@@ -4792,7 +4645,7 @@ paths:
       summary: Count segments
       tags:
       - Segments
-  /v1/organizations/{organization_id}/ledgers/{ledger_id}/segments/{id}:
+  /v1/organizations/{organization_id}/ledgers/{ledger_id}/segments/{segment_id}:
     delete:
       description: Permanently removes a segment from the specified ledger. This operation
         cannot be undone.
@@ -4822,7 +4675,7 @@ paths:
           type: string
       - description: Segment ID in UUID format
         in: path
-        name: id
+        name: segment_id
         required: true
         schema:
           type: string
@@ -4892,7 +4745,7 @@ paths:
           type: string
       - description: Segment ID in UUID format
         in: path
-        name: id
+        name: segment_id
         required: true
         schema:
           type: string
@@ -4959,7 +4812,7 @@ paths:
           type: string
       - description: Segment ID in UUID format
         in: path
-        name: id
+        name: segment_id
         required: true
         schema:
           type: string
@@ -5018,6 +4871,152 @@ paths:
       tags:
       - Segments
       x-codegen-request-body-name: segment
+  /v1/organizations/{organization_id}/ledgers/{ledger_id}/settings:
+    get:
+      description: Returns the current configuration settings for a specific ledger.
+        If no settings have been persisted, returns the default settings object.
+      parameters:
+      - description: 'Authorization Bearer Token with format: Bearer {token}'
+        in: header
+        name: Authorization
+        required: true
+        schema:
+          type: string
+      - description: Request ID for tracing
+        in: header
+        name: X-Request-Id
+        schema:
+          type: string
+      - description: Organization ID in UUID format
+        in: path
+        name: organization_id
+        required: true
+        schema:
+          type: string
+      - description: Ledger ID in UUID format
+        in: path
+        name: ledger_id
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/mmodel.LedgerSettings'
+          description: Successfully retrieved ledger settings
+        "401":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unauthorized access
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Forbidden access
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Ledger not found
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal server error
+      summary: Get ledger settings
+      tags:
+      - Ledgers
+    patch:
+      description: 'Updates the configuration settings for a specific ledger using
+        schema-aware deep merge. Only known settings fields are allowed - unknown
+        fields return error 0147 (ErrUnknownSettingsField). Type validation is enforced
+        - incorrect types return error 0148 (ErrInvalidSettingsFieldType). Nested
+        objects (like ''accounting'') are deep-merged, preserving existing properties
+        not specified in the update. Example: updating only ''accounting.validateRoutes''
+        preserves the existing ''accounting.validateAccountType'' value. Allowed fields:
+        accounting.validateAccountType (boolean), accounting.validateRoutes (boolean).'
+      parameters:
+      - description: 'Authorization Bearer Token with format: Bearer {token}'
+        in: header
+        name: Authorization
+        required: true
+        schema:
+          type: string
+      - description: Request ID for tracing
+        in: header
+        name: X-Request-Id
+        schema:
+          type: string
+      - description: Organization ID in UUID format
+        in: path
+        name: organization_id
+        required: true
+        schema:
+          type: string
+      - description: Ledger ID in UUID format
+        in: path
+        name: ledger_id
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+        description: 'Settings to merge with existing settings. Only known fields
+          allowed: accounting.validateAccountType (bool), accounting.validateRoutes
+          (bool)'
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/mmodel.LedgerSettings'
+          description: Successfully updated ledger settings
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Invalid request body, unknown field (0147), or invalid field
+            type (0148)
+        "401":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unauthorized access
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Forbidden access
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Ledger not found
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal server error
+      summary: Update ledger settings
+      tags:
+      - Ledgers
+      x-codegen-request-body-name: settings
   /v1/organizations/{organization_id}/ledgers/{ledger_id}/transaction-routes:
     get:
       description: Endpoint to get all Transaction Routes with optional metadata filtering.

--- a/components/ledger/api/swagger.json
+++ b/components/ledger/api/swagger.json
@@ -9,10 +9,10 @@
       "url": "https://discord.gg/DnhqKwkGv3"
     },
     "license": {
-      "name": "Apache 2.0",
-      "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
+      "name": "Elastic License 2.0",
+      "url": "https://www.elastic.co/licensing/elastic-license"
     },
-    "version": "v3.6.0"
+    "version": "v3.7.0"
   },
   "host": "localhost:3002",
   "basePath": "/",
@@ -272,7 +272,7 @@
         }
       }
     },
-    "/v1/organizations/{id}": {
+    "/v1/organizations/{organization_id}": {
       "get": {
         "description": "Returns detailed information about an organization identified by its UUID",
         "produces": [
@@ -299,7 +299,7 @@
           {
             "type": "string",
             "description": "Organization ID in UUID format",
-            "name": "id",
+            "name": "organization_id",
             "in": "path",
             "required": true
           }
@@ -360,7 +360,7 @@
           {
             "type": "string",
             "description": "Organization ID in UUID format",
-            "name": "id",
+            "name": "organization_id",
             "in": "path",
             "required": true
           }
@@ -430,7 +430,7 @@
           {
             "type": "string",
             "description": "Organization ID in UUID format",
-            "name": "id",
+            "name": "organization_id",
             "in": "path",
             "required": true
           },
@@ -765,7 +765,7 @@
         }
       }
     },
-    "/v1/organizations/{organization_id}/ledgers/{id}": {
+    "/v1/organizations/{organization_id}/ledgers/{ledger_id}": {
       "get": {
         "description": "Returns detailed information about a ledger identified by its UUID within the specified organization",
         "produces": [
@@ -799,7 +799,7 @@
           {
             "type": "string",
             "description": "Ledger ID in UUID format",
-            "name": "id",
+            "name": "ledger_id",
             "in": "path",
             "required": true
           }
@@ -867,7 +867,7 @@
           {
             "type": "string",
             "description": "Ledger ID in UUID format",
-            "name": "id",
+            "name": "ledger_id",
             "in": "path",
             "required": true
           }
@@ -944,7 +944,7 @@
           {
             "type": "string",
             "description": "Ledger ID in UUID format",
-            "name": "id",
+            "name": "ledger_id",
             "in": "path",
             "required": true
           },
@@ -985,168 +985,6 @@
           },
           "404": {
             "description": "Ledger or organization not found",
-            "schema": {
-              "$ref": "#/definitions/Error"
-            }
-          },
-          "500": {
-            "description": "Internal server error",
-            "schema": {
-              "$ref": "#/definitions/Error"
-            }
-          }
-        }
-      }
-    },
-    "/v1/organizations/{organization_id}/ledgers/{id}/settings": {
-      "get": {
-        "description": "Returns the current configuration settings for a specific ledger. If no settings have been persisted, returns the default settings object.",
-        "produces": [
-          "application/json"
-        ],
-        "tags": [
-          "Ledgers"
-        ],
-        "summary": "Get ledger settings",
-        "parameters": [
-          {
-            "type": "string",
-            "description": "Authorization Bearer Token with format: Bearer {token}",
-            "name": "Authorization",
-            "in": "header",
-            "required": true
-          },
-          {
-            "type": "string",
-            "description": "Request ID for tracing",
-            "name": "X-Request-Id",
-            "in": "header"
-          },
-          {
-            "type": "string",
-            "description": "Organization ID in UUID format",
-            "name": "organization_id",
-            "in": "path",
-            "required": true
-          },
-          {
-            "type": "string",
-            "description": "Ledger ID in UUID format",
-            "name": "id",
-            "in": "path",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successfully retrieved ledger settings",
-            "schema": {
-              "$ref": "#/definitions/mmodel.LedgerSettings"
-            }
-          },
-          "401": {
-            "description": "Unauthorized access",
-            "schema": {
-              "$ref": "#/definitions/Error"
-            }
-          },
-          "403": {
-            "description": "Forbidden access",
-            "schema": {
-              "$ref": "#/definitions/Error"
-            }
-          },
-          "404": {
-            "description": "Ledger not found",
-            "schema": {
-              "$ref": "#/definitions/Error"
-            }
-          },
-          "500": {
-            "description": "Internal server error",
-            "schema": {
-              "$ref": "#/definitions/Error"
-            }
-          }
-        }
-      },
-      "patch": {
-        "description": "Updates the configuration settings for a specific ledger using schema-aware deep merge. Only known settings fields are allowed - unknown fields return error 0147 (ErrUnknownSettingsField). Type validation is enforced - incorrect types return error 0148 (ErrInvalidSettingsFieldType). Nested objects (like 'accounting') are deep-merged, preserving existing properties not specified in the update. Example: updating only 'accounting.validateRoutes' preserves the existing 'accounting.validateAccountType' value. Allowed fields: accounting.validateAccountType (boolean), accounting.validateRoutes (boolean).",
-        "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/json"
-        ],
-        "tags": [
-          "Ledgers"
-        ],
-        "summary": "Update ledger settings",
-        "parameters": [
-          {
-            "type": "string",
-            "description": "Authorization Bearer Token with format: Bearer {token}",
-            "name": "Authorization",
-            "in": "header",
-            "required": true
-          },
-          {
-            "type": "string",
-            "description": "Request ID for tracing",
-            "name": "X-Request-Id",
-            "in": "header"
-          },
-          {
-            "type": "string",
-            "description": "Organization ID in UUID format",
-            "name": "organization_id",
-            "in": "path",
-            "required": true
-          },
-          {
-            "type": "string",
-            "description": "Ledger ID in UUID format",
-            "name": "id",
-            "in": "path",
-            "required": true
-          },
-          {
-            "description": "Settings to merge with existing settings. Only known fields allowed: accounting.validateAccountType (bool), accounting.validateRoutes (bool)",
-            "name": "settings",
-            "in": "body",
-            "required": true,
-            "schema": {
-              "type": "object"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successfully updated ledger settings",
-            "schema": {
-              "$ref": "#/definitions/mmodel.LedgerSettings"
-            }
-          },
-          "400": {
-            "description": "Invalid request body, unknown field (0147), or invalid field type (0148)",
-            "schema": {
-              "$ref": "#/definitions/Error"
-            }
-          },
-          "401": {
-            "description": "Unauthorized access",
-            "schema": {
-              "$ref": "#/definitions/Error"
-            }
-          },
-          "403": {
-            "description": "Forbidden access",
-            "schema": {
-              "$ref": "#/definitions/Error"
-            }
-          },
-          "404": {
-            "description": "Ledger not found",
             "schema": {
               "$ref": "#/definitions/Error"
             }
@@ -1385,7 +1223,7 @@
         }
       }
     },
-    "/v1/organizations/{organization_id}/ledgers/{ledger_id}/account-types/{id}": {
+    "/v1/organizations/{organization_id}/ledgers/{ledger_id}/account-types/{account_type_id}": {
       "get": {
         "description": "Returns detailed information about an account type identified by its UUID within the specified ledger",
         "produces": [
@@ -1426,7 +1264,7 @@
           {
             "type": "string",
             "description": "Account Type ID in UUID format",
-            "name": "id",
+            "name": "account_type_id",
             "in": "path",
             "required": true
           }
@@ -1504,7 +1342,7 @@
           {
             "type": "string",
             "description": "Account Type ID in UUID format",
-            "name": "id",
+            "name": "account_type_id",
             "in": "path",
             "required": true
           }
@@ -1576,7 +1414,7 @@
           {
             "type": "string",
             "description": "Account Type ID in UUID format",
-            "name": "id",
+            "name": "account_type_id",
             "in": "path",
             "required": true
           },
@@ -2295,6 +2133,266 @@
         }
       }
     },
+    "/v1/organizations/{organization_id}/ledgers/{ledger_id}/accounts/{account_id}": {
+      "get": {
+        "description": "Returns detailed information about an account identified by its UUID within the specified ledger",
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "Accounts"
+        ],
+        "summary": "Retrieve a specific account",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "Authorization Bearer Token with format: Bearer {token}",
+            "name": "Authorization",
+            "in": "header",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "Request ID for tracing",
+            "name": "X-Request-Id",
+            "in": "header"
+          },
+          {
+            "type": "string",
+            "description": "Organization ID in UUID format",
+            "name": "organization_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "Ledger ID in UUID format",
+            "name": "ledger_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "Account ID in UUID format",
+            "name": "account_id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully retrieved account",
+            "schema": {
+              "$ref": "#/definitions/Account"
+            }
+          },
+          "401": {
+            "description": "Unauthorized access",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "403": {
+            "description": "Forbidden access",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "404": {
+            "description": "Account, ledger, or organization not found",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      },
+      "delete": {
+        "description": "Permanently removes an account from the specified ledger. This operation cannot be undone.",
+        "tags": [
+          "Accounts"
+        ],
+        "summary": "Delete an account",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "Authorization Bearer Token with format: Bearer {token}",
+            "name": "Authorization",
+            "in": "header",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "Request ID for tracing",
+            "name": "X-Request-Id",
+            "in": "header"
+          },
+          {
+            "type": "string",
+            "description": "Organization ID in UUID format",
+            "name": "organization_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "Ledger ID in UUID format",
+            "name": "ledger_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "Account ID in UUID format",
+            "name": "account_id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Account successfully deleted"
+          },
+          "401": {
+            "description": "Unauthorized access",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "403": {
+            "description": "Forbidden access",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "404": {
+            "description": "Account, ledger, or organization not found",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "409": {
+            "description": "Conflict: Account cannot be deleted due to existing dependencies",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      },
+      "patch": {
+        "description": "Updates an existing account's properties such as name, status, portfolio, segment, and metadata within the specified ledger",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "Accounts"
+        ],
+        "summary": "Update an account",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "Authorization Bearer Token with format: Bearer {token}",
+            "name": "Authorization",
+            "in": "header",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "Request ID for tracing",
+            "name": "X-Request-Id",
+            "in": "header"
+          },
+          {
+            "type": "string",
+            "description": "Organization ID in UUID format",
+            "name": "organization_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "Ledger ID in UUID format",
+            "name": "ledger_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "Account ID in UUID format",
+            "name": "account_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "description": "Account properties to update including name, status, portfolio, segment, and optional metadata",
+            "name": "account",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/UpdateAccountInput"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully updated account",
+            "schema": {
+              "$ref": "#/definitions/Account"
+            }
+          },
+          "400": {
+            "description": "Invalid input, validation errors",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "401": {
+            "description": "Unauthorized access",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "403": {
+            "description": "Forbidden access",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "404": {
+            "description": "Account, ledger, organization, portfolio, or segment not found",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "409": {
+            "description": "Conflict: Account with the same name already exists",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
     "/v1/organizations/{organization_id}/ledgers/{ledger_id}/accounts/{account_id}/balances": {
       "get": {
         "description": "Get all balances by account id",
@@ -2862,266 +2960,6 @@
           },
           "404": {
             "description": "Operation not found",
-            "schema": {
-              "$ref": "#/definitions/Error"
-            }
-          },
-          "500": {
-            "description": "Internal server error",
-            "schema": {
-              "$ref": "#/definitions/Error"
-            }
-          }
-        }
-      }
-    },
-    "/v1/organizations/{organization_id}/ledgers/{ledger_id}/accounts/{id}": {
-      "get": {
-        "description": "Returns detailed information about an account identified by its UUID within the specified ledger",
-        "produces": [
-          "application/json"
-        ],
-        "tags": [
-          "Accounts"
-        ],
-        "summary": "Retrieve a specific account",
-        "parameters": [
-          {
-            "type": "string",
-            "description": "Authorization Bearer Token with format: Bearer {token}",
-            "name": "Authorization",
-            "in": "header",
-            "required": true
-          },
-          {
-            "type": "string",
-            "description": "Request ID for tracing",
-            "name": "X-Request-Id",
-            "in": "header"
-          },
-          {
-            "type": "string",
-            "description": "Organization ID in UUID format",
-            "name": "organization_id",
-            "in": "path",
-            "required": true
-          },
-          {
-            "type": "string",
-            "description": "Ledger ID in UUID format",
-            "name": "ledger_id",
-            "in": "path",
-            "required": true
-          },
-          {
-            "type": "string",
-            "description": "Account ID in UUID format",
-            "name": "id",
-            "in": "path",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successfully retrieved account",
-            "schema": {
-              "$ref": "#/definitions/Account"
-            }
-          },
-          "401": {
-            "description": "Unauthorized access",
-            "schema": {
-              "$ref": "#/definitions/Error"
-            }
-          },
-          "403": {
-            "description": "Forbidden access",
-            "schema": {
-              "$ref": "#/definitions/Error"
-            }
-          },
-          "404": {
-            "description": "Account, ledger, or organization not found",
-            "schema": {
-              "$ref": "#/definitions/Error"
-            }
-          },
-          "500": {
-            "description": "Internal server error",
-            "schema": {
-              "$ref": "#/definitions/Error"
-            }
-          }
-        }
-      },
-      "delete": {
-        "description": "Permanently removes an account from the specified ledger. This operation cannot be undone.",
-        "tags": [
-          "Accounts"
-        ],
-        "summary": "Delete an account",
-        "parameters": [
-          {
-            "type": "string",
-            "description": "Authorization Bearer Token with format: Bearer {token}",
-            "name": "Authorization",
-            "in": "header",
-            "required": true
-          },
-          {
-            "type": "string",
-            "description": "Request ID for tracing",
-            "name": "X-Request-Id",
-            "in": "header"
-          },
-          {
-            "type": "string",
-            "description": "Organization ID in UUID format",
-            "name": "organization_id",
-            "in": "path",
-            "required": true
-          },
-          {
-            "type": "string",
-            "description": "Ledger ID in UUID format",
-            "name": "ledger_id",
-            "in": "path",
-            "required": true
-          },
-          {
-            "type": "string",
-            "description": "Account ID in UUID format",
-            "name": "id",
-            "in": "path",
-            "required": true
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "Account successfully deleted"
-          },
-          "401": {
-            "description": "Unauthorized access",
-            "schema": {
-              "$ref": "#/definitions/Error"
-            }
-          },
-          "403": {
-            "description": "Forbidden access",
-            "schema": {
-              "$ref": "#/definitions/Error"
-            }
-          },
-          "404": {
-            "description": "Account, ledger, or organization not found",
-            "schema": {
-              "$ref": "#/definitions/Error"
-            }
-          },
-          "409": {
-            "description": "Conflict: Account cannot be deleted due to existing dependencies",
-            "schema": {
-              "$ref": "#/definitions/Error"
-            }
-          },
-          "500": {
-            "description": "Internal server error",
-            "schema": {
-              "$ref": "#/definitions/Error"
-            }
-          }
-        }
-      },
-      "patch": {
-        "description": "Updates an existing account's properties such as name, status, portfolio, segment, and metadata within the specified ledger",
-        "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/json"
-        ],
-        "tags": [
-          "Accounts"
-        ],
-        "summary": "Update an account",
-        "parameters": [
-          {
-            "type": "string",
-            "description": "Authorization Bearer Token with format: Bearer {token}",
-            "name": "Authorization",
-            "in": "header",
-            "required": true
-          },
-          {
-            "type": "string",
-            "description": "Request ID for tracing",
-            "name": "X-Request-Id",
-            "in": "header"
-          },
-          {
-            "type": "string",
-            "description": "Organization ID in UUID format",
-            "name": "organization_id",
-            "in": "path",
-            "required": true
-          },
-          {
-            "type": "string",
-            "description": "Ledger ID in UUID format",
-            "name": "ledger_id",
-            "in": "path",
-            "required": true
-          },
-          {
-            "type": "string",
-            "description": "Account ID in UUID format",
-            "name": "id",
-            "in": "path",
-            "required": true
-          },
-          {
-            "description": "Account properties to update including name, status, portfolio, segment, and optional metadata",
-            "name": "account",
-            "in": "body",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/UpdateAccountInput"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successfully updated account",
-            "schema": {
-              "$ref": "#/definitions/Account"
-            }
-          },
-          "400": {
-            "description": "Invalid input, validation errors",
-            "schema": {
-              "$ref": "#/definitions/Error"
-            }
-          },
-          "401": {
-            "description": "Unauthorized access",
-            "schema": {
-              "$ref": "#/definitions/Error"
-            }
-          },
-          "403": {
-            "description": "Forbidden access",
-            "schema": {
-              "$ref": "#/definitions/Error"
-            }
-          },
-          "404": {
-            "description": "Account, ledger, organization, portfolio, or segment not found",
-            "schema": {
-              "$ref": "#/definitions/Error"
-            }
-          },
-          "409": {
-            "description": "Conflict: Account with the same name already exists",
             "schema": {
               "$ref": "#/definitions/Error"
             }
@@ -3753,7 +3591,7 @@
         }
       }
     },
-    "/v1/organizations/{organization_id}/ledgers/{ledger_id}/assets/{id}": {
+    "/v1/organizations/{organization_id}/ledgers/{ledger_id}/assets/{asset_id}": {
       "get": {
         "description": "Returns detailed information about an asset identified by its UUID within the specified ledger",
         "produces": [
@@ -3794,7 +3632,7 @@
           {
             "type": "string",
             "description": "Asset ID in UUID format",
-            "name": "id",
+            "name": "asset_id",
             "in": "path",
             "required": true
           }
@@ -3869,7 +3707,7 @@
           {
             "type": "string",
             "description": "Asset ID in UUID format",
-            "name": "id",
+            "name": "asset_id",
             "in": "path",
             "required": true
           }
@@ -3953,7 +3791,7 @@
           {
             "type": "string",
             "description": "Asset ID in UUID format",
-            "name": "id",
+            "name": "asset_id",
             "in": "path",
             "required": true
           },
@@ -4698,7 +4536,7 @@
         }
       }
     },
-    "/v1/organizations/{organization_id}/ledgers/{ledger_id}/operation-routes/{id}": {
+    "/v1/organizations/{organization_id}/ledgers/{ledger_id}/operation-routes/{operation_route_id}": {
       "get": {
         "description": "Returns detailed information about an operation route identified by its UUID within the specified ledger",
         "produces": [
@@ -4739,7 +4577,7 @@
           {
             "type": "string",
             "description": "Operation Route ID in UUID format",
-            "name": "id",
+            "name": "operation_route_id",
             "in": "path",
             "required": true
           }
@@ -4758,9 +4596,7 @@
             }
           }
         }
-      }
-    },
-    "/v1/organizations/{organization_id}/ledgers/{ledger_id}/operation-routes/{operation_route_id}": {
+      },
       "delete": {
         "description": "Deletes an existing operation route identified by its UUID within the specified ledger",
         "produces": [
@@ -5240,7 +5076,7 @@
         }
       }
     },
-    "/v1/organizations/{organization_id}/ledgers/{ledger_id}/portfolios/{id}": {
+    "/v1/organizations/{organization_id}/ledgers/{ledger_id}/portfolios/{portfolio_id}": {
       "get": {
         "description": "Returns detailed information about a portfolio identified by its UUID within the specified ledger",
         "produces": [
@@ -5281,7 +5117,7 @@
           {
             "type": "string",
             "description": "Portfolio ID in UUID format",
-            "name": "id",
+            "name": "portfolio_id",
             "in": "path",
             "required": true
           }
@@ -5356,7 +5192,7 @@
           {
             "type": "string",
             "description": "Portfolio ID in UUID format",
-            "name": "id",
+            "name": "portfolio_id",
             "in": "path",
             "required": true
           }
@@ -5440,7 +5276,7 @@
           {
             "type": "string",
             "description": "Portfolio ID in UUID format",
-            "name": "id",
+            "name": "portfolio_id",
             "in": "path",
             "required": true
           },
@@ -5801,7 +5637,7 @@
         }
       }
     },
-    "/v1/organizations/{organization_id}/ledgers/{ledger_id}/segments/{id}": {
+    "/v1/organizations/{organization_id}/ledgers/{ledger_id}/segments/{segment_id}": {
       "get": {
         "description": "Returns detailed information about a segment identified by its UUID within the specified ledger",
         "produces": [
@@ -5842,7 +5678,7 @@
           {
             "type": "string",
             "description": "Segment ID in UUID format",
-            "name": "id",
+            "name": "segment_id",
             "in": "path",
             "required": true
           }
@@ -5917,7 +5753,7 @@
           {
             "type": "string",
             "description": "Segment ID in UUID format",
-            "name": "id",
+            "name": "segment_id",
             "in": "path",
             "required": true
           }
@@ -6001,7 +5837,7 @@
           {
             "type": "string",
             "description": "Segment ID in UUID format",
-            "name": "id",
+            "name": "segment_id",
             "in": "path",
             "required": true
           },
@@ -6048,6 +5884,168 @@
           },
           "409": {
             "description": "Conflict: Segment with the same name already exists",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/v1/organizations/{organization_id}/ledgers/{ledger_id}/settings": {
+      "get": {
+        "description": "Returns the current configuration settings for a specific ledger. If no settings have been persisted, returns the default settings object.",
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "Ledgers"
+        ],
+        "summary": "Get ledger settings",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "Authorization Bearer Token with format: Bearer {token}",
+            "name": "Authorization",
+            "in": "header",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "Request ID for tracing",
+            "name": "X-Request-Id",
+            "in": "header"
+          },
+          {
+            "type": "string",
+            "description": "Organization ID in UUID format",
+            "name": "organization_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "Ledger ID in UUID format",
+            "name": "ledger_id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully retrieved ledger settings",
+            "schema": {
+              "$ref": "#/definitions/mmodel.LedgerSettings"
+            }
+          },
+          "401": {
+            "description": "Unauthorized access",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "403": {
+            "description": "Forbidden access",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "404": {
+            "description": "Ledger not found",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      },
+      "patch": {
+        "description": "Updates the configuration settings for a specific ledger using schema-aware deep merge. Only known settings fields are allowed - unknown fields return error 0147 (ErrUnknownSettingsField). Type validation is enforced - incorrect types return error 0148 (ErrInvalidSettingsFieldType). Nested objects (like 'accounting') are deep-merged, preserving existing properties not specified in the update. Example: updating only 'accounting.validateRoutes' preserves the existing 'accounting.validateAccountType' value. Allowed fields: accounting.validateAccountType (boolean), accounting.validateRoutes (boolean).",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "Ledgers"
+        ],
+        "summary": "Update ledger settings",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "Authorization Bearer Token with format: Bearer {token}",
+            "name": "Authorization",
+            "in": "header",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "Request ID for tracing",
+            "name": "X-Request-Id",
+            "in": "header"
+          },
+          {
+            "type": "string",
+            "description": "Organization ID in UUID format",
+            "name": "organization_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "Ledger ID in UUID format",
+            "name": "ledger_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "description": "Settings to merge with existing settings. Only known fields allowed: accounting.validateAccountType (bool), accounting.validateRoutes (bool)",
+            "name": "settings",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully updated ledger settings",
+            "schema": {
+              "$ref": "#/definitions/mmodel.LedgerSettings"
+            }
+          },
+          "400": {
+            "description": "Invalid request body, unknown field (0147), or invalid field type (0148)",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "401": {
+            "description": "Unauthorized access",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "403": {
+            "description": "Forbidden access",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "404": {
+            "description": "Ledger not found",
             "schema": {
               "$ref": "#/definitions/Error"
             }

--- a/components/ledger/api/swagger.json
+++ b/components/ledger/api/swagger.json
@@ -8244,7 +8244,7 @@
       }
     },
     "AccountingEntries": {
-      "description": "AccountingEntries object containing optional accounting entries for each action type (direct, hold, commit, cancel, revert).",
+      "description": "AccountingEntries object containing optional accounting entries for each action type (direct, hold, commit, cancel, revert, overdraft, refund).",
       "type": "object",
       "properties": {
         "cancel": {
@@ -8273,6 +8273,14 @@
         },
         "hold": {
           "description": "The accounting entry for the hold action.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/AccountingEntry"
+            }
+          ]
+        },
+        "overdraft": {
+          "description": "The accounting entry for the overdraft lifecycle. Debit rubric classifies\noverdraft usage (deficit grows); credit rubric classifies overdraft\nrepayment (deficit shrinks). Both rubrics are REQUIRED when this entry\nis present.",
           "allOf": [
             {
               "$ref": "#/definitions/AccountingEntry"
@@ -8572,6 +8580,12 @@
           "minimum": 0,
           "example": 500
         },
+        "overdraftUsed": {
+          "description": "OverdraftUsed is populated from OperationSnapshot.OverdraftUsedBefore when this Balance\nrepresents the state BEFORE the operation, or from OperationSnapshot.OverdraftUsedAfter\nwhen it represents the state AFTER. Parsed from the snapshot's string-encoded decimal.\nAlways present under the always-populated wire-shape contract — non-overdraft\noperations carry decimal.Zero. Parse errors on malformed historical rows also\nfall back to decimal.Zero (read-only audit context, never a correctness gate).\nexample: 130\nminimum: 0",
+          "type": "number",
+          "minimum": 0,
+          "example": 130
+        },
         "version": {
           "description": "Balance version after the operation\nexample: 2\nminimum: 0",
           "type": "integer",
@@ -8621,6 +8635,11 @@
           "format": "date-time",
           "example": "2021-01-01T00:00:00Z"
         },
+        "direction": {
+          "description": "Direction is the accounting direction of the balance at the time of\nthe snapshot. One of \"credit\" or \"debit\". Empty string denotes\nlegacy rows predating the overdraft feature.\nexample: credit",
+          "type": "string",
+          "example": "credit"
+        },
         "id": {
           "description": "Unique identifier for the balance (UUID format)\nexample: 00000000-0000-0000-0000-000000000000\nformat: uuid",
           "type": "string",
@@ -8650,6 +8669,19 @@
           "type": "string",
           "format": "uuid",
           "example": "00000000-0000-0000-0000-000000000000"
+        },
+        "overdraftUsed": {
+          "description": "OverdraftUsed is the amount of overdraft consumed at the time of\nthe snapshot. Always non-negative.\nexample: 0",
+          "type": "number",
+          "example": 0
+        },
+        "settings": {
+          "description": "Settings is the per-balance configuration snapshot at the time the\nhistory row was recorded. Nil for legacy balances.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/mmodel.BalanceSettings"
+            }
+          ]
         },
         "updatedAt": {
           "description": "Timestamp when the balance was last updated (RFC3339 format)\nexample: 2021-01-01T00:00:00Z\nformat: date-time",
@@ -8787,11 +8819,24 @@
           "type": "boolean",
           "example": true
         },
+        "direction": {
+          "description": "Direction is the accounting direction of the balance (\"credit\" or\n\"debit\"). Optional at creation; when omitted, defaults to the\naccount's natural direction.\nrequired: false\nexample: credit",
+          "type": "string",
+          "example": "credit"
+        },
         "key": {
           "description": "Unique key for the balance\nrequired: true\nmaxLength: 100\nexample: asset-freeze",
           "type": "string",
           "maxLength": 100,
           "example": "asset-freeze"
+        },
+        "settings": {
+          "description": "Settings is the optional per-balance configuration (overdraft,\nbalance scope). When omitted, platform defaults are applied.\nrequired: false",
+          "allOf": [
+            {
+              "$ref": "#/definitions/mmodel.BalanceSettings"
+            }
+          ]
         }
       }
     },
@@ -9126,7 +9171,7 @@
       }
     },
     "CreateTransactionInflowInput": {
-      "description": "CreateTransactionInflowInput is the input payload to create an inflow transaction. Contains all necessary fields to create a financial transaction without source information, only destination.",
+      "description": "CreateTransactionInflowInput is the input payload to create an inflow transaction. Contains all necessary fields to create a financial transaction without source information, only destination. Pending is not supported for inflows because the auto-filled external source account cannot hold funds.",
       "type": "object",
       "required": [
         "send"
@@ -10475,6 +10520,14 @@
           "description": "Whether the account should be allowed to send funds from this balance\nrequired: false\nexample: true",
           "type": "boolean",
           "example": true
+        },
+        "settings": {
+          "description": "Settings is the per-balance configuration (overdraft, balance\nscope). When provided, replaces the existing settings in full.\nDirection is intentionally absent: it is immutable after creation.\nrequired: false",
+          "allOf": [
+            {
+              "$ref": "#/definitions/mmodel.BalanceSettings"
+            }
+          ]
         }
       }
     },
@@ -10801,6 +10854,11 @@
           "format": "date-time",
           "example": "2021-01-01T00:00:00Z"
         },
+        "direction": {
+          "description": "Direction is the accounting direction of the balance. One of\n\"credit\" or \"debit\". Empty string denotes legacy rows predating the\noverdraft feature and is treated as \"credit\" by the engine.\nexample: credit",
+          "type": "string",
+          "example": "credit"
+        },
         "id": {
           "description": "Unique identifier for the balance (UUID format)\nexample: 00000000-0000-0000-0000-000000000000\nformat: uuid",
           "type": "string",
@@ -10836,6 +10894,19 @@
           "format": "uuid",
           "example": "00000000-0000-0000-0000-000000000000"
         },
+        "overdraftUsed": {
+          "description": "OverdraftUsed is the amount of overdraft currently consumed by this\nbalance. Always non-negative; zero when the balance is in the black.\nexample: 0",
+          "type": "number",
+          "example": 0
+        },
+        "settings": {
+          "description": "Settings carries optional per-balance configuration (overdraft,\nbalance scope). Nil for legacy balances without custom settings.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/mmodel.BalanceSettings"
+            }
+          ]
+        },
         "updatedAt": {
           "description": "Timestamp when the balance was last updated (RFC3339 format)\nexample: 2021-01-01T00:00:00Z\nformat: date-time",
           "type": "string",
@@ -10847,6 +10918,32 @@
           "type": "integer",
           "minimum": 1,
           "example": 1
+        }
+      }
+    },
+    "mmodel.BalanceSettings": {
+      "description": "Optional per-balance configuration controlling overdraft behavior and balance scope.",
+      "type": "object",
+      "properties": {
+        "allowOverdraft": {
+          "description": "AllowOverdraft enables overdraft behavior for the balance. When false,\ntransactions that would drive Available below zero are rejected.\nexample: false",
+          "type": "boolean",
+          "example": false
+        },
+        "balanceScope": {
+          "description": "BalanceScope identifies how the balance participates in transactions.\nAllowed values: \"transactional\" (default), \"internal\". Empty string is\ntreated as \"transactional\" for backwards compatibility.\nexample: transactional",
+          "type": "string",
+          "example": "transactional"
+        },
+        "overdraftLimit": {
+          "description": "OverdraftLimit is the maximum overdraft amount the balance may carry,\nexpressed as a decimal string (to preserve precision). Ignored when\nOverdraftLimitEnabled is false.\nexample: 1000.00",
+          "type": "string",
+          "example": "1000.00"
+        },
+        "overdraftLimitEnabled": {
+          "description": "OverdraftLimitEnabled gates the OverdraftLimit field. When true, a\nnon-empty, strictly positive OverdraftLimit MUST be supplied. When\nfalse, OverdraftLimit MUST be absent (overdraft is unlimited if\nAllowOverdraft is true).\nexample: false",
+          "type": "boolean",
+          "example": false
         }
       }
     },

--- a/components/ledger/api/swagger.yaml
+++ b/components/ledger/api/swagger.yaml
@@ -1,25 +1,22 @@
+---
 swagger: '2.0'
 info:
   title: Midaz Ledger API (Unified)
-  description: This is a swagger documentation for the Midaz Unified Ledger API. This
-    API combines all Onboarding endpoints (organizations, ledgers, accounts, assets,
-    portfolios, segments), Transaction endpoints (transactions, balances, operations,
-    asset-rates), and Metadata Index endpoints in a single service.
+  description: This is a swagger documentation for the Midaz Unified Ledger API. This API combines all Onboarding endpoints (organizations, ledgers, accounts, assets, portfolios, segments), Transaction endpoints (transactions, balances, operations, asset-rates), and Metadata Index endpoints in a single service.
   termsOfService: http://swagger.io/terms/
   contact:
     name: Discord community
     url: https://discord.gg/DnhqKwkGv3
   license:
-    name: Apache 2.0
-    url: http://www.apache.org/licenses/LICENSE-2.0.html
-  version: v3.6.0
+    name: Elastic License 2.0
+    url: https://www.elastic.co/licensing/elastic-license
+  version: v3.7.0
 host: localhost:3002
-basePath: /
+basePath: "/"
 paths:
-  /v1/organizations:
+  "/v1/organizations":
     get:
-      description: Returns a paginated list of organizations, optionally filtered
-        by metadata, date range, and other criteria
+      description: Returns a paginated list of organizations, optionally filtered by metadata, date range, and other criteria
       produces:
       - application/json
       tags:
@@ -53,13 +50,11 @@ paths:
         name: page
         in: query
       - type: string
-        description: 'Filter organizations created on or after this date (format:
-          YYYY-MM-DD)'
+        description: 'Filter organizations created on or after this date (format: YYYY-MM-DD)'
         name: start_date
         in: query
       - type: string
-        description: 'Filter organizations created on or before this date (format:
-          YYYY-MM-DD)'
+        description: 'Filter organizations created on or before this date (format: YYYY-MM-DD)'
         name: end_date
         in: query
       - enum:
@@ -71,14 +66,12 @@ paths:
         in: query
       - maxLength: 256
         type: string
-        description: Filter organizations by legal name (case-insensitive, prefix
-          match)
+        description: Filter organizations by legal name (case-insensitive, prefix match)
         name: legal_name
         in: query
       - maxLength: 256
         type: string
-        description: Filter organizations by doing business as name (case-insensitive,
-          prefix match)
+        description: Filter organizations by doing business as name (case-insensitive, prefix match)
         name: doing_business_as
         in: query
       responses:
@@ -86,32 +79,31 @@ paths:
           description: Successfully retrieved organizations list
           schema:
             allOf:
-            - $ref: '#/definitions/http.Pagination'
+            - "$ref": "#/definitions/http.Pagination"
             - type: object
               properties:
                 items:
                   type: array
                   items:
-                    $ref: '#/definitions/Organization'
+                    "$ref": "#/definitions/Organization"
         '400':
           description: Invalid query parameters
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '401':
           description: Unauthorized access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '403':
           description: Forbidden access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '500':
           description: Internal server error
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
     post:
-      description: Creates a new organization with the provided details including
-        legal name, legal document, and optional address information
+      description: Creates a new organization with the provided details including legal name, legal document, and optional address information
       consumes:
       - application/json
       produces:
@@ -129,38 +121,36 @@ paths:
         description: Request ID for tracing
         name: X-Request-Id
         in: header
-      - description: Organization details including legal name, legal document, and
-          optional address information
+      - description: Organization details including legal name, legal document, and optional address information
         name: organization
         in: body
         required: true
         schema:
-          $ref: '#/definitions/CreateOrganizationInput'
+          "$ref": "#/definitions/CreateOrganizationInput"
       responses:
         '201':
           description: Successfully created organization
           schema:
-            $ref: '#/definitions/Organization'
+            "$ref": "#/definitions/Organization"
         '400':
           description: Invalid input, validation errors
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '401':
           description: Unauthorized access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '403':
           description: Forbidden access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '500':
           description: Internal server error
           schema:
-            $ref: '#/definitions/Error'
-  /v1/organizations/metrics/count:
+            "$ref": "#/definitions/Error"
+  "/v1/organizations/metrics/count":
     head:
-      description: Returns the total count of organizations as a header without a
-        response body
+      description: Returns the total count of organizations as a header without a response body
       tags:
       - Organizations
       summary: Count total organizations
@@ -180,23 +170,22 @@ paths:
         '401':
           description: Unauthorized access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '403':
           description: Forbidden access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '404':
           description: Organization not found
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '500':
           description: Internal server error
           schema:
-            $ref: '#/definitions/Error'
-  /v1/organizations/{id}:
+            "$ref": "#/definitions/Error"
+  "/v1/organizations/{organization_id}":
     get:
-      description: Returns detailed information about an organization identified by
-        its UUID
+      description: Returns detailed information about an organization identified by its UUID
       produces:
       - application/json
       tags:
@@ -214,33 +203,32 @@ paths:
         in: header
       - type: string
         description: Organization ID in UUID format
-        name: id
+        name: organization_id
         in: path
         required: true
       responses:
         '200':
           description: Successfully retrieved organization
           schema:
-            $ref: '#/definitions/Organization'
+            "$ref": "#/definitions/Organization"
         '401':
           description: Unauthorized access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '403':
           description: Forbidden access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '404':
           description: Organization not found
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '500':
           description: Internal server error
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
     delete:
-      description: 'Permanently removes an organization identified by its UUID. Note:
-        This operation is not available in production environments.'
+      description: 'Permanently removes an organization identified by its UUID. Note: This operation is not available in production environments.'
       tags:
       - Organizations
       summary: Delete an organization
@@ -256,7 +244,7 @@ paths:
         in: header
       - type: string
         description: Organization ID in UUID format
-        name: id
+        name: organization_id
         in: path
         required: true
       responses:
@@ -265,26 +253,25 @@ paths:
         '401':
           description: Unauthorized access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '403':
           description: Forbidden action or not permitted in production environment
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '404':
           description: Organization not found
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '409':
           description: 'Conflict: Cannot delete organization with dependent resources'
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '500':
           description: Internal server error
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
     patch:
-      description: Updates an organization's information such as legal name, address,
-        or status. Only supplied fields will be updated.
+      description: Updates an organization's information such as legal name, address, or status. Only supplied fields will be updated.
       consumes:
       - application/json
       produces:
@@ -304,7 +291,7 @@ paths:
         in: header
       - type: string
         description: Organization ID in UUID format
-        name: id
+        name: organization_id
         in: path
         required: true
       - description: Organization fields to update. Only supplied fields will be modified.
@@ -312,36 +299,35 @@ paths:
         in: body
         required: true
         schema:
-          $ref: '#/definitions/UpdateOrganizationInput'
+          "$ref": "#/definitions/UpdateOrganizationInput"
       responses:
         '200':
           description: Successfully updated organization
           schema:
-            $ref: '#/definitions/Organization'
+            "$ref": "#/definitions/Organization"
         '400':
           description: Invalid input, validation errors
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '401':
           description: Unauthorized access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '403':
           description: Forbidden access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '404':
           description: Organization not found
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '500':
           description: Internal server error
           schema:
-            $ref: '#/definitions/Error'
-  /v1/organizations/{organization_id}/ledgers:
+            "$ref": "#/definitions/Error"
+  "/v1/organizations/{organization_id}/ledgers":
     get:
-      description: Returns a paginated list of ledgers within the specified organization,
-        optionally filtered by metadata, date range, and other criteria
+      description: Returns a paginated list of ledgers within the specified organization, optionally filtered by metadata, date range, and other criteria
       produces:
       - application/json
       tags:
@@ -404,36 +390,35 @@ paths:
           description: Successfully retrieved ledgers list
           schema:
             allOf:
-            - $ref: '#/definitions/http.Pagination'
+            - "$ref": "#/definitions/http.Pagination"
             - type: object
               properties:
                 items:
                   type: array
                   items:
-                    $ref: '#/definitions/Ledger'
+                    "$ref": "#/definitions/Ledger"
         '400':
           description: Invalid query parameters
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '401':
           description: Unauthorized access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '403':
           description: Forbidden access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '404':
           description: Organization not found
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '500':
           description: Internal server error
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
     post:
-      description: Creates a new ledger within the specified organization. A ledger
-        is a financial record-keeping system for tracking assets, accounts, and transactions.
+      description: Creates a new ledger within the specified organization. A ledger is a financial record-keeping system for tracking assets, accounts, and transactions.
       consumes:
       - application/json
       produces:
@@ -461,36 +446,35 @@ paths:
         in: body
         required: true
         schema:
-          $ref: '#/definitions/CreateLedgerInput'
+          "$ref": "#/definitions/CreateLedgerInput"
       responses:
         '201':
           description: Successfully created ledger
           schema:
-            $ref: '#/definitions/Ledger'
+            "$ref": "#/definitions/Ledger"
         '400':
           description: Invalid input, validation errors
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '401':
           description: Unauthorized access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '403':
           description: Forbidden access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '404':
           description: Organization not found
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '500':
           description: Internal server error
           schema:
-            $ref: '#/definitions/Error'
-  /v1/organizations/{organization_id}/ledgers/metrics/count:
+            "$ref": "#/definitions/Error"
+  "/v1/organizations/{organization_id}/ledgers/metrics/count":
     head:
-      description: Returns the total count of ledgers for a specific organization
-        as a header without a response body
+      description: Returns the total count of ledgers for a specific organization as a header without a response body
       tags:
       - Ledgers
       summary: Count total ledgers
@@ -515,23 +499,22 @@ paths:
         '401':
           description: Unauthorized access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '403':
           description: Forbidden access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '404':
           description: Organization not found
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '500':
           description: Internal server error
           schema:
-            $ref: '#/definitions/Error'
-  /v1/organizations/{organization_id}/ledgers/{id}:
+            "$ref": "#/definitions/Error"
+  "/v1/organizations/{organization_id}/ledgers/{ledger_id}":
     get:
-      description: Returns detailed information about a ledger identified by its UUID
-        within the specified organization
+      description: Returns detailed information about a ledger identified by its UUID within the specified organization
       produces:
       - application/json
       tags:
@@ -554,33 +537,32 @@ paths:
         required: true
       - type: string
         description: Ledger ID in UUID format
-        name: id
+        name: ledger_id
         in: path
         required: true
       responses:
         '200':
           description: Successfully retrieved ledger
           schema:
-            $ref: '#/definitions/Ledger'
+            "$ref": "#/definitions/Ledger"
         '401':
           description: Unauthorized access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '403':
           description: Forbidden access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '404':
           description: Ledger or organization not found
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '500':
           description: Internal server error
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
     delete:
-      description: 'Permanently removes a ledger identified by its UUID. Note: This
-        operation is not available in production environments.'
+      description: 'Permanently removes a ledger identified by its UUID. Note: This operation is not available in production environments.'
       tags:
       - Ledgers
       summary: Delete a ledger
@@ -601,7 +583,7 @@ paths:
         required: true
       - type: string
         description: Ledger ID in UUID format
-        name: id
+        name: ledger_id
         in: path
         required: true
       responses:
@@ -610,26 +592,25 @@ paths:
         '401':
           description: Unauthorized access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '403':
           description: Forbidden action or not permitted in production environment
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '404':
           description: Ledger or organization not found
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '409':
           description: 'Conflict: Cannot delete ledger with dependent resources'
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '500':
           description: Internal server error
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
     patch:
-      description: Updates a ledger's information such as name, status, or metadata.
-        Only supplied fields will be updated.
+      description: Updates a ledger's information such as name, status, or metadata. Only supplied fields will be updated.
       consumes:
       - application/json
       produces:
@@ -654,7 +635,7 @@ paths:
         required: true
       - type: string
         description: Ledger ID in UUID format
-        name: id
+        name: ledger_id
         in: path
         required: true
       - description: Ledger fields to update. Only supplied fields will be modified.
@@ -662,156 +643,35 @@ paths:
         in: body
         required: true
         schema:
-          $ref: '#/definitions/UpdateLedgerInput'
+          "$ref": "#/definitions/UpdateLedgerInput"
       responses:
         '200':
           description: Successfully updated ledger
           schema:
-            $ref: '#/definitions/Ledger'
+            "$ref": "#/definitions/Ledger"
         '400':
           description: Invalid input, validation errors
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '401':
           description: Unauthorized access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '403':
           description: Forbidden access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '404':
           description: Ledger or organization not found
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '500':
           description: Internal server error
           schema:
-            $ref: '#/definitions/Error'
-  /v1/organizations/{organization_id}/ledgers/{id}/settings:
+            "$ref": "#/definitions/Error"
+  "/v1/organizations/{organization_id}/ledgers/{ledger_id}/account-types":
     get:
-      description: Returns the current configuration settings for a specific ledger.
-        If no settings have been persisted, returns the default settings object.
-      produces:
-      - application/json
-      tags:
-      - Ledgers
-      summary: Get ledger settings
-      parameters:
-      - type: string
-        description: 'Authorization Bearer Token with format: Bearer {token}'
-        name: Authorization
-        in: header
-        required: true
-      - type: string
-        description: Request ID for tracing
-        name: X-Request-Id
-        in: header
-      - type: string
-        description: Organization ID in UUID format
-        name: organization_id
-        in: path
-        required: true
-      - type: string
-        description: Ledger ID in UUID format
-        name: id
-        in: path
-        required: true
-      responses:
-        '200':
-          description: Successfully retrieved ledger settings
-          schema:
-            $ref: '#/definitions/mmodel.LedgerSettings'
-        '401':
-          description: Unauthorized access
-          schema:
-            $ref: '#/definitions/Error'
-        '403':
-          description: Forbidden access
-          schema:
-            $ref: '#/definitions/Error'
-        '404':
-          description: Ledger not found
-          schema:
-            $ref: '#/definitions/Error'
-        '500':
-          description: Internal server error
-          schema:
-            $ref: '#/definitions/Error'
-    patch:
-      description: 'Updates the configuration settings for a specific ledger using
-        schema-aware deep merge. Only known settings fields are allowed - unknown
-        fields return error 0147 (ErrUnknownSettingsField). Type validation is enforced
-        - incorrect types return error 0148 (ErrInvalidSettingsFieldType). Nested
-        objects (like ''accounting'') are deep-merged, preserving existing properties
-        not specified in the update. Example: updating only ''accounting.validateRoutes''
-        preserves the existing ''accounting.validateAccountType'' value. Allowed fields:
-        accounting.validateAccountType (boolean), accounting.validateRoutes (boolean).'
-      consumes:
-      - application/json
-      produces:
-      - application/json
-      tags:
-      - Ledgers
-      summary: Update ledger settings
-      parameters:
-      - type: string
-        description: 'Authorization Bearer Token with format: Bearer {token}'
-        name: Authorization
-        in: header
-        required: true
-      - type: string
-        description: Request ID for tracing
-        name: X-Request-Id
-        in: header
-      - type: string
-        description: Organization ID in UUID format
-        name: organization_id
-        in: path
-        required: true
-      - type: string
-        description: Ledger ID in UUID format
-        name: id
-        in: path
-        required: true
-      - description: 'Settings to merge with existing settings. Only known fields
-          allowed: accounting.validateAccountType (bool), accounting.validateRoutes
-          (bool)'
-        name: settings
-        in: body
-        required: true
-        schema:
-          type: object
-      responses:
-        '200':
-          description: Successfully updated ledger settings
-          schema:
-            $ref: '#/definitions/mmodel.LedgerSettings'
-        '400':
-          description: Invalid request body, unknown field (0147), or invalid field
-            type (0148)
-          schema:
-            $ref: '#/definitions/Error'
-        '401':
-          description: Unauthorized access
-          schema:
-            $ref: '#/definitions/Error'
-        '403':
-          description: Forbidden access
-          schema:
-            $ref: '#/definitions/Error'
-        '404':
-          description: Ledger not found
-          schema:
-            $ref: '#/definitions/Error'
-        '500':
-          description: Internal server error
-          schema:
-            $ref: '#/definitions/Error'
-  /v1/organizations/{organization_id}/ledgers/{ledger_id}/account-types:
-    get:
-      description: Returns a paginated list of all account types for the specified
-        organization and ledger, optionally filtered by metadata
+      description: Returns a paginated list of all account types for the specified organization and ledger, optionally filtered by metadata
       produces:
       - application/json
       tags:
@@ -870,33 +730,33 @@ paths:
           description: Successfully retrieved account types
           schema:
             allOf:
-            - $ref: '#/definitions/http.Pagination'
+            - "$ref": "#/definitions/http.Pagination"
             - type: object
               properties:
                 items:
                   type: array
                   items:
-                    $ref: '#/definitions/AccountType'
+                    "$ref": "#/definitions/AccountType"
         '400':
           description: Invalid query parameters
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '401':
           description: Unauthorized access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '403':
           description: Forbidden access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '404':
           description: Organization, ledger, or account types not found
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '500':
           description: Internal server error
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
     post:
       description: Endpoint to create a new Account Type.
       consumes:
@@ -931,36 +791,35 @@ paths:
         in: body
         required: true
         schema:
-          $ref: '#/definitions/CreateAccountTypeInput'
+          "$ref": "#/definitions/CreateAccountTypeInput"
       responses:
         '201':
           description: Successfully created account type
           schema:
-            $ref: '#/definitions/AccountType'
+            "$ref": "#/definitions/AccountType"
         '400':
           description: Invalid input, validation errors
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '401':
           description: Unauthorized access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '403':
           description: Forbidden access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '409':
           description: Conflict - account type key value already exists
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '500':
           description: Internal server error
           schema:
-            $ref: '#/definitions/Error'
-  /v1/organizations/{organization_id}/ledgers/{ledger_id}/account-types/{id}:
+            "$ref": "#/definitions/Error"
+  "/v1/organizations/{organization_id}/ledgers/{ledger_id}/account-types/{account_type_id}":
     get:
-      description: Returns detailed information about an account type identified by
-        its UUID within the specified ledger
+      description: Returns detailed information about an account type identified by its UUID within the specified ledger
       produces:
       - application/json
       tags:
@@ -988,33 +847,32 @@ paths:
         required: true
       - type: string
         description: Account Type ID in UUID format
-        name: id
+        name: account_type_id
         in: path
         required: true
       responses:
         '200':
           description: Successfully retrieved account type
           schema:
-            $ref: '#/definitions/AccountType'
+            "$ref": "#/definitions/AccountType"
         '401':
           description: Unauthorized access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '403':
           description: Forbidden access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '404':
           description: Account type, ledger, or organization not found
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '500':
           description: Internal server error
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
     delete:
-      description: Deletes an existing account type identified by its UUID within
-        the specified ledger
+      description: Deletes an existing account type identified by its UUID within the specified ledger
       produces:
       - application/json
       tags:
@@ -1042,7 +900,7 @@ paths:
         required: true
       - type: string
         description: Account Type ID in UUID format
-        name: id
+        name: account_type_id
         in: path
         required: true
       responses:
@@ -1051,15 +909,15 @@ paths:
         '401':
           description: Unauthorized access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '404':
           description: Account type not found
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '500':
           description: Internal server error
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
     patch:
       description: Endpoint to update an existing Account Type.
       consumes:
@@ -1091,7 +949,7 @@ paths:
         required: true
       - type: string
         description: Account Type ID in UUID format
-        name: id
+        name: account_type_id
         in: path
         required: true
       - description: Account Type Update Input
@@ -1099,36 +957,35 @@ paths:
         in: body
         required: true
         schema:
-          $ref: '#/definitions/UpdateAccountTypeInput'
+          "$ref": "#/definitions/UpdateAccountTypeInput"
       responses:
         '200':
           description: Successfully updated account type
           schema:
-            $ref: '#/definitions/AccountType'
+            "$ref": "#/definitions/AccountType"
         '400':
           description: Invalid input, validation errors
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '401':
           description: Unauthorized access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '403':
           description: Forbidden access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '404':
           description: Account type not found
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '500':
           description: Internal server error
           schema:
-            $ref: '#/definitions/Error'
-  /v1/organizations/{organization_id}/ledgers/{ledger_id}/accounts:
+            "$ref": "#/definitions/Error"
+  "/v1/organizations/{organization_id}/ledgers/{ledger_id}/accounts":
     get:
-      description: Returns a paginated list of accounts within the specified ledger,
-        optionally filtered by metadata, date range, and other criteria
+      description: Returns a paginated list of accounts within the specified ledger, optionally filtered by metadata, date range, and other criteria
       produces:
       - application/json
       tags:
@@ -1188,14 +1045,12 @@ paths:
         in: query
       - type: string
         format: uuid
-        description: Filter accounts by portfolio ID (UUID format). If both portfolio_id
-          and segment_id are provided, both filters are applied (AND semantics).
+        description: Filter accounts by portfolio ID (UUID format). If both portfolio_id and segment_id are provided, both filters are applied (AND semantics).
         name: portfolio_id
         in: query
       - type: string
         format: uuid
-        description: Filter accounts by segment ID (UUID format). If both portfolio_id
-          and segment_id are provided, both filters are applied (AND semantics).
+        description: Filter accounts by segment ID (UUID format). If both portfolio_id and segment_id are provided, both filters are applied (AND semantics).
         name: segment_id
         in: query
       responses:
@@ -1203,37 +1058,35 @@ paths:
           description: Successfully retrieved accounts list
           schema:
             allOf:
-            - $ref: '#/definitions/http.Pagination'
+            - "$ref": "#/definitions/http.Pagination"
             - type: object
               properties:
                 items:
                   type: array
                   items:
-                    $ref: '#/definitions/Account'
+                    "$ref": "#/definitions/Account"
         '400':
           description: Invalid query parameters
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '401':
           description: Unauthorized access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '403':
           description: Forbidden access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '404':
           description: Organization or ledger not found
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '500':
           description: Internal server error
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
     post:
-      description: Creates a new account within the specified ledger. Accounts represent
-        individual financial entities like bank accounts, credit cards, or expense
-        categories.
+      description: Creates a new account within the specified ledger. Accounts represent individual financial entities like bank accounts, credit cards, or expense categories.
       consumes:
       - application/json
       produces:
@@ -1261,47 +1114,44 @@ paths:
         name: ledger_id
         in: path
         required: true
-      - description: Account details including name, type, asset code, and optional
-          parent account, portfolio, segment, and metadata
+      - description: Account details including name, type, asset code, and optional parent account, portfolio, segment, and metadata
         name: account
         in: body
         required: true
         schema:
-          $ref: '#/definitions/CreateAccountInput'
+          "$ref": "#/definitions/CreateAccountInput"
       responses:
         '201':
           description: Successfully created account
           schema:
-            $ref: '#/definitions/Account'
+            "$ref": "#/definitions/Account"
         '400':
           description: Invalid input, validation errors
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '401':
           description: Unauthorized access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '403':
           description: Forbidden access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '404':
-          description: Organization, ledger, parent account, portfolio, or segment
-            not found
+          description: Organization, ledger, parent account, portfolio, or segment not found
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '409':
           description: 'Conflict: Account with the same alias already exists'
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '500':
           description: Internal server error
           schema:
-            $ref: '#/definitions/Error'
-  /v1/organizations/{organization_id}/ledgers/{ledger_id}/accounts/alias/{alias}:
+            "$ref": "#/definitions/Error"
+  "/v1/organizations/{organization_id}/ledgers/{ledger_id}/accounts/alias/{alias}":
     get:
-      description: Returns detailed information about an account identified by its
-        alias within the specified ledger
+      description: Returns detailed information about an account identified by its alias within the specified ledger
       produces:
       - application/json
       tags:
@@ -1336,25 +1186,24 @@ paths:
         '200':
           description: Successfully retrieved account
           schema:
-            $ref: '#/definitions/Account'
+            "$ref": "#/definitions/Account"
         '401':
           description: Unauthorized access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '403':
           description: Forbidden access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '404':
-          description: Account with the specified alias, ledger, or organization not
-            found
+          description: Account with the specified alias, ledger, or organization not found
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '500':
           description: Internal server error
           schema:
-            $ref: '#/definitions/Error'
-  /v1/organizations/{organization_id}/ledgers/{ledger_id}/accounts/alias/{alias}/balances:
+            "$ref": "#/definitions/Error"
+  "/v1/organizations/{organization_id}/ledgers/{ledger_id}/accounts/alias/{alias}/balances":
     get:
       description: Get Balances with alias
       produces:
@@ -1392,33 +1241,32 @@ paths:
           description: OK
           schema:
             allOf:
-            - $ref: '#/definitions/http.Pagination'
+            - "$ref": "#/definitions/http.Pagination"
             - type: object
               properties:
                 items:
                   type: array
                   items:
-                    $ref: '#/definitions/mmodel.Balance'
+                    "$ref": "#/definitions/mmodel.Balance"
         '401':
           description: Unauthorized access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '403':
           description: Forbidden access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '404':
           description: Balance not found
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '500':
           description: Internal server error
           schema:
-            $ref: '#/definitions/Error'
-  /v1/organizations/{organization_id}/ledgers/{ledger_id}/accounts/external/{code}:
+            "$ref": "#/definitions/Error"
+  "/v1/organizations/{organization_id}/ledgers/{ledger_id}/accounts/external/{code}":
     get:
-      description: Returns detailed information about an account identified by its
-        external code within the specified ledger
+      description: Returns detailed information about an account identified by its external code within the specified ledger
       produces:
       - application/json
       tags:
@@ -1453,25 +1301,24 @@ paths:
         '200':
           description: Successfully retrieved account
           schema:
-            $ref: '#/definitions/Account'
+            "$ref": "#/definitions/Account"
         '401':
           description: Unauthorized access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '403':
           description: Forbidden access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '404':
-          description: Account with the specified external code, ledger, or organization
-            not found
+          description: Account with the specified external code, ledger, or organization not found
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '500':
           description: Internal server error
           schema:
-            $ref: '#/definitions/Error'
-  /v1/organizations/{organization_id}/ledgers/{ledger_id}/accounts/external/{code}/balances:
+            "$ref": "#/definitions/Error"
+  "/v1/organizations/{organization_id}/ledgers/{ledger_id}/accounts/external/{code}/balances":
     get:
       description: Get External balances with code
       produces:
@@ -1509,33 +1356,32 @@ paths:
           description: OK
           schema:
             allOf:
-            - $ref: '#/definitions/http.Pagination'
+            - "$ref": "#/definitions/http.Pagination"
             - type: object
               properties:
                 items:
                   type: array
                   items:
-                    $ref: '#/definitions/mmodel.Balance'
+                    "$ref": "#/definitions/mmodel.Balance"
         '401':
           description: Unauthorized access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '403':
           description: Forbidden access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '404':
           description: Balance not found
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '500':
           description: Internal server error
           schema:
-            $ref: '#/definitions/Error'
-  /v1/organizations/{organization_id}/ledgers/{ledger_id}/accounts/metrics/count:
+            "$ref": "#/definitions/Error"
+  "/v1/organizations/{organization_id}/ledgers/{ledger_id}/accounts/metrics/count":
     head:
-      description: Returns the total count of accounts for the specified organization,
-        ledger, and optional portfolio
+      description: Returns the total count of accounts for the specified organization, ledger, and optional portfolio
       tags:
       - Accounts
       summary: Count accounts
@@ -1565,20 +1411,196 @@ paths:
         '401':
           description: Unauthorized access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '403':
           description: Forbidden access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '404':
           description: Organization or ledger not found
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '500':
           description: Internal server error
           schema:
-            $ref: '#/definitions/Error'
-  /v1/organizations/{organization_id}/ledgers/{ledger_id}/accounts/{account_id}/balances:
+            "$ref": "#/definitions/Error"
+  "/v1/organizations/{organization_id}/ledgers/{ledger_id}/accounts/{account_id}":
+    get:
+      description: Returns detailed information about an account identified by its UUID within the specified ledger
+      produces:
+      - application/json
+      tags:
+      - Accounts
+      summary: Retrieve a specific account
+      parameters:
+      - type: string
+        description: 'Authorization Bearer Token with format: Bearer {token}'
+        name: Authorization
+        in: header
+        required: true
+      - type: string
+        description: Request ID for tracing
+        name: X-Request-Id
+        in: header
+      - type: string
+        description: Organization ID in UUID format
+        name: organization_id
+        in: path
+        required: true
+      - type: string
+        description: Ledger ID in UUID format
+        name: ledger_id
+        in: path
+        required: true
+      - type: string
+        description: Account ID in UUID format
+        name: account_id
+        in: path
+        required: true
+      responses:
+        '200':
+          description: Successfully retrieved account
+          schema:
+            "$ref": "#/definitions/Account"
+        '401':
+          description: Unauthorized access
+          schema:
+            "$ref": "#/definitions/Error"
+        '403':
+          description: Forbidden access
+          schema:
+            "$ref": "#/definitions/Error"
+        '404':
+          description: Account, ledger, or organization not found
+          schema:
+            "$ref": "#/definitions/Error"
+        '500':
+          description: Internal server error
+          schema:
+            "$ref": "#/definitions/Error"
+    delete:
+      description: Permanently removes an account from the specified ledger. This operation cannot be undone.
+      tags:
+      - Accounts
+      summary: Delete an account
+      parameters:
+      - type: string
+        description: 'Authorization Bearer Token with format: Bearer {token}'
+        name: Authorization
+        in: header
+        required: true
+      - type: string
+        description: Request ID for tracing
+        name: X-Request-Id
+        in: header
+      - type: string
+        description: Organization ID in UUID format
+        name: organization_id
+        in: path
+        required: true
+      - type: string
+        description: Ledger ID in UUID format
+        name: ledger_id
+        in: path
+        required: true
+      - type: string
+        description: Account ID in UUID format
+        name: account_id
+        in: path
+        required: true
+      responses:
+        '204':
+          description: Account successfully deleted
+        '401':
+          description: Unauthorized access
+          schema:
+            "$ref": "#/definitions/Error"
+        '403':
+          description: Forbidden access
+          schema:
+            "$ref": "#/definitions/Error"
+        '404':
+          description: Account, ledger, or organization not found
+          schema:
+            "$ref": "#/definitions/Error"
+        '409':
+          description: 'Conflict: Account cannot be deleted due to existing dependencies'
+          schema:
+            "$ref": "#/definitions/Error"
+        '500':
+          description: Internal server error
+          schema:
+            "$ref": "#/definitions/Error"
+    patch:
+      description: Updates an existing account's properties such as name, status, portfolio, segment, and metadata within the specified ledger
+      consumes:
+      - application/json
+      produces:
+      - application/json
+      tags:
+      - Accounts
+      summary: Update an account
+      parameters:
+      - type: string
+        description: 'Authorization Bearer Token with format: Bearer {token}'
+        name: Authorization
+        in: header
+        required: true
+      - type: string
+        description: Request ID for tracing
+        name: X-Request-Id
+        in: header
+      - type: string
+        description: Organization ID in UUID format
+        name: organization_id
+        in: path
+        required: true
+      - type: string
+        description: Ledger ID in UUID format
+        name: ledger_id
+        in: path
+        required: true
+      - type: string
+        description: Account ID in UUID format
+        name: account_id
+        in: path
+        required: true
+      - description: Account properties to update including name, status, portfolio, segment, and optional metadata
+        name: account
+        in: body
+        required: true
+        schema:
+          "$ref": "#/definitions/UpdateAccountInput"
+      responses:
+        '200':
+          description: Successfully updated account
+          schema:
+            "$ref": "#/definitions/Account"
+        '400':
+          description: Invalid input, validation errors
+          schema:
+            "$ref": "#/definitions/Error"
+        '401':
+          description: Unauthorized access
+          schema:
+            "$ref": "#/definitions/Error"
+        '403':
+          description: Forbidden access
+          schema:
+            "$ref": "#/definitions/Error"
+        '404':
+          description: Account, ledger, organization, portfolio, or segment not found
+          schema:
+            "$ref": "#/definitions/Error"
+        '409':
+          description: 'Conflict: Account with the same name already exists'
+          schema:
+            "$ref": "#/definitions/Error"
+        '500':
+          description: Internal server error
+          schema:
+            "$ref": "#/definitions/Error"
+  "/v1/organizations/{organization_id}/ledgers/{ledger_id}/accounts/{account_id}/balances":
     get:
       description: Get all balances by account id
       produces:
@@ -1640,33 +1662,33 @@ paths:
           description: OK
           schema:
             allOf:
-            - $ref: '#/definitions/http.Pagination'
+            - "$ref": "#/definitions/http.Pagination"
             - type: object
               properties:
                 items:
                   type: array
                   items:
-                    $ref: '#/definitions/mmodel.Balance'
+                    "$ref": "#/definitions/mmodel.Balance"
         '400':
           description: Invalid query parameters
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '401':
           description: Unauthorized access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '403':
           description: Forbidden access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '404':
           description: Account not found
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '500':
           description: Internal server error
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
     post:
       description: Create an Additional Balance with the input payload
       consumes:
@@ -1706,36 +1728,35 @@ paths:
         in: body
         required: true
         schema:
-          $ref: '#/definitions/CreateAdditionalBalance'
+          "$ref": "#/definitions/CreateAdditionalBalance"
       responses:
         '201':
           description: Created
           schema:
-            $ref: '#/definitions/mmodel.Balance'
+            "$ref": "#/definitions/mmodel.Balance"
         '400':
           description: Invalid input, validation errors
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '401':
           description: Unauthorized access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '403':
           description: Forbidden access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '404':
           description: Balance not found
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '500':
           description: Internal server error
           schema:
-            $ref: '#/definitions/Error'
-  /v1/organizations/{organization_id}/ledgers/{ledger_id}/accounts/{account_id}/balances/history:
+            "$ref": "#/definitions/Error"
+  "/v1/organizations/{organization_id}/ledgers/{ledger_id}/accounts/{account_id}/balances/history":
     get:
-      description: Get the historical state of all Balances for an account at a specific
-        point in time (yyyy-mm-dd hh:mm:ss format)
+      description: Get the historical state of all Balances for an account at a specific point in time (yyyy-mm-dd hh:mm:ss format)
       produces:
       - application/json
       tags:
@@ -1767,8 +1788,7 @@ paths:
         in: path
         required: true
       - type: string
-        description: 'Point in time (format: yyyy-mm-dd hh:mm:ss, e.g. 2024-01-15
-          10:30:00)'
+        description: 'Point in time (format: yyyy-mm-dd hh:mm:ss, e.g. 2024-01-15 10:30:00)'
         name: date
         in: query
         required: true
@@ -1778,28 +1798,28 @@ paths:
           schema:
             type: array
             items:
-              $ref: '#/definitions/BalanceHistory'
+              "$ref": "#/definitions/BalanceHistory"
         '400':
           description: Invalid date format or date in the future
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '401':
           description: Unauthorized access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '403':
           description: Forbidden access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '404':
           description: Account not found or no data available at date
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '500':
           description: Internal server error
           schema:
-            $ref: '#/definitions/Error'
-  /v1/organizations/{organization_id}/ledgers/{ledger_id}/accounts/{account_id}/operations:
+            "$ref": "#/definitions/Error"
+  "/v1/organizations/{organization_id}/ledgers/{ledger_id}/accounts/{account_id}/operations":
     get:
       description: Get all Operations with the input ID
       produces:
@@ -1872,39 +1892,43 @@ paths:
         description: Filter by operation route ID
         name: route_id
         in: query
+      - type: string
+        description: Filter by operation route code
+        name: route_code
+        in: query
       responses:
         '200':
           description: OK
           schema:
             allOf:
-            - $ref: '#/definitions/http.Pagination'
+            - "$ref": "#/definitions/http.Pagination"
             - type: object
               properties:
                 items:
                   type: array
                   items:
-                    $ref: '#/definitions/Operation'
+                    "$ref": "#/definitions/Operation"
         '400':
           description: Invalid query parameters
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '401':
           description: Unauthorized access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '403':
           description: Forbidden access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '404':
           description: Account not found
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '500':
           description: Internal server error
           schema:
-            $ref: '#/definitions/Error'
-  /v1/organizations/{organization_id}/ledgers/{ledger_id}/accounts/{account_id}/operations/{operation_id}:
+            "$ref": "#/definitions/Error"
+  "/v1/organizations/{organization_id}/ledgers/{ledger_id}/accounts/{account_id}/operations/{operation_id}":
     get:
       description: Get an Operation with the input ID
       produces:
@@ -1946,204 +1970,24 @@ paths:
         '200':
           description: OK
           schema:
-            $ref: '#/definitions/Operation'
+            "$ref": "#/definitions/Operation"
         '401':
           description: Unauthorized access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '403':
           description: Forbidden access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '404':
           description: Operation not found
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '500':
           description: Internal server error
           schema:
-            $ref: '#/definitions/Error'
-  /v1/organizations/{organization_id}/ledgers/{ledger_id}/accounts/{id}:
-    get:
-      description: Returns detailed information about an account identified by its
-        UUID within the specified ledger
-      produces:
-      - application/json
-      tags:
-      - Accounts
-      summary: Retrieve a specific account
-      parameters:
-      - type: string
-        description: 'Authorization Bearer Token with format: Bearer {token}'
-        name: Authorization
-        in: header
-        required: true
-      - type: string
-        description: Request ID for tracing
-        name: X-Request-Id
-        in: header
-      - type: string
-        description: Organization ID in UUID format
-        name: organization_id
-        in: path
-        required: true
-      - type: string
-        description: Ledger ID in UUID format
-        name: ledger_id
-        in: path
-        required: true
-      - type: string
-        description: Account ID in UUID format
-        name: id
-        in: path
-        required: true
-      responses:
-        '200':
-          description: Successfully retrieved account
-          schema:
-            $ref: '#/definitions/Account'
-        '401':
-          description: Unauthorized access
-          schema:
-            $ref: '#/definitions/Error'
-        '403':
-          description: Forbidden access
-          schema:
-            $ref: '#/definitions/Error'
-        '404':
-          description: Account, ledger, or organization not found
-          schema:
-            $ref: '#/definitions/Error'
-        '500':
-          description: Internal server error
-          schema:
-            $ref: '#/definitions/Error'
-    delete:
-      description: Permanently removes an account from the specified ledger. This
-        operation cannot be undone.
-      tags:
-      - Accounts
-      summary: Delete an account
-      parameters:
-      - type: string
-        description: 'Authorization Bearer Token with format: Bearer {token}'
-        name: Authorization
-        in: header
-        required: true
-      - type: string
-        description: Request ID for tracing
-        name: X-Request-Id
-        in: header
-      - type: string
-        description: Organization ID in UUID format
-        name: organization_id
-        in: path
-        required: true
-      - type: string
-        description: Ledger ID in UUID format
-        name: ledger_id
-        in: path
-        required: true
-      - type: string
-        description: Account ID in UUID format
-        name: id
-        in: path
-        required: true
-      responses:
-        '204':
-          description: Account successfully deleted
-        '401':
-          description: Unauthorized access
-          schema:
-            $ref: '#/definitions/Error'
-        '403':
-          description: Forbidden access
-          schema:
-            $ref: '#/definitions/Error'
-        '404':
-          description: Account, ledger, or organization not found
-          schema:
-            $ref: '#/definitions/Error'
-        '409':
-          description: 'Conflict: Account cannot be deleted due to existing dependencies'
-          schema:
-            $ref: '#/definitions/Error'
-        '500':
-          description: Internal server error
-          schema:
-            $ref: '#/definitions/Error'
-    patch:
-      description: Updates an existing account's properties such as name, status,
-        portfolio, segment, and metadata within the specified ledger
-      consumes:
-      - application/json
-      produces:
-      - application/json
-      tags:
-      - Accounts
-      summary: Update an account
-      parameters:
-      - type: string
-        description: 'Authorization Bearer Token with format: Bearer {token}'
-        name: Authorization
-        in: header
-        required: true
-      - type: string
-        description: Request ID for tracing
-        name: X-Request-Id
-        in: header
-      - type: string
-        description: Organization ID in UUID format
-        name: organization_id
-        in: path
-        required: true
-      - type: string
-        description: Ledger ID in UUID format
-        name: ledger_id
-        in: path
-        required: true
-      - type: string
-        description: Account ID in UUID format
-        name: id
-        in: path
-        required: true
-      - description: Account properties to update including name, status, portfolio,
-          segment, and optional metadata
-        name: account
-        in: body
-        required: true
-        schema:
-          $ref: '#/definitions/UpdateAccountInput'
-      responses:
-        '200':
-          description: Successfully updated account
-          schema:
-            $ref: '#/definitions/Account'
-        '400':
-          description: Invalid input, validation errors
-          schema:
-            $ref: '#/definitions/Error'
-        '401':
-          description: Unauthorized access
-          schema:
-            $ref: '#/definitions/Error'
-        '403':
-          description: Forbidden access
-          schema:
-            $ref: '#/definitions/Error'
-        '404':
-          description: Account, ledger, organization, portfolio, or segment not found
-          schema:
-            $ref: '#/definitions/Error'
-        '409':
-          description: 'Conflict: Account with the same name already exists'
-          schema:
-            $ref: '#/definitions/Error'
-        '500':
-          description: Internal server error
-          schema:
-            $ref: '#/definitions/Error'
-  /v1/organizations/{organization_id}/ledgers/{ledger_id}/asset-rates:
+            "$ref": "#/definitions/Error"
+  "/v1/organizations/{organization_id}/ledgers/{ledger_id}/asset-rates":
     put:
       description: Create or Update an AssetRate with the input details
       consumes:
@@ -2178,33 +2022,33 @@ paths:
         in: body
         required: true
         schema:
-          $ref: '#/definitions/CreateAssetRateInput'
+          "$ref": "#/definitions/CreateAssetRateInput"
       responses:
         '200':
           description: OK
           schema:
-            $ref: '#/definitions/AssetRate'
+            "$ref": "#/definitions/AssetRate"
         '400':
           description: Invalid input, validation errors
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '401':
           description: Unauthorized access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '403':
           description: Forbidden access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '404':
           description: Ledger or organization not found
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '500':
           description: Internal server error
           schema:
-            $ref: '#/definitions/Error'
-  /v1/organizations/{organization_id}/ledgers/{ledger_id}/asset-rates/from/{asset_code}:
+            "$ref": "#/definitions/Error"
+  "/v1/organizations/{organization_id}/ledgers/{ledger_id}/asset-rates/from/{asset_code}":
     get:
       description: Get an AssetRate by the Asset Code with the input details
       produces:
@@ -2273,34 +2117,34 @@ paths:
           description: OK
           schema:
             allOf:
-            - $ref: '#/definitions/http.Pagination'
+            - "$ref": "#/definitions/http.Pagination"
             - type: object
               properties:
                 items:
                   type: array
                   items:
-                    $ref: '#/definitions/AssetRate'
+                    "$ref": "#/definitions/AssetRate"
         '400':
           description: Invalid query parameters
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '401':
           description: Unauthorized access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '403':
           description: Forbidden access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '404':
           description: Asset code not found
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '500':
           description: Internal server error
           schema:
-            $ref: '#/definitions/Error'
-  /v1/organizations/{organization_id}/ledgers/{ledger_id}/asset-rates/{external_id}:
+            "$ref": "#/definitions/Error"
+  "/v1/organizations/{organization_id}/ledgers/{ledger_id}/asset-rates/{external_id}":
     get:
       description: Get an AssetRate by External ID with the input details
       produces:
@@ -2337,27 +2181,26 @@ paths:
         '200':
           description: OK
           schema:
-            $ref: '#/definitions/AssetRate'
+            "$ref": "#/definitions/AssetRate"
         '401':
           description: Unauthorized access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '403':
           description: Forbidden access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '404':
           description: Asset rate not found
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '500':
           description: Internal server error
           schema:
-            $ref: '#/definitions/Error'
-  /v1/organizations/{organization_id}/ledgers/{ledger_id}/assets:
+            "$ref": "#/definitions/Error"
+  "/v1/organizations/{organization_id}/ledgers/{ledger_id}/assets":
     get:
-      description: Returns a paginated list of assets within the specified ledger,
-        optionally filtered by metadata, date range, and other criteria
+      description: Returns a paginated list of assets within the specified ledger, optionally filtered by metadata, date range, and other criteria
       produces:
       - application/json
       tags:
@@ -2420,37 +2263,35 @@ paths:
           description: Successfully retrieved assets list
           schema:
             allOf:
-            - $ref: '#/definitions/http.Pagination'
+            - "$ref": "#/definitions/http.Pagination"
             - type: object
               properties:
                 items:
                   type: array
                   items:
-                    $ref: '#/definitions/Asset'
+                    "$ref": "#/definitions/Asset"
         '400':
           description: Invalid query parameters
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '401':
           description: Unauthorized access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '403':
           description: Forbidden access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '404':
           description: Organization or ledger not found
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '500':
           description: Internal server error
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
     post:
-      description: Creates a new asset within the specified ledger. Assets represent
-        currencies, cryptocurrencies, commodities, or other financial instruments
-        tracked in the ledger.
+      description: Creates a new asset within the specified ledger. Assets represent currencies, cryptocurrencies, commodities, or other financial instruments tracked in the ledger.
       consumes:
       - application/json
       produces:
@@ -2478,46 +2319,44 @@ paths:
         name: ledger_id
         in: path
         required: true
-      - description: Asset details including name, code, type, status, and optional
-          metadata
+      - description: Asset details including name, code, type, status, and optional metadata
         name: asset
         in: body
         required: true
         schema:
-          $ref: '#/definitions/CreateAssetInput'
+          "$ref": "#/definitions/CreateAssetInput"
       responses:
         '201':
           description: Successfully created asset
           schema:
-            $ref: '#/definitions/Asset'
+            "$ref": "#/definitions/Asset"
         '400':
           description: Invalid input, validation errors
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '401':
           description: Unauthorized access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '403':
           description: Forbidden access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '404':
           description: Organization or ledger not found
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '409':
           description: 'Conflict: Asset with the same name or code already exists'
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '500':
           description: Internal server error
           schema:
-            $ref: '#/definitions/Error'
-  /v1/organizations/{organization_id}/ledgers/{ledger_id}/assets/metrics/count:
+            "$ref": "#/definitions/Error"
+  "/v1/organizations/{organization_id}/ledgers/{ledger_id}/assets/metrics/count":
     head:
-      description: Returns the total count of assets for a specific ledger in an organization
-        as a header without a response body
+      description: Returns the total count of assets for a specific ledger in an organization as a header without a response body
       tags:
       - Assets
       summary: Count total assets
@@ -2547,23 +2386,22 @@ paths:
         '401':
           description: Unauthorized access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '403':
           description: Forbidden access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '404':
           description: Organization or ledger not found
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '500':
           description: Internal server error
           schema:
-            $ref: '#/definitions/Error'
-  /v1/organizations/{organization_id}/ledgers/{ledger_id}/assets/{id}:
+            "$ref": "#/definitions/Error"
+  "/v1/organizations/{organization_id}/ledgers/{ledger_id}/assets/{asset_id}":
     get:
-      description: Returns detailed information about an asset identified by its UUID
-        within the specified ledger
+      description: Returns detailed information about an asset identified by its UUID within the specified ledger
       produces:
       - application/json
       tags:
@@ -2591,33 +2429,32 @@ paths:
         required: true
       - type: string
         description: Asset ID in UUID format
-        name: id
+        name: asset_id
         in: path
         required: true
       responses:
         '200':
           description: Successfully retrieved asset
           schema:
-            $ref: '#/definitions/Asset'
+            "$ref": "#/definitions/Asset"
         '401':
           description: Unauthorized access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '403':
           description: Forbidden access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '404':
           description: Asset, ledger, or organization not found
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '500':
           description: Internal server error
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
     delete:
-      description: Permanently removes an asset from the specified ledger. This operation
-        cannot be undone.
+      description: Permanently removes an asset from the specified ledger. This operation cannot be undone.
       tags:
       - Assets
       summary: Delete an asset
@@ -2643,7 +2480,7 @@ paths:
         required: true
       - type: string
         description: Asset ID in UUID format
-        name: id
+        name: asset_id
         in: path
         required: true
       responses:
@@ -2652,26 +2489,25 @@ paths:
         '401':
           description: Unauthorized access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '403':
           description: Forbidden access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '404':
           description: Asset, ledger, or organization not found
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '409':
           description: 'Conflict: Asset cannot be deleted due to existing dependencies'
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '500':
           description: Internal server error
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
     patch:
-      description: Updates an existing asset's properties such as name, status, and
-        metadata within the specified ledger
+      description: Updates an existing asset's properties such as name, status, and metadata within the specified ledger
       consumes:
       - application/json
       produces:
@@ -2701,46 +2537,45 @@ paths:
         required: true
       - type: string
         description: Asset ID in UUID format
-        name: id
+        name: asset_id
         in: path
         required: true
-      - description: Asset properties to update including name, status, and optional
-          metadata
+      - description: Asset properties to update including name, status, and optional metadata
         name: asset
         in: body
         required: true
         schema:
-          $ref: '#/definitions/UpdateAssetInput'
+          "$ref": "#/definitions/UpdateAssetInput"
       responses:
         '200':
           description: Successfully updated asset
           schema:
-            $ref: '#/definitions/Asset'
+            "$ref": "#/definitions/Asset"
         '400':
           description: Invalid input, validation errors
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '401':
           description: Unauthorized access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '403':
           description: Forbidden access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '404':
           description: Asset, ledger, or organization not found
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '409':
           description: 'Conflict: Asset with the same name already exists'
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '500':
           description: Internal server error
           schema:
-            $ref: '#/definitions/Error'
-  /v1/organizations/{organization_id}/ledgers/{ledger_id}/balances:
+            "$ref": "#/definitions/Error"
+  "/v1/organizations/{organization_id}/ledgers/{ledger_id}/balances":
     get:
       description: Get all balances
       produces:
@@ -2797,30 +2632,30 @@ paths:
           description: OK
           schema:
             allOf:
-            - $ref: '#/definitions/http.Pagination'
+            - "$ref": "#/definitions/http.Pagination"
             - type: object
               properties:
                 items:
                   type: array
                   items:
-                    $ref: '#/definitions/mmodel.Balance'
+                    "$ref": "#/definitions/mmodel.Balance"
         '400':
           description: Invalid query parameters
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '401':
           description: Unauthorized access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '403':
           description: Forbidden access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '500':
           description: Internal server error
           schema:
-            $ref: '#/definitions/Error'
-  /v1/organizations/{organization_id}/ledgers/{ledger_id}/balances/{balance_id}:
+            "$ref": "#/definitions/Error"
+  "/v1/organizations/{organization_id}/ledgers/{ledger_id}/balances/{balance_id}":
     get:
       description: Get a Balance with the input ID
       produces:
@@ -2857,23 +2692,23 @@ paths:
         '200':
           description: OK
           schema:
-            $ref: '#/definitions/mmodel.Balance'
+            "$ref": "#/definitions/mmodel.Balance"
         '401':
           description: Unauthorized access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '403':
           description: Forbidden access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '404':
           description: Balance not found
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '500':
           description: Internal server error
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
     delete:
       description: Delete a Balance with the input ID
       produces:
@@ -2912,23 +2747,23 @@ paths:
         '401':
           description: Unauthorized access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '403':
           description: Forbidden access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '404':
           description: Balance not found
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '409':
           description: 'Conflict: Cannot delete balance with active operations'
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '500':
           description: Internal server error
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
     patch:
       description: Update a Balance with the input payload
       consumes:
@@ -2968,36 +2803,35 @@ paths:
         in: body
         required: true
         schema:
-          $ref: '#/definitions/UpdateBalance'
+          "$ref": "#/definitions/UpdateBalance"
       responses:
         '200':
           description: OK
           schema:
-            $ref: '#/definitions/mmodel.Balance'
+            "$ref": "#/definitions/mmodel.Balance"
         '400':
           description: Invalid input, validation errors
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '401':
           description: Unauthorized access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '403':
           description: Forbidden access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '404':
           description: Balance not found
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '500':
           description: Internal server error
           schema:
-            $ref: '#/definitions/Error'
-  /v1/organizations/{organization_id}/ledgers/{ledger_id}/balances/{balance_id}/history:
+            "$ref": "#/definitions/Error"
+  "/v1/organizations/{organization_id}/ledgers/{ledger_id}/balances/{balance_id}/history":
     get:
-      description: Get the historical state of a Balance at a specific point in time
-        (yyyy-mm-dd hh:mm:ss format)
+      description: Get the historical state of a Balance at a specific point in time (yyyy-mm-dd hh:mm:ss format)
       produces:
       - application/json
       tags:
@@ -3029,8 +2863,7 @@ paths:
         in: path
         required: true
       - type: string
-        description: 'Point in time (format: yyyy-mm-dd hh:mm:ss, e.g. 2024-01-15
-          10:30:00)'
+        description: 'Point in time (format: yyyy-mm-dd hh:mm:ss, e.g. 2024-01-15 10:30:00)'
         name: date
         in: query
         required: true
@@ -3038,31 +2871,30 @@ paths:
         '200':
           description: OK
           schema:
-            $ref: '#/definitions/BalanceHistory'
+            "$ref": "#/definitions/BalanceHistory"
         '400':
           description: Invalid date format or date in the future
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '401':
           description: Unauthorized access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '403':
           description: Forbidden access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '404':
           description: Balance not found or no data available at date
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '500':
           description: Internal server error
           schema:
-            $ref: '#/definitions/Error'
-  /v1/organizations/{organization_id}/ledgers/{ledger_id}/operation-routes:
+            "$ref": "#/definitions/Error"
+  "/v1/organizations/{organization_id}/ledgers/{ledger_id}/operation-routes":
     get:
-      description: Returns a list of all operation routes within the specified ledger
-        with cursor-based pagination
+      description: Returns a list of all operation routes within the specified ledger with cursor-based pagination
       produces:
       - application/json
       tags:
@@ -3117,33 +2949,33 @@ paths:
           description: OK
           schema:
             allOf:
-            - $ref: '#/definitions/http.Pagination'
+            - "$ref": "#/definitions/http.Pagination"
             - type: object
               properties:
                 items:
                   type: array
                   items:
-                    $ref: '#/definitions/OperationRoute'
+                    "$ref": "#/definitions/OperationRoute"
         '400':
           description: Invalid input, validation errors
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '401':
           description: Unauthorized access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '403':
           description: Forbidden access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '404':
           description: Operation Route not found
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '500':
           description: Internal server error
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
     post:
       description: Endpoint to create a new Operation Route.
       consumes:
@@ -3178,32 +3010,31 @@ paths:
         in: body
         required: true
         schema:
-          $ref: '#/definitions/CreateOperationRouteInput'
+          "$ref": "#/definitions/CreateOperationRouteInput"
       responses:
         '201':
           description: Successfully created operation route
           schema:
-            $ref: '#/definitions/OperationRoute'
+            "$ref": "#/definitions/OperationRoute"
         '400':
           description: Invalid input, validation errors
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '401':
           description: Unauthorized access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '403':
           description: Forbidden access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '500':
           description: Internal server error
           schema:
-            $ref: '#/definitions/Error'
-  /v1/organizations/{organization_id}/ledgers/{ledger_id}/operation-routes/{id}:
+            "$ref": "#/definitions/Error"
+  "/v1/organizations/{organization_id}/ledgers/{ledger_id}/operation-routes/{operation_route_id}":
     get:
-      description: Returns detailed information about an operation route identified
-        by its UUID within the specified ledger
+      description: Returns detailed information about an operation route identified by its UUID within the specified ledger
       produces:
       - application/json
       tags:
@@ -3231,22 +3062,20 @@ paths:
         required: true
       - type: string
         description: Operation Route ID in UUID format
-        name: id
+        name: operation_route_id
         in: path
         required: true
       responses:
         '200':
           description: Successfully retrieved operation route
           schema:
-            $ref: '#/definitions/OperationRoute'
+            "$ref": "#/definitions/OperationRoute"
         '401':
           description: Unauthorized access
           schema:
-            $ref: '#/definitions/Error'
-  /v1/organizations/{organization_id}/ledgers/{ledger_id}/operation-routes/{operation_route_id}:
+            "$ref": "#/definitions/Error"
     delete:
-      description: Deletes an existing operation route identified by its UUID within
-        the specified ledger
+      description: Deletes an existing operation route identified by its UUID within the specified ledger
       produces:
       - application/json
       tags:
@@ -3283,18 +3112,17 @@ paths:
         '401':
           description: Unauthorized access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '404':
           description: Operation Route not found
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '500':
           description: Internal server error
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
     patch:
-      description: Updates an existing operation route's properties such as title,
-        description, and type within the specified ledger
+      description: Updates an existing operation route's properties such as title, description, and type within the specified ledger
       consumes:
       - application/json
       produces:
@@ -3332,40 +3160,39 @@ paths:
         in: body
         required: true
         schema:
-          $ref: '#/definitions/UpdateOperationRouteInput'
+          "$ref": "#/definitions/UpdateOperationRouteInput"
       responses:
         '200':
           description: Successfully updated operation route
           schema:
-            $ref: '#/definitions/OperationRoute'
+            "$ref": "#/definitions/OperationRoute"
         '400':
           description: Invalid input, validation errors
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '401':
           description: Unauthorized access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '403':
           description: Forbidden access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '404':
           description: Operation Route not found
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '409':
           description: 'Conflict: Operation Route with the same title already exists'
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '500':
           description: Internal server error
           schema:
-            $ref: '#/definitions/Error'
-  /v1/organizations/{organization_id}/ledgers/{ledger_id}/portfolios:
+            "$ref": "#/definitions/Error"
+  "/v1/organizations/{organization_id}/ledgers/{ledger_id}/portfolios":
     get:
-      description: Returns a paginated list of portfolios within the specified ledger,
-        optionally filtered by metadata, date range, and other criteria
+      description: Returns a paginated list of portfolios within the specified ledger, optionally filtered by metadata, date range, and other criteria
       produces:
       - application/json
       tags:
@@ -3428,37 +3255,35 @@ paths:
           description: Successfully retrieved portfolios list
           schema:
             allOf:
-            - $ref: '#/definitions/http.Pagination'
+            - "$ref": "#/definitions/http.Pagination"
             - type: object
               properties:
                 items:
                   type: array
                   items:
-                    $ref: '#/definitions/Portfolio'
+                    "$ref": "#/definitions/Portfolio"
         '400':
           description: Invalid query parameters
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '401':
           description: Unauthorized access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '403':
           description: Forbidden access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '404':
           description: Organization or ledger not found
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '500':
           description: Internal server error
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
     post:
-      description: Creates a new portfolio within the specified ledger. Portfolios
-        represent collections of accounts grouped for specific purposes such as business
-        units, departments, or client portfolios.
+      description: Creates a new portfolio within the specified ledger. Portfolios represent collections of accounts grouped for specific purposes such as business units, departments, or client portfolios.
       consumes:
       - application/json
       produces:
@@ -3486,46 +3311,44 @@ paths:
         name: ledger_id
         in: path
         required: true
-      - description: Portfolio details including name, optional entity ID, status,
-          and metadata
+      - description: Portfolio details including name, optional entity ID, status, and metadata
         name: portfolio
         in: body
         required: true
         schema:
-          $ref: '#/definitions/CreatePortfolioInput'
+          "$ref": "#/definitions/CreatePortfolioInput"
       responses:
         '201':
           description: Successfully created portfolio
           schema:
-            $ref: '#/definitions/Portfolio'
+            "$ref": "#/definitions/Portfolio"
         '400':
           description: Invalid input, validation errors
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '401':
           description: Unauthorized access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '403':
           description: Forbidden access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '404':
           description: Organization or ledger not found
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '409':
           description: 'Conflict: Portfolio with the same name already exists'
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '500':
           description: Internal server error
           schema:
-            $ref: '#/definitions/Error'
-  /v1/organizations/{organization_id}/ledgers/{ledger_id}/portfolios/metrics/count:
+            "$ref": "#/definitions/Error"
+  "/v1/organizations/{organization_id}/ledgers/{ledger_id}/portfolios/metrics/count":
     head:
-      description: Returns the total count of portfolios for a specific organization
-        and ledger as a header without a response body
+      description: Returns the total count of portfolios for a specific organization and ledger as a header without a response body
       tags:
       - Portfolios
       summary: Count total portfolios
@@ -3551,32 +3374,30 @@ paths:
         required: true
       responses:
         '204':
-          description: Successfully counted portfolios, total count available in X-Total-Count
-            header
+          description: Successfully counted portfolios, total count available in X-Total-Count header
         '400':
           description: Invalid UUID format
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '401':
           description: Unauthorized access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '403':
           description: Forbidden access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '404':
           description: Organization or ledger not found
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '500':
           description: Internal server error
           schema:
-            $ref: '#/definitions/Error'
-  /v1/organizations/{organization_id}/ledgers/{ledger_id}/portfolios/{id}:
+            "$ref": "#/definitions/Error"
+  "/v1/organizations/{organization_id}/ledgers/{ledger_id}/portfolios/{portfolio_id}":
     get:
-      description: Returns detailed information about a portfolio identified by its
-        UUID within the specified ledger
+      description: Returns detailed information about a portfolio identified by its UUID within the specified ledger
       produces:
       - application/json
       tags:
@@ -3604,33 +3425,32 @@ paths:
         required: true
       - type: string
         description: Portfolio ID in UUID format
-        name: id
+        name: portfolio_id
         in: path
         required: true
       responses:
         '200':
           description: Successfully retrieved portfolio
           schema:
-            $ref: '#/definitions/Portfolio'
+            "$ref": "#/definitions/Portfolio"
         '401':
           description: Unauthorized access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '403':
           description: Forbidden access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '404':
           description: Portfolio, ledger, or organization not found
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '500':
           description: Internal server error
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
     delete:
-      description: Permanently removes a portfolio from the specified ledger. This
-        operation cannot be undone.
+      description: Permanently removes a portfolio from the specified ledger. This operation cannot be undone.
       tags:
       - Portfolios
       summary: Delete a portfolio
@@ -3656,7 +3476,7 @@ paths:
         required: true
       - type: string
         description: Portfolio ID in UUID format
-        name: id
+        name: portfolio_id
         in: path
         required: true
       responses:
@@ -3665,26 +3485,25 @@ paths:
         '401':
           description: Unauthorized access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '403':
           description: Forbidden access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '404':
           description: Portfolio, ledger, or organization not found
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '409':
           description: 'Conflict: Portfolio cannot be deleted due to existing dependencies'
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '500':
           description: Internal server error
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
     patch:
-      description: Updates an existing portfolio's properties such as name, entity
-        ID, status, and metadata within the specified ledger
+      description: Updates an existing portfolio's properties such as name, entity ID, status, and metadata within the specified ledger
       consumes:
       - application/json
       produces:
@@ -3714,49 +3533,47 @@ paths:
         required: true
       - type: string
         description: Portfolio ID in UUID format
-        name: id
+        name: portfolio_id
         in: path
         required: true
-      - description: Portfolio properties to update including name, entity ID, status,
-          and optional metadata
+      - description: Portfolio properties to update including name, entity ID, status, and optional metadata
         name: portfolio
         in: body
         required: true
         schema:
-          $ref: '#/definitions/UpdatePortfolioInput'
+          "$ref": "#/definitions/UpdatePortfolioInput"
       responses:
         '200':
           description: Successfully updated portfolio
           schema:
-            $ref: '#/definitions/Portfolio'
+            "$ref": "#/definitions/Portfolio"
         '400':
           description: Invalid input, validation errors
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '401':
           description: Unauthorized access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '403':
           description: Forbidden access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '404':
           description: Portfolio, ledger, or organization not found
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '409':
           description: 'Conflict: Portfolio with the same name already exists'
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '500':
           description: Internal server error
           schema:
-            $ref: '#/definitions/Error'
-  /v1/organizations/{organization_id}/ledgers/{ledger_id}/segments:
+            "$ref": "#/definitions/Error"
+  "/v1/organizations/{organization_id}/ledgers/{ledger_id}/segments":
     get:
-      description: Returns a paginated list of segments within the specified ledger,
-        optionally filtered by metadata, date range, and other criteria
+      description: Returns a paginated list of segments within the specified ledger, optionally filtered by metadata, date range, and other criteria
       produces:
       - application/json
       tags:
@@ -3819,37 +3636,35 @@ paths:
           description: Successfully retrieved segments list
           schema:
             allOf:
-            - $ref: '#/definitions/http.Pagination'
+            - "$ref": "#/definitions/http.Pagination"
             - type: object
               properties:
                 items:
                   type: array
                   items:
-                    $ref: '#/definitions/Segment'
+                    "$ref": "#/definitions/Segment"
         '400':
           description: Invalid query parameters
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '401':
           description: Unauthorized access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '403':
           description: Forbidden access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '404':
           description: Organization or ledger not found
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '500':
           description: Internal server error
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
     post:
-      description: Creates a new segment within the specified ledger. Segments represent
-        logical divisions within a ledger, such as business areas, product lines,
-        or customer categories.
+      description: Creates a new segment within the specified ledger. Segments represent logical divisions within a ledger, such as business areas, product lines, or customer categories.
       consumes:
       - application/json
       produces:
@@ -3882,40 +3697,39 @@ paths:
         in: body
         required: true
         schema:
-          $ref: '#/definitions/CreateSegmentInput'
+          "$ref": "#/definitions/CreateSegmentInput"
       responses:
         '201':
           description: Successfully created segment
           schema:
-            $ref: '#/definitions/Segment'
+            "$ref": "#/definitions/Segment"
         '400':
           description: Invalid input, validation errors
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '401':
           description: Unauthorized access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '403':
           description: Forbidden access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '404':
           description: Organization or ledger not found
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '409':
           description: 'Conflict: Segment with the same name already exists'
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '500':
           description: Internal server error
           schema:
-            $ref: '#/definitions/Error'
-  /v1/organizations/{organization_id}/ledgers/{ledger_id}/segments/metrics/count:
+            "$ref": "#/definitions/Error"
+  "/v1/organizations/{organization_id}/ledgers/{ledger_id}/segments/metrics/count":
     head:
-      description: Returns the total count of segments for the specified organization
-        and ledger
+      description: Returns the total count of segments for the specified organization and ledger
       tags:
       - Segments
       summary: Count segments
@@ -3945,23 +3759,22 @@ paths:
         '401':
           description: Unauthorized access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '403':
           description: Forbidden access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '404':
           description: Organization or ledger not found
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '500':
           description: Internal server error
           schema:
-            $ref: '#/definitions/Error'
-  /v1/organizations/{organization_id}/ledgers/{ledger_id}/segments/{id}:
+            "$ref": "#/definitions/Error"
+  "/v1/organizations/{organization_id}/ledgers/{ledger_id}/segments/{segment_id}":
     get:
-      description: Returns detailed information about a segment identified by its
-        UUID within the specified ledger
+      description: Returns detailed information about a segment identified by its UUID within the specified ledger
       produces:
       - application/json
       tags:
@@ -3989,33 +3802,32 @@ paths:
         required: true
       - type: string
         description: Segment ID in UUID format
-        name: id
+        name: segment_id
         in: path
         required: true
       responses:
         '200':
           description: Successfully retrieved segment
           schema:
-            $ref: '#/definitions/Segment'
+            "$ref": "#/definitions/Segment"
         '401':
           description: Unauthorized access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '403':
           description: Forbidden access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '404':
           description: Segment, ledger, or organization not found
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '500':
           description: Internal server error
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
     delete:
-      description: Permanently removes a segment from the specified ledger. This operation
-        cannot be undone.
+      description: Permanently removes a segment from the specified ledger. This operation cannot be undone.
       tags:
       - Segments
       summary: Delete a segment
@@ -4041,7 +3853,7 @@ paths:
         required: true
       - type: string
         description: Segment ID in UUID format
-        name: id
+        name: segment_id
         in: path
         required: true
       responses:
@@ -4050,26 +3862,25 @@ paths:
         '401':
           description: Unauthorized access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '403':
           description: Forbidden access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '404':
           description: Segment, ledger, or organization not found
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '409':
           description: 'Conflict: Segment cannot be deleted due to existing dependencies'
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '500':
           description: Internal server error
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
     patch:
-      description: Updates an existing segment's properties such as name, status,
-        and metadata within the specified ledger
+      description: Updates an existing segment's properties such as name, status, and metadata within the specified ledger
       consumes:
       - application/json
       produces:
@@ -4099,46 +3910,154 @@ paths:
         required: true
       - type: string
         description: Segment ID in UUID format
-        name: id
+        name: segment_id
         in: path
         required: true
-      - description: Segment properties to update including name, status, and optional
-          metadata
+      - description: Segment properties to update including name, status, and optional metadata
         name: segment
         in: body
         required: true
         schema:
-          $ref: '#/definitions/UpdateSegmentInput'
+          "$ref": "#/definitions/UpdateSegmentInput"
       responses:
         '200':
           description: Successfully updated segment
           schema:
-            $ref: '#/definitions/Segment'
+            "$ref": "#/definitions/Segment"
         '400':
           description: Invalid input, validation errors
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '401':
           description: Unauthorized access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '403':
           description: Forbidden access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '404':
           description: Segment, ledger, or organization not found
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '409':
           description: 'Conflict: Segment with the same name already exists'
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '500':
           description: Internal server error
           schema:
-            $ref: '#/definitions/Error'
-  /v1/organizations/{organization_id}/ledgers/{ledger_id}/transaction-routes:
+            "$ref": "#/definitions/Error"
+  "/v1/organizations/{organization_id}/ledgers/{ledger_id}/settings":
+    get:
+      description: Returns the current configuration settings for a specific ledger. If no settings have been persisted, returns the default settings object.
+      produces:
+      - application/json
+      tags:
+      - Ledgers
+      summary: Get ledger settings
+      parameters:
+      - type: string
+        description: 'Authorization Bearer Token with format: Bearer {token}'
+        name: Authorization
+        in: header
+        required: true
+      - type: string
+        description: Request ID for tracing
+        name: X-Request-Id
+        in: header
+      - type: string
+        description: Organization ID in UUID format
+        name: organization_id
+        in: path
+        required: true
+      - type: string
+        description: Ledger ID in UUID format
+        name: ledger_id
+        in: path
+        required: true
+      responses:
+        '200':
+          description: Successfully retrieved ledger settings
+          schema:
+            "$ref": "#/definitions/mmodel.LedgerSettings"
+        '401':
+          description: Unauthorized access
+          schema:
+            "$ref": "#/definitions/Error"
+        '403':
+          description: Forbidden access
+          schema:
+            "$ref": "#/definitions/Error"
+        '404':
+          description: Ledger not found
+          schema:
+            "$ref": "#/definitions/Error"
+        '500':
+          description: Internal server error
+          schema:
+            "$ref": "#/definitions/Error"
+    patch:
+      description: 'Updates the configuration settings for a specific ledger using schema-aware deep merge. Only known settings fields are allowed - unknown fields return error 0147 (ErrUnknownSettingsField). Type validation is enforced - incorrect types return error 0148 (ErrInvalidSettingsFieldType). Nested objects (like ''accounting'') are deep-merged, preserving existing properties not specified in the update. Example: updating only ''accounting.validateRoutes'' preserves the existing ''accounting.validateAccountType'' value. Allowed fields: accounting.validateAccountType (boolean), accounting.validateRoutes (boolean).'
+      consumes:
+      - application/json
+      produces:
+      - application/json
+      tags:
+      - Ledgers
+      summary: Update ledger settings
+      parameters:
+      - type: string
+        description: 'Authorization Bearer Token with format: Bearer {token}'
+        name: Authorization
+        in: header
+        required: true
+      - type: string
+        description: Request ID for tracing
+        name: X-Request-Id
+        in: header
+      - type: string
+        description: Organization ID in UUID format
+        name: organization_id
+        in: path
+        required: true
+      - type: string
+        description: Ledger ID in UUID format
+        name: ledger_id
+        in: path
+        required: true
+      - description: 'Settings to merge with existing settings. Only known fields allowed: accounting.validateAccountType (bool), accounting.validateRoutes (bool)'
+        name: settings
+        in: body
+        required: true
+        schema:
+          type: object
+      responses:
+        '200':
+          description: Successfully updated ledger settings
+          schema:
+            "$ref": "#/definitions/mmodel.LedgerSettings"
+        '400':
+          description: Invalid request body, unknown field (0147), or invalid field type (0148)
+          schema:
+            "$ref": "#/definitions/Error"
+        '401':
+          description: Unauthorized access
+          schema:
+            "$ref": "#/definitions/Error"
+        '403':
+          description: Forbidden access
+          schema:
+            "$ref": "#/definitions/Error"
+        '404':
+          description: Ledger not found
+          schema:
+            "$ref": "#/definitions/Error"
+        '500':
+          description: Internal server error
+          schema:
+            "$ref": "#/definitions/Error"
+  "/v1/organizations/{organization_id}/ledgers/{ledger_id}/transaction-routes":
     get:
       description: Endpoint to get all Transaction Routes with optional metadata filtering.
       consumes:
@@ -4197,29 +4116,29 @@ paths:
           description: OK
           schema:
             allOf:
-            - $ref: '#/definitions/http.Pagination'
+            - "$ref": "#/definitions/http.Pagination"
             - type: object
               properties:
                 items:
                   type: array
                   items:
-                    $ref: '#/definitions/TransactionRoute'
+                    "$ref": "#/definitions/TransactionRoute"
         '400':
           description: Invalid input, validation errors
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '401':
           description: Unauthorized access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '403':
           description: Forbidden access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '500':
           description: Internal server error
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
     post:
       description: Endpoint to create a new Transaction Route.
       consumes:
@@ -4254,29 +4173,29 @@ paths:
         in: body
         required: true
         schema:
-          $ref: '#/definitions/CreateTransactionRouteInput'
+          "$ref": "#/definitions/CreateTransactionRouteInput"
       responses:
         '201':
           description: Successfully created transaction route
           schema:
-            $ref: '#/definitions/TransactionRoute'
+            "$ref": "#/definitions/TransactionRoute"
         '400':
           description: Invalid input, validation errors
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '401':
           description: Unauthorized access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '403':
           description: Forbidden access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '500':
           description: Internal server error
           schema:
-            $ref: '#/definitions/Error'
-  /v1/organizations/{organization_id}/ledgers/{ledger_id}/transaction-routes/{transaction_route_id}:
+            "$ref": "#/definitions/Error"
+  "/v1/organizations/{organization_id}/ledgers/{ledger_id}/transaction-routes/{transaction_route_id}":
     get:
       description: Endpoint to get a Transaction Route by its ID.
       consumes:
@@ -4315,27 +4234,27 @@ paths:
         '200':
           description: Successfully retrieved transaction route
           schema:
-            $ref: '#/definitions/TransactionRoute'
+            "$ref": "#/definitions/TransactionRoute"
         '400':
           description: Invalid input, validation errors
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '401':
           description: Unauthorized access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '403':
           description: Forbidden access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '404':
           description: Transaction Route not found
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '500':
           description: Internal server error
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
     delete:
       description: Endpoint to delete a Transaction Route by its ID.
       consumes:
@@ -4376,23 +4295,23 @@ paths:
         '400':
           description: Invalid input, validation errors
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '401':
           description: Unauthorized access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '403':
           description: Forbidden access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '404':
           description: Transaction Route not found
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '500':
           description: Internal server error
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
     patch:
       description: Endpoint to update a Transaction Route by its ID.
       consumes:
@@ -4432,29 +4351,29 @@ paths:
         in: body
         required: true
         schema:
-          $ref: '#/definitions/UpdateTransactionRouteInput'
+          "$ref": "#/definitions/UpdateTransactionRouteInput"
       responses:
         '200':
           description: Successfully updated transaction route
           schema:
-            $ref: '#/definitions/TransactionRoute'
+            "$ref": "#/definitions/TransactionRoute"
         '400':
           description: Invalid input, validation errors
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '401':
           description: Unauthorized access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '403':
           description: Forbidden access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '500':
           description: Internal server error
           schema:
-            $ref: '#/definitions/Error'
-  /v1/organizations/{organization_id}/ledgers/{ledger_id}/transactions:
+            "$ref": "#/definitions/Error"
+  "/v1/organizations/{organization_id}/ledgers/{ledger_id}/transactions":
     get:
       description: Get all Transactions with the input metadata or without metadata
       produces:
@@ -4511,30 +4430,30 @@ paths:
           description: OK
           schema:
             allOf:
-            - $ref: '#/definitions/http.Pagination'
+            - "$ref": "#/definitions/http.Pagination"
             - type: object
               properties:
                 items:
                   type: array
                   items:
-                    $ref: '#/definitions/Transaction'
+                    "$ref": "#/definitions/Transaction"
         '400':
           description: Invalid query parameters
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '401':
           description: Unauthorized access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '403':
           description: Forbidden access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '500':
           description: Internal server error
           schema:
-            $ref: '#/definitions/Error'
-  /v1/organizations/{organization_id}/ledgers/{ledger_id}/transactions/annotation:
+            "$ref": "#/definitions/Error"
+  "/v1/organizations/{organization_id}/ledgers/{ledger_id}/transactions/annotation":
     post:
       description: Create a Transaction Annotation with the input payload
       consumes:
@@ -4569,33 +4488,33 @@ paths:
         in: body
         required: true
         schema:
-          $ref: '#/definitions/github_com_LerianStudio_midaz_v3_components_ledger_internal_adapters_postgres_transaction.CreateTransactionSwaggerModel'
+          "$ref": "#/definitions/CreateTransactionInput"
       responses:
         '201':
           description: Created
           schema:
-            $ref: '#/definitions/Transaction'
+            "$ref": "#/definitions/Transaction"
         '400':
           description: Invalid input, validation errors
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '401':
           description: Unauthorized access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '403':
           description: Forbidden access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '422':
           description: Unprocessable Entity, validation errors
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '500':
           description: Internal server error
           schema:
-            $ref: '#/definitions/Error'
-  /v1/organizations/{organization_id}/ledgers/{ledger_id}/transactions/dsl:
+            "$ref": "#/definitions/Error"
+  "/v1/organizations/{organization_id}/ledgers/{ledger_id}/transactions/dsl":
     post:
       description: Create a Transaction with the input DSL file
       consumes:
@@ -4634,28 +4553,28 @@ paths:
         '200':
           description: OK
           schema:
-            $ref: '#/definitions/Transaction'
+            "$ref": "#/definitions/Transaction"
         '400':
           description: Invalid DSL file format or validation errors
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '401':
           description: Unauthorized access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '403':
           description: Forbidden access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '422':
           description: Unprocessable Entity, validation errors
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '500':
           description: Internal server error
           schema:
-            $ref: '#/definitions/Error'
-  /v1/organizations/{organization_id}/ledgers/{ledger_id}/transactions/inflow:
+            "$ref": "#/definitions/Error"
+  "/v1/organizations/{organization_id}/ledgers/{ledger_id}/transactions/inflow":
     post:
       description: Create a Transaction with the input payload
       consumes:
@@ -4690,33 +4609,33 @@ paths:
         in: body
         required: true
         schema:
-          $ref: '#/definitions/CreateTransactionInflowSwaggerModel'
+          "$ref": "#/definitions/CreateTransactionInflowInput"
       responses:
         '201':
           description: Created
           schema:
-            $ref: '#/definitions/Transaction'
+            "$ref": "#/definitions/Transaction"
         '400':
           description: Invalid input, validation errors
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '401':
           description: Unauthorized access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '403':
           description: Forbidden access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '422':
           description: Unprocessable Entity, validation errors
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '500':
           description: Internal server error
           schema:
-            $ref: '#/definitions/Error'
-  /v1/organizations/{organization_id}/ledgers/{ledger_id}/transactions/json:
+            "$ref": "#/definitions/Error"
+  "/v1/organizations/{organization_id}/ledgers/{ledger_id}/transactions/json":
     post:
       description: Create a Transaction with the input payload
       consumes:
@@ -4751,36 +4670,35 @@ paths:
         in: body
         required: true
         schema:
-          $ref: '#/definitions/github_com_LerianStudio_midaz_v3_components_ledger_internal_adapters_postgres_transaction.CreateTransactionSwaggerModel'
+          "$ref": "#/definitions/CreateTransactionInput"
       responses:
         '201':
           description: Created
           schema:
-            $ref: '#/definitions/Transaction'
+            "$ref": "#/definitions/Transaction"
         '400':
           description: Invalid input, validation errors
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '401':
           description: Unauthorized access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '403':
           description: Forbidden access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '422':
           description: Unprocessable Entity, validation errors
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '500':
           description: Internal server error
           schema:
-            $ref: '#/definitions/Error'
-  /v1/organizations/{organization_id}/ledgers/{ledger_id}/transactions/metrics/count:
+            "$ref": "#/definitions/Error"
+  "/v1/organizations/{organization_id}/ledgers/{ledger_id}/transactions/metrics/count":
     head:
-      description: Count transactions matching optional filters (route, status, date
-        range)
+      description: Count transactions matching optional filters (route, status, date range)
       tags:
       - Transactions
       summary: Count Transactions by Filters
@@ -4840,20 +4758,20 @@ paths:
         '400':
           description: Bad Request
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '401':
           description: Unauthorized
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '403':
           description: Forbidden
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '500':
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/Error'
-  /v1/organizations/{organization_id}/ledgers/{ledger_id}/transactions/outflow:
+            "$ref": "#/definitions/Error"
+  "/v1/organizations/{organization_id}/ledgers/{ledger_id}/transactions/outflow":
     post:
       description: Create a Transaction with the input payload
       consumes:
@@ -4888,33 +4806,33 @@ paths:
         in: body
         required: true
         schema:
-          $ref: '#/definitions/CreateTransactionOutflowSwaggerModel'
+          "$ref": "#/definitions/CreateTransactionOutflowInput"
       responses:
         '201':
           description: Created
           schema:
-            $ref: '#/definitions/Transaction'
+            "$ref": "#/definitions/Transaction"
         '400':
           description: Invalid input, validation errors
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '401':
           description: Unauthorized access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '403':
           description: Forbidden access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '422':
           description: Unprocessable Entity, validation errors
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '500':
           description: Internal server error
           schema:
-            $ref: '#/definitions/Error'
-  /v1/organizations/{organization_id}/ledgers/{ledger_id}/transactions/{transaction_id}:
+            "$ref": "#/definitions/Error"
+  "/v1/organizations/{organization_id}/ledgers/{ledger_id}/transactions/{transaction_id}":
     get:
       description: Get a Transaction with the input ID
       produces:
@@ -4951,27 +4869,27 @@ paths:
         '200':
           description: OK
           schema:
-            $ref: '#/definitions/Transaction'
+            "$ref": "#/definitions/Transaction"
         '400':
           description: Invalid query parameters
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '401':
           description: Unauthorized access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '403':
           description: Forbidden access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '404':
           description: Transaction not found
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '500':
           description: Internal server error
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
     patch:
       description: Update a Transaction with the input payload
       consumes:
@@ -5011,33 +4929,33 @@ paths:
         in: body
         required: true
         schema:
-          $ref: '#/definitions/UpdateTransactionInput'
+          "$ref": "#/definitions/UpdateTransactionInput"
       responses:
         '200':
           description: OK
           schema:
-            $ref: '#/definitions/Transaction'
+            "$ref": "#/definitions/Transaction"
         '400':
           description: Invalid input, validation errors
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '401':
           description: Unauthorized access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '403':
           description: Forbidden access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '404':
           description: Transaction not found
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '500':
           description: Internal server error
           schema:
-            $ref: '#/definitions/Error'
-  /v1/organizations/{organization_id}/ledgers/{ledger_id}/transactions/{transaction_id}/cancel:
+            "$ref": "#/definitions/Error"
+  "/v1/organizations/{organization_id}/ledgers/{ledger_id}/transactions/{transaction_id}/cancel":
     post:
       description: Cancel a previously created pre transaction
       consumes:
@@ -5076,32 +4994,32 @@ paths:
         '201':
           description: Created
           schema:
-            $ref: '#/definitions/Transaction'
+            "$ref": "#/definitions/Transaction"
         '400':
           description: Invalid request or transaction cannot be reverted
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '401':
           description: Unauthorized access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '403':
           description: Forbidden access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '404':
           description: Transaction not found
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '409':
           description: Transaction already has a parent transaction
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '500':
           description: Internal server error
           schema:
-            $ref: '#/definitions/Error'
-  /v1/organizations/{organization_id}/ledgers/{ledger_id}/transactions/{transaction_id}/commit:
+            "$ref": "#/definitions/Error"
+  "/v1/organizations/{organization_id}/ledgers/{ledger_id}/transactions/{transaction_id}/commit":
     post:
       description: Commit a previously created transaction
       consumes:
@@ -5140,32 +5058,32 @@ paths:
         '201':
           description: Created
           schema:
-            $ref: '#/definitions/Transaction'
+            "$ref": "#/definitions/Transaction"
         '400':
           description: Invalid request or transaction cannot be reverted
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '401':
           description: Unauthorized access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '403':
           description: Forbidden access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '404':
           description: Transaction not found
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '409':
           description: Transaction already has a parent transaction
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '500':
           description: Internal server error
           schema:
-            $ref: '#/definitions/Error'
-  /v1/organizations/{organization_id}/ledgers/{ledger_id}/transactions/{transaction_id}/operations/{operation_id}:
+            "$ref": "#/definitions/Error"
+  "/v1/organizations/{organization_id}/ledgers/{ledger_id}/transactions/{transaction_id}/operations/{operation_id}":
     patch:
       description: Update an Operation with the input payload
       consumes:
@@ -5210,33 +5128,33 @@ paths:
         in: body
         required: true
         schema:
-          $ref: '#/definitions/UpdateOperationInput'
+          "$ref": "#/definitions/UpdateOperationInput"
       responses:
         '200':
           description: OK
           schema:
-            $ref: '#/definitions/Operation'
+            "$ref": "#/definitions/Operation"
         '400':
           description: Invalid input, validation errors
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '401':
           description: Unauthorized access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '403':
           description: Forbidden access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '404':
           description: Operation not found
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '500':
           description: Internal server error
           schema:
-            $ref: '#/definitions/Error'
-  /v1/organizations/{organization_id}/ledgers/{ledger_id}/transactions/{transaction_id}/revert:
+            "$ref": "#/definitions/Error"
+  "/v1/organizations/{organization_id}/ledgers/{ledger_id}/transactions/{transaction_id}/revert":
     post:
       description: Revert a Transaction with Transaction ID only
       consumes:
@@ -5275,36 +5193,36 @@ paths:
         '200':
           description: OK
           schema:
-            $ref: '#/definitions/Transaction'
+            "$ref": "#/definitions/Transaction"
         '400':
           description: Invalid request or transaction cannot be reverted
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '401':
           description: Unauthorized access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '403':
           description: Forbidden access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '404':
           description: Transaction not found
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '409':
           description: Transaction already has a parent transaction
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '422':
           description: Unprocessable Entity, validation errors
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '500':
           description: Internal server error
           schema:
-            $ref: '#/definitions/Error'
-  /v1/settings/metadata-indexes:
+            "$ref": "#/definitions/Error"
+  "/v1/settings/metadata-indexes":
     get:
       description: Get all metadata indexes, optionally filtered by entity name
       produces:
@@ -5344,24 +5262,24 @@ paths:
           schema:
             type: array
             items:
-              $ref: '#/definitions/MetadataIndex'
+              "$ref": "#/definitions/MetadataIndex"
         '400':
           description: Invalid query parameters
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '401':
           description: Unauthorized access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '403':
           description: Forbidden access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '500':
           description: Internal server error
           schema:
-            $ref: '#/definitions/Error'
-  /v1/settings/metadata-indexes/entities/{entity_name}:
+            "$ref": "#/definitions/Error"
+  "/v1/settings/metadata-indexes/entities/{entity_name}":
     post:
       description: Create a metadata index for the specified entity
       consumes:
@@ -5403,33 +5321,33 @@ paths:
         in: body
         required: true
         schema:
-          $ref: '#/definitions/CreateMetadataIndexInput'
+          "$ref": "#/definitions/CreateMetadataIndexInput"
       responses:
         '201':
           description: Successfully created metadata index
           schema:
-            $ref: '#/definitions/MetadataIndex'
+            "$ref": "#/definitions/MetadataIndex"
         '400':
           description: Invalid input, validation errors
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '401':
           description: Unauthorized access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '403':
           description: Forbidden access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '409':
           description: 'Conflict: Metadata index already exists'
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '500':
           description: Internal server error
           schema:
-            $ref: '#/definitions/Error'
-  /v1/settings/metadata-indexes/entities/{entity_name}/key/{index_key}:
+            "$ref": "#/definitions/Error"
+  "/v1/settings/metadata-indexes/entities/{entity_name}/key/{index_key}":
     delete:
       description: Delete a metadata index by entity name and index key
       produces:
@@ -5475,48 +5393,41 @@ paths:
         '400':
           description: Invalid input, validation errors
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '401':
           description: Unauthorized access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '403':
           description: Forbidden access
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '404':
           description: Metadata index not found
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
         '500':
           description: Internal server error
           schema:
-            $ref: '#/definitions/Error'
+            "$ref": "#/definitions/Error"
 definitions:
   Account:
-    description: Complete account entity containing all fields including system-generated
-      fields like ID, creation timestamps, and metadata. This is the response format
-      for account operations. Accounts represent individual financial entities (bank
-      accounts, cards, expense categories, etc.) within a ledger and are the primary
-      structures for tracking balances and transactions.
+    description: Complete account entity containing all fields including system-generated fields like ID, creation timestamps, and metadata. This is the response format for account operations. Accounts represent individual financial entities (bank accounts, cards, expense categories, etc.) within a ledger and are the primary structures for tracking balances and transactions.
     type: object
     properties:
       alias:
-        description: 'Unique alias for the account (makes referencing easier)
-
+        description: |-
+          Unique alias for the account (makes referencing easier)
           example: @treasury_checking
-
-          maxLength: 100'
+          maxLength: 100
         type: string
         maxLength: 100
-        example: '@treasury_checking'
+        example: "@treasury_checking"
       assetCode:
-        description: 'Asset code associated with this account (determines currency/asset
-          type)
-
+        description: |-
+          Asset code associated with this account (determines currency/asset type)
           example: USD
-
-          maxLength: 100'
+          maxLength: 100
         type: string
         maxLength: 100
         example: USD
@@ -5524,125 +5435,111 @@ definitions:
         description: Indicates if the account is blocked
         type: boolean
       createdAt:
-        description: 'Timestamp when the account was created (RFC3339 format)
-
+        description: |-
+          Timestamp when the account was created (RFC3339 format)
           example: 2021-01-01T00:00:00Z
-
-          format: date-time'
+          format: date-time
         type: string
         format: date-time
         example: '2021-01-01T00:00:00Z'
       deletedAt:
-        description: 'Timestamp when the account was soft deleted, null if not deleted
-          (RFC3339 format)
-
+        description: |-
+          Timestamp when the account was soft deleted, null if not deleted (RFC3339 format)
           example: null
-
-          format: date-time'
+          format: date-time
         type: string
         format: date-time
         example: '2021-01-01T00:00:00Z'
       entityId:
-        description: 'Optional external identifier for linking to external systems
-
+        description: |-
+          Optional external identifier for linking to external systems
           example: EXT-ACC-12345
-
-          maxLength: 256'
+          maxLength: 256
         type: string
         maxLength: 256
         example: EXT-ACC-12345
       id:
-        description: 'Unique identifier for the account (UUID format)
-
+        description: |-
+          Unique identifier for the account (UUID format)
           example: 00000000-0000-0000-0000-000000000000
-
-          format: uuid'
+          format: uuid
         type: string
         format: uuid
         example: 00000000-0000-0000-0000-000000000000
       ledgerId:
-        description: 'ID of the ledger this account belongs to (UUID format)
-
+        description: |-
+          ID of the ledger this account belongs to (UUID format)
           example: 00000000-0000-0000-0000-000000000000
-
-          format: uuid'
+          format: uuid
         type: string
         format: uuid
         example: 00000000-0000-0000-0000-000000000000
       metadata:
-        description: 'Custom key-value pairs for extending the account information
-
-          example: {"department": "Treasury", "purpose": "Operating Expenses", "region":
-          "Global"}'
+        description: |-
+          Custom key-value pairs for extending the account information
+          example: {"department": "Treasury", "purpose": "Operating Expenses", "region": "Global"}
         type: object
         additionalProperties: {}
       name:
-        description: 'Human-readable name of the account
-
+        description: |-
+          Human-readable name of the account
           example: Corporate Checking Account
-
-          maxLength: 256'
+          maxLength: 256
         type: string
         maxLength: 256
         example: Corporate Checking Account
       organizationId:
-        description: 'ID of the organization that owns this account (UUID format)
-
+        description: |-
+          ID of the organization that owns this account (UUID format)
           example: 00000000-0000-0000-0000-000000000000
-
-          format: uuid'
+          format: uuid
         type: string
         format: uuid
         example: 00000000-0000-0000-0000-000000000000
       parentAccountId:
-        description: 'ID of the parent account if this is a sub-account (UUID format)
-
+        description: |-
+          ID of the parent account if this is a sub-account (UUID format)
           example: 00000000-0000-0000-0000-000000000000
-
-          format: uuid'
+          format: uuid
         type: string
         format: uuid
         example: 00000000-0000-0000-0000-000000000000
       portfolioId:
-        description: 'ID of the portfolio this account belongs to (UUID format)
-
+        description: |-
+          ID of the portfolio this account belongs to (UUID format)
           example: 00000000-0000-0000-0000-000000000000
-
-          format: uuid'
+          format: uuid
         type: string
         format: uuid
         example: 00000000-0000-0000-0000-000000000000
       segmentId:
-        description: 'ID of the segment this account belongs to (UUID format)
-
+        description: |-
+          ID of the segment this account belongs to (UUID format)
           example: 00000000-0000-0000-0000-000000000000
-
-          format: uuid'
+          format: uuid
         type: string
         format: uuid
         example: 00000000-0000-0000-0000-000000000000
       status:
         description: Current operating status of the account
         allOf:
-        - $ref: '#/definitions/Status'
+        - "$ref": "#/definitions/Status"
       type:
-        description: 'Type of the account.
-
-          example: deposit'
+        description: |-
+          Type of the account.
+          example: deposit
         type: string
         example: deposit
       updatedAt:
-        description: 'Timestamp when the account was last updated (RFC3339 format)
-
+        description: |-
+          Timestamp when the account was last updated (RFC3339 format)
           example: 2021-01-01T00:00:00Z
-
-          format: date-time'
+          format: date-time
         type: string
         format: date-time
         example: '2021-01-01T00:00:00Z'
   AccountRule:
-    description: AccountRule object containing the rule type and condition for account
-      selection in operation routes.
+    description: AccountRule object containing the rule type and condition for account selection in operation routes.
     type: object
     properties:
       ruleType:
@@ -5650,8 +5547,7 @@ definitions:
         type: string
         example: alias
       validIf:
-        description: The rule condition for account selection. String for alias type
-          (e.g. "@cash_account"), array for account_type.
+        description: The rule condition for account selection. String for alias type (e.g. "@cash_account"), array for account_type.
   AccountType:
     description: AccountType object
     type: object
@@ -5673,7 +5569,7 @@ definitions:
       id:
         description: The unique identifier of the Account Type.
         type: string
-        example: 01965ed9-7fa4-75b2-8872-fc9e8509ab0a
+        example: '01965ed9-7fa4-75b2-8872-fc9e8509ab0a'
       keyValue:
         description: A unique key value identifier for the account type.
         type: string
@@ -5681,12 +5577,11 @@ definitions:
       ledgerId:
         description: The unique identifier of the Ledger.
         type: string
-        example: 01965ed9-7fa4-75b2-8872-fc9e8509ab0a
+        example: '01965ed9-7fa4-75b2-8872-fc9e8509ab0a'
       metadata:
-        description: 'Custom key-value pairs for extending the account type information
-
-          example: {"department": "Treasury", "purpose": "Operating Expenses", "region":
-          "Global"}'
+        description: |-
+          Custom key-value pairs for extending the account type information
+          example: {"department": "Treasury", "purpose": "Operating Expenses", "region": "Global"}
         type: object
         additionalProperties: {}
       name:
@@ -5696,56 +5591,58 @@ definitions:
       organizationId:
         description: The unique identifier of the Organization.
         type: string
-        example: 01965ed9-7fa4-75b2-8872-fc9e8509ab0a
+        example: '01965ed9-7fa4-75b2-8872-fc9e8509ab0a'
       updatedAt:
         description: The timestamp when the account type was last updated.
         type: string
         format: date-time
         example: '2021-01-01T00:00:00Z'
   AccountingEntries:
-    description: AccountingEntries object containing optional accounting entries for
-      each action type (direct, hold, commit, cancel, revert).
+    description: AccountingEntries object containing optional accounting entries for each action type (direct, hold, commit, cancel, revert, overdraft, refund).
     type: object
     properties:
       cancel:
         description: The accounting entry for the cancel action.
         allOf:
-        - $ref: '#/definitions/AccountingEntry'
+        - "$ref": "#/definitions/AccountingEntry"
       commit:
         description: The accounting entry for the commit action.
         allOf:
-        - $ref: '#/definitions/AccountingEntry'
+        - "$ref": "#/definitions/AccountingEntry"
       direct:
         description: The accounting entry for the direct action.
         allOf:
-        - $ref: '#/definitions/AccountingEntry'
+        - "$ref": "#/definitions/AccountingEntry"
       hold:
         description: The accounting entry for the hold action.
         allOf:
-        - $ref: '#/definitions/AccountingEntry'
+        - "$ref": "#/definitions/AccountingEntry"
+      overdraft:
+        description: |-
+          The accounting entry for the overdraft lifecycle. Debit rubric classifies
+          overdraft usage (deficit grows); credit rubric classifies overdraft
+          repayment (deficit shrinks). Both rubrics are REQUIRED when this entry
+          is present.
+        allOf:
+        - "$ref": "#/definitions/AccountingEntry"
       revert:
         description: The accounting entry for the revert action.
         allOf:
-        - $ref: '#/definitions/AccountingEntry'
+        - "$ref": "#/definitions/AccountingEntry"
   AccountingEntry:
-    description: AccountingEntry object containing debit and credit rubrics for a
-      specific action.
+    description: 'AccountingEntry object containing debit and credit rubrics for a specific action.  Field requirements depend on the parent operationType and scenario: - source + direct or commit: debit is REQUIRED, credit is optional. - source + hold or cancel: both debit AND credit are REQUIRED. - destination + direct or commit: credit is REQUIRED, debit is optional. - destination + hold or cancel: NOT ALLOWED (rejected at creation). - destination + revert: NOT ALLOWED (rejected at creation). - source + revert: NOT ALLOWED (rejected at creation). - bidirectional (all scenarios including revert): both debit AND credit are REQUIRED.  An entry with neither debit nor credit is always rejected.'
     type: object
-    required:
-    - credit
-    - debit
     properties:
       credit:
-        description: The credit rubric for this entry.
+        description: The credit rubric for this entry. Required based on operationType/scenario matrix (see type description).
         allOf:
-        - $ref: '#/definitions/AccountingRubric'
+        - "$ref": "#/definitions/AccountingRubric"
       debit:
-        description: The debit rubric for this entry.
+        description: The debit rubric for this entry. Required based on operationType/scenario matrix (see type description).
         allOf:
-        - $ref: '#/definitions/AccountingRubric'
+        - "$ref": "#/definitions/AccountingRubric"
   AccountingRubric:
-    description: AccountingRubric object containing the code and description for a
-      debit or credit entry.
+    description: AccountingRubric object containing the code and description for a debit or credit entry.
     type: object
     required:
     - code
@@ -5762,97 +5659,82 @@ definitions:
         maxLength: 250
         example: Cash
   Address:
-    description: Structured address information following standard postal address
-      format. Country field follows ISO 3166-1 alpha-2 standard (2-letter country
-      codes). Used for organization physical locations and other address needs.
+    description: Structured address information following standard postal address format. Country field follows ISO 3166-1 alpha-2 standard (2-letter country codes). Used for organization physical locations and other address needs.
     type: object
     properties:
       city:
-        description: 'City or locality name
-
+        description: |-
+          City or locality name
           example: New York
-
-          maxLength: 100'
+          maxLength: 100
         type: string
         maxLength: 100
         example: New York
       country:
-        description: 'Country code in ISO 3166-1 alpha-2 format (two-letter country
-          code)
-
+        description: |-
+          Country code in ISO 3166-1 alpha-2 format (two-letter country code)
           example: US
-
           minLength: 2
-
-          maxLength: 2'
+          maxLength: 2
         type: string
         maxLength: 2
         minLength: 2
         example: US
       description:
-        description: 'A descriptive label for the address (e.g., "Home", "Office",
-          "Billing")
-
+        description: |-
+          A descriptive label for the address (e.g., "Home", "Office", "Billing")
           example: Home
-
-          maxLength: 100'
+          maxLength: 100
         type: string
         maxLength: 100
         example: Home
       line1:
-        description: 'Primary address line (street address or PO Box)
-
+        description: |-
+          Primary address line (street address or PO Box)
           example: 123 Financial Avenue
-
-          maxLength: 256'
+          maxLength: 256
         type: string
         maxLength: 256
         example: 123 Financial Avenue
       line2:
-        description: 'Secondary address information like apartment number, suite,
-          or floor
-
+        description: |-
+          Secondary address information like apartment number, suite, or floor
           example: Suite 1500
-
-          maxLength: 256'
+          maxLength: 256
         type: string
         maxLength: 256
         example: Suite 1500
       state:
-        description: 'State, province, or region name or code
-
+        description: |-
+          State, province, or region name or code
           example: NY
-
-          maxLength: 100'
+          maxLength: 100
         type: string
         maxLength: 100
         example: NY
       zipCode:
-        description: 'Postal code or ZIP code
-
+        description: |-
+          Postal code or ZIP code
           example: 10001
-
-          maxLength: 20'
+          maxLength: 20
         type: string
         maxLength: 20
         example: '10001'
   Amount:
     description: Amount is the struct designed to represent the amount of an operation.
-      Contains the value and scale (decimal places) of an operation amount.
     type: object
+    required:
+    - asset
+    - value
     properties:
+      asset:
+        type: string
+        example: BRL
       value:
-        description: 'The amount value in the smallest unit of the asset (e.g., cents)
-
-          example: 1500
-
-          minimum: 0'
         type: number
-        minimum: 0
-        example: 1500
+        example: 1000
   Asset:
-    description: Asset represents a financial instrument within a ledger, such as
-      a currency, cryptocurrency, commodity, or other asset type.
+    description: Asset represents a financial instrument within a ledger, such as a currency, cryptocurrency, commodity, or other asset type.
     type: object
     properties:
       code:
@@ -5897,10 +5779,9 @@ definitions:
       status:
         description: Status of the asset (active, inactive, pending)
         allOf:
-        - $ref: '#/definitions/Status'
+        - "$ref": "#/definitions/Status"
       type:
-        description: Type of the asset (e.g., currency, cryptocurrency, commodity,
-          stock)
+        description: Type of the asset (e.g., currency, cryptocurrency, commodity, stock)
         type: string
         example: currency
       updatedAt:
@@ -5909,398 +5790,374 @@ definitions:
         format: date-time
         example: '2021-01-01T00:00:00Z'
   AssetRate:
-    description: AssetRate is a struct designed to store asset rate data. Represents
-      a complete asset rate entity containing conversion information between two assets,
-      including all system-generated fields.
+    description: AssetRate is a struct designed to store asset rate data. Represents a complete asset rate entity containing conversion information between two assets, including all system-generated fields.
     type: object
     properties:
       createdAt:
-        description: 'Timestamp when the asset rate was created
-
+        description: |-
+          Timestamp when the asset rate was created
           example: 2021-01-01T00:00:00Z
-
-          format: date-time'
+          format: date-time
         type: string
         format: date-time
         example: '2021-01-01T00:00:00Z'
       externalId:
-        description: 'External identifier for integration with third-party systems
-
+        description: |-
+          External identifier for integration with third-party systems
           example: 00000000-0000-0000-0000-000000000000
-
-          format: uuid'
+          format: uuid
         type: string
         format: uuid
         example: 00000000-0000-0000-0000-000000000000
       from:
-        description: 'Source asset code
-
+        description: |-
+          Source asset code
           example: USD
-
           minLength: 2
-
-          maxLength: 10'
+          maxLength: 10
         type: string
         maxLength: 10
         minLength: 2
         example: USD
       id:
-        description: 'Unique identifier for the asset rate
-
+        description: |-
+          Unique identifier for the asset rate
           example: 00000000-0000-0000-0000-000000000000
-
-          format: uuid'
+          format: uuid
         type: string
         format: uuid
         example: 00000000-0000-0000-0000-000000000000
       ledgerId:
-        description: 'Ledger containing this asset rate
-
+        description: |-
+          Ledger containing this asset rate
           example: 00000000-0000-0000-0000-000000000000
-
-          format: uuid'
+          format: uuid
         type: string
         format: uuid
         example: 00000000-0000-0000-0000-000000000000
       metadata:
-        description: 'Additional custom attributes
-
-          example: {"provider": "Central Bank", "rateName": "Official Exchange Rate"}'
+        description: |-
+          Additional custom attributes
+          example: {"provider": "Central Bank", "rateName": "Official Exchange Rate"}
         type: object
         additionalProperties: {}
       organizationId:
-        description: 'Organization that owns this asset rate
-
+        description: |-
+          Organization that owns this asset rate
           example: 00000000-0000-0000-0000-000000000000
-
-          format: uuid'
+          format: uuid
         type: string
         format: uuid
         example: 00000000-0000-0000-0000-000000000000
       rate:
-        description: 'Conversion rate value
-
-          example: 100'
+        description: |-
+          Conversion rate value
+          example: 100
         type: number
         example: 100
       scale:
-        description: 'Decimal places for the rate
-
+        description: |-
+          Decimal places for the rate
           example: 2
-
-          minimum: 0'
+          minimum: 0
         type: number
         minimum: 0
         example: 2
       source:
-        description: 'Source of rate information
-
+        description: |-
+          Source of rate information
           example: External System
-
-          maxLength: 200'
+          maxLength: 200
         type: string
         maxLength: 200
         example: External System
       to:
-        description: 'Target asset code
-
+        description: |-
+          Target asset code
           example: BRL
-
           minLength: 2
-
-          maxLength: 10'
+          maxLength: 10
         type: string
         maxLength: 10
         minLength: 2
         example: BRL
       ttl:
-        description: 'Time-to-live in seconds
-
+        description: |-
+          Time-to-live in seconds
           example: 3600
-
-          minimum: 0'
+          minimum: 0
         type: integer
         minimum: 0
         example: 3600
       updatedAt:
-        description: 'Timestamp when the asset rate was last updated
-
+        description: |-
+          Timestamp when the asset rate was last updated
           example: 2021-01-01T00:00:00Z
-
-          format: date-time'
+          format: date-time
         type: string
         format: date-time
         example: '2021-01-01T00:00:00Z'
   Balance:
-    description: Balance is the struct designed to represent the account balance.
-      Contains available and on-hold amounts along with the scale (decimal places).
+    description: Balance is the struct designed to represent the account balance. Contains available and on-hold amounts along with the scale (decimal places).
     type: object
     properties:
       available:
-        description: 'Amount available for transactions (in the smallest unit of asset)
-
+        description: |-
+          Amount available for transactions (in the smallest unit of asset)
           example: 1500
-
-          minimum: 0'
+          minimum: 0
         type: number
         minimum: 0
         example: 1500
       onHold:
-        description: 'Amount on hold and unavailable for transactions (in the smallest
-          unit of asset)
-
+        description: |-
+          Amount on hold and unavailable for transactions (in the smallest unit of asset)
           example: 500
-
-          minimum: 0'
+          minimum: 0
         type: number
         minimum: 0
         example: 500
+      overdraftUsed:
+        description: |-
+          OverdraftUsed is populated from OperationSnapshot.OverdraftUsedBefore when this Balance
+          represents the state BEFORE the operation, or from OperationSnapshot.OverdraftUsedAfter
+          when it represents the state AFTER. Parsed from the snapshot's string-encoded decimal.
+          Always present under the always-populated wire-shape contract — non-overdraft
+          operations carry decimal.Zero. Parse errors on malformed historical rows also
+          fall back to decimal.Zero (read-only audit context, never a correctness gate).
+          example: 130
+          minimum: 0
+        type: number
+        minimum: 0
+        example: 130
       version:
-        description: 'Balance version after the operation
-
+        description: |-
+          Balance version after the operation
           example: 2
-
-          minimum: 0'
+          minimum: 0
         type: integer
         minimum: 0
         example: 2
   BalanceHistory:
-    description: Historical balance snapshot at a specific point in time. Does not
-      include permission flags (allowSending/allowReceiving) as these are not tracked
-      historically.
+    description: Historical balance snapshot at a specific point in time. Does not include permission flags (allowSending/allowReceiving) as these are not tracked historically.
     type: object
     properties:
       accountId:
-        description: 'Account that holds this balance
-
+        description: |-
+          Account that holds this balance
           example: 00000000-0000-0000-0000-000000000000
-
-          format: uuid'
+          format: uuid
         type: string
         format: uuid
         example: 00000000-0000-0000-0000-000000000000
       accountType:
-        description: 'Type of account holding this balance
-
+        description: |-
+          Type of account holding this balance
           example: creditCard
-
-          maxLength: 50'
+          maxLength: 50
         type: string
         maxLength: 50
         example: creditCard
       alias:
-        description: 'Alias for the account, used for easy identification or tagging
-
+        description: |-
+          Alias for the account, used for easy identification or tagging
           example: @person1
-
-          maxLength: 256'
+          maxLength: 256
         type: string
         maxLength: 256
-        example: '@person1'
+        example: "@person1"
       assetCode:
-        description: 'Asset code identifying the currency or asset type of this balance
-
+        description: |-
+          Asset code identifying the currency or asset type of this balance
           example: USD
-
           minLength: 2
-
-          maxLength: 10'
+          maxLength: 10
         type: string
         maxLength: 10
         minLength: 2
         example: USD
       available:
-        description: 'Amount available for transactions (in the smallest unit of the
-          asset, e.g. cents)
-
+        description: |-
+          Amount available for transactions (in the smallest unit of the asset, e.g. cents)
           example: 1500
-
-          minimum: 0'
+          minimum: 0
         type: number
         minimum: 0
         example: 1500
       createdAt:
-        description: 'Timestamp when the balance was created (RFC3339 format)
-
+        description: |-
+          Timestamp when the balance was created (RFC3339 format)
           example: 2021-01-01T00:00:00Z
-
-          format: date-time'
+          format: date-time
         type: string
         format: date-time
         example: '2021-01-01T00:00:00Z'
+      direction:
+        description: |-
+          Direction is the accounting direction of the balance at the time of
+          the snapshot. One of "credit" or "debit". Empty string denotes
+          legacy rows predating the overdraft feature.
+          example: credit
+        type: string
+        example: credit
       id:
-        description: 'Unique identifier for the balance (UUID format)
-
+        description: |-
+          Unique identifier for the balance (UUID format)
           example: 00000000-0000-0000-0000-000000000000
-
-          format: uuid'
+          format: uuid
         type: string
         format: uuid
         example: 00000000-0000-0000-0000-000000000000
       key:
-        description: 'Unique key for the balance
-
+        description: |-
+          Unique key for the balance
           example: asset-freeze
-
-          maxLength: 100'
+          maxLength: 100
         type: string
         maxLength: 100
         example: asset-freeze
       ledgerId:
-        description: 'Ledger containing the account this balance belongs to
-
+        description: |-
+          Ledger containing the account this balance belongs to
           example: 00000000-0000-0000-0000-000000000000
-
-          format: uuid'
+          format: uuid
         type: string
         format: uuid
         example: 00000000-0000-0000-0000-000000000000
       onHold:
-        description: 'Amount currently on hold and unavailable for transactions
-
+        description: |-
+          Amount currently on hold and unavailable for transactions
           example: 500
-
-          minimum: 0'
+          minimum: 0
         type: number
         minimum: 0
         example: 500
       organizationId:
-        description: 'Organization that owns this balance
-
+        description: |-
+          Organization that owns this balance
           example: 00000000-0000-0000-0000-000000000000
-
-          format: uuid'
+          format: uuid
         type: string
         format: uuid
         example: 00000000-0000-0000-0000-000000000000
+      overdraftUsed:
+        description: |-
+          OverdraftUsed is the amount of overdraft consumed at the time of
+          the snapshot. Always non-negative.
+          example: 0
+        type: number
+        example: 0
+      settings:
+        description: |-
+          Settings is the per-balance configuration snapshot at the time the
+          history row was recorded. Nil for legacy balances.
+        allOf:
+        - "$ref": "#/definitions/mmodel.BalanceSettings"
       updatedAt:
-        description: 'Timestamp when the balance was last updated (RFC3339 format)
-
+        description: |-
+          Timestamp when the balance was last updated (RFC3339 format)
           example: 2021-01-01T00:00:00Z
-
-          format: date-time'
+          format: date-time
         type: string
         format: date-time
         example: '2021-01-01T00:00:00Z'
       version:
-        description: 'Optimistic concurrency control version
-
+        description: |-
+          Optimistic concurrency control version
           example: 1
-
-          minimum: 1'
+          minimum: 1
         type: integer
         minimum: 1
         example: 1
   CreateAccountInput:
-    description: Request payload for creating a new account within a ledger. Accounts
-      represent individual financial entities such as bank accounts, credit cards,
-      expense categories, or any other financial buckets within a ledger. Accounts
-      are identified by a unique ID, can have aliases for easy reference, and are
-      associated with a specific asset type.
+    description: Request payload for creating a new account within a ledger. Accounts represent individual financial entities such as bank accounts, credit cards, expense categories, or any other financial buckets within a ledger. Accounts are identified by a unique ID, can have aliases for easy reference, and are associated with a specific asset type.
     type: object
     required:
     - assetCode
     - type
     properties:
       alias:
-        description: 'Unique alias for the account (optional, must follow alias format
-          rules)
-
+        description: |-
+          Unique alias for the account (optional, must follow alias format rules)
           required: false
-
           example: @treasury_checking
-
-          maxLength: 100'
+          maxLength: 100
         type: string
         maxLength: 100
-        example: '@treasury_checking'
+        example: "@treasury_checking"
       assetCode:
-        description: 'Asset code that this account will use for balances and transactions
-
+        description: |-
+          Asset code that this account will use for balances and transactions
           required: true
-
           example: USD
-
-          maxLength: 100'
+          maxLength: 100
         type: string
         maxLength: 100
         example: USD
       blocked:
-        description: 'Whether the account should start blocked
-
+        description: |-
+          Whether the account should start blocked
           required: false
-
-          default: false'
+          default: false
         type: boolean
       entityId:
-        description: 'Optional external identifier for linking to external systems
-
+        description: |-
+          Optional external identifier for linking to external systems
           required: false
-
           example: EXT-ACC-12345
-
-          maxLength: 256'
+          maxLength: 256
         type: string
         maxLength: 256
         example: EXT-ACC-12345
       metadata:
-        description: 'Custom key-value pairs for extending the account information
-
+        description: |-
+          Custom key-value pairs for extending the account information
           required: false
-
-          example: {"department": "Treasury", "purpose": "Operating Expenses", "region":
-          "Global"}'
+          example: {"department": "Treasury", "purpose": "Operating Expenses", "region": "Global"}
         type: object
         additionalProperties: {}
       name:
-        description: 'Human-readable name of the account
-
+        description: |-
+          Human-readable name of the account
           required: false
-
           example: Corporate Checking Account
-
-          maxLength: 256'
+          maxLength: 256
         type: string
         maxLength: 256
         example: Corporate Checking Account
       parentAccountId:
-        description: 'ID of the parent account if this is a subaccount (optional)
-
+        description: |-
+          ID of the parent account if this is a subaccount (optional)
           required: false
-
-          format: uuid'
+          format: uuid
         type: string
         format: uuid
       portfolioId:
-        description: 'ID of the portfolio this account belongs to (optional)
-
+        description: |-
+          ID of the portfolio this account belongs to (optional)
           required: false
-
-          format: uuid'
+          format: uuid
         type: string
         format: uuid
       segmentId:
-        description: 'ID of the segment this account belongs to (optional)
-
+        description: |-
+          ID of the segment this account belongs to (optional)
           required: false
-
-          format: uuid'
+          format: uuid
         type: string
         format: uuid
       status:
-        description: 'Current operating status of the account
-
-          required: false'
+        description: |-
+          Current operating status of the account
+          required: false
         allOf:
-        - $ref: '#/definitions/Status'
+        - "$ref": "#/definitions/Status"
       type:
-        description: 'Type of the account
-
+        description: |-
+          Type of the account
           required: true
-
           example: deposit
-
-          maxLength: 256'
+          maxLength: 256
         type: string
         maxLength: 256
         example: deposit
@@ -6322,12 +6179,10 @@ definitions:
         maxLength: 50
         example: current_assets
       metadata:
-        description: 'Custom key-value pairs for extending the account type information
-
+        description: |-
+          Custom key-value pairs for extending the account type information
           required: false
-
-          example: {"department": "Treasury", "purpose": "Operating Expenses", "region":
-          "Global"}'
+          example: {"department": "Treasury", "purpose": "Operating Expenses", "region": "Global"}
         type: object
         additionalProperties: {}
       name:
@@ -6336,44 +6191,52 @@ definitions:
         maxLength: 100
         example: Current Assets
   CreateAdditionalBalance:
-    description: Request payload for creating a new balance with specified permissions
-      and custom key.
+    description: Request payload for creating a new balance with specified permissions and custom key.
     type: object
     required:
     - key
     properties:
       allowReceiving:
-        description: 'Whether the account should be allowed to receive funds to this
-          balance
-
+        description: |-
+          Whether the account should be allowed to receive funds to this balance
           required: false
-
-          example: true'
+          example: true
         type: boolean
         example: true
       allowSending:
-        description: 'Whether the account should be allowed to send funds from this
-          balance
-
+        description: |-
+          Whether the account should be allowed to send funds from this balance
           required: false
-
-          example: true'
+          example: true
         type: boolean
         example: true
+      direction:
+        description: |-
+          Direction is the accounting direction of the balance ("credit" or
+          "debit"). Optional at creation; when omitted, defaults to the
+          account's natural direction.
+          required: false
+          example: credit
+        type: string
+        example: credit
       key:
-        description: 'Unique key for the balance
-
+        description: |-
+          Unique key for the balance
           required: true
-
           maxLength: 100
-
-          example: asset-freeze'
+          example: asset-freeze
         type: string
         maxLength: 100
         example: asset-freeze
+      settings:
+        description: |-
+          Settings is the optional per-balance configuration (overdraft,
+          balance scope). When omitted, platform defaults are applied.
+          required: false
+        allOf:
+        - "$ref": "#/definitions/mmodel.BalanceSettings"
   CreateAssetInput:
-    description: CreateAssetInput is the input payload to create an asset within a
-      ledger, such as a currency, cryptocurrency, or other financial instrument.
+    description: CreateAssetInput is the input payload to create an asset within a ledger, such as a currency, cryptocurrency, or other financial instrument.
     type: object
     required:
     - code
@@ -6386,9 +6249,9 @@ definitions:
         maxLength: 100
         example: USD
       metadata:
-        description: 'Additional custom attributes for the asset
-
-          Keys max length: 100 characters, Values max length: 2000 characters'
+        description: |-
+          Additional custom attributes for the asset
+          Keys max length: 100 characters, Values max length: 2000 characters
         type: object
         additionalProperties: {}
       name:
@@ -6399,16 +6262,13 @@ definitions:
       status:
         description: Status of the asset (active, inactive, pending)
         allOf:
-        - $ref: '#/definitions/Status'
+        - "$ref": "#/definitions/Status"
       type:
-        description: Type of the asset (e.g., currency, cryptocurrency, commodity,
-          stock)
+        description: Type of the asset (e.g., currency, cryptocurrency, commodity, stock)
         type: string
         example: currency
   CreateAssetRateInput:
-    description: CreateAssetRateInput is the input payload to create an asset rate.
-      Contains required fields for setting up asset conversion rates, including source
-      and target assets, rate value, scale, and optional metadata.
+    description: CreateAssetRateInput is the input payload to create an asset rate. Contains required fields for setting up asset conversion rates, including source and target assets, rate value, scale, and optional metadata.
     type: object
     required:
     - from
@@ -6416,121 +6276,104 @@ definitions:
     - to
     properties:
       externalId:
-        description: 'External identifier for integration (optional)
-
+        description: |-
+          External identifier for integration (optional)
           example: 00000000-0000-0000-0000-000000000000
-
-          format: uuid'
+          format: uuid
         type: string
         format: uuid
         example: 00000000-0000-0000-0000-000000000000
       from:
-        description: 'Source asset code (required)
-
+        description: |-
+          Source asset code (required)
           example: USD
-
           required: true
-
           minLength: 2
-
-          maxLength: 10'
+          maxLength: 10
         type: string
         maxLength: 10
         minLength: 2
         example: USD
       metadata:
-        description: 'Additional custom attributes (optional)
-
-          example: {"provider": "Central Bank", "rateName": "Official Exchange Rate"}'
+        description: |-
+          Additional custom attributes (optional)
+          example: {"provider": "Central Bank", "rateName": "Official Exchange Rate"}
         type: object
         additionalProperties: {}
       rate:
-        description: 'Conversion rate value (required)
-
+        description: |-
+          Conversion rate value (required)
           example: 100
-
-          required: true'
+          required: true
         type: integer
         example: 100
       scale:
-        description: 'Decimal places for the rate (optional)
-
+        description: |-
+          Decimal places for the rate (optional)
           example: 2
-
-          minimum: 0'
+          minimum: 0
         type: integer
         minimum: 0
         example: 2
       source:
-        description: 'Source of rate information (optional)
-
+        description: |-
+          Source of rate information (optional)
           example: External System
-
-          maxLength: 200'
+          maxLength: 200
         type: string
         maxLength: 200
         example: External System
       to:
-        description: 'Target asset code (required)
-
+        description: |-
+          Target asset code (required)
           example: BRL
-
           required: true
-
           minLength: 2
-
-          maxLength: 10'
+          maxLength: 10
         type: string
         maxLength: 10
         minLength: 2
         example: BRL
       ttl:
-        description: 'Time-to-live in seconds (optional)
-
+        description: |-
+          Time-to-live in seconds (optional)
           example: 3600
-
-          minimum: 0'
+          minimum: 0
         type: integer
         minimum: 0
         example: 3600
   CreateLedgerInput:
-    description: Request payload for creating a new ledger. Contains the ledger name
-      (required), status, and optional metadata. Ledgers are organizational units
-      within an organization that group related financial accounts and assets together.
+    description: Request payload for creating a new ledger. Contains the ledger name (required), status, and optional metadata. Ledgers are organizational units within an organization that group related financial accounts and assets together.
     type: object
     required:
     - name
     properties:
       metadata:
-        description: 'Custom key-value pairs for extending the ledger information
-
+        description: |-
+          Custom key-value pairs for extending the ledger information
           required: false
-
-          example: {"department": "Finance", "currency": "USD", "region": "North America"}'
+          example: {"department": "Finance", "currency": "USD", "region": "North America"}
         type: object
         additionalProperties: {}
       name:
-        description: 'Display name of the ledger
-
+        description: |-
+          Display name of the ledger
           required: true
-
-          maxLength: 256'
+          maxLength: 256
         type: string
         maxLength: 256
       settings:
-        description: 'Dynamic configuration settings for this ledger. When nil, no
-          settings are persisted (optional).
-
-          example: {"accounting": {"validateAccountType": true}}'
+        description: |-
+          Dynamic configuration settings for this ledger. When nil, no settings are persisted (optional).
+          example: {"accounting": {"validateAccountType": true}}
         allOf:
-        - $ref: '#/definitions/mmodel.LedgerSettings'
+        - "$ref": "#/definitions/mmodel.LedgerSettings"
       status:
-        description: 'Current operating status of the ledger (defaults to ACTIVE if
-          not specified)
-
-          required: false'
+        description: |-
+          Current operating status of the ledger (defaults to ACTIVE if not specified)
+          required: false
         allOf:
-        - $ref: '#/definitions/Status'
+        - "$ref": "#/definitions/Status"
   CreateMetadataIndexInput:
     description: CreateMetadataIndexInput payload
     type: object
@@ -6538,34 +6381,29 @@ definitions:
     - metadataKey
     properties:
       metadataKey:
-        description: 'The metadata key to index (without "metadata." prefix)
-
+        description: |-
+          The metadata key to index (without "metadata." prefix)
           required: true
-
-          maxLength: 100'
+          maxLength: 100
         type: string
         maxLength: 100
         example: tier
       sparse:
-        description: 'Whether the index should be sparse (only include documents with
-          the field)
-
+        description: |-
+          Whether the index should be sparse (only include documents with the field)
           required: false
-
-          default: true'
+          default: true
         type: boolean
         example: true
       unique:
-        description: 'Whether the index should enforce uniqueness
-
+        description: |-
+          Whether the index should enforce uniqueness
           required: false
-
-          default: false'
+          default: false
         type: boolean
         example: false
   CreateOperationRouteInput:
-    description: CreateOperationRouteInput payload for creating a new Operation Route
-      with title, description, operation type, and optional account rules.
+    description: CreateOperationRouteInput payload for creating a new Operation Route with title, description, operation type, and optional account rules.
     type: object
     required:
     - operationType
@@ -6574,14 +6412,17 @@ definitions:
       account:
         description: The account selection rule configuration.
         allOf:
-        - $ref: '#/definitions/AccountRule'
+        - "$ref": "#/definitions/AccountRule"
       accountingEntries:
-        description: Optional accounting entries for each action type associated with
-          this operation route.
+        description: Optional accounting entries for each action type associated with this operation route.
         allOf:
-        - $ref: '#/definitions/AccountingEntries'
+        - "$ref": "#/definitions/AccountingEntries"
       code:
-        description: External reference of the operation route.
+        description: |-
+          Deprecated: external reference code kept for backward compatibility. Use the rubric codes inside accountingEntries instead.
+          example: EXT-001
+          maxLength: 100
+          deprecated: true
         type: string
         maxLength: 100
         example: EXT-001
@@ -6589,8 +6430,7 @@ definitions:
         description: Detailed description of the operation route purpose and usage.
         type: string
         maxLength: 250
-        example: This operation route handles cash-in transactions from service charge
-          collections
+        example: This operation route handles cash-in transactions from service charge collections
       metadata:
         description: Additional metadata stored as JSON
         type: object
@@ -6600,89 +6440,72 @@ definitions:
         type: string
         example: source
       title:
-        description: Short text summarizing the purpose of the operation. Used as
-          an entry note for identification.
+        description: Short text summarizing the purpose of the operation. Used as an entry note for identification.
         type: string
         maxLength: 255
         example: Cashin from service charge
   CreateOrganizationInput:
-    description: Request payload for creating a new organization. Contains all the
-      necessary fields for organization creation, with required fields marked as such.
-      Organizations are the top-level entities in the hierarchy and contain ledgers,
-      which in turn contain accounts and assets.
+    description: Request payload for creating a new organization. Contains all the necessary fields for organization creation, with required fields marked as such. Organizations are the top-level entities in the hierarchy and contain ledgers, which in turn contain accounts and assets.
     type: object
     required:
     - legalDocument
     - legalName
     properties:
       address:
-        description: 'Physical address of the organization
-
-          required: false'
-        allOf:
-        - $ref: '#/definitions/Address'
-      doingBusinessAs:
-        description: 'Trading or brand name of the organization, if different from
-          legal name
-
+        description: |-
+          Physical address of the organization
           required: false
-
+        allOf:
+        - "$ref": "#/definitions/Address"
+      doingBusinessAs:
+        description: |-
+          Trading or brand name of the organization, if different from legal name
+          required: false
           example: Lerian FS
-
-          maxLength: 256'
+          maxLength: 256
         type: string
         maxLength: 256
         example: Lerian FS
       legalDocument:
-        description: 'Official tax ID, company registration number, or other legal
-          identification
-
+        description: |-
+          Official tax ID, company registration number, or other legal identification
           required: true
-
           example: 123456789012345
-
-          maxLength: 256'
+          maxLength: 256
         type: string
         maxLength: 256
         example: '123456789012345'
       legalName:
-        description: 'Official legal name of the organization
-
+        description: |-
+          Official legal name of the organization
           required: true
-
           example: Lerian Financial Services Ltd.
-
-          maxLength: 256'
+          maxLength: 256
         type: string
         maxLength: 256
         example: Lerian Financial Services Ltd.
       metadata:
-        description: 'Custom key-value pairs for extending the organization information
-
+        description: |-
+          Custom key-value pairs for extending the organization information
           required: false
-
-          example: {"industry": "Financial Services", "founded": 2020, "employees":
-          150}'
+          example: {"industry": "Financial Services", "founded": 2020, "employees": 150}
         type: object
         additionalProperties: {}
       parentOrganizationId:
-        description: 'UUID of the parent organization if this is a child organization
-
+        description: |-
+          UUID of the parent organization if this is a child organization
           required: false
-
-          format: uuid'
+          format: uuid
         type: string
         format: uuid
       status:
-        description: 'Current operating status of the organization (defaults to ACTIVE
-          if not specified)
-
-          required: false'
+        description: |-
+          Current operating status of the organization (defaults to ACTIVE if not specified)
+          required: false
         allOf:
-        - $ref: '#/definitions/Status'
+        - "$ref": "#/definitions/Status"
   CreatePortfolioInput:
-    description: CreatePortfolioInput is the input payload to create a portfolio within
-      a ledger, representing a collection of accounts grouped for specific purposes.
+    description: CreatePortfolioInput is the input payload to create a portfolio within a ledger, representing a collection of accounts grouped for specific purposes.
     type: object
     required:
     - name
@@ -6693,9 +6516,9 @@ definitions:
         maxLength: 256
         example: 00000000-0000-0000-0000-000000000000
       metadata:
-        description: 'Additional custom attributes for the portfolio
-
-          Keys max length: 100 characters, Values max length: 2000 characters'
+        description: |-
+          Additional custom attributes for the portfolio
+          Keys max length: 100 characters, Values max length: 2000 characters
         type: object
         additionalProperties: {}
       name:
@@ -6706,19 +6529,17 @@ definitions:
       status:
         description: Status of the portfolio (active, inactive, pending)
         allOf:
-        - $ref: '#/definitions/Status'
+        - "$ref": "#/definitions/Status"
   CreateSegmentInput:
-    description: CreateSegmentInput is the input payload to create a segment within
-      a ledger, representing a logical division such as a business area, product line,
-      or customer category.
+    description: CreateSegmentInput is the input payload to create a segment within a ledger, representing a logical division such as a business area, product line, or customer category.
     type: object
     required:
     - name
     properties:
       metadata:
-        description: 'Additional custom attributes for the segment
-
-          Keys max length: 100 characters, Values max length: 2000 characters'
+        description: |-
+          Additional custom attributes for the segment
+          Keys max length: 100 characters, Values max length: 2000 characters
         type: object
         additionalProperties: {}
       name:
@@ -6729,299 +6550,216 @@ definitions:
       status:
         description: Status of the segment (active, inactive, pending)
         allOf:
-        - $ref: '#/definitions/Status'
-  CreateTransactionInflowSwaggerModel:
-    description: Schema for creating inflow transaction with the complete SendInflow
-      operation structure defined inline
+        - "$ref": "#/definitions/Status"
+  CreateTransactionInflowInput:
+    description: CreateTransactionInflowInput is the input payload to create an inflow transaction. Contains all necessary fields to create a financial transaction without source information, only destination. Pending is not supported for inflows because the auto-filled external source account cannot hold funds.
     type: object
+    required:
+    - send
     properties:
       chartOfAccountsGroupName:
-        description: 'Chart of accounts group name for accounting purposes
-
+        description: |-
+          Chart of accounts group name for accounting purposes
           example: FUNDING
-
-          maxLength: 256'
+          maxLength: 256
         type: string
+        maxLength: 256
+        example: FUNDING
       code:
-        description: 'Transaction code for reference
-
+        description: |-
+          Transaction code for reference
           example: TR12345
-
-          maxLength: 100'
+          maxLength: 100
         type: string
+        maxLength: 100
+        example: TR12345
       description:
-        description: 'Human-readable description of the transaction
-
-          example: New Inflow Transaction
-
-          maxLength: 256'
+        description: |-
+          Human-readable description of the transaction
+          example: New Transaction
+          maxLength: 256
         type: string
+        maxLength: 256
+        example: New Transaction
       metadata:
-        description: 'Additional custom attributes
-
-          example: {"reference": "TRANSACTION-001", "source": "api"}'
+        description: |-
+          Additional custom key-value attributes. Values must be flat (string, number, boolean) — no nested objects.
+          example: {"reference": "TRANSACTION-001", "source": "api"}
         type: object
         additionalProperties: {}
       route:
-        description: 'Deprecated: legacy route identifier, use routeId instead. Contains
-          the transaction route UUID as a free-form string for backwards compatibility.
-
+        description: |-
+          Deprecated: legacy route identifier, use routeId instead. Contains the transaction route UUID as a free-form string for backwards compatibility.
           example: 00000000-0000-0000-0000-000000000000
-
           maxLength: 250
-
-          deprecated: true'
         type: string
         maxLength: 250
         example: 00000000-0000-0000-0000-000000000000
       routeId:
-        description: 'UUID of the transaction route. Used instead of route for proper
-          UUID validation and referential integrity.
-
+        description: |-
+          UUID of the transaction route. Used instead of route for proper UUID validation and referential integrity.
           example: 00000000-0000-0000-0000-000000000000
-
-          format: uuid'
+          format: uuid
         type: string
         format: uuid
         example: 00000000-0000-0000-0000-000000000000
       send:
-        description: 'Send operation details including distribution only
-
-          required: true'
-        type: object
-        properties:
-          asset:
-            description: 'Asset code for the transaction
-
-              example: USD
-
-              required: true'
-            type: string
-          distribute:
-            description: 'Destination accounts and amounts for the transaction
-
-              required: true'
-            type: object
-            properties:
-              to:
-                description: 'List of destination operations
-
-                  required: true'
-                type: array
-                items:
-                  type: object
-                  properties:
-                    accountAlias:
-                      description: 'Account identifier or alias
-
-                        example: @myAccount
-
-                        required: true'
-                      type: string
-                    amount:
-                      description: 'Amount details for the operation
-
-                        required: true'
-                      type: object
-                      properties:
-                        asset:
-                          description: 'Asset code
-
-                            example: USD
-
-                            required: true'
-                          type: string
-                        value:
-                          description: 'Amount value in smallest unit
-
-                            example: "100.00"
-
-                            required: true'
-                          type: string
-                    chartOfAccounts:
-                      description: 'Chart of accounts code
-
-                        example: FUNDING_CREDIT'
-                      type: string
-                    description:
-                      description: 'Operation description
-
-                        example: Credit Operation'
-                      type: string
-                    metadata:
-                      description: 'Additional metadata
-
-                        example: {"operation": "funding", "type": "account"}'
-                      type: object
-                      additionalProperties: {}
-          value:
-            description: 'Transaction amount value in the smallest unit of the asset
-
-              example: "100.00"
-
-              required: true'
-            type: string
+        description: |-
+          Send operation details including distribution only (no source)
+          required: true
+        allOf:
+        - "$ref": "#/definitions/SendInflow"
       transactionDate:
-        description: 'TransactionDate Period from transaction creation date until
-          now
-
+        description: |-
+          TransactionDate Period from transaction creation date until now
           Example "2021-01-01T00:00:00Z"
-
-          swagger: type string
-
-          required: false'
+          format: date-time
         type: string
         format: date-time
         example: '2021-01-01T00:00:00Z'
-  CreateTransactionOutflowSwaggerModel:
-    description: Schema for creating outflow transaction with the complete SendOutflow
-      operation structure defined inline
+  CreateTransactionInput:
+    description: CreateTransactionInput is the input payload to create a transaction. Contains all necessary fields to create a financial transaction, including source and destination information.
     type: object
+    required:
+    - send
     properties:
       chartOfAccountsGroupName:
-        description: 'Chart of accounts group name for accounting purposes
-
-          example: WITHDRAWAL
-
-          maxLength: 256'
+        description: |-
+          Chart of accounts group name for accounting purposes
+          example: FUNDING
+          maxLength: 256
         type: string
+        maxLength: 256
+        example: FUNDING
       code:
-        description: 'Transaction code for reference
-
+        description: |-
+          Transaction code for reference
           example: TR12345
-
-          maxLength: 100'
+          maxLength: 100
         type: string
+        maxLength: 100
+        example: TR12345
       description:
-        description: 'Human-readable description of the transaction
-
-          example: New Outflow Transaction
-
-          maxLength: 256'
+        description: |-
+          Human-readable description of the transaction
+          example: New Transaction
+          maxLength: 256
         type: string
+        maxLength: 256
+        example: New Transaction
       metadata:
-        description: 'Additional custom attributes
-
-          example: {"reference": "TRANSACTION-001", "source": "api"}'
+        description: |-
+          Additional custom key-value attributes. Values must be flat (string, number, boolean) — no nested objects.
+          example: {"reference": "TRANSACTION-001", "source": "api"}
         type: object
         additionalProperties: {}
       pending:
-        description: 'Whether the transaction should be created in pending state
-
+        description: |-
+          Whether the transaction should be created in pending state
           example: true
-
-          swagger: type boolean'
         type: boolean
         default: false
         example: true
       route:
-        description: 'Deprecated: legacy route identifier, use routeId instead. Contains
-          the transaction route UUID as a free-form string for backwards compatibility.
-
-          example: 00000000-0000-0000-0000-000000000000
-
+        description: |-
+          Deprecated: legacy route identifier, use routeId instead. Contains the transaction route UUID as a free-form string for backwards compatibility.
+          example: "00000000-0000-0000-0000-000000000000"
           maxLength: 250
-
-          deprecated: true'
         type: string
         maxLength: 250
         example: 00000000-0000-0000-0000-000000000000
       routeId:
-        description: 'UUID of the transaction route. Used instead of route for proper
-          UUID validation and referential integrity.
-
+        description: |-
+          UUID of the transaction route. Used instead of route for proper UUID validation and referential integrity.
           example: 00000000-0000-0000-0000-000000000000
-
-          format: uuid'
+          format: uuid
         type: string
         format: uuid
         example: 00000000-0000-0000-0000-000000000000
       send:
-        description: 'Send operation details including source only
-
-          required: true'
-        type: object
-        properties:
-          asset:
-            description: 'Asset code for the transaction
-
-              example: USD
-
-              required: true'
-            type: string
-          source:
-            description: 'Source accounts and amounts for the transaction
-
-              required: true'
-            type: object
-            properties:
-              from:
-                description: 'List of source operations
-
-                  required: true'
-                type: array
-                items:
-                  type: object
-                  properties:
-                    accountAlias:
-                      description: 'Account identifier or alias
-
-                        example: @myAccount
-
-                        required: true'
-                      type: string
-                    amount:
-                      description: 'Amount details for the operation
-
-                        required: true'
-                      type: object
-                      properties:
-                        asset:
-                          description: 'Asset code
-
-                            example: USD
-
-                            required: true'
-                          type: string
-                        value:
-                          description: 'Amount value in smallest unit
-
-                            example: "100.00"
-
-                            required: true'
-                          type: string
-                    chartOfAccounts:
-                      description: 'Chart of accounts code
-
-                        example: WITHDRAWAL_DEBIT'
-                      type: string
-                    description:
-                      description: 'Operation description
-
-                        example: Debit Operation'
-                      type: string
-                    metadata:
-                      description: 'Additional metadata
-
-                        example: {"operation": "withdrawal", "type": "account"}'
-                      type: object
-                      additionalProperties: {}
-          value:
-            description: 'Transaction amount value in the smallest unit of the asset
-
-              example: "100.00"
-
-              required: true'
-            type: string
+        description: |-
+          Send operation details including source and distribution
+          required: true
+        allOf:
+        - "$ref": "#/definitions/Send"
       transactionDate:
-        description: 'TransactionDate Period from transaction creation date until
-          now
-
+        description: |-
+          TransactionDate Period from transaction creation date until now
           Example "2021-01-01T00:00:00Z"
-
-          swagger: type string
-
-          required: false'
+          format: date-time
+        type: string
+        format: date-time
+        example: '2021-01-01T00:00:00Z'
+  CreateTransactionOutflowInput:
+    description: CreateTransactionOutflowInput is the input payload to create an outflow transaction. Contains all necessary fields to create a financial transaction with source information only, without destination.
+    type: object
+    required:
+    - send
+    properties:
+      chartOfAccountsGroupName:
+        description: |-
+          Chart of accounts group name for accounting purposes
+          example: WITHDRAWAL
+          maxLength: 256
+        type: string
+        maxLength: 256
+        example: WITHDRAWAL
+      code:
+        description: |-
+          Transaction code for reference
+          example: TR12345
+          maxLength: 100
+        type: string
+        maxLength: 100
+        example: TR12345
+      description:
+        description: |-
+          Human-readable description of the transaction
+          example: New Outflow Transaction
+          maxLength: 256
+        type: string
+        maxLength: 256
+        example: New Outflow Transaction
+      metadata:
+        description: |-
+          Additional custom key-value attributes. Values must be flat (string, number, boolean) — no nested objects.
+          example: {"reference": "TRANSACTION-001", "source": "api"}
+        type: object
+        additionalProperties: {}
+      pending:
+        description: |-
+          Whether the transaction should be created in pending state
+          example: true
+        type: boolean
+        default: false
+        example: true
+      route:
+        description: |-
+          Deprecated: legacy route identifier, use routeId instead. Contains the transaction route UUID as a free-form string for backwards compatibility.
+          example: 00000000-0000-0000-0000-000000000000
+          maxLength: 250
+        type: string
+        maxLength: 250
+        example: 00000000-0000-0000-0000-000000000000
+      routeId:
+        description: |-
+          UUID of the transaction route. Used instead of route for proper UUID validation and referential integrity.
+          example: 00000000-0000-0000-0000-000000000000
+          format: uuid
+        type: string
+        format: uuid
+        example: 00000000-0000-0000-0000-000000000000
+      send:
+        description: |-
+          Send operation details including source only (no distribution)
+          required: true
+        allOf:
+        - "$ref": "#/definitions/SendOutflow"
+      transactionDate:
+        description: |-
+          TransactionDate Period from transaction creation date until now
+          Example "2021-01-01T00:00:00Z"
+          format: date-time
         type: string
         format: date-time
         example: '2021-01-01T00:00:00Z'
@@ -7042,163 +6780,197 @@ definitions:
         type: object
         additionalProperties: {}
       operationRoutes:
-        description: A list of Operation Route IDs associated with the Transaction
-          Route.
+        description: A list of Operation Route IDs associated with the Transaction Route.
         type: array
         items:
           type: string
           format: uuid
       title:
-        description: Short text summarizing the purpose of the transaction. Used as
-          an entry note for identification.
+        description: Short text summarizing the purpose of the transaction. Used as an entry note for identification.
         type: string
         maxLength: 255
         example: Charge Settlement
+  Distribute:
+    description: Distribute is the struct designed to represent the distribution fields of an operation.
+    type: object
+    required:
+    - to
+    properties:
+      remaining:
+        type: string
+      to:
+        type: array
+        items:
+          "$ref": "#/definitions/FromTo"
   Error:
-    description: Standardized error response format used across all API endpoints
-      for error situations. Provides structured information about errors including
-      codes, messages, and field-specific validation details.
+    description: Standardized error response format used across all API endpoints for error situations. Provides structured information about errors including codes, messages, and field-specific validation details.
     type: object
     properties:
       code:
-        description: 'Error code identifying the specific error condition
-
+        description: |-
+          Error code identifying the specific error condition
           example: ERR_INVALID_INPUT
-
-          maxLength: 50'
+          maxLength: 50
         type: string
         maxLength: 50
         example: ERR_INVALID_INPUT
       entityType:
-        description: 'Optional type of entity associated with the error
-
+        description: |-
+          Optional type of entity associated with the error
           example: Organization
-
-          maxLength: 100'
+          maxLength: 100
         type: string
         maxLength: 100
         example: Organization
       fields:
-        description: 'Optional detailed field validations for client-side handling
-
-          example: {"name": "Field ''name'' is required"}'
+        description: |-
+          Optional detailed field validations for client-side handling
+          example: {"name": "Field 'name' is required"}
         type: object
         additionalProperties:
           type: string
       message:
-        description: 'Detailed error message explaining the issue
-
-          example: The request contains invalid fields. Please check the field ''name''
-          and try again.
-
-          maxLength: 500'
+        description: |-
+          Detailed error message explaining the issue
+          example: The request contains invalid fields. Please check the field 'name' and try again.
+          maxLength: 500
         type: string
         maxLength: 500
-        example: The request contains invalid fields. Please check the field 'name'
-          and try again.
+        example: The request contains invalid fields. Please check the field 'name' and try again.
       title:
-        description: 'Short, human-readable error title
-
+        description: |-
+          Short, human-readable error title
           example: Bad Request
-
-          maxLength: 100'
+          maxLength: 100
         type: string
         maxLength: 100
         example: Bad Request
+  FromTo:
+    description: FromTo is the struct designed to represent the from/to fields of an operation.
+    type: object
+    properties:
+      accountAlias:
+        type: string
+        example: "@person1"
+      amount:
+        "$ref": "#/definitions/Amount"
+      balanceKey:
+        type: string
+        example: asset-freeze
+      chartOfAccounts:
+        type: string
+        example: '1000'
+      description:
+        type: string
+        example: description
+      isFrom:
+        type: boolean
+        example: true
+      metadata:
+        type: object
+        additionalProperties: {}
+      rate:
+        "$ref": "#/definitions/Rate"
+      remaining:
+        type: string
+        example: remaining
+      route:
+        description: 'Deprecated: passive field kept for backward compatibility. Accepted from client and persisted, but not used in any validation or business logic. Use routeId instead.'
+        type: string
+        maxLength: 250
+        example: 00000000-0000-0000-0000-000000000000
+      routeId:
+        description: |-
+          UUID of the operation route. Primary field used for route validation and accounting rules.
+          format: uuid
+        type: string
+        format: uuid
+        example: 00000000-0000-0000-0000-000000000000
+      share:
+        "$ref": "#/definitions/Share"
   IndexStats:
     description: Usage statistics collected by MongoDB for an index
     type: object
     properties:
       accesses:
-        description: 'Number of operations that have used this index
-
-          example: 1523'
+        description: |-
+          Number of operations that have used this index
+          example: 1523
         type: integer
         example: 1523
       statsSince:
-        description: 'Timestamp since when the statistics are being collected
-
+        description: |-
+          Timestamp since when the statistics are being collected
           example: 2024-12-01T10:30:00Z
-
-          format: date-time'
+          format: date-time
         type: string
         format: date-time
         example: '2024-12-01T10:30:00Z'
   Ledger:
-    description: Complete ledger entity containing all fields including system-generated
-      fields like ID, creation timestamps, and metadata. This is the response format
-      for ledger operations. Ledgers are organizational units within an organization
-      that group related financial accounts and assets together.
+    description: Complete ledger entity containing all fields including system-generated fields like ID, creation timestamps, and metadata. This is the response format for ledger operations. Ledgers are organizational units within an organization that group related financial accounts and assets together.
     type: object
     properties:
       createdAt:
-        description: 'Timestamp when the ledger was created (RFC3339 format)
-
+        description: |-
+          Timestamp when the ledger was created (RFC3339 format)
           example: 2021-01-01T00:00:00Z
-
-          format: date-time'
+          format: date-time
         type: string
         format: date-time
         example: '2021-01-01T00:00:00Z'
       deletedAt:
-        description: 'Timestamp when the ledger was soft deleted, null if not deleted
-          (RFC3339 format)
-
+        description: |-
+          Timestamp when the ledger was soft deleted, null if not deleted (RFC3339 format)
           example: null
-
-          format: date-time'
+          format: date-time
         type: string
         format: date-time
         example: '2021-01-01T00:00:00Z'
       id:
-        description: 'Unique identifier for the ledger (UUID format)
-
+        description: |-
+          Unique identifier for the ledger (UUID format)
           example: 00000000-0000-0000-0000-000000000000
-
-          format: uuid'
+          format: uuid
         type: string
         format: uuid
         example: 00000000-0000-0000-0000-000000000000
       metadata:
-        description: 'Custom key-value pairs for extending the ledger information
-
-          example: {"department": "Finance", "currency": "USD", "region": "North America"}'
+        description: |-
+          Custom key-value pairs for extending the ledger information
+          example: {"department": "Finance", "currency": "USD", "region": "North America"}
         type: object
         additionalProperties: {}
       name:
-        description: 'Display name of the ledger
-
+        description: |-
+          Display name of the ledger
           example: Treasury Operations
-
-          maxLength: 256'
+          maxLength: 256
         type: string
         maxLength: 256
         example: Treasury Operations
       organizationId:
-        description: 'Reference to the organization that owns this ledger (UUID format)
-
+        description: |-
+          Reference to the organization that owns this ledger (UUID format)
           example: 00000000-0000-0000-0000-000000000000
-
-          format: uuid'
+          format: uuid
         type: string
         format: uuid
         example: 00000000-0000-0000-0000-000000000000
       settings:
-        description: 'Dynamic configuration settings for this ledger
-
-          example: {"accounting": {"validateAccountType": true}}'
+        description: |-
+          Dynamic configuration settings for this ledger
+          example: {"accounting": {"validateAccountType": true}}
         allOf:
-        - $ref: '#/definitions/mmodel.LedgerSettings'
+        - "$ref": "#/definitions/mmodel.LedgerSettings"
       status:
         description: Current operating status of the ledger
         allOf:
-        - $ref: '#/definitions/Status'
+        - "$ref": "#/definitions/Status"
       updatedAt:
-        description: 'Timestamp when the ledger was last updated (RFC3339 format)
-
+        description: |-
+          Timestamp when the ledger was last updated (RFC3339 format)
           example: 2021-01-01T00:00:00Z
-
-          format: date-time'
+          format: date-time
         type: string
         format: date-time
         example: '2021-01-01T00:00:00Z'
@@ -7223,50 +6995,43 @@ definitions:
         type: boolean
         example: true
       stats:
-        description: Usage statistics for this index (only available on GET, not on
-          CREATE)
+        description: Usage statistics for this index (only available on GET, not on CREATE)
         allOf:
-        - $ref: '#/definitions/IndexStats'
+        - "$ref": "#/definitions/IndexStats"
       unique:
         description: Whether the index enforces uniqueness
         type: boolean
         example: false
   Operation:
-    description: Operation is a struct designed to store operation data. Represents
-      a financial operation that affects account balances, including details such
-      as amount, balance before and after, transaction association, and metadata.
+    description: Operation is a struct designed to store operation data. Represents a financial operation that affects account balances, including details such as amount, balance before and after, transaction association, and metadata.
     type: object
     properties:
       accountAlias:
-        description: 'Human-readable alias for the account
-
+        description: |-
+          Human-readable alias for the account
           example: @person1
-
-          maxLength: 256'
+          maxLength: 256
         type: string
         maxLength: 256
-        example: '@person1'
+        example: "@person1"
       accountId:
-        description: 'Account identifier associated with this operation
-
+        description: |-
+          Account identifier associated with this operation
           example: 00000000-0000-0000-0000-000000000000
-
-          format: uuid'
+          format: uuid
         type: string
         format: uuid
         example: 00000000-0000-0000-0000-000000000000
       amount:
         description: Operation amount information
         allOf:
-        - $ref: '#/definitions/Amount'
+        - "$ref": "#/definitions/Amount"
       assetCode:
-        description: 'Asset code for the operation
-
+        description: |-
+          Asset code for the operation
           example: BRL
-
           minLength: 2
-
-          maxLength: 10'
+          maxLength: 10
         type: string
         maxLength: 10
         minLength: 2
@@ -7274,78 +7039,71 @@ definitions:
       balance:
         description: Balance before the operation
         allOf:
-        - $ref: '#/definitions/Balance'
+        - "$ref": "#/definitions/Balance"
       balanceAffected:
-        description: 'BalanceAffected default true
-
-          format: boolean'
+        description: |-
+          BalanceAffected default true
+          format: boolean
         type: boolean
         format: boolean
         example: true
       balanceAfter:
         description: Balance after the operation
         allOf:
-        - $ref: '#/definitions/Balance'
+        - "$ref": "#/definitions/Balance"
       balanceId:
-        description: 'Balance identifier affected by this operation
-
+        description: |-
+          Balance identifier affected by this operation
           example: 00000000-0000-0000-0000-000000000000
-
-          format: uuid'
+          format: uuid
         type: string
         format: uuid
         example: 00000000-0000-0000-0000-000000000000
       balanceKey:
-        description: 'Unique key for the balance
-
+        description: |-
+          Unique key for the balance
           example: asset-freeze
-
-          maxLength: 100'
+          maxLength: 100
         type: string
         maxLength: 100
         example: asset-freeze
       chartOfAccounts:
-        description: 'Chart of accounts code for accounting purposes
-
+        description: |-
+          Chart of accounts code for accounting purposes
           example: 1000
-
-          maxLength: 20'
+          maxLength: 20
         type: string
         maxLength: 20
         example: '1000'
       createdAt:
-        description: 'Timestamp when the operation was created
-
+        description: |-
+          Timestamp when the operation was created
           example: 2021-01-01T00:00:00Z
-
-          format: date-time'
+          format: date-time
         type: string
         format: date-time
         example: '2021-01-01T00:00:00Z'
       deletedAt:
-        description: 'Timestamp when the operation was deleted (if soft-deleted)
-
+        description: |-
+          Timestamp when the operation was deleted (if soft-deleted)
           example: 2021-01-01T00:00:00Z
-
-          format: date-time'
+          format: date-time
         type: string
         format: date-time
         example: '2021-01-01T00:00:00Z'
       description:
-        description: 'Human-readable description of the operation
-
+        description: |-
+          Human-readable description of the operation
           example: Credit card operation
-
-          maxLength: 256'
+          maxLength: 256
         type: string
         maxLength: 256
         example: Credit card operation
       direction:
-        description: 'Direction of the operation (debit, credit)
-
+        description: |-
+          Direction of the operation (debit, credit)
           example: debit
-
-          maxLength: 50'
+          maxLength: 50
         type: string
         maxLength: 50
         enum:
@@ -7353,107 +7111,93 @@ definitions:
         - credit
         example: debit
       id:
-        description: 'Unique identifier for the operation
-
+        description: |-
+          Unique identifier for the operation
           example: 00000000-0000-0000-0000-000000000000
-
-          format: uuid'
+          format: uuid
         type: string
         format: uuid
         example: 00000000-0000-0000-0000-000000000000
       ledgerId:
-        description: 'Ledger identifier
-
+        description: |-
+          Ledger identifier
           example: 00000000-0000-0000-0000-000000000000
-
-          format: uuid'
+          format: uuid
         type: string
         format: uuid
         example: 00000000-0000-0000-0000-000000000000
       metadata:
-        description: 'Additional custom attributes
-
-          example: {"reason": "Purchase refund", "reference": "INV-12345"}'
+        description: |-
+          Additional custom attributes
+          example: {"reason": "Purchase refund", "reference": "INV-12345"}
         type: object
         additionalProperties: {}
       organizationId:
-        description: 'Organization identifier
-
+        description: |-
+          Organization identifier
           example: 00000000-0000-0000-0000-000000000000
-
-          format: uuid'
+          format: uuid
         type: string
         format: uuid
         example: 00000000-0000-0000-0000-000000000000
       route:
-        description: 'Deprecated: passive field kept for backward compatibility. Not
-          used in validation or business logic. Use routeId instead.
-
+        description: |-
+          Deprecated: passive field kept for backward compatibility. Not used in validation or business logic. Use routeId instead.
           example: 00000000-0000-0000-0000-000000000000
-
           maxLength: 250
-
-          deprecated: true'
+          deprecated: true
         type: string
         maxLength: 250
         example: 00000000-0000-0000-0000-000000000000
       routeCode:
-        description: 'Human-readable code of the operation route for accounting traceability
-
+        description: |-
+          Human-readable code of the operation route for accounting traceability
           example: ROUTE-001
-
-          maxLength: 100'
+          maxLength: 100
         type: string
         maxLength: 100
         example: ROUTE-001
       routeDescription:
-        description: 'Human-readable description of the operation route for accounting
-          traceability
-
+        description: |-
+          Human-readable description of the operation route for accounting traceability
           example: Settlement route for service charges
-
-          maxLength: 250'
+          maxLength: 250
         type: string
         maxLength: 250
         example: Settlement route for service charges
       routeId:
-        description: 'UUID of the operation route that generated this operation. Primary
-          field for route identification, validation, and accounting.
-
+        description: |-
+          UUID of the operation route that generated this operation. Primary field for route identification, validation, and accounting.
           example: 00000000-0000-0000-0000-000000000000
-
-          format: uuid'
+          format: uuid
         type: string
         format: uuid
         example: 00000000-0000-0000-0000-000000000000
       status:
         description: Operation status information
         allOf:
-        - $ref: '#/definitions/Status'
+        - "$ref": "#/definitions/Status"
       transactionId:
-        description: 'Parent transaction identifier
-
+        description: |-
+          Parent transaction identifier
           example: 00000000-0000-0000-0000-000000000000
-
-          format: uuid'
+          format: uuid
         type: string
         format: uuid
         example: 00000000-0000-0000-0000-000000000000
       type:
-        description: 'Type of operation (e.g., DEBIT, CREDIT)
-
+        description: |-
+          Type of operation (e.g., DEBIT, CREDIT)
           example: DEBIT
-
-          maxLength: 50'
+          maxLength: 50
         type: string
         maxLength: 50
         example: DEBIT
       updatedAt:
-        description: 'Timestamp when the operation was last updated
-
+        description: |-
+          Timestamp when the operation was last updated
           example: 2021-01-01T00:00:00Z
-
-          format: date-time'
+          format: date-time
         type: string
         format: date-time
         example: '2021-01-01T00:00:00Z'
@@ -7464,14 +7208,16 @@ definitions:
       account:
         description: The account selection rule configuration.
         allOf:
-        - $ref: '#/definitions/AccountRule'
+        - "$ref": "#/definitions/AccountRule"
       accountingEntries:
-        description: Optional accounting entries for each action type associated with
-          this operation route.
+        description: Optional accounting entries for each action type associated with this operation route.
         allOf:
-        - $ref: '#/definitions/AccountingEntries'
+        - "$ref": "#/definitions/AccountingEntries"
       code:
-        description: External reference of the operation route.
+        description: |-
+          Deprecated: external reference code kept for backward compatibility. Use the rubric codes inside accountingEntries instead.
+          example: EXT-001
+          deprecated: true
         type: string
         example: EXT-001
       createdAt:
@@ -7487,16 +7233,15 @@ definitions:
       description:
         description: Detailed description of the operation route purpose and usage.
         type: string
-        example: This operation route handles cash-in transactions from service charge
-          collections
+        example: This operation route handles cash-in transactions from service charge collections
       id:
         description: The unique identifier of the Operation Route.
         type: string
-        example: 01965ed9-7fa4-75b2-8872-fc9e8509ab0a
+        example: '01965ed9-7fa4-75b2-8872-fc9e8509ab0a'
       ledgerId:
         description: The unique identifier of the Ledger.
         type: string
-        example: 01965ed9-7fa4-75b2-8872-fc9e8509ab0a
+        example: '01965ed9-7fa4-75b2-8872-fc9e8509ab0a'
       metadata:
         description: Additional metadata stored as JSON
         type: object
@@ -7512,10 +7257,9 @@ definitions:
       organizationId:
         description: The unique identifier of the Organization.
         type: string
-        example: 01965ed9-7fa4-75b2-8872-fc9e8509ab0a
+        example: '01965ed9-7fa4-75b2-8872-fc9e8509ab0a'
       title:
-        description: Short text summarizing the purpose of the operation. Used as
-          an entry note for identification.
+        description: Short text summarizing the purpose of the operation. Used as an entry note for identification.
         type: string
         example: Cashin from service charge
       updatedAt:
@@ -7524,104 +7268,88 @@ definitions:
         format: date-time
         example: '2021-01-01T00:00:00Z'
   Organization:
-    description: Complete organization entity containing all fields including system-generated
-      fields like ID, creation timestamps, and metadata. This is the response format
-      for organization operations. Organizations are the top-level entities in the
-      Midaz platform hierarchy.
+    description: Complete organization entity containing all fields including system-generated fields like ID, creation timestamps, and metadata. This is the response format for organization operations. Organizations are the top-level entities in the Midaz platform hierarchy.
     type: object
     properties:
       address:
         description: Physical address of the organization
         allOf:
-        - $ref: '#/definitions/Address'
+        - "$ref": "#/definitions/Address"
       createdAt:
-        description: 'Timestamp when the organization was created (RFC3339 format)
-
+        description: |-
+          Timestamp when the organization was created (RFC3339 format)
           example: 2021-01-01T00:00:00Z
-
-          format: date-time'
+          format: date-time
         type: string
         format: date-time
         example: '2021-01-01T00:00:00Z'
       deletedAt:
-        description: 'Timestamp when the organization was soft deleted, null if not
-          deleted (RFC3339 format)
-
+        description: |-
+          Timestamp when the organization was soft deleted, null if not deleted (RFC3339 format)
           example: null
-
-          format: date-time'
+          format: date-time
         type: string
         format: date-time
         example: '2021-01-01T00:00:00Z'
       doingBusinessAs:
-        description: 'Trading or brand name of the organization, if different from
-          legal name
-
+        description: |-
+          Trading or brand name of the organization, if different from legal name
           example: Lerian FS
-
-          maxLength: 256'
+          maxLength: 256
         type: string
         maxLength: 256
         example: Lerian FS
       id:
-        description: 'Unique identifier for the organization (UUID format)
-
+        description: |-
+          Unique identifier for the organization (UUID format)
           example: 00000000-0000-0000-0000-000000000000
-
-          format: uuid'
+          format: uuid
         type: string
         format: uuid
         example: 00000000-0000-0000-0000-000000000000
       legalDocument:
-        description: 'Official tax ID, company registration number, or other legal
-          identification
-
+        description: |-
+          Official tax ID, company registration number, or other legal identification
           example: 123456789012345
-
-          maxLength: 256'
+          maxLength: 256
         type: string
         maxLength: 256
         example: '123456789012345'
       legalName:
-        description: 'Official legal name of the organization
-
+        description: |-
+          Official legal name of the organization
           example: Lerian Financial Services Ltd.
-
-          maxLength: 256'
+          maxLength: 256
         type: string
         maxLength: 256
         example: Lerian Financial Services Ltd.
       metadata:
-        description: 'Custom key-value pairs for extending the organization information
-
-          example: {"industry": "Financial Services", "founded": 2020, "employees":
-          150}'
+        description: |-
+          Custom key-value pairs for extending the organization information
+          example: {"industry": "Financial Services", "founded": 2020, "employees": 150}
         type: object
         additionalProperties: {}
       parentOrganizationId:
-        description: 'Reference to the parent organization, if this is a child organization
-
+        description: |-
+          Reference to the parent organization, if this is a child organization
           example: 00000000-0000-0000-0000-000000000000
-
-          format: uuid'
+          format: uuid
         type: string
         format: uuid
       status:
         description: Current operating status of the organization
         allOf:
-        - $ref: '#/definitions/Status'
+        - "$ref": "#/definitions/Status"
       updatedAt:
-        description: 'Timestamp when the organization was last updated (RFC3339 format)
-
+        description: |-
+          Timestamp when the organization was last updated (RFC3339 format)
           example: 2021-01-01T00:00:00Z
-
-          format: date-time'
+          format: date-time
         type: string
         format: date-time
         example: '2021-01-01T00:00:00Z'
   Portfolio:
-    description: Portfolio represents a collection of accounts grouped for specific
-      purposes such as business units, departments, or client portfolios.
+    description: Portfolio represents a collection of accounts grouped for specific purposes such as business units, departments, or client portfolios.
     type: object
     properties:
       createdAt:
@@ -7666,15 +7394,35 @@ definitions:
       status:
         description: Status of the portfolio (active, inactive, pending)
         allOf:
-        - $ref: '#/definitions/Status'
+        - "$ref": "#/definitions/Status"
       updatedAt:
         description: Timestamp when the portfolio was last updated
         type: string
         format: date-time
         example: '2021-01-01T00:00:00Z'
+  Rate:
+    description: Rate is the struct designed to represent the rate fields of an operation.
+    type: object
+    required:
+    - externalId
+    - from
+    - to
+    - value
+    properties:
+      externalId:
+        type: string
+        example: 00000000-0000-0000-0000-000000000000
+      from:
+        type: string
+        example: BRL
+      to:
+        type: string
+        example: USDe
+      value:
+        type: number
+        example: 1000
   Segment:
-    description: Segment represents a logical division within a ledger such as a business
-      area, product line, or customer category.
+    description: Segment represents a logical division within a ledger such as a business area, product line, or customer category.
     type: object
     properties:
       createdAt:
@@ -7714,196 +7462,247 @@ definitions:
       status:
         description: Status of the segment (active, inactive, pending)
         allOf:
-        - $ref: '#/definitions/Status'
+        - "$ref": "#/definitions/Status"
       updatedAt:
         description: Timestamp when the segment was last updated
         type: string
         format: date-time
         example: '2021-01-01T00:00:00Z'
+  Send:
+    description: Send is the struct designed to represent the sending fields of an operation.
+    type: object
+    required:
+    - asset
+    - distribute
+    - source
+    - value
+    properties:
+      asset:
+        type: string
+        example: BRL
+      distribute:
+        "$ref": "#/definitions/Distribute"
+      source:
+        "$ref": "#/definitions/Source"
+      value:
+        type: number
+        example: 1000
+  SendInflow:
+    description: SendInflow is the struct designed to represent the sending fields of an inflow operation without source information.
+    type: object
+    required:
+    - asset
+    - distribute
+    - value
+    properties:
+      asset:
+        type: string
+        example: BRL
+      distribute:
+        "$ref": "#/definitions/Distribute"
+      value:
+        type: number
+        example: 1000
+  SendOutflow:
+    description: SendOutflow is the struct designed to represent the sending fields of an outflow operation without distribution information.
+    type: object
+    required:
+    - asset
+    - source
+    - value
+    properties:
+      asset:
+        type: string
+        example: BRL
+      source:
+        "$ref": "#/definitions/Source"
+      value:
+        type: number
+        example: 1000
+  Share:
+    description: Share is the struct designed to represent the sharing fields of an operation.
+    type: object
+    required:
+    - percentage
+    properties:
+      percentage:
+        type: integer
+      percentageOfPercentage:
+        type: integer
+  Source:
+    description: Source is the struct designed to represent the source fields of an operation.
+    type: object
+    required:
+    - from
+    properties:
+      from:
+        type: array
+        items:
+          "$ref": "#/definitions/FromTo"
+      remaining:
+        type: string
+        example: remaining
   Status:
-    description: Status is the struct designed to represent the status of a transaction.
-      Contains code and optional description for transaction states.
+    description: Status is the struct designed to represent the status of a transaction. Contains code and optional description for transaction states.
     type: object
     properties:
       code:
-        description: 'Status code identifying the state of the transaction
-
+        description: |-
+          Status code identifying the state of the transaction
           example: ACTIVE
-
-          maxLength: 100'
+          maxLength: 100
         type: string
         maxLength: 100
         example: ACTIVE
       description:
-        description: 'Optional descriptive text explaining the status
-
+        description: |-
+          Optional descriptive text explaining the status
           example: Active status
-
-          maxLength: 256'
+          maxLength: 256
         type: string
         maxLength: 256
         example: Active status
   Transaction:
-    description: Transaction is a struct designed to store transaction data. Represents
-      a financial transaction that consists of multiple operations affecting account
-      balances, including details about the transaction's status, amounts, and related
-      operations.
+    description: Transaction is a struct designed to store transaction data. Represents a financial transaction that consists of multiple operations affecting account balances, including details about the transaction's status, amounts, and related operations.
     type: object
     properties:
       amount:
-        description: 'Transaction amount value in the smallest unit of the asset
-
+        description: |-
+          Transaction amount value in the smallest unit of the asset
           example: 1500
-
-          minimum: 0'
+          minimum: 0
         type: number
         minimum: 0
         example: 1500
       assetCode:
-        description: 'Asset code for the transaction
-
+        description: |-
+          Asset code for the transaction
           example: BRL
-
           minLength: 2
-
-          maxLength: 10'
+          maxLength: 10
         type: string
         maxLength: 10
         minLength: 2
         example: BRL
       chartOfAccountsGroupName:
-        description: 'Chart of accounts group name for accounting purposes
-
+        description: |-
+          Chart of accounts group name for accounting purposes
           example: Chart of accounts group name
-
-          maxLength: 256'
+          maxLength: 256
         type: string
         maxLength: 256
         example: Chart of accounts group name
       createdAt:
-        description: 'Timestamp when the transaction was created
-
+        description: |-
+          Timestamp when the transaction was created
           example: 2021-01-01T00:00:00Z
-
-          format: date-time'
+          format: date-time
         type: string
         format: date-time
         example: '2021-01-01T00:00:00Z'
       deletedAt:
-        description: 'Timestamp when the transaction was deleted (if soft-deleted)
-
+        description: |-
+          Timestamp when the transaction was deleted (if soft-deleted)
           example: 2021-01-01T00:00:00Z
-
-          format: date-time'
+          format: date-time
         type: string
         format: date-time
         example: '2021-01-01T00:00:00Z'
       description:
-        description: 'Human-readable description of the transaction
-
+        description: |-
+          Human-readable description of the transaction
           example: Transaction description
-
-          maxLength: 256'
+          maxLength: 256
         type: string
         maxLength: 256
         example: Transaction description
       destination:
-        description: 'List of destination account aliases or identifiers
-
-          example: ["@person2"]'
+        description: |-
+          List of destination account aliases or identifiers
+          example: ["@person2"]
         type: array
         items:
           type: string
         example:
-        - '@person2'
+        - "@person2"
       id:
-        description: 'Unique identifier for the transaction
-
+        description: |-
+          Unique identifier for the transaction
           example: 00000000-0000-0000-0000-000000000000
-
-          format: uuid'
+          format: uuid
         type: string
         format: uuid
         example: 00000000-0000-0000-0000-000000000000
       ledgerId:
-        description: 'Ledger identifier
-
+        description: |-
+          Ledger identifier
           example: 00000000-0000-0000-0000-000000000000
-
-          format: uuid'
+          format: uuid
         type: string
         format: uuid
         example: 00000000-0000-0000-0000-000000000000
       metadata:
-        description: 'Additional custom attributes
-
-          example: {"purpose": "Monthly payment", "category": "Utility"}'
+        description: |-
+          Additional custom attributes
+          example: {"purpose": "Monthly payment", "category": "Utility"}
         type: object
         additionalProperties: {}
       operations:
         description: List of operations associated with this transaction
         type: array
         items:
-          $ref: '#/definitions/Operation'
+          "$ref": "#/definitions/Operation"
       organizationId:
-        description: 'Organization identifier
-
+        description: |-
+          Organization identifier
           example: 00000000-0000-0000-0000-000000000000
-
-          format: uuid'
+          format: uuid
         type: string
         format: uuid
         example: 00000000-0000-0000-0000-000000000000
       parentTransactionId:
-        description: 'Parent transaction identifier (for reversals or child transactions)
-
+        description: |-
+          Parent transaction identifier (for reversals or child transactions)
           example: 00000000-0000-0000-0000-000000000000
-
-          format: uuid'
+          format: uuid
         type: string
         format: uuid
         example: 00000000-0000-0000-0000-000000000000
       route:
-        description: 'Deprecated: legacy route identifier, use routeId instead. Contains
-          the transaction route UUID as a free-form string for backwards compatibility.
-
+        description: |-
+          Deprecated: legacy route identifier, use routeId instead. Contains the transaction route UUID as a free-form string for backwards compatibility.
           example: 00000000-0000-0000-0000-000000000000
-
           maxLength: 250
-
-          deprecated: true'
+          deprecated: true
         type: string
         maxLength: 250
         example: 00000000-0000-0000-0000-000000000000
       routeId:
-        description: 'UUID of the transaction route. Primary field for route identification,
-          validation, and accounting.
-
+        description: |-
+          UUID of the transaction route. Primary field for route identification, validation, and accounting.
           example: 00000000-0000-0000-0000-000000000000
-
-          format: uuid'
+          format: uuid
         type: string
         format: uuid
         example: 00000000-0000-0000-0000-000000000000
       source:
-        description: 'List of source account aliases or identifiers
-
-          example: ["@person1"]'
+        description: |-
+          List of source account aliases or identifiers
+          example: ["@person1"]
         type: array
         items:
           type: string
         example:
-        - '@person1'
+        - "@person1"
       status:
         description: Transaction status information
         allOf:
-        - $ref: '#/definitions/Status'
+        - "$ref": "#/definitions/Status"
       updatedAt:
-        description: 'Timestamp when the transaction was last updated
-
+        description: |-
+          Timestamp when the transaction was last updated
           example: 2021-01-01T00:00:00Z
-
-          format: date-time'
+          format: date-time
         type: string
         format: date-time
         example: '2021-01-01T00:00:00Z'
@@ -7926,28 +7725,26 @@ definitions:
       id:
         description: The unique identifier of the Transaction Route.
         type: string
-        example: 01965ed9-7fa4-75b2-8872-fc9e8509ab0a
+        example: '01965ed9-7fa4-75b2-8872-fc9e8509ab0a'
       ledgerId:
         description: The unique identifier of the Ledger.
         type: string
-        example: 01965ed9-7fa4-75b2-8872-fc9e8509ab0a
+        example: '01965ed9-7fa4-75b2-8872-fc9e8509ab0a'
       metadata:
         description: Additional metadata stored as JSON
         type: object
         additionalProperties: {}
       operationRoutes:
-        description: An object containing accounting data of Operation Routes from
-          the Transaction Route.
+        description: An object containing accounting data of Operation Routes from the Transaction Route.
         type: array
         items:
-          $ref: '#/definitions/OperationRoute'
+          "$ref": "#/definitions/OperationRoute"
       organizationId:
         description: The unique identifier of the Organization.
         type: string
-        example: 01965ed9-7fa4-75b2-8872-fc9e8509ab0a
+        example: '01965ed9-7fa4-75b2-8872-fc9e8509ab0a'
       title:
-        description: Short text summarizing the purpose of the transaction. Used as
-          an entry note for identification.
+        description: Short text summarizing the purpose of the transaction. Used as an entry note for identification.
         type: string
         example: Charge Settlement
       updatedAt:
@@ -7955,70 +7752,59 @@ definitions:
         type: string
         example: '2025-01-01T00:00:00Z'
   UpdateAccountInput:
-    description: Request payload for updating an existing account. All fields are
-      optional - only specified fields will be updated. Omitted fields will remain
-      unchanged. This allows partial updates to account properties such as name, status,
-      portfolio, segment, and metadata.
+    description: Request payload for updating an existing account. All fields are optional - only specified fields will be updated. Omitted fields will remain unchanged. This allows partial updates to account properties such as name, status, portfolio, segment, and metadata.
     type: object
     properties:
       blocked:
-        description: 'Whether the account should be blocked
-
-          required: false'
+        description: |-
+          Whether the account should be blocked
+          required: false
         type: boolean
       entityId:
-        description: 'Optional external identifier for linking to external systems
-
+        description: |-
+          Optional external identifier for linking to external systems
           required: false
-
           example: EXT-ACC-12345
-
-          maxLength: 256'
+          maxLength: 256
         type: string
         maxLength: 256
         example: EXT-ACC-12345
       metadata:
-        description: 'Updated custom key-value pairs for extending the account information
-
+        description: |-
+          Updated custom key-value pairs for extending the account information
           required: false
-
-          example: {"department": "Global Treasury", "purpose": "Primary Operations",
-          "region": "Global"}'
+          example: {"department": "Global Treasury", "purpose": "Primary Operations", "region": "Global"}
         type: object
         additionalProperties: {}
       name:
-        description: 'Updated name of the account
-
+        description: |-
+          Updated name of the account
           required: false
-
           example: Primary Corporate Checking Account
-
-          maxLength: 256'
+          maxLength: 256
         type: string
         maxLength: 256
         example: Primary Corporate Checking Account
       portfolioId:
-        description: 'Updated portfolio ID for the account
-
+        description: |-
+          Updated portfolio ID for the account
           required: false
-
-          format: uuid'
+          format: uuid
         type: string
         format: uuid
       segmentId:
-        description: 'Updated segment ID for the account
-
+        description: |-
+          Updated segment ID for the account
           required: false
-
-          format: uuid'
+          format: uuid
         type: string
         format: uuid
       status:
-        description: 'Updated status of the account
-
-          required: false'
+        description: |-
+          Updated status of the account
+          required: false
         allOf:
-        - $ref: '#/definitions/Status'
+        - "$ref": "#/definitions/Status"
   UpdateAccountTypeInput:
     description: UpdateAccountTypeInput payload
     type: object
@@ -8029,12 +7815,10 @@ definitions:
         maxLength: 500
         example: Assets that are expected to be converted to cash within one year
       metadata:
-        description: 'Custom key-value pairs for extending the account type information
-
+        description: |-
+          Custom key-value pairs for extending the account type information
           required: false
-
-          example: {"department": "Treasury", "purpose": "Operating Expenses", "region":
-          "Global"}'
+          example: {"department": "Treasury", "purpose": "Operating Expenses", "region": "Global"}
         type: object
         additionalProperties: {}
       name:
@@ -8043,14 +7827,13 @@ definitions:
         maxLength: 100
         example: Current Assets
   UpdateAssetInput:
-    description: UpdateAssetInput is the input payload to update an existing asset's
-      properties such as name, status, and metadata.
+    description: UpdateAssetInput is the input payload to update an existing asset's properties such as name, status, and metadata.
     type: object
     properties:
       metadata:
-        description: 'Updated or additional custom attributes for the asset
-
-          Keys max length: 100 characters, Values max length: 2000 characters'
+        description: |-
+          Updated or additional custom attributes for the asset
+          Keys max length: 100 characters, Values max length: 2000 characters
         type: object
         additionalProperties: {}
       name:
@@ -8061,79 +7844,75 @@ definitions:
       status:
         description: Updated status of the asset (active, inactive, pending)
         allOf:
-        - $ref: '#/definitions/Status'
+        - "$ref": "#/definitions/Status"
   UpdateBalance:
-    description: Request payload for updating an existing balance's permissions. All
-      fields are optional - only specified fields will be updated. Omitted fields
-      will remain unchanged.
+    description: Request payload for updating an existing balance's permissions. All fields are optional - only specified fields will be updated. Omitted fields will remain unchanged.
     type: object
     properties:
       allowReceiving:
-        description: 'Whether the account should be allowed to receive funds to this
-          balance
-
+        description: |-
+          Whether the account should be allowed to receive funds to this balance
           required: false
-
-          example: true'
+          example: true
         type: boolean
         example: true
       allowSending:
-        description: 'Whether the account should be allowed to send funds from this
-          balance
-
+        description: |-
+          Whether the account should be allowed to send funds from this balance
           required: false
-
-          example: true'
+          example: true
         type: boolean
         example: true
+      settings:
+        description: |-
+          Settings is the per-balance configuration (overdraft, balance
+          scope). When provided, replaces the existing settings in full.
+          Direction is intentionally absent: it is immutable after creation.
+          required: false
+        allOf:
+        - "$ref": "#/definitions/mmodel.BalanceSettings"
   UpdateLedgerInput:
-    description: Request payload for updating an existing ledger. All fields are optional
-      - only specified fields will be updated. Omitted fields will remain unchanged.
+    description: Request payload for updating an existing ledger. All fields are optional - only specified fields will be updated. Omitted fields will remain unchanged.
     type: object
     properties:
       metadata:
-        description: 'Updated custom key-value pairs for extending the ledger information
-
+        description: |-
+          Updated custom key-value pairs for extending the ledger information
           required: false
-
-          example: {"department": "Global Finance", "currency": "USD", "region": "Global"}'
+          example: {"department": "Global Finance", "currency": "USD", "region": "Global"}
         type: object
         additionalProperties: {}
       name:
-        description: 'Updated display name of the ledger
-
+        description: |-
+          Updated display name of the ledger
           required: false
-
           example: Treasury Operations Global
-
-          maxLength: 256'
+          maxLength: 256
         type: string
         maxLength: 256
         example: Treasury Operations Global
       status:
-        description: 'Updated status of the ledger
-
-          required: false'
+        description: |-
+          Updated status of the ledger
+          required: false
         allOf:
-        - $ref: '#/definitions/Status'
+        - "$ref": "#/definitions/Status"
   UpdateOperationInput:
-    description: UpdateOperationInput is the input payload to update an operation.
-      Contains fields that can be modified after an operation is created.
+    description: UpdateOperationInput is the input payload to update an operation. Contains fields that can be modified after an operation is created.
     type: object
     properties:
       description:
-        description: 'Human-readable description of the operation
-
+        description: |-
+          Human-readable description of the operation
           example: Credit card operation
-
-          maxLength: 256'
+          maxLength: 256
         type: string
         maxLength: 256
         example: Credit card operation
       metadata:
-        description: 'Additional custom attributes
-
-          example: {"reason": "Purchase refund", "reference": "INV-12345"}'
+        description: |-
+          Additional custom attributes
+          example: {"reason": "Purchase refund", "reference": "INV-12345"}
         type: object
         additionalProperties: {}
   UpdateOperationRouteInput:
@@ -8143,14 +7922,17 @@ definitions:
       account:
         description: The account selection rule configuration.
         allOf:
-        - $ref: '#/definitions/AccountRule'
+        - "$ref": "#/definitions/AccountRule"
       accountingEntries:
-        description: Optional accounting entries for each action type associated with
-          this operation route.
+        description: Optional accounting entries for each action type associated with this operation route.
         allOf:
-        - $ref: '#/definitions/AccountingEntries'
+        - "$ref": "#/definitions/AccountingEntries"
       code:
-        description: External reference of the operation route.
+        description: |-
+          Deprecated: external reference code kept for backward compatibility. Use the rubric codes inside accountingEntries instead.
+          example: EXT-001
+          maxLength: 100
+          deprecated: true
         type: string
         maxLength: 100
         example: EXT-001
@@ -8158,91 +7940,77 @@ definitions:
         description: Detailed description of the operation route purpose and usage.
         type: string
         maxLength: 250
-        example: This operation route handles cash-in transactions from service charge
-          collections
+        example: This operation route handles cash-in transactions from service charge collections
       metadata:
         description: Additional metadata stored as JSON
         type: object
         additionalProperties: {}
       title:
-        description: Short text summarizing the purpose of the operation. Used as
-          an entry note for identification.
+        description: Short text summarizing the purpose of the operation. Used as an entry note for identification.
         type: string
         maxLength: 255
         example: Cashin from service charge
   UpdateOrganizationInput:
-    description: Request payload for updating an existing organization. All fields
-      are optional - only specified fields will be updated. Omitted fields will remain
-      unchanged.
+    description: Request payload for updating an existing organization. All fields are optional - only specified fields will be updated. Omitted fields will remain unchanged.
     type: object
     properties:
       address:
-        description: 'Updated physical address of the organization
-
-          required: false'
-        allOf:
-        - $ref: '#/definitions/Address'
-      doingBusinessAs:
-        description: 'Updated trading or brand name of the organization
-
+        description: |-
+          Updated physical address of the organization
           required: false
-
+        allOf:
+        - "$ref": "#/definitions/Address"
+      doingBusinessAs:
+        description: |-
+          Updated trading or brand name of the organization
+          required: false
           example: Lerian Group
-
-          maxLength: 256'
+          maxLength: 256
         type: string
         maxLength: 256
         example: Lerian Group
       legalName:
-        description: 'Updated legal name of the organization
-
+        description: |-
+          Updated legal name of the organization
           required: false
-
           example: Lerian Financial Group Ltd.
-
-          maxLength: 256'
+          maxLength: 256
         type: string
         maxLength: 256
         example: Lerian Financial Group Ltd.
       metadata:
-        description: 'Updated custom key-value pairs for extending the organization
-          information
-
+        description: |-
+          Updated custom key-value pairs for extending the organization information
           required: false
-
-          example: {"industry": "Financial Technology", "founded": 2020, "employees":
-          200, "headquarters": "New York"}'
+          example: {"industry": "Financial Technology", "founded": 2020, "employees": 200, "headquarters": "New York"}
         type: object
         additionalProperties: {}
       parentOrganizationId:
-        description: 'Updated UUID of the parent organization if this is a child organization
-
+        description: |-
+          Updated UUID of the parent organization if this is a child organization
           required: false
-
-          format: uuid'
+          format: uuid
         type: string
         format: uuid
       status:
-        description: 'Updated status of the organization
-
-          required: false'
+        description: |-
+          Updated status of the organization
+          required: false
         allOf:
-        - $ref: '#/definitions/Status'
+        - "$ref": "#/definitions/Status"
   UpdatePortfolioInput:
-    description: UpdatePortfolioInput is the input payload to update an existing portfolio's
-      properties such as name, entity ID, status, and metadata.
+    description: UpdatePortfolioInput is the input payload to update an existing portfolio's properties such as name, entity ID, status, and metadata.
     type: object
     properties:
       entityId:
-        description: Updated external entity identifier (optional, max length 256
-          characters)
+        description: Updated external entity identifier (optional, max length 256 characters)
         type: string
         maxLength: 256
         example: 00000000-0000-0000-0000-000000000000
       metadata:
-        description: 'Updated or additional custom attributes for the portfolio
-
-          Keys max length: 100 characters, Values max length: 2000 characters'
+        description: |-
+          Updated or additional custom attributes for the portfolio
+          Keys max length: 100 characters, Values max length: 2000 characters
         type: object
         additionalProperties: {}
       name:
@@ -8253,16 +8021,15 @@ definitions:
       status:
         description: Updated status of the portfolio (active, inactive, pending)
         allOf:
-        - $ref: '#/definitions/Status'
+        - "$ref": "#/definitions/Status"
   UpdateSegmentInput:
-    description: UpdateSegmentInput is the input payload to update an existing segment's
-      properties such as name, status, and metadata.
+    description: UpdateSegmentInput is the input payload to update an existing segment's properties such as name, status, and metadata.
     type: object
     properties:
       metadata:
-        description: 'Updated or additional custom attributes for the segment
-
-          Keys max length: 100 characters, Values max length: 2000 characters'
+        description: |-
+          Updated or additional custom attributes for the segment
+          Keys max length: 100 characters, Values max length: 2000 characters
         type: object
         additionalProperties: {}
       name:
@@ -8273,25 +8040,23 @@ definitions:
       status:
         description: Updated status of the segment (active, inactive, pending)
         allOf:
-        - $ref: '#/definitions/Status'
+        - "$ref": "#/definitions/Status"
   UpdateTransactionInput:
-    description: UpdateTransactionInput is the input payload to update a transaction.
-      Contains fields that can be modified after a transaction is created.
+    description: UpdateTransactionInput is the input payload to update a transaction. Contains fields that can be modified after a transaction is created.
     type: object
     properties:
       description:
-        description: 'Human-readable description of the transaction
-
+        description: |-
+          Human-readable description of the transaction
           example: Transaction description
-
-          maxLength: 256'
+          maxLength: 256
         type: string
         maxLength: 256
         example: Transaction description
       metadata:
-        description: 'Additional custom attributes
-
-          example: {"purpose": "Monthly payment", "category": "Utility"}'
+        description: |-
+          Additional custom attributes
+          example: {"purpose": "Monthly payment", "category": "Utility"}
         type: object
         additionalProperties: {}
   UpdateTransactionRouteInput:
@@ -8308,228 +8073,16 @@ definitions:
         type: object
         additionalProperties: {}
       operationRoutes:
-        description: A list of Operation Route IDs associated with the Transaction
-          Route. Omit to leave existing associations unchanged. When provided, replaces
-          all current associations with the supplied UUIDs.
+        description: A list of Operation Route IDs associated with the Transaction Route. Omit to leave existing associations unchanged. When provided, replaces all current associations with the supplied UUIDs.
         type: array
         items:
           type: string
           format: uuid
       title:
-        description: Short text summarizing the purpose of the transaction. Used as
-          an entry note for identification.
+        description: Short text summarizing the purpose of the transaction. Used as an entry note for identification.
         type: string
         maxLength: 255
         example: Charge Settlement
-  github_com_LerianStudio_midaz_v3_components_ledger_internal_adapters_postgres_transaction.CreateTransactionSwaggerModel:
-    description: Schema for creating transaction with the complete Send operation
-      structure defined inline
-    type: object
-    properties:
-      chartOfAccountsGroupName:
-        description: 'Chart of accounts group name for accounting purposes
-
-          example: FUNDING
-
-          maxLength: 256'
-        type: string
-      code:
-        description: 'Transaction code for reference
-
-          example: TR12345
-
-          maxLength: 100'
-        type: string
-      description:
-        description: 'Human-readable description of the transaction
-
-          example: New Transaction
-
-          maxLength: 256'
-        type: string
-      metadata:
-        description: 'Additional custom attributes
-
-          example: {"reference": "TRANSACTION-001", "source": "api"}'
-        type: object
-        additionalProperties: {}
-      pending:
-        description: 'Whether the transaction should be created in pending state
-
-          example: true
-
-          swagger: type boolean'
-        type: boolean
-        default: false
-        example: true
-      route:
-        description: 'Deprecated: legacy route identifier, use routeId instead. Contains
-          the transaction route UUID as a free-form string for backwards compatibility.
-
-          example: 00000000-0000-0000-0000-000000000000
-
-          maxLength: 250
-
-          deprecated: true'
-        type: string
-        maxLength: 250
-        example: 00000000-0000-0000-0000-000000000000
-      routeId:
-        description: 'UUID of the transaction route. Used instead of route for proper
-          UUID validation and referential integrity.
-
-          example: 00000000-0000-0000-0000-000000000000
-
-          format: uuid'
-        type: string
-        format: uuid
-        example: 00000000-0000-0000-0000-000000000000
-      send:
-        description: 'Send operation details including source and distribution
-
-          required: true'
-        type: object
-        properties:
-          asset:
-            description: 'Asset code for the transaction
-
-              example: USD
-
-              required: true'
-            type: string
-          distribute:
-            description: 'Destination accounts and amounts for the transaction
-
-              required: true'
-            type: object
-            properties:
-              to:
-                description: 'List of destination operations
-
-                  required: true'
-                type: array
-                items:
-                  type: object
-                  properties:
-                    accountAlias:
-                      description: 'Account identifier or alias
-
-                        example: @myAccount
-
-                        required: true'
-                      type: string
-                    amount:
-                      description: 'Amount details for the operation
-
-                        required: true'
-                      type: object
-                      properties:
-                        asset:
-                          description: 'Asset code
-
-                            example: USD
-
-                            required: true'
-                          type: string
-                        value:
-                          description: 'Amount value in smallest unit
-
-                            example: "100.00"
-
-                            required: true'
-                          type: string
-                    chartOfAccounts:
-                      description: 'Chart of accounts code
-
-                        example: FUNDING_CREDIT'
-                      type: string
-                    description:
-                      description: 'Operation description
-
-                        example: Credit Operation'
-                      type: string
-                    metadata:
-                      description: 'Additional metadata
-
-                        example: {"operation": "funding", "type": "account"}'
-                      type: object
-                      additionalProperties: {}
-          source:
-            description: 'Source accounts and amounts for the transaction
-
-              required: true'
-            type: object
-            properties:
-              from:
-                description: 'List of source operations
-
-                  required: true'
-                type: array
-                items:
-                  type: object
-                  properties:
-                    accountAlias:
-                      description: 'Account identifier or alias
-
-                        example: @external/USD
-
-                        required: true'
-                      type: string
-                    amount:
-                      description: 'Amount details for the operation
-
-                        required: true'
-                      type: object
-                      properties:
-                        asset:
-                          description: 'Asset code
-
-                            example: USD
-
-                            required: true'
-                          type: string
-                        value:
-                          description: 'Amount value in smallest unit
-
-                            example: "100.00"
-
-                            required: true'
-                          type: string
-                    chartOfAccounts:
-                      description: 'Chart of accounts code
-
-                        example: FUNDING_DEBIT'
-                      type: string
-                    description:
-                      description: 'Operation description
-
-                        example: Debit Operation'
-                      type: string
-                    metadata:
-                      description: 'Additional metadata
-
-                        example: {"operation": "funding", "type": "external"}'
-                      type: object
-                      additionalProperties: {}
-          value:
-            description: 'Transaction amount value in the smallest unit of the asset
-
-              example: "100.00"
-
-              required: true'
-            type: string
-      transactionDate:
-        description: 'TransactionDate Period from transaction creation date until
-          now
-
-          Example "2021-01-01T00:00:00Z"
-
-          swagger: type string
-
-          required: false'
-        type: string
-        format: date-time
-        example: '2021-01-01T00:00:00Z'
   http.Pagination:
     type: object
     properties:
@@ -8546,188 +8099,220 @@ definitions:
     type: object
     properties:
       validateAccountType:
-        description: 'ValidateAccountType enables validation of account types during
-          transaction processing.
-
+        description: |-
+          ValidateAccountType enables validation of account types during transaction processing.
           When true, accounts must have types that match the operation route rules.
-
-          Default: false (permissive - no validation)'
+          Default: false (permissive - no validation)
         type: boolean
       validateRoutes:
-        description: 'ValidateRoutes enables validation of transaction routes during
-          processing.
-
+        description: |-
+          ValidateRoutes enables validation of transaction routes during processing.
           When true, transactions must specify valid route IDs that exist in the ledger.
-
-          Default: false (permissive - no validation)'
+          Default: false (permissive - no validation)
         type: boolean
   mmodel.Balance:
-    description: Complete balance entity containing all fields including system-generated
-      fields like ID, creation timestamps, and metadata. This is the response format
-      for balance operations. Balances represent the amount of a specific asset held
-      in an account, including available and on-hold amounts.
+    description: Complete balance entity containing all fields including system-generated fields like ID, creation timestamps, and metadata. This is the response format for balance operations. Balances represent the amount of a specific asset held in an account, including available and on-hold amounts.
     type: object
     properties:
       accountId:
-        description: 'Account that holds this balance
-
+        description: |-
+          Account that holds this balance
           example: 00000000-0000-0000-0000-000000000000
-
-          format: uuid'
+          format: uuid
         type: string
         format: uuid
         example: 00000000-0000-0000-0000-000000000000
       accountType:
-        description: 'Type of account holding this balance
-
+        description: |-
+          Type of account holding this balance
           example: creditCard
-
-          maxLength: 50'
+          maxLength: 50
         type: string
         maxLength: 50
         example: creditCard
       alias:
-        description: 'Alias for the account, used for easy identification or tagging
-
+        description: |-
+          Alias for the account, used for easy identification or tagging
           example: @person1
-
-          maxLength: 256'
+          maxLength: 256
         type: string
         maxLength: 256
-        example: '@person1'
+        example: "@person1"
       allowReceiving:
-        description: 'Whether the account can receive funds to this balance
-
-          example: true'
+        description: |-
+          Whether the account can receive funds to this balance
+          example: true
         type: boolean
         example: true
       allowSending:
-        description: 'Whether the account can send funds from this balance
-
-          example: true'
+        description: |-
+          Whether the account can send funds from this balance
+          example: true
         type: boolean
         example: true
       assetCode:
-        description: 'Asset code identifying the currency or asset type of this balance
-
+        description: |-
+          Asset code identifying the currency or asset type of this balance
           example: USD
-
           minLength: 2
-
-          maxLength: 10'
+          maxLength: 10
         type: string
         maxLength: 10
         minLength: 2
         example: USD
       available:
-        description: 'Amount available for transactions (in the smallest unit of the
-          asset, e.g. cents)
-
+        description: |-
+          Amount available for transactions (in the smallest unit of the asset, e.g. cents)
           example: 1500
-
-          minimum: 0'
+          minimum: 0
         type: number
         minimum: 0
         example: 1500
       createdAt:
-        description: 'Timestamp when the balance was created (RFC3339 format)
-
+        description: |-
+          Timestamp when the balance was created (RFC3339 format)
           example: 2021-01-01T00:00:00Z
-
-          format: date-time'
+          format: date-time
         type: string
         format: date-time
         example: '2021-01-01T00:00:00Z'
       deletedAt:
-        description: 'Timestamp when the balance was softly deleted, null if not deleted
-          (RFC3339 format)
-
+        description: |-
+          Timestamp when the balance was softly deleted, null if not deleted (RFC3339 format)
           example: null
-
-          format: date-time'
+          format: date-time
         type: string
         format: date-time
         example: '2021-01-01T00:00:00Z'
+      direction:
+        description: |-
+          Direction is the accounting direction of the balance. One of
+          "credit" or "debit". Empty string denotes legacy rows predating the
+          overdraft feature and is treated as "credit" by the engine.
+          example: credit
+        type: string
+        example: credit
       id:
-        description: 'Unique identifier for the balance (UUID format)
-
+        description: |-
+          Unique identifier for the balance (UUID format)
           example: 00000000-0000-0000-0000-000000000000
-
-          format: uuid'
+          format: uuid
         type: string
         format: uuid
         example: 00000000-0000-0000-0000-000000000000
       key:
-        description: 'Unique key for the balance
-
+        description: |-
+          Unique key for the balance
           example: asset-freeze
-
-          maxLength: 100'
+          maxLength: 100
         type: string
         maxLength: 100
         example: asset-freeze
       ledgerId:
-        description: 'Ledger containing the account this balance belongs to
-
+        description: |-
+          Ledger containing the account this balance belongs to
           example: 00000000-0000-0000-0000-000000000000
-
-          format: uuid'
+          format: uuid
         type: string
         format: uuid
         example: 00000000-0000-0000-0000-000000000000
       metadata:
-        description: 'Custom key-value pairs for extending the balance information
-
-          example: {"purpose": "Main savings", "category": "Personal"}'
+        description: |-
+          Custom key-value pairs for extending the balance information
+          example: {"purpose": "Main savings", "category": "Personal"}
         type: object
         additionalProperties: {}
       onHold:
-        description: 'Amount currently on hold and unavailable for transactions
-
+        description: |-
+          Amount currently on hold and unavailable for transactions
           example: 500
-
-          minimum: 0'
+          minimum: 0
         type: number
         minimum: 0
         example: 500
       organizationId:
-        description: 'Organization that owns this balance
-
+        description: |-
+          Organization that owns this balance
           example: 00000000-0000-0000-0000-000000000000
-
-          format: uuid'
+          format: uuid
         type: string
         format: uuid
         example: 00000000-0000-0000-0000-000000000000
+      overdraftUsed:
+        description: |-
+          OverdraftUsed is the amount of overdraft currently consumed by this
+          balance. Always non-negative; zero when the balance is in the black.
+          example: 0
+        type: number
+        example: 0
+      settings:
+        description: |-
+          Settings carries optional per-balance configuration (overdraft,
+          balance scope). Nil for legacy balances without custom settings.
+        allOf:
+        - "$ref": "#/definitions/mmodel.BalanceSettings"
       updatedAt:
-        description: 'Timestamp when the balance was last updated (RFC3339 format)
-
+        description: |-
+          Timestamp when the balance was last updated (RFC3339 format)
           example: 2021-01-01T00:00:00Z
-
-          format: date-time'
+          format: date-time
         type: string
         format: date-time
         example: '2021-01-01T00:00:00Z'
       version:
-        description: 'Optimistic concurrency control version
-
+        description: |-
+          Optimistic concurrency control version
           example: 1
-
-          minimum: 1'
+          minimum: 1
         type: integer
         minimum: 1
         example: 1
+  mmodel.BalanceSettings:
+    description: Optional per-balance configuration controlling overdraft behavior and balance scope.
+    type: object
+    properties:
+      allowOverdraft:
+        description: |-
+          AllowOverdraft enables overdraft behavior for the balance. When false,
+          transactions that would drive Available below zero are rejected.
+          example: false
+        type: boolean
+        example: false
+      balanceScope:
+        description: |-
+          BalanceScope identifies how the balance participates in transactions.
+          Allowed values: "transactional" (default), "internal". Empty string is
+          treated as "transactional" for backwards compatibility.
+          example: transactional
+        type: string
+        example: transactional
+      overdraftLimit:
+        description: |-
+          OverdraftLimit is the maximum overdraft amount the balance may carry,
+          expressed as a decimal string (to preserve precision). Ignored when
+          OverdraftLimitEnabled is false.
+          example: 1000.00
+        type: string
+        example: '1000.00'
+      overdraftLimitEnabled:
+        description: |-
+          OverdraftLimitEnabled gates the OverdraftLimit field. When true, a
+          non-empty, strictly positive OverdraftLimit MUST be supplied. When
+          false, OverdraftLimit MUST be absent (overdraft is unlimited if
+          AllowOverdraft is true).
+          example: false
+        type: boolean
+        example: false
   mmodel.LedgerSettings:
     type: object
     properties:
       accounting:
         description: Accounting contains validation settings for accounting operations.
         allOf:
-        - $ref: '#/definitions/mmodel.AccountingValidation'
+        - "$ref": "#/definitions/mmodel.AccountingValidation"
 securityDefinitions:
   BearerAuth:
     type: apiKey
     name: Authorization
     in: header
-    description: 'Bearer token authentication. Format: ''Bearer {access_token}''.
-      Only required when auth plugin is enabled.'
+    description: 'Bearer token authentication. Format: ''Bearer {access_token}''. Only required when auth plugin is enabled.'

--- a/components/ledger/cmd/app/main.go
+++ b/components/ledger/cmd/app/main.go
@@ -17,13 +17,13 @@ import (
 )
 
 // @title			Midaz Ledger API
-// @version		v1.48.0
+// @version		v3.7.0
 // @description	This is a swagger documentation for the Midaz Ledger API (unified onboarding + transaction)
 // @termsOfService	http://swagger.io/terms/
 // @contact.name	Discord community
 // @contact.url	https://discord.gg/DnhqKwkGv3
-// @license.name	Apache 2.0
-// @license.url	http://www.apache.org/licenses/LICENSE-2.0.html
+// @license.name	Elastic License 2.0
+// @license.url	https://www.elastic.co/licensing/elastic-license
 // @host			localhost:3000
 // @BasePath		/
 func main() {

--- a/components/ledger/internal/adapters/http/in/account.go
+++ b/components/ledger/internal/adapters/http/in/account.go
@@ -226,13 +226,13 @@ func (handler *AccountHandler) GetAllAccounts(c *fiber.Ctx) error {
 //	@Param			X-Request-Id	header		string			false	"Request ID for tracing"
 //	@Param			organization_id	path		string			true	"Organization ID in UUID format"
 //	@Param			ledger_id		path		string			true	"Ledger ID in UUID format"
-//	@Param			id				path		string			true	"Account ID in UUID format"
+//	@Param			account_id				path		string			true	"Account ID in UUID format"
 //	@Success		200				{object}	mmodel.Account	"Successfully retrieved account"
 //	@Failure		401				{object}	mmodel.Error	"Unauthorized access"
 //	@Failure		403				{object}	mmodel.Error	"Forbidden access"
 //	@Failure		404				{object}	mmodel.Error	"Account, ledger, or organization not found"
 //	@Failure		500				{object}	mmodel.Error	"Internal server error"
-//	@Router			/v1/organizations/{organization_id}/ledgers/{ledger_id}/accounts/{id} [get]
+//	@Router			/v1/organizations/{organization_id}/ledgers/{ledger_id}/accounts/{account_id} [get]
 func (handler *AccountHandler) GetAccountByID(c *fiber.Ctx) error {
 	ctx := c.UserContext()
 
@@ -391,7 +391,7 @@ func (handler *AccountHandler) GetAccountByAlias(c *fiber.Ctx) error {
 //	@Param			X-Request-Id	header		string						false	"Request ID for tracing"
 //	@Param			organization_id	path		string						true	"Organization ID in UUID format"
 //	@Param			ledger_id		path		string						true	"Ledger ID in UUID format"
-//	@Param			id				path		string						true	"Account ID in UUID format"
+//	@Param			account_id				path		string						true	"Account ID in UUID format"
 //	@Param			account			body		mmodel.UpdateAccountInput	true	"Account properties to update including name, status, portfolio, segment, and optional metadata"
 //	@Success		200				{object}	mmodel.Account				"Successfully updated account"
 //	@Failure		400				{object}	mmodel.Error				"Invalid input, validation errors"
@@ -400,7 +400,7 @@ func (handler *AccountHandler) GetAccountByAlias(c *fiber.Ctx) error {
 //	@Failure		404				{object}	mmodel.Error				"Account, ledger, organization, portfolio, or segment not found"
 //	@Failure		409				{object}	mmodel.Error				"Conflict: Account with the same name already exists"
 //	@Failure		500				{object}	mmodel.Error				"Internal server error"
-//	@Router			/v1/organizations/{organization_id}/ledgers/{ledger_id}/accounts/{id} [patch]
+//	@Router			/v1/organizations/{organization_id}/ledgers/{ledger_id}/accounts/{account_id} [patch]
 func (handler *AccountHandler) UpdateAccount(i any, c *fiber.Ctx) error {
 	ctx := c.UserContext()
 
@@ -462,14 +462,14 @@ func (handler *AccountHandler) UpdateAccount(i any, c *fiber.Ctx) error {
 //	@Param			X-Request-Id	header		string			false	"Request ID for tracing"
 //	@Param			organization_id	path		string			true	"Organization ID in UUID format"
 //	@Param			ledger_id		path		string			true	"Ledger ID in UUID format"
-//	@Param			id				path		string			true	"Account ID in UUID format"
+//	@Param			account_id				path		string			true	"Account ID in UUID format"
 //	@Success		204				"Account successfully deleted"
 //	@Failure		401				{object}	mmodel.Error	"Unauthorized access"
 //	@Failure		403				{object}	mmodel.Error	"Forbidden access"
 //	@Failure		404				{object}	mmodel.Error	"Account, ledger, or organization not found"
 //	@Failure		409				{object}	mmodel.Error	"Conflict: Account cannot be deleted due to existing dependencies"
 //	@Failure		500				{object}	mmodel.Error	"Internal server error"
-//	@Router			/v1/organizations/{organization_id}/ledgers/{ledger_id}/accounts/{id} [delete]
+//	@Router			/v1/organizations/{organization_id}/ledgers/{ledger_id}/accounts/{account_id} [delete]
 func (handler *AccountHandler) DeleteAccountByID(c *fiber.Ctx) error {
 	ctx := c.UserContext()
 

--- a/components/ledger/internal/adapters/http/in/accounttype.go
+++ b/components/ledger/internal/adapters/http/in/accounttype.go
@@ -87,13 +87,13 @@ func (handler *AccountTypeHandler) CreateAccountType(i any, c *fiber.Ctx) error 
 //	@Param			X-Request-Id	header		string				false	"Request ID for tracing"
 //	@Param			organization_id	path		string				true	"Organization ID in UUID format"
 //	@Param			ledger_id		path		string				true	"Ledger ID in UUID format"
-//	@Param			id				path		string				true	"Account Type ID in UUID format"
+//	@Param			account_type_id				path		string				true	"Account Type ID in UUID format"
 //	@Success		200				{object}	mmodel.AccountType	"Successfully retrieved account type"
 //	@Failure		401				{object}	mmodel.Error		"Unauthorized access"
 //	@Failure		403				{object}	mmodel.Error		"Forbidden access"
 //	@Failure		404				{object}	mmodel.Error		"Account type, ledger, or organization not found"
 //	@Failure		500				{object}	mmodel.Error		"Internal server error"
-//	@Router			/v1/organizations/{organization_id}/ledgers/{ledger_id}/account-types/{id} [get]
+//	@Router			/v1/organizations/{organization_id}/ledgers/{ledger_id}/account-types/{account_type_id} [get]
 func (handler *AccountTypeHandler) GetAccountTypeByID(c *fiber.Ctx) error {
 	ctx := c.UserContext()
 
@@ -144,7 +144,7 @@ func (handler *AccountTypeHandler) GetAccountTypeByID(c *fiber.Ctx) error {
 //	@Param			X-Request-Id	header		string							false	"Request ID for tracing"
 //	@Param			organization_id	path		string							true	"Organization ID in UUID format"
 //	@Param			ledger_id		path		string							true	"Ledger ID in UUID format"
-//	@Param			id				path		string							true	"Account Type ID in UUID format"
+//	@Param			account_type_id				path		string							true	"Account Type ID in UUID format"
 //	@Param			accountType		body		mmodel.UpdateAccountTypeInput	true	"Account Type Update Input"
 //	@Success		200				{object}	mmodel.AccountType				"Successfully updated account type"
 //	@Failure		400				{object}	mmodel.Error					"Invalid input, validation errors"
@@ -152,7 +152,7 @@ func (handler *AccountTypeHandler) GetAccountTypeByID(c *fiber.Ctx) error {
 //	@Failure		403				{object}	mmodel.Error					"Forbidden access"
 //	@Failure		404				{object}	mmodel.Error					"Account type not found"
 //	@Failure		500				{object}	mmodel.Error					"Internal server error"
-//	@Router			/v1/organizations/{organization_id}/ledgers/{ledger_id}/account-types/{id} [patch]
+//	@Router			/v1/organizations/{organization_id}/ledgers/{ledger_id}/account-types/{account_type_id} [patch]
 func (handler *AccountTypeHandler) UpdateAccountType(i any, c *fiber.Ctx) error {
 	ctx := c.UserContext()
 
@@ -213,12 +213,12 @@ func (handler *AccountTypeHandler) UpdateAccountType(i any, c *fiber.Ctx) error 
 //	@Param			X-Request-Id	header	string	false	"Request ID for tracing"
 //	@Param			organization_id	path	string	true	"Organization ID in UUID format"
 //	@Param			ledger_id		path	string	true	"Ledger ID in UUID format"
-//	@Param			id				path	string	true	"Account Type ID in UUID format"
+//	@Param			account_type_id				path	string	true	"Account Type ID in UUID format"
 //	@Success		204				"Successfully deleted account type"
 //	@Failure		401				{object}	mmodel.Error	"Unauthorized access"
 //	@Failure		404				{object}	mmodel.Error	"Account type not found"
 //	@Failure		500				{object}	mmodel.Error	"Internal server error"
-//	@Router			/v1/organizations/{organization_id}/ledgers/{ledger_id}/account-types/{id} [delete]
+//	@Router			/v1/organizations/{organization_id}/ledgers/{ledger_id}/account-types/{account_type_id} [delete]
 func (handler *AccountTypeHandler) DeleteAccountTypeByID(c *fiber.Ctx) error {
 	ctx := c.UserContext()
 

--- a/components/ledger/internal/adapters/http/in/asset.go
+++ b/components/ledger/internal/adapters/http/in/asset.go
@@ -199,13 +199,13 @@ func (handler *AssetHandler) GetAllAssets(c *fiber.Ctx) error {
 //	@Param			X-Request-Id	header		string			false	"Request ID for tracing"
 //	@Param			organization_id	path		string			true	"Organization ID in UUID format"
 //	@Param			ledger_id		path		string			true	"Ledger ID in UUID format"
-//	@Param			id				path		string			true	"Asset ID in UUID format"
+//	@Param			asset_id				path		string			true	"Asset ID in UUID format"
 //	@Success		200				{object}	mmodel.Asset	"Successfully retrieved asset"
 //	@Failure		401				{object}	mmodel.Error	"Unauthorized access"
 //	@Failure		403				{object}	mmodel.Error	"Forbidden access"
 //	@Failure		404				{object}	mmodel.Error	"Asset, ledger, or organization not found"
 //	@Failure		500				{object}	mmodel.Error	"Internal server error"
-//	@Router			/v1/organizations/{organization_id}/ledgers/{ledger_id}/assets/{id} [get]
+//	@Router			/v1/organizations/{organization_id}/ledgers/{ledger_id}/assets/{asset_id} [get]
 func (handler *AssetHandler) GetAssetByID(c *fiber.Ctx) error {
 	ctx := c.UserContext()
 
@@ -256,7 +256,7 @@ func (handler *AssetHandler) GetAssetByID(c *fiber.Ctx) error {
 //	@Param			X-Request-Id	header		string					false	"Request ID for tracing"
 //	@Param			organization_id	path		string					true	"Organization ID in UUID format"
 //	@Param			ledger_id		path		string					true	"Ledger ID in UUID format"
-//	@Param			id				path		string					true	"Asset ID in UUID format"
+//	@Param			asset_id				path		string					true	"Asset ID in UUID format"
 //	@Param			asset			body		mmodel.UpdateAssetInput	true	"Asset properties to update including name, status, and optional metadata"
 //	@Success		200				{object}	mmodel.Asset			"Successfully updated asset"
 //	@Failure		400				{object}	mmodel.Error			"Invalid input, validation errors"
@@ -265,7 +265,7 @@ func (handler *AssetHandler) GetAssetByID(c *fiber.Ctx) error {
 //	@Failure		404				{object}	mmodel.Error			"Asset, ledger, or organization not found"
 //	@Failure		409				{object}	mmodel.Error			"Conflict: Asset with the same name already exists"
 //	@Failure		500				{object}	mmodel.Error			"Internal server error"
-//	@Router			/v1/organizations/{organization_id}/ledgers/{ledger_id}/assets/{id} [patch]
+//	@Router			/v1/organizations/{organization_id}/ledgers/{ledger_id}/assets/{asset_id} [patch]
 func (handler *AssetHandler) UpdateAsset(a any, c *fiber.Ctx) error {
 	ctx := c.UserContext()
 
@@ -327,14 +327,14 @@ func (handler *AssetHandler) UpdateAsset(a any, c *fiber.Ctx) error {
 //	@Param			X-Request-Id	header		string			false	"Request ID for tracing"
 //	@Param			organization_id	path		string			true	"Organization ID in UUID format"
 //	@Param			ledger_id		path		string			true	"Ledger ID in UUID format"
-//	@Param			id				path		string			true	"Asset ID in UUID format"
+//	@Param			asset_id				path		string			true	"Asset ID in UUID format"
 //	@Success		204				"Asset successfully deleted"
 //	@Failure		401				{object}	mmodel.Error	"Unauthorized access"
 //	@Failure		403				{object}	mmodel.Error	"Forbidden access"
 //	@Failure		404				{object}	mmodel.Error	"Asset, ledger, or organization not found"
 //	@Failure		409				{object}	mmodel.Error	"Conflict: Asset cannot be deleted due to existing dependencies"
 //	@Failure		500				{object}	mmodel.Error	"Internal server error"
-//	@Router			/v1/organizations/{organization_id}/ledgers/{ledger_id}/assets/{id} [delete]
+//	@Router			/v1/organizations/{organization_id}/ledgers/{ledger_id}/assets/{asset_id} [delete]
 func (handler *AssetHandler) DeleteAssetByID(c *fiber.Ctx) error {
 	ctx := c.UserContext()
 

--- a/components/ledger/internal/adapters/http/in/balance_test.go
+++ b/components/ledger/internal/adapters/http/in/balance_test.go
@@ -952,6 +952,15 @@ func TestBalanceHandler_UpdateBalance(t *testing.T) {
 				AllowReceiving: testutils.Ptr(true),
 			},
 			setupMocks: func(balanceRepo *balance.MockRepository, redisRepo *redis.MockRedisRepository, orgID, ledgerID, balanceID uuid.UUID) {
+				// Find is always called (scope guard requires the current balance).
+				balanceRepo.EXPECT().
+					Find(gomock.Any(), orgID, ledgerID, balanceID).
+					Return(&mmodel.Balance{
+						ID:    balanceID.String(),
+						Alias: "@user1",
+						Key:   "default",
+					}, nil).
+					Times(1)
 				// Command.Update returns the updated balance directly (using RETURNING clause)
 				balanceRepo.EXPECT().
 					Update(gomock.Any(), orgID, ledgerID, balanceID, mmodel.UpdateBalance{
@@ -1000,10 +1009,15 @@ func TestBalanceHandler_UpdateBalance(t *testing.T) {
 				AllowSending: testutils.Ptr(true),
 			},
 			setupMocks: func(balanceRepo *balance.MockRepository, redisRepo *redis.MockRedisRepository, orgID, ledgerID, balanceID uuid.UUID) {
+				// Find is always called first (scope guard). 404 now comes from Find.
 				balanceRepo.EXPECT().
-					Update(gomock.Any(), orgID, ledgerID, balanceID, gomock.Any()).
+					Find(gomock.Any(), orgID, ledgerID, balanceID).
 					Return(nil, pkg.ValidateBusinessError(cn.ErrEntityNotFound, reflect.TypeOf(mmodel.Balance{}).Name())).
 					Times(1)
+				// Update must NOT be called when Find fails.
+				balanceRepo.EXPECT().
+					Update(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Times(0)
 			},
 			expectedStatus: 404,
 			validateBody: func(t *testing.T, body []byte) {
@@ -1021,6 +1035,15 @@ func TestBalanceHandler_UpdateBalance(t *testing.T) {
 				AllowReceiving: testutils.Ptr(false),
 			},
 			setupMocks: func(balanceRepo *balance.MockRepository, redisRepo *redis.MockRedisRepository, orgID, ledgerID, balanceID uuid.UUID) {
+				// Find is always called first (scope guard).
+				balanceRepo.EXPECT().
+					Find(gomock.Any(), orgID, ledgerID, balanceID).
+					Return(&mmodel.Balance{
+						ID:    balanceID.String(),
+						Alias: "@user1",
+						Key:   "default",
+					}, nil).
+					Times(1)
 				balanceRepo.EXPECT().
 					Update(gomock.Any(), orgID, ledgerID, balanceID, gomock.Any()).
 					Return(nil, pkg.InternalServerError{

--- a/components/ledger/internal/adapters/http/in/ledger.go
+++ b/components/ledger/internal/adapters/http/in/ledger.go
@@ -106,7 +106,7 @@ func (handler *LedgerHandler) GetLedgerByID(c *fiber.Ctx) error {
 		return http.WithError(c, err)
 	}
 
-	id, err := http.GetUUIDFromLocals(c, "id")
+	id, err := http.GetUUIDFromLocals(c, "ledger_id")
 	if err != nil {
 		return http.WithError(c, err)
 	}
@@ -256,7 +256,7 @@ func (handler *LedgerHandler) UpdateLedger(p any, c *fiber.Ctx) error {
 	ctx, span := tracer.Start(ctx, "handler.update_ledger")
 	defer span.End()
 
-	id, err := http.GetUUIDFromLocals(c, "id")
+	id, err := http.GetUUIDFromLocals(c, "ledger_id")
 	if err != nil {
 		return http.WithError(c, err)
 	}
@@ -324,7 +324,7 @@ func (handler *LedgerHandler) DeleteLedgerByID(c *fiber.Ctx) error {
 		return http.WithError(c, err)
 	}
 
-	id, err := http.GetUUIDFromLocals(c, "id")
+	id, err := http.GetUUIDFromLocals(c, "ledger_id")
 	if err != nil {
 		return http.WithError(c, err)
 	}
@@ -429,7 +429,7 @@ func (handler *LedgerHandler) GetLedgerSettings(c *fiber.Ctx) error {
 		return http.WithError(c, err)
 	}
 
-	id, err := http.GetUUIDFromLocals(c, "id")
+	id, err := http.GetUUIDFromLocals(c, "ledger_id")
 	if err != nil {
 		return http.WithError(c, err)
 	}
@@ -487,7 +487,7 @@ func (handler *LedgerHandler) UpdateLedgerSettings(i any, c *fiber.Ctx) error {
 		return http.WithError(c, err)
 	}
 
-	id, err := http.GetUUIDFromLocals(c, "id")
+	id, err := http.GetUUIDFromLocals(c, "ledger_id")
 	if err != nil {
 		return http.WithError(c, err)
 	}

--- a/components/ledger/internal/adapters/http/in/ledger.go
+++ b/components/ledger/internal/adapters/http/in/ledger.go
@@ -86,13 +86,13 @@ func (handler *LedgerHandler) CreateLedger(i any, c *fiber.Ctx) error {
 //	@Param			Authorization	header		string			true	"Authorization Bearer Token with format: Bearer {token}"
 //	@Param			X-Request-Id	header		string			false	"Request ID for tracing"
 //	@Param			organization_id	path		string			true	"Organization ID in UUID format"
-//	@Param			id				path		string			true	"Ledger ID in UUID format"
+//	@Param			ledger_id		path		string			true	"Ledger ID in UUID format"
 //	@Success		200				{object}	mmodel.Ledger	"Successfully retrieved ledger"
 //	@Failure		401				{object}	mmodel.Error	"Unauthorized access"
 //	@Failure		403				{object}	mmodel.Error	"Forbidden access"
 //	@Failure		404				{object}	mmodel.Error	"Ledger or organization not found"
 //	@Failure		500				{object}	mmodel.Error	"Internal server error"
-//	@Router			/v1/organizations/{organization_id}/ledgers/{id} [get]
+//	@Router			/v1/organizations/{organization_id}/ledgers/{ledger_id} [get]
 func (handler *LedgerHandler) GetLedgerByID(c *fiber.Ctx) error {
 	ctx := c.UserContext()
 
@@ -239,7 +239,7 @@ func (handler *LedgerHandler) GetAllLedgers(c *fiber.Ctx) error {
 //	@Param			Authorization	header		string						true	"Authorization Bearer Token with format: Bearer {token}"
 //	@Param			X-Request-Id	header		string						false	"Request ID for tracing"
 //	@Param			organization_id	path		string						true	"Organization ID in UUID format"
-//	@Param			id				path		string						true	"Ledger ID in UUID format"
+//	@Param			ledger_id		path		string						true	"Ledger ID in UUID format"
 //	@Param			ledger			body		mmodel.UpdateLedgerInput	true	"Ledger fields to update. Only supplied fields will be modified."
 //	@Success		200				{object}	mmodel.Ledger				"Successfully updated ledger"
 //	@Failure		400				{object}	mmodel.Error				"Invalid input, validation errors"
@@ -247,7 +247,7 @@ func (handler *LedgerHandler) GetAllLedgers(c *fiber.Ctx) error {
 //	@Failure		403				{object}	mmodel.Error				"Forbidden access"
 //	@Failure		404				{object}	mmodel.Error				"Ledger or organization not found"
 //	@Failure		500				{object}	mmodel.Error				"Internal server error"
-//	@Router			/v1/organizations/{organization_id}/ledgers/{id} [patch]
+//	@Router			/v1/organizations/{organization_id}/ledgers/{ledger_id} [patch]
 func (handler *LedgerHandler) UpdateLedger(p any, c *fiber.Ctx) error {
 	ctx := c.UserContext()
 
@@ -303,14 +303,14 @@ func (handler *LedgerHandler) UpdateLedger(p any, c *fiber.Ctx) error {
 //	@Param			Authorization	header		string			true	"Authorization Bearer Token with format: Bearer {token}"
 //	@Param			X-Request-Id	header		string			false	"Request ID for tracing"
 //	@Param			organization_id	path		string			true	"Organization ID in UUID format"
-//	@Param			id				path		string			true	"Ledger ID in UUID format"
+//	@Param			ledger_id		path		string			true	"Ledger ID in UUID format"
 //	@Success		204				"Ledger successfully deleted"
 //	@Failure		401				{object}	mmodel.Error	"Unauthorized access"
 //	@Failure		403				{object}	mmodel.Error	"Forbidden action or not permitted in production environment"
 //	@Failure		404				{object}	mmodel.Error	"Ledger or organization not found"
 //	@Failure		409				{object}	mmodel.Error	"Conflict: Cannot delete ledger with dependent resources"
 //	@Failure		500				{object}	mmodel.Error	"Internal server error"
-//	@Router			/v1/organizations/{organization_id}/ledgers/{id} [delete]
+//	@Router			/v1/organizations/{organization_id}/ledgers/{ledger_id} [delete]
 func (handler *LedgerHandler) DeleteLedgerByID(c *fiber.Ctx) error {
 	ctx := c.UserContext()
 
@@ -409,13 +409,13 @@ func (handler *LedgerHandler) CountLedgers(c *fiber.Ctx) error {
 //	@Param			Authorization	header		string	true	"Authorization Bearer Token with format: Bearer {token}"
 //	@Param			X-Request-Id	header		string	false	"Request ID for tracing"
 //	@Param			organization_id	path		string	true	"Organization ID in UUID format"
-//	@Param			id				path		string	true	"Ledger ID in UUID format"
+//	@Param			ledger_id		path		string	true	"Ledger ID in UUID format"
 //	@Success		200				{object}	mmodel.LedgerSettings	"Successfully retrieved ledger settings"
 //	@Failure		401				{object}	mmodel.Error			"Unauthorized access"
 //	@Failure		403				{object}	mmodel.Error			"Forbidden access"
 //	@Failure		404				{object}	mmodel.Error			"Ledger not found"
 //	@Failure		500				{object}	mmodel.Error			"Internal server error"
-//	@Router			/v1/organizations/{organization_id}/ledgers/{id}/settings [get]
+//	@Router			/v1/organizations/{organization_id}/ledgers/{ledger_id}/settings [get]
 func (handler *LedgerHandler) GetLedgerSettings(c *fiber.Ctx) error {
 	ctx := c.UserContext()
 
@@ -465,7 +465,7 @@ func (handler *LedgerHandler) GetLedgerSettings(c *fiber.Ctx) error {
 //	@Param			Authorization	header		string			true	"Authorization Bearer Token with format: Bearer {token}"
 //	@Param			X-Request-Id	header		string			false	"Request ID for tracing"
 //	@Param			organization_id	path		string			true	"Organization ID in UUID format"
-//	@Param			id				path		string			true	"Ledger ID in UUID format"
+//	@Param			ledger_id		path		string			true	"Ledger ID in UUID format"
 //	@Param			settings		body		object	true	"Settings to merge with existing settings. Only known fields allowed: accounting.validateAccountType (bool), accounting.validateRoutes (bool)"
 //	@Success		200				{object}	mmodel.LedgerSettings	"Successfully updated ledger settings"
 //	@Failure		400				{object}	mmodel.Error	"Invalid request body, unknown field (0147), or invalid field type (0148)"
@@ -473,7 +473,7 @@ func (handler *LedgerHandler) GetLedgerSettings(c *fiber.Ctx) error {
 //	@Failure		403				{object}	mmodel.Error	"Forbidden access"
 //	@Failure		404				{object}	mmodel.Error	"Ledger not found"
 //	@Failure		500				{object}	mmodel.Error	"Internal server error"
-//	@Router			/v1/organizations/{organization_id}/ledgers/{id}/settings [patch]
+//	@Router			/v1/organizations/{organization_id}/ledgers/{ledger_id}/settings [patch]
 func (handler *LedgerHandler) UpdateLedgerSettings(i any, c *fiber.Ctx) error {
 	ctx := c.UserContext()
 

--- a/components/ledger/internal/adapters/http/in/ledger_test.go
+++ b/components/ledger/internal/adapters/http/in/ledger_test.go
@@ -347,10 +347,10 @@ func TestHandler_UpdateLedger(t *testing.T) {
 			}
 
 			app := fiber.New()
-			app.Patch("/v1/organizations/:organization_id/ledgers/:id",
+			app.Patch("/v1/organizations/:organization_id/ledgers/:ledger_id",
 				func(c *fiber.Ctx) error {
 					c.Locals("organization_id", orgID)
-					c.Locals("id", ledgerID)
+					c.Locals("ledger_id", ledgerID)
 					return c.Next()
 				},
 				func(c *fiber.Ctx) error {
@@ -477,10 +477,10 @@ func TestHandler_GetLedgerByID(t *testing.T) {
 			handler := &LedgerHandler{Query: queryUC}
 
 			app := fiber.New()
-			app.Get("/v1/organizations/:organization_id/ledgers/:id",
+			app.Get("/v1/organizations/:organization_id/ledgers/:ledger_id",
 				func(c *fiber.Ctx) error {
 					c.Locals("organization_id", orgID)
-					c.Locals("id", ledgerID)
+					c.Locals("ledger_id", ledgerID)
 					return c.Next()
 				},
 				handler.GetLedgerByID,
@@ -870,10 +870,10 @@ func TestHandler_DeleteLedgerByID(t *testing.T) {
 			handler := &LedgerHandler{Command: cmdUC}
 
 			app := fiber.New()
-			app.Delete("/v1/organizations/:organization_id/ledgers/:id",
+			app.Delete("/v1/organizations/:organization_id/ledgers/:ledger_id",
 				func(c *fiber.Ctx) error {
 					c.Locals("organization_id", orgID)
-					c.Locals("id", ledgerID)
+					c.Locals("ledger_id", ledgerID)
 					return c.Next()
 				},
 				handler.DeleteLedgerByID,
@@ -1159,10 +1159,10 @@ func TestHandler_GetLedgerSettings(t *testing.T) {
 			handler := &LedgerHandler{Query: queryUC}
 
 			app := fiber.New()
-			app.Get("/v1/organizations/:organization_id/ledgers/:id/settings",
+			app.Get("/v1/organizations/:organization_id/ledgers/:ledger_id/settings",
 				func(c *fiber.Ctx) error {
 					c.Locals("organization_id", orgID)
-					c.Locals("id", ledgerID)
+					c.Locals("ledger_id", ledgerID)
 					return c.Next()
 				},
 				handler.GetLedgerSettings,
@@ -1349,10 +1349,10 @@ func TestHandler_UpdateLedgerSettings(t *testing.T) {
 			handler := &LedgerHandler{Command: cmdUC}
 
 			app := fiber.New()
-			app.Patch("/v1/organizations/:organization_id/ledgers/:id/settings",
+			app.Patch("/v1/organizations/:organization_id/ledgers/:ledger_id/settings",
 				func(c *fiber.Ctx) error {
 					c.Locals("organization_id", orgID)
-					c.Locals("id", ledgerID)
+					c.Locals("ledger_id", ledgerID)
 					return c.Next()
 				},
 				func(c *fiber.Ctx) error {

--- a/components/ledger/internal/adapters/http/in/operation_route.go
+++ b/components/ledger/internal/adapters/http/in/operation_route.go
@@ -580,7 +580,6 @@ func (handler *OperationRouteHandler) validateAccountingEntries(ctx context.Cont
 		{constant.ActionCancel, entries.Cancel, constant.ErrMissingFieldsInRequest},
 		{constant.ActionRevert, entries.Revert, constant.ErrMissingFieldsInRequest},
 		{constant.ActionOverdraft, entries.Overdraft, constant.ErrAccountingEntryFieldRequired},
-		{constant.ActionRefund, entries.Refund, constant.ErrAccountingEntryFieldRequired},
 	}
 
 	for _, action := range actions {
@@ -666,7 +665,6 @@ var validAccountingEntryKeys = map[string]struct{}{
 	constant.ActionCancel:    {},
 	constant.ActionRevert:    {},
 	constant.ActionOverdraft: {},
-	constant.ActionRefund:    {},
 }
 
 // findUnknownAccountingEntryKeys parses the raw JSON for accountingEntries and returns
@@ -706,18 +704,18 @@ type fieldRequirement struct {
 //	source:      direct[D], hold[D][C], commit[D], cancel[D][C]
 //	destination: direct[C], commit[C]
 //	bidirectional: all scenarios require [D][C]
-//	overdraft / refund: both debit and credit are required regardless of direction.
+//	overdraft: both debit and credit are required regardless of direction.
 //
 // Note: Blocked scenarios (source/revert, destination/hold, etc.) are validated
 // separately by validateDirectionScenarioMatrix. This function assumes the
 // scenario is allowed for the direction.
 func getFieldRequirements(operationType, scenario string) fieldRequirement {
-	// Overdraft and Refund always require both rubrics, regardless of direction.
+	// Overdraft always requires both rubrics, regardless of direction.
 	// Keeping this rule explicit (rather than relying on the default fallthrough)
 	// documents the requirement next to the scenario list above and makes it
 	// harder to accidentally loosen via future edits to the source/destination
 	// switches.
-	if scenario == constant.ActionOverdraft || scenario == constant.ActionRefund {
+	if scenario == constant.ActionOverdraft {
 		return fieldRequirement{debitRequired: true, creditRequired: true}
 	}
 
@@ -965,13 +963,13 @@ func (handler *OperationRouteHandler) validateDirectMandatory(
 	defer span.End()
 
 	hasDirect := entries.Direct != nil
-	// Overdraft and Refund are supplementary accounting scenarios that still
-	// require direct as a base. Without this, a payload setting only
-	// overdraft (or only refund) would bypass the direct-mandatory check and
-	// yield an incomplete accounting description.
+	// Overdraft is a supplementary accounting scenario that still requires
+	// direct as a base. Without this, a payload setting only overdraft
+	// would bypass the direct-mandatory check and yield an incomplete
+	// accounting description.
 	hasOtherScenarios := entries.Hold != nil || entries.Commit != nil ||
 		entries.Cancel != nil || entries.Revert != nil ||
-		entries.Overdraft != nil || entries.Refund != nil
+		entries.Overdraft != nil
 
 	// If any other scenario exists, direct must also exist
 	if hasOtherScenarios && !hasDirect {
@@ -1020,7 +1018,6 @@ func (handler *OperationRouteHandler) validateEntryFieldRequirements(
 		{constant.ActionCancel, entries.Cancel},
 		{constant.ActionRevert, entries.Revert},
 		{constant.ActionOverdraft, entries.Overdraft},
-		{constant.ActionRefund, entries.Refund},
 	}
 
 	for _, action := range actions {
@@ -1124,7 +1121,7 @@ func mergeAccountingEntries(existing, incoming *mmodel.AccountingEntries, rawUpd
 		return existingEntry
 	}
 
-	var incomingDirect, incomingHold, incomingCommit, incomingCancel, incomingRevert, incomingOverdraft, incomingRefund *mmodel.AccountingEntry
+	var incomingDirect, incomingHold, incomingCommit, incomingCancel, incomingRevert, incomingOverdraft *mmodel.AccountingEntry
 	if incoming != nil {
 		incomingDirect = incoming.Direct
 		incomingHold = incoming.Hold
@@ -1132,7 +1129,6 @@ func mergeAccountingEntries(existing, incoming *mmodel.AccountingEntries, rawUpd
 		incomingCancel = incoming.Cancel
 		incomingRevert = incoming.Revert
 		incomingOverdraft = incoming.Overdraft
-		incomingRefund = incoming.Refund
 	}
 
 	merged.Direct = applyMerge(constant.ActionDirect, existing.Direct, incomingDirect)
@@ -1141,12 +1137,11 @@ func mergeAccountingEntries(existing, incoming *mmodel.AccountingEntries, rawUpd
 	merged.Cancel = applyMerge(constant.ActionCancel, existing.Cancel, incomingCancel)
 	merged.Revert = applyMerge(constant.ActionRevert, existing.Revert, incomingRevert)
 	merged.Overdraft = applyMerge(constant.ActionOverdraft, existing.Overdraft, incomingOverdraft)
-	merged.Refund = applyMerge(constant.ActionRefund, existing.Refund, incomingRefund)
 
 	// Check if all entries are nil - return nil instead of empty struct
 	if merged.Direct == nil && merged.Hold == nil && merged.Commit == nil &&
 		merged.Cancel == nil && merged.Revert == nil &&
-		merged.Overdraft == nil && merged.Refund == nil {
+		merged.Overdraft == nil {
 		return nil
 	}
 
@@ -1196,12 +1191,6 @@ func mergeAccountingEntriesSimple(existing, incoming *mmodel.AccountingEntries) 
 		merged.Overdraft = incoming.Overdraft
 	} else if existing != nil {
 		merged.Overdraft = existing.Overdraft
-	}
-
-	if incoming.Refund != nil {
-		merged.Refund = incoming.Refund
-	} else if existing != nil {
-		merged.Refund = existing.Refund
 	}
 
 	return merged

--- a/components/ledger/internal/adapters/http/in/operation_route.go
+++ b/components/ledger/internal/adapters/http/in/operation_route.go
@@ -565,15 +565,22 @@ func (handler *OperationRouteHandler) validateAccountingEntries(ctx context.Cont
 
 	entityName := reflect.TypeOf(mmodel.OperationRoute{}).Name()
 
+	// newScenarios are validated with ErrAccountingEntryFieldRequired (0166 —
+	// UnprocessableOperationError) instead of ErrMissingFieldsInRequest (0009 —
+	// ValidationError) so HTTP callers get a 422-class response that surfaces
+	// the scenario-specific field path.
 	actions := []struct {
-		name  string
-		entry *mmodel.AccountingEntry
+		name    string
+		entry   *mmodel.AccountingEntry
+		errCode error
 	}{
-		{"direct", entries.Direct},
-		{"hold", entries.Hold},
-		{"commit", entries.Commit},
-		{"cancel", entries.Cancel},
-		{"revert", entries.Revert},
+		{constant.ActionDirect, entries.Direct, constant.ErrMissingFieldsInRequest},
+		{constant.ActionHold, entries.Hold, constant.ErrMissingFieldsInRequest},
+		{constant.ActionCommit, entries.Commit, constant.ErrMissingFieldsInRequest},
+		{constant.ActionCancel, entries.Cancel, constant.ErrMissingFieldsInRequest},
+		{constant.ActionRevert, entries.Revert, constant.ErrMissingFieldsInRequest},
+		{constant.ActionOverdraft, entries.Overdraft, constant.ErrAccountingEntryFieldRequired},
+		{constant.ActionRefund, entries.Refund, constant.ErrAccountingEntryFieldRequired},
 	}
 
 	for _, action := range actions {
@@ -585,7 +592,7 @@ func (handler *OperationRouteHandler) validateAccountingEntries(ctx context.Cont
 		if action.entry.Debit == nil && action.entry.Credit == nil {
 			fieldPath := "accountingEntries." + action.name + ".debit, accountingEntries." + action.name + ".credit"
 
-			err := pkg.ValidateBusinessError(constant.ErrMissingFieldsInRequest, entityName, fieldPath)
+			err := pkg.ValidateBusinessError(action.errCode, entityName, fieldPath)
 
 			libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Accounting entry missing both debit and credit", err)
 
@@ -596,14 +603,14 @@ func (handler *OperationRouteHandler) validateAccountingEntries(ctx context.Cont
 
 		// Validate debit rubric if present
 		if action.entry.Debit != nil {
-			if err := handler.validateRubricStructure(ctx, span, logger, entityName, action.name, "debit", action.entry.Debit); err != nil {
+			if err := handler.validateRubricStructure(ctx, span, logger, entityName, action.name, "debit", action.entry.Debit, action.errCode); err != nil {
 				return err
 			}
 		}
 
 		// Validate credit rubric if present
 		if action.entry.Credit != nil {
-			if err := handler.validateRubricStructure(ctx, span, logger, entityName, action.name, "credit", action.entry.Credit); err != nil {
+			if err := handler.validateRubricStructure(ctx, span, logger, entityName, action.name, "credit", action.entry.Credit, action.errCode); err != nil {
 				return err
 			}
 		}
@@ -613,17 +620,21 @@ func (handler *OperationRouteHandler) validateAccountingEntries(ctx context.Cont
 }
 
 // validateRubricStructure validates that a rubric has non-empty code and description.
+// The errCode parameter controls which business error is raised on failure so callers
+// can differentiate validation classes (e.g., legacy scenarios use 0009, new overdraft
+// and refund scenarios use 0166).
 func (handler *OperationRouteHandler) validateRubricStructure(
 	ctx context.Context,
 	span trace.Span,
 	logger libLog.Logger,
 	entityName, actionName, side string,
 	rubric *mmodel.AccountingRubric,
+	errCode error,
 ) error {
 	if strings.TrimSpace(rubric.Code) == "" {
 		fieldPath := "accountingEntries." + actionName + "." + side + ".code"
 
-		err := pkg.ValidateBusinessError(constant.ErrMissingFieldsInRequest, entityName, fieldPath)
+		err := pkg.ValidateBusinessError(errCode, entityName, fieldPath)
 
 		libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Accounting rubric code is empty", err)
 
@@ -635,7 +646,7 @@ func (handler *OperationRouteHandler) validateRubricStructure(
 	if strings.TrimSpace(rubric.Description) == "" {
 		fieldPath := "accountingEntries." + actionName + "." + side + ".description"
 
-		err := pkg.ValidateBusinessError(constant.ErrMissingFieldsInRequest, entityName, fieldPath)
+		err := pkg.ValidateBusinessError(errCode, entityName, fieldPath)
 
 		libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Accounting rubric description is empty", err)
 
@@ -649,15 +660,17 @@ func (handler *OperationRouteHandler) validateRubricStructure(
 
 // validAccountingEntryKeys defines the allowed top-level keys inside accountingEntries.
 var validAccountingEntryKeys = map[string]struct{}{
-	"direct": {},
-	"hold":   {},
-	"commit": {},
-	"cancel": {},
-	"revert": {},
+	constant.ActionDirect:    {},
+	constant.ActionHold:      {},
+	constant.ActionCommit:    {},
+	constant.ActionCancel:    {},
+	constant.ActionRevert:    {},
+	constant.ActionOverdraft: {},
+	constant.ActionRefund:    {},
 }
 
 // findUnknownAccountingEntryKeys parses the raw JSON for accountingEntries and returns
-// a map of keys that are not in the allowed set (direct, hold, commit, cancel, revert).
+// a map of keys that are not in the allowed set (see validAccountingEntryKeys).
 // Returns nil when all keys are valid. The returned map is suitable for use with
 // ValidateBadRequestFieldsError to produce a standard 0053 "Unexpected Fields" error.
 func findUnknownAccountingEntryKeys(raw json.RawMessage) map[string]any {
@@ -693,11 +706,21 @@ type fieldRequirement struct {
 //	source:      direct[D], hold[D][C], commit[D], cancel[D][C]
 //	destination: direct[C], commit[C]
 //	bidirectional: all scenarios require [D][C]
+//	overdraft / refund: both debit and credit are required regardless of direction.
 //
 // Note: Blocked scenarios (source/revert, destination/hold, etc.) are validated
 // separately by validateDirectionScenarioMatrix. This function assumes the
 // scenario is allowed for the direction.
 func getFieldRequirements(operationType, scenario string) fieldRequirement {
+	// Overdraft and Refund always require both rubrics, regardless of direction.
+	// Keeping this rule explicit (rather than relying on the default fallthrough)
+	// documents the requirement next to the scenario list above and makes it
+	// harder to accidentally loosen via future edits to the source/destination
+	// switches.
+	if scenario == constant.ActionOverdraft || scenario == constant.ActionRefund {
+		return fieldRequirement{debitRequired: true, creditRequired: true}
+	}
+
 	// Bidirectional always requires both
 	if operationType == constant.OperationRouteTypeBidirectional {
 		return fieldRequirement{debitRequired: true, creditRequired: true}
@@ -735,10 +758,15 @@ func getFieldRequirements(operationType, scenario string) fieldRequirement {
 //   - source: direct[D], hold[D][C], commit[D], cancel[D][C], revert[✗]
 //   - destination: direct[C], hold[✗], commit[C], cancel[✗], revert[✗]
 //   - bidirectional: all scenarios allowed with [D][C]
+//   - overdraft / refund: both debit and credit are required on every
+//     operationType. They fall through to the explicit early return in
+//     getFieldRequirements, so the default debit+credit requirement applies
+//     uniformly across source / destination / bidirectional routes.
 //
 // Additional rules:
 //   - Reserve group (hold, commit, cancel) must be atomic for source/bidirectional
-//   - direct is mandatory when any other scenario is present
+//   - direct is mandatory when any other scenario is present (including
+//     overdraft and refund)
 //   - revert is only allowed for bidirectional
 func (handler *OperationRouteHandler) validateAccountingRulesMatrix(
 	ctx context.Context,
@@ -937,8 +965,13 @@ func (handler *OperationRouteHandler) validateDirectMandatory(
 	defer span.End()
 
 	hasDirect := entries.Direct != nil
+	// Overdraft and Refund are supplementary accounting scenarios that still
+	// require direct as a base. Without this, a payload setting only
+	// overdraft (or only refund) would bypass the direct-mandatory check and
+	// yield an incomplete accounting description.
 	hasOtherScenarios := entries.Hold != nil || entries.Commit != nil ||
-		entries.Cancel != nil || entries.Revert != nil
+		entries.Cancel != nil || entries.Revert != nil ||
+		entries.Overdraft != nil || entries.Refund != nil
 
 	// If any other scenario exists, direct must also exist
 	if hasOtherScenarios && !hasDirect {
@@ -986,6 +1019,8 @@ func (handler *OperationRouteHandler) validateEntryFieldRequirements(
 		{constant.ActionCommit, entries.Commit},
 		{constant.ActionCancel, entries.Cancel},
 		{constant.ActionRevert, entries.Revert},
+		{constant.ActionOverdraft, entries.Overdraft},
+		{constant.ActionRefund, entries.Refund},
 	}
 
 	for _, action := range actions {
@@ -1089,24 +1124,29 @@ func mergeAccountingEntries(existing, incoming *mmodel.AccountingEntries, rawUpd
 		return existingEntry
 	}
 
-	var incomingDirect, incomingHold, incomingCommit, incomingCancel, incomingRevert *mmodel.AccountingEntry
+	var incomingDirect, incomingHold, incomingCommit, incomingCancel, incomingRevert, incomingOverdraft, incomingRefund *mmodel.AccountingEntry
 	if incoming != nil {
 		incomingDirect = incoming.Direct
 		incomingHold = incoming.Hold
 		incomingCommit = incoming.Commit
 		incomingCancel = incoming.Cancel
 		incomingRevert = incoming.Revert
+		incomingOverdraft = incoming.Overdraft
+		incomingRefund = incoming.Refund
 	}
 
-	merged.Direct = applyMerge("direct", existing.Direct, incomingDirect)
-	merged.Hold = applyMerge("hold", existing.Hold, incomingHold)
-	merged.Commit = applyMerge("commit", existing.Commit, incomingCommit)
-	merged.Cancel = applyMerge("cancel", existing.Cancel, incomingCancel)
-	merged.Revert = applyMerge("revert", existing.Revert, incomingRevert)
+	merged.Direct = applyMerge(constant.ActionDirect, existing.Direct, incomingDirect)
+	merged.Hold = applyMerge(constant.ActionHold, existing.Hold, incomingHold)
+	merged.Commit = applyMerge(constant.ActionCommit, existing.Commit, incomingCommit)
+	merged.Cancel = applyMerge(constant.ActionCancel, existing.Cancel, incomingCancel)
+	merged.Revert = applyMerge(constant.ActionRevert, existing.Revert, incomingRevert)
+	merged.Overdraft = applyMerge(constant.ActionOverdraft, existing.Overdraft, incomingOverdraft)
+	merged.Refund = applyMerge(constant.ActionRefund, existing.Refund, incomingRefund)
 
 	// Check if all entries are nil - return nil instead of empty struct
 	if merged.Direct == nil && merged.Hold == nil && merged.Commit == nil &&
-		merged.Cancel == nil && merged.Revert == nil {
+		merged.Cancel == nil && merged.Revert == nil &&
+		merged.Overdraft == nil && merged.Refund == nil {
 		return nil
 	}
 
@@ -1150,6 +1190,18 @@ func mergeAccountingEntriesSimple(existing, incoming *mmodel.AccountingEntries) 
 		merged.Revert = incoming.Revert
 	} else if existing != nil {
 		merged.Revert = existing.Revert
+	}
+
+	if incoming.Overdraft != nil {
+		merged.Overdraft = incoming.Overdraft
+	} else if existing != nil {
+		merged.Overdraft = existing.Overdraft
+	}
+
+	if incoming.Refund != nil {
+		merged.Refund = incoming.Refund
+	} else if existing != nil {
+		merged.Refund = existing.Refund
 	}
 
 	return merged

--- a/components/ledger/internal/adapters/http/in/operation_route.go
+++ b/components/ledger/internal/adapters/http/in/operation_route.go
@@ -132,10 +132,10 @@ func (handler *OperationRouteHandler) CreateOperationRoute(i any, c *fiber.Ctx) 
 //	@Param			X-Request-Id	header		string					false	"Request ID for tracing"
 //	@Param			organization_id	path		string					true	"Organization ID in UUID format"
 //	@Param			ledger_id		path		string					true	"Ledger ID in UUID format"
-//	@Param			id				path		string					true	"Operation Route ID in UUID format"
+//	@Param			operation_route_id				path		string					true	"Operation Route ID in UUID format"
 //	@Success		200				{object}	mmodel.OperationRoute	"Successfully retrieved operation route"
 //	@Failure		401				{object}	mmodel.Error			"Unauthorized access"
-//	@Router			/v1/organizations/{organization_id}/ledgers/{ledger_id}/operation-routes/{id} [get]
+//	@Router			/v1/organizations/{organization_id}/ledgers/{ledger_id}/operation-routes/{operation_route_id} [get]
 func (handler *OperationRouteHandler) GetOperationRouteByID(c *fiber.Ctx) error {
 	ctx := c.UserContext()
 

--- a/components/ledger/internal/adapters/http/in/operation_route_merge_overdraft_refund_test.go
+++ b/components/ledger/internal/adapters/http/in/operation_route_merge_overdraft_refund_test.go
@@ -1,0 +1,266 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package in
+
+import (
+	"testing"
+
+	"github.com/LerianStudio/midaz/v3/pkg/mmodel"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestMergeAccountingEntries_OverdraftRefundPreservation verifies that the RFC 7396
+// merge function preserves existing Overdraft and Refund entries when a PATCH body
+// updates an unrelated field (e.g., Direct). Without explicit handling of these
+// fields, existing Overdraft/Refund entries are silently dropped, causing data loss.
+//
+// Defect: mergeAccountingEntries historically handled only 5 fields (Direct, Hold,
+// Commit, Cancel, Revert). The AccountingEntries struct has 7 fields (adding
+// Overdraft and Refund). This test protects against regression.
+func TestMergeAccountingEntries_OverdraftRefundPreservation(t *testing.T) {
+	t.Parallel()
+
+	directEntry := &mmodel.AccountingEntry{
+		Debit:  &mmodel.AccountingRubric{Code: "1001", Description: "Direct Debit"},
+		Credit: &mmodel.AccountingRubric{Code: "2001", Description: "Direct Credit"},
+	}
+	newDirectEntry := &mmodel.AccountingEntry{
+		Debit:  &mmodel.AccountingRubric{Code: "NEW1", Description: "New Direct Debit"},
+		Credit: &mmodel.AccountingRubric{Code: "NEW2", Description: "New Direct Credit"},
+	}
+	overdraftEntry := &mmodel.AccountingEntry{
+		Debit:  &mmodel.AccountingRubric{Code: "1006", Description: "Overdraft Debit"},
+		Credit: &mmodel.AccountingRubric{Code: "2006", Description: "Overdraft Credit"},
+	}
+	refundEntry := &mmodel.AccountingEntry{
+		Debit:  &mmodel.AccountingRubric{Code: "1007", Description: "Refund Debit"},
+		Credit: &mmodel.AccountingRubric{Code: "2007", Description: "Refund Credit"},
+	}
+	newOverdraftEntry := &mmodel.AccountingEntry{
+		Debit:  &mmodel.AccountingRubric{Code: "NEW6D", Description: "New Overdraft Debit"},
+		Credit: &mmodel.AccountingRubric{Code: "NEW6C", Description: "New Overdraft Credit"},
+	}
+	newRefundEntry := &mmodel.AccountingEntry{
+		Debit:  &mmodel.AccountingRubric{Code: "NEW7D", Description: "New Refund Debit"},
+		Credit: &mmodel.AccountingRubric{Code: "NEW7C", Description: "New Refund Credit"},
+	}
+
+	tests := []struct {
+		name       string
+		existing   *mmodel.AccountingEntries
+		incoming   *mmodel.AccountingEntries
+		rawUpdates string
+		expected   *mmodel.AccountingEntries
+	}{
+		{
+			name: "rfc7396: updating only direct preserves existing overdraft and refund",
+			existing: &mmodel.AccountingEntries{
+				Direct:    directEntry,
+				Overdraft: overdraftEntry,
+				Refund:    refundEntry,
+			},
+			incoming: &mmodel.AccountingEntries{
+				Direct: newDirectEntry,
+			},
+			rawUpdates: `{"direct": {"debit": {"code": "NEW1", "description": "New Direct Debit"}, "credit": {"code": "NEW2", "description": "New Direct Credit"}}}`,
+			expected: &mmodel.AccountingEntries{
+				Direct:    newDirectEntry,
+				Overdraft: overdraftEntry,
+				Refund:    refundEntry,
+			},
+		},
+		{
+			name: "rfc7396: incoming overdraft and refund are applied to merged result",
+			existing: &mmodel.AccountingEntries{
+				Direct: directEntry,
+			},
+			incoming: &mmodel.AccountingEntries{
+				Overdraft: newOverdraftEntry,
+				Refund:    newRefundEntry,
+			},
+			rawUpdates: `{"overdraft": {"debit": {"code": "NEW6D", "description": "New Overdraft Debit"}, "credit": {"code": "NEW6C", "description": "New Overdraft Credit"}}, "refund": {"debit": {"code": "NEW7D", "description": "New Refund Debit"}, "credit": {"code": "NEW7C", "description": "New Refund Credit"}}}`,
+			expected: &mmodel.AccountingEntries{
+				Direct:    directEntry,
+				Overdraft: newOverdraftEntry,
+				Refund:    newRefundEntry,
+			},
+		},
+		{
+			name: "rfc7396: explicit null removes overdraft and refund entries",
+			existing: &mmodel.AccountingEntries{
+				Direct:    directEntry,
+				Overdraft: overdraftEntry,
+				Refund:    refundEntry,
+			},
+			incoming:   &mmodel.AccountingEntries{},
+			rawUpdates: `{"overdraft": null, "refund": null}`,
+			expected: &mmodel.AccountingEntries{
+				Direct:    directEntry,
+				Overdraft: nil,
+				Refund:    nil,
+			},
+		},
+		{
+			name: "rfc7396: nil-check returns nil only when all 7 fields are nil",
+			existing: &mmodel.AccountingEntries{
+				Overdraft: overdraftEntry,
+			},
+			incoming:   &mmodel.AccountingEntries{},
+			rawUpdates: `{"overdraft": null}`,
+			expected:   nil,
+		},
+		{
+			name: "rfc7396: refund-only existing removed returns nil",
+			existing: &mmodel.AccountingEntries{
+				Refund: refundEntry,
+			},
+			incoming:   &mmodel.AccountingEntries{},
+			rawUpdates: `{"refund": null}`,
+			expected:   nil,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			result := mergeAccountingEntries(tt.existing, tt.incoming, []byte(tt.rawUpdates))
+
+			if tt.expected == nil {
+				assert.Nil(t, result, "expected nil result when all fields are nil")
+				return
+			}
+
+			require.NotNil(t, result)
+			assert.Equal(t, tt.expected.Direct, result.Direct, "Direct mismatch")
+			assert.Equal(t, tt.expected.Hold, result.Hold, "Hold mismatch")
+			assert.Equal(t, tt.expected.Commit, result.Commit, "Commit mismatch")
+			assert.Equal(t, tt.expected.Cancel, result.Cancel, "Cancel mismatch")
+			assert.Equal(t, tt.expected.Revert, result.Revert, "Revert mismatch")
+			assert.Equal(t, tt.expected.Overdraft, result.Overdraft, "Overdraft mismatch")
+			assert.Equal(t, tt.expected.Refund, result.Refund, "Refund mismatch")
+		})
+	}
+}
+
+// TestMergeAccountingEntriesSimple_OverdraftRefundPreservation verifies that the
+// simple merge fallback (used when raw JSON is unavailable) preserves existing
+// Overdraft and Refund entries and applies incoming ones.
+//
+// Defect: mergeAccountingEntriesSimple historically handled only 5 fields,
+// silently dropping existing Overdraft/Refund entries during partial updates.
+func TestMergeAccountingEntriesSimple_OverdraftRefundPreservation(t *testing.T) {
+	t.Parallel()
+
+	directEntry := &mmodel.AccountingEntry{
+		Debit:  &mmodel.AccountingRubric{Code: "1001", Description: "Direct Debit"},
+		Credit: &mmodel.AccountingRubric{Code: "2001", Description: "Direct Credit"},
+	}
+	newDirectEntry := &mmodel.AccountingEntry{
+		Debit:  &mmodel.AccountingRubric{Code: "NEW1", Description: "New Direct Debit"},
+		Credit: &mmodel.AccountingRubric{Code: "NEW2", Description: "New Direct Credit"},
+	}
+	overdraftEntry := &mmodel.AccountingEntry{
+		Debit:  &mmodel.AccountingRubric{Code: "1006", Description: "Overdraft Debit"},
+		Credit: &mmodel.AccountingRubric{Code: "2006", Description: "Overdraft Credit"},
+	}
+	refundEntry := &mmodel.AccountingEntry{
+		Debit:  &mmodel.AccountingRubric{Code: "1007", Description: "Refund Debit"},
+		Credit: &mmodel.AccountingRubric{Code: "2007", Description: "Refund Credit"},
+	}
+	newOverdraftEntry := &mmodel.AccountingEntry{
+		Debit:  &mmodel.AccountingRubric{Code: "NEW6D", Description: "New Overdraft Debit"},
+		Credit: &mmodel.AccountingRubric{Code: "NEW6C", Description: "New Overdraft Credit"},
+	}
+	newRefundEntry := &mmodel.AccountingEntry{
+		Debit:  &mmodel.AccountingRubric{Code: "NEW7D", Description: "New Refund Debit"},
+		Credit: &mmodel.AccountingRubric{Code: "NEW7C", Description: "New Refund Credit"},
+	}
+
+	tests := []struct {
+		name     string
+		existing *mmodel.AccountingEntries
+		incoming *mmodel.AccountingEntries
+		expected *mmodel.AccountingEntries
+	}{
+		{
+			name: "simple: updating only direct preserves existing overdraft and refund",
+			existing: &mmodel.AccountingEntries{
+				Direct:    directEntry,
+				Overdraft: overdraftEntry,
+				Refund:    refundEntry,
+			},
+			incoming: &mmodel.AccountingEntries{
+				Direct: newDirectEntry,
+			},
+			expected: &mmodel.AccountingEntries{
+				Direct:    newDirectEntry,
+				Overdraft: overdraftEntry,
+				Refund:    refundEntry,
+			},
+		},
+		{
+			name: "simple: incoming overdraft overrides existing",
+			existing: &mmodel.AccountingEntries{
+				Direct:    directEntry,
+				Overdraft: overdraftEntry,
+			},
+			incoming: &mmodel.AccountingEntries{
+				Overdraft: newOverdraftEntry,
+			},
+			expected: &mmodel.AccountingEntries{
+				Direct:    directEntry,
+				Overdraft: newOverdraftEntry,
+			},
+		},
+		{
+			name: "simple: incoming refund overrides existing",
+			existing: &mmodel.AccountingEntries{
+				Direct: directEntry,
+				Refund: refundEntry,
+			},
+			incoming: &mmodel.AccountingEntries{
+				Refund: newRefundEntry,
+			},
+			expected: &mmodel.AccountingEntries{
+				Direct: directEntry,
+				Refund: newRefundEntry,
+			},
+		},
+		{
+			name:     "simple: incoming adds overdraft and refund to existing",
+			existing: &mmodel.AccountingEntries{Direct: directEntry},
+			incoming: &mmodel.AccountingEntries{
+				Overdraft: newOverdraftEntry,
+				Refund:    newRefundEntry,
+			},
+			expected: &mmodel.AccountingEntries{
+				Direct:    directEntry,
+				Overdraft: newOverdraftEntry,
+				Refund:    newRefundEntry,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			result := mergeAccountingEntriesSimple(tt.existing, tt.incoming)
+
+			require.NotNil(t, result)
+			assert.Equal(t, tt.expected.Direct, result.Direct, "Direct mismatch")
+			assert.Equal(t, tt.expected.Hold, result.Hold, "Hold mismatch")
+			assert.Equal(t, tt.expected.Commit, result.Commit, "Commit mismatch")
+			assert.Equal(t, tt.expected.Cancel, result.Cancel, "Cancel mismatch")
+			assert.Equal(t, tt.expected.Revert, result.Revert, "Revert mismatch")
+			assert.Equal(t, tt.expected.Overdraft, result.Overdraft, "Overdraft mismatch")
+			assert.Equal(t, tt.expected.Refund, result.Refund, "Refund mismatch")
+		})
+	}
+}

--- a/components/ledger/internal/adapters/http/in/operation_route_merge_overdraft_test.go
+++ b/components/ledger/internal/adapters/http/in/operation_route_merge_overdraft_test.go
@@ -12,15 +12,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestMergeAccountingEntries_OverdraftRefundPreservation verifies that the RFC 7396
-// merge function preserves existing Overdraft and Refund entries when a PATCH body
-// updates an unrelated field (e.g., Direct). Without explicit handling of these
-// fields, existing Overdraft/Refund entries are silently dropped, causing data loss.
-//
-// Defect: mergeAccountingEntries historically handled only 5 fields (Direct, Hold,
-// Commit, Cancel, Revert). The AccountingEntries struct has 7 fields (adding
-// Overdraft and Refund). This test protects against regression.
-func TestMergeAccountingEntries_OverdraftRefundPreservation(t *testing.T) {
+// TestMergeAccountingEntries_OverdraftPreservation verifies that the RFC 7396
+// merge function preserves existing Overdraft entries when a PATCH body
+// updates an unrelated field (e.g., Direct). Without explicit handling of
+// the Overdraft field, existing entries are silently dropped, causing data loss.
+func TestMergeAccountingEntries_OverdraftPreservation(t *testing.T) {
 	t.Parallel()
 
 	directEntry := &mmodel.AccountingEntry{
@@ -35,17 +31,9 @@ func TestMergeAccountingEntries_OverdraftRefundPreservation(t *testing.T) {
 		Debit:  &mmodel.AccountingRubric{Code: "1006", Description: "Overdraft Debit"},
 		Credit: &mmodel.AccountingRubric{Code: "2006", Description: "Overdraft Credit"},
 	}
-	refundEntry := &mmodel.AccountingEntry{
-		Debit:  &mmodel.AccountingRubric{Code: "1007", Description: "Refund Debit"},
-		Credit: &mmodel.AccountingRubric{Code: "2007", Description: "Refund Credit"},
-	}
 	newOverdraftEntry := &mmodel.AccountingEntry{
 		Debit:  &mmodel.AccountingRubric{Code: "NEW6D", Description: "New Overdraft Debit"},
 		Credit: &mmodel.AccountingRubric{Code: "NEW6C", Description: "New Overdraft Credit"},
-	}
-	newRefundEntry := &mmodel.AccountingEntry{
-		Debit:  &mmodel.AccountingRubric{Code: "NEW7D", Description: "New Refund Debit"},
-		Credit: &mmodel.AccountingRubric{Code: "NEW7C", Description: "New Refund Credit"},
 	}
 
 	tests := []struct {
@@ -56,11 +44,10 @@ func TestMergeAccountingEntries_OverdraftRefundPreservation(t *testing.T) {
 		expected   *mmodel.AccountingEntries
 	}{
 		{
-			name: "rfc7396: updating only direct preserves existing overdraft and refund",
+			name: "rfc7396: updating only direct preserves existing overdraft",
 			existing: &mmodel.AccountingEntries{
 				Direct:    directEntry,
 				Overdraft: overdraftEntry,
-				Refund:    refundEntry,
 			},
 			incoming: &mmodel.AccountingEntries{
 				Direct: newDirectEntry,
@@ -69,56 +56,42 @@ func TestMergeAccountingEntries_OverdraftRefundPreservation(t *testing.T) {
 			expected: &mmodel.AccountingEntries{
 				Direct:    newDirectEntry,
 				Overdraft: overdraftEntry,
-				Refund:    refundEntry,
 			},
 		},
 		{
-			name: "rfc7396: incoming overdraft and refund are applied to merged result",
+			name: "rfc7396: incoming overdraft is applied to merged result",
 			existing: &mmodel.AccountingEntries{
 				Direct: directEntry,
 			},
 			incoming: &mmodel.AccountingEntries{
 				Overdraft: newOverdraftEntry,
-				Refund:    newRefundEntry,
 			},
-			rawUpdates: `{"overdraft": {"debit": {"code": "NEW6D", "description": "New Overdraft Debit"}, "credit": {"code": "NEW6C", "description": "New Overdraft Credit"}}, "refund": {"debit": {"code": "NEW7D", "description": "New Refund Debit"}, "credit": {"code": "NEW7C", "description": "New Refund Credit"}}}`,
+			rawUpdates: `{"overdraft": {"debit": {"code": "NEW6D", "description": "New Overdraft Debit"}, "credit": {"code": "NEW6C", "description": "New Overdraft Credit"}}}`,
 			expected: &mmodel.AccountingEntries{
 				Direct:    directEntry,
 				Overdraft: newOverdraftEntry,
-				Refund:    newRefundEntry,
 			},
 		},
 		{
-			name: "rfc7396: explicit null removes overdraft and refund entries",
+			name: "rfc7396: explicit null removes overdraft entry",
 			existing: &mmodel.AccountingEntries{
 				Direct:    directEntry,
 				Overdraft: overdraftEntry,
-				Refund:    refundEntry,
 			},
 			incoming:   &mmodel.AccountingEntries{},
-			rawUpdates: `{"overdraft": null, "refund": null}`,
+			rawUpdates: `{"overdraft": null}`,
 			expected: &mmodel.AccountingEntries{
 				Direct:    directEntry,
 				Overdraft: nil,
-				Refund:    nil,
 			},
 		},
 		{
-			name: "rfc7396: nil-check returns nil only when all 7 fields are nil",
+			name: "rfc7396: nil-check returns nil only when all 6 fields are nil",
 			existing: &mmodel.AccountingEntries{
 				Overdraft: overdraftEntry,
 			},
 			incoming:   &mmodel.AccountingEntries{},
 			rawUpdates: `{"overdraft": null}`,
-			expected:   nil,
-		},
-		{
-			name: "rfc7396: refund-only existing removed returns nil",
-			existing: &mmodel.AccountingEntries{
-				Refund: refundEntry,
-			},
-			incoming:   &mmodel.AccountingEntries{},
-			rawUpdates: `{"refund": null}`,
 			expected:   nil,
 		},
 	}
@@ -142,18 +115,14 @@ func TestMergeAccountingEntries_OverdraftRefundPreservation(t *testing.T) {
 			assert.Equal(t, tt.expected.Cancel, result.Cancel, "Cancel mismatch")
 			assert.Equal(t, tt.expected.Revert, result.Revert, "Revert mismatch")
 			assert.Equal(t, tt.expected.Overdraft, result.Overdraft, "Overdraft mismatch")
-			assert.Equal(t, tt.expected.Refund, result.Refund, "Refund mismatch")
 		})
 	}
 }
 
-// TestMergeAccountingEntriesSimple_OverdraftRefundPreservation verifies that the
+// TestMergeAccountingEntriesSimple_OverdraftPreservation verifies that the
 // simple merge fallback (used when raw JSON is unavailable) preserves existing
-// Overdraft and Refund entries and applies incoming ones.
-//
-// Defect: mergeAccountingEntriesSimple historically handled only 5 fields,
-// silently dropping existing Overdraft/Refund entries during partial updates.
-func TestMergeAccountingEntriesSimple_OverdraftRefundPreservation(t *testing.T) {
+// Overdraft entries and applies incoming ones.
+func TestMergeAccountingEntriesSimple_OverdraftPreservation(t *testing.T) {
 	t.Parallel()
 
 	directEntry := &mmodel.AccountingEntry{
@@ -168,17 +137,9 @@ func TestMergeAccountingEntriesSimple_OverdraftRefundPreservation(t *testing.T) 
 		Debit:  &mmodel.AccountingRubric{Code: "1006", Description: "Overdraft Debit"},
 		Credit: &mmodel.AccountingRubric{Code: "2006", Description: "Overdraft Credit"},
 	}
-	refundEntry := &mmodel.AccountingEntry{
-		Debit:  &mmodel.AccountingRubric{Code: "1007", Description: "Refund Debit"},
-		Credit: &mmodel.AccountingRubric{Code: "2007", Description: "Refund Credit"},
-	}
 	newOverdraftEntry := &mmodel.AccountingEntry{
 		Debit:  &mmodel.AccountingRubric{Code: "NEW6D", Description: "New Overdraft Debit"},
 		Credit: &mmodel.AccountingRubric{Code: "NEW6C", Description: "New Overdraft Credit"},
-	}
-	newRefundEntry := &mmodel.AccountingEntry{
-		Debit:  &mmodel.AccountingRubric{Code: "NEW7D", Description: "New Refund Debit"},
-		Credit: &mmodel.AccountingRubric{Code: "NEW7C", Description: "New Refund Credit"},
 	}
 
 	tests := []struct {
@@ -188,11 +149,10 @@ func TestMergeAccountingEntriesSimple_OverdraftRefundPreservation(t *testing.T) 
 		expected *mmodel.AccountingEntries
 	}{
 		{
-			name: "simple: updating only direct preserves existing overdraft and refund",
+			name: "simple: updating only direct preserves existing overdraft",
 			existing: &mmodel.AccountingEntries{
 				Direct:    directEntry,
 				Overdraft: overdraftEntry,
-				Refund:    refundEntry,
 			},
 			incoming: &mmodel.AccountingEntries{
 				Direct: newDirectEntry,
@@ -200,7 +160,6 @@ func TestMergeAccountingEntriesSimple_OverdraftRefundPreservation(t *testing.T) 
 			expected: &mmodel.AccountingEntries{
 				Direct:    newDirectEntry,
 				Overdraft: overdraftEntry,
-				Refund:    refundEntry,
 			},
 		},
 		{
@@ -218,30 +177,14 @@ func TestMergeAccountingEntriesSimple_OverdraftRefundPreservation(t *testing.T) 
 			},
 		},
 		{
-			name: "simple: incoming refund overrides existing",
-			existing: &mmodel.AccountingEntries{
-				Direct: directEntry,
-				Refund: refundEntry,
-			},
-			incoming: &mmodel.AccountingEntries{
-				Refund: newRefundEntry,
-			},
-			expected: &mmodel.AccountingEntries{
-				Direct: directEntry,
-				Refund: newRefundEntry,
-			},
-		},
-		{
-			name:     "simple: incoming adds overdraft and refund to existing",
+			name:     "simple: incoming adds overdraft to existing",
 			existing: &mmodel.AccountingEntries{Direct: directEntry},
 			incoming: &mmodel.AccountingEntries{
 				Overdraft: newOverdraftEntry,
-				Refund:    newRefundEntry,
 			},
 			expected: &mmodel.AccountingEntries{
 				Direct:    directEntry,
 				Overdraft: newOverdraftEntry,
-				Refund:    newRefundEntry,
 			},
 		},
 	}
@@ -260,7 +203,6 @@ func TestMergeAccountingEntriesSimple_OverdraftRefundPreservation(t *testing.T) 
 			assert.Equal(t, tt.expected.Cancel, result.Cancel, "Cancel mismatch")
 			assert.Equal(t, tt.expected.Revert, result.Revert, "Revert mismatch")
 			assert.Equal(t, tt.expected.Overdraft, result.Overdraft, "Overdraft mismatch")
-			assert.Equal(t, tt.expected.Refund, result.Refund, "Refund mismatch")
 		})
 	}
 }

--- a/components/ledger/internal/adapters/http/in/operation_route_overdraft_refund_validation_test.go
+++ b/components/ledger/internal/adapters/http/in/operation_route_overdraft_refund_validation_test.go
@@ -1,0 +1,371 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+// T-008: Accounting Entries Extension — Overdraft & Refund validation.
+//
+// These tests capture the expected HTTP-handler validation behavior for
+// the new "overdraft" and "refund" accounting entries:
+//
+//  1. Both fields, when present, MUST include BOTH debit AND credit
+//     rubrics (same requirement as the bidirectional field pattern —
+//     source/hold, source/cancel, or any bidirectional scenario).
+//  2. Missing debit or credit yields ErrAccountingEntryFieldRequired (0166).
+//  3. Absence of the fields continues to pass validation (backward compat).
+//  4. Structural validation (empty code/description) still applies.
+//  5. The allowed-keys gate accepts "overdraft" and "refund" without
+//     triggering "Unexpected Fields" (error 0053).
+//
+// These tests MUST FAIL until T-008 GREEN introduces:
+//   - AccountingEntries.Overdraft and AccountingEntries.Refund fields
+//   - Handler validation for the new scenarios (debit+credit required)
+//   - "overdraft" and "refund" entries in validAccountingEntryKeys
+package in
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	pkg "github.com/LerianStudio/midaz/v3/pkg"
+	"github.com/LerianStudio/midaz/v3/pkg/constant"
+	"github.com/LerianStudio/midaz/v3/pkg/mmodel"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestValidateEntryFieldRequirements_Overdraft_RequiresDebitAndCredit
+// verifies that overdraft entries require BOTH debit and credit rubrics.
+func TestValidateEntryFieldRequirements_Overdraft_RequiresDebitAndCredit(t *testing.T) {
+	t.Parallel()
+
+	handler := &OperationRouteHandler{}
+
+	tests := []struct {
+		name          string
+		operationType string
+		entries       *mmodel.AccountingEntries
+		expectError   bool
+		errorCode     string
+		errorField    string
+	}{
+		{
+			name:          "overdraft with both debit and credit — valid",
+			operationType: constant.OperationRouteTypeBidirectional,
+			entries: &mmodel.AccountingEntries{
+				Direct: &mmodel.AccountingEntry{
+					Debit:  &mmodel.AccountingRubric{Code: "1001", Description: "Debit"},
+					Credit: &mmodel.AccountingRubric{Code: "2001", Description: "Credit"},
+				},
+				Overdraft: &mmodel.AccountingEntry{
+					Debit:  &mmodel.AccountingRubric{Code: "1006", Description: "Overdraft Debit"},
+					Credit: &mmodel.AccountingRubric{Code: "2006", Description: "Overdraft Credit"},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name:          "overdraft missing debit — invalid",
+			operationType: constant.OperationRouteTypeBidirectional,
+			entries: &mmodel.AccountingEntries{
+				Direct: &mmodel.AccountingEntry{
+					Debit:  &mmodel.AccountingRubric{Code: "1001", Description: "Debit"},
+					Credit: &mmodel.AccountingRubric{Code: "2001", Description: "Credit"},
+				},
+				Overdraft: &mmodel.AccountingEntry{
+					Credit: &mmodel.AccountingRubric{Code: "2006", Description: "Overdraft Credit"},
+				},
+			},
+			expectError: true,
+			errorCode:   constant.ErrAccountingEntryFieldRequired.Error(),
+			errorField:  "debit",
+		},
+		{
+			name:          "overdraft missing credit — invalid",
+			operationType: constant.OperationRouteTypeBidirectional,
+			entries: &mmodel.AccountingEntries{
+				Direct: &mmodel.AccountingEntry{
+					Debit:  &mmodel.AccountingRubric{Code: "1001", Description: "Debit"},
+					Credit: &mmodel.AccountingRubric{Code: "2001", Description: "Credit"},
+				},
+				Overdraft: &mmodel.AccountingEntry{
+					Debit: &mmodel.AccountingRubric{Code: "1006", Description: "Overdraft Debit"},
+				},
+			},
+			expectError: true,
+			errorCode:   constant.ErrAccountingEntryFieldRequired.Error(),
+			errorField:  "credit",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := context.Background()
+
+			err := handler.validateEntryFieldRequirements(ctx, tt.operationType, tt.entries, "OperationRoute")
+
+			if tt.expectError {
+				require.Error(t, err, "expected validation error")
+
+				var upErr pkg.UnprocessableOperationError
+				require.ErrorAs(t, err, &upErr, "expected UnprocessableOperationError")
+				assert.Equal(t, tt.errorCode, upErr.Code, "error code mismatch")
+
+				if tt.errorField != "" {
+					assert.Contains(t, upErr.Message, tt.errorField,
+						"error message should reference the missing field")
+				}
+			} else {
+				require.NoError(t, err, "expected no validation error")
+			}
+		})
+	}
+}
+
+// TestValidateEntryFieldRequirements_Refund_RequiresDebitAndCredit verifies
+// that refund entries require BOTH debit and credit rubrics.
+func TestValidateEntryFieldRequirements_Refund_RequiresDebitAndCredit(t *testing.T) {
+	t.Parallel()
+
+	handler := &OperationRouteHandler{}
+
+	tests := []struct {
+		name          string
+		operationType string
+		entries       *mmodel.AccountingEntries
+		expectError   bool
+		errorCode     string
+		errorField    string
+	}{
+		{
+			name:          "refund with both debit and credit — valid",
+			operationType: constant.OperationRouteTypeBidirectional,
+			entries: &mmodel.AccountingEntries{
+				Direct: &mmodel.AccountingEntry{
+					Debit:  &mmodel.AccountingRubric{Code: "1001", Description: "Debit"},
+					Credit: &mmodel.AccountingRubric{Code: "2001", Description: "Credit"},
+				},
+				Refund: &mmodel.AccountingEntry{
+					Debit:  &mmodel.AccountingRubric{Code: "1007", Description: "Refund Debit"},
+					Credit: &mmodel.AccountingRubric{Code: "2007", Description: "Refund Credit"},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name:          "refund missing debit — invalid",
+			operationType: constant.OperationRouteTypeBidirectional,
+			entries: &mmodel.AccountingEntries{
+				Direct: &mmodel.AccountingEntry{
+					Debit:  &mmodel.AccountingRubric{Code: "1001", Description: "Debit"},
+					Credit: &mmodel.AccountingRubric{Code: "2001", Description: "Credit"},
+				},
+				Refund: &mmodel.AccountingEntry{
+					Credit: &mmodel.AccountingRubric{Code: "2007", Description: "Refund Credit"},
+				},
+			},
+			expectError: true,
+			errorCode:   constant.ErrAccountingEntryFieldRequired.Error(),
+			errorField:  "debit",
+		},
+		{
+			name:          "refund missing credit — invalid",
+			operationType: constant.OperationRouteTypeBidirectional,
+			entries: &mmodel.AccountingEntries{
+				Direct: &mmodel.AccountingEntry{
+					Debit:  &mmodel.AccountingRubric{Code: "1001", Description: "Debit"},
+					Credit: &mmodel.AccountingRubric{Code: "2001", Description: "Credit"},
+				},
+				Refund: &mmodel.AccountingEntry{
+					Debit: &mmodel.AccountingRubric{Code: "1007", Description: "Refund Debit"},
+				},
+			},
+			expectError: true,
+			errorCode:   constant.ErrAccountingEntryFieldRequired.Error(),
+			errorField:  "credit",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := context.Background()
+
+			err := handler.validateEntryFieldRequirements(ctx, tt.operationType, tt.entries, "OperationRoute")
+
+			if tt.expectError {
+				require.Error(t, err, "expected validation error")
+
+				var upErr pkg.UnprocessableOperationError
+				require.ErrorAs(t, err, &upErr, "expected UnprocessableOperationError")
+				assert.Equal(t, tt.errorCode, upErr.Code, "error code mismatch")
+
+				if tt.errorField != "" {
+					assert.Contains(t, upErr.Message, tt.errorField,
+						"error message should reference the missing field")
+				}
+			} else {
+				require.NoError(t, err, "expected no validation error")
+			}
+		})
+	}
+}
+
+// TestValidateAccountingEntries_OverdraftRefund_StructuralValidation
+// verifies that the existing structure validator (debit/credit present,
+// non-empty code/description) also runs on the new fields.
+func TestValidateAccountingEntries_OverdraftRefund_StructuralValidation(t *testing.T) {
+	t.Parallel()
+
+	handler := &OperationRouteHandler{}
+	ctx := context.Background()
+
+	tests := []struct {
+		name        string
+		entries     *mmodel.AccountingEntries
+		expectError bool
+		errorField  string
+	}{
+		{
+			name: "overdraft with neither debit nor credit — invalid structure",
+			entries: &mmodel.AccountingEntries{
+				Overdraft: &mmodel.AccountingEntry{},
+			},
+			expectError: true,
+			errorField:  "accountingEntries.overdraft",
+		},
+		{
+			name: "refund with neither debit nor credit — invalid structure",
+			entries: &mmodel.AccountingEntries{
+				Refund: &mmodel.AccountingEntry{},
+			},
+			expectError: true,
+			errorField:  "accountingEntries.refund",
+		},
+		{
+			name: "overdraft with empty debit code — invalid structure",
+			entries: &mmodel.AccountingEntries{
+				Overdraft: &mmodel.AccountingEntry{
+					Debit:  &mmodel.AccountingRubric{Code: "", Description: "Overdraft Debit"},
+					Credit: &mmodel.AccountingRubric{Code: "2006", Description: "Overdraft Credit"},
+				},
+			},
+			expectError: true,
+			errorField:  "accountingEntries.overdraft.debit.code",
+		},
+		{
+			name: "refund with empty credit description — invalid structure",
+			entries: &mmodel.AccountingEntries{
+				Refund: &mmodel.AccountingEntry{
+					Debit:  &mmodel.AccountingRubric{Code: "1007", Description: "Refund Debit"},
+					Credit: &mmodel.AccountingRubric{Code: "2007", Description: ""},
+				},
+			},
+			expectError: true,
+			errorField:  "accountingEntries.refund.credit.description",
+		},
+		{
+			name: "overdraft and refund fully populated — valid structure",
+			entries: &mmodel.AccountingEntries{
+				Overdraft: &mmodel.AccountingEntry{
+					Debit:  &mmodel.AccountingRubric{Code: "1006", Description: "Overdraft Debit"},
+					Credit: &mmodel.AccountingRubric{Code: "2006", Description: "Overdraft Credit"},
+				},
+				Refund: &mmodel.AccountingEntry{
+					Debit:  &mmodel.AccountingRubric{Code: "1007", Description: "Refund Debit"},
+					Credit: &mmodel.AccountingRubric{Code: "2007", Description: "Refund Credit"},
+				},
+			},
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := handler.validateAccountingEntries(ctx, tt.entries)
+
+			if tt.expectError {
+				require.Error(t, err, "expected structural validation error")
+
+				var upErr pkg.UnprocessableOperationError
+				if assert.ErrorAs(t, err, &upErr) && tt.errorField != "" {
+					assert.Contains(t, upErr.Message, tt.errorField,
+						"error message should reference the offending field path")
+				}
+			} else {
+				require.NoError(t, err, "expected no validation error")
+			}
+		})
+	}
+}
+
+// TestValidateAccountingEntries_BackwardCompatible_NoOverdraftRefund
+// ensures operation routes without the new fields continue to validate
+// as before — no hidden required fields, no new errors.
+func TestValidateAccountingEntries_BackwardCompatible_NoOverdraftRefund(t *testing.T) {
+	t.Parallel()
+
+	handler := &OperationRouteHandler{}
+	ctx := context.Background()
+
+	// A minimal legacy payload (T-007 and earlier): only Direct is set.
+	entries := &mmodel.AccountingEntries{
+		Direct: &mmodel.AccountingEntry{
+			Debit:  &mmodel.AccountingRubric{Code: "1001", Description: "Cash"},
+			Credit: &mmodel.AccountingRubric{Code: "2001", Description: "Revenue"},
+		},
+	}
+
+	// Structure validation passes.
+	require.NoError(t, handler.validateAccountingEntries(ctx, entries),
+		"legacy entries must still pass structural validation")
+
+	// Full matrix validation passes on every operation type.
+	for _, opType := range []string{
+		constant.OperationRouteTypeSource,
+		constant.OperationRouteTypeDestination,
+		constant.OperationRouteTypeBidirectional,
+	} {
+		opType := opType
+		t.Run("matrix validation — "+opType, func(t *testing.T) {
+			t.Parallel()
+
+			err := handler.validateAccountingRulesMatrix(ctx, opType, entries)
+			require.NoError(t, err,
+				"legacy entries without overdraft/refund must still pass matrix validation for %s", opType)
+		})
+	}
+}
+
+// TestFindUnknownAccountingEntryKeys_AllowsOverdraftAndRefund verifies
+// that the allowed-keys gate recognizes "overdraft" and "refund" as
+// valid top-level keys — without this, the handler would reject any
+// payload containing these new fields as "Unexpected Fields".
+func TestFindUnknownAccountingEntryKeys_AllowsOverdraftAndRefund(t *testing.T) {
+	t.Parallel()
+
+	raw := json.RawMessage(`{
+		"direct":{"debit":{"code":"1001","description":"Cash"}},
+		"overdraft":{
+			"debit":{"code":"1006","description":"Overdraft Debit"},
+			"credit":{"code":"2006","description":"Overdraft Credit"}
+		},
+		"refund":{
+			"debit":{"code":"1007","description":"Refund Debit"},
+			"credit":{"code":"2007","description":"Refund Credit"}
+		}
+	}`)
+
+	unknowns := findUnknownAccountingEntryKeys(raw)
+
+	assert.Nil(t, unknowns,
+		`"overdraft" and "refund" must be valid top-level keys; got unknowns = %v`, unknowns)
+}

--- a/components/ledger/internal/adapters/http/in/operation_route_overdraft_refund_validation_test.go
+++ b/components/ledger/internal/adapters/http/in/operation_route_overdraft_refund_validation_test.go
@@ -2,24 +2,20 @@
 // Use of this source code is governed by the Elastic License 2.0
 // that can be found in the LICENSE file.
 
-// T-008: Accounting Entries Extension — Overdraft & Refund validation.
+// T-008 + T-014: Accounting Entries Extension — Overdraft validation.
 //
-// These tests capture the expected HTTP-handler validation behavior for
-// the new "overdraft" and "refund" accounting entries:
+// After T-014, the "refund" accounting entry was collapsed into "overdraft".
+// These tests capture the expected HTTP-handler validation behavior for the
+// "overdraft" accounting entry:
 //
-//  1. Both fields, when present, MUST include BOTH debit AND credit
-//     rubrics (same requirement as the bidirectional field pattern —
-//     source/hold, source/cancel, or any bidirectional scenario).
+//  1. The field, when present, MUST include BOTH debit AND credit rubrics.
 //  2. Missing debit or credit yields ErrAccountingEntryFieldRequired (0166).
-//  3. Absence of the fields continues to pass validation (backward compat).
+//  3. Absence of the field continues to pass validation (backward compat).
 //  4. Structural validation (empty code/description) still applies.
-//  5. The allowed-keys gate accepts "overdraft" and "refund" without
-//     triggering "Unexpected Fields" (error 0053).
-//
-// These tests MUST FAIL until T-008 GREEN introduces:
-//   - AccountingEntries.Overdraft and AccountingEntries.Refund fields
-//   - Handler validation for the new scenarios (debit+credit required)
-//   - "overdraft" and "refund" entries in validAccountingEntryKeys
+//  5. The allowed-keys gate accepts "overdraft" without triggering
+//     "Unexpected Fields" (error 0053).
+//  6. After T-014, the "refund" key is no longer recognized and produces
+//     an "Unexpected Fields" error (0053).
 package in
 
 import (
@@ -125,101 +121,10 @@ func TestValidateEntryFieldRequirements_Overdraft_RequiresDebitAndCredit(t *test
 	}
 }
 
-// TestValidateEntryFieldRequirements_Refund_RequiresDebitAndCredit verifies
-// that refund entries require BOTH debit and credit rubrics.
-func TestValidateEntryFieldRequirements_Refund_RequiresDebitAndCredit(t *testing.T) {
-	t.Parallel()
-
-	handler := &OperationRouteHandler{}
-
-	tests := []struct {
-		name          string
-		operationType string
-		entries       *mmodel.AccountingEntries
-		expectError   bool
-		errorCode     string
-		errorField    string
-	}{
-		{
-			name:          "refund with both debit and credit — valid",
-			operationType: constant.OperationRouteTypeBidirectional,
-			entries: &mmodel.AccountingEntries{
-				Direct: &mmodel.AccountingEntry{
-					Debit:  &mmodel.AccountingRubric{Code: "1001", Description: "Debit"},
-					Credit: &mmodel.AccountingRubric{Code: "2001", Description: "Credit"},
-				},
-				Refund: &mmodel.AccountingEntry{
-					Debit:  &mmodel.AccountingRubric{Code: "1007", Description: "Refund Debit"},
-					Credit: &mmodel.AccountingRubric{Code: "2007", Description: "Refund Credit"},
-				},
-			},
-			expectError: false,
-		},
-		{
-			name:          "refund missing debit — invalid",
-			operationType: constant.OperationRouteTypeBidirectional,
-			entries: &mmodel.AccountingEntries{
-				Direct: &mmodel.AccountingEntry{
-					Debit:  &mmodel.AccountingRubric{Code: "1001", Description: "Debit"},
-					Credit: &mmodel.AccountingRubric{Code: "2001", Description: "Credit"},
-				},
-				Refund: &mmodel.AccountingEntry{
-					Credit: &mmodel.AccountingRubric{Code: "2007", Description: "Refund Credit"},
-				},
-			},
-			expectError: true,
-			errorCode:   constant.ErrAccountingEntryFieldRequired.Error(),
-			errorField:  "debit",
-		},
-		{
-			name:          "refund missing credit — invalid",
-			operationType: constant.OperationRouteTypeBidirectional,
-			entries: &mmodel.AccountingEntries{
-				Direct: &mmodel.AccountingEntry{
-					Debit:  &mmodel.AccountingRubric{Code: "1001", Description: "Debit"},
-					Credit: &mmodel.AccountingRubric{Code: "2001", Description: "Credit"},
-				},
-				Refund: &mmodel.AccountingEntry{
-					Debit: &mmodel.AccountingRubric{Code: "1007", Description: "Refund Debit"},
-				},
-			},
-			expectError: true,
-			errorCode:   constant.ErrAccountingEntryFieldRequired.Error(),
-			errorField:  "credit",
-		},
-	}
-
-	for _, tt := range tests {
-		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			ctx := context.Background()
-
-			err := handler.validateEntryFieldRequirements(ctx, tt.operationType, tt.entries, "OperationRoute")
-
-			if tt.expectError {
-				require.Error(t, err, "expected validation error")
-
-				var upErr pkg.UnprocessableOperationError
-				require.ErrorAs(t, err, &upErr, "expected UnprocessableOperationError")
-				assert.Equal(t, tt.errorCode, upErr.Code, "error code mismatch")
-
-				if tt.errorField != "" {
-					assert.Contains(t, upErr.Message, tt.errorField,
-						"error message should reference the missing field")
-				}
-			} else {
-				require.NoError(t, err, "expected no validation error")
-			}
-		})
-	}
-}
-
-// TestValidateAccountingEntries_OverdraftRefund_StructuralValidation
+// TestValidateAccountingEntries_Overdraft_StructuralValidation
 // verifies that the existing structure validator (debit/credit present,
-// non-empty code/description) also runs on the new fields.
-func TestValidateAccountingEntries_OverdraftRefund_StructuralValidation(t *testing.T) {
+// non-empty code/description) also runs on the overdraft field.
+func TestValidateAccountingEntries_Overdraft_StructuralValidation(t *testing.T) {
 	t.Parallel()
 
 	handler := &OperationRouteHandler{}
@@ -240,14 +145,6 @@ func TestValidateAccountingEntries_OverdraftRefund_StructuralValidation(t *testi
 			errorField:  "accountingEntries.overdraft",
 		},
 		{
-			name: "refund with neither debit nor credit — invalid structure",
-			entries: &mmodel.AccountingEntries{
-				Refund: &mmodel.AccountingEntry{},
-			},
-			expectError: true,
-			errorField:  "accountingEntries.refund",
-		},
-		{
 			name: "overdraft with empty debit code — invalid structure",
 			entries: &mmodel.AccountingEntries{
 				Overdraft: &mmodel.AccountingEntry{
@@ -259,26 +156,11 @@ func TestValidateAccountingEntries_OverdraftRefund_StructuralValidation(t *testi
 			errorField:  "accountingEntries.overdraft.debit.code",
 		},
 		{
-			name: "refund with empty credit description — invalid structure",
-			entries: &mmodel.AccountingEntries{
-				Refund: &mmodel.AccountingEntry{
-					Debit:  &mmodel.AccountingRubric{Code: "1007", Description: "Refund Debit"},
-					Credit: &mmodel.AccountingRubric{Code: "2007", Description: ""},
-				},
-			},
-			expectError: true,
-			errorField:  "accountingEntries.refund.credit.description",
-		},
-		{
-			name: "overdraft and refund fully populated — valid structure",
+			name: "overdraft fully populated — valid structure",
 			entries: &mmodel.AccountingEntries{
 				Overdraft: &mmodel.AccountingEntry{
 					Debit:  &mmodel.AccountingRubric{Code: "1006", Description: "Overdraft Debit"},
 					Credit: &mmodel.AccountingRubric{Code: "2006", Description: "Overdraft Credit"},
-				},
-				Refund: &mmodel.AccountingEntry{
-					Debit:  &mmodel.AccountingRubric{Code: "1007", Description: "Refund Debit"},
-					Credit: &mmodel.AccountingRubric{Code: "2007", Description: "Refund Credit"},
 				},
 			},
 			expectError: false,
@@ -307,16 +189,15 @@ func TestValidateAccountingEntries_OverdraftRefund_StructuralValidation(t *testi
 	}
 }
 
-// TestValidateAccountingEntries_BackwardCompatible_NoOverdraftRefund
-// ensures operation routes without the new fields continue to validate
-// as before — no hidden required fields, no new errors.
-func TestValidateAccountingEntries_BackwardCompatible_NoOverdraftRefund(t *testing.T) {
+// TestValidateAccountingEntries_BackwardCompatible_NoOverdraft
+// ensures operation routes without the overdraft field continue to
+// validate as before — no hidden required fields, no new errors.
+func TestValidateAccountingEntries_BackwardCompatible_NoOverdraft(t *testing.T) {
 	t.Parallel()
 
 	handler := &OperationRouteHandler{}
 	ctx := context.Background()
 
-	// A minimal legacy payload (T-007 and earlier): only Direct is set.
 	entries := &mmodel.AccountingEntries{
 		Direct: &mmodel.AccountingEntry{
 			Debit:  &mmodel.AccountingRubric{Code: "1001", Description: "Cash"},
@@ -324,11 +205,9 @@ func TestValidateAccountingEntries_BackwardCompatible_NoOverdraftRefund(t *testi
 		},
 	}
 
-	// Structure validation passes.
 	require.NoError(t, handler.validateAccountingEntries(ctx, entries),
 		"legacy entries must still pass structural validation")
 
-	// Full matrix validation passes on every operation type.
 	for _, opType := range []string{
 		constant.OperationRouteTypeSource,
 		constant.OperationRouteTypeDestination,
@@ -340,16 +219,14 @@ func TestValidateAccountingEntries_BackwardCompatible_NoOverdraftRefund(t *testi
 
 			err := handler.validateAccountingRulesMatrix(ctx, opType, entries)
 			require.NoError(t, err,
-				"legacy entries without overdraft/refund must still pass matrix validation for %s", opType)
+				"legacy entries without overdraft must still pass matrix validation for %s", opType)
 		})
 	}
 }
 
-// TestFindUnknownAccountingEntryKeys_AllowsOverdraftAndRefund verifies
-// that the allowed-keys gate recognizes "overdraft" and "refund" as
-// valid top-level keys — without this, the handler would reject any
-// payload containing these new fields as "Unexpected Fields".
-func TestFindUnknownAccountingEntryKeys_AllowsOverdraftAndRefund(t *testing.T) {
+// TestFindUnknownAccountingEntryKeys_AllowsOverdraft verifies that the
+// allowed-keys gate recognizes "overdraft" as a valid top-level key.
+func TestFindUnknownAccountingEntryKeys_AllowsOverdraft(t *testing.T) {
 	t.Parallel()
 
 	raw := json.RawMessage(`{
@@ -357,7 +234,22 @@ func TestFindUnknownAccountingEntryKeys_AllowsOverdraftAndRefund(t *testing.T) {
 		"overdraft":{
 			"debit":{"code":"1006","description":"Overdraft Debit"},
 			"credit":{"code":"2006","description":"Overdraft Credit"}
-		},
+		}
+	}`)
+
+	unknowns := findUnknownAccountingEntryKeys(raw)
+
+	assert.Nil(t, unknowns,
+		`"overdraft" must be a valid top-level key; got unknowns = %v`, unknowns)
+}
+
+// TestFindUnknownAccountingEntryKeys_RejectsRefund verifies that after T-014,
+// the "refund" key is no longer recognized and is flagged as unknown.
+func TestFindUnknownAccountingEntryKeys_RejectsRefund(t *testing.T) {
+	t.Parallel()
+
+	raw := json.RawMessage(`{
+		"direct":{"debit":{"code":"1001","description":"Cash"}},
 		"refund":{
 			"debit":{"code":"1007","description":"Refund Debit"},
 			"credit":{"code":"2007","description":"Refund Credit"}
@@ -366,6 +258,7 @@ func TestFindUnknownAccountingEntryKeys_AllowsOverdraftAndRefund(t *testing.T) {
 
 	unknowns := findUnknownAccountingEntryKeys(raw)
 
-	assert.Nil(t, unknowns,
-		`"overdraft" and "refund" must be valid top-level keys; got unknowns = %v`, unknowns)
+	require.NotNil(t, unknowns, `"refund" must be flagged as unknown after T-014`)
+	_, hasRefund := unknowns["refund"]
+	assert.True(t, hasRefund, `unknowns map must contain "refund"`)
 }

--- a/components/ledger/internal/adapters/http/in/operation_route_validation_test.go
+++ b/components/ledger/internal/adapters/http/in/operation_route_validation_test.go
@@ -788,9 +788,54 @@ func TestOperationRouteHandler_validateDirectMandatory(t *testing.T) {
 			expectError: true,
 			errorCode:   "0164",
 		},
+		{
+			// Overdraft is a supplementary accounting scenario: it still
+			// needs the direct rubrics as its accounting base.
+			name: "overdraft without direct - invalid",
+			entries: &mmodel.AccountingEntries{
+				Overdraft: &mmodel.AccountingEntry{
+					Debit:  &mmodel.AccountingRubric{Code: "1006", Description: "Overdraft Debit"},
+					Credit: &mmodel.AccountingRubric{Code: "2006", Description: "Overdraft Credit"},
+				},
+			},
+			expectError: true,
+			errorCode:   "0164",
+		},
+		{
+			// Refund is a supplementary accounting scenario: it still needs
+			// the direct rubrics as its accounting base.
+			name: "refund without direct - invalid",
+			entries: &mmodel.AccountingEntries{
+				Refund: &mmodel.AccountingEntry{
+					Debit:  &mmodel.AccountingRubric{Code: "1007", Description: "Refund Debit"},
+					Credit: &mmodel.AccountingRubric{Code: "2007", Description: "Refund Credit"},
+				},
+			},
+			expectError: true,
+			errorCode:   "0164",
+		},
+		{
+			name: "direct with overdraft and refund - valid",
+			entries: &mmodel.AccountingEntries{
+				Direct: &mmodel.AccountingEntry{
+					Debit:  &mmodel.AccountingRubric{Code: "1001", Description: "Debit"},
+					Credit: &mmodel.AccountingRubric{Code: "2001", Description: "Credit"},
+				},
+				Overdraft: &mmodel.AccountingEntry{
+					Debit:  &mmodel.AccountingRubric{Code: "1006", Description: "Overdraft Debit"},
+					Credit: &mmodel.AccountingRubric{Code: "2006", Description: "Overdraft Credit"},
+				},
+				Refund: &mmodel.AccountingEntry{
+					Debit:  &mmodel.AccountingRubric{Code: "1007", Description: "Refund Debit"},
+					Credit: &mmodel.AccountingRubric{Code: "2007", Description: "Refund Credit"},
+				},
+			},
+			expectError: false,
+		},
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/components/ledger/internal/adapters/http/in/operation_route_validation_test.go
+++ b/components/ledger/internal/adapters/http/in/operation_route_validation_test.go
@@ -802,20 +802,7 @@ func TestOperationRouteHandler_validateDirectMandatory(t *testing.T) {
 			errorCode:   "0164",
 		},
 		{
-			// Refund is a supplementary accounting scenario: it still needs
-			// the direct rubrics as its accounting base.
-			name: "refund without direct - invalid",
-			entries: &mmodel.AccountingEntries{
-				Refund: &mmodel.AccountingEntry{
-					Debit:  &mmodel.AccountingRubric{Code: "1007", Description: "Refund Debit"},
-					Credit: &mmodel.AccountingRubric{Code: "2007", Description: "Refund Credit"},
-				},
-			},
-			expectError: true,
-			errorCode:   "0164",
-		},
-		{
-			name: "direct with overdraft and refund - valid",
+			name: "direct with overdraft - valid",
 			entries: &mmodel.AccountingEntries{
 				Direct: &mmodel.AccountingEntry{
 					Debit:  &mmodel.AccountingRubric{Code: "1001", Description: "Debit"},
@@ -824,10 +811,6 @@ func TestOperationRouteHandler_validateDirectMandatory(t *testing.T) {
 				Overdraft: &mmodel.AccountingEntry{
 					Debit:  &mmodel.AccountingRubric{Code: "1006", Description: "Overdraft Debit"},
 					Credit: &mmodel.AccountingRubric{Code: "2006", Description: "Overdraft Credit"},
-				},
-				Refund: &mmodel.AccountingEntry{
-					Debit:  &mmodel.AccountingRubric{Code: "1007", Description: "Refund Debit"},
-					Credit: &mmodel.AccountingRubric{Code: "2007", Description: "Refund Credit"},
 				},
 			},
 			expectError: false,

--- a/components/ledger/internal/adapters/http/in/organization.go
+++ b/components/ledger/internal/adapters/http/in/organization.go
@@ -81,7 +81,7 @@ func (handler *OrganizationHandler) CreateOrganization(p any, c *fiber.Ctx) erro
 //	@Produce		json
 //	@Param			Authorization	header		string							true	"Authorization Bearer Token with format: Bearer {token}"
 //	@Param			X-Request-Id	header		string							false	"Request ID for tracing"
-//	@Param			id				path		string							true	"Organization ID in UUID format"
+//	@Param			organization_id	path		string							true	"Organization ID in UUID format"
 //	@Param			organization	body		mmodel.UpdateOrganizationInput	true	"Organization fields to update. Only supplied fields will be modified."
 //	@Success		200				{object}	mmodel.Organization				"Successfully updated organization"
 //	@Failure		400				{object}	mmodel.Error					"Invalid input, validation errors"
@@ -89,7 +89,7 @@ func (handler *OrganizationHandler) CreateOrganization(p any, c *fiber.Ctx) erro
 //	@Failure		403				{object}	mmodel.Error					"Forbidden access"
 //	@Failure		404				{object}	mmodel.Error					"Organization not found"
 //	@Failure		500				{object}	mmodel.Error					"Internal server error"
-//	@Router			/v1/organizations/{id} [patch]
+//	@Router			/v1/organizations/{organization_id} [patch]
 func (handler *OrganizationHandler) UpdateOrganization(p any, c *fiber.Ctx) error {
 	ctx := c.UserContext()
 
@@ -126,13 +126,13 @@ func (handler *OrganizationHandler) UpdateOrganization(p any, c *fiber.Ctx) erro
 //	@Produce		json
 //	@Param			Authorization	header		string				true	"Authorization Bearer Token with format: Bearer {token}"
 //	@Param			X-Request-Id	header		string				false	"Request ID for tracing"
-//	@Param			id				path		string				true	"Organization ID in UUID format"
+//	@Param			organization_id	path		string				true	"Organization ID in UUID format"
 //	@Success		200				{object}	mmodel.Organization	"Successfully retrieved organization"
 //	@Failure		401				{object}	mmodel.Error		"Unauthorized access"
 //	@Failure		403				{object}	mmodel.Error		"Forbidden access"
 //	@Failure		404				{object}	mmodel.Error		"Organization not found"
 //	@Failure		500				{object}	mmodel.Error		"Internal server error"
-//	@Router			/v1/organizations/{id} [get]
+//	@Router			/v1/organizations/{organization_id} [get]
 func (handler *OrganizationHandler) GetOrganizationByID(c *fiber.Ctx) error {
 	ctx := c.UserContext()
 
@@ -265,14 +265,14 @@ func (handler *OrganizationHandler) GetAllOrganizations(c *fiber.Ctx) error {
 //	@Tags			Organizations
 //	@Param			Authorization	header		string			true	"Authorization Bearer Token with format: Bearer {token}"
 //	@Param			X-Request-Id	header		string			false	"Request ID for tracing"
-//	@Param			id				path		string			true	"Organization ID in UUID format"
+//	@Param			organization_id	path		string			true	"Organization ID in UUID format"
 //	@Success		204				"Organization successfully deleted"
 //	@Failure		401				{object}	mmodel.Error	"Unauthorized access"
 //	@Failure		403				{object}	mmodel.Error	"Forbidden action or not permitted in production environment"
 //	@Failure		404				{object}	mmodel.Error	"Organization not found"
 //	@Failure		409				{object}	mmodel.Error	"Conflict: Cannot delete organization with dependent resources"
 //	@Failure		500				{object}	mmodel.Error	"Internal server error"
-//	@Router			/v1/organizations/{id} [delete]
+//	@Router			/v1/organizations/{organization_id} [delete]
 func (handler *OrganizationHandler) DeleteOrganizationByID(c *fiber.Ctx) error {
 	ctx := c.UserContext()
 

--- a/components/ledger/internal/adapters/http/in/portfolio.go
+++ b/components/ledger/internal/adapters/http/in/portfolio.go
@@ -193,13 +193,13 @@ func (handler *PortfolioHandler) GetAllPortfolios(c *fiber.Ctx) error {
 //	@Param			X-Request-Id	header		string				false	"Request ID for tracing"
 //	@Param			organization_id	path		string				true	"Organization ID in UUID format"
 //	@Param			ledger_id		path		string				true	"Ledger ID in UUID format"
-//	@Param			id				path		string				true	"Portfolio ID in UUID format"
+//	@Param			portfolio_id				path		string				true	"Portfolio ID in UUID format"
 //	@Success		200				{object}	mmodel.Portfolio	"Successfully retrieved portfolio"
 //	@Failure		401				{object}	mmodel.Error		"Unauthorized access"
 //	@Failure		403				{object}	mmodel.Error		"Forbidden access"
 //	@Failure		404				{object}	mmodel.Error		"Portfolio, ledger, or organization not found"
 //	@Failure		500				{object}	mmodel.Error		"Internal server error"
-//	@Router			/v1/organizations/{organization_id}/ledgers/{ledger_id}/portfolios/{id} [get]
+//	@Router			/v1/organizations/{organization_id}/ledgers/{ledger_id}/portfolios/{portfolio_id} [get]
 func (handler *PortfolioHandler) GetPortfolioByID(c *fiber.Ctx) error {
 	ctx := c.UserContext()
 
@@ -250,7 +250,7 @@ func (handler *PortfolioHandler) GetPortfolioByID(c *fiber.Ctx) error {
 //	@Param			X-Request-Id	header		string						false	"Request ID for tracing"
 //	@Param			organization_id	path		string						true	"Organization ID in UUID format"
 //	@Param			ledger_id		path		string						true	"Ledger ID in UUID format"
-//	@Param			id				path		string						true	"Portfolio ID in UUID format"
+//	@Param			portfolio_id				path		string						true	"Portfolio ID in UUID format"
 //	@Param			portfolio		body		mmodel.UpdatePortfolioInput	true	"Portfolio properties to update including name, entity ID, status, and optional metadata"
 //	@Success		200				{object}	mmodel.Portfolio			"Successfully updated portfolio"
 //	@Failure		400				{object}	mmodel.Error				"Invalid input, validation errors"
@@ -259,7 +259,7 @@ func (handler *PortfolioHandler) GetPortfolioByID(c *fiber.Ctx) error {
 //	@Failure		404				{object}	mmodel.Error				"Portfolio, ledger, or organization not found"
 //	@Failure		409				{object}	mmodel.Error				"Conflict: Portfolio with the same name already exists"
 //	@Failure		500				{object}	mmodel.Error				"Internal server error"
-//	@Router			/v1/organizations/{organization_id}/ledgers/{ledger_id}/portfolios/{id} [patch]
+//	@Router			/v1/organizations/{organization_id}/ledgers/{ledger_id}/portfolios/{portfolio_id} [patch]
 func (handler *PortfolioHandler) UpdatePortfolio(i any, c *fiber.Ctx) error {
 	ctx := c.UserContext()
 
@@ -321,14 +321,14 @@ func (handler *PortfolioHandler) UpdatePortfolio(i any, c *fiber.Ctx) error {
 //	@Param			X-Request-Id	header		string			false	"Request ID for tracing"
 //	@Param			organization_id	path		string			true	"Organization ID in UUID format"
 //	@Param			ledger_id		path		string			true	"Ledger ID in UUID format"
-//	@Param			id				path		string			true	"Portfolio ID in UUID format"
+//	@Param			portfolio_id				path		string			true	"Portfolio ID in UUID format"
 //	@Success		204				"Portfolio successfully deleted"
 //	@Failure		401				{object}	mmodel.Error	"Unauthorized access"
 //	@Failure		403				{object}	mmodel.Error	"Forbidden access"
 //	@Failure		404				{object}	mmodel.Error	"Portfolio, ledger, or organization not found"
 //	@Failure		409				{object}	mmodel.Error	"Conflict: Portfolio cannot be deleted due to existing dependencies"
 //	@Failure		500				{object}	mmodel.Error	"Internal server error"
-//	@Router			/v1/organizations/{organization_id}/ledgers/{ledger_id}/portfolios/{id} [delete]
+//	@Router			/v1/organizations/{organization_id}/ledgers/{ledger_id}/portfolios/{portfolio_id} [delete]
 func (handler *PortfolioHandler) DeletePortfolioByID(c *fiber.Ctx) error {
 	ctx := c.UserContext()
 

--- a/components/ledger/internal/adapters/http/in/routes.go
+++ b/components/ledger/internal/adapters/http/in/routes.go
@@ -110,12 +110,12 @@ func RegisterOnboardingRoutesToApp(f fiber.Router, auth *middleware.AuthClient, 
 
 	// Ledgers
 	f.Post("/v1/organizations/:organization_id/ledgers", protectedMidaz(auth, "ledgers", "post", routeOptions, http.ParseUUIDPathParameters("ledger"), http.WithBody(new(mmodel.CreateLedgerInput), lh.CreateLedger))...)
-	f.Patch("/v1/organizations/:organization_id/ledgers/:id", protectedMidaz(auth, "ledgers", "patch", routeOptions, http.ParseUUIDPathParameters("ledger"), http.WithBody(new(mmodel.UpdateLedgerInput), lh.UpdateLedger))...)
+	f.Patch("/v1/organizations/:organization_id/ledgers/:ledger_id", protectedMidaz(auth, "ledgers", "patch", routeOptions, http.ParseUUIDPathParameters("ledger"), http.WithBody(new(mmodel.UpdateLedgerInput), lh.UpdateLedger))...)
 	f.Get("/v1/organizations/:organization_id/ledgers", protectedMidaz(auth, "ledgers", "get", routeOptions, http.ParseUUIDPathParameters("ledger"), lh.GetAllLedgers)...)
-	f.Get("/v1/organizations/:organization_id/ledgers/:id", protectedMidaz(auth, "ledgers", "get", routeOptions, http.ParseUUIDPathParameters("ledger"), lh.GetLedgerByID)...)
-	f.Get("/v1/organizations/:organization_id/ledgers/:id/settings", protectedMidaz(auth, "ledgers", "get", routeOptions, http.ParseUUIDPathParameters("ledger"), lh.GetLedgerSettings)...)
-	f.Patch("/v1/organizations/:organization_id/ledgers/:id/settings", protectedMidaz(auth, "ledgers", "patch", routeOptions, http.ParseUUIDPathParameters("ledger"), http.WithBodyLimit(SettingsMaxPayloadSize), http.WithBody(new(map[string]any), lh.UpdateLedgerSettings))...)
-	f.Delete("/v1/organizations/:organization_id/ledgers/:id", protectedMidaz(auth, "ledgers", "delete", routeOptions, http.ParseUUIDPathParameters("ledger"), lh.DeleteLedgerByID)...)
+	f.Get("/v1/organizations/:organization_id/ledgers/:ledger_id", protectedMidaz(auth, "ledgers", "get", routeOptions, http.ParseUUIDPathParameters("ledger"), lh.GetLedgerByID)...)
+	f.Get("/v1/organizations/:organization_id/ledgers/:ledger_id/settings", protectedMidaz(auth, "ledgers", "get", routeOptions, http.ParseUUIDPathParameters("ledger"), lh.GetLedgerSettings)...)
+	f.Patch("/v1/organizations/:organization_id/ledgers/:ledger_id/settings", protectedMidaz(auth, "ledgers", "patch", routeOptions, http.ParseUUIDPathParameters("ledger"), http.WithBodyLimit(SettingsMaxPayloadSize), http.WithBody(new(map[string]any), lh.UpdateLedgerSettings))...)
+	f.Delete("/v1/organizations/:organization_id/ledgers/:ledger_id", protectedMidaz(auth, "ledgers", "delete", routeOptions, http.ParseUUIDPathParameters("ledger"), lh.DeleteLedgerByID)...)
 	f.Head("/v1/organizations/:organization_id/ledgers/metrics/count", protectedMidaz(auth, "ledgers", "head", routeOptions, http.ParseUUIDPathParameters("ledger"), lh.CountLedgers)...)
 
 	// Assets

--- a/components/ledger/internal/adapters/http/in/segment.go
+++ b/components/ledger/internal/adapters/http/in/segment.go
@@ -193,13 +193,13 @@ func (handler *SegmentHandler) GetAllSegments(c *fiber.Ctx) error {
 //	@Param			X-Request-Id	header		string			false	"Request ID for tracing"
 //	@Param			organization_id	path		string			true	"Organization ID in UUID format"
 //	@Param			ledger_id		path		string			true	"Ledger ID in UUID format"
-//	@Param			id				path		string			true	"Segment ID in UUID format"
+//	@Param			segment_id				path		string			true	"Segment ID in UUID format"
 //	@Success		200				{object}	mmodel.Segment	"Successfully retrieved segment"
 //	@Failure		401				{object}	mmodel.Error	"Unauthorized access"
 //	@Failure		403				{object}	mmodel.Error	"Forbidden access"
 //	@Failure		404				{object}	mmodel.Error	"Segment, ledger, or organization not found"
 //	@Failure		500				{object}	mmodel.Error	"Internal server error"
-//	@Router			/v1/organizations/{organization_id}/ledgers/{ledger_id}/segments/{id} [get]
+//	@Router			/v1/organizations/{organization_id}/ledgers/{ledger_id}/segments/{segment_id} [get]
 func (handler *SegmentHandler) GetSegmentByID(c *fiber.Ctx) error {
 	ctx := c.UserContext()
 
@@ -250,7 +250,7 @@ func (handler *SegmentHandler) GetSegmentByID(c *fiber.Ctx) error {
 //	@Param			X-Request-Id	header		string						false	"Request ID for tracing"
 //	@Param			organization_id	path		string						true	"Organization ID in UUID format"
 //	@Param			ledger_id		path		string						true	"Ledger ID in UUID format"
-//	@Param			id				path		string						true	"Segment ID in UUID format"
+//	@Param			segment_id				path		string						true	"Segment ID in UUID format"
 //	@Param			segment			body		mmodel.UpdateSegmentInput	true	"Segment properties to update including name, status, and optional metadata"
 //	@Success		200				{object}	mmodel.Segment				"Successfully updated segment"
 //	@Failure		400				{object}	mmodel.Error				"Invalid input, validation errors"
@@ -259,7 +259,7 @@ func (handler *SegmentHandler) GetSegmentByID(c *fiber.Ctx) error {
 //	@Failure		404				{object}	mmodel.Error				"Segment, ledger, or organization not found"
 //	@Failure		409				{object}	mmodel.Error				"Conflict: Segment with the same name already exists"
 //	@Failure		500				{object}	mmodel.Error				"Internal server error"
-//	@Router			/v1/organizations/{organization_id}/ledgers/{ledger_id}/segments/{id} [patch]
+//	@Router			/v1/organizations/{organization_id}/ledgers/{ledger_id}/segments/{segment_id} [patch]
 func (handler *SegmentHandler) UpdateSegment(i any, c *fiber.Ctx) error {
 	ctx := c.UserContext()
 
@@ -321,14 +321,14 @@ func (handler *SegmentHandler) UpdateSegment(i any, c *fiber.Ctx) error {
 //	@Param			X-Request-Id	header		string			false	"Request ID for tracing"
 //	@Param			organization_id	path		string			true	"Organization ID in UUID format"
 //	@Param			ledger_id		path		string			true	"Ledger ID in UUID format"
-//	@Param			id				path		string			true	"Segment ID in UUID format"
+//	@Param			segment_id				path		string			true	"Segment ID in UUID format"
 //	@Success		204				"Segment successfully deleted"
 //	@Failure		401				{object}	mmodel.Error	"Unauthorized access"
 //	@Failure		403				{object}	mmodel.Error	"Forbidden access"
 //	@Failure		404				{object}	mmodel.Error	"Segment, ledger, or organization not found"
 //	@Failure		409				{object}	mmodel.Error	"Conflict: Segment cannot be deleted due to existing dependencies"
 //	@Failure		500				{object}	mmodel.Error	"Internal server error"
-//	@Router			/v1/organizations/{organization_id}/ledgers/{ledger_id}/segments/{id} [delete]
+//	@Router			/v1/organizations/{organization_id}/ledgers/{ledger_id}/segments/{segment_id} [delete]
 func (handler *SegmentHandler) DeleteSegmentByID(c *fiber.Ctx) error {
 	ctx := c.UserContext()
 

--- a/components/ledger/internal/adapters/http/in/transaction_builder_routecode_test.go
+++ b/components/ledger/internal/adapters/http/in/transaction_builder_routecode_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/LerianStudio/midaz/v3/components/ledger/internal/adapters/postgres/operation"
 	"github.com/LerianStudio/midaz/v3/components/ledger/internal/adapters/postgres/transaction"
+	"github.com/LerianStudio/midaz/v3/pkg/constant"
 	"github.com/LerianStudio/midaz/v3/pkg/mmodel"
 	"github.com/LerianStudio/midaz/v3/pkg/mtransaction"
 	"github.com/shopspring/decimal"
@@ -189,16 +190,20 @@ func buildCacheWithEntries(action, routeID, routeType, description, debitCode, c
 	}
 
 	switch action {
-	case "direct":
+	case constant.ActionDirect:
 		rc.AccountingEntries.Direct = entry
-	case "hold":
+	case constant.ActionHold:
 		rc.AccountingEntries.Hold = entry
-	case "commit":
+	case constant.ActionCommit:
 		rc.AccountingEntries.Commit = entry
-	case "cancel":
+	case constant.ActionCancel:
 		rc.AccountingEntries.Cancel = entry
-	case "revert":
+	case constant.ActionRevert:
 		rc.AccountingEntries.Revert = entry
+	case constant.ActionOverdraft:
+		rc.AccountingEntries.Overdraft = entry
+	case constant.ActionRefund:
+		rc.AccountingEntries.Refund = entry
 	}
 
 	actionCache := mmodel.ActionRouteCache{
@@ -427,6 +432,176 @@ func TestResolveRouteCodesFromCache_CommitAction(t *testing.T) {
 	assert.Equal(t, "COMMIT-DEBIT", *ops[0].RouteCode)
 }
 
+// TestResolveRouteCodesFromCache_OverdraftAction verifies resolution for the
+// overdraft accounting-entry action. Overdraft is a supplementary scenario
+// that must resolve its Debit/Credit rubrics through the same cache lookup
+// path as the legacy actions (direct/hold/commit/cancel/revert).
+func TestResolveRouteCodesFromCache_OverdraftAction(t *testing.T) {
+	routeID := "route-uuid-1"
+	cache := buildCacheWithEntries(constant.ActionOverdraft, routeID, "bidirectional", "Overdraft route", "OVERDRAFT-DEBIT", "OVERDRAFT-CREDIT")
+
+	ops := []*operation.Operation{
+		{ID: "op-1", RouteID: &routeID, Direction: "debit"},
+	}
+
+	resolveRouteCodesFromCache(ops, cache, constant.ActionOverdraft)
+
+	require.NotNil(t, ops[0].RouteCode, "RouteCode should be populated for overdraft action")
+	assert.Equal(t, "OVERDRAFT-DEBIT", *ops[0].RouteCode)
+	require.NotNil(t, ops[0].RouteDescription, "RouteDescription should be populated for overdraft action")
+	assert.Equal(t, "Debit desc", *ops[0].RouteDescription)
+}
+
+// TestResolveRouteCodesFromCache_RefundAction verifies resolution for the
+// refund accounting-entry action. Refund is a supplementary scenario that
+// must resolve its Debit/Credit rubrics through the same cache lookup path
+// as the legacy actions (direct/hold/commit/cancel/revert).
+func TestResolveRouteCodesFromCache_RefundAction(t *testing.T) {
+	routeID := "route-uuid-1"
+	cache := buildCacheWithEntries(constant.ActionRefund, routeID, "bidirectional", "Refund route", "REFUND-DEBIT", "REFUND-CREDIT")
+
+	ops := []*operation.Operation{
+		{ID: "op-1", RouteID: &routeID, Direction: "credit"},
+	}
+
+	resolveRouteCodesFromCache(ops, cache, constant.ActionRefund)
+
+	require.NotNil(t, ops[0].RouteCode, "RouteCode should be populated for refund action")
+	assert.Equal(t, "REFUND-CREDIT", *ops[0].RouteCode)
+	require.NotNil(t, ops[0].RouteDescription, "RouteDescription should be populated for refund action")
+	assert.Equal(t, "Credit desc", *ops[0].RouteDescription)
+}
+
+// TestResolveRouteCodesFromCache_CompanionUsesOverdraftAction pins the
+// behaviour required for overdraft/refund enrichment: when operations
+// include companion entries on the `#overdraft` balance, those entries
+// MUST resolve their RouteCode/RouteDescription through the OVERDRAFT (or
+// REFUND) accounting action even though the transaction-wide action is
+// still `direct` (or `hold`/`commit`). The same RouteID is reused; only
+// the action differs — exactly mirroring how hold/commit reuse the direct
+// routeId but resolve different rubrics.
+//
+// Failure mode guarded against: without the second pass, the companion
+// op stays with RouteCode=nil because the `direct` rubric is the Direct
+// AccountingEntry, not the Overdraft one.
+func TestResolveRouteCodesFromCache_CompanionUsesOverdraftAction(t *testing.T) {
+	routeID := "route-uuid-1"
+
+	// Build a cache that contains entries for BOTH "direct" and "overdraft"
+	// actions, as the real ToCache() emits whenever a route has both Direct
+	// and Overdraft AccountingEntries.
+	rc := mmodel.OperationRouteCache{
+		Description: "Bidirectional route",
+		AccountingEntries: &mmodel.AccountingEntries{
+			Direct: &mmodel.AccountingEntry{
+				Debit:  &mmodel.AccountingRubric{Code: "DIRECT-DEBIT", Description: "Direct debit desc"},
+				Credit: &mmodel.AccountingRubric{Code: "DIRECT-CREDIT", Description: "Direct credit desc"},
+			},
+			Overdraft: &mmodel.AccountingEntry{
+				Debit:  &mmodel.AccountingRubric{Code: "OVERDRAFT-DEBIT", Description: "Overdraft debit desc"},
+				Credit: &mmodel.AccountingRubric{Code: "OVERDRAFT-CREDIT", Description: "Overdraft credit desc"},
+			},
+		},
+	}
+
+	directAction := mmodel.ActionRouteCache{
+		Source:        map[string]mmodel.OperationRouteCache{},
+		Destination:   map[string]mmodel.OperationRouteCache{},
+		Bidirectional: map[string]mmodel.OperationRouteCache{routeID: rc},
+	}
+	overdraftAction := mmodel.ActionRouteCache{
+		Source:        map[string]mmodel.OperationRouteCache{},
+		Destination:   map[string]mmodel.OperationRouteCache{},
+		Bidirectional: map[string]mmodel.OperationRouteCache{routeID: rc},
+	}
+
+	cache := &mmodel.TransactionRouteCache{
+		Actions: map[string]mmodel.ActionRouteCache{
+			constant.ActionDirect:    directAction,
+			constant.ActionOverdraft: overdraftAction,
+		},
+	}
+
+	primary := &operation.Operation{
+		ID:         "primary-op",
+		RouteID:    &routeID,
+		Direction:  "debit",
+		BalanceKey: constant.DefaultBalanceKey,
+	}
+	companion := &operation.Operation{
+		ID:         "companion-op",
+		RouteID:    &routeID,
+		Direction:  "debit",
+		BalanceKey: constant.OverdraftBalanceKey,
+	}
+
+	ops := []*operation.Operation{primary, companion}
+
+	resolveRouteCodesFromCache(ops, cache, constant.ActionDirect)
+
+	// Primary resolves to DIRECT rubric.
+	require.NotNil(t, primary.RouteCode, "primary op must resolve via direct action")
+	assert.Equal(t, "DIRECT-DEBIT", *primary.RouteCode,
+		"primary (BalanceKey=default) must resolve from Direct AccountingEntry")
+
+	// Companion resolves to OVERDRAFT rubric despite the top-level action
+	// being `direct`, because it lives on the overdraft balance and
+	// represents the overdraft leg of the enrichment.
+	require.NotNil(t, companion.RouteCode, "companion op must resolve via overdraft action")
+	assert.Equal(t, "OVERDRAFT-DEBIT", *companion.RouteCode,
+		"companion (BalanceKey=overdraft) must resolve from Overdraft AccountingEntry, not Direct")
+}
+
+// TestResolveRouteCodesFromCache_CompanionUsesRefundAction mirrors the
+// overdraft test for the credit/repayment side: companion CREDIT ops on the
+// overdraft balance must resolve their rubric via the REFUND action.
+func TestResolveRouteCodesFromCache_CompanionUsesRefundAction(t *testing.T) {
+	routeID := "route-uuid-1"
+
+	rc := mmodel.OperationRouteCache{
+		Description: "Bidirectional route",
+		AccountingEntries: &mmodel.AccountingEntries{
+			Direct: &mmodel.AccountingEntry{
+				Debit:  &mmodel.AccountingRubric{Code: "DIRECT-DEBIT", Description: "Direct debit desc"},
+				Credit: &mmodel.AccountingRubric{Code: "DIRECT-CREDIT", Description: "Direct credit desc"},
+			},
+			Refund: &mmodel.AccountingEntry{
+				Debit:  &mmodel.AccountingRubric{Code: "REFUND-DEBIT", Description: "Refund debit desc"},
+				Credit: &mmodel.AccountingRubric{Code: "REFUND-CREDIT", Description: "Refund credit desc"},
+			},
+		},
+	}
+
+	cache := &mmodel.TransactionRouteCache{
+		Actions: map[string]mmodel.ActionRouteCache{
+			constant.ActionDirect: {
+				Source:        map[string]mmodel.OperationRouteCache{},
+				Destination:   map[string]mmodel.OperationRouteCache{},
+				Bidirectional: map[string]mmodel.OperationRouteCache{routeID: rc},
+			},
+			constant.ActionRefund: {
+				Source:        map[string]mmodel.OperationRouteCache{},
+				Destination:   map[string]mmodel.OperationRouteCache{},
+				Bidirectional: map[string]mmodel.OperationRouteCache{routeID: rc},
+			},
+		},
+	}
+
+	companion := &operation.Operation{
+		ID:         "companion-op",
+		RouteID:    &routeID,
+		Direction:  "credit",
+		BalanceKey: constant.OverdraftBalanceKey,
+	}
+	ops := []*operation.Operation{companion}
+
+	resolveRouteCodesFromCache(ops, cache, constant.ActionDirect)
+
+	require.NotNil(t, companion.RouteCode, "companion credit must resolve via refund action")
+	assert.Equal(t, "REFUND-CREDIT", *companion.RouteCode,
+		"companion CREDIT on overdraft balance must resolve from Refund AccountingEntry, not Direct")
+}
+
 // TestStatusToAction verifies the mapping from transaction status to accounting action.
 func TestStatusToAction(t *testing.T) {
 	assert.Equal(t, "direct", mtransaction.StatusToAction("CREATED"))
@@ -460,6 +635,14 @@ func TestResolveAccountingRubric(t *testing.T) {
 			Debit:  &mmodel.AccountingRubric{Code: "D-REVERT", Description: "Revert debit"},
 			Credit: &mmodel.AccountingRubric{Code: "C-REVERT", Description: "Revert credit"},
 		},
+		Overdraft: &mmodel.AccountingEntry{
+			Debit:  &mmodel.AccountingRubric{Code: "D-OVERDRAFT", Description: "Overdraft debit"},
+			Credit: &mmodel.AccountingRubric{Code: "C-OVERDRAFT", Description: "Overdraft credit"},
+		},
+		Refund: &mmodel.AccountingEntry{
+			Debit:  &mmodel.AccountingRubric{Code: "D-REFUND", Description: "Refund debit"},
+			Credit: &mmodel.AccountingRubric{Code: "C-REFUND", Description: "Refund credit"},
+		},
 	}
 
 	tests := []struct {
@@ -479,6 +662,10 @@ func TestResolveAccountingRubric(t *testing.T) {
 		{"cancel credit", "cancel", "credit", "C-CANCEL", false},
 		{"revert debit", "revert", "debit", "D-REVERT", false},
 		{"revert credit", "revert", "credit", "C-REVERT", false},
+		{"overdraft debit", "overdraft", "debit", "D-OVERDRAFT", false},
+		{"overdraft credit", "overdraft", "credit", "C-OVERDRAFT", false},
+		{"refund debit", "refund", "debit", "D-REFUND", false},
+		{"refund credit", "refund", "credit", "C-REFUND", false},
 		{"unknown action", "unknown", "debit", "", true},
 		{"unknown direction", "direct", "unknown", "", true},
 		{"nil entries", "direct", "debit", "", true},

--- a/components/ledger/internal/adapters/http/in/transaction_builder_routecode_test.go
+++ b/components/ledger/internal/adapters/http/in/transaction_builder_routecode_test.go
@@ -73,6 +73,45 @@ func TestBuildStandardOp_ReturnsOperation(t *testing.T) {
 	assert.Equal(t, "balance-1", op.BalanceID)
 }
 
+func TestBuildStandardOp_OverdraftCompanionUsesOverdraftType(t *testing.T) {
+	handler := &TransactionHandler{}
+	now := time.Now()
+
+	blc := &mmodel.Balance{
+		ID:             "balance-overdraft",
+		OrganizationID: "org-1",
+		LedgerID:       "ledger-1",
+		AccountID:      "account-1",
+		Alias:          "@sender",
+		Key:            constant.OverdraftBalanceKey,
+		Available:      decimal.Zero,
+		OnHold:         decimal.Zero,
+		Version:        1,
+	}
+	amt := mtransaction.Amount{
+		Asset:     "BRL",
+		Value:     decimal.NewFromInt(50),
+		Operation: constant.DEBIT,
+		Direction: constant.DirectionDebit,
+	}
+
+	op, err := handler.buildStandardOp(
+		blc,
+		mtransaction.FromTo{AccountAlias: "@sender", BalanceKey: constant.OverdraftBalanceKey},
+		amt,
+		mtransaction.Balance{Available: decimal.NewFromInt(50), OnHold: decimal.Zero, Version: 2},
+		transaction.Transaction{ID: "txn-1"},
+		mtransaction.Transaction{Description: "overdraft companion", Send: mtransaction.Send{Asset: "BRL"}},
+		now,
+		false,
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, constant.OVERDRAFT, op.Type)
+	assert.Equal(t, constant.DirectionDebit, op.Direction,
+		"direction still carries draw/repayment semantics for overdraft rows")
+}
+
 // TestBuildDoubleEntryPendingOps_ReturnsTwoOperations verifies that buildDoubleEntryPendingOps
 // returns exactly 2 operations.
 func TestBuildDoubleEntryPendingOps_ReturnsTwoOperations(t *testing.T) {
@@ -617,7 +656,7 @@ func TestResolveRouteCodesFromCache_CompanionUsesOverdraftAction(t *testing.T) {
 	companion := &operation.Operation{
 		ID:         "companion-op",
 		RouteID:    &routeID,
-		Type:       "DEBIT",
+		Type:       constant.OVERDRAFT,
 		Direction:  "debit",
 		BalanceKey: constant.OverdraftBalanceKey,
 	}
@@ -640,10 +679,9 @@ func TestResolveRouteCodesFromCache_CompanionUsesOverdraftAction(t *testing.T) {
 }
 
 // TestResolveRouteCodesFromCache_CompanionCreditUsesOverdraftAction verifies
-// that companion CREDIT ops on the overdraft balance resolve their rubric via
-// Overdraft.Credit (not Overdraft.Debit). The companion's Direction field is
-// "debit" (inherited from the overdraft balance's direction), so the resolver
-// must use op.Type ("CREDIT") to pick the rubric, not op.Direction ("debit").
+// that repayment companions on the overdraft balance resolve their rubric via
+// Overdraft.Credit (not Overdraft.Debit). Public type is always "overdraft";
+// the Direction field carries debit/draw vs credit/repayment semantics.
 func TestResolveRouteCodesFromCache_CompanionCreditUsesOverdraftAction(t *testing.T) {
 	routeID := "route-uuid-1"
 
@@ -683,7 +721,7 @@ func TestResolveRouteCodesFromCache_CompanionCreditUsesOverdraftAction(t *testin
 	companion := &operation.Operation{
 		ID:         "companion-op",
 		RouteID:    &routeID,
-		Type:       "CREDIT",
+		Type:       constant.OVERDRAFT,
 		Direction:  "credit",
 		BalanceKey: constant.OverdraftBalanceKey,
 	}

--- a/components/ledger/internal/adapters/http/in/transaction_builder_routecode_test.go
+++ b/components/ledger/internal/adapters/http/in/transaction_builder_routecode_test.go
@@ -202,8 +202,6 @@ func buildCacheWithEntries(action, routeID, routeType, description, debitCode, c
 		rc.AccountingEntries.Revert = entry
 	case constant.ActionOverdraft:
 		rc.AccountingEntries.Overdraft = entry
-	case constant.ActionRefund:
-		rc.AccountingEntries.Refund = entry
 	}
 
 	actionCache := mmodel.ActionRouteCache{
@@ -452,34 +450,36 @@ func TestResolveRouteCodesFromCache_OverdraftAction(t *testing.T) {
 	assert.Equal(t, "Debit desc", *ops[0].RouteDescription)
 }
 
-// TestResolveRouteCodesFromCache_RefundAction verifies resolution for the
-// refund accounting-entry action. Refund is a supplementary scenario that
-// must resolve its Debit/Credit rubrics through the same cache lookup path
-// as the legacy actions (direct/hold/commit/cancel/revert).
-func TestResolveRouteCodesFromCache_RefundAction(t *testing.T) {
+// TestResolveRouteCodesFromCache_OverdraftCreditAction verifies that a CREDIT
+// operation on the overdraft balance resolves to Overdraft.Credit (not a
+// separate "refund" action). After T-014 collapsed the refund slot into the
+// overdraft slot, both DEBIT and CREDIT on the overdraft balance resolve
+// through the single ActionOverdraft entry.
+func TestResolveRouteCodesFromCache_OverdraftCreditAction(t *testing.T) {
 	routeID := "route-uuid-1"
-	cache := buildCacheWithEntries(constant.ActionRefund, routeID, "bidirectional", "Refund route", "REFUND-DEBIT", "REFUND-CREDIT")
+	cache := buildCacheWithEntries(constant.ActionOverdraft, routeID, "bidirectional", "Overdraft route", "OVERDRAFT-DEBIT", "OVERDRAFT-CREDIT")
 
 	ops := []*operation.Operation{
 		{ID: "op-1", RouteID: &routeID, Direction: "credit"},
 	}
 
-	resolveRouteCodesFromCache(ops, cache, constant.ActionRefund)
+	resolveRouteCodesFromCache(ops, cache, constant.ActionOverdraft)
 
-	require.NotNil(t, ops[0].RouteCode, "RouteCode should be populated for refund action")
-	assert.Equal(t, "REFUND-CREDIT", *ops[0].RouteCode)
-	require.NotNil(t, ops[0].RouteDescription, "RouteDescription should be populated for refund action")
+	require.NotNil(t, ops[0].RouteCode, "RouteCode should be populated for overdraft credit action")
+	assert.Equal(t, "OVERDRAFT-CREDIT", *ops[0].RouteCode)
+	require.NotNil(t, ops[0].RouteDescription, "RouteDescription should be populated for overdraft credit action")
 	assert.Equal(t, "Credit desc", *ops[0].RouteDescription)
 }
 
 // TestResolveRouteCodesFromCache_CompanionUsesOverdraftAction pins the
-// behaviour required for overdraft/refund enrichment: when operations
-// include companion entries on the `#overdraft` balance, those entries
-// MUST resolve their RouteCode/RouteDescription through the OVERDRAFT (or
-// REFUND) accounting action even though the transaction-wide action is
-// still `direct` (or `hold`/`commit`). The same RouteID is reused; only
-// the action differs — exactly mirroring how hold/commit reuse the direct
-// routeId but resolve different rubrics.
+// behaviour required for overdraft enrichment: when operations include
+// companion entries on the `#overdraft` balance, those entries MUST resolve
+// their RouteCode/RouteDescription through the OVERDRAFT accounting action
+// even though the transaction-wide action is still `direct` (or
+// `hold`/`commit`). The same RouteID is reused; only the action differs —
+// exactly mirroring how hold/commit reuse the direct routeId but resolve
+// different rubrics. Both DEBIT (deficit grows) and CREDIT (repayment)
+// companions resolve via the single Overdraft entry.
 //
 // Failure mode guarded against: without the second pass, the companion
 // op stays with RouteCode=nil because the `direct` rubric is the Direct
@@ -525,12 +525,14 @@ func TestResolveRouteCodesFromCache_CompanionUsesOverdraftAction(t *testing.T) {
 	primary := &operation.Operation{
 		ID:         "primary-op",
 		RouteID:    &routeID,
+		Type:       "DEBIT",
 		Direction:  "debit",
 		BalanceKey: constant.DefaultBalanceKey,
 	}
 	companion := &operation.Operation{
 		ID:         "companion-op",
 		RouteID:    &routeID,
+		Type:       "DEBIT",
 		Direction:  "debit",
 		BalanceKey: constant.OverdraftBalanceKey,
 	}
@@ -552,10 +554,12 @@ func TestResolveRouteCodesFromCache_CompanionUsesOverdraftAction(t *testing.T) {
 		"companion (BalanceKey=overdraft) must resolve from Overdraft AccountingEntry, not Direct")
 }
 
-// TestResolveRouteCodesFromCache_CompanionUsesRefundAction mirrors the
-// overdraft test for the credit/repayment side: companion CREDIT ops on the
-// overdraft balance must resolve their rubric via the REFUND action.
-func TestResolveRouteCodesFromCache_CompanionUsesRefundAction(t *testing.T) {
+// TestResolveRouteCodesFromCache_CompanionCreditUsesOverdraftAction verifies
+// that companion CREDIT ops on the overdraft balance resolve their rubric via
+// Overdraft.Credit (not Overdraft.Debit). The companion's Direction field is
+// "debit" (inherited from the overdraft balance's direction), so the resolver
+// must use op.Type ("CREDIT") to pick the rubric, not op.Direction ("debit").
+func TestResolveRouteCodesFromCache_CompanionCreditUsesOverdraftAction(t *testing.T) {
 	routeID := "route-uuid-1"
 
 	rc := mmodel.OperationRouteCache{
@@ -565,9 +569,9 @@ func TestResolveRouteCodesFromCache_CompanionUsesRefundAction(t *testing.T) {
 				Debit:  &mmodel.AccountingRubric{Code: "DIRECT-DEBIT", Description: "Direct debit desc"},
 				Credit: &mmodel.AccountingRubric{Code: "DIRECT-CREDIT", Description: "Direct credit desc"},
 			},
-			Refund: &mmodel.AccountingEntry{
-				Debit:  &mmodel.AccountingRubric{Code: "REFUND-DEBIT", Description: "Refund debit desc"},
-				Credit: &mmodel.AccountingRubric{Code: "REFUND-CREDIT", Description: "Refund credit desc"},
+			Overdraft: &mmodel.AccountingEntry{
+				Debit:  &mmodel.AccountingRubric{Code: "OVERDRAFT-DEBIT", Description: "Overdraft debit desc"},
+				Credit: &mmodel.AccountingRubric{Code: "OVERDRAFT-CREDIT", Description: "Overdraft credit desc"},
 			},
 		},
 	}
@@ -579,7 +583,7 @@ func TestResolveRouteCodesFromCache_CompanionUsesRefundAction(t *testing.T) {
 				Destination:   map[string]mmodel.OperationRouteCache{},
 				Bidirectional: map[string]mmodel.OperationRouteCache{routeID: rc},
 			},
-			constant.ActionRefund: {
+			constant.ActionOverdraft: {
 				Source:        map[string]mmodel.OperationRouteCache{},
 				Destination:   map[string]mmodel.OperationRouteCache{},
 				Bidirectional: map[string]mmodel.OperationRouteCache{routeID: rc},
@@ -587,9 +591,14 @@ func TestResolveRouteCodesFromCache_CompanionUsesRefundAction(t *testing.T) {
 		},
 	}
 
+	// Direction is "credit" — set by the enrichment engine for repayment
+	// companions (buildCompanionCreditOp), reflecting the operation semantics
+	// rather than the balance direction. This allows the resolver to pick
+	// Overdraft.Credit via the standard op.Direction path.
 	companion := &operation.Operation{
 		ID:         "companion-op",
 		RouteID:    &routeID,
+		Type:       "CREDIT",
 		Direction:  "credit",
 		BalanceKey: constant.OverdraftBalanceKey,
 	}
@@ -597,9 +606,9 @@ func TestResolveRouteCodesFromCache_CompanionUsesRefundAction(t *testing.T) {
 
 	resolveRouteCodesFromCache(ops, cache, constant.ActionDirect)
 
-	require.NotNil(t, companion.RouteCode, "companion credit must resolve via refund action")
-	assert.Equal(t, "REFUND-CREDIT", *companion.RouteCode,
-		"companion CREDIT on overdraft balance must resolve from Refund AccountingEntry, not Direct")
+	require.NotNil(t, companion.RouteCode, "companion CREDIT must resolve via overdraft action")
+	assert.Equal(t, "OVERDRAFT-CREDIT", *companion.RouteCode,
+		"companion CREDIT on overdraft balance must resolve from Overdraft.Credit, not Overdraft.Debit")
 }
 
 // TestStatusToAction verifies the mapping from transaction status to accounting action.
@@ -639,10 +648,6 @@ func TestResolveAccountingRubric(t *testing.T) {
 			Debit:  &mmodel.AccountingRubric{Code: "D-OVERDRAFT", Description: "Overdraft debit"},
 			Credit: &mmodel.AccountingRubric{Code: "C-OVERDRAFT", Description: "Overdraft credit"},
 		},
-		Refund: &mmodel.AccountingEntry{
-			Debit:  &mmodel.AccountingRubric{Code: "D-REFUND", Description: "Refund debit"},
-			Credit: &mmodel.AccountingRubric{Code: "C-REFUND", Description: "Refund credit"},
-		},
 	}
 
 	tests := []struct {
@@ -664,8 +669,7 @@ func TestResolveAccountingRubric(t *testing.T) {
 		{"revert credit", "revert", "credit", "C-REVERT", false},
 		{"overdraft debit", "overdraft", "debit", "D-OVERDRAFT", false},
 		{"overdraft credit", "overdraft", "credit", "C-OVERDRAFT", false},
-		{"refund debit", "refund", "debit", "D-REFUND", false},
-		{"refund credit", "refund", "credit", "C-REFUND", false},
+		{"refund action returns nil (removed)", "refund", "debit", "", true},
 		{"unknown action", "unknown", "debit", "", true},
 		{"unknown direction", "direct", "unknown", "", true},
 		{"nil entries", "direct", "debit", "", true},

--- a/components/ledger/internal/adapters/http/in/transaction_builder_routecode_test.go
+++ b/components/ledger/internal/adapters/http/in/transaction_builder_routecode_test.go
@@ -125,6 +125,91 @@ func TestBuildDoubleEntryPendingOps_ReturnsTwoOperations(t *testing.T) {
 	assert.Equal(t, "txn-1", ops[1].TransactionID)
 }
 
+func TestBuildOperations_DoubleEntryPendingOverdraftUsesLuaAfterState(t *testing.T) {
+	handler := &TransactionHandler{}
+	ctx := context.Background()
+	now := time.Now()
+
+	before := &mmodel.Balance{
+		ID:             "balance-default",
+		OrganizationID: "org-1",
+		LedgerID:       "ledger-1",
+		AccountID:      "account-1",
+		Alias:          "0#@sender#default",
+		Key:            constant.DefaultBalanceKey,
+		Available:      decimal.NewFromInt(50),
+		OnHold:         decimal.Zero,
+		Version:        1,
+		Direction:      constant.DirectionCredit,
+		OverdraftUsed:  decimal.Zero,
+	}
+	after := &mmodel.Balance{
+		ID:             before.ID,
+		OrganizationID: before.OrganizationID,
+		LedgerID:       before.LedgerID,
+		AccountID:      before.AccountID,
+		Alias:          before.Alias,
+		Key:            before.Key,
+		Available:      decimal.Zero,
+		OnHold:         decimal.NewFromInt(100),
+		Version:        3,
+		Direction:      before.Direction,
+		OverdraftUsed:  decimal.NewFromInt(50),
+	}
+
+	amount := mtransaction.Amount{
+		Asset:                  "BRL",
+		Value:                  decimal.NewFromInt(100),
+		Operation:              constant.ONHOLD,
+		TransactionType:        constant.PENDING,
+		RouteValidationEnabled: true,
+	}
+	fromTo := []mtransaction.FromTo{{
+		AccountAlias: before.Alias,
+		BalanceKey:   constant.DefaultBalanceKey,
+		Amount:       &amount,
+		IsFrom:       true,
+	}}
+	validate := &mtransaction.Responses{
+		From: map[string]mtransaction.Amount{
+			before.Alias: amount,
+		},
+		Sources: []string{"@sender#default"},
+		Aliases: []string{"@sender#default"},
+	}
+	tran := transaction.Transaction{
+		ID:             "txn-1",
+		OrganizationID: before.OrganizationID,
+		LedgerID:       before.LedgerID,
+	}
+	input := mtransaction.Transaction{
+		Pending:     true,
+		Description: "pending overdraft",
+		Send:        mtransaction.Send{Asset: "BRL"},
+	}
+
+	ops, _, err := handler.BuildOperations(ctx, []*mmodel.Balance{before}, []*mmodel.Balance{after}, fromTo,
+		input, tran, validate, now, false, true, nil, constant.ActionHold)
+	require.NoError(t, err)
+	require.Len(t, ops, 2)
+
+	debit := ops[0]
+	require.Equal(t, constant.DEBIT, debit.Type)
+	assert.True(t, debit.Amount.Value.Equal(decimal.NewFromInt(50)),
+		"DEBIT amount must be clipped to the Lua-authoritative available movement")
+	assert.True(t, debit.BalanceAfter.Available.Equal(decimal.Zero),
+		"DEBIT after available must be floored at zero, not locally recomputed as -50")
+	assert.True(t, debit.BalanceAfter.OverdraftUsed.Equal(decimal.NewFromInt(50)))
+	assert.Equal(t, "0", debit.Snapshot.OverdraftUsedBefore)
+	assert.Equal(t, "50", debit.Snapshot.OverdraftUsedAfter)
+
+	onHold := ops[1]
+	require.Equal(t, constant.ONHOLD, onHold.Type)
+	assert.True(t, onHold.BalanceAfter.Available.Equal(decimal.Zero))
+	assert.True(t, onHold.BalanceAfter.OnHold.Equal(decimal.NewFromInt(100)))
+	assert.True(t, onHold.BalanceAfter.OverdraftUsed.Equal(decimal.NewFromInt(50)))
+}
+
 // TestBuildDoubleEntryCanceledOps_ReturnsTwoOperations verifies that buildDoubleEntryCanceledOps
 // returns exactly 2 operations.
 func TestBuildDoubleEntryCanceledOps_ReturnsTwoOperations(t *testing.T) {

--- a/components/ledger/internal/adapters/http/in/transaction_create.go
+++ b/components/ledger/internal/adapters/http/in/transaction_create.go
@@ -34,6 +34,7 @@ import (
 func (handler *TransactionHandler) BuildOperations(
 	ctx context.Context,
 	balances []*mmodel.Balance,
+	balancesAfter []*mmodel.Balance,
 	fromTo []mtransaction.FromTo,
 	transactionInput mtransaction.Transaction,
 	tran transaction.Transaction,
@@ -59,6 +60,26 @@ func (handler *TransactionHandler) BuildOperations(
 		span.SetAttributes(attribute.Bool("app.route_validation_enabled", true))
 	}
 
+	// Index Lua's authoritative post-mutation balances by `alias#key` so we
+	// can resolve the "balance after" side of each Operation record directly
+	// instead of recomputing it via OperateBalances. This is what keeps
+	// operation records in sync with the balance table when the Lua
+	// overdraft branch floors a credit balance at zero — without this,
+	// `available_balance_after` carries the naive `before - amount` arithmetic
+	// (e.g. `50 - 100 = -50`) while the DB balance itself shows 0. The map
+	// is nil-tolerant: legacy callers (replay path in bootstrap/redis.consumer.go)
+	// that cannot supply `balancesAfter` fall back to OperateBalances
+	// gracefully.
+	afterByAliasKey := make(map[string]*mmodel.Balance, len(balancesAfter))
+
+	for _, b := range balancesAfter {
+		if b == nil {
+			continue
+		}
+
+		afterByAliasKey[b.Alias+"#"+b.Key] = b
+	}
+
 	// Track aliases that already had double-entry operations built, so we skip
 	// the second Lua before-balance for the same source account.
 	processedDoubleEntry := make(map[string]bool)
@@ -77,6 +98,16 @@ func (handler *TransactionHandler) BuildOperations(
 					logger.Log(ctx, libLog.LevelWarn, "Failed to validate balance", libLog.Err(err))
 
 					return nil, nil, err
+				}
+
+				// Prefer the Lua-authoritative after-state when available —
+				// it correctly reflects the overdraft floor-at-zero and any
+				// OverdraftUsed repayment decrement that the naive
+				// OperateBalances path above cannot model.
+				if after, ok := afterByAliasKey[blc.Alias+"#"+blc.Key]; ok && after != nil {
+					bat.Available = after.Available
+					bat.OnHold = after.OnHold
+					bat.Version = after.Version
 				}
 
 				if ops, handled, err := handler.tryBuildDoubleEntryOps(
@@ -775,7 +806,48 @@ func (handler *TransactionHandler) executeCreateTransaction(c *fiber.Ctx, transa
 		return http.WithError(c, err)
 	}
 
+	// Scope protection on the CREATE path: SendTransactionToRedisQueue above
+	// runs with nil balances (the queue seed precedes GetBalances), so its
+	// built-in scope guard is a no-op for user-created transactions. Re-check
+	// here now that balances are loaded. Rejecting a direct operation on an
+	// internal-scope balance BEFORE enrichment runs keeps the companion
+	// balance isolated from client-initiated mutations.
+	if err := rejectInternalScopeBalances(ctx, balances); err != nil {
+		libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Rejected transaction targeting internal-scope balance", err)
+		logger.Log(ctx, libLog.LevelWarn, "Rejected transaction targeting internal-scope balance", libLog.Err(err))
+
+		handler.deleteIdempotencyKey(ctx, idempotencyResult.InternalKey)
+		handler.Command.RemoveTransactionFromRedisQueue(ctx, logger, params.OrganizationID, params.LedgerID, transactionID.String())
+
+		return http.WithError(c, err)
+	}
+
 	balanceOps := buildBalanceOperations(ctx, params.OrganizationID, params.LedgerID, validate, balances)
+
+	// Overdraft enrichment: when a source debit exceeds available funds on a
+	// credit-direction balance with AllowOverdraft=true, append a debit op on
+	// the companion #overdraft balance for the deficit. See
+	// transaction_overdraft_enrichment.go for the full rationale. Disabled
+	// balances and out-of-scope operations fall through as a no-op so legacy
+	// transaction flows remain untouched.
+	//
+	// `companionFromTos` are returned so the caller can splice them into the
+	// `fromTo` slice built below; without this, BuildOperations' match loop
+	// never emits an Operation record for the companion balance and the
+	// audit trail is missing the overdraft leg (DB balances still converge
+	// correctly, but `response.operations` and Postgres `operation` rows do
+	// not include the companion).
+	balanceOps, companionFromTos, err := enrichOverdraftOperations(ctx, params.OrganizationID, params.LedgerID, balanceOps,
+		validate, handler.Query.GetBalances)
+	if err != nil {
+		libOpentelemetry.HandleSpanError(span, "Failed to enrich overdraft operations", err)
+		logger.Log(ctx, libLog.LevelError, "Failed to enrich overdraft operations", libLog.Err(err))
+
+		handler.deleteIdempotencyKey(ctx, idempotencyResult.InternalKey)
+		handler.Command.RemoveTransactionFromRedisQueue(ctx, logger, params.OrganizationID, params.LedgerID, transactionID.String())
+
+		return http.WithError(c, err)
+	}
 
 	routeCache, err := handler.Query.ValidateAccountingRules(ctx, params.OrganizationID, params.LedgerID, balanceOps, validate, action)
 	if err != nil {
@@ -816,6 +888,15 @@ func (handler *TransactionHandler) executeCreateTransaction(c *fiber.Ctx, transa
 		fromTo = append(fromTo, to...)
 	}
 
+	// Splice the enrichment-produced companion FromTo entries into the slice
+	// BEFORE BuildOperations runs. Each companion carries an AccountAlias in
+	// concat form ("<i>#@alias#overdraft") that matches the Lua-returned
+	// `balance.Alias`, so the `balances × fromTo` loop in BuildOperations
+	// now emits one Operation record per companion balance mutation. This
+	// is the audit-trail half of the enrichment contract; the balance-state
+	// half is handled by the enrichment engine up above.
+	fromTo = append(fromTo, companionFromTos...)
+
 	amount := transactionInput.Send.Value
 
 	tran := &transaction.Transaction{
@@ -838,7 +919,7 @@ func (handler *TransactionHandler) executeCreateTransaction(c *fiber.Ctx, transa
 		},
 	}
 
-	operations, _, err := handler.BuildOperations(ctx, balancesBefore, fromTo, transactionInput, *tran, validate, transactionDate, transactionStatus == constant.NOTED, ledgerSettings.Accounting.ValidateRoutes, routeCache, action)
+	operations, _, err := handler.BuildOperations(ctx, balancesBefore, balancesAfter, fromTo, transactionInput, *tran, validate, transactionDate, transactionStatus == constant.NOTED, ledgerSettings.Accounting.ValidateRoutes, routeCache, action)
 	if err != nil {
 		libOpentelemetry.HandleSpanError(span, "Failed to build operations", err)
 		logger.Log(ctx, libLog.LevelError, "Failed to build operations", libLog.Err(err))
@@ -851,8 +932,15 @@ func (handler *TransactionHandler) executeCreateTransaction(c *fiber.Ctx, transa
 		return http.WithError(c, err)
 	}
 
-	tran.Source = getAliasWithoutKey(validate.Sources)
-	tran.Destination = getAliasWithoutKey(validate.Destinations)
+	// The companion overdraft balances participate in the transaction at the
+	// ledger layer but are NOT user-facing sources or destinations — they are
+	// system-managed liability ledgers. Filter them out of the alias-key
+	// lists before stripping `#key` so `tran.Source` / `tran.Destination`
+	// reflect only the client-submitted accounts (and do not produce duplicates
+	// like `[@alice, @alice]` when the companion's bare alias collapses to
+	// the same value after the strip).
+	tran.Source = getAliasWithoutKey(filterCompanionAliases(validate.Sources))
+	tran.Destination = getAliasWithoutKey(filterCompanionAliases(validate.Destinations))
 	tran.Operations = operations
 
 	handler.Command.UpdateTransactionBackupOperations(ctx, params.OrganizationID, params.LedgerID, transactionID.String(), operations, action)

--- a/components/ledger/internal/adapters/http/in/transaction_create.go
+++ b/components/ledger/internal/adapters/http/in/transaction_create.go
@@ -91,7 +91,16 @@ func (handler *TransactionHandler) BuildOperations(
 
 				preBalances = append(preBalances, blc)
 
-				amt, bat, err := mtransaction.ValidateFromToOperation(fromTo[i], *validate, blc.ToTransactionBalance())
+				txBal, tErr := blc.ToTransactionBalance()
+				if tErr != nil {
+					libOpentelemetry.HandleSpanError(span, "Corrupted balance for validation", tErr)
+
+					logger.Log(ctx, libLog.LevelWarn, "Corrupted balance OverdraftLimit", libLog.Err(tErr))
+
+					return nil, nil, tErr
+				}
+
+				amt, bat, err := mtransaction.ValidateFromToOperation(fromTo[i], *validate, txBal)
 				if err != nil {
 					libOpentelemetry.HandleSpanError(span, "Failed to validate balances", err)
 

--- a/components/ledger/internal/adapters/http/in/transaction_create.go
+++ b/components/ledger/internal/adapters/http/in/transaction_create.go
@@ -104,7 +104,14 @@ func (handler *TransactionHandler) BuildOperations(
 				// it correctly reflects the overdraft floor-at-zero and any
 				// OverdraftUsed repayment decrement that the naive
 				// OperateBalances path above cannot model.
-				if after, ok := afterByAliasKey[blc.Alias+"#"+blc.Key]; ok && after != nil {
+				//
+				// Hoist `after` into the outer scope so the snapshot builder
+				// can use it below (after is nil when the legacy replay path
+				// cannot supply `balancesAfter`).
+				var after *mmodel.Balance
+
+				if a, ok := afterByAliasKey[blc.Alias+"#"+blc.Key]; ok && a != nil {
+					after = a
 					bat.Available = after.Available
 					bat.OnHold = after.OnHold
 					bat.Version = after.Version
@@ -135,6 +142,30 @@ func (handler *TransactionHandler) BuildOperations(
 					return nil, nil, err
 				} else if handled {
 					if len(ops) > 0 {
+						// Always-populated snapshot contract: every op carries
+						// snapshot + typed Balance.OverdraftUsed / BalanceAfter
+						// .OverdraftUsed regardless of overdraft participation.
+						// PENDING/CANCELED legs do not mutate OverdraftUsed,
+						// so before==after; annotation legs carry "0"/"0"
+						// + decimal.Zero (no balance movement to snapshot, but
+						// the wire shape stays uniform).
+						for _, pendingOp := range ops {
+							if isAnnotation {
+								pendingOp.Snapshot = buildOperationSnapshot(nil, nil)
+								pendingOp.Balance.OverdraftUsed = decimal.Zero
+								pendingOp.BalanceAfter.OverdraftUsed = decimal.Zero
+							} else {
+								pendingOp.Snapshot = buildOperationSnapshot(blc, blc)
+								if blc != nil {
+									pendingOp.Balance.OverdraftUsed = blc.OverdraftUsed
+									pendingOp.BalanceAfter.OverdraftUsed = blc.OverdraftUsed
+								} else {
+									pendingOp.Balance.OverdraftUsed = decimal.Zero
+									pendingOp.BalanceAfter.OverdraftUsed = decimal.Zero
+								}
+							}
+						}
+
 						operations = append(operations, ops...)
 
 						if err := metricFactory.RecordTransactionProcessed(
@@ -156,6 +187,31 @@ func (handler *TransactionHandler) BuildOperations(
 					return nil, nil, err
 				}
 
+				// Always-populated snapshot contract: every op carries snapshot
+				// + typed Balance.OverdraftUsed / BalanceAfter.OverdraftUsed
+				// regardless of overdraft participation. Annotation ops carry
+				// "0"/"0" + decimal.Zero (no balance movement, but the wire
+				// shape stays uniform).
+				if isAnnotation {
+					op.Snapshot = buildOperationSnapshot(nil, nil)
+					op.Balance.OverdraftUsed = decimal.Zero
+					op.BalanceAfter.OverdraftUsed = decimal.Zero
+				} else {
+					op.Snapshot = buildOperationSnapshot(blc, after)
+
+					if blc != nil {
+						op.Balance.OverdraftUsed = blc.OverdraftUsed
+					} else {
+						op.Balance.OverdraftUsed = decimal.Zero
+					}
+
+					if after != nil {
+						op.BalanceAfter.OverdraftUsed = after.OverdraftUsed
+					} else {
+						op.BalanceAfter.OverdraftUsed = decimal.Zero
+					}
+				}
+
 				operations = append(operations, op)
 
 				if err := metricFactory.RecordTransactionProcessed(
@@ -167,6 +223,32 @@ func (handler *TransactionHandler) BuildOperations(
 				}
 			}
 		}
+	}
+
+	// Companion snapshot propagation: overdraft companions are built from their
+	// own blc/after values (which have OverdraftUsed=0 since the companion balance
+	// doesn't track overdraft usage). The primary (default key) operation carries
+	// the DEFAULT balance's overdraft lifecycle; propagate it to companions so
+	// both rows in the pair tell the same story. Under the always-populated
+	// contract every primary already carries a snapshot value; companions get a
+	// value-copy of the primary's data.
+	snapshotAdapters := make([]*operationForSnapshot, len(operations))
+	for idx, op := range operations {
+		snapshotAdapters[idx] = &operationForSnapshot{
+			accountAlias:              op.AccountAlias,
+			balanceKey:                op.BalanceKey,
+			snapshot:                  op.Snapshot,
+			balanceOverdraftUsed:      op.Balance.OverdraftUsed,
+			balanceAfterOverdraftUsed: op.BalanceAfter.OverdraftUsed,
+		}
+	}
+
+	propagateSnapshotToCompanions(snapshotAdapters)
+
+	for idx, a := range snapshotAdapters {
+		operations[idx].Snapshot = a.snapshot
+		operations[idx].Balance.OverdraftUsed = a.balanceOverdraftUsed
+		operations[idx].BalanceAfter.OverdraftUsed = a.balanceAfterOverdraftUsed
 	}
 
 	resolveRouteCodesFromCache(operations, transactionRouteCache, action)
@@ -351,6 +433,79 @@ func effectiveOperationAmount(
 	}
 
 	return movement
+}
+
+// buildOperationSnapshot returns a snapshot for the operation. Always
+// populated — non-overdraft operations carry "0" / "0", matching the
+// always-populated wire-shape contract.
+//
+// `before` and `after` are the pre- and post-mutation balance values for
+// the balance the operation acts on. Either may be nil (defensive against
+// builder paths that don't have one or the other in scope) — nil decays
+// to "0" for the corresponding field.
+//
+// For PENDING / CANCELED paths, call with before == after (the hold/cancel
+// does not mutate OverdraftUsed, but capturing the pre-state keeps shape
+// consistent with the standard path).
+func buildOperationSnapshot(before, after *mmodel.Balance) mmodel.OperationSnapshot {
+	snap := mmodel.OperationSnapshot{
+		OverdraftUsedBefore: "0",
+		OverdraftUsedAfter:  "0",
+	}
+
+	if before != nil {
+		snap.OverdraftUsedBefore = before.OverdraftUsed.String()
+	}
+
+	if after != nil {
+		snap.OverdraftUsedAfter = after.OverdraftUsed.String()
+	}
+
+	return snap
+}
+
+// operationForSnapshot is a lightweight adapter used by propagateSnapshotToCompanions
+// to decouple the propagation logic from the concrete operation.Operation type,
+// making the function independently testable.
+type operationForSnapshot struct {
+	accountAlias              string
+	balanceKey                string
+	snapshot                  mmodel.OperationSnapshot
+	balanceOverdraftUsed      decimal.Decimal
+	balanceAfterOverdraftUsed decimal.Decimal
+}
+
+// propagateSnapshotToCompanions copies the primary (default-key) operation's
+// snapshot and typed OverdraftUsed fields to each companion (overdraft-key)
+// operation that shares the same account alias. This ensures both rows in the
+// operation pair tell the same lifecycle story.
+//
+// Under the always-populated contract every primary already carries a snapshot
+// value; companions get a value-copy of the primary's data.
+func propagateSnapshotToCompanions(ops []*operationForSnapshot) {
+	// Index primaries by bare account alias.
+	primaryByAlias := make(map[string]*operationForSnapshot, len(ops))
+
+	for _, op := range ops {
+		if op.balanceKey != constant.OverdraftBalanceKey {
+			primaryByAlias[op.accountAlias] = op
+		}
+	}
+
+	for _, op := range ops {
+		if op.balanceKey != constant.OverdraftBalanceKey {
+			continue
+		}
+
+		primary, ok := primaryByAlias[op.accountAlias]
+		if !ok {
+			continue
+		}
+
+		op.snapshot = primary.snapshot
+		op.balanceOverdraftUsed = primary.balanceOverdraftUsed
+		op.balanceAfterOverdraftUsed = primary.balanceAfterOverdraftUsed
+	}
 }
 
 // zeroAnnotationBalances zeroes out the Available, OnHold, and Version fields of the

--- a/components/ledger/internal/adapters/http/in/transaction_create.go
+++ b/components/ledger/internal/adapters/http/in/transaction_create.go
@@ -921,11 +921,16 @@ func (handler *TransactionHandler) buildStandardOp(
 		return nil, err
 	}
 
+	opType := amt.Operation
+	if blc.Key == constant.OverdraftBalanceKey {
+		opType = constant.OVERDRAFT
+	}
+
 	return &operation.Operation{
 		ID:              operationID.String(),
 		TransactionID:   tran.ID,
 		Description:     description,
-		Type:            amt.Operation,
+		Type:            opType,
 		AssetCode:       transactionInput.Send.Asset,
 		ChartOfAccounts: ft.ChartOfAccounts,
 		Amount:          amount,

--- a/components/ledger/internal/adapters/http/in/transaction_create.go
+++ b/components/ledger/internal/adapters/http/in/transaction_create.go
@@ -154,23 +154,26 @@ func (handler *TransactionHandler) BuildOperations(
 						// Always-populated snapshot contract: every op carries
 						// snapshot + typed Balance.OverdraftUsed / BalanceAfter
 						// .OverdraftUsed regardless of overdraft participation.
-						// PENDING/CANCELED legs do not mutate OverdraftUsed,
-						// so before==after; annotation legs carry "0"/"0"
-						// + decimal.Zero (no balance movement to snapshot, but
-						// the wire shape stays uniform).
+						// Double-entry rows share the Lua-authoritative final
+						// overdraft lifecycle so pending/cancel overdraft rows do
+						// not show stale 0->0 snapshots.
 						for _, pendingOp := range ops {
 							if isAnnotation {
 								pendingOp.Snapshot = buildOperationSnapshot(nil, nil)
 								pendingOp.Balance.OverdraftUsed = decimal.Zero
 								pendingOp.BalanceAfter.OverdraftUsed = decimal.Zero
 							} else {
-								pendingOp.Snapshot = buildOperationSnapshot(blc, blc)
+								pendingOp.Snapshot = buildOperationSnapshot(blc, after)
 								if blc != nil {
 									pendingOp.Balance.OverdraftUsed = blc.OverdraftUsed
 									pendingOp.BalanceAfter.OverdraftUsed = blc.OverdraftUsed
 								} else {
 									pendingOp.Balance.OverdraftUsed = decimal.Zero
 									pendingOp.BalanceAfter.OverdraftUsed = decimal.Zero
+								}
+
+								if after != nil {
+									pendingOp.BalanceAfter.OverdraftUsed = after.OverdraftUsed
 								}
 							}
 						}
@@ -551,7 +554,7 @@ func (handler *TransactionHandler) buildDoubleEntryPendingOps(
 	blc *mmodel.Balance,
 	ft mtransaction.FromTo,
 	amt mtransaction.Amount,
-	_ mtransaction.Balance,
+	bat mtransaction.Balance,
 	tran transaction.Transaction,
 	transactionInput mtransaction.Transaction,
 	transactionDate time.Time,
@@ -569,11 +572,25 @@ func (handler *TransactionHandler) buildDoubleEntryPendingOps(
 		description = transactionInput.Description
 	}
 
-	// Op1: DEBIT (debit) - Available-- only
-	// Balance before: original balance
-	// Balance after: Available decreased, OnHold unchanged
+	// Op1: DEBIT (debit) - Available-- only. Prefer Lua's authoritative
+	// final Available when present; the overdraft branch floors at zero, while
+	// naive local arithmetic would record negative audit balances.
 	debitAvailable := blc.Available.Sub(amt.Value)
+	debitAmount := amt.Value
 	debitVersion := blc.Version + 1
+	onholdOnHold := blc.OnHold.Add(amt.Value)
+	onholdVersion := debitVersion + 1
+
+	if bat.Version > 0 {
+		debitAvailable = bat.Available
+		onholdOnHold = bat.OnHold
+		onholdVersion = bat.Version
+
+		debitAmount = blc.Available.Sub(debitAvailable).Abs()
+		if debitAmount.GreaterThan(amt.Value) {
+			debitAmount = amt.Value
+		}
+	}
 
 	debitBalance := operation.Balance{
 		Available: &blc.Available,
@@ -603,7 +620,7 @@ func (handler *TransactionHandler) buildDoubleEntryPendingOps(
 		Type:            constant.DEBIT,
 		AssetCode:       transactionInput.Send.Asset,
 		ChartOfAccounts: ft.ChartOfAccounts,
-		Amount:          operation.Amount{Value: &amt.Value},
+		Amount:          operation.Amount{Value: &debitAmount},
 		Balance:         debitBalance,
 		BalanceAfter:    debitBalanceAfter,
 		BalanceID:       blc.ID,
@@ -624,8 +641,6 @@ func (handler *TransactionHandler) buildDoubleEntryPendingOps(
 	// Op2: ONHOLD (credit) - OnHold++ only
 	// Balance before: op1's balance after (chaining)
 	// Balance after: OnHold increased, Available unchanged from op1
-	onholdOnHold := blc.OnHold.Add(amt.Value)
-	onholdVersion := debitVersion + 1
 
 	onholdBalance := operation.Balance{
 		Available: &debitAvailable,

--- a/components/ledger/internal/adapters/http/in/transaction_create.go
+++ b/components/ledger/internal/adapters/http/in/transaction_create.go
@@ -194,28 +194,24 @@ func resolveRouteCodesFromCache(operations []*operation.Operation, cache *mmodel
 		}
 
 		// Companion operations (BalanceKey = "overdraft") are emitted by
-		// the enrichment engine and represent the OVERDRAFT/REFUND leg of
-		// the transaction. They share the primary's RouteID but must
-		// resolve their rubric through the `overdraft` or `refund`
-		// AccountingEntry — not the top-level transaction action. This
-		// mirrors the hold/commit/cancel pattern where a single routeID
-		// drives multiple action-specific rubric lookups.
+		// the enrichment engine and represent the overdraft leg of the
+		// transaction. They share the primary's RouteID but must resolve
+		// their rubric through the `overdraft` AccountingEntry — not the
+		// top-level transaction action. This mirrors the hold/commit/cancel
+		// pattern where a single routeID drives multiple action-specific
+		// rubric lookups.
 		//
-		// Selection rule:
-		//   - DEBIT on overdraft balance → ActionOverdraft rubric
-		//   - CREDIT on overdraft balance → ActionRefund rubric
-		// (The enrichment engine only emits DEBIT on overdraft (deficit)
-		// and CREDIT on overdraft (refund repayment), so the direction
-		// unambiguously selects the action.)
+		// Both DEBIT (overdraft usage — deficit grows) and CREDIT
+		// (repayment — deficit shrinks) on the overdraft balance resolve
+		// to ActionOverdraft. The direction-based rubric selection
+		// (Debit vs Credit) happens inside resolveAccountingRubric via
+		// op.Direction. The enrichment engine sets Direction="credit" on
+		// repayment companions so the resolver picks Overdraft.Credit
+		// without special-casing here.
 		resolvedAction := action
 
 		if op.BalanceKey == constant.OverdraftBalanceKey {
-			switch strings.ToLower(op.Direction) {
-			case constant.DirectionDebit:
-				resolvedAction = constant.ActionOverdraft
-			case constant.DirectionCredit:
-				resolvedAction = constant.ActionRefund
-			}
+			resolvedAction = constant.ActionOverdraft
 		}
 
 		actionCache, ok := cache.Actions[resolvedAction]
@@ -266,8 +262,6 @@ func resolveAccountingRubric(entries *mmodel.AccountingEntries, action, directio
 		entry = entries.Revert
 	case constant.ActionOverdraft:
 		entry = entries.Overdraft
-	case constant.ActionRefund:
-		entry = entries.Refund
 	}
 
 	if entry == nil {

--- a/components/ledger/internal/adapters/http/in/transaction_create.go
+++ b/components/ledger/internal/adapters/http/in/transaction_create.go
@@ -108,6 +108,24 @@ func (handler *TransactionHandler) BuildOperations(
 					bat.Available = after.Available
 					bat.OnHold = after.OnHold
 					bat.Version = after.Version
+
+					// Clip the Operation record's amount to the ACTUAL
+					// movement on this balance. Without overdraft the
+					// movement equals the requested amount; with
+					// overdraft, Lua redirects part of it onto the
+					// companion balance (a separate Operation record with
+					// its own amount), so the primary op's "amount"
+					// field should reflect only what really moved on
+					// this balance. This preserves double-entry across
+					// the enriched record set:
+					//   sum(primary.amount, companion.amount) == requested amount
+					// Pre-fix, the primary recorded the full requested
+					// amount AND the companion recorded the redirected
+					// portion, so sum(debits) > sum(credits) and the
+					// audit trail broke. See regression: operation row
+					// for overdraft debit split showing amount=100 while
+					// the default balance only moved 50.
+					amt.Value = effectiveOperationAmount(amt, blc.Available, after.Available, blc.OnHold, after.OnHold)
 				}
 
 				if ops, handled, err := handler.tryBuildDoubleEntryOps(
@@ -249,6 +267,63 @@ func findRouteInActionCache(actionCache mmodel.ActionRouteCache, routeID string)
 	}
 
 	return mmodel.OperationRouteCache{}, false
+}
+
+// effectiveOperationAmount returns the amount that should be recorded on a
+// standard Operation record when the Lua-authoritative after-state differs
+// from the naive "before − requested amount" arithmetic. The only case
+// where this happens today is the overdraft engine redirecting part of a
+// debit/credit onto the companion balance:
+//
+//   - Debit split: source.default goes from 50 → 0 for a requested debit of
+//     100 (the remaining 50 is debited onto the companion's Available via a
+//     separate, enrichment-produced Operation record). The primary
+//     Operation record's `amount` should be 50, not 100, so that
+//     `sum(debits) == sum(credits)` across the enriched record set.
+//   - Credit repayment: destination.default goes from 0 → 30 for a
+//     requested credit of 80 because the first 50 repaid outstanding
+//     overdraft (recorded as a CREDIT on the companion). The primary
+//     Operation record's `amount` should be 30.
+//
+// For every non-overdraft operation the |Available delta| + |OnHold delta|
+// equals the requested amount, so the clip is a no-op — the function is
+// safe to call on every operation. Direction-aware arithmetic does not
+// need special handling here: what matters is the absolute movement on the
+// balance, which is always non-negative.
+//
+// Returns the smaller of the requested amount and the observed movement,
+// so a balance that somehow moves MORE than the requested amount (a bug
+// that should not exist) never retroactively inflates the Operation
+// amount — we keep the request as the upper bound and surface the anomaly
+// via the balance vs. operation divergence in downstream reconciliation.
+func effectiveOperationAmount(
+	amt mtransaction.Amount,
+	beforeAvailable, afterAvailable, beforeOnHold, afterOnHold decimal.Decimal,
+) decimal.Decimal {
+	availableDelta := beforeAvailable.Sub(afterAvailable).Abs()
+	onHoldDelta := beforeOnHold.Sub(afterOnHold).Abs()
+
+	// Available and OnHold deltas are additive for the PENDING/COMMIT/CANCEL
+	// transaction-type flow (a PENDING entry moves amount from Available
+	// into OnHold; both deltas individually equal the amount, so adding
+	// them would double-count). Use the max instead — it matches the
+	// requested amount on every non-overdraft path and only shrinks in
+	// the overdraft redirect case (where OnHold is untouched and only
+	// Available shrinks by the non-redirected portion).
+	movement := availableDelta
+	if onHoldDelta.GreaterThan(movement) {
+		movement = onHoldDelta
+	}
+
+	// Upper-bound at the requested amount. A movement greater than the
+	// requested amount would indicate a ledger bug (e.g. Lua applied more
+	// than it was asked to); we do not want the Operation record to
+	// silently inflate in that case.
+	if movement.GreaterThan(amt.Value) {
+		return amt.Value
+	}
+
+	return movement
 }
 
 // zeroAnnotationBalances zeroes out the Available, OnHold, and Version fields of the

--- a/components/ledger/internal/adapters/http/in/transaction_create.go
+++ b/components/ledger/internal/adapters/http/in/transaction_create.go
@@ -188,20 +188,49 @@ func resolveRouteCodesFromCache(operations []*operation.Operation, cache *mmodel
 		return
 	}
 
-	actionCache, ok := cache.Actions[action]
-	if !ok {
-		return
-	}
-
 	for _, op := range operations {
 		if op.RouteID == nil || *op.RouteID == "" {
+			continue
+		}
+
+		// Companion operations (BalanceKey = "overdraft") are emitted by
+		// the enrichment engine and represent the OVERDRAFT/REFUND leg of
+		// the transaction. They share the primary's RouteID but must
+		// resolve their rubric through the `overdraft` or `refund`
+		// AccountingEntry — not the top-level transaction action. This
+		// mirrors the hold/commit/cancel pattern where a single routeID
+		// drives multiple action-specific rubric lookups.
+		//
+		// Selection rule:
+		//   - DEBIT on overdraft balance → ActionOverdraft rubric
+		//   - CREDIT on overdraft balance → ActionRefund rubric
+		// (The enrichment engine only emits DEBIT on overdraft (deficit)
+		// and CREDIT on overdraft (refund repayment), so the direction
+		// unambiguously selects the action.)
+		resolvedAction := action
+
+		if op.BalanceKey == constant.OverdraftBalanceKey {
+			switch strings.ToLower(op.Direction) {
+			case constant.DirectionDebit:
+				resolvedAction = constant.ActionOverdraft
+			case constant.DirectionCredit:
+				resolvedAction = constant.ActionRefund
+			}
+		}
+
+		actionCache, ok := cache.Actions[resolvedAction]
+		if !ok {
+			// No entries for this action — e.g. route defines only Direct
+			// and the companion wants Overdraft. Leave RouteCode nil; the
+			// primary op still resolves correctly, and the companion
+			// simply carries no accounting rubric.
 			continue
 		}
 
 		routeID := *op.RouteID
 
 		if rc, ok := findRouteInActionCache(actionCache, routeID); ok {
-			if rubric := resolveAccountingRubric(rc.AccountingEntries, action, op.Direction); rubric != nil && rubric.Code != "" {
+			if rubric := resolveAccountingRubric(rc.AccountingEntries, resolvedAction, op.Direction); rubric != nil && rubric.Code != "" {
 				code := rubric.Code
 				op.RouteCode = &code
 
@@ -235,6 +264,10 @@ func resolveAccountingRubric(entries *mmodel.AccountingEntries, action, directio
 		entry = entries.Cancel
 	case constant.ActionRevert:
 		entry = entries.Revert
+	case constant.ActionOverdraft:
+		entry = entries.Overdraft
+	case constant.ActionRefund:
+		entry = entries.Refund
 	}
 
 	if entry == nil {

--- a/components/ledger/internal/adapters/http/in/transaction_create_snapshot_test.go
+++ b/components/ledger/internal/adapters/http/in/transaction_create_snapshot_test.go
@@ -1,0 +1,402 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package in
+
+import (
+	"testing"
+
+	"github.com/LerianStudio/midaz/v3/components/ledger/internal/adapters/postgres/operation"
+	"github.com/LerianStudio/midaz/v3/pkg/constant"
+	"github.com/LerianStudio/midaz/v3/pkg/mmodel"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBuildOperationSnapshot_NonOverdraft verifies that two zero-OverdraftUsed
+// balances (the vast majority of operations) produce a snapshot with both
+// fields explicitly set to "0". Under the always-populated wire-shape contract,
+// non-overdraft ops carry the zero shape rather than absent fields.
+func TestBuildOperationSnapshot_NonOverdraft(t *testing.T) {
+	t.Parallel()
+
+	before := &mmodel.Balance{
+		OverdraftUsed: decimal.Zero,
+	}
+
+	after := &mmodel.Balance{
+		OverdraftUsed: decimal.Zero,
+	}
+
+	snap := buildOperationSnapshot(before, after)
+	assert.Equal(t, "0", snap.OverdraftUsedBefore, "non-overdraft ops carry '0' explicitly")
+	assert.Equal(t, "0", snap.OverdraftUsedAfter)
+}
+
+// TestBuildOperationSnapshot_DebitSplit verifies a debit that triggers an
+// overdraft split: before=0, after=50. Both fields populated; before is the
+// canonical "0" string.
+func TestBuildOperationSnapshot_DebitSplit(t *testing.T) {
+	t.Parallel()
+
+	before := &mmodel.Balance{OverdraftUsed: decimal.Zero}
+	after := &mmodel.Balance{OverdraftUsed: decimal.NewFromInt(50)}
+
+	snap := buildOperationSnapshot(before, after)
+	assert.Equal(t, "0", snap.OverdraftUsedBefore, "zero before serializes as '0'")
+	assert.Equal(t, "50", snap.OverdraftUsedAfter)
+}
+
+// TestBuildOperationSnapshot_CreditRepayment verifies a credit that fully
+// repays outstanding overdraft: before=130, after=0. Both fields populated.
+func TestBuildOperationSnapshot_CreditRepayment(t *testing.T) {
+	t.Parallel()
+
+	before := &mmodel.Balance{OverdraftUsed: decimal.NewFromInt(130)}
+	after := &mmodel.Balance{OverdraftUsed: decimal.Zero}
+
+	snap := buildOperationSnapshot(before, after)
+	assert.Equal(t, "130", snap.OverdraftUsedBefore)
+	assert.Equal(t, "0", snap.OverdraftUsedAfter, "zero after serializes as '0'")
+}
+
+// TestBuildOperationSnapshot_CumulativeOverdraft verifies cumulative overdraft
+// usage: before=50, after=130 (a second debit while overdraft is already active).
+func TestBuildOperationSnapshot_CumulativeOverdraft(t *testing.T) {
+	t.Parallel()
+
+	before := &mmodel.Balance{OverdraftUsed: decimal.NewFromInt(50)}
+	after := &mmodel.Balance{OverdraftUsed: decimal.NewFromInt(130)}
+
+	snap := buildOperationSnapshot(before, after)
+	assert.Equal(t, "50", snap.OverdraftUsedBefore)
+	assert.Equal(t, "130", snap.OverdraftUsedAfter)
+}
+
+// TestBuildOperationSnapshot_NilBalances verifies that nil before/after
+// balances default to "0" without panicking. nil decays to "0" so callers
+// in defensive paths (where one or both balances aren't in scope) still get
+// a wire-compliant snapshot.
+func TestBuildOperationSnapshot_NilBalances(t *testing.T) {
+	t.Parallel()
+
+	snap := buildOperationSnapshot(nil, nil)
+	assert.Equal(t, "0", snap.OverdraftUsedBefore, "both nil → both '0'")
+	assert.Equal(t, "0", snap.OverdraftUsedAfter)
+
+	snap = buildOperationSnapshot(nil, &mmodel.Balance{OverdraftUsed: decimal.Zero})
+	assert.Equal(t, "0", snap.OverdraftUsedBefore, "nil before → '0'")
+	assert.Equal(t, "0", snap.OverdraftUsedAfter)
+
+	snap = buildOperationSnapshot(&mmodel.Balance{OverdraftUsed: decimal.Zero}, nil)
+	assert.Equal(t, "0", snap.OverdraftUsedBefore)
+	assert.Equal(t, "0", snap.OverdraftUsedAfter, "nil after → '0'")
+
+	// Non-zero with nil counterpart → counterpart still "0".
+	snap = buildOperationSnapshot(nil, &mmodel.Balance{OverdraftUsed: decimal.NewFromInt(50)})
+	assert.Equal(t, "0", snap.OverdraftUsedBefore)
+	assert.Equal(t, "50", snap.OverdraftUsedAfter)
+}
+
+// TestBuildOperationSnapshot_PendingPath verifies PENDING operations where
+// before == after (overdraft is active but not mutated by the hold).
+func TestBuildOperationSnapshot_PendingPath(t *testing.T) {
+	t.Parallel()
+
+	blc := &mmodel.Balance{OverdraftUsed: decimal.NewFromInt(50)}
+
+	snap := buildOperationSnapshot(blc, blc)
+	assert.Equal(t, "50", snap.OverdraftUsedBefore)
+	assert.Equal(t, "50", snap.OverdraftUsedAfter, "before==after on PENDING")
+}
+
+// TestBuildOperationSnapshot_PendingNoOverdraft verifies PENDING operations on
+// a non-overdraft balance still carry the zero shape (always-populated).
+func TestBuildOperationSnapshot_PendingNoOverdraft(t *testing.T) {
+	t.Parallel()
+
+	blc := &mmodel.Balance{OverdraftUsed: decimal.Zero}
+
+	snap := buildOperationSnapshot(blc, blc)
+	assert.Equal(t, "0", snap.OverdraftUsedBefore)
+	assert.Equal(t, "0", snap.OverdraftUsedAfter)
+}
+
+// TestBuildOperationSnapshot_AnnotationZeroShape verifies that annotation
+// (NOTED) transactions emit the zero shape via buildOperationSnapshot(nil, nil).
+// Under the always-populated contract annotations carry "0"/"0" so the wire
+// shape remains uniform — the snapshot is meaningless on annotations (no
+// balance movement) but the contract requires presence.
+func TestBuildOperationSnapshot_AnnotationZeroShape(t *testing.T) {
+	t.Parallel()
+
+	snap := buildOperationSnapshot(nil, nil)
+	assert.Equal(t, "0", snap.OverdraftUsedBefore, "annotation ops carry '0' explicitly")
+	assert.Equal(t, "0", snap.OverdraftUsedAfter)
+}
+
+// TestPropagateSnapshotToCompanions verifies that after building all operations,
+// companion (overdraft) operations inherit the primary (default) operation's
+// snapshot value and typed OverdraftUsed fields so both rows in the pair tell
+// the same lifecycle story.
+func TestPropagateSnapshotToCompanions(t *testing.T) {
+	t.Parallel()
+
+	primarySnapshot := mmodel.OperationSnapshot{
+		OverdraftUsedBefore: "50",
+		OverdraftUsedAfter:  "130",
+	}
+
+	beforeDec := decimal.NewFromInt(50)
+	afterDec := decimal.NewFromInt(130)
+
+	// Simulate: primary op for @alice#default and companion for @alice#overdraft.
+	ops := []*operationForSnapshot{
+		{
+			accountAlias:              "@alice",
+			balanceKey:                "default",
+			snapshot:                  primarySnapshot,
+			balanceOverdraftUsed:      beforeDec,
+			balanceAfterOverdraftUsed: afterDec,
+		},
+		{
+			accountAlias: "@alice",
+			balanceKey:   "overdraft",
+			snapshot: mmodel.OperationSnapshot{
+				OverdraftUsedBefore: "0",
+				OverdraftUsedAfter:  "0",
+			}, // companion's own builder result, to be overwritten by propagation
+		},
+	}
+
+	propagateSnapshotToCompanions(ops)
+
+	assert.Equal(t, "50", ops[1].snapshot.OverdraftUsedBefore, "companion inherits primary's snapshot")
+	assert.Equal(t, "130", ops[1].snapshot.OverdraftUsedAfter)
+	assert.True(t, beforeDec.Equal(ops[1].balanceOverdraftUsed))
+	assert.True(t, afterDec.Equal(ops[1].balanceAfterOverdraftUsed))
+}
+
+// TestPropagateSnapshotToCompanions_NoOverdraft verifies that propagation copies
+// the primary's zero shape onto the companion when neither participates in the
+// overdraft lifecycle. Under the always-populated contract every primary
+// carries a snapshot, so the propagation always runs — there's no "skip when
+// nil" path anymore.
+func TestPropagateSnapshotToCompanions_NoOverdraft(t *testing.T) {
+	t.Parallel()
+
+	zeroShape := mmodel.OperationSnapshot{
+		OverdraftUsedBefore: "0",
+		OverdraftUsedAfter:  "0",
+	}
+
+	ops := []*operationForSnapshot{
+		{
+			accountAlias:              "@alice",
+			balanceKey:                "default",
+			snapshot:                  zeroShape,
+			balanceOverdraftUsed:      decimal.Zero,
+			balanceAfterOverdraftUsed: decimal.Zero,
+		},
+		{
+			accountAlias: "@alice",
+			balanceKey:   "overdraft",
+			// Companion-side state — to be overwritten with the primary's
+			// zero shape.
+			snapshot:                  mmodel.OperationSnapshot{},
+			balanceOverdraftUsed:      decimal.Zero,
+			balanceAfterOverdraftUsed: decimal.Zero,
+		},
+	}
+
+	propagateSnapshotToCompanions(ops)
+	assert.Equal(t, "0", ops[1].snapshot.OverdraftUsedBefore, "companion inherits primary's zero shape")
+	assert.Equal(t, "0", ops[1].snapshot.OverdraftUsedAfter)
+	assert.True(t, ops[1].balanceOverdraftUsed.Equal(decimal.Zero))
+	assert.True(t, ops[1].balanceAfterOverdraftUsed.Equal(decimal.Zero))
+}
+
+// TestBuildOperations_CompanionPropagation_EndToEnd exercises the full
+// snapshot propagation pipeline as executed by BuildOperations in
+// transaction_create.go: adapter construction → propagateSnapshotToCompanions
+// → writeback onto []*operation.Operation. It verifies that a companion
+// (overdraft-key) operation inherits the primary (default-key) operation's
+// snapshot and typed OverdraftUsed fields, and that a non-participating
+// destination operation carries zero-shape values.
+//
+// Regression guard: if the writeback loop is accidentally dropped or the
+// adapter construction is broken, the assertions on the companion operation
+// will fail.
+func TestBuildOperations_CompanionPropagation_EndToEnd(t *testing.T) {
+	t.Parallel()
+
+	// Construct 3 operations simulating the output of the build loop:
+	//   0: source default DEBIT  — carries real overdraft snapshot
+	//   1: source overdraft companion DEBIT — initially has zero-shape
+	//       (mimics companion builders which use their own blc/after,
+	//        and the overdraft balance itself has OverdraftUsed=0)
+	//   2: destination CREDIT — non-overdraft, zero-shape throughout
+	operations := []*operation.Operation{
+		{
+			AccountAlias: "@alice",
+			BalanceKey:   constant.DefaultBalanceKey,
+			Snapshot: mmodel.OperationSnapshot{
+				OverdraftUsedBefore: "0",
+				OverdraftUsedAfter:  "50",
+			},
+			Balance: operation.Balance{
+				OverdraftUsed: decimal.Zero,
+			},
+			BalanceAfter: operation.Balance{
+				OverdraftUsed: decimal.NewFromInt(50),
+			},
+		},
+		{
+			AccountAlias: "@alice",
+			BalanceKey:   constant.OverdraftBalanceKey,
+			// Companion's own builder result — will be overwritten by propagation.
+			Snapshot: mmodel.OperationSnapshot{
+				OverdraftUsedBefore: "0",
+				OverdraftUsedAfter:  "0",
+			},
+			Balance: operation.Balance{
+				OverdraftUsed: decimal.Zero,
+			},
+			BalanceAfter: operation.Balance{
+				OverdraftUsed: decimal.Zero,
+			},
+		},
+		{
+			AccountAlias: "@bob",
+			BalanceKey:   constant.DefaultBalanceKey,
+			Snapshot: mmodel.OperationSnapshot{
+				OverdraftUsedBefore: "0",
+				OverdraftUsedAfter:  "0",
+			},
+			Balance: operation.Balance{
+				OverdraftUsed: decimal.Zero,
+			},
+			BalanceAfter: operation.Balance{
+				OverdraftUsed: decimal.Zero,
+			},
+		},
+	}
+
+	// ── Execute the exact same bridge code as BuildOperations lines 235-252 ──
+
+	snapshotAdapters := make([]*operationForSnapshot, len(operations))
+	for idx, op := range operations {
+		snapshotAdapters[idx] = &operationForSnapshot{
+			accountAlias:              op.AccountAlias,
+			balanceKey:                op.BalanceKey,
+			snapshot:                  op.Snapshot,
+			balanceOverdraftUsed:      op.Balance.OverdraftUsed,
+			balanceAfterOverdraftUsed: op.BalanceAfter.OverdraftUsed,
+		}
+	}
+
+	propagateSnapshotToCompanions(snapshotAdapters)
+
+	for idx, a := range snapshotAdapters {
+		operations[idx].Snapshot = a.snapshot
+		operations[idx].Balance.OverdraftUsed = a.balanceOverdraftUsed
+		operations[idx].BalanceAfter.OverdraftUsed = a.balanceAfterOverdraftUsed
+	}
+
+	// ── Assert: companion mirrors primary ──
+
+	require.Len(t, operations, 3, "expected 3 operations (source default, source overdraft, destination)")
+
+	primary := operations[0]
+	companion := operations[1]
+	destination := operations[2]
+
+	// Companion snapshot must equal primary's snapshot (propagated).
+	assert.Equal(t, primary.Snapshot.OverdraftUsedBefore, companion.Snapshot.OverdraftUsedBefore,
+		"companion must inherit primary's OverdraftUsedBefore")
+	assert.Equal(t, "0", companion.Snapshot.OverdraftUsedBefore)
+	assert.Equal(t, primary.Snapshot.OverdraftUsedAfter, companion.Snapshot.OverdraftUsedAfter,
+		"companion must inherit primary's OverdraftUsedAfter")
+	assert.Equal(t, "50", companion.Snapshot.OverdraftUsedAfter)
+
+	// Companion typed fields must equal primary's typed fields (propagated).
+	assert.True(t, companion.Balance.OverdraftUsed.Equal(primary.Balance.OverdraftUsed),
+		"companion Balance.OverdraftUsed must mirror primary: got %s want %s",
+		companion.Balance.OverdraftUsed.String(), primary.Balance.OverdraftUsed.String())
+	assert.True(t, companion.BalanceAfter.OverdraftUsed.Equal(primary.BalanceAfter.OverdraftUsed),
+		"companion BalanceAfter.OverdraftUsed must mirror primary: got %s want %s",
+		companion.BalanceAfter.OverdraftUsed.String(), primary.BalanceAfter.OverdraftUsed.String())
+	assert.True(t, companion.BalanceAfter.OverdraftUsed.Equal(decimal.NewFromInt(50)),
+		"companion BalanceAfter.OverdraftUsed must be 50")
+
+	// Destination must NOT be affected by propagation — retains zero-shape.
+	assert.Equal(t, "0", destination.Snapshot.OverdraftUsedBefore,
+		"destination must retain zero OverdraftUsedBefore")
+	assert.Equal(t, "0", destination.Snapshot.OverdraftUsedAfter,
+		"destination must retain zero OverdraftUsedAfter")
+	assert.True(t, destination.Balance.OverdraftUsed.Equal(decimal.Zero),
+		"destination Balance.OverdraftUsed must remain zero")
+	assert.True(t, destination.BalanceAfter.OverdraftUsed.Equal(decimal.Zero),
+		"destination BalanceAfter.OverdraftUsed must remain zero")
+}
+
+// TestBuildOperations_CompanionPropagation_WritebackRequired verifies that
+// removing the writeback loop in transaction_create.go causes companion
+// operations to miss propagated values. This is the RED half of the
+// regression guard — without the writeback, the companion retains its
+// original zero-shape values instead of inheriting the primary's snapshot.
+func TestBuildOperations_CompanionPropagation_WritebackRequired(t *testing.T) {
+	t.Parallel()
+
+	// Same setup as the end-to-end test above.
+	operations := []*operation.Operation{
+		{
+			AccountAlias: "@alice",
+			BalanceKey:   constant.DefaultBalanceKey,
+			Snapshot: mmodel.OperationSnapshot{
+				OverdraftUsedBefore: "0",
+				OverdraftUsedAfter:  "50",
+			},
+			Balance:      operation.Balance{OverdraftUsed: decimal.Zero},
+			BalanceAfter: operation.Balance{OverdraftUsed: decimal.NewFromInt(50)},
+		},
+		{
+			AccountAlias: "@alice",
+			BalanceKey:   constant.OverdraftBalanceKey,
+			Snapshot: mmodel.OperationSnapshot{
+				OverdraftUsedBefore: "0",
+				OverdraftUsedAfter:  "0",
+			},
+			Balance:      operation.Balance{OverdraftUsed: decimal.Zero},
+			BalanceAfter: operation.Balance{OverdraftUsed: decimal.Zero},
+		},
+	}
+
+	// Run adapter construction + propagation WITHOUT writeback.
+	snapshotAdapters := make([]*operationForSnapshot, len(operations))
+	for idx, op := range operations {
+		snapshotAdapters[idx] = &operationForSnapshot{
+			accountAlias:              op.AccountAlias,
+			balanceKey:                op.BalanceKey,
+			snapshot:                  op.Snapshot,
+			balanceOverdraftUsed:      op.Balance.OverdraftUsed,
+			balanceAfterOverdraftUsed: op.BalanceAfter.OverdraftUsed,
+		}
+	}
+
+	propagateSnapshotToCompanions(snapshotAdapters)
+
+	// Intentionally skip writeback — this simulates the regression.
+	// The adapters are propagated, but operations[1] still has zero-shape.
+
+	// The adapter itself IS propagated...
+	assert.Equal(t, "50", snapshotAdapters[1].snapshot.OverdraftUsedAfter,
+		"adapter should be propagated")
+
+	// ...but without writeback the operation still has the original value.
+	assert.Equal(t, "0", operations[1].Snapshot.OverdraftUsedAfter,
+		"without writeback, operation retains original zero-shape — "+
+			"this proves the writeback loop is required")
+}

--- a/components/ledger/internal/adapters/http/in/transaction_effective_amount_test.go
+++ b/components/ledger/internal/adapters/http/in/transaction_effective_amount_test.go
@@ -1,0 +1,130 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package in
+
+import (
+	"testing"
+
+	"github.com/LerianStudio/midaz/v3/pkg/mtransaction"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestEffectiveOperationAmount locks the overdraft audit-trail contract:
+// the primary Operation record's `amount` must equal the ACTUAL balance
+// movement when the overdraft engine redirects part of a debit/credit
+// onto the companion balance. A companion Operation record with its own
+// amount carries the redirected portion, so `sum(primary, companion)`
+// still equals the user-requested amount and double-entry holds across
+// the enriched record set.
+//
+// Regression trigger: a debit of 100 on a balance with Available=50 and
+// overdraft enabled persisted `amount=100` on the primary DEBIT row while
+// the default balance only moved 50 (the other 50 was accrued on the
+// companion via a second DEBIT row also showing amount=50). sum(debits)
+// then equaled 150 while sum(credits) was 100, which breaks every
+// reconciliation report downstream.
+func TestEffectiveOperationAmount(t *testing.T) {
+	dec := decimal.NewFromInt
+
+	cases := []struct {
+		name            string
+		requested       int64
+		beforeAvailable int64
+		afterAvailable  int64
+		beforeOnHold    int64
+		afterOnHold     int64
+		expected        int64
+	}{
+		{
+			name:            "normal debit — no overdraft, movement equals requested",
+			requested:       100,
+			beforeAvailable: 500,
+			afterAvailable:  400,
+			expected:        100,
+		},
+		{
+			name:            "overdraft debit split — balance floored at 0, only actual movement recorded",
+			requested:       100,
+			beforeAvailable: 50,
+			afterAvailable:  0,
+			expected:        50,
+		},
+		{
+			name:            "overdraft debit from already-at-zero — primary movement is 0, full redirect to companion",
+			requested:       80,
+			beforeAvailable: 0,
+			afterAvailable:  0,
+			expected:        0,
+		},
+		{
+			name:            "credit repayment — destination receives only the remainder after overdraft is cleared",
+			requested:       80,
+			beforeAvailable: 0,
+			afterAvailable:  30,
+			expected:        30,
+		},
+		{
+			name:            "full repayment with no remainder — primary movement is 0, full redirect to companion",
+			requested:       40,
+			beforeAvailable: 0,
+			afterAvailable:  0,
+			expected:        0,
+		},
+		{
+			name:            "normal credit — no overdraft, movement equals requested",
+			requested:       250,
+			beforeAvailable: 100,
+			afterAvailable:  350,
+			expected:        250,
+		},
+		{
+			name:            "direction=debit DEBIT companion op — liability grows, movement equals requested",
+			requested:       50,
+			beforeAvailable: 0,
+			afterAvailable:  50,
+			expected:        50,
+		},
+		{
+			name:            "direction=debit CREDIT companion op — liability shrinks, movement equals requested",
+			requested:       50,
+			beforeAvailable: 50,
+			afterAvailable:  0,
+			expected:        50,
+		},
+		{
+			name:            "pending entry — amount shifts from Available into OnHold, max-delta preserves full amount",
+			requested:       100,
+			beforeAvailable: 500,
+			afterAvailable:  400,
+			beforeOnHold:    0,
+			afterOnHold:     100,
+			expected:        100,
+		},
+		{
+			name:            "movement exceeds request — clipped to requested amount to guard against ledger bug",
+			requested:       100,
+			beforeAvailable: 500,
+			afterAvailable:  300,
+			expected:        100,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			amt := mtransaction.Amount{Value: dec(tc.requested)}
+
+			got := effectiveOperationAmount(
+				amt,
+				dec(tc.beforeAvailable), dec(tc.afterAvailable),
+				dec(tc.beforeOnHold), dec(tc.afterOnHold),
+			)
+
+			assert.True(t, got.Equal(dec(tc.expected)),
+				"expected effective amount %d, got %s (requested=%d, before=%d, after=%d)",
+				tc.expected, got.String(), tc.requested, tc.beforeAvailable, tc.afterAvailable)
+		})
+	}
+}

--- a/components/ledger/internal/adapters/http/in/transaction_helper.go
+++ b/components/ledger/internal/adapters/http/in/transaction_helper.go
@@ -82,6 +82,36 @@ func getAliasWithoutKey(array []string) []string {
 	return result
 }
 
+// filterCompanionAliases removes alias-key entries that target the system-
+// managed overdraft companion balance (key == "overdraft"). These companions
+// are added to `validate.Sources` / `validate.Destinations` by the enrichment
+// engine so ValidateBalancesRules sees consistent counts, but they MUST NOT
+// appear in the user-facing `tran.Source` / `tran.Destination` lists —
+// otherwise the response would show duplicate aliases (the bare alias is
+// identical to the default balance's bare alias) and leak the existence of
+// a system-managed ledger into the client API contract.
+func filterCompanionAliases(aliases []string) []string {
+	if len(aliases) == 0 {
+		return aliases
+	}
+
+	out := make([]string, 0, len(aliases))
+
+	for _, a := range aliases {
+		// Alias format produced by AliasKey/CalculateTotal is
+		// "<alias>#<balanceKey>"; a missing "#" means the entry is already
+		// bare (defensive path) — pass it through unchanged.
+		idx := strings.LastIndex(a, "#")
+		if idx >= 0 && a[idx+1:] == constant.OverdraftBalanceKey {
+			continue
+		}
+
+		out = append(out, a)
+	}
+
+	return out
+}
+
 // balanceRef holds a pre-computed balance reference for O(1) lookup by aliasKey.
 type balanceRef struct {
 	balance     *mmodel.Balance

--- a/components/ledger/internal/adapters/http/in/transaction_overdraft_enrichment.go
+++ b/components/ledger/internal/adapters/http/in/transaction_overdraft_enrichment.go
@@ -494,6 +494,11 @@ func collectOverdraftRefundSplits(balanceOps []mmodel.BalanceOperation) []overdr
 // overdraft is repaid first, then the remainder (if any) lands on the
 // default balance via the primary op.
 //
+// Direction is set to "credit" (the operation semantics — this is a
+// repayment), NOT the balance direction ("debit"). This ensures that
+// downstream rubric resolution (resolveAccountingRubric) picks
+// Overdraft.Credit without special-casing in the resolver.
+//
 // Alias shape: same positional-prefix convention as the debit path (see
 // buildCompanionDebitOp) — uses the destination op's index so that
 // `BuildOperations` can match the companion balance against the companion
@@ -502,7 +507,7 @@ func buildCompanionCreditOp(organizationID, ledgerID uuid.UUID, r overdraftRefun
 	companionAmount := r.destination.Amount
 	companionAmount.Value = r.repayAmount
 	companionAmount.Operation = libConstants.CREDIT
-	companionAmount.Direction = constant.DirectionDebit
+	companionAmount.Direction = constant.DirectionCredit
 
 	internalKey := utils.BalanceInternalKey(organizationID, ledgerID,
 		companion.Alias+"#"+companion.Key)

--- a/components/ledger/internal/adapters/http/in/transaction_overdraft_enrichment.go
+++ b/components/ledger/internal/adapters/http/in/transaction_overdraft_enrichment.go
@@ -182,12 +182,19 @@ func enrichOverdraftOperations(
 		companionOp := buildCompanionDebitOp(organizationID, ledgerID, s, companion)
 		balanceOps = append(balanceOps, companionOp)
 
+		// Inherit the primary source op's RouteID (if any) so the companion
+		// carries an accounting route through validation. Mirrors the
+		// hold/commit/cancel pattern: same routeId, different action
+		// determines the rubric. Pulled from validate.OperationRoutesFrom
+		// (keyed by the concat alias of the primary op).
+		primaryRouteID := lookupRouteID(validate, s.source.Alias, true /* isFrom */)
+
 		if validate != nil {
-			registerCompanionInValidate(validate, s.source, companionOp)
+			registerCompanionInValidate(validate, s.source, companionOp, primaryRouteID)
 		}
 
 		companionFromTos = append(companionFromTos,
-			buildCompanionFromTo(s.source, companionOp, true /* isFrom */))
+			buildCompanionFromTo(s.source, companionOp, true /* isFrom */, primaryRouteID))
 	}
 
 	for _, r := range refunds {
@@ -203,15 +210,42 @@ func enrichOverdraftOperations(
 		companionOp := buildCompanionCreditOp(organizationID, ledgerID, r, companion)
 		balanceOps = append(balanceOps, companionOp)
 
+		// Mirror of the debit path: the refund companion inherits the
+		// destination primary's RouteID from validate.OperationRoutesTo.
+		primaryRouteID := lookupRouteID(validate, r.destination.Alias, false /* isFrom */)
+
 		if validate != nil {
-			registerCompanionInValidateTo(validate, r.destination, companionOp)
+			registerCompanionInValidateTo(validate, r.destination, companionOp, primaryRouteID)
 		}
 
 		companionFromTos = append(companionFromTos,
-			buildCompanionFromTo(r.destination, companionOp, false /* isFrom */))
+			buildCompanionFromTo(r.destination, companionOp, false /* isFrom */, primaryRouteID))
 	}
 
 	return balanceOps, companionFromTos, nil
+}
+
+// lookupRouteID returns the primary op's routeID from validate's operation
+// route maps, or "" when not present (route validation disabled or legacy
+// transaction shape without routeId). The `primaryAlias` is the concat-form
+// key used both as the Alias on the BalanceOperation and as the key in
+// validate.From / validate.OperationRoutesFrom.
+//
+// Returning an empty string when the primary has no routeID is the correct
+// fallback: downstream helpers (buildCompanionFromTo,
+// registerCompanionInValidate) treat "" as "no route" and leave the
+// FromTo.RouteID pointer nil so transactions without route validation keep
+// working unchanged.
+func lookupRouteID(validate *mtransaction.Responses, primaryAlias string, isFrom bool) string {
+	if validate == nil {
+		return ""
+	}
+
+	if isFrom {
+		return validate.OperationRoutesFrom[primaryAlias]
+	}
+
+	return validate.OperationRoutesTo[primaryAlias]
 }
 
 // registerCompanionInValidate mirrors the companion op into `validate.From`
@@ -225,7 +259,15 @@ func enrichOverdraftOperations(
 //   - `validate.Sources` / `validate.Aliases` use the bare alias-key form
 //     ("@alice#overdraft") — matching how `CalculateTotal` populates them
 //     for user-submitted entries via `AliasKey(SplitAlias(...), BalanceKey)`.
-func registerCompanionInValidate(validate *mtransaction.Responses, _ mmodel.BalanceOperation, companionOp mmodel.BalanceOperation) {
+//
+// `primaryRouteID` carries the routeID from the primary op's FromTo entry
+// (as resolved by ValidateSendSourceAndDistribute). When non-empty we mirror
+// it into `validate.OperationRoutesFrom` keyed by the companion's concat
+// alias so the route-validation step (validateAccountRules) finds a matching
+// route instead of rejecting with 0117 (Accounting Route Not Found). Passing
+// an empty string keeps the map entry absent, preserving the legacy no-route
+// behaviour for transactions where route validation is disabled.
+func registerCompanionInValidate(validate *mtransaction.Responses, _ mmodel.BalanceOperation, companionOp mmodel.BalanceOperation, primaryRouteID string) {
 	if validate.From == nil {
 		validate.From = make(map[string]mtransaction.Amount, 1)
 	}
@@ -235,6 +277,19 @@ func registerCompanionInValidate(validate *mtransaction.Responses, _ mmodel.Bala
 	// only one companion entry is needed — the amount is identical.
 	if _, exists := validate.From[companionOp.Alias]; !exists {
 		validate.From[companionOp.Alias] = companionOp.Amount
+	}
+
+	if primaryRouteID != "" {
+		if validate.OperationRoutesFrom == nil {
+			validate.OperationRoutesFrom = make(map[string]string, 1)
+		}
+
+		// First-wins mirrors the From-map convention above: double-entry
+		// splits emitted on the same companion alias carry the same
+		// routeID, so overwriting would be a no-op anyway.
+		if _, exists := validate.OperationRoutesFrom[companionOp.Alias]; !exists {
+			validate.OperationRoutesFrom[companionOp.Alias] = primaryRouteID
+		}
 	}
 
 	bareAlias := stripIndexPrefix(companionOp.Alias)
@@ -482,7 +537,15 @@ func buildCompanionCreditOp(organizationID, ledgerID uuid.UUID, r overdraftRefun
 //     is what the Operation record will display as the companion's amount.
 //     The value is independent of the primary op's amount; they are two
 //     distinct balance mutations with two distinct amounts.
-func buildCompanionFromTo(primary mmodel.BalanceOperation, companionOp mmodel.BalanceOperation, isFrom bool) mtransaction.FromTo {
+//
+// `primaryRouteID` carries the routeID from the primary op's FromTo entry.
+// When non-empty it is propagated onto both FromTo.Route and FromTo.RouteID
+// so downstream consumers — BuildOperations (which copies ft.RouteID to
+// op.RouteID) and resolveRouteCodesFromCache (which looks the routeID up in
+// the transaction route cache) — see the companion as a routed operation.
+// Mirrors the hold/commit/cancel pattern where companion operations reuse
+// the direct op's routeId and the action determines the rubric.
+func buildCompanionFromTo(primary mmodel.BalanceOperation, companionOp mmodel.BalanceOperation, isFrom bool, primaryRouteID string) mtransaction.FromTo {
 	amount := mtransaction.Amount{
 		Asset:                  companionOp.Amount.Asset,
 		Value:                  companionOp.Amount.Value,
@@ -512,7 +575,7 @@ func buildCompanionFromTo(primary mmodel.BalanceOperation, companionOp mmodel.Ba
 		_ = primary.Balance // intentionally unused — placeholder for T-008
 	}
 
-	return mtransaction.FromTo{
+	ft := mtransaction.FromTo{
 		AccountAlias:    companionOp.Alias,
 		BalanceKey:      constant.OverdraftBalanceKey,
 		Amount:          &amount,
@@ -520,19 +583,49 @@ func buildCompanionFromTo(primary mmodel.BalanceOperation, companionOp mmodel.Ba
 		Metadata:        metadata,
 		IsFrom:          isFrom,
 	}
+
+	// Only propagate routeID when the primary carries one. A nil RouteID on
+	// the companion preserves the legacy no-route behaviour (route validation
+	// disabled or transaction without routeId) — setting a non-nil empty
+	// pointer here would incorrectly signal "routed with empty id" and trip
+	// the 0117 guard in validateAccountRules.
+	if primaryRouteID != "" {
+		routeID := primaryRouteID
+		ft.Route = routeID
+		ft.RouteID = &routeID
+	}
+
+	return ft
 }
 
 // registerCompanionInValidateTo mirrors the refund companion op into
 // validate.To so ValidateBalancesRules sees matching counts. Follows the
 // same key-shape convention as registerCompanionInValidate: concat-form for
 // the `To` map key, bare alias-key for the `Destinations` / `Aliases` slices.
-func registerCompanionInValidateTo(validate *mtransaction.Responses, _ mmodel.BalanceOperation, companionOp mmodel.BalanceOperation) {
+//
+// `primaryRouteID` propagation: when non-empty we mirror it into
+// `validate.OperationRoutesTo` under the companion's concat alias — this is
+// what lets validateAccountRules look up a non-empty routeID for the
+// companion and resolve it against the destination / bidirectional route
+// caches. See registerCompanionInValidate for the same mechanism on the
+// source side.
+func registerCompanionInValidateTo(validate *mtransaction.Responses, _ mmodel.BalanceOperation, companionOp mmodel.BalanceOperation, primaryRouteID string) {
 	if validate.To == nil {
 		validate.To = make(map[string]mtransaction.Amount, 1)
 	}
 
 	if _, exists := validate.To[companionOp.Alias]; !exists {
 		validate.To[companionOp.Alias] = companionOp.Amount
+	}
+
+	if primaryRouteID != "" {
+		if validate.OperationRoutesTo == nil {
+			validate.OperationRoutesTo = make(map[string]string, 1)
+		}
+
+		if _, exists := validate.OperationRoutesTo[companionOp.Alias]; !exists {
+			validate.OperationRoutesTo[companionOp.Alias] = primaryRouteID
+		}
 	}
 
 	bareAlias := stripIndexPrefix(companionOp.Alias)

--- a/components/ledger/internal/adapters/http/in/transaction_overdraft_enrichment.go
+++ b/components/ledger/internal/adapters/http/in/transaction_overdraft_enrichment.go
@@ -7,6 +7,7 @@ package in
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	libCommons "github.com/LerianStudio/lib-commons/v4/commons"
 	libConstants "github.com/LerianStudio/lib-commons/v4/commons/constants"
@@ -14,6 +15,8 @@ import (
 	"github.com/google/uuid"
 	"github.com/shopspring/decimal"
 
+	"github.com/LerianStudio/midaz/v3/components/ledger/internal/adapters/postgres/operation"
+	"github.com/LerianStudio/midaz/v3/components/ledger/internal/adapters/postgres/transaction"
 	"github.com/LerianStudio/midaz/v3/pkg"
 	"github.com/LerianStudio/midaz/v3/pkg/constant"
 	"github.com/LerianStudio/midaz/v3/pkg/mmodel"
@@ -127,8 +130,9 @@ func enrichOverdraftOperations(
 
 	debits := collectOverdraftDebitSplits(balanceOps)
 	refunds := collectOverdraftRefundSplits(balanceOps)
+	cancellations := collectOverdraftCancelSplits(balanceOps)
 
-	if len(debits) == 0 && len(refunds) == 0 {
+	if len(debits) == 0 && len(refunds) == 0 && len(cancellations) == 0 {
 		return balanceOps, nil, nil
 	}
 
@@ -138,7 +142,7 @@ func enrichOverdraftOperations(
 	// same balance can also appear as both a debit and a refund candidate
 	// across a transaction (e.g. a multi-leg transfer), so the alias set is
 	// built from the union of both.
-	aliasSet := make(map[string]struct{}, len(debits)+len(refunds))
+	aliasSet := make(map[string]struct{}, len(debits)+len(refunds)+len(cancellations))
 
 	for _, s := range debits {
 		aliasSet[s.companionAliasKey] = struct{}{}
@@ -146,6 +150,10 @@ func enrichOverdraftOperations(
 
 	for _, r := range refunds {
 		aliasSet[r.companionAliasKey] = struct{}{}
+	}
+
+	for _, c := range cancellations {
+		aliasSet[c.companionAliasKey] = struct{}{}
 	}
 
 	uniqueAliases := make([]string, 0, len(aliasSet))
@@ -220,6 +228,33 @@ func enrichOverdraftOperations(
 
 		companionFromTos = append(companionFromTos,
 			buildCompanionFromTo(r.destination, companionOp, false /* isFrom */, primaryRouteID))
+	}
+
+	for _, c := range cancellations {
+		companion, ok := companionByAliasKey[c.companionAliasKey]
+		if !ok {
+			logger.Log(ctx, libLog.LevelWarn,
+				"Overdraft companion balance not found; skipping cancel enrichment",
+				libLog.String("alias_key", c.companionAliasKey))
+
+			continue
+		}
+
+		companionOp := buildCompanionCreditOp(organizationID, ledgerID, overdraftRefund{
+			destination:       c.source,
+			repayAmount:       c.repayAmount,
+			companionAliasKey: c.companionAliasKey,
+		}, companion)
+		balanceOps = append(balanceOps, companionOp)
+
+		primaryRouteID := lookupRouteID(validate, c.source.Alias, true /* isFrom */)
+
+		if validate != nil {
+			registerCompanionInValidate(validate, c.source, companionOp, primaryRouteID)
+		}
+
+		companionFromTos = append(companionFromTos,
+			buildCompanionFromTo(c.source, companionOp, true /* isFrom */, primaryRouteID))
 	}
 
 	return balanceOps, companionFromTos, nil
@@ -368,10 +403,7 @@ func collectOverdraftDebitSplits(balanceOps []mmodel.BalanceOperation) []overdra
 			continue
 		}
 
-		// DetectOverdraftSplit consumes the transaction-layer Balance shape,
-		// so we convert lazily only when the op is a DEBIT. This keeps the
-		// common (non-overdraft) path free of allocation.
-		if op.Amount.Operation != libConstants.DEBIT {
+		if !isOverdraftDebitSplitCandidate(op.Amount) {
 			continue
 		}
 
@@ -380,7 +412,10 @@ func collectOverdraftDebitSplits(balanceOps []mmodel.BalanceOperation) []overdra
 			continue
 		}
 
-		split, deficit := mtransaction.DetectOverdraftSplit(op.Amount, *txBalance)
+		detectAmount := op.Amount
+		detectAmount.Operation = libConstants.DEBIT
+
+		split, deficit := mtransaction.DetectOverdraftSplit(detectAmount, *txBalance)
 		if !split {
 			continue
 		}
@@ -393,6 +428,16 @@ func collectOverdraftDebitSplits(balanceOps []mmodel.BalanceOperation) []overdra
 	}
 
 	return splits
+}
+
+func isOverdraftDebitSplitCandidate(amount mtransaction.Amount) bool {
+	if amount.Operation == libConstants.DEBIT {
+		return true
+	}
+
+	return amount.Operation == constant.ONHOLD &&
+		amount.TransactionType == constant.PENDING &&
+		!amount.RouteValidationEnabled
 }
 
 // buildCompanionDebitOp constructs the BalanceOperation that mirrors the
@@ -463,7 +508,7 @@ func collectOverdraftRefundSplits(balanceOps []mmodel.BalanceOperation) []overdr
 			continue
 		}
 
-		if op.Amount.Operation != libConstants.CREDIT {
+		if op.Amount.Operation != libConstants.CREDIT || isCancelOverdraftOverride(op.Amount) {
 			continue
 		}
 
@@ -485,6 +530,56 @@ func collectOverdraftRefundSplits(balanceOps []mmodel.BalanceOperation) []overdr
 	}
 
 	return refunds
+}
+
+type overdraftCancel struct {
+	source            mmodel.BalanceOperation
+	repayAmount       decimal.Decimal
+	companionAliasKey string
+}
+
+func collectOverdraftCancelSplits(balanceOps []mmodel.BalanceOperation) []overdraftCancel {
+	cancellations := make([]overdraftCancel, 0)
+
+	for _, op := range balanceOps {
+		if op.Balance == nil || !isCancelOverdraftOverride(op.Amount) {
+			continue
+		}
+
+		txBalance, tErr := op.Balance.ToTransactionBalance()
+		if tErr != nil || txBalance == nil {
+			continue
+		}
+
+		if txBalance.Direction != constant.DirectionCredit || !txBalance.OverdraftUsed.GreaterThan(decimal.Zero) {
+			continue
+		}
+
+		repay := decimal.Min(op.Amount.OverdraftAmount, txBalance.OverdraftUsed)
+		if repay.GreaterThan(op.Amount.Value) {
+			repay = op.Amount.Value
+		}
+
+		if !repay.GreaterThan(decimal.Zero) {
+			continue
+		}
+
+		cancellations = append(cancellations, overdraftCancel{
+			source:            op,
+			repayAmount:       repay,
+			companionAliasKey: op.Balance.Alias + "#" + constant.OverdraftBalanceKey,
+		})
+	}
+
+	return cancellations
+}
+
+func isCancelOverdraftOverride(amount mtransaction.Amount) bool {
+	if amount.TransactionType != constant.CANCELED || !amount.OverdraftAmount.GreaterThan(decimal.Zero) {
+		return false
+	}
+
+	return amount.Operation == constant.RELEASE || amount.Operation == libConstants.CREDIT
 }
 
 // buildCompanionCreditOp constructs the CREDIT op on the direction=debit
@@ -659,4 +754,93 @@ func stripIndexPrefix(alias string) string {
 	}
 
 	return alias[len(prefix):]
+}
+
+func accountAliasFromOperationAlias(alias string) string {
+	bare := stripIndexPrefix(alias)
+	idx := strings.LastIndex(bare, "#")
+	if idx < 0 {
+		return bare
+	}
+
+	return bare[:idx]
+}
+
+func pendingOverdraftUsageByAlias(ops []*operation.Operation) map[string]decimal.Decimal {
+	usage := make(map[string]decimal.Decimal)
+
+	for _, op := range ops {
+		if op == nil || op.BalanceKey != constant.OverdraftBalanceKey || op.Type != libConstants.DEBIT || op.Amount.Value == nil {
+			continue
+		}
+
+		if !op.Amount.Value.GreaterThan(decimal.Zero) {
+			continue
+		}
+
+		usage[op.AccountAlias] = usage[op.AccountAlias].Add(*op.Amount.Value)
+	}
+
+	for _, op := range ops {
+		if op == nil || op.BalanceKey == constant.OverdraftBalanceKey || op.Type != constant.ONHOLD {
+			continue
+		}
+
+		if existing, ok := usage[op.AccountAlias]; ok && existing.GreaterThan(decimal.Zero) {
+			continue
+		}
+
+		before, beforeErr := decimal.NewFromString(op.Snapshot.OverdraftUsedBefore)
+		after, afterErr := decimal.NewFromString(op.Snapshot.OverdraftUsedAfter)
+		if beforeErr != nil || afterErr != nil {
+			continue
+		}
+
+		delta := after.Sub(before)
+		if delta.GreaterThan(decimal.Zero) {
+			usage[op.AccountAlias] = usage[op.AccountAlias].Add(delta)
+		}
+	}
+
+	return usage
+}
+
+func annotateCanceledOverdraftAmounts(balanceOps []mmodel.BalanceOperation, tran *transaction.Transaction) []mmodel.BalanceOperation {
+	if tran == nil || len(tran.Operations) == 0 {
+		return balanceOps
+	}
+
+	usageByAlias := pendingOverdraftUsageByAlias(tran.Operations)
+	if len(usageByAlias) == 0 {
+		return balanceOps
+	}
+
+	for i := range balanceOps {
+		amount := balanceOps[i].Amount
+		if amount.TransactionType != constant.CANCELED {
+			continue
+		}
+
+		if amount.Operation != constant.RELEASE && amount.Operation != libConstants.CREDIT {
+			continue
+		}
+
+		if amount.RouteValidationEnabled && amount.Operation != libConstants.CREDIT {
+			continue
+		}
+
+		if !amount.RouteValidationEnabled && amount.Operation != constant.RELEASE {
+			continue
+		}
+
+		alias := accountAliasFromOperationAlias(balanceOps[i].Alias)
+		usage, ok := usageByAlias[alias]
+		if !ok || !usage.GreaterThan(decimal.Zero) {
+			continue
+		}
+
+		balanceOps[i].Amount.OverdraftAmount = usage
+	}
+
+	return balanceOps
 }

--- a/components/ledger/internal/adapters/http/in/transaction_overdraft_enrichment.go
+++ b/components/ledger/internal/adapters/http/in/transaction_overdraft_enrichment.go
@@ -771,7 +771,15 @@ func pendingOverdraftUsageByAlias(ops []*operation.Operation) map[string]decimal
 	usage := make(map[string]decimal.Decimal)
 
 	for _, op := range ops {
-		if op == nil || op.BalanceKey != constant.OverdraftBalanceKey || op.Type != libConstants.DEBIT || op.Amount.Value == nil {
+		if op == nil || op.BalanceKey != constant.OverdraftBalanceKey || op.Amount.Value == nil {
+			continue
+		}
+
+		if op.Type != constant.OVERDRAFT && op.Type != libConstants.DEBIT {
+			continue
+		}
+
+		if op.Direction != "" && op.Direction != constant.DirectionDebit {
 			continue
 		}
 

--- a/components/ledger/internal/adapters/http/in/transaction_overdraft_enrichment.go
+++ b/components/ledger/internal/adapters/http/in/transaction_overdraft_enrichment.go
@@ -375,8 +375,8 @@ func collectOverdraftDebitSplits(balanceOps []mmodel.BalanceOperation) []overdra
 			continue
 		}
 
-		txBalance := op.Balance.ToTransactionBalance()
-		if txBalance == nil {
+		txBalance, tErr := op.Balance.ToTransactionBalance()
+		if tErr != nil || txBalance == nil {
 			continue
 		}
 
@@ -467,8 +467,8 @@ func collectOverdraftRefundSplits(balanceOps []mmodel.BalanceOperation) []overdr
 			continue
 		}
 
-		txBalance := op.Balance.ToTransactionBalance()
-		if txBalance == nil {
+		txBalance, tErr := op.Balance.ToTransactionBalance()
+		if tErr != nil || txBalance == nil {
 			continue
 		}
 

--- a/components/ledger/internal/adapters/http/in/transaction_overdraft_enrichment.go
+++ b/components/ledger/internal/adapters/http/in/transaction_overdraft_enrichment.go
@@ -1,0 +1,564 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package in
+
+import (
+	"context"
+	"fmt"
+
+	libCommons "github.com/LerianStudio/lib-commons/v4/commons"
+	libConstants "github.com/LerianStudio/lib-commons/v4/commons/constants"
+	libLog "github.com/LerianStudio/lib-commons/v4/commons/log"
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+
+	"github.com/LerianStudio/midaz/v3/pkg"
+	"github.com/LerianStudio/midaz/v3/pkg/constant"
+	"github.com/LerianStudio/midaz/v3/pkg/mmodel"
+	"github.com/LerianStudio/midaz/v3/pkg/mtransaction"
+	"github.com/LerianStudio/midaz/v3/pkg/utils"
+)
+
+// companionBalanceLoader abstracts the lookup used by overdraft enrichment to
+// fetch the system-managed companion balance. It mirrors the signature of the
+// existing query.GetBalances call so the enrichment code can be exercised in
+// tests without spinning up the full query use case.
+type companionBalanceLoader func(ctx context.Context, organizationID, ledgerID uuid.UUID, aliases []string) ([]*mmodel.Balance, error)
+
+// rejectInternalScopeBalances returns a business error (0168) when any loaded
+// balance is marked BalanceScope=internal. Internal balances (e.g. the
+// auto-created overdraft companion) are system-managed and may only be
+// mutated by the enrichment engine; direct client-initiated operations must
+// be rejected before they enter the Lua atomic path.
+//
+// Mirrors the scope guard in
+// services/command/create_balance_transaction_operations_async.go:312-324
+// which runs during state transitions. The CREATE path reaches
+// SendTransactionToRedisQueue with nil balances, so its built-in guard is a
+// no-op for brand-new transactions — this helper fills the gap by enforcing
+// the same invariant once GetBalances has returned.
+func rejectInternalScopeBalances(ctx context.Context, balances []*mmodel.Balance) error {
+	logger := libCommons.NewLoggerFromContext(ctx)
+
+	for _, b := range balances {
+		if b == nil || b.Settings == nil {
+			continue
+		}
+
+		if b.Settings.BalanceScope != mmodel.BalanceScopeInternal {
+			continue
+		}
+
+		logger.Log(ctx, libLog.LevelWarn,
+			"Rejected transaction targeting internal-scope balance",
+			libLog.String("alias", b.Alias),
+			libLog.String("key", b.Key))
+
+		// Surface the canonical error so the HTTP layer returns 422/0168 and
+		// any upstream client sees a consistent code whether the rejection
+		// came from the CREATE path or a state transition.
+		return pkg.ValidateBusinessError(constant.ErrDirectOperationOnInternalBalance, constant.EntityBalance, b.Alias)
+	}
+
+	return nil
+}
+
+// enrichOverdraftOperations implements the transaction enrichment contract
+// described in the TRD (2.2 — Enrichment Engine): when a debit on a
+// direction=credit balance exceeds available funds and the balance has
+// overdraft enabled, we append a *debit* operation on the companion
+// "#overdraft" balance for the deficit amount.
+//
+// Rationale for appending (not splitting the original op):
+//   - The Lua atomic script already owns the floor-at-zero math and the
+//     overdraft_used accrual on the credit balance. Splitting the amount in
+//     Go would have two independent places computing the same split, making
+//     it impossible to keep them in lock-step under concurrency (TRD 242-246,
+//     "dual source of truth" risk).
+//   - Accounting parity: the appended op is an *extra* balance mutation that
+//     never participates in ValidateSendSourceAndDistribute (which ran on user
+//     input before we reach this point). The user-visible send value therefore
+//     still matches the destination credit total, and only the balance layer
+//     observes the additional overdraft-companion mutation.
+//
+// Net effect on the atomic script:
+//   - Original op on alias#default triggers the Lua overdraft branch — floors
+//     Available at 0 and accrues `overdraft_used` by the deficit on the
+//     credit balance.
+//   - Appended op on alias#overdraft applies a DEBIT on a direction=debit
+//     companion balance, which increments its Available by the deficit
+//     (direction=debit semantics: DEBIT grows the liability).
+//
+// If the companion balance cannot be found (e.g., was never auto-created
+// because AllowOverdraft was set before companion provisioning landed), the
+// enrichment skips the pair silently; the Lua script's built-in split still
+// keeps the default balance correct, only the companion balance's Available
+// will lag — surfaced by the existing E2E tests and balance listing.
+//
+// Side effects on `validate`:
+//
+// `mtransaction.ValidateBalancesRules` enforces `len(balances) ==
+// len(validate.From) + len(validate.To)` as the first check after
+// deduplication. Appending a companion op adds a fresh alias to the balance
+// list, so we MUST mirror that alias as a pseudo-entry in `validate.From`
+// (the companion is always on the source side of the transaction) to keep
+// the count invariant. The pseudo-entry re-uses the companion's amount,
+// direction, and transaction metadata; it is not billed against the user-
+// visible send total because the split happens after
+// ValidateSendSourceAndDistribute has already signed off on the totals.
+//
+// Return values:
+//   - enriched balanceOps (primary ops + appended companion ops)
+//   - companion FromTo entries that the handler MUST append to its fromTo
+//     slice before calling BuildOperations, so the operation-record loop
+//     (balances × fromTo) generates a persisted Operation for each companion.
+//     Without this, the balance tables converge correctly but the audit trail
+//     is missing the overdraft leg (TRD PRD §1 "Enriched Transaction Flow").
+func enrichOverdraftOperations(
+	ctx context.Context,
+	organizationID, ledgerID uuid.UUID,
+	balanceOps []mmodel.BalanceOperation,
+	validate *mtransaction.Responses,
+	loader companionBalanceLoader,
+) ([]mmodel.BalanceOperation, []mtransaction.FromTo, error) {
+	logger := libCommons.NewLoggerFromContext(ctx)
+
+	debits := collectOverdraftDebitSplits(balanceOps)
+	refunds := collectOverdraftRefundSplits(balanceOps)
+
+	if len(debits) == 0 && len(refunds) == 0 {
+		return balanceOps, nil, nil
+	}
+
+	// Deduplicate companion alias lookups: multiple source ops on the same
+	// alias#default balance (e.g. double-entry PENDING splits) share a single
+	// companion balance. Loading it once keeps the request path cheap. The
+	// same balance can also appear as both a debit and a refund candidate
+	// across a transaction (e.g. a multi-leg transfer), so the alias set is
+	// built from the union of both.
+	aliasSet := make(map[string]struct{}, len(debits)+len(refunds))
+
+	for _, s := range debits {
+		aliasSet[s.companionAliasKey] = struct{}{}
+	}
+
+	for _, r := range refunds {
+		aliasSet[r.companionAliasKey] = struct{}{}
+	}
+
+	uniqueAliases := make([]string, 0, len(aliasSet))
+	for k := range aliasSet {
+		uniqueAliases = append(uniqueAliases, k)
+	}
+
+	companions, err := loader(ctx, organizationID, ledgerID, uniqueAliases)
+	if err != nil {
+		return nil, nil, fmt.Errorf("load overdraft companion balances: %w", err)
+	}
+
+	companionByAliasKey := make(map[string]*mmodel.Balance, len(companions))
+	for _, b := range companions {
+		companionByAliasKey[b.Alias+"#"+b.Key] = b
+	}
+
+	companionFromTos := make([]mtransaction.FromTo, 0, len(debits)+len(refunds))
+
+	for _, s := range debits {
+		companion, ok := companionByAliasKey[s.companionAliasKey]
+		if !ok {
+			// No companion found — log and skip. This is recoverable at the
+			// Lua layer (default balance still gets overdraft_used accrual)
+			// but the overdraft balance will not see the liability increase
+			// until a future reconciliation path picks it up.
+			logger.Log(ctx, libLog.LevelWarn,
+				"Overdraft companion balance not found; skipping debit enrichment",
+				libLog.String("alias_key", s.companionAliasKey))
+
+			continue
+		}
+
+		companionOp := buildCompanionDebitOp(organizationID, ledgerID, s, companion)
+		balanceOps = append(balanceOps, companionOp)
+
+		if validate != nil {
+			registerCompanionInValidate(validate, s.source, companionOp)
+		}
+
+		companionFromTos = append(companionFromTos,
+			buildCompanionFromTo(s.source, companionOp, true /* isFrom */))
+	}
+
+	for _, r := range refunds {
+		companion, ok := companionByAliasKey[r.companionAliasKey]
+		if !ok {
+			logger.Log(ctx, libLog.LevelWarn,
+				"Overdraft companion balance not found; skipping refund enrichment",
+				libLog.String("alias_key", r.companionAliasKey))
+
+			continue
+		}
+
+		companionOp := buildCompanionCreditOp(organizationID, ledgerID, r, companion)
+		balanceOps = append(balanceOps, companionOp)
+
+		if validate != nil {
+			registerCompanionInValidateTo(validate, r.destination, companionOp)
+		}
+
+		companionFromTos = append(companionFromTos,
+			buildCompanionFromTo(r.destination, companionOp, false /* isFrom */))
+	}
+
+	return balanceOps, companionFromTos, nil
+}
+
+// registerCompanionInValidate mirrors the companion op into `validate.From`
+// and `validate.Sources` so downstream count-based invariants
+// (ValidateBalancesRules len check, alias lookup paths) treat the companion
+// as a first-class source balance.
+//
+// Key-shape convention (must match user ops to avoid duplicate counters):
+//   - `validate.From` is keyed by the concat-form alias ("0#@alice#…") — so
+//     the key is `companionOp.Alias` as-is (the builder now emits the prefix).
+//   - `validate.Sources` / `validate.Aliases` use the bare alias-key form
+//     ("@alice#overdraft") — matching how `CalculateTotal` populates them
+//     for user-submitted entries via `AliasKey(SplitAlias(...), BalanceKey)`.
+func registerCompanionInValidate(validate *mtransaction.Responses, _ mmodel.BalanceOperation, companionOp mmodel.BalanceOperation) {
+	if validate.From == nil {
+		validate.From = make(map[string]mtransaction.Amount, 1)
+	}
+
+	// First-wins: double-entry splits can produce two source ops on the same
+	// alias (e.g. DEBIT + ONHOLD for PENDING). Both would lead us here but
+	// only one companion entry is needed — the amount is identical.
+	if _, exists := validate.From[companionOp.Alias]; !exists {
+		validate.From[companionOp.Alias] = companionOp.Amount
+	}
+
+	bareAlias := stripIndexPrefix(companionOp.Alias)
+
+	for _, existing := range validate.Sources {
+		if existing == bareAlias {
+			return
+		}
+	}
+
+	validate.Sources = append(validate.Sources, bareAlias)
+
+	if !containsString(validate.Aliases, bareAlias) {
+		validate.Aliases = append(validate.Aliases, bareAlias)
+	}
+}
+
+// indexPrefix extracts the "<index>#" segment from an alias such as
+// "0#@alice#default". If the alias has no leading index (defensive path —
+// should not happen in production), an empty prefix is returned so the
+// companion entry still lands in validate.From, albeit without a positional
+// tag. Returning "" rather than panicking keeps the enrichment non-fatal in
+// the face of unexpected alias shapes.
+func indexPrefix(alias string) string {
+	for i := 0; i < len(alias); i++ {
+		if alias[i] == '#' {
+			return alias[:i+1]
+		}
+	}
+
+	return ""
+}
+
+// containsString is a tiny helper kept local to the enrichment file so we do
+// not bloat the http/in package surface with another utility.
+func containsString(list []string, want string) bool {
+	for _, s := range list {
+		if s == want {
+			return true
+		}
+	}
+
+	return false
+}
+
+// overdraftSplit captures the information required to enrich a single source
+// operation with its companion debit op. It is intentionally a plain value
+// type so the enrichment step has a single, testable seam.
+type overdraftSplit struct {
+	// source is the original user-initiated op on the credit balance. We keep
+	// a reference so the companion op can inherit transaction metadata
+	// (TransactionType, RouteID pointers, etc.) without re-deriving them.
+	source mmodel.BalanceOperation
+	// deficit is the positive amount (= source.Amount.Value - balance.Available)
+	// that overflows the available funds and must be routed to the overdraft
+	// companion. Always strictly greater than zero when the split is emitted.
+	deficit decimal.Decimal
+	// companionAliasKey is the "<alias>#overdraft" string used both as the
+	// alias lookup key on the loaded companion balance and as the alias
+	// attached to the emitted BalanceOperation.
+	companionAliasKey string
+}
+
+// collectOverdraftDebitSplits walks the primary balance operations and returns
+// the split descriptors for every source op whose debit amount exceeds the
+// credit balance's available funds with overdraft enabled.
+//
+// The function is deliberately read-only: it does not mutate balanceOps. All
+// mutations (appending the companion op) happen once on the caller side, so
+// the rest of the pipeline still sees the primary ops in their original form.
+func collectOverdraftDebitSplits(balanceOps []mmodel.BalanceOperation) []overdraftSplit {
+	splits := make([]overdraftSplit, 0)
+
+	for _, op := range balanceOps {
+		if op.Balance == nil {
+			continue
+		}
+
+		// DetectOverdraftSplit consumes the transaction-layer Balance shape,
+		// so we convert lazily only when the op is a DEBIT. This keeps the
+		// common (non-overdraft) path free of allocation.
+		if op.Amount.Operation != libConstants.DEBIT {
+			continue
+		}
+
+		txBalance := op.Balance.ToTransactionBalance()
+		if txBalance == nil {
+			continue
+		}
+
+		split, deficit := mtransaction.DetectOverdraftSplit(op.Amount, *txBalance)
+		if !split {
+			continue
+		}
+
+		splits = append(splits, overdraftSplit{
+			source:            op,
+			deficit:           deficit,
+			companionAliasKey: op.Balance.Alias + "#" + constant.OverdraftBalanceKey,
+		})
+	}
+
+	return splits
+}
+
+// buildCompanionDebitOp constructs the BalanceOperation that mirrors the
+// overdraft deficit onto the direction=debit companion balance. The operation
+// inherits transaction metadata (TransactionType, route ids, pending flag)
+// from the source op so downstream consumers (aggregation, accounting entries)
+// treat the companion as part of the same logical transaction.
+//
+// Direction is set to debit explicitly: the companion balance is always
+// direction=debit (TRD 2.2 table row 2), and passing the direction lets the
+// state machine skip the inference path.
+//
+// Alias shape: the companion's Alias is built in the SAME positional-prefix
+// form as user-initiated ops (e.g. "0#@alice#overdraft") — sharing the
+// originating source's positional index. The Lua script copies this string
+// verbatim into the returned balance record, and BuildOperations (later in
+// the pipeline) matches it against `fromTo[i].AccountAlias`. Without the
+// positional prefix the match loop `balance.Alias == fromTo[i].AccountAlias`
+// fails and no operation record is emitted for the companion balance — the
+// audit trail would converge on the wrong answer even though Lua did the
+// right thing.
+func buildCompanionDebitOp(organizationID, ledgerID uuid.UUID, s overdraftSplit, companion *mmodel.Balance) mmodel.BalanceOperation {
+	companionAmount := s.source.Amount
+	companionAmount.Value = s.deficit
+	companionAmount.Operation = libConstants.DEBIT
+	companionAmount.Direction = constant.DirectionDebit
+
+	internalKey := utils.BalanceInternalKey(organizationID, ledgerID,
+		companion.Alias+"#"+companion.Key)
+
+	return mmodel.BalanceOperation{
+		Balance:     companion,
+		Alias:       indexPrefix(s.source.Alias) + s.companionAliasKey,
+		Amount:      companionAmount,
+		InternalKey: internalKey,
+	}
+}
+
+// overdraftRefund captures the information required to enrich a destination
+// credit op with its companion repayment. Mirrors overdraftSplit but carries
+// the repayment amount (min(credit, overdraft_used)) instead of the debit
+// deficit.
+type overdraftRefund struct {
+	// destination is the original user-initiated CREDIT op on the credit
+	// balance that currently carries outstanding overdraft. We keep it so
+	// the companion op can inherit metadata (asset, TransactionType, etc.).
+	destination mmodel.BalanceOperation
+	// repayAmount is min(credit, overdraft_used) — the portion of the credit
+	// that flows to the companion balance (reducing its Available under
+	// direction=debit CREDIT semantics). Always greater than zero when the
+	// refund is emitted.
+	repayAmount decimal.Decimal
+	// companionAliasKey is "<alias>#overdraft" for the balance that carries
+	// the outstanding liability we are repaying.
+	companionAliasKey string
+}
+
+// collectOverdraftRefundSplits walks the primary balance operations and
+// returns a refund descriptor for every destination op whose credit amount
+// should repay outstanding overdraft on a direction=credit balance with
+// OverdraftUsed > 0. The function is read-only; the caller appends the
+// companion CREDIT op once the companion balance has been loaded.
+func collectOverdraftRefundSplits(balanceOps []mmodel.BalanceOperation) []overdraftRefund {
+	refunds := make([]overdraftRefund, 0)
+
+	for _, op := range balanceOps {
+		if op.Balance == nil {
+			continue
+		}
+
+		if op.Amount.Operation != libConstants.CREDIT {
+			continue
+		}
+
+		txBalance := op.Balance.ToTransactionBalance()
+		if txBalance == nil {
+			continue
+		}
+
+		split, repay, _ := mtransaction.DetectRefundSplit(op.Amount, *txBalance)
+		if !split {
+			continue
+		}
+
+		refunds = append(refunds, overdraftRefund{
+			destination:       op,
+			repayAmount:       repay,
+			companionAliasKey: op.Balance.Alias + "#" + constant.OverdraftBalanceKey,
+		})
+	}
+
+	return refunds
+}
+
+// buildCompanionCreditOp constructs the CREDIT op on the direction=debit
+// overdraft companion. A CREDIT on a direction=debit balance DECREASES its
+// Available (the liability is being paid down), so this operation matches
+// the causal ordering described in the PRD (§ Overdraft Repayment): the
+// overdraft is repaid first, then the remainder (if any) lands on the
+// default balance via the primary op.
+//
+// Alias shape: same positional-prefix convention as the debit path (see
+// buildCompanionDebitOp) — uses the destination op's index so that
+// `BuildOperations` can match the companion balance against the companion
+// FromTo entry produced alongside this op.
+func buildCompanionCreditOp(organizationID, ledgerID uuid.UUID, r overdraftRefund, companion *mmodel.Balance) mmodel.BalanceOperation {
+	companionAmount := r.destination.Amount
+	companionAmount.Value = r.repayAmount
+	companionAmount.Operation = libConstants.CREDIT
+	companionAmount.Direction = constant.DirectionDebit
+
+	internalKey := utils.BalanceInternalKey(organizationID, ledgerID,
+		companion.Alias+"#"+companion.Key)
+
+	return mmodel.BalanceOperation{
+		Balance:     companion,
+		Alias:       indexPrefix(r.destination.Alias) + r.companionAliasKey,
+		Amount:      companionAmount,
+		InternalKey: internalKey,
+	}
+}
+
+// buildCompanionFromTo constructs the synthetic FromTo entry that tells
+// BuildOperations to emit an Operation record for the companion balance.
+// Without this entry, the `balances × fromTo` loop in BuildOperations never
+// matches the companion (its alias is not in the user-submitted transaction
+// DSL) and the persisted audit trail is missing the overdraft leg — the
+// failure mode observed in the feature before this fix: DB balances correct,
+// response.operations incomplete, Postgres `operation` table missing rows.
+//
+// The returned entry:
+//   - Carries `AccountAlias` in the same concat form as the companion
+//     BalanceOperation so `blc.Alias == fromTo[i].AccountAlias` matches.
+//   - Inherits `ChartOfAccounts`, `Route`, `RouteID`, `Metadata`, and
+//     `Description` from the user-submitted primary op so the companion
+//     record shows up in accounting reports alongside the primary leg.
+//   - Sets `IsFrom` based on which side of the transaction triggered the
+//     enrichment (debit split → source side; refund split → destination
+//     side). The state machine downstream reads this flag when deciding
+//     double-entry splitting and polarity.
+//   - Carries an `Amount` pointer with the deficit/repayment value — this
+//     is what the Operation record will display as the companion's amount.
+//     The value is independent of the primary op's amount; they are two
+//     distinct balance mutations with two distinct amounts.
+func buildCompanionFromTo(primary mmodel.BalanceOperation, companionOp mmodel.BalanceOperation, isFrom bool) mtransaction.FromTo {
+	amount := mtransaction.Amount{
+		Asset:                  companionOp.Amount.Asset,
+		Value:                  companionOp.Amount.Value,
+		Operation:              companionOp.Amount.Operation,
+		TransactionType:        companionOp.Amount.TransactionType,
+		Direction:              companionOp.Amount.Direction,
+		RouteValidationEnabled: companionOp.Amount.RouteValidationEnabled,
+	}
+
+	// `primary` is the user-submitted BalanceOperation; we reach through its
+	// Balance (user-facing credit balance) to inherit metadata the companion
+	// should carry. Defensive nil-check: the enrichment's precondition is
+	// Balance != nil on the primary, but we fall back to empty metadata
+	// rather than panicking if someone later changes that invariant.
+	var (
+		chartOfAccounts string
+		metadata        map[string]any
+	)
+
+	if primary.Balance != nil {
+		// There is no Route/ChartOfAccounts on the Balance type directly —
+		// those live on the user's DSL entry. For companion entries we
+		// currently leave them empty so they do not leak user-facing
+		// accounting rubrics onto the system-managed companion op. Future
+		// work (T-008 AccountingEntries Extension) may fill these in from
+		// an `overdraft`/`refund` accounting-route rubric.
+		_ = primary.Balance // intentionally unused — placeholder for T-008
+	}
+
+	return mtransaction.FromTo{
+		AccountAlias:    companionOp.Alias,
+		BalanceKey:      constant.OverdraftBalanceKey,
+		Amount:          &amount,
+		ChartOfAccounts: chartOfAccounts,
+		Metadata:        metadata,
+		IsFrom:          isFrom,
+	}
+}
+
+// registerCompanionInValidateTo mirrors the refund companion op into
+// validate.To so ValidateBalancesRules sees matching counts. Follows the
+// same key-shape convention as registerCompanionInValidate: concat-form for
+// the `To` map key, bare alias-key for the `Destinations` / `Aliases` slices.
+func registerCompanionInValidateTo(validate *mtransaction.Responses, _ mmodel.BalanceOperation, companionOp mmodel.BalanceOperation) {
+	if validate.To == nil {
+		validate.To = make(map[string]mtransaction.Amount, 1)
+	}
+
+	if _, exists := validate.To[companionOp.Alias]; !exists {
+		validate.To[companionOp.Alias] = companionOp.Amount
+	}
+
+	bareAlias := stripIndexPrefix(companionOp.Alias)
+
+	for _, existing := range validate.Destinations {
+		if existing == bareAlias {
+			return
+		}
+	}
+
+	validate.Destinations = append(validate.Destinations, bareAlias)
+
+	if !containsString(validate.Aliases, bareAlias) {
+		validate.Aliases = append(validate.Aliases, bareAlias)
+	}
+}
+
+// stripIndexPrefix is the inverse of indexPrefix: given an alias like
+// "0#@alice#overdraft" it returns "@alice#overdraft". If no leading
+// "<digits>#" prefix is present the alias is returned unchanged, so the
+// helper is safe to call on values of either shape.
+func stripIndexPrefix(alias string) string {
+	prefix := indexPrefix(alias)
+	if prefix == "" {
+		return alias
+	}
+
+	return alias[len(prefix):]
+}

--- a/components/ledger/internal/adapters/http/in/transaction_overdraft_enrichment.go
+++ b/components/ledger/internal/adapters/http/in/transaction_overdraft_enrichment.go
@@ -758,6 +758,7 @@ func stripIndexPrefix(alias string) string {
 
 func accountAliasFromOperationAlias(alias string) string {
 	bare := stripIndexPrefix(alias)
+
 	idx := strings.LastIndex(bare, "#")
 	if idx < 0 {
 		return bare
@@ -791,6 +792,7 @@ func pendingOverdraftUsageByAlias(ops []*operation.Operation) map[string]decimal
 		}
 
 		before, beforeErr := decimal.NewFromString(op.Snapshot.OverdraftUsedBefore)
+
 		after, afterErr := decimal.NewFromString(op.Snapshot.OverdraftUsedAfter)
 		if beforeErr != nil || afterErr != nil {
 			continue
@@ -834,6 +836,7 @@ func annotateCanceledOverdraftAmounts(balanceOps []mmodel.BalanceOperation, tran
 		}
 
 		alias := accountAliasFromOperationAlias(balanceOps[i].Alias)
+
 		usage, ok := usageByAlias[alias]
 		if !ok || !usage.GreaterThan(decimal.Zero) {
 			continue

--- a/components/ledger/internal/adapters/http/in/transaction_overdraft_enrichment_test.go
+++ b/components/ledger/internal/adapters/http/in/transaction_overdraft_enrichment_test.go
@@ -443,8 +443,8 @@ func TestEnrichOverdraftOperations_DestinationRefundSplit(t *testing.T) {
 	companionOp := enriched[1]
 	assert.Equal(t, libConstants.CREDIT, companionOp.Amount.Operation,
 		"companion op must be a CREDIT so direction=debit semantics shrink the liability")
-	assert.Equal(t, constant.DirectionDebit, companionOp.Amount.Direction,
-		"companion direction must be explicit for the state machine")
+	assert.Equal(t, constant.DirectionCredit, companionOp.Amount.Direction,
+		"companion direction must be credit (repayment semantics) for rubric resolution")
 	assert.True(t, companionOp.Amount.Value.Equal(decimal.NewFromInt(50)),
 		"companion repay amount must equal min(80, 50) = 50, got %s", companionOp.Amount.Value)
 

--- a/components/ledger/internal/adapters/http/in/transaction_overdraft_enrichment_test.go
+++ b/components/ledger/internal/adapters/http/in/transaction_overdraft_enrichment_test.go
@@ -1,0 +1,523 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package in
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	libConstants "github.com/LerianStudio/lib-commons/v4/commons/constants"
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/LerianStudio/midaz/v3/pkg/constant"
+	"github.com/LerianStudio/midaz/v3/pkg/mmodel"
+	"github.com/LerianStudio/midaz/v3/pkg/mtransaction"
+	"github.com/LerianStudio/midaz/v3/pkg/utils"
+)
+
+// overdraftEnabledBalance builds a credit-direction balance with overdraft
+// turned on and the provided limit. It mirrors the shape produced by
+// getBalancesFromCache (Settings materialized from the Redis payload).
+func overdraftEnabledBalance(t *testing.T, alias string, available decimal.Decimal, limit string) *mmodel.Balance {
+	t.Helper()
+
+	limitCopy := limit
+
+	return &mmodel.Balance{
+		ID:             uuid.New().String(),
+		AccountID:      uuid.New().String(),
+		Alias:          alias,
+		Key:            constant.DefaultBalanceKey,
+		AssetCode:      "BRL",
+		Available:      available,
+		OnHold:         decimal.Zero,
+		Version:        1,
+		AccountType:    "deposit",
+		AllowSending:   true,
+		AllowReceiving: true,
+		Direction:      constant.DirectionCredit,
+		OverdraftUsed:  decimal.Zero,
+		Settings: &mmodel.BalanceSettings{
+			BalanceScope:          mmodel.BalanceScopeTransactional,
+			AllowOverdraft:        true,
+			OverdraftLimitEnabled: limit != "" && limit != "0",
+			OverdraftLimit:        ptrIfNotEmpty(&limitCopy),
+		},
+	}
+}
+
+func ptrIfNotEmpty(s *string) *string {
+	if s == nil || *s == "" || *s == "0" {
+		return nil
+	}
+
+	return s
+}
+
+// companionOverdraftBalance builds the direction=debit companion for an alias.
+func companionOverdraftBalance(alias string) *mmodel.Balance {
+	return &mmodel.Balance{
+		ID:             uuid.New().String(),
+		AccountID:      uuid.New().String(),
+		Alias:          alias,
+		Key:            constant.OverdraftBalanceKey,
+		AssetCode:      "BRL",
+		Available:      decimal.Zero,
+		OnHold:         decimal.Zero,
+		Version:        1,
+		AccountType:    "deposit",
+		AllowSending:   true,
+		AllowReceiving: true,
+		Direction:      constant.DirectionDebit,
+		OverdraftUsed:  decimal.Zero,
+	}
+}
+
+// TestEnrichOverdraftOperations_SourceDebitSplit is the functional spec for
+// the happy path: a source op that overflows a credit balance with overdraft
+// enabled must yield one additional DEBIT op on the companion overdraft
+// balance for the deficit amount.
+func TestEnrichOverdraftOperations_SourceDebitSplit(t *testing.T) {
+	orgID := uuid.New()
+	ledgerID := uuid.New()
+
+	source := overdraftEnabledBalance(t, "@alice", decimal.NewFromInt(50), "100")
+	companion := companionOverdraftBalance("@alice")
+
+	primary := mmodel.BalanceOperation{
+		Balance: source,
+		Alias:   "0#@alice#default",
+		Amount: mtransaction.Amount{
+			Asset:           "BRL",
+			Value:           decimal.NewFromInt(100),
+			Operation:       libConstants.DEBIT,
+			TransactionType: libConstants.CREATED,
+			Direction:       constant.DirectionCredit,
+		},
+		InternalKey: utils.BalanceInternalKey(orgID, ledgerID, "@alice#default"),
+	}
+
+	var loaderCalls [][]string
+
+	loader := func(_ context.Context, _ uuid.UUID, _ uuid.UUID, aliases []string) ([]*mmodel.Balance, error) {
+		loaderCalls = append(loaderCalls, append([]string(nil), aliases...))
+		return []*mmodel.Balance{companion}, nil
+	}
+
+	validate := &mtransaction.Responses{
+		From: map[string]mtransaction.Amount{
+			"0#@alice#default": primary.Amount,
+		},
+		Sources: []string{"@alice#default"},
+		Aliases: []string{"@alice#default"},
+	}
+
+	enriched, companionFromTos, err := enrichOverdraftOperations(context.Background(), orgID, ledgerID,
+		[]mmodel.BalanceOperation{primary}, validate, loader)
+	require.NoError(t, err)
+
+	// Loader must have been asked for exactly the companion alias.
+	require.Len(t, loaderCalls, 1)
+	assert.Equal(t, []string{"@alice#overdraft"}, loaderCalls[0])
+
+	// Enriched output: primary op first, companion op appended. Order matters
+	// because the Lua script relies on a stable alphabetical internal-key sort
+	// done later by the caller; see buildBalanceOperations.
+	require.Len(t, enriched, 2)
+	assert.Equal(t, primary, enriched[0], "primary op must pass through untouched")
+
+	companionOp := enriched[1]
+	assert.Same(t, companion, companionOp.Balance,
+		"companion op must reference the loaded overdraft balance")
+	// Companion Alias MUST be in concat form matching the source's positional
+	// prefix — this is what lets BuildOperations later match the companion
+	// against its synthetic FromTo entry via `blc.Alias == fromTo[i].AccountAlias`.
+	assert.Equal(t, "0#@alice#overdraft", companionOp.Alias,
+		"companion alias must carry the source's positional prefix so BuildOperations matches it against the companion FromTo entry")
+	assert.Equal(t, libConstants.DEBIT, companionOp.Amount.Operation,
+		"companion op must be a DEBIT so direction=debit semantics grow the liability")
+	assert.Equal(t, constant.DirectionDebit, companionOp.Amount.Direction,
+		"companion direction must be explicit to skip state-machine inference")
+	assert.True(t, companionOp.Amount.Value.Equal(decimal.NewFromInt(50)),
+		"companion amount must equal the deficit (100 - 50 = 50), got %s", companionOp.Amount.Value)
+	assert.Equal(t, utils.BalanceInternalKey(orgID, ledgerID, "@alice#overdraft"),
+		companionOp.InternalKey,
+		"internal key must use the companion alias+key so Redis targets the right blob")
+
+	// Transaction metadata must be inherited so downstream consumers treat
+	// the companion as part of the same logical transaction.
+	assert.Equal(t, libConstants.CREATED, companionOp.Amount.TransactionType)
+	assert.Equal(t, "BRL", companionOp.Amount.Asset)
+
+	// validate must be mirrored so ValidateBalancesRules sees matching counts.
+	// The concat-form key matches the companion BalanceOperation.Alias so
+	// there is exactly one canonical key per companion entry.
+	companionKey := "0#@alice#overdraft"
+	companionEntry, ok := validate.From[companionKey]
+	require.True(t, ok, "companion alias must be present in validate.From under its positional key")
+	assert.True(t, companionEntry.Value.Equal(decimal.NewFromInt(50)),
+		"validate.From entry must carry the deficit amount")
+	assert.Equal(t, libConstants.DEBIT, companionEntry.Operation)
+
+	// Sources and Aliases carry the BARE form (no positional prefix) because
+	// that is how CalculateTotal emits entries for user-submitted ops — keeping
+	// the slice shape consistent lets getAliasWithoutKey strip `#key` in a
+	// single pass without any special handling for enriched entries.
+	assert.Contains(t, validate.Sources, "@alice#overdraft",
+		"companion alias-key must join the sources list so downstream maps have a slot")
+	assert.Contains(t, validate.Aliases, "@alice#overdraft",
+		"companion alias-key must join the aliases list so secondary lookups find it")
+
+	// Companion FromTo entries are the audit-trail half of the enrichment
+	// contract: the caller appends these to its `fromTo` slice so
+	// BuildOperations emits one Operation record per companion balance
+	// mutation. The AccountAlias MUST match the BalanceOperation.Alias so
+	// the `balances × fromTo` match loop produces a persisted Operation.
+	require.Len(t, companionFromTos, 1, "one companion FromTo per debit split")
+
+	ft := companionFromTos[0]
+	assert.Equal(t, "0#@alice#overdraft", ft.AccountAlias,
+		"FromTo.AccountAlias must match companion BalanceOperation.Alias exactly — otherwise BuildOperations cannot match them")
+	assert.Equal(t, constant.OverdraftBalanceKey, ft.BalanceKey,
+		"FromTo.BalanceKey must be 'overdraft' so operation record reflects the companion ledger")
+	require.NotNil(t, ft.Amount, "FromTo.Amount pointer must be set for BuildOperations to dereference")
+	assert.True(t, ft.Amount.Value.Equal(decimal.NewFromInt(50)),
+		"companion FromTo amount must equal the deficit")
+	assert.True(t, ft.IsFrom, "debit enrichment companion lives on the source side")
+}
+
+// TestEnrichOverdraftOperations_NoSplitForNonOverflow guards the common path:
+// when the debit fits within the available balance, no enrichment happens and
+// the loader is not called.
+func TestEnrichOverdraftOperations_NoSplitForNonOverflow(t *testing.T) {
+	orgID := uuid.New()
+	ledgerID := uuid.New()
+
+	source := overdraftEnabledBalance(t, "@alice", decimal.NewFromInt(500), "100")
+
+	primary := mmodel.BalanceOperation{
+		Balance: source,
+		Alias:   "0#@alice#default",
+		Amount: mtransaction.Amount{
+			Value:     decimal.NewFromInt(100),
+			Operation: libConstants.DEBIT,
+			Direction: constant.DirectionCredit,
+		},
+		InternalKey: utils.BalanceInternalKey(orgID, ledgerID, "@alice#default"),
+	}
+
+	loader := func(_ context.Context, _ uuid.UUID, _ uuid.UUID, _ []string) ([]*mmodel.Balance, error) {
+		t.Fatalf("loader must not be invoked when the debit fits within available funds")
+		return nil, nil
+	}
+
+	enriched, _, err := enrichOverdraftOperations(context.Background(), orgID, ledgerID,
+		[]mmodel.BalanceOperation{primary}, nil, loader)
+	require.NoError(t, err)
+	assert.Equal(t, []mmodel.BalanceOperation{primary}, enriched,
+		"non-overflowing ops must pass through unchanged")
+}
+
+// TestEnrichOverdraftOperations_NoSplitWhenOverdraftDisabled verifies that a
+// credit balance without AllowOverdraft falls back to the legacy
+// insufficient-funds path — the Lua layer rejects the transaction at 0018 —
+// and never triggers the enrichment loader.
+func TestEnrichOverdraftOperations_NoSplitWhenOverdraftDisabled(t *testing.T) {
+	orgID := uuid.New()
+	ledgerID := uuid.New()
+
+	source := &mmodel.Balance{
+		ID:             uuid.New().String(),
+		AccountID:      uuid.New().String(),
+		Alias:          "@alice",
+		Key:            constant.DefaultBalanceKey,
+		AssetCode:      "BRL",
+		Available:      decimal.NewFromInt(50),
+		Version:        1,
+		AccountType:    "deposit",
+		AllowSending:   true,
+		AllowReceiving: true,
+		Direction:      constant.DirectionCredit,
+		// No Settings → overdraft disabled.
+	}
+
+	primary := mmodel.BalanceOperation{
+		Balance: source,
+		Alias:   "0#@alice#default",
+		Amount: mtransaction.Amount{
+			Value:     decimal.NewFromInt(100),
+			Operation: libConstants.DEBIT,
+			Direction: constant.DirectionCredit,
+		},
+	}
+
+	loader := func(_ context.Context, _ uuid.UUID, _ uuid.UUID, _ []string) ([]*mmodel.Balance, error) {
+		t.Fatalf("loader must not be invoked when AllowOverdraft is false")
+		return nil, nil
+	}
+
+	enriched, _, err := enrichOverdraftOperations(context.Background(), orgID, ledgerID,
+		[]mmodel.BalanceOperation{primary}, nil, loader)
+	require.NoError(t, err)
+	assert.Equal(t, []mmodel.BalanceOperation{primary}, enriched)
+}
+
+// TestEnrichOverdraftOperations_LoaderError propagates infra failures so the
+// handler can roll back idempotency and the redis queue. Dropping the error
+// silently would leave the transaction mid-enrichment without observable
+// failure in the API response.
+func TestEnrichOverdraftOperations_LoaderError(t *testing.T) {
+	orgID := uuid.New()
+	ledgerID := uuid.New()
+
+	source := overdraftEnabledBalance(t, "@alice", decimal.NewFromInt(50), "100")
+
+	primary := mmodel.BalanceOperation{
+		Balance: source,
+		Alias:   "0#@alice#default",
+		Amount: mtransaction.Amount{
+			Value:     decimal.NewFromInt(100),
+			Operation: libConstants.DEBIT,
+			Direction: constant.DirectionCredit,
+		},
+	}
+
+	sentinel := errors.New("redis connection refused")
+	loader := func(_ context.Context, _ uuid.UUID, _ uuid.UUID, _ []string) ([]*mmodel.Balance, error) {
+		return nil, sentinel
+	}
+
+	_, _, err := enrichOverdraftOperations(context.Background(), orgID, ledgerID,
+		[]mmodel.BalanceOperation{primary}, nil, loader)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, sentinel, "loader errors must be wrapped transparently")
+}
+
+// TestEnrichOverdraftOperations_MissingCompanionIsNoisyButNonFatal documents
+// the defensive fallback: if the companion balance was not auto-created (e.g.
+// legacy data or a failed Create call during a settings PATCH), the primary
+// op still flows through and the Lua script's internal split keeps the
+// default balance correct. The absence of the companion op is logged but
+// does NOT block the transaction.
+func TestEnrichOverdraftOperations_MissingCompanionIsNoisyButNonFatal(t *testing.T) {
+	orgID := uuid.New()
+	ledgerID := uuid.New()
+
+	source := overdraftEnabledBalance(t, "@alice", decimal.NewFromInt(50), "100")
+
+	primary := mmodel.BalanceOperation{
+		Balance: source,
+		Alias:   "0#@alice#default",
+		Amount: mtransaction.Amount{
+			Value:     decimal.NewFromInt(100),
+			Operation: libConstants.DEBIT,
+			Direction: constant.DirectionCredit,
+		},
+	}
+
+	loader := func(_ context.Context, _ uuid.UUID, _ uuid.UUID, _ []string) ([]*mmodel.Balance, error) {
+		// Return an empty list — no companion found.
+		return []*mmodel.Balance{}, nil
+	}
+
+	enriched, _, err := enrichOverdraftOperations(context.Background(), orgID, ledgerID,
+		[]mmodel.BalanceOperation{primary}, nil, loader)
+	require.NoError(t, err, "missing companion must not abort the transaction")
+	assert.Equal(t, []mmodel.BalanceOperation{primary}, enriched,
+		"no companion op appended when the companion balance is missing")
+}
+
+// TestRejectInternalScopeBalances_BlocksDirectTargeting locks in the CREATE-
+// path scope guard: when the user builds a transaction that references a
+// balance with BalanceScope=internal (e.g. "@account#overdraft"), the handler
+// must surface the canonical 0168 error instead of letting the transaction
+// enter the Lua atomic path (where it would be indistinguishable from a
+// plain insufficient-funds failure).
+//
+// This test mirrors the state-transition guard in
+// services/command/create_balance_transaction_operations_async.go and
+// ensures the two call sites stay in lock-step.
+func TestRejectInternalScopeBalances_BlocksDirectTargeting(t *testing.T) {
+	internal := &mmodel.Balance{
+		Alias: "@alice",
+		Key:   constant.OverdraftBalanceKey,
+		Settings: &mmodel.BalanceSettings{
+			BalanceScope: mmodel.BalanceScopeInternal,
+		},
+	}
+
+	regular := &mmodel.Balance{
+		Alias: "@bob",
+		Key:   constant.DefaultBalanceKey,
+		Settings: &mmodel.BalanceSettings{
+			BalanceScope: mmodel.BalanceScopeTransactional,
+		},
+	}
+
+	err := rejectInternalScopeBalances(context.Background(), []*mmodel.Balance{regular, internal})
+	require.Error(t, err, "any internal-scope balance in the slice must abort the flow")
+
+	// The rejection MUST carry the canonical 0168 code so the HTTP layer
+	// returns 422 and downstream observability reports the right category.
+	assert.Contains(t, err.Error(), constant.ErrDirectOperationOnInternalBalance.Error(),
+		"error must surface as 0168; got %v", err)
+}
+
+// TestEnrichOverdraftOperations_DestinationRefundSplit verifies the credit-
+// repayment path: when a credit destination has OverdraftUsed > 0, the
+// enrichment appends a CREDIT op on the companion overdraft balance for
+// min(amount, overdraftUsed). The primary op stays at the full credit
+// amount — the Lua atomic script reconciles the split by decrementing
+// OverdraftUsed and growing Available only by the remainder.
+func TestEnrichOverdraftOperations_DestinationRefundSplit(t *testing.T) {
+	orgID := uuid.New()
+	ledgerID := uuid.New()
+
+	// Destination balance carries outstanding overdraft. The refund detector
+	// keys off OverdraftUsed > 0 and the operation being a plain CREDIT on
+	// a direction=credit balance.
+	destination := &mmodel.Balance{
+		ID:             uuid.New().String(),
+		AccountID:      uuid.New().String(),
+		Alias:          "@alice",
+		Key:            constant.DefaultBalanceKey,
+		AssetCode:      "BRL",
+		Available:      decimal.Zero,
+		OnHold:         decimal.Zero,
+		Version:        2,
+		AccountType:    "deposit",
+		AllowSending:   true,
+		AllowReceiving: true,
+		Direction:      constant.DirectionCredit,
+		// 50 outstanding — partial repayment will cap at this value.
+		OverdraftUsed: decimal.NewFromInt(50),
+	}
+	companion := companionOverdraftBalance("@alice")
+	// Simulate the companion balance holding the matching liability.
+	companion.Available = decimal.NewFromInt(50)
+
+	primary := mmodel.BalanceOperation{
+		Balance: destination,
+		Alias:   "0#@alice#default",
+		Amount: mtransaction.Amount{
+			Asset:           "BRL",
+			Value:           decimal.NewFromInt(80),
+			Operation:       libConstants.CREDIT,
+			TransactionType: libConstants.CREATED,
+			Direction:       constant.DirectionCredit,
+		},
+		InternalKey: utils.BalanceInternalKey(orgID, ledgerID, "@alice#default"),
+	}
+
+	var loaderCalls [][]string
+
+	loader := func(_ context.Context, _ uuid.UUID, _ uuid.UUID, aliases []string) ([]*mmodel.Balance, error) {
+		loaderCalls = append(loaderCalls, append([]string(nil), aliases...))
+		return []*mmodel.Balance{companion}, nil
+	}
+
+	validate := &mtransaction.Responses{
+		To: map[string]mtransaction.Amount{
+			"0#@alice#default": primary.Amount,
+		},
+		Destinations: []string{"@alice#default"},
+		Aliases:      []string{"@alice#default"},
+	}
+
+	enriched, _, err := enrichOverdraftOperations(context.Background(), orgID, ledgerID,
+		[]mmodel.BalanceOperation{primary}, validate, loader)
+	require.NoError(t, err)
+
+	require.Len(t, loaderCalls, 1, "loader must be called once for the refund's companion")
+	assert.Equal(t, []string{"@alice#overdraft"}, loaderCalls[0])
+
+	require.Len(t, enriched, 2)
+	assert.Equal(t, primary, enriched[0], "primary credit op must flow through untouched")
+
+	companionOp := enriched[1]
+	assert.Equal(t, libConstants.CREDIT, companionOp.Amount.Operation,
+		"companion op must be a CREDIT so direction=debit semantics shrink the liability")
+	assert.Equal(t, constant.DirectionDebit, companionOp.Amount.Direction,
+		"companion direction must be explicit for the state machine")
+	assert.True(t, companionOp.Amount.Value.Equal(decimal.NewFromInt(50)),
+		"companion repay amount must equal min(80, 50) = 50, got %s", companionOp.Amount.Value)
+
+	// Validate must carry the companion in validate.To so ValidateBalancesRules
+	// keeps its len(balances) == len(From)+len(To) invariant.
+	companionKey := "0#@alice#overdraft"
+	entry, ok := validate.To[companionKey]
+	require.True(t, ok, "companion alias must be registered in validate.To")
+	assert.True(t, entry.Value.Equal(decimal.NewFromInt(50)))
+	assert.Equal(t, libConstants.CREDIT, entry.Operation)
+	assert.Contains(t, validate.Destinations, "@alice#overdraft")
+}
+
+// TestEnrichOverdraftOperations_RefundCappedAtOverdraftUsed pins the upper
+// bound: when the incoming credit is smaller than OverdraftUsed, the
+// companion op amount equals the full credit (the whole credit repays
+// overdraft; Available on default stays at zero). When it is larger, the
+// companion op is capped at OverdraftUsed and the primary op handles the
+// remainder via the Lua split.
+func TestEnrichOverdraftOperations_RefundCappedAtOverdraftUsed(t *testing.T) {
+	orgID := uuid.New()
+	ledgerID := uuid.New()
+
+	destination := &mmodel.Balance{
+		ID:             uuid.New().String(),
+		AccountID:      uuid.New().String(),
+		Alias:          "@alice",
+		Key:            constant.DefaultBalanceKey,
+		AssetCode:      "BRL",
+		Direction:      constant.DirectionCredit,
+		OverdraftUsed:  decimal.NewFromInt(500),
+		AllowSending:   true,
+		AllowReceiving: true,
+	}
+	companion := companionOverdraftBalance("@alice")
+
+	primary := mmodel.BalanceOperation{
+		Balance: destination,
+		Alias:   "0#@alice#default",
+		Amount: mtransaction.Amount{
+			Value:     decimal.NewFromInt(1), // smaller than 500 overdraft
+			Operation: libConstants.CREDIT,
+			Direction: constant.DirectionCredit,
+		},
+	}
+
+	loader := func(_ context.Context, _ uuid.UUID, _ uuid.UUID, _ []string) ([]*mmodel.Balance, error) {
+		return []*mmodel.Balance{companion}, nil
+	}
+
+	enriched, _, err := enrichOverdraftOperations(context.Background(), orgID, ledgerID,
+		[]mmodel.BalanceOperation{primary}, nil, loader)
+	require.NoError(t, err)
+	require.Len(t, enriched, 2)
+
+	assert.True(t, enriched[1].Amount.Value.Equal(decimal.NewFromInt(1)),
+		"refund cap must be min(credit, overdraft) — credit 1 against overdraft 500 yields 1, got %s",
+		enriched[1].Amount.Value)
+}
+
+// TestRejectInternalScopeBalances_AllowsTransactionalBalances is the happy
+// path: every balance is transactional, so the guard must be a no-op and let
+// the handler continue.
+func TestRejectInternalScopeBalances_AllowsTransactionalBalances(t *testing.T) {
+	transactional := []*mmodel.Balance{
+		{Alias: "@alice", Key: constant.DefaultBalanceKey,
+			Settings: &mmodel.BalanceSettings{BalanceScope: mmodel.BalanceScopeTransactional}},
+		{Alias: "@bob", Key: constant.DefaultBalanceKey},
+		// nil balance entries can appear after failed lookups — the guard
+		// must tolerate them without panicking or false-positiving.
+		nil,
+	}
+
+	err := rejectInternalScopeBalances(context.Background(), transactional)
+	require.NoError(t, err, "transactional balances and nil entries must pass through")
+}

--- a/components/ledger/internal/adapters/http/in/transaction_overdraft_enrichment_test.go
+++ b/components/ledger/internal/adapters/http/in/transaction_overdraft_enrichment_test.go
@@ -521,3 +521,185 @@ func TestRejectInternalScopeBalances_AllowsTransactionalBalances(t *testing.T) {
 	err := rejectInternalScopeBalances(context.Background(), transactional)
 	require.NoError(t, err, "transactional balances and nil entries must pass through")
 }
+
+// TestEnrichOverdraftOperations_DebitCompanionInheritsRouteID locks in the
+// route-propagation contract for the debit-split (overdraft) enrichment path:
+// when the primary source op carries a RouteID (either directly on its
+// FromTo entry or via validate.OperationRoutesFrom), the companion FromTo
+// entry MUST inherit the same RouteID. This mirrors the hold/commit/cancel
+// pattern where companion operations reuse the direct op's routeId — the
+// action determines which AccountingEntry rubric is resolved, not a
+// different RouteID.
+//
+// Failure mode this test prevents: with route validation enabled,
+// ValidateAccountingRules iterates companion ops in validate.From and looks
+// up validate.OperationRoutesFrom[companionAlias]. Without propagation this
+// returns "" and the validator rejects the transaction with 0117
+// (Accounting Route Not Found).
+func TestEnrichOverdraftOperations_DebitCompanionInheritsRouteID(t *testing.T) {
+	orgID := uuid.New()
+	ledgerID := uuid.New()
+
+	source := overdraftEnabledBalance(t, "@alice", decimal.NewFromInt(50), "100")
+	companion := companionOverdraftBalance("@alice")
+
+	primary := mmodel.BalanceOperation{
+		Balance: source,
+		Alias:   "0#@alice#default",
+		Amount: mtransaction.Amount{
+			Asset:     "BRL",
+			Value:     decimal.NewFromInt(100),
+			Operation: libConstants.DEBIT,
+			Direction: constant.DirectionCredit,
+		},
+		InternalKey: utils.BalanceInternalKey(orgID, ledgerID, "@alice#default"),
+	}
+
+	routeID := uuid.NewString()
+
+	loader := func(_ context.Context, _ uuid.UUID, _ uuid.UUID, _ []string) ([]*mmodel.Balance, error) {
+		return []*mmodel.Balance{companion}, nil
+	}
+
+	// validate mirrors what ValidateSendSourceAndDistribute would produce
+	// when the user supplies routeId on from[0].routeId — the concat key
+	// "0#@alice#default" maps to the routeID string.
+	validate := &mtransaction.Responses{
+		From: map[string]mtransaction.Amount{
+			"0#@alice#default": primary.Amount,
+		},
+		Sources: []string{"@alice#default"},
+		Aliases: []string{"@alice#default"},
+		OperationRoutesFrom: map[string]string{
+			"0#@alice#default": routeID,
+		},
+	}
+
+	_, companionFromTos, err := enrichOverdraftOperations(context.Background(), orgID, ledgerID,
+		[]mmodel.BalanceOperation{primary}, validate, loader)
+	require.NoError(t, err)
+	require.Len(t, companionFromTos, 1, "one companion FromTo per debit split")
+
+	ft := companionFromTos[0]
+	require.NotNil(t, ft.RouteID, "companion FromTo must inherit the primary's RouteID so ValidateAccountingRules can resolve it")
+	assert.Equal(t, routeID, *ft.RouteID,
+		"companion routeID must EQUAL the primary's routeID — same route, action determines rubric (hold/commit/cancel pattern)")
+
+	// Mirror check: validate.OperationRoutesFrom must now carry an entry for
+	// the companion alias so validateAccountRules sees a non-empty routeID
+	// when it iterates companion operations.
+	gotFrom, ok := validate.OperationRoutesFrom["0#@alice#overdraft"]
+	require.True(t, ok, "companion alias must be registered in validate.OperationRoutesFrom so route validation finds it")
+	assert.Equal(t, routeID, gotFrom,
+		"OperationRoutesFrom entry for the companion must point at the primary's routeID")
+}
+
+// TestEnrichOverdraftOperations_RefundCompanionInheritsRouteID mirrors the
+// debit test for the credit-repayment (refund) path: when the primary
+// destination op carries a RouteID, the refund companion FromTo entry MUST
+// inherit the same RouteID and it MUST appear in validate.OperationRoutesTo.
+func TestEnrichOverdraftOperations_RefundCompanionInheritsRouteID(t *testing.T) {
+	orgID := uuid.New()
+	ledgerID := uuid.New()
+
+	destination := &mmodel.Balance{
+		ID:             uuid.New().String(),
+		AccountID:      uuid.New().String(),
+		Alias:          "@alice",
+		Key:            constant.DefaultBalanceKey,
+		AssetCode:      "BRL",
+		Direction:      constant.DirectionCredit,
+		OverdraftUsed:  decimal.NewFromInt(50),
+		AllowSending:   true,
+		AllowReceiving: true,
+	}
+	companion := companionOverdraftBalance("@alice")
+
+	primary := mmodel.BalanceOperation{
+		Balance: destination,
+		Alias:   "0#@alice#default",
+		Amount: mtransaction.Amount{
+			Asset:     "BRL",
+			Value:     decimal.NewFromInt(80),
+			Operation: libConstants.CREDIT,
+			Direction: constant.DirectionCredit,
+		},
+		InternalKey: utils.BalanceInternalKey(orgID, ledgerID, "@alice#default"),
+	}
+
+	routeID := uuid.NewString()
+
+	loader := func(_ context.Context, _ uuid.UUID, _ uuid.UUID, _ []string) ([]*mmodel.Balance, error) {
+		return []*mmodel.Balance{companion}, nil
+	}
+
+	validate := &mtransaction.Responses{
+		To: map[string]mtransaction.Amount{
+			"0#@alice#default": primary.Amount,
+		},
+		Destinations: []string{"@alice#default"},
+		Aliases:      []string{"@alice#default"},
+		OperationRoutesTo: map[string]string{
+			"0#@alice#default": routeID,
+		},
+	}
+
+	_, companionFromTos, err := enrichOverdraftOperations(context.Background(), orgID, ledgerID,
+		[]mmodel.BalanceOperation{primary}, validate, loader)
+	require.NoError(t, err)
+	require.Len(t, companionFromTos, 1, "one companion FromTo per refund split")
+
+	ft := companionFromTos[0]
+	require.NotNil(t, ft.RouteID, "refund companion FromTo must inherit the primary's RouteID")
+	assert.Equal(t, routeID, *ft.RouteID)
+
+	gotTo, ok := validate.OperationRoutesTo["0#@alice#overdraft"]
+	require.True(t, ok, "refund companion alias must be registered in validate.OperationRoutesTo")
+	assert.Equal(t, routeID, gotTo,
+		"OperationRoutesTo entry for the refund companion must point at the primary's routeID")
+}
+
+// TestEnrichOverdraftOperations_CompanionRouteIDNilWhenPrimaryHasNone is the
+// backward-compat guard: when route validation is disabled or the primary
+// op has no routeId (legacy transaction shape), the companion FromTo must
+// also carry a nil RouteID so downstream flows that do not use route
+// validation keep working unchanged.
+func TestEnrichOverdraftOperations_CompanionRouteIDNilWhenPrimaryHasNone(t *testing.T) {
+	orgID := uuid.New()
+	ledgerID := uuid.New()
+
+	source := overdraftEnabledBalance(t, "@alice", decimal.NewFromInt(50), "100")
+	companion := companionOverdraftBalance("@alice")
+
+	primary := mmodel.BalanceOperation{
+		Balance: source,
+		Alias:   "0#@alice#default",
+		Amount: mtransaction.Amount{
+			Value:     decimal.NewFromInt(100),
+			Operation: libConstants.DEBIT,
+			Direction: constant.DirectionCredit,
+		},
+	}
+
+	loader := func(_ context.Context, _ uuid.UUID, _ uuid.UUID, _ []string) ([]*mmodel.Balance, error) {
+		return []*mmodel.Balance{companion}, nil
+	}
+
+	// No OperationRoutesFrom entry — simulates route validation disabled or
+	// legacy transaction shape without routeId.
+	validate := &mtransaction.Responses{
+		From: map[string]mtransaction.Amount{
+			"0#@alice#default": primary.Amount,
+		},
+		Sources: []string{"@alice#default"},
+		Aliases: []string{"@alice#default"},
+	}
+
+	_, companionFromTos, err := enrichOverdraftOperations(context.Background(), orgID, ledgerID,
+		[]mmodel.BalanceOperation{primary}, validate, loader)
+	require.NoError(t, err)
+	require.Len(t, companionFromTos, 1)
+
+	assert.Nil(t, companionFromTos[0].RouteID,
+		"companion RouteID must be nil when the primary has no routeId so legacy flows stay unchanged")
+}

--- a/components/ledger/internal/adapters/http/in/transaction_overdraft_enrichment_test.go
+++ b/components/ledger/internal/adapters/http/in/transaction_overdraft_enrichment_test.go
@@ -15,6 +15,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/LerianStudio/midaz/v3/components/ledger/internal/adapters/postgres/operation"
+	"github.com/LerianStudio/midaz/v3/components/ledger/internal/adapters/postgres/transaction"
 	"github.com/LerianStudio/midaz/v3/pkg/constant"
 	"github.com/LerianStudio/midaz/v3/pkg/mmodel"
 	"github.com/LerianStudio/midaz/v3/pkg/mtransaction"
@@ -190,6 +192,104 @@ func TestEnrichOverdraftOperations_SourceDebitSplit(t *testing.T) {
 	assert.True(t, ft.Amount.Value.Equal(decimal.NewFromInt(50)),
 		"companion FromTo amount must equal the deficit")
 	assert.True(t, ft.IsFrom, "debit enrichment companion lives on the source side")
+}
+
+func TestEnrichOverdraftOperations_PendingLegacyOnHoldSplit(t *testing.T) {
+	orgID := uuid.New()
+	ledgerID := uuid.New()
+
+	source := overdraftEnabledBalance(t, "@alice", decimal.NewFromInt(50), "100")
+	companion := companionOverdraftBalance("@alice")
+
+	primary := mmodel.BalanceOperation{
+		Balance: source,
+		Alias:   "0#@alice#default",
+		Amount: mtransaction.Amount{
+			Asset:                  "BRL",
+			Value:                  decimal.NewFromInt(100),
+			Operation:              constant.ONHOLD,
+			TransactionType:        constant.PENDING,
+			Direction:              constant.DirectionDebit,
+			RouteValidationEnabled: false,
+		},
+		InternalKey: utils.BalanceInternalKey(orgID, ledgerID, "@alice#default"),
+	}
+
+	loader := func(_ context.Context, _ uuid.UUID, _ uuid.UUID, aliases []string) ([]*mmodel.Balance, error) {
+		assert.Equal(t, []string{"@alice#overdraft"}, aliases)
+
+		return []*mmodel.Balance{companion}, nil
+	}
+
+	validate := &mtransaction.Responses{
+		From: map[string]mtransaction.Amount{
+			"0#@alice#default": primary.Amount,
+		},
+		Sources: []string{"@alice#default"},
+		Aliases: []string{"@alice#default"},
+	}
+
+	enriched, companionFromTos, err := enrichOverdraftOperations(context.Background(), orgID, ledgerID,
+		[]mmodel.BalanceOperation{primary}, validate, loader)
+	require.NoError(t, err)
+	require.Len(t, enriched, 2)
+
+	companionOp := enriched[1]
+	assert.Equal(t, libConstants.DEBIT, companionOp.Amount.Operation,
+		"pending legacy hold must still debit the direction=debit companion")
+	assert.Equal(t, constant.DirectionDebit, companionOp.Amount.Direction)
+	assert.True(t, companionOp.Amount.Value.Equal(decimal.NewFromInt(50)))
+	assert.Equal(t, constant.PENDING, companionOp.Amount.TransactionType)
+
+	require.Len(t, companionFromTos, 1)
+	assert.Equal(t, "0#@alice#overdraft", companionFromTos[0].AccountAlias)
+	assert.True(t, companionFromTos[0].IsFrom)
+	assert.Contains(t, validate.Sources, "@alice#overdraft")
+}
+
+func TestEnrichOverdraftOperations_PendingRouteValidationOnHoldDoesNotDoubleSplit(t *testing.T) {
+	orgID := uuid.New()
+	ledgerID := uuid.New()
+
+	source := overdraftEnabledBalance(t, "@alice", decimal.NewFromInt(50), "100")
+	companion := companionOverdraftBalance("@alice")
+
+	debit := mmodel.BalanceOperation{
+		Balance: source,
+		Alias:   "0#@alice#default",
+		Amount: mtransaction.Amount{
+			Asset:                  "BRL",
+			Value:                  decimal.NewFromInt(100),
+			Operation:              libConstants.DEBIT,
+			TransactionType:        constant.PENDING,
+			Direction:              constant.DirectionDebit,
+			RouteValidationEnabled: true,
+		},
+	}
+	onHold := debit
+	onHold.Amount.Operation = constant.ONHOLD
+	onHold.Amount.Direction = constant.DirectionCredit
+
+	loader := func(_ context.Context, _ uuid.UUID, _ uuid.UUID, _ []string) ([]*mmodel.Balance, error) {
+		return []*mmodel.Balance{companion}, nil
+	}
+
+	validate := &mtransaction.Responses{
+		From: map[string]mtransaction.Amount{
+			"0#@alice#default": onHold.Amount,
+		},
+		Sources: []string{"@alice#default"},
+		Aliases: []string{"@alice#default"},
+	}
+
+	enriched, companionFromTos, err := enrichOverdraftOperations(context.Background(), orgID, ledgerID,
+		[]mmodel.BalanceOperation{debit, onHold}, validate, loader)
+	require.NoError(t, err)
+
+	require.Len(t, enriched, 3, "only the generated DEBIT leg may create a companion")
+	assert.Equal(t, libConstants.DEBIT, enriched[2].Amount.Operation)
+	assert.True(t, enriched[2].Amount.Value.Equal(decimal.NewFromInt(50)))
+	require.Len(t, companionFromTos, 1, "route-validation ON_HOLD leg must not create a duplicate companion")
 }
 
 // TestEnrichOverdraftOperations_NoSplitForNonOverflow guards the common path:
@@ -520,6 +620,120 @@ func TestRejectInternalScopeBalances_AllowsTransactionalBalances(t *testing.T) {
 
 	err := rejectInternalScopeBalances(context.Background(), transactional)
 	require.NoError(t, err, "transactional balances and nil entries must pass through")
+}
+
+func TestAnnotateCanceledOverdraftAmounts_UsesPendingCompanionAmount(t *testing.T) {
+	release := mmodel.BalanceOperation{
+		Alias: "0#@alice#default",
+		Amount: mtransaction.Amount{
+			Value:                  decimal.NewFromInt(100),
+			Operation:              constant.RELEASE,
+			TransactionType:        constant.CANCELED,
+			RouteValidationEnabled: false,
+		},
+	}
+
+	tran := &transaction.Transaction{
+		Operations: []*operation.Operation{
+			{
+				Type:         libConstants.DEBIT,
+				BalanceKey:   constant.OverdraftBalanceKey,
+				AccountAlias: "@alice",
+				Amount:       operation.Amount{Value: decimalPtr(decimal.NewFromInt(50))},
+			},
+		},
+	}
+
+	annotated := annotateCanceledOverdraftAmounts([]mmodel.BalanceOperation{release}, tran)
+	require.Len(t, annotated, 1)
+	assert.True(t, annotated[0].Amount.OverdraftAmount.Equal(decimal.NewFromInt(50)),
+		"legacy RELEASE needs the exact pending overdraft deficit so Lua restores only the non-overdraft portion")
+}
+
+func TestAnnotateCanceledOverdraftAmounts_RouteValidationAnnotatesCreditOnly(t *testing.T) {
+	release := mmodel.BalanceOperation{
+		Alias: "0#@alice#default",
+		Amount: mtransaction.Amount{
+			Value:                  decimal.NewFromInt(100),
+			Operation:              constant.RELEASE,
+			TransactionType:        constant.CANCELED,
+			RouteValidationEnabled: true,
+		},
+	}
+	credit := release
+	credit.Amount.Operation = libConstants.CREDIT
+
+	tran := &transaction.Transaction{
+		Operations: []*operation.Operation{
+			{
+				Type:         libConstants.DEBIT,
+				BalanceKey:   constant.OverdraftBalanceKey,
+				AccountAlias: "@alice",
+				Amount:       operation.Amount{Value: decimalPtr(decimal.NewFromInt(20))},
+			},
+		},
+	}
+
+	annotated := annotateCanceledOverdraftAmounts([]mmodel.BalanceOperation{release, credit}, tran)
+	require.Len(t, annotated, 2)
+	assert.True(t, annotated[0].Amount.OverdraftAmount.IsZero(),
+		"route-validation RELEASE only clears OnHold; CREDIT carries the overdraft repayment override")
+	assert.True(t, annotated[1].Amount.OverdraftAmount.Equal(decimal.NewFromInt(20)))
+}
+
+func TestEnrichOverdraftOperations_CanceledReleaseAddsSourceCompanionCredit(t *testing.T) {
+	orgID := uuid.New()
+	ledgerID := uuid.New()
+
+	source := overdraftEnabledBalance(t, "@alice", decimal.Zero, "100")
+	source.OverdraftUsed = decimal.NewFromInt(50)
+	companion := companionOverdraftBalance("@alice")
+	companion.Available = decimal.NewFromInt(50)
+
+	release := mmodel.BalanceOperation{
+		Balance: source,
+		Alias:   "0#@alice#default",
+		Amount: mtransaction.Amount{
+			Asset:           "BRL",
+			Value:           decimal.NewFromInt(100),
+			Operation:       constant.RELEASE,
+			TransactionType: constant.CANCELED,
+			Direction:       constant.DirectionCredit,
+			OverdraftAmount: decimal.NewFromInt(50),
+		},
+	}
+
+	loader := func(_ context.Context, _ uuid.UUID, _ uuid.UUID, aliases []string) ([]*mmodel.Balance, error) {
+		assert.Equal(t, []string{"@alice#overdraft"}, aliases)
+
+		return []*mmodel.Balance{companion}, nil
+	}
+
+	validate := &mtransaction.Responses{
+		From: map[string]mtransaction.Amount{
+			"0#@alice#default": release.Amount,
+		},
+		Sources: []string{"@alice#default"},
+		Aliases: []string{"@alice#default"},
+	}
+
+	enriched, companionFromTos, err := enrichOverdraftOperations(context.Background(), orgID, ledgerID,
+		[]mmodel.BalanceOperation{release}, validate, loader)
+	require.NoError(t, err)
+	require.Len(t, enriched, 2)
+
+	companionOp := enriched[1]
+	assert.Equal(t, libConstants.CREDIT, companionOp.Amount.Operation,
+		"cancel must credit the direction=debit companion to remove the pending liability")
+	assert.True(t, companionOp.Amount.Value.Equal(decimal.NewFromInt(50)))
+
+	require.Len(t, companionFromTos, 1)
+	assert.True(t, companionFromTos[0].IsFrom, "cancel companion remains on the source side")
+	assert.Contains(t, validate.Sources, "@alice#overdraft")
+}
+
+func decimalPtr(value decimal.Decimal) *decimal.Decimal {
+	return &value
 }
 
 // TestEnrichOverdraftOperations_DebitCompanionInheritsRouteID locks in the

--- a/components/ledger/internal/adapters/http/in/transaction_state_handlers.go
+++ b/components/ledger/internal/adapters/http/in/transaction_state_handlers.go
@@ -472,6 +472,21 @@ func (handler *TransactionHandler) commitOrCancelTransaction(c *fiber.Ctx, tran 
 	}
 
 	balanceOps := buildBalanceOperations(ctx, organizationID, ledgerID, validate, balances)
+	balanceOps = annotateCanceledOverdraftAmounts(balanceOps, tran)
+
+	var companionFromTos []mtransaction.FromTo
+	if transactionStatus == constant.CANCELED {
+		balanceOps, companionFromTos, err = enrichOverdraftOperations(ctx, organizationID, ledgerID, balanceOps,
+			validate, handler.Query.GetBalances)
+		if err != nil {
+			libOpentelemetry.HandleSpanError(span, "Failed to enrich canceled overdraft operations", err)
+			logger.Log(ctx, libLog.LevelError, "Failed to enrich canceled overdraft operations", libLog.Err(err))
+
+			deleteLockOnError()
+
+			return http.WithError(c, err)
+		}
+	}
 
 	routeCache, err := handler.Query.ValidateAccountingRules(ctx, organizationID, ledgerID, balanceOps, validate, action)
 	if err != nil {
@@ -528,6 +543,8 @@ func (handler *TransactionHandler) commitOrCancelTransaction(c *fiber.Ctx, tran 
 		fromTo = append(fromTo, to...)
 	}
 
+	fromTo = append(fromTo, companionFromTos...)
+
 	tran.UpdatedAt = time.Now()
 	tran.Status = transaction.Status{
 		Code:        transactionStatus,
@@ -544,8 +561,8 @@ func (handler *TransactionHandler) commitOrCancelTransaction(c *fiber.Ctx, tran 
 		return http.WithError(c, err)
 	}
 
-	tran.Source = getAliasWithoutKey(validate.Sources)
-	tran.Destination = getAliasWithoutKey(validate.Destinations)
+	tran.Source = getAliasWithoutKey(filterCompanionAliases(validate.Sources))
+	tran.Destination = getAliasWithoutKey(filterCompanionAliases(validate.Destinations))
 	tran.Operations = operations
 
 	ctxBackup, spanBackup := tracer.Start(ctx, "handler.commit_or_cancel_transaction.send_to_redis_queue")

--- a/components/ledger/internal/adapters/http/in/transaction_state_handlers.go
+++ b/components/ledger/internal/adapters/http/in/transaction_state_handlers.go
@@ -534,7 +534,7 @@ func (handler *TransactionHandler) commitOrCancelTransaction(c *fiber.Ctx, tran 
 		Description: &transactionStatus,
 	}
 
-	operations, preBalances, err := handler.BuildOperations(ctx, balancesBefore, fromTo, transactionInput, *tran, validate, time.Now(), false, ledgerSettings.Accounting.ValidateRoutes, routeCache, action)
+	operations, preBalances, err := handler.BuildOperations(ctx, balancesBefore, balancesAfter, fromTo, transactionInput, *tran, validate, time.Now(), false, ledgerSettings.Accounting.ValidateRoutes, routeCache, action)
 	if err != nil {
 		libOpentelemetry.HandleSpanError(span, "Failed to build operations", err)
 		logger.Log(ctx, libLog.LevelError, "Failed to build operations", libLog.Err(err))

--- a/components/ledger/internal/adapters/postgres/balance/balance.go
+++ b/components/ledger/internal/adapters/postgres/balance/balance.go
@@ -7,6 +7,7 @@ package balance
 import (
 	"database/sql"
 	"encoding/json"
+	"log"
 	"time"
 
 	libCommons "github.com/LerianStudio/lib-commons/v4/commons"
@@ -108,7 +109,14 @@ func (b *BalancePostgreSQLModel) ToEntity() *mmodel.Balance {
 
 	if len(b.Settings) > 0 {
 		var settings mmodel.BalanceSettings
-		if err := json.Unmarshal(b.Settings, &settings); err == nil {
+		if err := json.Unmarshal(b.Settings, &settings); err != nil {
+			// Log corruption but don't fail reads — Settings stays nil
+			// which makes the balance behave like a legacy row (no
+			// overdraft, scope=transactional). The span/logger context is
+			// not available at this layer, so we use the standard log
+			// package as a last-resort signal.
+			log.Printf("WARN: failed to unmarshal balance settings for balance %s: %v", b.ID, err)
+		} else {
 			balance.Settings = &settings
 		}
 	}

--- a/components/ledger/internal/adapters/postgres/balance/balance.go
+++ b/components/ledger/internal/adapters/postgres/balance/balance.go
@@ -6,6 +6,7 @@ package balance
 
 import (
 	"database/sql"
+	"encoding/json"
 	"time"
 
 	libCommons "github.com/LerianStudio/lib-commons/v4/commons"
@@ -29,6 +30,9 @@ type BalancePostgreSQLModel struct {
 	AccountType    string
 	AllowSending   bool
 	AllowReceiving bool
+	Direction      string          `db:"direction"`
+	OverdraftUsed  decimal.Decimal `db:"overdraft_used"`
+	Settings       []byte          `db:"settings"`
 	CreatedAt      time.Time
 	UpdatedAt      time.Time
 	DeletedAt      sql.NullTime
@@ -49,8 +53,18 @@ func (b *BalancePostgreSQLModel) FromEntity(balance *mmodel.Balance) {
 		AccountType:    balance.AccountType,
 		AllowSending:   balance.AllowSending,
 		AllowReceiving: balance.AllowReceiving,
+		Direction:      balance.Direction,
+		OverdraftUsed:  balance.OverdraftUsed,
 		CreatedAt:      balance.CreatedAt,
 		UpdatedAt:      balance.UpdatedAt,
+	}
+
+	if balance.Settings != nil {
+		// json.Marshal cannot fail for BalanceSettings: it contains only
+		// JSON-safe primitives (string, bool, *string). We intentionally
+		// discard the error and leave b.Settings as nil on the (impossible)
+		// failure path, matching the existing behavior for a nil Settings.
+		b.Settings, _ = json.Marshal(balance.Settings)
 	}
 
 	if libCommons.IsNilOrEmpty(&balance.Key) {
@@ -86,8 +100,17 @@ func (b *BalancePostgreSQLModel) ToEntity() *mmodel.Balance {
 		AccountType:    b.AccountType,
 		AllowSending:   b.AllowSending,
 		AllowReceiving: b.AllowReceiving,
+		Direction:      b.Direction,
+		OverdraftUsed:  b.OverdraftUsed,
 		CreatedAt:      b.CreatedAt,
 		UpdatedAt:      b.UpdatedAt,
+	}
+
+	if len(b.Settings) > 0 {
+		var settings mmodel.BalanceSettings
+		if err := json.Unmarshal(b.Settings, &settings); err == nil {
+			balance.Settings = &settings
+		}
 	}
 
 	return balance

--- a/components/ledger/internal/adapters/postgres/balance/balance.postgresql.go
+++ b/components/ledger/internal/adapters/postgres/balance/balance.postgresql.go
@@ -48,6 +48,9 @@ var balanceColumnList = []string{
 	"updated_at",
 	"deleted_at",
 	"key",
+	"direction",
+	"overdraft_used",
+	"settings",
 }
 
 // Repository provides an interface for operations related to balance template entities.
@@ -156,6 +159,9 @@ func (r *BalancePostgreSQLRepository) Create(ctx context.Context, balance *mmode
 			record.UpdatedAt,
 			record.DeletedAt,
 			record.Key,
+			record.Direction,
+			record.OverdraftUsed,
+			record.Settings,
 		).
 		Suffix("RETURNING " + strings.Join(balanceColumnList, ", ")).
 		PlaceholderFormat(squirrel.Dollar)
@@ -191,6 +197,9 @@ func (r *BalancePostgreSQLRepository) Create(ctx context.Context, balance *mmode
 		&created.UpdatedAt,
 		&created.DeletedAt,
 		&created.Key,
+		&created.Direction,
+		&created.OverdraftUsed,
+		&created.Settings,
 	); err != nil {
 		libOpentelemetry.HandleSpanError(spanExec, "Failed to execute insert query", err)
 		logger.Log(ctx, libLog.LevelError, "Failed to execute insert query", libLog.Err(err))
@@ -268,6 +277,9 @@ func (r *BalancePostgreSQLRepository) ListByAccountIDs(ctx context.Context, orga
 			&balance.UpdatedAt,
 			&balance.DeletedAt,
 			&balance.Key,
+			&balance.Direction,
+			&balance.OverdraftUsed,
+			&balance.Settings,
 		); err != nil {
 			libOpentelemetry.HandleSpanError(span, "Failed to scan row", err)
 
@@ -363,6 +375,9 @@ func (r *BalancePostgreSQLRepository) ListByIDs(ctx context.Context, organizatio
 			&balance.UpdatedAt,
 			&balance.DeletedAt,
 			&balance.Key,
+			&balance.Direction,
+			&balance.OverdraftUsed,
+			&balance.Settings,
 		); err != nil {
 			libOpentelemetry.HandleSpanError(span, "Failed to scan row", err)
 			logger.Log(ctx, libLog.LevelError, fmt.Sprintf("Failed to scan row: %v", err))
@@ -473,6 +488,9 @@ func (r *BalancePostgreSQLRepository) ListAll(ctx context.Context, organizationI
 			&balance.UpdatedAt,
 			&balance.DeletedAt,
 			&balance.Key,
+			&balance.Direction,
+			&balance.OverdraftUsed,
+			&balance.Settings,
 		); err != nil {
 			libOpentelemetry.HandleSpanError(span, "Failed to scan row", err)
 
@@ -603,6 +621,9 @@ func (r *BalancePostgreSQLRepository) ListAllByAccountID(ctx context.Context, or
 			&balance.UpdatedAt,
 			&balance.DeletedAt,
 			&balance.Key,
+			&balance.Direction,
+			&balance.OverdraftUsed,
+			&balance.Settings,
 		); err != nil {
 			libOpentelemetry.HandleSpanError(span, "Failed to scan row", err)
 
@@ -711,6 +732,9 @@ func (r *BalancePostgreSQLRepository) ListByAliases(ctx context.Context, organiz
 			&balance.UpdatedAt,
 			&balance.DeletedAt,
 			&balance.Key,
+			&balance.Direction,
+			&balance.OverdraftUsed,
+			&balance.Settings,
 		); err != nil {
 			libOpentelemetry.HandleSpanError(span, "Failed to scan row", err)
 
@@ -821,6 +845,9 @@ func (r *BalancePostgreSQLRepository) ListByAliasesWithKeys(ctx context.Context,
 			&balance.UpdatedAt,
 			&balance.DeletedAt,
 			&balance.Key,
+			&balance.Direction,
+			&balance.OverdraftUsed,
+			&balance.Settings,
 		); err != nil {
 			libOpentelemetry.HandleSpanError(span, "Failed to scan row", err)
 			logger.Log(ctx, libLog.LevelError, "Failed to scan row", libLog.Err(err))
@@ -842,6 +869,11 @@ func (r *BalancePostgreSQLRepository) ListByAliasesWithKeys(ctx context.Context,
 }
 
 // BalancesUpdate updates the balances in the database.
+//
+// Note: this method intentionally persists only available, on_hold, and version.
+// overdraft_used is not synced here yet — it will be added once the cache script
+// is extended to track overdraft_used per balance. Until then, overdraft_used
+// remains whatever was last written by Create or a dedicated overdraft update path.
 func (r *BalancePostgreSQLRepository) BalancesUpdate(ctx context.Context, organizationID, ledgerID uuid.UUID, balances []*mmodel.Balance) error {
 	logger, tracer, _, _ := libCommons.NewTrackingFromContext(ctx)
 
@@ -994,6 +1026,9 @@ func (r *BalancePostgreSQLRepository) Find(ctx context.Context, organizationID, 
 		&balance.UpdatedAt,
 		&balance.DeletedAt,
 		&balance.Key,
+		&balance.Direction,
+		&balance.OverdraftUsed,
+		&balance.Settings,
 	); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			err := pkg.ValidateBusinessError(constant.ErrEntityNotFound, reflect.TypeOf(mmodel.Balance{}).Name())
@@ -1049,6 +1084,9 @@ func (r *BalancePostgreSQLRepository) FindByAccountIDAndKey(ctx context.Context,
 			   account_type,
 			   allow_sending,
 			   allow_receiving,
+			   direction,
+			   overdraft_used,
+			   settings,
 			   created_at,
 			   updated_at,
 			   deleted_at
@@ -1077,6 +1115,9 @@ func (r *BalancePostgreSQLRepository) FindByAccountIDAndKey(ctx context.Context,
 		&balance.AccountType,
 		&balance.AllowSending,
 		&balance.AllowReceiving,
+		&balance.Direction,
+		&balance.OverdraftUsed,
+		&balance.Settings,
 		&balance.CreatedAt,
 		&balance.UpdatedAt,
 		&balance.DeletedAt,
@@ -1348,7 +1389,7 @@ func (r *BalancePostgreSQLRepository) Update(ctx context.Context, organizationID
 		` AND ledger_id = $` + strconv.Itoa(len(args)-1) +
 		` AND id = $` + strconv.Itoa(len(args)) +
 		` AND deleted_at IS NULL` +
-		` RETURNING id, organization_id, ledger_id, account_id, alias, asset_code, available, on_hold, version, account_type, allow_sending, allow_receiving, created_at, updated_at, deleted_at, key`
+		` RETURNING id, organization_id, ledger_id, account_id, alias, asset_code, available, on_hold, version, account_type, allow_sending, allow_receiving, created_at, updated_at, deleted_at, key, direction, overdraft_used, settings`
 
 	record := &BalancePostgreSQLModel{}
 
@@ -1370,6 +1411,9 @@ func (r *BalancePostgreSQLRepository) Update(ctx context.Context, organizationID
 		&record.UpdatedAt,
 		&record.DeletedAt,
 		&record.Key,
+		&record.Direction,
+		&record.OverdraftUsed,
+		&record.Settings,
 	); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			err = pkg.ValidateBusinessError(constant.ErrEntityNotFound, reflect.TypeOf(mmodel.Balance{}).Name())
@@ -1402,6 +1446,11 @@ func (r *BalancePostgreSQLRepository) Update(ctx context.Context, organizationID
 // Note: this method uses raw SQL instead of Squirrel because UPDATE ... FROM (VALUES ...)
 // is a PostgreSQL-specific extension that Squirrel's Update builder does not support.
 // Wrapping it in squirrel.Expr would add complexity without benefit.
+//
+// Note: this method intentionally persists only available, on_hold, and version.
+// overdraft_used is not synced here yet — it will be added once the cache script
+// is extended to track overdraft_used per balance. Until then, overdraft_used
+// remains whatever was last written by Create or a dedicated overdraft update path.
 func (r *BalancePostgreSQLRepository) UpdateMany(ctx context.Context, organizationID, ledgerID uuid.UUID, balances []mmodel.BalanceRedis) (int64, error) {
 	if len(balances) == 0 {
 		return 0, nil
@@ -1651,6 +1700,9 @@ func (r *BalancePostgreSQLRepository) ListByAccountID(ctx context.Context, organ
 			&balance.UpdatedAt,
 			&balance.DeletedAt,
 			&balance.Key,
+			&balance.Direction,
+			&balance.OverdraftUsed,
+			&balance.Settings,
 		); err != nil {
 			libOpentelemetry.HandleSpanError(span, "Failed to scan row", err)
 			logger.Log(ctx, libLog.LevelError, fmt.Sprintf("Failed to scan row: %v", err))

--- a/components/ledger/internal/adapters/postgres/balance/balance.postgresql.go
+++ b/components/ledger/internal/adapters/postgres/balance/balance.postgresql.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log"
 	"reflect"
 	"strconv"
 	"strings"
@@ -1522,25 +1523,33 @@ func (r *BalancePostgreSQLRepository) UpdateMany(ctx context.Context, organizati
 	// Note: batch size is capped at construction time (maxBatchSize = 13000) to stay
 	// within PostgreSQL's 65535 bind-parameter limit: (65535 - 3) / 5 = 13106.
 	now := time.Now()
-	valuesClauses := make([]string, len(deduped))
+	valuesClauses := make([]string, 0, len(deduped))
 	args := make([]any, 0, len(deduped)*5+3)
 	paramIdx := 1
 
 	for i, balance := range deduped {
-		valuesClauses[i] = fmt.Sprintf("($%d::uuid, $%d::numeric, $%d::numeric, $%d::bigint, $%d::numeric)",
-			paramIdx, paramIdx+1, paramIdx+2, paramIdx+3, paramIdx+4)
-
 		// OverdraftUsed is stored on BalanceRedis as a decimal string; parse
 		// into decimal.Decimal so PostgreSQL receives a numeric-compatible
-		// value. An unparseable value is treated as zero (conservative) so
-		// a single malformed cache entry does not abort the whole batch.
+		// value. A malformed value causes the row to be SKIPPED — not
+		// coerced to zero — so the last good value in PostgreSQL is
+		// preserved until the next sync delivers a valid string. Coercing
+		// to zero would silently erase outstanding overdraft debt.
 		overdraftUsed, parseErr := decimal.NewFromString(balance.OverdraftUsed)
 		if parseErr != nil {
-			overdraftUsed = decimal.Zero
+			log.Printf("WARN: skipping balance sync for id=%s: malformed OverdraftUsed %q: %v", ids[i], balance.OverdraftUsed, parseErr)
+
+			continue
 		}
+
+		valuesClauses = append(valuesClauses, fmt.Sprintf("($%d::uuid, $%d::numeric, $%d::numeric, $%d::bigint, $%d::numeric)",
+			paramIdx, paramIdx+1, paramIdx+2, paramIdx+3, paramIdx+4))
 
 		args = append(args, ids[i], balance.Available, balance.OnHold, balance.Version, overdraftUsed)
 		paramIdx += 5
+	}
+
+	if len(valuesClauses) == 0 {
+		return 0, nil
 	}
 
 	// Shared parameters: updated_at, organization_id, ledger_id

--- a/components/ledger/internal/adapters/postgres/balance/balance.postgresql.go
+++ b/components/ledger/internal/adapters/postgres/balance/balance.postgresql.go
@@ -7,6 +7,7 @@ package balance
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"reflect"
@@ -29,6 +30,7 @@ import (
 	"github.com/bxcodec/dbresolver/v2"
 	"github.com/google/uuid"
 	"github.com/lib/pq"
+	"github.com/shopspring/decimal"
 )
 
 var balanceColumnList = []string{
@@ -870,10 +872,19 @@ func (r *BalancePostgreSQLRepository) ListByAliasesWithKeys(ctx context.Context,
 
 // BalancesUpdate updates the balances in the database.
 //
-// Note: this method intentionally persists only available, on_hold, and version.
-// overdraft_used is not synced here yet — it will be added once the cache script
-// is extended to track overdraft_used per balance. Until then, overdraft_used
-// remains whatever was last written by Create or a dedicated overdraft update path.
+// Scope: this method is the synchronous transaction-commit path and intentionally
+// persists only available, on_hold, and version. It operates exclusively on the
+// default balance touched by the commit — not on any overdraft-related state.
+//
+// Why overdraft_used is NOT written here: the overdraft balance state (Direction,
+// OverdraftUsed, Settings) is managed entirely through the cache-aside pipeline
+// — the atomic Lua script mutates Redis, the balance-sync worker drains the
+// schedule set, and `UpdateMany` persists the full overdraft snapshot to
+// PostgreSQL. Writing overdraft_used from this synchronous path would race the
+// worker and risk overwriting an atomically computed value with a stale one.
+//
+// Net effect: this method keeps the hot commit path narrow (no overdraft
+// coupling), while `UpdateMany` (sync worker path) owns overdraft_used durability.
 func (r *BalancePostgreSQLRepository) BalancesUpdate(ctx context.Context, organizationID, ledgerID uuid.UUID, balances []*mmodel.Balance) error {
 	logger, tracer, _, _ := libCommons.NewTrackingFromContext(ctx)
 
@@ -1328,8 +1339,15 @@ func (r *BalancePostgreSQLRepository) DeleteAllByIDs(ctx context.Context, organi
 	return nil
 }
 
-// Update updates the allow_sending and allow_receiving fields of a Balance in the database.
-// Returns the updated balance to avoid a second query and potential replication lag issues.
+// Update updates the allow_sending, allow_receiving, and settings fields of a
+// Balance in the database. Returns the updated balance to avoid a second query
+// and potential replication lag issues.
+//
+// The settings JSONB column is written when update.Settings != nil. Marshaling
+// uses the same path as FromEntity (json.Marshal of *mmodel.BalanceSettings).
+// The use-case layer is responsible for validating the settings payload and
+// enforcing overdraft transition invariants before calling Update — the
+// repository trusts the inbound value.
 func (r *BalancePostgreSQLRepository) Update(ctx context.Context, organizationID, ledgerID, id uuid.UUID, balance mmodel.UpdateBalance) (*mmodel.Balance, error) {
 	logger, tracer, _, _ := libCommons.NewTrackingFromContext(ctx)
 
@@ -1360,6 +1378,23 @@ func (r *BalancePostgreSQLRepository) Update(ctx context.Context, organizationID
 	if balance.AllowReceiving != nil {
 		updates = append(updates, "allow_receiving = $"+strconv.Itoa(len(args)+1))
 		args = append(args, balance.AllowReceiving)
+	}
+
+	if balance.Settings != nil {
+		// Marshal to JSON bytes and cast to jsonb so PostgreSQL stores
+		// the payload as structured JSONB rather than a quoted string.
+		// json.Marshal of *BalanceSettings cannot fail (all fields are
+		// JSON-safe primitives), matching the Create/FromEntity path.
+		settingsJSON, marshalErr := json.Marshal(balance.Settings)
+		if marshalErr != nil {
+			libOpentelemetry.HandleSpanError(span, "Failed to marshal balance settings", marshalErr)
+			logger.Log(ctx, libLog.LevelError, fmt.Sprintf("Failed to marshal balance settings: %v", marshalErr))
+
+			return nil, marshalErr
+		}
+
+		updates = append(updates, "settings = $"+strconv.Itoa(len(args)+1)+"::jsonb")
+		args = append(args, settingsJSON)
 	}
 
 	updates = append(updates, "updated_at = $"+strconv.Itoa(len(args)+1))
@@ -1428,10 +1463,10 @@ func (r *BalancePostgreSQLRepository) Update(ctx context.Context, organizationID
 // is a PostgreSQL-specific extension that Squirrel's Update builder does not support.
 // Wrapping it in squirrel.Expr would add complexity without benefit.
 //
-// Note: this method intentionally persists only available, on_hold, and version.
-// overdraft_used is not synced here yet — it will be added once the cache script
-// is extended to track overdraft_used per balance. Until then, overdraft_used
-// remains whatever was last written by Create or a dedicated overdraft update path.
+// Persisted columns: available, on_hold, version, overdraft_used. The cache
+// script (balance_atomic_operation.lua) now tracks overdraft_used alongside
+// available/on_hold, so this writer includes it in the batch update to keep
+// PostgreSQL in sync with the authoritative cache state.
 func (r *BalancePostgreSQLRepository) UpdateMany(ctx context.Context, organizationID, ledgerID uuid.UUID, balances []mmodel.BalanceRedis) (int64, error) {
 	if len(balances) == 0 {
 		return 0, nil
@@ -1482,20 +1517,30 @@ func (r *BalancePostgreSQLRepository) UpdateMany(ctx context.Context, organizati
 	}
 
 	// Build a single UPDATE ... FROM (VALUES ...) statement.
-	// Each balance contributes 4 parameters: (id, available, on_hold, version).
+	// Each balance contributes 5 parameters: (id, available, on_hold, version, overdraft_used).
 	// Shared parameters (updated_at, organization_id, ledger_id) are appended at the end.
-	// Note: batch size is capped at construction time (maxBatchSize = 16000) to stay
-	// within PostgreSQL's 65535 bind-parameter limit.
+	// Note: batch size is capped at construction time (maxBatchSize = 13000) to stay
+	// within PostgreSQL's 65535 bind-parameter limit: (65535 - 3) / 5 = 13106.
 	now := time.Now()
 	valuesClauses := make([]string, len(deduped))
-	args := make([]any, 0, len(deduped)*4+3)
+	args := make([]any, 0, len(deduped)*5+3)
 	paramIdx := 1
 
 	for i, balance := range deduped {
-		valuesClauses[i] = fmt.Sprintf("($%d::uuid, $%d::numeric, $%d::numeric, $%d::bigint)",
-			paramIdx, paramIdx+1, paramIdx+2, paramIdx+3)
-		args = append(args, ids[i], balance.Available, balance.OnHold, balance.Version)
-		paramIdx += 4
+		valuesClauses[i] = fmt.Sprintf("($%d::uuid, $%d::numeric, $%d::numeric, $%d::bigint, $%d::numeric)",
+			paramIdx, paramIdx+1, paramIdx+2, paramIdx+3, paramIdx+4)
+
+		// OverdraftUsed is stored on BalanceRedis as a decimal string; parse
+		// into decimal.Decimal so PostgreSQL receives a numeric-compatible
+		// value. An unparseable value is treated as zero (conservative) so
+		// a single malformed cache entry does not abort the whole batch.
+		overdraftUsed, parseErr := decimal.NewFromString(balance.OverdraftUsed)
+		if parseErr != nil {
+			overdraftUsed = decimal.Zero
+		}
+
+		args = append(args, ids[i], balance.Available, balance.OnHold, balance.Version, overdraftUsed)
+		paramIdx += 5
 	}
 
 	// Shared parameters: updated_at, organization_id, ledger_id
@@ -1510,8 +1555,9 @@ func (r *BalancePostgreSQLRepository) UpdateMany(ctx context.Context, organizati
 		SET available = v.available,
 		    on_hold = v.on_hold,
 		    version = v.version,
+		    overdraft_used = v.overdraft_used,
 		    updated_at = $%d
-		FROM (VALUES %s) AS v(id, available, on_hold, version)
+		FROM (VALUES %s) AS v(id, available, on_hold, version, overdraft_used)
 		WHERE b.id = v.id
 		  AND b.organization_id = $%d
 		  AND b.ledger_id = $%d

--- a/components/ledger/internal/adapters/postgres/balance/balance.postgresql.go
+++ b/components/ledger/internal/adapters/postgres/balance/balance.postgresql.go
@@ -1070,26 +1070,7 @@ func (r *BalancePostgreSQLRepository) FindByAccountIDAndKey(ctx context.Context,
 
 	ctx, spanQuery := tracer.Start(ctx, "postgres.find.query")
 
-	query := `SELECT 
-			   id,
-			   organization_id,
-			   ledger_id,
-			   account_id,
-			   alias,
-			   key,
-			   asset_code,
-			   available,
-			   on_hold,
-			   version,
-			   account_type,
-			   allow_sending,
-			   allow_receiving,
-			   direction,
-			   overdraft_used,
-			   settings,
-			   created_at,
-			   updated_at,
-			   deleted_at
+	query := `SELECT ` + strings.Join(balanceColumnList, ", ") + `
 			FROM balance 
 			WHERE organization_id = $1 
 			   AND ledger_id = $2 
@@ -1107,7 +1088,6 @@ func (r *BalancePostgreSQLRepository) FindByAccountIDAndKey(ctx context.Context,
 		&balance.LedgerID,
 		&balance.AccountID,
 		&balance.Alias,
-		&balance.Key,
 		&balance.AssetCode,
 		&balance.Available,
 		&balance.OnHold,
@@ -1115,12 +1095,13 @@ func (r *BalancePostgreSQLRepository) FindByAccountIDAndKey(ctx context.Context,
 		&balance.AccountType,
 		&balance.AllowSending,
 		&balance.AllowReceiving,
-		&balance.Direction,
-		&balance.OverdraftUsed,
-		&balance.Settings,
 		&balance.CreatedAt,
 		&balance.UpdatedAt,
 		&balance.DeletedAt,
+		&balance.Key,
+		&balance.Direction,
+		&balance.OverdraftUsed,
+		&balance.Settings,
 	); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			err := pkg.ValidateBusinessError(constant.ErrEntityNotFound, reflect.TypeOf(mmodel.Balance{}).Name())
@@ -1389,7 +1370,7 @@ func (r *BalancePostgreSQLRepository) Update(ctx context.Context, organizationID
 		` AND ledger_id = $` + strconv.Itoa(len(args)-1) +
 		` AND id = $` + strconv.Itoa(len(args)) +
 		` AND deleted_at IS NULL` +
-		` RETURNING id, organization_id, ledger_id, account_id, alias, asset_code, available, on_hold, version, account_type, allow_sending, allow_receiving, created_at, updated_at, deleted_at, key, direction, overdraft_used, settings`
+		` RETURNING ` + strings.Join(balanceColumnList, ", ")
 
 	record := &BalancePostgreSQLModel{}
 

--- a/components/ledger/internal/adapters/postgres/balance/balance_overdraft_integration_test.go
+++ b/components/ledger/internal/adapters/postgres/balance/balance_overdraft_integration_test.go
@@ -1,0 +1,280 @@
+//go:build integration
+
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package balance
+
+import (
+	"database/sql"
+	"encoding/json"
+	"testing"
+	"time"
+
+	libCommons "github.com/LerianStudio/lib-commons/v4/commons"
+	"github.com/LerianStudio/midaz/v3/pkg/mmodel"
+	pgtestutil "github.com/LerianStudio/midaz/v3/tests/utils/postgres"
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ============================================================================
+// Overdraft Column Integration Tests
+// ============================================================================
+
+func TestIntegration_BalanceOverdraft_DirectionPersisted(t *testing.T) {
+	// Arrange
+	container := pgtestutil.SetupContainer(t)
+
+	orgID := uuid.Must(libCommons.GenerateUUIDv7())
+	ledgerID := uuid.Must(libCommons.GenerateUUIDv7())
+	accountID := createTestAccountID()
+	balanceID := uuid.Must(libCommons.GenerateUUIDv7())
+	now := time.Now().Truncate(time.Microsecond)
+
+	_, err := container.DB.Exec(`
+		INSERT INTO balance (id, organization_id, ledger_id, account_id, alias, key,
+			asset_code, available, on_hold, version, account_type,
+			allow_sending, allow_receiving, created_at, updated_at, direction)
+		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16)`,
+		balanceID, orgID, ledgerID, accountID, "@dir-test", "default",
+		"USD", 1000, 0, 1, "deposit",
+		true, true, now, now, "debit",
+	)
+	require.NoError(t, err, "inserting balance with direction=debit")
+
+	// Act — read back via raw SQL to verify column value
+	var direction string
+
+	err = container.DB.QueryRow(
+		`SELECT direction FROM balance WHERE id = $1`, balanceID,
+	).Scan(&direction)
+
+	// Assert
+	require.NoError(t, err, "querying direction")
+	assert.Equal(t, "debit", direction, "direction should round-trip as debit")
+}
+
+func TestIntegration_BalanceOverdraft_SchemaDefaults(t *testing.T) {
+	// Arrange — insert a row WITHOUT specifying overdraft columns
+	container := pgtestutil.SetupContainer(t)
+
+	orgID := uuid.Must(libCommons.GenerateUUIDv7())
+	ledgerID := uuid.Must(libCommons.GenerateUUIDv7())
+	accountID := createTestAccountID()
+	balanceID := uuid.Must(libCommons.GenerateUUIDv7())
+	now := time.Now().Truncate(time.Microsecond)
+
+	_, err := container.DB.Exec(`
+		INSERT INTO balance (id, organization_id, ledger_id, account_id, alias, key,
+			asset_code, available, on_hold, version, account_type,
+			allow_sending, allow_receiving, created_at, updated_at)
+		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15)`,
+		balanceID, orgID, ledgerID, accountID, "@defaults-test", "default",
+		"USD", 500, 0, 0, "deposit",
+		true, true, now, now,
+	)
+	require.NoError(t, err, "inserting balance without overdraft columns")
+
+	// Act
+	var direction string
+	var overdraftUsed decimal.Decimal
+	var settingsRaw []byte
+
+	err = container.DB.QueryRow(`
+		SELECT direction, overdraft_used, settings
+		FROM balance WHERE id = $1`, balanceID,
+	).Scan(&direction, &overdraftUsed, &settingsRaw)
+
+	// Assert
+	require.NoError(t, err, "querying default overdraft columns")
+	assert.Equal(t, "credit", direction, "default direction should be credit")
+	assert.True(t, overdraftUsed.IsZero(), "default overdraft_used should be 0")
+	assert.Nil(t, settingsRaw, "default settings should be NULL")
+}
+
+func TestIntegration_BalanceOverdraft_SettingsJSONBRoundTrip(t *testing.T) {
+	// Arrange
+	container := pgtestutil.SetupContainer(t)
+
+	orgID := uuid.Must(libCommons.GenerateUUIDv7())
+	ledgerID := uuid.Must(libCommons.GenerateUUIDv7())
+	accountID := createTestAccountID()
+	balanceID := uuid.Must(libCommons.GenerateUUIDv7())
+	now := time.Now().Truncate(time.Microsecond)
+
+	limit := "500.00"
+	inputSettings := &mmodel.BalanceSettings{
+		AllowOverdraft:        true,
+		OverdraftLimitEnabled: true,
+		OverdraftLimit:        &limit,
+		BalanceScope:          "transactional",
+	}
+
+	settingsJSON, err := json.Marshal(inputSettings)
+	require.NoError(t, err, "marshalling settings to JSON")
+
+	_, err = container.DB.Exec(`
+		INSERT INTO balance (id, organization_id, ledger_id, account_id, alias, key,
+			asset_code, available, on_hold, version, account_type,
+			allow_sending, allow_receiving, created_at, updated_at,
+			direction, overdraft_used, settings)
+		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18)`,
+		balanceID, orgID, ledgerID, accountID, "@settings-test", "default",
+		"USD", 1000, 0, 1, "deposit",
+		true, true, now, now,
+		"credit", 0, settingsJSON,
+	)
+	require.NoError(t, err, "inserting balance with JSONB settings")
+
+	// Act — read settings back
+	var raw []byte
+
+	err = container.DB.QueryRow(
+		`SELECT settings FROM balance WHERE id = $1`, balanceID,
+	).Scan(&raw)
+	require.NoError(t, err, "querying settings JSONB")
+
+	var got mmodel.BalanceSettings
+	err = json.Unmarshal(raw, &got)
+
+	// Assert
+	require.NoError(t, err, "unmarshalling settings JSONB")
+	assert.True(t, got.AllowOverdraft, "allowOverdraft should be true")
+	assert.True(t, got.OverdraftLimitEnabled, "overdraftLimitEnabled should be true")
+	require.NotNil(t, got.OverdraftLimit, "overdraftLimit should not be nil")
+	assert.Equal(t, "500.00", *got.OverdraftLimit, "overdraftLimit should round-trip")
+	assert.Equal(t, "transactional", got.BalanceScope, "balanceScope should round-trip")
+}
+
+func TestIntegration_BalanceOverdraft_UpdateOverdraftUsedViaSQLBatch(t *testing.T) {
+	// Arrange — simulates the UpdateMany path (Redis→PG sync) at the SQL level.
+	// When the repository is updated to include overdraft_used in UpdateMany,
+	// this test verifies the column can be modified via a batch UPDATE.
+	container := pgtestutil.SetupContainer(t)
+
+	orgID := uuid.Must(libCommons.GenerateUUIDv7())
+	ledgerID := uuid.Must(libCommons.GenerateUUIDv7())
+	accountID := createTestAccountID()
+	balanceID := uuid.Must(libCommons.GenerateUUIDv7())
+	now := time.Now().Truncate(time.Microsecond)
+
+	_, err := container.DB.Exec(`
+		INSERT INTO balance (id, organization_id, ledger_id, account_id, alias, key,
+			asset_code, available, on_hold, version, account_type,
+			allow_sending, allow_receiving, created_at, updated_at,
+			direction, overdraft_used)
+		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17)`,
+		balanceID, orgID, ledgerID, accountID, "@update-od", "default",
+		"USD", 800, 0, 1, "deposit",
+		true, true, now, now,
+		"credit", 0,
+	)
+	require.NoError(t, err, "inserting initial balance")
+
+	// Act — update overdraft_used via batch-style UPDATE … FROM (VALUES …)
+	_, err = container.DB.Exec(`
+		UPDATE balance AS b
+		SET overdraft_used = v.overdraft_used,
+		    version = v.version,
+		    updated_at = $4
+		FROM (VALUES ($1::uuid, $2::numeric, $3::bigint)) AS v(id, overdraft_used, version)
+		WHERE b.id = v.id
+		  AND b.version < v.version
+		  AND b.deleted_at IS NULL`,
+		balanceID, decimal.NewFromInt(150), int64(2), time.Now(),
+	)
+	require.NoError(t, err, "updating overdraft_used via batch SQL")
+
+	// Assert
+	var overdraftUsed decimal.Decimal
+
+	err = container.DB.QueryRow(
+		`SELECT overdraft_used FROM balance WHERE id = $1`, balanceID,
+	).Scan(&overdraftUsed)
+
+	require.NoError(t, err, "querying updated overdraft_used")
+	assert.True(t, overdraftUsed.Equal(decimal.NewFromInt(150)),
+		"overdraft_used should be 150 after update, got %s", overdraftUsed)
+}
+
+func TestIntegration_BalanceOverdraft_NilSettingsDoesNotCauseParseError(t *testing.T) {
+	// Arrange — insert with NULL settings (legacy/no-overdraft balance)
+	container := pgtestutil.SetupContainer(t)
+
+	orgID := uuid.Must(libCommons.GenerateUUIDv7())
+	ledgerID := uuid.Must(libCommons.GenerateUUIDv7())
+	accountID := createTestAccountID()
+	balanceID := uuid.Must(libCommons.GenerateUUIDv7())
+	now := time.Now().Truncate(time.Microsecond)
+
+	_, err := container.DB.Exec(`
+		INSERT INTO balance (id, organization_id, ledger_id, account_id, alias, key,
+			asset_code, available, on_hold, version, account_type,
+			allow_sending, allow_receiving, created_at, updated_at)
+		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15)`,
+		balanceID, orgID, ledgerID, accountID, "@nil-settings", "default",
+		"BRL", 200, 0, 0, "deposit",
+		true, true, now, now,
+	)
+	require.NoError(t, err, "inserting balance without settings")
+
+	// Act — scan settings into a nullable byte slice
+	var raw sql.NullString
+
+	err = container.DB.QueryRow(
+		`SELECT settings FROM balance WHERE id = $1`, balanceID,
+	).Scan(&raw)
+
+	// Assert
+	require.NoError(t, err, "querying NULL settings should not error")
+	assert.False(t, raw.Valid, "settings should be SQL NULL for legacy balance")
+}
+
+func TestIntegration_BalanceOverdraft_ListByAliasesReturnsOverdraftColumns(t *testing.T) {
+	// Arrange
+	container := pgtestutil.SetupContainer(t)
+
+	orgID := uuid.Must(libCommons.GenerateUUIDv7())
+	ledgerID := uuid.Must(libCommons.GenerateUUIDv7())
+	accountID := createTestAccountID()
+	balanceID := uuid.Must(libCommons.GenerateUUIDv7())
+	now := time.Now().Truncate(time.Microsecond)
+	alias := "@list-od-test"
+
+	_, err := container.DB.Exec(`
+		INSERT INTO balance (id, organization_id, ledger_id, account_id, alias, key,
+			asset_code, available, on_hold, version, account_type,
+			allow_sending, allow_receiving, created_at, updated_at,
+			direction, overdraft_used)
+		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17)`,
+		balanceID, orgID, ledgerID, accountID, alias, "default",
+		"EUR", 300, 10, 1, "checking",
+		true, true, now, now,
+		"debit", 75,
+	)
+	require.NoError(t, err, "inserting balance with overdraft columns for list test")
+
+	// Act — read raw columns back via the alias to verify the data is present
+	var direction string
+	var overdraftUsed decimal.Decimal
+
+	err = container.DB.QueryRow(`
+		SELECT direction, overdraft_used
+		FROM balance
+		WHERE organization_id = $1
+		  AND ledger_id = $2
+		  AND alias = $3
+		  AND deleted_at IS NULL`,
+		orgID, ledgerID, alias,
+	).Scan(&direction, &overdraftUsed)
+
+	// Assert
+	require.NoError(t, err, "querying overdraft columns by alias")
+	assert.Equal(t, "debit", direction, "direction should be debit")
+	assert.True(t, overdraftUsed.Equal(decimal.NewFromInt(75)),
+		"overdraft_used should be 75, got %s", overdraftUsed)
+}

--- a/components/ledger/internal/adapters/postgres/balance/balance_overdraft_test.go
+++ b/components/ledger/internal/adapters/postgres/balance/balance_overdraft_test.go
@@ -1,0 +1,191 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package balance
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	"github.com/LerianStudio/midaz/v3/pkg/mmodel"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBalancePostgreSQLModel_HasOverdraftFields verifies via reflection that
+// BalancePostgreSQLModel exposes the overdraft fields with the expected types
+// and db struct tags required for repository persistence.
+func TestBalancePostgreSQLModel_HasOverdraftFields(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		fieldName    string
+		expectedType reflect.Type
+		expectedTag  string
+	}{
+		{
+			name:         "direction field",
+			fieldName:    "Direction",
+			expectedType: reflect.TypeOf(""),
+			expectedTag:  "direction",
+		},
+		{
+			name:         "overdraft_used field",
+			fieldName:    "OverdraftUsed",
+			expectedType: reflect.TypeOf(decimal.Decimal{}),
+			expectedTag:  "overdraft_used",
+		},
+		{
+			name:         "settings field",
+			fieldName:    "Settings",
+			expectedType: reflect.TypeOf([]byte(nil)),
+			expectedTag:  "settings",
+		},
+	}
+
+	modelType := reflect.TypeOf(BalancePostgreSQLModel{})
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			field, ok := modelType.FieldByName(tt.fieldName)
+			require.True(t, ok, "expected field %q on BalancePostgreSQLModel", tt.fieldName)
+			assert.Equal(t, tt.expectedType, field.Type, "field %q type mismatch", tt.fieldName)
+			assert.Equal(t, tt.expectedTag, field.Tag.Get("db"), "field %q db tag mismatch", tt.fieldName)
+		})
+	}
+}
+
+// TestBalancePostgreSQLModel_FromEntity_MapsOverdraftFields verifies that
+// FromEntity copies the scalar overdraft fields and marshals Settings as
+// valid JSON suitable for the JSONB column.
+func TestBalancePostgreSQLModel_FromEntity_MapsOverdraftFields(t *testing.T) {
+	t.Parallel()
+
+	limit := "500.00"
+	entity := &mmodel.Balance{
+		ID:            "00000000-0000-0000-0000-000000000001",
+		Direction:     "debit",
+		OverdraftUsed: decimal.NewFromFloat(50.00),
+		Settings: &mmodel.BalanceSettings{
+			AllowOverdraft:        true,
+			OverdraftLimitEnabled: true,
+			OverdraftLimit:        &limit,
+			BalanceScope:          mmodel.BalanceScopeTransactional,
+		},
+	}
+
+	var model BalancePostgreSQLModel
+	model.FromEntity(entity)
+
+	assert.Equal(t, "debit", model.Direction)
+	assert.True(t, model.OverdraftUsed.Equal(decimal.NewFromFloat(50.00)),
+		"expected overdraft_used=50.00, got %s", model.OverdraftUsed.String())
+
+	require.NotNil(t, model.Settings, "expected Settings to be marshaled to non-nil bytes")
+	assert.True(t, json.Valid(model.Settings), "expected Settings to be valid JSON")
+
+	var decoded mmodel.BalanceSettings
+	require.NoError(t, json.Unmarshal(model.Settings, &decoded))
+	assert.True(t, decoded.AllowOverdraft)
+	assert.True(t, decoded.OverdraftLimitEnabled)
+	require.NotNil(t, decoded.OverdraftLimit)
+	assert.Equal(t, "500.00", *decoded.OverdraftLimit)
+	assert.Equal(t, mmodel.BalanceScopeTransactional, decoded.BalanceScope)
+}
+
+// TestBalancePostgreSQLModel_ToEntity_MapsOverdraftFields verifies that
+// ToEntity round-trips the overdraft fields and unmarshals the Settings
+// JSON bytes back into a typed BalanceSettings on the entity.
+func TestBalancePostgreSQLModel_ToEntity_MapsOverdraftFields(t *testing.T) {
+	t.Parallel()
+
+	limit := "500.00"
+	settings := mmodel.BalanceSettings{
+		AllowOverdraft:        true,
+		OverdraftLimitEnabled: true,
+		OverdraftLimit:        &limit,
+		BalanceScope:          mmodel.BalanceScopeTransactional,
+	}
+	settingsBytes, err := json.Marshal(settings)
+	require.NoError(t, err)
+
+	model := BalancePostgreSQLModel{
+		ID:            "00000000-0000-0000-0000-000000000001",
+		Key:           "default",
+		Direction:     "debit",
+		OverdraftUsed: decimal.NewFromInt(50),
+		Settings:      settingsBytes,
+	}
+
+	entity := model.ToEntity()
+
+	assert.Equal(t, "debit", entity.Direction)
+	assert.True(t, entity.OverdraftUsed.Equal(decimal.NewFromInt(50)),
+		"expected overdraft_used=50, got %s", entity.OverdraftUsed.String())
+
+	require.NotNil(t, entity.Settings, "expected Settings unmarshaled onto entity")
+	assert.True(t, entity.Settings.AllowOverdraft)
+	assert.True(t, entity.Settings.OverdraftLimitEnabled)
+	require.NotNil(t, entity.Settings.OverdraftLimit)
+	assert.Equal(t, "500.00", *entity.Settings.OverdraftLimit)
+	assert.Equal(t, mmodel.BalanceScopeTransactional, entity.Settings.BalanceScope)
+}
+
+// TestBalancePostgreSQLModel_ToEntity_NilSettings ensures a model with nil
+// Settings bytes produces an entity with nil Settings (legacy-row
+// backwards compatibility).
+func TestBalancePostgreSQLModel_ToEntity_NilSettings(t *testing.T) {
+	t.Parallel()
+
+	model := BalancePostgreSQLModel{
+		ID:       "00000000-0000-0000-0000-000000000001",
+		Key:      "default",
+		Settings: nil,
+	}
+
+	entity := model.ToEntity()
+
+	assert.Nil(t, entity.Settings, "expected nil Settings on entity when model Settings is nil")
+}
+
+// TestBalancePostgreSQLModel_FromEntity_NilSettings ensures an entity with
+// nil Settings produces a model with nil Settings bytes, so the repository
+// writes SQL NULL rather than a JSON null literal.
+func TestBalancePostgreSQLModel_FromEntity_NilSettings(t *testing.T) {
+	t.Parallel()
+
+	entity := &mmodel.Balance{
+		ID:       "00000000-0000-0000-0000-000000000001",
+		Settings: nil,
+	}
+
+	var model BalancePostgreSQLModel
+	model.FromEntity(entity)
+
+	assert.Nil(t, model.Settings, "expected nil Settings bytes when entity Settings is nil")
+}
+
+// TestBalanceColumnList_IncludesOverdraftColumns ensures the column list used
+// by SELECT/INSERT/UPDATE statements references the overdraft columns, so
+// reads and writes stay in sync with the physical schema.
+func TestBalanceColumnList_IncludesOverdraftColumns(t *testing.T) {
+	t.Parallel()
+
+	expected := []string{"direction", "overdraft_used", "settings"}
+
+	for _, col := range expected {
+		col := col
+		t.Run(col, func(t *testing.T) {
+			t.Parallel()
+			assert.Contains(t, balanceColumnList, col,
+				"balanceColumnList must contain %q for repository round-trip", col)
+		})
+	}
+}

--- a/components/ledger/internal/adapters/postgres/operation/export_test_helpers.go
+++ b/components/ledger/internal/adapters/postgres/operation/export_test_helpers.go
@@ -1,0 +1,12 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package operation
+
+// ExportedOperationColumnListLen returns the length of the canonical
+// operationColumnList for use by cross-package tests that need to verify
+// column-list parity (e.g., transaction package's prefixed copy).
+func ExportedOperationColumnListLen() int {
+	return len(operationColumnList)
+}

--- a/components/ledger/internal/adapters/postgres/operation/operation.go
+++ b/components/ledger/internal/adapters/postgres/operation/operation.go
@@ -6,6 +6,7 @@ package operation
 
 import (
 	"database/sql"
+	"encoding/json"
 	"time"
 
 	libCommons "github.com/LerianStudio/lib-commons/v4/commons"
@@ -14,6 +15,33 @@ import (
 	"github.com/google/uuid"
 	"github.com/shopspring/decimal"
 )
+
+// emptyJSONObject is the canonical fallback JSONB payload used when marshal
+// of the snapshot fails (practically unreachable, but defensive). The
+// always-populated zero shape — `{"overdraftUsedBefore":"0","overdraftUsedAfter":"0"}`
+// — is preferred when the entity carries the (default-zero) snapshot value;
+// this constant only covers the impossible-marshal-error fallback.
+var emptyJSONObject = json.RawMessage(`{"overdraftUsedBefore":"0","overdraftUsedAfter":"0"}`)
+
+// parseDecimalOrZero parses a string-encoded decimal from an OperationSnapshot
+// field (e.g., OverdraftUsedBefore / OverdraftUsedAfter) into a decimal.Decimal
+// suitable for the typed Balance.OverdraftUsed convenience field. Empty input
+// or parse errors fall back to decimal.Zero — the snapshot is read-only audit
+// context, never a correctness gate, so unparseable strings on historical rows
+// must surface as zero rather than poison the read path. Per-field isolation:
+// a malformed "before" must not poison the "after" parse.
+func parseDecimalOrZero(s string) decimal.Decimal {
+	if s == "" {
+		return decimal.Zero
+	}
+
+	d, err := decimal.NewFromString(s)
+	if err != nil {
+		return decimal.Zero
+	}
+
+	return d
+}
 
 // OperationPostgreSQLModel represents the entity OperationPostgreSQLModel into SQL context in Database
 //
@@ -50,6 +78,13 @@ type OperationPostgreSQLModel struct {
 	RouteCode             *string          // Route code for accounting traceability
 	RouteDescription      *string          // Route description for accounting traceability
 	Metadata              map[string]any   // Additional custom attributes
+	// Snapshot holds the pre-marshalled JSONB payload for the operation.snapshot
+	// column. The raw bytes are round-tripped as-is to avoid double-marshal
+	// with pgx. NOT NULL in PG (DEFAULT '{}'); ToEntity defaults missing keys
+	// to "0" so the in-memory entity always carries a fully populated snapshot
+	// value (never nil) regardless of row age — legacy rows with `'{}'` decode
+	// to the same shape as a freshly written non-overdraft op.
+	Snapshot json.RawMessage `db:"snapshot"`
 }
 
 // OperationPointInTimeModel is a lightweight model for point-in-time balance queries.
@@ -66,6 +101,10 @@ type OperationPointInTimeModel struct {
 	OnHoldBalanceAfter    *decimal.Decimal // On-hold balance after operation
 	VersionBalanceAfter   *int64           // Balance version after operation
 	CreatedAt             time.Time        // Creation timestamp (used as UpdatedAt for balance)
+	// Snapshot holds the pre-marshalled JSONB payload for the operation.snapshot
+	// column. Point-in-time queries carry it through so historical balance
+	// reconstruction surfaces the same overdraft context as live reads.
+	Snapshot json.RawMessage `db:"snapshot"`
 }
 
 // ToEntity converts an OperationPointInTimeModel to entity Operation with only point-in-time relevant fields
@@ -76,7 +115,7 @@ func (t *OperationPointInTimeModel) ToEntity() *Operation {
 		Version:   t.VersionBalanceAfter,
 	}
 
-	return &Operation{
+	op := &Operation{
 		ID:           t.ID,
 		BalanceID:    t.BalanceID,
 		AccountID:    t.AccountID,
@@ -85,6 +124,39 @@ func (t *OperationPointInTimeModel) ToEntity() *Operation {
 		BalanceAfter: balanceAfter,
 		CreatedAt:    t.CreatedAt,
 	}
+
+	// Always-populated snapshot contract: default to zero values, then
+	// overlay any fields present in the JSONB. Legacy rows (snapshot = '{}'),
+	// missing keys, and malformed JSON all decode to the same shape — uniform
+	// wire response regardless of row age.
+	op.Snapshot = mmodel.OperationSnapshot{
+		OverdraftUsedBefore: "0",
+		OverdraftUsedAfter:  "0",
+	}
+
+	if len(t.Snapshot) > 0 {
+		var decoded mmodel.OperationSnapshot
+		if err := json.Unmarshal(t.Snapshot, &decoded); err == nil {
+			if decoded.OverdraftUsedBefore != "" {
+				op.Snapshot.OverdraftUsedBefore = decoded.OverdraftUsedBefore
+			}
+
+			if decoded.OverdraftUsedAfter != "" {
+				op.Snapshot.OverdraftUsedAfter = decoded.OverdraftUsedAfter
+			}
+		}
+		// Malformed JSON: silently keep the zero defaults. Read-side
+		// resilience policy — historical bad rows must not crash live
+		// reads. No logger in scope at this layer.
+	}
+
+	// Only BalanceAfter is populated on PIT models — these queries
+	// reconstruct a single historical balance state (the "after" view at
+	// a given timestamp), not a pre/post pair. See the PIT model comment
+	// above for the rationale.
+	op.BalanceAfter.OverdraftUsed = parseDecimalOrZero(op.Snapshot.OverdraftUsedAfter)
+
+	return op
 }
 
 // Status structure for marshaling/unmarshalling JSON.
@@ -143,6 +215,16 @@ type Balance struct {
 	// example: 2
 	// minimum: 0
 	Version *int64 `json:"version" example:"2" minimum:"0"`
+
+	// OverdraftUsed is populated from OperationSnapshot.OverdraftUsedBefore when this Balance
+	// represents the state BEFORE the operation, or from OperationSnapshot.OverdraftUsedAfter
+	// when it represents the state AFTER. Parsed from the snapshot's string-encoded decimal.
+	// Always present under the always-populated wire-shape contract — non-overdraft
+	// operations carry decimal.Zero. Parse errors on malformed historical rows also
+	// fall back to decimal.Zero (read-only audit context, never a correctness gate).
+	// example: 130
+	// minimum: 0
+	OverdraftUsed decimal.Decimal `json:"overdraftUsed" example:"130" minimum:"0"`
 } // @name Balance
 
 // IsEmpty method that set empty or nil in fields
@@ -276,6 +358,15 @@ type Operation struct {
 	// Additional custom attributes
 	// example: {"reason": "Purchase refund", "reference": "INV-12345"}
 	Metadata map[string]any `json:"metadata"`
+
+	// System-generated per-operation context snapshot (e.g., overdraft lifecycle).
+	// Internal only — NOT emitted on the public JSON wire. The snapshot's information
+	// surfaces via the typed balance.overdraftUsed and balanceAfter.overdraftUsed
+	// fields instead, which are parsed from the snapshot on the PG/Redis read paths.
+	// Still populated in memory by the operation builders, persisted as JSONB in the
+	// `snapshot` column, and round-tripped through the Redis cache envelope.
+	// Forward-compatible: future keys may be added without schema migration.
+	Snapshot mmodel.OperationSnapshot `json:"-"`
 } // @name Operation
 
 // ToEntity converts an OperationPostgreSQLModel to entity Operation
@@ -347,6 +438,38 @@ func (t *OperationPostgreSQLModel) ToEntity() *Operation {
 		Operation.DeletedAt = &deletedAtCopy
 	}
 
+	// Always-populated snapshot contract: default to zero values, then
+	// overlay any fields present in the JSONB. Legacy rows (snapshot = '{}'),
+	// missing keys, and malformed JSON all decode to the same shape — uniform
+	// wire response regardless of row age. Malformed payloads are tolerated
+	// silently (read-only audit context, never a correctness gate); the
+	// write-path validation in FromEntity is the authoritative gate.
+	Operation.Snapshot = mmodel.OperationSnapshot{
+		OverdraftUsedBefore: "0",
+		OverdraftUsedAfter:  "0",
+	}
+
+	if len(t.Snapshot) > 0 {
+		var decoded mmodel.OperationSnapshot
+		if err := json.Unmarshal(t.Snapshot, &decoded); err == nil {
+			if decoded.OverdraftUsedBefore != "" {
+				Operation.Snapshot.OverdraftUsedBefore = decoded.OverdraftUsedBefore
+			}
+
+			if decoded.OverdraftUsedAfter != "" {
+				Operation.Snapshot.OverdraftUsedAfter = decoded.OverdraftUsedAfter
+			}
+		}
+	}
+
+	// Surface the string-encoded overdraftUsed as typed decimal values on
+	// the nested Balance DTOs so HTTP consumers and audit-log pipelines
+	// don't need to re-parse the snapshot string. Each field is parsed
+	// independently — a malformed before must not poison the after, and
+	// vice versa. Both fields always populated; parse errors yield zero.
+	Operation.Balance.OverdraftUsed = parseDecimalOrZero(Operation.Snapshot.OverdraftUsedBefore)
+	Operation.BalanceAfter.OverdraftUsed = parseDecimalOrZero(Operation.Snapshot.OverdraftUsedAfter)
+
 	return Operation
 }
 
@@ -411,6 +534,19 @@ func (t *OperationPostgreSQLModel) FromEntity(operation *Operation) {
 		deletedAtCopy := *operation.DeletedAt
 		t.DeletedAt = sql.NullTime{Time: deletedAtCopy, Valid: true}
 	}
+
+	// Always marshal the snapshot — entity.Snapshot is a value type, never
+	// nil. The default zero shape — {"overdraftUsedBefore":"0","overdraftUsedAfter":"0"}
+	// — is what non-overdraft ops persist. A marshal error on a struct of two
+	// strings is practically unreachable, but we fall back to the canonical
+	// zero JSON literal to keep the write path from failing on a non-critical
+	// audit field. The existing FromEntity signature has no error return.
+	raw, err := json.Marshal(operation.Snapshot)
+	if err != nil || len(raw) == 0 {
+		t.Snapshot = append(json.RawMessage(nil), emptyJSONObject...)
+	} else {
+		t.Snapshot = raw
+	}
 }
 
 // ToRedis converts an Operation to its flat Redis cache representation.
@@ -470,6 +606,9 @@ func (op *Operation) ToRedis() mmodel.OperationRedis {
 	r.StatusCode = op.Status.Code
 	r.StatusDescription = op.Status.Description
 
+	// Value copy: Snapshot is a value type, copies are independent.
+	r.Snapshot = op.Snapshot
+
 	return r
 }
 
@@ -483,7 +622,7 @@ func OperationFromRedis(r mmodel.OperationRedis) *Operation {
 	balAfterOnHold := r.BalanceAfterOnHold
 	balAfterVersion := r.BalanceAfterVersion
 
-	return &Operation{
+	op := &Operation{
 		ID:              r.ID,
 		TransactionID:   r.TransactionID,
 		Description:     r.Description,
@@ -520,7 +659,29 @@ func OperationFromRedis(r mmodel.OperationRedis) *Operation {
 		RouteCode:        r.RouteCode,
 		RouteDescription: r.RouteDescription,
 		Metadata:         r.Metadata,
+		Snapshot:         r.Snapshot,
 	}
+
+	// Legacy cache envelopes (no `snapshot` key) decode to the zero-value
+	// OperationSnapshot{"", ""}. Promote empty strings to "0" so the
+	// rehydrated entity matches the always-populated wire-shape contract —
+	// same shape as freshly written non-overdraft ops.
+	if op.Snapshot.OverdraftUsedBefore == "" {
+		op.Snapshot.OverdraftUsedBefore = "0"
+	}
+
+	if op.Snapshot.OverdraftUsedAfter == "" {
+		op.Snapshot.OverdraftUsedAfter = "0"
+	}
+
+	// Rehydrate typed Balance.OverdraftUsed fields from the snapshot so the
+	// Redis read path is consistent with the PG read path (ToEntity) and the
+	// HTTP write path (BuildOperations). Parse errors fall back to zero —
+	// snapshot is read-only audit context, never a correctness gate.
+	op.Balance.OverdraftUsed = parseDecimalOrZero(op.Snapshot.OverdraftUsedBefore)
+	op.BalanceAfter.OverdraftUsed = parseDecimalOrZero(op.Snapshot.OverdraftUsedAfter)
+
+	return op
 }
 
 // UpdateOperationInput is a struct design to encapsulate payload data.
@@ -658,6 +819,13 @@ type OperationLog struct {
 	// example: Settlement route for service charges
 	// maxLength: 250
 	RouteDescription *string `json:"routeDescription,omitempty" example:"Settlement route for service charges" maxLength:"250"`
+
+	// System-generated per-operation context snapshot (e.g., overdraft lifecycle).
+	// Internal only — NOT emitted on the audit-log JSON wire. Mirrors
+	// Operation.Snapshot verbatim. The snapshot's information surfaces via
+	// the typed balance.overdraftUsed and balanceAfter.overdraftUsed fields.
+	// Forward-compatible: future keys may be added without a schema migration.
+	Snapshot mmodel.OperationSnapshot `json:"-"`
 }
 
 // ToLog converts an Operation excluding the fields that are not immutable
@@ -683,5 +851,7 @@ func (o *Operation) ToLog() *OperationLog {
 		RouteID:          o.RouteID,
 		RouteCode:        o.RouteCode,
 		RouteDescription: o.RouteDescription,
+		// Value copy: snapshot is a value type, copies are independent.
+		Snapshot: o.Snapshot,
 	}
 }

--- a/components/ledger/internal/adapters/postgres/operation/operation.postgresql.go
+++ b/components/ledger/internal/adapters/postgres/operation/operation.postgresql.go
@@ -99,6 +99,11 @@ var operationColumnList = []string{
 	"route_id",
 	"route_code",
 	"route_description",
+	// snapshot is a JSONB column (NOT NULL DEFAULT '{}') carrying system-generated
+	// per-operation context (overdraft before/after, future audit fields).
+	// Appended at the end to minimize scan-site churn — every site extends by
+	// one trailing field.
+	"snapshot",
 }
 
 // operationColumns is derived from operationColumnList for use with squirrel.Select.
@@ -118,6 +123,9 @@ var operationPointInTimeColumns = []string{
 	"on_hold_balance_after",
 	"balance_version_after",
 	"created_at",
+	// snapshot propagates through point-in-time queries so historical balance
+	// reconstruction surfaces the same overdraft context as live reads.
+	"snapshot",
 }
 
 // NewOperationPostgreSQLRepository returns a new instance of OperationPostgreSQLRepository using the given Postgres connection.
@@ -213,6 +221,7 @@ func (r *OperationPostgreSQLRepository) Create(ctx context.Context, operation *O
 			record.RouteID,
 			record.RouteCode,
 			record.RouteDescription,
+			record.Snapshot,
 		).
 		PlaceholderFormat(squirrel.Dollar)
 
@@ -356,7 +365,7 @@ func (r *OperationPostgreSQLRepository) createBulkInternal(
 	}
 
 	// Chunk into bulks of ~1,000 rows to stay within PostgreSQL's parameter limit
-	// Operation has 30 columns, so 1000 rows = 30,000 parameters (under 65,535 limit)
+	// Operation has 31 columns, so 1000 rows = 31,000 parameters (under 65,535 limit)
 	const chunkSize = 1000
 
 	for i := 0; i < len(operations); i += chunkSize {
@@ -450,6 +459,7 @@ func (r *OperationPostgreSQLRepository) insertOperationChunk(ctx context.Context
 			record.RouteID,
 			record.RouteCode,
 			record.RouteDescription,
+			record.Snapshot,
 		)
 	}
 
@@ -609,6 +619,7 @@ func (r *OperationPostgreSQLRepository) FindAll(ctx context.Context, organizatio
 			&operation.RouteID,
 			&operation.RouteCode,
 			&operation.RouteDescription,
+			&operation.Snapshot,
 		); err != nil {
 			libOpentelemetry.HandleSpanError(span, "Failed to scan row", err)
 
@@ -731,6 +742,7 @@ func (r *OperationPostgreSQLRepository) ListByIDs(ctx context.Context, organizat
 			&operation.RouteID,
 			&operation.RouteCode,
 			&operation.RouteDescription,
+			&operation.Snapshot,
 		); err != nil {
 			libOpentelemetry.HandleSpanError(span, "Failed to scan row", err)
 
@@ -826,6 +838,7 @@ func (r *OperationPostgreSQLRepository) Find(ctx context.Context, organizationID
 		&operation.RouteID,
 		&operation.RouteCode,
 		&operation.RouteDescription,
+		&operation.Snapshot,
 	); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			err := pkg.ValidateBusinessError(constant.ErrEntityNotFound, reflect.TypeOf(Operation{}).Name())
@@ -920,6 +933,7 @@ func (r *OperationPostgreSQLRepository) FindByAccount(ctx context.Context, organ
 		&operation.RouteID,
 		&operation.RouteCode,
 		&operation.RouteDescription,
+		&operation.Snapshot,
 	); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			err := pkg.ValidateBusinessError(constant.ErrEntityNotFound, reflect.TypeOf(Operation{}).Name())
@@ -1204,6 +1218,7 @@ func (r *OperationPostgreSQLRepository) FindAllByAccount(ctx context.Context, or
 			&operation.RouteID,
 			&operation.RouteCode,
 			&operation.RouteDescription,
+			&operation.Snapshot,
 		); err != nil {
 			libOpentelemetry.HandleSpanError(span, "Failed to scan row", err)
 
@@ -1300,6 +1315,7 @@ func (r *OperationPostgreSQLRepository) FindLastOperationBeforeTimestamp(ctx con
 		&operation.OnHoldBalanceAfter,
 		&operation.VersionBalanceAfter,
 		&operation.CreatedAt,
+		&operation.Snapshot,
 	); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			libOpentelemetry.HandleSpanBusinessErrorEvent(span, "No operation found before timestamp", err)
@@ -1410,6 +1426,7 @@ func (r *OperationPostgreSQLRepository) FindLastOperationsForAccountBeforeTimest
 			&operation.OnHoldBalanceAfter,
 			&operation.VersionBalanceAfter,
 			&operation.CreatedAt,
+			&operation.Snapshot,
 		); err != nil {
 			libOpentelemetry.HandleSpanError(span, "Failed to scan row", err)
 			logger.Log(ctx, libLog.LevelError, fmt.Sprintf("Failed to scan row: %v", err))

--- a/components/ledger/internal/adapters/postgres/operation/operation_balance_overdraft_used_test.go
+++ b/components/ledger/internal/adapters/postgres/operation/operation_balance_overdraft_used_test.go
@@ -1,0 +1,303 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package operation
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/LerianStudio/midaz/v3/pkg/mmodel"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestOperationPostgreSQLModel_ToEntity_BalanceOverdraftUsed verifies that the
+// typed decimal.Decimal convenience fields on operation.Balance and
+// operation.BalanceAfter are populated from the snapshot's string-encoded
+// OverdraftUsedBefore / OverdraftUsedAfter. Under the always-populated wire-
+// shape contract, these fields are ALWAYS set (decimal.Zero for non-overdraft
+// ops, parsed value otherwise). ToEntity is the canonical entry point for
+// PG-to-domain mapping, so this is where the surface needs to be correct for
+// both the HTTP response DTO and the audit log.
+//
+// Resilience posture: malformed historical rows (non-parseable strings) MUST
+// surface OverdraftUsed as decimal.Zero without surfacing an error or
+// panicking. The snapshot is read-only audit context, not a correctness-
+// critical field.
+func TestOperationPostgreSQLModel_ToEntity_BalanceOverdraftUsed(t *testing.T) {
+	t.Parallel()
+
+	expectedBefore := decimal.RequireFromString("50.00")
+	expectedAfter := decimal.RequireFromString("130.00")
+
+	tests := []struct {
+		name            string
+		raw             json.RawMessage
+		wantBeforeValue decimal.Decimal
+		wantAfterValue  decimal.Decimal
+	}{
+		{
+			name:            "nil snapshot → both OverdraftUsed default to zero",
+			raw:             nil,
+			wantBeforeValue: decimal.Zero,
+			wantAfterValue:  decimal.Zero,
+		},
+		{
+			name:            "empty-object snapshot → both OverdraftUsed default to zero",
+			raw:             json.RawMessage(`{}`),
+			wantBeforeValue: decimal.Zero,
+			wantAfterValue:  decimal.Zero,
+		},
+		{
+			name:            "explicit zero shape → both decimal.Zero",
+			raw:             json.RawMessage(`{"overdraftUsedBefore":"0","overdraftUsedAfter":"0"}`),
+			wantBeforeValue: decimal.Zero,
+			wantAfterValue:  decimal.Zero,
+		},
+		{
+			name:            "both fields populated",
+			raw:             json.RawMessage(`{"overdraftUsedBefore":"50.00","overdraftUsedAfter":"130.00"}`),
+			wantBeforeValue: expectedBefore,
+			wantAfterValue:  expectedAfter,
+		},
+		{
+			name:            "only OverdraftUsedAfter set → Before defaults to zero",
+			raw:             json.RawMessage(`{"overdraftUsedAfter":"130.00"}`),
+			wantBeforeValue: decimal.Zero,
+			wantAfterValue:  expectedAfter,
+		},
+		{
+			name: "malformed OverdraftUsedBefore → Before defaults to zero, After populated (per-field isolation)",
+			raw: func() json.RawMessage {
+				b, _ := json.Marshal(map[string]string{
+					"overdraftUsedBefore": "not-a-number",
+					"overdraftUsedAfter":  "130.00",
+				})
+				return b
+			}(),
+			wantBeforeValue: decimal.Zero,
+			wantAfterValue:  expectedAfter,
+		},
+		{
+			name: "malformed OverdraftUsedAfter → Before populated, After defaults to zero",
+			raw: func() json.RawMessage {
+				b, _ := json.Marshal(map[string]string{
+					"overdraftUsedBefore": "50.00",
+					"overdraftUsedAfter":  "also-garbage",
+				})
+				return b
+			}(),
+			wantBeforeValue: expectedBefore,
+			wantAfterValue:  decimal.Zero,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			model := &OperationPostgreSQLModel{
+				ID:              "op-1",
+				TransactionID:   "tx-1",
+				BalanceAffected: true,
+				Snapshot:        tt.raw,
+			}
+
+			entity := model.ToEntity()
+			require.NotNil(t, entity)
+
+			assert.True(t,
+				entity.Balance.OverdraftUsed.Equal(tt.wantBeforeValue),
+				"Balance.OverdraftUsed: want %s, got %s",
+				tt.wantBeforeValue.String(), entity.Balance.OverdraftUsed.String(),
+			)
+			assert.True(t,
+				entity.BalanceAfter.OverdraftUsed.Equal(tt.wantAfterValue),
+				"BalanceAfter.OverdraftUsed: want %s, got %s",
+				tt.wantAfterValue.String(), entity.BalanceAfter.OverdraftUsed.String(),
+			)
+		})
+	}
+}
+
+// TestOperationPointInTimeModel_ToEntity_BalanceOverdraftUsed verifies the same
+// mapping for the point-in-time reconstruction path. PIT queries only build
+// BalanceAfter (they reconstruct historical state from a single snapshot), so
+// only OverdraftUsedAfter → BalanceAfter.OverdraftUsed is asserted.
+func TestOperationPointInTimeModel_ToEntity_BalanceOverdraftUsed(t *testing.T) {
+	t.Parallel()
+
+	expectedAfter := decimal.RequireFromString("130.00")
+
+	tests := []struct {
+		name           string
+		raw            json.RawMessage
+		wantAfterValue decimal.Decimal
+	}{
+		{
+			name:           "nil snapshot → BalanceAfter.OverdraftUsed defaults to zero",
+			raw:            nil,
+			wantAfterValue: decimal.Zero,
+		},
+		{
+			name:           "empty-object snapshot → BalanceAfter.OverdraftUsed defaults to zero",
+			raw:            json.RawMessage(`{}`),
+			wantAfterValue: decimal.Zero,
+		},
+		{
+			name:           "explicit zero shape → BalanceAfter.OverdraftUsed is zero",
+			raw:            json.RawMessage(`{"overdraftUsedBefore":"0","overdraftUsedAfter":"0"}`),
+			wantAfterValue: decimal.Zero,
+		},
+		{
+			name:           "OverdraftUsedAfter populated",
+			raw:            json.RawMessage(`{"overdraftUsedAfter":"130.00"}`),
+			wantAfterValue: expectedAfter,
+		},
+		{
+			name:           "malformed OverdraftUsedAfter → defaults to zero, no panic",
+			raw:            json.RawMessage(`{"overdraftUsedAfter":"garbage"}`),
+			wantAfterValue: decimal.Zero,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			pit := &OperationPointInTimeModel{
+				ID:        "op-1",
+				BalanceID: "bal-1",
+				AccountID: "acc-1",
+				AssetCode: "BRL",
+				Snapshot:  tt.raw,
+			}
+
+			entity := pit.ToEntity()
+			require.NotNil(t, entity)
+
+			assert.True(t,
+				entity.BalanceAfter.OverdraftUsed.Equal(tt.wantAfterValue),
+				"BalanceAfter.OverdraftUsed: want %s, got %s",
+				tt.wantAfterValue.String(), entity.BalanceAfter.OverdraftUsed.String(),
+			)
+		})
+	}
+}
+
+// TestOperation_ToLog_SnapshotAndOverdraftUsed verifies that:
+//   - OperationLog carries the Snapshot value verbatim (value copy — Snapshot is a value type).
+//   - OperationLog.Balance shares the Balance type so OverdraftUsed propagates via the nested struct.
+//   - JSON shape of OperationLog includes `snapshot` and `overdraftUsed` on nested Balance/BalanceAfter
+//     (always present under the always-populated wire-shape contract).
+func TestOperation_ToLog_SnapshotAndOverdraftUsed(t *testing.T) {
+	t.Parallel()
+
+	snap := mmodel.OperationSnapshot{
+		OverdraftUsedBefore: "50.00",
+		OverdraftUsedAfter:  "130.00",
+	}
+
+	usedBefore := decimal.RequireFromString("50.00")
+	usedAfter := decimal.RequireFromString("130.00")
+
+	op := &Operation{
+		ID:            "op-1",
+		TransactionID: "tx-1",
+		Balance: Balance{
+			OverdraftUsed: usedBefore,
+		},
+		BalanceAfter: Balance{
+			OverdraftUsed: usedAfter,
+		},
+		Snapshot: snap,
+	}
+
+	logEntry := op.ToLog()
+	require.NotNil(t, logEntry)
+
+	// Snapshot value-copied onto the log entry. Independent value-typed
+	// copies, asserting field equality covers both identity-preserved-by-
+	// value-copy and the no-mutation invariant.
+	assert.Equal(t, snap.OverdraftUsedBefore, logEntry.Snapshot.OverdraftUsedBefore)
+	assert.Equal(t, snap.OverdraftUsedAfter, logEntry.Snapshot.OverdraftUsedAfter)
+
+	// Balance.OverdraftUsed propagated via the shared Balance type.
+	assert.True(t, logEntry.Balance.OverdraftUsed.Equal(usedBefore))
+	assert.True(t, logEntry.BalanceAfter.OverdraftUsed.Equal(usedAfter))
+
+	// JSON surface check: the log entry marshals with camelCase keys.
+	// Snapshot is internal-only (json:"-") — it must NOT appear on the
+	// wire. The typed balance.overdraftUsed / balanceAfter.overdraftUsed
+	// fields carry the same information.
+	raw, err := json.Marshal(logEntry)
+	require.NoError(t, err)
+
+	var generic map[string]any
+	require.NoError(t, json.Unmarshal(raw, &generic))
+
+	assert.NotContains(t, generic, "snapshot",
+		"snapshot must NOT appear on JSON wire — values surface via balance.overdraftUsed/balanceAfter.overdraftUsed")
+
+	bal, ok := generic["balance"].(map[string]any)
+	require.True(t, ok, "balance field must be an object")
+	assert.Equal(t, "50", bal["overdraftUsed"], "Balance.overdraftUsed serializes as decimal string")
+
+	balAfter, ok := generic["balanceAfter"].(map[string]any)
+	require.True(t, ok, "balanceAfter field must be an object")
+	assert.Equal(t, "130", balAfter["overdraftUsed"], "BalanceAfter.overdraftUsed serializes as decimal string")
+}
+
+// TestOperation_ToLog_NonOverdraft_SnapshotInternalOnly verifies the wire-
+// internal contract for non-overdraft operations: the snapshot block MUST NOT
+// appear on the JSON wire even when zero. The typed balance.overdraftUsed and
+// balanceAfter.overdraftUsed fields carry the "0" value instead.
+func TestOperation_ToLog_NonOverdraft_SnapshotInternalOnly(t *testing.T) {
+	t.Parallel()
+
+	op := &Operation{
+		ID:            "op-1",
+		TransactionID: "tx-1",
+		Balance: Balance{
+			OverdraftUsed: decimal.Zero,
+		},
+		BalanceAfter: Balance{
+			OverdraftUsed: decimal.Zero,
+		},
+		Snapshot: mmodel.OperationSnapshot{
+			OverdraftUsedBefore: "0",
+			OverdraftUsedAfter:  "0",
+		},
+	}
+
+	logEntry := op.ToLog()
+	require.NotNil(t, logEntry)
+
+	// In-memory: snapshot value carries zero strings.
+	assert.Equal(t, "0", logEntry.Snapshot.OverdraftUsedBefore)
+	assert.Equal(t, "0", logEntry.Snapshot.OverdraftUsedAfter)
+
+	raw, err := json.Marshal(logEntry)
+	require.NoError(t, err)
+
+	var generic map[string]any
+	require.NoError(t, json.Unmarshal(raw, &generic))
+
+	// snapshot key MUST NOT appear on the wire.
+	assert.NotContains(t, generic, "snapshot",
+		"snapshot must NOT appear on JSON wire — values surface via balance.overdraftUsed/balanceAfter.overdraftUsed")
+
+	// Typed balance.overdraftUsed MUST still be present with "0".
+	bal, ok := generic["balance"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "0", bal["overdraftUsed"])
+
+	balAfter, ok := generic["balanceAfter"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "0", balAfter["overdraftUsed"])
+}

--- a/components/ledger/internal/adapters/postgres/operation/operation_createbulk_benchmark_test.go
+++ b/components/ledger/internal/adapters/postgres/operation/operation_createbulk_benchmark_test.go
@@ -303,7 +303,7 @@ func BenchmarkOperation_CreateBulk_Concurrent(b *testing.B) {
 }
 
 // BenchmarkOperation_CreateBulk_Chunking benchmarks large batches that require chunking.
-// Operation has 30 columns, so chunks are 1000 rows each.
+// Operation has 31 columns, so chunks are 1000 rows each.
 func BenchmarkOperation_CreateBulk_Chunking(b *testing.B) {
 	infra := setupBenchmarkInfra(b)
 	ctx := context.Background()
@@ -434,13 +434,13 @@ func BenchmarkOperation_CreateBulk_MemoryAllocation(b *testing.B) {
 	}
 }
 
-// BenchmarkOperation_CreateBulk_FieldCount demonstrates impact of Operation's 30 columns
+// BenchmarkOperation_CreateBulk_FieldCount demonstrates impact of Operation's 31 columns
 // compared to simpler entities. This benchmark helps understand query building overhead.
 func BenchmarkOperation_CreateBulk_FieldCount(b *testing.B) {
 	infra := setupBenchmarkInfra(b)
 	ctx := context.Background()
 
-	// Operation has 30 columns, testing query building impact at different sizes
+	// Operation has 31 columns, testing query building impact at different sizes
 	benchmarks := []struct {
 		name      string
 		batchSize int

--- a/components/ledger/internal/adapters/postgres/operation/operation_createbulk_integration_test.go
+++ b/components/ledger/internal/adapters/postgres/operation/operation_createbulk_integration_test.go
@@ -343,7 +343,7 @@ func TestIntegration_OperationRepository_CreateBulk_SortingVerification(t *testi
 }
 
 // TestIntegration_OperationRepository_CreateBulk_Chunking tests that large batches
-// are correctly chunked (operation has 30 columns, chunk size is 1000).
+// are correctly chunked (operation has 31 columns, chunk size is 1000).
 func TestIntegration_OperationRepository_CreateBulk_Chunking(t *testing.T) {
 	// Arrange
 	infra := setupBulkTestInfra(t)

--- a/components/ledger/internal/adapters/postgres/operation/operation_createbulk_test.go
+++ b/components/ledger/internal/adapters/postgres/operation/operation_createbulk_test.go
@@ -503,8 +503,10 @@ func TestInsertOperationChunk_ColumnCount(t *testing.T) {
 	t.Parallel()
 
 	// Verify that operationColumnList has expected number of columns
-	// This ensures the bulk insert won't have column/value mismatch
-	expectedColumns := 30 // Based on operationColumnList definition
+	// This ensures the bulk insert won't have column/value mismatch.
+	// Count was bumped from 30 → 31 when the `snapshot` JSONB column was
+	// appended to the list.
+	expectedColumns := 31 // Based on operationColumnList definition
 	assert.Equal(t, expectedColumns, len(operationColumnList),
 		"operationColumnList should have %d columns", expectedColumns)
 }
@@ -512,9 +514,11 @@ func TestInsertOperationChunk_ColumnCount(t *testing.T) {
 func TestInsertOperationChunk_ParameterLimitCalculation(t *testing.T) {
 	t.Parallel()
 
-	// Verify that 1000 rows * 30 columns stays under PostgreSQL's 65,535 limit
+	// Verify that 1000 rows * 31 columns stays under PostgreSQL's 65,535 limit.
+	// Column count was bumped from 30 → 31 when the `snapshot` JSONB column
+	// was appended.
 	const chunkSize = 1000
-	const columnCount = 30 // operationColumnList length
+	const columnCount = 31 // operationColumnList length
 	const postgresLimit = 65535
 
 	parametersPerChunk := chunkSize * columnCount

--- a/components/ledger/internal/adapters/postgres/operation/operation_redis_snapshot_integration_test.go
+++ b/components/ledger/internal/adapters/postgres/operation/operation_redis_snapshot_integration_test.go
@@ -1,0 +1,274 @@
+//go:build integration
+
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package operation
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/LerianStudio/midaz/v3/pkg/mmodel"
+	redistestutil "github.com/LerianStudio/midaz/v3/tests/utils/redis"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// These tests verify the snapshot round-trip through a real Redis container.
+// They complement the pure-Go round-trip tests in operation_redis_snapshot_test.go
+// by exercising the actual JSON wire encoding the production code uses when
+// caching Operations in Redis (e.g. via TransactionRedisQueue.Operations —
+// see components/ledger/internal/services/command/create_balance_transaction_operations_async.go).
+//
+// The production path is:
+//
+//	op.ToRedis() → json.Marshal(OperationRedis) → redis.SET → json.Unmarshal → OperationFromRedis(...)
+//
+// Wire-shape contract: every Operation carries a populated Snapshot value
+// (never nil) and Balance.OverdraftUsed / BalanceAfter.OverdraftUsed
+// (decimal.Decimal, always set). Legacy cache envelopes (no `snapshot` key)
+// decode to the zero-value struct, which OperationFromRedis normalises to
+// the always-populated zero shape.
+
+// ============================================================================
+// Round-Trip: Active Overdraft (Both Fields Non-Zero)
+// ============================================================================
+
+// TestIntegration_OperationRedis_RoundTrip_NonZeroSnapshot verifies that an
+// Operation with a non-zero snapshot survives the full Redis round-trip
+// (ToRedis → JSON → redis.SET → redis.GET → JSON → OperationFromRedis) with
+// typed decimal rehydration intact on both Balance.OverdraftUsed and
+// BalanceAfter.OverdraftUsed.
+func TestIntegration_OperationRedis_RoundTrip_NonZeroSnapshot(t *testing.T) {
+	redisContainer := redistestutil.SetupContainer(t)
+
+	ctx := context.Background()
+
+	amt := decimal.NewFromInt(80)
+	availBefore := decimal.NewFromInt(0)
+	availAfter := decimal.NewFromInt(0)
+	onHold := decimal.Zero
+	versionBefore := int64(2)
+	versionAfter := int64(3)
+
+	op := &Operation{
+		ID:            "op-non-zero",
+		TransactionID: "tx-non-zero",
+		Type:          "DEBIT",
+		AssetCode:     "USD",
+		Amount:        Amount{Value: &amt},
+		Balance: Balance{
+			Available: &availBefore,
+			OnHold:    &onHold,
+			Version:   &versionBefore,
+		},
+		BalanceAfter: Balance{
+			Available: &availAfter,
+			OnHold:    &onHold,
+			Version:   &versionAfter,
+		},
+		Status: Status{Code: "APPROVED"},
+		Snapshot: mmodel.OperationSnapshot{
+			OverdraftUsedBefore: "50",
+			OverdraftUsedAfter:  "130",
+		},
+	}
+
+	// Serialize via the production path: op.ToRedis() → json.Marshal.
+	redisRepr := op.ToRedis()
+	payload, err := json.Marshal(redisRepr)
+	require.NoError(t, err, "OperationRedis must marshal to JSON")
+
+	// Store in real Redis.
+	key := "test:operation:non-zero:" + op.ID
+	err = redisContainer.Client.Set(ctx, key, payload, 0).Err()
+	require.NoError(t, err, "Redis SET should succeed")
+
+	// Read back and deserialize.
+	stored, err := redisContainer.Client.Get(ctx, key).Bytes()
+	require.NoError(t, err, "Redis GET should succeed")
+
+	var restoredRedis mmodel.OperationRedis
+	err = json.Unmarshal(stored, &restoredRedis)
+	require.NoError(t, err, "stored payload must unmarshal back into OperationRedis")
+
+	// Rehydrate via the production path: OperationFromRedis(...).
+	restored := OperationFromRedis(restoredRedis)
+	require.NotNil(t, restored)
+
+	// Assert: snapshot survives the round-trip with both string fields intact.
+	assert.Equal(t, "50", restored.Snapshot.OverdraftUsedBefore)
+	assert.Equal(t, "130", restored.Snapshot.OverdraftUsedAfter)
+
+	// Assert: typed decimal fields are rehydrated from the snapshot.
+	assert.True(t, decimal.NewFromInt(50).Equal(restored.Balance.OverdraftUsed))
+	assert.True(t, decimal.NewFromInt(130).Equal(restored.BalanceAfter.OverdraftUsed))
+}
+
+// ============================================================================
+// Round-Trip: Zero Shape (Non-Overdraft Op)
+// ============================================================================
+
+// TestIntegration_OperationRedis_RoundTrip_ZeroShape verifies that an
+// Operation with the zero-shape snapshot (the common non-overdraft case)
+// survives the full Redis round-trip with the always-populated zero shape
+// preserved. Both `snapshot` and the typed Balance.OverdraftUsed fields
+// surface uniformly regardless of overdraft participation.
+func TestIntegration_OperationRedis_RoundTrip_ZeroShape(t *testing.T) {
+	redisContainer := redistestutil.SetupContainer(t)
+
+	ctx := context.Background()
+
+	amt := decimal.NewFromInt(100)
+	avail := decimal.NewFromInt(500)
+	onHold := decimal.Zero
+	version := int64(1)
+
+	op := &Operation{
+		ID:            "op-zero",
+		TransactionID: "tx-zero",
+		Type:          "CREDIT",
+		AssetCode:     "USD",
+		Amount:        Amount{Value: &amt},
+		Balance: Balance{
+			Available:     &avail,
+			OnHold:        &onHold,
+			Version:       &version,
+			OverdraftUsed: decimal.Zero,
+		},
+		BalanceAfter: Balance{
+			Available:     &avail,
+			OnHold:        &onHold,
+			Version:       &version,
+			OverdraftUsed: decimal.Zero,
+		},
+		Status: Status{Code: "APPROVED"},
+		Snapshot: mmodel.OperationSnapshot{
+			OverdraftUsedBefore: "0",
+			OverdraftUsedAfter:  "0",
+		},
+	}
+
+	redisRepr := op.ToRedis()
+	assert.Equal(t, "0", redisRepr.Snapshot.OverdraftUsedBefore, "zero shape preserved on the Redis side")
+	assert.Equal(t, "0", redisRepr.Snapshot.OverdraftUsedAfter)
+
+	payload, err := json.Marshal(redisRepr)
+	require.NoError(t, err)
+
+	// Wire-level assertion: the JSON envelope MUST include the snapshot key
+	// with both fields present (always-populated contract).
+	var probe map[string]any
+	require.NoError(t, json.Unmarshal(payload, &probe))
+	require.Contains(t, probe, "snapshot", "snapshot key MUST be present on every cached envelope")
+
+	snap, ok := probe["snapshot"].(map[string]any)
+	require.True(t, ok, "snapshot must be an object")
+	assert.Equal(t, "0", snap["overdraftUsedBefore"], "zero shape carries '0' verbatim on the wire")
+	assert.Equal(t, "0", snap["overdraftUsedAfter"])
+
+	key := "test:operation:zero:" + op.ID
+	require.NoError(t, redisContainer.Client.Set(ctx, key, payload, 0).Err())
+
+	stored, err := redisContainer.Client.Get(ctx, key).Bytes()
+	require.NoError(t, err)
+
+	var restoredRedis mmodel.OperationRedis
+	require.NoError(t, json.Unmarshal(stored, &restoredRedis))
+
+	restored := OperationFromRedis(restoredRedis)
+	require.NotNil(t, restored)
+
+	assert.Equal(t, "0", restored.Snapshot.OverdraftUsedBefore)
+	assert.Equal(t, "0", restored.Snapshot.OverdraftUsedAfter)
+	assert.True(t, restored.Balance.OverdraftUsed.Equal(decimal.Zero))
+	assert.True(t, restored.BalanceAfter.OverdraftUsed.Equal(decimal.Zero))
+}
+
+// ============================================================================
+// Backward Compatibility — Legacy Cache Envelope
+// ============================================================================
+
+// TestIntegration_OperationRedis_LegacyEnvelope verifies that an
+// OperationRedis JSON payload written by older code (no snapshot key in the
+// envelope) unmarshals cleanly via OperationFromRedis, with the snapshot
+// normalised to the always-populated zero shape. This guards the Kiwi
+// consumer replay path against in-flight cache entries from before the
+// snapshot column landed.
+//
+// We write the payload directly as raw JSON (not via op.ToRedis) to simulate
+// the bytes that actually sit in Redis from an older build.
+func TestIntegration_OperationRedis_LegacyEnvelope(t *testing.T) {
+	redisContainer := redistestutil.SetupContainer(t)
+
+	ctx := context.Background()
+
+	// Hand-crafted payload simulating a cache entry from before the snapshot
+	// column was added. Mirrors the OperationRedis shape but WITHOUT the
+	// snapshot key.
+	legacyPayload := []byte(`{
+		"id":"op-legacy",
+		"transactionId":"tx-legacy",
+		"description":"legacy cache envelope",
+		"type":"DEBIT",
+		"assetCode":"USD",
+		"chartOfAccounts":"1000",
+		"amountValue":"100",
+		"balanceAvailable":"500",
+		"balanceOnHold":"0",
+		"balanceVersion":1,
+		"balanceAfterAvailable":"400",
+		"balanceAfterOnHold":"0",
+		"balanceAfterVersion":2,
+		"statusCode":"APPROVED",
+		"balanceId":"bal-legacy",
+		"accountId":"acc-legacy",
+		"accountAlias":"@legacy",
+		"balanceKey":"default",
+		"organizationId":"org-legacy",
+		"ledgerId":"ledger-legacy",
+		"createdAt":"2026-04-20T00:00:00Z",
+		"updatedAt":"2026-04-20T00:00:00Z",
+		"route":"",
+		"balanceAffected":true
+	}`)
+
+	key := "test:operation:legacy:op-legacy"
+	require.NoError(t, redisContainer.Client.Set(ctx, key, legacyPayload, 0).Err())
+
+	stored, err := redisContainer.Client.Get(ctx, key).Bytes()
+	require.NoError(t, err)
+
+	// Unmarshal must succeed — missing `snapshot` key must be tolerated.
+	var restoredRedis mmodel.OperationRedis
+	err = json.Unmarshal(stored, &restoredRedis)
+	require.NoError(t, err, "legacy envelope without snapshot key must unmarshal without error")
+
+	// On the Redis side the missing key decodes to the zero-value struct
+	// (empty strings on both fields).
+	assert.Equal(t, "", restoredRedis.Snapshot.OverdraftUsedBefore,
+		"legacy envelope decodes to empty strings on the Redis representation")
+	assert.Equal(t, "", restoredRedis.Snapshot.OverdraftUsedAfter)
+
+	// Rehydrate via OperationFromRedis — this is the production-critical
+	// entry point, hit by the cron consumer on replay. It normalises empty
+	// strings to "0" so the rehydrated entity matches the always-populated
+	// wire-shape contract.
+	restored := OperationFromRedis(restoredRedis)
+	require.NotNil(t, restored)
+
+	assert.Equal(t, "0", restored.Snapshot.OverdraftUsedBefore,
+		"legacy envelope normalises to '0' on the rehydrated entity")
+	assert.Equal(t, "0", restored.Snapshot.OverdraftUsedAfter)
+	assert.True(t, restored.Balance.OverdraftUsed.Equal(decimal.Zero))
+	assert.True(t, restored.BalanceAfter.OverdraftUsed.Equal(decimal.Zero))
+
+	// Sanity: the non-snapshot fields survived the round-trip normally.
+	assert.Equal(t, "op-legacy", restored.ID)
+	assert.Equal(t, "DEBIT", restored.Type)
+	assert.Equal(t, "APPROVED", restored.Status.Code)
+}

--- a/components/ledger/internal/adapters/postgres/operation/operation_redis_snapshot_test.go
+++ b/components/ledger/internal/adapters/postgres/operation/operation_redis_snapshot_test.go
@@ -1,0 +1,140 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package operation
+
+import (
+	"testing"
+
+	"github.com/LerianStudio/midaz/v3/pkg/mmodel"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRedisRoundTrip_ZeroShape verifies that an operation with the zero-
+// shape snapshot (the common non-overdraft case) round-trips through ToRedis
+// → OperationFromRedis with both Snapshot fields and the typed
+// Balance.OverdraftUsed fields preserved as "0" / decimal.Zero. Under the
+// always-populated wire-shape contract, snapshot is a value type — never nil —
+// and Balance.OverdraftUsed is always set.
+func TestRedisRoundTrip_ZeroShape(t *testing.T) {
+	t.Parallel()
+
+	amt := decimal.NewFromInt(100)
+	avail := decimal.NewFromInt(500)
+	onHold := decimal.Zero
+	version := int64(1)
+
+	op := &Operation{
+		ID:            "op-zero",
+		TransactionID: "tx-1",
+		Amount:        Amount{Value: &amt},
+		Balance: Balance{
+			Available:     &avail,
+			OnHold:        &onHold,
+			Version:       &version,
+			OverdraftUsed: decimal.Zero,
+		},
+		BalanceAfter: Balance{
+			Available:     &avail,
+			OnHold:        &onHold,
+			Version:       &version,
+			OverdraftUsed: decimal.Zero,
+		},
+		Snapshot: mmodel.OperationSnapshot{
+			OverdraftUsedBefore: "0",
+			OverdraftUsedAfter:  "0",
+		},
+	}
+
+	r := op.ToRedis()
+	assert.Equal(t, "0", r.Snapshot.OverdraftUsedBefore, "zero shape preserves '0' on the Redis side")
+	assert.Equal(t, "0", r.Snapshot.OverdraftUsedAfter)
+
+	restored := OperationFromRedis(r)
+	assert.Equal(t, "0", restored.Snapshot.OverdraftUsedBefore, "zero shape round-trips")
+	assert.Equal(t, "0", restored.Snapshot.OverdraftUsedAfter)
+	assert.True(t, restored.Balance.OverdraftUsed.Equal(decimal.Zero), "rehydrated typed field is zero")
+	assert.True(t, restored.BalanceAfter.OverdraftUsed.Equal(decimal.Zero))
+}
+
+// TestRedisRoundTrip_BothFieldsPopulated verifies that a snapshot with both
+// OverdraftUsedBefore and OverdraftUsedAfter round-trips correctly, including
+// rehydration of the typed Balance.OverdraftUsed fields.
+func TestRedisRoundTrip_BothFieldsPopulated(t *testing.T) {
+	t.Parallel()
+
+	amt := decimal.NewFromInt(80)
+	avail := decimal.NewFromInt(0)
+	onHold := decimal.Zero
+	version := int64(3)
+	afterAvail := decimal.NewFromInt(0)
+
+	op := &Operation{
+		ID:            "op-both",
+		TransactionID: "tx-2",
+		Amount:        Amount{Value: &amt},
+		Balance: Balance{
+			Available: &avail,
+			OnHold:    &onHold,
+			Version:   &version,
+		},
+		BalanceAfter: Balance{
+			Available: &afterAvail,
+			OnHold:    &onHold,
+			Version:   &version,
+		},
+		Snapshot: mmodel.OperationSnapshot{
+			OverdraftUsedBefore: "50",
+			OverdraftUsedAfter:  "130",
+		},
+	}
+
+	r := op.ToRedis()
+	assert.Equal(t, "50", r.Snapshot.OverdraftUsedBefore)
+	assert.Equal(t, "130", r.Snapshot.OverdraftUsedAfter)
+
+	restored := OperationFromRedis(r)
+	assert.Equal(t, "50", restored.Snapshot.OverdraftUsedBefore)
+	assert.Equal(t, "130", restored.Snapshot.OverdraftUsedAfter)
+
+	// Typed fields rehydrated from snapshot.
+	assert.True(t, decimal.NewFromInt(50).Equal(restored.Balance.OverdraftUsed),
+		"Balance.OverdraftUsed must be rehydrated from snapshot.Before; got %s",
+		restored.Balance.OverdraftUsed.String())
+	assert.True(t, decimal.NewFromInt(130).Equal(restored.BalanceAfter.OverdraftUsed),
+		"BalanceAfter.OverdraftUsed must be rehydrated from snapshot.After; got %s",
+		restored.BalanceAfter.OverdraftUsed.String())
+}
+
+// TestRedisRoundTrip_LegacyEmptyEnvelope verifies that an OperationRedis loaded
+// from a legacy cache envelope (no `snapshot` key in the JSON, deserialized
+// to the zero-value struct with both fields empty strings) is normalised to
+// the always-populated zero shape on rehydration. This is the
+// backwards-compatibility guarantee for in-flight cache entries written by
+// older code, replayed under the new contract.
+func TestRedisRoundTrip_LegacyEmptyEnvelope(t *testing.T) {
+	t.Parallel()
+
+	r := mmodel.OperationRedis{
+		ID:            "op-legacy",
+		TransactionID: "tx-legacy",
+		Type:          "DEBIT",
+		// Snapshot left at zero value — empty strings for both fields,
+		// simulating an envelope from before snapshot was added.
+	}
+
+	require.Equal(t, "", r.Snapshot.OverdraftUsedBefore)
+	require.Equal(t, "", r.Snapshot.OverdraftUsedAfter)
+
+	restored := OperationFromRedis(r)
+	require.NotNil(t, restored)
+
+	assert.Equal(t, "0", restored.Snapshot.OverdraftUsedBefore,
+		"legacy empty-string envelope normalises to '0' on rehydration")
+	assert.Equal(t, "0", restored.Snapshot.OverdraftUsedAfter)
+	assert.True(t, restored.Balance.OverdraftUsed.Equal(decimal.Zero))
+	assert.True(t, restored.BalanceAfter.OverdraftUsed.Equal(decimal.Zero))
+}

--- a/components/ledger/internal/adapters/postgres/operation/operation_snapshot_integration_test.go
+++ b/components/ledger/internal/adapters/postgres/operation/operation_snapshot_integration_test.go
@@ -1,0 +1,417 @@
+//go:build integration
+
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package operation
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	libCommons "github.com/LerianStudio/lib-commons/v4/commons"
+	"github.com/LerianStudio/midaz/v3/pkg/mmodel"
+	pgtestutil "github.com/LerianStudio/midaz/v3/tests/utils/postgres"
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// These tests verify the end-to-end snapshot round-trip:
+// domain Operation.Snapshot → OperationPostgreSQLModel.Snapshot (JSONB bytes) →
+// row in operation.snapshot column → scan → ToEntity → typed
+// Balance.OverdraftUsed / BalanceAfter.OverdraftUsed.
+//
+// Companion files already cover pure-Go paths (ToEntity / FromEntity /
+// parseDecimalOrZero) via unit tests; this file exercises the actual PG
+// driver / JSONB column interaction to catch column-list drift, scan-site
+// misalignment, and legacy row compatibility that unit tests cannot.
+//
+// Wire-shape contract: every operation row decodes to a fully populated
+// Operation.Snapshot (value type, never nil) and Balance.OverdraftUsed /
+// BalanceAfter.OverdraftUsed (decimal.Decimal, always set). Legacy rows
+// (snapshot = '{}'), missing keys, and freshly-written non-overdraft ops all
+// surface the same uniform wire shape.
+
+// snapshotFixtureOperation builds an Operation suitable for Create() using the
+// shared test dependencies. Snapshot is the only variant between scenarios;
+// every other field is set to the same safe default as in
+// operation.postgresql_integration_test.go.
+func snapshotFixtureOperation(ids testIDs, now time.Time, snapshot mmodel.OperationSnapshot) *Operation {
+	amount := decimal.NewFromInt(100)
+	availableBefore := decimal.NewFromInt(1000)
+	onHoldBefore := decimal.Zero
+	availableAfter := decimal.NewFromInt(900)
+	onHoldAfter := decimal.Zero
+	versionBefore := int64(1)
+	versionAfter := int64(2)
+
+	return &Operation{
+		ID:              uuid.Must(libCommons.GenerateUUIDv7()).String(),
+		TransactionID:   ids.TransactionID.String(),
+		Description:     "Snapshot round-trip test",
+		Type:            "DEBIT",
+		AssetCode:       "USD",
+		ChartOfAccounts: "1000",
+		Amount:          Amount{Value: &amount},
+		Balance: Balance{
+			Available: &availableBefore,
+			OnHold:    &onHoldBefore,
+			Version:   &versionBefore,
+		},
+		BalanceAfter: Balance{
+			Available: &availableAfter,
+			OnHold:    &onHoldAfter,
+			Version:   &versionAfter,
+		},
+		Status:          Status{Code: "APPROVED"},
+		AccountID:       ids.AccountID.String(),
+		AccountAlias:    "@test-account",
+		BalanceKey:      "default",
+		BalanceID:       ids.BalanceID.String(),
+		OrganizationID:  ids.OrgID.String(),
+		LedgerID:        ids.LedgerID.String(),
+		BalanceAffected: true,
+		CreatedAt:       now,
+		UpdatedAt:       now,
+		Snapshot:        snapshot,
+	}
+}
+
+// ============================================================================
+// Create + Read Round-Trip — Active Overdraft (Both Fields Populated)
+// ============================================================================
+
+// TestIntegration_OperationSnapshot_CreateAndRead_NonZero verifies the happy
+// path: an Operation with both overdraftUsedBefore and overdraftUsedAfter
+// populated to non-zero values survives a PG round-trip with byte-level
+// JSONB fidelity and typed decimal rehydration.
+func TestIntegration_OperationSnapshot_CreateAndRead_NonZero(t *testing.T) {
+	container := pgtestutil.SetupContainer(t)
+	repo := createRepository(t, container)
+	ids := createTestDependencies(t, container)
+
+	ctx := context.Background()
+	now := time.Now().Truncate(time.Microsecond)
+
+	snapshot := mmodel.OperationSnapshot{
+		OverdraftUsedBefore: "50",
+		OverdraftUsedAfter:  "130",
+	}
+	op := snapshotFixtureOperation(ids, now, snapshot)
+
+	// Act: Create writes the snapshot as JSONB; Find reads it back.
+	created, err := repo.Create(ctx, op)
+	require.NoError(t, err, "Create should not return error")
+	require.NotNil(t, created)
+
+	found, err := repo.Find(ctx, ids.OrgID, ids.LedgerID, ids.TransactionID, uuid.MustParse(created.ID))
+	require.NoError(t, err, "Find should succeed")
+	require.NotNil(t, found)
+
+	// Assert: Snapshot struct round-trips with both fields intact.
+	assert.Equal(t, "50", found.Snapshot.OverdraftUsedBefore, "OverdraftUsedBefore must preserve string literal")
+	assert.Equal(t, "130", found.Snapshot.OverdraftUsedAfter, "OverdraftUsedAfter must preserve string literal")
+
+	// Assert: typed decimal fields rehydrated from the snapshot strings.
+	assert.True(t, decimal.NewFromInt(50).Equal(found.Balance.OverdraftUsed),
+		"Balance.OverdraftUsed must equal decimal(50); got %s", found.Balance.OverdraftUsed.String())
+	assert.True(t, decimal.NewFromInt(130).Equal(found.BalanceAfter.OverdraftUsed),
+		"BalanceAfter.OverdraftUsed must equal decimal(130); got %s", found.BalanceAfter.OverdraftUsed.String())
+
+	// Assert: the raw JSONB stored in the column matches the canonical shape.
+	var rawSnapshot string
+	err = container.DB.QueryRow(`SELECT snapshot::text FROM operation WHERE id = $1`, created.ID).Scan(&rawSnapshot)
+	require.NoError(t, err, "direct JSONB read should succeed")
+	assert.JSONEq(t, `{"overdraftUsedBefore":"50","overdraftUsedAfter":"130"}`, rawSnapshot,
+		"raw JSONB column payload should match the canonical shape")
+}
+
+// ============================================================================
+// Create + Read Round-Trip — Zero Shape (Non-Overdraft Op)
+// ============================================================================
+
+// TestIntegration_OperationSnapshot_CreateAndRead_ZeroShape verifies the
+// dominant production case: a non-overdraft operation persists the always-
+// populated zero shape. Under the new contract the JSONB column carries
+// `{"overdraftUsedBefore":"0","overdraftUsedAfter":"0"}` rather than `{}`,
+// and the read path surfaces a fully populated Snapshot value with both
+// typed Balance.OverdraftUsed / BalanceAfter.OverdraftUsed set to
+// decimal.Zero.
+func TestIntegration_OperationSnapshot_CreateAndRead_ZeroShape(t *testing.T) {
+	container := pgtestutil.SetupContainer(t)
+	repo := createRepository(t, container)
+	ids := createTestDependencies(t, container)
+
+	ctx := context.Background()
+	now := time.Now().Truncate(time.Microsecond)
+
+	zeroShape := mmodel.OperationSnapshot{
+		OverdraftUsedBefore: "0",
+		OverdraftUsedAfter:  "0",
+	}
+	op := snapshotFixtureOperation(ids, now, zeroShape)
+
+	// Act
+	created, err := repo.Create(ctx, op)
+	require.NoError(t, err)
+	require.NotNil(t, created)
+
+	found, err := repo.Find(ctx, ids.OrgID, ids.LedgerID, ids.TransactionID, uuid.MustParse(created.ID))
+	require.NoError(t, err)
+	require.NotNil(t, found)
+
+	// Assert: zero shape round-trips intact; both fields surface as "0".
+	assert.Equal(t, "0", found.Snapshot.OverdraftUsedBefore, "non-overdraft op carries '0' verbatim")
+	assert.Equal(t, "0", found.Snapshot.OverdraftUsedAfter)
+	assert.True(t, found.Balance.OverdraftUsed.Equal(decimal.Zero), "no overdraft → Balance.OverdraftUsed is decimal.Zero")
+	assert.True(t, found.BalanceAfter.OverdraftUsed.Equal(decimal.Zero))
+
+	// Assert: the JSONB column carries the always-populated zero shape (not '{}').
+	var rawSnapshot string
+	err = container.DB.QueryRow(`SELECT snapshot::text FROM operation WHERE id = $1`, created.ID).Scan(&rawSnapshot)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"overdraftUsedBefore":"0","overdraftUsedAfter":"0"}`, rawSnapshot,
+		"non-overdraft snapshot must persist as the always-populated zero shape")
+}
+
+// ============================================================================
+// Read-Many Consistency (FindAll)
+// ============================================================================
+
+// TestIntegration_OperationSnapshot_FindAll_MixedSnapshots verifies that
+// reading multiple operations in a single FindAll call preserves each row's
+// snapshot independently. Catches scan-site drift that would be hidden when
+// every row happens to have the same snapshot.
+func TestIntegration_OperationSnapshot_FindAll_MixedSnapshots(t *testing.T) {
+	container := pgtestutil.SetupContainer(t)
+	repo := createRepository(t, container)
+	ids := createTestDependencies(t, container)
+
+	ctx := context.Background()
+	now := time.Now().Truncate(time.Microsecond)
+
+	// Three operations: one with active overdraft, two with the zero shape.
+	withOverdraft := snapshotFixtureOperation(ids, now, mmodel.OperationSnapshot{
+		OverdraftUsedBefore: "25",
+		OverdraftUsedAfter:  "75",
+	})
+	withOverdraft.Description = "has snapshot"
+
+	zeroShape := mmodel.OperationSnapshot{
+		OverdraftUsedBefore: "0",
+		OverdraftUsedAfter:  "0",
+	}
+
+	zeroA := snapshotFixtureOperation(ids, now.Add(time.Microsecond), zeroShape)
+	zeroA.Description = "zero A"
+
+	zeroB := snapshotFixtureOperation(ids, now.Add(2*time.Microsecond), zeroShape)
+	zeroB.Description = "zero B"
+
+	for _, toCreate := range []*Operation{withOverdraft, zeroA, zeroB} {
+		_, err := repo.Create(ctx, toCreate)
+		require.NoError(t, err, "Create should succeed for %q", toCreate.Description)
+	}
+
+	// Act
+	operations, _, err := repo.FindAll(ctx, ids.OrgID, ids.LedgerID, ids.TransactionID, defaultPagination())
+	require.NoError(t, err)
+	assert.Len(t, operations, 3, "should return all three operations")
+
+	// Assert: each operation's snapshot is correctly preserved after the scan.
+	byDescription := make(map[string]*Operation, len(operations))
+	for _, o := range operations {
+		byDescription[o.Description] = o
+	}
+
+	require.Contains(t, byDescription, "has snapshot")
+	gotWith := byDescription["has snapshot"]
+	assert.Equal(t, "25", gotWith.Snapshot.OverdraftUsedBefore)
+	assert.Equal(t, "75", gotWith.Snapshot.OverdraftUsedAfter)
+	assert.True(t, decimal.NewFromInt(25).Equal(gotWith.Balance.OverdraftUsed))
+	assert.True(t, decimal.NewFromInt(75).Equal(gotWith.BalanceAfter.OverdraftUsed))
+
+	for _, description := range []string{"zero A", "zero B"} {
+		require.Contains(t, byDescription, description)
+		got := byDescription[description]
+		assert.Equal(t, "0", got.Snapshot.OverdraftUsedBefore, "%q must carry zero shape", description)
+		assert.Equal(t, "0", got.Snapshot.OverdraftUsedAfter)
+		assert.True(t, got.Balance.OverdraftUsed.Equal(decimal.Zero), "%q Balance.OverdraftUsed must be zero", description)
+		assert.True(t, got.BalanceAfter.OverdraftUsed.Equal(decimal.Zero))
+	}
+}
+
+// ============================================================================
+// Legacy Row Behavior
+// ============================================================================
+
+// TestIntegration_OperationSnapshot_LegacyRow verifies that a row inserted
+// WITHOUT specifying the snapshot column — simulating an existing row from
+// before the column was added — reads back with the always-populated zero
+// shape on the entity. The column's NOT NULL DEFAULT '{}' ensures valid
+// JSONB is always stored, and ToEntity's default-fill applies the zero
+// shape when keys are absent.
+//
+// This is the critical backwards-compatibility guarantee — existing
+// production rows from before the snapshot migration landed must produce
+// exactly the same wire shape as freshly written non-overdraft ops.
+func TestIntegration_OperationSnapshot_LegacyRow(t *testing.T) {
+	container := pgtestutil.SetupContainer(t)
+	repo := createRepository(t, container)
+	ids := createTestDependencies(t, container)
+
+	ctx := context.Background()
+
+	// Use CreateTestOperation (which does NOT specify snapshot) to simulate a
+	// row written before the snapshot column landed. The DB default
+	// '{}'::jsonb applies.
+	opParams := pgtestutil.OperationParams{
+		TransactionID:         ids.TransactionID,
+		Description:           "legacy row",
+		Type:                  "DEBIT",
+		AccountID:             ids.AccountID,
+		AccountAlias:          "@test-account",
+		BalanceID:             ids.BalanceID,
+		AssetCode:             "USD",
+		Amount:                decimal.NewFromInt(100),
+		AvailableBalance:      decimal.NewFromInt(1000),
+		OnHoldBalance:         decimal.Zero,
+		AvailableBalanceAfter: decimal.NewFromInt(900),
+		OnHoldBalanceAfter:    decimal.Zero,
+		BalanceVersionBefore:  1,
+		BalanceVersionAfter:   2,
+		Status:                "APPROVED",
+		BalanceAffected:       true,
+	}
+	opID := pgtestutil.CreateTestOperation(t, container.DB, ids.OrgID, ids.LedgerID, opParams)
+
+	// Sanity-check: the DB default actually produced '{}' in the column.
+	var rawSnapshot string
+	err := container.DB.QueryRow(`SELECT snapshot::text FROM operation WHERE id = $1`, opID).Scan(&rawSnapshot)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{}`, rawSnapshot,
+		"snapshot column NOT NULL DEFAULT should produce '{}' for rows without explicit snapshot")
+
+	// Act
+	found, err := repo.Find(ctx, ids.OrgID, ids.LedgerID, ids.TransactionID, opID)
+	require.NoError(t, err)
+	require.NotNil(t, found)
+
+	// Assert: legacy '{}' decodes to the same shape as a fresh non-overdraft
+	// op — uniform wire response regardless of row age.
+	assert.Equal(t, "0", found.Snapshot.OverdraftUsedBefore, "legacy row default-fills to '0'")
+	assert.Equal(t, "0", found.Snapshot.OverdraftUsedAfter)
+	assert.True(t, found.Balance.OverdraftUsed.Equal(decimal.Zero))
+	assert.True(t, found.BalanceAfter.OverdraftUsed.Equal(decimal.Zero))
+}
+
+// ============================================================================
+// Point-in-Time Query
+// ============================================================================
+
+// TestIntegration_OperationSnapshot_PointInTime verifies that the point-in-time
+// balance reconstruction path (FindLastOperationBeforeTimestamp, which uses
+// the lean operationPointInTimeColumns scan list) correctly carries the
+// snapshot through. The PIT model only populates BalanceAfter (the "after"
+// view at the queried timestamp), so we only assert the After side.
+//
+// Without snapshot propagation on the PIT scan list, historical balance
+// reconstruction would surface typed OverdraftUsed as decimal.Zero, defeating
+// the audit-trail purpose of the snapshot column.
+func TestIntegration_OperationSnapshot_PointInTime(t *testing.T) {
+	container := pgtestutil.SetupContainer(t)
+	repo := createRepository(t, container)
+	ids := createTestDependencies(t, container)
+
+	ctx := context.Background()
+	now := time.Now().Truncate(time.Microsecond)
+
+	snapshot := mmodel.OperationSnapshot{
+		OverdraftUsedBefore: "100",
+		OverdraftUsedAfter:  "250",
+	}
+	op := snapshotFixtureOperation(ids, now, snapshot)
+
+	created, err := repo.Create(ctx, op)
+	require.NoError(t, err)
+	require.NotNil(t, created)
+
+	// Act: query the operation via the PIT path, using a timestamp after the
+	// operation's createdAt. The PIT query orders by created_at DESC and
+	// takes the latest matching row.
+	found, err := repo.FindLastOperationBeforeTimestamp(
+		ctx,
+		ids.OrgID,
+		ids.LedgerID,
+		ids.AccountID,
+		ids.BalanceID,
+		now.Add(time.Second),
+	)
+	require.NoError(t, err)
+	require.NotNil(t, found, "PIT query should find the operation")
+
+	// Assert: the PIT model carries the snapshot through.
+	assert.Equal(t, "250", found.Snapshot.OverdraftUsedAfter)
+	// PIT path doesn't populate Before-side typed Balance.OverdraftUsed
+	// (it reconstructs a single historical balance state, not a pre/post
+	// pair). The snapshot string is still present because ToEntity decodes
+	// it whole; it's just the typed field on Balance (not BalanceAfter)
+	// that the PIT path leaves alone.
+	assert.True(t, decimal.NewFromInt(250).Equal(found.BalanceAfter.OverdraftUsed),
+		"PIT BalanceAfter.OverdraftUsed must equal decimal(250); got %s",
+		found.BalanceAfter.OverdraftUsed.String())
+}
+
+// TestIntegration_OperationSnapshot_PointInTime_LegacyRow mirrors
+// TestIntegration_OperationSnapshot_LegacyRow but through the PIT query
+// path, guarding against scan-site drift on the narrower
+// operationPointInTimeColumns list. Legacy rows decode to the always-
+// populated zero shape on the PIT path too.
+func TestIntegration_OperationSnapshot_PointInTime_LegacyRow(t *testing.T) {
+	container := pgtestutil.SetupContainer(t)
+	repo := createRepository(t, container)
+	ids := createTestDependencies(t, container)
+
+	ctx := context.Background()
+
+	opParams := pgtestutil.OperationParams{
+		TransactionID:         ids.TransactionID,
+		Description:           "legacy PIT row",
+		Type:                  "DEBIT",
+		AccountID:             ids.AccountID,
+		AccountAlias:          "@test-account",
+		BalanceID:             ids.BalanceID,
+		AssetCode:             "USD",
+		Amount:                decimal.NewFromInt(100),
+		AvailableBalance:      decimal.NewFromInt(1000),
+		OnHoldBalance:         decimal.Zero,
+		AvailableBalanceAfter: decimal.NewFromInt(900),
+		OnHoldBalanceAfter:    decimal.Zero,
+		BalanceVersionBefore:  1,
+		BalanceVersionAfter:   2,
+		Status:                "APPROVED",
+		BalanceAffected:       true,
+	}
+	pgtestutil.CreateTestOperation(t, container.DB, ids.OrgID, ids.LedgerID, opParams)
+
+	// Act
+	found, err := repo.FindLastOperationBeforeTimestamp(
+		ctx,
+		ids.OrgID,
+		ids.LedgerID,
+		ids.AccountID,
+		ids.BalanceID,
+		time.Now().Add(time.Second),
+	)
+	require.NoError(t, err)
+	require.NotNil(t, found, "PIT query should find the legacy row")
+
+	// Assert: legacy row default-fills to the zero shape on the PIT path.
+	assert.Equal(t, "0", found.Snapshot.OverdraftUsedBefore)
+	assert.Equal(t, "0", found.Snapshot.OverdraftUsedAfter)
+	assert.True(t, found.BalanceAfter.OverdraftUsed.Equal(decimal.Zero))
+}

--- a/components/ledger/internal/adapters/postgres/operation/operation_snapshot_mapper_test.go
+++ b/components/ledger/internal/adapters/postgres/operation/operation_snapshot_mapper_test.go
@@ -1,0 +1,274 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package operation
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/LerianStudio/midaz/v3/pkg/mmodel"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestOperationPostgreSQLModel_FromEntity_Snapshot verifies that FromEntity
+// always marshals the domain Operation.Snapshot into the PG model's
+// json.RawMessage. Under the always-populated wire-shape contract the entity
+// snapshot is a value type (never nil) — non-overdraft ops carry the zero
+// shape `{"overdraftUsedBefore":"0","overdraftUsedAfter":"0"}` rather than `{}`.
+func TestOperationPostgreSQLModel_FromEntity_Snapshot(t *testing.T) {
+	tests := []struct {
+		name     string
+		snapshot mmodel.OperationSnapshot
+		// expectedJSON is compared structurally (unmarshal both sides and
+		// assert equality) to avoid key-ordering brittleness.
+		expectedJSON string
+	}{
+		{
+			name: "non-overdraft op emits zero shape",
+			snapshot: mmodel.OperationSnapshot{
+				OverdraftUsedBefore: "0",
+				OverdraftUsedAfter:  "0",
+			},
+			expectedJSON: `{"overdraftUsedBefore":"0","overdraftUsedAfter":"0"}`,
+		},
+		{
+			name: "active overdraft emits non-zero values",
+			snapshot: mmodel.OperationSnapshot{
+				OverdraftUsedBefore: "50.00",
+				OverdraftUsedAfter:  "130.00",
+			},
+			expectedJSON: `{"overdraftUsedBefore":"50.00","overdraftUsedAfter":"130.00"}`,
+		},
+		{
+			name: "debit split (before=0, after=50) emits both keys",
+			snapshot: mmodel.OperationSnapshot{
+				OverdraftUsedBefore: "0",
+				OverdraftUsedAfter:  "50.00",
+			},
+			expectedJSON: `{"overdraftUsedBefore":"0","overdraftUsedAfter":"50.00"}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			entity := &Operation{
+				ID:            "op-1",
+				TransactionID: "tx-1",
+				Snapshot:      tt.snapshot,
+			}
+
+			model := &OperationPostgreSQLModel{}
+			model.FromEntity(entity)
+
+			require.NotNil(t, model.Snapshot, "Snapshot must never be nil on PG model; DB column is NOT NULL DEFAULT '{}'")
+
+			// Structural comparison: unmarshal both sides to a map and compare.
+			var got, want map[string]any
+			require.NoError(t, json.Unmarshal(model.Snapshot, &got), "PG model snapshot must be valid JSON")
+			require.NoError(t, json.Unmarshal([]byte(tt.expectedJSON), &want))
+			assert.Equal(t, want, got)
+		})
+	}
+}
+
+// TestOperationPostgreSQLModel_ToEntity_Snapshot verifies that ToEntity
+// always populates the domain Operation.Snapshot value (never nil). Legacy
+// rows (snapshot='{}'), missing keys, and malformed JSON all decode to the
+// always-populated zero shape — uniform wire response regardless of row age.
+func TestOperationPostgreSQLModel_ToEntity_Snapshot(t *testing.T) {
+	tests := []struct {
+		name     string
+		raw      json.RawMessage
+		expected mmodel.OperationSnapshot
+	}{
+		{
+			name:     "nil raw bytes default-fill to zero shape",
+			raw:      nil,
+			expected: mmodel.OperationSnapshot{OverdraftUsedBefore: "0", OverdraftUsedAfter: "0"},
+		},
+		{
+			name:     "empty object default-fills to zero shape",
+			raw:      json.RawMessage(`{}`),
+			expected: mmodel.OperationSnapshot{OverdraftUsedBefore: "0", OverdraftUsedAfter: "0"},
+		},
+		{
+			name:     "both fields populated",
+			raw:      json.RawMessage(`{"overdraftUsedBefore":"50.00","overdraftUsedAfter":"130.00"}`),
+			expected: mmodel.OperationSnapshot{OverdraftUsedBefore: "50.00", OverdraftUsedAfter: "130.00"},
+		},
+		{
+			name:     "only OverdraftUsedAfter present — Before defaults to 0",
+			raw:      json.RawMessage(`{"overdraftUsedAfter":"130.00"}`),
+			expected: mmodel.OperationSnapshot{OverdraftUsedBefore: "0", OverdraftUsedAfter: "130.00"},
+		},
+		{
+			name:     "explicit zero shape from PG round-trips intact",
+			raw:      json.RawMessage(`{"overdraftUsedBefore":"0","overdraftUsedAfter":"0"}`),
+			expected: mmodel.OperationSnapshot{OverdraftUsedBefore: "0", OverdraftUsedAfter: "0"},
+		},
+		{
+			name:     "malformed JSON falls back to zero shape (resilience)",
+			raw:      json.RawMessage(`{not valid json`),
+			expected: mmodel.OperationSnapshot{OverdraftUsedBefore: "0", OverdraftUsedAfter: "0"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			model := &OperationPostgreSQLModel{
+				ID:              "op-1",
+				TransactionID:   "tx-1",
+				BalanceAffected: true,
+				Snapshot:        tt.raw,
+			}
+
+			entity := model.ToEntity()
+			require.NotNil(t, entity)
+
+			assert.Equal(t, tt.expected.OverdraftUsedBefore, entity.Snapshot.OverdraftUsedBefore,
+				"OverdraftUsedBefore mismatch")
+			assert.Equal(t, tt.expected.OverdraftUsedAfter, entity.Snapshot.OverdraftUsedAfter,
+				"OverdraftUsedAfter mismatch")
+
+			// Typed Balance.OverdraftUsed must reflect the snapshot strings.
+			expectedBefore := decimal.Zero
+			if tt.expected.OverdraftUsedBefore != "" && tt.expected.OverdraftUsedBefore != "0" {
+				expectedBefore = decimal.RequireFromString(tt.expected.OverdraftUsedBefore)
+			}
+			assert.True(t, entity.Balance.OverdraftUsed.Equal(expectedBefore),
+				"Balance.OverdraftUsed: want %s, got %s",
+				expectedBefore.String(), entity.Balance.OverdraftUsed.String())
+
+			expectedAfter := decimal.Zero
+			if tt.expected.OverdraftUsedAfter != "" && tt.expected.OverdraftUsedAfter != "0" {
+				expectedAfter = decimal.RequireFromString(tt.expected.OverdraftUsedAfter)
+			}
+			assert.True(t, entity.BalanceAfter.OverdraftUsed.Equal(expectedAfter),
+				"BalanceAfter.OverdraftUsed: want %s, got %s",
+				expectedAfter.String(), entity.BalanceAfter.OverdraftUsed.String())
+		})
+	}
+}
+
+// TestOperationPostgreSQLModel_Snapshot_RoundTrip verifies that a domain
+// Operation.Snapshot survives FromEntity → ToEntity with semantic equality.
+// This is the core invariant that protects against scan-site drift and
+// marshal/unmarshal asymmetry under the always-populated contract.
+func TestOperationPostgreSQLModel_Snapshot_RoundTrip(t *testing.T) {
+	tests := []struct {
+		name     string
+		snapshot mmodel.OperationSnapshot
+	}{
+		{
+			name: "non-overdraft (zero shape) round-trips identically",
+			snapshot: mmodel.OperationSnapshot{
+				OverdraftUsedBefore: "0",
+				OverdraftUsedAfter:  "0",
+			},
+		},
+		{
+			name: "active overdraft round-trips identically",
+			snapshot: mmodel.OperationSnapshot{
+				OverdraftUsedBefore: "50.00",
+				OverdraftUsedAfter:  "130.00",
+			},
+		},
+		{
+			name: "credit repayment (after=0) round-trips identically",
+			snapshot: mmodel.OperationSnapshot{
+				OverdraftUsedBefore: "130.00",
+				OverdraftUsedAfter:  "0",
+			},
+		},
+		{
+			name: "debit split (before=0) round-trips identically",
+			snapshot: mmodel.OperationSnapshot{
+				OverdraftUsedBefore: "0",
+				OverdraftUsedAfter:  "50.00",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			entity := &Operation{
+				ID:              "op-1",
+				TransactionID:   "tx-1",
+				BalanceAffected: true,
+				Snapshot:        tt.snapshot,
+			}
+
+			model := &OperationPostgreSQLModel{}
+			model.FromEntity(entity)
+
+			roundTripped := model.ToEntity()
+			require.NotNil(t, roundTripped)
+
+			assert.Equal(t, tt.snapshot.OverdraftUsedBefore, roundTripped.Snapshot.OverdraftUsedBefore)
+			assert.Equal(t, tt.snapshot.OverdraftUsedAfter, roundTripped.Snapshot.OverdraftUsedAfter)
+		})
+	}
+}
+
+// TestOperationPointInTimeModel_ToEntity_Snapshot verifies that the
+// point-in-time reconstruction model also default-fills the snapshot to the
+// zero shape and applies any decoded fields on top. PIT queries must surface
+// the same uniform wire shape as live reads.
+func TestOperationPointInTimeModel_ToEntity_Snapshot(t *testing.T) {
+	tests := []struct {
+		name     string
+		raw      json.RawMessage
+		expected mmodel.OperationSnapshot
+	}{
+		{
+			name:     "nil raw default-fills to zero shape",
+			raw:      nil,
+			expected: mmodel.OperationSnapshot{OverdraftUsedBefore: "0", OverdraftUsedAfter: "0"},
+		},
+		{
+			name:     "empty object default-fills to zero shape",
+			raw:      json.RawMessage(`{}`),
+			expected: mmodel.OperationSnapshot{OverdraftUsedBefore: "0", OverdraftUsedAfter: "0"},
+		},
+		{
+			name:     "both fields populated",
+			raw:      json.RawMessage(`{"overdraftUsedBefore":"50.00","overdraftUsedAfter":"130.00"}`),
+			expected: mmodel.OperationSnapshot{OverdraftUsedBefore: "50.00", OverdraftUsedAfter: "130.00"},
+		},
+		{
+			name:     "only OverdraftUsedAfter present — Before defaults to 0",
+			raw:      json.RawMessage(`{"overdraftUsedAfter":"130.00"}`),
+			expected: mmodel.OperationSnapshot{OverdraftUsedBefore: "0", OverdraftUsedAfter: "130.00"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			pit := &OperationPointInTimeModel{
+				ID:        "op-1",
+				BalanceID: "bal-1",
+				AccountID: "acc-1",
+				AssetCode: "BRL",
+				Snapshot:  tt.raw,
+			}
+
+			entity := pit.ToEntity()
+			require.NotNil(t, entity)
+
+			assert.Equal(t, tt.expected.OverdraftUsedBefore, entity.Snapshot.OverdraftUsedBefore)
+			assert.Equal(t, tt.expected.OverdraftUsedAfter, entity.Snapshot.OverdraftUsedAfter)
+		})
+	}
+}

--- a/components/ledger/internal/adapters/postgres/operation/operation_test.go
+++ b/components/ledger/internal/adapters/postgres/operation/operation_test.go
@@ -6,9 +6,11 @@ package operation
 
 import (
 	"database/sql"
+	"encoding/json"
 	"testing"
 	"time"
 
+	"github.com/LerianStudio/midaz/v3/pkg/mmodel"
 	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -1096,4 +1098,58 @@ func TestOperationColumnList_ContainsRouteDescription(t *testing.T) {
 	}
 
 	assert.True(t, found, "operationColumnList must contain 'route_description'")
+}
+
+// TestOperation_JSONMarshal_OmitsSnapshot is a regression guard: the snapshot
+// block must NOT appear on the public JSON wire. The snapshot's information
+// surfaces via the typed balance.overdraftUsed / balanceAfter.overdraftUsed
+// fields instead. Removing the outer `json:"-"` tag on Operation.Snapshot
+// would break API consumers that depend on the lean wire shape.
+func TestOperation_JSONMarshal_OmitsSnapshot(t *testing.T) {
+	t.Parallel()
+
+	op := Operation{
+		ID: "op-wire-guard",
+		Snapshot: mmodel.OperationSnapshot{
+			OverdraftUsedBefore: "0",
+			OverdraftUsedAfter:  "50",
+		},
+	}
+
+	b, err := json.Marshal(op)
+	require.NoError(t, err)
+
+	raw := string(b)
+	assert.NotContains(t, raw, `"snapshot"`,
+		"Operation JSON wire shape must not include snapshot block; values surface via balance.overdraftUsed/balanceAfter.overdraftUsed")
+	assert.NotContains(t, raw, `"overdraftUsedBefore"`,
+		"Operation JSON must not leak inner snapshot keys")
+	assert.NotContains(t, raw, `"overdraftUsedAfter"`,
+		"Operation JSON must not leak inner snapshot keys")
+}
+
+// TestOperationLog_JSONMarshal_OmitsSnapshot is a regression guard for the
+// audit-log projection: the snapshot block must NOT appear on OperationLog's
+// JSON output. Same rationale as TestOperation_JSONMarshal_OmitsSnapshot.
+func TestOperationLog_JSONMarshal_OmitsSnapshot(t *testing.T) {
+	t.Parallel()
+
+	log := OperationLog{
+		ID: "oplog-wire-guard",
+		Snapshot: mmodel.OperationSnapshot{
+			OverdraftUsedBefore: "25",
+			OverdraftUsedAfter:  "100",
+		},
+	}
+
+	b, err := json.Marshal(log)
+	require.NoError(t, err)
+
+	raw := string(b)
+	assert.NotContains(t, raw, `"snapshot"`,
+		"OperationLog JSON wire shape must not include snapshot block")
+	assert.NotContains(t, raw, `"overdraftUsedBefore"`,
+		"OperationLog JSON must not leak inner snapshot keys")
+	assert.NotContains(t, raw, `"overdraftUsedAfter"`,
+		"OperationLog JSON must not leak inner snapshot keys")
 }

--- a/components/ledger/internal/adapters/postgres/operationroute/operationroute_overdraft_refund_test.go
+++ b/components/ledger/internal/adapters/postgres/operationroute/operationroute_overdraft_refund_test.go
@@ -1,0 +1,216 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+// T-008: Accounting Entries Extension — JSONB persistence for Overdraft
+// and Refund fields in the PostgreSQL adapter.
+//
+// These tests prove that:
+//  1. ToEntity() restores the new fields from JSONB bytes stored in the
+//     accounting_entries column.
+//  2. FromEntity() serialises the new fields into JSONB bytes.
+//  3. Round-trip (entity → model → entity) preserves all new-field values.
+//  4. Legacy JSONB rows (missing overdraft/refund) unmarshal cleanly —
+//     both new fields become nil pointers (Go zero value for pointer
+//     types) without returning an error.
+//
+// These tests MUST FAIL until T-008 GREEN introduces the Overdraft and
+// Refund fields on mmodel.AccountingEntries; they cannot even compile
+// against the current model.
+package operationroute
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/LerianStudio/midaz/v3/pkg/mmodel"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestToEntity_OverdraftAndRefund_JSONB verifies that JSONB bytes
+// containing the new overdraft/refund keys are restored onto the entity.
+func TestToEntity_OverdraftAndRefund_JSONB(t *testing.T) {
+	entries := &mmodel.AccountingEntries{
+		Direct: &mmodel.AccountingEntry{
+			Debit:  &mmodel.AccountingRubric{Code: "1001", Description: "Cash"},
+			Credit: &mmodel.AccountingRubric{Code: "2001", Description: "Revenue"},
+		},
+		Overdraft: &mmodel.AccountingEntry{
+			Debit:  &mmodel.AccountingRubric{Code: "1006", Description: "Overdraft Debit"},
+			Credit: &mmodel.AccountingRubric{Code: "2006", Description: "Overdraft Credit"},
+		},
+		Refund: &mmodel.AccountingEntry{
+			Debit:  &mmodel.AccountingRubric{Code: "1007", Description: "Refund Debit"},
+			Credit: &mmodel.AccountingRubric{Code: "2007", Description: "Refund Credit"},
+		},
+	}
+
+	raw, err := json.Marshal(entries)
+	require.NoError(t, err)
+
+	model := &OperationRoutePostgreSQLModel{
+		ID:                uuid.New(),
+		OrganizationID:    uuid.New(),
+		LedgerID:          uuid.New(),
+		Title:             "Overdraft Route",
+		OperationType:     "bidirectional",
+		AccountingEntries: raw,
+		CreatedAt:         time.Now(),
+		UpdatedAt:         time.Now(),
+	}
+
+	entity := model.ToEntity()
+	require.NotNil(t, entity)
+	require.NotNil(t, entity.AccountingEntries)
+
+	require.NotNil(t, entity.AccountingEntries.Overdraft,
+		"Overdraft must be unmarshalled from JSONB bytes")
+	require.NotNil(t, entity.AccountingEntries.Refund,
+		"Refund must be unmarshalled from JSONB bytes")
+
+	assert.Equal(t, "1006", entity.AccountingEntries.Overdraft.Debit.Code)
+	assert.Equal(t, "Overdraft Debit", entity.AccountingEntries.Overdraft.Debit.Description)
+	assert.Equal(t, "2006", entity.AccountingEntries.Overdraft.Credit.Code)
+	assert.Equal(t, "Overdraft Credit", entity.AccountingEntries.Overdraft.Credit.Description)
+
+	assert.Equal(t, "1007", entity.AccountingEntries.Refund.Debit.Code)
+	assert.Equal(t, "Refund Debit", entity.AccountingEntries.Refund.Debit.Description)
+	assert.Equal(t, "2007", entity.AccountingEntries.Refund.Credit.Code)
+	assert.Equal(t, "Refund Credit", entity.AccountingEntries.Refund.Credit.Description)
+}
+
+// TestToEntity_LegacyJSONB_NoOverdraftRefund verifies that JSONB bytes
+// stored BEFORE T-008 (no overdraft/refund keys) unmarshal cleanly and
+// leave both new pointer fields at nil.
+func TestToEntity_LegacyJSONB_NoOverdraftRefund(t *testing.T) {
+	// Simulate a legacy JSONB row stored before T-008.
+	legacyBytes := []byte(`{
+		"direct":{
+			"debit":{"code":"1001","description":"Cash"},
+			"credit":{"code":"2001","description":"Revenue"}
+		},
+		"hold":{
+			"debit":{"code":"1002","description":"Held"},
+			"credit":{"code":"2002","description":"Held Revenue"}
+		}
+	}`)
+
+	model := &OperationRoutePostgreSQLModel{
+		ID:                uuid.New(),
+		OrganizationID:    uuid.New(),
+		LedgerID:          uuid.New(),
+		Title:             "Legacy Route",
+		OperationType:     "source",
+		AccountingEntries: legacyBytes,
+		CreatedAt:         time.Now(),
+		UpdatedAt:         time.Now(),
+	}
+
+	entity := model.ToEntity()
+	require.NotNil(t, entity)
+	require.NotNil(t, entity.AccountingEntries, "legacy JSONB must unmarshal successfully")
+	require.NotNil(t, entity.AccountingEntries.Direct)
+	require.NotNil(t, entity.AccountingEntries.Hold)
+
+	// JSONB backward compatibility: new pointer fields default to nil.
+	assert.Nil(t, entity.AccountingEntries.Overdraft,
+		"Overdraft must be nil on legacy rows lacking the key")
+	assert.Nil(t, entity.AccountingEntries.Refund,
+		"Refund must be nil on legacy rows lacking the key")
+}
+
+// TestFromEntity_OverdraftAndRefund_JSONB verifies that FromEntity
+// serialises Overdraft and Refund into JSONB bytes.
+func TestFromEntity_OverdraftAndRefund_JSONB(t *testing.T) {
+	entity := &mmodel.OperationRoute{
+		ID:             uuid.New(),
+		OrganizationID: uuid.New(),
+		LedgerID:       uuid.New(),
+		Title:          "Overdraft Route",
+		OperationType:  "bidirectional",
+		AccountingEntries: &mmodel.AccountingEntries{
+			Direct: &mmodel.AccountingEntry{
+				Debit:  &mmodel.AccountingRubric{Code: "1001", Description: "Cash"},
+				Credit: &mmodel.AccountingRubric{Code: "2001", Description: "Revenue"},
+			},
+			Overdraft: &mmodel.AccountingEntry{
+				Debit:  &mmodel.AccountingRubric{Code: "1006", Description: "Overdraft Debit"},
+				Credit: &mmodel.AccountingRubric{Code: "2006", Description: "Overdraft Credit"},
+			},
+			Refund: &mmodel.AccountingEntry{
+				Debit:  &mmodel.AccountingRubric{Code: "1007", Description: "Refund Debit"},
+				Credit: &mmodel.AccountingRubric{Code: "2007", Description: "Refund Credit"},
+			},
+		},
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+	}
+
+	var model OperationRoutePostgreSQLModel
+	model.FromEntity(entity)
+
+	require.NotNil(t, model.AccountingEntries, "JSONB bytes must be populated")
+
+	var result mmodel.AccountingEntries
+	require.NoError(t, json.Unmarshal(model.AccountingEntries, &result))
+
+	require.NotNil(t, result.Overdraft)
+	require.NotNil(t, result.Refund)
+
+	assert.Equal(t, "1006", result.Overdraft.Debit.Code)
+	assert.Equal(t, "Overdraft Debit", result.Overdraft.Debit.Description)
+	assert.Equal(t, "2006", result.Overdraft.Credit.Code)
+	assert.Equal(t, "2007", result.Refund.Credit.Code)
+	assert.Equal(t, "Refund Credit", result.Refund.Credit.Description)
+}
+
+// TestOverdraftRefund_RoundTrip_Entity_Model_Entity verifies that a full
+// entity → model → entity cycle through JSONB preserves Overdraft and
+// Refund fields without loss.
+func TestOverdraftRefund_RoundTrip_Entity_Model_Entity(t *testing.T) {
+	original := &mmodel.OperationRoute{
+		ID:             uuid.New(),
+		OrganizationID: uuid.New(),
+		LedgerID:       uuid.New(),
+		Title:          "Round Trip Route",
+		Description:    "Overdraft + Refund round-trip",
+		OperationType:  "bidirectional",
+		AccountingEntries: &mmodel.AccountingEntries{
+			Direct: &mmodel.AccountingEntry{
+				Debit:  &mmodel.AccountingRubric{Code: "1001", Description: "Cash"},
+				Credit: &mmodel.AccountingRubric{Code: "2001", Description: "Revenue"},
+			},
+			Overdraft: &mmodel.AccountingEntry{
+				Debit:  &mmodel.AccountingRubric{Code: "1006", Description: "Overdraft Debit"},
+				Credit: &mmodel.AccountingRubric{Code: "2006", Description: "Overdraft Credit"},
+			},
+			Refund: &mmodel.AccountingEntry{
+				Debit:  &mmodel.AccountingRubric{Code: "1007", Description: "Refund Debit"},
+				Credit: &mmodel.AccountingRubric{Code: "2007", Description: "Refund Credit"},
+			},
+		},
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+	}
+
+	var model OperationRoutePostgreSQLModel
+	model.FromEntity(original)
+
+	roundTripped := model.ToEntity()
+	require.NotNil(t, roundTripped)
+	require.NotNil(t, roundTripped.AccountingEntries)
+	require.NotNil(t, roundTripped.AccountingEntries.Overdraft)
+	require.NotNil(t, roundTripped.AccountingEntries.Refund)
+
+	assert.Equal(t, original.AccountingEntries.Overdraft.Debit.Code,
+		roundTripped.AccountingEntries.Overdraft.Debit.Code)
+	assert.Equal(t, original.AccountingEntries.Overdraft.Credit.Description,
+		roundTripped.AccountingEntries.Overdraft.Credit.Description)
+	assert.Equal(t, original.AccountingEntries.Refund.Debit.Code,
+		roundTripped.AccountingEntries.Refund.Debit.Code)
+	assert.Equal(t, original.AccountingEntries.Refund.Credit.Description,
+		roundTripped.AccountingEntries.Refund.Credit.Description)
+}

--- a/components/ledger/internal/adapters/postgres/operationroute/operationroute_overdraft_test.go
+++ b/components/ledger/internal/adapters/postgres/operationroute/operationroute_overdraft_test.go
@@ -2,21 +2,16 @@
 // Use of this source code is governed by the Elastic License 2.0
 // that can be found in the LICENSE file.
 
-// T-008: Accounting Entries Extension — JSONB persistence for Overdraft
-// and Refund fields in the PostgreSQL adapter.
+// T-008 + T-014: Accounting Entries Extension — JSONB persistence for
+// Overdraft field in the PostgreSQL adapter.
 //
-// These tests prove that:
-//  1. ToEntity() restores the new fields from JSONB bytes stored in the
-//     accounting_entries column.
-//  2. FromEntity() serialises the new fields into JSONB bytes.
-//  3. Round-trip (entity → model → entity) preserves all new-field values.
-//  4. Legacy JSONB rows (missing overdraft/refund) unmarshal cleanly —
-//     both new fields become nil pointers (Go zero value for pointer
-//     types) without returning an error.
-//
-// These tests MUST FAIL until T-008 GREEN introduces the Overdraft and
-// Refund fields on mmodel.AccountingEntries; they cannot even compile
-// against the current model.
+// After T-014, the Refund field was collapsed into Overdraft. These tests
+// prove that:
+//  1. ToEntity() restores the Overdraft field from JSONB bytes.
+//  2. FromEntity() serialises the Overdraft field into JSONB bytes.
+//  3. Round-trip (entity → model → entity) preserves all values.
+//  4. Legacy JSONB rows (missing overdraft) unmarshal cleanly.
+//  5. Legacy JSONB rows containing "refund" keys are silently ignored.
 package operationroute
 
 import (
@@ -30,9 +25,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestToEntity_OverdraftAndRefund_JSONB verifies that JSONB bytes
-// containing the new overdraft/refund keys are restored onto the entity.
-func TestToEntity_OverdraftAndRefund_JSONB(t *testing.T) {
+// TestToEntity_Overdraft_JSONB verifies that JSONB bytes containing
+// the overdraft key are restored onto the entity.
+func TestToEntity_Overdraft_JSONB(t *testing.T) {
 	entries := &mmodel.AccountingEntries{
 		Direct: &mmodel.AccountingEntry{
 			Debit:  &mmodel.AccountingRubric{Code: "1001", Description: "Cash"},
@@ -41,10 +36,6 @@ func TestToEntity_OverdraftAndRefund_JSONB(t *testing.T) {
 		Overdraft: &mmodel.AccountingEntry{
 			Debit:  &mmodel.AccountingRubric{Code: "1006", Description: "Overdraft Debit"},
 			Credit: &mmodel.AccountingRubric{Code: "2006", Description: "Overdraft Credit"},
-		},
-		Refund: &mmodel.AccountingEntry{
-			Debit:  &mmodel.AccountingRubric{Code: "1007", Description: "Refund Debit"},
-			Credit: &mmodel.AccountingRubric{Code: "2007", Description: "Refund Credit"},
 		},
 	}
 
@@ -68,25 +59,17 @@ func TestToEntity_OverdraftAndRefund_JSONB(t *testing.T) {
 
 	require.NotNil(t, entity.AccountingEntries.Overdraft,
 		"Overdraft must be unmarshalled from JSONB bytes")
-	require.NotNil(t, entity.AccountingEntries.Refund,
-		"Refund must be unmarshalled from JSONB bytes")
 
 	assert.Equal(t, "1006", entity.AccountingEntries.Overdraft.Debit.Code)
 	assert.Equal(t, "Overdraft Debit", entity.AccountingEntries.Overdraft.Debit.Description)
 	assert.Equal(t, "2006", entity.AccountingEntries.Overdraft.Credit.Code)
 	assert.Equal(t, "Overdraft Credit", entity.AccountingEntries.Overdraft.Credit.Description)
-
-	assert.Equal(t, "1007", entity.AccountingEntries.Refund.Debit.Code)
-	assert.Equal(t, "Refund Debit", entity.AccountingEntries.Refund.Debit.Description)
-	assert.Equal(t, "2007", entity.AccountingEntries.Refund.Credit.Code)
-	assert.Equal(t, "Refund Credit", entity.AccountingEntries.Refund.Credit.Description)
 }
 
-// TestToEntity_LegacyJSONB_NoOverdraftRefund verifies that JSONB bytes
-// stored BEFORE T-008 (no overdraft/refund keys) unmarshal cleanly and
-// leave both new pointer fields at nil.
-func TestToEntity_LegacyJSONB_NoOverdraftRefund(t *testing.T) {
-	// Simulate a legacy JSONB row stored before T-008.
+// TestToEntity_LegacyJSONB_NoOverdraft verifies that JSONB bytes stored
+// BEFORE overdraft was added unmarshal cleanly and leave the new pointer
+// field at nil.
+func TestToEntity_LegacyJSONB_NoOverdraft(t *testing.T) {
 	legacyBytes := []byte(`{
 		"direct":{
 			"debit":{"code":"1001","description":"Cash"},
@@ -115,16 +98,51 @@ func TestToEntity_LegacyJSONB_NoOverdraftRefund(t *testing.T) {
 	require.NotNil(t, entity.AccountingEntries.Direct)
 	require.NotNil(t, entity.AccountingEntries.Hold)
 
-	// JSONB backward compatibility: new pointer fields default to nil.
 	assert.Nil(t, entity.AccountingEntries.Overdraft,
 		"Overdraft must be nil on legacy rows lacking the key")
-	assert.Nil(t, entity.AccountingEntries.Refund,
-		"Refund must be nil on legacy rows lacking the key")
 }
 
-// TestFromEntity_OverdraftAndRefund_JSONB verifies that FromEntity
-// serialises Overdraft and Refund into JSONB bytes.
-func TestFromEntity_OverdraftAndRefund_JSONB(t *testing.T) {
+// TestToEntity_LegacyJSONB_WithRefundKey verifies that JSONB bytes
+// containing the removed "refund" key (from pre-T-014 dev rows)
+// unmarshal cleanly — the unknown key is silently dropped.
+func TestToEntity_LegacyJSONB_WithRefundKey(t *testing.T) {
+	legacyBytes := []byte(`{
+		"direct":{
+			"debit":{"code":"1001","description":"Cash"},
+			"credit":{"code":"2001","description":"Revenue"}
+		},
+		"overdraft":{
+			"debit":{"code":"1006","description":"Overdraft Debit"},
+			"credit":{"code":"2006","description":"Overdraft Credit"}
+		},
+		"refund":{
+			"debit":{"code":"1007","description":"Legacy Refund Debit"},
+			"credit":{"code":"2007","description":"Legacy Refund Credit"}
+		}
+	}`)
+
+	model := &OperationRoutePostgreSQLModel{
+		ID:                uuid.New(),
+		OrganizationID:    uuid.New(),
+		LedgerID:          uuid.New(),
+		Title:             "Legacy Route with Refund",
+		OperationType:     "bidirectional",
+		AccountingEntries: legacyBytes,
+		CreatedAt:         time.Now(),
+		UpdatedAt:         time.Now(),
+	}
+
+	entity := model.ToEntity()
+	require.NotNil(t, entity)
+	require.NotNil(t, entity.AccountingEntries)
+	require.NotNil(t, entity.AccountingEntries.Overdraft,
+		"Overdraft must still be decoded even when refund key is present")
+	assert.Equal(t, "1006", entity.AccountingEntries.Overdraft.Debit.Code)
+}
+
+// TestFromEntity_Overdraft_JSONB verifies that FromEntity serialises
+// the Overdraft field into JSONB bytes.
+func TestFromEntity_Overdraft_JSONB(t *testing.T) {
 	entity := &mmodel.OperationRoute{
 		ID:             uuid.New(),
 		OrganizationID: uuid.New(),
@@ -140,10 +158,6 @@ func TestFromEntity_OverdraftAndRefund_JSONB(t *testing.T) {
 				Debit:  &mmodel.AccountingRubric{Code: "1006", Description: "Overdraft Debit"},
 				Credit: &mmodel.AccountingRubric{Code: "2006", Description: "Overdraft Credit"},
 			},
-			Refund: &mmodel.AccountingEntry{
-				Debit:  &mmodel.AccountingRubric{Code: "1007", Description: "Refund Debit"},
-				Credit: &mmodel.AccountingRubric{Code: "2007", Description: "Refund Credit"},
-			},
 		},
 		CreatedAt: time.Now(),
 		UpdatedAt: time.Now(),
@@ -158,25 +172,22 @@ func TestFromEntity_OverdraftAndRefund_JSONB(t *testing.T) {
 	require.NoError(t, json.Unmarshal(model.AccountingEntries, &result))
 
 	require.NotNil(t, result.Overdraft)
-	require.NotNil(t, result.Refund)
-
 	assert.Equal(t, "1006", result.Overdraft.Debit.Code)
 	assert.Equal(t, "Overdraft Debit", result.Overdraft.Debit.Description)
 	assert.Equal(t, "2006", result.Overdraft.Credit.Code)
-	assert.Equal(t, "2007", result.Refund.Credit.Code)
-	assert.Equal(t, "Refund Credit", result.Refund.Credit.Description)
+	assert.Equal(t, "Overdraft Credit", result.Overdraft.Credit.Description)
 }
 
-// TestOverdraftRefund_RoundTrip_Entity_Model_Entity verifies that a full
-// entity → model → entity cycle through JSONB preserves Overdraft and
-// Refund fields without loss.
-func TestOverdraftRefund_RoundTrip_Entity_Model_Entity(t *testing.T) {
+// TestOverdraft_RoundTrip_Entity_Model_Entity verifies that a full
+// entity → model → entity cycle through JSONB preserves the Overdraft
+// field without loss.
+func TestOverdraft_RoundTrip_Entity_Model_Entity(t *testing.T) {
 	original := &mmodel.OperationRoute{
 		ID:             uuid.New(),
 		OrganizationID: uuid.New(),
 		LedgerID:       uuid.New(),
 		Title:          "Round Trip Route",
-		Description:    "Overdraft + Refund round-trip",
+		Description:    "Overdraft round-trip",
 		OperationType:  "bidirectional",
 		AccountingEntries: &mmodel.AccountingEntries{
 			Direct: &mmodel.AccountingEntry{
@@ -186,10 +197,6 @@ func TestOverdraftRefund_RoundTrip_Entity_Model_Entity(t *testing.T) {
 			Overdraft: &mmodel.AccountingEntry{
 				Debit:  &mmodel.AccountingRubric{Code: "1006", Description: "Overdraft Debit"},
 				Credit: &mmodel.AccountingRubric{Code: "2006", Description: "Overdraft Credit"},
-			},
-			Refund: &mmodel.AccountingEntry{
-				Debit:  &mmodel.AccountingRubric{Code: "1007", Description: "Refund Debit"},
-				Credit: &mmodel.AccountingRubric{Code: "2007", Description: "Refund Credit"},
 			},
 		},
 		CreatedAt: time.Now(),
@@ -203,14 +210,9 @@ func TestOverdraftRefund_RoundTrip_Entity_Model_Entity(t *testing.T) {
 	require.NotNil(t, roundTripped)
 	require.NotNil(t, roundTripped.AccountingEntries)
 	require.NotNil(t, roundTripped.AccountingEntries.Overdraft)
-	require.NotNil(t, roundTripped.AccountingEntries.Refund)
 
 	assert.Equal(t, original.AccountingEntries.Overdraft.Debit.Code,
 		roundTripped.AccountingEntries.Overdraft.Debit.Code)
 	assert.Equal(t, original.AccountingEntries.Overdraft.Credit.Description,
 		roundTripped.AccountingEntries.Overdraft.Credit.Description)
-	assert.Equal(t, original.AccountingEntries.Refund.Debit.Code,
-		roundTripped.AccountingEntries.Refund.Debit.Code)
-	assert.Equal(t, original.AccountingEntries.Refund.Credit.Description,
-		roundTripped.AccountingEntries.Refund.Credit.Description)
 }

--- a/components/ledger/internal/adapters/postgres/transaction/transaction.go
+++ b/components/ledger/internal/adapters/postgres/transaction/transaction.go
@@ -13,6 +13,7 @@ import (
 
 	libCommons "github.com/LerianStudio/lib-commons/v4/commons"
 	"github.com/LerianStudio/midaz/v3/components/ledger/internal/adapters/postgres/operation"
+	pkgConstant "github.com/LerianStudio/midaz/v3/pkg/constant"
 	"github.com/LerianStudio/midaz/v3/pkg/mmodel"
 	"github.com/LerianStudio/midaz/v3/pkg/mtransaction"
 	"github.com/google/uuid"
@@ -296,6 +297,23 @@ func (t Transaction) TransactionRevert() mtransaction.Transaction {
 
 	froms := make([]mtransaction.FromTo, 0)
 	tos := make([]mtransaction.FromTo, 0)
+	fromByAlias := make(map[string]int)
+	toByAlias := make(map[string]int)
+
+	addCompanionAmount := func(entries []mtransaction.FromTo, indexByAlias map[string]int, op *operation.Operation) []mtransaction.FromTo {
+		idx, ok := indexByAlias[op.AccountAlias]
+		if !ok {
+			return entries
+		}
+
+		if entries[idx].Amount == nil {
+			return entries
+		}
+
+		entries[idx].Amount.Value = entries[idx].Amount.Value.Add(*op.Amount.Value)
+
+		return entries
+	}
 
 	for _, op := range t.Operations {
 		if op.Amount.Value == nil {
@@ -306,10 +324,32 @@ func (t Transaction) TransactionRevert() mtransaction.Transaction {
 		// Only CREDIT and DEBIT appear in APPROVED transactions, which is the
 		// only status eligible for revert (guarded upstream).  ONHOLD and
 		// RELEASE are excluded because they belong to PENDING flows.
+		case pkgConstant.OVERDRAFT:
+			switch op.Direction {
+			case pkgConstant.DirectionCredit:
+				froms = addCompanionAmount(froms, fromByAlias, op)
+			case pkgConstant.DirectionDebit, "":
+				tos = addCompanionAmount(tos, toByAlias, op)
+			}
+
+			continue
+
 		case constant.CREDIT:
+			if op.BalanceKey == pkgConstant.OverdraftBalanceKey {
+				froms = addCompanionAmount(froms, fromByAlias, op)
+
+				continue
+			}
+
+			balanceKey := op.BalanceKey
+			if balanceKey == "" {
+				balanceKey = pkgConstant.DefaultBalanceKey
+			}
+
 			froms = append(froms, mtransaction.FromTo{
 				IsFrom:          true,
 				AccountAlias:    op.AccountAlias,
+				BalanceKey:      balanceKey,
 				Amount:          &mtransaction.Amount{Asset: op.AssetCode, Value: *op.Amount.Value},
 				Description:     op.Description,
 				ChartOfAccounts: op.ChartOfAccounts,
@@ -317,10 +357,23 @@ func (t Transaction) TransactionRevert() mtransaction.Transaction {
 				Route:           op.Route,
 				RouteID:         op.RouteID,
 			})
+			fromByAlias[op.AccountAlias] = len(froms) - 1
 		case constant.DEBIT:
+			if op.BalanceKey == pkgConstant.OverdraftBalanceKey {
+				tos = addCompanionAmount(tos, toByAlias, op)
+
+				continue
+			}
+
+			balanceKey := op.BalanceKey
+			if balanceKey == "" {
+				balanceKey = pkgConstant.DefaultBalanceKey
+			}
+
 			tos = append(tos, mtransaction.FromTo{
 				IsFrom:          false,
 				AccountAlias:    op.AccountAlias,
+				BalanceKey:      balanceKey,
 				Amount:          &mtransaction.Amount{Asset: op.AssetCode, Value: *op.Amount.Value},
 				Description:     op.Description,
 				ChartOfAccounts: op.ChartOfAccounts,
@@ -328,6 +381,7 @@ func (t Transaction) TransactionRevert() mtransaction.Transaction {
 				Route:           op.Route,
 				RouteID:         op.RouteID,
 			})
+			toByAlias[op.AccountAlias] = len(tos) - 1
 		}
 	}
 

--- a/components/ledger/internal/adapters/postgres/transaction/transaction.go
+++ b/components/ledger/internal/adapters/postgres/transaction/transaction.go
@@ -310,7 +310,7 @@ func (t Transaction) TransactionRevert() mtransaction.Transaction {
 			return entries
 		}
 
-		entries[idx].Amount.Value = entries[idx].Amount.Value.Add(*op.Amount.Value)
+		entries[idx].Amount.Value = decimal.Min(entries[idx].Amount.Value.Add(*op.Amount.Value), *t.Amount)
 
 		return entries
 	}
@@ -321,23 +321,8 @@ func (t Transaction) TransactionRevert() mtransaction.Transaction {
 		}
 
 		switch op.Type {
-		// Only CREDIT and DEBIT appear in APPROVED transactions, which is the
-		// only status eligible for revert (guarded upstream).  ONHOLD and
-		// RELEASE are excluded because they belong to PENDING flows.
-		case pkgConstant.OVERDRAFT:
-			switch op.Direction {
-			case pkgConstant.DirectionCredit:
-				froms = addCompanionAmount(froms, fromByAlias, op)
-			case pkgConstant.DirectionDebit, "":
-				tos = addCompanionAmount(tos, toByAlias, op)
-			}
-
-			continue
-
 		case constant.CREDIT:
 			if op.BalanceKey == pkgConstant.OverdraftBalanceKey {
-				froms = addCompanionAmount(froms, fromByAlias, op)
-
 				continue
 			}
 
@@ -360,8 +345,6 @@ func (t Transaction) TransactionRevert() mtransaction.Transaction {
 			fromByAlias[op.AccountAlias] = len(froms) - 1
 		case constant.DEBIT:
 			if op.BalanceKey == pkgConstant.OverdraftBalanceKey {
-				tos = addCompanionAmount(tos, toByAlias, op)
-
 				continue
 			}
 
@@ -382,6 +365,19 @@ func (t Transaction) TransactionRevert() mtransaction.Transaction {
 				RouteID:         op.RouteID,
 			})
 			toByAlias[op.AccountAlias] = len(tos) - 1
+		}
+	}
+
+	for _, op := range t.Operations {
+		if op.Amount.Value == nil || (op.Type != pkgConstant.OVERDRAFT && op.BalanceKey != pkgConstant.OverdraftBalanceKey) {
+			continue
+		}
+
+		switch op.Direction {
+		case pkgConstant.DirectionCredit:
+			froms = addCompanionAmount(froms, fromByAlias, op)
+		case pkgConstant.DirectionDebit, "":
+			tos = addCompanionAmount(tos, toByAlias, op)
 		}
 	}
 

--- a/components/ledger/internal/adapters/postgres/transaction/transaction.postgresql.go
+++ b/components/ledger/internal/adapters/postgres/transaction/transaction.postgresql.go
@@ -74,6 +74,22 @@ var transactionColumnListPrefixed = []string{
 	"t.route_id",
 }
 
+// operationColumnListPrefixed mirrors operation.operationColumnList with the "o."
+// table prefix for JOIN queries. Shared by FindWithOperations and
+// FindOrListAllWithOperations so that column-set drift is impossible.
+// When operation.operationColumnList gains a column, add the prefixed entry here
+// at the same trailing position to keep scan-site alignment.
+var operationColumnListPrefixed = []string{
+	"o.id", "o.transaction_id", "o.description", "o.type", "o.asset_code",
+	"o.amount", "o.available_balance", "o.on_hold_balance", "o.available_balance_after",
+	"o.on_hold_balance_after", "o.status", "o.status_description", "o.account_id",
+	"o.account_alias", "o.balance_id", "o.chart_of_accounts", "o.organization_id",
+	"o.ledger_id", "o.created_at", "o.updated_at", "o.deleted_at", "o.route",
+	"o.balance_affected", "o.balance_key", "o.balance_version_before", "o.balance_version_after",
+	"o.direction", "o.route_id", "o.route_code", "o.route_description",
+	"o.snapshot",
+}
+
 // Repository provides an interface for operations related to transaction template entities.
 // It defines methods for creating, retrieving, updating, and deleting transactions.
 type Repository interface {
@@ -1243,16 +1259,6 @@ func (r *TransactionPostgreSQLRepository) FindWithOperations(ctx context.Context
 	ctx, spanQuery := tracer.Start(ctx, "postgres.find_transaction_with_operations.query")
 	defer spanQuery.End()
 
-	operationColumnListPrefixed := []string{
-		"o.id", "o.transaction_id", "o.description", "o.type", "o.asset_code",
-		"o.amount", "o.available_balance", "o.on_hold_balance", "o.available_balance_after",
-		"o.on_hold_balance_after", "o.status", "o.status_description", "o.account_id",
-		"o.account_alias", "o.balance_id", "o.chart_of_accounts", "o.organization_id",
-		"o.ledger_id", "o.created_at", "o.updated_at", "o.deleted_at", "o.route",
-		"o.balance_affected", "o.balance_key", "o.balance_version_before", "o.balance_version_after",
-		"o.direction", "o.route_id", "o.route_code", "o.route_description",
-	}
-
 	selectColumns := append(transactionColumnListPrefixed, operationColumnListPrefixed...)
 
 	findWithOps := squirrel.Select(selectColumns...).
@@ -1339,6 +1345,7 @@ func (r *TransactionPostgreSQLRepository) FindWithOperations(ctx context.Context
 			&op.RouteID,
 			&op.RouteCode,
 			&op.RouteDescription,
+			&op.Snapshot,
 		); err != nil {
 			libOpentelemetry.HandleSpanError(span, "Failed to scan rows", err)
 
@@ -1427,16 +1434,6 @@ func (r *TransactionPostgreSQLRepository) FindOrListAllWithOperations(ctx contex
 		return nil, libHTTP.CursorPagination{}, err
 	}
 
-	operationColumnListPrefixed := []string{
-		"o.id", "o.transaction_id", "o.description", "o.type", "o.asset_code",
-		"o.amount", "o.available_balance", "o.on_hold_balance", "o.available_balance_after",
-		"o.on_hold_balance_after", "o.status", "o.status_description", "o.account_id",
-		"o.account_alias", "o.balance_id", "o.chart_of_accounts", "o.organization_id",
-		"o.ledger_id", "o.created_at", "o.updated_at", "o.deleted_at", "o.route",
-		"o.balance_affected", "o.balance_key", "o.balance_version_before", "o.balance_version_after",
-		"o.direction", "o.route_id", "o.route_code", "o.route_description",
-	}
-
 	selectColumns := append(transactionColumnListPrefixed, operationColumnListPrefixed...)
 
 	findAll := squirrel.
@@ -1492,6 +1489,7 @@ func (r *TransactionPostgreSQLRepository) FindOrListAllWithOperations(ctx contex
 			opBalanceAffected                                            *bool
 			opVersionBalance, opVersionBalanceAfter                      *int64
 			opDirection, opRouteID, opRouteCode, opRouteDescription      *string
+			opSnapshot                                                   json.RawMessage
 		)
 
 		if err := rows.Scan(
@@ -1541,6 +1539,7 @@ func (r *TransactionPostgreSQLRepository) FindOrListAllWithOperations(ctx contex
 			&opRouteID,
 			&opRouteCode,
 			&opRouteDescription,
+			&opSnapshot,
 		); err != nil {
 			libOpentelemetry.HandleSpanError(span, "Failed to scan rows", err)
 
@@ -1604,6 +1603,7 @@ func (r *TransactionPostgreSQLRepository) FindOrListAllWithOperations(ctx contex
 				RouteID:               opRouteID,
 				RouteCode:             opRouteCode,
 				RouteDescription:      opRouteDescription,
+				Snapshot:              opSnapshot,
 			}
 
 			t.Operations = append(t.Operations, op.ToEntity())

--- a/components/ledger/internal/adapters/postgres/transaction/transaction_test.go
+++ b/components/ledger/internal/adapters/postgres/transaction/transaction_test.go
@@ -11,6 +11,7 @@ import (
 
 	constant "github.com/LerianStudio/lib-commons/v4/commons/constants"
 	"github.com/LerianStudio/midaz/v3/components/ledger/internal/adapters/postgres/operation"
+	pkgConstant "github.com/LerianStudio/midaz/v3/pkg/constant"
 	"github.com/LerianStudio/midaz/v3/pkg/mtransaction"
 	"github.com/google/uuid"
 	"github.com/shopspring/decimal"
@@ -770,6 +771,90 @@ func TestTransactionRevert_NilAmount(t *testing.T) {
 	assert.Empty(t, result.Send.Asset, "should return empty transaction when Amount is nil")
 	assert.Empty(t, result.Send.Source.From, "should return empty froms when Amount is nil")
 	assert.Empty(t, result.Send.Distribute.To, "should return empty tos when Amount is nil")
+}
+
+func TestTransactionRevert_PreservesBalanceKey(t *testing.T) {
+	t.Parallel()
+
+	amount := decimal.NewFromInt(40)
+	txn := Transaction{
+		Description: "additional balance transfer",
+		AssetCode:   "BRL",
+		Amount:      &amount,
+		Operations: []*operation.Operation{
+			{
+				Type:         constant.CREDIT,
+				AccountAlias: "@receiver",
+				BalanceKey:   "voucher",
+				AssetCode:    "BRL",
+				Amount:       operation.Amount{Value: &amount},
+			},
+			{
+				Type:         constant.DEBIT,
+				AccountAlias: "@sender",
+				BalanceKey:   "reserve",
+				AssetCode:    "BRL",
+				Amount:       operation.Amount{Value: &amount},
+			},
+		},
+	}
+
+	reverted := txn.TransactionRevert()
+
+	require.Len(t, reverted.Send.Source.From, 1)
+	assert.Equal(t, "voucher", reverted.Send.Source.From[0].BalanceKey)
+	require.Len(t, reverted.Send.Distribute.To, 1)
+	assert.Equal(t, "reserve", reverted.Send.Distribute.To[0].BalanceKey)
+}
+
+func TestTransactionRevert_FoldsOverdraftCompanionIntoDefaultLeg(t *testing.T) {
+	t.Parallel()
+
+	amount100 := decimal.NewFromInt(100)
+	amount50 := decimal.NewFromInt(50)
+	txn := Transaction{
+		Description: "overdraft transfer",
+		AssetCode:   "BRL",
+		Amount:      &amount100,
+		Operations: []*operation.Operation{
+			{
+				Type:         constant.DEBIT,
+				AccountAlias: "@source",
+				BalanceKey:   pkgConstant.DefaultBalanceKey,
+				AssetCode:    "BRL",
+				Amount:       operation.Amount{Value: &amount50},
+			},
+			{
+				Type:         pkgConstant.OVERDRAFT,
+				Direction:    pkgConstant.DirectionDebit,
+				AccountAlias: "@source",
+				BalanceKey:   pkgConstant.OverdraftBalanceKey,
+				AssetCode:    "BRL",
+				Amount:       operation.Amount{Value: &amount50},
+			},
+			{
+				Type:         constant.CREDIT,
+				AccountAlias: "@destination",
+				BalanceKey:   pkgConstant.DefaultBalanceKey,
+				AssetCode:    "BRL",
+				Amount:       operation.Amount{Value: &amount100},
+			},
+		},
+	}
+
+	reverted := txn.TransactionRevert()
+
+	require.Len(t, reverted.Send.Source.From, 1)
+	assert.Equal(t, "@destination", reverted.Send.Source.From[0].AccountAlias)
+	assert.Equal(t, pkgConstant.DefaultBalanceKey, reverted.Send.Source.From[0].BalanceKey)
+	assert.True(t, reverted.Send.Source.From[0].Amount.Value.Equal(amount100))
+
+	require.Len(t, reverted.Send.Distribute.To, 1,
+		"internal overdraft companion must not be targeted directly by public revert transaction")
+	assert.Equal(t, "@source", reverted.Send.Distribute.To[0].AccountAlias)
+	assert.Equal(t, pkgConstant.DefaultBalanceKey, reverted.Send.Distribute.To[0].BalanceKey)
+	assert.True(t, reverted.Send.Distribute.To[0].Amount.Value.Equal(amount100),
+		"default reverse credit must include the default movement plus overdraft companion amount")
 }
 
 func TestTransactionRevert_DirectionNotSet(t *testing.T) {

--- a/components/ledger/internal/adapters/postgres/transaction/transaction_test.go
+++ b/components/ledger/internal/adapters/postgres/transaction/transaction_test.go
@@ -857,6 +857,108 @@ func TestTransactionRevert_FoldsOverdraftCompanionIntoDefaultLeg(t *testing.T) {
 		"default reverse credit must include the default movement plus overdraft companion amount")
 }
 
+func TestTransactionRevert_FoldsOverdraftCompanionRegardlessOfOperationOrder(t *testing.T) {
+	t.Parallel()
+
+	amount100 := decimal.NewFromInt(100)
+	amount50 := decimal.NewFromInt(50)
+	txn := Transaction{
+		Description: "overdraft transfer with companion before default",
+		AssetCode:   "BRL",
+		Amount:      &amount100,
+		Operations: []*operation.Operation{
+			{
+				Type:         pkgConstant.OVERDRAFT,
+				Direction:    pkgConstant.DirectionDebit,
+				AccountAlias: "@source",
+				BalanceKey:   pkgConstant.OverdraftBalanceKey,
+				AssetCode:    "BRL",
+				Amount:       operation.Amount{Value: &amount50},
+			},
+			{
+				Type:         constant.DEBIT,
+				AccountAlias: "@source",
+				BalanceKey:   pkgConstant.DefaultBalanceKey,
+				AssetCode:    "BRL",
+				Amount:       operation.Amount{Value: &amount50},
+			},
+			{
+				Type:         constant.CREDIT,
+				AccountAlias: "@destination",
+				BalanceKey:   pkgConstant.DefaultBalanceKey,
+				AssetCode:    "BRL",
+				Amount:       operation.Amount{Value: &amount100},
+			},
+		},
+	}
+
+	reverted := txn.TransactionRevert()
+
+	require.Len(t, reverted.Send.Source.From, 1)
+	assert.Equal(t, "@destination", reverted.Send.Source.From[0].AccountAlias)
+	assert.True(t, reverted.Send.Source.From[0].Amount.Value.Equal(amount100))
+	require.Len(t, reverted.Send.Distribute.To, 1)
+	assert.Equal(t, "@source", reverted.Send.Distribute.To[0].AccountAlias)
+	assert.Equal(t, pkgConstant.DefaultBalanceKey, reverted.Send.Distribute.To[0].BalanceKey)
+	assert.True(t, reverted.Send.Distribute.To[0].Amount.Value.Equal(amount100),
+		"companion amount must be folded even when PostgreSQL returns it before the default DEBIT")
+}
+
+func TestTransactionRevert_DoesNotDoubleCountCommittedPendingOverdraftCompanion(t *testing.T) {
+	t.Parallel()
+
+	amount100 := decimal.NewFromInt(100)
+	amount50 := decimal.NewFromInt(50)
+	txn := Transaction{
+		Description: "committed pending overdraft transfer",
+		AssetCode:   "BRL",
+		Amount:      &amount100,
+		Operations: []*operation.Operation{
+			{
+				Type:         constant.ONHOLD,
+				Direction:    pkgConstant.DirectionDebit,
+				AccountAlias: "@source",
+				BalanceKey:   pkgConstant.DefaultBalanceKey,
+				AssetCode:    "BRL",
+				Amount:       operation.Amount{Value: &amount100},
+			},
+			{
+				Type:         pkgConstant.OVERDRAFT,
+				Direction:    pkgConstant.DirectionDebit,
+				AccountAlias: "@source",
+				BalanceKey:   pkgConstant.OverdraftBalanceKey,
+				AssetCode:    "BRL",
+				Amount:       operation.Amount{Value: &amount50},
+			},
+			{
+				Type:         constant.CREDIT,
+				AccountAlias: "@destination",
+				BalanceKey:   pkgConstant.DefaultBalanceKey,
+				AssetCode:    "BRL",
+				Amount:       operation.Amount{Value: &amount100},
+			},
+			{
+				Type:         constant.DEBIT,
+				AccountAlias: "@source",
+				BalanceKey:   pkgConstant.DefaultBalanceKey,
+				AssetCode:    "BRL",
+				Amount:       operation.Amount{Value: &amount100},
+			},
+		},
+	}
+
+	reverted := txn.TransactionRevert()
+
+	require.Len(t, reverted.Send.Source.From, 1)
+	assert.Equal(t, "@destination", reverted.Send.Source.From[0].AccountAlias)
+	assert.True(t, reverted.Send.Source.From[0].Amount.Value.Equal(amount100))
+	require.Len(t, reverted.Send.Distribute.To, 1)
+	assert.Equal(t, "@source", reverted.Send.Distribute.To[0].AccountAlias)
+	assert.Equal(t, pkgConstant.DefaultBalanceKey, reverted.Send.Distribute.To[0].BalanceKey)
+	assert.True(t, reverted.Send.Distribute.To[0].Amount.Value.Equal(amount100),
+		"committed pending DEBIT already carries the full amount; companion must not inflate revert to 150")
+}
+
 func TestTransactionRevert_DirectionNotSet(t *testing.T) {
 	t.Parallel()
 

--- a/components/ledger/internal/adapters/postgres/transaction/transaction_test.go
+++ b/components/ledger/internal/adapters/postgres/transaction/transaction_test.go
@@ -970,3 +970,33 @@ func TestTransactionRevert_RoutePreservation(t *testing.T) {
 		})
 	}
 }
+
+// TestOperationColumnListPrefixed_IncludesSnapshot is a compile-time-safe guard
+// that prevents column-list drift between the canonical operation.operationColumnList
+// (which includes "snapshot") and the prefixed copy used by FindWithOperations /
+// FindOrListAllWithOperations.
+func TestOperationColumnListPrefixed_IncludesSnapshot(t *testing.T) {
+	t.Parallel()
+
+	found := false
+
+	for _, col := range operationColumnListPrefixed {
+		if col == "o.snapshot" {
+			found = true
+
+			break
+		}
+	}
+
+	require.True(t, found,
+		"operationColumnListPrefixed must include 'o.snapshot'; "+
+			"without it, FindWithOperations and FindOrListAllWithOperations "+
+			"return operations with nil Snapshot, causing ToEntity to default "+
+			"all overdraft fields to zero regardless of stored values")
+
+	// Also verify total count matches operation.operationColumnList (31 columns).
+	// This catches additions to the canonical list that aren't mirrored here.
+	assert.Len(t, operationColumnListPrefixed, operation.ExportedOperationColumnListLen(),
+		"operationColumnListPrefixed column count must match operation.operationColumnList; "+
+			"a column was added to the canonical list but not to the prefixed copy")
+}

--- a/components/ledger/internal/adapters/redis/transaction/consumer.redis.go
+++ b/components/ledger/internal/adapters/redis/transaction/consumer.redis.go
@@ -749,9 +749,9 @@ func (rr *RedisConsumerRepository) buildBalanceAtomicOperationPlan(ctx context.C
 //   - "0098" → ErrOnHoldExternalAccount (external account used in pending source)
 //   - "0139" → ErrTransactionBackupCacheRetrievalFailed (balance key vanished mid-script)
 //   - "0167" → ErrOverdraftLimitExceeded (transaction would push usage past the configured limit)
-//   - "0175" → ErrStaleBalanceVersion (balance changed between Go read and Lua execution)
+//   - "0174" → ErrStaleBalanceVersion (balance changed between Go read and Lua execution)
 //
-// Ordering note: more specific codes ("0167", "0175") are matched before the
+// Ordering note: more specific codes ("0167", "0174") are matched before the
 // generic "0018" insufficient-funds branch so that a single error string like
 // "0167" is not misclassified by loose substring matching.
 func mapBalanceAtomicScriptError(span trace.Span, err error) error {

--- a/components/ledger/internal/adapters/redis/transaction/consumer.redis.go
+++ b/components/ledger/internal/adapters/redis/transaction/consumer.redis.go
@@ -119,6 +119,20 @@ type RedisRepository interface {
 	// preventing removal of entries re-scheduled by newer mutations.
 	// Returns the number of keys actually removed from the schedule.
 	RemoveBalanceSyncKeysBatch(ctx context.Context, keys []SyncKey) (int64, error)
+	// UpdateBalanceCacheSettings performs an in-place, settings-only update of a
+	// cached balance entry. It GETs the current JSON blob, mutates ONLY the
+	// overdraft/scope settings fields, and SETs it back with the Lua script's
+	// canonical 1-hour TTL.
+	//
+	// Transactional fields (Available, OnHold, Version, OverdraftUsed) are
+	// deliberately NOT touched: the Redis copy is the authoritative live state
+	// that the atomic Lua script mutates on every transaction, and may be ahead
+	// of PostgreSQL while sync is pending. Overwriting them — or deleting the
+	// key outright — would lose in-flight mutations.
+	//
+	// A cache miss (key absent) is a no-op: the next transaction will load the
+	// freshly-updated settings directly from PostgreSQL on its first SETNX.
+	UpdateBalanceCacheSettings(ctx context.Context, organizationID, ledgerID uuid.UUID, cacheKey string, settings *mmodel.BalanceSettings) error
 }
 
 // RedisConsumerRepository is a Redis implementation of the Redis consumer.
@@ -1422,6 +1436,131 @@ func (rr *RedisConsumerRepository) ListBalanceByKey(ctx context.Context, organiz
 	}
 
 	return balance, nil
+}
+
+// balanceCacheSettingsTTL matches the TTL the balance atomic Lua script applies
+// to each cached balance key (`local ttl = 3600 -- 1 hour` in
+// scripts/balance_atomic_operation.lua). Keeping the two in lock-step ensures
+// a settings-only rewrite does not silently extend or shrink the lifetime of
+// an entry relative to the transactional refreshes driven by Lua.
+const balanceCacheSettingsTTL = 3600 * time.Second
+
+// UpdateBalanceCacheSettings rewrites the settings fields of a cached balance
+// JSON blob in-place, preserving the live transactional state (Available,
+// OnHold, Version, OverdraftUsed) that the Lua atomic script may have mutated
+// but not yet flushed to PostgreSQL.
+//
+// Flow:
+//  1. GET the current JSON by the tenant-prefixed internal key.
+//  2. On cache miss (redis.Nil), return nil — the next transaction's SETNX
+//     will load the just-persisted settings from PostgreSQL.
+//  3. Unmarshal, overwrite ONLY the settings-derived fields, remarshal.
+//  4. SET back with the Lua script's canonical TTL (1 hour).
+//
+// Errors are surfaced to the caller so the command layer can decide whether to
+// log (best-effort) or escalate; this method does not swallow them internally.
+func (rr *RedisConsumerRepository) UpdateBalanceCacheSettings(ctx context.Context, organizationID, ledgerID uuid.UUID, cacheKey string, settings *mmodel.BalanceSettings) error {
+	logger, tracer, _, _ := libCommons.NewTrackingFromContext(ctx)
+
+	ctx, span := tracer.Start(ctx, "redis.update_balance_cache_settings")
+	defer span.End()
+
+	span.SetAttributes(
+		attribute.String("app.organization_id", organizationID.String()),
+		attribute.String("app.ledger_id", ledgerID.String()),
+	)
+
+	internalKey := utils.BalanceInternalKey(organizationID, ledgerID, cacheKey)
+
+	prefixedKey, err := tenantKeyFromContextOrError(ctx, internalKey)
+	if err != nil {
+		libOpentelemetry.HandleSpanError(span, "Failed to namespace balance cache key", err)
+		logger.Log(ctx, libLog.LevelError, "Failed to namespace balance cache key", libLog.Err(err))
+
+		return err
+	}
+
+	rds, err := rr.conn.GetClient(ctx)
+	if err != nil {
+		libOpentelemetry.HandleSpanError(span, "Failed to get redis client", err)
+		logger.Log(ctx, libLog.LevelError, "Failed to get Redis client", libLog.Err(err))
+
+		return err
+	}
+
+	// Read the current JSON. A missing key means the Lua script has not yet
+	// primed the cache for this balance; the next transaction will load the
+	// fresh settings directly from PostgreSQL, so there is nothing to rewrite.
+	val, err := rds.Get(ctx, prefixedKey).Result()
+	if errors.Is(err, redis.Nil) {
+		logger.Log(ctx, libLog.LevelDebug, "Balance cache miss on settings update (no-op)")
+
+		return nil
+	}
+
+	if err != nil {
+		libOpentelemetry.HandleSpanError(span, "Failed to get balance cache for settings update", err)
+		logger.Log(ctx, libLog.LevelError, "Failed to get balance cache for settings update", libLog.Err(err))
+
+		return err
+	}
+
+	var cached mmodel.BalanceRedis
+	if err := json.Unmarshal([]byte(val), &cached); err != nil {
+		libOpentelemetry.HandleSpanError(span, "Failed to unmarshal cached balance for settings update", err)
+		logger.Log(ctx, libLog.LevelError, "Failed to unmarshal cached balance for settings update", libLog.Err(err))
+
+		return err
+	}
+
+	// Only settings fields are mutated. Available, OnHold, Version,
+	// OverdraftUsed, and identity fields (ID, Alias, Key, AssetCode, etc.)
+	// remain untouched so any in-flight transactional state is preserved.
+	if settings != nil {
+		cached.AllowOverdraft = boolToInt(settings.AllowOverdraft)
+		cached.OverdraftLimitEnabled = boolToInt(settings.OverdraftLimitEnabled)
+
+		// OverdraftLimit pointer-to-string: overwrite when provided, otherwise
+		// reset to the Lua-compatible "0" placeholder to mirror the behaviour
+		// of buildBalanceAtomicOperationPlan for disabled/unset limits.
+		if settings.OverdraftLimit != nil {
+			cached.OverdraftLimit = *settings.OverdraftLimit
+		} else {
+			cached.OverdraftLimit = "0"
+		}
+
+		if settings.BalanceScope != "" {
+			cached.BalanceScope = settings.BalanceScope
+		} else {
+			cached.BalanceScope = mmodel.BalanceScopeTransactional
+		}
+	} else {
+		// A nil settings payload means: reset to defaults. Matches the Lua
+		// plan-builder's zero-state for balances without Settings.
+		cached.AllowOverdraft = 0
+		cached.OverdraftLimitEnabled = 0
+		cached.OverdraftLimit = "0"
+		cached.BalanceScope = mmodel.BalanceScopeTransactional
+	}
+
+	data, err := json.Marshal(&cached)
+	if err != nil {
+		libOpentelemetry.HandleSpanError(span, "Failed to marshal updated cached balance", err)
+		logger.Log(ctx, libLog.LevelError, "Failed to marshal updated cached balance", libLog.Err(err))
+
+		return err
+	}
+
+	if err := rds.Set(ctx, prefixedKey, string(data), balanceCacheSettingsTTL).Err(); err != nil {
+		libOpentelemetry.HandleSpanError(span, "Failed to write settings-only balance cache update", err)
+		logger.Log(ctx, libLog.LevelError, "Failed to write settings-only balance cache update", libLog.Err(err))
+
+		return err
+	}
+
+	logger.Log(ctx, libLog.LevelDebug, "Balance cache settings updated in place")
+
+	return nil
 }
 
 // GetBalancesByKeys retrieves multiple balance values using MGET.

--- a/components/ledger/internal/adapters/redis/transaction/consumer.redis.go
+++ b/components/ledger/internal/adapters/redis/transaction/consumer.redis.go
@@ -25,6 +25,7 @@ import (
 	"github.com/LerianStudio/midaz/v3/pkg/utils"
 	"github.com/google/uuid"
 	"github.com/redis/go-redis/v9"
+	"github.com/shopspring/decimal"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 )
@@ -535,6 +536,17 @@ func (r *balanceAtomicResponse) UnmarshalJSON(data []byte) error {
 
 // balanceRedisToBalance converts a BalanceRedis (Lua/cache format) to a Balance (domain model),
 // enriching it with fields from the mapBalances lookup that are not stored in Redis.
+//
+// Overdraft fields (Direction, OverdraftUsed, Settings) are propagated from the
+// BalanceRedis payload so downstream consumers (sync worker, history writer)
+// observe the post-Lua state computed atomically in the cache. OverdraftUsed is
+// parsed from its decimal-string cache representation; on parse failure we fall
+// back to zero (matching the safe default the Lua script uses on missing
+// fields) rather than corrupting the domain value.
+//
+// A non-nil BalanceSettings is materialized when any of the overdraft settings
+// fields is non-default, preserving backwards compatibility with legacy
+// balances that have no Settings payload.
 func balanceRedisToBalance(b mmodel.BalanceRedis, mapBalances map[string]*mmodel.Balance) *mmodel.Balance {
 	mapBalance, ok := mapBalances[b.Alias]
 	if !ok {
@@ -544,6 +556,37 @@ func balanceRedisToBalance(b mmodel.BalanceRedis, mapBalances map[string]*mmodel
 	balanceKey := mapBalance.Key
 	if balanceKey == "" {
 		balanceKey = constant.DefaultBalanceKey
+	}
+
+	// OverdraftUsed is stored as a decimal string in the Lua/Redis layer.
+	// An unparseable value is treated as zero to match the Lua fallback
+	// rather than corrupting the domain model with an arbitrary number.
+	overdraftUsed, err := decimal.NewFromString(b.OverdraftUsed)
+	if err != nil {
+		overdraftUsed = decimal.Zero
+	}
+
+	// Synthesize Settings only when at least one field diverges from the
+	// defaults. This preserves nil Settings for legacy balances that never
+	// had custom configuration, avoiding spurious non-nil snapshots in the
+	// history pipeline.
+	var settings *mmodel.BalanceSettings
+	if b.AllowOverdraft != 0 || b.OverdraftLimitEnabled != 0 ||
+		(b.BalanceScope != "" && b.BalanceScope != mmodel.BalanceScopeTransactional) ||
+		(b.OverdraftLimit != "" && b.OverdraftLimit != "0") {
+		settings = &mmodel.BalanceSettings{
+			BalanceScope:          b.BalanceScope,
+			AllowOverdraft:        b.AllowOverdraft == 1,
+			OverdraftLimitEnabled: b.OverdraftLimitEnabled == 1,
+		}
+		// Only expose OverdraftLimit when the limit is actively enforced.
+		// Settings.Validate() requires OverdraftLimit to be nil whenever
+		// OverdraftLimitEnabled is false, and the cache carries "0" as a
+		// placeholder for legacy/unused entries.
+		if b.OverdraftLimitEnabled == 1 && b.OverdraftLimit != "" {
+			limit := b.OverdraftLimit
+			settings.OverdraftLimit = &limit
+		}
 	}
 
 	return &mmodel.Balance{
@@ -560,6 +603,9 @@ func balanceRedisToBalance(b mmodel.BalanceRedis, mapBalances map[string]*mmodel
 		AssetCode:      mapBalance.AssetCode,
 		OrganizationID: mapBalance.OrganizationID,
 		LedgerID:       mapBalance.LedgerID,
+		Direction:      b.Direction,
+		OverdraftUsed:  overdraftUsed,
+		Settings:       settings,
 		CreatedAt:      mapBalance.CreatedAt,
 		UpdatedAt:      mapBalance.UpdatedAt,
 	}
@@ -567,8 +613,10 @@ func balanceRedisToBalance(b mmodel.BalanceRedis, mapBalances map[string]*mmodel
 
 // luaArgsPerOperation is the number of ARGV entries appended per balance
 // operation. It must match the stride used in the Lua script's parsing loop
-// (balance_atomic_operation.lua: `for i = 2, #ARGV, groupSize do`).
-const luaArgsPerOperation = 17
+// (balance_atomic_operation.lua: `for i = 1, #ARGV, groupSize do`).
+//
+// Layout: 17 base fields + 6 overdraft fields = 23 total.
+const luaArgsPerOperation = 23
 
 func (rr *RedisConsumerRepository) buildBalanceAtomicOperationPlan(ctx context.Context, transactionStatus string, pending bool, balancesOperation []mmodel.BalanceOperation) (*balanceAtomicOperationPlan, error) {
 	logger, tracer, _, _ := libCommons.NewTrackingFromContext(ctx)
@@ -601,9 +649,35 @@ func (rr *RedisConsumerRepository) buildBalanceAtomicOperationPlan(ctx context.C
 			return nil, err
 		}
 
-		// Each group of luaArgsPerOperation (17) values maps to one iteration
-		// of the Lua script's `for i = 2, #ARGV, groupSize` loop.
-		// See: scripts/balance_atomic_operation.lua lines 256-300.
+		// Flatten optional per-balance settings into primitive ARGV values.
+		// When Settings is nil (legacy balances), defaults are used:
+		// overdraft disabled, limit disabled, zero limit, transactional scope.
+		allowOverdraft := 0
+		overdraftLimitEnabled := 0
+		overdraftLimit := "0"
+		balanceScope := mmodel.BalanceScopeTransactional
+
+		if blcs.Balance.Settings != nil {
+			if blcs.Balance.Settings.AllowOverdraft {
+				allowOverdraft = 1
+			}
+
+			if blcs.Balance.Settings.OverdraftLimitEnabled {
+				overdraftLimitEnabled = 1
+			}
+
+			if blcs.Balance.Settings.OverdraftLimit != nil {
+				overdraftLimit = *blcs.Balance.Settings.OverdraftLimit
+			}
+
+			if blcs.Balance.Settings.BalanceScope != "" {
+				balanceScope = blcs.Balance.Settings.BalanceScope
+			}
+		}
+
+		// Each group of luaArgsPerOperation (23) values maps to one iteration
+		// of the Lua script's `for i = 1, #ARGV, groupSize` loop.
+		// See: scripts/balance_atomic_operation.lua.
 		plan.args = append(plan.args,
 			prefixedInternalKey,        // ARGV[i+0]  → redisBalanceKey
 			isPending,                  // ARGV[i+1]  → isPending
@@ -622,6 +696,12 @@ func (rr *RedisConsumerRepository) buildBalanceAtomicOperationPlan(ctx context.C
 			boolToInt(blcs.Balance.AllowSending),        // ARGV[i+14] → balance.AllowSending    (cache-only)
 			boolToInt(blcs.Balance.AllowReceiving),      // ARGV[i+15] → balance.AllowReceiving  (cache-only)
 			blcs.Balance.Key,                            // ARGV[i+16] → balance.Key             (cache-only)
+			blcs.Balance.Direction,                      // ARGV[i+17] → balance.Direction
+			blcs.Balance.OverdraftUsed.String(),         // ARGV[i+18] → balance.OverdraftUsed
+			allowOverdraft,                              // ARGV[i+19] → balance.AllowOverdraft (0/1)
+			overdraftLimitEnabled,                       // ARGV[i+20] → balance.OverdraftLimitEnabled (0/1)
+			overdraftLimit,                              // ARGV[i+21] → balance.OverdraftLimit
+			balanceScope,                                // ARGV[i+22] → balance.BalanceScope
 		)
 
 		plan.mapBalances[blcs.Alias] = blcs.Balance
@@ -652,8 +732,28 @@ func (rr *RedisConsumerRepository) buildBalanceAtomicOperationPlan(ctx context.C
 // Lua error codes emitted by balance_atomic_operation.lua:
 //   - "0018" → ErrInsufficientFunds (negative available on non-external, or positive on external CREDIT)
 //   - "0098" → ErrOnHoldExternalAccount (external account used in pending source)
-//   - "0061" → ErrTransactionBackupCacheRetrievalFailed (balance key vanished mid-script)
+//   - "0139" → ErrTransactionBackupCacheRetrievalFailed (balance key vanished mid-script)
+//   - "0167" → ErrOverdraftLimitExceeded (transaction would push usage past the configured limit)
+//   - "0175" → ErrStaleBalanceVersion (balance changed between Go read and Lua execution)
+//
+// Ordering note: more specific codes ("0167", "0175") are matched before the
+// generic "0018" insufficient-funds branch so that a single error string like
+// "0167" is not misclassified by loose substring matching.
 func mapBalanceAtomicScriptError(span trace.Span, err error) error {
+	if strings.Contains(err.Error(), constant.ErrOverdraftLimitExceeded.Error()) {
+		mappedErr := pkg.ValidateBusinessError(constant.ErrOverdraftLimitExceeded, "validateBalance")
+		libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Overdraft limit exceeded", mappedErr)
+
+		return mappedErr
+	}
+
+	if strings.Contains(err.Error(), constant.ErrStaleBalanceVersion.Error()) {
+		mappedErr := pkg.ValidateBusinessError(constant.ErrStaleBalanceVersion, "validateBalance")
+		libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Stale balance version detected", mappedErr)
+
+		return mappedErr
+	}
+
 	if strings.Contains(err.Error(), constant.ErrInsufficientFunds.Error()) {
 		mappedErr := pkg.ValidateBusinessError(constant.ErrInsufficientFunds, "validateBalance")
 		libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Failed run lua script on redis", mappedErr)

--- a/components/ledger/internal/adapters/redis/transaction/consumer.redis.go
+++ b/components/ledger/internal/adapters/redis/transaction/consumer.redis.go
@@ -1438,6 +1438,20 @@ func (rr *RedisConsumerRepository) ListBalanceByKey(ctx context.Context, organiz
 	return balance, nil
 }
 
+// luaBalanceSettingKey deletes every legacy alias for a cached balance settings
+// field so the subsequent authoritative write carries exactly one key per
+// field. The first argument is the Lua-native CamelCase key that the atomic
+// script reads; the variadic arguments enumerate camelCase / legacy spellings
+// that must be dropped from the map to avoid duplicate keys in the JSON
+// document (Go encoders emit both which Lua then sees twice).
+func luaBalanceSettingKey(m map[string]any, primary string, aliases ...string) {
+	delete(m, primary)
+
+	for _, alias := range aliases {
+		delete(m, alias)
+	}
+}
+
 // balanceCacheSettingsTTL matches the TTL the balance atomic Lua script applies
 // to each cached balance key (`local ttl = 3600 -- 1 hour` in
 // scripts/balance_atomic_operation.lua). Keeping the two in lock-step ensures
@@ -1505,7 +1519,21 @@ func (rr *RedisConsumerRepository) UpdateBalanceCacheSettings(ctx context.Contex
 		return err
 	}
 
-	var cached mmodel.BalanceRedis
+	// The cache payload is primed by the Lua atomic script
+	// (scripts/balance_atomic_operation.lua), which uses cjson.encode() on a
+	// table with CamelCase keys (ID, Available, Direction, AllowOverdraft, …).
+	// Lua table access is case-sensitive, so if we re-marshal through
+	// mmodel.BalanceRedis — whose struct tags are camelCase — the subsequent
+	// cjson.decode in the script would see `balance.Available == nil`,
+	// `balance.Direction == nil`, and blow up in arithmetic helpers with
+	// "attempt to compare nil with number".
+	//
+	// To avoid that incompatibility we work on an untyped map: Go's case-
+	// insensitive unmarshal handles legacy cache entries in either casing,
+	// and we write back using the Lua-native CamelCase keys. Any stale
+	// camelCase duplicates from a buggy earlier writer are removed so the
+	// cache carries a single authoritative key per field.
+	var cached map[string]any
 	if err := json.Unmarshal([]byte(val), &cached); err != nil {
 		libOpentelemetry.HandleSpanError(span, "Failed to unmarshal cached balance for settings update", err)
 		logger.Log(ctx, libLog.LevelError, "Failed to unmarshal cached balance for settings update", libLog.Err(err))
@@ -1516,34 +1544,44 @@ func (rr *RedisConsumerRepository) UpdateBalanceCacheSettings(ctx context.Contex
 	// Only settings fields are mutated. Available, OnHold, Version,
 	// OverdraftUsed, and identity fields (ID, Alias, Key, AssetCode, etc.)
 	// remain untouched so any in-flight transactional state is preserved.
+	//
+	// For each managed field we drop every camelCase variant produced by
+	// earlier (pre-fix) writers before setting the Lua-native CamelCase
+	// key. Keeping both casings in the same document would let Lua read
+	// a stale value while Go reads the fresh one.
+	luaBalanceSettingKey(cached, "AllowOverdraft", "allowOverdraft", "allowoverdraft")
+	luaBalanceSettingKey(cached, "OverdraftLimitEnabled", "overdraftLimitEnabled", "overdraftlimitenabled")
+	luaBalanceSettingKey(cached, "OverdraftLimit", "overdraftLimit", "overdraftlimit")
+	luaBalanceSettingKey(cached, "BalanceScope", "balanceScope", "balancescope")
+
 	if settings != nil {
-		cached.AllowOverdraft = boolToInt(settings.AllowOverdraft)
-		cached.OverdraftLimitEnabled = boolToInt(settings.OverdraftLimitEnabled)
+		cached["AllowOverdraft"] = boolToInt(settings.AllowOverdraft)
+		cached["OverdraftLimitEnabled"] = boolToInt(settings.OverdraftLimitEnabled)
 
 		// OverdraftLimit pointer-to-string: overwrite when provided, otherwise
 		// reset to the Lua-compatible "0" placeholder to mirror the behaviour
 		// of buildBalanceAtomicOperationPlan for disabled/unset limits.
 		if settings.OverdraftLimit != nil {
-			cached.OverdraftLimit = *settings.OverdraftLimit
+			cached["OverdraftLimit"] = *settings.OverdraftLimit
 		} else {
-			cached.OverdraftLimit = "0"
+			cached["OverdraftLimit"] = "0"
 		}
 
 		if settings.BalanceScope != "" {
-			cached.BalanceScope = settings.BalanceScope
+			cached["BalanceScope"] = settings.BalanceScope
 		} else {
-			cached.BalanceScope = mmodel.BalanceScopeTransactional
+			cached["BalanceScope"] = mmodel.BalanceScopeTransactional
 		}
 	} else {
 		// A nil settings payload means: reset to defaults. Matches the Lua
 		// plan-builder's zero-state for balances without Settings.
-		cached.AllowOverdraft = 0
-		cached.OverdraftLimitEnabled = 0
-		cached.OverdraftLimit = "0"
-		cached.BalanceScope = mmodel.BalanceScopeTransactional
+		cached["AllowOverdraft"] = 0
+		cached["OverdraftLimitEnabled"] = 0
+		cached["OverdraftLimit"] = "0"
+		cached["BalanceScope"] = mmodel.BalanceScopeTransactional
 	}
 
-	data, err := json.Marshal(&cached)
+	data, err := json.Marshal(cached)
 	if err != nil {
 		libOpentelemetry.HandleSpanError(span, "Failed to marshal updated cached balance", err)
 		logger.Log(ctx, libLog.LevelError, "Failed to marshal updated cached balance", libLog.Err(err))

--- a/components/ledger/internal/adapters/redis/transaction/consumer.redis.go
+++ b/components/ledger/internal/adapters/redis/transaction/consumer.redis.go
@@ -1444,6 +1444,13 @@ func (rr *RedisConsumerRepository) ListBalanceByKey(ctx context.Context, organiz
 // script reads; the variadic arguments enumerate camelCase / legacy spellings
 // that must be dropped from the map to avoid duplicate keys in the JSON
 // document (Go encoders emit both which Lua then sees twice).
+//
+// This helper is the SINGLE SOURCE OF TRUTH for the CamelCase ↔ camelCase
+// mapping between Go writers and the Lua atomic script. If additional Go
+// writers to the balance cache appear (e.g. tenant migration, admin tooling),
+// they MUST use this helper (or its equivalent mapping) to ensure the cached
+// JSON is Lua-compatible. See the CACHE JSON CASING CONTRACT on BalanceRedis
+// in pkg/mmodel/balance.go for the full rationale.
 func luaBalanceSettingKey(m map[string]any, primary string, aliases ...string) {
 	delete(m, primary)
 

--- a/components/ledger/internal/adapters/redis/transaction/consumer.redis.go
+++ b/components/ledger/internal/adapters/redis/transaction/consumer.redis.go
@@ -629,8 +629,8 @@ func balanceRedisToBalance(b mmodel.BalanceRedis, mapBalances map[string]*mmodel
 // operation. It must match the stride used in the Lua script's parsing loop
 // (balance_atomic_operation.lua: `for i = 1, #ARGV, groupSize do`).
 //
-// Layout: 17 base fields + 6 overdraft fields = 23 total.
-const luaArgsPerOperation = 23
+// Layout: 17 base fields + 7 overdraft fields = 24 total.
+const luaArgsPerOperation = 24
 
 func (rr *RedisConsumerRepository) buildBalanceAtomicOperationPlan(ctx context.Context, transactionStatus string, pending bool, balancesOperation []mmodel.BalanceOperation) (*balanceAtomicOperationPlan, error) {
 	logger, tracer, _, _ := libCommons.NewTrackingFromContext(ctx)
@@ -689,7 +689,7 @@ func (rr *RedisConsumerRepository) buildBalanceAtomicOperationPlan(ctx context.C
 			}
 		}
 
-		// Each group of luaArgsPerOperation (23) values maps to one iteration
+		// Each group of luaArgsPerOperation (24) values maps to one iteration
 		// of the Lua script's `for i = 1, #ARGV, groupSize` loop.
 		// See: scripts/balance_atomic_operation.lua.
 		plan.args = append(plan.args,
@@ -716,6 +716,7 @@ func (rr *RedisConsumerRepository) buildBalanceAtomicOperationPlan(ctx context.C
 			overdraftLimitEnabled,                       // ARGV[i+20] → balance.OverdraftLimitEnabled (0/1)
 			overdraftLimit,                              // ARGV[i+21] → balance.OverdraftLimit
 			balanceScope,                                // ARGV[i+22] → balance.BalanceScope
+			blcs.Amount.OverdraftAmount.String(),        // ARGV[i+23] → overdraft reversal amount
 		)
 
 		plan.mapBalances[blcs.Alias] = blcs.Balance

--- a/components/ledger/internal/adapters/redis/transaction/consumer.redis_mock.go
+++ b/components/ledger/internal/adapters/redis/transaction/consumer.redis_mock.go
@@ -325,3 +325,17 @@ func (mr *MockRedisRepositoryMockRecorder) SetNX(ctx, key, value, ttl any) *gomo
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetNX", reflect.TypeOf((*MockRedisRepository)(nil).SetNX), ctx, key, value, ttl)
 }
+
+// UpdateBalanceCacheSettings mocks base method.
+func (m *MockRedisRepository) UpdateBalanceCacheSettings(ctx context.Context, organizationID, ledgerID uuid.UUID, cacheKey string, settings *mmodel.BalanceSettings) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateBalanceCacheSettings", ctx, organizationID, ledgerID, cacheKey, settings)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateBalanceCacheSettings indicates an expected call of UpdateBalanceCacheSettings.
+func (mr *MockRedisRepositoryMockRecorder) UpdateBalanceCacheSettings(ctx, organizationID, ledgerID, cacheKey, settings any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateBalanceCacheSettings", reflect.TypeOf((*MockRedisRepository)(nil).UpdateBalanceCacheSettings), ctx, organizationID, ledgerID, cacheKey, settings)
+}

--- a/components/ledger/internal/adapters/redis/transaction/consumer.redis_settings_update_test.go
+++ b/components/ledger/internal/adapters/redis/transaction/consumer.redis_settings_update_test.go
@@ -1,0 +1,318 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package redis
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/LerianStudio/midaz/v3/pkg/mmodel"
+	"github.com/google/uuid"
+	"github.com/redis/go-redis/v9"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// settingsUpdateStubClient is a test double for redis.UniversalClient that
+// captures GET and SET calls for UpdateBalanceCacheSettings assertions. It
+// supports per-key Get responses (including redis.Nil for cache misses) and
+// records every SET so the test can inspect both the key and the marshalled
+// BalanceRedis payload written back.
+type settingsUpdateStubClient struct {
+	redis.UniversalClient
+
+	getResponses map[string]struct {
+		val string
+		err error
+	}
+	getCalls []string
+
+	setCalls []recordedSetCall
+	setErr   error
+}
+
+func (c *settingsUpdateStubClient) Get(ctx context.Context, key string) *redis.StringCmd {
+	c.getCalls = append(c.getCalls, key)
+
+	cmd := redis.NewStringCmd(ctx)
+
+	if resp, ok := c.getResponses[key]; ok {
+		if resp.err != nil {
+			cmd.SetErr(resp.err)
+
+			return cmd
+		}
+
+		cmd.SetVal(resp.val)
+
+		return cmd
+	}
+
+	// Default to cache miss when no response is pre-configured. This makes
+	// the stub safe to use even if a test forgets to seed a key.
+	cmd.SetErr(redis.Nil)
+
+	return cmd
+}
+
+func (c *settingsUpdateStubClient) Set(ctx context.Context, key string, value any, expiration time.Duration) *redis.StatusCmd {
+	c.setCalls = append(c.setCalls, recordedSetCall{Key: key, Value: value, TTL: expiration})
+
+	cmd := redis.NewStatusCmd(ctx)
+	if c.setErr != nil {
+		cmd.SetErr(c.setErr)
+
+		return cmd
+	}
+
+	cmd.SetVal("OK")
+
+	return cmd
+}
+
+// TestUpdateBalanceCacheSettings_PreservesLiveTransactionalState is the HARD
+// GATE for the settings-only rewrite: it pins the invariant that the repo
+// method MUST NOT touch Available, OnHold, Version, or OverdraftUsed — those
+// fields are owned by the atomic Lua script and may be ahead of PostgreSQL
+// while sync is pending. Deleting the key or overwriting those fields would
+// lose in-flight mutations and was the bug motivating this test's existence.
+func TestUpdateBalanceCacheSettings_PreservesLiveTransactionalState(t *testing.T) {
+	t.Parallel()
+
+	organizationID := uuid.New()
+	ledgerID := uuid.New()
+
+	// Seed the cache with a balance that has live transactional state
+	// "ahead" of PostgreSQL: higher Version, mutated Available, OverdraftUsed
+	// incurred by a previous transaction. Any settings rewrite MUST keep all
+	// of these fields intact.
+	cached := mmodel.BalanceRedis{
+		ID:                    "balance-id",
+		Alias:                 "@alice",
+		Key:                   "default",
+		AccountID:             "account-id",
+		AssetCode:             "USD",
+		Available:             decimal.NewFromInt(7777),
+		OnHold:                decimal.NewFromInt(123),
+		Version:               42,
+		AccountType:           "liability",
+		AllowSending:          1,
+		AllowReceiving:        1,
+		Direction:             "credit",
+		OverdraftUsed:         "250.50",
+		AllowOverdraft:        0, // currently disabled — the update will enable it
+		OverdraftLimitEnabled: 0,
+		OverdraftLimit:        "0",
+		BalanceScope:          mmodel.BalanceScopeTransactional,
+	}
+
+	cachedJSON, err := json.Marshal(&cached)
+	require.NoError(t, err)
+
+	// The repo builds "balance:{transactions}:<org>:<ledger>:@alice#default".
+	expectedKey := "balance:{transactions}:" +
+		organizationID.String() + ":" + ledgerID.String() + ":@alice#default"
+
+	stub := &settingsUpdateStubClient{
+		getResponses: map[string]struct {
+			val string
+			err error
+		}{
+			expectedKey: {val: string(cachedJSON)},
+		},
+	}
+
+	rr := &RedisConsumerRepository{conn: &staticRedisProvider{client: stub}}
+
+	// New settings: enable overdraft with a concrete limit and keep scope
+	// transactional. This is the same payload shape the command layer
+	// forwards verbatim from UpdateBalance.Settings.
+	limit := "1000.00"
+	newSettings := &mmodel.BalanceSettings{
+		BalanceScope:          mmodel.BalanceScopeTransactional,
+		AllowOverdraft:        true,
+		OverdraftLimitEnabled: true,
+		OverdraftLimit:        &limit,
+	}
+
+	err = rr.UpdateBalanceCacheSettings(context.Background(), organizationID, ledgerID, "@alice#default", newSettings)
+	require.NoError(t, err)
+
+	// Exactly one GET (read current) and one SET (write back) — no DEL.
+	require.Len(t, stub.getCalls, 1, "must read the cache exactly once")
+	require.Len(t, stub.setCalls, 1, "must write the cache back exactly once")
+	assert.Equal(t, expectedKey, stub.getCalls[0])
+	assert.Equal(t, expectedKey, stub.setCalls[0].Key)
+	assert.Equal(t, balanceCacheSettingsTTL, stub.setCalls[0].TTL,
+		"TTL must match the Lua script's 1-hour canonical value to avoid silent lifetime drift")
+
+	// Decode the written payload and pin every invariant.
+	raw, ok := stub.setCalls[0].Value.(string)
+	require.True(t, ok, "SET value must be a string (JSON-encoded BalanceRedis)")
+
+	var written mmodel.BalanceRedis
+
+	require.NoError(t, json.Unmarshal([]byte(raw), &written))
+
+	// Settings-derived fields MUST be updated from the new settings payload.
+	assert.Equal(t, 1, written.AllowOverdraft,
+		"AllowOverdraft must reflect the new settings")
+	assert.Equal(t, 1, written.OverdraftLimitEnabled,
+		"OverdraftLimitEnabled must reflect the new settings")
+	assert.Equal(t, "1000.00", written.OverdraftLimit,
+		"OverdraftLimit must be copied from the settings pointer")
+	assert.Equal(t, mmodel.BalanceScopeTransactional, written.BalanceScope,
+		"BalanceScope must reflect the new settings (or default)")
+
+	// Live transactional state MUST be untouched — this is the whole point
+	// of replacing Del with a settings-only rewrite.
+	assert.True(t, written.Available.Equal(decimal.NewFromInt(7777)),
+		"Available must be preserved verbatim")
+	assert.True(t, written.OnHold.Equal(decimal.NewFromInt(123)),
+		"OnHold must be preserved verbatim")
+	assert.Equal(t, int64(42), written.Version,
+		"Version must be preserved (losing it corrupts optimistic concurrency)")
+	assert.Equal(t, "250.50", written.OverdraftUsed,
+		"OverdraftUsed is transactional state and must not be reset by a settings update")
+
+	// Identity + non-settings fields MUST also survive the rewrite so the
+	// next Lua read sees a well-formed BalanceRedis payload.
+	assert.Equal(t, "balance-id", written.ID)
+	assert.Equal(t, "@alice", written.Alias)
+	assert.Equal(t, "default", written.Key)
+	assert.Equal(t, "account-id", written.AccountID)
+	assert.Equal(t, "USD", written.AssetCode)
+	assert.Equal(t, "liability", written.AccountType)
+	assert.Equal(t, 1, written.AllowSending)
+	assert.Equal(t, 1, written.AllowReceiving)
+	assert.Equal(t, "credit", written.Direction)
+}
+
+// TestUpdateBalanceCacheSettings_CacheMissIsNoOp verifies that a missing
+// Redis key is treated as a silent no-op: the next transaction's SETNX path
+// will load the freshly-persisted settings from PostgreSQL, so there is
+// nothing for this method to rewrite.
+func TestUpdateBalanceCacheSettings_CacheMissIsNoOp(t *testing.T) {
+	t.Parallel()
+
+	organizationID := uuid.New()
+	ledgerID := uuid.New()
+
+	// No pre-configured Get response → the stub returns redis.Nil by default.
+	stub := &settingsUpdateStubClient{}
+
+	rr := &RedisConsumerRepository{conn: &staticRedisProvider{client: stub}}
+
+	err := rr.UpdateBalanceCacheSettings(context.Background(), organizationID, ledgerID, "@alice#default",
+		&mmodel.BalanceSettings{AllowOverdraft: true})
+
+	require.NoError(t, err, "cache miss must be a silent no-op")
+	require.Len(t, stub.getCalls, 1, "the single GET that discovered the miss is expected")
+	assert.Empty(t, stub.setCalls, "no SET must fire when the key is absent")
+}
+
+// TestUpdateBalanceCacheSettings_GetErrorIsPropagated verifies that a Redis
+// connectivity failure on the read path bubbles up so the command layer can
+// decide whether to swallow (best-effort) or escalate. The repo itself must
+// not silently swallow infrastructure errors — that decision belongs to the
+// caller.
+func TestUpdateBalanceCacheSettings_GetErrorIsPropagated(t *testing.T) {
+	t.Parallel()
+
+	organizationID := uuid.New()
+	ledgerID := uuid.New()
+
+	expectedKey := "balance:{transactions}:" +
+		organizationID.String() + ":" + ledgerID.String() + ":@alice#default"
+
+	boom := errors.New("redis connection reset")
+
+	stub := &settingsUpdateStubClient{
+		getResponses: map[string]struct {
+			val string
+			err error
+		}{
+			expectedKey: {err: boom},
+		},
+	}
+
+	rr := &RedisConsumerRepository{conn: &staticRedisProvider{client: stub}}
+
+	err := rr.UpdateBalanceCacheSettings(context.Background(), organizationID, ledgerID, "@alice#default",
+		&mmodel.BalanceSettings{AllowOverdraft: true})
+
+	require.ErrorIs(t, err, boom, "transport errors on GET must propagate unchanged")
+	assert.Empty(t, stub.setCalls, "no SET must fire when the GET failed")
+}
+
+// TestUpdateBalanceCacheSettings_NilSettingsResetsToDefaults verifies that
+// passing nil Settings collapses the cached entry to the Lua-compatible
+// zero-state used by buildBalanceAtomicOperationPlan for balances without
+// Settings. This keeps the cache and the plan-builder in lock-step on the
+// "no settings" interpretation.
+func TestUpdateBalanceCacheSettings_NilSettingsResetsToDefaults(t *testing.T) {
+	t.Parallel()
+
+	organizationID := uuid.New()
+	ledgerID := uuid.New()
+
+	// Start with overdraft enabled so we can observe the reset taking effect.
+	cached := mmodel.BalanceRedis{
+		ID:                    "balance-id",
+		Alias:                 "@alice",
+		Key:                   "default",
+		Available:             decimal.NewFromInt(100),
+		OnHold:                decimal.Zero,
+		Version:               1,
+		AllowOverdraft:        1,
+		OverdraftLimitEnabled: 1,
+		OverdraftLimit:        "500.00",
+		BalanceScope:          mmodel.BalanceScopeInternal,
+		OverdraftUsed:         "42.00",
+	}
+
+	cachedJSON, err := json.Marshal(&cached)
+	require.NoError(t, err)
+
+	expectedKey := "balance:{transactions}:" +
+		organizationID.String() + ":" + ledgerID.String() + ":@alice#default"
+
+	stub := &settingsUpdateStubClient{
+		getResponses: map[string]struct {
+			val string
+			err error
+		}{
+			expectedKey: {val: string(cachedJSON)},
+		},
+	}
+
+	rr := &RedisConsumerRepository{conn: &staticRedisProvider{client: stub}}
+
+	err = rr.UpdateBalanceCacheSettings(context.Background(), organizationID, ledgerID, "@alice#default", nil)
+	require.NoError(t, err)
+
+	require.Len(t, stub.setCalls, 1)
+
+	raw, ok := stub.setCalls[0].Value.(string)
+	require.True(t, ok)
+
+	var written mmodel.BalanceRedis
+
+	require.NoError(t, json.Unmarshal([]byte(raw), &written))
+
+	assert.Equal(t, 0, written.AllowOverdraft)
+	assert.Equal(t, 0, written.OverdraftLimitEnabled)
+	assert.Equal(t, "0", written.OverdraftLimit)
+	assert.Equal(t, mmodel.BalanceScopeTransactional, written.BalanceScope)
+
+	// Transactional state still preserved even when settings are reset.
+	assert.Equal(t, "42.00", written.OverdraftUsed,
+		"OverdraftUsed is not a settings field and must survive a nil-settings reset")
+	assert.Equal(t, int64(1), written.Version)
+}

--- a/components/ledger/internal/adapters/redis/transaction/consumer.redis_settings_update_test.go
+++ b/components/ledger/internal/adapters/redis/transaction/consumer.redis_settings_update_test.go
@@ -316,3 +316,111 @@ func TestUpdateBalanceCacheSettings_NilSettingsResetsToDefaults(t *testing.T) {
 		"OverdraftUsed is not a settings field and must survive a nil-settings reset")
 	assert.Equal(t, int64(1), written.Version)
 }
+
+// TestUpdateBalanceCacheSettings_WritesLuaCompatibleCasing pins the invariant
+// that the cache JSON produced by the Go-side settings rewrite uses CamelCase
+// field names (AllowOverdraft, OverdraftLimit, …) to match what the Lua
+// atomic script emits via cjson.encode and reads via balance.<Field>.
+//
+// Lua table access is case-sensitive: a camelCase field name (allowOverdraft)
+// would yield `balance.AllowOverdraft == nil` on the next cjson.decode, and
+// arithmetic helpers that touch the balance would explode with
+// "attempt to compare nil with number" in scripts/balance_atomic_operation.lua.
+// The regression reproduced end-to-end as a 500 on the first overdraft-enabled
+// debit after a settings PATCH.
+//
+// This test also covers the cleanup of legacy camelCase keys left behind by
+// pre-fix writers: writing a second time must produce exactly one casing for
+// each field so Lua never sees a stale duplicate.
+func TestUpdateBalanceCacheSettings_WritesLuaCompatibleCasing(t *testing.T) {
+	t.Parallel()
+
+	organizationID := uuid.New()
+	ledgerID := uuid.New()
+
+	// Seed the cache with a legacy document that has the camelCase spellings
+	// emitted by the pre-fix code path, mixed with CamelCase transactional
+	// state the Lua script would have written. The rewrite must converge
+	// both to a single, Lua-native CamelCase key per field.
+	legacy := map[string]any{
+		"ID":                    "balance-id",
+		"Alias":                 "@alice",
+		"Key":                   "default",
+		"AccountID":             "account-id",
+		"AssetCode":             "USD",
+		"Available":             "100",
+		"OnHold":                "0",
+		"Version":               3,
+		"AccountType":           "deposit",
+		"AllowSending":          1,
+		"AllowReceiving":        1,
+		"Direction":             "credit",
+		"OverdraftUsed":         "0",
+		// Legacy camelCase keys from a pre-fix Go writer that must be dropped.
+		"allowOverdraft":        0,
+		"overdraftLimitEnabled": 0,
+		"overdraftLimit":        "0",
+		"balanceScope":          "transactional",
+	}
+	legacyJSON, err := json.Marshal(legacy)
+	require.NoError(t, err)
+
+	expectedKey := "balance:{transactions}:" +
+		organizationID.String() + ":" + ledgerID.String() + ":@alice#default"
+
+	stub := &settingsUpdateStubClient{
+		getResponses: map[string]struct {
+			val string
+			err error
+		}{
+			expectedKey: {val: string(legacyJSON)},
+		},
+	}
+
+	rr := &RedisConsumerRepository{conn: &staticRedisProvider{client: stub}}
+
+	limit := "500.00"
+	err = rr.UpdateBalanceCacheSettings(context.Background(), organizationID, ledgerID, "@alice#default",
+		&mmodel.BalanceSettings{
+			BalanceScope:          mmodel.BalanceScopeTransactional,
+			AllowOverdraft:        true,
+			OverdraftLimitEnabled: true,
+			OverdraftLimit:        &limit,
+		})
+	require.NoError(t, err)
+
+	require.Len(t, stub.setCalls, 1)
+	raw, ok := stub.setCalls[0].Value.(string)
+	require.True(t, ok)
+
+	// Decode into a generic map so we can assert exact JSON keys — the
+	// CamelCase-vs-camelCase distinction is invisible through BalanceRedis
+	// because Go's json.Unmarshal matches struct fields case-insensitively.
+	var written map[string]any
+	require.NoError(t, json.Unmarshal([]byte(raw), &written))
+
+	// Lua-native CamelCase keys MUST be present with the new values.
+	assert.EqualValues(t, 1, written["AllowOverdraft"],
+		"AllowOverdraft must use CamelCase so the Lua script can read it")
+	assert.EqualValues(t, 1, written["OverdraftLimitEnabled"],
+		"OverdraftLimitEnabled must use CamelCase so the Lua script can read it")
+	assert.Equal(t, "500.00", written["OverdraftLimit"],
+		"OverdraftLimit must use CamelCase so the Lua script can read it")
+	assert.Equal(t, mmodel.BalanceScopeTransactional, written["BalanceScope"],
+		"BalanceScope must use CamelCase so the Lua script can read it")
+
+	// Legacy camelCase keys MUST be purged so Lua never sees a stale duplicate
+	// alongside the fresh CamelCase write.
+	for _, legacyKey := range []string{"allowOverdraft", "overdraftLimitEnabled", "overdraftLimit", "balanceScope"} {
+		_, present := written[legacyKey]
+		assert.False(t, present, "legacy camelCase key %q must be removed from the cache document", legacyKey)
+	}
+
+	// Identity + transactional state MUST be preserved under their existing
+	// CamelCase spellings. These fields pass through the rewrite untouched.
+	assert.Equal(t, "balance-id", written["ID"])
+	assert.Equal(t, "credit", written["Direction"])
+	assert.Equal(t, "100", written["Available"])
+	assert.Equal(t, "0", written["OverdraftUsed"])
+	assert.EqualValues(t, 3, written["Version"])
+}

--- a/components/ledger/internal/adapters/redis/transaction/consumer_overdraft_error_mapper_test.go
+++ b/components/ledger/internal/adapters/redis/transaction/consumer_overdraft_error_mapper_test.go
@@ -102,10 +102,7 @@ func TestMapError_ExistingCodes_StillWork(t *testing.T) {
 func TestMapError_StaleBalance(t *testing.T) {
 	t.Parallel()
 
-	// The stale-balance Lua error is expected to use code "0175" which does
-	// not exist yet — this test will fail until both the constant and the
-	// mapper branch are added.
-	const staleBalanceCode = "0175"
+	staleBalanceCode := constant.ErrStaleBalanceVersion.Error()
 
 	tracer := noop.NewTracerProvider().Tracer("test")
 	_, span := tracer.Start(t.Context(), "test")

--- a/components/ledger/internal/adapters/redis/transaction/consumer_overdraft_error_mapper_test.go
+++ b/components/ledger/internal/adapters/redis/transaction/consumer_overdraft_error_mapper_test.go
@@ -1,0 +1,125 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package redis
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/LerianStudio/midaz/v3/pkg"
+	"github.com/LerianStudio/midaz/v3/pkg/constant"
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/otel/trace/noop"
+)
+
+// =============================================================================
+// Error mapper — overdraft Lua error codes
+// =============================================================================
+
+func TestMapError_OverdraftLimitExceeded(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name    string
+		luaErr  string
+		wantErr error
+	}{
+		{
+			name:    "bare code",
+			luaErr:  "0167",
+			wantErr: constant.ErrOverdraftLimitExceeded,
+		},
+		{
+			name:    "prefixed message",
+			luaErr:  "ERR 0167 overdraft limit exceeded for balance xyz",
+			wantErr: constant.ErrOverdraftLimitExceeded,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			tracer := noop.NewTracerProvider().Tracer("test")
+			_, span := tracer.Start(t.Context(), "test")
+			defer span.End()
+
+			rawErr := errors.New(tc.luaErr)
+			mapped := mapBalanceAtomicScriptError(span, rawErr)
+
+			expectedMsg := pkg.ValidateBusinessError(tc.wantErr, "validateBalance").Error()
+			assert.Equal(t, expectedMsg, mapped.Error(),
+				"Lua error %q must map to ErrOverdraftLimitExceeded", tc.luaErr)
+		})
+	}
+}
+
+func TestMapError_ExistingCodes_StillWork(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name    string
+		luaErr  string
+		wantErr error
+	}{
+		{
+			name:    "insufficient funds",
+			luaErr:  "0018",
+			wantErr: constant.ErrInsufficientFunds,
+		},
+		{
+			name:    "on hold external",
+			luaErr:  "0098",
+			wantErr: constant.ErrOnHoldExternalAccount,
+		},
+		{
+			name:    "backup cache retrieval failed",
+			luaErr:  "0139",
+			wantErr: constant.ErrTransactionBackupCacheRetrievalFailed,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			tracer := noop.NewTracerProvider().Tracer("test")
+			_, span := tracer.Start(t.Context(), "test")
+			defer span.End()
+
+			rawErr := errors.New(tc.luaErr)
+			mapped := mapBalanceAtomicScriptError(span, rawErr)
+
+			expectedMsg := pkg.ValidateBusinessError(tc.wantErr, "validateBalance").Error()
+			assert.Equal(t, expectedMsg, mapped.Error(),
+				"Lua error %q must map to the correct business error", tc.luaErr)
+		})
+	}
+}
+
+func TestMapError_StaleBalance(t *testing.T) {
+	t.Parallel()
+
+	// The stale-balance Lua error is expected to use code "0175" which does
+	// not exist yet — this test will fail until both the constant and the
+	// mapper branch are added.
+	const staleBalanceCode = "0175"
+
+	tracer := noop.NewTracerProvider().Tracer("test")
+	_, span := tracer.Start(t.Context(), "test")
+	defer span.End()
+
+	rawErr := errors.New(staleBalanceCode)
+	mapped := mapBalanceAtomicScriptError(span, rawErr)
+
+	// The mapped error must NOT be the raw input — it must be translated.
+	assert.NotEqual(t, rawErr.Error(), mapped.Error(),
+		"Stale-balance Lua error %q must be mapped to a typed business error, "+
+			"not returned as raw redis error", staleBalanceCode)
+
+	// The mapped error message must contain the code so callers can identify it.
+	assert.Contains(t, mapped.Error(), staleBalanceCode,
+		"Mapped stale-balance error must contain the error code")
+}

--- a/components/ledger/internal/adapters/redis/transaction/consumer_overdraft_pending_integration_test.go
+++ b/components/ledger/internal/adapters/redis/transaction/consumer_overdraft_pending_integration_test.go
@@ -80,6 +80,25 @@ func findBalanceByKey(t *testing.T, balances []*mmodel.Balance, key string) *mmo
 	return nil
 }
 
+func findLatestBalanceByKey(t *testing.T, balances []*mmodel.Balance, key string) *mmodel.Balance {
+	t.Helper()
+
+	var latest *mmodel.Balance
+	for _, balance := range balances {
+		if balance == nil || balance.Key != key {
+			continue
+		}
+
+		if latest == nil || balance.Version > latest.Version {
+			latest = balance
+		}
+	}
+
+	require.NotNil(t, latest, "expected balance key %q in result", key)
+
+	return latest
+}
+
 func TestIntegration_Overdraft_PendingLegacyHoldMutatesCompanion(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode")
@@ -149,7 +168,7 @@ func TestIntegration_Overdraft_PendingLegacyCancelRestoresCompanion(t *testing.T
 		uuid.New(), constant.PENDING, true, []mmodel.BalanceOperation{pendingDefault, pendingCompanion})
 	require.NoError(t, err)
 
-	defaultAfterPending := findBalanceByKey(t, pendingResult.After, constant.DefaultBalanceKey)
+	defaultAfterPending := findLatestBalanceByKey(t, pendingResult.After, constant.DefaultBalanceKey)
 	companionAfterPending := findBalanceByKey(t, pendingResult.After, constant.OverdraftBalanceKey)
 
 	cancelDefault := pendingOverdraftBalanceOp(orgID, ledgerID, alias, constant.DefaultBalanceKey, constant.DirectionCredit,
@@ -164,7 +183,66 @@ func TestIntegration_Overdraft_PendingLegacyCancelRestoresCompanion(t *testing.T
 	require.NoError(t, err)
 	require.Len(t, cancelResult.After, 2)
 
-	defaultAfterCancel := findBalanceByKey(t, cancelResult.After, constant.DefaultBalanceKey)
+	defaultAfterCancel := findLatestBalanceByKey(t, cancelResult.After, constant.DefaultBalanceKey)
+	companionAfterCancel := findBalanceByKey(t, cancelResult.After, constant.OverdraftBalanceKey)
+
+	assert.True(t, defaultAfterCancel.Available.Equal(decimal.NewFromInt(50)))
+	assert.True(t, defaultAfterCancel.OnHold.IsZero())
+	assert.True(t, defaultAfterCancel.OverdraftUsed.IsZero())
+	assert.True(t, companionAfterCancel.Available.IsZero())
+}
+
+func TestIntegration_Overdraft_PendingRouteValidationCancelAllowsSameBatchVersionChain(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	infra := setupRedisIntegrationInfra(t)
+	ctx := context.Background()
+	orgID := uuid.New()
+	ledgerID := uuid.New()
+	alias := "@t17-route-cancel"
+
+	settings := &mmodel.BalanceSettings{
+		BalanceScope:          mmodel.BalanceScopeTransactional,
+		AllowOverdraft:        true,
+		OverdraftLimitEnabled: true,
+		OverdraftLimit:        ptrString("100"),
+	}
+
+	pendingDebit := pendingOverdraftBalanceOp(orgID, ledgerID, alias, constant.DefaultBalanceKey, constant.DirectionCredit,
+		decimal.NewFromInt(50), decimal.Zero, decimal.Zero, 1, settings,
+		constant.DEBIT, constant.PENDING, decimal.NewFromInt(100), decimal.Zero, true)
+	pendingOnHold := pendingOverdraftBalanceOp(orgID, ledgerID, alias, constant.DefaultBalanceKey, constant.DirectionCredit,
+		decimal.NewFromInt(50), decimal.Zero, decimal.Zero, 1, settings,
+		constant.ONHOLD, constant.PENDING, decimal.NewFromInt(100), decimal.Zero, true)
+	pendingCompanion := pendingOverdraftBalanceOp(orgID, ledgerID, alias, constant.OverdraftBalanceKey, constant.DirectionDebit,
+		decimal.Zero, decimal.Zero, decimal.Zero, 1, nil,
+		constant.DEBIT, constant.PENDING, decimal.NewFromInt(50), decimal.Zero, true)
+
+	pendingResult, err := infra.repo.ProcessBalanceAtomicOperation(ctx, orgID, ledgerID,
+		uuid.New(), constant.PENDING, true, []mmodel.BalanceOperation{pendingDebit, pendingOnHold, pendingCompanion})
+	require.NoError(t, err)
+
+	defaultAfterPending := findLatestBalanceByKey(t, pendingResult.After, constant.DefaultBalanceKey)
+	companionAfterPending := findBalanceByKey(t, pendingResult.After, constant.OverdraftBalanceKey)
+
+	cancelRelease := pendingOverdraftBalanceOp(orgID, ledgerID, alias, constant.DefaultBalanceKey, constant.DirectionCredit,
+		defaultAfterPending.Available, defaultAfterPending.OnHold, defaultAfterPending.OverdraftUsed, defaultAfterPending.Version, settings,
+		constant.RELEASE, constant.CANCELED, decimal.NewFromInt(100), decimal.Zero, true)
+	cancelCredit := pendingOverdraftBalanceOp(orgID, ledgerID, alias, constant.DefaultBalanceKey, constant.DirectionCredit,
+		defaultAfterPending.Available, defaultAfterPending.OnHold, defaultAfterPending.OverdraftUsed, defaultAfterPending.Version, settings,
+		constant.CREDIT, constant.CANCELED, decimal.NewFromInt(100), decimal.NewFromInt(50), true)
+	cancelCompanion := pendingOverdraftBalanceOp(orgID, ledgerID, alias, constant.OverdraftBalanceKey, constant.DirectionDebit,
+		companionAfterPending.Available, companionAfterPending.OnHold, companionAfterPending.OverdraftUsed, companionAfterPending.Version, nil,
+		constant.CREDIT, constant.CANCELED, decimal.NewFromInt(50), decimal.Zero, true)
+
+	cancelResult, err := infra.repo.ProcessBalanceAtomicOperation(ctx, orgID, ledgerID,
+		uuid.New(), constant.CANCELED, true, []mmodel.BalanceOperation{cancelRelease, cancelCredit, cancelCompanion})
+	require.NoError(t, err, "same-batch RELEASE must not make the following overdraft CREDIT look stale")
+	require.Len(t, cancelResult.After, 3)
+
+	defaultAfterCancel := findLatestBalanceByKey(t, cancelResult.After, constant.DefaultBalanceKey)
 	companionAfterCancel := findBalanceByKey(t, cancelResult.After, constant.OverdraftBalanceKey)
 
 	assert.True(t, defaultAfterCancel.Available.Equal(decimal.NewFromInt(50)))

--- a/components/ledger/internal/adapters/redis/transaction/consumer_overdraft_pending_integration_test.go
+++ b/components/ledger/internal/adapters/redis/transaction/consumer_overdraft_pending_integration_test.go
@@ -1,0 +1,174 @@
+//go:build integration
+
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package redis
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/LerianStudio/midaz/v3/pkg/constant"
+	"github.com/LerianStudio/midaz/v3/pkg/mmodel"
+	"github.com/LerianStudio/midaz/v3/pkg/mtransaction"
+	"github.com/LerianStudio/midaz/v3/pkg/utils"
+)
+
+func pendingOverdraftBalanceOp(
+	orgID, ledgerID uuid.UUID,
+	alias, key, direction string,
+	available, onHold, overdraftUsed decimal.Decimal,
+	version int64,
+	settings *mmodel.BalanceSettings,
+	operation, transactionType string,
+	amount, overdraftAmount decimal.Decimal,
+	routeValidationEnabled bool,
+) mmodel.BalanceOperation {
+	return mmodel.BalanceOperation{
+		Balance: &mmodel.Balance{
+			ID:             uuid.NewString(),
+			OrganizationID: orgID.String(),
+			LedgerID:       ledgerID.String(),
+			AccountID:      uuid.NewString(),
+			Alias:          alias,
+			Key:            key,
+			AssetCode:      "USD",
+			Available:      available,
+			OnHold:         onHold,
+			Version:        version,
+			AccountType:    "deposit",
+			AllowSending:   true,
+			AllowReceiving: true,
+			Direction:      direction,
+			OverdraftUsed:  overdraftUsed,
+			Settings:       settings,
+			CreatedAt:      time.Now(),
+			UpdatedAt:      time.Now(),
+		},
+		Alias: alias + "#" + key,
+		Amount: mtransaction.Amount{
+			Asset:                  "USD",
+			Value:                  amount,
+			Operation:              operation,
+			TransactionType:        transactionType,
+			OverdraftAmount:        overdraftAmount,
+			RouteValidationEnabled: routeValidationEnabled,
+		},
+		InternalKey: utils.BalanceInternalKey(orgID, ledgerID, alias+"#"+key),
+	}
+}
+
+func findBalanceByKey(t *testing.T, balances []*mmodel.Balance, key string) *mmodel.Balance {
+	t.Helper()
+
+	for _, balance := range balances {
+		if balance != nil && balance.Key == key {
+			return balance
+		}
+	}
+
+	require.Failf(t, "balance not found", "key %q not found", key)
+
+	return nil
+}
+
+func TestIntegration_Overdraft_PendingLegacyHoldMutatesCompanion(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	infra := setupRedisIntegrationInfra(t)
+	ctx := context.Background()
+	orgID := uuid.New()
+	ledgerID := uuid.New()
+	alias := "@t17-pending-hold"
+
+	settings := &mmodel.BalanceSettings{
+		BalanceScope:          mmodel.BalanceScopeTransactional,
+		AllowOverdraft:        true,
+		OverdraftLimitEnabled: true,
+		OverdraftLimit:        ptrString("100"),
+	}
+
+	defaultOp := pendingOverdraftBalanceOp(orgID, ledgerID, alias, constant.DefaultBalanceKey, constant.DirectionCredit,
+		decimal.NewFromInt(50), decimal.Zero, decimal.Zero, 1, settings,
+		constant.ONHOLD, constant.PENDING, decimal.NewFromInt(100), decimal.Zero, false)
+	companionOp := pendingOverdraftBalanceOp(orgID, ledgerID, alias, constant.OverdraftBalanceKey, constant.DirectionDebit,
+		decimal.Zero, decimal.Zero, decimal.Zero, 1, nil,
+		constant.DEBIT, constant.PENDING, decimal.NewFromInt(50), decimal.Zero, false)
+
+	result, err := infra.repo.ProcessBalanceAtomicOperation(ctx, orgID, ledgerID,
+		uuid.New(), constant.PENDING, true, []mmodel.BalanceOperation{defaultOp, companionOp})
+
+	require.NoError(t, err)
+	require.Len(t, result.After, 2)
+
+	defaultAfter := findBalanceByKey(t, result.After, constant.DefaultBalanceKey)
+	companionAfter := findBalanceByKey(t, result.After, constant.OverdraftBalanceKey)
+
+	assert.True(t, defaultAfter.Available.IsZero())
+	assert.True(t, defaultAfter.OnHold.Equal(decimal.NewFromInt(100)))
+	assert.True(t, defaultAfter.OverdraftUsed.Equal(decimal.NewFromInt(50)))
+	assert.True(t, companionAfter.Available.Equal(decimal.NewFromInt(50)))
+}
+
+func TestIntegration_Overdraft_PendingLegacyCancelRestoresCompanion(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	infra := setupRedisIntegrationInfra(t)
+	ctx := context.Background()
+	orgID := uuid.New()
+	ledgerID := uuid.New()
+	alias := "@t17-pending-cancel"
+
+	settings := &mmodel.BalanceSettings{
+		BalanceScope:          mmodel.BalanceScopeTransactional,
+		AllowOverdraft:        true,
+		OverdraftLimitEnabled: true,
+		OverdraftLimit:        ptrString("100"),
+	}
+
+	pendingDefault := pendingOverdraftBalanceOp(orgID, ledgerID, alias, constant.DefaultBalanceKey, constant.DirectionCredit,
+		decimal.NewFromInt(50), decimal.Zero, decimal.Zero, 1, settings,
+		constant.ONHOLD, constant.PENDING, decimal.NewFromInt(100), decimal.Zero, false)
+	pendingCompanion := pendingOverdraftBalanceOp(orgID, ledgerID, alias, constant.OverdraftBalanceKey, constant.DirectionDebit,
+		decimal.Zero, decimal.Zero, decimal.Zero, 1, nil,
+		constant.DEBIT, constant.PENDING, decimal.NewFromInt(50), decimal.Zero, false)
+
+	pendingResult, err := infra.repo.ProcessBalanceAtomicOperation(ctx, orgID, ledgerID,
+		uuid.New(), constant.PENDING, true, []mmodel.BalanceOperation{pendingDefault, pendingCompanion})
+	require.NoError(t, err)
+
+	defaultAfterPending := findBalanceByKey(t, pendingResult.After, constant.DefaultBalanceKey)
+	companionAfterPending := findBalanceByKey(t, pendingResult.After, constant.OverdraftBalanceKey)
+
+	cancelDefault := pendingOverdraftBalanceOp(orgID, ledgerID, alias, constant.DefaultBalanceKey, constant.DirectionCredit,
+		defaultAfterPending.Available, defaultAfterPending.OnHold, defaultAfterPending.OverdraftUsed, defaultAfterPending.Version, settings,
+		constant.RELEASE, constant.CANCELED, decimal.NewFromInt(100), decimal.NewFromInt(50), false)
+	cancelCompanion := pendingOverdraftBalanceOp(orgID, ledgerID, alias, constant.OverdraftBalanceKey, constant.DirectionDebit,
+		companionAfterPending.Available, companionAfterPending.OnHold, companionAfterPending.OverdraftUsed, companionAfterPending.Version, nil,
+		constant.CREDIT, constant.CANCELED, decimal.NewFromInt(50), decimal.Zero, false)
+
+	cancelResult, err := infra.repo.ProcessBalanceAtomicOperation(ctx, orgID, ledgerID,
+		uuid.New(), constant.CANCELED, true, []mmodel.BalanceOperation{cancelDefault, cancelCompanion})
+	require.NoError(t, err)
+	require.Len(t, cancelResult.After, 2)
+
+	defaultAfterCancel := findBalanceByKey(t, cancelResult.After, constant.DefaultBalanceKey)
+	companionAfterCancel := findBalanceByKey(t, cancelResult.After, constant.OverdraftBalanceKey)
+
+	assert.True(t, defaultAfterCancel.Available.Equal(decimal.NewFromInt(50)))
+	assert.True(t, defaultAfterCancel.OnHold.IsZero())
+	assert.True(t, defaultAfterCancel.OverdraftUsed.IsZero())
+	assert.True(t, companionAfterCancel.Available.IsZero())
+}

--- a/components/ledger/internal/adapters/redis/transaction/consumer_overdraft_split_integration_test.go
+++ b/components/ledger/internal/adapters/redis/transaction/consumer_overdraft_split_integration_test.go
@@ -1,0 +1,300 @@
+//go:build integration
+
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package redis
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/LerianStudio/midaz/v3/pkg/constant"
+	"github.com/LerianStudio/midaz/v3/pkg/mmodel"
+	"github.com/LerianStudio/midaz/v3/pkg/mtransaction"
+	"github.com/LerianStudio/midaz/v3/pkg/utils"
+
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// =============================================================================
+// SHARED OVERDRAFT TEST HELPERS (used by both overdraft integration files)
+// =============================================================================
+// overdraftOp builds a BalanceOperation with Direction/Settings populated,
+// since the shared fixtures helper does not expose those fields.
+func overdraftOp(
+	orgID, ledgerID uuid.UUID,
+	alias, accountType, direction string,
+	available, overdraftUsed decimal.Decimal,
+	version int64, settings *mmodel.BalanceSettings,
+	operation string, amount decimal.Decimal,
+) mmodel.BalanceOperation {
+	balanceKey := alias + "#default"
+
+	return mmodel.BalanceOperation{
+		Balance: &mmodel.Balance{
+			ID:             uuid.New().String(),
+			OrganizationID: orgID.String(),
+			LedgerID:       ledgerID.String(),
+			AccountID:      uuid.New().String(),
+			Alias:          alias,
+			Key:            balanceKey,
+			AssetCode:      "USD",
+			Available:      available,
+			OnHold:         decimal.Zero,
+			Version:        version,
+			AccountType:    accountType,
+			AllowSending:   true,
+			AllowReceiving: true,
+			Direction:      direction,
+			OverdraftUsed:  overdraftUsed,
+			Settings:       settings,
+			CreatedAt:      time.Now(),
+			UpdatedAt:      time.Now(),
+		},
+		Alias: alias,
+		Amount: mtransaction.Amount{
+			Asset:     "USD",
+			Value:     amount,
+			Operation: operation,
+		},
+		InternalKey: utils.BalanceInternalKey(orgID, ledgerID, balanceKey),
+	}
+}
+
+func ptrString(s string) *string { return &s }
+
+// cachedBalance mirrors the JSON shape the Lua script writes to Redis.
+type cachedBalance struct {
+	ID                    string `json:"ID"`
+	Available             string `json:"Available"`
+	OnHold                string `json:"OnHold"`
+	Version               int64  `json:"Version"`
+	AccountType           string `json:"AccountType"`
+	AccountID             string `json:"AccountID"`
+	AssetCode             string `json:"AssetCode"`
+	AllowSending          int    `json:"AllowSending"`
+	AllowReceiving        int    `json:"AllowReceiving"`
+	Key                   string `json:"Key"`
+	Direction             string `json:"Direction"`
+	OverdraftUsed         string `json:"OverdraftUsed"`
+	AllowOverdraft        int    `json:"AllowOverdraft"`
+	OverdraftLimitEnabled int    `json:"OverdraftLimitEnabled"`
+	OverdraftLimit        string `json:"OverdraftLimit"`
+	BalanceScope          string `json:"BalanceScope"`
+}
+
+// =============================================================================
+// OVERDRAFT SPLIT & LIMIT INTEGRATION TESTS (IS-1..IS-5, IS-9)
+// =============================================================================
+// TestIntegration_Overdraft_DirectionAwareDebit_NoOverdraft exercises IS-1:
+// a debit on a credit-direction balance with overdraft disabled simply
+// decreases Available and never touches OverdraftUsed.
+func TestIntegration_Overdraft_DirectionAwareDebit_NoOverdraft(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	infra := setupRedisIntegrationInfra(t)
+	ctx := context.Background()
+	orgID := uuid.New()
+	ledgerID := uuid.New()
+
+	op := overdraftOp(orgID, ledgerID, "@is1-credit", "deposit", "credit",
+		decimal.NewFromInt(500), decimal.Zero, 1, nil,
+		constant.DEBIT, decimal.NewFromInt(200))
+
+	result, err := infra.repo.ProcessBalanceAtomicOperation(ctx, orgID, ledgerID,
+		uuid.New(), constant.APPROVED, false, []mmodel.BalanceOperation{op})
+
+	require.NoError(t, err)
+	require.Len(t, result.After, 1)
+
+	assert.True(t, result.After[0].Available.Equal(decimal.NewFromInt(300)),
+		"Available should decrement normally without overdraft, got %s",
+		result.After[0].Available)
+	assert.True(t, result.After[0].OverdraftUsed.IsZero(),
+		"OverdraftUsed must remain zero, got %s", result.After[0].OverdraftUsed)
+}
+
+// TestIntegration_Overdraft_UnlimitedSplit_FloorsAtZero exercises IS-2:
+// unlimited overdraft floors Available at zero and accrues the deficit
+// in OverdraftUsed.
+func TestIntegration_Overdraft_UnlimitedSplit_FloorsAtZero(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	infra := setupRedisIntegrationInfra(t)
+	ctx := context.Background()
+	orgID := uuid.New()
+	ledgerID := uuid.New()
+
+	settings := &mmodel.BalanceSettings{
+		BalanceScope:          mmodel.BalanceScopeTransactional,
+		AllowOverdraft:        true,
+		OverdraftLimitEnabled: false,
+	}
+	op := overdraftOp(orgID, ledgerID, "@is2-split", "deposit", "credit",
+		decimal.NewFromInt(100), decimal.Zero, 1, settings,
+		constant.DEBIT, decimal.NewFromInt(250))
+
+	result, err := infra.repo.ProcessBalanceAtomicOperation(ctx, orgID, ledgerID,
+		uuid.New(), constant.APPROVED, false, []mmodel.BalanceOperation{op})
+
+	require.NoError(t, err)
+	require.Len(t, result.After, 1)
+
+	assert.True(t, result.After[0].Available.IsZero(),
+		"Available should floor at zero, got %s", result.After[0].Available)
+	assert.True(t, result.After[0].OverdraftUsed.Equal(decimal.NewFromInt(150)),
+		"OverdraftUsed should equal the deficit (150), got %s",
+		result.After[0].OverdraftUsed)
+}
+
+// TestIntegration_Overdraft_LimitExceeded_Returns0167 exercises IS-3: a
+// projected OverdraftUsed strictly above the limit is rejected with 0167
+// and the cached balance is rolled back to its pre-op state.
+func TestIntegration_Overdraft_LimitExceeded_Returns0167(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	infra := setupRedisIntegrationInfra(t)
+	ctx := context.Background()
+	orgID := uuid.New()
+	ledgerID := uuid.New()
+
+	settings := &mmodel.BalanceSettings{
+		BalanceScope:          mmodel.BalanceScopeTransactional,
+		AllowOverdraft:        true,
+		OverdraftLimitEnabled: true,
+		OverdraftLimit:        ptrString("50"),
+	}
+	op := overdraftOp(orgID, ledgerID, "@is3-rejected", "deposit", "credit",
+		decimal.NewFromInt(100), decimal.Zero, 1, settings,
+		constant.DEBIT, decimal.NewFromInt(200))
+
+	_, err := infra.repo.ProcessBalanceAtomicOperation(ctx, orgID, ledgerID,
+		uuid.New(), constant.APPROVED, false, []mmodel.BalanceOperation{op})
+
+	require.Error(t, err, "deficit=100 with limit=50 must be rejected")
+	assert.True(t, strings.Contains(err.Error(), constant.ErrOverdraftLimitExceeded.Error()),
+		"error should contain 0167, got: %v", err)
+
+	// Rollback invariant: the balance cache retains the pre-operation snapshot.
+	raw, getErr := infra.redisContainer.Client.Get(context.Background(), op.InternalKey).Result()
+	require.NoError(t, getErr, "balance key should still exist after rollback")
+
+	var cb cachedBalance
+
+	require.NoError(t, json.Unmarshal([]byte(raw), &cb))
+	assert.Equal(t, "100", cb.Available, "Available must be unchanged after rollback")
+	assert.Equal(t, "0", cb.OverdraftUsed, "OverdraftUsed must be unchanged after rollback")
+	assert.Equal(t, int64(1), cb.Version, "Version must not increment on rollback")
+}
+
+// TestIntegration_Overdraft_LimitBoundary_Allowed exercises IS-4: a deficit
+// exactly equal to the limit is allowed (inclusive boundary).
+func TestIntegration_Overdraft_LimitBoundary_Allowed(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	infra := setupRedisIntegrationInfra(t)
+	ctx := context.Background()
+	orgID := uuid.New()
+	ledgerID := uuid.New()
+
+	settings := &mmodel.BalanceSettings{
+		BalanceScope:          mmodel.BalanceScopeTransactional,
+		AllowOverdraft:        true,
+		OverdraftLimitEnabled: true,
+		OverdraftLimit:        ptrString("100"),
+	}
+	op := overdraftOp(orgID, ledgerID, "@is4-boundary", "deposit", "credit",
+		decimal.NewFromInt(100), decimal.Zero, 1, settings,
+		constant.DEBIT, decimal.NewFromInt(200))
+
+	result, err := infra.repo.ProcessBalanceAtomicOperation(ctx, orgID, ledgerID,
+		uuid.New(), constant.APPROVED, false, []mmodel.BalanceOperation{op})
+
+	require.NoError(t, err, "deficit=limit=100 is inclusive and must be allowed")
+	require.Len(t, result.After, 1)
+
+	assert.True(t, result.After[0].Available.IsZero(), "Available should be zero")
+	assert.True(t, result.After[0].OverdraftUsed.Equal(decimal.NewFromInt(100)),
+		"OverdraftUsed should equal limit (100), got %s",
+		result.After[0].OverdraftUsed)
+}
+
+// TestIntegration_Overdraft_CumulativeAccrual exercises IS-5: an existing
+// OverdraftUsed accumulates with the new deficit under the limit.
+func TestIntegration_Overdraft_CumulativeAccrual(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	infra := setupRedisIntegrationInfra(t)
+	ctx := context.Background()
+	orgID := uuid.New()
+	ledgerID := uuid.New()
+
+	settings := &mmodel.BalanceSettings{
+		BalanceScope:          mmodel.BalanceScopeTransactional,
+		AllowOverdraft:        true,
+		OverdraftLimitEnabled: true,
+		OverdraftLimit:        ptrString("200"),
+	}
+	op := overdraftOp(orgID, ledgerID, "@is5-cumulative", "deposit", "credit",
+		decimal.Zero, decimal.NewFromInt(80), 1, settings,
+		constant.DEBIT, decimal.NewFromInt(50))
+
+	result, err := infra.repo.ProcessBalanceAtomicOperation(ctx, orgID, ledgerID,
+		uuid.New(), constant.APPROVED, false, []mmodel.BalanceOperation{op})
+
+	require.NoError(t, err)
+	require.Len(t, result.After, 1)
+
+	assert.True(t, result.After[0].Available.IsZero(), "Available stays floored at zero")
+	assert.True(t, result.After[0].OverdraftUsed.Equal(decimal.NewFromInt(130)),
+		"OverdraftUsed should be 80+50=130, got %s",
+		result.After[0].OverdraftUsed)
+}
+
+// TestIntegration_Overdraft_ExternalAccount_BypassesOverdraft exercises IS-9:
+// external accounts bypass the overdraft branch and still accept negative
+// Available on DEBIT.
+func TestIntegration_Overdraft_ExternalAccount_BypassesOverdraft(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	infra := setupRedisIntegrationInfra(t)
+	ctx := context.Background()
+	orgID := uuid.New()
+	ledgerID := uuid.New()
+
+	op := overdraftOp(orgID, ledgerID, "@is9-external", "external", "credit",
+		decimal.NewFromInt(100), decimal.Zero, 1, nil,
+		constant.DEBIT, decimal.NewFromInt(200))
+
+	result, err := infra.repo.ProcessBalanceAtomicOperation(ctx, orgID, ledgerID,
+		uuid.New(), constant.APPROVED, false, []mmodel.BalanceOperation{op})
+
+	require.NoError(t, err, "external DEBIT must succeed even when going negative")
+	require.Len(t, result.After, 1)
+
+	assert.True(t, result.After[0].Available.Equal(decimal.NewFromInt(-100)),
+		"external account Available should be -100, got %s",
+		result.After[0].Available)
+	assert.True(t, result.After[0].OverdraftUsed.IsZero(),
+		"overdraft logic must not trigger for external accounts")
+}

--- a/components/ledger/internal/adapters/redis/transaction/consumer_overdraft_test.go
+++ b/components/ledger/internal/adapters/redis/transaction/consumer_overdraft_test.go
@@ -1,0 +1,295 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package redis
+
+import (
+	"strconv"
+	"testing"
+
+	libCommons "github.com/LerianStudio/lib-commons/v4/commons"
+	"github.com/LerianStudio/midaz/v3/pkg/constant"
+	"github.com/LerianStudio/midaz/v3/pkg/mmodel"
+	"github.com/LerianStudio/midaz/v3/pkg/mtransaction"
+	"github.com/LerianStudio/midaz/v3/pkg/utils"
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// =============================================================================
+// ARGV Builder — overdraft field propagation
+// =============================================================================
+
+func TestBuildPlan_IncludesOverdraftFields(t *testing.T) {
+	t.Parallel()
+
+	organizationID := uuid.Must(libCommons.GenerateUUIDv7())
+	ledgerID := uuid.Must(libCommons.GenerateUUIDv7())
+
+	overdraftLimit := "500.00"
+	balanceOps := []mmodel.BalanceOperation{
+		{
+			Balance: &mmodel.Balance{
+				ID:             uuid.Must(libCommons.GenerateUUIDv7()).String(),
+				OrganizationID: organizationID.String(),
+				LedgerID:       ledgerID.String(),
+				AccountID:      uuid.Must(libCommons.GenerateUUIDv7()).String(),
+				Alias:          "@sender",
+				Key:            "default",
+				AssetCode:      "USD",
+				Available:      decimal.NewFromInt(1000),
+				OnHold:         decimal.Zero,
+				Version:        3,
+				AccountType:    "deposit",
+				AllowSending:   true,
+				AllowReceiving: true,
+				Direction:      "debit",
+				OverdraftUsed:  decimal.NewFromInt(50),
+				Settings: &mmodel.BalanceSettings{
+					AllowOverdraft:        true,
+					OverdraftLimitEnabled: true,
+					OverdraftLimit:        &overdraftLimit,
+					BalanceScope:          mmodel.BalanceScopeTransactional,
+				},
+			},
+			Alias: "@sender",
+			Amount: mtransaction.Amount{
+				Asset:     "USD",
+				Value:     decimal.NewFromInt(200),
+				Operation: constant.DEBIT,
+			},
+			InternalKey: utils.BalanceInternalKey(organizationID, ledgerID, "default"),
+		},
+	}
+
+	repo := &RedisConsumerRepository{conn: newFailOnCallConnection(t)}
+
+	plan, err := repo.buildBalanceAtomicOperationPlan(
+		t.Context(), constant.APPROVED, false, balanceOps,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, plan)
+	require.Len(t, plan.args, 23,
+		"ARGV must contain 23 entries per balance (groupSize=23)")
+
+	assert.Equal(t, "debit", plan.args[17], "ARGV[i+17] balance.Direction")
+	assert.Equal(t, "50", plan.args[18], "ARGV[i+18] balance.OverdraftUsed")
+	assert.Equal(t, 1, plan.args[19], "ARGV[i+19] AllowOverdraft (1=true)")
+	assert.Equal(t, 1, plan.args[20], "ARGV[i+20] OverdraftLimitEnabled (1=true)")
+	assert.Equal(t, "500.00", plan.args[21], "ARGV[i+21] OverdraftLimit")
+	assert.Equal(t, mmodel.BalanceScopeTransactional, plan.args[22], "ARGV[i+22] BalanceScope")
+}
+
+func TestBuildPlan_DefaultOverdraftFields(t *testing.T) {
+	t.Parallel()
+
+	organizationID := uuid.Must(libCommons.GenerateUUIDv7())
+	ledgerID := uuid.Must(libCommons.GenerateUUIDv7())
+
+	balanceOps := []mmodel.BalanceOperation{
+		{
+			Balance: &mmodel.Balance{
+				ID:             uuid.Must(libCommons.GenerateUUIDv7()).String(),
+				OrganizationID: organizationID.String(),
+				LedgerID:       ledgerID.String(),
+				AccountID:      uuid.Must(libCommons.GenerateUUIDv7()).String(),
+				Alias:          "@receiver",
+				Key:            "default",
+				AssetCode:      "USD",
+				Available:      decimal.NewFromInt(500),
+				OnHold:         decimal.Zero,
+				Version:        1,
+				AccountType:    "deposit",
+				AllowSending:   true,
+				AllowReceiving: true,
+			},
+			Alias: "@receiver",
+			Amount: mtransaction.Amount{
+				Asset:     "USD",
+				Value:     decimal.NewFromInt(100),
+				Operation: constant.CREDIT,
+			},
+			InternalKey: utils.BalanceInternalKey(organizationID, ledgerID, "default"),
+		},
+	}
+
+	repo := &RedisConsumerRepository{conn: newFailOnCallConnection(t)}
+
+	plan, err := repo.buildBalanceAtomicOperationPlan(
+		t.Context(), constant.APPROVED, false, balanceOps,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, plan)
+	require.Len(t, plan.args, 23,
+		"ARGV must contain 23 entries even when overdraft fields are defaults")
+
+	dirVal, ok := plan.args[17].(string)
+	require.True(t, ok, "ARGV[i+17] (Direction) must be a string")
+	assert.Contains(t, []string{"", "credit"}, dirVal,
+		"ARGV[i+17] default Direction")
+
+	assert.Equal(t, "0", plan.args[18], "ARGV[i+18] zero OverdraftUsed")
+	assert.Equal(t, 0, plan.args[19], "ARGV[i+19] AllowOverdraft=false")
+	assert.Equal(t, 0, plan.args[20], "ARGV[i+20] OverdraftLimitEnabled=false")
+	assert.Equal(t, "0", plan.args[21], "ARGV[i+21] zero OverdraftLimit")
+	assert.Equal(t, mmodel.BalanceScopeTransactional, plan.args[22],
+		"ARGV[i+22] default BalanceScope")
+}
+
+func TestBuildPlan_GroupSizeMatchesLua(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, 23, luaArgsPerOperation,
+		"luaArgsPerOperation must be 23 to include the 6 new overdraft ARGV fields")
+}
+
+func TestBuildPlan_MultipleBalancesOverdraftPositions(t *testing.T) {
+	t.Parallel()
+
+	organizationID := uuid.Must(libCommons.GenerateUUIDv7())
+	ledgerID := uuid.Must(libCommons.GenerateUUIDv7())
+	limit := "1000.00"
+
+	balanceOps := []mmodel.BalanceOperation{
+		{
+			Balance: &mmodel.Balance{
+				ID:             uuid.Must(libCommons.GenerateUUIDv7()).String(),
+				OrganizationID: organizationID.String(),
+				LedgerID:       ledgerID.String(),
+				AccountID:      uuid.Must(libCommons.GenerateUUIDv7()).String(),
+				Alias:          "@first",
+				Key:            "default",
+				AssetCode:      "BRL",
+				Available:      decimal.NewFromInt(100),
+				OnHold:         decimal.Zero,
+				Version:        1,
+				AccountType:    "deposit",
+				AllowSending:   true,
+				AllowReceiving: true,
+				Direction:      "credit",
+				OverdraftUsed:  decimal.Zero,
+			},
+			Alias: "@first",
+			Amount: mtransaction.Amount{
+				Asset:     "BRL",
+				Value:     decimal.NewFromInt(10),
+				Operation: constant.DEBIT,
+			},
+			InternalKey: utils.BalanceInternalKey(organizationID, ledgerID, "default"),
+		},
+		{
+			Balance: &mmodel.Balance{
+				ID:             uuid.Must(libCommons.GenerateUUIDv7()).String(),
+				OrganizationID: organizationID.String(),
+				LedgerID:       ledgerID.String(),
+				AccountID:      uuid.Must(libCommons.GenerateUUIDv7()).String(),
+				Alias:          "@second",
+				Key:            "default",
+				AssetCode:      "BRL",
+				Available:      decimal.NewFromInt(200),
+				OnHold:         decimal.Zero,
+				Version:        2,
+				AccountType:    "deposit",
+				AllowSending:   true,
+				AllowReceiving: true,
+				Direction:      "debit",
+				OverdraftUsed:  decimal.NewFromInt(75),
+				Settings: &mmodel.BalanceSettings{
+					AllowOverdraft:        true,
+					OverdraftLimitEnabled: true,
+					OverdraftLimit:        &limit,
+					BalanceScope:          mmodel.BalanceScopeInternal,
+				},
+			},
+			Alias: "@second",
+			Amount: mtransaction.Amount{
+				Asset:     "BRL",
+				Value:     decimal.NewFromInt(10),
+				Operation: constant.CREDIT,
+			},
+			InternalKey: utils.BalanceInternalKey(organizationID, ledgerID, "default"),
+		},
+	}
+
+	repo := &RedisConsumerRepository{conn: newFailOnCallConnection(t)}
+
+	plan, err := repo.buildBalanceAtomicOperationPlan(
+		t.Context(), constant.APPROVED, false, balanceOps,
+	)
+	require.NoError(t, err)
+	require.Len(t, plan.args, 46, "Two operations × 23 fields = 46 ARGV entries")
+
+	secondBase := 23
+	assert.Equal(t, "debit", plan.args[secondBase+17], "2nd balance Direction")
+	assert.Equal(t, "75", plan.args[secondBase+18], "2nd balance OverdraftUsed")
+	assert.Equal(t, 1, plan.args[secondBase+19], "2nd balance AllowOverdraft")
+	assert.Equal(t, 1, plan.args[secondBase+20], "2nd balance OverdraftLimitEnabled")
+	assert.Equal(t, "1000.00", plan.args[secondBase+21], "2nd balance OverdraftLimit")
+	assert.Equal(t, mmodel.BalanceScopeInternal, plan.args[secondBase+22], "2nd balance BalanceScope")
+}
+
+func TestBuildPlan_ExistingFieldPositionsUnchanged(t *testing.T) {
+	t.Parallel()
+
+	organizationID := uuid.Must(libCommons.GenerateUUIDv7())
+	ledgerID := uuid.Must(libCommons.GenerateUUIDv7())
+	balanceID := uuid.Must(libCommons.GenerateUUIDv7()).String()
+	accountID := uuid.Must(libCommons.GenerateUUIDv7()).String()
+
+	balanceOps := []mmodel.BalanceOperation{
+		{
+			Balance: &mmodel.Balance{
+				ID:             balanceID,
+				OrganizationID: organizationID.String(),
+				LedgerID:       ledgerID.String(),
+				AccountID:      accountID,
+				Alias:          "@test",
+				Key:            "default",
+				AssetCode:      "USD",
+				Available:      decimal.NewFromInt(750),
+				OnHold:         decimal.NewFromInt(25),
+				Version:        5,
+				AccountType:    "deposit",
+				AllowSending:   true,
+				AllowReceiving: false,
+			},
+			Alias: "@test",
+			Amount: mtransaction.Amount{
+				Asset:                  "USD",
+				Value:                  decimal.NewFromInt(100),
+				Operation:              constant.DEBIT,
+				RouteValidationEnabled: true,
+			},
+			InternalKey: utils.BalanceInternalKey(organizationID, ledgerID, "default"),
+		},
+	}
+
+	repo := &RedisConsumerRepository{conn: newFailOnCallConnection(t)}
+
+	plan, err := repo.buildBalanceAtomicOperationPlan(
+		t.Context(), constant.APPROVED, true, balanceOps,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, plan)
+
+	// Positions 0-16 must remain unchanged from the original layout.
+	assert.Equal(t, 1, plan.args[1], "ARGV[i+1] isPending")
+	assert.Equal(t, constant.APPROVED, plan.args[2], "ARGV[i+2] transactionStatus")
+	assert.Equal(t, constant.DEBIT, plan.args[3], "ARGV[i+3] operation")
+	assert.Equal(t, "100", plan.args[4], "ARGV[i+4] amount")
+	assert.Equal(t, "@test", plan.args[5], "ARGV[i+5] alias")
+	assert.Equal(t, 1, plan.args[6], "ARGV[i+6] routeValidationEnabled")
+	assert.Equal(t, balanceID, plan.args[7], "ARGV[i+7] balance.ID")
+	assert.Equal(t, "750", plan.args[8], "ARGV[i+8] balance.Available")
+	assert.Equal(t, "25", plan.args[9], "ARGV[i+9] balance.OnHold")
+	assert.Equal(t, strconv.FormatInt(5, 10), plan.args[10], "ARGV[i+10] balance.Version")
+	assert.Equal(t, "deposit", plan.args[11], "ARGV[i+11] balance.AccountType")
+	assert.Equal(t, accountID, plan.args[12], "ARGV[i+12] balance.AccountID")
+	assert.Equal(t, "USD", plan.args[13], "ARGV[i+13] balance.AssetCode")
+	assert.Equal(t, 1, plan.args[14], "ARGV[i+14] balance.AllowSending")
+	assert.Equal(t, 0, plan.args[15], "ARGV[i+15] balance.AllowReceiving")
+	assert.Equal(t, "default", plan.args[16], "ARGV[i+16] balance.Key")
+}

--- a/components/ledger/internal/adapters/redis/transaction/consumer_overdraft_test.go
+++ b/components/ledger/internal/adapters/redis/transaction/consumer_overdraft_test.go
@@ -72,8 +72,8 @@ func TestBuildPlan_IncludesOverdraftFields(t *testing.T) {
 	)
 	require.NoError(t, err)
 	require.NotNil(t, plan)
-	require.Len(t, plan.args, 23,
-		"ARGV must contain 23 entries per balance (groupSize=23)")
+	require.Len(t, plan.args, 24,
+		"ARGV must contain 24 entries per balance (groupSize=24)")
 
 	assert.Equal(t, "debit", plan.args[17], "ARGV[i+17] balance.Direction")
 	assert.Equal(t, "50", plan.args[18], "ARGV[i+18] balance.OverdraftUsed")
@@ -81,6 +81,7 @@ func TestBuildPlan_IncludesOverdraftFields(t *testing.T) {
 	assert.Equal(t, 1, plan.args[20], "ARGV[i+20] OverdraftLimitEnabled (1=true)")
 	assert.Equal(t, "500.00", plan.args[21], "ARGV[i+21] OverdraftLimit")
 	assert.Equal(t, mmodel.BalanceScopeTransactional, plan.args[22], "ARGV[i+22] BalanceScope")
+	assert.Equal(t, "0", plan.args[23], "ARGV[i+23] default OverdraftAmount")
 }
 
 func TestBuildPlan_DefaultOverdraftFields(t *testing.T) {
@@ -123,8 +124,8 @@ func TestBuildPlan_DefaultOverdraftFields(t *testing.T) {
 	)
 	require.NoError(t, err)
 	require.NotNil(t, plan)
-	require.Len(t, plan.args, 23,
-		"ARGV must contain 23 entries even when overdraft fields are defaults")
+	require.Len(t, plan.args, 24,
+		"ARGV must contain 24 entries even when overdraft fields are defaults")
 
 	dirVal, ok := plan.args[17].(string)
 	require.True(t, ok, "ARGV[i+17] (Direction) must be a string")
@@ -137,13 +138,14 @@ func TestBuildPlan_DefaultOverdraftFields(t *testing.T) {
 	assert.Equal(t, "0", plan.args[21], "ARGV[i+21] zero OverdraftLimit")
 	assert.Equal(t, mmodel.BalanceScopeTransactional, plan.args[22],
 		"ARGV[i+22] default BalanceScope")
+	assert.Equal(t, "0", plan.args[23], "ARGV[i+23] default OverdraftAmount")
 }
 
 func TestBuildPlan_GroupSizeMatchesLua(t *testing.T) {
 	t.Parallel()
 
-	assert.Equal(t, 23, luaArgsPerOperation,
-		"luaArgsPerOperation must be 23 to include the 6 new overdraft ARGV fields")
+	assert.Equal(t, 24, luaArgsPerOperation,
+		"luaArgsPerOperation must be 24 to include the 7 overdraft ARGV fields")
 }
 
 func TestBuildPlan_MultipleBalancesOverdraftPositions(t *testing.T) {
@@ -220,9 +222,9 @@ func TestBuildPlan_MultipleBalancesOverdraftPositions(t *testing.T) {
 		t.Context(), constant.APPROVED, false, balanceOps,
 	)
 	require.NoError(t, err)
-	require.Len(t, plan.args, 46, "Two operations × 23 fields = 46 ARGV entries")
+	require.Len(t, plan.args, 48, "Two operations × 24 fields = 48 ARGV entries")
 
-	secondBase := 23
+	secondBase := 24
 	assert.Equal(t, "debit", plan.args[secondBase+17], "2nd balance Direction")
 	assert.Equal(t, "75", plan.args[secondBase+18], "2nd balance OverdraftUsed")
 	assert.Equal(t, 1, plan.args[secondBase+19], "2nd balance AllowOverdraft")

--- a/components/ledger/internal/adapters/redis/transaction/consumer_overdraft_versioning_integration_test.go
+++ b/components/ledger/internal/adapters/redis/transaction/consumer_overdraft_versioning_integration_test.go
@@ -88,15 +88,15 @@ func TestIntegration_Overdraft_DebitDirection_CreditOperation(t *testing.T) {
 		result.After[0].Available)
 }
 
-// TestIntegration_Overdraft_StaleVersion_Returns0175 exercises IS-8: when the
+// TestIntegration_Overdraft_StaleVersion_Returns0174 exercises IS-8: when the
 // cache holds a newer Version than the caller supplied, the Lua overdraft
-// branch refuses to apply the split and returns error code 0175.
+// branch refuses to apply the split and returns error code 0174.
 //
 // The setup pre-seeds the balance key with Version=6, then submits an
 // operation carrying Version=5 in ARGV. The script's `SET NX` fails, the
 // cached entry is loaded (Version=6), the deficit triggers the overdraft
 // branch, and the stale-version guard fires.
-func TestIntegration_Overdraft_StaleVersion_Returns0175(t *testing.T) {
+func TestIntegration_Overdraft_StaleVersion_Returns0174(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode")
 	}
@@ -170,7 +170,7 @@ func TestIntegration_Overdraft_StaleVersion_Returns0175(t *testing.T) {
 
 	require.Error(t, err, "stale version must be rejected")
 	assert.True(t, strings.Contains(err.Error(), constant.ErrStaleBalanceVersion.Error()),
-		"error should contain 0175, got: %v", err)
+		"error should contain %s, got: %v", constant.ErrStaleBalanceVersion.Error(), err)
 }
 
 // TestIntegration_Overdraft_VersionIncrementAndSyncScheduling exercises IS-10:

--- a/components/ledger/internal/adapters/redis/transaction/consumer_overdraft_versioning_integration_test.go
+++ b/components/ledger/internal/adapters/redis/transaction/consumer_overdraft_versioning_integration_test.go
@@ -1,0 +1,214 @@
+//go:build integration
+
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package redis
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/LerianStudio/midaz/v3/pkg/constant"
+	"github.com/LerianStudio/midaz/v3/pkg/mmodel"
+	"github.com/LerianStudio/midaz/v3/pkg/mtransaction"
+	"github.com/LerianStudio/midaz/v3/pkg/utils"
+
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// =============================================================================
+// DIRECTION, STALE-VERSION, AND SYNC-SCHEDULING TESTS (IS-6..IS-8, IS-10)
+// =============================================================================
+//
+// Helpers (`overdraftOp`, `ptrString`, `cachedBalance`) are defined in the
+// companion file `consumer_overdraft_split_integration_test.go`.
+
+// TestIntegration_Overdraft_DebitDirection_DebitOperation exercises IS-6.
+// For direction=debit balances, DEBIT increases Available (inverted polarity).
+// This matches Go's applyDebitDirectionBalance and the PRD's overdraft model
+// where debiting the overdraft balance records usage (increases the debt).
+func TestIntegration_Overdraft_DebitDirection_DebitOperation(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	infra := setupRedisIntegrationInfra(t)
+	ctx := context.Background()
+	orgID := uuid.New()
+	ledgerID := uuid.New()
+
+	// direction=debit: DEBIT adds → 100 + 50 = 150
+	op := overdraftOp(orgID, ledgerID, "@is6-debit-dir", "deposit", "debit",
+		decimal.NewFromInt(100), decimal.Zero, 1, nil,
+		constant.DEBIT, decimal.NewFromInt(50))
+
+	result, err := infra.repo.ProcessBalanceAtomicOperation(ctx, orgID, ledgerID,
+		uuid.New(), constant.APPROVED, false, []mmodel.BalanceOperation{op})
+
+	require.NoError(t, err)
+	require.Len(t, result.After, 1)
+	assert.True(t, result.After[0].Available.Equal(decimal.NewFromInt(150)),
+		"DEBIT on direction=debit should increase Available, got %s", result.After[0].Available)
+}
+
+// TestIntegration_Overdraft_DebitDirection_CreditOperation exercises IS-7.
+// For direction=debit balances, CREDIT decreases Available (inverted polarity).
+// This matches Go's applyDebitDirectionBalance and the PRD's repayment model
+// where crediting the overdraft balance reduces the tracked debt.
+func TestIntegration_Overdraft_DebitDirection_CreditOperation(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	infra := setupRedisIntegrationInfra(t)
+	ctx := context.Background()
+	orgID := uuid.New()
+	ledgerID := uuid.New()
+
+	// direction=debit: CREDIT subtracts → 100 - 30 = 70
+	op := overdraftOp(orgID, ledgerID, "@is7-debit-credit", "deposit", "debit",
+		decimal.NewFromInt(100), decimal.Zero, 1, nil,
+		constant.CREDIT, decimal.NewFromInt(30))
+
+	result, err := infra.repo.ProcessBalanceAtomicOperation(ctx, orgID, ledgerID,
+		uuid.New(), constant.APPROVED, false, []mmodel.BalanceOperation{op})
+
+	require.NoError(t, err)
+	require.Len(t, result.After, 1)
+	assert.True(t, result.After[0].Available.Equal(decimal.NewFromInt(70)),
+		"CREDIT on direction=debit should decrease Available, got %s",
+		result.After[0].Available)
+}
+
+// TestIntegration_Overdraft_StaleVersion_Returns0175 exercises IS-8: when the
+// cache holds a newer Version than the caller supplied, the Lua overdraft
+// branch refuses to apply the split and returns error code 0175.
+//
+// The setup pre-seeds the balance key with Version=6, then submits an
+// operation carrying Version=5 in ARGV. The script's `SET NX` fails, the
+// cached entry is loaded (Version=6), the deficit triggers the overdraft
+// branch, and the stale-version guard fires.
+func TestIntegration_Overdraft_StaleVersion_Returns0175(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	infra := setupRedisIntegrationInfra(t)
+	ctx := context.Background()
+	orgID := uuid.New()
+	ledgerID := uuid.New()
+
+	alias := "@is8-stale"
+	balanceKey := alias + "#default"
+	internalKey := utils.BalanceInternalKey(orgID, ledgerID, balanceKey)
+
+	seeded := cachedBalance{
+		ID:                    uuid.New().String(),
+		Available:             "100",
+		OnHold:                "0",
+		Version:               6,
+		AccountType:           "deposit",
+		AccountID:             uuid.New().String(),
+		AssetCode:             "USD",
+		AllowSending:          1,
+		AllowReceiving:        1,
+		Key:                   balanceKey,
+		Direction:             "credit",
+		OverdraftUsed:         "0",
+		AllowOverdraft:        1,
+		OverdraftLimitEnabled: 0,
+		OverdraftLimit:        "0",
+		BalanceScope:          mmodel.BalanceScopeTransactional,
+	}
+	payload, marshalErr := json.Marshal(seeded)
+	require.NoError(t, marshalErr)
+	require.NoError(t, infra.redisContainer.Client.Set(
+		context.Background(), internalKey, payload, time.Hour).Err())
+
+	settings := &mmodel.BalanceSettings{
+		BalanceScope:   mmodel.BalanceScopeTransactional,
+		AllowOverdraft: true,
+	}
+	op := mmodel.BalanceOperation{
+		Balance: &mmodel.Balance{
+			ID:             seeded.ID,
+			OrganizationID: orgID.String(),
+			LedgerID:       ledgerID.String(),
+			AccountID:      seeded.AccountID,
+			Alias:          alias,
+			Key:            balanceKey,
+			AssetCode:      "USD",
+			Available:      decimal.NewFromInt(100),
+			OnHold:         decimal.Zero,
+			Version:        5, // stale: cache has 6
+			AccountType:    "deposit",
+			AllowSending:   true,
+			AllowReceiving: true,
+			Direction:      "credit",
+			OverdraftUsed:  decimal.Zero,
+			Settings:       settings,
+		},
+		Alias: alias,
+		Amount: mtransaction.Amount{
+			Asset:     "USD",
+			Value:     decimal.NewFromInt(200),
+			Operation: constant.DEBIT,
+		},
+		InternalKey: internalKey,
+	}
+
+	_, err := infra.repo.ProcessBalanceAtomicOperation(ctx, orgID, ledgerID,
+		uuid.New(), constant.APPROVED, false, []mmodel.BalanceOperation{op})
+
+	require.Error(t, err, "stale version must be rejected")
+	assert.True(t, strings.Contains(err.Error(), constant.ErrStaleBalanceVersion.Error()),
+		"error should contain 0175, got: %v", err)
+}
+
+// TestIntegration_Overdraft_VersionIncrementAndSyncScheduling exercises IS-10:
+// when overdraft accrual changes OverdraftUsed, the Lua script must increment
+// Version and enqueue the balance key in the sync-scheduling ZSET so the
+// balance-sync worker picks it up for PostgreSQL persistence.
+func TestIntegration_Overdraft_VersionIncrementAndSyncScheduling(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	infra := setupRedisIntegrationInfra(t)
+	ctx := context.Background()
+	orgID := uuid.New()
+	ledgerID := uuid.New()
+
+	settings := &mmodel.BalanceSettings{
+		BalanceScope:          mmodel.BalanceScopeTransactional,
+		AllowOverdraft:        true,
+		OverdraftLimitEnabled: false,
+	}
+	op := overdraftOp(orgID, ledgerID, "@is10-sync", "deposit", "credit",
+		decimal.NewFromInt(100), decimal.Zero, 1, settings,
+		constant.DEBIT, decimal.NewFromInt(150))
+
+	result, err := infra.repo.ProcessBalanceAtomicOperation(ctx, orgID, ledgerID,
+		uuid.New(), constant.APPROVED, false, []mmodel.BalanceOperation{op})
+
+	require.NoError(t, err)
+	require.Len(t, result.After, 1)
+
+	assert.Equal(t, int64(2), result.After[0].Version,
+		"Version must increment when OverdraftUsed changes, got %d",
+		result.After[0].Version)
+
+	// ZSET entry proves the balance was scheduled for async PostgreSQL sync.
+	score, zerr := infra.redisContainer.Client.ZScore(
+		context.Background(), utils.BalanceSyncScheduleKey, op.InternalKey).Result()
+	require.NoError(t, zerr, "balance key should be present in the sync-schedule ZSET")
+	assert.Greater(t, score, float64(0), "scheduled dueAt must be a positive timestamp")
+}

--- a/components/ledger/internal/adapters/redis/transaction/scripts/balance_atomic_operation.lua
+++ b/components/ledger/internal/adapters/redis/transaction/scripts/balance_atomic_operation.lua
@@ -241,7 +241,7 @@ end
 local function main()
     local ttl = 3600 -- 1 hour
 
-    local groupSize = 23
+    local groupSize = 24
     local returnBalances = {}
     local returnBalancesAfter = {}
     local rollbackBalances = {}
@@ -322,6 +322,11 @@ local function main()
             BalanceScope = ARGV[i + 22],
         }
 
+        -- Exact overdraft delta supplied by Go for pending-cancel reversals.
+        -- Normal transaction paths pass zero and keep Lua's live-state split
+        -- calculation authoritative.
+        local overdraftAmount = ARGV[i + 23]
+
         -- Preserve the Go-provided version before the cache may overwrite it.
         -- Used for stale-version detection on overdraft-relevant operations.
         local incomingVersion = balance.Version
@@ -386,6 +391,12 @@ local function main()
                 else
                     result = sub_decimal(balance.Available, amount)
                 end
+            elseif operation == "DEBIT" and transactionStatus == "PENDING" and isDebitDirection then
+                -- Legacy pending overdraft companion: the user-facing source
+                -- is an ON_HOLD, but the internal direction=debit companion
+                -- receives a synthetic DEBIT so liability state matches the
+                -- one-phase overdraft path.
+                result = add_decimal(balance.Available, amount)
             elseif operation == "ON_HOLD" and transactionStatus == "PENDING" and routeValidationEnabled == 1 then
                 -- Double-entry: ON_HOLD only increments OnHold.
                 -- The Available-- was already done by the separate DEBIT operation.
@@ -415,6 +426,11 @@ local function main()
                 else
                     result = add_decimal(balance.Available, amount)
                 end
+            elseif operation == "CREDIT" and transactionStatus == "CANCELED" and isDebitDirection then
+                -- Legacy pending overdraft companion cancel: shrink the
+                -- direction=debit liability that was created by the pending
+                -- companion DEBIT.
+                result = sub_decimal(balance.Available, amount)
             elseif operation == "ON_HOLD" and transactionStatus == "APPROVED" and routeValidationEnabled == 1 then
                 -- Double-entry: ON_HOLD in APPROVED only decrements OnHold.
                 -- The Available++ will be a separate CREDIT operation.
@@ -476,6 +492,9 @@ local function main()
             end
 
             local repay = min_decimal(amount, balance.OverdraftUsed)
+            if isPositive(overdraftAmount) then
+                repay = min_decimal(min_decimal(overdraftAmount, amount), balance.OverdraftUsed)
+            end
 
             newOverdraftUsed = sub_decimal(balance.OverdraftUsed, repay)
             -- `result` was already computed as balance.Available + amount
@@ -483,6 +502,22 @@ local function main()
             -- portion to expose just the remainder that flows into
             -- Available; the repayment itself leaves Available untouched
             -- because it goes toward paying down OverdraftUsed.
+            result = sub_decimal(result, repay)
+        end
+
+        -- Legacy pending cancel reversal: RELEASE both clears OnHold and
+        -- restores Available. If the original hold consumed overdraft, only
+        -- the non-overdraft portion should return to Available and the exact
+        -- overdraft delta must be removed from OverdraftUsed.
+        if operation == "RELEASE" and transactionStatus == "CANCELED" and routeValidationEnabled == 0 and
+            not isDebitDirection and balance.AccountType ~= "external" and isPositive(overdraftAmount) then
+            if balance.Version ~= incomingVersion then
+                rollback(rollbackBalances, ttl)
+                return redis.error_reply("0175")
+            end
+
+            local repay = min_decimal(min_decimal(overdraftAmount, amount), balance.OverdraftUsed)
+            newOverdraftUsed = sub_decimal(balance.OverdraftUsed, repay)
             result = sub_decimal(result, repay)
         end
 

--- a/components/ledger/internal/adapters/redis/transaction/scripts/balance_atomic_operation.lua
+++ b/components/ledger/internal/adapters/redis/transaction/scripts/balance_atomic_operation.lua
@@ -481,7 +481,7 @@ local function main()
         -- stale-version check below keeps Go's repayAmount in sync with
         -- Lua's authoritative decrement — if they disagree (e.g. a
         -- concurrent transaction already reduced OverdraftUsed), the whole
-        -- batch rolls back with 0175 so the caller re-reads state and
+        -- batch rolls back with 0174 so the caller re-reads state and
         -- retries with a consistent split.
         if operation == "CREDIT" and not isDebitDirection and
             balance.AccountType ~= "external" and
@@ -490,7 +490,7 @@ local function main()
                 routeValidationEnabled == 1 and tonumber(balance.Version) == (tonumber(incomingVersion) + 1)
             if balance.Version ~= incomingVersion and not sameBatchCancelCredit then
                 rollback(rollbackBalances, ttl)
-                return redis.error_reply("0175")
+                return redis.error_reply("0174")
             end
 
             local repay = min_decimal(amount, balance.OverdraftUsed)
@@ -515,7 +515,7 @@ local function main()
             not isDebitDirection and balance.AccountType ~= "external" and isPositive(overdraftAmount) then
             if balance.Version ~= incomingVersion then
                 rollback(rollbackBalances, ttl)
-                return redis.error_reply("0175")
+                return redis.error_reply("0174")
             end
 
             local repay = min_decimal(min_decimal(overdraftAmount, amount), balance.OverdraftUsed)
@@ -542,7 +542,7 @@ local function main()
                 -- retry is added in Phase 2).
                 if balance.Version ~= incomingVersion then
                     rollback(rollbackBalances, ttl)
-                    return redis.error_reply("0175")
+                    return redis.error_reply("0174")
                 end
 
                 -- Compute the candidate OverdraftUsed locally; the limit

--- a/components/ledger/internal/adapters/redis/transaction/scripts/balance_atomic_operation.lua
+++ b/components/ledger/internal/adapters/redis/transaction/scripts/balance_atomic_operation.lua
@@ -230,7 +230,7 @@ end
 local function main()
     local ttl = 3600 -- 1 hour
 
-    local groupSize = 17
+    local groupSize = 23
     local returnBalances = {}
     local returnBalancesAfter = {}
     local rollbackBalances = {}
@@ -273,6 +273,12 @@ local function main()
         --   - Version:     Optimistic concurrency control
         --   - AccountType: Validation 0018 (external account cannot have positive balance)
         --   - AccountID:   Returned to Go for operation tracking
+        --   - Direction:   Direction-aware overdraft gating ("credit" vs "debit")
+        --   - OverdraftUsed:        Tracked when a debit exceeds Available
+        --   - AllowOverdraft:       Enables negative-result pass-through
+        --   - OverdraftLimitEnabled:Gates the OverdraftLimit check
+        --   - OverdraftLimit:       Hard cap on OverdraftUsed (when enabled)
+        --   - BalanceScope:         "transactional" / "internal" (cache-only)
         --
         -- Fields NOT used by Lua, but required in cache for Go pre-validation:
         --   - AssetCode:      Used by ValidateIfBalanceExistsOnRedis for validation 0034
@@ -296,7 +302,18 @@ local function main()
             AllowSending = tonumber(ARGV[i + 14]),
             AllowReceiving = tonumber(ARGV[i + 15]),
             Key = ARGV[i + 16],
+            -- Overdraft fields
+            Direction = ARGV[i + 17],
+            OverdraftUsed = ARGV[i + 18],
+            AllowOverdraft = tonumber(ARGV[i + 19]),
+            OverdraftLimitEnabled = tonumber(ARGV[i + 20]),
+            OverdraftLimit = ARGV[i + 21],
+            BalanceScope = ARGV[i + 22],
         }
+
+        -- Preserve the Go-provided version before the cache may overwrite it.
+        -- Used for stale-version detection on overdraft-relevant operations.
+        local incomingVersion = balance.Version
 
         local redisBalance = cjson.encode(balance)
         local ok = redis.call("SET", redisBalanceKey, redisBalance, "EX", ttl, "NX")
@@ -306,7 +323,33 @@ local function main()
                 return redis.error_reply("0061")
             end
             balance = cjson.decode(currentBalance)
+
+            -- Backwards compatibility: legacy cache entries may lack the new
+            -- overdraft fields. Fill in safe defaults so subsequent logic does
+            -- not reference nil values.
+            if balance.Direction == nil then
+                balance.Direction = ""
+            end
+            if balance.OverdraftUsed == nil then
+                balance.OverdraftUsed = "0"
+            end
+            if balance.AllowOverdraft == nil then
+                balance.AllowOverdraft = 0
+            end
+            if balance.OverdraftLimitEnabled == nil then
+                balance.OverdraftLimitEnabled = 0
+            end
+            if balance.OverdraftLimit == nil then
+                balance.OverdraftLimit = "0"
+            end
+            if balance.BalanceScope == nil then
+                balance.BalanceScope = "transactional"
+            end
         end
+
+        -- Capture pre-operation OverdraftUsed so hasChange can detect repayment
+        -- or accrual even when Available/OnHold remain unchanged.
+        local originalOverdraftUsed = balance.OverdraftUsed
 
         if not rollbackBalances[redisBalanceKey] then
             rollbackBalances[redisBalanceKey] = cjson.encode(balance)
@@ -315,17 +358,33 @@ local function main()
         local result = balance.Available
         local resultOnHold = balance.OnHold
 
+        -- Direction-aware arithmetic on Available:
+        -- For direction=debit balances (e.g., overdraft tracking), DEBIT
+        -- increases Available and CREDIT decreases it. For direction=credit
+        -- balances (and empty/legacy), DEBIT decreases and CREDIT increases.
+        -- OnHold semantics are direction-agnostic: holds always add, releases
+        -- always subtract, regardless of balance direction.
+        local isDebitDirection = (balance.Direction == "debit")
+
         if isPending == 1 then
             if operation == "DEBIT" and transactionStatus == "PENDING" and routeValidationEnabled == 1 then
-                -- Double-entry: DEBIT only decrements Available.
+                -- Double-entry: DEBIT only updates Available.
                 -- The OnHold++ will be a separate ON_HOLD operation.
-                result = sub_decimal(balance.Available, amount)
+                if isDebitDirection then
+                    result = add_decimal(balance.Available, amount)
+                else
+                    result = sub_decimal(balance.Available, amount)
+                end
             elseif operation == "ON_HOLD" and transactionStatus == "PENDING" and routeValidationEnabled == 1 then
                 -- Double-entry: ON_HOLD only increments OnHold.
                 -- The Available-- was already done by the separate DEBIT operation.
                 resultOnHold = add_decimal(balance.OnHold, amount)
             elseif operation == "ON_HOLD" and transactionStatus == "PENDING" then
-                result = sub_decimal(balance.Available, amount)
+                if isDebitDirection then
+                    result = add_decimal(balance.Available, amount)
+                else
+                    result = sub_decimal(balance.Available, amount)
+                end
                 resultOnHold = add_decimal(balance.OnHold, amount)
             elseif operation == "RELEASE" and transactionStatus == "CANCELED" and routeValidationEnabled == 1 then
                 -- Double-entry: RELEASE only decrements OnHold.
@@ -333,10 +392,18 @@ local function main()
                 resultOnHold = sub_decimal(balance.OnHold, amount)
             elseif operation == "RELEASE" and transactionStatus == "CANCELED" then
                 resultOnHold = sub_decimal(balance.OnHold, amount)
-                result = add_decimal(balance.Available, amount)
+                if isDebitDirection then
+                    result = sub_decimal(balance.Available, amount)
+                else
+                    result = add_decimal(balance.Available, amount)
+                end
             elseif operation == "CREDIT" and transactionStatus == "CANCELED" and routeValidationEnabled == 1 then
-                -- Double-entry: CREDIT adds to Available only.
-                result = add_decimal(balance.Available, amount)
+                -- Double-entry: CREDIT updates Available only.
+                if isDebitDirection then
+                    result = sub_decimal(balance.Available, amount)
+                else
+                    result = add_decimal(balance.Available, amount)
+                end
             elseif operation == "ON_HOLD" and transactionStatus == "APPROVED" and routeValidationEnabled == 1 then
                 -- Double-entry: ON_HOLD in APPROVED only decrements OnHold.
                 -- The Available++ will be a separate CREDIT operation.
@@ -345,21 +412,78 @@ local function main()
                 if operation == "DEBIT" then
                     resultOnHold = sub_decimal(balance.OnHold, amount)
                 else
-                    result = add_decimal(balance.Available, amount)
+                    if isDebitDirection then
+                        result = sub_decimal(balance.Available, amount)
+                    else
+                        result = add_decimal(balance.Available, amount)
+                    end
                 end
             end
         else
-            if operation == "DEBIT" then
-                result = sub_decimal(balance.Available, amount)
+            if isDebitDirection then
+                if operation == "DEBIT" then
+                    result = add_decimal(balance.Available, amount)
+                else
+                    result = sub_decimal(balance.Available, amount)
+                end
             else
-                result = add_decimal(balance.Available, amount)
+                if operation == "DEBIT" then
+                    result = sub_decimal(balance.Available, amount)
+                else
+                    result = add_decimal(balance.Available, amount)
+                end
             end
         end
 
 
+        -- newOverdraftUsed holds the post-operation OverdraftUsed candidate.
+        -- It is written back to `balance.OverdraftUsed` only AFTER the
+        -- pre-mutation snapshot is cloned into `returnBalances`, so the
+        -- "before" snapshot faithfully reflects the state the caller read.
+        local newOverdraftUsed = balance.OverdraftUsed
+
         if startsWithMinus(result) and balance.AccountType ~= "external" then
-            rollback(rollbackBalances, ttl)
-            return redis.error_reply("0018")
+            -- Direction-aware overdraft: credit-direction balances with
+            -- AllowOverdraft=1 may go temporarily negative. The shortfall
+            -- is floored at zero in Available and accrued in OverdraftUsed,
+            -- subject to OverdraftLimit when enabled.
+            --
+            -- Debit-direction balances and credit-direction balances without
+            -- AllowOverdraft fall through to the legacy 0018 rejection.
+            if balance.Direction == "credit" and (balance.AllowOverdraft or 0) == 1 then
+                -- deficit = abs(result). Because result is negative,
+                -- sub_decimal("0", result) produces the absolute value.
+                local deficit = sub_decimal("0", result)
+
+                -- Stale-version check: if Go's pre-computed split assumed an
+                -- older OverdraftUsed/Available, the floor math will be wrong.
+                -- Reject so the caller can re-read and retry (Phase 1 behavior;
+                -- retry is added in Phase 2).
+                if balance.Version ~= incomingVersion then
+                    rollback(rollbackBalances, ttl)
+                    return redis.error_reply("0175")
+                end
+
+                -- Compute the candidate OverdraftUsed locally; the limit
+                -- check below operates on this candidate so the "before"
+                -- snapshot remains untouched.
+                newOverdraftUsed = add_decimal(balance.OverdraftUsed, deficit)
+
+                if (balance.OverdraftLimitEnabled or 0) == 1 then
+                    -- sub_decimal(limit, newOverdraftUsed) is negative iff
+                    -- the candidate strictly exceeds limit. Equal is allowed
+                    -- (at-limit).
+                    if startsWithMinus(sub_decimal(balance.OverdraftLimit, newOverdraftUsed)) then
+                        rollback(rollbackBalances, ttl)
+                        return redis.error_reply("0167")
+                    end
+                end
+
+                result = "0"
+            else
+                rollback(rollbackBalances, ttl)
+                return redis.error_reply("0018")
+            end
         end
 
         -- External accounts cannot have positive balance (they represent debt to external entities)
@@ -373,14 +497,25 @@ local function main()
         -- Only update balance and increment version if there was an actual change.
         -- This prevents version gaps when destinations are processed during PENDING
         -- transactions (CREDIT + PENDING has no effect, so no version increment).
-        local hasChange = (result ~= balance.Available) or (resultOnHold ~= balance.OnHold)
+        --
+        -- OverdraftUsed is included so pure overdraft accrual paths (Available
+        -- floored at 0, OverdraftUsed incremented) still mark the balance as
+        -- changed and trigger a cache + sync update. We compare against
+        -- `newOverdraftUsed` (the candidate computed above) rather than the
+        -- still-original `balance.OverdraftUsed` to detect overdraft deltas.
+        local hasChange = (result ~= balance.Available)
+            or (resultOnHold ~= balance.OnHold)
+            or (newOverdraftUsed ~= originalOverdraftUsed)
 
         if hasChange then
             balance.Alias = alias
+            -- Snapshot the pre-mutation state first so the "before" payload
+            -- reflects what the caller read (especially OverdraftUsed).
             table.insert(returnBalances, cloneBalance(balance))
 
             balance.Available = result
             balance.OnHold = resultOnHold
+            balance.OverdraftUsed = newOverdraftUsed
             balance.Version = balance.Version + 1
 
             table.insert(returnBalancesAfter, cloneBalance(balance))

--- a/components/ledger/internal/adapters/redis/transaction/scripts/balance_atomic_operation.lua
+++ b/components/ledger/internal/adapters/redis/transaction/scripts/balance_atomic_operation.lua
@@ -486,7 +486,9 @@ local function main()
         if operation == "CREDIT" and not isDebitDirection and
             balance.AccountType ~= "external" and
             isPositive(balance.OverdraftUsed) then
-            if balance.Version ~= incomingVersion then
+            local sameBatchCancelCredit = operation == "CREDIT" and transactionStatus == "CANCELED" and
+                routeValidationEnabled == 1 and tonumber(balance.Version) == (tonumber(incomingVersion) + 1)
+            if balance.Version ~= incomingVersion and not sameBatchCancelCredit then
                 rollback(rollbackBalances, ttl)
                 return redis.error_reply("0175")
             end

--- a/components/ledger/internal/adapters/redis/transaction/scripts/balance_atomic_operation.lua
+++ b/components/ledger/internal/adapters/redis/transaction/scripts/balance_atomic_operation.lua
@@ -189,6 +189,17 @@ local function cloneBalance(tbl)
     return copy
 end
 
+-- min_decimal returns the smaller of two decimal strings. Implemented via
+-- sub_decimal so the caller does not need a numeric coercion step — this
+-- keeps the precision behavior identical to add_decimal/sub_decimal for
+-- values that overflow Lua's double representation.
+local function min_decimal(a, b)
+    if startsWithMinus(sub_decimal(a, b)) then
+        return a
+    end
+    return b
+end
+
 local function updateTransactionHash(transactionBackupQueue, transactionKey, balances, balancesAfter)
     local transaction
 
@@ -441,6 +452,39 @@ local function main()
         -- pre-mutation snapshot is cloned into `returnBalances`, so the
         -- "before" snapshot faithfully reflects the state the caller read.
         local newOverdraftUsed = balance.OverdraftUsed
+
+        -- Overdraft repayment: a credit that arrives on a direction=credit
+        -- balance with outstanding OverdraftUsed repays the overdraft first
+        -- before growing Available. This mirrors the debit path in reverse:
+        -- the deficit is paid down, and only the remainder increases the
+        -- account holder's spendable balance.
+        --
+        -- The companion balance's Available is decremented in lock-step by a
+        -- sibling CREDIT op queued by the Go enrichment layer
+        -- (transaction_overdraft_enrichment.go:buildCompanionCreditOp). The
+        -- stale-version check below keeps Go's repayAmount in sync with
+        -- Lua's authoritative decrement — if they disagree (e.g. a
+        -- concurrent transaction already reduced OverdraftUsed), the whole
+        -- batch rolls back with 0175 so the caller re-reads state and
+        -- retries with a consistent split.
+        if operation == "CREDIT" and not isDebitDirection and
+            balance.AccountType ~= "external" and
+            isPositive(balance.OverdraftUsed) then
+            if balance.Version ~= incomingVersion then
+                rollback(rollbackBalances, ttl)
+                return redis.error_reply("0175")
+            end
+
+            local repay = min_decimal(amount, balance.OverdraftUsed)
+
+            newOverdraftUsed = sub_decimal(balance.OverdraftUsed, repay)
+            -- `result` was already computed as balance.Available + amount
+            -- by the direction-aware block above. Subtract the repayment
+            -- portion to expose just the remainder that flows into
+            -- Available; the repayment itself leaves Available untouched
+            -- because it goes toward paying down OverdraftUsed.
+            result = sub_decimal(result, repay)
+        end
 
         if startsWithMinus(result) and balance.AccountType ~= "external" then
             -- Direction-aware overdraft: credit-direction balances with

--- a/components/ledger/internal/bootstrap/balance_sync.worker.go
+++ b/components/ledger/internal/bootstrap/balance_sync.worker.go
@@ -71,9 +71,10 @@ type tenantCollector struct {
 const tenantReconcileInterval = 10 * time.Second
 
 // maxBatchSize is the upper bound for batch size, derived from PostgreSQL's 65535
-// bind-parameter limit. Each balance uses 4 params + 3 shared = (65535-3)/4 = 16383.
-// In practice, batches above a few hundred rarely make sense for this workload.
-const maxBatchSize = 16000
+// bind-parameter limit. Each balance uses 5 params + 3 shared = (65535-3)/5 = 13106.
+// The 5th parameter is overdraft_used (added once the cache script began
+// tracking it). Batches above a few hundred rarely make sense for this workload.
+const maxBatchSize = 13000
 
 func NewBalanceSyncWorker(logger libLog.Logger, useCase *command.UseCase, syncCfg BalanceSyncConfig) *BalanceSyncWorker {
 	// Apply safe defaults for zero-value config (e.g., in tests)

--- a/components/ledger/internal/bootstrap/redis.consumer.go
+++ b/components/ledger/internal/bootstrap/redis.consumer.go
@@ -503,8 +503,17 @@ func (r *RedisQueueConsumer) processMessage(ctx context.Context, key string, m m
 
 		var buildErr error
 
+		// Replay path: Lua's authoritative `balancesAfter` is not captured
+		// in the backup envelope, so BuildOperations falls back to the
+		// OperateBalances-recomputation branch. For non-overdraft
+		// transactions this is correct; for overdraft transactions the
+		// operation records will carry the naive `before - amount`
+		// arithmetic — the balance table remains consistent (Lua already
+		// flushed it) but the audit trail may diverge. Capturing Lua's
+		// after-state in the backup envelope is tracked under T-006.1 /
+		// T-009 hardening items.
 		operations, _, buildErr = r.TransactionHandler.BuildOperations(
-			msgCtxWithSpan, balances, fromTo, m.TransactionInput, *tran, m.Validate, m.TransactionDate, m.TransactionStatus == constant.NOTED, ledgerSettings.Accounting.ValidateRoutes, routeCache, action,
+			msgCtxWithSpan, balances, nil /* balancesAfter */, fromTo, m.TransactionInput, *tran, m.Validate, m.TransactionDate, m.TransactionStatus == constant.NOTED, ledgerSettings.Accounting.ValidateRoutes, routeCache, action,
 		)
 		if buildErr != nil {
 			libOpentelemetry.HandleSpanError(msgSpan, "Failed to validate balances", buildErr)

--- a/components/ledger/internal/services/command/create_balance.go
+++ b/components/ledger/internal/services/command/create_balance.go
@@ -91,6 +91,8 @@ func (uc *UseCase) CreateBalanceSync(ctx context.Context, input mmodel.CreateBal
 	// includes "direction" and would otherwise send an empty string and
 	// fail the CHECK. Setting it here also ensures the Go model stays
 	// consistent with the persisted row returned by RETURNING.
+	now := time.Now()
+
 	newBalance := &mmodel.Balance{
 		ID:             uuid.Must(libCommons.GenerateUUIDv7()).String(),
 		Alias:          input.Alias,
@@ -103,8 +105,8 @@ func (uc *UseCase) CreateBalanceSync(ctx context.Context, input mmodel.CreateBal
 		AllowSending:   input.AllowSending,
 		AllowReceiving: input.AllowReceiving,
 		Direction:      constant.DirectionCredit,
-		CreatedAt:      time.Now(),
-		UpdatedAt:      time.Now(),
+		CreatedAt:      now,
+		UpdatedAt:      now,
 	}
 
 	created, err := uc.BalanceRepo.Create(ctx, newBalance)

--- a/components/ledger/internal/services/command/create_balance.go
+++ b/components/ledger/internal/services/command/create_balance.go
@@ -21,7 +21,6 @@ import (
 	// If key != "default", it validates that the default balance exists and that the account type allows additional balances.
 
 	libLog "github.com/LerianStudio/lib-commons/v4/commons/log"
-	"github.com/google/uuid"
 )
 
 func (uc *UseCase) CreateBalanceSync(ctx context.Context, input mmodel.CreateBalanceInput) (*mmodel.Balance, error) {
@@ -93,8 +92,16 @@ func (uc *UseCase) CreateBalanceSync(ctx context.Context, input mmodel.CreateBal
 	// consistent with the persisted row returned by RETURNING.
 	now := time.Now()
 
+	balanceUUID, uuidErr := libCommons.GenerateUUIDv7()
+	if uuidErr != nil {
+		libOpentelemetry.HandleSpanError(span, "Failed to generate UUID for balance", uuidErr)
+		logger.Log(ctx, libLog.LevelError, "Failed to generate UUID for balance", libLog.Err(uuidErr))
+
+		return nil, uuidErr
+	}
+
 	newBalance := &mmodel.Balance{
-		ID:             uuid.Must(libCommons.GenerateUUIDv7()).String(),
+		ID:             balanceUUID.String(),
 		Alias:          input.Alias,
 		Key:            normalizedKey,
 		OrganizationID: input.OrganizationID.String(),

--- a/components/ledger/internal/services/command/create_balance.go
+++ b/components/ledger/internal/services/command/create_balance.go
@@ -84,6 +84,13 @@ func (uc *UseCase) CreateBalanceSync(ctx context.Context, input mmodel.CreateBal
 		return nil, err
 	}
 
+	// Default balances (created alongside an account or asset) always use
+	// the "credit" direction. The migration defines direction as NOT NULL
+	// with a CHECK constraint (credit|debit), so we must set an explicit
+	// value rather than relying on the DB default — the INSERT column list
+	// includes "direction" and would otherwise send an empty string and
+	// fail the CHECK. Setting it here also ensures the Go model stays
+	// consistent with the persisted row returned by RETURNING.
 	newBalance := &mmodel.Balance{
 		ID:             uuid.Must(libCommons.GenerateUUIDv7()).String(),
 		Alias:          input.Alias,
@@ -95,6 +102,7 @@ func (uc *UseCase) CreateBalanceSync(ctx context.Context, input mmodel.CreateBal
 		AccountType:    input.AccountType,
 		AllowSending:   input.AllowSending,
 		AllowReceiving: input.AllowReceiving,
+		Direction:      constant.DirectionCredit,
 		CreatedAt:      time.Now(),
 		UpdatedAt:      time.Now(),
 	}

--- a/components/ledger/internal/services/command/create_balance_additional.go
+++ b/components/ledger/internal/services/command/create_balance_additional.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"reflect"
 	"strings"
 	"time"
 
@@ -34,9 +33,9 @@ func (uc *UseCase) CreateAdditionalBalance(ctx context.Context, organizationID, 
 	// repository call so a rejected request never touches persistence.
 	if strings.EqualFold(cbi.Key, constant.OverdraftBalanceKey) {
 		libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Reserved balance key", nil)
-		logger.Log(ctx, libLog.LevelWarn, fmt.Sprintf("Rejected reserved balance key: %v", cbi.Key))
+		logger.Log(ctx, libLog.LevelWarn, "Rejected reserved balance key", libLog.String("key", cbi.Key))
 
-		return nil, pkg.ValidateBusinessError(constant.ErrReservedBalanceKey, reflect.TypeOf(mmodel.Balance{}).Name(), cbi.Key)
+		return nil, pkg.ValidateBusinessError(constant.ErrReservedBalanceKey, constant.EntityBalance, cbi.Key)
 	}
 
 	// Direction validation runs before any repository call so invalid
@@ -48,9 +47,9 @@ func (uc *UseCase) CreateAdditionalBalance(ctx context.Context, organizationID, 
 			// valid
 		default:
 			libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Invalid balance direction", nil)
-			logger.Log(ctx, libLog.LevelWarn, fmt.Sprintf("Rejected invalid direction: %v", *cbi.Direction))
+			logger.Log(ctx, libLog.LevelWarn, "Rejected invalid balance direction", libLog.String("direction", *cbi.Direction))
 
-			return nil, pkg.ValidateBusinessError(constant.ErrInvalidBalanceDirection, reflect.TypeOf(mmodel.Balance{}).Name(), *cbi.Direction)
+			return nil, pkg.ValidateBusinessError(constant.ErrInvalidBalanceDirection, constant.EntityBalance, *cbi.Direction)
 		}
 	}
 
@@ -59,9 +58,9 @@ func (uc *UseCase) CreateAdditionalBalance(ctx context.Context, organizationID, 
 	if cbi.Settings != nil {
 		if err := cbi.Settings.Validate(); err != nil {
 			libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Invalid balance settings", err)
-			logger.Log(ctx, libLog.LevelWarn, fmt.Sprintf("Rejected invalid balance settings: %v", err))
+			logger.Log(ctx, libLog.LevelWarn, "Rejected invalid balance settings", libLog.Err(err))
 
-			return nil, pkg.ValidateBusinessError(constant.ErrInvalidBalanceSettings, reflect.TypeOf(mmodel.Balance{}).Name())
+			return nil, pkg.ValidateBusinessError(constant.ErrInvalidBalanceSettings, constant.EntityBalance)
 		}
 	}
 
@@ -71,9 +70,9 @@ func (uc *UseCase) CreateAdditionalBalance(ctx context.Context, organizationID, 
 	// those are permanently undeletable and bypass normal controls.
 	if cbi.Settings != nil && cbi.Settings.BalanceScope == mmodel.BalanceScopeInternal {
 		libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Reserved balance scope", nil)
-		logger.Log(ctx, libLog.LevelWarn, fmt.Sprintf("Rejected reserved balance scope: %v", cbi.Settings.BalanceScope))
+		logger.Log(ctx, libLog.LevelWarn, "Rejected reserved balance scope", libLog.String("scope", cbi.Settings.BalanceScope))
 
-		return nil, pkg.ValidateBusinessError(constant.ErrInvalidBalanceSettings, reflect.TypeOf(mmodel.Balance{}).Name())
+		return nil, pkg.ValidateBusinessError(constant.ErrInvalidBalanceSettings, constant.EntityBalance)
 	}
 
 	existingBalance, err := uc.BalanceRepo.FindByAccountIDAndKey(ctx, organizationID, ledgerID, accountID, strings.ToLower(cbi.Key))
@@ -93,7 +92,7 @@ func (uc *UseCase) CreateAdditionalBalance(ctx context.Context, organizationID, 
 
 		logger.Log(ctx, libLog.LevelInfo, fmt.Sprintf("Additional balance already exists: %v", cbi.Key))
 
-		return nil, pkg.ValidateBusinessError(constant.ErrDuplicatedAliasKeyValue, reflect.TypeOf(mmodel.Balance{}).Name(), cbi.Key)
+		return nil, pkg.ValidateBusinessError(constant.ErrDuplicatedAliasKeyValue, constant.EntityBalance, cbi.Key)
 	}
 
 	defaultBalance, err := uc.BalanceRepo.FindByAccountIDAndKey(ctx, organizationID, ledgerID, accountID, constant.DefaultBalanceKey)
@@ -108,7 +107,7 @@ func (uc *UseCase) CreateAdditionalBalance(ctx context.Context, organizationID, 
 	if defaultBalance.AccountType == constant.ExternalAccountType {
 		libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Additional balance not allowed for external account type", nil)
 
-		return nil, pkg.ValidateBusinessError(constant.ErrAdditionalBalanceNotAllowed, reflect.TypeOf(mmodel.Balance{}).Name(), defaultBalance.Alias)
+		return nil, pkg.ValidateBusinessError(constant.ErrAdditionalBalanceNotAllowed, constant.EntityBalance, defaultBalance.Alias)
 	}
 
 	// Direction defaults to "credit" when the caller omits it. Validation

--- a/components/ledger/internal/services/command/create_balance_additional.go
+++ b/components/ledger/internal/services/command/create_balance_additional.go
@@ -29,6 +29,53 @@ func (uc *UseCase) CreateAdditionalBalance(ctx context.Context, organizationID, 
 	ctx, span := tracer.Start(ctx, "command.create_additional_balance")
 	defer span.End()
 
+	// Reserved key guard: "overdraft" (any case) is system-managed and MUST
+	// not be created through the public API. This check runs BEFORE any
+	// repository call so a rejected request never touches persistence.
+	if strings.EqualFold(cbi.Key, constant.OverdraftBalanceKey) {
+		libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Reserved balance key", nil)
+		logger.Log(ctx, libLog.LevelWarn, fmt.Sprintf("Rejected reserved balance key: %v", cbi.Key))
+
+		return nil, pkg.ValidateBusinessError(constant.ErrReservedBalanceKey, reflect.TypeOf(mmodel.Balance{}).Name(), cbi.Key)
+	}
+
+	// Direction validation runs before any repository call so invalid
+	// payloads never touch persistence. Nil Direction is allowed and
+	// defaults to "credit" at construction time below.
+	if cbi.Direction != nil {
+		switch *cbi.Direction {
+		case constant.DirectionCredit, constant.DirectionDebit:
+			// valid
+		default:
+			libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Invalid balance direction", nil)
+			logger.Log(ctx, libLog.LevelWarn, fmt.Sprintf("Rejected invalid direction: %v", *cbi.Direction))
+
+			return nil, pkg.ValidateBusinessError(constant.ErrInvalidBalanceDirection, reflect.TypeOf(mmodel.Balance{}).Name(), *cbi.Direction)
+		}
+	}
+
+	// Settings validation also runs pre-persistence to keep the repository
+	// free of corrupt payloads.
+	if cbi.Settings != nil {
+		if err := cbi.Settings.Validate(); err != nil {
+			libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Invalid balance settings", err)
+			logger.Log(ctx, libLog.LevelWarn, fmt.Sprintf("Rejected invalid balance settings: %v", err))
+
+			return nil, pkg.ValidateBusinessError(constant.ErrInvalidBalanceSettings, reflect.TypeOf(mmodel.Balance{}).Name())
+		}
+	}
+
+	// Reserved scope guard: "internal" is reserved for system-managed
+	// balances (e.g., the auto-created overdraft balance). A client-facing
+	// request MUST NOT be able to create an internal-scoped balance —
+	// those are permanently undeletable and bypass normal controls.
+	if cbi.Settings != nil && cbi.Settings.BalanceScope == mmodel.BalanceScopeInternal {
+		libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Reserved balance scope", nil)
+		logger.Log(ctx, libLog.LevelWarn, fmt.Sprintf("Rejected reserved balance scope: %v", cbi.Settings.BalanceScope))
+
+		return nil, pkg.ValidateBusinessError(constant.ErrInvalidBalanceSettings, reflect.TypeOf(mmodel.Balance{}).Name())
+	}
+
 	existingBalance, err := uc.BalanceRepo.FindByAccountIDAndKey(ctx, organizationID, ledgerID, accountID, strings.ToLower(cbi.Key))
 	if err != nil {
 		var notFound pkg.EntityNotFoundError
@@ -64,6 +111,14 @@ func (uc *UseCase) CreateAdditionalBalance(ctx context.Context, organizationID, 
 		return nil, pkg.ValidateBusinessError(constant.ErrAdditionalBalanceNotAllowed, reflect.TypeOf(mmodel.Balance{}).Name(), defaultBalance.Alias)
 	}
 
+	// Direction defaults to "credit" when the caller omits it. Validation
+	// above guarantees that any provided value is one of the supported
+	// enum members.
+	direction := constant.DirectionCredit
+	if cbi.Direction != nil {
+		direction = *cbi.Direction
+	}
+
 	additionalBalance := &mmodel.Balance{
 		ID:             uuid.Must(libCommons.GenerateUUIDv7()).String(),
 		Alias:          defaultBalance.Alias,
@@ -75,6 +130,8 @@ func (uc *UseCase) CreateAdditionalBalance(ctx context.Context, organizationID, 
 		AccountType:    defaultBalance.AccountType,
 		AllowSending:   cbi.AllowSending == nil || *cbi.AllowSending,
 		AllowReceiving: cbi.AllowReceiving == nil || *cbi.AllowReceiving,
+		Direction:      direction,
+		Settings:       cbi.Settings,
 		CreatedAt:      time.Now(),
 		UpdatedAt:      time.Now(),
 	}

--- a/components/ledger/internal/services/command/create_balance_overdraft_test.go
+++ b/components/ledger/internal/services/command/create_balance_overdraft_test.go
@@ -1,0 +1,239 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package command
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/LerianStudio/midaz/v3/components/ledger/internal/adapters/postgres/balance"
+	"github.com/LerianStudio/midaz/v3/pkg"
+	"github.com/LerianStudio/midaz/v3/pkg/constant"
+	"github.com/LerianStudio/midaz/v3/pkg/mmodel"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+// defaultBalanceForOverdraft builds a default balance fixture used as the
+// reference account for additional-balance creation in these tests.
+func defaultBalanceForOverdraft(orgID, ledgerID, accountID uuid.UUID, alias string) *mmodel.Balance {
+	return &mmodel.Balance{
+		ID:             uuid.New().String(),
+		Alias:          alias,
+		Key:            constant.DefaultBalanceKey,
+		OrganizationID: orgID.String(),
+		LedgerID:       ledgerID.String(),
+		AccountID:      accountID.String(),
+		AssetCode:      "USD",
+		AccountType:    "deposit",
+		AllowSending:   true,
+		AllowReceiving: true,
+	}
+}
+
+// TestCreateAdditionalBalance_WithDirection verifies that when the caller
+// provides Direction="debit", the created balance carries that direction
+// instead of the default "credit".
+func TestCreateAdditionalBalance_WithDirection(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
+	ctx := context.Background()
+	orgID := uuid.New()
+	ledgerID := uuid.New()
+	accountID := uuid.New()
+	alias := "@debit-holder"
+
+	direction := constant.DirectionDebit
+	allow := true
+
+	cbi := &mmodel.CreateAdditionalBalance{
+		Key:            "savings",
+		AllowSending:   &allow,
+		AllowReceiving: &allow,
+		Direction:      &direction,
+	}
+
+	mockBalanceRepo := balance.NewMockRepository(ctrl)
+
+	mockBalanceRepo.EXPECT().
+		FindByAccountIDAndKey(gomock.Any(), orgID, ledgerID, accountID, "savings").
+		Return(nil, pkg.ValidateBusinessError(constant.ErrEntityNotFound, reflect.TypeOf(mmodel.Balance{}).Name())).
+		Times(1)
+
+	mockBalanceRepo.EXPECT().
+		FindByAccountIDAndKey(gomock.Any(), orgID, ledgerID, accountID, constant.DefaultBalanceKey).
+		Return(defaultBalanceForOverdraft(orgID, ledgerID, accountID, alias), nil).
+		Times(1)
+
+	mockBalanceRepo.EXPECT().
+		Create(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, b *mmodel.Balance) (*mmodel.Balance, error) {
+			assert.Equal(t, constant.DirectionDebit, b.Direction,
+				"created balance MUST carry the requested direction")
+			return b, nil
+		}).
+		Times(1)
+
+	uc := &UseCase{BalanceRepo: mockBalanceRepo}
+
+	result, err := uc.CreateAdditionalBalance(ctx, orgID, ledgerID, accountID, cbi)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, constant.DirectionDebit, result.Direction,
+		"returned balance MUST expose the requested direction")
+}
+
+// TestCreateAdditionalBalance_DefaultDirection verifies that when Direction
+// is omitted from the request, the created balance defaults to "credit".
+func TestCreateAdditionalBalance_DefaultDirection(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
+	ctx := context.Background()
+	orgID := uuid.New()
+	ledgerID := uuid.New()
+	accountID := uuid.New()
+	alias := "@default-direction"
+
+	allow := true
+
+	cbi := &mmodel.CreateAdditionalBalance{
+		Key:            "reserve",
+		AllowSending:   &allow,
+		AllowReceiving: &allow,
+		// Direction intentionally nil
+	}
+
+	mockBalanceRepo := balance.NewMockRepository(ctrl)
+
+	mockBalanceRepo.EXPECT().
+		FindByAccountIDAndKey(gomock.Any(), orgID, ledgerID, accountID, "reserve").
+		Return(nil, pkg.ValidateBusinessError(constant.ErrEntityNotFound, reflect.TypeOf(mmodel.Balance{}).Name())).
+		Times(1)
+
+	mockBalanceRepo.EXPECT().
+		FindByAccountIDAndKey(gomock.Any(), orgID, ledgerID, accountID, constant.DefaultBalanceKey).
+		Return(defaultBalanceForOverdraft(orgID, ledgerID, accountID, alias), nil).
+		Times(1)
+
+	mockBalanceRepo.EXPECT().
+		Create(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, b *mmodel.Balance) (*mmodel.Balance, error) {
+			assert.Equal(t, constant.DirectionCredit, b.Direction,
+				"missing direction MUST default to credit")
+			return b, nil
+		}).
+		Times(1)
+
+	uc := &UseCase{BalanceRepo: mockBalanceRepo}
+
+	result, err := uc.CreateAdditionalBalance(ctx, orgID, ledgerID, accountID, cbi)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, constant.DirectionCredit, result.Direction,
+		"returned balance MUST default to credit")
+}
+
+// TestCreateAdditionalBalance_InvalidDirection verifies that supplying an
+// unsupported direction returns a validation error before any persistence
+// is attempted.
+func TestCreateAdditionalBalance_InvalidDirection(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
+	ctx := context.Background()
+	orgID := uuid.New()
+	ledgerID := uuid.New()
+	accountID := uuid.New()
+
+	invalid := "sideways"
+	allow := true
+
+	cbi := &mmodel.CreateAdditionalBalance{
+		Key:            "weird",
+		AllowSending:   &allow,
+		AllowReceiving: &allow,
+		Direction:      &invalid,
+	}
+
+	mockBalanceRepo := balance.NewMockRepository(ctrl)
+
+	// Create MUST NOT be called when direction is invalid.
+	mockBalanceRepo.EXPECT().
+		Create(gomock.Any(), gomock.Any()).
+		Times(0)
+
+	uc := &UseCase{BalanceRepo: mockBalanceRepo}
+
+	result, err := uc.CreateAdditionalBalance(ctx, orgID, ledgerID, accountID, cbi)
+
+	require.Error(t, err, "invalid direction MUST return an error")
+	assert.Nil(t, result, "no balance should be returned on validation failure")
+}
+
+// TestCreateAdditionalBalance_ReservedKey verifies that the reserved
+// "overdraft" key cannot be created through the public API — it is
+// exclusively managed by the system when overdraft is enabled.
+func TestCreateAdditionalBalance_ReservedKey(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
+	ctx := context.Background()
+	orgID := uuid.New()
+	ledgerID := uuid.New()
+	accountID := uuid.New()
+
+	allow := true
+
+	cases := []struct {
+		name string
+		key  string
+	}{
+		{name: "lowercase", key: "overdraft"},
+		{name: "uppercase", key: "OVERDRAFT"},
+		{name: "mixed case", key: "Overdraft"},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			cbi := &mmodel.CreateAdditionalBalance{
+				Key:            tc.key,
+				AllowSending:   &allow,
+				AllowReceiving: &allow,
+			}
+
+			mockBalanceRepo := balance.NewMockRepository(ctrl)
+
+			// Create MUST NOT be invoked for the reserved key.
+			mockBalanceRepo.EXPECT().
+				Create(gomock.Any(), gomock.Any()).
+				Times(0)
+
+			uc := &UseCase{BalanceRepo: mockBalanceRepo}
+
+			result, err := uc.CreateAdditionalBalance(ctx, orgID, ledgerID, accountID, cbi)
+
+			require.Error(t, err, "reserved key MUST be rejected")
+			assert.Nil(t, result, "no balance should be returned when key is reserved")
+		})
+	}
+}

--- a/components/ledger/internal/services/command/create_balance_overdraft_test.go
+++ b/components/ledger/internal/services/command/create_balance_overdraft_test.go
@@ -6,7 +6,6 @@ package command
 
 import (
 	"context"
-	"reflect"
 	"testing"
 
 	"github.com/LerianStudio/midaz/v3/components/ledger/internal/adapters/postgres/balance"
@@ -65,7 +64,7 @@ func TestCreateAdditionalBalance_WithDirection(t *testing.T) {
 
 	mockBalanceRepo.EXPECT().
 		FindByAccountIDAndKey(gomock.Any(), orgID, ledgerID, accountID, "savings").
-		Return(nil, pkg.ValidateBusinessError(constant.ErrEntityNotFound, reflect.TypeOf(mmodel.Balance{}).Name())).
+		Return(nil, pkg.ValidateBusinessError(constant.ErrEntityNotFound, constant.EntityBalance)).
 		Times(1)
 
 	mockBalanceRepo.EXPECT().
@@ -119,7 +118,7 @@ func TestCreateAdditionalBalance_DefaultDirection(t *testing.T) {
 
 	mockBalanceRepo.EXPECT().
 		FindByAccountIDAndKey(gomock.Any(), orgID, ledgerID, accountID, "reserve").
-		Return(nil, pkg.ValidateBusinessError(constant.ErrEntityNotFound, reflect.TypeOf(mmodel.Balance{}).Name())).
+		Return(nil, pkg.ValidateBusinessError(constant.ErrEntityNotFound, constant.EntityBalance)).
 		Times(1)
 
 	mockBalanceRepo.EXPECT().
@@ -236,4 +235,36 @@ func TestCreateAdditionalBalance_ReservedKey(t *testing.T) {
 			assert.Nil(t, result, "no balance should be returned when key is reserved")
 		})
 	}
+}
+
+// TestCreateAdditionalBalance_RejectsInternalScope verifies that clients
+// cannot create balances with balanceScope="internal" through the public API.
+func TestCreateAdditionalBalance_RejectsInternalScope(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ctx := context.Background()
+	orgID := uuid.New()
+	ledgerID := uuid.New()
+	accountID := uuid.New()
+
+	mockBalanceRepo := balance.NewMockRepository(ctrl)
+
+	cbi := &mmodel.CreateAdditionalBalance{
+		Key: "savings",
+		Settings: &mmodel.BalanceSettings{
+			BalanceScope: mmodel.BalanceScopeInternal,
+		},
+	}
+
+	uc := &UseCase{BalanceRepo: mockBalanceRepo}
+
+	result, err := uc.CreateAdditionalBalance(ctx, orgID, ledgerID, accountID, cbi)
+
+	require.Error(t, err, "internal scope MUST be rejected on client creation")
+	assert.Nil(t, result, "no balance should be returned when scope is internal")
+	assert.Contains(t, err.Error(), constant.ErrInvalidBalanceSettings.Error(),
+		"error must reference the invalid-settings code")
 }

--- a/components/ledger/internal/services/command/create_balance_transaction_operations_async.go
+++ b/components/ledger/internal/services/command/create_balance_transaction_operations_async.go
@@ -20,6 +20,7 @@ import (
 	mongodb "github.com/LerianStudio/midaz/v3/components/ledger/internal/adapters/mongodb/transaction"
 	"github.com/LerianStudio/midaz/v3/components/ledger/internal/adapters/postgres/operation"
 	"github.com/LerianStudio/midaz/v3/components/ledger/internal/adapters/postgres/transaction"
+	"github.com/LerianStudio/midaz/v3/pkg"
 	"github.com/LerianStudio/midaz/v3/pkg/constant"
 	"github.com/LerianStudio/midaz/v3/pkg/mmodel"
 	"github.com/LerianStudio/midaz/v3/pkg/mtransaction"
@@ -307,6 +308,20 @@ func (uc *UseCase) RemoveTransactionFromRedisQueueIfStatus(ctx context.Context, 
 func (uc *UseCase) SendTransactionToRedisQueue(ctx context.Context, organizationID, ledgerID, transactionID uuid.UUID, transactionInput mtransaction.Transaction, validate *mtransaction.Responses, transactionStatus, action string, transactionDate time.Time, balances []*mmodel.Balance) error {
 	logger, _, reqId, _ := libCommons.NewTrackingFromContext(ctx)
 	transactionKey := utils.TransactionInternalKey(organizationID, ledgerID, transactionID.String())
+
+	// Scope protection: a transaction that targets any internal-scope
+	// balance (e.g. auto-created overdraft reserves) MUST be rejected
+	// BEFORE the transaction is published to the Redis queue. This keeps
+	// system-managed balances out of the user-initiated mutation path
+	// across every entry point (HTTP, gRPC, DSL).
+	for _, b := range balances {
+		if b != nil && b.Settings != nil && b.Settings.BalanceScope == mmodel.BalanceScopeInternal {
+			err := pkg.ValidateBusinessError(constant.ErrDirectOperationOnInternalBalance, reflect.TypeOf(mmodel.Balance{}).Name(), b.Alias)
+			logger.Log(ctx, libLog.LevelWarn, fmt.Sprintf("Rejected transaction targeting internal balance alias=%s key=%s", b.Alias, b.Key))
+
+			return err
+		}
+	}
 
 	utils.SanitizeAccountAliases(&transactionInput)
 

--- a/components/ledger/internal/services/command/create_balance_transaction_operations_async.go
+++ b/components/ledger/internal/services/command/create_balance_transaction_operations_async.go
@@ -148,6 +148,7 @@ func (uc *UseCase) CreateBalanceTransactionOperationsAsync(ctx context.Context, 
 	}
 
 	go uc.SendTransactionEvents(ctx, tran)
+	go uc.SendOverdraftEvents(ctx, tran)
 
 	logger.Log(ctx, libLog.LevelInfo, fmt.Sprintf("Backup queue: cleaning up transaction %s after successful processing", tran.ID))
 

--- a/components/ledger/internal/services/command/create_balance_transaction_operations_async.go
+++ b/components/ledger/internal/services/command/create_balance_transaction_operations_async.go
@@ -317,11 +317,10 @@ func (uc *UseCase) SendTransactionToRedisQueue(ctx context.Context, organization
 	// across every entry point (HTTP, gRPC, DSL).
 	for _, b := range balances {
 		if b != nil && b.Settings != nil && b.Settings.BalanceScope == mmodel.BalanceScopeInternal {
-			err := pkg.ValidateBusinessError(constant.ErrDirectOperationOnInternalBalance, constant.EntityBalance, b.Alias)
 			logger.Log(ctx, libLog.LevelWarn, "Rejected transaction targeting internal balance",
 				libLog.String("event", "rejected_internal_balance_transaction"))
 
-			return err
+			return pkg.ValidateBusinessError(constant.ErrDirectOperationOnInternalBalance, constant.EntityBalance, b.Alias)
 		}
 	}
 

--- a/components/ledger/internal/services/command/create_balance_transaction_operations_async.go
+++ b/components/ledger/internal/services/command/create_balance_transaction_operations_async.go
@@ -318,7 +318,8 @@ func (uc *UseCase) SendTransactionToRedisQueue(ctx context.Context, organization
 	for _, b := range balances {
 		if b != nil && b.Settings != nil && b.Settings.BalanceScope == mmodel.BalanceScopeInternal {
 			err := pkg.ValidateBusinessError(constant.ErrDirectOperationOnInternalBalance, constant.EntityBalance, b.Alias)
-			logger.Log(ctx, libLog.LevelWarn, fmt.Sprintf("Rejected transaction targeting internal balance alias=%s key=%s", b.Alias, b.Key))
+			logger.Log(ctx, libLog.LevelWarn, "Rejected transaction targeting internal balance",
+				libLog.String("event", "rejected_internal_balance_transaction"))
 
 			return err
 		}

--- a/components/ledger/internal/services/command/create_balance_transaction_operations_async.go
+++ b/components/ledger/internal/services/command/create_balance_transaction_operations_async.go
@@ -316,7 +316,7 @@ func (uc *UseCase) SendTransactionToRedisQueue(ctx context.Context, organization
 	// across every entry point (HTTP, gRPC, DSL).
 	for _, b := range balances {
 		if b != nil && b.Settings != nil && b.Settings.BalanceScope == mmodel.BalanceScopeInternal {
-			err := pkg.ValidateBusinessError(constant.ErrDirectOperationOnInternalBalance, reflect.TypeOf(mmodel.Balance{}).Name(), b.Alias)
+			err := pkg.ValidateBusinessError(constant.ErrDirectOperationOnInternalBalance, constant.EntityBalance, b.Alias)
 			logger.Log(ctx, libLog.LevelWarn, fmt.Sprintf("Rejected transaction targeting internal balance alias=%s key=%s", b.Alias, b.Key))
 
 			return err

--- a/components/ledger/internal/services/command/create_balance_transaction_operations_async_test.go
+++ b/components/ledger/internal/services/command/create_balance_transaction_operations_async_test.go
@@ -388,7 +388,11 @@ func TestCreateBalanceTransactionOperationsAsync(t *testing.T) {
 			},
 		}
 
-		// Create operations for the transaction
+		// Create operations for the transaction.
+		// operation1 carries non-zero overdraft snapshot values so that the
+		// msgpack round-trip assertion in the OperationRepo.Create mock is
+		// non-trivial — a regression that drops snapshot during serialization
+		// will fail with a clear message.
 		Amount := decimal.NewFromInt(50)
 		operation1 := &operation.Operation{
 			ID:             uuid.New().String(),
@@ -401,11 +405,17 @@ func TestCreateBalanceTransactionOperationsAsync(t *testing.T) {
 			Amount: operation.Amount{
 				Value: &Amount,
 			},
-			Balance: operation.Balance{ // ensure version before is present
-				Version: Int64Ptr(1),
+			Balance: operation.Balance{
+				Version:       Int64Ptr(1),
+				OverdraftUsed: decimal.Zero,
 			},
-			BalanceAfter: operation.Balance{ // ensure version after is present
-				Version: Int64Ptr(2),
+			BalanceAfter: operation.Balance{
+				Version:       Int64Ptr(2),
+				OverdraftUsed: decimal.NewFromInt(50),
+			},
+			Snapshot: mmodel.OperationSnapshot{
+				OverdraftUsedBefore: "0",
+				OverdraftUsedAfter:  "50",
 			},
 			Metadata: map[string]interface{}{"key1": "value1"},
 		}
@@ -422,11 +432,17 @@ func TestCreateBalanceTransactionOperationsAsync(t *testing.T) {
 			Amount: operation.Amount{
 				Value: &Amount,
 			},
-			Balance: operation.Balance{ // ensure version before is present
-				Version: Int64Ptr(1),
+			Balance: operation.Balance{
+				Version:       Int64Ptr(1),
+				OverdraftUsed: decimal.Zero,
 			},
-			BalanceAfter: operation.Balance{ // ensure version after is present
-				Version: Int64Ptr(2),
+			BalanceAfter: operation.Balance{
+				Version:       Int64Ptr(2),
+				OverdraftUsed: decimal.Zero,
+			},
+			Snapshot: mmodel.OperationSnapshot{
+				OverdraftUsedBefore: "0",
+				OverdraftUsedAfter:  "0",
 			},
 			Metadata: map[string]interface{}{"key2": "value2"},
 		}
@@ -479,22 +495,50 @@ func TestCreateBalanceTransactionOperationsAsync(t *testing.T) {
 			Return(nil).
 			Times(1)
 
-		// Mock OperationRepo.Create for both operations and assert versions exist
+		// Mock OperationRepo.Create for both operations and assert versions exist.
+		// Identity is asserted by ID inside DoAndReturn — direct struct equality
+		// against operation1 / operation2 isn't usable here because the
+		// transaction payload survives a msgpack round-trip via the queue, and
+		// msgpack normalizes the internal big.Int of zero-valued
+		// decimal.Decimal fields (Balance.OverdraftUsed under the always-
+		// populated snapshot contract). The decimals still compare equal
+		// semantically (`decimal.Equal`) but reflect.DeepEqual returns false,
+		// which is the implicit matcher gomock uses when given a concrete
+		// argument. Match by gomock.Any() and assert identity + snapshot
+		// preservation explicitly.
+		expectedOps := map[string]*operation.Operation{
+			operation1.ID: operation1,
+			operation2.ID: operation2,
+		}
 		mockOperationRepo.EXPECT().
-			Create(gomock.Any(), operation1).
+			Create(gomock.Any(), gomock.Any()).
 			DoAndReturn(func(_ context.Context, op *operation.Operation) (*operation.Operation, error) {
-				assert.NotNil(t, op.Balance.Version)
-				assert.NotNil(t, op.BalanceAfter.Version)
-				return op, nil
-			})
+				exp, ok := expectedOps[op.ID]
+				require.True(t, ok, "unexpected operation ID: %s", op.ID)
+				delete(expectedOps, op.ID)
 
-		mockOperationRepo.EXPECT().
-			Create(gomock.Any(), operation2).
-			DoAndReturn(func(_ context.Context, op *operation.Operation) (*operation.Operation, error) {
 				assert.NotNil(t, op.Balance.Version)
 				assert.NotNil(t, op.BalanceAfter.Version)
+
+				// Always-populated snapshot contract: msgpack must preserve snapshot fields.
+				assert.Equal(t, exp.Snapshot.OverdraftUsedBefore, op.Snapshot.OverdraftUsedBefore,
+					"msgpack must preserve Snapshot.OverdraftUsedBefore for op %s", op.ID)
+				assert.Equal(t, exp.Snapshot.OverdraftUsedAfter, op.Snapshot.OverdraftUsedAfter,
+					"msgpack must preserve Snapshot.OverdraftUsedAfter for op %s", op.ID)
+
+				// Decimal-aware equality survives msgpack big.Int normalization
+				// (decimal.Zero{} vs decimal.NewFromInt(0) are .Equal() but not
+				// reflect.DeepEqual).
+				assert.True(t, op.Balance.OverdraftUsed.Equal(exp.Balance.OverdraftUsed),
+					"msgpack must preserve Balance.OverdraftUsed for op %s: got %s want %s",
+					op.ID, op.Balance.OverdraftUsed.String(), exp.Balance.OverdraftUsed.String())
+				assert.True(t, op.BalanceAfter.OverdraftUsed.Equal(exp.BalanceAfter.OverdraftUsed),
+					"msgpack must preserve BalanceAfter.OverdraftUsed for op %s: got %s want %s",
+					op.ID, op.BalanceAfter.OverdraftUsed.String(), exp.BalanceAfter.OverdraftUsed.String())
+
 				return op, nil
-			})
+			}).
+			Times(2)
 
 		// Mock MetadataRepo.Create for operation metadata
 		mockMetadataRepo.EXPECT().

--- a/components/ledger/internal/services/command/create_bulk_transaction_operations_async.go
+++ b/components/ledger/internal/services/command/create_bulk_transaction_operations_async.go
@@ -553,6 +553,7 @@ func (uc *UseCase) processMetadataAndEvents(
 			defer cancel()
 
 			uc.SendTransactionEvents(opCtx, tx)
+			uc.SendOverdraftEvents(opCtx, tx)
 		}()
 	}
 }

--- a/components/ledger/internal/services/command/delete_balance.go
+++ b/components/ledger/internal/services/command/delete_balance.go
@@ -12,6 +12,7 @@ import (
 	libOpentelemetry "github.com/LerianStudio/lib-commons/v4/commons/opentelemetry"
 	"github.com/LerianStudio/midaz/v3/pkg"
 	"github.com/LerianStudio/midaz/v3/pkg/constant"
+	"github.com/LerianStudio/midaz/v3/pkg/mmodel"
 	"github.com/google/uuid"
 
 	// DeleteBalance delete balance in the repository.
@@ -31,6 +32,18 @@ func (uc *UseCase) DeleteBalance(ctx context.Context, organizationID, ledgerID, 
 		libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Failed to get balance on repo by id", err)
 
 		logger.Log(ctx, libLog.LevelError, fmt.Sprintf("Error getting balance: %v", err))
+
+		return err
+	}
+
+	// Scope protection: internal-scope balances are managed exclusively by
+	// the system (e.g. overdraft reserves) and cannot be deleted via the
+	// public API. This guard runs BEFORE the funds-check so the caller
+	// receives the specific 0169 code instead of a generic validation.
+	if balance != nil && balance.Settings != nil && balance.Settings.BalanceScope == mmodel.BalanceScopeInternal {
+		err = pkg.ValidateBusinessError(constant.ErrDeletionOfInternalBalance, "DeleteBalance")
+		libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Internal-scope balance cannot be deleted", err)
+		logger.Log(ctx, libLog.LevelWarn, fmt.Sprintf("Error deleting internal balance: %v", err))
 
 		return err
 	}

--- a/components/ledger/internal/services/command/delete_balance.go
+++ b/components/ledger/internal/services/command/delete_balance.go
@@ -41,15 +41,15 @@ func (uc *UseCase) DeleteBalance(ctx context.Context, organizationID, ledgerID, 
 	// public API. This guard runs BEFORE the funds-check so the caller
 	// receives the specific 0169 code instead of a generic validation.
 	if balance != nil && balance.Settings != nil && balance.Settings.BalanceScope == mmodel.BalanceScopeInternal {
-		err = pkg.ValidateBusinessError(constant.ErrDeletionOfInternalBalance, "DeleteBalance")
+		err = pkg.ValidateBusinessError(constant.ErrDeletionOfInternalBalance, constant.EntityBalance)
 		libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Internal-scope balance cannot be deleted", err)
-		logger.Log(ctx, libLog.LevelWarn, fmt.Sprintf("Error deleting internal balance: %v", err))
+		logger.Log(ctx, libLog.LevelWarn, "Rejected deletion of internal-scope balance", libLog.Err(err))
 
 		return err
 	}
 
 	if balance != nil && (!balance.Available.IsZero() || !balance.OnHold.IsZero()) {
-		err = pkg.ValidateBusinessError(constant.ErrBalancesCantBeDeleted, "DeleteBalance")
+		err = pkg.ValidateBusinessError(constant.ErrBalancesCantBeDeleted, constant.EntityBalance)
 		libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Balance cannot be deleted because it still has funds in it.", err)
 		logger.Log(ctx, libLog.LevelWarn, fmt.Sprintf("Error deleting balance: %v", err))
 

--- a/components/ledger/internal/services/command/process_balance_operations.go
+++ b/components/ledger/internal/services/command/process_balance_operations.go
@@ -6,6 +6,7 @@ package command
 
 import (
 	"context"
+	"fmt"
 
 	libCommons "github.com/LerianStudio/lib-commons/v4/commons"
 	libLog "github.com/LerianStudio/lib-commons/v4/commons/log"
@@ -66,7 +67,13 @@ func (uc *UseCase) ProcessBalanceOperations(ctx context.Context, input ProcessBa
 	// Validate balance rules (eligibility, asset codes, sending/receiving permissions).
 	// Skipped for state transitions where rules were enforced on the original transaction.
 	if !skipBalanceValidation {
-		txBalances := deduplicateBalances(input.BalanceOperations)
+		txBalances, err := deduplicateBalances(input.BalanceOperations)
+		if err != nil {
+			libOpentelemetry.HandleSpanError(span, "Corrupted balance OverdraftLimit", err)
+			logger.Log(ctx, libLog.LevelError, "Corrupted balance OverdraftLimit during deduplication", libLog.Err(err))
+
+			return nil, err
+		}
 
 		if err := mtransaction.ValidateBalancesRules(
 			ctx,
@@ -111,7 +118,11 @@ func (uc *UseCase) ProcessBalanceOperations(ctx context.Context, input ProcessBa
 // len(balances) == len(validate.From) + len(validate.To) relies on this
 // deduplication. This invariant holds because validate.From/To maps use the
 // composite alias as key (one entry per account), not per split operation.
-func deduplicateBalances(operations []mmodel.BalanceOperation) []*mtransaction.Balance {
+//
+// Returns an error when any balance has a corrupted OverdraftLimit string,
+// so the caller can fail the transaction rather than silently treat the
+// limit as zero — see Balance.ToTransactionBalance.
+func deduplicateBalances(operations []mmodel.BalanceOperation) ([]*mtransaction.Balance, error) {
 	seen := make(map[string]bool, len(operations))
 	balances := make([]*mtransaction.Balance, 0, len(operations))
 
@@ -122,8 +133,13 @@ func deduplicateBalances(operations []mmodel.BalanceOperation) []*mtransaction.B
 
 		seen[bo.Alias] = true
 
-		balances = append(balances, bo.Balance.ToTransactionBalance())
+		txBal, err := bo.Balance.ToTransactionBalance()
+		if err != nil {
+			return nil, fmt.Errorf("corrupted balance %s: %w", bo.Balance.ID, err)
+		}
+
+		balances = append(balances, txBal)
 	}
 
-	return balances
+	return balances, nil
 }

--- a/components/ledger/internal/services/command/scope_protection_test.go
+++ b/components/ledger/internal/services/command/scope_protection_test.go
@@ -115,7 +115,7 @@ func TestTransactionCreate_RejectsInternalBalance(t *testing.T) {
 
 // TestBalanceUpdate_RejectsInternalBalance_WithSettings verifies that a PATCH
 // request carrying a Settings payload against an internal-scope balance is
-// rejected with ErrUpdateOfInternalBalance (0176) BEFORE any Settings
+// rejected with ErrUpdateOfInternalBalance (0175) BEFORE any Settings
 // validation, overdraft transition enforcement, or repo Update runs.
 func TestBalanceUpdate_RejectsInternalBalance_WithSettings(t *testing.T) {
 	t.Parallel()
@@ -176,7 +176,7 @@ func TestBalanceUpdate_RejectsInternalBalance_WithSettings(t *testing.T) {
 	require.True(t, errors.As(err, &vErr),
 		"scope protection MUST surface an UnprocessableOperationError")
 	assert.Equal(t, constant.ErrUpdateOfInternalBalance.Error(), vErr.Code,
-		"error code MUST be 0176 (ErrUpdateOfInternalBalance)")
+		"error code MUST be 0175 (ErrUpdateOfInternalBalance)")
 }
 
 // TestBalanceUpdate_RejectsInternalBalance_WithoutSettings verifies that the
@@ -241,7 +241,7 @@ func TestBalanceUpdate_RejectsInternalBalance_WithoutSettings(t *testing.T) {
 	require.True(t, errors.As(err, &vErr),
 		"scope protection MUST surface an UnprocessableOperationError")
 	assert.Equal(t, constant.ErrUpdateOfInternalBalance.Error(), vErr.Code,
-		"error code MUST be 0176 (ErrUpdateOfInternalBalance)")
+		"error code MUST be 0175 (ErrUpdateOfInternalBalance)")
 }
 
 // TestBalanceUpdate_AllowsNormalBalance verifies that the scope guard does
@@ -304,7 +304,7 @@ func TestBalanceUpdate_AllowsNormalBalance(t *testing.T) {
 
 // TestBalanceUpdate_FindError_Returns404NotScopeError verifies that when
 // Find fails (e.g. balance not found), the error is surfaced as-is —
-// NOT as a 0176 scope error. This proves guard ordering: Find before guard.
+// NOT as a 0175 scope error. This proves guard ordering: Find before guard.
 func TestBalanceUpdate_FindError_Returns404NotScopeError(t *testing.T) {
 	t.Parallel()
 

--- a/components/ledger/internal/services/command/scope_protection_test.go
+++ b/components/ledger/internal/services/command/scope_protection_test.go
@@ -113,6 +113,242 @@ func TestTransactionCreate_RejectsInternalBalance(t *testing.T) {
 		"error code MUST be 0168 (ErrDirectOperationOnInternalBalance)")
 }
 
+// TestBalanceUpdate_RejectsInternalBalance_WithSettings verifies that a PATCH
+// request carrying a Settings payload against an internal-scope balance is
+// rejected with ErrUpdateOfInternalBalance (0176) BEFORE any Settings
+// validation, overdraft transition enforcement, or repo Update runs.
+func TestBalanceUpdate_RejectsInternalBalance_WithSettings(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
+	orgID := uuid.Must(libCommons.GenerateUUIDv7())
+	ledgerID := uuid.Must(libCommons.GenerateUUIDv7())
+	balanceID := uuid.Must(libCommons.GenerateUUIDv7())
+
+	internalBalance := &mmodel.Balance{
+		ID:             balanceID.String(),
+		OrganizationID: orgID.String(),
+		LedgerID:       ledgerID.String(),
+		AccountID:      uuid.New().String(),
+		Alias:          "@indebted",
+		Key:            "overdraft",
+		Available:      decimal.Zero,
+		OnHold:         decimal.Zero,
+		Direction:      constant.DirectionDebit,
+		Settings: &mmodel.BalanceSettings{
+			BalanceScope: mmodel.BalanceScopeInternal,
+		},
+	}
+
+	mockBalanceRepo := balance.NewMockRepository(ctrl)
+	mockRedisRepo := redis.NewMockRedisRepository(ctrl)
+
+	mockBalanceRepo.EXPECT().
+		Find(gomock.Any(), orgID, ledgerID, balanceID).
+		Return(internalBalance, nil).
+		Times(1)
+
+	// Update MUST NOT be invoked for internal-scope balances.
+	mockBalanceRepo.EXPECT().
+		Update(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Times(0)
+
+	uc := UseCase{
+		BalanceRepo:          mockBalanceRepo,
+		TransactionRedisRepo: mockRedisRepo,
+	}
+
+	allowOverdraft := true
+	update := mmodel.UpdateBalance{
+		Settings: &mmodel.BalanceSettings{
+			AllowOverdraft: allowOverdraft,
+		},
+	}
+
+	result, err := uc.Update(context.TODO(), orgID, ledgerID, balanceID, update)
+
+	require.Nil(t, result)
+	require.Error(t, err, "updating an internal-scope balance MUST be rejected")
+
+	var vErr pkg.UnprocessableOperationError
+	require.True(t, errors.As(err, &vErr),
+		"scope protection MUST surface an UnprocessableOperationError")
+	assert.Equal(t, constant.ErrUpdateOfInternalBalance.Error(), vErr.Code,
+		"error code MUST be 0176 (ErrUpdateOfInternalBalance)")
+}
+
+// TestBalanceUpdate_RejectsInternalBalance_WithoutSettings verifies that the
+// scope guard fires even when the PATCH payload carries ONLY AllowSending
+// (no Settings block). This closes the bypass where the prior implementation
+// only loaded the balance when update.Settings was non-nil.
+func TestBalanceUpdate_RejectsInternalBalance_WithoutSettings(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
+	orgID := uuid.Must(libCommons.GenerateUUIDv7())
+	ledgerID := uuid.Must(libCommons.GenerateUUIDv7())
+	balanceID := uuid.Must(libCommons.GenerateUUIDv7())
+
+	internalBalance := &mmodel.Balance{
+		ID:             balanceID.String(),
+		OrganizationID: orgID.String(),
+		LedgerID:       ledgerID.String(),
+		AccountID:      uuid.New().String(),
+		Alias:          "@indebted",
+		Key:            "overdraft",
+		Available:      decimal.Zero,
+		OnHold:         decimal.Zero,
+		Direction:      constant.DirectionDebit,
+		Settings: &mmodel.BalanceSettings{
+			BalanceScope: mmodel.BalanceScopeInternal,
+		},
+	}
+
+	mockBalanceRepo := balance.NewMockRepository(ctrl)
+	mockRedisRepo := redis.NewMockRedisRepository(ctrl)
+
+	mockBalanceRepo.EXPECT().
+		Find(gomock.Any(), orgID, ledgerID, balanceID).
+		Return(internalBalance, nil).
+		Times(1)
+
+	// Update MUST NOT be invoked.
+	mockBalanceRepo.EXPECT().
+		Update(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Times(0)
+
+	uc := UseCase{
+		BalanceRepo:          mockBalanceRepo,
+		TransactionRedisRepo: mockRedisRepo,
+	}
+
+	allowSending := false
+	update := mmodel.UpdateBalance{
+		AllowSending: &allowSending,
+		// Settings is intentionally nil — this is the bypass scenario.
+	}
+
+	result, err := uc.Update(context.TODO(), orgID, ledgerID, balanceID, update)
+
+	require.Nil(t, result)
+	require.Error(t, err, "updating an internal-scope balance MUST be rejected even without Settings")
+
+	var vErr pkg.UnprocessableOperationError
+	require.True(t, errors.As(err, &vErr),
+		"scope protection MUST surface an UnprocessableOperationError")
+	assert.Equal(t, constant.ErrUpdateOfInternalBalance.Error(), vErr.Code,
+		"error code MUST be 0176 (ErrUpdateOfInternalBalance)")
+}
+
+// TestBalanceUpdate_AllowsNormalBalance verifies that the scope guard does
+// NOT block updates on normal (non-internal) balances.
+func TestBalanceUpdate_AllowsNormalBalance(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
+	orgID := uuid.Must(libCommons.GenerateUUIDv7())
+	ledgerID := uuid.Must(libCommons.GenerateUUIDv7())
+	balanceID := uuid.Must(libCommons.GenerateUUIDv7())
+
+	normalBalance := &mmodel.Balance{
+		ID:             balanceID.String(),
+		OrganizationID: orgID.String(),
+		LedgerID:       ledgerID.String(),
+		Alias:          "@normal",
+		Key:            "default",
+		Available:      decimal.NewFromInt(100),
+		OnHold:         decimal.Zero,
+		AllowSending:   true,
+		AllowReceiving: true,
+	}
+
+	mockBalanceRepo := balance.NewMockRepository(ctrl)
+	mockRedisRepo := redis.NewMockRedisRepository(ctrl)
+
+	mockBalanceRepo.EXPECT().
+		Find(gomock.Any(), orgID, ledgerID, balanceID).
+		Return(normalBalance, nil).
+		Times(1)
+
+	mockBalanceRepo.EXPECT().
+		Update(gomock.Any(), orgID, ledgerID, balanceID, gomock.Any()).
+		Return(normalBalance, nil).
+		Times(1)
+
+	mockRedisRepo.EXPECT().
+		Get(gomock.Any(), gomock.Any()).
+		Return("", nil).
+		Times(1)
+
+	uc := UseCase{
+		BalanceRepo:          mockBalanceRepo,
+		TransactionRedisRepo: mockRedisRepo,
+	}
+
+	allowSending := false
+	update := mmodel.UpdateBalance{
+		AllowSending: &allowSending,
+	}
+
+	result, err := uc.Update(context.TODO(), orgID, ledgerID, balanceID, update)
+
+	require.NoError(t, err, "updating a normal balance MUST succeed")
+	require.NotNil(t, result)
+}
+
+// TestBalanceUpdate_FindError_Returns404NotScopeError verifies that when
+// Find fails (e.g. balance not found), the error is surfaced as-is —
+// NOT as a 0176 scope error. This proves guard ordering: Find before guard.
+func TestBalanceUpdate_FindError_Returns404NotScopeError(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
+	orgID := uuid.Must(libCommons.GenerateUUIDv7())
+	ledgerID := uuid.Must(libCommons.GenerateUUIDv7())
+	balanceID := uuid.Must(libCommons.GenerateUUIDv7())
+
+	mockBalanceRepo := balance.NewMockRepository(ctrl)
+
+	mockBalanceRepo.EXPECT().
+		Find(gomock.Any(), orgID, ledgerID, balanceID).
+		Return(nil, errors.New("errDatabaseItemNotFound")).
+		Times(1)
+
+	// Update MUST NOT be invoked when Find fails.
+	mockBalanceRepo.EXPECT().
+		Update(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Times(0)
+
+	uc := UseCase{
+		BalanceRepo: mockBalanceRepo,
+	}
+
+	allowSending := false
+	update := mmodel.UpdateBalance{
+		AllowSending: &allowSending,
+	}
+
+	result, err := uc.Update(context.TODO(), orgID, ledgerID, balanceID, update)
+
+	require.Nil(t, result)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "errDatabaseItemNotFound",
+		"Find error MUST surface directly, not as a scope-protection error")
+
+	// Must NOT be a scope error.
+	var vErr pkg.UnprocessableOperationError
+	assert.False(t, errors.As(err, &vErr),
+		"Find failure MUST NOT be wrapped as an UnprocessableOperationError")
+}
+
 // TestBalanceDelete_RejectsInternalBalance verifies that attempting to delete
 // a balance whose scope is "internal" is rejected with
 // ErrDeletionOfInternalBalance (0169) BEFORE the repository Delete is called.

--- a/components/ledger/internal/services/command/scope_protection_test.go
+++ b/components/ledger/internal/services/command/scope_protection_test.go
@@ -1,0 +1,169 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package command
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	libCommons "github.com/LerianStudio/lib-commons/v4/commons"
+	"github.com/LerianStudio/midaz/v3/components/ledger/internal/adapters/postgres/balance"
+	redis "github.com/LerianStudio/midaz/v3/components/ledger/internal/adapters/redis/transaction"
+	"github.com/LerianStudio/midaz/v3/pkg"
+	"github.com/LerianStudio/midaz/v3/pkg/constant"
+	"github.com/LerianStudio/midaz/v3/pkg/mmodel"
+	"github.com/LerianStudio/midaz/v3/pkg/mtransaction"
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+// TestTransactionCreate_RejectsInternalBalance verifies that a transaction
+// which targets a balance whose scope is "internal" is rejected with
+// ErrDirectOperationOnInternalBalance (0168) BEFORE it is published to the
+// Redis transaction queue.
+//
+// The scope guard protects system-managed balances (e.g. overdraft reserves)
+// from client-initiated operations. Enforcement lives in the transaction
+// command use case so that every entry point — HTTP, gRPC, DSL — benefits
+// from the same guarantee.
+func TestTransactionCreate_RejectsInternalBalance(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
+	orgID := uuid.Must(libCommons.GenerateUUIDv7())
+	ledgerID := uuid.Must(libCommons.GenerateUUIDv7())
+	transactionID := uuid.Must(libCommons.GenerateUUIDv7())
+
+	internalBalance := &mmodel.Balance{
+		ID:             uuid.New().String(),
+		OrganizationID: orgID.String(),
+		LedgerID:       ledgerID.String(),
+		AccountID:      uuid.New().String(),
+		Alias:          "@indebted",
+		Key:            "overdraft",
+		AssetCode:      "USD",
+		Direction:      constant.DirectionDebit,
+		Available:      decimal.NewFromInt(0),
+		OnHold:         decimal.NewFromInt(0),
+		Version:        1,
+		Settings: &mmodel.BalanceSettings{
+			BalanceScope: mmodel.BalanceScopeInternal,
+		},
+	}
+
+	mockBalanceRepo := balance.NewMockRepository(ctrl)
+	mockRedisRepo := redis.NewMockRedisRepository(ctrl)
+
+	// The scope guard MUST run BEFORE any Redis queue publishing.
+	mockRedisRepo.EXPECT().
+		AddMessageToQueue(gomock.Any(), gomock.Any(), gomock.Any()).
+		Times(0)
+
+	uc := UseCase{
+		BalanceRepo:          mockBalanceRepo,
+		TransactionRedisRepo: mockRedisRepo,
+	}
+
+	// Transaction targeting the overdraft (internal) balance.
+	validate := &mtransaction.Responses{
+		From: map[string]mtransaction.Amount{
+			"@indebted#overdraft": {
+				Value:           decimal.NewFromInt(100),
+				Operation:       "DEBIT",
+				TransactionType: "CREATED",
+			},
+		},
+	}
+
+	input := mtransaction.Transaction{
+		ChartOfAccountsGroupName: "test",
+	}
+
+	// When the resolved balance slice contains an internal-scope balance,
+	// the use case MUST refuse to enqueue the transaction and surface the
+	// 0168 error.
+	err := uc.SendTransactionToRedisQueue(
+		context.TODO(),
+		orgID,
+		ledgerID,
+		transactionID,
+		input,
+		validate,
+		constant.CREATED,
+		"CREATED",
+		time.Now(),
+		[]*mmodel.Balance{internalBalance},
+	)
+
+	require.Error(t, err, "transactions against an internal balance MUST be rejected")
+
+	var vErr pkg.UnprocessableOperationError
+	require.True(t, errors.As(err, &vErr),
+		"scope protection MUST surface an UnprocessableOperationError")
+	assert.Equal(t, constant.ErrDirectOperationOnInternalBalance.Error(), vErr.Code,
+		"error code MUST be 0168 (ErrDirectOperationOnInternalBalance)")
+}
+
+// TestBalanceDelete_RejectsInternalBalance verifies that attempting to delete
+// a balance whose scope is "internal" is rejected with
+// ErrDeletionOfInternalBalance (0169) BEFORE the repository Delete is called.
+func TestBalanceDelete_RejectsInternalBalance(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
+	orgID := uuid.Must(libCommons.GenerateUUIDv7())
+	ledgerID := uuid.Must(libCommons.GenerateUUIDv7())
+	balanceID := uuid.Must(libCommons.GenerateUUIDv7())
+
+	internalBalance := &mmodel.Balance{
+		ID:             balanceID.String(),
+		OrganizationID: orgID.String(),
+		LedgerID:       ledgerID.String(),
+		AccountID:      uuid.New().String(),
+		Alias:          "@indebted",
+		Key:            "overdraft",
+		Available:      decimal.Zero,
+		OnHold:         decimal.Zero,
+		Direction:      constant.DirectionDebit,
+		Settings: &mmodel.BalanceSettings{
+			BalanceScope: mmodel.BalanceScopeInternal,
+		},
+	}
+
+	mockBalanceRepo := balance.NewMockRepository(ctrl)
+
+	mockBalanceRepo.EXPECT().
+		Find(gomock.Any(), orgID, ledgerID, balanceID).
+		Return(internalBalance, nil).
+		Times(1)
+
+	// Delete MUST NOT be invoked for internal-scope balances.
+	mockBalanceRepo.EXPECT().
+		Delete(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Times(0)
+
+	uc := UseCase{
+		BalanceRepo: mockBalanceRepo,
+	}
+
+	err := uc.DeleteBalance(context.TODO(), orgID, ledgerID, balanceID)
+
+	require.Error(t, err, "deleting an internal-scope balance MUST be rejected")
+
+	var vErr pkg.UnprocessableOperationError
+	require.True(t, errors.As(err, &vErr),
+		"scope protection MUST surface an UnprocessableOperationError")
+	assert.Equal(t, constant.ErrDeletionOfInternalBalance.Error(), vErr.Code,
+		"error code MUST be 0169 (ErrDeletionOfInternalBalance)")
+}

--- a/components/ledger/internal/services/command/send_overdraft_events.go
+++ b/components/ledger/internal/services/command/send_overdraft_events.go
@@ -1,0 +1,263 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package command
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"strings"
+	"time"
+
+	libCommons "github.com/LerianStudio/lib-commons/v4/commons"
+	libLog "github.com/LerianStudio/lib-commons/v4/commons/log"
+	libOpentelemetry "github.com/LerianStudio/lib-commons/v4/commons/opentelemetry"
+	"github.com/LerianStudio/midaz/v3/components/ledger/internal/adapters/postgres/operation"
+	"github.com/LerianStudio/midaz/v3/components/ledger/internal/adapters/postgres/transaction"
+	"github.com/LerianStudio/midaz/v3/pkg/constant"
+	"github.com/LerianStudio/midaz/v3/pkg/mmodel"
+	"github.com/shopspring/decimal"
+)
+
+// Overdraft event constants used in the Event envelope and routing key.
+const (
+	OverdraftEventType = "balance"
+
+	// OverdraftActionDrawn is emitted when overdraft is consumed during a
+	// debit that exceeds the credit balance's available funds.
+	OverdraftActionDrawn = "overdraft.drawn"
+
+	// OverdraftActionRepaid is emitted when an incoming credit repays
+	// (partially or fully) the outstanding overdraft.
+	OverdraftActionRepaid = "overdraft.repaid"
+
+	// OverdraftActionCleared is emitted when overdraft usage reaches zero
+	// after a repayment — the balance is no longer in an overdrafted state.
+	OverdraftActionCleared = "overdraft.cleared"
+)
+
+// OverdraftEventPayload carries the business fields for an overdraft
+// lifecycle event. It is marshalled as the Payload field inside mmodel.Event.
+type OverdraftEventPayload struct {
+	// AccountID is the account that holds the overdrafted balance.
+	AccountID string `json:"accountId"`
+
+	// TransactionID is the transaction that triggered the overdraft change.
+	TransactionID string `json:"transactionId"`
+
+	// Amount is the overdraft movement in this event:
+	//   - For drawn: the deficit added to overdraft usage.
+	//   - For repaid/cleared: the amount repaid.
+	Amount decimal.Decimal `json:"amount"`
+
+	// OverdraftBalance is the companion overdraft balance's Available value
+	// AFTER the transaction. Equals the total outstanding overdraft.
+	OverdraftBalance decimal.Decimal `json:"overdraftBalance"`
+
+	// OverdraftLimit is the configured overdraft limit for the account.
+	// nil means the limit is not available in the current event context.
+	// Consumers should treat nil as "unknown" — not as "unlimited".
+	// This field will be populated once T-010 (Operation record overdraftUsed
+	// extension) lands, making overdraft state visible on every operation.
+	OverdraftLimit *decimal.Decimal `json:"overdraftLimit,omitempty"`
+
+	// Timestamp is the time the event was generated.
+	Timestamp time.Time `json:"timestamp"`
+}
+
+// SendOverdraftEvents inspects a persisted transaction's operations for
+// overdraft companion operations (BalanceKey == "overdraft") and emits the
+// appropriate lifecycle events via the message broker.
+//
+// Three event actions are supported:
+//   - overdraft.drawn:   a DEBIT on a direction=debit companion balance
+//     (overdraft usage increased).
+//   - overdraft.repaid:  a CREDIT on a direction=debit companion balance
+//     (overdraft usage decreased but not fully cleared).
+//   - overdraft.cleared: a CREDIT on a direction=debit companion balance
+//     where the balance reaches zero (overdraft fully repaid).
+//
+// The function is non-blocking and fire-and-forget: emission failures are
+// logged but never propagate to the caller. This mirrors the contract of
+// SendTransactionEvents.
+func (uc *UseCase) SendOverdraftEvents(ctx context.Context, tran *transaction.Transaction) {
+	logger, tracer, _, _ := libCommons.NewTrackingFromContext(ctx)
+
+	if !isOverdraftEventEnabled() {
+		logger.Log(ctx, libLog.LevelInfo, "Overdraft events not enabled",
+			libLog.String("RABBITMQ_OVERDRAFT_EVENTS_ENABLED", os.Getenv("RABBITMQ_OVERDRAFT_EVENTS_ENABLED")))
+		return
+	}
+
+	payloads := buildOverdraftEvents(tran)
+	if len(payloads) == 0 {
+		return
+	}
+
+	ctxSend, span := tracer.Start(ctx, "command.send_overdraft_events_async")
+	defer span.End()
+
+	exchange := os.Getenv("RABBITMQ_OVERDRAFT_EVENTS_EXCHANGE")
+
+	for _, ep := range payloads {
+		raw, err := json.Marshal(ep.payload)
+		if err != nil {
+			libOpentelemetry.HandleSpanError(span, "Failed to marshal overdraft event payload", err)
+			logger.Log(ctx, libLog.LevelError, "Failed to marshal overdraft event payload",
+				libLog.String("action", ep.action))
+
+			continue
+		}
+
+		evt := mmodel.Event{
+			Source:         Source,
+			EventType:      OverdraftEventType,
+			Action:         ep.action,
+			TimeStamp:      time.Now(),
+			Version:        os.Getenv("VERSION"),
+			OrganizationID: tran.OrganizationID,
+			LedgerID:       tran.LedgerID,
+			Payload:        raw,
+		}
+
+		message, err := json.Marshal(evt)
+		if err != nil {
+			libOpentelemetry.HandleSpanError(span, "Failed to marshal overdraft event envelope", err)
+			logger.Log(ctx, libLog.LevelError, "Failed to marshal overdraft event envelope",
+				libLog.String("action", ep.action))
+
+			continue
+		}
+
+		var key strings.Builder
+
+		key.WriteString(Source)
+		key.WriteString(".")
+		key.WriteString(OverdraftEventType)
+		key.WriteString(".")
+		key.WriteString(ep.action)
+
+		logger.Log(ctx, libLog.LevelInfo, "Sending overdraft event",
+			libLog.String("key", key.String()),
+			libLog.String("action", ep.action))
+
+		if _, err := uc.RabbitMQRepo.ProducerDefault(
+			ctxSend,
+			exchange,
+			key.String(),
+			message,
+		); err != nil {
+			libOpentelemetry.HandleSpanError(span, "Failed to send overdraft event to exchange", err)
+			logger.Log(ctx, libLog.LevelError, "Failed to send overdraft event",
+				libLog.String("action", ep.action),
+				libLog.Err(err))
+		}
+	}
+}
+
+// overdraftEventItem pairs a classified action with its pre-marshal payload.
+// This is an internal type used between buildOverdraftEvents and SendOverdraftEvents
+// so that marshal errors are handled where logger and span are available.
+type overdraftEventItem struct {
+	action  string
+	payload OverdraftEventPayload
+}
+
+// buildOverdraftEvents scans tran.Operations for overdraft companion
+// operations and returns the corresponding event items (pre-marshal structs).
+// The caller (SendOverdraftEvents) handles JSON marshalling where it has
+// access to logger and span for proper error reporting.
+func buildOverdraftEvents(tran *transaction.Transaction) []overdraftEventItem {
+	if tran == nil || len(tran.Operations) == 0 {
+		return nil
+	}
+
+	var items []overdraftEventItem
+
+	for _, op := range tran.Operations {
+		if op == nil || op.BalanceKey != constant.OverdraftBalanceKey {
+			continue
+		}
+
+		action, amount, afterAvail := classifyOverdraftOperation(op)
+		if action == "" {
+			continue
+		}
+
+		items = append(items, overdraftEventItem{
+			action: action,
+			payload: OverdraftEventPayload{
+				AccountID:        op.AccountID,
+				TransactionID:    tran.ID,
+				Amount:           amount,
+				OverdraftBalance: afterAvail,
+				Timestamp:        time.Now(),
+			},
+		})
+	}
+
+	return items
+}
+
+// classifyOverdraftOperation determines the event action for a companion
+// overdraft operation and returns the absolute movement amount together with
+// the balance-after-available value.
+//
+// For a direction=debit companion balance:
+//   - DEBIT increases Available (overdraft drawn)
+//   - CREDIT decreases Available (overdraft repaid or cleared)
+//
+// The "cleared" action is emitted instead of "repaid" when the companion
+// balance reaches zero after the credit.
+//
+// The third return value (afterAvail) is the companion balance's Available
+// after the operation, eliminating redundant calls to overdraftBalanceAfter.
+func classifyOverdraftOperation(op *operation.Operation) (action string, amount decimal.Decimal, afterAvail decimal.Decimal) {
+	if op.Amount.Value == nil {
+		return "", decimal.Zero, decimal.Zero
+	}
+
+	amt := *op.Amount.Value
+	if amt.IsZero() {
+		return "", decimal.Zero, decimal.Zero
+	}
+
+	after := overdraftBalanceAfter(op)
+
+	switch strings.ToUpper(op.Type) {
+	case "DEBIT":
+		return OverdraftActionDrawn, amt, after
+
+	case "CREDIT":
+		if after.IsZero() {
+			return OverdraftActionCleared, amt, after
+		}
+
+		return OverdraftActionRepaid, amt, after
+
+	default:
+		return "", decimal.Zero, decimal.Zero
+	}
+}
+
+// overdraftBalanceAfter returns the companion overdraft balance's Available
+// value after the operation. Falls back to zero if the balance snapshot is
+// absent.
+func overdraftBalanceAfter(op *operation.Operation) decimal.Decimal {
+	if op.BalanceAfter.Available != nil {
+		return *op.BalanceAfter.Available
+	}
+
+	return decimal.Zero
+}
+
+// isOverdraftEventEnabled returns true unless the environment variable
+// RABBITMQ_OVERDRAFT_EVENTS_ENABLED is explicitly set to "false".
+// Unset or any other value means enabled — consistent with the transaction
+// event flag pattern.
+func isOverdraftEventEnabled() bool {
+	envValue := strings.ToLower(strings.TrimSpace(os.Getenv("RABBITMQ_OVERDRAFT_EVENTS_ENABLED")))
+	return envValue != "false"
+}

--- a/components/ledger/internal/services/command/send_overdraft_events.go
+++ b/components/ledger/internal/services/command/send_overdraft_events.go
@@ -206,9 +206,10 @@ func buildOverdraftEvents(tran *transaction.Transaction) []overdraftEventItem {
 // overdraft operation and returns the absolute movement amount together with
 // the balance-after-available value.
 //
-// For a direction=debit companion balance:
-//   - DEBIT increases Available (overdraft drawn)
-//   - CREDIT decreases Available (overdraft repaid or cleared)
+// For a direction=debit companion balance, public operation type is always
+// "overdraft". The Direction field carries the semantic movement:
+//   - direction=debit increases Available (overdraft drawn)
+//   - direction=credit decreases Available (overdraft repaid or cleared)
 //
 // The "cleared" action is emitted instead of "repaid" when the companion
 // balance reaches zero after the credit.
@@ -227,11 +228,11 @@ func classifyOverdraftOperation(op *operation.Operation) (action string, amount 
 
 	after := overdraftBalanceAfter(op)
 
-	switch strings.ToUpper(op.Type) {
-	case "DEBIT":
+	switch op.Direction {
+	case constant.DirectionDebit:
 		return OverdraftActionDrawn, amt, after
 
-	case "CREDIT":
+	case constant.DirectionCredit:
 		if after.IsZero() {
 			return OverdraftActionCleared, amt, after
 		}

--- a/components/ledger/internal/services/command/send_overdraft_events.go
+++ b/components/ledger/internal/services/command/send_overdraft_events.go
@@ -88,6 +88,7 @@ func (uc *UseCase) SendOverdraftEvents(ctx context.Context, tran *transaction.Tr
 	if !isOverdraftEventEnabled() {
 		logger.Log(ctx, libLog.LevelInfo, "Overdraft events not enabled",
 			libLog.String("RABBITMQ_OVERDRAFT_EVENTS_ENABLED", os.Getenv("RABBITMQ_OVERDRAFT_EVENTS_ENABLED")))
+
 		return
 	}
 

--- a/components/ledger/internal/services/command/send_overdraft_events_test.go
+++ b/components/ledger/internal/services/command/send_overdraft_events_test.go
@@ -1,0 +1,537 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package command
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"testing"
+	"time"
+
+	libCommons "github.com/LerianStudio/lib-commons/v4/commons"
+	"github.com/LerianStudio/midaz/v3/components/ledger/internal/adapters/postgres/operation"
+	"github.com/LerianStudio/midaz/v3/components/ledger/internal/adapters/postgres/transaction"
+	"github.com/LerianStudio/midaz/v3/components/ledger/internal/adapters/rabbitmq"
+	"github.com/LerianStudio/midaz/v3/pkg/constant"
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+// newTestTransaction creates a transaction with the given operations for testing.
+func newTestTransaction(ops []*operation.Operation) *transaction.Transaction {
+	amount := decimal.NewFromInt(100)
+	desc := "APPROVED"
+
+	return &transaction.Transaction{
+		ID:             uuid.Must(libCommons.GenerateUUIDv7()).String(),
+		OrganizationID: uuid.Must(libCommons.GenerateUUIDv7()).String(),
+		LedgerID:       uuid.Must(libCommons.GenerateUUIDv7()).String(),
+		Description:    "Test transaction",
+		Status: transaction.Status{
+			Code:        desc,
+			Description: &desc,
+		},
+		Amount:    &amount,
+		AssetCode: "BRL",
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+		Operations: ops,
+	}
+}
+
+// newOverdraftOp creates an operation on the overdraft companion balance.
+func newOverdraftOp(accountID, opType string, amount decimal.Decimal, afterAvailable decimal.Decimal) *operation.Operation {
+	return &operation.Operation{
+		ID:            uuid.Must(libCommons.GenerateUUIDv7()).String(),
+		TransactionID: uuid.Must(libCommons.GenerateUUIDv7()).String(),
+		Type:          opType,
+		AssetCode:     "BRL",
+		AccountID:     accountID,
+		BalanceKey:    constant.OverdraftBalanceKey,
+		Direction:     "debit",
+		Amount:        operation.Amount{Value: &amount},
+		BalanceAfter:  operation.Balance{Available: &afterAvailable},
+	}
+}
+
+// newDefaultOp creates an operation on the default balance.
+func newDefaultOp(accountID, opType string, amount decimal.Decimal, afterAvailable decimal.Decimal) *operation.Operation {
+	return &operation.Operation{
+		ID:            uuid.Must(libCommons.GenerateUUIDv7()).String(),
+		TransactionID: uuid.Must(libCommons.GenerateUUIDv7()).String(),
+		Type:          opType,
+		AssetCode:     "BRL",
+		AccountID:     accountID,
+		BalanceKey:    constant.DefaultBalanceKey,
+		Direction:     "credit",
+		Amount:        operation.Amount{Value: &amount},
+		BalanceAfter:  operation.Balance{Available: &afterAvailable},
+	}
+}
+
+func TestBuildOverdraftEvents(t *testing.T) {
+	accountID := uuid.Must(libCommons.GenerateUUIDv7()).String()
+
+	t.Run("nil transaction returns nil", func(t *testing.T) {
+		items := buildOverdraftEvents(nil)
+		assert.Nil(t, items)
+	})
+
+	t.Run("transaction with no operations returns nil", func(t *testing.T) {
+		tran := newTestTransaction(nil)
+		items := buildOverdraftEvents(tran)
+		assert.Nil(t, items)
+	})
+
+	t.Run("transaction with only default operations returns nil", func(t *testing.T) {
+		amt := decimal.NewFromInt(100)
+		after := decimal.NewFromInt(200)
+		tran := newTestTransaction([]*operation.Operation{
+			newDefaultOp(accountID, "CREDIT", amt, after),
+		})
+		items := buildOverdraftEvents(tran)
+		assert.Nil(t, items)
+	})
+
+	t.Run("overdraft drawn event on DEBIT companion op", func(t *testing.T) {
+		amt := decimal.NewFromInt(50)
+		afterAvail := decimal.NewFromInt(50)
+		tran := newTestTransaction([]*operation.Operation{
+			newOverdraftOp(accountID, "DEBIT", amt, afterAvail),
+		})
+
+		items := buildOverdraftEvents(tran)
+		require.Len(t, items, 1)
+		assert.Equal(t, OverdraftActionDrawn, items[0].action)
+		assert.Equal(t, accountID, items[0].payload.AccountID)
+		assert.Equal(t, tran.ID, items[0].payload.TransactionID)
+		assert.True(t, amt.Equal(items[0].payload.Amount))
+		assert.True(t, afterAvail.Equal(items[0].payload.OverdraftBalance))
+		assert.Nil(t, items[0].payload.OverdraftLimit, "OverdraftLimit should be nil until T-010")
+	})
+
+	t.Run("overdraft repaid event on CREDIT companion op with remaining balance", func(t *testing.T) {
+		amt := decimal.NewFromInt(30)
+		afterAvail := decimal.NewFromInt(20) // still has 20 outstanding
+		tran := newTestTransaction([]*operation.Operation{
+			newOverdraftOp(accountID, "CREDIT", amt, afterAvail),
+		})
+
+		items := buildOverdraftEvents(tran)
+		require.Len(t, items, 1)
+		assert.Equal(t, OverdraftActionRepaid, items[0].action)
+		assert.True(t, amt.Equal(items[0].payload.Amount))
+		assert.True(t, afterAvail.Equal(items[0].payload.OverdraftBalance))
+	})
+
+	t.Run("overdraft cleared event on CREDIT companion op reaching zero", func(t *testing.T) {
+		amt := decimal.NewFromInt(50)
+		afterAvail := decimal.Zero // fully repaid
+		tran := newTestTransaction([]*operation.Operation{
+			newOverdraftOp(accountID, "CREDIT", amt, afterAvail),
+		})
+
+		items := buildOverdraftEvents(tran)
+		require.Len(t, items, 1)
+		assert.Equal(t, OverdraftActionCleared, items[0].action)
+		assert.True(t, amt.Equal(items[0].payload.Amount))
+		assert.True(t, decimal.Zero.Equal(items[0].payload.OverdraftBalance))
+	})
+
+	t.Run("zero amount overdraft op is skipped", func(t *testing.T) {
+		amt := decimal.Zero
+		afterAvail := decimal.NewFromInt(50)
+		tran := newTestTransaction([]*operation.Operation{
+			newOverdraftOp(accountID, "DEBIT", amt, afterAvail),
+		})
+
+		items := buildOverdraftEvents(tran)
+		assert.Nil(t, items)
+	})
+
+	t.Run("nil amount value is skipped", func(t *testing.T) {
+		op := newOverdraftOp(accountID, "DEBIT", decimal.NewFromInt(50), decimal.NewFromInt(50))
+		op.Amount.Value = nil
+
+		tran := newTestTransaction([]*operation.Operation{op})
+		items := buildOverdraftEvents(tran)
+		assert.Nil(t, items)
+	})
+
+	t.Run("nil operation in slice is skipped", func(t *testing.T) {
+		amt := decimal.NewFromInt(50)
+		afterAvail := decimal.NewFromInt(50)
+		tran := newTestTransaction([]*operation.Operation{
+			nil,
+			newOverdraftOp(accountID, "DEBIT", amt, afterAvail),
+		})
+
+		items := buildOverdraftEvents(tran)
+		require.Len(t, items, 1)
+		assert.Equal(t, OverdraftActionDrawn, items[0].action)
+	})
+
+	t.Run("mixed transaction produces multiple events", func(t *testing.T) {
+		// Scenario: one account draws overdraft, another gets repaid in same transaction.
+		accountA := uuid.Must(libCommons.GenerateUUIDv7()).String()
+		accountB := uuid.Must(libCommons.GenerateUUIDv7()).String()
+
+		drawAmt := decimal.NewFromInt(80)
+		drawAfter := decimal.NewFromInt(80)
+		repayAmt := decimal.NewFromInt(40)
+		repayAfter := decimal.NewFromInt(10)
+
+		tran := newTestTransaction([]*operation.Operation{
+			newDefaultOp(accountA, "DEBIT", decimal.NewFromInt(50), decimal.Zero),
+			newOverdraftOp(accountA, "DEBIT", drawAmt, drawAfter),
+			newDefaultOp(accountB, "CREDIT", decimal.NewFromInt(100), decimal.NewFromInt(100)),
+			newOverdraftOp(accountB, "CREDIT", repayAmt, repayAfter),
+		})
+
+		items := buildOverdraftEvents(tran)
+		require.Len(t, items, 2)
+		assert.Equal(t, OverdraftActionDrawn, items[0].action)
+		assert.Equal(t, OverdraftActionRepaid, items[1].action)
+	})
+
+	t.Run("OverdraftLimit is omitted from JSON when nil", func(t *testing.T) {
+		amt := decimal.NewFromInt(50)
+		afterAvail := decimal.NewFromInt(50)
+		tran := newTestTransaction([]*operation.Operation{
+			newOverdraftOp(accountID, "DEBIT", amt, afterAvail),
+		})
+
+		items := buildOverdraftEvents(tran)
+		require.Len(t, items, 1)
+
+		raw, err := json.Marshal(items[0].payload)
+		require.NoError(t, err)
+
+		var asMap map[string]json.RawMessage
+		require.NoError(t, json.Unmarshal(raw, &asMap))
+		_, hasLimit := asMap["overdraftLimit"]
+		assert.False(t, hasLimit, "overdraftLimit should be omitted from JSON when nil")
+	})
+}
+
+func TestClassifyOverdraftOperation(t *testing.T) {
+	accountID := uuid.Must(libCommons.GenerateUUIDv7()).String()
+
+	tests := []struct {
+		name           string
+		opType         string
+		amount         decimal.Decimal
+		afterAvailable decimal.Decimal
+		wantAction     string
+		wantAmount     decimal.Decimal
+		wantAfter      decimal.Decimal
+	}{
+		{
+			name:           "DEBIT produces drawn",
+			opType:         "DEBIT",
+			amount:         decimal.NewFromInt(50),
+			afterAvailable: decimal.NewFromInt(50),
+			wantAction:     OverdraftActionDrawn,
+			wantAmount:     decimal.NewFromInt(50),
+			wantAfter:      decimal.NewFromInt(50),
+		},
+		{
+			name:           "debit lowercase produces drawn",
+			opType:         "debit",
+			amount:         decimal.NewFromInt(25),
+			afterAvailable: decimal.NewFromInt(75),
+			wantAction:     OverdraftActionDrawn,
+			wantAmount:     decimal.NewFromInt(25),
+			wantAfter:      decimal.NewFromInt(75),
+		},
+		{
+			name:           "CREDIT with remaining produces repaid",
+			opType:         "CREDIT",
+			amount:         decimal.NewFromInt(30),
+			afterAvailable: decimal.NewFromInt(20),
+			wantAction:     OverdraftActionRepaid,
+			wantAmount:     decimal.NewFromInt(30),
+			wantAfter:      decimal.NewFromInt(20),
+		},
+		{
+			name:           "CREDIT reaching zero produces cleared",
+			opType:         "CREDIT",
+			amount:         decimal.NewFromInt(50),
+			afterAvailable: decimal.Zero,
+			wantAction:     OverdraftActionCleared,
+			wantAmount:     decimal.NewFromInt(50),
+			wantAfter:      decimal.Zero,
+		},
+		{
+			name:           "unknown type produces empty",
+			opType:         "HOLD",
+			amount:         decimal.NewFromInt(10),
+			afterAvailable: decimal.NewFromInt(10),
+			wantAction:     "",
+			wantAmount:     decimal.Zero,
+			wantAfter:      decimal.Zero,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			op := newOverdraftOp(accountID, tt.opType, tt.amount, tt.afterAvailable)
+			action, amount, afterAvail := classifyOverdraftOperation(op)
+			assert.Equal(t, tt.wantAction, action)
+			assert.True(t, tt.wantAmount.Equal(amount), "expected amount %s, got %s", tt.wantAmount, amount)
+			assert.True(t, tt.wantAfter.Equal(afterAvail), "expected afterAvail %s, got %s", tt.wantAfter, afterAvail)
+		})
+	}
+}
+
+func TestSendOverdraftEvents(t *testing.T) {
+	accountID := uuid.Must(libCommons.GenerateUUIDv7()).String()
+
+	t.Run("events disabled does not publish", func(t *testing.T) {
+		os.Setenv("RABBITMQ_OVERDRAFT_EVENTS_ENABLED", "false")
+		defer os.Unsetenv("RABBITMQ_OVERDRAFT_EVENTS_ENABLED")
+
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockRabbitMQRepo := rabbitmq.NewMockProducerRepository(ctrl)
+		uc := &UseCase{RabbitMQRepo: mockRabbitMQRepo}
+
+		// No ProducerDefault expectations — it should not be called.
+		amt := decimal.NewFromInt(50)
+		tran := newTestTransaction([]*operation.Operation{
+			newOverdraftOp(accountID, "DEBIT", amt, amt),
+		})
+
+		uc.SendOverdraftEvents(context.Background(), tran)
+	})
+
+	t.Run("events enabled by default when env unset", func(t *testing.T) {
+		os.Unsetenv("RABBITMQ_OVERDRAFT_EVENTS_ENABLED")
+		os.Setenv("RABBITMQ_OVERDRAFT_EVENTS_EXCHANGE", "test-overdraft-exchange")
+		os.Setenv("VERSION", "1.0.0")
+		defer func() {
+			os.Unsetenv("RABBITMQ_OVERDRAFT_EVENTS_EXCHANGE")
+			os.Unsetenv("VERSION")
+		}()
+
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockRabbitMQRepo := rabbitmq.NewMockProducerRepository(ctrl)
+		uc := &UseCase{RabbitMQRepo: mockRabbitMQRepo}
+
+		amt := decimal.NewFromInt(50)
+		tran := newTestTransaction([]*operation.Operation{
+			newOverdraftOp(accountID, "DEBIT", amt, amt),
+		})
+
+		mockRabbitMQRepo.EXPECT().
+			ProducerDefault(gomock.Any(), "test-overdraft-exchange", "midaz.balance.overdraft.drawn", gomock.Any()).
+			Return(nil, nil).
+			Times(1)
+
+		uc.SendOverdraftEvents(context.Background(), tran)
+	})
+
+	t.Run("drawn event publishes correct routing key", func(t *testing.T) {
+		os.Setenv("RABBITMQ_OVERDRAFT_EVENTS_ENABLED", "true")
+		os.Setenv("RABBITMQ_OVERDRAFT_EVENTS_EXCHANGE", "test-overdraft-exchange")
+		os.Setenv("VERSION", "1.0.0")
+		defer func() {
+			os.Unsetenv("RABBITMQ_OVERDRAFT_EVENTS_ENABLED")
+			os.Unsetenv("RABBITMQ_OVERDRAFT_EVENTS_EXCHANGE")
+			os.Unsetenv("VERSION")
+		}()
+
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockRabbitMQRepo := rabbitmq.NewMockProducerRepository(ctrl)
+		uc := &UseCase{RabbitMQRepo: mockRabbitMQRepo}
+
+		amt := decimal.NewFromInt(80)
+		afterAvail := decimal.NewFromInt(80)
+		tran := newTestTransaction([]*operation.Operation{
+			newOverdraftOp(accountID, "DEBIT", amt, afterAvail),
+		})
+
+		mockRabbitMQRepo.EXPECT().
+			ProducerDefault(gomock.Any(), "test-overdraft-exchange", "midaz.balance.overdraft.drawn", gomock.Any()).
+			DoAndReturn(func(_ context.Context, exchange, key string, message []byte) (*string, error) {
+				// Verify the envelope structure.
+				var evt map[string]json.RawMessage
+				require.NoError(t, json.Unmarshal(message, &evt))
+				assert.Contains(t, string(evt["action"]), "overdraft.drawn")
+				assert.Contains(t, string(evt["eventType"]), "balance")
+
+				// Verify payload does not contain overdraftLimit.
+				var payload map[string]json.RawMessage
+				require.NoError(t, json.Unmarshal(evt["payload"], &payload))
+				_, hasLimit := payload["overdraftLimit"]
+				assert.False(t, hasLimit, "overdraftLimit should be omitted from payload")
+				return nil, nil
+			}).
+			Times(1)
+
+		uc.SendOverdraftEvents(context.Background(), tran)
+	})
+
+	t.Run("cleared event publishes correct routing key", func(t *testing.T) {
+		os.Setenv("RABBITMQ_OVERDRAFT_EVENTS_ENABLED", "true")
+		os.Setenv("RABBITMQ_OVERDRAFT_EVENTS_EXCHANGE", "test-overdraft-exchange")
+		os.Setenv("VERSION", "1.0.0")
+		defer func() {
+			os.Unsetenv("RABBITMQ_OVERDRAFT_EVENTS_ENABLED")
+			os.Unsetenv("RABBITMQ_OVERDRAFT_EVENTS_EXCHANGE")
+			os.Unsetenv("VERSION")
+		}()
+
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockRabbitMQRepo := rabbitmq.NewMockProducerRepository(ctrl)
+		uc := &UseCase{RabbitMQRepo: mockRabbitMQRepo}
+
+		amt := decimal.NewFromInt(50)
+		tran := newTestTransaction([]*operation.Operation{
+			newOverdraftOp(accountID, "CREDIT", amt, decimal.Zero),
+		})
+
+		mockRabbitMQRepo.EXPECT().
+			ProducerDefault(gomock.Any(), "test-overdraft-exchange", "midaz.balance.overdraft.cleared", gomock.Any()).
+			Return(nil, nil).
+			Times(1)
+
+		uc.SendOverdraftEvents(context.Background(), tran)
+	})
+
+	t.Run("repaid event publishes correct routing key", func(t *testing.T) {
+		os.Setenv("RABBITMQ_OVERDRAFT_EVENTS_ENABLED", "true")
+		os.Setenv("RABBITMQ_OVERDRAFT_EVENTS_EXCHANGE", "test-overdraft-exchange")
+		os.Setenv("VERSION", "1.0.0")
+		defer func() {
+			os.Unsetenv("RABBITMQ_OVERDRAFT_EVENTS_ENABLED")
+			os.Unsetenv("RABBITMQ_OVERDRAFT_EVENTS_EXCHANGE")
+			os.Unsetenv("VERSION")
+		}()
+
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockRabbitMQRepo := rabbitmq.NewMockProducerRepository(ctrl)
+		uc := &UseCase{RabbitMQRepo: mockRabbitMQRepo}
+
+		amt := decimal.NewFromInt(30)
+		afterAvail := decimal.NewFromInt(20) // not cleared
+		tran := newTestTransaction([]*operation.Operation{
+			newOverdraftOp(accountID, "CREDIT", amt, afterAvail),
+		})
+
+		mockRabbitMQRepo.EXPECT().
+			ProducerDefault(gomock.Any(), "test-overdraft-exchange", "midaz.balance.overdraft.repaid", gomock.Any()).
+			Return(nil, nil).
+			Times(1)
+
+		uc.SendOverdraftEvents(context.Background(), tran)
+	})
+
+	t.Run("no overdraft ops produces no publish calls", func(t *testing.T) {
+		os.Setenv("RABBITMQ_OVERDRAFT_EVENTS_ENABLED", "true")
+		defer os.Unsetenv("RABBITMQ_OVERDRAFT_EVENTS_ENABLED")
+
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockRabbitMQRepo := rabbitmq.NewMockProducerRepository(ctrl)
+		uc := &UseCase{RabbitMQRepo: mockRabbitMQRepo}
+
+		// Only default balance operations — no overdraft.
+		amt := decimal.NewFromInt(100)
+		afterAvail := decimal.NewFromInt(200)
+		tran := newTestTransaction([]*operation.Operation{
+			newDefaultOp(accountID, "CREDIT", amt, afterAvail),
+		})
+
+		// No expectations — ProducerDefault should not be called.
+		uc.SendOverdraftEvents(context.Background(), tran)
+	})
+
+	t.Run("multiple overdraft ops produce multiple publish calls", func(t *testing.T) {
+		os.Setenv("RABBITMQ_OVERDRAFT_EVENTS_ENABLED", "true")
+		os.Setenv("RABBITMQ_OVERDRAFT_EVENTS_EXCHANGE", "test-overdraft-exchange")
+		os.Setenv("VERSION", "1.0.0")
+		defer func() {
+			os.Unsetenv("RABBITMQ_OVERDRAFT_EVENTS_ENABLED")
+			os.Unsetenv("RABBITMQ_OVERDRAFT_EVENTS_EXCHANGE")
+			os.Unsetenv("VERSION")
+		}()
+
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockRabbitMQRepo := rabbitmq.NewMockProducerRepository(ctrl)
+		uc := &UseCase{RabbitMQRepo: mockRabbitMQRepo}
+
+		accountA := uuid.Must(libCommons.GenerateUUIDv7()).String()
+		accountB := uuid.Must(libCommons.GenerateUUIDv7()).String()
+
+		tran := newTestTransaction([]*operation.Operation{
+			newOverdraftOp(accountA, "DEBIT", decimal.NewFromInt(80), decimal.NewFromInt(80)),
+			newOverdraftOp(accountB, "CREDIT", decimal.NewFromInt(40), decimal.Zero),
+		})
+
+		// Expect two calls: one drawn, one cleared.
+		mockRabbitMQRepo.EXPECT().
+			ProducerDefault(gomock.Any(), "test-overdraft-exchange", "midaz.balance.overdraft.drawn", gomock.Any()).
+			Return(nil, nil).
+			Times(1)
+
+		mockRabbitMQRepo.EXPECT().
+			ProducerDefault(gomock.Any(), "test-overdraft-exchange", "midaz.balance.overdraft.cleared", gomock.Any()).
+			Return(nil, nil).
+			Times(1)
+
+		uc.SendOverdraftEvents(context.Background(), tran)
+	})
+}
+
+func TestIsOverdraftEventEnabled(t *testing.T) {
+	tests := []struct {
+		name     string
+		envValue *string // nil means unset
+		want     bool
+	}{
+		{name: "unset returns true", envValue: nil, want: true},
+		{name: "empty string returns true", envValue: strPtr(""), want: true},
+		{name: "true returns true", envValue: strPtr("true"), want: true},
+		{name: "TRUE returns true", envValue: strPtr("TRUE"), want: true},
+		{name: "false returns false", envValue: strPtr("false"), want: false},
+		{name: "FALSE returns false", envValue: strPtr("FALSE"), want: false},
+		{name: "False returns false", envValue: strPtr("False"), want: false},
+		{name: "  false  with spaces returns false", envValue: strPtr("  false  "), want: false},
+		{name: "other value returns true", envValue: strPtr("yes"), want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.envValue == nil {
+				os.Unsetenv("RABBITMQ_OVERDRAFT_EVENTS_ENABLED")
+			} else {
+				os.Setenv("RABBITMQ_OVERDRAFT_EVENTS_ENABLED", *tt.envValue)
+			}
+			defer os.Unsetenv("RABBITMQ_OVERDRAFT_EVENTS_ENABLED")
+
+			got := isOverdraftEventEnabled()
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// strPtr is declared in update_balance_overdraft_test.go in the same package.

--- a/components/ledger/internal/services/command/send_overdraft_events_test.go
+++ b/components/ledger/internal/services/command/send_overdraft_events_test.go
@@ -37,24 +37,31 @@ func newTestTransaction(ops []*operation.Operation) *transaction.Transaction {
 			Code:        desc,
 			Description: &desc,
 		},
-		Amount:    &amount,
-		AssetCode: "BRL",
-		CreatedAt: time.Now(),
-		UpdatedAt: time.Now(),
+		Amount:     &amount,
+		AssetCode:  "BRL",
+		CreatedAt:  time.Now(),
+		UpdatedAt:  time.Now(),
 		Operations: ops,
 	}
 }
 
 // newOverdraftOp creates an operation on the overdraft companion balance.
-func newOverdraftOp(accountID, opType string, amount decimal.Decimal, afterAvailable decimal.Decimal) *operation.Operation {
+func newOverdraftOp(accountID, direction string, amount decimal.Decimal, afterAvailable decimal.Decimal) *operation.Operation {
+	switch direction {
+	case "DEBIT":
+		direction = constant.DirectionDebit
+	case "CREDIT":
+		direction = constant.DirectionCredit
+	}
+
 	return &operation.Operation{
 		ID:            uuid.Must(libCommons.GenerateUUIDv7()).String(),
 		TransactionID: uuid.Must(libCommons.GenerateUUIDv7()).String(),
-		Type:          opType,
+		Type:          constant.OVERDRAFT,
 		AssetCode:     "BRL",
 		AccountID:     accountID,
 		BalanceKey:    constant.OverdraftBalanceKey,
-		Direction:     "debit",
+		Direction:     direction,
 		Amount:        operation.Amount{Value: &amount},
 		BalanceAfter:  operation.Balance{Available: &afterAvailable},
 	}

--- a/components/ledger/internal/services/command/update_balance.go
+++ b/components/ledger/internal/services/command/update_balance.go
@@ -10,18 +10,15 @@ import (
 	"fmt"
 
 	libCommons "github.com/LerianStudio/lib-commons/v4/commons"
+	libLog "github.com/LerianStudio/lib-commons/v4/commons/log"
 	libOpentelemetry "github.com/LerianStudio/lib-commons/v4/commons/opentelemetry"
+	"github.com/LerianStudio/midaz/v3/pkg"
+	"github.com/LerianStudio/midaz/v3/pkg/constant"
 	"github.com/LerianStudio/midaz/v3/pkg/mmodel"
 	"github.com/LerianStudio/midaz/v3/pkg/mtransaction"
 	"github.com/LerianStudio/midaz/v3/pkg/utils"
 	"github.com/google/uuid"
 	"go.opentelemetry.io/otel/attribute"
-
-	// UpdateBalances persists balance updates to PostgreSQL.
-	// When balancesAfter is non-empty, it uses the Lua-computed AFTER states directly (primary path).
-	// When balancesAfter is empty (legacy payloads during rolling update), it falls back to
-	// recalculating via OperateBalances for backward compatibility.
-	libLog "github.com/LerianStudio/lib-commons/v4/commons/log"
 )
 
 func (uc *UseCase) UpdateBalances(ctx context.Context, organizationID, ledgerID uuid.UUID, validate mtransaction.Responses, balances []*mmodel.Balance, balancesAfter []*mmodel.Balance) error {
@@ -113,16 +110,17 @@ func (uc *UseCase) UpdateBalances(ctx context.Context, organizationID, ledgerID 
 // Update balance in the repository and returns the updated balance.
 // Overlays Redis cached values for Available, OnHold, and Version to ensure freshest data.
 //
-// When update.Settings is non-nil, the use case:
+// The method always loads the current balance first to enforce scope
+// protection: internal-scope balances (e.g. overdraft companions) are
+// rejected with 0176 regardless of which fields the payload carries.
+//
+// When update.Settings is non-nil, the use case additionally:
 //  1. Validates the Settings payload (HARD GATE — fails closed, no partial writes).
-//  2. Loads the current balance to enforce overdraft transition invariants:
+//  2. Enforces overdraft transition invariants:
 //     - disable-with-debt is rejected
 //     - reducing limit below current usage is rejected
 //  3. Auto-creates the system-managed "overdraft" balance on a false→true
 //     transition (idempotent — existing overdraft balances are reused).
-//
-// When update.Settings is nil, legacy behaviour is preserved: no Find call,
-// no settings validation, no auto-creation.
 func (uc *UseCase) Update(ctx context.Context, organizationID, ledgerID, balanceID uuid.UUID, update mmodel.UpdateBalance) (*mmodel.Balance, error) {
 	logger, tracer, _, _ := libCommons.NewTrackingFromContext(ctx)
 
@@ -131,26 +129,41 @@ func (uc *UseCase) Update(ctx context.Context, organizationID, ledgerID, balance
 
 	logger.Log(ctx, libLog.LevelInfo, "Trying to update balance")
 
-	var current *mmodel.Balance
+	// Always load the current balance so the scope guard can fire
+	// regardless of which fields the payload contains (Settings,
+	// AllowSending, AllowReceiving, or any combination). Without this
+	// unconditional Find, a payload without Settings bypasses the guard.
+	current, err := uc.BalanceRepo.Find(ctx, organizationID, ledgerID, balanceID)
+	if err != nil {
+		libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Failed to fetch current balance for update", err)
+		logger.Log(ctx, libLog.LevelError, "Error fetching current balance", libLog.Err(err))
+
+		return nil, err
+	}
+
+	// Scope protection: internal-scope balances are managed exclusively by
+	// the system (e.g. overdraft reserves) and cannot be updated via the
+	// public API. This guard runs AFTER Find (so a non-existent balance
+	// returns 404, not 422) and BEFORE any Settings validation, overdraft
+	// transition enforcement, or repo Update — no partial mutations.
+	if current != nil && current.Settings != nil && current.Settings.BalanceScope == mmodel.BalanceScopeInternal {
+		err = pkg.ValidateBusinessError(constant.ErrUpdateOfInternalBalance, constant.EntityBalance)
+		libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Rejected update on internal-scope balance", err)
+		logger.Log(ctx, libLog.LevelWarn, "Rejected update on internal-scope balance",
+			libLog.String("alias", current.Alias),
+			libLog.String("key", current.Key))
+
+		return nil, err
+	}
 
 	if update.Settings != nil {
 		if err := validateUpdateSettings(ctx, logger, span, update.Settings); err != nil {
 			return nil, err
 		}
 
-		existing, err := uc.BalanceRepo.Find(ctx, organizationID, ledgerID, balanceID)
-		if err != nil {
-			libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Failed to fetch current balance for settings update", err)
-			logger.Log(ctx, libLog.LevelError, fmt.Sprintf("Error fetching current balance: %v", err))
-
+		if err := enforceOverdraftTransition(ctx, logger, span, current, update.Settings); err != nil {
 			return nil, err
 		}
-
-		if err := enforceOverdraftTransition(ctx, logger, span, existing, update.Settings); err != nil {
-			return nil, err
-		}
-
-		current = existing
 	}
 
 	// Auto-create the system-managed overdraft balance BEFORE persisting

--- a/components/ledger/internal/services/command/update_balance.go
+++ b/components/ledger/internal/services/command/update_balance.go
@@ -84,8 +84,8 @@ func (uc *UseCase) UpdateBalances(ctx context.Context, organizationID, ledgerID 
 			calculateBalances, err := mtransaction.OperateBalances(fromTo[balance.Alias], *txBal)
 			if err != nil {
 				libOpentelemetry.HandleSpanError(spanUpdateBalances, "Failed to update balances on database", err)
-			logger.Log(ctx, libLog.LevelError, "Failed to update balances on database", libLog.Err(err))
-			spanBalance.End()
+				logger.Log(ctx, libLog.LevelError, "Failed to update balances on database", libLog.Err(err))
+				spanBalance.End()
 
 				return err
 			}

--- a/components/ledger/internal/services/command/update_balance.go
+++ b/components/ledger/internal/services/command/update_balance.go
@@ -122,12 +122,11 @@ func (uc *UseCase) UpdateBalances(ctx context.Context, organizationID, ledgerID 
 //
 // The method always loads the current balance first to enforce scope
 // protection: internal-scope balances (e.g. overdraft companions) are
-// rejected with 0176 regardless of which fields the payload carries.
+// rejected with 0175 regardless of which fields the payload carries.
 //
 // When update.Settings is non-nil, the use case additionally:
 //  1. Validates the Settings payload (HARD GATE — fails closed, no partial writes).
 //  2. Enforces overdraft transition invariants:
-//     - disable-with-debt is rejected
 //     - reducing limit below current usage is rejected
 //  3. Auto-creates the system-managed "overdraft" balance on a false→true
 //     transition (idempotent — existing overdraft balances are reused).

--- a/components/ledger/internal/services/command/update_balance.go
+++ b/components/ledger/internal/services/command/update_balance.go
@@ -112,6 +112,17 @@ func (uc *UseCase) UpdateBalances(ctx context.Context, organizationID, ledgerID 
 
 // Update balance in the repository and returns the updated balance.
 // Overlays Redis cached values for Available, OnHold, and Version to ensure freshest data.
+//
+// When update.Settings is non-nil, the use case:
+//  1. Validates the Settings payload (HARD GATE — fails closed, no partial writes).
+//  2. Loads the current balance to enforce overdraft transition invariants:
+//     - disable-with-debt is rejected
+//     - reducing limit below current usage is rejected
+//  3. Auto-creates the system-managed "overdraft" balance on a false→true
+//     transition (idempotent — existing overdraft balances are reused).
+//
+// When update.Settings is nil, legacy behaviour is preserved: no Find call,
+// no settings validation, no auto-creation.
 func (uc *UseCase) Update(ctx context.Context, organizationID, ledgerID, balanceID uuid.UUID, update mmodel.UpdateBalance) (*mmodel.Balance, error) {
 	logger, tracer, _, _ := libCommons.NewTrackingFromContext(ctx)
 
@@ -119,6 +130,40 @@ func (uc *UseCase) Update(ctx context.Context, organizationID, ledgerID, balance
 	defer span.End()
 
 	logger.Log(ctx, libLog.LevelInfo, "Trying to update balance")
+
+	var current *mmodel.Balance
+
+	if update.Settings != nil {
+		if err := validateUpdateSettings(ctx, logger, span, update.Settings); err != nil {
+			return nil, err
+		}
+
+		existing, err := uc.BalanceRepo.Find(ctx, organizationID, ledgerID, balanceID)
+		if err != nil {
+			libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Failed to fetch current balance for settings update", err)
+			logger.Log(ctx, libLog.LevelError, fmt.Sprintf("Error fetching current balance: %v", err))
+
+			return nil, err
+		}
+
+		if err := enforceOverdraftTransition(ctx, logger, span, existing, update.Settings); err != nil {
+			return nil, err
+		}
+
+		current = existing
+	}
+
+	// Auto-create the system-managed overdraft balance BEFORE persisting
+	// the settings update. If auto-creation fails (e.g., Create returns a
+	// database error), the parent balance's settings MUST NOT have been
+	// mutated — this keeps the pair (parent.AllowOverdraft, overdraft
+	// balance) consistent on failure. Guarded so the path only runs when
+	// the caller actually provided new settings.
+	if update.Settings != nil {
+		if err := uc.ensureOverdraftBalance(ctx, logger, span, organizationID, ledgerID, current, update.Settings); err != nil {
+			return nil, err
+		}
+	}
 
 	balance, err := uc.BalanceRepo.Update(ctx, organizationID, ledgerID, balanceID, update)
 	if err != nil {

--- a/components/ledger/internal/services/command/update_balance.go
+++ b/components/ledger/internal/services/command/update_balance.go
@@ -72,11 +72,20 @@ func (uc *UseCase) UpdateBalances(ctx context.Context, organizationID, ledgerID 
 		for _, balance := range balances {
 			_, spanBalance := tracer.Start(ctx, "command.update_balances_new.balance")
 
-			calculateBalances, err := mtransaction.OperateBalances(fromTo[balance.Alias], *balance.ToTransactionBalance())
+			txBal, tErr := balance.ToTransactionBalance()
+			if tErr != nil {
+				libOpentelemetry.HandleSpanError(spanUpdateBalances, "Corrupted balance for fallback path", tErr)
+				logger.Log(ctx, libLog.LevelError, "Corrupted balance OverdraftLimit in fallback path", libLog.Err(tErr))
+				spanBalance.End()
+
+				return tErr
+			}
+
+			calculateBalances, err := mtransaction.OperateBalances(fromTo[balance.Alias], *txBal)
 			if err != nil {
 				libOpentelemetry.HandleSpanError(spanUpdateBalances, "Failed to update balances on database", err)
-				logger.Log(ctx, libLog.LevelError, fmt.Sprintf("Failed to update balances on database: %v", err.Error()))
-				spanBalance.End()
+			logger.Log(ctx, libLog.LevelError, "Failed to update balances on database", libLog.Err(err))
+			spanBalance.End()
 
 				return err
 			}
@@ -99,7 +108,7 @@ func (uc *UseCase) UpdateBalances(ctx context.Context, organizationID, ledgerID 
 
 	if err := uc.BalanceRepo.BalancesUpdate(ctxProcessBalances, organizationID, ledgerID, newBalances); err != nil {
 		libOpentelemetry.HandleSpanBusinessErrorEvent(spanUpdateBalances, "Failed to update balances on database", err)
-		logger.Log(ctx, libLog.LevelError, fmt.Sprintf("Failed to update balances on database: %v", err.Error()))
+		logger.Log(ctx, libLog.LevelError, "Failed to update balances on database", libLog.Err(err))
 
 		return err
 	}
@@ -127,7 +136,7 @@ func (uc *UseCase) Update(ctx context.Context, organizationID, ledgerID, balance
 	ctx, span := tracer.Start(ctx, "exec.update_balance")
 	defer span.End()
 
-	logger.Log(ctx, libLog.LevelInfo, "Trying to update balance")
+	logger.Log(ctx, libLog.LevelInfo, "Updating balance")
 
 	// Always load the current balance so the scope guard can fire
 	// regardless of which fields the payload contains (Settings,
@@ -181,7 +190,7 @@ func (uc *UseCase) Update(ctx context.Context, organizationID, ledgerID, balance
 	balance, err := uc.BalanceRepo.Update(ctx, organizationID, ledgerID, balanceID, update)
 	if err != nil {
 		libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Failed to update balance on repo", err)
-		logger.Log(ctx, libLog.LevelError, fmt.Sprintf("Error update balance: %v", err))
+		logger.Log(ctx, libLog.LevelError, "Failed to update balance", libLog.Err(err))
 
 		return nil, err
 	}
@@ -192,13 +201,13 @@ func (uc *UseCase) Update(ctx context.Context, organizationID, ledgerID, balance
 	value, rerr := uc.TransactionRedisRepo.Get(ctx, internalKey)
 	if rerr != nil {
 		libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Failed to get balance cache value on redis", rerr)
-		logger.Log(ctx, libLog.LevelWarn, fmt.Sprintf("Failed to get balance cache value on redis: %v", rerr))
+		logger.Log(ctx, libLog.LevelWarn, "Failed to get balance cache value on Redis", libLog.Err(rerr))
 	}
 
 	if value != "" {
 		cached := mmodel.BalanceRedis{}
 		if uerr := json.Unmarshal([]byte(value), &cached); uerr != nil {
-			logger.Log(ctx, libLog.LevelWarn, fmt.Sprintf("Error unmarshalling balance cache value: %v", uerr))
+			logger.Log(ctx, libLog.LevelWarn, "Failed to unmarshal balance cache value", libLog.Err(uerr))
 		} else {
 			balance.Available = cached.Available
 			balance.OnHold = cached.OnHold

--- a/components/ledger/internal/services/command/update_balance.go
+++ b/components/ledger/internal/services/command/update_balance.go
@@ -193,5 +193,32 @@ func (uc *UseCase) Update(ctx context.Context, organizationID, ledgerID, balance
 		}
 	}
 
+	// When the caller updates overdraft/scope Settings, rewrite ONLY those
+	// fields in the cached JSON blob in place. Deleting the key would discard
+	// live transactional state (Available, OnHold, Version, OverdraftUsed)
+	// that the Lua atomic script may have mutated but not yet flushed to
+	// PostgreSQL. An in-place settings rewrite preserves that state while
+	// making the new overdraft configuration visible to the next transaction.
+	//
+	// The repo method composes its own BalanceInternalKey from (org, ledger,
+	// alias#key) and applies the tenant prefix internally, mirroring the Get
+	// above. A cache miss inside the repo is a no-op — the next transaction
+	// will load the freshly-persisted settings via the Lua SETNX path.
+	//
+	// Non-settings updates (e.g. AllowSending, AllowReceiving) do not trigger
+	// this rewrite: those fields are not part of the settings contract this
+	// method guards, and leaving the cache alone avoids a useless round-trip.
+	//
+	// This is best-effort: the PostgreSQL write is already durable, so a
+	// Redis-side failure here is logged and swallowed. A subsequent cache
+	// miss or the sync worker will reconcile.
+	if update.Settings != nil {
+		cacheKey := balance.Alias + "#" + balance.Key
+		if uerr := uc.TransactionRedisRepo.UpdateBalanceCacheSettings(ctx, organizationID, ledgerID, cacheKey, update.Settings); uerr != nil {
+			libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Failed to update balance cache settings on redis", uerr)
+			logger.Log(ctx, libLog.LevelWarn, "Failed to update balance cache settings on Redis", libLog.Err(uerr))
+		}
+	}
+
 	return balance, nil
 }

--- a/components/ledger/internal/services/command/update_balance.go
+++ b/components/ledger/internal/services/command/update_balance.go
@@ -18,6 +18,7 @@ import (
 	"github.com/LerianStudio/midaz/v3/pkg/mtransaction"
 	"github.com/LerianStudio/midaz/v3/pkg/utils"
 	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
 	"go.opentelemetry.io/otel/attribute"
 )
 
@@ -212,6 +213,10 @@ func (uc *UseCase) Update(ctx context.Context, organizationID, ledgerID, balance
 			balance.Available = cached.Available
 			balance.OnHold = cached.OnHold
 			balance.Version = cached.Version
+
+			if ou, perr := decimal.NewFromString(cached.OverdraftUsed); perr == nil {
+				balance.OverdraftUsed = ou
+			}
 		}
 	}
 

--- a/components/ledger/internal/services/command/update_balance_auto_overdraft_test.go
+++ b/components/ledger/internal/services/command/update_balance_auto_overdraft_test.go
@@ -106,6 +106,13 @@ func TestUpdateBalance_EnableOverdraft_AutoCreatesOverdraftBalance(t *testing.T)
 		Return("", nil).
 		AnyTimes()
 
+	// Cache settings are rewritten in-place after a settings update (live
+	// transactional state is preserved — no Del).
+	mockRedisRepo.EXPECT().
+		UpdateBalanceCacheSettings(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(nil).
+		AnyTimes()
+
 	uc := UseCase{
 		BalanceRepo:          mockBalanceRepo,
 		TransactionRedisRepo: mockRedisRepo,
@@ -197,6 +204,13 @@ func TestUpdateBalance_EnableOverdraft_Idempotent(t *testing.T) {
 	mockRedisRepo.EXPECT().
 		Get(gomock.Any(), gomock.Any()).
 		Return("", nil).
+		AnyTimes()
+
+	// Cache settings are rewritten in-place after a settings update (live
+	// transactional state is preserved — no Del).
+	mockRedisRepo.EXPECT().
+		UpdateBalanceCacheSettings(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(nil).
 		AnyTimes()
 
 	uc := UseCase{

--- a/components/ledger/internal/services/command/update_balance_auto_overdraft_test.go
+++ b/components/ledger/internal/services/command/update_balance_auto_overdraft_test.go
@@ -1,0 +1,212 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package command
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	libCommons "github.com/LerianStudio/lib-commons/v4/commons"
+	"github.com/LerianStudio/midaz/v3/components/ledger/internal/adapters/postgres/balance"
+	redis "github.com/LerianStudio/midaz/v3/components/ledger/internal/adapters/redis/transaction"
+	"github.com/LerianStudio/midaz/v3/pkg"
+	"github.com/LerianStudio/midaz/v3/pkg/constant"
+	"github.com/LerianStudio/midaz/v3/pkg/mmodel"
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+// TestUpdateBalance_EnableOverdraft_AutoCreatesOverdraftBalance verifies that
+// flipping AllowOverdraft from false to true triggers the auto-creation of
+// a system-managed "overdraft" balance with direction=debit and scope=internal.
+func TestUpdateBalance_EnableOverdraft_AutoCreatesOverdraftBalance(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
+	orgID := uuid.Must(libCommons.GenerateUUIDv7())
+	ledgerID := uuid.Must(libCommons.GenerateUUIDv7())
+	balanceID := uuid.Must(libCommons.GenerateUUIDv7())
+	accountID := uuid.New()
+
+	current := &mmodel.Balance{
+		ID:             balanceID.String(),
+		OrganizationID: orgID.String(),
+		LedgerID:       ledgerID.String(),
+		AccountID:      accountID.String(),
+		Alias:          "@fresh",
+		Key:            "default",
+		AssetCode:      "USD",
+		Direction:      constant.DirectionCredit,
+		OverdraftUsed:  decimal.Zero,
+		Settings:       mmodel.NewDefaultBalanceSettings(),
+	}
+
+	update := mmodel.UpdateBalance{
+		Settings: &mmodel.BalanceSettings{
+			AllowOverdraft:        true,
+			OverdraftLimitEnabled: true,
+			OverdraftLimit:        strPtr("500.00"),
+		},
+	}
+
+	updated := *current
+	updated.Settings = update.Settings
+
+	mockBalanceRepo := balance.NewMockRepository(ctrl)
+	mockRedisRepo := redis.NewMockRedisRepository(ctrl)
+
+	mockBalanceRepo.EXPECT().
+		Find(gomock.Any(), orgID, ledgerID, balanceID).
+		Return(current, nil).
+		AnyTimes()
+
+	mockBalanceRepo.EXPECT().
+		Update(gomock.Any(), orgID, ledgerID, balanceID, update).
+		Return(&updated, nil).
+		Times(1)
+
+	// No existing overdraft balance yet. The repository signals "not
+	// found" by returning an EntityNotFoundError (mirroring the real
+	// PostgreSQL adapter which maps sql.ErrNoRows to this error), and
+	// the use case MUST treat it as the trigger for auto-creation.
+	mockBalanceRepo.EXPECT().
+		FindByAccountIDAndKey(gomock.Any(), orgID, ledgerID, accountID, "overdraft").
+		Return(nil, pkg.ValidateBusinessError(constant.ErrEntityNotFound, reflect.TypeOf(mmodel.Balance{}).Name())).
+		Times(1)
+
+	// Auto-creation MUST happen with direction=debit, scope=internal.
+	mockBalanceRepo.EXPECT().
+		Create(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, b *mmodel.Balance) (*mmodel.Balance, error) {
+			assert.Equal(t, "overdraft", b.Key,
+				"auto-created balance MUST use the overdraft key")
+			assert.Equal(t, constant.DirectionDebit, b.Direction,
+				"overdraft balance MUST have debit direction")
+			assert.Equal(t, accountID.String(), b.AccountID,
+				"overdraft balance MUST belong to the same account")
+			assert.Equal(t, current.AssetCode, b.AssetCode,
+				"overdraft balance MUST match the parent asset code")
+			require.NotNil(t, b.Settings,
+				"overdraft balance MUST carry settings")
+			assert.Equal(t, mmodel.BalanceScopeInternal, b.Settings.BalanceScope,
+				"overdraft balance MUST be scoped as internal")
+			return b, nil
+		}).
+		Times(1)
+
+	mockRedisRepo.EXPECT().
+		Get(gomock.Any(), gomock.Any()).
+		Return("", nil).
+		AnyTimes()
+
+	uc := UseCase{
+		BalanceRepo:          mockBalanceRepo,
+		TransactionRedisRepo: mockRedisRepo,
+	}
+
+	result, err := uc.Update(context.TODO(), orgID, ledgerID, balanceID, update)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+}
+
+// TestUpdateBalance_EnableOverdraft_Idempotent verifies that re-enabling
+// overdraft on a balance that already has a system overdraft balance does
+// NOT create a duplicate — the operation MUST be idempotent.
+func TestUpdateBalance_EnableOverdraft_Idempotent(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
+	orgID := uuid.Must(libCommons.GenerateUUIDv7())
+	ledgerID := uuid.Must(libCommons.GenerateUUIDv7())
+	balanceID := uuid.Must(libCommons.GenerateUUIDv7())
+	accountID := uuid.New()
+
+	current := &mmodel.Balance{
+		ID:             balanceID.String(),
+		OrganizationID: orgID.String(),
+		LedgerID:       ledgerID.String(),
+		AccountID:      accountID.String(),
+		Alias:          "@fresh",
+		Key:            "default",
+		AssetCode:      "USD",
+		Direction:      constant.DirectionCredit,
+		OverdraftUsed:  decimal.Zero,
+		Settings:       mmodel.NewDefaultBalanceSettings(),
+	}
+
+	existingOverdraft := &mmodel.Balance{
+		ID:             uuid.New().String(),
+		OrganizationID: orgID.String(),
+		LedgerID:       ledgerID.String(),
+		AccountID:      accountID.String(),
+		Alias:          "@fresh",
+		Key:            "overdraft",
+		AssetCode:      "USD",
+		Direction:      constant.DirectionDebit,
+		OverdraftUsed:  decimal.Zero,
+		Settings: &mmodel.BalanceSettings{
+			BalanceScope: mmodel.BalanceScopeInternal,
+		},
+	}
+
+	update := mmodel.UpdateBalance{
+		Settings: &mmodel.BalanceSettings{
+			AllowOverdraft:        true,
+			OverdraftLimitEnabled: true,
+			OverdraftLimit:        strPtr("500.00"),
+		},
+	}
+
+	updated := *current
+	updated.Settings = update.Settings
+
+	mockBalanceRepo := balance.NewMockRepository(ctrl)
+	mockRedisRepo := redis.NewMockRedisRepository(ctrl)
+
+	mockBalanceRepo.EXPECT().
+		Find(gomock.Any(), orgID, ledgerID, balanceID).
+		Return(current, nil).
+		AnyTimes()
+
+	mockBalanceRepo.EXPECT().
+		Update(gomock.Any(), orgID, ledgerID, balanceID, update).
+		Return(&updated, nil).
+		Times(1)
+
+	// Overdraft balance already exists — the use case MUST detect it.
+	mockBalanceRepo.EXPECT().
+		FindByAccountIDAndKey(gomock.Any(), orgID, ledgerID, accountID, "overdraft").
+		Return(existingOverdraft, nil).
+		Times(1)
+
+	// Create MUST NOT be called when the overdraft balance already exists.
+	mockBalanceRepo.EXPECT().
+		Create(gomock.Any(), gomock.Any()).
+		Times(0)
+
+	mockRedisRepo.EXPECT().
+		Get(gomock.Any(), gomock.Any()).
+		Return("", nil).
+		AnyTimes()
+
+	uc := UseCase{
+		BalanceRepo:          mockBalanceRepo,
+		TransactionRedisRepo: mockRedisRepo,
+	}
+
+	result, err := uc.Update(context.TODO(), orgID, ledgerID, balanceID, update)
+
+	require.NoError(t, err, "idempotent enable MUST succeed without errors")
+	require.NotNil(t, result)
+}

--- a/components/ledger/internal/services/command/update_balance_auto_overdraft_test.go
+++ b/components/ledger/internal/services/command/update_balance_auto_overdraft_test.go
@@ -6,7 +6,6 @@ package command
 
 import (
 	"context"
-	"reflect"
 	"testing"
 
 	libCommons "github.com/LerianStudio/lib-commons/v4/commons"
@@ -79,7 +78,7 @@ func TestUpdateBalance_EnableOverdraft_AutoCreatesOverdraftBalance(t *testing.T)
 	// the use case MUST treat it as the trigger for auto-creation.
 	mockBalanceRepo.EXPECT().
 		FindByAccountIDAndKey(gomock.Any(), orgID, ledgerID, accountID, "overdraft").
-		Return(nil, pkg.ValidateBusinessError(constant.ErrEntityNotFound, reflect.TypeOf(mmodel.Balance{}).Name())).
+		Return(nil, pkg.ValidateBusinessError(constant.ErrEntityNotFound, constant.EntityBalance)).
 		Times(1)
 
 	// Auto-creation MUST happen with direction=debit, scope=internal.

--- a/components/ledger/internal/services/command/update_balance_overdraft.go
+++ b/components/ledger/internal/services/command/update_balance_overdraft.go
@@ -127,6 +127,16 @@ func enforceOverdraftTransition(ctx context.Context, logger libLog.Logger, span 
 // Any other Create failure (connectivity, constraint violations we did not
 // trigger, etc.) is propagated unchanged.
 func (uc *UseCase) ensureOverdraftBalance(ctx context.Context, logger libLog.Logger, span trace.Span, organizationID, ledgerID uuid.UUID, current *mmodel.Balance, nextSettings *mmodel.BalanceSettings) error {
+	// Concurrency model: auto-creation is idempotent. Two concurrent
+	// PATCH-enable requests on the same account will both attempt to
+	// create the overdraft companion balance. The partial unique index
+	// idx_unique_balance_account_key (migration 000032) on
+	// (organization_id, ledger_id, account_id, asset_code, key)
+	// WHERE deleted_at IS NULL guarantees only one row survives.
+	// isUniqueViolation (line ~247) catches the duplicate-key error
+	// and treats it as a no-op — the second caller proceeds with the
+	// companion that the first caller created.
+
 	if current == nil || nextSettings == nil {
 		return nil
 	}

--- a/components/ledger/internal/services/command/update_balance_overdraft.go
+++ b/components/ledger/internal/services/command/update_balance_overdraft.go
@@ -237,8 +237,8 @@ func (uc *UseCase) ensureOverdraftBalance(ctx context.Context, logger libLog.Log
 		// we were about to create. Verify with a follow-up Find so we
 		// never silently swallow a 23505 triggered by an unrelated index.
 		if isUniqueViolation(cerr) {
-			existing, reloadErr := uc.BalanceRepo.FindByAccountIDAndKey(ctx, organizationID, ledgerID, accountID, constant.OverdraftBalanceKey)
-			if reloadErr == nil && existing != nil {
+			reloaded, reloadErr := uc.BalanceRepo.FindByAccountIDAndKey(ctx, organizationID, ledgerID, accountID, constant.OverdraftBalanceKey)
+			if reloadErr == nil && reloaded != nil {
 				logger.Log(ctx, libLog.LevelInfo, "Overdraft balance created concurrently by peer request, treating as idempotent success", libLog.String("accountID", current.AccountID))
 
 				return nil

--- a/components/ledger/internal/services/command/update_balance_overdraft.go
+++ b/components/ledger/internal/services/command/update_balance_overdraft.go
@@ -16,6 +16,7 @@ import (
 	"github.com/LerianStudio/midaz/v3/pkg/constant"
 	"github.com/LerianStudio/midaz/v3/pkg/mmodel"
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/shopspring/decimal"
 	"go.opentelemetry.io/otel/trace"
 )
@@ -109,6 +110,22 @@ func enforceOverdraftTransition(ctx context.Context, logger libLog.Logger, span 
 //   - scope      = "internal" (protected from direct operations)
 //   - alias      = same as the parent balance
 //   - asset code = same as the parent balance
+//
+// Concurrency model:
+//
+// Two concurrent PATCH requests flipping AllowOverdraft from false→true on
+// the same account would each observe "no overdraft balance" in the initial
+// Find lookup and race to Create. Application-level locking cannot close
+// this window cleanly across replicas, so the invariant is enforced at the
+// storage layer: a partial UNIQUE index on
+// (organization_id, ledger_id, account_id, asset_code, key) rejects the
+// second insert with SQLSTATE 23505.
+//
+// When that happens we treat the race as benign — the peer request already
+// created the balance we were about to create — and re-fetch it so the
+// caller sees the same state it would have in the single-request case.
+// Any other Create failure (connectivity, constraint violations we did not
+// trigger, etc.) is propagated unchanged.
 func (uc *UseCase) ensureOverdraftBalance(ctx context.Context, logger libLog.Logger, span trace.Span, organizationID, ledgerID uuid.UUID, current *mmodel.Balance, nextSettings *mmodel.BalanceSettings) error {
 	if current == nil || nextSettings == nil {
 		return nil
@@ -186,6 +203,24 @@ func (uc *UseCase) ensureOverdraftBalance(ctx context.Context, logger libLog.Log
 	}
 
 	if _, cerr := uc.BalanceRepo.Create(ctx, overdraftBalance); cerr != nil {
+		// Benign race: a concurrent request won the Create. The partial
+		// UNIQUE index idx_unique_balance_account_key surfaces this as a
+		// PostgreSQL unique_violation (SQLSTATE 23505). Treat it as
+		// idempotent success — the peer request materialized the same row
+		// we were about to create. Verify with a follow-up Find so we
+		// never silently swallow a 23505 triggered by an unrelated index.
+		if isUniqueViolation(cerr) {
+			existing, reloadErr := uc.BalanceRepo.FindByAccountIDAndKey(ctx, organizationID, ledgerID, accountID, constant.OverdraftBalanceKey)
+			if reloadErr == nil && existing != nil {
+				logger.Log(ctx, libLog.LevelInfo, "Overdraft balance created concurrently by peer request, treating as idempotent success", libLog.String("accountID", current.AccountID))
+
+				return nil
+			}
+			// Fall through and surface the original Create error if the
+			// reload failed or still returned nil — that means the 23505
+			// did not come from our target tuple.
+		}
+
 		libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Failed to auto-create overdraft balance", cerr)
 		logger.Log(ctx, libLog.LevelError, "Failed to auto-create overdraft balance", libLog.Err(cerr))
 
@@ -195,4 +230,14 @@ func (uc *UseCase) ensureOverdraftBalance(ctx context.Context, logger libLog.Log
 	logger.Log(ctx, libLog.LevelInfo, "Auto-created overdraft balance", libLog.String("accountID", current.AccountID))
 
 	return nil
+}
+
+// isUniqueViolation reports whether err is a PostgreSQL unique_violation
+// (SQLSTATE 23505). Used by ensureOverdraftBalance to distinguish a benign
+// concurrent-insert race from real Create failures. Matches the pattern
+// already used in create_balance_transaction_operations_async.go.
+func isUniqueViolation(err error) bool {
+	var pgErr *pgconn.PgError
+
+	return errors.As(err, &pgErr) && pgErr.Code == constant.UniqueViolationCode
 }

--- a/components/ledger/internal/services/command/update_balance_overdraft.go
+++ b/components/ledger/internal/services/command/update_balance_overdraft.go
@@ -69,7 +69,7 @@ func enforceOverdraftTransition(ctx context.Context, logger libLog.Logger, span 
 	if !next.AllowOverdraft {
 		err := pkg.ValidateBusinessError(constant.ErrOverdraftDisableWithUsage, constant.EntityBalance)
 		libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Cannot disable overdraft while usage is non-zero", err)
-		logger.Log(ctx, libLog.LevelWarn, "Rejected overdraft disable with active usage", libLog.String("overdraftUsed", usage.String()))
+		logger.Log(ctx, libLog.LevelWarn, "Rejected overdraft disable with active usage")
 
 		return err
 	}
@@ -90,7 +90,7 @@ func enforceOverdraftTransition(ctx context.Context, logger libLog.Logger, span 
 		if limit.LessThan(usage) {
 			err := pkg.ValidateBusinessError(constant.ErrOverdraftLimitBelowUsage, constant.EntityBalance)
 			libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Overdraft limit below current usage", err)
-			logger.Log(ctx, libLog.LevelWarn, "Rejected overdraft limit below current usage", libLog.String("limit", limit.String()), libLog.String("overdraftUsed", usage.String()))
+			logger.Log(ctx, libLog.LevelWarn, "Rejected overdraft limit below current usage")
 
 			return err
 		}
@@ -136,7 +136,6 @@ func (uc *UseCase) ensureOverdraftBalance(ctx context.Context, logger libLog.Log
 	// isUniqueViolation (line ~247) catches the duplicate-key error
 	// and treats it as a no-op — the second caller proceeds with the
 	// companion that the first caller created.
-
 	if current == nil || nextSettings == nil {
 		return nil
 	}
@@ -200,8 +199,18 @@ func (uc *UseCase) ensureOverdraftBalance(ctx context.Context, logger libLog.Log
 	// AllowSending=true does NOT expose the companion to client-initiated
 	// transactions — only the system enrichment engine can route operations
 	// onto it.
+	balanceUUID, uuidErr := libCommons.GenerateUUIDv7()
+	if uuidErr != nil {
+		libOpentelemetry.HandleSpanError(span, "Failed to generate UUID for overdraft balance", uuidErr)
+		logger.Log(ctx, libLog.LevelError, "Failed to generate UUID for overdraft balance", libLog.Err(uuidErr))
+
+		return uuidErr
+	}
+
+	now := time.Now()
+
 	overdraftBalance := &mmodel.Balance{
-		ID:             uuid.Must(libCommons.GenerateUUIDv7()).String(),
+		ID:             balanceUUID.String(),
 		OrganizationID: current.OrganizationID,
 		LedgerID:       current.LedgerID,
 		AccountID:      current.AccountID,
@@ -216,8 +225,8 @@ func (uc *UseCase) ensureOverdraftBalance(ctx context.Context, logger libLog.Log
 		Settings: &mmodel.BalanceSettings{
 			BalanceScope: mmodel.BalanceScopeInternal,
 		},
-		CreatedAt: time.Now(),
-		UpdatedAt: time.Now(),
+		CreatedAt: now,
+		UpdatedAt: now,
 	}
 
 	if _, cerr := uc.BalanceRepo.Create(ctx, overdraftBalance); cerr != nil {

--- a/components/ledger/internal/services/command/update_balance_overdraft.go
+++ b/components/ledger/internal/services/command/update_balance_overdraft.go
@@ -48,14 +48,14 @@ func validateUpdateSettings(ctx context.Context, logger libLog.Logger, span trac
 }
 
 // enforceOverdraftTransition protects balances that carry outstanding
-// overdraft usage. Two transitions are rejected:
+// overdraft usage from being reconfigured into an impossible limit state.
+// Disabling AllowOverdraft is allowed even when OverdraftUsed > 0: the flag
+// controls future debit-side overdraft usage, while incoming credits must still
+// be able to repay the existing debt.
 //
-//  1. disabling AllowOverdraft while OverdraftUsed > 0 — would orphan debt.
-//  2. reducing OverdraftLimit below OverdraftUsed — would leave the balance
-//     in a permanently over-limit state with no ability to recover.
-//
-// Both rules are enforced before the repository
-// Update is invoked.
+// The only rejected transition is reducing OverdraftLimit below OverdraftUsed,
+// which would leave the balance permanently over-limit. This rule is enforced
+// before the repository Update is invoked.
 func enforceOverdraftTransition(ctx context.Context, logger libLog.Logger, span trace.Span, current *mmodel.Balance, next *mmodel.BalanceSettings) error {
 	if current == nil || next == nil {
 		return nil
@@ -64,14 +64,6 @@ func enforceOverdraftTransition(ctx context.Context, logger libLog.Logger, span 
 	usage := current.OverdraftUsed
 	if usage.IsZero() {
 		return nil
-	}
-
-	if !next.AllowOverdraft {
-		err := pkg.ValidateBusinessError(constant.ErrOverdraftDisableWithUsage, constant.EntityBalance)
-		libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Cannot disable overdraft while usage is non-zero", err)
-		logger.Log(ctx, libLog.LevelWarn, "Rejected overdraft disable with active usage")
-
-		return err
 	}
 
 	if next.OverdraftLimitEnabled && next.OverdraftLimit != nil {

--- a/components/ledger/internal/services/command/update_balance_overdraft.go
+++ b/components/ledger/internal/services/command/update_balance_overdraft.go
@@ -182,6 +182,14 @@ func (uc *UseCase) ensureOverdraftBalance(ctx context.Context, logger libLog.Log
 		return nil
 	}
 
+	// The companion balance participates as BOTH a source (DEBIT grows the
+	// liability when the credit balance overdraws) and a destination (CREDIT
+	// shrinks the liability when the overdraft is repaid). Both flags are
+	// therefore true. Direct user access is blocked by the scope guard at
+	// SendTransactionToRedisQueue (BalanceScope=internal → 0168), so leaving
+	// AllowSending=true does NOT expose the companion to client-initiated
+	// transactions — only the system enrichment engine can route operations
+	// onto it.
 	overdraftBalance := &mmodel.Balance{
 		ID:             uuid.Must(libCommons.GenerateUUIDv7()).String(),
 		OrganizationID: current.OrganizationID,
@@ -191,7 +199,7 @@ func (uc *UseCase) ensureOverdraftBalance(ctx context.Context, logger libLog.Log
 		Key:            constant.OverdraftBalanceKey,
 		AssetCode:      current.AssetCode,
 		AccountType:    current.AccountType,
-		AllowSending:   false,
+		AllowSending:   true,
 		AllowReceiving: true,
 		Direction:      constant.DirectionDebit,
 		OverdraftUsed:  decimal.Zero,

--- a/components/ledger/internal/services/command/update_balance_overdraft.go
+++ b/components/ledger/internal/services/command/update_balance_overdraft.go
@@ -1,0 +1,199 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package command
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"reflect"
+	"time"
+
+	libCommons "github.com/LerianStudio/lib-commons/v4/commons"
+	libLog "github.com/LerianStudio/lib-commons/v4/commons/log"
+	libOpentelemetry "github.com/LerianStudio/lib-commons/v4/commons/opentelemetry"
+	"github.com/LerianStudio/midaz/v3/pkg"
+	"github.com/LerianStudio/midaz/v3/pkg/constant"
+	"github.com/LerianStudio/midaz/v3/pkg/mmodel"
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// validateUpdateSettings runs the BalanceSettings contract check before any
+// repository interaction. Failing closed here keeps corrupt payloads out of
+// PostgreSQL and guarantees no partial writes on validation failure.
+//
+// It also rejects any attempt to set BalanceScope="internal" via PATCH:
+// internal scope is reserved for system-managed balances (auto-created
+// overdraft balances) and MUST NOT be settable through the public API.
+func validateUpdateSettings(ctx context.Context, logger libLog.Logger, span trace.Span, settings *mmodel.BalanceSettings) error {
+	if err := settings.Validate(); err != nil {
+		libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Invalid balance settings payload", err)
+		logger.Log(ctx, libLog.LevelWarn, fmt.Sprintf("Rejected invalid balance settings: %v", err))
+
+		return pkg.ValidateBusinessError(constant.ErrInvalidBalanceSettings, reflect.TypeOf(mmodel.Balance{}).Name())
+	}
+
+	if settings.BalanceScope == mmodel.BalanceScopeInternal {
+		err := pkg.ValidateBusinessError(constant.ErrInvalidBalanceSettings, reflect.TypeOf(mmodel.Balance{}).Name())
+		libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Reserved balance scope", err)
+		logger.Log(ctx, libLog.LevelWarn, fmt.Sprintf("Rejected reserved balance scope on update: %v", settings.BalanceScope))
+
+		return err
+	}
+
+	return nil
+}
+
+// enforceOverdraftTransition protects balances that carry outstanding
+// overdraft usage. Two transitions are rejected:
+//
+//  1. disabling AllowOverdraft while OverdraftUsed > 0 — would orphan debt.
+//  2. reducing OverdraftLimit below OverdraftUsed — would leave the balance
+//     in a permanently over-limit state with no ability to recover.
+//
+// Both rules are enforced before the repository
+// Update is invoked.
+func enforceOverdraftTransition(ctx context.Context, logger libLog.Logger, span trace.Span, current *mmodel.Balance, next *mmodel.BalanceSettings) error {
+	if current == nil || next == nil {
+		return nil
+	}
+
+	usage := current.OverdraftUsed
+	if usage.IsZero() {
+		return nil
+	}
+
+	if !next.AllowOverdraft {
+		err := pkg.ValidateBusinessError(constant.ErrOverdraftDisableWithUsage, reflect.TypeOf(mmodel.Balance{}).Name())
+		libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Cannot disable overdraft while usage is non-zero", err)
+		logger.Log(ctx, libLog.LevelWarn, fmt.Sprintf("Rejected overdraft disable with usage=%s", usage.String()))
+
+		return err
+	}
+
+	if next.OverdraftLimitEnabled && next.OverdraftLimit != nil {
+		limit, perr := decimal.NewFromString(*next.OverdraftLimit)
+		if perr != nil {
+			// Should not happen — Validate() already parsed it. Treat as
+			// invalid payload to stay fail-closed.
+			wrapped := pkg.ValidateBusinessError(constant.ErrInvalidBalanceSettings, reflect.TypeOf(mmodel.Balance{}).Name())
+			libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Overdraft limit is not a valid decimal", perr)
+			logger.Log(ctx, libLog.LevelWarn, fmt.Sprintf("Invalid overdraft limit after validation: %v", perr))
+
+			return wrapped
+		}
+
+		if limit.LessThan(usage) {
+			err := pkg.ValidateBusinessError(constant.ErrOverdraftLimitBelowUsage, reflect.TypeOf(mmodel.Balance{}).Name())
+			libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Overdraft limit below current usage", err)
+			logger.Log(ctx, libLog.LevelWarn, fmt.Sprintf("Rejected overdraft limit=%s below usage=%s", limit.String(), usage.String()))
+
+			return err
+		}
+	}
+
+	return nil
+}
+
+// ensureOverdraftBalance auto-creates the system-managed overdraft balance
+// when AllowOverdraft transitions from false to true. The operation is
+// idempotent: if a balance with key="overdraft" already exists for the
+// account, no new row is created.
+//
+// The auto-created balance is:
+//   - key        = "overdraft"
+//   - direction  = "debit"
+//   - scope      = "internal" (protected from direct operations)
+//   - alias      = same as the parent balance
+//   - asset code = same as the parent balance
+func (uc *UseCase) ensureOverdraftBalance(ctx context.Context, logger libLog.Logger, span trace.Span, organizationID, ledgerID uuid.UUID, current *mmodel.Balance, nextSettings *mmodel.BalanceSettings) error {
+	if current == nil || nextSettings == nil {
+		return nil
+	}
+
+	if !nextSettings.AllowOverdraft {
+		return nil
+	}
+
+	// Only act on the false→true transition. Anything else is a no-op.
+	if current.Settings != nil && current.Settings.AllowOverdraft {
+		return nil
+	}
+
+	// An empty AccountID can only occur in tests that seed a minimal
+	// balance fixture. We fall back to uuid.Nil rather than failing the
+	// update because the overdraft auto-creation is a best-effort extension
+	// of the settings update — the parent balance has already been persisted.
+	var accountID uuid.UUID
+
+	if current.AccountID != "" {
+		parsed, perr := uuid.Parse(current.AccountID)
+		if perr != nil {
+			libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Invalid account id on current balance", perr)
+			logger.Log(ctx, libLog.LevelError, fmt.Sprintf("Failed to parse account id %q: %v", current.AccountID, perr))
+
+			return perr
+		}
+
+		accountID = parsed
+	}
+
+	existing, ferr := uc.BalanceRepo.FindByAccountIDAndKey(ctx, organizationID, ledgerID, accountID, constant.OverdraftBalanceKey)
+	if ferr != nil {
+		// The repository signals "not found" by returning an
+		// EntityNotFoundError (see FindByAccountIDAndKey in
+		// balance.postgresql.go — sql.ErrNoRows is mapped to
+		// pkg.ValidateBusinessError(constant.ErrEntityNotFound, ...)).
+		// Only propagate real infrastructure errors; a not-found result
+		// is the expected trigger for the auto-creation path below.
+		var notFound pkg.EntityNotFoundError
+		if !errors.As(ferr, &notFound) {
+			libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Failed to check for existing overdraft balance", ferr)
+			logger.Log(ctx, libLog.LevelError, fmt.Sprintf("Error checking overdraft balance: %v", ferr))
+
+			return ferr
+		}
+
+		existing = nil
+	}
+
+	if existing != nil {
+		// Idempotent: the overdraft balance already exists.
+		return nil
+	}
+
+	overdraftBalance := &mmodel.Balance{
+		ID:             uuid.Must(libCommons.GenerateUUIDv7()).String(),
+		OrganizationID: current.OrganizationID,
+		LedgerID:       current.LedgerID,
+		AccountID:      current.AccountID,
+		Alias:          current.Alias,
+		Key:            constant.OverdraftBalanceKey,
+		AssetCode:      current.AssetCode,
+		AccountType:    current.AccountType,
+		AllowSending:   false,
+		AllowReceiving: true,
+		Direction:      constant.DirectionDebit,
+		OverdraftUsed:  decimal.Zero,
+		Settings: &mmodel.BalanceSettings{
+			BalanceScope: mmodel.BalanceScopeInternal,
+		},
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+	}
+
+	if _, cerr := uc.BalanceRepo.Create(ctx, overdraftBalance); cerr != nil {
+		libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Failed to auto-create overdraft balance", cerr)
+		logger.Log(ctx, libLog.LevelError, fmt.Sprintf("Error auto-creating overdraft balance: %v", cerr))
+
+		return cerr
+	}
+
+	logger.Log(ctx, libLog.LevelInfo, fmt.Sprintf("Auto-created overdraft balance for account %s", current.AccountID))
+
+	return nil
+}

--- a/components/ledger/internal/services/command/update_balance_overdraft.go
+++ b/components/ledger/internal/services/command/update_balance_overdraft.go
@@ -7,8 +7,6 @@ package command
 import (
 	"context"
 	"errors"
-	"fmt"
-	"reflect"
 	"time"
 
 	libCommons "github.com/LerianStudio/lib-commons/v4/commons"
@@ -32,15 +30,15 @@ import (
 func validateUpdateSettings(ctx context.Context, logger libLog.Logger, span trace.Span, settings *mmodel.BalanceSettings) error {
 	if err := settings.Validate(); err != nil {
 		libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Invalid balance settings payload", err)
-		logger.Log(ctx, libLog.LevelWarn, fmt.Sprintf("Rejected invalid balance settings: %v", err))
+		logger.Log(ctx, libLog.LevelWarn, "Rejected invalid balance settings", libLog.Err(err))
 
-		return pkg.ValidateBusinessError(constant.ErrInvalidBalanceSettings, reflect.TypeOf(mmodel.Balance{}).Name())
+		return pkg.ValidateBusinessError(constant.ErrInvalidBalanceSettings, constant.EntityBalance)
 	}
 
 	if settings.BalanceScope == mmodel.BalanceScopeInternal {
-		err := pkg.ValidateBusinessError(constant.ErrInvalidBalanceSettings, reflect.TypeOf(mmodel.Balance{}).Name())
+		err := pkg.ValidateBusinessError(constant.ErrInvalidBalanceSettings, constant.EntityBalance)
 		libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Reserved balance scope", err)
-		logger.Log(ctx, libLog.LevelWarn, fmt.Sprintf("Rejected reserved balance scope on update: %v", settings.BalanceScope))
+		logger.Log(ctx, libLog.LevelWarn, "Rejected reserved balance scope on update", libLog.String("scope", settings.BalanceScope))
 
 		return err
 	}
@@ -68,9 +66,9 @@ func enforceOverdraftTransition(ctx context.Context, logger libLog.Logger, span 
 	}
 
 	if !next.AllowOverdraft {
-		err := pkg.ValidateBusinessError(constant.ErrOverdraftDisableWithUsage, reflect.TypeOf(mmodel.Balance{}).Name())
+		err := pkg.ValidateBusinessError(constant.ErrOverdraftDisableWithUsage, constant.EntityBalance)
 		libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Cannot disable overdraft while usage is non-zero", err)
-		logger.Log(ctx, libLog.LevelWarn, fmt.Sprintf("Rejected overdraft disable with usage=%s", usage.String()))
+		logger.Log(ctx, libLog.LevelWarn, "Rejected overdraft disable with active usage", libLog.String("overdraftUsed", usage.String()))
 
 		return err
 	}
@@ -80,17 +78,18 @@ func enforceOverdraftTransition(ctx context.Context, logger libLog.Logger, span 
 		if perr != nil {
 			// Should not happen — Validate() already parsed it. Treat as
 			// invalid payload to stay fail-closed.
-			wrapped := pkg.ValidateBusinessError(constant.ErrInvalidBalanceSettings, reflect.TypeOf(mmodel.Balance{}).Name())
+			wrapped := pkg.ValidateBusinessError(constant.ErrInvalidBalanceSettings, constant.EntityBalance)
+
 			libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Overdraft limit is not a valid decimal", perr)
-			logger.Log(ctx, libLog.LevelWarn, fmt.Sprintf("Invalid overdraft limit after validation: %v", perr))
+			logger.Log(ctx, libLog.LevelWarn, "Invalid overdraft limit after validation", libLog.Err(perr))
 
 			return wrapped
 		}
 
 		if limit.LessThan(usage) {
-			err := pkg.ValidateBusinessError(constant.ErrOverdraftLimitBelowUsage, reflect.TypeOf(mmodel.Balance{}).Name())
+			err := pkg.ValidateBusinessError(constant.ErrOverdraftLimitBelowUsage, constant.EntityBalance)
 			libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Overdraft limit below current usage", err)
-			logger.Log(ctx, libLog.LevelWarn, fmt.Sprintf("Rejected overdraft limit=%s below usage=%s", limit.String(), usage.String()))
+			logger.Log(ctx, libLog.LevelWarn, "Rejected overdraft limit below current usage", libLog.String("limit", limit.String()), libLog.String("overdraftUsed", usage.String()))
 
 			return err
 		}
@@ -134,7 +133,7 @@ func (uc *UseCase) ensureOverdraftBalance(ctx context.Context, logger libLog.Log
 		parsed, perr := uuid.Parse(current.AccountID)
 		if perr != nil {
 			libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Invalid account id on current balance", perr)
-			logger.Log(ctx, libLog.LevelError, fmt.Sprintf("Failed to parse account id %q: %v", current.AccountID, perr))
+			logger.Log(ctx, libLog.LevelError, "Failed to parse account ID", libLog.String("accountID", current.AccountID), libLog.Err(perr))
 
 			return perr
 		}
@@ -153,7 +152,7 @@ func (uc *UseCase) ensureOverdraftBalance(ctx context.Context, logger libLog.Log
 		var notFound pkg.EntityNotFoundError
 		if !errors.As(ferr, &notFound) {
 			libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Failed to check for existing overdraft balance", ferr)
-			logger.Log(ctx, libLog.LevelError, fmt.Sprintf("Error checking overdraft balance: %v", ferr))
+			logger.Log(ctx, libLog.LevelError, "Failed to check existing overdraft balance", libLog.Err(ferr))
 
 			return ferr
 		}
@@ -188,12 +187,12 @@ func (uc *UseCase) ensureOverdraftBalance(ctx context.Context, logger libLog.Log
 
 	if _, cerr := uc.BalanceRepo.Create(ctx, overdraftBalance); cerr != nil {
 		libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Failed to auto-create overdraft balance", cerr)
-		logger.Log(ctx, libLog.LevelError, fmt.Sprintf("Error auto-creating overdraft balance: %v", cerr))
+		logger.Log(ctx, libLog.LevelError, "Failed to auto-create overdraft balance", libLog.Err(cerr))
 
 		return cerr
 	}
 
-	logger.Log(ctx, libLog.LevelInfo, fmt.Sprintf("Auto-created overdraft balance for account %s", current.AccountID))
+	logger.Log(ctx, libLog.LevelInfo, "Auto-created overdraft balance", libLog.String("accountID", current.AccountID))
 
 	return nil
 }

--- a/components/ledger/internal/services/command/update_balance_overdraft_race_test.go
+++ b/components/ledger/internal/services/command/update_balance_overdraft_race_test.go
@@ -116,6 +116,11 @@ func TestEnsureOverdraftBalance_ConcurrentCreate_ReturnsBenignSuccess(t *testing
 		Times(1)
 
 	mockRedisRepo.EXPECT().Get(gomock.Any(), gomock.Any()).Return("", nil).AnyTimes()
+	// Cache settings are rewritten in-place after a settings update (live
+	// transactional state is preserved — no Del).
+	mockRedisRepo.EXPECT().
+		UpdateBalanceCacheSettings(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(nil).AnyTimes()
 
 	uc := UseCase{
 		BalanceRepo:          mockBalanceRepo,

--- a/components/ledger/internal/services/command/update_balance_overdraft_race_test.go
+++ b/components/ledger/internal/services/command/update_balance_overdraft_race_test.go
@@ -1,0 +1,275 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package command
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	libCommons "github.com/LerianStudio/lib-commons/v4/commons"
+	"github.com/LerianStudio/midaz/v3/components/ledger/internal/adapters/postgres/balance"
+	redis "github.com/LerianStudio/midaz/v3/components/ledger/internal/adapters/redis/transaction"
+	"github.com/LerianStudio/midaz/v3/pkg/constant"
+	"github.com/LerianStudio/midaz/v3/pkg/mmodel"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+// raceTestFixture returns a canonical (orgID, ledgerID, balanceID, current,
+// update) bundle driving the false→true AllowOverdraft transition. Centralised
+// so every race-handling test exercises the same initial state.
+func raceTestFixture(t *testing.T) (uuid.UUID, uuid.UUID, uuid.UUID, *mmodel.Balance, mmodel.UpdateBalance) {
+	t.Helper()
+
+	orgID := uuid.Must(libCommons.GenerateUUIDv7())
+	ledgerID := uuid.Must(libCommons.GenerateUUIDv7())
+	balanceID := uuid.Must(libCommons.GenerateUUIDv7())
+	accountID := uuid.Must(libCommons.GenerateUUIDv7())
+
+	newSettings := &mmodel.BalanceSettings{
+		BalanceScope:   mmodel.BalanceScopeTransactional,
+		AllowOverdraft: true,
+	}
+
+	current := &mmodel.Balance{
+		ID:             balanceID.String(),
+		OrganizationID: orgID.String(),
+		LedgerID:       ledgerID.String(),
+		AccountID:      accountID.String(),
+		Alias:          "@race",
+		Key:            "default",
+		AssetCode:      "USD",
+		Direction:      constant.DirectionCredit,
+		OverdraftUsed:  decimal.Zero,
+		Settings:       mmodel.NewDefaultBalanceSettings(),
+	}
+
+	return orgID, ledgerID, balanceID, current, mmodel.UpdateBalance{Settings: newSettings}
+}
+
+// TestEnsureOverdraftBalance_ConcurrentCreate_ReturnsBenignSuccess verifies
+// that when BalanceRepo.Create returns a PostgreSQL unique_violation
+// (SQLSTATE 23505), ensureOverdraftBalance treats it as idempotent success
+// as long as the second FindByAccountIDAndKey resolves the peer-created
+// row. This is the core race-condition guarantee: two concurrent PATCH
+// requests flipping AllowOverdraft MUST both succeed, with exactly one
+// overdraft balance materialised in the end.
+func TestEnsureOverdraftBalance_ConcurrentCreate_ReturnsBenignSuccess(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
+	orgID, ledgerID, balanceID, current, update := raceTestFixture(t)
+
+	expected := *current
+	expected.Settings = update.Settings
+
+	peerOverdraft := &mmodel.Balance{
+		ID:             uuid.Must(libCommons.GenerateUUIDv7()).String(),
+		OrganizationID: current.OrganizationID,
+		LedgerID:       current.LedgerID,
+		AccountID:      current.AccountID,
+		Alias:          current.Alias,
+		Key:            constant.OverdraftBalanceKey,
+		AssetCode:      current.AssetCode,
+		Direction:      constant.DirectionDebit,
+	}
+
+	mockBalanceRepo := balance.NewMockRepository(ctrl)
+	mockRedisRepo := redis.NewMockRedisRepository(ctrl)
+
+	mockBalanceRepo.EXPECT().
+		Find(gomock.Any(), orgID, ledgerID, balanceID).
+		Return(current, nil).
+		Times(1)
+
+	// First lookup: peer request has not yet committed → not found.
+	// Second lookup (after the 23505 from Create): peer's row is visible.
+	gomock.InOrder(
+		mockBalanceRepo.EXPECT().
+			FindByAccountIDAndKey(gomock.Any(), orgID, ledgerID, gomock.Any(), constant.OverdraftBalanceKey).
+			Return(nil, nil).
+			Times(1),
+		mockBalanceRepo.EXPECT().
+			FindByAccountIDAndKey(gomock.Any(), orgID, ledgerID, gomock.Any(), constant.OverdraftBalanceKey).
+			Return(peerOverdraft, nil).
+			Times(1),
+	)
+
+	// Simulate the partial UNIQUE index rejecting our insert.
+	mockBalanceRepo.EXPECT().
+		Create(gomock.Any(), gomock.Any()).
+		Return(nil, &pgconn.PgError{Code: constant.UniqueViolationCode}).
+		Times(1)
+
+	mockBalanceRepo.EXPECT().
+		Update(gomock.Any(), orgID, ledgerID, balanceID, update).
+		Return(&expected, nil).
+		Times(1)
+
+	mockRedisRepo.EXPECT().Get(gomock.Any(), gomock.Any()).Return("", nil).AnyTimes()
+
+	uc := UseCase{
+		BalanceRepo:          mockBalanceRepo,
+		TransactionRedisRepo: mockRedisRepo,
+	}
+
+	result, err := uc.Update(context.TODO(), orgID, ledgerID, balanceID, update)
+
+	require.NoError(t, err, "a benign 23505 race MUST NOT surface as an error to the caller")
+	require.NotNil(t, result)
+	require.NotNil(t, result.Settings)
+	assert.True(t, result.Settings.AllowOverdraft)
+}
+
+// TestEnsureOverdraftBalance_UniqueViolation_WithMissingRow_PropagatesError
+// covers the defensive branch: a 23505 was raised but the follow-up Find
+// still returns nil. That almost certainly means the unique violation came
+// from a DIFFERENT index than the one guarding our tuple, so we must NOT
+// silently swallow the error — the caller needs to see it.
+func TestEnsureOverdraftBalance_UniqueViolation_WithMissingRow_PropagatesError(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
+	orgID, ledgerID, balanceID, current, update := raceTestFixture(t)
+
+	mockBalanceRepo := balance.NewMockRepository(ctrl)
+	mockRedisRepo := redis.NewMockRedisRepository(ctrl)
+
+	mockBalanceRepo.EXPECT().
+		Find(gomock.Any(), orgID, ledgerID, balanceID).
+		Return(current, nil).
+		Times(1)
+
+	// Both lookups return nil — peer did not actually create the row, so
+	// the 23505 did not come from our target tuple.
+	mockBalanceRepo.EXPECT().
+		FindByAccountIDAndKey(gomock.Any(), orgID, ledgerID, gomock.Any(), constant.OverdraftBalanceKey).
+		Return(nil, nil).
+		Times(2)
+
+	pgErr := &pgconn.PgError{Code: constant.UniqueViolationCode}
+	mockBalanceRepo.EXPECT().
+		Create(gomock.Any(), gomock.Any()).
+		Return(nil, pgErr).
+		Times(1)
+
+	// Update MUST NOT be called when ensureOverdraftBalance fails — the
+	// parent balance's settings stay intact so the pair remains consistent.
+	mockBalanceRepo.EXPECT().
+		Update(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Times(0)
+
+	uc := UseCase{
+		BalanceRepo:          mockBalanceRepo,
+		TransactionRedisRepo: mockRedisRepo,
+	}
+
+	result, err := uc.Update(context.TODO(), orgID, ledgerID, balanceID, update)
+
+	require.Error(t, err, "unexplained 23505 MUST be surfaced to the caller")
+	assert.Nil(t, result)
+	assert.ErrorIs(t, err, pgErr, "the original Create error MUST be preserved")
+}
+
+// TestEnsureOverdraftBalance_NonUniqueViolation_PropagatesError verifies
+// that non-23505 errors from Create (connectivity failures, FK violations,
+// etc.) are propagated unchanged without touching the reload path.
+func TestEnsureOverdraftBalance_NonUniqueViolation_PropagatesError(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
+	orgID, ledgerID, balanceID, current, update := raceTestFixture(t)
+
+	mockBalanceRepo := balance.NewMockRepository(ctrl)
+	mockRedisRepo := redis.NewMockRedisRepository(ctrl)
+
+	mockBalanceRepo.EXPECT().
+		Find(gomock.Any(), orgID, ledgerID, balanceID).
+		Return(current, nil).
+		Times(1)
+
+	// Only the initial idempotency check runs. The reload path MUST NOT
+	// fire for non-unique-violation errors.
+	mockBalanceRepo.EXPECT().
+		FindByAccountIDAndKey(gomock.Any(), orgID, ledgerID, gomock.Any(), constant.OverdraftBalanceKey).
+		Return(nil, nil).
+		Times(1)
+
+	createErr := errors.New("connection reset by peer")
+	mockBalanceRepo.EXPECT().
+		Create(gomock.Any(), gomock.Any()).
+		Return(nil, createErr).
+		Times(1)
+
+	mockBalanceRepo.EXPECT().
+		Update(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Times(0)
+
+	uc := UseCase{
+		BalanceRepo:          mockBalanceRepo,
+		TransactionRedisRepo: mockRedisRepo,
+	}
+
+	result, err := uc.Update(context.TODO(), orgID, ledgerID, balanceID, update)
+
+	require.Error(t, err, "non-23505 Create errors MUST surface to the caller")
+	assert.Nil(t, result)
+	assert.ErrorIs(t, err, createErr, "the original Create error MUST be preserved")
+}
+
+// TestIsUniqueViolation_PgError_Code23505 asserts the helper that gates the
+// race-recovery branch. It MUST return true only for pgconn.PgError values
+// carrying SQLSTATE 23505 and false for every other error type (generic
+// errors, wrapped errors with a different code, nil).
+func TestIsUniqueViolation_PgError_Code23505(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "PgError with code 23505 is a unique violation",
+			err:  &pgconn.PgError{Code: constant.UniqueViolationCode},
+			want: true,
+		},
+		{
+			name: "PgError with another code is not a unique violation",
+			err:  &pgconn.PgError{Code: "23503"},
+			want: false,
+		},
+		{
+			name: "generic error is not a unique violation",
+			err:  errors.New("boom"),
+			want: false,
+		},
+		{
+			name: "nil error is not a unique violation",
+			err:  nil,
+			want: false,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tc.want, isUniqueViolation(tc.err))
+		})
+	}
+}

--- a/components/ledger/internal/services/command/update_balance_overdraft_test.go
+++ b/components/ledger/internal/services/command/update_balance_overdraft_test.go
@@ -65,8 +65,8 @@ func TestUpdateBalance_WithSettings(t *testing.T) {
 	mockRedisRepo := redis.NewMockRedisRepository(ctrl)
 
 	// The use case MUST read the current balance BEFORE applying the
-	// update so it can enforce transition invariants (usage vs. limit,
-	// disable-with-debt). Exactly one Find call is expected.
+	// update so it can enforce transition invariants (usage vs. limit).
+	// Exactly one Find call is expected.
 	mockBalanceRepo.EXPECT().Find(gomock.Any(), orgID, ledgerID, balanceID).
 		Return(&existing, nil).Times(1)
 
@@ -187,9 +187,10 @@ func TestUpdateBalance_SettingsValidation(t *testing.T) {
 	}
 }
 
-// TestUpdateBalance_CannotDisableOverdraftWithUsage verifies that overdraft
-// cannot be disabled while the balance is still carrying debt.
-func TestUpdateBalance_CannotDisableOverdraftWithUsage(t *testing.T) {
+// TestUpdateBalance_CanDisableOverdraftWithUsage verifies that disabling
+// overdraft is allowed while the balance is still carrying debt. The setting
+// only blocks future overdraft usage; repayment credits must still be accepted.
+func TestUpdateBalance_CanDisableOverdraftWithUsage(t *testing.T) {
 	t.Parallel()
 
 	ctrl := gomock.NewController(t)
@@ -229,10 +230,23 @@ func TestUpdateBalance_CannotDisableOverdraftWithUsage(t *testing.T) {
 		Return(current, nil).
 		Times(1)
 
-	// Must NOT persist a disable that would leave debt orphaned.
+	expected := *current
+	expected.Settings = update.Settings
+
 	mockBalanceRepo.EXPECT().
-		Update(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-		Times(0)
+		Update(gomock.Any(), orgID, ledgerID, balanceID, update).
+		Return(&expected, nil).
+		Times(1)
+
+	mockRedisRepo.EXPECT().
+		Get(gomock.Any(), gomock.Any()).
+		Return("", nil).
+		Times(1)
+
+	mockRedisRepo.EXPECT().
+		UpdateBalanceCacheSettings(gomock.Any(), orgID, ledgerID, "@indebted#default", update.Settings).
+		Return(nil).
+		Times(1)
 
 	uc := UseCase{
 		BalanceRepo:          mockBalanceRepo,
@@ -241,8 +255,11 @@ func TestUpdateBalance_CannotDisableOverdraftWithUsage(t *testing.T) {
 
 	result, err := uc.Update(context.TODO(), orgID, ledgerID, balanceID, update)
 
-	require.Error(t, err, "disabling overdraft with outstanding usage MUST fail")
-	assert.Nil(t, result)
+	require.NoError(t, err, "disabling overdraft with outstanding usage must be allowed")
+	require.NotNil(t, result)
+	require.NotNil(t, result.Settings)
+	assert.False(t, result.Settings.AllowOverdraft)
+	assert.Equal(t, decimal.NewFromInt(250), result.OverdraftUsed)
 }
 
 // TestUpdateBalance_CannotReduceLimitBelowUsage verifies that the limit

--- a/components/ledger/internal/services/command/update_balance_overdraft_test.go
+++ b/components/ledger/internal/services/command/update_balance_overdraft_test.go
@@ -1,0 +1,298 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package command
+
+import (
+	"context"
+	"testing"
+
+	libCommons "github.com/LerianStudio/lib-commons/v4/commons"
+	"github.com/LerianStudio/midaz/v3/components/ledger/internal/adapters/postgres/balance"
+	redis "github.com/LerianStudio/midaz/v3/components/ledger/internal/adapters/redis/transaction"
+	"github.com/LerianStudio/midaz/v3/pkg/constant"
+	"github.com/LerianStudio/midaz/v3/pkg/mmodel"
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+// strPtr returns a pointer to the given string, used for decimal string
+// literals carried by BalanceSettings.OverdraftLimit.
+func strPtr(s string) *string { return &s }
+
+// TestUpdateBalance_WithSettings verifies that a valid Settings payload is
+// forwarded to the repository and reflected on the returned balance.
+func TestUpdateBalance_WithSettings(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
+	orgID := uuid.Must(libCommons.GenerateUUIDv7())
+	ledgerID := uuid.Must(libCommons.GenerateUUIDv7())
+	balanceID := uuid.Must(libCommons.GenerateUUIDv7())
+
+	newSettings := &mmodel.BalanceSettings{
+		BalanceScope:          mmodel.BalanceScopeTransactional,
+		AllowOverdraft:        true,
+		OverdraftLimitEnabled: true,
+		OverdraftLimit:        strPtr("1000.00"),
+	}
+
+	update := mmodel.UpdateBalance{Settings: newSettings}
+
+	baseBalance := &mmodel.Balance{
+		ID:             balanceID.String(),
+		OrganizationID: orgID.String(),
+		LedgerID:       ledgerID.String(),
+		Alias:          "@alice",
+		Key:            "default",
+		Direction:      constant.DirectionCredit,
+		OverdraftUsed:  decimal.Zero,
+	}
+
+	existing := *baseBalance
+	existing.Settings = mmodel.NewDefaultBalanceSettings()
+
+	expected := *baseBalance
+	expected.Settings = newSettings
+
+	mockBalanceRepo := balance.NewMockRepository(ctrl)
+	mockRedisRepo := redis.NewMockRedisRepository(ctrl)
+
+	// The use case MUST read the current balance BEFORE applying the
+	// update so it can enforce transition invariants (usage vs. limit,
+	// disable-with-debt). Exactly one Find call is expected.
+	mockBalanceRepo.EXPECT().Find(gomock.Any(), orgID, ledgerID, balanceID).
+		Return(&existing, nil).Times(1)
+
+	// Idempotency check for the auto-managed overdraft balance.
+	mockBalanceRepo.EXPECT().
+		FindByAccountIDAndKey(gomock.Any(), orgID, ledgerID, gomock.Any(), "overdraft").
+		Return(nil, nil).AnyTimes()
+
+	mockBalanceRepo.EXPECT().Create(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, b *mmodel.Balance) (*mmodel.Balance, error) { return b, nil }).
+		AnyTimes()
+
+	mockBalanceRepo.EXPECT().
+		Update(gomock.Any(), orgID, ledgerID, balanceID, update).
+		Return(&expected, nil).Times(1)
+
+	mockRedisRepo.EXPECT().Get(gomock.Any(), gomock.Any()).Return("", nil).AnyTimes()
+
+	uc := UseCase{
+		BalanceRepo:          mockBalanceRepo,
+		TransactionRedisRepo: mockRedisRepo,
+	}
+
+	result, err := uc.Update(context.TODO(), orgID, ledgerID, balanceID, update)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.NotNil(t, result.Settings,
+		"Settings MUST be present on the updated balance")
+	assert.True(t, result.Settings.AllowOverdraft,
+		"AllowOverdraft MUST be persisted from the update payload")
+	assert.True(t, result.Settings.OverdraftLimitEnabled)
+	require.NotNil(t, result.Settings.OverdraftLimit)
+	assert.Equal(t, "1000.00", *result.Settings.OverdraftLimit)
+}
+
+// TestUpdateBalance_SettingsValidation verifies that invalid settings are
+// rejected before the repository is hit (HARD GATE — no partial writes).
+func TestUpdateBalance_SettingsValidation(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
+	orgID := uuid.Must(libCommons.GenerateUUIDv7())
+	ledgerID := uuid.Must(libCommons.GenerateUUIDv7())
+	balanceID := uuid.Must(libCommons.GenerateUUIDv7())
+
+	cases := []struct {
+		name     string
+		settings *mmodel.BalanceSettings
+	}{
+		{
+			name: "limit enabled without limit value",
+			settings: &mmodel.BalanceSettings{
+				AllowOverdraft: true, OverdraftLimitEnabled: true, OverdraftLimit: nil,
+			},
+		},
+		{
+			name: "limit disabled but limit value present",
+			settings: &mmodel.BalanceSettings{
+				AllowOverdraft: true, OverdraftLimitEnabled: false, OverdraftLimit: strPtr("100.00"),
+			},
+		},
+		{
+			name:     "invalid balance scope",
+			settings: &mmodel.BalanceSettings{BalanceScope: "galactic"},
+		},
+		{
+			name: "overdraft limit zero with flag enabled",
+			settings: &mmodel.BalanceSettings{
+				AllowOverdraft: true, OverdraftLimitEnabled: true, OverdraftLimit: strPtr("0"),
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			mockBalanceRepo := balance.NewMockRepository(ctrl)
+			mockRedisRepo := redis.NewMockRedisRepository(ctrl)
+
+			// Repository MUST NOT receive a corrupt settings payload.
+			mockBalanceRepo.EXPECT().
+				Update(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+				Times(0)
+
+			mockBalanceRepo.EXPECT().
+				Find(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+				AnyTimes().
+				Return(&mmodel.Balance{
+					ID:            balanceID.String(),
+					Direction:     constant.DirectionCredit,
+					OverdraftUsed: decimal.Zero,
+					Settings:      mmodel.NewDefaultBalanceSettings(),
+				}, nil)
+
+			uc := UseCase{
+				BalanceRepo:          mockBalanceRepo,
+				TransactionRedisRepo: mockRedisRepo,
+			}
+
+			update := mmodel.UpdateBalance{Settings: tc.settings}
+
+			result, err := uc.Update(context.TODO(), orgID, ledgerID, balanceID, update)
+
+			require.Error(t, err, "invalid settings MUST produce a validation error")
+			assert.Nil(t, result, "no balance should be returned when settings are invalid")
+		})
+	}
+}
+
+// TestUpdateBalance_CannotDisableOverdraftWithUsage verifies that overdraft
+// cannot be disabled while the balance is still carrying debt.
+func TestUpdateBalance_CannotDisableOverdraftWithUsage(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
+	orgID := uuid.Must(libCommons.GenerateUUIDv7())
+	ledgerID := uuid.Must(libCommons.GenerateUUIDv7())
+	balanceID := uuid.Must(libCommons.GenerateUUIDv7())
+
+	current := &mmodel.Balance{
+		ID:             balanceID.String(),
+		OrganizationID: orgID.String(),
+		LedgerID:       ledgerID.String(),
+		Alias:          "@indebted",
+		Key:            "default",
+		Direction:      constant.DirectionCredit,
+		OverdraftUsed:  decimal.NewFromInt(250),
+		Settings: &mmodel.BalanceSettings{
+			AllowOverdraft:        true,
+			OverdraftLimitEnabled: true,
+			OverdraftLimit:        strPtr("500.00"),
+		},
+	}
+
+	update := mmodel.UpdateBalance{
+		Settings: &mmodel.BalanceSettings{
+			AllowOverdraft:        false,
+			OverdraftLimitEnabled: false,
+		},
+	}
+
+	mockBalanceRepo := balance.NewMockRepository(ctrl)
+	mockRedisRepo := redis.NewMockRedisRepository(ctrl)
+
+	mockBalanceRepo.EXPECT().
+		Find(gomock.Any(), orgID, ledgerID, balanceID).
+		Return(current, nil).
+		Times(1)
+
+	// Must NOT persist a disable that would leave debt orphaned.
+	mockBalanceRepo.EXPECT().
+		Update(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Times(0)
+
+	uc := UseCase{
+		BalanceRepo:          mockBalanceRepo,
+		TransactionRedisRepo: mockRedisRepo,
+	}
+
+	result, err := uc.Update(context.TODO(), orgID, ledgerID, balanceID, update)
+
+	require.Error(t, err, "disabling overdraft with outstanding usage MUST fail")
+	assert.Nil(t, result)
+}
+
+// TestUpdateBalance_CannotReduceLimitBelowUsage verifies that the limit
+// cannot be reduced below the currently used overdraft amount.
+func TestUpdateBalance_CannotReduceLimitBelowUsage(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
+	orgID := uuid.Must(libCommons.GenerateUUIDv7())
+	ledgerID := uuid.Must(libCommons.GenerateUUIDv7())
+	balanceID := uuid.Must(libCommons.GenerateUUIDv7())
+
+	current := &mmodel.Balance{
+		ID:             balanceID.String(),
+		OrganizationID: orgID.String(),
+		LedgerID:       ledgerID.String(),
+		Alias:          "@indebted",
+		Key:            "default",
+		Direction:      constant.DirectionCredit,
+		OverdraftUsed:  decimal.NewFromInt(400),
+		Settings: &mmodel.BalanceSettings{
+			AllowOverdraft:        true,
+			OverdraftLimitEnabled: true,
+			OverdraftLimit:        strPtr("1000.00"),
+		},
+	}
+
+	update := mmodel.UpdateBalance{
+		Settings: &mmodel.BalanceSettings{
+			AllowOverdraft:        true,
+			OverdraftLimitEnabled: true,
+			OverdraftLimit:        strPtr("100.00"),
+		},
+	}
+
+	mockBalanceRepo := balance.NewMockRepository(ctrl)
+	mockRedisRepo := redis.NewMockRedisRepository(ctrl)
+
+	mockBalanceRepo.EXPECT().
+		Find(gomock.Any(), orgID, ledgerID, balanceID).
+		Return(current, nil).
+		Times(1)
+
+	mockBalanceRepo.EXPECT().
+		Update(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Times(0)
+
+	uc := UseCase{
+		BalanceRepo:          mockBalanceRepo,
+		TransactionRedisRepo: mockRedisRepo,
+	}
+
+	result, err := uc.Update(context.TODO(), orgID, ledgerID, balanceID, update)
+
+	require.Error(t, err, "reducing limit below current usage MUST fail")
+	assert.Nil(t, result)
+}

--- a/components/ledger/internal/services/command/update_balance_overdraft_test.go
+++ b/components/ledger/internal/services/command/update_balance_overdraft_test.go
@@ -84,6 +84,12 @@ func TestUpdateBalance_WithSettings(t *testing.T) {
 		Return(&expected, nil).Times(1)
 
 	mockRedisRepo.EXPECT().Get(gomock.Any(), gomock.Any()).Return("", nil).AnyTimes()
+	// Cache settings are rewritten in-place after a settings update to make
+	// the new overdraft configuration visible without discarding live
+	// transactional state (Available, OnHold, Version, OverdraftUsed).
+	mockRedisRepo.EXPECT().
+		UpdateBalanceCacheSettings(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(nil).AnyTimes()
 
 	uc := UseCase{
 		BalanceRepo:          mockBalanceRepo,

--- a/components/ledger/internal/services/command/update_balance_test.go
+++ b/components/ledger/internal/services/command/update_balance_test.go
@@ -53,6 +53,12 @@ func TestUpdateBalance(t *testing.T) {
 	mockBalanceRepo := balance.NewMockRepository(ctrl)
 	mockRedisRepo := redis.NewMockRedisRepository(ctrl)
 
+	// Find is always called (scope guard requires the current balance).
+	mockBalanceRepo.EXPECT().
+		Find(gomock.Any(), organizationID, ledgerID, balanceID).
+		Return(expectedBalance, nil).
+		Times(1)
+
 	mockBalanceRepo.EXPECT().
 		Update(gomock.Any(), organizationID, ledgerID, balanceID, balanceUpdate).
 		Return(expectedBalance, nil).
@@ -106,6 +112,17 @@ func TestUpdateBalance_RepoError(t *testing.T) {
 	}
 
 	mockBalanceRepo := balance.NewMockRepository(ctrl)
+
+	// Find is always called (scope guard requires the current balance).
+	normalBalance := &mmodel.Balance{
+		ID:    balanceID.String(),
+		Alias: "@test",
+		Key:   "default",
+	}
+	mockBalanceRepo.EXPECT().
+		Find(gomock.Any(), organizationID, ledgerID, balanceID).
+		Return(normalBalance, nil).
+		Times(1)
 
 	mockBalanceRepo.EXPECT().
 		Update(gomock.Any(), organizationID, ledgerID, balanceID, balanceUpdate).
@@ -167,6 +184,12 @@ func TestUpdateBalance_RedisOverlay(t *testing.T) {
 
 	mockBalanceRepo := balance.NewMockRepository(ctrl)
 	mockRedisRepo := redis.NewMockRedisRepository(ctrl)
+
+	// Find is always called (scope guard requires the current balance).
+	mockBalanceRepo.EXPECT().
+		Find(gomock.Any(), organizationID, ledgerID, balanceID).
+		Return(repoBalance, nil).
+		Times(1)
 
 	mockBalanceRepo.EXPECT().
 		Update(gomock.Any(), organizationID, ledgerID, balanceID, balanceUpdate).

--- a/components/ledger/internal/services/command/update_balance_test.go
+++ b/components/ledger/internal/services/command/update_balance_test.go
@@ -64,6 +64,14 @@ func TestUpdateBalance(t *testing.T) {
 		Return("", nil).
 		Times(1)
 
+	// No Settings in the update payload → the cache settings rewrite MUST NOT
+	// fire. AllowSending/AllowReceiving mutations don't touch the overdraft
+	// settings contract guarded by UpdateBalanceCacheSettings, so the cached
+	// balance JSON (including its live transactional state) is left alone.
+	mockRedisRepo.EXPECT().
+		UpdateBalanceCacheSettings(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Times(0)
+
 	uc := UseCase{
 		BalanceRepo:          mockBalanceRepo,
 		TransactionRedisRepo: mockRedisRepo,
@@ -170,6 +178,15 @@ func TestUpdateBalance_RedisOverlay(t *testing.T) {
 		Return(string(cachedJSON), nil).
 		Times(1)
 
+	// No Settings in the update → the cache rewrite MUST NOT run, so the
+	// in-flight transactional snapshot held in Redis (Available=500, OnHold=50,
+	// Version=5) is neither overwritten nor deleted. This is the whole point
+	// of replacing the prior Del: preserving live state across settings-free
+	// updates.
+	mockRedisRepo.EXPECT().
+		UpdateBalanceCacheSettings(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Times(0)
+
 	uc := UseCase{
 		BalanceRepo:          mockBalanceRepo,
 		TransactionRedisRepo: mockRedisRepo,
@@ -191,6 +208,187 @@ func TestUpdateBalance_RedisOverlay(t *testing.T) {
 	assert.Equal(t, "USD", result.AssetCode)
 	assert.False(t, result.AllowSending)
 	assert.True(t, result.AllowReceiving)
+}
+
+// TestUpdateBalance_CacheSettingsUpdate_UsesCompositeAliasKey pins the exact
+// composite `alias#key` that the command layer passes to the Redis repo when
+// rewriting settings in the cached balance. If the composition rule drifts
+// (e.g. a refactor separates alias and key into distinct arguments or
+// re-orders them), this test fails loudly so the Lua-mutated balance key
+// and the command-side cache key stay in lock-step.
+//
+// The repo method is responsible for composing BalanceInternalKey from the
+// composite cacheKey + (org, ledger); this test pins the command-side
+// contract with the repo, not the full prefixed Redis key.
+func TestUpdateBalance_CacheSettingsUpdate_UsesCompositeAliasKey(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
+	organizationID := uuid.Must(libCommons.GenerateUUIDv7())
+	ledgerID := uuid.Must(libCommons.GenerateUUIDv7())
+	balanceID := uuid.Must(libCommons.GenerateUUIDv7())
+
+	allowOverdraft := true
+	newSettings := &mmodel.BalanceSettings{
+		AllowOverdraft: allowOverdraft,
+	}
+	balanceUpdate := mmodel.UpdateBalance{Settings: newSettings}
+
+	expectedBalance := &mmodel.Balance{
+		ID:             balanceID.String(),
+		OrganizationID: organizationID.String(),
+		LedgerID:       ledgerID.String(),
+		Alias:          "@user1",
+		Key:            "default",
+		AllowSending:   true,
+		AllowReceiving: true,
+	}
+
+	// The command layer MUST pass the composite "alias#key" form so the repo
+	// can rebuild BalanceInternalKey consistently with the Lua script's
+	// SET NX key. Any other separator or ordering would desynchronize the
+	// write and the transactional read.
+	expectedCompositeKey := "@user1#default"
+
+	mockBalanceRepo := balance.NewMockRepository(ctrl)
+	mockRedisRepo := redis.NewMockRedisRepository(ctrl)
+
+	// Settings path triggers Find + ensureOverdraftBalance; stub them as no-ops
+	// that simulate a balance which already has overdraft enabled (avoids the
+	// auto-create side-effect). Find returns a balance whose settings match the
+	// update — enforceOverdraftTransition treats this as a no-op transition.
+	existing := &mmodel.Balance{
+		ID:             balanceID.String(),
+		OrganizationID: organizationID.String(),
+		LedgerID:       ledgerID.String(),
+		Alias:          "@user1",
+		Key:            "default",
+		Settings: &mmodel.BalanceSettings{
+			AllowOverdraft: true,
+		},
+	}
+
+	mockBalanceRepo.EXPECT().
+		Find(gomock.Any(), organizationID, ledgerID, balanceID).
+		Return(existing, nil).
+		Times(1)
+
+	mockBalanceRepo.EXPECT().
+		Update(gomock.Any(), organizationID, ledgerID, balanceID, balanceUpdate).
+		Return(expectedBalance, nil).
+		Times(1)
+
+	// The Get overlay still uses the same prefixed key; keep it tolerant.
+	mockRedisRepo.EXPECT().
+		Get(gomock.Any(), gomock.Any()).
+		Return("", nil).
+		Times(1)
+
+	// HARD GATE: the cacheKey arg MUST be the composite "alias#key".
+	// The new settings payload MUST be forwarded verbatim so the repo can
+	// apply an in-place rewrite without losing live transactional state.
+	mockRedisRepo.EXPECT().
+		UpdateBalanceCacheSettings(gomock.Any(), organizationID, ledgerID, expectedCompositeKey, newSettings).
+		Return(nil).
+		Times(1)
+
+	uc := UseCase{
+		BalanceRepo:          mockBalanceRepo,
+		TransactionRedisRepo: mockRedisRepo,
+	}
+
+	result, err := uc.Update(context.TODO(), organizationID, ledgerID, balanceID, balanceUpdate)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, expectedBalance.ID, result.ID)
+}
+
+// TestUpdateBalance_CacheSettingsUpdate_FailureIsBestEffort verifies that a
+// Redis failure during the settings-only cache rewrite does not propagate to
+// the caller: the PostgreSQL write has already succeeded and is durable, so
+// the update must still return the updated balance. A subsequent
+// transaction's cache miss (or the sync worker) will reconcile.
+//
+// A Settings payload is used to guarantee the cache-rewrite path actually
+// executes (non-settings updates skip the rewrite by design).
+func TestUpdateBalance_CacheSettingsUpdate_FailureIsBestEffort(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
+	organizationID := uuid.Must(libCommons.GenerateUUIDv7())
+	ledgerID := uuid.Must(libCommons.GenerateUUIDv7())
+	balanceID := uuid.Must(libCommons.GenerateUUIDv7())
+
+	allowOverdraft := true
+	balanceUpdate := mmodel.UpdateBalance{
+		Settings: &mmodel.BalanceSettings{
+			AllowOverdraft: allowOverdraft,
+		},
+	}
+
+	expectedBalance := &mmodel.Balance{
+		ID:             balanceID.String(),
+		OrganizationID: organizationID.String(),
+		LedgerID:       ledgerID.String(),
+		Alias:          "@user1",
+		Key:            "default",
+	}
+
+	// Find returns a balance whose settings already match the update — the
+	// enforceOverdraftTransition check treats this as a no-op transition so
+	// the test stays focused on the cache-rewrite failure path.
+	existing := &mmodel.Balance{
+		ID:             balanceID.String(),
+		OrganizationID: organizationID.String(),
+		LedgerID:       ledgerID.String(),
+		Alias:          "@user1",
+		Key:            "default",
+		Settings: &mmodel.BalanceSettings{
+			AllowOverdraft: true,
+		},
+	}
+
+	mockBalanceRepo := balance.NewMockRepository(ctrl)
+	mockRedisRepo := redis.NewMockRedisRepository(ctrl)
+
+	mockBalanceRepo.EXPECT().
+		Find(gomock.Any(), organizationID, ledgerID, balanceID).
+		Return(existing, nil).
+		Times(1)
+
+	mockBalanceRepo.EXPECT().
+		Update(gomock.Any(), organizationID, ledgerID, balanceID, balanceUpdate).
+		Return(expectedBalance, nil).
+		Times(1)
+
+	mockRedisRepo.EXPECT().
+		Get(gomock.Any(), gomock.Any()).
+		Return("", nil).
+		Times(1)
+
+	// Redis is down / network partition. The use case must swallow the error
+	// and return the updated balance anyway — the PG write is the source of
+	// truth and cannot be rolled back at this point.
+	mockRedisRepo.EXPECT().
+		UpdateBalanceCacheSettings(gomock.Any(), organizationID, ledgerID, gomock.Any(), gomock.Any()).
+		Return(errors.New("redis connection refused")).
+		Times(1)
+
+	uc := UseCase{
+		BalanceRepo:          mockBalanceRepo,
+		TransactionRedisRepo: mockRedisRepo,
+	}
+
+	result, err := uc.Update(context.TODO(), organizationID, ledgerID, balanceID, balanceUpdate)
+
+	require.NoError(t, err, "Cache rewrite failure must not propagate — PG write is durable")
+	require.NotNil(t, result)
+	assert.Equal(t, expectedBalance.ID, result.ID)
 }
 
 func TestUpdateBalances_PrimaryPath_UsesAfterDirectly(t *testing.T) {

--- a/components/ledger/internal/services/query/balance_cache_overlay.go
+++ b/components/ledger/internal/services/query/balance_cache_overlay.go
@@ -1,0 +1,113 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package query
+
+import (
+	"github.com/LerianStudio/midaz/v3/pkg/mmodel"
+	"github.com/shopspring/decimal"
+)
+
+// applyBalanceCacheOverlay overlays the Redis cache state onto a
+// PostgreSQL-sourced balance. The cache is authoritative for runtime state
+// because the Lua atomic script mutates Redis synchronously while the
+// write-behind worker syncs PostgreSQL asynchronously, so a balance read
+// immediately after a transaction commit may carry stale PG values until
+// the worker catches up.
+//
+// Three field families are propagated:
+//
+//  1. Mutable runtime state: Available, OnHold, Version. Always overlaid
+//     when the cache entry is present.
+//  2. Direction. Always overlaid from a non-empty cache value. Empty cache
+//     values fall back to PG, covering legacy entries that predate the
+//     direction-aware balance model.
+//  3. OverdraftUsed and Settings. The cache is the source of truth post-
+//     transaction. OverdraftUsed always overlays; an unparseable value
+//     defaults to zero, mirroring the Lua-side fallback. Settings are
+//     synthesised from the cache only when the cache carries divergent
+//     values; otherwise the PG-sourced Settings are preserved to avoid
+//     stomping legitimate configuration with cache defaults.
+//
+// This helper centralises the overlay logic shared by GetAllBalancesByAccountID,
+// GetAllBalances, and GetAllBalancesByAlias. Any future overlay caller MUST
+// route through this function so the cache-to-response contract stays uniform.
+func applyBalanceCacheOverlay(b *mmodel.Balance, c *mmodel.BalanceRedis) {
+	if b == nil || c == nil {
+		return
+	}
+
+	b.Available = c.Available
+	b.OnHold = c.OnHold
+	b.Version = c.Version
+
+	if c.Direction != "" {
+		b.Direction = c.Direction
+	}
+
+	// OverdraftUsed is stored as a decimal string in Redis. An unparseable
+	// value defaults to zero rather than corrupting the domain model with
+	// an arbitrary number, matching the Lua-side fallback applied by
+	// getBalancesFromCache.
+	overdraftUsed, err := decimal.NewFromString(c.OverdraftUsed)
+	if err != nil {
+		overdraftUsed = decimal.Zero
+	}
+
+	b.OverdraftUsed = overdraftUsed
+
+	// Synthesise Settings from the cache only when at least one field
+	// diverges from the defaults. This guards against overwriting legitimate
+	// PG settings with empty defaults from legacy cache entries that predate
+	// the overdraft feature. The divergence check mirrors the materialisation
+	// guard in getBalancesFromCache so transaction flows and balance-query
+	// flows observe the same overdraft configuration regardless of the read
+	// path.
+	if cacheHasDivergentSettings(c) {
+		b.Settings = synthesiseSettingsFromCache(c)
+	}
+}
+
+// cacheHasDivergentSettings reports whether the cache entry carries any
+// non-default settings value worth overlaying onto the PG-sourced Balance.
+// Empty / zero cache values are treated as "no information" rather than
+// "settings disabled" — the PG row is the source of truth in that case.
+func cacheHasDivergentSettings(c *mmodel.BalanceRedis) bool {
+	if c.AllowOverdraft != 0 || c.OverdraftLimitEnabled != 0 {
+		return true
+	}
+
+	if c.BalanceScope != "" && c.BalanceScope != mmodel.BalanceScopeTransactional {
+		return true
+	}
+
+	if c.OverdraftLimit != "" && c.OverdraftLimit != "0" {
+		return true
+	}
+
+	return false
+}
+
+// synthesiseSettingsFromCache constructs a BalanceSettings value from the
+// fields carried on a Redis cache entry. The caller must have verified
+// divergence via cacheHasDivergentSettings before invoking this function;
+// otherwise the resulting Settings would carry pure defaults and clobber
+// legitimate PG data.
+func synthesiseSettingsFromCache(c *mmodel.BalanceRedis) *mmodel.BalanceSettings {
+	s := &mmodel.BalanceSettings{
+		BalanceScope:          c.BalanceScope,
+		AllowOverdraft:        c.AllowOverdraft == 1,
+		OverdraftLimitEnabled: c.OverdraftLimitEnabled == 1,
+	}
+
+	// Only expose OverdraftLimit when the limit is actively enforced.
+	// BalanceSettings.Validate() requires OverdraftLimit to be nil whenever
+	// OverdraftLimitEnabled is false.
+	if c.OverdraftLimitEnabled == 1 && c.OverdraftLimit != "" {
+		limit := c.OverdraftLimit
+		s.OverdraftLimit = &limit
+	}
+
+	return s
+}

--- a/components/ledger/internal/services/query/balance_cache_overlay_integration_test.go
+++ b/components/ledger/internal/services/query/balance_cache_overlay_integration_test.go
@@ -458,7 +458,7 @@ func TestGetBalanceByID_PositionField_NegativeOnOverdrafted(t *testing.T) {
 		Position struct {
 			Available               string  `json:"available"`
 			OnHold                  string  `json:"onHold"`
-			AvailableOverdraftLimit *string `json:"availableOverdraftLimit"`
+			OverdraftLimitAvailable *string `json:"overdraftLimitAvailable"`
 		} `json:"position"`
 	}
 	require.NoError(t, json.Unmarshal(wire, &envelope))
@@ -466,9 +466,9 @@ func TestGetBalanceByID_PositionField_NegativeOnOverdrafted(t *testing.T) {
 	assert.Equal(t, "-100", envelope.Position.Available,
 		"position.available must be Available − OverdraftUsed = 0 − 100 = -100")
 	assert.Equal(t, "0", envelope.Position.OnHold)
-	require.NotNil(t, envelope.Position.AvailableOverdraftLimit)
-	assert.Equal(t, "400", *envelope.Position.AvailableOverdraftLimit,
-		"position.availableOverdraftLimit must be limit − used = 500 − 100 = 400")
+	require.NotNil(t, envelope.Position.OverdraftLimitAvailable)
+	assert.Equal(t, "400", *envelope.Position.OverdraftLimitAvailable,
+		"position.overdraftLimitAvailable must be limit − used = 500 − 100 = 400")
 }
 
 // TestGetAllBalances_CachePresentButSettingsDefault_PreservesPGSettings is the

--- a/components/ledger/internal/services/query/balance_cache_overlay_integration_test.go
+++ b/components/ledger/internal/services/query/balance_cache_overlay_integration_test.go
@@ -1,0 +1,532 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package query
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	libCommons "github.com/LerianStudio/lib-commons/v4/commons"
+	libHTTP "github.com/LerianStudio/lib-commons/v4/commons/net/http"
+	"github.com/LerianStudio/midaz/v3/components/ledger/internal/adapters/postgres/balance"
+	redis "github.com/LerianStudio/midaz/v3/components/ledger/internal/adapters/redis/transaction"
+	"github.com/LerianStudio/midaz/v3/pkg/mmodel"
+	"github.com/LerianStudio/midaz/v3/pkg/net/http"
+	"github.com/LerianStudio/midaz/v3/pkg/utils"
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+// These tests exercise the cache-overlay completeness contract end-to-end at
+// every query method that overlays the Redis cache onto a PostgreSQL-sourced
+// balance: GetAllBalancesByAccountID, GetAllBalances, GetAllBalancesByAlias,
+// and GetBalanceByID. The goal is to catch the original bug class (cache
+// fields silently lost on the response path) regardless of whether a future
+// refactor inlines, splits, or relocates the overlay helper.
+
+// makeOverdraftCacheJSON builds a Redis-shape balance payload with the
+// overdraft fields populated. Mirrors the CamelCase-aware shape used by the
+// Lua atomic script and consumer.redis.go.
+func makeOverdraftCacheJSON(t *testing.T, version int64, overdraftUsed string, allowOverdraft, limitEnabled int, overdraftLimit, scope, direction string) string {
+	t.Helper()
+
+	c := mmodel.BalanceRedis{
+		Available:             decimal.Zero,
+		OnHold:                decimal.Zero,
+		Version:               version,
+		Direction:             direction,
+		OverdraftUsed:         overdraftUsed,
+		AllowOverdraft:        allowOverdraft,
+		OverdraftLimitEnabled: limitEnabled,
+		OverdraftLimit:        overdraftLimit,
+		BalanceScope:          scope,
+	}
+	data, err := json.Marshal(c)
+	require.NoError(t, err)
+
+	return string(data)
+}
+
+// makeStaleBalance returns a PG-sourced Balance carrying pre-transaction
+// values. After the cache overlay runs it must be visibly newer.
+func makeStaleBalance(alias, key string) *mmodel.Balance {
+	return &mmodel.Balance{
+		ID:            uuid.New().String(),
+		Alias:         alias,
+		Key:           key,
+		AssetCode:     "BRL",
+		Available:     decimal.NewFromInt(50), // pre-transaction
+		OnHold:        decimal.Zero,
+		Version:       1,
+		Direction:     "credit",
+		OverdraftUsed: decimal.Zero, // stale: PG hasn't seen the transaction
+		Settings: &mmodel.BalanceSettings{
+			BalanceScope:          mmodel.BalanceScopeTransactional,
+			AllowOverdraft:        true,
+			OverdraftLimitEnabled: true,
+			OverdraftLimit:        ptrString("500"),
+		},
+	}
+}
+
+func ptrString(s string) *string { return &s }
+
+// --- GetAllBalancesByAccountID ---------------------------------------------
+
+func TestGetAllBalancesByAccountID_CacheOverlay_PropagatesOverdraftFields(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
+	organizationID := uuid.Must(libCommons.GenerateUUIDv7())
+	ledgerID := uuid.Must(libCommons.GenerateUUIDv7())
+	accountID := uuid.Must(libCommons.GenerateUUIDv7())
+	filter := http.QueryHeader{
+		Limit:        10,
+		StartDate:    time.Now().AddDate(0, -1, 0),
+		EndDate:      time.Now(),
+		ToAssetCodes: []string{"BRL"},
+	}
+	mockCur := libHTTP.CursorPagination{Next: "n", Prev: "p"}
+
+	mockBalanceRepo := balance.NewMockRepository(ctrl)
+	mockRedisRepo := redis.NewMockRedisRepository(ctrl)
+
+	bal := makeStaleBalance("@user", "default")
+	mockBalanceRepo.
+		EXPECT().
+		ListAllByAccountID(gomock.Any(), organizationID, ledgerID, accountID, filter.ToCursorPagination()).
+		Return([]*mmodel.Balance{bal}, mockCur, nil).
+		Times(1)
+
+	cacheKey := utils.BalanceInternalKey(organizationID, ledgerID, bal.Alias+"#"+bal.Key)
+	// Cache is post-transaction: deficit of 130, full overdraft state.
+	payload := makeOverdraftCacheJSON(t, 7, "130.00", 1, 1, "500", mmodel.BalanceScopeTransactional, "credit")
+	mockRedisRepo.
+		EXPECT().
+		MGet(gomock.Any(), []string{cacheKey}).
+		Return(map[string]string{cacheKey: payload}, nil).
+		Times(1)
+
+	uc := UseCase{BalanceRepo: mockBalanceRepo, TransactionRedisRepo: mockRedisRepo}
+	res, _, err := uc.GetAllBalancesByAccountID(context.TODO(), organizationID, ledgerID, accountID, filter)
+
+	require.NoError(t, err)
+	require.Len(t, res, 1)
+
+	assert.Equal(t, int64(7), res[0].Version, "Version must overlay from cache")
+	assert.Equal(t, "credit", res[0].Direction, "Direction must overlay from cache")
+	assert.True(t, res[0].OverdraftUsed.Equal(decimal.NewFromInt(130)),
+		"OverdraftUsed must overlay from cache")
+	require.NotNil(t, res[0].Settings)
+	assert.True(t, res[0].Settings.AllowOverdraft)
+	assert.True(t, res[0].Settings.OverdraftLimitEnabled)
+	require.NotNil(t, res[0].Settings.OverdraftLimit)
+	assert.Equal(t, "500", *res[0].Settings.OverdraftLimit)
+}
+
+func TestGetAllBalancesByAccountID_CacheMiss_PreservesPGOverdraftFields(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
+	organizationID := uuid.Must(libCommons.GenerateUUIDv7())
+	ledgerID := uuid.Must(libCommons.GenerateUUIDv7())
+	accountID := uuid.Must(libCommons.GenerateUUIDv7())
+	filter := http.QueryHeader{
+		Limit:     10,
+		StartDate: time.Now().AddDate(0, -1, 0),
+		EndDate:   time.Now(),
+	}
+
+	mockBalanceRepo := balance.NewMockRepository(ctrl)
+	mockRedisRepo := redis.NewMockRedisRepository(ctrl)
+
+	bal := &mmodel.Balance{
+		ID:            uuid.New().String(),
+		Alias:         "@user",
+		Key:           "default",
+		Available:     decimal.NewFromInt(75),
+		OnHold:        decimal.Zero,
+		Version:       3,
+		Direction:     "credit",
+		OverdraftUsed: decimal.NewFromInt(25),
+		Settings: &mmodel.BalanceSettings{
+			AllowOverdraft:        true,
+			OverdraftLimitEnabled: true,
+			OverdraftLimit:        ptrString("100"),
+			BalanceScope:          mmodel.BalanceScopeTransactional,
+		},
+	}
+
+	mockBalanceRepo.
+		EXPECT().
+		ListAllByAccountID(gomock.Any(), organizationID, ledgerID, accountID, filter.ToCursorPagination()).
+		Return([]*mmodel.Balance{bal}, libHTTP.CursorPagination{}, nil).
+		Times(1)
+
+	cacheKey := utils.BalanceInternalKey(organizationID, ledgerID, bal.Alias+"#"+bal.Key)
+	mockRedisRepo.
+		EXPECT().
+		MGet(gomock.Any(), []string{cacheKey}).
+		Return(map[string]string{}, nil). // cache miss
+		Times(1)
+
+	uc := UseCase{BalanceRepo: mockBalanceRepo, TransactionRedisRepo: mockRedisRepo}
+	res, _, err := uc.GetAllBalancesByAccountID(context.TODO(), organizationID, ledgerID, accountID, filter)
+
+	require.NoError(t, err)
+	require.Len(t, res, 1)
+
+	// All fields must come from PG since the cache had nothing to say.
+	assert.True(t, res[0].Available.Equal(decimal.NewFromInt(75)))
+	assert.True(t, res[0].OverdraftUsed.Equal(decimal.NewFromInt(25)))
+	assert.Equal(t, "credit", res[0].Direction)
+	require.NotNil(t, res[0].Settings)
+	require.NotNil(t, res[0].Settings.OverdraftLimit)
+	assert.Equal(t, "100", *res[0].Settings.OverdraftLimit)
+}
+
+func TestGetAllBalancesByAccountID_MixedBatch_PerBalanceResolution(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
+	organizationID := uuid.Must(libCommons.GenerateUUIDv7())
+	ledgerID := uuid.Must(libCommons.GenerateUUIDv7())
+	accountID := uuid.Must(libCommons.GenerateUUIDv7())
+	filter := http.QueryHeader{
+		Limit:     10,
+		StartDate: time.Now().AddDate(0, -1, 0),
+		EndDate:   time.Now(),
+	}
+
+	mockBalanceRepo := balance.NewMockRepository(ctrl)
+	mockRedisRepo := redis.NewMockRedisRepository(ctrl)
+
+	cached := makeStaleBalance("@user", "default")
+	missing := makeStaleBalance("@user", "savings")
+
+	mockBalanceRepo.
+		EXPECT().
+		ListAllByAccountID(gomock.Any(), organizationID, ledgerID, accountID, filter.ToCursorPagination()).
+		Return([]*mmodel.Balance{cached, missing}, libHTTP.CursorPagination{}, nil).
+		Times(1)
+
+	keyCached := utils.BalanceInternalKey(organizationID, ledgerID, cached.Alias+"#"+cached.Key)
+	keyMissing := utils.BalanceInternalKey(organizationID, ledgerID, missing.Alias+"#"+missing.Key)
+	payload := makeOverdraftCacheJSON(t, 9, "200", 1, 1, "500", mmodel.BalanceScopeTransactional, "credit")
+
+	mockRedisRepo.
+		EXPECT().
+		MGet(gomock.Any(), []string{keyCached, keyMissing}).
+		Return(map[string]string{keyCached: payload}, nil).
+		Times(1)
+
+	uc := UseCase{BalanceRepo: mockBalanceRepo, TransactionRedisRepo: mockRedisRepo}
+	res, _, err := uc.GetAllBalancesByAccountID(context.TODO(), organizationID, ledgerID, accountID, filter)
+
+	require.NoError(t, err)
+	require.Len(t, res, 2)
+
+	// First balance: overlay applied
+	assert.True(t, res[0].OverdraftUsed.Equal(decimal.NewFromInt(200)))
+	assert.Equal(t, int64(9), res[0].Version)
+
+	// Second balance: cache miss, PG values preserved
+	assert.True(t, res[1].OverdraftUsed.Equal(decimal.Zero))
+	assert.Equal(t, int64(1), res[1].Version)
+}
+
+// --- GetAllBalances --------------------------------------------------------
+
+func TestGetAllBalances_CacheOverlay_PropagatesOverdraftFields(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
+	organizationID := uuid.Must(libCommons.GenerateUUIDv7())
+	ledgerID := uuid.Must(libCommons.GenerateUUIDv7())
+	filter := http.QueryHeader{
+		Limit:     10,
+		StartDate: time.Now().AddDate(0, -1, 0),
+		EndDate:   time.Now(),
+	}
+
+	mockBalanceRepo := balance.NewMockRepository(ctrl)
+	mockRedisRepo := redis.NewMockRedisRepository(ctrl)
+
+	bal := makeStaleBalance("@user", "default")
+	mockBalanceRepo.
+		EXPECT().
+		ListAll(gomock.Any(), organizationID, ledgerID, filter.ToCursorPagination()).
+		Return([]*mmodel.Balance{bal}, libHTTP.CursorPagination{}, nil).
+		Times(1)
+
+	cacheKey := utils.BalanceInternalKey(organizationID, ledgerID, bal.Alias+"#"+bal.Key)
+	payload := makeOverdraftCacheJSON(t, 4, "75.00", 1, 1, "500", mmodel.BalanceScopeTransactional, "credit")
+	mockRedisRepo.
+		EXPECT().
+		MGet(gomock.Any(), []string{cacheKey}).
+		Return(map[string]string{cacheKey: payload}, nil).
+		Times(1)
+
+	uc := UseCase{BalanceRepo: mockBalanceRepo, TransactionRedisRepo: mockRedisRepo}
+	res, _, err := uc.GetAllBalances(context.TODO(), organizationID, ledgerID, filter)
+
+	require.NoError(t, err)
+	require.Len(t, res, 1)
+
+	assert.Equal(t, int64(4), res[0].Version)
+	assert.True(t, res[0].OverdraftUsed.Equal(decimal.NewFromInt(75)))
+	assert.Equal(t, "credit", res[0].Direction)
+	require.NotNil(t, res[0].Settings)
+	assert.True(t, res[0].Settings.AllowOverdraft)
+}
+
+// --- GetAllBalancesByAlias -------------------------------------------------
+
+func TestGetAllBalancesByAlias_CacheOverlay_PropagatesOverdraftFields(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
+	organizationID := uuid.Must(libCommons.GenerateUUIDv7())
+	ledgerID := uuid.Must(libCommons.GenerateUUIDv7())
+
+	mockBalanceRepo := balance.NewMockRepository(ctrl)
+	mockRedisRepo := redis.NewMockRedisRepository(ctrl)
+
+	bal := makeStaleBalance("@user", "default")
+	mockBalanceRepo.
+		EXPECT().
+		ListByAliases(gomock.Any(), organizationID, ledgerID, []string{bal.Alias}).
+		Return([]*mmodel.Balance{bal}, nil).
+		Times(1)
+
+	cacheKey := utils.BalanceInternalKey(organizationID, ledgerID, bal.Alias+"#"+bal.Key)
+	payload := makeOverdraftCacheJSON(t, 11, "33", 1, 1, "500", mmodel.BalanceScopeTransactional, "credit")
+	mockRedisRepo.
+		EXPECT().
+		MGet(gomock.Any(), []string{cacheKey}).
+		Return(map[string]string{cacheKey: payload}, nil).
+		Times(1)
+
+	uc := UseCase{BalanceRepo: mockBalanceRepo, TransactionRedisRepo: mockRedisRepo}
+	res, err := uc.GetAllBalancesByAlias(context.TODO(), organizationID, ledgerID, bal.Alias)
+
+	require.NoError(t, err)
+	require.Len(t, res, 1)
+
+	assert.Equal(t, int64(11), res[0].Version)
+	assert.True(t, res[0].OverdraftUsed.Equal(decimal.NewFromInt(33)))
+	assert.Equal(t, "credit", res[0].Direction)
+}
+
+// --- GetBalanceByID --------------------------------------------------------
+
+// TestGetBalanceByID_CacheOverlay_PropagatesOverdraftFields covers the
+// single-balance read path used by GET /v1/.../balances/{id}. It must
+// propagate OverdraftUsed, Direction, and Settings from the cache
+// identically to the list endpoints; otherwise the response carries stale
+// PG values until the write-behind worker syncs, and the derived
+// position.available field on overdrafted accounts surfaces as zero
+// instead of negative.
+func TestGetBalanceByID_CacheOverlay_PropagatesOverdraftFields(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
+	organizationID := uuid.Must(libCommons.GenerateUUIDv7())
+	ledgerID := uuid.Must(libCommons.GenerateUUIDv7())
+	balanceID := uuid.Must(libCommons.GenerateUUIDv7())
+
+	mockBalanceRepo := balance.NewMockRepository(ctrl)
+	mockRedisRepo := redis.NewMockRedisRepository(ctrl)
+
+	bal := makeStaleBalance("@user", "default")
+	bal.ID = balanceID.String()
+
+	mockBalanceRepo.
+		EXPECT().
+		Find(gomock.Any(), organizationID, ledgerID, balanceID).
+		Return(bal, nil).
+		Times(1)
+
+	cacheKey := utils.BalanceInternalKey(organizationID, ledgerID, bal.Alias+"#"+bal.Key)
+	// Cache is post-transaction: source overdrafted by 100 (Available=0,
+	// OverdraftUsed=100). This is the exact scenario that drove the position
+	// E2E test failure.
+	payload := makeOverdraftCacheJSON(t, 5, "100", 1, 1, "500", mmodel.BalanceScopeTransactional, "credit")
+	mockRedisRepo.
+		EXPECT().
+		Get(gomock.Any(), cacheKey).
+		Return(payload, nil).
+		Times(1)
+
+	uc := UseCase{BalanceRepo: mockBalanceRepo, TransactionRedisRepo: mockRedisRepo}
+	res, err := uc.GetBalanceByID(context.TODO(), organizationID, ledgerID, balanceID)
+
+	require.NoError(t, err)
+	require.NotNil(t, res)
+
+	assert.Equal(t, int64(5), res.Version, "Version must overlay from cache")
+	assert.Equal(t, "credit", res.Direction, "Direction must overlay from cache")
+	assert.True(t, res.OverdraftUsed.Equal(decimal.NewFromInt(100)),
+		"OverdraftUsed must overlay from cache (was the position-test gap)")
+	require.NotNil(t, res.Settings)
+	assert.True(t, res.Settings.AllowOverdraft)
+	assert.True(t, res.Settings.OverdraftLimitEnabled)
+	require.NotNil(t, res.Settings.OverdraftLimit)
+	assert.Equal(t, "500", *res.Settings.OverdraftLimit)
+}
+
+// TestGetBalanceByID_PositionField_NegativeOnOverdrafted exercises the full
+// stack from the GetBalanceByID return value through Balance.MarshalJSON's
+// Position computation, asserting the wire shape carries position.available
+// = -100 when Available=0 and OverdraftUsed=100. Pins the negative-position
+// contract on overdrafted accounts.
+func TestGetBalanceByID_PositionField_NegativeOnOverdrafted(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
+	organizationID := uuid.Must(libCommons.GenerateUUIDv7())
+	ledgerID := uuid.Must(libCommons.GenerateUUIDv7())
+	balanceID := uuid.Must(libCommons.GenerateUUIDv7())
+
+	mockBalanceRepo := balance.NewMockRepository(ctrl)
+	mockRedisRepo := redis.NewMockRedisRepository(ctrl)
+
+	// PG view: stale, claims Available=50, OverdraftUsed=0 (pre-transaction).
+	bal := makeStaleBalance("@user", "default")
+	bal.ID = balanceID.String()
+
+	mockBalanceRepo.
+		EXPECT().
+		Find(gomock.Any(), organizationID, ledgerID, balanceID).
+		Return(bal, nil).
+		Times(1)
+
+	cacheKey := utils.BalanceInternalKey(organizationID, ledgerID, bal.Alias+"#"+bal.Key)
+	// Cache view: post-transaction, Available=0 OverdraftUsed=100.
+	cached := mmodel.BalanceRedis{
+		Available:             decimal.Zero,
+		OnHold:                decimal.Zero,
+		Version:               5,
+		Direction:             "credit",
+		OverdraftUsed:         "100",
+		AllowOverdraft:        1,
+		OverdraftLimitEnabled: 1,
+		OverdraftLimit:        "500",
+		BalanceScope:          mmodel.BalanceScopeTransactional,
+	}
+	data, _ := json.Marshal(cached)
+
+	mockRedisRepo.
+		EXPECT().
+		Get(gomock.Any(), cacheKey).
+		Return(string(data), nil).
+		Times(1)
+
+	uc := UseCase{BalanceRepo: mockBalanceRepo, TransactionRedisRepo: mockRedisRepo}
+	res, err := uc.GetBalanceByID(context.TODO(), organizationID, ledgerID, balanceID)
+
+	require.NoError(t, err)
+	require.NotNil(t, res)
+
+	// Marshal through Balance.MarshalJSON to exercise the full position
+	// surface the way an HTTP client would receive it.
+	wire, err := json.Marshal(res)
+	require.NoError(t, err)
+
+	var envelope struct {
+		Position struct {
+			Available               string  `json:"available"`
+			OnHold                  string  `json:"onHold"`
+			AvailableOverdraftLimit *string `json:"availableOverdraftLimit"`
+		} `json:"position"`
+	}
+	require.NoError(t, json.Unmarshal(wire, &envelope))
+
+	assert.Equal(t, "-100", envelope.Position.Available,
+		"position.available must be Available − OverdraftUsed = 0 − 100 = -100")
+	assert.Equal(t, "0", envelope.Position.OnHold)
+	require.NotNil(t, envelope.Position.AvailableOverdraftLimit)
+	assert.Equal(t, "400", *envelope.Position.AvailableOverdraftLimit,
+		"position.availableOverdraftLimit must be limit − used = 500 − 100 = 400")
+}
+
+// TestGetAllBalances_CachePresentButSettingsDefault_PreservesPGSettings is the
+// regression guard for the Settings nil-safety contract: if the cache carries
+// no divergent settings (e.g. a legacy entry written before the settings
+// write-through path), the PG-sourced Settings must NOT be clobbered by an
+// empty BalanceSettings struct.
+func TestGetAllBalances_CachePresentButSettingsDefault_PreservesPGSettings(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
+	organizationID := uuid.Must(libCommons.GenerateUUIDv7())
+	ledgerID := uuid.Must(libCommons.GenerateUUIDv7())
+	filter := http.QueryHeader{
+		Limit:     10,
+		StartDate: time.Now().AddDate(0, -1, 0),
+		EndDate:   time.Now(),
+	}
+
+	mockBalanceRepo := balance.NewMockRepository(ctrl)
+	mockRedisRepo := redis.NewMockRedisRepository(ctrl)
+
+	bal := makeStaleBalance("@user", "default")
+	mockBalanceRepo.
+		EXPECT().
+		ListAll(gomock.Any(), organizationID, ledgerID, filter.ToCursorPagination()).
+		Return([]*mmodel.Balance{bal}, libHTTP.CursorPagination{}, nil).
+		Times(1)
+
+	cacheKey := utils.BalanceInternalKey(organizationID, ledgerID, bal.Alias+"#"+bal.Key)
+	// Cache reports fresh runtime numbers but ZERO divergent settings —
+	// represents either a legacy entry or a balance where overdraft was
+	// never enabled. Either way: PG Settings must stay intact.
+	payload := makeOverdraftCacheJSON(t, 6, "0", 0, 0, "", "", "")
+	mockRedisRepo.
+		EXPECT().
+		MGet(gomock.Any(), []string{cacheKey}).
+		Return(map[string]string{cacheKey: payload}, nil).
+		Times(1)
+
+	uc := UseCase{BalanceRepo: mockBalanceRepo, TransactionRedisRepo: mockRedisRepo}
+	res, _, err := uc.GetAllBalances(context.TODO(), organizationID, ledgerID, filter)
+
+	require.NoError(t, err)
+	require.Len(t, res, 1)
+
+	// Runtime fields overlaid from cache:
+	assert.Equal(t, int64(6), res[0].Version)
+	assert.True(t, res[0].OverdraftUsed.Equal(decimal.Zero))
+
+	// Settings: PG value preserved (cache had no divergent data).
+	require.NotNil(t, res[0].Settings, "PG Settings must not be nilled out by an empty cache entry")
+	assert.True(t, res[0].Settings.AllowOverdraft)
+	require.NotNil(t, res[0].Settings.OverdraftLimit)
+	assert.Equal(t, "500", *res[0].Settings.OverdraftLimit)
+
+	// Direction: cache empty, PG preserved.
+	assert.Equal(t, "credit", res[0].Direction)
+}

--- a/components/ledger/internal/services/query/balance_cache_overlay_test.go
+++ b/components/ledger/internal/services/query/balance_cache_overlay_test.go
@@ -1,0 +1,320 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package query
+
+import (
+	"testing"
+
+	"github.com/LerianStudio/midaz/v3/pkg/mmodel"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestApplyBalanceCacheOverlay_PropagatesAvailableOnHoldVersion validates the
+// baseline overlay (Available, OnHold, Version).
+func TestApplyBalanceCacheOverlay_PropagatesAvailableOnHoldVersion(t *testing.T) {
+	t.Parallel()
+
+	b := &mmodel.Balance{
+		Available: decimal.NewFromInt(10),
+		OnHold:    decimal.NewFromInt(2),
+		Version:   1,
+	}
+	c := &mmodel.BalanceRedis{
+		Available: decimal.NewFromInt(500),
+		OnHold:    decimal.NewFromInt(50),
+		Version:   42,
+	}
+
+	applyBalanceCacheOverlay(b, c)
+
+	assert.True(t, b.Available.Equal(decimal.NewFromInt(500)))
+	assert.True(t, b.OnHold.Equal(decimal.NewFromInt(50)))
+	assert.Equal(t, int64(42), b.Version)
+}
+
+// TestApplyBalanceCacheOverlay_PropagatesOverdraftUsed verifies the cache value
+// for OverdraftUsed wins over the (potentially stale) PG value.
+func TestApplyBalanceCacheOverlay_PropagatesOverdraftUsed(t *testing.T) {
+	t.Parallel()
+
+	b := &mmodel.Balance{
+		OverdraftUsed: decimal.Zero, // PG says "no overdraft used"
+	}
+	c := &mmodel.BalanceRedis{
+		OverdraftUsed: "50.00", // cache says "50 in overdraft"
+	}
+
+	applyBalanceCacheOverlay(b, c)
+
+	assert.True(t, b.OverdraftUsed.Equal(decimal.NewFromInt(50)),
+		"cache OverdraftUsed must overlay stale PG value")
+}
+
+// TestApplyBalanceCacheOverlay_OverdraftUsed_UnparseableFallsBackToZero
+// matches the Lua/getBalancesFromCache fallback contract.
+func TestApplyBalanceCacheOverlay_OverdraftUsed_UnparseableFallsBackToZero(t *testing.T) {
+	t.Parallel()
+
+	b := &mmodel.Balance{
+		OverdraftUsed: decimal.NewFromInt(99), // PG value to be replaced
+	}
+	c := &mmodel.BalanceRedis{
+		OverdraftUsed: "not-a-number",
+	}
+
+	applyBalanceCacheOverlay(b, c)
+
+	assert.True(t, b.OverdraftUsed.Equal(decimal.Zero),
+		"unparseable cache OverdraftUsed must fall back to zero, matching Lua")
+}
+
+// TestApplyBalanceCacheOverlay_OverdraftUsed_EmptyStringFallsBackToZero
+// confirms legacy cache entries that predate the overdraft fields are
+// handled cleanly.
+func TestApplyBalanceCacheOverlay_OverdraftUsed_EmptyStringFallsBackToZero(t *testing.T) {
+	t.Parallel()
+
+	b := &mmodel.Balance{
+		OverdraftUsed: decimal.NewFromInt(7),
+	}
+	c := &mmodel.BalanceRedis{
+		OverdraftUsed: "",
+	}
+
+	applyBalanceCacheOverlay(b, c)
+
+	assert.True(t, b.OverdraftUsed.Equal(decimal.Zero))
+}
+
+// TestApplyBalanceCacheOverlay_PropagatesDirectionWhenNonEmpty checks the
+// direction-overlay rule: cache wins when populated.
+func TestApplyBalanceCacheOverlay_PropagatesDirectionWhenNonEmpty(t *testing.T) {
+	t.Parallel()
+
+	b := &mmodel.Balance{Direction: ""}
+	c := &mmodel.BalanceRedis{Direction: "debit"}
+
+	applyBalanceCacheOverlay(b, c)
+
+	assert.Equal(t, "debit", b.Direction)
+}
+
+// TestApplyBalanceCacheOverlay_PreservesDirectionWhenCacheEmpty covers legacy
+// cache entries that predate the direction-aware balance model.
+func TestApplyBalanceCacheOverlay_PreservesDirectionWhenCacheEmpty(t *testing.T) {
+	t.Parallel()
+
+	b := &mmodel.Balance{Direction: "credit"}
+	c := &mmodel.BalanceRedis{Direction: ""}
+
+	applyBalanceCacheOverlay(b, c)
+
+	assert.Equal(t, "credit", b.Direction,
+		"empty cache Direction must not stomp PG value")
+}
+
+// TestApplyBalanceCacheOverlay_PropagatesSettings_AllowOverdraftEnabled
+// covers the most common divergence: overdraft is enabled and the cache
+// carries the active settings.
+func TestApplyBalanceCacheOverlay_PropagatesSettings_AllowOverdraftEnabled(t *testing.T) {
+	t.Parallel()
+
+	b := &mmodel.Balance{Settings: nil}
+	c := &mmodel.BalanceRedis{
+		AllowOverdraft:        1,
+		OverdraftLimitEnabled: 1,
+		OverdraftLimit:        "500",
+		BalanceScope:          mmodel.BalanceScopeTransactional,
+	}
+
+	applyBalanceCacheOverlay(b, c)
+
+	require.NotNil(t, b.Settings)
+	assert.True(t, b.Settings.AllowOverdraft)
+	assert.True(t, b.Settings.OverdraftLimitEnabled)
+	require.NotNil(t, b.Settings.OverdraftLimit)
+	assert.Equal(t, "500", *b.Settings.OverdraftLimit)
+	assert.Equal(t, mmodel.BalanceScopeTransactional, b.Settings.BalanceScope)
+}
+
+// TestApplyBalanceCacheOverlay_PropagatesSettings_InternalScope confirms the
+// internal-scope marker on the auto-created overdraft companion is overlaid.
+func TestApplyBalanceCacheOverlay_PropagatesSettings_InternalScope(t *testing.T) {
+	t.Parallel()
+
+	b := &mmodel.Balance{Settings: nil}
+	c := &mmodel.BalanceRedis{
+		BalanceScope: mmodel.BalanceScopeInternal,
+	}
+
+	applyBalanceCacheOverlay(b, c)
+
+	require.NotNil(t, b.Settings)
+	assert.Equal(t, mmodel.BalanceScopeInternal, b.Settings.BalanceScope)
+	assert.False(t, b.Settings.AllowOverdraft)
+}
+
+// TestApplyBalanceCacheOverlay_PropagatesSettings_UnlimitedOverdraft asserts
+// that an unlimited-overdraft cache entry (limit disabled) carries no
+// OverdraftLimit pointer through to the synthesised Settings, matching the
+// validation contract that requires nil OverdraftLimit when the flag is off.
+func TestApplyBalanceCacheOverlay_PropagatesSettings_UnlimitedOverdraft(t *testing.T) {
+	t.Parallel()
+
+	b := &mmodel.Balance{Settings: nil}
+	c := &mmodel.BalanceRedis{
+		AllowOverdraft:        1,
+		OverdraftLimitEnabled: 0,
+		OverdraftLimit:        "", // no concrete limit
+	}
+
+	applyBalanceCacheOverlay(b, c)
+
+	require.NotNil(t, b.Settings)
+	assert.True(t, b.Settings.AllowOverdraft)
+	assert.False(t, b.Settings.OverdraftLimitEnabled)
+	assert.Nil(t, b.Settings.OverdraftLimit,
+		"OverdraftLimit must remain nil when OverdraftLimitEnabled is false")
+}
+
+// TestApplyBalanceCacheOverlay_NilSafety_PreservesPGSettingsWhenCacheIsDefault
+// covers the nil-safety contract: a cache entry with no divergent settings
+// must NOT clobber a populated PG Settings value.
+func TestApplyBalanceCacheOverlay_NilSafety_PreservesPGSettingsWhenCacheIsDefault(t *testing.T) {
+	t.Parallel()
+
+	limit := "1000"
+
+	pgSettings := &mmodel.BalanceSettings{
+		BalanceScope:          mmodel.BalanceScopeTransactional,
+		AllowOverdraft:        true,
+		OverdraftLimitEnabled: true,
+		OverdraftLimit:        &limit,
+	}
+
+	b := &mmodel.Balance{Settings: pgSettings}
+	c := &mmodel.BalanceRedis{
+		// Pure defaults — cache carries no divergent settings.
+		AllowOverdraft:        0,
+		OverdraftLimitEnabled: 0,
+		OverdraftLimit:        "",
+		BalanceScope:          "",
+	}
+
+	applyBalanceCacheOverlay(b, c)
+
+	require.NotNil(t, b.Settings, "PG Settings must not be nilled out by an empty cache entry")
+	assert.True(t, b.Settings.AllowOverdraft)
+	assert.True(t, b.Settings.OverdraftLimitEnabled)
+	require.NotNil(t, b.Settings.OverdraftLimit)
+	assert.Equal(t, "1000", *b.Settings.OverdraftLimit)
+}
+
+// TestApplyBalanceCacheOverlay_NilSafety_TransactionalScopeAlone covers the
+// borderline case: a cache entry that only carries BalanceScope="transactional"
+// (the default) is treated as "no divergence" so PG wins.
+func TestApplyBalanceCacheOverlay_NilSafety_TransactionalScopeAlone(t *testing.T) {
+	t.Parallel()
+
+	pgSettings := &mmodel.BalanceSettings{
+		AllowOverdraft: true,
+		BalanceScope:   mmodel.BalanceScopeTransactional,
+	}
+
+	b := &mmodel.Balance{Settings: pgSettings}
+	c := &mmodel.BalanceRedis{
+		BalanceScope: mmodel.BalanceScopeTransactional,
+	}
+
+	applyBalanceCacheOverlay(b, c)
+
+	require.NotNil(t, b.Settings)
+	assert.True(t, b.Settings.AllowOverdraft,
+		"transactional-scope cache entry must not stomp PG AllowOverdraft=true")
+}
+
+// TestApplyBalanceCacheOverlay_NilSafety_OverdraftLimitZero matches the
+// reference helper getBalancesFromCache: "0" is treated as no information.
+func TestApplyBalanceCacheOverlay_NilSafety_OverdraftLimitZero(t *testing.T) {
+	t.Parallel()
+
+	pgLimit := "750"
+	pgSettings := &mmodel.BalanceSettings{
+		AllowOverdraft:        true,
+		OverdraftLimitEnabled: true,
+		OverdraftLimit:        &pgLimit,
+	}
+
+	b := &mmodel.Balance{Settings: pgSettings}
+	c := &mmodel.BalanceRedis{
+		OverdraftLimit: "0", // sentinel for "no limit info" in cache
+	}
+
+	applyBalanceCacheOverlay(b, c)
+
+	require.NotNil(t, b.Settings.OverdraftLimit)
+	assert.Equal(t, "750", *b.Settings.OverdraftLimit)
+}
+
+// TestApplyBalanceCacheOverlay_NilGuards confirms the helper is safe to call
+// with nil arguments.
+func TestApplyBalanceCacheOverlay_NilGuards(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil balance is no-op", func(t *testing.T) {
+		t.Parallel()
+		assert.NotPanics(t, func() {
+			applyBalanceCacheOverlay(nil, &mmodel.BalanceRedis{})
+		})
+	})
+
+	t.Run("nil cache is no-op", func(t *testing.T) {
+		t.Parallel()
+		b := &mmodel.Balance{Available: decimal.NewFromInt(10)}
+		applyBalanceCacheOverlay(b, nil)
+		assert.True(t, b.Available.Equal(decimal.NewFromInt(10)))
+	})
+}
+
+// TestApplyBalanceCacheOverlay_FullOverdraftEntry_EndToEnd asserts that a
+// fully-populated cache entry (Lua-CamelCase shape, all fields present) round-
+// trips every field onto the target Balance, with the Settings struct exactly
+// reflecting the divergent values.
+func TestApplyBalanceCacheOverlay_FullOverdraftEntry_EndToEnd(t *testing.T) {
+	t.Parallel()
+
+	b := &mmodel.Balance{
+		Available:     decimal.NewFromInt(0),
+		OnHold:        decimal.NewFromInt(0),
+		Version:       1,
+		Direction:     "",
+		OverdraftUsed: decimal.Zero,
+		Settings:      nil,
+	}
+	c := &mmodel.BalanceRedis{
+		Available:             decimal.NewFromInt(0),
+		OnHold:                decimal.NewFromInt(0),
+		Version:               7,
+		Direction:             "credit",
+		OverdraftUsed:         "130",
+		AllowOverdraft:        1,
+		OverdraftLimitEnabled: 1,
+		OverdraftLimit:        "500",
+		BalanceScope:          mmodel.BalanceScopeTransactional,
+	}
+
+	applyBalanceCacheOverlay(b, c)
+
+	assert.Equal(t, int64(7), b.Version)
+	assert.Equal(t, "credit", b.Direction)
+	assert.True(t, b.OverdraftUsed.Equal(decimal.NewFromInt(130)))
+	require.NotNil(t, b.Settings)
+	assert.True(t, b.Settings.AllowOverdraft)
+	assert.True(t, b.Settings.OverdraftLimitEnabled)
+	require.NotNil(t, b.Settings.OverdraftLimit)
+	assert.Equal(t, "500", *b.Settings.OverdraftLimit)
+}

--- a/components/ledger/internal/services/query/get_all_balances.go
+++ b/components/ledger/internal/services/query/get_all_balances.go
@@ -67,9 +67,7 @@ func (uc *UseCase) GetAllBalances(ctx context.Context, organizationID, ledgerID 
 				continue
 			}
 
-			balances[i].Available = cachedBalance.Available
-			balances[i].OnHold = cachedBalance.OnHold
-			balances[i].Version = cachedBalance.Version
+			applyBalanceCacheOverlay(balances[i], &cachedBalance)
 		}
 	}
 
@@ -124,9 +122,7 @@ func (uc *UseCase) GetAllBalancesByAlias(ctx context.Context, organizationID, le
 				continue
 			}
 
-			balances[i].Available = cachedBalance.Available
-			balances[i].OnHold = cachedBalance.OnHold
-			balances[i].Version = cachedBalance.Version
+			applyBalanceCacheOverlay(balances[i], &cachedBalance)
 		}
 	}
 

--- a/components/ledger/internal/services/query/get_all_balances_account.go
+++ b/components/ledger/internal/services/query/get_all_balances_account.go
@@ -67,9 +67,7 @@ func (uc *UseCase) GetAllBalancesByAccountID(ctx context.Context, organizationID
 				continue
 			}
 
-			balance[i].Available = cachedBalance.Available
-			balance[i].OnHold = cachedBalance.OnHold
-			balance[i].Version = cachedBalance.Version
+			applyBalanceCacheOverlay(balance[i], &cachedBalance)
 		}
 	}
 

--- a/components/ledger/internal/services/query/get_balances.go
+++ b/components/ledger/internal/services/query/get_balances.go
@@ -13,6 +13,7 @@ import (
 	libLog "github.com/LerianStudio/lib-commons/v4/commons/log"
 	libOpentelemetry "github.com/LerianStudio/lib-commons/v4/commons/opentelemetry"
 	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
 
 	"github.com/LerianStudio/midaz/v3/pkg/constant"
 	"github.com/LerianStudio/midaz/v3/pkg/mmodel"
@@ -92,6 +93,38 @@ func (uc *UseCase) getBalancesFromCache(ctx context.Context, organizationID, led
 			balanceKey = constant.DefaultBalanceKey
 		}
 
+		// OverdraftUsed is stored as a decimal string in the Lua/Redis layer.
+		// An unparseable value is treated as zero to match the Lua fallback
+		// rather than corrupting the domain model with an arbitrary number.
+		overdraftUsed, derr := decimal.NewFromString(b.OverdraftUsed)
+		if derr != nil {
+			overdraftUsed = decimal.Zero
+		}
+
+		// Synthesize Settings only when at least one field diverges from the
+		// defaults. This preserves nil Settings for legacy balances that never
+		// had custom configuration. Mirrors the materialization logic used by
+		// consumer.redis.go:balanceRedisToBalance so transaction flows observe
+		// the same overdraft configuration whether the balance is read from
+		// the cache path (here) or returned from the Lua script.
+		var settings *mmodel.BalanceSettings
+		if b.AllowOverdraft != 0 || b.OverdraftLimitEnabled != 0 ||
+			(b.BalanceScope != "" && b.BalanceScope != mmodel.BalanceScopeTransactional) ||
+			(b.OverdraftLimit != "" && b.OverdraftLimit != "0") {
+			settings = &mmodel.BalanceSettings{
+				BalanceScope:          b.BalanceScope,
+				AllowOverdraft:        b.AllowOverdraft == 1,
+				OverdraftLimitEnabled: b.OverdraftLimitEnabled == 1,
+			}
+			// Only expose OverdraftLimit when the limit is actively enforced.
+			// BalanceSettings.Validate() requires OverdraftLimit to be nil
+			// whenever OverdraftLimitEnabled is false.
+			if b.OverdraftLimitEnabled == 1 && b.OverdraftLimit != "" {
+				limit := b.OverdraftLimit
+				settings.OverdraftLimit = &limit
+			}
+		}
+
 		cached = append(cached, &mmodel.Balance{
 			ID:             b.ID,
 			AccountID:      b.AccountID,
@@ -106,6 +139,9 @@ func (uc *UseCase) getBalancesFromCache(ctx context.Context, organizationID, led
 			AllowSending:   b.AllowSending == 1,
 			AllowReceiving: b.AllowReceiving == 1,
 			AssetCode:      b.AssetCode,
+			Direction:      b.Direction,
+			OverdraftUsed:  overdraftUsed,
+			Settings:       settings,
 		})
 	}
 

--- a/components/ledger/internal/services/query/get_balances_test.go
+++ b/components/ledger/internal/services/query/get_balances_test.go
@@ -238,6 +238,148 @@ func TestGetBalancesFromCache(t *testing.T) {
 	})
 }
 
+// TestGetBalancesFromCache_PropagatesOverdraftFields guards against the
+// regression where the cache path stripped Direction, OverdraftUsed, and
+// Settings off of mmodel.Balance, causing the Lua atomic script to observe
+// Direction="" + AllowOverdraft=0 and reject overdraft-enabled transactions
+// with 0018 (insufficient funds) instead of splitting at zero.
+func TestGetBalancesFromCache_PropagatesOverdraftFields(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockRedisRepo := redis.NewMockRedisRepository(ctrl)
+
+	uc := &UseCase{
+		TransactionRedisRepo: mockRedisRepo,
+	}
+
+	ctx := context.Background()
+	organizationID := uuid.New()
+	ledgerID := uuid.New()
+
+	t.Run("overdraft enabled with limit", func(t *testing.T) {
+		aliases := []string{"@alice#default"}
+
+		cached := mmodel.BalanceRedis{
+			ID:                    uuid.New().String(),
+			AccountID:             uuid.New().String(),
+			Available:             decimal.NewFromInt(50),
+			OnHold:                decimal.NewFromInt(0),
+			Version:               3,
+			AccountType:           "deposit",
+			AllowSending:          1,
+			AllowReceiving:        1,
+			AssetCode:             "BRL",
+			Direction:             "credit",
+			OverdraftUsed:         "10",
+			AllowOverdraft:        1,
+			OverdraftLimitEnabled: 1,
+			OverdraftLimit:        "100",
+			BalanceScope:          mmodel.BalanceScopeTransactional,
+		}
+		cachedJSON, err := json.Marshal(cached)
+		assert.NoError(t, err)
+
+		internalKey := utils.BalanceInternalKey(organizationID, ledgerID, "@alice#default")
+		mockRedisRepo.EXPECT().
+			Get(gomock.Any(), internalKey).
+			Return(string(cachedJSON), nil).
+			Times(1)
+
+		balances, misses := uc.getBalancesFromCache(ctx, organizationID, ledgerID, aliases)
+		assert.Empty(t, misses)
+		assert.Len(t, balances, 1)
+
+		got := balances[0]
+		assert.Equal(t, "credit", got.Direction, "Direction must propagate so Lua can gate overdraft")
+		assert.True(t, got.OverdraftUsed.Equal(decimal.NewFromInt(10)),
+			"OverdraftUsed must round-trip through the cache path, got %s", got.OverdraftUsed)
+		if assert.NotNil(t, got.Settings, "Settings must be materialized when overdraft is configured") {
+			assert.True(t, got.Settings.AllowOverdraft, "AllowOverdraft must flow into Settings")
+			assert.True(t, got.Settings.OverdraftLimitEnabled, "OverdraftLimitEnabled must flow into Settings")
+			if assert.NotNil(t, got.Settings.OverdraftLimit, "OverdraftLimit must be exposed when enabled") {
+				assert.Equal(t, "100", *got.Settings.OverdraftLimit)
+			}
+		}
+	})
+
+	t.Run("legacy balance without overdraft stays nil", func(t *testing.T) {
+		aliases := []string{"@legacy#default"}
+
+		cached := mmodel.BalanceRedis{
+			ID:             uuid.New().String(),
+			AccountID:      uuid.New().String(),
+			Available:      decimal.NewFromInt(500),
+			OnHold:         decimal.NewFromInt(0),
+			Version:        1,
+			AccountType:    "deposit",
+			AllowSending:   1,
+			AllowReceiving: 1,
+			AssetCode:      "USD",
+			// All overdraft fields zero/empty, as a legacy cache entry.
+		}
+		cachedJSON, err := json.Marshal(cached)
+		assert.NoError(t, err)
+
+		internalKey := utils.BalanceInternalKey(organizationID, ledgerID, "@legacy#default")
+		mockRedisRepo.EXPECT().
+			Get(gomock.Any(), internalKey).
+			Return(string(cachedJSON), nil).
+			Times(1)
+
+		balances, misses := uc.getBalancesFromCache(ctx, organizationID, ledgerID, aliases)
+		assert.Empty(t, misses)
+		assert.Len(t, balances, 1)
+
+		got := balances[0]
+		assert.Nil(t, got.Settings,
+			"Settings must stay nil for legacy balances to avoid spurious history snapshots")
+		assert.True(t, got.OverdraftUsed.IsZero(), "OverdraftUsed must default to zero")
+	})
+
+	t.Run("overdraft enabled without limit omits OverdraftLimit pointer", func(t *testing.T) {
+		aliases := []string{"@unlimited#default"}
+
+		cached := mmodel.BalanceRedis{
+			ID:                    uuid.New().String(),
+			AccountID:             uuid.New().String(),
+			Available:             decimal.NewFromInt(0),
+			OnHold:                decimal.NewFromInt(0),
+			Version:               1,
+			AccountType:           "deposit",
+			AllowSending:          1,
+			AllowReceiving:        1,
+			AssetCode:             "BRL",
+			Direction:             "credit",
+			OverdraftUsed:         "0",
+			AllowOverdraft:        1,
+			OverdraftLimitEnabled: 0,
+			OverdraftLimit:        "0",
+			BalanceScope:          mmodel.BalanceScopeTransactional,
+		}
+		cachedJSON, err := json.Marshal(cached)
+		assert.NoError(t, err)
+
+		internalKey := utils.BalanceInternalKey(organizationID, ledgerID, "@unlimited#default")
+		mockRedisRepo.EXPECT().
+			Get(gomock.Any(), internalKey).
+			Return(string(cachedJSON), nil).
+			Times(1)
+
+		balances, misses := uc.getBalancesFromCache(ctx, organizationID, ledgerID, aliases)
+		assert.Empty(t, misses)
+		assert.Len(t, balances, 1)
+
+		got := balances[0]
+		if assert.NotNil(t, got.Settings) {
+			assert.True(t, got.Settings.AllowOverdraft)
+			assert.False(t, got.Settings.OverdraftLimitEnabled)
+			assert.Nil(t, got.Settings.OverdraftLimit,
+				"OverdraftLimit must be nil when OverdraftLimitEnabled is false (Validate() contract)")
+		}
+	})
+}
+
 func TestBalanceRedis_UnmarshalJSON(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/components/ledger/internal/services/query/get_id_balance.go
+++ b/components/ledger/internal/services/query/get_id_balance.go
@@ -62,9 +62,7 @@ func (uc *UseCase) GetBalanceByID(ctx context.Context, organizationID, ledgerID,
 		if uerr := json.Unmarshal([]byte(value), &cached); uerr != nil {
 			logger.Log(ctx, libLog.LevelWarn, fmt.Sprintf("Error unmarshalling balance cache value: %v", uerr))
 		} else {
-			balance.Available = cached.Available
-			balance.OnHold = cached.OnHold
-			balance.Version = cached.Version
+			applyBalanceCacheOverlay(balance, &cached)
 		}
 	}
 

--- a/components/ledger/internal/services/query/validate_accounting_routes.go
+++ b/components/ledger/internal/services/query/validate_accounting_routes.go
@@ -429,6 +429,18 @@ func uniqueValues(m map[string]string) int {
 // validateDirectionRouteMatch validates that an operation's direction is compatible with the route's operation type.
 // Source routes only accept debit, destination routes only accept credit, bidirectional routes accept both.
 func validateDirectionRouteMatch(operation mmodel.BalanceOperation, routeCache mmodel.OperationRouteCache) error {
+	// System-generated companion operations on the overdraft balance are exempt
+	// from direction validation. The companion's balance has direction=debit
+	// (set during auto-creation), which clashes with destination-type routes
+	// that expect direction=credit. Since companion ops are system-generated
+	// with a direction determined by the overdraft balance's immutable direction,
+	// blocking them serves no user-facing safety purpose. The OverdraftBalanceKey
+	// is set only by the enrichment engine and cannot be specified by the user
+	// (key "overdraft" is reserved — see T-003 scope protection).
+	if operation.Balance != nil && operation.Balance.Key == constant.OverdraftBalanceKey {
+		return nil
+	}
+
 	// Double-entry split operations use ON_HOLD, RELEASE, and reversal CREDIT/DEBIT
 	// that intentionally cross the normal direction-route mapping. Skip validation
 	// for these:

--- a/components/ledger/internal/services/query/validate_accounting_routes_test.go
+++ b/components/ledger/internal/services/query/validate_accounting_routes_test.go
@@ -873,6 +873,73 @@ func TestValidateDirectionRouteMatch(t *testing.T) {
 		err := validateDirectionRouteMatch(operation, routeCache)
 		assert.NoError(t, err)
 	})
+
+	t.Run("overdraft companion CREDIT on destination route skips direction validation", func(t *testing.T) {
+		// Companion CREDIT on the overdraft balance has direction=debit (inherited
+		// from the balance). Destination routes expect credit. Without the exemption
+		// this would fail with 0152. The OverdraftBalanceKey gate ensures only
+		// system-generated companion ops are exempt, not user-specified operations.
+		op := mmodel.BalanceOperation{
+			Alias: "test-alias",
+			Amount: mtransaction.Amount{
+				Direction: "debit",
+			},
+			Balance: &mmodel.Balance{
+				Key:         constant.OverdraftBalanceKey,
+				AccountType: "asset",
+			},
+		}
+
+		routeCache := mmodel.OperationRouteCache{
+			OperationType: "destination",
+		}
+
+		err := validateDirectionRouteMatch(op, routeCache)
+		assert.NoError(t, err, "overdraft companion ops must be exempt from direction validation")
+	})
+
+	t.Run("overdraft companion DEBIT on source route also passes", func(t *testing.T) {
+		op := mmodel.BalanceOperation{
+			Alias: "test-alias",
+			Amount: mtransaction.Amount{
+				Direction: "debit",
+			},
+			Balance: &mmodel.Balance{
+				Key:         constant.OverdraftBalanceKey,
+				AccountType: "asset",
+			},
+		}
+
+		routeCache := mmodel.OperationRouteCache{
+			OperationType: "source",
+		}
+
+		err := validateDirectionRouteMatch(op, routeCache)
+		assert.NoError(t, err)
+	})
+
+	t.Run("user-specified debit on destination route still fails 0152", func(t *testing.T) {
+		// Non-overdraft balance with debit direction on a destination route must
+		// still be rejected — the exemption only applies to OverdraftBalanceKey.
+		op := mmodel.BalanceOperation{
+			Alias: "test-alias",
+			Amount: mtransaction.Amount{
+				Direction: "debit",
+			},
+			Balance: &mmodel.Balance{
+				Key:         "default",
+				AccountType: "asset",
+			},
+		}
+
+		routeCache := mmodel.OperationRouteCache{
+			OperationType: "destination",
+		}
+
+		err := validateDirectionRouteMatch(op, routeCache)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "0152")
+	})
 }
 
 func TestValidateCounterparts(t *testing.T) {

--- a/components/ledger/migrations/transaction/000031_add_overdraft_fields_to_balance.down.sql
+++ b/components/ledger/migrations/transaction/000031_add_overdraft_fields_to_balance.down.sql
@@ -1,0 +1,9 @@
+-- Rollback: remove the overdraft fields from the balance table.
+--
+-- Uses IF EXISTS so the rollback is safe to run against databases that
+-- never received the up migration.
+
+ALTER TABLE balance
+    DROP COLUMN IF EXISTS direction,
+    DROP COLUMN IF EXISTS overdraft_used,
+    DROP COLUMN IF EXISTS settings;

--- a/components/ledger/migrations/transaction/000031_add_overdraft_fields_to_balance.up.sql
+++ b/components/ledger/migrations/transaction/000031_add_overdraft_fields_to_balance.up.sql
@@ -1,0 +1,18 @@
+-- Add overdraft fields to the balance table.
+--
+-- Adds three columns required by the overdraft feature:
+--   * direction       — accounting direction of the balance ("credit"/"debit").
+--                        Defaults to 'credit' so legacy rows match the prior
+--                        implicit behavior.
+--   * overdraft_used  — amount of overdraft currently consumed. Non-negative.
+--   * settings        — optional per-balance configuration stored as JSONB
+--                        (allowOverdraft, overdraftLimitEnabled, overdraftLimit,
+--                        balanceScope).
+--
+-- All statements use IF NOT EXISTS for idempotent re-runs.
+
+ALTER TABLE balance
+    ADD COLUMN IF NOT EXISTS direction       VARCHAR(16)   NOT NULL DEFAULT 'credit'
+                                              CHECK (direction IN ('credit', 'debit')),
+    ADD COLUMN IF NOT EXISTS overdraft_used  DECIMAL        NOT NULL DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS settings        JSONB;

--- a/components/ledger/migrations/transaction/000031_add_overdraft_fields_to_balance.up.sql
+++ b/components/ledger/migrations/transaction/000031_add_overdraft_fields_to_balance.up.sql
@@ -14,5 +14,6 @@
 ALTER TABLE balance
     ADD COLUMN IF NOT EXISTS direction       VARCHAR(16)   NOT NULL DEFAULT 'credit'
                                               CHECK (direction IN ('credit', 'debit')),
-    ADD COLUMN IF NOT EXISTS overdraft_used  DECIMAL        NOT NULL DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS overdraft_used  DECIMAL        NOT NULL DEFAULT 0
+                                              CHECK (overdraft_used >= 0),
     ADD COLUMN IF NOT EXISTS settings        JSONB;

--- a/components/ledger/migrations/transaction/000031_add_overdraft_fields_to_balance_test.go
+++ b/components/ledger/migrations/transaction/000031_add_overdraft_fields_to_balance_test.go
@@ -1,0 +1,126 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package migrations
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestMigration000031_FilesExist verifies that migration 000031 ships both
+// up and down SQL files and that neither is empty.
+func TestMigration000031_FilesExist(t *testing.T) {
+	t.Parallel()
+
+	dir := migrationsDir(t)
+
+	tests := []struct {
+		name     string
+		filename string
+	}{
+		{
+			name:     "up migration file exists",
+			filename: "000031_add_overdraft_fields_to_balance.up.sql",
+		},
+		{
+			name:     "down migration file exists",
+			filename: "000031_add_overdraft_fields_to_balance.down.sql",
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			path := filepath.Join(dir, tc.filename)
+			_, err := os.Stat(path)
+			require.NoError(t, err, "migration file %s must exist", tc.filename)
+
+			content, err := os.ReadFile(path)
+			require.NoError(t, err, "migration file %s must be readable", tc.filename)
+			assert.NotEmpty(t, string(content), "migration file %s must not be empty", tc.filename)
+		})
+	}
+}
+
+// TestMigration000031_UpSQL_AddsOverdraftColumns verifies the up migration
+// adds the three columns required by the overdraft feature to the balance table.
+func TestMigration000031_UpSQL_AddsOverdraftColumns(t *testing.T) {
+	t.Parallel()
+
+	dir := migrationsDir(t)
+	path := filepath.Join(dir, "000031_add_overdraft_fields_to_balance.up.sql")
+
+	content, err := os.ReadFile(path)
+	require.NoError(t, err, "up migration file must be readable")
+
+	sql := strings.ToLower(string(content))
+
+	tests := []struct {
+		name        string
+		substring   string
+		description string
+	}{
+		{name: "targets balance table", substring: "alter table balance", description: "must alter the balance table"},
+		{name: "uses IF NOT EXISTS for idempotency", substring: "if not exists", description: "must use IF NOT EXISTS for idempotent re-runs"},
+		{name: "adds direction column", substring: "direction", description: "must add direction column"},
+		{name: "adds overdraft_used column", substring: "overdraft_used", description: "must add overdraft_used column"},
+		{name: "adds settings column", substring: "settings", description: "must add settings column"},
+		{name: "direction defaults to 'credit'", substring: "'credit'", description: "direction column must default to 'credit'"},
+		{name: "settings column is JSONB", substring: "jsonb", description: "settings column must use JSONB type"},
+		{name: "direction has CHECK constraint", substring: "check (direction in ('credit', 'debit'))", description: "direction column must have a CHECK constraint limiting values to credit/debit"},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Contains(t, sql, tc.substring, tc.description)
+		})
+	}
+}
+
+// TestMigration000031_DownSQL_DropsOverdraftColumns verifies the down migration
+// removes the three columns added by the up migration.
+func TestMigration000031_DownSQL_DropsOverdraftColumns(t *testing.T) {
+	t.Parallel()
+
+	dir := migrationsDir(t)
+	path := filepath.Join(dir, "000031_add_overdraft_fields_to_balance.down.sql")
+
+	content, err := os.ReadFile(path)
+	require.NoError(t, err, "down migration file must be readable")
+
+	sql := strings.ToLower(string(content))
+
+	tests := []struct {
+		name        string
+		substring   string
+		description string
+	}{
+		{name: "targets balance table", substring: "alter table balance", description: "must alter the balance table"},
+		{name: "uses IF EXISTS for idempotency", substring: "if exists", description: "must use IF EXISTS for idempotent rollback"},
+		{name: "drops direction column", substring: "direction", description: "must drop direction column"},
+		{name: "drops overdraft_used column", substring: "overdraft_used", description: "must drop overdraft_used column"},
+		{name: "drops settings column", substring: "settings", description: "must drop settings column"},
+		{name: "uses DROP COLUMN statements", substring: "drop column", description: "must DROP COLUMN the overdraft fields"},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Contains(t, sql, tc.substring, tc.description)
+		})
+	}
+}

--- a/components/ledger/migrations/transaction/000031_add_overdraft_fields_to_balance_test.go
+++ b/components/ledger/migrations/transaction/000031_add_overdraft_fields_to_balance_test.go
@@ -77,6 +77,7 @@ func TestMigration000031_UpSQL_AddsOverdraftColumns(t *testing.T) {
 		{name: "direction defaults to 'credit'", substring: "'credit'", description: "direction column must default to 'credit'"},
 		{name: "settings column is JSONB", substring: "jsonb", description: "settings column must use JSONB type"},
 		{name: "direction has CHECK constraint", substring: "check (direction in ('credit', 'debit'))", description: "direction column must have a CHECK constraint limiting values to credit/debit"},
+		{name: "overdraft_used has CHECK constraint", substring: "check (overdraft_used >= 0)", description: "overdraft_used column must have a non-negative CHECK constraint"},
 	}
 
 	for _, tc := range tests {

--- a/components/ledger/migrations/transaction/000032_add_unique_balance_account_key.down.sql
+++ b/components/ledger/migrations/transaction/000032_add_unique_balance_account_key.down.sql
@@ -1,0 +1,3 @@
+-- Roll back the partial unique index guarding (organization_id, ledger_id,
+-- account_id, asset_code, key) for live balance rows.
+DROP INDEX CONCURRENTLY IF EXISTS idx_unique_balance_account_key;

--- a/components/ledger/migrations/transaction/000032_add_unique_balance_account_key.up.sql
+++ b/components/ledger/migrations/transaction/000032_add_unique_balance_account_key.up.sql
@@ -1,0 +1,10 @@
+-- Prevent duplicate balances for the same account + key combination.
+-- Uses a partial index (WHERE deleted_at IS NULL) so soft-deleted rows
+-- do not block new balances with the same key.
+--
+-- CONCURRENTLY avoids long-lived ACCESS EXCLUSIVE locks on the balance
+-- table during deployment. Combined with IF NOT EXISTS, the migration
+-- is safe to re-run.
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS idx_unique_balance_account_key
+    ON balance (organization_id, ledger_id, account_id, asset_code, key)
+    WHERE deleted_at IS NULL;

--- a/components/ledger/migrations/transaction/000032_add_unique_balance_account_key_test.go
+++ b/components/ledger/migrations/transaction/000032_add_unique_balance_account_key_test.go
@@ -1,0 +1,131 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package migrations
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestMigration000032_FilesExist verifies that the migration ships both
+// up and down SQL files and that neither is empty.
+func TestMigration000032_FilesExist(t *testing.T) {
+	t.Parallel()
+
+	dir := migrationsDir(t)
+
+	tests := []struct {
+		name     string
+		filename string
+	}{
+		{
+			name:     "up migration file exists",
+			filename: "000032_add_unique_balance_account_key.up.sql",
+		},
+		{
+			name:     "down migration file exists",
+			filename: "000032_add_unique_balance_account_key.down.sql",
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			path := filepath.Join(dir, tc.filename)
+			_, err := os.Stat(path)
+			require.NoError(t, err, "migration file %s must exist", tc.filename)
+
+			content, err := os.ReadFile(path)
+			require.NoError(t, err, "migration file %s must be readable", tc.filename)
+			assert.NotEmpty(t, string(content), "migration file %s must not be empty", tc.filename)
+		})
+	}
+}
+
+// TestMigration000032_UpSQL_CreatesUniqueIndex verifies the up migration
+// creates the partial unique index that guards against duplicate balance
+// rows for the same (organization, ledger, account, asset, key) tuple.
+// The index MUST be UNIQUE (to enforce the invariant) and MUST use
+// CONCURRENTLY (to avoid table locks on live data).
+func TestMigration000032_UpSQL_CreatesUniqueIndex(t *testing.T) {
+	t.Parallel()
+
+	dir := migrationsDir(t)
+	path := filepath.Join(dir, "000032_add_unique_balance_account_key.up.sql")
+
+	content, err := os.ReadFile(path)
+	require.NoError(t, err, "up migration file must be readable")
+
+	sql := strings.ToLower(string(content))
+
+	tests := []struct {
+		name        string
+		substring   string
+		description string
+	}{
+		{name: "creates a UNIQUE index", substring: "create unique index", description: "must declare the index as UNIQUE so duplicates raise 23505"},
+		{name: "uses CONCURRENTLY", substring: "concurrently", description: "must build the index CONCURRENTLY to avoid table locks"},
+		{name: "uses IF NOT EXISTS for idempotency", substring: "if not exists", description: "must use IF NOT EXISTS for idempotent re-runs"},
+		{name: "names the index idx_unique_balance_account_key", substring: "idx_unique_balance_account_key", description: "must use the canonical index name"},
+		{name: "targets balance table", substring: "on balance", description: "must create the index on the balance table"},
+		{name: "includes organization_id column", substring: "organization_id", description: "index key must include organization_id"},
+		{name: "includes ledger_id column", substring: "ledger_id", description: "index key must include ledger_id"},
+		{name: "includes account_id column", substring: "account_id", description: "index key must include account_id"},
+		{name: "includes asset_code column", substring: "asset_code", description: "index key must include asset_code"},
+		{name: "includes key column", substring: "key", description: "index key must include the key column"},
+		{name: "is a partial index filtering soft-deleted rows", substring: "where deleted_at is null", description: "must be a partial index so soft-deleted rows do not block new balances"},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Contains(t, sql, tc.substring, tc.description)
+		})
+	}
+}
+
+// TestMigration000032_DownSQL_DropsUniqueIndex verifies the down migration
+// removes the index added by the up migration. DROP must also use
+// CONCURRENTLY to stay symmetric with the up migration and avoid locks.
+func TestMigration000032_DownSQL_DropsUniqueIndex(t *testing.T) {
+	t.Parallel()
+
+	dir := migrationsDir(t)
+	path := filepath.Join(dir, "000032_add_unique_balance_account_key.down.sql")
+
+	content, err := os.ReadFile(path)
+	require.NoError(t, err, "down migration file must be readable")
+
+	sql := strings.ToLower(string(content))
+
+	tests := []struct {
+		name        string
+		substring   string
+		description string
+	}{
+		{name: "drops the index", substring: "drop index", description: "must drop the index added by the up migration"},
+		{name: "uses CONCURRENTLY", substring: "concurrently", description: "must drop the index CONCURRENTLY to avoid table locks"},
+		{name: "uses IF EXISTS for idempotency", substring: "if exists", description: "must use IF EXISTS for idempotent rollback"},
+		{name: "targets idx_unique_balance_account_key", substring: "idx_unique_balance_account_key", description: "must drop the canonical index name"},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Contains(t, sql, tc.substring, tc.description)
+		})
+	}
+}

--- a/components/ledger/migrations/transaction/000033_add_snapshot_to_operation.down.sql
+++ b/components/ledger/migrations/transaction/000033_add_snapshot_to_operation.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE operation DROP COLUMN IF EXISTS snapshot;

--- a/components/ledger/migrations/transaction/000033_add_snapshot_to_operation.up.sql
+++ b/components/ledger/migrations/transaction/000033_add_snapshot_to_operation.up.sql
@@ -1,0 +1,11 @@
+-- Add snapshot JSONB column to operation table.
+-- System-generated per-operation context (e.g., overdraftUsedBefore/After).
+--
+-- This is a metadata-only ALTER on PostgreSQL 11+ (non-volatile default).
+-- No table rewrite is triggered because the default value is a constant.
+-- Pre-existing rows receive the default '{}' on read without physical update.
+--
+-- No GIN index: the column is read-per-row; if future queries need filtering by
+-- snapshot keys, add an index in a follow-up migration.
+ALTER TABLE operation
+    ADD COLUMN snapshot JSONB NOT NULL DEFAULT '{}'::jsonb;

--- a/components/ledger/migrations/transaction/000033_add_snapshot_to_operation_test.go
+++ b/components/ledger/migrations/transaction/000033_add_snapshot_to_operation_test.go
@@ -1,0 +1,125 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package migrations
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestMigration000033_FilesExist verifies that migration 000033 ships both
+// up and down SQL files and that neither is empty.
+func TestMigration000033_FilesExist(t *testing.T) {
+	t.Parallel()
+
+	dir := migrationsDir(t)
+
+	tests := []struct {
+		name     string
+		filename string
+	}{
+		{
+			name:     "up migration file exists",
+			filename: "000033_add_snapshot_to_operation.up.sql",
+		},
+		{
+			name:     "down migration file exists",
+			filename: "000033_add_snapshot_to_operation.down.sql",
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			path := filepath.Join(dir, tc.filename)
+			_, err := os.Stat(path)
+			require.NoError(t, err, "migration file %s must exist", tc.filename)
+
+			content, err := os.ReadFile(path)
+			require.NoError(t, err, "migration file %s must be readable", tc.filename)
+			assert.NotEmpty(t, string(content), "migration file %s must not be empty", tc.filename)
+		})
+	}
+}
+
+// TestMigration000033_UpSQL_AddsSnapshotColumn verifies the up migration
+// adds a snapshot JSONB column with NOT NULL and a DEFAULT '{}' to the
+// operation table. The column is metadata-only on PostgreSQL 11+
+// (non-volatile default does not trigger a table rewrite).
+func TestMigration000033_UpSQL_AddsSnapshotColumn(t *testing.T) {
+	t.Parallel()
+
+	dir := migrationsDir(t)
+	path := filepath.Join(dir, "000033_add_snapshot_to_operation.up.sql")
+
+	content, err := os.ReadFile(path)
+	require.NoError(t, err, "up migration file must be readable")
+
+	sql := strings.ToLower(string(content))
+
+	tests := []struct {
+		name        string
+		substring   string
+		description string
+	}{
+		{name: "targets operation table", substring: "alter table operation", description: "must alter the operation table"},
+		{name: "adds snapshot column", substring: "snapshot", description: "must add snapshot column"},
+		{name: "snapshot is JSONB type", substring: "jsonb", description: "snapshot column must use JSONB type"},
+		{name: "snapshot is NOT NULL", substring: "not null", description: "snapshot column must be NOT NULL"},
+		{name: "snapshot has empty object default", substring: "'{}'::jsonb", description: "snapshot column must default to empty JSONB object"},
+		{name: "documents metadata-only nature", substring: "metadata-only", description: "must document that this is a metadata-only ALTER on PostgreSQL 11+"},
+		{name: "documents no GIN index decision", substring: "gin", description: "must document the decision not to add a GIN index"},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Contains(t, sql, tc.substring, tc.description)
+		})
+	}
+}
+
+// TestMigration000033_DownSQL_DropsSnapshotColumn verifies the down migration
+// removes the snapshot column added by the up migration.
+func TestMigration000033_DownSQL_DropsSnapshotColumn(t *testing.T) {
+	t.Parallel()
+
+	dir := migrationsDir(t)
+	path := filepath.Join(dir, "000033_add_snapshot_to_operation.down.sql")
+
+	content, err := os.ReadFile(path)
+	require.NoError(t, err, "down migration file must be readable")
+
+	sql := strings.ToLower(string(content))
+
+	tests := []struct {
+		name        string
+		substring   string
+		description string
+	}{
+		{name: "targets operation table", substring: "alter table operation", description: "must alter the operation table"},
+		{name: "uses IF EXISTS for idempotency", substring: "if exists", description: "must use IF EXISTS for idempotent rollback"},
+		{name: "drops snapshot column", substring: "snapshot", description: "must drop snapshot column"},
+		{name: "uses DROP COLUMN statement", substring: "drop column", description: "must DROP COLUMN the snapshot field"},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Contains(t, sql, tc.substring, tc.description)
+		})
+	}
+}

--- a/components/ledger/scripts/merge-swagger.sh
+++ b/components/ledger/scripts/merge-swagger.sh
@@ -65,8 +65,8 @@ jq --arg version "$VERSION" '
         "url": "https://discord.gg/DnhqKwkGv3"
     },
     "license": {
-        "name": "Apache 2.0",
-        "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
+        "name": "Elastic License 2.0",
+        "url": "https://www.elastic.co/licensing/elastic-license"
     },
     "version": $version
 } |
@@ -131,9 +131,19 @@ if command -v yq &> /dev/null; then
     yq -p json -o yaml "$OUTPUT_FILE" > "$OUTPUT_DIR/swagger.yaml"
     echo "YAML written to $OUTPUT_DIR/swagger.yaml"
 elif command -v python3 &> /dev/null; then
-    python3 -c "import json, yaml, sys; yaml.dump(json.load(open('$OUTPUT_FILE')), open('$OUTPUT_DIR/swagger.yaml', 'w'), default_flow_style=False, allow_unicode=True, sort_keys=False)" 2>/dev/null && echo "YAML written to $OUTPUT_DIR/swagger.yaml (via python)" || echo "Python yaml module not available, skipping YAML"
+    if python3 -c "import json, yaml, sys; yaml.dump(json.load(open('$OUTPUT_FILE')), open('$OUTPUT_DIR/swagger.yaml', 'w'), default_flow_style=False, allow_unicode=True, sort_keys=False)" 2>/dev/null; then
+        echo "YAML written to $OUTPUT_DIR/swagger.yaml (via python)"
+    elif command -v ruby &> /dev/null; then
+        ruby -rjson -ryaml -e 'File.write(ARGV[1], JSON.parse(File.read(ARGV[0])).to_yaml(line_width: -1))' "$OUTPUT_FILE" "$OUTPUT_DIR/swagger.yaml"
+        echo "YAML written to $OUTPUT_DIR/swagger.yaml (via ruby)"
+    else
+        echo "Python yaml module not available, skipping YAML"
+    fi
+elif command -v ruby &> /dev/null; then
+    ruby -rjson -ryaml -e 'File.write(ARGV[1], JSON.parse(File.read(ARGV[0])).to_yaml(line_width: -1))' "$OUTPUT_FILE" "$OUTPUT_DIR/swagger.yaml"
+    echo "YAML written to $OUTPUT_DIR/swagger.yaml (via ruby)"
 else
-    echo "Neither yq nor python3 found, skipping YAML generation"
+    echo "Neither yq, python3, nor ruby found, skipping YAML generation"
 fi
 
 # Clean up intermediate swag-generated files

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -270,7 +270,7 @@ Manages holders, aliases, related parties. Uses MongoDB for persistence. Support
 
 ### 5.1 Error Codes (pkg/constant/errors.go)
 
-176 numeric codes (0001–0176) for ledger errors. 29 CRM errors prefixed with `CRM-`.
+175 numeric codes (0001–0175) for ledger errors. 29 CRM errors prefixed with `CRM-`.
 
 #### Ledger Error Codes (selected key codes)
 - `0007` ErrEntityNotFound — entity not found
@@ -293,17 +293,16 @@ Manages holders, aliases, related parties. Uses MongoDB for persistence. Support
 - `0160` ErrTenantNotFound — tenant does not exist
 - `0161` ErrTenantServiceUnavailable — tenant resolution failed
 
-#### Overdraft Feature Error Codes (0167–0176)
+#### Overdraft Feature Error Codes (0167–0175)
 - `0167` ErrOverdraftLimitExceeded — transaction exceeds overdraft limit
 - `0168` ErrDirectOperationOnInternalBalance — user operation targets internal-scope balance
 - `0169` ErrDeletionOfInternalBalance — delete targets internal-scope balance
 - `0170` ErrReservedBalanceKey — client used system-managed balance key (e.g. "overdraft")
 - `0171` ErrInvalidBalanceDirection — unsupported direction enum value
 - `0172` ErrInvalidBalanceSettings — settings payload fails validation
-- `0173` ErrOverdraftDisableWithUsage — cannot disable overdraft while debt outstanding
-- `0174` ErrOverdraftLimitBelowUsage — cannot reduce limit below current usage
-- `0175` ErrStaleBalanceVersion — balance modified between read and write (retry needed)
-- `0176` ErrUpdateOfInternalBalance — PATCH targets internal-scope balance
+- `0173` ErrOverdraftLimitBelowUsage — cannot reduce limit below current usage
+- `0174` ErrStaleBalanceVersion — balance modified between read and write (retry needed)
+- `0175` ErrUpdateOfInternalBalance — PATCH targets internal-scope balance
 
 #### CRM Error Codes (all 29)
 - `CRM-0001` ErrInvalidMetadataNestingCRM — nested metadata not allowed

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -270,7 +270,7 @@ Manages holders, aliases, related parties. Uses MongoDB for persistence. Support
 
 ### 5.1 Error Codes (pkg/constant/errors.go)
 
-161 numeric codes (0001–0161) for ledger errors. 29 CRM errors prefixed with `CRM-`.
+176 numeric codes (0001–0176) for ledger errors. 29 CRM errors prefixed with `CRM-`.
 
 #### Ledger Error Codes (selected key codes)
 - `0007` ErrEntityNotFound — entity not found
@@ -292,6 +292,18 @@ Manages holders, aliases, related parties. Uses MongoDB for persistence. Support
 - `0159` ErrTenantServiceSuspended — tenant service suspended
 - `0160` ErrTenantNotFound — tenant does not exist
 - `0161` ErrTenantServiceUnavailable — tenant resolution failed
+
+#### Overdraft Feature Error Codes (0167–0176)
+- `0167` ErrOverdraftLimitExceeded — transaction exceeds overdraft limit
+- `0168` ErrDirectOperationOnInternalBalance — user operation targets internal-scope balance
+- `0169` ErrDeletionOfInternalBalance — delete targets internal-scope balance
+- `0170` ErrReservedBalanceKey — client used system-managed balance key (e.g. "overdraft")
+- `0171` ErrInvalidBalanceDirection — unsupported direction enum value
+- `0172` ErrInvalidBalanceSettings — settings payload fails validation
+- `0173` ErrOverdraftDisableWithUsage — cannot disable overdraft while debt outstanding
+- `0174` ErrOverdraftLimitBelowUsage — cannot reduce limit below current usage
+- `0175` ErrStaleBalanceVersion — balance modified between read and write (retry needed)
+- `0176` ErrUpdateOfInternalBalance — PATCH targets internal-scope balance
 
 #### CRM Error Codes (all 29)
 - `CRM-0001` ErrInvalidMetadataNestingCRM — nested metadata not allowed

--- a/llms.txt
+++ b/llms.txt
@@ -41,7 +41,7 @@ Midaz implements a financial hierarchy: Organizations → Ledgers → Assets, Po
 - [Infrastructure](components/infra/): Docker Compose for PostgreSQL, MongoDB, RabbitMQ, Valkey, Grafana/OTEL
 - [Shared Packages](pkg/): Cross-component libraries
   - [Domain Models](pkg/mmodel/): Organization, Ledger, Account, Asset, Transaction, Balance, etc.
-  - [Error Constants](pkg/constant/errors.go): Numeric error codes (0001–0176) and CRM error codes (includes overdraft codes 0167–0176)
+  - [Error Constants](pkg/constant/errors.go): Numeric error codes (0001–0175) and CRM error codes (includes overdraft codes 0167–0175)
   - [Error Types](pkg/errors.go): Typed errors — EntityNotFound, Validation, Conflict, Unauthorized, Forbidden, etc.
   - [Gold DSL](pkg/gold/): ANTLR4 grammar and parser for transaction DSL
   - [HTTP Utilities](pkg/net/http/): Middleware, pagination, protected routes, response helpers

--- a/llms.txt
+++ b/llms.txt
@@ -41,7 +41,7 @@ Midaz implements a financial hierarchy: Organizations → Ledgers → Assets, Po
 - [Infrastructure](components/infra/): Docker Compose for PostgreSQL, MongoDB, RabbitMQ, Valkey, Grafana/OTEL
 - [Shared Packages](pkg/): Cross-component libraries
   - [Domain Models](pkg/mmodel/): Organization, Ledger, Account, Asset, Transaction, Balance, etc.
-  - [Error Constants](pkg/constant/errors.go): Numeric error codes (0001–0161) and CRM error codes
+  - [Error Constants](pkg/constant/errors.go): Numeric error codes (0001–0176) and CRM error codes (includes overdraft codes 0167–0176)
   - [Error Types](pkg/errors.go): Typed errors — EntityNotFound, Validation, Conflict, Unauthorized, Forbidden, etc.
   - [Gold DSL](pkg/gold/): ANTLR4 grammar and parser for transaction DSL
   - [HTTP Utilities](pkg/net/http/): Middleware, pagination, protected routes, response helpers

--- a/pkg/constant/action.go
+++ b/pkg/constant/action.go
@@ -15,7 +15,26 @@ const (
 	ActionRevert = "revert"
 )
 
+// Supplementary accounting entry actions.
+//
+// These are NOT valid transaction-route action values and therefore are NOT
+// included in ValidActions or the migration 000023 CHECK constraint. They
+// identify additional accounting entries on an operation route
+// (AccountingEntries.Overdraft / AccountingEntries.Refund) that are recorded
+// alongside the primary direct scenario to describe the accounting impact of
+// overdraft usage and refunds. Keeping them separate from ValidActions avoids
+// loosening the DB-level whitelist for transaction-route associations.
+const (
+	ActionOverdraft = "overdraft"
+	ActionRefund    = "refund"
+)
+
 // ValidActions contains all valid action values for programmatic validation.
+//
+// This slice mirrors the migration 000023 CHECK constraint on the
+// transaction-route association table and MUST NOT include ActionOverdraft /
+// ActionRefund: those are accounting-entry actions, not transaction-route
+// actions, and the DB constraint rejects them by design.
 var ValidActions = []string{
 	ActionDirect,
 	ActionHold,

--- a/pkg/constant/action.go
+++ b/pkg/constant/action.go
@@ -20,21 +20,20 @@ const (
 // These are NOT valid transaction-route action values and therefore are NOT
 // included in ValidActions or the migration 000023 CHECK constraint. They
 // identify additional accounting entries on an operation route
-// (AccountingEntries.Overdraft / AccountingEntries.Refund) that are recorded
-// alongside the primary direct scenario to describe the accounting impact of
-// overdraft usage and refunds. Keeping them separate from ValidActions avoids
-// loosening the DB-level whitelist for transaction-route associations.
+// (AccountingEntries.Overdraft) that are recorded alongside the primary
+// direct scenario to describe the accounting impact of overdraft usage and
+// repayment. Keeping them separate from ValidActions avoids loosening the
+// DB-level whitelist for transaction-route associations.
 const (
 	ActionOverdraft = "overdraft"
-	ActionRefund    = "refund"
 )
 
 // ValidActions contains all valid action values for programmatic validation.
 //
 // This slice mirrors the migration 000023 CHECK constraint on the
-// transaction-route association table and MUST NOT include ActionOverdraft /
-// ActionRefund: those are accounting-entry actions, not transaction-route
-// actions, and the DB constraint rejects them by design.
+// transaction-route association table and MUST NOT include ActionOverdraft:
+// it is an accounting-entry action, not a transaction-route action, and the
+// DB constraint rejects it by design.
 var ValidActions = []string{
 	ActionDirect,
 	ActionHold,

--- a/pkg/constant/balance.go
+++ b/pkg/constant/balance.go
@@ -5,5 +5,12 @@
 package constant
 
 const (
+	// DefaultBalanceKey identifies the primary balance automatically created
+	// for every account. It is the only balance key guaranteed to exist.
 	DefaultBalanceKey = "default"
+
+	// OverdraftBalanceKey identifies the system-managed balance that tracks
+	// overdraft usage. It is auto-created when overdraft is enabled on the
+	// parent balance and is protected from direct public operations.
+	OverdraftBalanceKey = "overdraft"
 )

--- a/pkg/constant/errors.go
+++ b/pkg/constant/errors.go
@@ -206,6 +206,13 @@ var (
 	// ErrOverdraftLimitBelowUsage is returned when a caller attempts to
 	// reduce the overdraft limit below the currently used amount.
 	ErrOverdraftLimitBelowUsage = errors.New("0174")
+	// ErrStaleBalanceVersion is returned when the Redis atomic balance
+	// script detects that the balance version read by the caller no longer
+	// matches the version currently in the cache. This indicates another
+	// transaction mutated the balance between read and write, making the
+	// caller's pre-computed overdraft split/repayment amounts potentially
+	// incorrect. Callers should retry after re-reading the balance.
+	ErrStaleBalanceVersion = errors.New("0175")
 )
 
 // List of CRM errors.

--- a/pkg/constant/errors.go
+++ b/pkg/constant/errors.go
@@ -179,6 +179,18 @@ var (
 	ErrDirectScenarioRequired         = errors.New("0164")
 	ErrRevertOnlyBidirectional        = errors.New("0165")
 	ErrAccountingEntryFieldRequired   = errors.New("0166")
+
+	// Overdraft Feature Errors
+	//
+	// ErrOverdraftLimitExceeded is returned when a transaction would drive a
+	// balance past its configured overdraft limit.
+	ErrOverdraftLimitExceeded = errors.New("0167")
+	// ErrDirectOperationOnInternalBalance is returned when a user-initiated
+	// operation targets a balance whose scope is "internal".
+	ErrDirectOperationOnInternalBalance = errors.New("0168")
+	// ErrDeletionOfInternalBalance is returned when a delete request targets
+	// a balance whose scope is "internal".
+	ErrDeletionOfInternalBalance = errors.New("0169")
 )
 
 // List of CRM errors.

--- a/pkg/constant/errors.go
+++ b/pkg/constant/errors.go
@@ -213,6 +213,11 @@ var (
 	// caller's pre-computed overdraft split/repayment amounts potentially
 	// incorrect. Callers should retry after re-reading the balance.
 	ErrStaleBalanceVersion = errors.New("0175")
+	// ErrUpdateOfInternalBalance is returned when a PATCH request targets
+	// a balance whose scope is "internal". Internal balances are
+	// system-managed (e.g. overdraft companions) and cannot be modified
+	// through the public API.
+	ErrUpdateOfInternalBalance = errors.New("0176")
 )
 
 // List of CRM errors.

--- a/pkg/constant/errors.go
+++ b/pkg/constant/errors.go
@@ -191,6 +191,21 @@ var (
 	// ErrDeletionOfInternalBalance is returned when a delete request targets
 	// a balance whose scope is "internal".
 	ErrDeletionOfInternalBalance = errors.New("0169")
+	// ErrReservedBalanceKey is returned when a public create-balance request
+	// uses a system-managed key (e.g. "overdraft").
+	ErrReservedBalanceKey = errors.New("0170")
+	// ErrInvalidBalanceDirection is returned when the supplied balance
+	// direction is not one of the supported enum members.
+	ErrInvalidBalanceDirection = errors.New("0171")
+	// ErrInvalidBalanceSettings is returned when a balance settings payload
+	// fails validation (e.g. limit enabled without a value, invalid scope).
+	ErrInvalidBalanceSettings = errors.New("0172")
+	// ErrOverdraftDisableWithUsage is returned when a caller attempts to
+	// disable overdraft on a balance that still carries outstanding debt.
+	ErrOverdraftDisableWithUsage = errors.New("0173")
+	// ErrOverdraftLimitBelowUsage is returned when a caller attempts to
+	// reduce the overdraft limit below the currently used amount.
+	ErrOverdraftLimitBelowUsage = errors.New("0174")
 )
 
 // List of CRM errors.

--- a/pkg/constant/errors.go
+++ b/pkg/constant/errors.go
@@ -200,24 +200,21 @@ var (
 	// ErrInvalidBalanceSettings is returned when a balance settings payload
 	// fails validation (e.g. limit enabled without a value, invalid scope).
 	ErrInvalidBalanceSettings = errors.New("0172")
-	// ErrOverdraftDisableWithUsage is returned when a caller attempts to
-	// disable overdraft on a balance that still carries outstanding debt.
-	ErrOverdraftDisableWithUsage = errors.New("0173")
 	// ErrOverdraftLimitBelowUsage is returned when a caller attempts to
 	// reduce the overdraft limit below the currently used amount.
-	ErrOverdraftLimitBelowUsage = errors.New("0174")
+	ErrOverdraftLimitBelowUsage = errors.New("0173")
 	// ErrStaleBalanceVersion is returned when the Redis atomic balance
 	// script detects that the balance version read by the caller no longer
 	// matches the version currently in the cache. This indicates another
 	// transaction mutated the balance between read and write, making the
 	// caller's pre-computed overdraft split/repayment amounts potentially
 	// incorrect. Callers should retry after re-reading the balance.
-	ErrStaleBalanceVersion = errors.New("0175")
+	ErrStaleBalanceVersion = errors.New("0174")
 	// ErrUpdateOfInternalBalance is returned when a PATCH request targets
 	// a balance whose scope is "internal". Internal balances are
 	// system-managed (e.g. overdraft companions) and cannot be modified
 	// through the public API.
-	ErrUpdateOfInternalBalance = errors.New("0176")
+	ErrUpdateOfInternalBalance = errors.New("0175")
 )
 
 // List of CRM errors.

--- a/pkg/constant/errors_overdraft_test.go
+++ b/pkg/constant/errors_overdraft_test.go
@@ -35,12 +35,13 @@ func TestOverdraftErrorCodes_Registered(t *testing.T) {
 			expected:    "0168",
 			description: "direct operation attempted on an internal-scope balance",
 		},
-		{
-			name:        "ErrDeletionOfInternalBalance is code 0169",
-			sentinel:    ErrDeletionOfInternalBalance,
-			expected:    "0169",
-			description: "attempt to delete an internal-scope balance",
-		},
+		{name: "ErrDeletionOfInternalBalance is code 0169", sentinel: ErrDeletionOfInternalBalance, expected: "0169", description: "attempt to delete an internal-scope balance"},
+		{name: "ErrReservedBalanceKey is code 0170", sentinel: ErrReservedBalanceKey, expected: "0170", description: "attempt to create a reserved balance key"},
+		{name: "ErrInvalidBalanceDirection is code 0171", sentinel: ErrInvalidBalanceDirection, expected: "0171", description: "unsupported balance direction"},
+		{name: "ErrInvalidBalanceSettings is code 0172", sentinel: ErrInvalidBalanceSettings, expected: "0172", description: "invalid overdraft settings"},
+		{name: "ErrOverdraftLimitBelowUsage is code 0173", sentinel: ErrOverdraftLimitBelowUsage, expected: "0173", description: "new overdraft limit below current usage"},
+		{name: "ErrStaleBalanceVersion is code 0174", sentinel: ErrStaleBalanceVersion, expected: "0174", description: "balance version changed between read and write"},
+		{name: "ErrUpdateOfInternalBalance is code 0175", sentinel: ErrUpdateOfInternalBalance, expected: "0175", description: "attempt to update an internal-scope balance"},
 	}
 
 	for _, tt := range tests {

--- a/pkg/constant/errors_overdraft_test.go
+++ b/pkg/constant/errors_overdraft_test.go
@@ -13,7 +13,7 @@ import (
 
 // TestOverdraftErrorCodes_Registered verifies that the three overdraft
 // error codes are registered in the sentinel error table with the exact
-// numeric codes mandated by the TRD.
+// numeric codes for the overdraft feature.
 func TestOverdraftErrorCodes_Registered(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/constant/errors_overdraft_test.go
+++ b/pkg/constant/errors_overdraft_test.go
@@ -1,0 +1,56 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package constant
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestOverdraftErrorCodes_Registered verifies that the three overdraft
+// error codes are registered in the sentinel error table with the exact
+// numeric codes mandated by the TRD.
+func TestOverdraftErrorCodes_Registered(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		sentinel    error
+		expected    string
+		description string
+	}{
+		{
+			name:        "ErrOverdraftLimitExceeded is code 0167",
+			sentinel:    ErrOverdraftLimitExceeded,
+			expected:    "0167",
+			description: "transaction would exceed the balance's overdraft limit",
+		},
+		{
+			name:        "ErrDirectOperationOnInternalBalance is code 0168",
+			sentinel:    ErrDirectOperationOnInternalBalance,
+			expected:    "0168",
+			description: "direct operation attempted on an internal-scope balance",
+		},
+		{
+			name:        "ErrDeletionOfInternalBalance is code 0169",
+			sentinel:    ErrDeletionOfInternalBalance,
+			expected:    "0169",
+			description: "attempt to delete an internal-scope balance",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			require.NotNil(t, tt.sentinel, "%s: sentinel must be registered", tt.description)
+			assert.Equal(t, tt.expected, tt.sentinel.Error(),
+				"%s: sentinel error code must equal %s", tt.description, tt.expected)
+		})
+	}
+}

--- a/pkg/constant/operation.go
+++ b/pkg/constant/operation.go
@@ -5,10 +5,13 @@
 package constant
 
 const (
-	DEBIT   = "DEBIT"
-	CREDIT  = "CREDIT"
-	ONHOLD  = "ON_HOLD"
-	RELEASE = "RELEASE"
+	DEBIT  = "DEBIT"
+	CREDIT = "CREDIT"
+	// OVERDRAFT is the public/persisted operation type for system-generated
+	// overdraft companion rows. Direction still carries debit/credit semantics.
+	OVERDRAFT = "OVERDRAFT"
+	ONHOLD    = "ON_HOLD"
+	RELEASE   = "RELEASE"
 
 	DirectionDebit  = "debit"
 	DirectionCredit = "credit"

--- a/pkg/errors.go
+++ b/pkg/errors.go
@@ -485,12 +485,6 @@ func ValidateBusinessError(err error, entityType string, args ...any) error {
 			Title:      "Invalid Balance Settings Error",
 			Message:    "The balance settings payload is invalid. Please review overdraft, limit, and scope fields and try again.",
 		},
-		constant.ErrOverdraftDisableWithUsage: UnprocessableOperationError{
-			EntityType: entityType,
-			Code:       constant.ErrOverdraftDisableWithUsage.Error(),
-			Title:      "Overdraft Disable With Usage Error",
-			Message:    "Overdraft cannot be disabled while the balance still carries outstanding overdraft usage. Repay the outstanding amount before disabling overdraft.",
-		},
 		constant.ErrOverdraftLimitBelowUsage: UnprocessableOperationError{
 			EntityType: entityType,
 			Code:       constant.ErrOverdraftLimitBelowUsage.Error(),

--- a/pkg/errors.go
+++ b/pkg/errors.go
@@ -497,6 +497,12 @@ func ValidateBusinessError(err error, entityType string, args ...any) error {
 			Title:      "Overdraft Limit Below Usage Error",
 			Message:    "The new overdraft limit is below the amount currently used. Raise the limit above the current usage or repay the outstanding amount before reducing the limit.",
 		},
+		constant.ErrStaleBalanceVersion: UnprocessableOperationError{
+			EntityType: entityType,
+			Code:       constant.ErrStaleBalanceVersion.Error(),
+			Title:      "Stale Balance Version Error",
+			Message:    "The balance was modified by another transaction between read and write. Please retry the operation after reading the latest balance state.",
+		},
 		constant.ErrAccountIneligibility: UnprocessableOperationError{
 			EntityType: entityType,
 			Code:       constant.ErrAccountIneligibility.Error(),

--- a/pkg/errors.go
+++ b/pkg/errors.go
@@ -467,6 +467,36 @@ func ValidateBusinessError(err error, entityType string, args ...any) error {
 			Title:      "Deletion Of Internal Balance Error",
 			Message:    "Internal-scope balances cannot be deleted. They are managed by the system and must remain for accounting consistency.",
 		},
+		constant.ErrReservedBalanceKey: ValidationError{
+			EntityType: entityType,
+			Code:       constant.ErrReservedBalanceKey.Error(),
+			Title:      "Reserved Balance Key Error",
+			Message:    fmt.Sprintf("The balance key %v is reserved for system use and cannot be created through the public API. Please choose a different key and try again.", args...),
+		},
+		constant.ErrInvalidBalanceDirection: ValidationError{
+			EntityType: entityType,
+			Code:       constant.ErrInvalidBalanceDirection.Error(),
+			Title:      "Invalid Balance Direction Error",
+			Message:    fmt.Sprintf("The balance direction %v is not supported. Allowed values are \"credit\" and \"debit\".", args...),
+		},
+		constant.ErrInvalidBalanceSettings: ValidationError{
+			EntityType: entityType,
+			Code:       constant.ErrInvalidBalanceSettings.Error(),
+			Title:      "Invalid Balance Settings Error",
+			Message:    "The balance settings payload is invalid. Please review overdraft, limit, and scope fields and try again.",
+		},
+		constant.ErrOverdraftDisableWithUsage: UnprocessableOperationError{
+			EntityType: entityType,
+			Code:       constant.ErrOverdraftDisableWithUsage.Error(),
+			Title:      "Overdraft Disable With Usage Error",
+			Message:    "Overdraft cannot be disabled while the balance still carries outstanding overdraft usage. Repay the outstanding amount before disabling overdraft.",
+		},
+		constant.ErrOverdraftLimitBelowUsage: UnprocessableOperationError{
+			EntityType: entityType,
+			Code:       constant.ErrOverdraftLimitBelowUsage.Error(),
+			Title:      "Overdraft Limit Below Usage Error",
+			Message:    "The new overdraft limit is below the amount currently used. Raise the limit above the current usage or repay the outstanding amount before reducing the limit.",
+		},
 		constant.ErrAccountIneligibility: UnprocessableOperationError{
 			EntityType: entityType,
 			Code:       constant.ErrAccountIneligibility.Error(),

--- a/pkg/errors.go
+++ b/pkg/errors.go
@@ -449,6 +449,24 @@ func ValidateBusinessError(err error, entityType string, args ...any) error {
 			Title:      "Insufficient Funds Error",
 			Message:    "The transaction could not be completed due to insufficient funds in the account. Please add sufficient funds to your account and try again.",
 		},
+		constant.ErrOverdraftLimitExceeded: UnprocessableOperationError{
+			EntityType: entityType,
+			Code:       constant.ErrOverdraftLimitExceeded.Error(),
+			Title:      "Overdraft Limit Exceeded Error",
+			Message:    "The transaction could not be completed because it would exceed the configured overdraft limit for the balance. Please reduce the amount or increase the overdraft limit and try again.",
+		},
+		constant.ErrDirectOperationOnInternalBalance: UnprocessableOperationError{
+			EntityType: entityType,
+			Code:       constant.ErrDirectOperationOnInternalBalance.Error(),
+			Title:      "Direct Operation On Internal Balance Error",
+			Message:    "Direct operations on internal-scope balances are not permitted. Internal balances are managed exclusively by the system. Please target a transactional balance and try again.",
+		},
+		constant.ErrDeletionOfInternalBalance: UnprocessableOperationError{
+			EntityType: entityType,
+			Code:       constant.ErrDeletionOfInternalBalance.Error(),
+			Title:      "Deletion Of Internal Balance Error",
+			Message:    "Internal-scope balances cannot be deleted. They are managed by the system and must remain for accounting consistency.",
+		},
 		constant.ErrAccountIneligibility: UnprocessableOperationError{
 			EntityType: entityType,
 			Code:       constant.ErrAccountIneligibility.Error(),

--- a/pkg/errors.go
+++ b/pkg/errors.go
@@ -503,6 +503,12 @@ func ValidateBusinessError(err error, entityType string, args ...any) error {
 			Title:      "Stale Balance Version Error",
 			Message:    "The balance was modified by another transaction between read and write. Please retry the operation after reading the latest balance state.",
 		},
+		constant.ErrUpdateOfInternalBalance: UnprocessableOperationError{
+			EntityType: entityType,
+			Code:       constant.ErrUpdateOfInternalBalance.Error(),
+			Title:      "Update Of Internal Balance Error",
+			Message:    "Internal balances are system-managed and cannot be updated through the public API. They are maintained by the system for accounting consistency.",
+		},
 		constant.ErrAccountIneligibility: UnprocessableOperationError{
 			EntityType: entityType,
 			Code:       constant.ErrAccountIneligibility.Error(),

--- a/pkg/errors_overdraft_test.go
+++ b/pkg/errors_overdraft_test.go
@@ -1,0 +1,71 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package pkg_test
+
+import (
+	"testing"
+
+	"github.com/LerianStudio/midaz/v3/pkg"
+	"github.com/LerianStudio/midaz/v3/pkg/constant"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestValidateBusinessError_OverdraftErrors verifies that ValidateBusinessError
+// maps the three overdraft sentinels (0167, 0168, 0169) to
+// UnprocessableOperationError (HTTP 422) with the correct codes, mirroring the
+// existing ErrInsufficientFunds mapping at pkg/errors.go:446.
+func TestValidateBusinessError_OverdraftErrors(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		sentinel   error
+		wantCode   string
+		entityType string
+	}{
+		{
+			name:       "ErrOverdraftLimitExceeded maps to UnprocessableOperationError (0167)",
+			sentinel:   constant.ErrOverdraftLimitExceeded,
+			wantCode:   "0167",
+			entityType: "Balance",
+		},
+		{
+			name:       "ErrDirectOperationOnInternalBalance maps to UnprocessableOperationError (0168)",
+			sentinel:   constant.ErrDirectOperationOnInternalBalance,
+			wantCode:   "0168",
+			entityType: "Balance",
+		},
+		{
+			name:       "ErrDeletionOfInternalBalance maps to UnprocessableOperationError (0169)",
+			sentinel:   constant.ErrDeletionOfInternalBalance,
+			wantCode:   "0169",
+			entityType: "Balance",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := pkg.ValidateBusinessError(tt.sentinel, tt.entityType)
+			require.Error(t, got, "ValidateBusinessError must return a mapped error for %s", tt.sentinel.Error())
+
+			mapped, ok := got.(pkg.UnprocessableOperationError)
+			require.True(t, ok,
+				"%s must map to UnprocessableOperationError (HTTP 422), got %T", tt.sentinel.Error(), got)
+
+			assert.Equal(t, tt.wantCode, mapped.Code,
+				"mapped error code must match sentinel error string")
+			assert.Equal(t, tt.entityType, mapped.EntityType,
+				"entityType must be propagated through ValidateBusinessError")
+			assert.NotEmpty(t, mapped.Title,
+				"mapped error must have a non-empty Title")
+			assert.NotEmpty(t, mapped.Message,
+				"mapped error must have a non-empty Message")
+		})
+	}
+}

--- a/pkg/errors_overdraft_test.go
+++ b/pkg/errors_overdraft_test.go
@@ -38,12 +38,10 @@ func TestValidateBusinessError_OverdraftErrors(t *testing.T) {
 			wantCode:   "0168",
 			entityType: "Balance",
 		},
-		{
-			name:       "ErrDeletionOfInternalBalance maps to UnprocessableOperationError (0169)",
-			sentinel:   constant.ErrDeletionOfInternalBalance,
-			wantCode:   "0169",
-			entityType: "Balance",
-		},
+		{name: "ErrDeletionOfInternalBalance maps to UnprocessableOperationError (0169)", sentinel: constant.ErrDeletionOfInternalBalance, wantCode: "0169", entityType: "Balance"},
+		{name: "ErrOverdraftLimitBelowUsage maps to UnprocessableOperationError (0173)", sentinel: constant.ErrOverdraftLimitBelowUsage, wantCode: "0173", entityType: "Balance"},
+		{name: "ErrStaleBalanceVersion maps to UnprocessableOperationError (0174)", sentinel: constant.ErrStaleBalanceVersion, wantCode: "0174", entityType: "Balance"},
+		{name: "ErrUpdateOfInternalBalance maps to UnprocessableOperationError (0175)", sentinel: constant.ErrUpdateOfInternalBalance, wantCode: "0175", entityType: "Balance"},
 	}
 
 	for _, tt := range tests {

--- a/pkg/mmodel/balance.go
+++ b/pkg/mmodel/balance.go
@@ -84,6 +84,21 @@ type Balance struct {
 	// example: true
 	AllowReceiving bool `json:"allowReceiving" example:"true"`
 
+	// Direction is the accounting direction of the balance. One of
+	// "credit" or "debit". Empty string denotes legacy rows predating the
+	// overdraft feature and is treated as "credit" by the engine.
+	// example: credit
+	Direction string `json:"direction,omitempty" example:"credit"`
+
+	// OverdraftUsed is the amount of overdraft currently consumed by this
+	// balance. Always non-negative; zero when the balance is in the black.
+	// example: 0
+	OverdraftUsed decimal.Decimal `json:"overdraftUsed" example:"0"`
+
+	// Settings carries optional per-balance configuration (overdraft,
+	// balance scope). Nil for legacy balances without custom settings.
+	Settings *BalanceSettings `json:"settings,omitempty"`
+
 	// Timestamp when the balance was created (RFC3339 format)
 	// example: 2021-01-01T00:00:00Z
 	// format: date-time
@@ -166,6 +181,21 @@ type BalanceHistory struct {
 	// maxLength: 50
 	AccountType string `json:"accountType" example:"creditCard" maxLength:"50"`
 
+	// Direction is the accounting direction of the balance at the time of
+	// the snapshot. One of "credit" or "debit". Empty string denotes
+	// legacy rows predating the overdraft feature.
+	// example: credit
+	Direction string `json:"direction,omitempty" example:"credit"`
+
+	// OverdraftUsed is the amount of overdraft consumed at the time of
+	// the snapshot. Always non-negative.
+	// example: 0
+	OverdraftUsed decimal.Decimal `json:"overdraftUsed" example:"0"`
+
+	// Settings is the per-balance configuration snapshot at the time the
+	// history row was recorded. Nil for legacy balances.
+	Settings *BalanceSettings `json:"settings,omitempty"`
+
 	// Timestamp when the balance was created (RFC3339 format)
 	// example: 2021-01-01T00:00:00Z
 	// format: date-time
@@ -177,7 +207,9 @@ type BalanceHistory struct {
 	UpdatedAt time.Time `json:"updatedAt" example:"2021-01-01T00:00:00Z" format:"date-time"`
 } // @name BalanceHistory
 
-// ToHistoryResponse converts a Balance to BalanceHistory (without permission flags)
+// ToHistoryResponse converts a Balance to BalanceHistory (without permission flags).
+// Settings are deep-copied so the history snapshot is fully independent of the
+// live balance — mutations on either side cannot affect the other.
 func (b *Balance) ToHistoryResponse() *BalanceHistory {
 	return &BalanceHistory{
 		ID:             b.ID,
@@ -191,14 +223,35 @@ func (b *Balance) ToHistoryResponse() *BalanceHistory {
 		OnHold:         b.OnHold,
 		Version:        b.Version,
 		AccountType:    b.AccountType,
+		Direction:      b.Direction,
+		OverdraftUsed:  b.OverdraftUsed,
+		Settings:       deepCopySettings(b.Settings),
 		CreatedAt:      b.CreatedAt,
 		UpdatedAt:      b.UpdatedAt,
 	}
 }
 
-// ToTransactionBalance converts mmodel.Balance to mtransaction.Balance
+// deepCopySettings returns an independent copy of the given BalanceSettings,
+// including the inner OverdraftLimit pointer. Returns nil when src is nil.
+func deepCopySettings(src *BalanceSettings) *BalanceSettings {
+	if src == nil {
+		return nil
+	}
+
+	cp := *src
+
+	if src.OverdraftLimit != nil {
+		v := *src.OverdraftLimit
+		cp.OverdraftLimit = &v
+	}
+
+	return &cp
+}
+
+// ToTransactionBalance converts mmodel.Balance to mtransaction.Balance,
+// flattening the optional Settings into individual fields.
 func (b *Balance) ToTransactionBalance() *mtransaction.Balance {
-	return &mtransaction.Balance{
+	result := &mtransaction.Balance{
 		ID:             b.ID,
 		OrganizationID: b.OrganizationID,
 		LedgerID:       b.LedgerID,
@@ -212,11 +265,28 @@ func (b *Balance) ToTransactionBalance() *mtransaction.Balance {
 		AccountType:    b.AccountType,
 		AllowSending:   b.AllowSending,
 		AllowReceiving: b.AllowReceiving,
+		Direction:      b.Direction,
+		OverdraftUsed:  b.OverdraftUsed,
 		CreatedAt:      b.CreatedAt,
 		UpdatedAt:      b.UpdatedAt,
 		DeletedAt:      b.DeletedAt,
 		Metadata:       b.Metadata,
 	}
+
+	if b.Settings != nil {
+		result.AllowOverdraft = b.Settings.AllowOverdraft
+		result.OverdraftLimitEnabled = b.Settings.OverdraftLimitEnabled
+		result.BalanceScope = b.Settings.BalanceScope
+
+		if b.Settings.OverdraftLimit != nil {
+			lim, err := decimal.NewFromString(*b.Settings.OverdraftLimit)
+			if err == nil {
+				result.OverdraftLimit = lim
+			}
+		}
+	}
+
+	return result
 }
 
 // CreateAdditionalBalance is a struct designed to encapsulate balance create request payload data.
@@ -238,6 +308,18 @@ type CreateAdditionalBalance struct {
 	// required: false
 	// example: true
 	AllowReceiving *bool `json:"allowReceiving" example:"true"`
+
+	// Direction is the accounting direction of the balance ("credit" or
+	// "debit"). Optional at creation; when omitted, defaults to the
+	// account's natural direction.
+	// required: false
+	// example: credit
+	Direction *string `json:"direction,omitempty" example:"credit"`
+
+	// Settings is the optional per-balance configuration (overdraft,
+	// balance scope). When omitted, platform defaults are applied.
+	// required: false
+	Settings *BalanceSettings `json:"settings,omitempty"`
 } // @name CreateAdditionalBalance
 
 // UpdateBalance is a struct designed to encapsulate balance update request payload data.
@@ -254,6 +336,12 @@ type UpdateBalance struct {
 	// required: false
 	// example: true
 	AllowReceiving *bool `json:"allowReceiving" example:"true"`
+
+	// Settings is the per-balance configuration (overdraft, balance
+	// scope). When provided, replaces the existing settings in full.
+	// Direction is intentionally absent: it is immutable after creation.
+	// required: false
+	Settings *BalanceSettings `json:"settings,omitempty"`
 } // @name UpdateBalance
 
 // CreateBalanceInput is the input model used by services to create a balance synchronously.

--- a/pkg/mmodel/balance.go
+++ b/pkg/mmodel/balance.go
@@ -283,6 +283,14 @@ func (b *Balance) ToTransactionBalance() *mtransaction.Balance {
 			if err == nil {
 				result.OverdraftLimit = lim
 			}
+			// If parsing fails, OverdraftLimit stays at zero while
+			// OverdraftLimitEnabled may be true. This is the conservative
+			// default: zero limit with enabled=true means "reject all
+			// overdraft", which is safer than silently allowing unlimited.
+			// Validate() guards creation, so this path only triggers on
+			// data corruption (manual DB edits, migration bugs). Proper
+			// error propagation requires changing this function's signature
+			// to return error — deferred to hardening.
 		}
 	}
 

--- a/pkg/mmodel/balance.go
+++ b/pkg/mmodel/balance.go
@@ -251,7 +251,15 @@ func deepCopySettings(src *BalanceSettings) *BalanceSettings {
 
 // ToTransactionBalance converts mmodel.Balance to mtransaction.Balance,
 // flattening the optional Settings into individual fields.
-func (b *Balance) ToTransactionBalance() *mtransaction.Balance {
+//
+// Returns an error when Settings.OverdraftLimit is non-nil but cannot be
+// parsed as a decimal. Callers must surface this error rather than continue
+// with a silently-zeroed limit, because a corrupted limit combined with
+// OverdraftLimitEnabled=true would otherwise admit an unbounded overdraft
+// authorization at the validation/Lua boundary. Validate() prevents creation
+// of invalid limits, so this only triggers on data corruption (manual DB
+// edits, migration bugs) — fail closed.
+func (b *Balance) ToTransactionBalance() (*mtransaction.Balance, error) {
 	result := &mtransaction.Balance{
 		ID:             b.ID,
 		OrganizationID: b.OrganizationID,
@@ -281,21 +289,15 @@ func (b *Balance) ToTransactionBalance() *mtransaction.Balance {
 
 		if b.Settings.OverdraftLimit != nil {
 			lim, err := decimal.NewFromString(*b.Settings.OverdraftLimit)
-			if err == nil {
-				result.OverdraftLimit = lim
+			if err != nil {
+				return nil, fmt.Errorf("invalid OverdraftLimit %q on balance %s: %w", *b.Settings.OverdraftLimit, b.ID, err)
 			}
-			// If parsing fails, OverdraftLimit stays at zero while
-			// OverdraftLimitEnabled may be true. This is the conservative
-			// default: zero limit with enabled=true means "reject all
-			// overdraft", which is safer than silently allowing unlimited.
-			// Validate() guards creation, so this path only triggers on
-			// data corruption (manual DB edits, migration bugs). Proper
-			// error propagation requires changing this function's signature
-			// to return error — deferred to hardening.
+
+			result.OverdraftLimit = lim
 		}
 	}
 
-	return result
+	return result, nil
 }
 
 // CreateAdditionalBalance is a struct designed to encapsulate balance create request payload data.
@@ -437,6 +439,22 @@ type Balances struct {
 // BalanceRedis is an internal struct for Redis cache representation of balance data.
 //
 // This is an internal model not exposed via API.
+//
+// CACHE JSON CASING CONTRACT: the Redis balance entry is a JSON string whose
+// keys are CamelCase (e.g. "Available", "Direction", "AllowOverdraft") because
+// the original writer is the Lua atomic script (cjson.encode on a table with
+// CamelCase keys) and Lua table access is case-sensitive. Every Go writer to
+// the same key MUST emit CamelCase. If a Go writer uses the default BalanceRedis
+// struct tags (which are camelCase: "available", "direction", etc.), the next
+// Lua cjson.decode will see balance.Available == nil and arithmetic helpers
+// will fail with "attempt to compare nil with number".
+//
+// The canonical Go writer that respects this contract is
+// UpdateBalanceCacheSettings in adapters/redis/transaction/consumer.redis.go,
+// which operates on map[string]any with explicit CamelCase keys and uses the
+// luaBalanceSettingKey helper to purge legacy camelCase aliases. Any new Go
+// writer to the balance cache MUST follow the same pattern — do NOT marshal
+// BalanceRedis directly; use map[string]any with CamelCase keys.
 type BalanceRedis struct {
 	// Unique identifier for the balance (UUID format)
 	ID string `json:"id"`

--- a/pkg/mmodel/balance.go
+++ b/pkg/mmodel/balance.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/LerianStudio/midaz/v3/pkg/constant"
 	"github.com/LerianStudio/midaz/v3/pkg/mtransaction"
+	"github.com/LerianStudio/midaz/v3/pkg/utils"
 	"github.com/google/uuid"
 	"github.com/shopspring/decimal"
 )
@@ -572,7 +573,7 @@ func (b *BalanceRedis) UnmarshalJSON(data []byte) error {
 		b.OnHold = decimal.NewFromFloat(f)
 	}
 
-	b.OverdraftUsed = parseDecimalString(aux.OverdraftUsed, "0")
+	b.OverdraftUsed = utils.ParseDecimalString(aux.OverdraftUsed, "0")
 
 	if b.OverdraftLimit == "" {
 		b.OverdraftLimit = "0"
@@ -584,21 +585,6 @@ func (b *BalanceRedis) UnmarshalJSON(data []byte) error {
 	}
 
 	return nil
-}
-
-// parseDecimalString normalizes a value that may arrive as string, float64,
-// or json.Number into a plain decimal string. Returns defaultVal when v is nil.
-func parseDecimalString(v any, defaultVal string) string {
-	switch t := v.(type) {
-	case string:
-		return t
-	case float64:
-		return decimal.NewFromFloat(t).String()
-	case json.Number:
-		return t.String()
-	default:
-		return defaultVal
-	}
 }
 
 // BalanceErrorResponse represents an error response for balance operations.

--- a/pkg/mmodel/balance.go
+++ b/pkg/mmodel/balance.go
@@ -473,6 +473,24 @@ type BalanceRedis struct {
 
 	// Whether the account can receive funds (1=true, 0=false)
 	AllowReceiving int `json:"allowReceiving"`
+
+	// Accounting direction of the balance ("credit" or "debit")
+	Direction string `json:"direction"`
+
+	// Amount of overdraft currently consumed (decimal string for Lua)
+	OverdraftUsed string `json:"overdraftUsed"`
+
+	// Whether overdraft is allowed (1=true, 0=false for Lua)
+	AllowOverdraft int `json:"allowOverdraft"`
+
+	// Whether the overdraft limit is enabled (1=true, 0=false for Lua)
+	OverdraftLimitEnabled int `json:"overdraftLimitEnabled"`
+
+	// Maximum overdraft amount (decimal string for Lua)
+	OverdraftLimit string `json:"overdraftLimit"`
+
+	// Balance scope ("transactional" or "internal")
+	BalanceScope string `json:"balanceScope"`
 }
 
 // UnmarshalJSON is a custom unmarshal function for BalanceRedis
@@ -480,8 +498,9 @@ func (b *BalanceRedis) UnmarshalJSON(data []byte) error {
 	type Alias BalanceRedis
 
 	aux := struct {
-		Available any `json:"available"`
-		OnHold    any `json:"onHold"`
+		Available     any `json:"available"`
+		OnHold        any `json:"onHold"`
+		OverdraftUsed any `json:"overdraftUsed"`
 		*Alias
 	}{
 		Alias: (*Alias)(b),
@@ -553,12 +572,33 @@ func (b *BalanceRedis) UnmarshalJSON(data []byte) error {
 		b.OnHold = decimal.NewFromFloat(f)
 	}
 
+	b.OverdraftUsed = parseDecimalString(aux.OverdraftUsed, "0")
+
+	if b.OverdraftLimit == "" {
+		b.OverdraftLimit = "0"
+	}
+
 	// Set default value for Key if not provided (backwards compatibility)
 	if b.Key == "" {
 		b.Key = constant.DefaultBalanceKey
 	}
 
 	return nil
+}
+
+// parseDecimalString normalizes a value that may arrive as string, float64,
+// or json.Number into a plain decimal string. Returns defaultVal when v is nil.
+func parseDecimalString(v any, defaultVal string) string {
+	switch t := v.(type) {
+	case string:
+		return t
+	case float64:
+		return decimal.NewFromFloat(t).String()
+	case json.Number:
+		return t.String()
+	default:
+		return defaultVal
+	}
 }
 
 // BalanceErrorResponse represents an error response for balance operations.

--- a/pkg/mmodel/balance.go
+++ b/pkg/mmodel/balance.go
@@ -321,8 +321,7 @@ type CreateAdditionalBalance struct {
 	AllowReceiving *bool `json:"allowReceiving" example:"true"`
 
 	// Direction is the accounting direction of the balance ("credit" or
-	// "debit"). Optional at creation; when omitted, defaults to the
-	// account's natural direction.
+	// "debit"). Optional at creation; when omitted, defaults to "credit".
 	// required: false
 	// example: credit
 	Direction *string `json:"direction,omitempty" example:"credit"`

--- a/pkg/mmodel/balance_overdraft_test.go
+++ b/pkg/mmodel/balance_overdraft_test.go
@@ -1,0 +1,220 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package mmodel
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/shopspring/decimal"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBalance_HasOverdraftFields verifies the Balance struct exposes the new
+// overdraft fields (Direction, OverdraftUsed, Settings) used by the overdraft
+// feature.
+func TestBalance_HasOverdraftFields(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		fieldName string
+		fieldType string
+	}{
+		{name: "Direction field is string", fieldName: "Direction", fieldType: "string"},
+		{name: "OverdraftUsed field is decimal.Decimal", fieldName: "OverdraftUsed", fieldType: "decimal.Decimal"},
+		{name: "Settings field is *BalanceSettings", fieldName: "Settings", fieldType: "*mmodel.BalanceSettings"},
+	}
+
+	bt := reflect.TypeOf(Balance{})
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			field, ok := bt.FieldByName(tt.fieldName)
+			require.True(t, ok, "Balance struct must have field %q", tt.fieldName)
+			assert.Equal(t, tt.fieldType, field.Type.String(),
+				"Balance.%s must be of type %s", tt.fieldName, tt.fieldType)
+		})
+	}
+}
+
+// TestBalanceHistory_HasOverdraftFields verifies BalanceHistory also carries
+// the new fields so historical snapshots preserve overdraft state.
+func TestBalanceHistory_HasOverdraftFields(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		fieldName string
+		fieldType string
+	}{
+		{name: "Direction field is string", fieldName: "Direction", fieldType: "string"},
+		{name: "OverdraftUsed field is decimal.Decimal", fieldName: "OverdraftUsed", fieldType: "decimal.Decimal"},
+		{name: "Settings field is *BalanceSettings", fieldName: "Settings", fieldType: "*mmodel.BalanceSettings"},
+	}
+
+	bt := reflect.TypeOf(BalanceHistory{})
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			field, ok := bt.FieldByName(tt.fieldName)
+			require.True(t, ok, "BalanceHistory struct must have field %q", tt.fieldName)
+			assert.Equal(t, tt.fieldType, field.Type.String(),
+				"BalanceHistory.%s must be of type %s", tt.fieldName, tt.fieldType)
+		})
+	}
+}
+
+// TestCreateAdditionalBalance_HasOverdraftFields verifies the create payload
+// accepts Direction (optional) and Settings (optional).
+func TestCreateAdditionalBalance_HasOverdraftFields(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		fieldName string
+		fieldType string
+	}{
+		{name: "Direction pointer is *string", fieldName: "Direction", fieldType: "*string"},
+		{name: "Settings is *BalanceSettings", fieldName: "Settings", fieldType: "*mmodel.BalanceSettings"},
+	}
+
+	bt := reflect.TypeOf(CreateAdditionalBalance{})
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			field, ok := bt.FieldByName(tt.fieldName)
+			require.True(t, ok, "CreateAdditionalBalance must have field %q", tt.fieldName)
+			assert.Equal(t, tt.fieldType, field.Type.String(),
+				"CreateAdditionalBalance.%s must be of type %s", tt.fieldName, tt.fieldType)
+		})
+	}
+}
+
+// TestUpdateBalance_HasSettingsField verifies the update payload exposes
+// Settings (optional). Direction is immutable after creation per PRD §4, so
+// UpdateBalance must NOT expose Direction.
+func TestUpdateBalance_HasSettingsField(t *testing.T) {
+	t.Parallel()
+
+	bt := reflect.TypeOf(UpdateBalance{})
+
+	field, ok := bt.FieldByName("Settings")
+	require.True(t, ok, "UpdateBalance must have field Settings")
+	assert.Equal(t, "*mmodel.BalanceSettings", field.Type.String(),
+		"UpdateBalance.Settings must be *BalanceSettings")
+
+	_, hasDirection := bt.FieldByName("Direction")
+	assert.False(t, hasDirection,
+		"UpdateBalance must NOT expose Direction - direction is immutable after creation")
+}
+
+// TestBalance_ToTransactionBalance_IncludesOverdraftFields ensures that
+// converting a Balance to mtransaction.Balance propagates the overdraft
+// fields Direction, OverdraftUsed, and the flattened settings fields.
+func TestBalance_ToTransactionBalance_IncludesOverdraftFields(t *testing.T) {
+	t.Parallel()
+
+	limit := "2500.00"
+	settings := &BalanceSettings{
+		BalanceScope:          "transactional",
+		AllowOverdraft:        true,
+		OverdraftLimitEnabled: true,
+		OverdraftLimit:        &limit,
+	}
+
+	tests := []struct {
+		name                      string
+		direction                 string
+		overdraftUsed             decimal.Decimal
+		settings                  *BalanceSettings
+		wantDirection             string
+		wantOverdraftUsed         decimal.Decimal
+		wantAllowOverdraft        bool
+		wantOverdraftLimitEnabled bool
+		wantOverdraftLimit        decimal.Decimal
+		wantBalanceScope          string
+	}{
+		{
+			name:                      "credit direction, zero used, full settings",
+			direction:                 "credit",
+			overdraftUsed:             decimal.Zero,
+			settings:                  settings,
+			wantDirection:             "credit",
+			wantOverdraftUsed:         decimal.Zero,
+			wantAllowOverdraft:        true,
+			wantOverdraftLimitEnabled: true,
+			wantOverdraftLimit:        decimal.RequireFromString("2500.00"),
+			wantBalanceScope:          "transactional",
+		},
+		{
+			name:                      "debit direction, non-zero used, nil settings",
+			direction:                 "debit",
+			overdraftUsed:             decimal.NewFromInt(250),
+			settings:                  nil,
+			wantDirection:             "debit",
+			wantOverdraftUsed:         decimal.NewFromInt(250),
+			wantAllowOverdraft:        false,
+			wantOverdraftLimitEnabled: false,
+			wantOverdraftLimit:        decimal.Zero,
+			wantBalanceScope:          "",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			b := &Balance{
+				ID:             "123e4567-e89b-12d3-a456-426614174000",
+				OrganizationID: "org-1",
+				LedgerID:       "ledger-1",
+				AccountID:      "account-1",
+				Alias:          "@acc",
+				Key:            "default",
+				AssetCode:      "USD",
+				Available:      decimal.NewFromInt(1000),
+				OnHold:         decimal.Zero,
+				Version:        1,
+				AccountType:    "deposit",
+				AllowSending:   true,
+				AllowReceiving: true,
+				Direction:      tt.direction,
+				OverdraftUsed:  tt.overdraftUsed,
+				Settings:       tt.settings,
+			}
+
+			got := b.ToTransactionBalance()
+			require.NotNil(t, got)
+
+			assert.Equal(t, tt.wantDirection, got.Direction,
+				"Direction must be propagated through ToTransactionBalance")
+			assert.True(t, tt.wantOverdraftUsed.Equal(got.OverdraftUsed),
+				"OverdraftUsed must be propagated: want %s got %s",
+				tt.wantOverdraftUsed, got.OverdraftUsed)
+			assert.Equal(t, tt.wantAllowOverdraft, got.AllowOverdraft,
+				"AllowOverdraft must be propagated")
+			assert.Equal(t, tt.wantOverdraftLimitEnabled, got.OverdraftLimitEnabled,
+				"OverdraftLimitEnabled must be propagated")
+			assert.True(t, tt.wantOverdraftLimit.Equal(got.OverdraftLimit),
+				"OverdraftLimit must be propagated: want %s got %s",
+				tt.wantOverdraftLimit, got.OverdraftLimit)
+			assert.Equal(t, tt.wantBalanceScope, got.BalanceScope,
+				"BalanceScope must be propagated")
+		})
+	}
+}

--- a/pkg/mmodel/balance_overdraft_test.go
+++ b/pkg/mmodel/balance_overdraft_test.go
@@ -105,7 +105,7 @@ func TestCreateAdditionalBalance_HasOverdraftFields(t *testing.T) {
 }
 
 // TestUpdateBalance_HasSettingsField verifies the update payload exposes
-// Settings (optional). Direction is immutable after creation per PRD §4, so
+// Settings (optional). Direction is immutable after creation, so
 // UpdateBalance must NOT expose Direction.
 func TestUpdateBalance_HasSettingsField(t *testing.T) {
 	t.Parallel()

--- a/pkg/mmodel/balance_overdraft_test.go
+++ b/pkg/mmodel/balance_overdraft_test.go
@@ -198,7 +198,8 @@ func TestBalance_ToTransactionBalance_IncludesOverdraftFields(t *testing.T) {
 				Settings:       tt.settings,
 			}
 
-			got := b.ToTransactionBalance()
+			got, err := b.ToTransactionBalance()
+			require.NoError(t, err)
 			require.NotNil(t, got)
 
 			assert.Equal(t, tt.wantDirection, got.Direction,

--- a/pkg/mmodel/balance_position.go
+++ b/pkg/mmodel/balance_position.go
@@ -1,0 +1,153 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package mmodel
+
+import (
+	"encoding/json"
+
+	"github.com/shopspring/decimal"
+)
+
+// Position is a derived view computed from the balance state at response
+// time. It is response-only — never persisted, never cached. Always
+// present on Balance and BalanceHistory JSON responses.
+//
+// AvailableOverdraftLimit has three documented cases:
+//
+//   - "0"          when overdraft is disabled (Settings nil OR
+//     Settings.AllowOverdraft = false). The customer has no
+//     headroom because no overdraft is permitted.
+//   - positive     when overdraft is limited (AllowOverdraft = true AND
+//     OverdraftLimitEnabled = true). Value is
+//     OverdraftLimit − OverdraftUsed. May be zero when used
+//     exactly equals limit, or negative on malformed limit
+//     strings (read-side resilience: never crash).
+//   - omitted/null when overdraft is unlimited (AllowOverdraft = true AND
+//     OverdraftLimitEnabled = false). The field is absent
+//     from the JSON wire (omitempty on a nil pointer).
+//
+// swagger:model Position
+// @Description Calculated balance position. Derived from Available, OnHold, OverdraftUsed, and Settings — never stored. The position object centralises customer-facing arithmetic so consumers don't have to reimplement it client-side.
+type Position struct {
+	// Available is the net spendable amount: Balance.Available minus
+	// Balance.OverdraftUsed. Negative when the balance is overdrafted
+	// (Available pinned at 0, OverdraftUsed > 0). Always present.
+	// example: 950
+	Available decimal.Decimal `json:"available" example:"950"`
+
+	// OnHold mirrors Balance.OnHold verbatim. Always present.
+	// example: 100
+	OnHold decimal.Decimal `json:"onHold" example:"100"`
+
+	// AvailableOverdraftLimit is the remaining overdraft headroom.
+	// Omitted from JSON when overdraft is unlimited (nil pointer).
+	// example: 500
+	AvailableOverdraftLimit *decimal.Decimal `json:"availableOverdraftLimit,omitempty" example:"500"`
+} // @name Position
+
+// ComputePosition derives a Position from the current Balance state.
+// Pure function, no side effects, no I/O.
+//
+// See the Position type doc for the full semantics of each field.
+func (b Balance) ComputePosition() Position {
+	return computePosition(b.Available, b.OnHold, b.OverdraftUsed, b.Settings)
+}
+
+// ComputePosition derives a Position from the BalanceHistory snapshot.
+// Mirrors Balance.ComputePosition so historical responses carry the same
+// position shape as live reads.
+func (bh BalanceHistory) ComputePosition() Position {
+	return computePosition(bh.Available, bh.OnHold, bh.OverdraftUsed, bh.Settings)
+}
+
+// computePosition is the shared implementation used by both
+// Balance.ComputePosition and BalanceHistory.ComputePosition. Keeping the
+// logic in one place prevents drift between the live and historical
+// surfaces.
+//
+// Resilience policy: a malformed Settings.OverdraftLimit string falls
+// back to decimal.Zero (matching the existing posture in
+// Balance.ToTransactionBalance). The position field is read-only audit
+// context — never a correctness gate — so unparseable strings on
+// historical or corrupted rows surface as conservative numeric values
+// rather than crashing the read path.
+func computePosition(available, onHold, overdraftUsed decimal.Decimal, settings *BalanceSettings) Position {
+	pos := Position{
+		Available: available.Sub(overdraftUsed),
+		OnHold:    onHold,
+	}
+
+	// Settings nil OR overdraft disabled → no headroom permitted.
+	// Emit an explicit "0" so consumers can distinguish "no overdraft"
+	// from "unlimited overdraft" (the latter omits the field entirely).
+	if settings == nil || !settings.AllowOverdraft {
+		zero := decimal.Zero
+		pos.AvailableOverdraftLimit = &zero
+
+		return pos
+	}
+
+	// Overdraft enabled but unlimited → omit the field entirely
+	// (nil pointer + omitempty). Absence on the wire = unlimited.
+	if !settings.OverdraftLimitEnabled {
+		return pos
+	}
+
+	// Overdraft enabled AND limited → headroom = limit − used.
+	var limit decimal.Decimal
+	if settings.OverdraftLimit != nil {
+		if parsed, err := decimal.NewFromString(*settings.OverdraftLimit); err == nil {
+			limit = parsed
+		}
+		// Parse failure: limit stays at decimal.Zero. Conservative —
+		// headroom = 0 − overdraftUsed, possibly negative.
+	}
+
+	headroom := limit.Sub(overdraftUsed)
+	pos.AvailableOverdraftLimit = &headroom
+
+	return pos
+}
+
+// MarshalJSON injects the computed Position block into the JSON output
+// alongside the standard Balance fields.
+//
+// Implementation detail: the alias-type pattern (`type Alias Balance`)
+// strips the MarshalJSON receiver from the inner struct so the encoder
+// falls back to default tag-based serialization, avoiding infinite
+// recursion. The outer anonymous struct embeds the alias and adds the
+// computed position field with its own json tag.
+//
+// This receiver only fires for `mmodel.Balance` values. The cache
+// envelope `BalanceRedis` is a separate type and is unaffected. The DB
+// model `BalancePostgreSQLModel` is never JSON-marshalled (SQL only).
+// The queue path uses msgpack, not JSON. The wire-shape contract for
+// the position block is therefore JSON-response-only by construction.
+func (b Balance) MarshalJSON() ([]byte, error) {
+	type Alias Balance
+
+	return json.Marshal(struct {
+		Alias
+		Position Position `json:"position"`
+	}{
+		Alias:    Alias(b),
+		Position: b.ComputePosition(),
+	})
+}
+
+// MarshalJSON injects the computed Position block into BalanceHistory's
+// JSON output. Mirrors Balance.MarshalJSON so historical responses
+// carry the same wire shape as live responses.
+func (bh BalanceHistory) MarshalJSON() ([]byte, error) {
+	type Alias BalanceHistory
+
+	return json.Marshal(struct {
+		Alias
+		Position Position `json:"position"`
+	}{
+		Alias:    Alias(bh),
+		Position: bh.ComputePosition(),
+	})
+}

--- a/pkg/mmodel/balance_position.go
+++ b/pkg/mmodel/balance_position.go
@@ -14,7 +14,7 @@ import (
 // time. It is response-only — never persisted, never cached. Always
 // present on Balance and BalanceHistory JSON responses.
 //
-// AvailableOverdraftLimit has three documented cases:
+// OverdraftLimitAvailable has three documented cases:
 //
 //   - "0"          when overdraft is disabled (Settings nil OR
 //     Settings.AllowOverdraft = false). The customer has no
@@ -41,10 +41,10 @@ type Position struct {
 	// example: 100
 	OnHold decimal.Decimal `json:"onHold" example:"100"`
 
-	// AvailableOverdraftLimit is the remaining overdraft headroom.
+	// OverdraftLimitAvailable is the remaining overdraft headroom.
 	// Omitted from JSON when overdraft is unlimited (nil pointer).
 	// example: 500
-	AvailableOverdraftLimit *decimal.Decimal `json:"availableOverdraftLimit,omitempty" example:"500"`
+	OverdraftLimitAvailable *decimal.Decimal `json:"overdraftLimitAvailable,omitempty" example:"500"`
 } // @name Position
 
 // ComputePosition derives a Position from the current Balance state.
@@ -84,7 +84,7 @@ func computePosition(available, onHold, overdraftUsed decimal.Decimal, settings 
 	// from "unlimited overdraft" (the latter omits the field entirely).
 	if settings == nil || !settings.AllowOverdraft {
 		zero := decimal.Zero
-		pos.AvailableOverdraftLimit = &zero
+		pos.OverdraftLimitAvailable = &zero
 
 		return pos
 	}
@@ -106,7 +106,7 @@ func computePosition(available, onHold, overdraftUsed decimal.Decimal, settings 
 	}
 
 	headroom := limit.Sub(overdraftUsed)
-	pos.AvailableOverdraftLimit = &headroom
+	pos.OverdraftLimitAvailable = &headroom
 
 	return pos
 }

--- a/pkg/mmodel/balance_position_test.go
+++ b/pkg/mmodel/balance_position_test.go
@@ -100,10 +100,10 @@ func TestComputePosition_OnHold_MirroredVerbatim(t *testing.T) {
 }
 
 // ============================================================================
-// ComputePosition — AvailableOverdraftLimit (all four cases)
+// ComputePosition — OverdraftLimitAvailable (all four cases)
 // ============================================================================
 
-func TestComputePosition_AvailableOverdraftLimit_Cases(t *testing.T) {
+func TestComputePosition_OverdraftLimitAvailable_Cases(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -212,10 +212,10 @@ func TestComputePosition_AvailableOverdraftLimit_Cases(t *testing.T) {
 			pos := b.ComputePosition()
 
 			if tt.wantHeadroomNil {
-				assert.Nil(t, pos.AvailableOverdraftLimit, "headroom should be nil for unlimited overdraft")
+				assert.Nil(t, pos.OverdraftLimitAvailable, "headroom should be nil for unlimited overdraft")
 			} else {
-				require.NotNil(t, pos.AvailableOverdraftLimit, "headroom should be present")
-				decimalEqual(t, tt.wantHeadroom, *pos.AvailableOverdraftLimit, "headroom value")
+				require.NotNil(t, pos.OverdraftLimitAvailable, "headroom should be present")
+				decimalEqual(t, tt.wantHeadroom, *pos.OverdraftLimitAvailable, "headroom value")
 			}
 		})
 	}
@@ -253,10 +253,10 @@ func TestBalance_MarshalJSON_IncludesPositionBlock(t *testing.T) {
 
 	assert.Equal(t, "1000", pos["available"], "position.available should equal Available - OverdraftUsed (1000 - 0)")
 	assert.Equal(t, "100", pos["onHold"], "position.onHold should mirror OnHold")
-	assert.Equal(t, "500", pos["availableOverdraftLimit"], "position.availableOverdraftLimit should equal limit - used (500 - 0)")
+	assert.Equal(t, "500", pos["overdraftLimitAvailable"], "position.overdraftLimitAvailable should equal limit - used (500 - 0)")
 }
 
-func TestBalance_MarshalJSON_OmitsAvailableOverdraftLimit_WhenUnlimited(t *testing.T) {
+func TestBalance_MarshalJSON_OmitsOverdraftLimitAvailable_WhenUnlimited(t *testing.T) {
 	t.Parallel()
 
 	b := Balance{
@@ -274,8 +274,8 @@ func TestBalance_MarshalJSON_OmitsAvailableOverdraftLimit_WhenUnlimited(t *testi
 	require.NoError(t, err)
 
 	// Assert the key is literally absent from the JSON (omitempty on nil pointer).
-	assert.NotContains(t, string(raw), `"availableOverdraftLimit"`,
-		"availableOverdraftLimit must be omitted when overdraft is unlimited")
+	assert.NotContains(t, string(raw), `"overdraftLimitAvailable"`,
+		"overdraftLimitAvailable must be omitted when overdraft is unlimited")
 
 	// Position block is still present with available + onHold.
 	assert.Contains(t, string(raw), `"position"`)
@@ -305,7 +305,7 @@ func TestBalance_MarshalJSON_NegativeAvailable_OnOverdraftedAccount(t *testing.T
 
 	pos := decoded["position"].(map[string]any)
 	assert.Equal(t, "-75", pos["available"], "position.available is negative when fully overdrafted")
-	assert.Equal(t, "25", pos["availableOverdraftLimit"], "position.availableOverdraftLimit = 100 - 75 = 25")
+	assert.Equal(t, "25", pos["overdraftLimitAvailable"], "position.overdraftLimitAvailable = 100 - 75 = 25")
 }
 
 func TestBalance_MarshalJSON_NoInfiniteRecursion(t *testing.T) {
@@ -410,7 +410,7 @@ func TestBalanceHistory_MarshalJSON_IncludesPositionBlock(t *testing.T) {
 
 	assert.Equal(t, "1900", pos["available"], "position.available = 2000 - 100")
 	assert.Equal(t, "500", pos["onHold"])
-	assert.Equal(t, "200", pos["availableOverdraftLimit"], "headroom = 300 - 100")
+	assert.Equal(t, "200", pos["overdraftLimitAvailable"], "headroom = 300 - 100")
 }
 
 func TestBalanceHistory_ComputePosition_LegacySettingsNil(t *testing.T) {
@@ -425,8 +425,8 @@ func TestBalanceHistory_ComputePosition_LegacySettingsNil(t *testing.T) {
 
 	pos := bh.ComputePosition()
 
-	require.NotNil(t, pos.AvailableOverdraftLimit)
-	decimalEqual(t, decimal.Zero, *pos.AvailableOverdraftLimit, "legacy → zero headroom")
+	require.NotNil(t, pos.OverdraftLimitAvailable)
+	decimalEqual(t, decimal.Zero, *pos.OverdraftLimitAvailable, "legacy → zero headroom")
 }
 
 // ============================================================================
@@ -467,7 +467,7 @@ func TestBalanceRedis_MarshalJSON_NoPositionBlock(t *testing.T) {
 	// The cache envelope must NOT carry a position block.
 	assert.NotContains(t, string(raw), `"position"`,
 		"BalanceRedis JSON envelope must not include a position block")
-	assert.NotContains(t, string(raw), `"availableOverdraftLimit"`)
+	assert.NotContains(t, string(raw), `"overdraftLimitAvailable"`)
 }
 
 // ============================================================================
@@ -547,6 +547,6 @@ func TestBalance_MarshalJSON_PositionBlockShape(t *testing.T) {
 	// Substring check (order is what Go's encoder produces by struct field
 	// order in the alias type).
 	assert.True(t,
-		strings.Contains(string(raw), `"position":{"available":"980","onHold":"50","availableOverdraftLimit":"80"}`),
+		strings.Contains(string(raw), `"position":{"available":"980","onHold":"50","overdraftLimitAvailable":"80"}`),
 		"position block shape: %s", string(raw))
 }

--- a/pkg/mmodel/balance_position_test.go
+++ b/pkg/mmodel/balance_position_test.go
@@ -1,0 +1,552 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package mmodel
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// stringPtr is a tiny helper to take the address of a string literal in
+// table-driven test data. The settings.OverdraftLimit field is *string.
+func stringPtr(s string) *string { return &s }
+
+// decimalEqual is a small assertion helper that prefers `decimal.Equal`
+// over `reflect.DeepEqual` for decimal.Decimal values, because two
+// decimals with the same numeric value can have different internal
+// big.Int representations after arithmetic.
+func decimalEqual(t *testing.T, want, got decimal.Decimal, msgAndArgs ...any) {
+	t.Helper()
+	assert.Truef(t, want.Equal(got), "want %s, got %s%v", want.String(), got.String(), msgAndArgs)
+}
+
+// ============================================================================
+// ComputePosition — Available
+// ============================================================================
+
+func TestComputePosition_Available_PositiveNormalBalance(t *testing.T) {
+	t.Parallel()
+
+	b := Balance{
+		Available:     decimal.NewFromInt(1000),
+		OnHold:        decimal.NewFromInt(50),
+		OverdraftUsed: decimal.Zero,
+	}
+
+	pos := b.ComputePosition()
+
+	decimalEqual(t, decimal.NewFromInt(1000), pos.Available, "available with no overdraft used")
+}
+
+func TestComputePosition_Available_ZeroAtBoundary(t *testing.T) {
+	t.Parallel()
+
+	b := Balance{
+		Available:     decimal.NewFromInt(50),
+		OnHold:        decimal.Zero,
+		OverdraftUsed: decimal.NewFromInt(50),
+	}
+
+	pos := b.ComputePosition()
+
+	decimalEqual(t, decimal.Zero, pos.Available, "available - overdraftUsed = 0 at boundary")
+}
+
+func TestComputePosition_Available_NegativeWhenOverdrafted(t *testing.T) {
+	t.Parallel()
+
+	b := Balance{
+		Available:     decimal.Zero,
+		OnHold:        decimal.Zero,
+		OverdraftUsed: decimal.NewFromInt(50),
+	}
+
+	pos := b.ComputePosition()
+
+	decimalEqual(t, decimal.NewFromInt(-50), pos.Available, "negative position when fully overdrafted")
+}
+
+// ============================================================================
+// ComputePosition — OnHold
+// ============================================================================
+
+func TestComputePosition_OnHold_MirroredVerbatim(t *testing.T) {
+	t.Parallel()
+
+	cases := []decimal.Decimal{
+		decimal.Zero,
+		decimal.NewFromInt(100),
+		decimal.NewFromFloat(3.14159),
+		decimal.NewFromInt(999_999_999),
+	}
+
+	for _, want := range cases {
+		b := Balance{
+			Available: decimal.NewFromInt(1000),
+			OnHold:    want,
+		}
+
+		pos := b.ComputePosition()
+
+		decimalEqual(t, want, pos.OnHold, "onHold should mirror verbatim")
+	}
+}
+
+// ============================================================================
+// ComputePosition — AvailableOverdraftLimit (all four cases)
+// ============================================================================
+
+func TestComputePosition_AvailableOverdraftLimit_Cases(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		settings        *BalanceSettings
+		overdraftUsed   decimal.Decimal
+		wantHeadroomNil bool
+		wantHeadroom    decimal.Decimal
+	}{
+		{
+			name:            "Settings nil (legacy balance) → headroom = 0",
+			settings:        nil,
+			overdraftUsed:   decimal.Zero,
+			wantHeadroomNil: false,
+			wantHeadroom:    decimal.Zero,
+		},
+		{
+			name: "AllowOverdraft=false → headroom = 0",
+			settings: &BalanceSettings{
+				AllowOverdraft:        false,
+				OverdraftLimitEnabled: false,
+				OverdraftLimit:        nil,
+			},
+			overdraftUsed:   decimal.Zero,
+			wantHeadroomNil: false,
+			wantHeadroom:    decimal.Zero,
+		},
+		{
+			name: "AllowOverdraft=true unlimited → headroom = nil (omitted)",
+			settings: &BalanceSettings{
+				AllowOverdraft:        true,
+				OverdraftLimitEnabled: false,
+				OverdraftLimit:        nil,
+			},
+			overdraftUsed:   decimal.NewFromInt(123),
+			wantHeadroomNil: true,
+		},
+		{
+			name: "AllowOverdraft=true limited unused → headroom = limit",
+			settings: &BalanceSettings{
+				AllowOverdraft:        true,
+				OverdraftLimitEnabled: true,
+				OverdraftLimit:        stringPtr("500"),
+			},
+			overdraftUsed:   decimal.Zero,
+			wantHeadroomNil: false,
+			wantHeadroom:    decimal.NewFromInt(500),
+		},
+		{
+			name: "AllowOverdraft=true limited partially used → headroom = limit - used",
+			settings: &BalanceSettings{
+				AllowOverdraft:        true,
+				OverdraftLimitEnabled: true,
+				OverdraftLimit:        stringPtr("500"),
+			},
+			overdraftUsed:   decimal.NewFromInt(200),
+			wantHeadroomNil: false,
+			wantHeadroom:    decimal.NewFromInt(300),
+		},
+		{
+			name: "AllowOverdraft=true limited exactly at limit → headroom = 0",
+			settings: &BalanceSettings{
+				AllowOverdraft:        true,
+				OverdraftLimitEnabled: true,
+				OverdraftLimit:        stringPtr("500"),
+			},
+			overdraftUsed:   decimal.NewFromInt(500),
+			wantHeadroomNil: false,
+			wantHeadroom:    decimal.Zero,
+		},
+		{
+			name: "AllowOverdraft=true limited with malformed limit → falls back to zero",
+			settings: &BalanceSettings{
+				AllowOverdraft:        true,
+				OverdraftLimitEnabled: true,
+				OverdraftLimit:        stringPtr("not-a-number"),
+			},
+			overdraftUsed:   decimal.NewFromInt(50),
+			wantHeadroomNil: false,
+			wantHeadroom:    decimal.NewFromInt(-50), // 0 - 50
+		},
+		{
+			name: "AllowOverdraft=true OverdraftLimitEnabled=true but Limit nil → zero",
+			settings: &BalanceSettings{
+				AllowOverdraft:        true,
+				OverdraftLimitEnabled: true,
+				OverdraftLimit:        nil,
+			},
+			overdraftUsed:   decimal.Zero,
+			wantHeadroomNil: false,
+			wantHeadroom:    decimal.Zero,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			b := Balance{
+				Available:     decimal.NewFromInt(1000),
+				OnHold:        decimal.Zero,
+				OverdraftUsed: tt.overdraftUsed,
+				Settings:      tt.settings,
+			}
+
+			pos := b.ComputePosition()
+
+			if tt.wantHeadroomNil {
+				assert.Nil(t, pos.AvailableOverdraftLimit, "headroom should be nil for unlimited overdraft")
+			} else {
+				require.NotNil(t, pos.AvailableOverdraftLimit, "headroom should be present")
+				decimalEqual(t, tt.wantHeadroom, *pos.AvailableOverdraftLimit, "headroom value")
+			}
+		})
+	}
+}
+
+// ============================================================================
+// MarshalJSON — Balance
+// ============================================================================
+
+func TestBalance_MarshalJSON_IncludesPositionBlock(t *testing.T) {
+	t.Parallel()
+
+	b := Balance{
+		ID:            "11111111-1111-1111-1111-111111111111",
+		Alias:         "@alice",
+		Available:     decimal.NewFromInt(1000),
+		OnHold:        decimal.NewFromInt(100),
+		OverdraftUsed: decimal.Zero,
+		Settings: &BalanceSettings{
+			AllowOverdraft:        true,
+			OverdraftLimitEnabled: true,
+			OverdraftLimit:        stringPtr("500"),
+		},
+	}
+
+	raw, err := json.Marshal(b)
+	require.NoError(t, err)
+
+	// Decode into a generic map to assert structure.
+	var decoded map[string]any
+	require.NoError(t, json.Unmarshal(raw, &decoded))
+
+	pos, ok := decoded["position"].(map[string]any)
+	require.True(t, ok, "position must be present and be a JSON object")
+
+	assert.Equal(t, "1000", pos["available"], "position.available should equal Available - OverdraftUsed (1000 - 0)")
+	assert.Equal(t, "100", pos["onHold"], "position.onHold should mirror OnHold")
+	assert.Equal(t, "500", pos["availableOverdraftLimit"], "position.availableOverdraftLimit should equal limit - used (500 - 0)")
+}
+
+func TestBalance_MarshalJSON_OmitsAvailableOverdraftLimit_WhenUnlimited(t *testing.T) {
+	t.Parallel()
+
+	b := Balance{
+		Available:     decimal.NewFromInt(1000),
+		OnHold:        decimal.Zero,
+		OverdraftUsed: decimal.Zero,
+		Settings: &BalanceSettings{
+			AllowOverdraft:        true,
+			OverdraftLimitEnabled: false, // unlimited
+			OverdraftLimit:        nil,
+		},
+	}
+
+	raw, err := json.Marshal(b)
+	require.NoError(t, err)
+
+	// Assert the key is literally absent from the JSON (omitempty on nil pointer).
+	assert.NotContains(t, string(raw), `"availableOverdraftLimit"`,
+		"availableOverdraftLimit must be omitted when overdraft is unlimited")
+
+	// Position block is still present with available + onHold.
+	assert.Contains(t, string(raw), `"position"`)
+	assert.Contains(t, string(raw), `"available"`)
+	assert.Contains(t, string(raw), `"onHold"`)
+}
+
+func TestBalance_MarshalJSON_NegativeAvailable_OnOverdraftedAccount(t *testing.T) {
+	t.Parallel()
+
+	b := Balance{
+		Available:     decimal.Zero,
+		OnHold:        decimal.Zero,
+		OverdraftUsed: decimal.NewFromInt(75),
+		Settings: &BalanceSettings{
+			AllowOverdraft:        true,
+			OverdraftLimitEnabled: true,
+			OverdraftLimit:        stringPtr("100"),
+		},
+	}
+
+	raw, err := json.Marshal(b)
+	require.NoError(t, err)
+
+	var decoded map[string]any
+	require.NoError(t, json.Unmarshal(raw, &decoded))
+
+	pos := decoded["position"].(map[string]any)
+	assert.Equal(t, "-75", pos["available"], "position.available is negative when fully overdrafted")
+	assert.Equal(t, "25", pos["availableOverdraftLimit"], "position.availableOverdraftLimit = 100 - 75 = 25")
+}
+
+func TestBalance_MarshalJSON_NoInfiniteRecursion(t *testing.T) {
+	t.Parallel()
+
+	// If MarshalJSON is incorrectly implemented (e.g. calls json.Marshal on
+	// the receiver type rather than the alias type), it recurses forever
+	// and crashes with a stack-overflow / "encountered a cycle" error.
+	// This sanity test calls Marshal on a populated Balance and just
+	// asserts the call returns without panicking.
+	b := Balance{
+		ID:            "deadbeef-dead-beef-dead-beefdeadbeef",
+		Alias:         "@recursion-guard",
+		Available:     decimal.NewFromInt(1),
+		OnHold:        decimal.Zero,
+		OverdraftUsed: decimal.Zero,
+	}
+
+	require.NotPanics(t, func() {
+		_, err := json.Marshal(b)
+		require.NoError(t, err)
+	})
+}
+
+// ============================================================================
+// MarshalJSON — Balance preserves all original fields
+// ============================================================================
+
+func TestBalance_MarshalJSON_PreservesOriginalFields(t *testing.T) {
+	t.Parallel()
+
+	b := Balance{
+		ID:             "22222222-2222-2222-2222-222222222222",
+		OrganizationID: "org-id",
+		LedgerID:       "ledger-id",
+		AccountID:      "account-id",
+		Alias:          "@bob",
+		Key:            "default",
+		AssetCode:      "USD",
+		Available:      decimal.NewFromInt(500),
+		OnHold:         decimal.NewFromInt(25),
+		Version:        7,
+		AccountType:    "creditCard",
+		AllowSending:   true,
+		AllowReceiving: true,
+		Direction:      "credit",
+		OverdraftUsed:  decimal.Zero,
+		Metadata:       map[string]any{"foo": "bar"},
+	}
+
+	raw, err := json.Marshal(b)
+	require.NoError(t, err)
+
+	var decoded map[string]any
+	require.NoError(t, json.Unmarshal(raw, &decoded))
+
+	// Spot-check the original fields are still emitted.
+	assert.Equal(t, "22222222-2222-2222-2222-222222222222", decoded["id"])
+	assert.Equal(t, "@bob", decoded["alias"])
+	assert.Equal(t, "default", decoded["key"])
+	assert.Equal(t, "USD", decoded["assetCode"])
+	assert.Equal(t, "500", decoded["available"])
+	assert.Equal(t, "25", decoded["onHold"])
+	assert.Equal(t, float64(7), decoded["version"])
+	assert.Equal(t, "creditCard", decoded["accountType"])
+	assert.Equal(t, true, decoded["allowSending"])
+	assert.Equal(t, "credit", decoded["direction"])
+	assert.Equal(t, "0", decoded["overdraftUsed"])
+
+	// Plus the new position block.
+	require.NotNil(t, decoded["position"])
+}
+
+// ============================================================================
+// MarshalJSON — BalanceHistory
+// ============================================================================
+
+func TestBalanceHistory_MarshalJSON_IncludesPositionBlock(t *testing.T) {
+	t.Parallel()
+
+	bh := BalanceHistory{
+		ID:            "33333333-3333-3333-3333-333333333333",
+		Alias:         "@charlie",
+		Available:     decimal.NewFromInt(2000),
+		OnHold:        decimal.NewFromInt(500),
+		OverdraftUsed: decimal.NewFromInt(100),
+		Settings: &BalanceSettings{
+			AllowOverdraft:        true,
+			OverdraftLimitEnabled: true,
+			OverdraftLimit:        stringPtr("300"),
+		},
+	}
+
+	raw, err := json.Marshal(bh)
+	require.NoError(t, err)
+
+	var decoded map[string]any
+	require.NoError(t, json.Unmarshal(raw, &decoded))
+
+	pos, ok := decoded["position"].(map[string]any)
+	require.True(t, ok, "position must be present on BalanceHistory")
+
+	assert.Equal(t, "1900", pos["available"], "position.available = 2000 - 100")
+	assert.Equal(t, "500", pos["onHold"])
+	assert.Equal(t, "200", pos["availableOverdraftLimit"], "headroom = 300 - 100")
+}
+
+func TestBalanceHistory_ComputePosition_LegacySettingsNil(t *testing.T) {
+	t.Parallel()
+
+	bh := BalanceHistory{
+		Available:     decimal.NewFromInt(100),
+		OnHold:        decimal.Zero,
+		OverdraftUsed: decimal.Zero,
+		Settings:      nil,
+	}
+
+	pos := bh.ComputePosition()
+
+	require.NotNil(t, pos.AvailableOverdraftLimit)
+	decimalEqual(t, decimal.Zero, *pos.AvailableOverdraftLimit, "legacy → zero headroom")
+}
+
+// ============================================================================
+// Non-pollution: BalanceRedis JSON shape unaffected
+// ============================================================================
+
+// TestBalanceRedis_MarshalJSON_NoPositionBlock asserts that adding
+// MarshalJSON on Balance does NOT leak the position block into the
+// BalanceRedis cache envelope. BalanceRedis is a separate type with its
+// own (default) JSON marshaling; the Balance.MarshalJSON receiver only
+// fires for Balance values.
+func TestBalanceRedis_MarshalJSON_NoPositionBlock(t *testing.T) {
+	t.Parallel()
+
+	br := BalanceRedis{
+		ID:                    "redis-id",
+		Alias:                 "@cache",
+		Key:                   "default",
+		AccountID:             "account-id",
+		AssetCode:             "USD",
+		Available:             decimal.NewFromInt(100),
+		OnHold:                decimal.Zero,
+		Version:               1,
+		AccountType:           "deposit",
+		AllowSending:          1,
+		AllowReceiving:        1,
+		Direction:             "credit",
+		OverdraftUsed:         "0",
+		AllowOverdraft:        0,
+		OverdraftLimitEnabled: 0,
+		OverdraftLimit:        "0",
+		BalanceScope:          "transactional",
+	}
+
+	raw, err := json.Marshal(br)
+	require.NoError(t, err)
+
+	// The cache envelope must NOT carry a position block.
+	assert.NotContains(t, string(raw), `"position"`,
+		"BalanceRedis JSON envelope must not include a position block")
+	assert.NotContains(t, string(raw), `"availableOverdraftLimit"`)
+}
+
+// ============================================================================
+// Non-pollution: Balance round-trip through marshal + custom unmarshal
+// ============================================================================
+
+// TestBalance_MarshalJSON_RoundTrip verifies that a marshal-then-unmarshal
+// cycle preserves the source fields. The Position block injected by
+// MarshalJSON is read-only on the wire — Go has no symmetrical
+// UnmarshalJSON on Balance, so the unmarshal side will silently drop the
+// `position` key (consumers don't need to round-trip it because it's
+// always derivable from the source fields).
+func TestBalance_MarshalJSON_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	original := Balance{
+		ID:            "44444444-4444-4444-4444-444444444444",
+		Alias:         "@round-trip",
+		Available:     decimal.NewFromInt(123),
+		OnHold:        decimal.NewFromInt(45),
+		OverdraftUsed: decimal.NewFromInt(7),
+		Direction:     "credit",
+		Settings: &BalanceSettings{
+			AllowOverdraft:        true,
+			OverdraftLimitEnabled: true,
+			OverdraftLimit:        stringPtr("100"),
+		},
+	}
+
+	raw, err := json.Marshal(original)
+	require.NoError(t, err)
+
+	// Sanity: position is in the wire.
+	require.Contains(t, string(raw), `"position"`)
+
+	// Unmarshal back into a fresh Balance. The default decoder ignores
+	// the unknown `position` key (Go's json package skips fields that
+	// don't match any struct field — Balance has no `Position` member).
+	var restored Balance
+	require.NoError(t, json.Unmarshal(raw, &restored))
+
+	assert.Equal(t, original.ID, restored.ID)
+	assert.Equal(t, original.Alias, restored.Alias)
+	decimalEqual(t, original.Available, restored.Available)
+	decimalEqual(t, original.OnHold, restored.OnHold)
+	decimalEqual(t, original.OverdraftUsed, restored.OverdraftUsed)
+	assert.Equal(t, original.Direction, restored.Direction)
+	require.NotNil(t, restored.Settings)
+	assert.Equal(t, original.Settings.AllowOverdraft, restored.Settings.AllowOverdraft)
+}
+
+// ============================================================================
+// Wire-format spot check
+// ============================================================================
+
+// TestBalance_MarshalJSON_PositionBlockShape locks the exact JSON shape of
+// the position block — three keys, in the order produced by the Go
+// encoder. Useful as a documentation anchor: a contributor reading this
+// test sees the wire-format contract at a glance.
+func TestBalance_MarshalJSON_PositionBlockShape(t *testing.T) {
+	t.Parallel()
+
+	b := Balance{
+		Available:     decimal.NewFromInt(1000),
+		OnHold:        decimal.NewFromInt(50),
+		OverdraftUsed: decimal.NewFromInt(20),
+		Settings: &BalanceSettings{
+			AllowOverdraft:        true,
+			OverdraftLimitEnabled: true,
+			OverdraftLimit:        stringPtr("100"),
+		},
+	}
+
+	raw, err := json.Marshal(b)
+	require.NoError(t, err)
+
+	// Substring check (order is what Go's encoder produces by struct field
+	// order in the alias type).
+	assert.True(t,
+		strings.Contains(string(raw), `"position":{"available":"980","onHold":"50","availableOverdraftLimit":"80"}`),
+		"position block shape: %s", string(raw))
+}

--- a/pkg/mmodel/balance_redis_overdraft_test.go
+++ b/pkg/mmodel/balance_redis_overdraft_test.go
@@ -154,34 +154,6 @@ func TestBalanceRedis_UnmarshalJSON_OverdraftUsedFromFloat(t *testing.T) {
 	}
 }
 
-// TestBalanceRedis_UnmarshalJSON_OverdraftUsedFromNumber verifies that
-// the json.Number branch of parseDecimalString preserves the exact
-// textual representation supplied by the caller — the precision-safe
-// path for high-magnitude or high-precision decimals.
-func TestBalanceRedis_UnmarshalJSON_OverdraftUsedFromNumber(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name     string
-		input    json.Number
-		expected string
-	}{
-		{name: "high precision decimal", input: json.Number("123.456789012345"), expected: "123.456789012345"},
-		{name: "large integer", input: json.Number("9999999999999999"), expected: "9999999999999999"},
-		{name: "small fractional", input: json.Number("0.000001"), expected: "0.000001"},
-	}
-
-	for _, tt := range tests {
-		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			got := parseDecimalString(tt.input, "0")
-			assert.Equal(t, tt.expected, got)
-		})
-	}
-}
-
 // TestBalanceRedis_UnmarshalJSON_MissingOverdraftFields verifies legacy
 // payloads (written before the overdraft feature) still decode cleanly,
 // with sensible defaults applied to the overdraft fields.

--- a/pkg/mmodel/balance_redis_overdraft_test.go
+++ b/pkg/mmodel/balance_redis_overdraft_test.go
@@ -1,0 +1,213 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package mmodel
+
+import (
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBalanceRedis_HasOverdraftFields verifies via reflection that the
+// Redis cache projection exposes the overdraft fields with the right
+// types and json tags that the Lua scripts depend on.
+func TestBalanceRedis_HasOverdraftFields(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		fieldName    string
+		expectedType reflect.Type
+		expectedJSON string
+	}{
+		{
+			name:         "direction field",
+			fieldName:    "Direction",
+			expectedType: reflect.TypeOf(""),
+			expectedJSON: "direction",
+		},
+		{
+			name:         "overdraft_used field",
+			fieldName:    "OverdraftUsed",
+			expectedType: reflect.TypeOf(""),
+			expectedJSON: "overdraftUsed",
+		},
+		{
+			name:         "allow_overdraft field",
+			fieldName:    "AllowOverdraft",
+			expectedType: reflect.TypeOf(0),
+			expectedJSON: "allowOverdraft",
+		},
+		{
+			name:         "overdraft_limit_enabled field",
+			fieldName:    "OverdraftLimitEnabled",
+			expectedType: reflect.TypeOf(0),
+			expectedJSON: "overdraftLimitEnabled",
+		},
+		{
+			name:         "overdraft_limit field",
+			fieldName:    "OverdraftLimit",
+			expectedType: reflect.TypeOf(""),
+			expectedJSON: "overdraftLimit",
+		},
+		{
+			name:         "balance_scope field",
+			fieldName:    "BalanceScope",
+			expectedType: reflect.TypeOf(""),
+			expectedJSON: "balanceScope",
+		},
+	}
+
+	redisType := reflect.TypeOf(BalanceRedis{})
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			field, ok := redisType.FieldByName(tt.fieldName)
+			require.True(t, ok, "expected field %q on BalanceRedis", tt.fieldName)
+			assert.Equal(t, tt.expectedType, field.Type, "field %q type mismatch", tt.fieldName)
+
+			// JSON tag may have options (e.g. "name,omitempty"); take the name.
+			jsonTag := strings.Split(field.Tag.Get("json"), ",")[0]
+			assert.Equal(t, tt.expectedJSON, jsonTag, "field %q json tag mismatch", tt.fieldName)
+		})
+	}
+}
+
+// TestBalanceRedis_UnmarshalJSON_OverdraftFields verifies that a fully
+// populated JSON payload — matching what the Lua scripts write back — is
+// correctly deserialized, including the overdraft fields.
+func TestBalanceRedis_UnmarshalJSON_OverdraftFields(t *testing.T) {
+	t.Parallel()
+
+	payload := `{
+		"id": "00000000-0000-0000-0000-000000000001",
+		"alias": "@person1",
+		"key": "default",
+		"accountId": "00000000-0000-0000-0000-000000000002",
+		"assetCode": "USD",
+		"available": 1500,
+		"onHold": 500,
+		"version": 3,
+		"accountType": "deposit",
+		"allowSending": 1,
+		"allowReceiving": 1,
+		"direction": "debit",
+		"overdraftUsed": "50.00",
+		"allowOverdraft": 1,
+		"overdraftLimitEnabled": 1,
+		"overdraftLimit": "500.00",
+		"balanceScope": "transactional"
+	}`
+
+	var br BalanceRedis
+	require.NoError(t, json.Unmarshal([]byte(payload), &br))
+
+	assert.Equal(t, "debit", br.Direction)
+	assert.Equal(t, "50.00", br.OverdraftUsed)
+	assert.Equal(t, 1, br.AllowOverdraft)
+	assert.Equal(t, 1, br.OverdraftLimitEnabled)
+	assert.Equal(t, "500.00", br.OverdraftLimit)
+	assert.Equal(t, "transactional", br.BalanceScope)
+}
+
+// TestBalanceRedis_UnmarshalJSON_OverdraftUsedFromFloat verifies that
+// numeric OverdraftUsed values (common when Lua emits a plain number) are
+// normalized into a decimal string, preserving the integer/decimal value.
+func TestBalanceRedis_UnmarshalJSON_OverdraftUsedFromFloat(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{name: "decimal value", input: "50.5", expected: "50.5"},
+		{name: "zero value", input: "0", expected: "0"},
+		{name: "integer value", input: "100", expected: "100"},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			payload := `{
+				"available": 0,
+				"onHold": 0,
+				"overdraftUsed": ` + tt.input + `
+			}`
+
+			var br BalanceRedis
+			require.NoError(t, json.Unmarshal([]byte(payload), &br))
+
+			assert.Equal(t, tt.expected, br.OverdraftUsed)
+		})
+	}
+}
+
+// TestBalanceRedis_UnmarshalJSON_OverdraftUsedFromNumber verifies that
+// the json.Number branch of parseDecimalString preserves the exact
+// textual representation supplied by the caller — the precision-safe
+// path for high-magnitude or high-precision decimals.
+func TestBalanceRedis_UnmarshalJSON_OverdraftUsedFromNumber(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    json.Number
+		expected string
+	}{
+		{name: "high precision decimal", input: json.Number("123.456789012345"), expected: "123.456789012345"},
+		{name: "large integer", input: json.Number("9999999999999999"), expected: "9999999999999999"},
+		{name: "small fractional", input: json.Number("0.000001"), expected: "0.000001"},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := parseDecimalString(tt.input, "0")
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}
+
+// TestBalanceRedis_UnmarshalJSON_MissingOverdraftFields verifies legacy
+// payloads (written before the overdraft feature) still decode cleanly,
+// with sensible defaults applied to the overdraft fields.
+func TestBalanceRedis_UnmarshalJSON_MissingOverdraftFields(t *testing.T) {
+	t.Parallel()
+
+	payload := `{
+		"id": "00000000-0000-0000-0000-000000000001",
+		"alias": "@legacy",
+		"accountId": "00000000-0000-0000-0000-000000000002",
+		"assetCode": "USD",
+		"available": 100,
+		"onHold": 0,
+		"version": 1,
+		"accountType": "deposit",
+		"allowSending": 1,
+		"allowReceiving": 1
+	}`
+
+	var br BalanceRedis
+	require.NoError(t, json.Unmarshal([]byte(payload), &br))
+
+	assert.Equal(t, "", br.Direction, "legacy payload must leave Direction empty")
+	assert.Equal(t, "0", br.OverdraftUsed, "missing overdraftUsed must default to \"0\"")
+	assert.Equal(t, 0, br.AllowOverdraft)
+	assert.Equal(t, 0, br.OverdraftLimitEnabled)
+	assert.Equal(t, "0", br.OverdraftLimit, "missing overdraftLimit must default to \"0\"")
+	assert.Equal(t, "", br.BalanceScope)
+}

--- a/pkg/mmodel/balance_settings.go
+++ b/pkg/mmodel/balance_settings.go
@@ -1,0 +1,157 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package mmodel
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/shopspring/decimal"
+)
+
+// Balance scope constants for BalanceSettings.BalanceScope.
+const (
+	// BalanceScopeTransactional identifies a balance that can participate in
+	// user-initiated transactions. This is the default scope.
+	BalanceScopeTransactional = "transactional"
+
+	// BalanceScopeInternal identifies a balance managed exclusively by the
+	// system (e.g. overdraft reserves). Direct operations on internal-scope
+	// balances are rejected by the transaction engine.
+	BalanceScopeInternal = "internal"
+)
+
+// BalanceSettings captures the optional per-balance configuration introduced by
+// the overdraft feature. It is stored as a JSONB column on the balance row and
+// propagated through the transaction engine via Balance.Settings.
+//
+// swagger:model BalanceSettings
+// @Description Optional per-balance configuration controlling overdraft behavior and balance scope.
+type BalanceSettings struct {
+	// BalanceScope identifies how the balance participates in transactions.
+	// Allowed values: "transactional" (default), "internal". Empty string is
+	// treated as "transactional" for backwards compatibility.
+	// example: transactional
+	BalanceScope string `json:"balanceScope,omitempty" example:"transactional"`
+
+	// AllowOverdraft enables overdraft behavior for the balance. When false,
+	// transactions that would drive Available below zero are rejected.
+	// example: false
+	AllowOverdraft bool `json:"allowOverdraft" example:"false"`
+
+	// OverdraftLimitEnabled gates the OverdraftLimit field. When true, a
+	// non-empty, strictly positive OverdraftLimit MUST be supplied. When
+	// false, OverdraftLimit MUST be absent (overdraft is unlimited if
+	// AllowOverdraft is true).
+	// example: false
+	OverdraftLimitEnabled bool `json:"overdraftLimitEnabled" example:"false"`
+
+	// OverdraftLimit is the maximum overdraft amount the balance may carry,
+	// expressed as a decimal string (to preserve precision). Ignored when
+	// OverdraftLimitEnabled is false.
+	// example: 1000.00
+	OverdraftLimit *string `json:"overdraftLimit,omitempty" example:"1000.00"`
+}
+
+// NewDefaultBalanceSettings returns a BalanceSettings initialized with the
+// defaults mandated by PRD RF-1:
+//   - BalanceScope  = "transactional"
+//   - AllowOverdraft = false
+//   - OverdraftLimitEnabled = false
+//   - OverdraftLimit = nil
+//
+// The constructor centralizes default creation so call sites never end up
+// with a zero-valued BalanceSettings that would leave BalanceScope empty.
+func NewDefaultBalanceSettings() *BalanceSettings {
+	return &BalanceSettings{
+		BalanceScope:          BalanceScopeTransactional,
+		AllowOverdraft:        false,
+		OverdraftLimitEnabled: false,
+		OverdraftLimit:        nil,
+	}
+}
+
+// Validate enforces the balance settings contract from PRD §4 RF-1.
+//
+// Rules:
+//   - BalanceScope MUST be "transactional", "internal", or empty (=>
+//     defaults to "transactional"). Any other value (including case
+//     variants) is rejected.
+//   - When OverdraftLimitEnabled is true, OverdraftLimit MUST be present,
+//     parse as a valid decimal via shopspring/decimal, and be strictly
+//     greater than zero.
+//   - When OverdraftLimitEnabled is false, OverdraftLimit MUST be absent
+//     (nil). A present OverdraftLimit with the flag disabled is ambiguous
+//     and therefore rejected.
+func (s *BalanceSettings) Validate() error {
+	if s == nil {
+		return nil
+	}
+
+	if err := s.validateScope(); err != nil {
+		return err
+	}
+
+	return s.validateOverdraftLimit()
+}
+
+// validateScope returns an error when BalanceScope is not one of the
+// allowed values. Empty string is accepted and interpreted as the default
+// "transactional" scope by downstream consumers.
+func (s *BalanceSettings) validateScope() error {
+	switch s.BalanceScope {
+	case "", BalanceScopeTransactional, BalanceScopeInternal:
+		return nil
+	default:
+		return fmt.Errorf(
+			"invalid balanceScope %q: must be %q or %q",
+			s.BalanceScope, BalanceScopeTransactional, BalanceScopeInternal,
+		)
+	}
+}
+
+// validateOverdraftLimit enforces the cross-field rule between
+// OverdraftLimitEnabled and OverdraftLimit.
+func (s *BalanceSettings) validateOverdraftLimit() error {
+	if !s.OverdraftLimitEnabled {
+		if s.OverdraftLimit != nil {
+			return errors.New(
+				"overdraftLimit must be absent when overdraftLimitEnabled is false",
+			)
+		}
+
+		return nil
+	}
+
+	// OverdraftLimitEnabled == true: require a strictly positive decimal.
+	if s.OverdraftLimit == nil {
+		return errors.New(
+			"overdraftLimit is required when overdraftLimitEnabled is true",
+		)
+	}
+
+	if *s.OverdraftLimit == "" {
+		return errors.New(
+			"overdraftLimit must be a non-empty decimal string when overdraftLimitEnabled is true",
+		)
+	}
+
+	limit, err := decimal.NewFromString(*s.OverdraftLimit)
+	if err != nil {
+		return fmt.Errorf(
+			"overdraftLimit %q is not a valid decimal: %w",
+			*s.OverdraftLimit, err,
+		)
+	}
+
+	if !limit.IsPositive() {
+		return fmt.Errorf(
+			"overdraftLimit %q must be strictly greater than zero",
+			*s.OverdraftLimit,
+		)
+	}
+
+	return nil
+}

--- a/pkg/mmodel/balance_settings.go
+++ b/pkg/mmodel/balance_settings.go
@@ -56,7 +56,7 @@ type BalanceSettings struct {
 }
 
 // NewDefaultBalanceSettings returns a BalanceSettings initialized with the
-// defaults mandated by PRD RF-1:
+// safe defaults for the overdraft feature:
 //   - BalanceScope  = "transactional"
 //   - AllowOverdraft = false
 //   - OverdraftLimitEnabled = false
@@ -73,7 +73,7 @@ func NewDefaultBalanceSettings() *BalanceSettings {
 	}
 }
 
-// Validate enforces the balance settings contract from PRD §4 RF-1.
+// Validate enforces the balance settings contract.
 //
 // Rules:
 //   - BalanceScope MUST be "transactional", "internal", or empty (=>

--- a/pkg/mmodel/balance_settings_test.go
+++ b/pkg/mmodel/balance_settings_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 // TestBalanceSettings_Defaults verifies the default BalanceSettings produced by
-// NewDefaultBalanceSettings matches PRD RF-1:
+// NewDefaultBalanceSettings returns safe defaults:
 //   - BalanceScope = "transactional"
 //   - AllowOverdraft = false
 //   - OverdraftLimitEnabled = false
@@ -30,7 +30,7 @@ func TestBalanceSettings_Defaults(t *testing.T) {
 }
 
 // TestBalanceSettings_Validate_ValidCombinations covers the 4 valid combinations
-// from PRD §4 RF-1 (balance settings contract).
+// from the balance settings contract.
 func TestBalanceSettings_Validate_ValidCombinations(t *testing.T) {
 	t.Parallel()
 
@@ -96,7 +96,7 @@ func TestBalanceSettings_Validate_ValidCombinations(t *testing.T) {
 }
 
 // TestBalanceSettings_Validate_InvalidCombinations covers every rejection path
-// described in PRD §4 RF-1 and the TRD.
+// described in the balance settings contract.
 func TestBalanceSettings_Validate_InvalidCombinations(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/mmodel/balance_settings_test.go
+++ b/pkg/mmodel/balance_settings_test.go
@@ -1,0 +1,206 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package mmodel
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBalanceSettings_Defaults verifies the default BalanceSettings produced by
+// NewDefaultBalanceSettings matches PRD RF-1:
+//   - BalanceScope = "transactional"
+//   - AllowOverdraft = false
+//   - OverdraftLimitEnabled = false
+//   - OverdraftLimit = nil
+func TestBalanceSettings_Defaults(t *testing.T) {
+	t.Parallel()
+
+	got := NewDefaultBalanceSettings()
+
+	require.NotNil(t, got, "NewDefaultBalanceSettings must return non-nil value")
+	assert.Equal(t, "transactional", got.BalanceScope, "default BalanceScope must be 'transactional'")
+	assert.False(t, got.AllowOverdraft, "default AllowOverdraft must be false")
+	assert.False(t, got.OverdraftLimitEnabled, "default OverdraftLimitEnabled must be false")
+	assert.Nil(t, got.OverdraftLimit, "default OverdraftLimit must be nil")
+}
+
+// TestBalanceSettings_Validate_ValidCombinations covers the 4 valid combinations
+// from PRD §4 RF-1 (balance settings contract).
+func TestBalanceSettings_Validate_ValidCombinations(t *testing.T) {
+	t.Parallel()
+
+	limit := "1000.00"
+
+	tests := []struct {
+		name     string
+		settings BalanceSettings
+	}{
+		{
+			name: "transactional, no overdraft allowed (default)",
+			settings: BalanceSettings{
+				BalanceScope:          "transactional",
+				AllowOverdraft:        false,
+				OverdraftLimitEnabled: false,
+			},
+		},
+		{
+			name: "transactional, overdraft allowed without limit (unlimited)",
+			settings: BalanceSettings{
+				BalanceScope:          "transactional",
+				AllowOverdraft:        true,
+				OverdraftLimitEnabled: false,
+			},
+		},
+		{
+			name: "transactional, overdraft allowed with limit",
+			settings: BalanceSettings{
+				BalanceScope:          "transactional",
+				AllowOverdraft:        true,
+				OverdraftLimitEnabled: true,
+				OverdraftLimit:        &limit,
+			},
+		},
+		{
+			name: "internal scope with default overdraft flags",
+			settings: BalanceSettings{
+				BalanceScope:          "internal",
+				AllowOverdraft:        false,
+				OverdraftLimitEnabled: false,
+			},
+		},
+		{
+			name: "empty scope is accepted and defaults to transactional",
+			settings: BalanceSettings{
+				BalanceScope:          "",
+				AllowOverdraft:        false,
+				OverdraftLimitEnabled: false,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := tt.settings.Validate()
+
+			require.NoError(t, err, "valid settings must not return error")
+		})
+	}
+}
+
+// TestBalanceSettings_Validate_InvalidCombinations covers every rejection path
+// described in PRD §4 RF-1 and the TRD.
+func TestBalanceSettings_Validate_InvalidCombinations(t *testing.T) {
+	t.Parallel()
+
+	zero := "0"
+	negative := "-100.00"
+	empty := ""
+	notANumber := "not-a-number"
+	valid := "500.00"
+
+	tests := []struct {
+		name            string
+		settings        BalanceSettings
+		wantErrContains string
+	}{
+		{
+			name: "overdraftLimitEnabled true without overdraftLimit",
+			settings: BalanceSettings{
+				BalanceScope:          "transactional",
+				AllowOverdraft:        true,
+				OverdraftLimitEnabled: true,
+				OverdraftLimit:        nil,
+			},
+			wantErrContains: "overdraftLimit is required",
+		},
+		{
+			name: "overdraftLimitEnabled true with empty overdraftLimit",
+			settings: BalanceSettings{
+				BalanceScope:          "transactional",
+				AllowOverdraft:        true,
+				OverdraftLimitEnabled: true,
+				OverdraftLimit:        &empty,
+			},
+			wantErrContains: "non-empty decimal string",
+		},
+		{
+			name: "overdraftLimitEnabled true with zero overdraftLimit",
+			settings: BalanceSettings{
+				BalanceScope:          "transactional",
+				AllowOverdraft:        true,
+				OverdraftLimitEnabled: true,
+				OverdraftLimit:        &zero,
+			},
+			wantErrContains: "strictly greater than zero",
+		},
+		{
+			name: "overdraftLimitEnabled true with negative overdraftLimit",
+			settings: BalanceSettings{
+				BalanceScope:          "transactional",
+				AllowOverdraft:        true,
+				OverdraftLimitEnabled: true,
+				OverdraftLimit:        &negative,
+			},
+			wantErrContains: "strictly greater than zero",
+		},
+		{
+			name: "overdraftLimitEnabled true with non-numeric overdraftLimit",
+			settings: BalanceSettings{
+				BalanceScope:          "transactional",
+				AllowOverdraft:        true,
+				OverdraftLimitEnabled: true,
+				OverdraftLimit:        &notANumber,
+			},
+			wantErrContains: "not a valid decimal",
+		},
+		{
+			name: "overdraftLimitEnabled false with overdraftLimit present (ambiguous)",
+			settings: BalanceSettings{
+				BalanceScope:          "transactional",
+				AllowOverdraft:        true,
+				OverdraftLimitEnabled: false,
+				OverdraftLimit:        &valid,
+			},
+			wantErrContains: "must be absent",
+		},
+		{
+			name: "balanceScope is not one of allowed values",
+			settings: BalanceSettings{
+				BalanceScope:          "external",
+				AllowOverdraft:        false,
+				OverdraftLimitEnabled: false,
+			},
+			wantErrContains: "invalid balanceScope",
+		},
+		{
+			name: "balanceScope has random casing / typo",
+			settings: BalanceSettings{
+				BalanceScope:          "TRANSACTIONAL",
+				AllowOverdraft:        false,
+				OverdraftLimitEnabled: false,
+			},
+			wantErrContains: "invalid balanceScope",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := tt.settings.Validate()
+
+			require.Error(t, err, "invalid settings must return error for: %s", tt.name)
+			assert.Contains(t, err.Error(), tt.wantErrContains,
+				"error message must contain %q for case: %s", tt.wantErrContains, tt.name)
+		})
+	}
+}

--- a/pkg/mmodel/balance_settings_test.go
+++ b/pkg/mmodel/balance_settings_test.go
@@ -5,6 +5,7 @@
 package mmodel
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -202,5 +203,55 @@ func TestBalanceSettings_Validate_InvalidCombinations(t *testing.T) {
 			assert.Contains(t, err.Error(), tt.wantErrContains,
 				"error message must contain %q for case: %s", tt.wantErrContains, tt.name)
 		})
+	}
+}
+
+// TestDeepCopySettings_ReflectionGuard uses reflection to detect new pointer
+// fields added to BalanceSettings in the future. If a developer adds a new
+// *string or *SomeStruct field to BalanceSettings but forgets to deep-copy it
+// in deepCopySettings, this test fails — forcing the copy to be updated.
+func TestDeepCopySettings_ReflectionGuard(t *testing.T) {
+	t.Parallel()
+
+	// Seed every pointer field with a non-nil value so the reflection
+	// check can distinguish shallow copy (same address) from deep copy
+	// (different address, same value).
+	limit := "500.00"
+	src := &BalanceSettings{
+		BalanceScope:          "transactional",
+		AllowOverdraft:        true,
+		OverdraftLimitEnabled: true,
+		OverdraftLimit:        &limit,
+	}
+
+	cp := deepCopySettings(src)
+	require.NotNil(t, cp)
+
+	srcVal := reflect.ValueOf(src).Elem()
+	cpVal := reflect.ValueOf(cp).Elem()
+
+	for i := 0; i < srcVal.NumField(); i++ {
+		field := srcVal.Type().Field(i)
+		srcField := srcVal.Field(i)
+		cpField := cpVal.Field(i)
+
+		if srcField.Kind() != reflect.Ptr {
+			continue
+		}
+
+		if srcField.IsNil() {
+			t.Errorf("reflection guard: field %q is nil on the seed object — "+
+				"add a non-nil seed value so the deep-copy check can verify "+
+				"that deepCopySettings copies it", field.Name)
+			continue
+		}
+
+		require.False(t, cpField.IsNil(),
+			"field %q was non-nil on source but nil on copy — deepCopySettings must copy it", field.Name)
+		assert.NotEqual(t, srcField.Pointer(), cpField.Pointer(),
+			"field %q has the same pointer address on source and copy — "+
+				"deepCopySettings must allocate a new value, not share the pointer", field.Name)
+		assert.Equal(t, srcField.Elem().Interface(), cpField.Elem().Interface(),
+			"field %q has different values on source and copy — deep copy must preserve the value", field.Name)
 	}
 }

--- a/pkg/mmodel/balance_test.go
+++ b/pkg/mmodel/balance_test.go
@@ -168,6 +168,7 @@ func TestBalance_ToTransactionBalance(t *testing.T) {
 		name    string
 		balance *Balance
 		want    *mtransaction.Balance
+		wantErr bool
 	}{
 		{
 			name: "all fields populated",
@@ -292,13 +293,31 @@ func TestBalance_ToTransactionBalance(t *testing.T) {
 				Metadata:       nil,
 			},
 		},
+		{
+			name: "corrupted OverdraftLimit returns error",
+			balance: &Balance{
+				ID: "bal-corrupted",
+				Settings: &BalanceSettings{
+					OverdraftLimit: func() *string { s := "not-a-number"; return &s }(),
+				},
+			},
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			got := tt.balance.ToTransactionBalance()
+			got, err := tt.balance.ToTransactionBalance()
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Nil(t, got)
+
+				return
+			}
+
+			require.NoError(t, err)
 
 			assert.Equal(t, tt.want.ID, got.ID)
 			assert.Equal(t, tt.want.OrganizationID, got.OrganizationID)

--- a/pkg/mmodel/operation-route-overdraft-refund_test.go
+++ b/pkg/mmodel/operation-route-overdraft-refund_test.go
@@ -1,0 +1,380 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+// T-008: Accounting Entries Extension — Overdraft & Refund
+//
+// These tests capture the expected behavior for the new `Overdraft` and
+// `Refund` fields on the AccountingEntries struct. Both fields follow the
+// same pattern as the existing scenario fields (Direct, Hold, Commit,
+// Cancel, Revert) and, per the task spec, BOTH require `Debit` + `Credit`
+// rubrics to be present (the "bidirectional-like" requirement).
+//
+// This file is written as TDD-RED: it MUST FAIL until the model, handler
+// validation, and PostgreSQL JSONB adapter are extended (T-008 GREEN).
+package mmodel
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestAccountingEntries_HasOverdraftAndRefundFields verifies that the new
+// Overdraft and Refund fields exist on the AccountingEntries struct.
+//
+// This test uses struct-literal field assignment; if the fields do not
+// exist the file fails to compile (which is the expected RED behavior).
+func TestAccountingEntries_HasOverdraftAndRefundFields(t *testing.T) {
+	t.Parallel()
+
+	entries := &AccountingEntries{
+		Overdraft: &AccountingEntry{
+			Debit:  &AccountingRubric{Code: "1006", Description: "Overdraft Debit"},
+			Credit: &AccountingRubric{Code: "2006", Description: "Overdraft Credit"},
+		},
+		Refund: &AccountingEntry{
+			Debit:  &AccountingRubric{Code: "1007", Description: "Refund Debit"},
+			Credit: &AccountingRubric{Code: "2007", Description: "Refund Credit"},
+		},
+	}
+
+	require.NotNil(t, entries.Overdraft, "Overdraft field must exist on AccountingEntries")
+	require.NotNil(t, entries.Refund, "Refund field must exist on AccountingEntries")
+	require.NotNil(t, entries.Overdraft.Debit, "Overdraft.Debit must be addressable")
+	require.NotNil(t, entries.Overdraft.Credit, "Overdraft.Credit must be addressable")
+	require.NotNil(t, entries.Refund.Debit, "Refund.Debit must be addressable")
+	require.NotNil(t, entries.Refund.Credit, "Refund.Credit must be addressable")
+
+	assert.Equal(t, "1006", entries.Overdraft.Debit.Code)
+	assert.Equal(t, "2006", entries.Overdraft.Credit.Code)
+	assert.Equal(t, "1007", entries.Refund.Debit.Code)
+	assert.Equal(t, "2007", entries.Refund.Credit.Code)
+}
+
+// TestAccountingEntries_Actions_IncludesOverdraftAndRefund ensures that
+// the Actions() helper reports "overdraft" and "refund" when the
+// respective fields are non-nil (same pattern as direct/hold/commit/...).
+func TestAccountingEntries_Actions_IncludesOverdraftAndRefund(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		entries  *AccountingEntries
+		expected []string
+	}{
+		{
+			name: "overdraft only",
+			entries: &AccountingEntries{
+				Overdraft: &AccountingEntry{},
+			},
+			expected: []string{"overdraft"},
+		},
+		{
+			name: "refund only",
+			entries: &AccountingEntries{
+				Refund: &AccountingEntry{},
+			},
+			expected: []string{"refund"},
+		},
+		{
+			name: "overdraft and refund",
+			entries: &AccountingEntries{
+				Overdraft: &AccountingEntry{},
+				Refund:    &AccountingEntry{},
+			},
+			expected: []string{"overdraft", "refund"},
+		},
+		{
+			name: "direct + overdraft + refund",
+			entries: &AccountingEntries{
+				Direct:    &AccountingEntry{},
+				Overdraft: &AccountingEntry{},
+				Refund:    &AccountingEntry{},
+			},
+			expected: []string{"direct", "overdraft", "refund"},
+		},
+		{
+			name: "all seven scenarios",
+			entries: &AccountingEntries{
+				Direct:    &AccountingEntry{},
+				Hold:      &AccountingEntry{},
+				Commit:    &AccountingEntry{},
+				Cancel:    &AccountingEntry{},
+				Revert:    &AccountingEntry{},
+				Overdraft: &AccountingEntry{},
+				Refund:    &AccountingEntry{},
+			},
+			expected: []string{"direct", "hold", "commit", "cancel", "revert", "overdraft", "refund"},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tt.expected, tt.entries.Actions())
+		})
+	}
+}
+
+// TestAccountingEntries_OverdraftRefund_JSONMarshal checks that the new
+// fields are correctly serialized with the expected camelCase JSON keys
+// "overdraft" and "refund", and that nil fields remain omitted.
+func TestAccountingEntries_OverdraftRefund_JSONMarshal(t *testing.T) {
+	t.Parallel()
+
+	route := OperationRoute{
+		ID:            uuid.New(),
+		OperationType: "source",
+		AccountingEntries: &AccountingEntries{
+			Direct: &AccountingEntry{
+				Debit:  &AccountingRubric{Code: "1001", Description: "Cash"},
+				Credit: &AccountingRubric{Code: "2001", Description: "Revenue"},
+			},
+			Overdraft: &AccountingEntry{
+				Debit:  &AccountingRubric{Code: "1006", Description: "Overdraft Debit"},
+				Credit: &AccountingRubric{Code: "2006", Description: "Overdraft Credit"},
+			},
+			Refund: &AccountingEntry{
+				Debit:  &AccountingRubric{Code: "1007", Description: "Refund Debit"},
+				Credit: &AccountingRubric{Code: "2007", Description: "Refund Credit"},
+			},
+		},
+	}
+
+	data, err := json.Marshal(route)
+	require.NoError(t, err)
+
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal(data, &raw))
+
+	ae, ok := raw["accountingEntries"].(map[string]any)
+	require.True(t, ok, "accountingEntries must be a JSON object")
+
+	_, hasOverdraft := ae["overdraft"]
+	_, hasRefund := ae["refund"]
+	assert.True(t, hasOverdraft, `JSON must contain the "overdraft" key`)
+	assert.True(t, hasRefund, `JSON must contain the "refund" key`)
+
+	// Nil new fields must be omitted (omitempty) — backward compatible payload.
+	routeWithoutNew := OperationRoute{
+		ID:            uuid.New(),
+		OperationType: "source",
+		AccountingEntries: &AccountingEntries{
+			Direct: &AccountingEntry{
+				Debit: &AccountingRubric{Code: "1001", Description: "Cash"},
+			},
+		},
+	}
+
+	data2, err := json.Marshal(routeWithoutNew)
+	require.NoError(t, err)
+
+	var raw2 map[string]any
+	require.NoError(t, json.Unmarshal(data2, &raw2))
+
+	ae2, ok := raw2["accountingEntries"].(map[string]any)
+	require.True(t, ok)
+
+	_, hasOverdraft2 := ae2["overdraft"]
+	_, hasRefund2 := ae2["refund"]
+	assert.False(t, hasOverdraft2, "nil Overdraft must be omitted from JSON")
+	assert.False(t, hasRefund2, "nil Refund must be omitted from JSON")
+}
+
+// TestAccountingEntries_OverdraftRefund_JSONUnmarshal verifies that both
+// fields are decoded correctly from JSON input.
+func TestAccountingEntries_OverdraftRefund_JSONUnmarshal(t *testing.T) {
+	t.Parallel()
+
+	jsonInput := `{
+		"operationType":"source",
+		"accountingEntries":{
+			"direct":{"debit":{"code":"1001","description":"Cash"}},
+			"overdraft":{
+				"debit":{"code":"1006","description":"Overdraft Debit"},
+				"credit":{"code":"2006","description":"Overdraft Credit"}
+			},
+			"refund":{
+				"debit":{"code":"1007","description":"Refund Debit"},
+				"credit":{"code":"2007","description":"Refund Credit"}
+			}
+		}
+	}`
+
+	var route OperationRoute
+	require.NoError(t, json.Unmarshal([]byte(jsonInput), &route))
+
+	require.NotNil(t, route.AccountingEntries)
+	require.NotNil(t, route.AccountingEntries.Overdraft, "Overdraft must be decoded from JSON")
+	require.NotNil(t, route.AccountingEntries.Refund, "Refund must be decoded from JSON")
+
+	assert.Equal(t, "1006", route.AccountingEntries.Overdraft.Debit.Code)
+	assert.Equal(t, "Overdraft Debit", route.AccountingEntries.Overdraft.Debit.Description)
+	assert.Equal(t, "2006", route.AccountingEntries.Overdraft.Credit.Code)
+	assert.Equal(t, "Overdraft Credit", route.AccountingEntries.Overdraft.Credit.Description)
+
+	assert.Equal(t, "1007", route.AccountingEntries.Refund.Debit.Code)
+	assert.Equal(t, "Refund Debit", route.AccountingEntries.Refund.Debit.Description)
+	assert.Equal(t, "2007", route.AccountingEntries.Refund.Credit.Code)
+	assert.Equal(t, "Refund Credit", route.AccountingEntries.Refund.Credit.Description)
+}
+
+// TestAccountingEntries_OverdraftRefund_JSONUnmarshal_BackwardCompatible
+// guarantees that JSON payloads *without* the new fields still unmarshal
+// cleanly — old stored rows continue to work.
+func TestAccountingEntries_OverdraftRefund_JSONUnmarshal_BackwardCompatible(t *testing.T) {
+	t.Parallel()
+
+	// JSON representing a row stored BEFORE T-008: no overdraft / refund keys.
+	legacyJSON := `{
+		"operationType":"source",
+		"accountingEntries":{
+			"direct":{
+				"debit":{"code":"1001","description":"Cash"},
+				"credit":{"code":"2001","description":"Revenue"}
+			},
+			"hold":{
+				"debit":{"code":"1002","description":"Held"},
+				"credit":{"code":"2002","description":"Held Revenue"}
+			}
+		}
+	}`
+
+	var route OperationRoute
+	require.NoError(t, json.Unmarshal([]byte(legacyJSON), &route))
+
+	require.NotNil(t, route.AccountingEntries)
+	require.NotNil(t, route.AccountingEntries.Direct)
+	require.NotNil(t, route.AccountingEntries.Hold)
+
+	// New fields must be nil — absent JSON keys stay at zero value.
+	assert.Nil(t, route.AccountingEntries.Overdraft,
+		"Overdraft must be nil when absent from legacy JSON (JSONB backward compat)")
+	assert.Nil(t, route.AccountingEntries.Refund,
+		"Refund must be nil when absent from legacy JSON (JSONB backward compat)")
+}
+
+// TestAccountingEntries_OverdraftRefund_RoundTrip verifies lossless JSON
+// round-trip: marshal → unmarshal preserves all new-field values.
+// This simulates the PostgreSQL JSONB persistence cycle.
+func TestAccountingEntries_OverdraftRefund_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	original := OperationRoute{
+		ID:            uuid.New(),
+		OperationType: "bidirectional",
+		AccountingEntries: &AccountingEntries{
+			Direct: &AccountingEntry{
+				Debit:  &AccountingRubric{Code: "1001", Description: "Cash"},
+				Credit: &AccountingRubric{Code: "2001", Description: "Revenue"},
+			},
+			Overdraft: &AccountingEntry{
+				Debit:  &AccountingRubric{Code: "1006", Description: "Overdraft Debit"},
+				Credit: &AccountingRubric{Code: "2006", Description: "Overdraft Credit"},
+			},
+			Refund: &AccountingEntry{
+				Debit:  &AccountingRubric{Code: "1007", Description: "Refund Debit"},
+				Credit: &AccountingRubric{Code: "2007", Description: "Refund Credit"},
+			},
+		},
+	}
+
+	data, err := json.Marshal(original)
+	require.NoError(t, err)
+
+	var roundTripped OperationRoute
+	require.NoError(t, json.Unmarshal(data, &roundTripped))
+
+	ae := roundTripped.AccountingEntries
+	require.NotNil(t, ae)
+	require.NotNil(t, ae.Overdraft)
+	require.NotNil(t, ae.Refund)
+
+	assert.Equal(t, "1006", ae.Overdraft.Debit.Code)
+	assert.Equal(t, "Overdraft Debit", ae.Overdraft.Debit.Description)
+	assert.Equal(t, "2006", ae.Overdraft.Credit.Code)
+	assert.Equal(t, "Overdraft Credit", ae.Overdraft.Credit.Description)
+
+	assert.Equal(t, "1007", ae.Refund.Debit.Code)
+	assert.Equal(t, "Refund Debit", ae.Refund.Debit.Description)
+	assert.Equal(t, "2007", ae.Refund.Credit.Code)
+	assert.Equal(t, "Refund Credit", ae.Refund.Credit.Description)
+
+	// Unused scenarios remain nil.
+	assert.Nil(t, ae.Hold)
+	assert.Nil(t, ae.Commit)
+	assert.Nil(t, ae.Cancel)
+	assert.Nil(t, ae.Revert)
+}
+
+// TestCreateOperationRouteInput_AcceptsOverdraftAndRefund verifies that
+// the CreateOperationRouteInput payload accepts the new scenarios so
+// the HTTP create handler surface exposes them to API clients.
+func TestCreateOperationRouteInput_AcceptsOverdraftAndRefund(t *testing.T) {
+	t.Parallel()
+
+	input := CreateOperationRouteInput{
+		Title:         "Overdraft Route",
+		OperationType: "bidirectional",
+		AccountingEntries: &AccountingEntries{
+			Overdraft: &AccountingEntry{
+				Debit:  &AccountingRubric{Code: "1006", Description: "Overdraft Debit"},
+				Credit: &AccountingRubric{Code: "2006", Description: "Overdraft Credit"},
+			},
+			Refund: &AccountingEntry{
+				Debit:  &AccountingRubric{Code: "1007", Description: "Refund Debit"},
+				Credit: &AccountingRubric{Code: "2007", Description: "Refund Credit"},
+			},
+		},
+	}
+
+	data, err := json.Marshal(input)
+	require.NoError(t, err)
+
+	var decoded CreateOperationRouteInput
+	require.NoError(t, json.Unmarshal(data, &decoded))
+
+	require.NotNil(t, decoded.AccountingEntries)
+	require.NotNil(t, decoded.AccountingEntries.Overdraft)
+	require.NotNil(t, decoded.AccountingEntries.Refund)
+	assert.Equal(t, "1006", decoded.AccountingEntries.Overdraft.Debit.Code)
+	assert.Equal(t, "2007", decoded.AccountingEntries.Refund.Credit.Code)
+}
+
+// TestUpdateOperationRouteInput_AcceptsOverdraftAndRefund verifies the
+// update (PATCH) payload exposes the same new fields.
+func TestUpdateOperationRouteInput_AcceptsOverdraftAndRefund(t *testing.T) {
+	t.Parallel()
+
+	input := UpdateOperationRouteInput{
+		Title: "Updated Overdraft Route",
+		AccountingEntries: &AccountingEntries{
+			Overdraft: &AccountingEntry{
+				Debit:  &AccountingRubric{Code: "1006", Description: "Overdraft Debit"},
+				Credit: &AccountingRubric{Code: "2006", Description: "Overdraft Credit"},
+			},
+			Refund: &AccountingEntry{
+				Debit:  &AccountingRubric{Code: "1007", Description: "Refund Debit"},
+				Credit: &AccountingRubric{Code: "2007", Description: "Refund Credit"},
+			},
+		},
+	}
+
+	data, err := json.Marshal(input)
+	require.NoError(t, err)
+
+	var decoded UpdateOperationRouteInput
+	require.NoError(t, json.Unmarshal(data, &decoded))
+
+	require.NotNil(t, decoded.AccountingEntries)
+	require.NotNil(t, decoded.AccountingEntries.Overdraft)
+	require.NotNil(t, decoded.AccountingEntries.Refund)
+	assert.Equal(t, "1006", decoded.AccountingEntries.Overdraft.Debit.Code)
+	assert.Equal(t, "2007", decoded.AccountingEntries.Refund.Credit.Code)
+}

--- a/pkg/mmodel/operation-route-overdraft_test.go
+++ b/pkg/mmodel/operation-route-overdraft_test.go
@@ -2,16 +2,16 @@
 // Use of this source code is governed by the Elastic License 2.0
 // that can be found in the LICENSE file.
 
-// T-008: Accounting Entries Extension — Overdraft & Refund
+// T-008 + T-014: Accounting Entries Extension — Overdraft
 //
-// These tests capture the expected behavior for the new `Overdraft` and
-// `Refund` fields on the AccountingEntries struct. Both fields follow the
-// same pattern as the existing scenario fields (Direct, Hold, Commit,
-// Cancel, Revert) and, per the task spec, BOTH require `Debit` + `Credit`
-// rubrics to be present (the "bidirectional-like" requirement).
+// These tests capture the expected behavior for the `Overdraft` field on
+// the AccountingEntries struct. After T-014, the separate `Refund` field
+// was collapsed into Overdraft — the single entry covers the full overdraft
+// lifecycle (Debit rubric = deficit grows, Credit rubric = repayment).
 //
-// This file is written as TDD-RED: it MUST FAIL until the model, handler
-// validation, and PostgreSQL JSONB adapter are extended (T-008 GREEN).
+// The field follows the same pattern as the existing scenario fields
+// (Direct, Hold, Commit, Cancel, Revert) and requires BOTH `Debit` +
+// `Credit` rubrics to be present.
 package mmodel
 
 import (
@@ -23,12 +23,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestAccountingEntries_HasOverdraftAndRefundFields verifies that the new
-// Overdraft and Refund fields exist on the AccountingEntries struct.
-//
-// This test uses struct-literal field assignment; if the fields do not
-// exist the file fails to compile (which is the expected RED behavior).
-func TestAccountingEntries_HasOverdraftAndRefundFields(t *testing.T) {
+// TestAccountingEntries_HasOverdraftField verifies that the Overdraft
+// field exists on the AccountingEntries struct.
+func TestAccountingEntries_HasOverdraftField(t *testing.T) {
 	t.Parallel()
 
 	entries := &AccountingEntries{
@@ -36,29 +33,20 @@ func TestAccountingEntries_HasOverdraftAndRefundFields(t *testing.T) {
 			Debit:  &AccountingRubric{Code: "1006", Description: "Overdraft Debit"},
 			Credit: &AccountingRubric{Code: "2006", Description: "Overdraft Credit"},
 		},
-		Refund: &AccountingEntry{
-			Debit:  &AccountingRubric{Code: "1007", Description: "Refund Debit"},
-			Credit: &AccountingRubric{Code: "2007", Description: "Refund Credit"},
-		},
 	}
 
 	require.NotNil(t, entries.Overdraft, "Overdraft field must exist on AccountingEntries")
-	require.NotNil(t, entries.Refund, "Refund field must exist on AccountingEntries")
 	require.NotNil(t, entries.Overdraft.Debit, "Overdraft.Debit must be addressable")
 	require.NotNil(t, entries.Overdraft.Credit, "Overdraft.Credit must be addressable")
-	require.NotNil(t, entries.Refund.Debit, "Refund.Debit must be addressable")
-	require.NotNil(t, entries.Refund.Credit, "Refund.Credit must be addressable")
 
 	assert.Equal(t, "1006", entries.Overdraft.Debit.Code)
 	assert.Equal(t, "2006", entries.Overdraft.Credit.Code)
-	assert.Equal(t, "1007", entries.Refund.Debit.Code)
-	assert.Equal(t, "2007", entries.Refund.Credit.Code)
 }
 
-// TestAccountingEntries_Actions_IncludesOverdraftAndRefund ensures that
-// the Actions() helper reports "overdraft" and "refund" when the
-// respective fields are non-nil (same pattern as direct/hold/commit/...).
-func TestAccountingEntries_Actions_IncludesOverdraftAndRefund(t *testing.T) {
+// TestAccountingEntries_Actions_IncludesOverdraft ensures that the
+// Actions() helper reports "overdraft" when the field is non-nil.
+// After T-014, "refund" is no longer a valid action.
+func TestAccountingEntries_Actions_IncludesOverdraft(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -74,31 +62,15 @@ func TestAccountingEntries_Actions_IncludesOverdraftAndRefund(t *testing.T) {
 			expected: []string{"overdraft"},
 		},
 		{
-			name: "refund only",
-			entries: &AccountingEntries{
-				Refund: &AccountingEntry{},
-			},
-			expected: []string{"refund"},
-		},
-		{
-			name: "overdraft and refund",
-			entries: &AccountingEntries{
-				Overdraft: &AccountingEntry{},
-				Refund:    &AccountingEntry{},
-			},
-			expected: []string{"overdraft", "refund"},
-		},
-		{
-			name: "direct + overdraft + refund",
+			name: "direct + overdraft",
 			entries: &AccountingEntries{
 				Direct:    &AccountingEntry{},
 				Overdraft: &AccountingEntry{},
-				Refund:    &AccountingEntry{},
 			},
-			expected: []string{"direct", "overdraft", "refund"},
+			expected: []string{"direct", "overdraft"},
 		},
 		{
-			name: "all seven scenarios",
+			name: "all six scenarios",
 			entries: &AccountingEntries{
 				Direct:    &AccountingEntry{},
 				Hold:      &AccountingEntry{},
@@ -106,9 +78,8 @@ func TestAccountingEntries_Actions_IncludesOverdraftAndRefund(t *testing.T) {
 				Cancel:    &AccountingEntry{},
 				Revert:    &AccountingEntry{},
 				Overdraft: &AccountingEntry{},
-				Refund:    &AccountingEntry{},
 			},
-			expected: []string{"direct", "hold", "commit", "cancel", "revert", "overdraft", "refund"},
+			expected: []string{"direct", "hold", "commit", "cancel", "revert", "overdraft"},
 		},
 	}
 
@@ -122,10 +93,10 @@ func TestAccountingEntries_Actions_IncludesOverdraftAndRefund(t *testing.T) {
 	}
 }
 
-// TestAccountingEntries_OverdraftRefund_JSONMarshal checks that the new
-// fields are correctly serialized with the expected camelCase JSON keys
-// "overdraft" and "refund", and that nil fields remain omitted.
-func TestAccountingEntries_OverdraftRefund_JSONMarshal(t *testing.T) {
+// TestAccountingEntries_Overdraft_JSONMarshal checks that the Overdraft
+// field is serialized with the expected JSON key "overdraft", and that
+// a nil Overdraft is omitted from JSON output.
+func TestAccountingEntries_Overdraft_JSONMarshal(t *testing.T) {
 	t.Parallel()
 
 	route := OperationRoute{
@@ -140,10 +111,6 @@ func TestAccountingEntries_OverdraftRefund_JSONMarshal(t *testing.T) {
 				Debit:  &AccountingRubric{Code: "1006", Description: "Overdraft Debit"},
 				Credit: &AccountingRubric{Code: "2006", Description: "Overdraft Credit"},
 			},
-			Refund: &AccountingEntry{
-				Debit:  &AccountingRubric{Code: "1007", Description: "Refund Debit"},
-				Credit: &AccountingRubric{Code: "2007", Description: "Refund Credit"},
-			},
 		},
 	}
 
@@ -157,11 +124,13 @@ func TestAccountingEntries_OverdraftRefund_JSONMarshal(t *testing.T) {
 	require.True(t, ok, "accountingEntries must be a JSON object")
 
 	_, hasOverdraft := ae["overdraft"]
-	_, hasRefund := ae["refund"]
 	assert.True(t, hasOverdraft, `JSON must contain the "overdraft" key`)
-	assert.True(t, hasRefund, `JSON must contain the "refund" key`)
 
-	// Nil new fields must be omitted (omitempty) — backward compatible payload.
+	// Refund key must NOT appear (field removed in T-014)
+	_, hasRefund := ae["refund"]
+	assert.False(t, hasRefund, `JSON must NOT contain the "refund" key (removed in T-014)`)
+
+	// Nil Overdraft must be omitted (omitempty) — backward compatible payload.
 	routeWithoutNew := OperationRoute{
 		ID:            uuid.New(),
 		OperationType: "source",
@@ -182,14 +151,14 @@ func TestAccountingEntries_OverdraftRefund_JSONMarshal(t *testing.T) {
 	require.True(t, ok)
 
 	_, hasOverdraft2 := ae2["overdraft"]
-	_, hasRefund2 := ae2["refund"]
 	assert.False(t, hasOverdraft2, "nil Overdraft must be omitted from JSON")
-	assert.False(t, hasRefund2, "nil Refund must be omitted from JSON")
 }
 
-// TestAccountingEntries_OverdraftRefund_JSONUnmarshal verifies that both
-// fields are decoded correctly from JSON input.
-func TestAccountingEntries_OverdraftRefund_JSONUnmarshal(t *testing.T) {
+// TestAccountingEntries_Overdraft_JSONUnmarshal verifies that the
+// Overdraft field is decoded correctly from JSON input. Also verifies
+// that a legacy "refund" key in JSON is silently dropped (unknown keys
+// are ignored by Go's json.Unmarshal).
+func TestAccountingEntries_Overdraft_JSONUnmarshal(t *testing.T) {
 	t.Parallel()
 
 	jsonInput := `{
@@ -199,10 +168,6 @@ func TestAccountingEntries_OverdraftRefund_JSONUnmarshal(t *testing.T) {
 			"overdraft":{
 				"debit":{"code":"1006","description":"Overdraft Debit"},
 				"credit":{"code":"2006","description":"Overdraft Credit"}
-			},
-			"refund":{
-				"debit":{"code":"1007","description":"Refund Debit"},
-				"credit":{"code":"2007","description":"Refund Credit"}
 			}
 		}
 	}`
@@ -212,26 +177,48 @@ func TestAccountingEntries_OverdraftRefund_JSONUnmarshal(t *testing.T) {
 
 	require.NotNil(t, route.AccountingEntries)
 	require.NotNil(t, route.AccountingEntries.Overdraft, "Overdraft must be decoded from JSON")
-	require.NotNil(t, route.AccountingEntries.Refund, "Refund must be decoded from JSON")
 
 	assert.Equal(t, "1006", route.AccountingEntries.Overdraft.Debit.Code)
 	assert.Equal(t, "Overdraft Debit", route.AccountingEntries.Overdraft.Debit.Description)
 	assert.Equal(t, "2006", route.AccountingEntries.Overdraft.Credit.Code)
 	assert.Equal(t, "Overdraft Credit", route.AccountingEntries.Overdraft.Credit.Description)
-
-	assert.Equal(t, "1007", route.AccountingEntries.Refund.Debit.Code)
-	assert.Equal(t, "Refund Debit", route.AccountingEntries.Refund.Debit.Description)
-	assert.Equal(t, "2007", route.AccountingEntries.Refund.Credit.Code)
-	assert.Equal(t, "Refund Credit", route.AccountingEntries.Refund.Credit.Description)
 }
 
-// TestAccountingEntries_OverdraftRefund_JSONUnmarshal_BackwardCompatible
-// guarantees that JSON payloads *without* the new fields still unmarshal
-// cleanly — old stored rows continue to work.
-func TestAccountingEntries_OverdraftRefund_JSONUnmarshal_BackwardCompatible(t *testing.T) {
+// TestAccountingEntries_LegacyRefundKey_SilentlyDropped verifies that
+// JSON payloads containing the removed "refund" key unmarshal cleanly —
+// the unknown key is silently ignored by Go's json.Unmarshal.
+func TestAccountingEntries_LegacyRefundKey_SilentlyDropped(t *testing.T) {
 	t.Parallel()
 
-	// JSON representing a row stored BEFORE T-008: no overdraft / refund keys.
+	jsonWithRefund := `{
+		"operationType":"source",
+		"accountingEntries":{
+			"direct":{"debit":{"code":"1001","description":"Cash"}},
+			"overdraft":{
+				"debit":{"code":"1006","description":"Overdraft Debit"},
+				"credit":{"code":"2006","description":"Overdraft Credit"}
+			},
+			"refund":{
+				"debit":{"code":"1007","description":"Legacy Refund Debit"},
+				"credit":{"code":"2007","description":"Legacy Refund Credit"}
+			}
+		}
+	}`
+
+	var route OperationRoute
+	require.NoError(t, json.Unmarshal([]byte(jsonWithRefund), &route))
+
+	require.NotNil(t, route.AccountingEntries)
+	require.NotNil(t, route.AccountingEntries.Overdraft, "Overdraft must still be decoded")
+	assert.Equal(t, "1006", route.AccountingEntries.Overdraft.Debit.Code)
+}
+
+// TestAccountingEntries_JSONUnmarshal_BackwardCompatible guarantees that
+// JSON payloads without overdraft unmarshal cleanly — old stored rows
+// continue to work.
+func TestAccountingEntries_JSONUnmarshal_BackwardCompatible(t *testing.T) {
+	t.Parallel()
+
 	legacyJSON := `{
 		"operationType":"source",
 		"accountingEntries":{
@@ -253,17 +240,14 @@ func TestAccountingEntries_OverdraftRefund_JSONUnmarshal_BackwardCompatible(t *t
 	require.NotNil(t, route.AccountingEntries.Direct)
 	require.NotNil(t, route.AccountingEntries.Hold)
 
-	// New fields must be nil — absent JSON keys stay at zero value.
 	assert.Nil(t, route.AccountingEntries.Overdraft,
 		"Overdraft must be nil when absent from legacy JSON (JSONB backward compat)")
-	assert.Nil(t, route.AccountingEntries.Refund,
-		"Refund must be nil when absent from legacy JSON (JSONB backward compat)")
 }
 
-// TestAccountingEntries_OverdraftRefund_RoundTrip verifies lossless JSON
-// round-trip: marshal → unmarshal preserves all new-field values.
+// TestAccountingEntries_Overdraft_RoundTrip verifies lossless JSON
+// round-trip: marshal → unmarshal preserves all overdraft field values.
 // This simulates the PostgreSQL JSONB persistence cycle.
-func TestAccountingEntries_OverdraftRefund_RoundTrip(t *testing.T) {
+func TestAccountingEntries_Overdraft_RoundTrip(t *testing.T) {
 	t.Parallel()
 
 	original := OperationRoute{
@@ -278,10 +262,6 @@ func TestAccountingEntries_OverdraftRefund_RoundTrip(t *testing.T) {
 				Debit:  &AccountingRubric{Code: "1006", Description: "Overdraft Debit"},
 				Credit: &AccountingRubric{Code: "2006", Description: "Overdraft Credit"},
 			},
-			Refund: &AccountingEntry{
-				Debit:  &AccountingRubric{Code: "1007", Description: "Refund Debit"},
-				Credit: &AccountingRubric{Code: "2007", Description: "Refund Credit"},
-			},
 		},
 	}
 
@@ -294,17 +274,11 @@ func TestAccountingEntries_OverdraftRefund_RoundTrip(t *testing.T) {
 	ae := roundTripped.AccountingEntries
 	require.NotNil(t, ae)
 	require.NotNil(t, ae.Overdraft)
-	require.NotNil(t, ae.Refund)
 
 	assert.Equal(t, "1006", ae.Overdraft.Debit.Code)
 	assert.Equal(t, "Overdraft Debit", ae.Overdraft.Debit.Description)
 	assert.Equal(t, "2006", ae.Overdraft.Credit.Code)
 	assert.Equal(t, "Overdraft Credit", ae.Overdraft.Credit.Description)
-
-	assert.Equal(t, "1007", ae.Refund.Debit.Code)
-	assert.Equal(t, "Refund Debit", ae.Refund.Debit.Description)
-	assert.Equal(t, "2007", ae.Refund.Credit.Code)
-	assert.Equal(t, "Refund Credit", ae.Refund.Credit.Description)
 
 	// Unused scenarios remain nil.
 	assert.Nil(t, ae.Hold)
@@ -313,10 +287,10 @@ func TestAccountingEntries_OverdraftRefund_RoundTrip(t *testing.T) {
 	assert.Nil(t, ae.Revert)
 }
 
-// TestCreateOperationRouteInput_AcceptsOverdraftAndRefund verifies that
-// the CreateOperationRouteInput payload accepts the new scenarios so
-// the HTTP create handler surface exposes them to API clients.
-func TestCreateOperationRouteInput_AcceptsOverdraftAndRefund(t *testing.T) {
+// TestCreateOperationRouteInput_AcceptsOverdraft verifies that
+// the CreateOperationRouteInput payload accepts the overdraft scenario
+// so the HTTP create handler surface exposes it to API clients.
+func TestCreateOperationRouteInput_AcceptsOverdraft(t *testing.T) {
 	t.Parallel()
 
 	input := CreateOperationRouteInput{
@@ -326,10 +300,6 @@ func TestCreateOperationRouteInput_AcceptsOverdraftAndRefund(t *testing.T) {
 			Overdraft: &AccountingEntry{
 				Debit:  &AccountingRubric{Code: "1006", Description: "Overdraft Debit"},
 				Credit: &AccountingRubric{Code: "2006", Description: "Overdraft Credit"},
-			},
-			Refund: &AccountingEntry{
-				Debit:  &AccountingRubric{Code: "1007", Description: "Refund Debit"},
-				Credit: &AccountingRubric{Code: "2007", Description: "Refund Credit"},
 			},
 		},
 	}
@@ -342,14 +312,13 @@ func TestCreateOperationRouteInput_AcceptsOverdraftAndRefund(t *testing.T) {
 
 	require.NotNil(t, decoded.AccountingEntries)
 	require.NotNil(t, decoded.AccountingEntries.Overdraft)
-	require.NotNil(t, decoded.AccountingEntries.Refund)
 	assert.Equal(t, "1006", decoded.AccountingEntries.Overdraft.Debit.Code)
-	assert.Equal(t, "2007", decoded.AccountingEntries.Refund.Credit.Code)
+	assert.Equal(t, "2006", decoded.AccountingEntries.Overdraft.Credit.Code)
 }
 
-// TestUpdateOperationRouteInput_AcceptsOverdraftAndRefund verifies the
-// update (PATCH) payload exposes the same new fields.
-func TestUpdateOperationRouteInput_AcceptsOverdraftAndRefund(t *testing.T) {
+// TestUpdateOperationRouteInput_AcceptsOverdraft verifies the
+// update (PATCH) payload exposes the overdraft field.
+func TestUpdateOperationRouteInput_AcceptsOverdraft(t *testing.T) {
 	t.Parallel()
 
 	input := UpdateOperationRouteInput{
@@ -358,10 +327,6 @@ func TestUpdateOperationRouteInput_AcceptsOverdraftAndRefund(t *testing.T) {
 			Overdraft: &AccountingEntry{
 				Debit:  &AccountingRubric{Code: "1006", Description: "Overdraft Debit"},
 				Credit: &AccountingRubric{Code: "2006", Description: "Overdraft Credit"},
-			},
-			Refund: &AccountingEntry{
-				Debit:  &AccountingRubric{Code: "1007", Description: "Refund Debit"},
-				Credit: &AccountingRubric{Code: "2007", Description: "Refund Credit"},
 			},
 		},
 	}
@@ -374,7 +339,6 @@ func TestUpdateOperationRouteInput_AcceptsOverdraftAndRefund(t *testing.T) {
 
 	require.NotNil(t, decoded.AccountingEntries)
 	require.NotNil(t, decoded.AccountingEntries.Overdraft)
-	require.NotNil(t, decoded.AccountingEntries.Refund)
 	assert.Equal(t, "1006", decoded.AccountingEntries.Overdraft.Debit.Code)
-	assert.Equal(t, "2007", decoded.AccountingEntries.Refund.Credit.Code)
+	assert.Equal(t, "2006", decoded.AccountingEntries.Overdraft.Credit.Code)
 }

--- a/pkg/mmodel/operation-route.go
+++ b/pkg/mmodel/operation-route.go
@@ -57,10 +57,11 @@ type AccountingEntries struct {
 	Cancel *AccountingEntry `json:"cancel,omitempty" msgpack:"cancel"`
 	// The accounting entry for the revert action.
 	Revert *AccountingEntry `json:"revert,omitempty" msgpack:"revert"`
-	// The accounting entry for the overdraft action. Requires BOTH debit and credit rubrics when present.
+	// The accounting entry for the overdraft lifecycle. Debit rubric classifies
+	// overdraft usage (deficit grows); credit rubric classifies overdraft
+	// repayment (deficit shrinks). Both rubrics are REQUIRED when this entry
+	// is present.
 	Overdraft *AccountingEntry `json:"overdraft,omitempty" msgpack:"overdraft"`
-	// The accounting entry for the refund action. Requires BOTH debit and credit rubrics when present.
-	Refund *AccountingEntry `json:"refund,omitempty" msgpack:"refund"`
 } // @name AccountingEntries
 
 // Actions returns the action names for which this AccountingEntries has non-nil entries.
@@ -93,10 +94,6 @@ func (ae *AccountingEntries) Actions() []string {
 
 	if ae.Overdraft != nil {
 		actions = append(actions, constant.ActionOverdraft)
-	}
-
-	if ae.Refund != nil {
-		actions = append(actions, constant.ActionRefund)
 	}
 
 	return actions

--- a/pkg/mmodel/operation-route.go
+++ b/pkg/mmodel/operation-route.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"time"
 
+	"github.com/LerianStudio/midaz/v3/pkg/constant"
 	"github.com/google/uuid"
 )
 
@@ -44,7 +45,7 @@ type AccountingEntry struct {
 
 // AccountingEntries groups accounting entries by transaction action type.
 //
-// @Description AccountingEntries object containing optional accounting entries for each action type (direct, hold, commit, cancel, revert).
+// @Description AccountingEntries object containing optional accounting entries for each action type (direct, hold, commit, cancel, revert, overdraft, refund).
 type AccountingEntries struct {
 	// The accounting entry for the direct action.
 	Direct *AccountingEntry `json:"direct,omitempty" msgpack:"direct"`
@@ -56,6 +57,10 @@ type AccountingEntries struct {
 	Cancel *AccountingEntry `json:"cancel,omitempty" msgpack:"cancel"`
 	// The accounting entry for the revert action.
 	Revert *AccountingEntry `json:"revert,omitempty" msgpack:"revert"`
+	// The accounting entry for the overdraft action. Requires BOTH debit and credit rubrics when present.
+	Overdraft *AccountingEntry `json:"overdraft,omitempty" msgpack:"overdraft"`
+	// The accounting entry for the refund action. Requires BOTH debit and credit rubrics when present.
+	Refund *AccountingEntry `json:"refund,omitempty" msgpack:"refund"`
 } // @name AccountingEntries
 
 // Actions returns the action names for which this AccountingEntries has non-nil entries.
@@ -67,23 +72,31 @@ func (ae *AccountingEntries) Actions() []string {
 	var actions []string
 
 	if ae.Direct != nil {
-		actions = append(actions, "direct")
+		actions = append(actions, constant.ActionDirect)
 	}
 
 	if ae.Hold != nil {
-		actions = append(actions, "hold")
+		actions = append(actions, constant.ActionHold)
 	}
 
 	if ae.Commit != nil {
-		actions = append(actions, "commit")
+		actions = append(actions, constant.ActionCommit)
 	}
 
 	if ae.Cancel != nil {
-		actions = append(actions, "cancel")
+		actions = append(actions, constant.ActionCancel)
 	}
 
 	if ae.Revert != nil {
-		actions = append(actions, "revert")
+		actions = append(actions, constant.ActionRevert)
+	}
+
+	if ae.Overdraft != nil {
+		actions = append(actions, constant.ActionOverdraft)
+	}
+
+	if ae.Refund != nil {
+		actions = append(actions, constant.ActionRefund)
 	}
 
 	return actions

--- a/pkg/mmodel/operation.go
+++ b/pkg/mmodel/operation.go
@@ -10,6 +10,33 @@ import (
 	"github.com/shopspring/decimal"
 )
 
+// OperationSnapshot carries system-generated per-operation context fields.
+// Always populated on every operation record — non-overdraft operations carry
+// "0" / "0" rather than absent fields, so the wire shape is uniform across
+// the entire ledger. Additional fields may be added in the future without a
+// schema migration.
+//
+// Key conventions (enforced via code review):
+//   - camelCase (matches Midaz API JSON convention).
+//   - Additive-only over time — never remove a shipped key, never repurpose.
+//   - All decimals are string-encoded (preserves precision regardless of client parser).
+//   - Always present. Non-overdraft operations carry "0" for both fields.
+//   - Reserved for system-generated context; user-supplied tagging goes in the separate `metadata` column.
+//
+// For companion rows on `@account#overdraft`, the snapshot mirrors the DEFAULT
+// balance's before/after — same values appear on both the primary and companion
+// rows so the lifecycle is visible from either.
+//
+// @Description Per-operation state snapshot. Read-only, system-generated. Always populated.
+type OperationSnapshot struct {
+	// String-encoded decimal of the default balance's overdraftUsed BEFORE this operation mutated it.
+	// "0" when the operation does not participate in the overdraft lifecycle.
+	OverdraftUsedBefore string `json:"overdraftUsedBefore" example:"50"`
+	// String-encoded decimal of the default balance's overdraftUsed AFTER this operation committed.
+	// "0" when the operation does not participate in the overdraft lifecycle.
+	OverdraftUsedAfter string `json:"overdraftUsedAfter" example:"130"`
+} // @name OperationSnapshot
+
 // OperationRedis is a flat Redis cache representation of an operation.
 // It mirrors the essential fields from the internal operation.Operation type
 // without nested structs, enabling storage in pkg/mmodel without importing
@@ -45,4 +72,8 @@ type OperationRedis struct {
 	RouteCode             *string         `json:"routeCode,omitempty"`
 	RouteDescription      *string         `json:"routeDescription,omitempty"`
 	Metadata              map[string]any  `json:"metadata,omitempty"`
+	// Snapshot is always populated — non-overdraft operations carry zero
+	// values rather than absent fields, matching the always-populated wire-
+	// shape contract.
+	Snapshot OperationSnapshot `json:"snapshot"`
 }

--- a/pkg/mmodel/operation_snapshot_test.go
+++ b/pkg/mmodel/operation_snapshot_test.go
@@ -1,0 +1,178 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package mmodel
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestOperationSnapshot_JSONMarshal verifies that OperationSnapshot serializes
+// to JSON using camelCase keys with both fields ALWAYS present. Under the
+// always-populated wire-shape contract, non-overdraft operations carry "0" /
+// "0" rather than absent fields, so the wire shape is uniform across the
+// entire ledger.
+func TestOperationSnapshot_JSONMarshal(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		snapshot OperationSnapshot
+		want     string
+	}{
+		{
+			name: "non-overdraft op carries zero values explicitly",
+			snapshot: OperationSnapshot{
+				OverdraftUsedBefore: "0",
+				OverdraftUsedAfter:  "0",
+			},
+			want: `{"overdraftUsedBefore":"0","overdraftUsedAfter":"0"}`,
+		},
+		{
+			name: "active overdraft populated with non-zero before and after",
+			snapshot: OperationSnapshot{
+				OverdraftUsedBefore: "50.00",
+				OverdraftUsedAfter:  "130.00",
+			},
+			want: `{"overdraftUsedBefore":"50.00","overdraftUsedAfter":"130.00"}`,
+		},
+		{
+			name: "debit split: zero before, non-zero after",
+			snapshot: OperationSnapshot{
+				OverdraftUsedBefore: "0",
+				OverdraftUsedAfter:  "50.00",
+			},
+			want: `{"overdraftUsedBefore":"0","overdraftUsedAfter":"50.00"}`,
+		},
+		{
+			name: "credit repayment: non-zero before, zero after",
+			snapshot: OperationSnapshot{
+				OverdraftUsedBefore: "130.00",
+				OverdraftUsedAfter:  "0",
+			},
+			want: `{"overdraftUsedBefore":"130.00","overdraftUsedAfter":"0"}`,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := json.Marshal(tc.snapshot)
+			require.NoError(t, err, "marshal must not fail")
+			assert.JSONEq(t, tc.want, string(got))
+		})
+	}
+}
+
+// TestOperationSnapshot_JSONUnmarshal verifies that OperationSnapshot
+// deserializes from JSON. Unlike pre-reversal behaviour, missing keys decode
+// to the empty string rather than nil — the always-populated contract is
+// applied at the persistence-layer mappers (ToEntity / OperationFromRedis),
+// not here. This test pins the raw JSON ↔ struct mapping.
+func TestOperationSnapshot_JSONUnmarshal(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		input      string
+		wantBefore string
+		wantAfter  string
+	}{
+		{
+			name:       "both fields populated round-trip",
+			input:      `{"overdraftUsedBefore":"50.00","overdraftUsedAfter":"130.00"}`,
+			wantBefore: "50.00",
+			wantAfter:  "130.00",
+		},
+		{
+			name:       "explicit zero values round-trip",
+			input:      `{"overdraftUsedBefore":"0","overdraftUsedAfter":"0"}`,
+			wantBefore: "0",
+			wantAfter:  "0",
+		},
+		{
+			name:       "empty object decodes to empty strings (legacy row shape)",
+			input:      `{}`,
+			wantBefore: "",
+			wantAfter:  "",
+		},
+		{
+			name:       "only overdraftUsedAfter present (legacy partial row)",
+			input:      `{"overdraftUsedAfter":"130.00"}`,
+			wantBefore: "",
+			wantAfter:  "130.00",
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var got OperationSnapshot
+			err := json.Unmarshal([]byte(tc.input), &got)
+			require.NoError(t, err, "unmarshal must not fail")
+
+			assert.Equal(t, tc.wantBefore, got.OverdraftUsedBefore)
+			assert.Equal(t, tc.wantAfter, got.OverdraftUsedAfter)
+		})
+	}
+}
+
+// TestOperationSnapshot_RoundTrip verifies that marshal→unmarshal is an
+// identity operation for representative shapes under the always-populated
+// contract.
+func TestOperationSnapshot_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		snapshot OperationSnapshot
+	}{
+		{
+			name: "active overdraft round-trips",
+			snapshot: OperationSnapshot{
+				OverdraftUsedBefore: "50.00",
+				OverdraftUsedAfter:  "130.00",
+			},
+		},
+		{
+			name: "non-overdraft (both zero) round-trips",
+			snapshot: OperationSnapshot{
+				OverdraftUsedBefore: "0",
+				OverdraftUsedAfter:  "0",
+			},
+		},
+		{
+			name: "credit repayment (after=0) round-trips",
+			snapshot: OperationSnapshot{
+				OverdraftUsedBefore: "130.00",
+				OverdraftUsedAfter:  "0",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			data, err := json.Marshal(tc.snapshot)
+			require.NoError(t, err, "marshal must not fail")
+
+			var roundTripped OperationSnapshot
+			err = json.Unmarshal(data, &roundTripped)
+			require.NoError(t, err, "unmarshal must not fail")
+
+			assert.Equal(t, tc.snapshot.OverdraftUsedBefore, roundTripped.OverdraftUsedBefore)
+			assert.Equal(t, tc.snapshot.OverdraftUsedAfter, roundTripped.OverdraftUsedAfter)
+		})
+	}
+}

--- a/pkg/mtransaction/balance_overdraft_test.go
+++ b/pkg/mtransaction/balance_overdraft_test.go
@@ -1,0 +1,48 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package mtransaction
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestTransactionBalance_HasOverdraftFields verifies that the internal
+// mtransaction.Balance struct exposes the overdraft fields required for
+// the overdraft feature. These fields travel with the balance through
+// transaction processing so the engine can evaluate overdraft limits.
+func TestTransactionBalance_HasOverdraftFields(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		fieldName string
+		fieldType string
+	}{
+		{name: "Direction field is string", fieldName: "Direction", fieldType: "string"},
+		{name: "OverdraftUsed field is decimal.Decimal", fieldName: "OverdraftUsed", fieldType: "decimal.Decimal"},
+		{name: "AllowOverdraft field is bool", fieldName: "AllowOverdraft", fieldType: "bool"},
+		{name: "OverdraftLimitEnabled field is bool", fieldName: "OverdraftLimitEnabled", fieldType: "bool"},
+		{name: "OverdraftLimit field is decimal.Decimal", fieldName: "OverdraftLimit", fieldType: "decimal.Decimal"},
+		{name: "BalanceScope field is string", fieldName: "BalanceScope", fieldType: "string"},
+	}
+
+	bt := reflect.TypeOf(Balance{})
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			field, ok := bt.FieldByName(tt.fieldName)
+			require.True(t, ok, "mtransaction.Balance must have field %q", tt.fieldName)
+			assert.Equal(t, tt.fieldType, field.Type.String(),
+				"mtransaction.Balance.%s must be of type %s", tt.fieldName, tt.fieldType)
+		})
+	}
+}

--- a/pkg/mtransaction/direction_test.go
+++ b/pkg/mtransaction/direction_test.go
@@ -1,0 +1,275 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package mtransaction
+
+import (
+	"testing"
+
+	constant "github.com/LerianStudio/lib-commons/v4/commons/constants"
+	pkgConstant "github.com/LerianStudio/midaz/v3/pkg/constant"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestOperateBalances_DirectionAwareArithmetic verifies that the balance
+// state machine applies the correct sign to Available based on the
+// balance's accounting direction.
+//
+// For direction=credit (asset-like balances), a DEBIT operation decreases
+// Available and a CREDIT increases it. For direction=debit (liability-like
+// balances), the arithmetic is INVERTED: a DEBIT increases Available and a
+// CREDIT decreases it. Legacy balances with an empty Direction MUST be
+// treated as direction=credit for backward compatibility.
+func TestOperateBalances_DirectionAwareArithmetic(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name              string
+		direction         string
+		operation         string
+		transactionType   string
+		startAvailable    decimal.Decimal
+		amount            decimal.Decimal
+		wantNewAvailable  decimal.Decimal
+	}{
+		{
+			name:             "direction=credit DEBIT decreases available",
+			direction:        pkgConstant.DirectionCredit,
+			operation:        constant.DEBIT,
+			transactionType:  constant.CREATED,
+			startAvailable:   decimal.NewFromInt(1000),
+			amount:           decimal.NewFromInt(250),
+			wantNewAvailable: decimal.NewFromInt(750),
+		},
+		{
+			name:             "direction=credit CREDIT increases available",
+			direction:        pkgConstant.DirectionCredit,
+			operation:        constant.CREDIT,
+			transactionType:  constant.CREATED,
+			startAvailable:   decimal.NewFromInt(1000),
+			amount:           decimal.NewFromInt(300),
+			wantNewAvailable: decimal.NewFromInt(1300),
+		},
+		{
+			name:             "direction=debit DEBIT increases available",
+			direction:        pkgConstant.DirectionDebit,
+			operation:        constant.DEBIT,
+			transactionType:  constant.CREATED,
+			startAvailable:   decimal.NewFromInt(1000),
+			amount:           decimal.NewFromInt(400),
+			wantNewAvailable: decimal.NewFromInt(1400),
+		},
+		{
+			name:             "direction=debit CREDIT decreases available",
+			direction:        pkgConstant.DirectionDebit,
+			operation:        constant.CREDIT,
+			transactionType:  constant.CREATED,
+			startAvailable:   decimal.NewFromInt(1000),
+			amount:           decimal.NewFromInt(200),
+			wantNewAvailable: decimal.NewFromInt(800),
+		},
+		{
+			name:             "empty direction defaults to credit behavior DEBIT",
+			direction:        "",
+			operation:        constant.DEBIT,
+			transactionType:  constant.CREATED,
+			startAvailable:   decimal.NewFromInt(1000),
+			amount:           decimal.NewFromInt(150),
+			wantNewAvailable: decimal.NewFromInt(850),
+		},
+		{
+			name:             "empty direction defaults to credit behavior CREDIT",
+			direction:        "",
+			operation:        constant.CREDIT,
+			transactionType:  constant.CREATED,
+			startAvailable:   decimal.NewFromInt(1000),
+			amount:           decimal.NewFromInt(100),
+			wantNewAvailable: decimal.NewFromInt(1100),
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			balance := Balance{
+				Available: tt.startAvailable,
+				OnHold:    decimal.NewFromInt(0),
+				Direction: tt.direction,
+				Version:   1,
+			}
+			amount := Amount{
+				Value:           tt.amount,
+				Operation:       tt.operation,
+				TransactionType: tt.transactionType,
+			}
+
+			result, err := OperateBalances(amount, balance)
+			require.NoError(t, err)
+			assert.True(t, tt.wantNewAvailable.Equal(result.Available),
+				"direction=%s op=%s: want available=%s, got %s",
+				tt.direction, tt.operation, tt.wantNewAvailable, result.Available)
+		})
+	}
+}
+
+// TestOperateBalances_DirectionAwareArithmetic_Approved mirrors the
+// CREATED-state check against APPROVED commits. The direction inversion
+// MUST apply uniformly across transaction states so that commits on a
+// debit-direction balance move Available in the opposite direction from
+// a credit-direction balance.
+func TestOperateBalances_DirectionAwareArithmetic_Approved(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name             string
+		direction        string
+		operation        string
+		startAvailable   decimal.Decimal
+		startOnHold      decimal.Decimal
+		amount           decimal.Decimal
+		wantNewAvailable decimal.Decimal
+	}{
+		{
+			name:             "direction=credit APPROVED CREDIT increases available",
+			direction:        pkgConstant.DirectionCredit,
+			operation:        constant.CREDIT,
+			startAvailable:   decimal.NewFromInt(500),
+			startOnHold:      decimal.NewFromInt(0),
+			amount:           decimal.NewFromInt(100),
+			wantNewAvailable: decimal.NewFromInt(600),
+		},
+		{
+			name:             "direction=debit APPROVED CREDIT decreases available",
+			direction:        pkgConstant.DirectionDebit,
+			operation:        constant.CREDIT,
+			startAvailable:   decimal.NewFromInt(500),
+			startOnHold:      decimal.NewFromInt(0),
+			amount:           decimal.NewFromInt(100),
+			wantNewAvailable: decimal.NewFromInt(400),
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			balance := Balance{
+				Available: tt.startAvailable,
+				OnHold:    tt.startOnHold,
+				Direction: tt.direction,
+				Version:   1,
+			}
+			amount := Amount{
+				Value:           tt.amount,
+				Operation:       tt.operation,
+				TransactionType: constant.APPROVED,
+			}
+
+			result, err := OperateBalances(amount, balance)
+			require.NoError(t, err)
+			assert.True(t, tt.wantNewAvailable.Equal(result.Available),
+				"direction=%s op=%s: want available=%s, got %s",
+				tt.direction, tt.operation, tt.wantNewAvailable, result.Available)
+		})
+	}
+}
+
+// TestOperateBalances_OverdraftSplitDetection verifies that when a debit
+// on a direction=credit balance exceeds available funds AND overdraft is
+// enabled, the operation is flagged for splitting. The caller expects a
+// signal that a secondary operation targeting the overdraft balance MUST
+// be appended to the transaction. Without overdraft enabled, no split is
+// signalled and the caller falls back to existing insufficient-funds
+// handling at the script layer.
+func TestOperateBalances_OverdraftSplitDetection(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		balance         Balance
+		amount          Amount
+		wantSplitNeeded bool
+		wantDeficit     decimal.Decimal
+	}{
+		{
+			name: "credit balance debit within available does not split",
+			balance: Balance{
+				Available:      decimal.NewFromInt(1000),
+				Direction:      pkgConstant.DirectionCredit,
+				AllowOverdraft: true,
+			},
+			amount: Amount{
+				Value:           decimal.NewFromInt(500),
+				Operation:       constant.DEBIT,
+				TransactionType: constant.CREATED,
+			},
+			wantSplitNeeded: false,
+			wantDeficit:     decimal.NewFromInt(0),
+		},
+		{
+			name: "credit balance debit exceeds available with overdraft enabled splits",
+			balance: Balance{
+				Available:      decimal.NewFromInt(100),
+				Direction:      pkgConstant.DirectionCredit,
+				AllowOverdraft: true,
+			},
+			amount: Amount{
+				Value:           decimal.NewFromInt(250),
+				Operation:       constant.DEBIT,
+				TransactionType: constant.CREATED,
+			},
+			wantSplitNeeded: true,
+			wantDeficit:     decimal.NewFromInt(150),
+		},
+		{
+			name: "credit balance debit exceeds available without overdraft does not split",
+			balance: Balance{
+				Available:      decimal.NewFromInt(100),
+				Direction:      pkgConstant.DirectionCredit,
+				AllowOverdraft: false,
+			},
+			amount: Amount{
+				Value:           decimal.NewFromInt(250),
+				Operation:       constant.DEBIT,
+				TransactionType: constant.CREATED,
+			},
+			wantSplitNeeded: false,
+			wantDeficit:     decimal.NewFromInt(0),
+		},
+		{
+			name: "debit balance never splits regardless of overdraft flag",
+			balance: Balance{
+				Available:      decimal.NewFromInt(0),
+				Direction:      pkgConstant.DirectionDebit,
+				AllowOverdraft: true,
+			},
+			amount: Amount{
+				Value:           decimal.NewFromInt(500),
+				Operation:       constant.DEBIT,
+				TransactionType: constant.CREATED,
+			},
+			wantSplitNeeded: false,
+			wantDeficit:     decimal.NewFromInt(0),
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			splitNeeded, deficit := DetectOverdraftSplit(tt.amount, tt.balance)
+
+			assert.Equal(t, tt.wantSplitNeeded, splitNeeded,
+				"split detection mismatch for %s", tt.name)
+			assert.True(t, tt.wantDeficit.Equal(deficit),
+				"deficit mismatch: want %s, got %s", tt.wantDeficit, deficit)
+		})
+	}
+}

--- a/pkg/mtransaction/direction_test.go
+++ b/pkg/mtransaction/direction_test.go
@@ -27,13 +27,13 @@ func TestOperateBalances_DirectionAwareArithmetic(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name              string
-		direction         string
-		operation         string
-		transactionType   string
-		startAvailable    decimal.Decimal
-		amount            decimal.Decimal
-		wantNewAvailable  decimal.Decimal
+		name             string
+		direction        string
+		operation        string
+		transactionType  string
+		startAvailable   decimal.Decimal
+		amount           decimal.Decimal
+		wantNewAvailable decimal.Decimal
 	}{
 		{
 			name:             "direction=credit DEBIT decreases available",
@@ -176,6 +176,124 @@ func TestOperateBalances_DirectionAwareArithmetic_Approved(t *testing.T) {
 			assert.True(t, tt.wantNewAvailable.Equal(result.Available),
 				"direction=%s op=%s: want available=%s, got %s",
 				tt.direction, tt.operation, tt.wantNewAvailable, result.Available)
+		})
+	}
+}
+
+// TestOperateBalances_DirectionDebit_PendingAndCanceled closes the coverage
+// gap on applyDebitDirectionBalance for transaction states that involve
+// ON_HOLD and RELEASE operations. Per the implementation, these delegate
+// to the credit-direction machinery (applyBalanceChange) because the
+// hold semantics are identical regardless of accounting direction.
+//
+// Note on DEBIT and CREDIT: applyDebitDirectionBalance catches these
+// operations at the top of the switch and applies the inverted arithmetic
+// for direction=debit balances (DEBIT increases Available, CREDIT
+// decreases it). This inversion holds uniformly across PENDING and
+// CANCELED transaction states because direction=debit balances do not
+// participate in the Available↔OnHold flow used by credit-direction
+// balances.
+func TestOperateBalances_DirectionDebit_PendingAndCanceled(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name                   string
+		operation              string
+		transactionType        string
+		routeValidationEnabled bool
+		wantNewAvailable       decimal.Decimal
+		wantNewOnHold          decimal.Decimal
+	}{
+		{
+			// ON_HOLD falls through to applyBalanceChange → applyPendingBalance.
+			// Route-validated ON_HOLD only increments OnHold; Available is preserved.
+			name:                   "PENDING ON_HOLD with route validation increments OnHold only",
+			operation:              constant.ONHOLD,
+			transactionType:        constant.PENDING,
+			routeValidationEnabled: true,
+			wantNewAvailable:       decimal.NewFromInt(1000),
+			wantNewOnHold:          decimal.NewFromInt(300),
+		},
+		{
+			// Legacy ON_HOLD (no route validation) moves funds from Available to OnHold.
+			name:                   "PENDING ON_HOLD legacy moves Available to OnHold",
+			operation:              constant.ONHOLD,
+			transactionType:        constant.PENDING,
+			routeValidationEnabled: false,
+			wantNewAvailable:       decimal.NewFromInt(900),
+			wantNewOnHold:          decimal.NewFromInt(300),
+		},
+		{
+			// DEBIT is caught by applyDebitDirectionBalance directly: for
+			// direction=debit balances, DEBIT INCREASES Available regardless
+			// of transaction state. OnHold is preserved.
+			name:                   "PENDING DEBIT with route validation increases Available (direction=debit inversion)",
+			operation:              constant.DEBIT,
+			transactionType:        constant.PENDING,
+			routeValidationEnabled: true,
+			wantNewAvailable:       decimal.NewFromInt(1100),
+			wantNewOnHold:          decimal.NewFromInt(200),
+		},
+		{
+			// RELEASE falls through to applyBalanceChange → applyCanceledBalance.
+			// Route-validated RELEASE only decrements OnHold; Available is preserved.
+			name:                   "CANCELED RELEASE with route validation decrements OnHold only",
+			operation:              constant.RELEASE,
+			transactionType:        constant.CANCELED,
+			routeValidationEnabled: true,
+			wantNewAvailable:       decimal.NewFromInt(1000),
+			wantNewOnHold:          decimal.NewFromInt(100),
+		},
+		{
+			// Legacy RELEASE (no route validation) moves funds from OnHold to Available.
+			name:                   "CANCELED RELEASE legacy moves OnHold to Available",
+			operation:              constant.RELEASE,
+			transactionType:        constant.CANCELED,
+			routeValidationEnabled: false,
+			wantNewAvailable:       decimal.NewFromInt(1100),
+			wantNewOnHold:          decimal.NewFromInt(100),
+		},
+		{
+			// CREDIT is caught by applyDebitDirectionBalance directly: for
+			// direction=debit balances, CREDIT DECREASES Available regardless
+			// of transaction state. OnHold is preserved.
+			name:                   "CANCELED CREDIT with route validation decreases Available (direction=debit inversion)",
+			operation:              constant.CREDIT,
+			transactionType:        constant.CANCELED,
+			routeValidationEnabled: true,
+			wantNewAvailable:       decimal.NewFromInt(900),
+			wantNewOnHold:          decimal.NewFromInt(200),
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			balance := Balance{
+				Available: decimal.NewFromInt(1000),
+				OnHold:    decimal.NewFromInt(200),
+				Direction: pkgConstant.DirectionDebit,
+				Version:   1,
+			}
+			amount := Amount{
+				Value:                  decimal.NewFromInt(100),
+				Operation:              tt.operation,
+				TransactionType:        tt.transactionType,
+				RouteValidationEnabled: tt.routeValidationEnabled,
+			}
+
+			result, err := OperateBalances(amount, balance)
+			require.NoError(t, err)
+			assert.True(t, tt.wantNewAvailable.Equal(result.Available),
+				"direction=debit op=%s txType=%s routeValidation=%v: want available=%s, got %s",
+				tt.operation, tt.transactionType, tt.routeValidationEnabled,
+				tt.wantNewAvailable, result.Available)
+			assert.True(t, tt.wantNewOnHold.Equal(result.OnHold),
+				"direction=debit op=%s txType=%s routeValidation=%v: want onHold=%s, got %s",
+				tt.operation, tt.transactionType, tt.routeValidationEnabled,
+				tt.wantNewOnHold, result.OnHold)
 		})
 	}
 }

--- a/pkg/mtransaction/overdraft.go
+++ b/pkg/mtransaction/overdraft.go
@@ -1,0 +1,90 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package mtransaction
+
+import (
+	"github.com/LerianStudio/midaz/v3/pkg"
+	pkgConstant "github.com/LerianStudio/midaz/v3/pkg/constant"
+	"github.com/shopspring/decimal"
+
+	constant "github.com/LerianStudio/lib-commons/v4/commons/constants"
+)
+
+// CalculateOverdraftSplit partitions a debit amount targeted at a
+// direction=credit balance whose Available funds may be insufficient to cover
+// the full debit. The returned pair satisfies:
+//
+//	debitOnDefault   = min(available, debitAmount)
+//	debitOnOverdraft = debitAmount - debitOnDefault
+//
+// Invariants (enforced by tests):
+//   - debitOnDefault + debitOnOverdraft == debitAmount
+//   - neither half is negative
+//
+// Decimal precision is preserved because all arithmetic is performed on
+// shopspring/decimal values with no intermediate float conversion.
+func CalculateOverdraftSplit(available, debitAmount decimal.Decimal) (debitOnDefault, debitOnOverdraft decimal.Decimal) {
+	debitOnDefault = decimal.Min(available, debitAmount)
+	debitOnOverdraft = debitAmount.Sub(debitOnDefault)
+
+	return debitOnDefault, debitOnOverdraft
+}
+
+// ValidateOverdraftLimit checks whether adding a deficit to the currently
+// consumed overdraft would breach the configured overdraft limit.
+//
+//   - When limitEnabled is false the balance is treated as having unlimited
+//     overdraft and the function always returns nil.
+//   - When the resulting cumulative usage (currentOverdraftUsed + deficit)
+//     is less than or equal to the limit the function returns nil.
+//   - Otherwise the function returns an error wrapping the canonical
+//     constant.ErrOverdraftLimitExceeded sentinel (code 0167) so callers
+//     can branch with errors.Is.
+func ValidateOverdraftLimit(currentOverdraftUsed, deficit, overdraftLimit decimal.Decimal, limitEnabled bool) error {
+	if !limitEnabled {
+		return nil
+	}
+
+	projected := currentOverdraftUsed.Add(deficit)
+	if projected.GreaterThan(overdraftLimit) {
+		return pkg.ValidateBusinessError(pkgConstant.ErrOverdraftLimitExceeded, pkgConstant.EntityTransaction)
+	}
+
+	return nil
+}
+
+// DetectOverdraftSplit reports whether a given (amount, balance) pair needs
+// to be split into two operations: one that consumes available funds on the
+// default balance and one that routes the remaining deficit to the overdraft
+// balance.
+//
+// A split is signalled only when all of the following hold:
+//   - the balance direction is "credit" (asset-like balance);
+//   - the operation is a DEBIT;
+//   - overdraft is enabled on the balance (AllowOverdraft == true);
+//   - the debit amount strictly exceeds the balance's Available funds.
+//
+// For every other case (including direction=debit balances) no split is
+// signalled and the deficit is zero. The caller is then expected to fall
+// back to existing insufficient-funds handling at the script layer.
+func DetectOverdraftSplit(amount Amount, balance Balance) (splitNeeded bool, deficit decimal.Decimal) {
+	if balance.Direction != pkgConstant.DirectionCredit {
+		return false, decimal.Zero
+	}
+
+	if !balance.AllowOverdraft {
+		return false, decimal.Zero
+	}
+
+	if amount.Operation != constant.DEBIT {
+		return false, decimal.Zero
+	}
+
+	if !amount.Value.GreaterThan(balance.Available) {
+		return false, decimal.Zero
+	}
+
+	return true, amount.Value.Sub(balance.Available)
+}

--- a/pkg/mtransaction/overdraft.go
+++ b/pkg/mtransaction/overdraft.go
@@ -55,6 +55,15 @@ func ValidateOverdraftLimit(currentOverdraftUsed, deficit, overdraftLimit decima
 	return nil
 }
 
+// NOTE: Empty-direction balances (Direction="") return (false, decimal.Zero)
+// because the first check requires DirectionCredit. This is intentional:
+// legacy balances that predate the overdraft feature never have
+// AllowOverdraft=true (the Settings block is nil or default), so the
+// !AllowOverdraft early return below would catch them even if the
+// direction check were relaxed. The direction check is a defense-in-depth
+// guard against data corruption where AllowOverdraft was manually set on
+// a legacy balance without also setting Direction.
+
 // DetectOverdraftSplit reports whether a given (amount, balance) pair needs
 // to be split into two operations: one that consumes available funds on the
 // default balance and one that routes the remaining deficit to the overdraft

--- a/pkg/mtransaction/overdraft.go
+++ b/pkg/mtransaction/overdraft.go
@@ -88,3 +88,56 @@ func DetectOverdraftSplit(amount Amount, balance Balance) (splitNeeded bool, def
 
 	return true, amount.Value.Sub(balance.Available)
 }
+
+// CalculateRefundSplit partitions a credit amount targeted at a
+// direction=credit balance whose OverdraftUsed is greater than zero. The
+// returned pair satisfies:
+//
+//	creditOnOverdraft = min(creditAmount, overdraftUsed)
+//	creditOnDefault   = creditAmount - creditOnOverdraft
+//
+// Invariants (enforced by tests):
+//   - creditOnOverdraft + creditOnDefault == creditAmount
+//   - neither half is negative
+//   - creditOnOverdraft never exceeds overdraftUsed
+//
+// Decimal precision is preserved because all arithmetic is performed on
+// shopspring/decimal values with no intermediate float conversion.
+func CalculateRefundSplit(creditAmount, overdraftUsed decimal.Decimal) (creditOnOverdraft, creditOnDefault decimal.Decimal) {
+	creditOnOverdraft = decimal.Min(creditAmount, overdraftUsed)
+	creditOnDefault = creditAmount.Sub(creditOnOverdraft)
+
+	return creditOnOverdraft, creditOnDefault
+}
+
+// DetectRefundSplit reports whether an incoming credit on a direction=credit
+// balance should trigger an overdraft repayment split. A split is signalled
+// only when all of the following hold:
+//   - the balance direction is exactly "credit" (legacy empty direction is
+//     intentionally excluded: Direction is an explicit opt-in signal);
+//   - the operation is a CREDIT;
+//   - the balance has outstanding overdraft usage (OverdraftUsed > 0).
+//
+// When a split is signalled, repayAmount is capped at the outstanding
+// overdraft (min(creditAmount, overdraftUsed)) and cleared is true when the
+// repayment fully extinguishes the overdraft (overdraftUsed - repay == 0).
+// For every non-signalling case the repay amount is zero and cleared is
+// false.
+func DetectRefundSplit(amount Amount, balance Balance) (splitNeeded bool, repayAmount decimal.Decimal, cleared bool) {
+	if balance.Direction != pkgConstant.DirectionCredit {
+		return false, decimal.Zero, false
+	}
+
+	if amount.Operation != constant.CREDIT {
+		return false, decimal.Zero, false
+	}
+
+	if !balance.OverdraftUsed.GreaterThan(decimal.Zero) {
+		return false, decimal.Zero, false
+	}
+
+	repayAmount = decimal.Min(amount.Value, balance.OverdraftUsed)
+	cleared = balance.OverdraftUsed.Sub(repayAmount).IsZero()
+
+	return true, repayAmount, cleared
+}

--- a/pkg/mtransaction/overdraft_test.go
+++ b/pkg/mtransaction/overdraft_test.go
@@ -1,0 +1,213 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package mtransaction
+
+import (
+	"testing"
+
+	pkgConstant "github.com/LerianStudio/midaz/v3/pkg/constant"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCalculateOverdraftSplit verifies the pure-function debit-split helper
+// used when a debit operation targets a direction=credit balance whose
+// available funds are insufficient. The function MUST partition the debit
+// into a portion that consumes available funds (capped at available) and a
+// deficit that must flow to the overdraft balance. Decimal precision MUST
+// be preserved across all arithmetic.
+func TestCalculateOverdraftSplit(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name                    string
+		available               decimal.Decimal
+		debitAmount             decimal.Decimal
+		wantDebitOnDefault      decimal.Decimal
+		wantDebitOnOverdraft    decimal.Decimal
+	}{
+		{
+			name:                 "debit within available produces no deficit",
+			available:            decimal.NewFromInt(500),
+			debitAmount:          decimal.NewFromInt(200),
+			wantDebitOnDefault:   decimal.NewFromInt(200),
+			wantDebitOnOverdraft: decimal.NewFromInt(0),
+		},
+		{
+			name:                 "debit exceeds available splits into deficit",
+			available:            decimal.NewFromInt(100),
+			debitAmount:          decimal.NewFromInt(250),
+			wantDebitOnDefault:   decimal.NewFromInt(100),
+			wantDebitOnOverdraft: decimal.NewFromInt(150),
+		},
+		{
+			name:                 "zero available routes full amount to overdraft",
+			available:            decimal.NewFromInt(0),
+			debitAmount:          decimal.NewFromInt(300),
+			wantDebitOnDefault:   decimal.NewFromInt(0),
+			wantDebitOnOverdraft: decimal.NewFromInt(300),
+		},
+		{
+			name:                 "debit exactly equals available produces no deficit",
+			available:            decimal.NewFromInt(750),
+			debitAmount:          decimal.NewFromInt(750),
+			wantDebitOnDefault:   decimal.NewFromInt(750),
+			wantDebitOnOverdraft: decimal.NewFromInt(0),
+		},
+		{
+			name:                 "large amounts preserve decimal precision",
+			available:            decimal.RequireFromString("123456789.123456789"),
+			debitAmount:          decimal.RequireFromString("987654321.987654321"),
+			wantDebitOnDefault:   decimal.RequireFromString("123456789.123456789"),
+			wantDebitOnOverdraft: decimal.RequireFromString("864197532.864197532"),
+		},
+		{
+			name:                 "fractional cent deficit preserves precision",
+			available:            decimal.RequireFromString("10.005"),
+			debitAmount:          decimal.RequireFromString("10.010"),
+			wantDebitOnDefault:   decimal.RequireFromString("10.005"),
+			wantDebitOnOverdraft: decimal.RequireFromString("0.005"),
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			gotDefault, gotOverdraft := CalculateOverdraftSplit(tt.available, tt.debitAmount)
+
+			assert.True(t, tt.wantDebitOnDefault.Equal(gotDefault),
+				"debitOnDefault mismatch: want %s, got %s", tt.wantDebitOnDefault, gotDefault)
+			assert.True(t, tt.wantDebitOnOverdraft.Equal(gotOverdraft),
+				"debitOnOverdraft mismatch: want %s, got %s", tt.wantDebitOnOverdraft, gotOverdraft)
+
+			// Invariant: the two halves MUST sum back to the original debit.
+			sum := gotDefault.Add(gotOverdraft)
+			assert.True(t, tt.debitAmount.Equal(sum),
+				"split halves must sum to debitAmount: want %s, got %s", tt.debitAmount, sum)
+
+			// Invariant: neither half may be negative.
+			assert.False(t, gotDefault.IsNegative(), "debitOnDefault must never be negative")
+			assert.False(t, gotOverdraft.IsNegative(), "debitOnOverdraft must never be negative")
+		})
+	}
+}
+
+// TestValidateOverdraftLimit verifies the pure-function limit check that
+// rejects a debit whose resulting overdraft usage would exceed the
+// configured limit. When the limit is disabled the function MUST treat
+// the balance as having unlimited overdraft.
+func TestValidateOverdraftLimit(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name                 string
+		currentOverdraftUsed decimal.Decimal
+		deficit              decimal.Decimal
+		overdraftLimit       decimal.Decimal
+		limitEnabled         bool
+		wantErr              bool
+		wantErrCode          string
+	}{
+		{
+			name:                 "limit disabled allows any deficit",
+			currentOverdraftUsed: decimal.NewFromInt(500),
+			deficit:              decimal.NewFromInt(1000000),
+			overdraftLimit:       decimal.NewFromInt(100),
+			limitEnabled:         false,
+			wantErr:              false,
+		},
+		{
+			name:                 "deficit within remaining limit allowed",
+			currentOverdraftUsed: decimal.NewFromInt(200),
+			deficit:              decimal.NewFromInt(300),
+			overdraftLimit:       decimal.NewFromInt(1000),
+			limitEnabled:         true,
+			wantErr:              false,
+		},
+		{
+			name:                 "deficit plus usage exactly at limit allowed",
+			currentOverdraftUsed: decimal.NewFromInt(400),
+			deficit:              decimal.NewFromInt(600),
+			overdraftLimit:       decimal.NewFromInt(1000),
+			limitEnabled:         true,
+			wantErr:              false,
+		},
+		{
+			name:                 "deficit exceeds limit is rejected with 0167",
+			currentOverdraftUsed: decimal.NewFromInt(800),
+			deficit:              decimal.NewFromInt(500),
+			overdraftLimit:       decimal.NewFromInt(1000),
+			limitEnabled:         true,
+			wantErr:              true,
+			wantErrCode:          "0167",
+		},
+		{
+			name:                 "first use of overdraft within limit allowed",
+			currentOverdraftUsed: decimal.NewFromInt(0),
+			deficit:              decimal.NewFromInt(500),
+			overdraftLimit:       decimal.NewFromInt(500),
+			limitEnabled:         true,
+			wantErr:              false,
+		},
+		{
+			name:                 "first use of overdraft exceeds limit rejected",
+			currentOverdraftUsed: decimal.NewFromInt(0),
+			deficit:              decimal.NewFromInt(501),
+			overdraftLimit:       decimal.NewFromInt(500),
+			limitEnabled:         true,
+			wantErr:              true,
+			wantErrCode:          "0167",
+		},
+		{
+			name:                 "cumulative usage precision preserved",
+			currentOverdraftUsed: decimal.RequireFromString("99.995"),
+			deficit:              decimal.RequireFromString("0.010"),
+			overdraftLimit:       decimal.RequireFromString("100.000"),
+			limitEnabled:         true,
+			wantErr:              true,
+			wantErrCode:          "0167",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := ValidateOverdraftLimit(tt.currentOverdraftUsed, tt.deficit, tt.overdraftLimit, tt.limitEnabled)
+
+			if tt.wantErr {
+				require.Error(t, err, "expected limit violation to return error")
+				if tt.wantErrCode != "" {
+					assert.Equal(t, tt.wantErrCode, codeFromError(err),
+						"expected error code %s, got %s from %v", tt.wantErrCode, codeFromError(err), err)
+				}
+				return
+			}
+			require.NoError(t, err, "expected success but got error: %v", err)
+		})
+	}
+}
+
+// TestValidateOverdraftLimit_SentinelMatches ensures the returned error
+// wraps the canonical overdraft-limit sentinel so downstream callers can
+// branch on the error with errors.Is.
+func TestValidateOverdraftLimit_SentinelMatches(t *testing.T) {
+	t.Parallel()
+
+	err := ValidateOverdraftLimit(
+		decimal.NewFromInt(0),
+		decimal.NewFromInt(10),
+		decimal.NewFromInt(5),
+		true,
+	)
+
+	require.Error(t, err)
+	assert.Equal(t, pkgConstant.ErrOverdraftLimitExceeded.Error(), codeFromError(err),
+		"returned error must carry the 0167 sentinel code")
+}

--- a/pkg/mtransaction/overdraft_test.go
+++ b/pkg/mtransaction/overdraft_test.go
@@ -23,11 +23,11 @@ func TestCalculateOverdraftSplit(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name                    string
-		available               decimal.Decimal
-		debitAmount             decimal.Decimal
-		wantDebitOnDefault      decimal.Decimal
-		wantDebitOnOverdraft    decimal.Decimal
+		name                 string
+		available            decimal.Decimal
+		debitAmount          decimal.Decimal
+		wantDebitOnDefault   decimal.Decimal
+		wantDebitOnOverdraft decimal.Decimal
 	}{
 		{
 			name:                 "debit within available produces no deficit",

--- a/pkg/mtransaction/refund_test.go
+++ b/pkg/mtransaction/refund_test.go
@@ -1,0 +1,325 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package mtransaction
+
+import (
+	"testing"
+
+	pkgConstant "github.com/LerianStudio/midaz/v3/pkg/constant"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+
+	constant "github.com/LerianStudio/lib-commons/v4/commons/constants"
+)
+
+// TestCalculateRefundSplit verifies the pure-function credit-split helper
+// used when a credit operation targets a direction=credit balance whose
+// OverdraftUsed is greater than zero. The function MUST partition the
+// credit into a portion that repays overdraft (capped at OverdraftUsed)
+// and a remainder that flows to the default balance. Decimal precision
+// MUST be preserved across all arithmetic.
+//
+// Invariants asserted on every case:
+//   - creditOnOverdraft + creditOnDefault == creditAmount (sum preservation)
+//   - creditOnOverdraft >= 0 && creditOnDefault >= 0      (non-negativity)
+//   - creditOnOverdraft <= overdraftUsed                  (never repay more than owed)
+func TestCalculateRefundSplit(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name                  string
+		creditAmount          decimal.Decimal
+		overdraftUsed         decimal.Decimal
+		wantCreditOnOverdraft decimal.Decimal
+		wantCreditOnDefault   decimal.Decimal
+	}{
+		{
+			// PRD Scenario 2: credit $80 to account with overdraft_used=$50
+			// → repay $50 on overdraft, $30 to default.
+			name:                  "full repayment with remainder routes overflow to default",
+			creditAmount:          decimal.NewFromInt(80),
+			overdraftUsed:         decimal.NewFromInt(50),
+			wantCreditOnOverdraft: decimal.NewFromInt(50),
+			wantCreditOnDefault:   decimal.NewFromInt(30),
+		},
+		{
+			// PRD Scenario 3: credit $60 to account with overdraft_used=$100
+			// → repay $60 on overdraft, $0 to default.
+			name:                  "partial repayment sends full credit to overdraft",
+			creditAmount:          decimal.NewFromInt(60),
+			overdraftUsed:         decimal.NewFromInt(100),
+			wantCreditOnOverdraft: decimal.NewFromInt(60),
+			wantCreditOnDefault:   decimal.NewFromInt(0),
+		},
+		{
+			name:                  "exact repayment fully clears overdraft with nothing to default",
+			creditAmount:          decimal.NewFromInt(250),
+			overdraftUsed:         decimal.NewFromInt(250),
+			wantCreditOnOverdraft: decimal.NewFromInt(250),
+			wantCreditOnDefault:   decimal.NewFromInt(0),
+		},
+		{
+			// Normal credit: overdraft_used=$0 → no split, full credit to default.
+			name:                  "no overdraft routes full credit to default",
+			creditAmount:          decimal.NewFromInt(500),
+			overdraftUsed:         decimal.NewFromInt(0),
+			wantCreditOnOverdraft: decimal.NewFromInt(0),
+			wantCreditOnDefault:   decimal.NewFromInt(500),
+		},
+		{
+			// PRD Scenario 7: credit $1 to account with overdraft_used=$500
+			// → repay $1 on overdraft, $0 to default.
+			name:                  "small credit against large overdraft fully absorbed",
+			creditAmount:          decimal.NewFromInt(1),
+			overdraftUsed:         decimal.NewFromInt(500),
+			wantCreditOnOverdraft: decimal.NewFromInt(1),
+			wantCreditOnDefault:   decimal.NewFromInt(0),
+		},
+		{
+			name:                  "fractional cent credit preserves precision",
+			creditAmount:          decimal.RequireFromString("0.01"),
+			overdraftUsed:         decimal.RequireFromString("10000.00"),
+			wantCreditOnOverdraft: decimal.RequireFromString("0.01"),
+			wantCreditOnDefault:   decimal.RequireFromString("0.00"),
+		},
+		{
+			name:                  "large amounts preserve decimal precision on split",
+			creditAmount:          decimal.RequireFromString("987654321.987654321"),
+			overdraftUsed:         decimal.RequireFromString("123456789.123456789"),
+			wantCreditOnOverdraft: decimal.RequireFromString("123456789.123456789"),
+			wantCreditOnDefault:   decimal.RequireFromString("864197532.864197532"),
+		},
+		{
+			name:                  "fractional overdraft fully repaid with fractional remainder",
+			creditAmount:          decimal.RequireFromString("10.010"),
+			overdraftUsed:         decimal.RequireFromString("10.005"),
+			wantCreditOnOverdraft: decimal.RequireFromString("10.005"),
+			wantCreditOnDefault:   decimal.RequireFromString("0.005"),
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			gotOverdraft, gotDefault := CalculateRefundSplit(tt.creditAmount, tt.overdraftUsed)
+
+			assert.True(t, tt.wantCreditOnOverdraft.Equal(gotOverdraft),
+				"creditOnOverdraft mismatch: want %s, got %s", tt.wantCreditOnOverdraft, gotOverdraft)
+			assert.True(t, tt.wantCreditOnDefault.Equal(gotDefault),
+				"creditOnDefault mismatch: want %s, got %s", tt.wantCreditOnDefault, gotDefault)
+
+			// Invariant 1: halves MUST sum back to the original credit.
+			sum := gotOverdraft.Add(gotDefault)
+			assert.True(t, tt.creditAmount.Equal(sum),
+				"split halves must sum to creditAmount: want %s, got %s", tt.creditAmount, sum)
+
+			// Invariant 2: neither half may be negative.
+			assert.False(t, gotOverdraft.IsNegative(), "creditOnOverdraft must never be negative")
+			assert.False(t, gotDefault.IsNegative(), "creditOnDefault must never be negative")
+
+			// Invariant 3: repayment MUST never exceed the outstanding overdraft.
+			assert.False(t, gotOverdraft.GreaterThan(tt.overdraftUsed),
+				"creditOnOverdraft (%s) must not exceed overdraftUsed (%s)",
+				gotOverdraft, tt.overdraftUsed)
+		})
+	}
+}
+
+// TestDetectRefundSplit verifies the detection predicate that reports
+// whether an incoming credit on a direction=credit balance should trigger
+// an overdraft repayment split. The predicate MUST signal a split only
+// when all three conditions hold: direction=credit, CREDIT operation, and
+// OverdraftUsed > 0. For every other case no split is signalled and the
+// returned repay amount is zero.
+//
+// The cleared flag MUST be true when the repayment fully extinguishes the
+// outstanding overdraft (overdraftUsed - repay == 0) and false otherwise.
+func TestDetectRefundSplit(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		balance         Balance
+		amount          Amount
+		wantSplitNeeded bool
+		wantRepay       decimal.Decimal
+		wantCleared     bool
+	}{
+		{
+			// PRD Scenario 2: full repayment triggers cleared=true.
+			name: "credit direction with CREDIT op fully repays and clears overdraft",
+			balance: Balance{
+				Available:     decimal.NewFromInt(0),
+				Direction:     pkgConstant.DirectionCredit,
+				OverdraftUsed: decimal.NewFromInt(50),
+			},
+			amount: Amount{
+				Value:     decimal.NewFromInt(80),
+				Operation: constant.CREDIT,
+			},
+			wantSplitNeeded: true,
+			wantRepay:       decimal.NewFromInt(50),
+			wantCleared:     true,
+		},
+		{
+			// PRD Scenario 3: partial repayment leaves cleared=false.
+			name: "credit direction with CREDIT op partially repays without clearing",
+			balance: Balance{
+				Available:     decimal.NewFromInt(0),
+				Direction:     pkgConstant.DirectionCredit,
+				OverdraftUsed: decimal.NewFromInt(100),
+			},
+			amount: Amount{
+				Value:     decimal.NewFromInt(60),
+				Operation: constant.CREDIT,
+			},
+			wantSplitNeeded: true,
+			wantRepay:       decimal.NewFromInt(60),
+			wantCleared:     false,
+		},
+		{
+			// PRD Scenario 7: small credit against large overdraft.
+			name: "tiny credit against large overdraft yields repay=credit and not cleared",
+			balance: Balance{
+				Available:     decimal.NewFromInt(0),
+				Direction:     pkgConstant.DirectionCredit,
+				OverdraftUsed: decimal.NewFromInt(500),
+			},
+			amount: Amount{
+				Value:     decimal.NewFromInt(1),
+				Operation: constant.CREDIT,
+			},
+			wantSplitNeeded: true,
+			wantRepay:       decimal.NewFromInt(1),
+			wantCleared:     false,
+		},
+		{
+			// Exact repayment edge case: cleared=true with repay == overdraftUsed.
+			name: "credit exactly equal to overdraft clears the balance",
+			balance: Balance{
+				Available:     decimal.NewFromInt(0),
+				Direction:     pkgConstant.DirectionCredit,
+				OverdraftUsed: decimal.NewFromInt(250),
+			},
+			amount: Amount{
+				Value:     decimal.NewFromInt(250),
+				Operation: constant.CREDIT,
+			},
+			wantSplitNeeded: true,
+			wantRepay:       decimal.NewFromInt(250),
+			wantCleared:     true,
+		},
+		{
+			// Normal credit: overdraft_used=0 → no split.
+			name: "credit direction with CREDIT op and no overdraft used signals no split",
+			balance: Balance{
+				Available:     decimal.NewFromInt(500),
+				Direction:     pkgConstant.DirectionCredit,
+				OverdraftUsed: decimal.NewFromInt(0),
+			},
+			amount: Amount{
+				Value:     decimal.NewFromInt(100),
+				Operation: constant.CREDIT,
+			},
+			wantSplitNeeded: false,
+			wantRepay:       decimal.Zero,
+			wantCleared:     false,
+		},
+		{
+			// DEBIT operation on a direction=credit balance must NOT trigger
+			// a refund split — that path belongs to the debit-side overdraft
+			// flow, not the credit-side refund flow.
+			name: "credit direction with DEBIT op never triggers refund split",
+			balance: Balance{
+				Available:     decimal.NewFromInt(0),
+				Direction:     pkgConstant.DirectionCredit,
+				OverdraftUsed: decimal.NewFromInt(100),
+			},
+			amount: Amount{
+				Value:     decimal.NewFromInt(40),
+				Operation: constant.DEBIT,
+			},
+			wantSplitNeeded: false,
+			wantRepay:       decimal.Zero,
+			wantCleared:     false,
+		},
+		{
+			// direction=debit balance represents the overdraft ledger itself;
+			// credits flowing to it must not be re-routed.
+			name: "debit direction balance never triggers refund split",
+			balance: Balance{
+				Available:     decimal.NewFromInt(0),
+				Direction:     pkgConstant.DirectionDebit,
+				OverdraftUsed: decimal.NewFromInt(200),
+			},
+			amount: Amount{
+				Value:     decimal.NewFromInt(75),
+				Operation: constant.CREDIT,
+			},
+			wantSplitNeeded: false,
+			wantRepay:       decimal.Zero,
+			wantCleared:     false,
+		},
+		{
+			// Legacy balances with empty Direction are treated as credit by
+			// OperateBalances but MUST NOT opt-in to the refund split flow
+			// since Direction is an explicit signal. Only direction=="credit"
+			// (the exact constant) enables the flow.
+			name: "empty direction balance never triggers refund split",
+			balance: Balance{
+				Available:     decimal.NewFromInt(0),
+				Direction:     "",
+				OverdraftUsed: decimal.NewFromInt(100),
+			},
+			amount: Amount{
+				Value:     decimal.NewFromInt(40),
+				Operation: constant.CREDIT,
+			},
+			wantSplitNeeded: false,
+			wantRepay:       decimal.Zero,
+			wantCleared:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			gotSplitNeeded, gotRepay, gotCleared := DetectRefundSplit(tt.amount, tt.balance)
+
+			assert.Equal(t, tt.wantSplitNeeded, gotSplitNeeded,
+				"splitNeeded mismatch: want %v, got %v", tt.wantSplitNeeded, gotSplitNeeded)
+
+			assert.True(t, tt.wantRepay.Equal(gotRepay),
+				"repay mismatch: want %s, got %s", tt.wantRepay, gotRepay)
+
+			assert.Equal(t, tt.wantCleared, gotCleared,
+				"cleared mismatch: want %v, got %v", tt.wantCleared, gotCleared)
+
+			// Invariant: when no split is needed the repay amount MUST be
+			// exactly zero and the cleared flag MUST be false.
+			if !gotSplitNeeded {
+				assert.True(t, gotRepay.Equal(decimal.Zero),
+					"repay must be zero when split is not signalled, got %s", gotRepay)
+				assert.False(t, gotCleared,
+					"cleared must be false when split is not signalled")
+			}
+
+			// Invariant: repay must never exceed the outstanding overdraft
+			// nor the incoming credit amount.
+			if gotSplitNeeded {
+				assert.False(t, gotRepay.GreaterThan(tt.balance.OverdraftUsed),
+					"repay (%s) must not exceed overdraftUsed (%s)",
+					gotRepay, tt.balance.OverdraftUsed)
+				assert.False(t, gotRepay.GreaterThan(tt.amount.Value),
+					"repay (%s) must not exceed credit amount (%s)",
+					gotRepay, tt.amount.Value)
+			}
+		})
+	}
+}

--- a/pkg/mtransaction/transaction.go
+++ b/pkg/mtransaction/transaction.go
@@ -19,19 +19,19 @@ import (
 // swagger:model Balance
 // @Description Balance is the struct designed to represent the account balance.
 type Balance struct {
-	ID             string                   `json:"id" example:"00000000-0000-0000-0000-000000000000"`
-	OrganizationID string                   `json:"organizationId" example:"00000000-0000-0000-0000-000000000000"`
-	LedgerID       string                   `json:"ledgerId" example:"00000000-0000-0000-0000-000000000000"`
-	AccountID      string                   `json:"accountId" example:"00000000-0000-0000-0000-000000000000"`
-	Alias          string                   `json:"alias" example:"@person1"`
-	Key            string                   `json:"key" example:"asset-freeze"`
-	AssetCode      string                   `json:"assetCode" example:"BRL"`
-	Available      decimal.Decimal          `json:"available" example:"1500"`
-	OnHold         decimal.Decimal          `json:"onHold" example:"500"`
-	Version        int64                    `json:"version" example:"1"`
-	AccountType    string                   `json:"accountType" example:"creditCard"`
-	AllowSending   bool                     `json:"allowSending" example:"true"`
-	AllowReceiving bool                     `json:"allowReceiving" example:"true"`
+	ID             string          `json:"id" example:"00000000-0000-0000-0000-000000000000"`
+	OrganizationID string          `json:"organizationId" example:"00000000-0000-0000-0000-000000000000"`
+	LedgerID       string          `json:"ledgerId" example:"00000000-0000-0000-0000-000000000000"`
+	AccountID      string          `json:"accountId" example:"00000000-0000-0000-0000-000000000000"`
+	Alias          string          `json:"alias" example:"@person1"`
+	Key            string          `json:"key" example:"asset-freeze"`
+	AssetCode      string          `json:"assetCode" example:"BRL"`
+	Available      decimal.Decimal `json:"available" example:"1500"`
+	OnHold         decimal.Decimal `json:"onHold" example:"500"`
+	Version        int64           `json:"version" example:"1"`
+	AccountType    string          `json:"accountType" example:"creditCard"`
+	AllowSending   bool            `json:"allowSending" example:"true"`
+	AllowReceiving bool            `json:"allowReceiving" example:"true"`
 	// Direction is the accounting direction of the balance ("credit" or
 	// "debit"). Empty string denotes a legacy balance that predates the
 	// overdraft feature and is treated as "credit" by the engine.
@@ -46,14 +46,21 @@ type Balance struct {
 	OverdraftLimitEnabled bool `json:"overdraftLimitEnabled"`
 	// OverdraftLimit is the maximum overdraft amount as a decimal.
 	// Only meaningful when OverdraftLimitEnabled is true.
+	//
+	// Type asymmetry note: this field is decimal.Decimal for runtime
+	// arithmetic (comparison, subtraction in ValidateOverdraftLimit). The
+	// corresponding BalanceSettings.OverdraftLimit is *string to preserve
+	// JSON precision across marshal/unmarshal cycles. ToTransactionBalance()
+	// in pkg/mmodel/balance.go bridges the two: it parses the *string into
+	// a decimal.Decimal, returning an error on malformed values.
 	OverdraftLimit decimal.Decimal `json:"overdraftLimit"`
 	// BalanceScope is the balance scope ("transactional" or "internal").
 	// Empty string is treated as "transactional" for backward compatibility.
-	BalanceScope   string    `json:"balanceScope"`
-	CreatedAt      time.Time `json:"createdAt" example:"2021-01-01T00:00:00Z"`
-	UpdatedAt      time.Time                `json:"updatedAt" example:"2021-01-01T00:00:00Z"`
-	DeletedAt      *time.Time               `json:"deletedAt" example:"2021-01-01T00:00:00Z"`
-	Metadata       map[string]any           `json:"metadata,omitempty"`
+	BalanceScope string         `json:"balanceScope"`
+	CreatedAt    time.Time      `json:"createdAt" example:"2021-01-01T00:00:00Z"`
+	UpdatedAt    time.Time      `json:"updatedAt" example:"2021-01-01T00:00:00Z"`
+	DeletedAt    *time.Time     `json:"deletedAt" example:"2021-01-01T00:00:00Z"`
+	Metadata     map[string]any `json:"metadata,omitempty"`
 } // @name Balance
 
 type Responses struct {

--- a/pkg/mtransaction/transaction.go
+++ b/pkg/mtransaction/transaction.go
@@ -99,6 +99,10 @@ type Amount struct {
 	TransactionType        string `json:"transactionType,omitempty" swaggerignore:"true"`
 	Direction              string `json:"direction,omitempty" swaggerignore:"true"`
 	RouteValidationEnabled bool   `json:"routeValidationEnabled,omitempty" swaggerignore:"true"`
+	// OverdraftAmount carries the exact overdraft delta for state-transition
+	// reversals. It is zero for normal transactions, where Lua derives the
+	// split from live balance state.
+	OverdraftAmount decimal.Decimal `json:"overdraftAmount,omitempty" swaggerignore:"true"`
 } // @name Amount
 
 // Share structure for marshaling/unmarshalling JSON.

--- a/pkg/mtransaction/transaction.go
+++ b/pkg/mtransaction/transaction.go
@@ -19,23 +19,41 @@ import (
 // swagger:model Balance
 // @Description Balance is the struct designed to represent the account balance.
 type Balance struct {
-	ID             string          `json:"id" example:"00000000-0000-0000-0000-000000000000"`
-	OrganizationID string          `json:"organizationId" example:"00000000-0000-0000-0000-000000000000"`
-	LedgerID       string          `json:"ledgerId" example:"00000000-0000-0000-0000-000000000000"`
-	AccountID      string          `json:"accountId" example:"00000000-0000-0000-0000-000000000000"`
-	Alias          string          `json:"alias" example:"@person1"`
-	Key            string          `json:"key" example:"asset-freeze"`
-	AssetCode      string          `json:"assetCode" example:"BRL"`
-	Available      decimal.Decimal `json:"available" example:"1500"`
-	OnHold         decimal.Decimal `json:"onHold" example:"500"`
-	Version        int64           `json:"version" example:"1"`
-	AccountType    string          `json:"accountType" example:"creditCard"`
-	AllowSending   bool            `json:"allowSending" example:"true"`
-	AllowReceiving bool            `json:"allowReceiving" example:"true"`
-	CreatedAt      time.Time       `json:"createdAt" example:"2021-01-01T00:00:00Z"`
-	UpdatedAt      time.Time       `json:"updatedAt" example:"2021-01-01T00:00:00Z"`
-	DeletedAt      *time.Time      `json:"deletedAt" example:"2021-01-01T00:00:00Z"`
-	Metadata       map[string]any  `json:"metadata,omitempty"`
+	ID             string                   `json:"id" example:"00000000-0000-0000-0000-000000000000"`
+	OrganizationID string                   `json:"organizationId" example:"00000000-0000-0000-0000-000000000000"`
+	LedgerID       string                   `json:"ledgerId" example:"00000000-0000-0000-0000-000000000000"`
+	AccountID      string                   `json:"accountId" example:"00000000-0000-0000-0000-000000000000"`
+	Alias          string                   `json:"alias" example:"@person1"`
+	Key            string                   `json:"key" example:"asset-freeze"`
+	AssetCode      string                   `json:"assetCode" example:"BRL"`
+	Available      decimal.Decimal          `json:"available" example:"1500"`
+	OnHold         decimal.Decimal          `json:"onHold" example:"500"`
+	Version        int64                    `json:"version" example:"1"`
+	AccountType    string                   `json:"accountType" example:"creditCard"`
+	AllowSending   bool                     `json:"allowSending" example:"true"`
+	AllowReceiving bool                     `json:"allowReceiving" example:"true"`
+	// Direction is the accounting direction of the balance ("credit" or
+	// "debit"). Empty string denotes a legacy balance that predates the
+	// overdraft feature and is treated as "credit" by the engine.
+	Direction string `json:"direction,omitempty" example:"credit"`
+	// OverdraftUsed is the amount of overdraft currently consumed by the
+	// balance. Always non-negative. Zero when the balance is in the black.
+	OverdraftUsed decimal.Decimal `json:"overdraftUsed" example:"0"`
+	// AllowOverdraft enables overdraft behavior when true.
+	AllowOverdraft bool `json:"allowOverdraft"`
+	// OverdraftLimitEnabled gates the OverdraftLimit value. When false,
+	// the limit is zero (unlimited if AllowOverdraft is true).
+	OverdraftLimitEnabled bool `json:"overdraftLimitEnabled"`
+	// OverdraftLimit is the maximum overdraft amount as a decimal.
+	// Only meaningful when OverdraftLimitEnabled is true.
+	OverdraftLimit decimal.Decimal `json:"overdraftLimit"`
+	// BalanceScope is the balance scope ("transactional" or "internal").
+	// Empty string is treated as "transactional" for backward compatibility.
+	BalanceScope   string    `json:"balanceScope"`
+	CreatedAt      time.Time `json:"createdAt" example:"2021-01-01T00:00:00Z"`
+	UpdatedAt      time.Time                `json:"updatedAt" example:"2021-01-01T00:00:00Z"`
+	DeletedAt      *time.Time               `json:"deletedAt" example:"2021-01-01T00:00:00Z"`
+	Metadata       map[string]any           `json:"metadata,omitempty"`
 } // @name Balance
 
 type Responses struct {

--- a/pkg/mtransaction/validations.go
+++ b/pkg/mtransaction/validations.go
@@ -165,8 +165,30 @@ func ConcatAlias(i int, alias string) string {
 	return strconv.Itoa(i) + "#" + alias
 }
 
-// OperateBalances Function to sum or sub two balances and Normalize the scale
+// OperateBalances Function to sum or sub two balances and Normalize the scale.
+//
+// For balances with Direction == "debit" (liability-like balances) the
+// arithmetic for DEBIT and CREDIT operations is INVERTED relative to a
+// "credit" (asset-like) balance: a DEBIT increases Available and a CREDIT
+// decreases it. The inversion applies uniformly across transaction states
+// (CREATED, APPROVED, PENDING, CANCELED) because direction=debit balances
+// do not participate in the Available↔OnHold flow used by credit-direction
+// balances; they mutate Available directly. Legacy balances with an empty
+// Direction are treated as "credit" to preserve backward compatibility.
 func OperateBalances(amount Amount, balance Balance) (Balance, error) {
+	if balance.Direction == pkgConstant.DirectionDebit {
+		available, onHold, matched := applyDebitDirectionBalance(amount, balance)
+		if !matched {
+			return balance, nil
+		}
+
+		return Balance{
+			Available: available,
+			OnHold:    onHold,
+			Version:   balance.Version + 1,
+		}, nil
+	}
+
 	available, onHold, matched := applyBalanceChange(amount, balance)
 	if !matched {
 		return balance, nil
@@ -177,6 +199,23 @@ func OperateBalances(amount Amount, balance Balance) (Balance, error) {
 		OnHold:    onHold,
 		Version:   balance.Version + 1,
 	}, nil
+}
+
+// applyDebitDirectionBalance computes the new Available and OnHold values for
+// a direction=debit balance. DEBIT increases Available, CREDIT decreases it;
+// OnHold is preserved across DEBIT/CREDIT operations because the Available↔
+// OnHold flow used by credit-direction balances does not apply here. ON_HOLD
+// and RELEASE delegate to the credit-direction machinery because the hold
+// semantics are identical regardless of accounting direction.
+func applyDebitDirectionBalance(amount Amount, balance Balance) (available, onHold decimal.Decimal, matched bool) {
+	switch amount.Operation {
+	case constant.DEBIT:
+		return balance.Available.Add(amount.Value), balance.OnHold, true
+	case constant.CREDIT:
+		return balance.Available.Sub(amount.Value), balance.OnHold, true
+	default:
+		return applyBalanceChange(amount, balance)
+	}
 }
 
 // applyBalanceChange computes the new Available and OnHold values for a given

--- a/pkg/utils/decimal.go
+++ b/pkg/utils/decimal.go
@@ -1,0 +1,34 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package utils
+
+import (
+	"encoding/json"
+
+	"github.com/shopspring/decimal"
+)
+
+// ParseDecimalString normalizes a value that may arrive as string, float64,
+// or json.Number into a plain decimal string. Returns defaultVal when v is
+// nil or of an unsupported type.
+//
+// This helper is typically used inside custom JSON unmarshalers where the
+// same numeric field can be emitted as a string (e.g. by Lua/Redis), a
+// float64 (standard JSON number), or json.Number (when the decoder is
+// configured with UseNumber). It preserves the exact textual representation
+// for string and json.Number inputs, and converts float64 via
+// decimal.NewFromFloat to avoid binary-float surprises in the output.
+func ParseDecimalString(v any, defaultVal string) string {
+	switch t := v.(type) {
+	case string:
+		return t
+	case float64:
+		return decimal.NewFromFloat(t).String()
+	case json.Number:
+		return t.String()
+	default:
+		return defaultVal
+	}
+}

--- a/pkg/utils/decimal_test.go
+++ b/pkg/utils/decimal_test.go
@@ -1,0 +1,120 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package utils
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestParseDecimalString_FromNumber verifies that the json.Number branch of
+// ParseDecimalString preserves the exact textual representation supplied by
+// the caller — the precision-safe path for high-magnitude or high-precision
+// decimals.
+func TestParseDecimalString_FromNumber(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    json.Number
+		expected string
+	}{
+		{name: "high precision decimal", input: json.Number("123.456789012345"), expected: "123.456789012345"},
+		{name: "large integer", input: json.Number("9999999999999999"), expected: "9999999999999999"},
+		{name: "small fractional", input: json.Number("0.000001"), expected: "0.000001"},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := ParseDecimalString(tt.input, "0")
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}
+
+// TestParseDecimalString_FromString verifies that string inputs are returned
+// verbatim, preserving the exact representation provided by the caller.
+func TestParseDecimalString_FromString(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{name: "plain integer", input: "100", expected: "100"},
+		{name: "decimal value", input: "50.25", expected: "50.25"},
+		{name: "zero", input: "0", expected: "0"},
+		{name: "high precision", input: "123.456789012345", expected: "123.456789012345"},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := ParseDecimalString(tt.input, "default")
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}
+
+// TestParseDecimalString_FromFloat64 verifies that float64 inputs are
+// normalized into a decimal string via shopspring/decimal.
+func TestParseDecimalString_FromFloat64(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    float64
+		expected string
+	}{
+		{name: "whole number", input: 100, expected: "100"},
+		{name: "decimal", input: 50.5, expected: "50.5"},
+		{name: "zero", input: 0, expected: "0"},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := ParseDecimalString(tt.input, "default")
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}
+
+// TestParseDecimalString_DefaultValue verifies that unsupported or nil
+// inputs fall through to the caller-provided default.
+func TestParseDecimalString_DefaultValue(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    any
+		expected string
+	}{
+		{name: "nil input", input: nil, expected: "0"},
+		{name: "int input", input: 42, expected: "0"},
+		{name: "bool input", input: true, expected: "0"},
+		{name: "struct input", input: struct{}{}, expected: "0"},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := ParseDecimalString(tt.input, "0")
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}

--- a/postman/MIDAZ.postman_collection.json
+++ b/postman/MIDAZ.postman_collection.json
@@ -24,7 +24,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "b920988b-54a5-42a7-abaf-294c8535cfe1",
+                "id": "df7a3639-044d-48bb-83d2-d4ed89b0eac2",
                 "exec": [
                   "// Request not found in collection for: POST /v1/organizations",
                   "// Variables to extract: [\"organizationId\"]"
@@ -47,7 +47,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "3b07fd29-aa3f-457a-9f55-888c2dfd1a79",
+                "id": "8c6e2473-4963-497c-ab98-07daea530077",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}",
                   "// Variables to extract: []"
@@ -70,7 +70,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "a9bddfca-9655-4bf2-9881-49b9745f326b",
+                "id": "03933b92-2ed6-4bb0-b9ba-5b77ea6639e4",
                 "exec": [
                   "// Request not found in collection for: PATCH /v1/organizations/{organizationId}",
                   "// Variables to extract: []"
@@ -93,7 +93,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "5a585ef7-0d9e-4c01-910d-5277ee73f424",
+                "id": "f56bd9d0-6452-4e8b-9924-b3c97e0385aa",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations",
                   "// Variables to extract: []"
@@ -116,7 +116,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "f837d5e0-ea63-4c5e-9c80-72889f12f7b0",
+                "id": "125561bd-456c-4e5a-872c-62886be4e046",
                 "exec": [
                   "// Request not found in collection for: POST /v1/organizations/{organizationId}/ledgers",
                   "// Variables to extract: [\"ledgerId\"]"
@@ -139,7 +139,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "ca61efe8-eaab-43f7-92a0-0ecf460cc59d",
+                "id": "ddcdf6de-9306-4f8a-9e14-b6e5aaf9f4cf",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}",
                   "// Variables to extract: []"
@@ -162,7 +162,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "7acf5295-b9f7-4e58-b595-bf6a3a87d23a",
+                "id": "2e750dae-effd-49ca-8777-9e5ce45542f8",
                 "exec": [
                   "// Request not found in collection for: PATCH /v1/organizations/{organizationId}/ledgers/{ledgerId}",
                   "// Variables to extract: []"
@@ -185,7 +185,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "64fbfd2e-104f-4f2a-8b65-7d2d2c8e9880",
+                "id": "d6079cf6-7604-4fa5-b488-fdb1c0d1d207",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers",
                   "// Variables to extract: []"
@@ -208,7 +208,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "7cd38874-4eba-4a3d-b0f6-efef602a68f3",
+                "id": "09c62d3c-2ec7-4a83-9d4b-19e4cda1a9cb",
                 "exec": [
                   "// Request not found in collection for: POST /v1/organizations/{organizationId}/ledgers/{ledgerId}/assets",
                   "// Variables to extract: [\"assetId\"]"
@@ -231,7 +231,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "a3ae0bf0-d06d-4e87-81e1-f3b6c11b9bc5",
+                "id": "4aa96d38-d3d3-4090-bade-bc8036756ea2",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/assets/{assetId}",
                   "// Variables to extract: []"
@@ -254,7 +254,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "b6ee24d9-cb4c-4e18-8324-212ea58a436a",
+                "id": "433dfae0-7f60-4b4c-951c-fd44a0f479f1",
                 "exec": [
                   "// Request not found in collection for: PATCH /v1/organizations/{organizationId}/ledgers/{ledgerId}/assets/{assetId}",
                   "// Variables to extract: []"
@@ -277,7 +277,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "c4ef5e7c-94ba-4be8-ada7-511cec6bfb5f",
+                "id": "7f41c365-b527-4b5d-accf-d891e36d594a",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/assets",
                   "// Variables to extract: []"
@@ -300,7 +300,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "08c3f541-f343-4f7a-af73-22c990993757",
+                "id": "b7da825b-c92a-4db5-ad5f-a23076e27791",
                 "exec": [
                   "// Request not found in collection for: POST /v1/organizations/{organizationId}/ledgers/{ledgerId}/accounts",
                   "// Variables to extract: [\"accountId\",\"accountAlias\"]"
@@ -323,7 +323,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "4f1d19a0-c01c-4325-b9ee-3cdf68e6c9fa",
+                "id": "55bbd824-d2c7-4581-8858-29664b2fc877",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/accounts/{accountId}",
                   "// Variables to extract: []"
@@ -346,7 +346,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "e83ece55-ef5a-4d58-9963-4eddd71a5b9e",
+                "id": "9820c200-97b1-4117-9a27-7db98172bc95",
                 "exec": [
                   "// Request not found in collection for: PATCH /v1/organizations/{organizationId}/ledgers/{ledgerId}/accounts/{accountId}",
                   "// Variables to extract: []"
@@ -369,7 +369,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "2209b520-aa21-4dde-87d2-059e66ec4e02",
+                "id": "be53d7f3-b763-4a60-9107-58f98f62b819",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/accounts",
                   "// Variables to extract: []"
@@ -392,7 +392,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "2876759f-cbde-4f54-8601-4f05878a0885",
+                "id": "4feb3268-1fe0-402e-9eb5-f18283fe7ed9",
                 "exec": [
                   "// Request not found in collection for: POST /v1/organizations/{organizationId}/ledgers/{ledgerId}/portfolios",
                   "// Variables to extract: [\"portfolioId\"]"
@@ -415,7 +415,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "a228333a-2104-4a11-b70c-8f83a6981aaa",
+                "id": "88d2c620-f9ab-4701-8af3-6fe55226e046",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/portfolios/{portfolioId}",
                   "// Variables to extract: []"
@@ -438,7 +438,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "8c55bf11-6a85-4a79-a9fe-df583be59852",
+                "id": "1e86c097-c08b-4fa3-b3cc-9aa05386efc1",
                 "exec": [
                   "// Request not found in collection for: PATCH /v1/organizations/{organizationId}/ledgers/{ledgerId}/portfolios/{portfolioId}",
                   "// Variables to extract: []"
@@ -461,7 +461,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "a7265d0c-c288-487c-89a7-6539d70d4400",
+                "id": "1557e88c-a718-4723-a9b5-90ada926e298",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/portfolios",
                   "// Variables to extract: []"
@@ -484,7 +484,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "4383d13a-ca4a-4c05-bffe-56cb53db9621",
+                "id": "a7280ae9-3aa4-4ae0-b8bd-90e11a1961e0",
                 "exec": [
                   "// Request not found in collection for: POST /v1/organizations/{organizationId}/ledgers/{ledgerId}/segments",
                   "// Variables to extract: [\"segmentId\"]"
@@ -507,7 +507,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "5a0a667d-4f1c-4d53-8927-6f02a53513fd",
+                "id": "91607753-2659-4cce-b828-5c28a935705b",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/segments/{segmentId}",
                   "// Variables to extract: []"
@@ -530,7 +530,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "a79ff7f3-5539-4c3b-ab40-99a4b12fc5a8",
+                "id": "34f8da52-df4c-4397-96c5-b5f3d3fc0f88",
                 "exec": [
                   "// Request not found in collection for: PATCH /v1/organizations/{organizationId}/ledgers/{ledgerId}/segments/{segmentId}",
                   "// Variables to extract: []"
@@ -553,7 +553,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "4fe40c43-2498-4301-97c9-57bc5591472a",
+                "id": "51600a9a-183b-46b9-877b-ffacad8dfd56",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/segments",
                   "// Variables to extract: []"
@@ -576,7 +576,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "b47c0e72-d0b4-4c79-8b09-26f0458506ff",
+                "id": "8532aeef-213b-4aec-94aa-a29d39c5eb21",
                 "exec": [
                   "// Request not found in collection for: HEAD /v1/organizations/metrics/count",
                   "// Variables to extract: []"
@@ -599,7 +599,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "908fa9a0-d751-4ba3-904a-063a29b8f26e",
+                "id": "5d83b164-3d68-4934-8778-e7809b57022e",
                 "exec": [
                   "// Request not found in collection for: HEAD /v1/organizations/{organizationId}/ledgers/metrics/count",
                   "// Variables to extract: []"
@@ -622,7 +622,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "332812d4-5498-40ac-b6cc-29b4b74cb28d",
+                "id": "4e64a691-fb97-43b7-b87e-55f6b7bb1c08",
                 "exec": [
                   "// Request not found in collection for: HEAD /v1/organizations/{organizationId}/ledgers/{ledgerId}/accounts/metrics/count",
                   "// Variables to extract: []"
@@ -645,7 +645,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "f901569e-3b8c-4f30-8d77-791e17969ba7",
+                "id": "59c97b06-7361-4740-9aac-06ca2346f769",
                 "exec": [
                   "// Request not found in collection for: HEAD /v1/organizations/{organizationId}/ledgers/{ledgerId}/assets/metrics/count",
                   "// Variables to extract: []"
@@ -668,7 +668,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "5a5a8588-b513-4077-ad9c-1ec37a718f73",
+                "id": "4970b437-d75f-4938-8258-ed519332f3d3",
                 "exec": [
                   "// Request not found in collection for: HEAD /v1/organizations/{organizationId}/ledgers/{ledgerId}/portfolios/metrics/count",
                   "// Variables to extract: []"
@@ -691,7 +691,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "ba146414-25bc-4101-829c-3290ed34552d",
+                "id": "8d0a4aac-15fc-485b-b492-aa3550213427",
                 "exec": [
                   "// Request not found in collection for: HEAD /v1/organizations/{organizationId}/ledgers/{ledgerId}/segments/metrics/count",
                   "// Variables to extract: []"
@@ -714,7 +714,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "b0dbf933-4c59-44b3-a27e-5d979b2284ce",
+                "id": "f6db7804-2e3b-449d-88a8-79439f42c802",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/accounts/alias/{alias}",
                   "// Variables to extract: []"
@@ -737,7 +737,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "f19f8f49-9a81-460b-baa0-3dbe4bbf627c",
+                "id": "e9513f01-fbba-4d4d-8e0e-240ef7ba3aac",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/accounts/external/{code}",
                   "// Variables to extract: []"
@@ -760,7 +760,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "6e679811-ea17-4eb4-aa9d-cf77d32b250b",
+                "id": "f809af29-1ce4-4e14-90a0-2486c82c18de",
                 "exec": [
                   "// Request not found in collection for: POST /v1/organizations/{organizationId}/ledgers/{ledgerId}/transactions/json",
                   "// Variables to extract: [\"transactionId\",\"balanceId\",\"operationId\"]"
@@ -783,7 +783,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "f238f6af-5298-44d0-b66f-2318df9522b8",
+                "id": "ec4eab1f-8059-4e0e-ae6e-4da61cfc41fd",
                 "exec": [
                   "// Request not found in collection for: POST /v1/organizations/{organizationId}/ledgers/{ledgerId}/transactions/inflow",
                   "// Variables to extract: [\"inflowTransactionId\"]"
@@ -806,7 +806,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "43011ad4-935d-4eac-a1f4-3b95fb3a3e84",
+                "id": "ffd2313f-3858-41f2-ab84-f085e9c5b059",
                 "exec": [
                   "// Request not found in collection for: POST /v1/organizations/{organizationId}/ledgers/{ledgerId}/transactions/outflow",
                   "// Variables to extract: [\"outflowTransactionId\"]"
@@ -829,7 +829,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "1d4e9a2f-ba13-47ad-93d3-4e20994fdcb5",
+                "id": "b2fcdbaf-1438-437c-8c02-a841bc689e63",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/transactions/{transactionId}",
                   "// Variables to extract: []"
@@ -852,7 +852,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "65d327e0-93d5-45ca-9052-3318e15fdeac",
+                "id": "14227809-8fa8-4abf-a753-db2a47011d5b",
                 "exec": [
                   "// Request not found in collection for: PATCH /v1/organizations/{organizationId}/ledgers/{ledgerId}/transactions/{transactionId}",
                   "// Variables to extract: []"
@@ -875,7 +875,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "99c41c63-b124-4aca-bd46-2f33bcf7e6b5",
+                "id": "a548faa8-7f64-4722-95b9-7c6224b8342c",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/transactions",
                   "// Variables to extract: []"
@@ -898,7 +898,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "ad5804ca-8252-4586-b86e-dcc58eef57b7",
+                "id": "be106017-62ed-4bec-843c-78a77555fd78",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/accounts/{accountId}/operations/{operationId}",
                   "// Variables to extract: []"
@@ -921,7 +921,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "a66f3856-0257-4f22-be98-70de39ca7d00",
+                "id": "997ff9d8-ad8b-4f8e-818e-3c152b4ce755",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/accounts/{accountId}/operations",
                   "// Variables to extract: []"
@@ -944,7 +944,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "bfff784f-d9d0-43cc-bc74-6f70dec79ee7",
+                "id": "9629d9db-97cd-4f79-86cd-26efbcaff35e",
                 "exec": [
                   "// Request not found in collection for: PATCH /v1/organizations/{organizationId}/ledgers/{ledgerId}/transactions/{transactionId}/operations/{operationId}",
                   "// Variables to extract: []"
@@ -967,7 +967,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "d8ab6610-d1ca-4406-ba02-97a6f9e5a2f6",
+                "id": "fdc5a66a-5f71-4441-8a20-d411df0d74e3",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/balances/{balanceId}",
                   "// Variables to extract: []"
@@ -990,7 +990,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "bec0e24a-b4fa-45eb-a74f-4dfbba84c5bf",
+                "id": "be9d7958-32c9-4c22-8d7e-4f32bee5a01d",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/accounts/{accountId}/balances",
                   "// Variables to extract: []"
@@ -1013,7 +1013,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "4ec661e9-78a1-4072-9869-86aab9cdc2f2",
+                "id": "ba3e9920-33bf-4234-a5ae-814c487e2178",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/accounts/alias/{alias}/balances",
                   "// Variables to extract: []"
@@ -1036,7 +1036,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "1d1358eb-2fad-4fb2-9701-3944cbe90ae8",
+                "id": "6bdbf2d5-dadc-4655-b759-a8f82b9c70f6",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/accounts/external/{code}/balances",
                   "// Variables to extract: []"
@@ -1059,7 +1059,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "7174f868-7c77-4fef-9275-e7cb527b4bd4",
+                "id": "c391551e-bd53-44d7-a0fd-4ce7d4f2b074",
                 "exec": [
                   "// Request not found in collection for: PATCH /v1/organizations/{organizationId}/ledgers/{ledgerId}/balances/{balanceId}",
                   "// Variables to extract: []"
@@ -1082,7 +1082,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "4722cb1f-e3ed-491d-a2a0-95999c16817b",
+                "id": "983360ea-4902-4fe5-98da-a020dd113bd7",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/balances",
                   "// Variables to extract: []"
@@ -1105,7 +1105,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "741d4e05-939c-4af4-9449-08d5700ed6d0",
+                "id": "c2338ecf-2fb6-4ad6-a93e-f957cf6a6653",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/accounts/alias/{alias}/balances",
                   "// Variables to extract: [\"currentBalanceAmount\"]"
@@ -1128,7 +1128,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "37238bfd-80fd-484a-9ad5-8a6d460dbb8e",
+                "id": "e60389cc-3a45-4cd1-a85d-ac8fe2fbecb6",
                 "exec": [
                   "// Request not found in collection for: POST /v1/organizations/{organizationId}/ledgers/{ledgerId}/transactions/json",
                   "// Variables to extract: []"
@@ -1151,7 +1151,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "93da7d79-df28-44b8-9c23-d9b5a05f3204",
+                "id": "015b62b4-dbec-407b-9513-66280455ddfe",
                 "exec": [
                   "// Request not found in collection for: DELETE /v1/organizations/{organizationId}/ledgers/{ledgerId}/balances/{balanceId}",
                   "// Variables to extract: []"
@@ -1174,7 +1174,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "7afcd786-47fa-4205-a778-d6467ef6f2bf",
+                "id": "505bc69d-e9e4-44cb-a32e-83d44d62ae45",
                 "exec": [
                   "// Request not found in collection for: DELETE /v1/organizations/{organizationId}/ledgers/{ledgerId}/segments/{segmentId}",
                   "// Variables to extract: []"
@@ -1197,7 +1197,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "1479c6c4-ef2c-4912-a4f5-d4f2c75a900e",
+                "id": "596db77c-1ef0-4f33-996e-0a91537bc3a6",
                 "exec": [
                   "// Request not found in collection for: DELETE /v1/organizations/{organizationId}/ledgers/{ledgerId}/portfolios/{portfolioId}",
                   "// Variables to extract: []"
@@ -1220,7 +1220,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "87e32c42-84c7-4bd8-b434-e0cbf92fd59e",
+                "id": "c2edc398-b85d-4ae3-9a42-f2e7f6e47062",
                 "exec": [
                   "// Request not found in collection for: DELETE /v1/organizations/{organizationId}/ledgers/{ledgerId}/accounts/{accountId}",
                   "// Variables to extract: []"
@@ -1243,7 +1243,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "4c7cddfd-0738-47d7-832d-46028bdf4003",
+                "id": "c05facfb-1682-49dc-b73f-058c732d4969",
                 "exec": [
                   "// Request not found in collection for: DELETE /v1/organizations/{organizationId}/ledgers/{ledgerId}/assets/{assetId}",
                   "// Variables to extract: []"
@@ -1266,7 +1266,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "643167ef-6e93-453d-99e6-5f1a80921775",
+                "id": "625966eb-0489-43b5-9c8b-de3944b54711",
                 "exec": [
                   "// Request not found in collection for: DELETE /v1/organizations/{organizationId}/ledgers/{ledgerId}",
                   "// Variables to extract: []"
@@ -1289,7 +1289,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "dfb80f8f-cc4d-48f4-bd48-743374f6f108",
+                "id": "2cc6c206-fe70-4d22-aad3-cb24ae5828b9",
                 "exec": [
                   "// Request not found in collection for: DELETE /v1/organizations/{organizationId}",
                   "// Variables to extract: []"
@@ -1318,7 +1318,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "ee35685d-b5ed-4d45-855a-bd0651fc74a8",
+                "id": "1837b905-2650-44c1-b9a7-df81b26c5827",
                 "exec": [
                   "\n// ===== WORKFLOW SUMMARY =====\nconsole.log(\"📊 Workflow Execution Summary\");\nconsole.log(\"Total Steps: 56\");\n\n// Calculate total execution time\nconst startTime = pm.globals.get(\"workflow_start_time\");\nif (startTime) {\n    const totalTime = Date.now() - startTime;\n    console.log(\"⏱️ Total Execution Time: \" + totalTime + \"ms\");\n    pm.globals.set(\"workflow_total_time\", totalTime);\n}\n\n// Summary of step performance\nconsole.log(\"📈 Performance Summary:\");\nfor (let i = 1; i <= 56; i++) {\n    const stepTime = pm.environment.get(\"perf_step_\" + i);\n    if (stepTime) {\n        console.log(\"  Step \" + i + \": \" + stepTime + \"ms\");\n    }\n}\n\nconsole.log(\"✅ Workflow completed successfully\");\n"
                 ],
@@ -1328,7 +1328,7 @@
           ]
         }
       ],
-      "_postman_id": "038d77e1-a483-481b-8ca8-9a3f4c0d76cb",
+      "_postman_id": "0303c175-9e32-4ab5-aec0-36d9c8660300",
       "event": []
     },
     {

--- a/postman/MIDAZ.postman_collection.json
+++ b/postman/MIDAZ.postman_collection.json
@@ -3,7 +3,7 @@
     "name": "MIDAZ",
     "description": "The CRM API provides a set of endpoints for managing holder data, including information related to their ledger accounts.\n\n**IMPORTANT**: This collection requires the **MIDAZ Environment** to be selected for proper functionality. Please ensure you have imported and selected the MIDAZ environment before using this collection.",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-    "version": "1.0.0",
+    "version": "v3.7.0",
     "_postman_id": "00b3869d-895d-49b2-a6b5-68b193471560"
   },
   "item": [
@@ -24,7 +24,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "df7a3639-044d-48bb-83d2-d4ed89b0eac2",
+                "id": "f0c8450f-1e6e-4954-8699-714873192979",
                 "exec": [
                   "// Request not found in collection for: POST /v1/organizations",
                   "// Variables to extract: [\"organizationId\"]"
@@ -47,7 +47,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "8c6e2473-4963-497c-ab98-07daea530077",
+                "id": "11536e29-50bf-4aaa-8702-0fd5ffc53802",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}",
                   "// Variables to extract: []"
@@ -70,7 +70,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "03933b92-2ed6-4bb0-b9ba-5b77ea6639e4",
+                "id": "9c4f3f99-02b7-44ba-b402-4ec3f57fd646",
                 "exec": [
                   "// Request not found in collection for: PATCH /v1/organizations/{organizationId}",
                   "// Variables to extract: []"
@@ -93,7 +93,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "f56bd9d0-6452-4e8b-9924-b3c97e0385aa",
+                "id": "03486e10-41cb-4805-8786-e42c4433cfda",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations",
                   "// Variables to extract: []"
@@ -116,7 +116,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "125561bd-456c-4e5a-872c-62886be4e046",
+                "id": "77deb762-bf5e-4e70-bdf7-2a6fcc8beb93",
                 "exec": [
                   "// Request not found in collection for: POST /v1/organizations/{organizationId}/ledgers",
                   "// Variables to extract: [\"ledgerId\"]"
@@ -139,7 +139,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "ddcdf6de-9306-4f8a-9e14-b6e5aaf9f4cf",
+                "id": "95fe5261-4a73-4690-b8db-f4767f1dcab4",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}",
                   "// Variables to extract: []"
@@ -162,7 +162,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "2e750dae-effd-49ca-8777-9e5ce45542f8",
+                "id": "9544e412-afcf-4678-aa60-40f8870966c5",
                 "exec": [
                   "// Request not found in collection for: PATCH /v1/organizations/{organizationId}/ledgers/{ledgerId}",
                   "// Variables to extract: []"
@@ -185,7 +185,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "d6079cf6-7604-4fa5-b488-fdb1c0d1d207",
+                "id": "28f1d119-bde2-47d3-bb24-b7f035381510",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers",
                   "// Variables to extract: []"
@@ -208,7 +208,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "09c62d3c-2ec7-4a83-9d4b-19e4cda1a9cb",
+                "id": "d00c1627-a2ff-4d9b-88b0-d4ebd811710f",
                 "exec": [
                   "// Request not found in collection for: POST /v1/organizations/{organizationId}/ledgers/{ledgerId}/assets",
                   "// Variables to extract: [\"assetId\"]"
@@ -231,7 +231,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "4aa96d38-d3d3-4090-bade-bc8036756ea2",
+                "id": "f688cd7a-60d9-46fb-984a-9b59476f76f2",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/assets/{assetId}",
                   "// Variables to extract: []"
@@ -254,7 +254,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "433dfae0-7f60-4b4c-951c-fd44a0f479f1",
+                "id": "7dd75fed-7381-4124-966b-73336a132c41",
                 "exec": [
                   "// Request not found in collection for: PATCH /v1/organizations/{organizationId}/ledgers/{ledgerId}/assets/{assetId}",
                   "// Variables to extract: []"
@@ -277,7 +277,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "7f41c365-b527-4b5d-accf-d891e36d594a",
+                "id": "e94d7eed-1876-4f07-83cd-77233b1b9623",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/assets",
                   "// Variables to extract: []"
@@ -300,7 +300,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "b7da825b-c92a-4db5-ad5f-a23076e27791",
+                "id": "f39127d5-c2c9-4388-ba38-212387326ace",
                 "exec": [
                   "// Request not found in collection for: POST /v1/organizations/{organizationId}/ledgers/{ledgerId}/accounts",
                   "// Variables to extract: [\"accountId\",\"accountAlias\"]"
@@ -323,7 +323,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "55bbd824-d2c7-4581-8858-29664b2fc877",
+                "id": "9cb4fe80-3519-4b0d-b98c-9be0cc235388",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/accounts/{accountId}",
                   "// Variables to extract: []"
@@ -346,7 +346,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "9820c200-97b1-4117-9a27-7db98172bc95",
+                "id": "8e2c7424-6c2b-49e8-ba99-5c54547e9a51",
                 "exec": [
                   "// Request not found in collection for: PATCH /v1/organizations/{organizationId}/ledgers/{ledgerId}/accounts/{accountId}",
                   "// Variables to extract: []"
@@ -369,7 +369,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "be53d7f3-b763-4a60-9107-58f98f62b819",
+                "id": "4b58e86e-afaf-4cd7-92a1-21f74b67c2d7",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/accounts",
                   "// Variables to extract: []"
@@ -392,7 +392,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "4feb3268-1fe0-402e-9eb5-f18283fe7ed9",
+                "id": "b307c489-1adc-4ed3-bf9c-90ad7ed4bc97",
                 "exec": [
                   "// Request not found in collection for: POST /v1/organizations/{organizationId}/ledgers/{ledgerId}/portfolios",
                   "// Variables to extract: [\"portfolioId\"]"
@@ -415,7 +415,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "88d2c620-f9ab-4701-8af3-6fe55226e046",
+                "id": "6ea9573e-742a-4704-91b2-efa016c9c872",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/portfolios/{portfolioId}",
                   "// Variables to extract: []"
@@ -438,7 +438,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "1e86c097-c08b-4fa3-b3cc-9aa05386efc1",
+                "id": "bc80f22d-82e9-4714-8066-e19dc272219d",
                 "exec": [
                   "// Request not found in collection for: PATCH /v1/organizations/{organizationId}/ledgers/{ledgerId}/portfolios/{portfolioId}",
                   "// Variables to extract: []"
@@ -461,7 +461,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "1557e88c-a718-4723-a9b5-90ada926e298",
+                "id": "2ca0cb95-c8f8-44c1-8afb-1002b1747c06",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/portfolios",
                   "// Variables to extract: []"
@@ -484,7 +484,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "a7280ae9-3aa4-4ae0-b8bd-90e11a1961e0",
+                "id": "a381b3ea-8bd5-4e04-91b6-e8aab0b86709",
                 "exec": [
                   "// Request not found in collection for: POST /v1/organizations/{organizationId}/ledgers/{ledgerId}/segments",
                   "// Variables to extract: [\"segmentId\"]"
@@ -507,7 +507,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "91607753-2659-4cce-b828-5c28a935705b",
+                "id": "875b6c18-35a2-4230-a38c-434ed864d702",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/segments/{segmentId}",
                   "// Variables to extract: []"
@@ -530,7 +530,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "34f8da52-df4c-4397-96c5-b5f3d3fc0f88",
+                "id": "b6c062f8-7caa-492e-85c2-b6683fa716a6",
                 "exec": [
                   "// Request not found in collection for: PATCH /v1/organizations/{organizationId}/ledgers/{ledgerId}/segments/{segmentId}",
                   "// Variables to extract: []"
@@ -553,7 +553,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "51600a9a-183b-46b9-877b-ffacad8dfd56",
+                "id": "dd08fd95-6bd6-4e28-9c0a-f39c31b17486",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/segments",
                   "// Variables to extract: []"
@@ -576,7 +576,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "8532aeef-213b-4aec-94aa-a29d39c5eb21",
+                "id": "8648f583-03b7-4851-88e5-e8df3fbd1d1a",
                 "exec": [
                   "// Request not found in collection for: HEAD /v1/organizations/metrics/count",
                   "// Variables to extract: []"
@@ -599,7 +599,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "5d83b164-3d68-4934-8778-e7809b57022e",
+                "id": "cb8d69b0-4709-46ff-bdc7-749dbbd9f4f9",
                 "exec": [
                   "// Request not found in collection for: HEAD /v1/organizations/{organizationId}/ledgers/metrics/count",
                   "// Variables to extract: []"
@@ -622,7 +622,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "4e64a691-fb97-43b7-b87e-55f6b7bb1c08",
+                "id": "6a6bf616-0d07-4a30-8229-f7dc1ccfcd2b",
                 "exec": [
                   "// Request not found in collection for: HEAD /v1/organizations/{organizationId}/ledgers/{ledgerId}/accounts/metrics/count",
                   "// Variables to extract: []"
@@ -645,7 +645,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "59c97b06-7361-4740-9aac-06ca2346f769",
+                "id": "f19cab81-3290-40af-80d8-a8f280807bf5",
                 "exec": [
                   "// Request not found in collection for: HEAD /v1/organizations/{organizationId}/ledgers/{ledgerId}/assets/metrics/count",
                   "// Variables to extract: []"
@@ -668,7 +668,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "4970b437-d75f-4938-8258-ed519332f3d3",
+                "id": "204d8c14-64ac-457e-94ba-7197c0bba187",
                 "exec": [
                   "// Request not found in collection for: HEAD /v1/organizations/{organizationId}/ledgers/{ledgerId}/portfolios/metrics/count",
                   "// Variables to extract: []"
@@ -691,7 +691,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "8d0a4aac-15fc-485b-b492-aa3550213427",
+                "id": "b40f0e8c-3f06-4724-9bbc-f60bc5d13880",
                 "exec": [
                   "// Request not found in collection for: HEAD /v1/organizations/{organizationId}/ledgers/{ledgerId}/segments/metrics/count",
                   "// Variables to extract: []"
@@ -714,7 +714,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "f6db7804-2e3b-449d-88a8-79439f42c802",
+                "id": "38af1eec-0f07-4803-803d-9d0b0355fae9",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/accounts/alias/{alias}",
                   "// Variables to extract: []"
@@ -737,7 +737,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "e9513f01-fbba-4d4d-8e0e-240ef7ba3aac",
+                "id": "8ff41f3b-16a8-4196-8ab3-50dc3f83c3bb",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/accounts/external/{code}",
                   "// Variables to extract: []"
@@ -760,7 +760,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "f809af29-1ce4-4e14-90a0-2486c82c18de",
+                "id": "a13da6a4-5fe1-4464-86c2-e9130527315a",
                 "exec": [
                   "// Request not found in collection for: POST /v1/organizations/{organizationId}/ledgers/{ledgerId}/transactions/json",
                   "// Variables to extract: [\"transactionId\",\"balanceId\",\"operationId\"]"
@@ -783,7 +783,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "ec4eab1f-8059-4e0e-ae6e-4da61cfc41fd",
+                "id": "67826e81-47db-4272-8047-89717ca29cdd",
                 "exec": [
                   "// Request not found in collection for: POST /v1/organizations/{organizationId}/ledgers/{ledgerId}/transactions/inflow",
                   "// Variables to extract: [\"inflowTransactionId\"]"
@@ -806,7 +806,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "ffd2313f-3858-41f2-ab84-f085e9c5b059",
+                "id": "6fc8bbdc-9bf6-4d0f-b159-1441d9198588",
                 "exec": [
                   "// Request not found in collection for: POST /v1/organizations/{organizationId}/ledgers/{ledgerId}/transactions/outflow",
                   "// Variables to extract: [\"outflowTransactionId\"]"
@@ -829,7 +829,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "b2fcdbaf-1438-437c-8c02-a841bc689e63",
+                "id": "c8e0ac19-33b0-41d2-9524-5fe87fe355e4",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/transactions/{transactionId}",
                   "// Variables to extract: []"
@@ -852,7 +852,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "14227809-8fa8-4abf-a753-db2a47011d5b",
+                "id": "98a96a04-dad2-4c88-a2b3-dc45350fd19e",
                 "exec": [
                   "// Request not found in collection for: PATCH /v1/organizations/{organizationId}/ledgers/{ledgerId}/transactions/{transactionId}",
                   "// Variables to extract: []"
@@ -875,7 +875,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "a548faa8-7f64-4722-95b9-7c6224b8342c",
+                "id": "3342dc95-2724-4aa1-a1e7-421e5c0b025e",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/transactions",
                   "// Variables to extract: []"
@@ -898,7 +898,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "be106017-62ed-4bec-843c-78a77555fd78",
+                "id": "db6d4d9a-80d4-4282-a250-24b902e76273",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/accounts/{accountId}/operations/{operationId}",
                   "// Variables to extract: []"
@@ -921,7 +921,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "997ff9d8-ad8b-4f8e-818e-3c152b4ce755",
+                "id": "03deb5b6-9b9a-45f2-8bee-6671dd2afd11",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/accounts/{accountId}/operations",
                   "// Variables to extract: []"
@@ -944,7 +944,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "9629d9db-97cd-4f79-86cd-26efbcaff35e",
+                "id": "da855a93-50f5-4c80-b30e-cbaa914eba3d",
                 "exec": [
                   "// Request not found in collection for: PATCH /v1/organizations/{organizationId}/ledgers/{ledgerId}/transactions/{transactionId}/operations/{operationId}",
                   "// Variables to extract: []"
@@ -967,7 +967,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "fdc5a66a-5f71-4441-8a20-d411df0d74e3",
+                "id": "da54d25e-485d-496a-9467-39990ce1b18b",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/balances/{balanceId}",
                   "// Variables to extract: []"
@@ -990,7 +990,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "be9d7958-32c9-4c22-8d7e-4f32bee5a01d",
+                "id": "923266c0-2f1f-4039-8548-57e7570c9bf3",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/accounts/{accountId}/balances",
                   "// Variables to extract: []"
@@ -1013,7 +1013,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "ba3e9920-33bf-4234-a5ae-814c487e2178",
+                "id": "5620d6cc-fd4f-463d-a888-970aa6c2fb0a",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/accounts/alias/{alias}/balances",
                   "// Variables to extract: []"
@@ -1036,7 +1036,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "6bdbf2d5-dadc-4655-b759-a8f82b9c70f6",
+                "id": "fd7a07ca-d176-4a93-9616-c59fb3f6781a",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/accounts/external/{code}/balances",
                   "// Variables to extract: []"
@@ -1059,7 +1059,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "c391551e-bd53-44d7-a0fd-4ce7d4f2b074",
+                "id": "eceddafb-aa6a-473a-b300-136f21660662",
                 "exec": [
                   "// Request not found in collection for: PATCH /v1/organizations/{organizationId}/ledgers/{ledgerId}/balances/{balanceId}",
                   "// Variables to extract: []"
@@ -1082,7 +1082,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "983360ea-4902-4fe5-98da-a020dd113bd7",
+                "id": "95043320-79d0-400e-a8dd-c92cfcf7e705",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/balances",
                   "// Variables to extract: []"
@@ -1105,7 +1105,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "c2338ecf-2fb6-4ad6-a93e-f957cf6a6653",
+                "id": "b9dbc6b6-cc37-424b-b0f4-1a04b2baf4af",
                 "exec": [
                   "// Request not found in collection for: GET /v1/organizations/{organizationId}/ledgers/{ledgerId}/accounts/alias/{alias}/balances",
                   "// Variables to extract: [\"currentBalanceAmount\"]"
@@ -1128,7 +1128,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "e60389cc-3a45-4cd1-a85d-ac8fe2fbecb6",
+                "id": "bfb257c8-0664-4e24-af9b-aa9317dcc907",
                 "exec": [
                   "// Request not found in collection for: POST /v1/organizations/{organizationId}/ledgers/{ledgerId}/transactions/json",
                   "// Variables to extract: []"
@@ -1151,7 +1151,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "015b62b4-dbec-407b-9513-66280455ddfe",
+                "id": "0238906e-4243-4de5-827d-b78bde80f669",
                 "exec": [
                   "// Request not found in collection for: DELETE /v1/organizations/{organizationId}/ledgers/{ledgerId}/balances/{balanceId}",
                   "// Variables to extract: []"
@@ -1174,7 +1174,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "505bc69d-e9e4-44cb-a32e-83d44d62ae45",
+                "id": "ac9ecc3b-2f5d-49de-8f84-2097bd801e68",
                 "exec": [
                   "// Request not found in collection for: DELETE /v1/organizations/{organizationId}/ledgers/{ledgerId}/segments/{segmentId}",
                   "// Variables to extract: []"
@@ -1197,7 +1197,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "596db77c-1ef0-4f33-996e-0a91537bc3a6",
+                "id": "79f7e306-a22d-4dc3-bac9-7b5690e74430",
                 "exec": [
                   "// Request not found in collection for: DELETE /v1/organizations/{organizationId}/ledgers/{ledgerId}/portfolios/{portfolioId}",
                   "// Variables to extract: []"
@@ -1220,7 +1220,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "c2edc398-b85d-4ae3-9a42-f2e7f6e47062",
+                "id": "442a34bf-3231-48b7-8d6a-03fe373968d4",
                 "exec": [
                   "// Request not found in collection for: DELETE /v1/organizations/{organizationId}/ledgers/{ledgerId}/accounts/{accountId}",
                   "// Variables to extract: []"
@@ -1243,7 +1243,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "c05facfb-1682-49dc-b73f-058c732d4969",
+                "id": "3c8f39c4-7ec5-45d7-be27-da4c90b39c88",
                 "exec": [
                   "// Request not found in collection for: DELETE /v1/organizations/{organizationId}/ledgers/{ledgerId}/assets/{assetId}",
                   "// Variables to extract: []"
@@ -1266,7 +1266,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "625966eb-0489-43b5-9c8b-de3944b54711",
+                "id": "77d8c2e7-52aa-498b-ba3d-217975730319",
                 "exec": [
                   "// Request not found in collection for: DELETE /v1/organizations/{organizationId}/ledgers/{ledgerId}",
                   "// Variables to extract: []"
@@ -1289,7 +1289,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "2cc6c206-fe70-4d22-aad3-cb24ae5828b9",
+                "id": "e01d7fbe-b11a-4bab-95ff-81c477471f7e",
                 "exec": [
                   "// Request not found in collection for: DELETE /v1/organizations/{organizationId}",
                   "// Variables to extract: []"
@@ -1318,7 +1318,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "1837b905-2650-44c1-b9a7-df81b26c5827",
+                "id": "128d2691-33e0-4fe7-9f8b-b3dd86bd963c",
                 "exec": [
                   "\n// ===== WORKFLOW SUMMARY =====\nconsole.log(\"📊 Workflow Execution Summary\");\nconsole.log(\"Total Steps: 56\");\n\n// Calculate total execution time\nconst startTime = pm.globals.get(\"workflow_start_time\");\nif (startTime) {\n    const totalTime = Date.now() - startTime;\n    console.log(\"⏱️ Total Execution Time: \" + totalTime + \"ms\");\n    pm.globals.set(\"workflow_total_time\", totalTime);\n}\n\n// Summary of step performance\nconsole.log(\"📈 Performance Summary:\");\nfor (let i = 1; i <= 56; i++) {\n    const stepTime = pm.environment.get(\"perf_step_\" + i);\n    if (stepTime) {\n        console.log(\"  Step \" + i + \": \" + stepTime + \"ms\");\n    }\n}\n\nconsole.log(\"✅ Workflow completed successfully\");\n"
                 ],
@@ -1328,7 +1328,7 @@
           ]
         }
       ],
-      "_postman_id": "0303c175-9e32-4ab5-aec0-36d9c8660300",
+      "_postman_id": "c221e4f2-ba4e-49bc-9322-5076668bcbc4",
       "event": []
     },
     {

--- a/scripts/generate-docs.sh
+++ b/scripts/generate-docs.sh
@@ -50,6 +50,34 @@ print_step() {
     fi
 }
 
+# Resolve swag even when GOPATH/bin is not on PATH.
+resolve_swag_bin() {
+    if command -v swag >/dev/null 2>&1; then
+        command -v swag
+        return 0
+    fi
+
+    local go_bin=""
+    go_bin="$(go env GOBIN 2>/dev/null || true)"
+
+    if [ -z "${go_bin}" ]; then
+        local go_path=""
+        go_path="$(go env GOPATH 2>/dev/null || true)"
+        if [ -n "${go_path}" ]; then
+            go_bin="${go_path}/bin"
+        fi
+    fi
+
+    if [ -n "${go_bin}" ] && [ -x "${go_bin}/swag" ]; then
+        printf '%s\n' "${go_bin}/swag"
+        return 0
+    fi
+
+    return 1
+}
+
+SWAG_BIN=""
+
 # Generate OpenAPI specs for a component
 generate_openapi_spec() {
     local component="$1"
@@ -62,7 +90,7 @@ generate_openapi_spec() {
     local out_log="${LOG_DIR}/${component}_swag.out"
     local err_log="${LOG_DIR}/${component}_swag.err"
 
-    if (cd "${component_dir}" && swag init -g cmd/app/main.go -o api --parseDependency --parseInternal --instanceName "${component}" > "${out_log}" 2> "${err_log}"); then
+    if (cd "${component_dir}" && "${SWAG_BIN}" init -g cmd/app/main.go -o api --parseDependency --parseInternal --instanceName "${component}" > "${out_log}" 2> "${err_log}"); then
         local end_time=$(date +%s.%N)
         local elapsed=$(echo "scale=1; $end_time - $start_time" | bc 2>/dev/null || echo "0.0")
         print_step "Generated ${component} OpenAPI spec" "SUCCESS" "${elapsed}"
@@ -122,17 +150,24 @@ install_npm_dependencies() {
         return 0
     fi
     
-    if (cd "${postman_dir}" && npm install --silent > "${npm_out}" 2> "${npm_err}"); then
+    if [ -f "${postman_dir}/package-lock.json" ]; then
+        if (cd "${postman_dir}" && npm ci --silent > "${npm_out}" 2> "${npm_err}"); then
+            local end_time=$(date +%s.%N)
+            local elapsed=$(echo "scale=1; $end_time - $start_time" | bc 2>/dev/null || echo "0.0")
+            print_step "Installed Node.js dependencies" "SUCCESS" "${elapsed}"
+            return 0
+        fi
+    elif (cd "${postman_dir}" && npm install --silent > "${npm_out}" 2> "${npm_err}"); then
         local end_time=$(date +%s.%N)
         local elapsed=$(echo "scale=1; $end_time - $start_time" | bc 2>/dev/null || echo "0.0")
         print_step "Installed Node.js dependencies" "SUCCESS" "${elapsed}"
         return 0
-    else
-        print_step "Install Node.js dependencies" "FAILED"
-        echo -e "      ${RED}Error details:${NC}"
-        head -5 "${npm_err}" | sed 's/^/        /'
-        return 1
     fi
+
+    print_step "Install Node.js dependencies" "FAILED"
+    echo -e "      ${RED}Error details:${NC}"
+    head -5 "${npm_err}" | sed 's/^/        /'
+    return 1
 }
 
 # Convert to Postman collection
@@ -182,14 +217,24 @@ main() {
     
     # Track overall success
     local overall_success=true
+
+    if ! SWAG_BIN="$(resolve_swag_bin)"; then
+        print_step "Resolve swag executable" "FAILED"
+        echo -e "      ${RED}Error details:${NC}"
+        echo "        swag was not found on PATH or in Go's bin directory."
+        echo "        Install it with: go install github.com/swaggo/swag/cmd/swag@v1.16.6"
+        overall_success=false
+    fi
     
     # Generate OpenAPI specs for each component
-    for component in "${COMPONENTS[@]}"; do
-        if ! generate_openapi_spec "$component"; then
-            overall_success=false
-            break
-        fi
-    done
+    if [ "$overall_success" = true ]; then
+        for component in "${COMPONENTS[@]}"; do
+            if ! generate_openapi_spec "$component"; then
+                overall_success=false
+                break
+            fi
+        done
+    fi
 
     # Generate openapi.yaml for each component
     if [ "$overall_success" = true ]; then


### PR DESCRIPTION
## Summary
Introduces overdraft support in Midaz through a **direction-based balance model**. Each balance now declares a `direction` (`credit` or `debit`) that determines how operations affect its `available` amount, with a hard floor at zero. **Balances never go negative** — when a debit would exceed a credit balance's available amount, the transaction is enriched with an additional operation on a companion `overdraft` balance (`direction: debit`), preserving the accounting invariant that `Assets = Liabilities + Equity` holds with all positive numbers.

### Domain model
- New `direction` field on Balance (`credit` | `debit`, immutable, defaults to `credit`)
- New `overdraft_used` decimal field tracking per-balance overdraft contribution
- New balance settings: `balanceScope` (`transactional` | `internal`), `allowOverdraft`, `overdraftLimitEnabled`, `overdraftLimit`
- Auto-managed `overdraft` companion balance (`direction: debit`, `balanceScope: internal`) created on demand when `allowOverdraft=true`
- New `position` field computed on read (`available - overdraft_used`)

### Transaction enrichment
- Debit exceeding credit balance → split: debit credit balance to `0`, debit remainder on overdraft companion
- Debit on already-zero credit balance → redirect entire amount to overdraft companion
- Credit on balance with `overdraft_used > 0` → split: credit repays overdraft first, remainder to credit balance
- All enrichment happens atomically inside the existing Lua script (direction-aware, version-checked)
- Operation snapshots persisted on companion ops so audit trail reads in chronological order

### Validation & protection
- `balanceScope: internal` balances are read-only via API (no direct transactions, no deletes)
- Reserved key `"overdraft"` cannot be used by clients
- `direction` is immutable after creation
- Cannot disable overdraft while `overdraft_used > 0`
- Cannot reduce `overdraftLimit` below current `overdraft_used`

### Events
- `overdraft.created` — overdraft operations added to a transaction
- `overdraft.refunded` — refund operations added to a transaction
- `overdraft.cleared` — overdraft balance zeroed out

### New error codes (`pkg/constant/errors.go`)
- `0167` `ErrOverdraftLimitExceeded`
- `0168` `ErrDirectOperationOnInternalBalance`
- `0169` `ErrDeletionOfInternalBalance`
- `0170` `ErrReservedBalanceKey`
- `0171` `ErrInvalidBalanceDirection`
- `0172` `ErrInvalidBalanceSettings`
- `0173` `ErrOverdraftDisableWithUsage`
- `0174` `ErrOverdraftLimitBelowUsage`
- `0175` `ErrStaleBalanceVersion`

### Accounting integration
- New `overdraft` and `refund` accounting entries registered on operation routes alongside `direct`/`hold`/`cancel`/`commit`/`revert`
- `routeId` propagated to companion ops for COSIF code resolution

### Persistence & cache
- Migration `000033` adds `direction`, `overdraft_used`, `settings` (JSONB), and `snapshot` JSONB on operations
- `CHECK` constraint enforces `overdraft_used >= 0`
- Unique index on `(account, asset, key)` prevents duplicate overdraft balances
- Settings written through to Redis with CamelCase JSON (Lua-compatible)
- Direction, overdraft_used, and settings flow through the cache→domain mapping

## Backwards Compatibility
- Existing balances default to `direction=credit`, `overdraft_used=0`, `balanceScope=transactional`
- Accounts without overdraft enabled behave exactly as before
- No changes to existing API contracts beyond additive fields

## Testing
- Unit tests for split/repay/limit/direction pure functions and JSON deserializers
- Integration tests for Lua overdraft split, direction arithmetic, stale-version detection, and JSONB round-trip
- Concurrency test for duplicate overdraft auto-creation under unique-violation recovery