### PR TITLE
fix: remove semicolon from SQL comment in migration 000033

### DIFF
--- a/components/ledger/migrations/transaction/000033_add_snapshot_to_operation.up.sql
+++ b/components/ledger/migrations/transaction/000033_add_snapshot_to_operation.up.sql
@@ -5,7 +5,7 @@
 -- No table rewrite is triggered because the default value is a constant.
 -- Pre-existing rows receive the default '{}' on read without physical update.
 --
--- No GIN index: the column is read-per-row; if future queries need filtering by
+-- No GIN index: the column is read-per-row. If future queries need filtering by
 -- snapshot keys, add an index in a follow-up migration.
 ALTER TABLE operation
     ADD COLUMN snapshot JSONB NOT NULL DEFAULT '{}'::jsonb;


### PR DESCRIPTION
## Problem

Migration `000033_add_snapshot_to_operation.up.sql` contains a semicolon inside a SQL comment:

```sql
-- No GIN index: the column is read-per-row; if future queries need filtering by
```

Migration runners that split statements on `;` (e.g. `golang-migrate` with `x-multi-statement`) incorrectly split at this semicolon, producing an invalid statement starting with `if future queries need filtering by...`, which fails with:

```
syntax error at or near "if" (column 2) in line 1
```

This affects AWS RDS environments where multi-statement splitting is enabled, while self-hosted PostgreSQL (where the file is sent as a single execution) works fine.

## Fix

Replace `;` with `.` in the comment — no functional change to the migration itself.

Requested by: @ClaraTersi