### PR TITLE
chore: promote develop to release-candidate

### DIFF
--- a/components/ledger/migrations/transaction/000033_add_snapshot_to_operation.up.sql
+++ b/components/ledger/migrations/transaction/000033_add_snapshot_to_operation.up.sql
@@ -5,7 +5,7 @@
 -- No table rewrite is triggered because the default value is a constant.
 -- Pre-existing rows receive the default '{}' on read without physical update.
 --
--- No GIN index: the column is read-per-row; if future queries need filtering by
+-- No GIN index: the column is read-per-row. If future queries need filtering by
 -- snapshot keys, add an index in a follow-up migration.
 ALTER TABLE operation
     ADD COLUMN snapshot JSONB NOT NULL DEFAULT '{}'::jsonb;


### PR DESCRIPTION
## Summary

Promote current `develop` into `release-candidate`, including the migration fix from #2089.

### Notable change

• *fix(migration):* removed semicolon from SQL comment in migration 000033 that caused failures on AWS RDS environments with multi-statement splitting enabled.

Requested by: @ClaraTersi