### PR TITLE
fix: operation route delete when operation missing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,671 +1,189 @@
-# CLAUDE.md — Midaz Deep Technical Reference
+# CLAUDE.md - Midaz Agent Reference
 
-This file is a deep technical reference for AI coding agents working on the Midaz codebase.
-For a quick-start overview, see [AGENTS.md](AGENTS.md).
-For full API and env var reference, see [llms-full.txt](llms-full.txt).
-For project rules and coding standards, see [docs/PROJECT_RULES.md](docs/PROJECT_RULES.md).
+Concise rules for AI agents working in Midaz. For expanded references, use `AGENTS.md`, `llms-full.txt`, and `docs/PROJECT_RULES.md`.
 
----
+## Project
 
-## What Is Midaz
+- Midaz is an enterprise double-entry ledger system.
+- Module: `github.com/LerianStudio/midaz/v3`.
+- Go: 1.25+.
+- License: Elastic License 2.0.
+- Main component: `components/ledger`.
+- CRM component: `components/crm`.
+- Shared code: `pkg`.
 
-Midaz is an enterprise-grade open-source **double-entry ledger system**. It is the core ledger component of a banking platform. The hierarchy is: Organization → Ledger → (Assets, Portfolios, Segments) → Accounts → Transactions → Operations → Balances.
+## Architecture
 
-- **Module path**: `github.com/LerianStudio/midaz/v3`
-- **Go version**: 1.25+
-- **License**: Elastic License 2.0 (ELv2) — not MIT/Apache
+Flow: HTTP handlers -> command/query use cases -> repository interfaces -> adapters.
 
-## Repository Layout
+- Handlers: `components/ledger/internal/adapters/http/in`.
+- Write use cases: `components/ledger/internal/services/command`.
+- Read use cases: `components/ledger/internal/services/query`.
+- PostgreSQL adapters: `components/ledger/internal/adapters/postgres`.
+- Metadata adapters: MongoDB repositories.
+- Domain models live in `pkg/mmodel`; do not create `/internal/domain`.
+- Interfaces are defined where used. Repository interfaces usually sit in the adapter or service package that owns the contract.
+- Dependencies flow inward; do not import outer layers from inner layers.
+- Do not put domain logic in handlers or repositories.
 
-```
-midaz/
-├── components/
-│   ├── ledger/           # Main component — unified onboarding + transaction API
-│   │   ├── cmd/app/      # main.go
-│   │   ├── internal/
-│   │   │   ├── adapters/ # http/in, postgres, mongodb, redis, rabbitmq
-│   │   │   ├── bootstrap/# Config struct, InitServers, DI, workers
-│   │   │   └── services/ # command/ (writes), query/ (reads)
-│   │   ├── migrations/   # onboarding/ and transaction/ SQL migrations
-│   │   └── api/          # Swagger docs
-│   ├── crm/              # CRM plugin (MongoDB-backed)
-│   └── infra/            # Docker Compose infrastructure
-├── pkg/                  # Shared packages — imported by all components
-│   ├── mmodel/           # Domain models (Organization, Ledger, Account, Transaction, Balance, etc.)
-│   ├── constant/         # Error codes (0001–0161), action constants, HTTP constants
-│   ├── errors.go         # Typed error structs + factory functions
-│   ├── gold/             # ANTLR4 transaction DSL (grammar + parser + builder)
-│   ├── net/http/         # Fiber middleware, pagination, protected route chain
-│   ├── transaction/      # Transaction processing utilities
-│   └── ...               # mongo, repository, pagination, utils
-├── tests/                # Integration + chaos test suites
-├── docs/PROJECT_RULES.md # 1130-line coding standards (DO NOT overwrite)
-├── Makefile              # Root orchestrator
-└── go.mod                # Single go.mod for entire monorepo
-```
+## Key Files
 
-## Architecture Patterns
+- Composition root/config: `components/ledger/internal/bootstrap/config.go`.
+- Routes: `components/ledger/internal/adapters/http/in/routes.go`.
+- Error codes: `pkg/constant/errors.go`.
+- Entity constants: `pkg/constant/entity.go`.
+- Error factories/types: `pkg/errors.go`.
+- Coding standards: `docs/PROJECT_RULES.md`.
+- Full API/env reference: `llms-full.txt`.
 
-### Hexagonal Architecture with CQRS
+## Coding Rules
 
-```
-HTTP Handlers → Command/Query Use Cases → Repository Interfaces → Adapters (Postgres/Mongo/Redis/RabbitMQ)
-```
+- Use `any`, never `interface{}`.
+- Use `uuid.UUID` for IDs, not strings.
+- Context is always the first parameter; check `ctx.Err()` before expensive work.
+- Validate in this order: normalize -> defaults -> validate -> execute.
+- Business errors return directly; technical errors wrap with `%w` where adding context is useful.
+- Use `constant.Entity*` instead of `reflect.TypeOf(mmodel.Foo{}).Name()`.
+- Error sentinels must be unique and defined in `pkg/constant/errors.go`.
+- Source files use `snake_case.go`; imports are stdlib -> external -> internal.
+- Capture `time.Now()` once on create and reuse for `CreatedAt` and `UpdatedAt`.
+- Do not use `time.Now()` in tests; use fixed times/utilities.
+- PATCH optional `*string` fields: use `!= nil`, not `IsNilOrEmpty`, so empty strings can clear values.
+- HTTP methods use `http.Method*` constants, not string literals.
+- Metadata is flat only: no nesting, key max 100, value max 2000.
+- Soft delete uses `DeletedAt` and status `DELETED` semantics.
+- Pagination for new endpoints is cursor/page constrained by max limit 100; do not introduce offset pagination.
 
-- **Handlers** (`components/ledger/internal/adapters/http/in/`): Parse HTTP, validate input, call use cases
-- **Services** (`components/ledger/internal/services/command/` and `query/`): Business logic, one file per operation
-- **Repositories**: Interfaces defined where used (in services), implemented in adapters
-- **Models** (`pkg/mmodel/`): Shared domain types, no business logic
+## Declaration And Docs
 
-### Key Principles
-- Dependencies flow inward: handlers → services → repos → DB drivers
-- No `/internal/domain` folder — entities live in `pkg/mmodel/`
-- Interfaces defined in the package that USES them, not in `/port` folders
-- One handler per entity, one service operation per file
+Within files, prefer this order:
 
-## Bootstrap & Configuration
+1. Exported interface.
+2. Exported types.
+3. Constructor.
+4. Exported methods.
+5. Unexported helpers.
 
-The Config struct is in `components/ledger/internal/bootstrap/config.go`. It loads all env vars via `libCommons.SetConfigFromEnvVars(cfg)`.
+Documentation rules:
 
-**InitServersWithOptions** (config.go:234) is the composition root:
-1. Loads Config from env vars
-2. Validates multi-tenant + auth coupling
-3. Creates logger, telemetry
-4. Initializes tenant client (if multi-tenant)
-5. Initializes PG (onboarding + transaction), MongoDB (onboarding + transaction), Redis, RabbitMQ
-6. Creates Command + Query use cases
-7. Creates HTTP handlers
-8. Registers routes (onboarding, transaction, metadata)
-9. Creates workers (RedisQueueConsumer, BalanceSyncWorker)
-10. Returns Service struct
+- Put repository/service method comments on the interface contract.
+- Do not duplicate interface method comments on implementations unless implementation-specific behavior needs explanation.
+- Keep comments short and behavioral; avoid comments that restate obvious code.
 
-## HTTP Framework
+## SQL And Repositories
 
-Uses **Fiber v2** (`github.com/gofiber/fiber/v2`).
+- Use `squirrel` for SQL construction: SELECT, INSERT, UPDATE, DELETE.
+- Do not manually concatenate SQL placeholders with `strconv.Itoa`.
+- Use `PlaceholderFormat(squirrel.Dollar)` for PostgreSQL.
+- After `ToSql()` succeeds, optionally log assembled SQL at `Debug`; log query string only, never args.
+- Check `RowsAffected()` for update/delete operations that should report not found; zero rows should map to the repository sentinel expected by the service layer.
+- Repository/adapter code should be covered with integration tests using real dependencies/testcontainers. Unit tests are appropriate only for pure helpers/business branches.
 
-### Route Registration
-- `RegisterOnboardingRoutesToApp()` — organizations, ledgers, assets, portfolios, segments, accounts, account types
-- `RegisterTransactionRoutesToApp()` — transactions, operations, asset-rates, balances, operation-routes, transaction-routes
-- `RegisterMetadataRoutesToApp()` — metadata indexes
+## Logging
 
-### Route Protection
-All routes use `http.ProtectedRouteChain()` which applies:
-1. Auth middleware (RBAC via lib-auth)
-2. Optional post-auth middlewares (multi-tenant DB resolution)
-3. Body parsing, UUID path parameter validation, handler
+Use structured logs:
 
-### Middleware
-- Telemetry middleware (`libHTTP.NewTelemetryMiddleware`)
-- CORS (`cors.New()`)
-- HTTP logging (`libHTTP.WithHTTPLogging`)
-- Body limit (`http.WithBodyLimit(SettingsMaxPayloadSize)`)
-
-## Error Handling
-
-### Error Types (pkg/errors.go)
-| Type | HTTP | Use |
-|------|------|-----|
-| `EntityNotFoundError` | 404 | Entity not found |
-| `ValidationError` | 400 | Input validation |
-| `EntityConflictError` | 409 | Duplicates |
-| `UnauthorizedError` | 401 | Auth missing |
-| `ForbiddenError` | 403 | Insufficient privileges |
-| `UnprocessableOperationError` | 422 | Business rule violation |
-| `InternalServerError` | 500 | Unexpected failures |
-| `ServiceUnavailableError` | 503 | Infrastructure down |
-
-### Error Constants (pkg/constant/errors.go)
-Numeric codes as `errors.New("0007")`. Factory: `pkg.ValidateBusinessError(constant.ErrEntityNotFound, "Entity")`.
-
-### Pattern
 ```go
-// Business error — return directly (expected)
-if errors.Is(err, constant.ErrEntityNotFound) {
-    return nil, pkg.ValidateBusinessError(constant.ErrEntityNotFound, "Account")
-}
-// Technical error — wrap with context
-return nil, fmt.Errorf("failed to query accounts: %w", err)
+logger.Log(ctx, libLog.LevelError, "Failed to execute query", libLog.Err(err))
+logger.Log(ctx, libLog.LevelWarn, "Operation route not found", libLog.String("operation_route_id", id.String()))
 ```
 
-## Domain Models (pkg/mmodel/)
+Do not use:
 
-Key entities and their files:
-- `organization.go` — Organization, Address, CreateOrganizationInput, UpdateOrganizationInput
-- `ledger.go` — Ledger, LedgerSettings, CreateLedgerInput, UpdateLedgerInput
-- `account.go` — Account, CreateAccountInput, UpdateAccountInput
-- `asset.go` — Asset, CreateAssetInput, UpdateAssetInput
-- `balance.go` — Balance, UpdateBalance, CreateAdditionalBalance
-- `operation.go` — Operation
-- `portfolio.go` — Portfolio
-- `segment.go` — Segment
-- `status.go` — Status struct (code-based status pattern)
-- `transaction-route.go` — TransactionRoute, CreateTransactionRouteInput
-- `operation-route.go` — OperationRoute, CreateOperationRouteInput
-- `account-type.go` — AccountType, CreateAccountTypeInput
-- `holder.go` — Holder (CRM)
-- `queue.go` — Queue message models
-- `settings.go` — LedgerSettings
-- `alias.go` — Alias models
-- `date.go` — Date range utilities
-- `metadata.go` — Metadata index models
-
-### Status Pattern
 ```go
-type Status struct {
-    Code        string  `json:"code"`
-    Description *string `json:"description"`
-}
+logger.Log(ctx, libLog.LevelError, fmt.Sprintf("Failed to execute query: %v", err))
 ```
-Common codes: `ACTIVE`, `INACTIVE`, `DELETED`, `PENDING`, `CANCELLED`.
-When omitted on create, `Code` defaults to `"ACTIVE"`.
 
-### Metadata
-- Flat key-value pairs (no nesting allowed)
-- Key max: 100 chars, Value max: 2000 chars
-- Stored in MongoDB, queried via metadata indexes
+Log levels:
 
-## Transaction Processing
+- `Debug`: troubleshooting details, assembled SQL, cache details, batch stats.
+- `Info`: sparse production milestones only.
+- `Warn`: caller/business validation failures or degraded-but-recoverable fallback.
+- `Error`: infrastructure/system failures requiring operator attention.
 
-### Creation Modes
-1. **JSON** (`POST .../transactions/json`): Full source/destination specification
-2. **DSL** (`POST .../transactions/dsl`): Gold DSL text format
-3. **Inflow** (`POST .../transactions/inflow`): Simplified credit-only
-4. **Outflow** (`POST .../transactions/outflow`): Simplified debit-only
-5. **Annotation** (`POST .../transactions/annotation`): Informational entries
+Never log secrets, credentials, tokens, balances, financial values, PII, raw payloads, or SQL args.
 
-### Transaction Lifecycle
-- `ACTIVE`: Completed immediately
-- `PENDING`: Created with pending status → `commit` or `cancel`
-- `revert`: Creates a reverse transaction (parentTransactionID linkage)
+Avoid repeating broad scope IDs (`organization_id`, `ledger_id`, tenant IDs) on every log when spans already carry them. Logs may include the immediate failing resource ID when useful for search, e.g. `operation_route_id`.
 
-### Async Processing
-When `RABBITMQ_TRANSACTION_ASYNC=true`:
-1. Transaction created, published to RabbitMQ
-2. Workers consume messages, update balances
-3. Bulk recorder batches inserts for 10x throughput
-4. Circuit breaker protects against RabbitMQ outages
+## Observability
 
-### Balance Model
-- `Available`: Spendable balance
-- `OnHold`: Pending transaction holds
-- `Scale`: Decimal precision
-- `Version`: Optimistic concurrency (lock version)
-- History queries: balance state at any timestamp
+Span lifecycle:
+
+- Always `defer span.End()` immediately after `tracer.Start`.
+- For child I/O spans, preserve parent context: use `_, spanExec := tracer.Start(ctx, "...")`, not `ctx, spanExec := ...`.
+- Do not create child spans for in-memory mapping/validation.
+- Do not add redundant "Initiating..." logs; spans already mark operation starts.
+
+Span attributes:
+
+- Use `app.request.*` for inputs from handlers or method arguments: IDs, query params, payload-derived values.
+- Use non-request namespaces for outputs/system observations: `db.rows_affected`, `db.rows_returned`, `app.operation_route_has_transaction_route_links`.
+- Do not attach sensitive data, raw payloads, SQL args, balances, financial values, or PII.
+
+Example:
+
+```go
+span.SetAttributes(
+    attribute.String("app.request.organization_id", organizationID.String()),
+    attribute.String("app.request.ledger_id", ledgerID.String()),
+)
+spanExec.SetAttributes(attribute.Int64("db.rows_affected", rowsAffected))
+```
+
+## Errors
+
+- API errors use typed errors from `pkg/errors.go` and constants from `pkg/constant/errors.go`.
+- Use `pkg.ValidateBusinessError(constant.Err..., constant.Entity...)`.
+- Not found maps to `EntityNotFoundError` / HTTP 404.
+- Business rule violations map to `UnprocessableOperationError` / HTTP 422.
+- Do not expose internal technical error details to API clients.
+- Do not create duplicate `errors.New("code")` sentinels outside `pkg/constant/errors.go`.
+
+## HTTP
+
+- Framework: Fiber v2.
+- All routes use `http.ProtectedRouteChain()`.
+- Route protection includes auth, optional post-auth middlewares, body parsing, UUID path validation, and handler.
+- Use existing route helpers and middleware patterns in `components/ledger/internal/adapters/http/in`.
+
+## Domain Notes
+
+- Hierarchy: Organization -> Ledger -> Assets/Portfolios/Segments -> Accounts -> Transactions -> Operations -> Balances.
+- Status common codes: `ACTIVE`, `INACTIVE`, `DELETED`, `PENDING`, `CANCELLED`.
+- Transaction creation modes: JSON, DSL, inflow, outflow, annotation.
+- Pending transactions can be committed/cancelled; revert creates a reverse transaction.
+- Async transaction processing is controlled by `RABBITMQ_TRANSACTION_ASYNC`.
+- Balance fields: `Available`, `OnHold`, `Scale`, `Version`.
 
 ## Multi-Tenancy
 
-Enabled via `MULTI_TENANT_ENABLED=true`. Requires auth enabled.
-
-**Architecture**:
-- Tenant ID extracted from JWT by auth middleware
-- `TenantMiddleware.WithTenantDB` resolves per-tenant PG/Mongo connections
-- `tmpostgres.Manager` / `tmmongo.Manager` manage connection pools per tenant
-- `TenantCache` + `TenantLoader` provide process-local caching
-- `TenantEventListener` subscribes to Redis Pub/Sub for tenant lifecycle events
-- On tenant add: start RabbitMQ consumer, warm cache
-- On tenant remove: stop consumer, close all connections, invalidate cache
-
-**Modules**: Each module (`onboarding`, `transaction`) has independent PG and Mongo managers.
-
-## lib-commons v4 Integration
-
-Import prefix: `github.com/LerianStudio/lib-commons/v4/commons/...`
-
-Key packages used:
-- `libCommons` — `SetConfigFromEnvVars`, `NewTrackingFromContext`
-- `libLog` — Structured logging interface
-- `libZap` — Zap logger implementation
-- `libOpentelemetry` — Telemetry, span management
-- `libRedis` — Redis client (standalone/sentinel/cluster)
-- `libHTTP` — HTTP response helpers, middleware, Fiber error handler
-- `libCircuitBreaker` — Circuit breaker pattern
-- `tmclient` — Tenant manager HTTP client
-- `tmcore` — Tenant manager core types/errors
-- `tmevent` — Tenant event dispatcher/listener
-- `tmmiddleware` — Fiber middleware for tenant DB injection
-- `tmpostgres` / `tmmongo` / `tmredis` — Per-tenant connection managers
-
-## Database Schemas
-
-### PostgreSQL
-- **onboarding** database: organizations, ledgers, assets, portfolios, segments, accounts, account_types
-- **transaction** database: transactions, operations, balances, asset_rates, operation_routes, transaction_routes
-
-Migrations in `components/ledger/migrations/onboarding/` and `components/ledger/migrations/transaction/`.
-
-### MongoDB
-- **onboarding** database: metadata collections
-- **transaction** database: metadata collections
-- **crm** database: holders, aliases, related parties
-
-## Environment Variables — Complete Reference
-
-Source: `components/ledger/internal/bootstrap/config.go` (Ledger) and `components/crm/internal/bootstrap/config.go` (CRM).
-Defaults shown in parentheses where set by `applyConfigDefaults()` or env tags.
-
-### Application
-
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `APPLICATION_NAME` | — | Application identity (used for tenant-manager service name) |
-| `ENV_NAME` | development | Environment: development, staging, uat, production, local |
-| `VERSION` | — | Application version string |
-| `LOG_LEVEL` | debug | Log level |
-| `SERVER_ADDRESS` | :3002 | Listen address (Ledger) |
-
-### Auth / Casdoor
-
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `PLUGIN_AUTH_ENABLED` | false | Enable auth middleware |
-| `PLUGIN_AUTH_HOST` | — | Auth service host (Ledger) |
-| `CASDOOR_JWK_ADDRESS` | — | JWK endpoint for Casdoor JWT validation |
-
-### PostgreSQL — Onboarding (Primary + Replica)
-
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `DB_ONBOARDING_HOST` | midaz-postgres-primary | Primary host |
-| `DB_ONBOARDING_USER` | midaz | Username |
-| `DB_ONBOARDING_PASSWORD` | lerian | Password |
-| `DB_ONBOARDING_NAME` | onboarding | Database name |
-| `DB_ONBOARDING_PORT` | 5701 | Port |
-| `DB_ONBOARDING_SSLMODE` | disable | SSL mode |
-| `DB_ONBOARDING_REPLICA_HOST` | midaz-postgres-replica | Replica host |
-| `DB_ONBOARDING_REPLICA_USER` | midaz | Replica username |
-| `DB_ONBOARDING_REPLICA_PASSWORD` | lerian | Replica password |
-| `DB_ONBOARDING_REPLICA_NAME` | onboarding | Replica database name |
-| `DB_ONBOARDING_REPLICA_PORT` | 5702 | Replica port |
-| `DB_ONBOARDING_REPLICA_SSLMODE` | disable | Replica SSL mode |
-| `DB_ONBOARDING_MAX_OPEN_CONNS` | 3000 | Max open connections |
-| `DB_ONBOARDING_MAX_IDLE_CONNS` | 3000 | Max idle connections |
-
-### PostgreSQL — Transaction (Primary + Replica)
-
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `DB_TRANSACTION_HOST` | midaz-postgres-primary | Primary host |
-| `DB_TRANSACTION_USER` | midaz | Username |
-| `DB_TRANSACTION_PASSWORD` | lerian | Password |
-| `DB_TRANSACTION_NAME` | transaction | Database name |
-| `DB_TRANSACTION_PORT` | 5701 | Port |
-| `DB_TRANSACTION_SSLMODE` | disable | SSL mode |
-| `DB_TRANSACTION_REPLICA_HOST` | midaz-postgres-replica | Replica host |
-| `DB_TRANSACTION_REPLICA_USER` | midaz | Replica username |
-| `DB_TRANSACTION_REPLICA_PASSWORD` | lerian | Replica password |
-| `DB_TRANSACTION_REPLICA_NAME` | transaction | Replica database name |
-| `DB_TRANSACTION_REPLICA_PORT` | 5702 | Replica port |
-| `DB_TRANSACTION_REPLICA_SSLMODE` | disable | Replica SSL mode |
-| `DB_TRANSACTION_MAX_OPEN_CONNS` | 3000 | Max open connections |
-| `DB_TRANSACTION_MAX_IDLE_CONNS` | 3000 | Max idle connections |
-
-### MongoDB — Onboarding
-
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `MONGO_ONBOARDING_URI` | mongodb | Connection URI scheme |
-| `MONGO_ONBOARDING_HOST` | midaz-mongodb | Host |
-| `MONGO_ONBOARDING_NAME` | onboarding | Database name |
-| `MONGO_ONBOARDING_USER` | midaz | Username |
-| `MONGO_ONBOARDING_PASSWORD` | lerian | Password |
-| `MONGO_ONBOARDING_PORT` | 5703 | Port |
-| `MONGO_ONBOARDING_PARAMETERS` | — | Extra connection params (appended to URI) |
-| `MONGO_ONBOARDING_MAX_POOL_SIZE` | 1000 | Max pool size |
-
-### MongoDB — Transaction
-
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `MONGO_TRANSACTION_URI` | mongodb | Connection URI scheme |
-| `MONGO_TRANSACTION_HOST` | midaz-mongodb | Host |
-| `MONGO_TRANSACTION_NAME` | transaction | Database name |
-| `MONGO_TRANSACTION_USER` | midaz | Username |
-| `MONGO_TRANSACTION_PASSWORD` | lerian | Password |
-| `MONGO_TRANSACTION_PORT` | 5703 | Port |
-| `MONGO_TRANSACTION_PARAMETERS` | — | Extra connection params |
-| `MONGO_TRANSACTION_MAX_POOL_SIZE` | 1000 | Max pool size |
-
-### Redis / Valkey
-
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `REDIS_HOST` | midaz-valkey:5704 | Host(s); comma-separated for cluster/sentinel |
-| `REDIS_MASTER_NAME` | — | Sentinel master name (enables sentinel mode) |
-| `REDIS_PASSWORD` | lerian | Password |
-| `REDIS_DB` | 0 | Database index |
-| `REDIS_PROTOCOL` | (3) | RESP protocol version |
-| `REDIS_TLS` | false | Enable TLS |
-| `REDIS_CA_CERT` | — | CA certificate (base64) for TLS |
-| `REDIS_USE_GCP_IAM` | false | Use GCP IAM auth instead of password |
-| `REDIS_SERVICE_ACCOUNT` | — | GCP service account for IAM auth |
-| `GOOGLE_APPLICATION_CREDENTIALS` | — | GCP credentials (base64) for IAM auth |
-| `REDIS_TOKEN_LIFETIME` | (60) | GCP IAM token lifetime (minutes) |
-| `REDIS_TOKEN_REFRESH_DURATION` | (45) | GCP IAM token refresh interval (minutes) |
-| `REDIS_POOL_SIZE` | (10) | Connection pool size |
-| `REDIS_MIN_IDLE_CONNS` | 0 | Minimum idle connections |
-| `REDIS_READ_TIMEOUT` | (3) | Read timeout (seconds) |
-| `REDIS_WRITE_TIMEOUT` | (3) | Write timeout (seconds) |
-| `REDIS_DIAL_TIMEOUT` | (5) | Dial timeout (seconds) |
-| `REDIS_POOL_TIMEOUT` | (2) | Pool wait timeout (seconds) |
-| `REDIS_MAX_RETRIES` | (3) | Max retries per command |
-| `REDIS_MIN_RETRY_BACKOFF` | (8) | Min retry backoff (milliseconds) |
-| `REDIS_MAX_RETRY_BACKOFF` | (1) | Max retry backoff (seconds) |
-
-### RabbitMQ
-
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `RABBITMQ_URI` | amqp | Protocol scheme (amqp/amqps) |
-| `RABBITMQ_HOST` | midaz-rabbitmq | Host |
-| `RABBITMQ_PORT_HOST` | 3003 | Management port |
-| `RABBITMQ_PORT_AMQP` | 3004 | AMQP port |
-| `RABBITMQ_DEFAULT_USER` | transaction | Producer username |
-| `RABBITMQ_DEFAULT_PASS` | lerian | Producer password |
-| `RABBITMQ_CONSUMER_USER` | consumer | Consumer username |
-| `RABBITMQ_CONSUMER_PASS` | lerian | Consumer password |
-| `RABBITMQ_VHOST` | — | Virtual host (empty = default "/") |
-| `RABBITMQ_NUMBERS_OF_WORKERS` | 5 | Consumer worker count |
-| `RABBITMQ_NUMBERS_OF_PREFETCH` | 10 | Prefetch count per worker |
-| `RABBITMQ_HEALTH_CHECK_URL` | — | Health check URL |
-| `RABBITMQ_TLS` | false | Enable TLS |
-| `RABBITMQ_TRANSACTION_BALANCE_OPERATION_QUEUE` | — | Balance operation queue name |
-| `RABBITMQ_TRANSACTION_ASYNC` | false | Enable async transaction processing |
-| `RABBITMQ_OPERATION_TIMEOUT` | — | Operation timeout (e.g., "30s") |
-| `RABBITMQ_TRANSACTION_EVENTS_ENABLED` | false | Enable transaction event exchange |
-| `RABBITMQ_TRANSACTION_EVENTS_EXCHANGE` | — | Events exchange name |
-| `AUDIT_LOG_ENABLED` | false | Enable audit log publishing |
-| `RABBITMQ_AUDIT_EXCHANGE` | — | Audit exchange name |
-| `RABBITMQ_AUDIT_KEY` | — | Audit routing key |
-
-### RabbitMQ Circuit Breaker
-
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `RABBITMQ_CIRCUIT_BREAKER_CONSECUTIVE_FAILURES` | 15 | Consecutive failures before open |
-| `RABBITMQ_CIRCUIT_BREAKER_FAILURE_RATIO` | 50 | Failure % to trigger open (0-100) |
-| `RABBITMQ_CIRCUIT_BREAKER_INTERVAL` | 120 | Failure counting window (seconds) |
-| `RABBITMQ_CIRCUIT_BREAKER_MAX_REQUESTS` | 3 | Requests allowed in half-open |
-| `RABBITMQ_CIRCUIT_BREAKER_MIN_REQUESTS` | 10 | Min requests before ratio evaluated |
-| `RABBITMQ_CIRCUIT_BREAKER_TIMEOUT` | 30 | Open → half-open wait (seconds) |
-| `RABBITMQ_CIRCUIT_BREAKER_HEALTH_CHECK_INTERVAL` | 30 | Health check interval (seconds) |
-| `RABBITMQ_CIRCUIT_BREAKER_HEALTH_CHECK_TIMEOUT` | 10 | Health check timeout (seconds) |
-
-### Bulk Recorder
-
-Activates only when `RABBITMQ_TRANSACTION_ASYNC=true` AND `BULK_RECORDER_ENABLED=true`.
-
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `BULK_RECORDER_ENABLED` | (true) | Enable bulk mode |
-| `BULK_RECORDER_SIZE` | (workers×prefetch) | Batch size (0 = auto-calculated) |
-| `BULK_RECORDER_FLUSH_TIMEOUT_MS` | (100) | Max wait before flush (ms) |
-| `BULK_RECORDER_MAX_ROWS_PER_INSERT` | (1000) | Max rows per INSERT statement |
-
-### Balance Sync / Settings
-
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `BALANCE_SYNC_BATCH_SIZE` | (50) | Keys accumulated before flush (SIZE trigger) |
-| `BALANCE_SYNC_FLUSH_TIMEOUT_MS` | (500) | Max ms before flushing incomplete batch (TIMEOUT trigger) |
-| `BALANCE_SYNC_POLL_INTERVAL_MS` | (50) | ZSET polling interval when draining |
-| `SETTINGS_CACHE_TTL` | (5m) | Settings cache duration (Go duration) |
-
-### Pagination
-
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `MAX_PAGINATION_LIMIT` | 100 | Max items per page |
-| `MAX_PAGINATION_MONTH_DATE_RANGE` | 3 | Max date range for queries (months) |
-
-### Telemetry (OpenTelemetry)
-
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `OTEL_RESOURCE_SERVICE_NAME` | ledger | Service name in traces |
-| `OTEL_LIBRARY_NAME` | — | Instrumentation library name |
-| `OTEL_RESOURCE_SERVICE_VERSION` | — | Service version in traces |
-| `OTEL_RESOURCE_DEPLOYMENT_ENVIRONMENT` | — | Deployment environment in traces |
-| `OTEL_EXPORTER_OTLP_ENDPOINT` | midaz-otel-lgtm:4317 | OTLP gRPC collector endpoint |
-| `ENABLE_TELEMETRY` | false | Enable telemetry export |
-
-### Multi-Tenant (Ledger)
-
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `MULTI_TENANT_ENABLED` | false | Enable multi-tenant mode |
-| `MULTI_TENANT_URL` | — | Tenant Manager API URL |
-| `MULTI_TENANT_SERVICE_API_KEY` | — | Service API key for tenant-manager |
-| `MULTI_TENANT_CIRCUIT_BREAKER_THRESHOLD` | (5) | CB failures before open |
-| `MULTI_TENANT_CIRCUIT_BREAKER_TIMEOUT_SEC` | (30) | CB open → half-open (seconds) |
-| `MULTI_TENANT_CONNECTIONS_CHECK_INTERVAL_SEC` | — | Interval for revalidation checks |
-| `MULTI_TENANT_CACHE_TTL_SEC` | (120) | Tenant config cache TTL (seconds) |
-| `MULTI_TENANT_REDIS_HOST` | — | Redis for tenant Pub/Sub events |
-| `MULTI_TENANT_REDIS_PORT` | 6379 | Redis port for Pub/Sub |
-| `MULTI_TENANT_REDIS_PASSWORD` | — | Redis password for Pub/Sub |
-| `MULTI_TENANT_REDIS_TLS` | false | Enable TLS for Pub/Sub Redis |
-
-### CRM-Specific Variables
-
-Source: `components/crm/internal/bootstrap/config.go`
-
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `ENV_NAME` | development | Environment name |
-| `SERVER_ADDRESS` | :4003 | HTTP listen address |
-| `LOG_LEVEL` | debug | Log level |
-| `MONGO_URI` | mongodb | Connection URI scheme |
-| `MONGO_HOST` | midaz-mongodb | MongoDB host |
-| `MONGO_NAME` | crm | Database name |
-| `MONGO_USER` | midaz | Username |
-| `MONGO_PASSWORD` | lerian | Password |
-| `MONGO_PORT` | 5703 | Port |
-| `MONGO_PARAMETERS` | — | Extra connection parameters |
-| `MONGO_MAX_POOL_SIZE` | 1000 | Max pool size |
-| `LCRYPTO_HASH_SECRET_KEY` | — | PII hash key (data security) |
-| `LCRYPTO_ENCRYPT_SECRET_KEY` | — | PII encryption key (data security) |
-| `PLUGIN_AUTH_ADDRESS` | — | Auth service address (CRM uses different var from Ledger) |
-| `PLUGIN_AUTH_ENABLED` | false | Enable auth |
-| `APPLICATION_NAME` | ledger | Application identity |
-| `MULTI_TENANT_ENABLED` | false | Enable multi-tenant |
-| `MULTI_TENANT_URL` | — | Tenant Manager API URL |
-| `MULTI_TENANT_TIMEOUT` | — | HTTP client timeout (seconds) |
-| `MULTI_TENANT_IDLE_TIMEOUT_SEC` | — | Idle connection eviction (seconds) |
-| `MULTI_TENANT_MAX_TENANT_POOLS` | — | Max concurrent tenant pools |
-| `MULTI_TENANT_CIRCUIT_BREAKER_THRESHOLD` | — | CB failures before open |
-| `MULTI_TENANT_CIRCUIT_BREAKER_TIMEOUT_SEC` | — | CB open → half-open (seconds) |
-| `MULTI_TENANT_SERVICE_API_KEY` | — | Service API key |
-| `MULTI_TENANT_CONNECTIONS_CHECK_INTERVAL_SEC` | — | Revalidation interval (seconds) |
-| `MULTI_TENANT_CACHE_TTL_SEC` | (120) | Tenant config cache TTL (seconds) |
-| `MULTI_TENANT_REDIS_HOST` | — | Redis for Pub/Sub |
-| `MULTI_TENANT_REDIS_PORT` | 6379 | Redis port |
-| `MULTI_TENANT_REDIS_PASSWORD` | — | Redis password |
-| `MULTI_TENANT_REDIS_TLS` | false | TLS for Redis |
-
-## Build & Make Targets — Complete Reference
-
-### Setup
-```bash
-make set-env              # Copy .env.example → .env for all components
-make clear-envs           # Remove all .env files
-make dev-setup            # Install tools (gitleaks, gofumpt, goimports, gosec, golangci-lint) + git hooks
-make setup-git-hooks      # Configure git hooks (core.hooksPath = .githooks)
-```
-
-### Build & Run
-```bash
-make build                # Build ledger + CRM binaries
-make up                   # Start all services (infra → ledger → CRM)
-make down                 # Stop all services (CRM → ledger → infra)
-make start                # Start existing containers
-make stop                 # Stop containers (no removal)
-make restart              # down + up
-make rebuild-up           # Rebuild images and restart
-make logs                 # Show logs for all services (tail 50)
-make clean                # Clean build artifacts (./scripts/clean-artifacts.sh)
-make clean-docker         # Clean Docker resources (containers, networks, volumes, prune)
-```
-
-### Code Quality
-```bash
-make lint                 # Lint all components + tests/ + pkg/ (golangci-lint v2.4.0)
-make format               # Format code in all components
-make tidy                 # go mod tidy
-make check-logs           # Verify error logging in usecases
-make check-tests          # Verify test coverage for components
-make check-hooks          # Verify git hooks installation
-make check-envs           # Check hooks + secret env files not exposed
-make sec                  # Run gosec + govulncheck
-make sec-gosec            # Run gosec only (SARIF=1 for GitHub Security tab)
-make sec-govulncheck      # Run govulncheck only
-```
-
-### Testing
-```bash
-make test                 # Run all tests (scripts/run-tests.sh)
-make test-unit            # Unit tests only (excludes tests/ and api/ dirs)
-make test-all             # Unit + integration tests
-make test-integration     # Integration tests (testcontainers, -p=1; RUN=, PKG=, CHAOS=1)
-make test-fuzz            # Native Go fuzz tests (FUZZ=target, FUZZTIME=10s)
-make test-bench           # Benchmark tests (BENCH=pattern, BENCH_PKG=./...)
-make test-chaos-system    # Chaos tests with full Docker stack (starts/stops services)
-```
-
-### Coverage
-```bash
-make cover                # Legacy coverage (scripts/coverage.sh → coverage.html)
-make coverage             # All coverage targets (unit + integration)
-make coverage-unit        # Unit test coverage (PKG=, uses .ignorecoverunit)
-make coverage-integration # Integration test coverage (PKG=, CHAOS=1)
-```
-
-### Component Delegation
-```bash
-make infra COMMAND=<cmd>          # Run make target in infra component
-make ledger COMMAND=<cmd>         # Run make target in ledger component
-make all-components COMMAND=<cmd> # Run make target across all components
-```
-
-### Documentation & Migrations
-```bash
-make generate-docs                 # Generate Swagger docs (scripts/generate-docs.sh)
-make migrate-lint                  # Lint SQL migrations for dangerous patterns
-make migrate-create COMPONENT=<onboarding|transaction> NAME=<name>  # Create new migration
-```
-
-### Test Tooling
-```bash
-make tools                # Install test tools (gotestsum)
-make tools-gotestsum      # Install gotestsum
-make wait-for-services    # Wait for backend services healthy (TEST_HEALTH_WAIT=60s)
-```
-
-## Coding Conventions
-
-Full rules in `docs/PROJECT_RULES.md` (1130 lines). Key points:
-
-1. **Go 1.25+**: Use `any` not `interface{}`, use generics for utilities
-2. **File naming**: `snake_case.go` with dot-separated component types (e.g., `balance_sync.worker.go`, `redis.consumer.go`)
-3. **Import groups**: stdlib → external → internal (blank-line separated)
-4. **Context**: Always first param, check `ctx.Err()` before work
-5. **Error wrapping**: `%w` for technical, direct return for business errors
-6. **Validation**: Normalize → Apply defaults → Validate → Execute
-7. **Struct tags**: `json`, `validate`, `example`, `format`, `maxLength`
-8. **Metadata**: Flat only (no nesting), key max 100, value max 2000
-9. **IDs**: Use `uuid.UUID` type, not strings
-10. **Soft delete**: `DeletedAt` field, status `DELETED`
-11. **Pagination**: Page-based (page + limit), max 100 per page
-12. **Structured logging**: Use `libLog.Err(err)`, `libLog.String()`, `libLog.Int()` fields instead of `fmt.Sprintf` inside log calls
-13. **MT naming**: Multi-tenant code uses `MT` suffix (`NewFooMT`, `runFooMT`, `mtEnabled`, `isMTReady`). Default (single-tenant) uses no qualifier.
-14. **Query builder**: Use `squirrel` for all SQL query construction (SELECT, INSERT, UPDATE). Do not use raw SQL string concatenation with `strconv.Itoa` for parameter placeholders.
-15. **Entity name constants**: Use `constant.Entity*` instead of `reflect.TypeOf(mmodel.Foo{}).Name()`. See `pkg/constant/entity.go`.
-16. **Timestamps on create**: Capture `time.Now()` once and reuse for both `CreatedAt` and `UpdatedAt` to guarantee identical values.
-17. **Declaration order**: Within a file, declare in this order: exported interface → exported types → constructor → exported methods → unexported helpers. The interface is the contract readers look for first.
-18. **Repository tests**: Repository/adapter code (thin wrappers around Redis, Postgres, etc.) should be covered by integration tests with testcontainers, not unit tests. Unit-testing mock interactions only verifies you called the mock correctly — it does not catch real issues like key format mismatches, TTL semantics, or Lua script behavior. Unit tests in adapter packages should be reserved for pure functions and business logic branches that don't require external dependencies.
-
-## Observability Conventions
-
-### Structured Logging
-Use structured fields instead of `fmt.Sprintf` inside log calls. Structured fields are preserved as
-separate attributes in the OTLP pipeline (searchable in Grafana/Loki), while `Sprintf` embeds them in
-the message string.
-
-```go
-// Good — structured fields
-logger.Log(ctx, libLog.LevelError, "Failed to create organization", libLog.Err(err))
-logger.Log(ctx, libLog.LevelInfo, "Organization created", libLog.String("id", org.ID))
-
-// Bad — fmt.Sprintf buries fields in the message
-logger.Log(ctx, libLog.LevelError, fmt.Sprintf("Failed to create organization: %v", err))
-```
-
-### Log Level Guidelines
-
-**Never log sensitive data (balances, financial values, PII) at any log level.**
-
-Use the correct log level based on **who caused the problem**, not just what went wrong:
-
-| Level | When to use | Example |
-|-------|------------|---------|
-| **Debug** | Operational details useful only during development or troubleshooting. | Cache key written, Lua script completed, batch stats |
-| **Info** | Significant state changes or milestones in a business flow. Should be sparse enough to read in production without filtering. | Transaction created, balance sync flushed, idempotency key claimed |
-| **Warn** | **Business validation failures** (the caller sent invalid data, not a system fault). The system is healthy; the request was rejected. Also used for degraded-but-recoverable situations (e.g., cache connection error with DB fallback). Note: a normal cache miss (TTL expiry) is not a warning — it is the expected flow and needs no log at all. | Insufficient funds, asset mismatch, account sending disabled, accounting rule violation, Redis connection error with DB fallback |
-| **Error** | **Infrastructure or system failures** that indicate something is broken and may need operator attention. The system could not fulfill a valid request. | Redis connection refused, DB query failed, Lua script execution error, message broker unavailable |
-
-Key principle: if the fix requires the **caller** to change their request → **Warn**. If the fix requires an **operator** to investigate the system → **Error**.
-
-```go
-// Business validation failure — Warn (caller's problem)
-logger.Log(ctx, libLog.LevelWarn, "Balance rule validation failed", libLog.Err(err))
-
-// Infrastructure failure — Error (system's problem)
-logger.Log(ctx, libLog.LevelError, "Failed to execute atomic balance operation", libLog.Err(err))
-
-// Operational detail — Debug (development only)
-logger.Log(ctx, libLog.LevelDebug, "Lua script executed successfully",
-    libLog.String("backup_queue", prefixedKeys[0]))
-```
-
-### Span Lifecycle
-- Always use `defer span.End()` immediately after `tracer.Start`.
-- Child spans for I/O operations (DB exec, external calls) should use `defer` and must not
-  overwrite the parent `ctx` (use `_, spanExec := tracer.Start(...)` instead of `ctx, spanExec`).
-- Do NOT create child spans for in-memory operations (validation, mapping). The parent span covers them.
-- Redundant "Initiating..." or "Trying to..." log messages add no value when the span already marks
-  the start of the operation. Omit them.
-
-### Entity Name Constants
-Use `constant.Entity*` constants (in `pkg/constant/entity.go`) instead of `reflect.TypeOf(mmodel.Foo{}).Name()`
-for error reporting, metadata tagging, and audit logging. The reflect approach allocates a zero-value struct
-on every call just to obtain a compile-time constant string.
-
-```go
-// Good
-err := pkg.ValidateBusinessError(constant.ErrInvalidCountryCode, constant.EntityOrganization)
-
-// Bad — allocates mmodel.Organization{} at runtime
-err := pkg.ValidateBusinessError(constant.ErrInvalidCountryCode, reflect.TypeOf(mmodel.Organization{}).Name())
-```
-
-### Error Sentinel Uniqueness
-Each error code must have exactly one `errors.New` sentinel, defined in `pkg/constant/errors.go`.
-Do NOT create duplicate sentinels in other packages (e.g., `utils.ErrInvalidCountryCode` vs
-`constant.ErrInvalidCountryCode`). `ValidateBusinessError` looks up errors by identity (pointer
-equality), not by string value — duplicates cause silent lookup failures and 500 responses.
-
-## What NOT To Do
-
-- Do NOT overwrite `docs/PROJECT_RULES.md` — it is maintained separately
-- Do NOT use `interface{}` — use `any`
-- Do NOT use offset-based pagination for new endpoints
-- Do NOT create domain logic in handler or repository layers
-- Do NOT panic — return errors from constructors
-- Do NOT use `time.Now()` in tests — use fixed time utilities
-- Do NOT store nested metadata values
-- Do NOT expose internal error details to API clients
-- Do NOT import outer layers from inner layers
-- Do NOT use string literals for HTTP methods — use `http.Method*` constants
-- Do NOT create duplicate error sentinels — use the single source in `pkg/constant/errors.go`
-- Do NOT use `reflect.TypeOf(mmodel.Foo{}).Name()` — use `constant.Entity*` constants
-- Do NOT use `fmt.Sprintf` inside logger calls — use structured fields (`libLog.Err`, `libLog.String`)
-- Do NOT overwrite `ctx` with child spans (`ctx, spanExec :=`) — use `_, spanExec :=` to preserve parent context
-- Do NOT use `IsNilOrEmpty` to guard optional `*string` fields in PATCH updates — use `!= nil` so empty strings can clear the field
+- Enabled via `MULTI_TENANT_ENABLED=true`; auth must also be enabled.
+- Tenant ID comes from JWT via auth middleware.
+- Tenant DB resolution uses tenant middleware and lib-commons tenant managers.
+- Modules `onboarding` and `transaction` have independent PostgreSQL and MongoDB managers.
+- Multi-tenant code uses `MT` suffix for names (`NewFooMT`, `runFooMT`, `mtEnabled`, `isMTReady`). Single-tenant code uses no qualifier.
+
+## Commands
+
+- Setup env: `make set-env`.
+- Start stack: `make up`.
+- Stop stack: `make down`.
+- Unit tests: `make test-unit`.
+- Integration tests: `make test-integration`.
+- Lint: `make lint`.
+- Format: `make format`.
+- Security: `make sec`.
+- Component delegation: `make ledger COMMAND=<target>`.
+
+## Do Not
+
+- Do not overwrite `docs/PROJECT_RULES.md`.
+- Do not panic; return errors.
+- Do not store nested metadata.
+- Do not import outer layers from inner layers.
+- Do not use raw SQL string concatenation for placeholders.
+- Do not use `reflect.TypeOf(mmodel.Foo{}).Name()` for entity names.
+- Do not use `fmt.Sprintf` inside logger calls.
+- Do not overwrite parent `ctx` with child spans.
+- Do not use non-request span attributes for input data.
+- Do not log SQL args, payload values, secrets, balances, financial values, or PII.

--- a/components/ledger/internal/adapters/http/in/operation_route_test.go
+++ b/components/ledger/internal/adapters/http/in/operation_route_test.go
@@ -865,7 +865,7 @@ func TestOperationRouteHandler_DeleteOperationRouteByID(t *testing.T) {
 			setupMocks: func(operationRouteRepo *operationroute.MockRepository, orgID, ledgerID, operationRouteID uuid.UUID) {
 				// Check for transaction route links
 				operationRouteRepo.EXPECT().
-					HasTransactionRouteLinks(gomock.Any(), operationRouteID).
+					HasTransactionRouteLinks(gomock.Any(), orgID, ledgerID, operationRouteID).
 					Return(false, nil).
 					Times(1)
 
@@ -883,7 +883,7 @@ func TestOperationRouteHandler_DeleteOperationRouteByID(t *testing.T) {
 			setupMocks: func(operationRouteRepo *operationroute.MockRepository, orgID, ledgerID, operationRouteID uuid.UUID) {
 				// Check for transaction route links
 				operationRouteRepo.EXPECT().
-					HasTransactionRouteLinks(gomock.Any(), operationRouteID).
+					HasTransactionRouteLinks(gomock.Any(), orgID, ledgerID, operationRouteID).
 					Return(false, nil).
 					Times(1)
 
@@ -907,7 +907,7 @@ func TestOperationRouteHandler_DeleteOperationRouteByID(t *testing.T) {
 			setupMocks: func(operationRouteRepo *operationroute.MockRepository, orgID, ledgerID, operationRouteID uuid.UUID) {
 				// Check for transaction route links - returns true
 				operationRouteRepo.EXPECT().
-					HasTransactionRouteLinks(gomock.Any(), operationRouteID).
+					HasTransactionRouteLinks(gomock.Any(), orgID, ledgerID, operationRouteID).
 					Return(true, nil).
 					Times(1)
 				// Delete should NOT be called
@@ -926,7 +926,7 @@ func TestOperationRouteHandler_DeleteOperationRouteByID(t *testing.T) {
 			name: "has links check error returns 500",
 			setupMocks: func(operationRouteRepo *operationroute.MockRepository, orgID, ledgerID, operationRouteID uuid.UUID) {
 				operationRouteRepo.EXPECT().
-					HasTransactionRouteLinks(gomock.Any(), operationRouteID).
+					HasTransactionRouteLinks(gomock.Any(), orgID, ledgerID, operationRouteID).
 					Return(false, pkg.InternalServerError{
 						Code:    "0046",
 						Title:   "Internal Server Error",
@@ -948,7 +948,7 @@ func TestOperationRouteHandler_DeleteOperationRouteByID(t *testing.T) {
 			name: "repository delete error returns 500",
 			setupMocks: func(operationRouteRepo *operationroute.MockRepository, orgID, ledgerID, operationRouteID uuid.UUID) {
 				operationRouteRepo.EXPECT().
-					HasTransactionRouteLinks(gomock.Any(), operationRouteID).
+					HasTransactionRouteLinks(gomock.Any(), orgID, ledgerID, operationRouteID).
 					Return(false, nil).
 					Times(1)
 

--- a/components/ledger/internal/adapters/postgres/operationroute/operationroute.postgresql.go
+++ b/components/ledger/internal/adapters/postgres/operationroute/operationroute.postgresql.go
@@ -46,7 +46,7 @@ type Repository interface {
 	Update(ctx context.Context, organizationID, ledgerID, id uuid.UUID, operationRoute *mmodel.OperationRoute) (*mmodel.OperationRoute, error)
 	Delete(ctx context.Context, organizationID, ledgerID, id uuid.UUID) error
 	FindAll(ctx context.Context, organizationID, ledgerID uuid.UUID, filter http.Pagination) ([]*mmodel.OperationRoute, libHTTP.CursorPagination, error)
-	HasTransactionRouteLinks(ctx context.Context, operationRouteID uuid.UUID) (bool, error)
+	HasTransactionRouteLinks(ctx context.Context, organizationID, ledgerID, operationRouteID uuid.UUID) (bool, error)
 	FindTransactionRouteIDs(ctx context.Context, operationRouteID uuid.UUID) ([]uuid.UUID, error)
 }
 
@@ -488,45 +488,68 @@ func (r *OperationRoutePostgreSQLRepository) Update(ctx context.Context, organiz
 	return record.ToEntity(), nil
 }
 
-// Delete an Operation Route entity from the database (soft delete) using the provided ID.
+// Delete soft-deletes an operation route using the provided IDs.
 func (r *OperationRoutePostgreSQLRepository) Delete(ctx context.Context, organizationID, ledgerID, id uuid.UUID) error {
 	logger, tracer, _, _ := libCommons.NewTrackingFromContext(ctx)
 
 	ctx, span := tracer.Start(ctx, "postgres.delete_operation_route")
 	defer span.End()
 
+	if err := ctx.Err(); err != nil {
+		libOpentelemetry.HandleSpanError(span, "Context finished before deleting operation route", err)
+
+		return err
+	}
+
 	db, err := r.getDB(ctx)
 	if err != nil {
 		libOpentelemetry.HandleSpanError(span, "Failed to get database connection", err)
 
-		logger.Log(ctx, libLog.LevelError, fmt.Sprintf("Failed to get database connection: %v", err))
+		logger.Log(ctx, libLog.LevelError, "Failed to get database connection", libLog.Err(err))
 
 		return err
 	}
 
-	query := "UPDATE operation_route SET deleted_at = now() WHERE organization_id = $1 AND ledger_id = $2 AND id = $3 AND deleted_at IS NULL"
-	args := []any{organizationID, ledgerID, id}
+	query, args, err := squirrel.Update(r.tableName).
+		Set("deleted_at", squirrel.Expr("now()")).
+		Where(squirrel.Eq{
+			"organization_id": organizationID,
+			"ledger_id":       ledgerID,
+			"id":              id,
+			"deleted_at":      nil,
+		}).
+		PlaceholderFormat(squirrel.Dollar).
+		ToSql()
+	if err != nil {
+		libOpentelemetry.HandleSpanError(span, "Failed to build delete query", err)
 
-	ctx, spanExec := tracer.Start(ctx, "postgres.delete.exec")
+		logger.Log(ctx, libLog.LevelError, "Failed to build delete query", libLog.Err(err))
+
+		return err
+	}
+
+	_, spanExec := tracer.Start(ctx, "postgres.delete.exec")
+	defer spanExec.End()
 
 	result, err := db.ExecContext(ctx, query, args...)
 	if err != nil {
-		err := pkg.ValidateBusinessError(constant.ErrOperationRouteNotFound, reflect.TypeOf(mmodel.OperationRoute{}).Name())
+		libOpentelemetry.HandleSpanError(spanExec, "Failed to execute delete query", err)
 
-		libOpentelemetry.HandleSpanBusinessErrorEvent(spanExec, "Failed to execute query", err)
-
-		logger.Log(ctx, libLog.LevelError, fmt.Sprintf("Failed to execute query: %v", err))
+		logger.Log(ctx, libLog.LevelError, "Failed to execute delete query",
+			libLog.Err(err),
+			libLog.String("organization_id", organizationID.String()),
+			libLog.String("ledger_id", ledgerID.String()),
+			libLog.String("operation_route_id", id.String()),
+		)
 
 		return err
 	}
-
-	spanExec.End()
 
 	rowsAffected, err := result.RowsAffected()
 	if err != nil {
 		libOpentelemetry.HandleSpanError(span, "Failed to get rows affected", err)
 
-		logger.Log(ctx, libLog.LevelError, fmt.Sprintf("Failed to get rows affected: %v", err))
+		logger.Log(ctx, libLog.LevelError, "Failed to get rows affected", libLog.Err(err))
 
 		return err
 	}
@@ -536,7 +559,13 @@ func (r *OperationRoutePostgreSQLRepository) Delete(ctx context.Context, organiz
 
 		libOpentelemetry.HandleSpanBusinessErrorEvent(spanExec, "Failed to delete operation route. Rows affected is 0", err)
 
-		logger.Log(ctx, libLog.LevelWarn, fmt.Sprintf("Failed to delete operation route. Rows affected is 0: %v", err))
+		logger.Log(ctx, libLog.LevelWarn, "Operation route not found for delete",
+			libLog.Err(err),
+			libLog.String("organization_id", organizationID.String()),
+			libLog.String("ledger_id", ledgerID.String()),
+			libLog.String("operation_route_id", id.String()),
+			libLog.Any("rows_affected", rowsAffected),
+		)
 
 		return err
 	}
@@ -677,7 +706,7 @@ func (r *OperationRoutePostgreSQLRepository) FindAll(ctx context.Context, organi
 
 // HasTransactionRouteLinks checks if an operation route is linked to any transaction routes.
 // It returns true if the operation route is linked to at least one transaction route, false otherwise.
-func (r *OperationRoutePostgreSQLRepository) HasTransactionRouteLinks(ctx context.Context, operationRouteID uuid.UUID) (bool, error) {
+func (r *OperationRoutePostgreSQLRepository) HasTransactionRouteLinks(ctx context.Context, organizationID, ledgerID, operationRouteID uuid.UUID) (bool, error) {
 	logger, tracer, _, _ := libCommons.NewTrackingFromContext(ctx)
 
 	ctx, span := tracer.Start(ctx, "postgres.has_transaction_route_links")
@@ -692,8 +721,17 @@ func (r *OperationRoutePostgreSQLRepository) HasTransactionRouteLinks(ctx contex
 		return false, err
 	}
 
-	query := `SELECT EXISTS(SELECT 1 FROM operation_transaction_route WHERE operation_route_id = $1 AND deleted_at IS NULL)`
-	args := []any{operationRouteID}
+	query := `SELECT EXISTS(
+		SELECT 1
+		FROM operation_transaction_route otr
+		JOIN operation_route opr ON opr.id = otr.operation_route_id
+		WHERE otr.operation_route_id = $1
+		AND opr.organization_id = $2
+		AND opr.ledger_id = $3
+		AND otr.deleted_at IS NULL
+		AND opr.deleted_at IS NULL
+	)`
+	args := []any{operationRouteID, organizationID, ledgerID}
 
 	ctx, spanQuery := tracer.Start(ctx, "postgres.has_transaction_route_links.query")
 

--- a/components/ledger/internal/adapters/postgres/operationroute/operationroute.postgresql.go
+++ b/components/ledger/internal/adapters/postgres/operationroute/operationroute.postgresql.go
@@ -509,7 +509,8 @@ func (r *OperationRoutePostgreSQLRepository) Delete(ctx context.Context, organiz
 
 	ctx, spanExec := tracer.Start(ctx, "postgres.delete.exec")
 
-	if _, err := db.ExecContext(ctx, query, args...); err != nil {
+	result, err := db.ExecContext(ctx, query, args...)
+	if err != nil {
 		err := pkg.ValidateBusinessError(constant.ErrOperationRouteNotFound, reflect.TypeOf(mmodel.OperationRoute{}).Name())
 
 		libOpentelemetry.HandleSpanBusinessErrorEvent(spanExec, "Failed to execute query", err)
@@ -520,6 +521,25 @@ func (r *OperationRoutePostgreSQLRepository) Delete(ctx context.Context, organiz
 	}
 
 	spanExec.End()
+
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		libOpentelemetry.HandleSpanError(span, "Failed to get rows affected", err)
+
+		logger.Log(ctx, libLog.LevelError, fmt.Sprintf("Failed to get rows affected: %v", err))
+
+		return err
+	}
+
+	if rowsAffected == 0 {
+		err := services.ErrDatabaseItemNotFound
+
+		libOpentelemetry.HandleSpanBusinessErrorEvent(spanExec, "Failed to delete operation route. Rows affected is 0", err)
+
+		logger.Log(ctx, libLog.LevelWarn, fmt.Sprintf("Failed to delete operation route. Rows affected is 0: %v", err))
+
+		return err
+	}
 
 	return nil
 }

--- a/components/ledger/internal/adapters/postgres/operationroute/operationroute.postgresql.go
+++ b/components/ledger/internal/adapters/postgres/operationroute/operationroute.postgresql.go
@@ -103,6 +103,7 @@ func (r *OperationRoutePostgreSQLRepository) getDB(ctx context.Context) (dbresol
 
 func (r *OperationRoutePostgreSQLRepository) Create(ctx context.Context, organizationID, ledgerID uuid.UUID, operationRoute *mmodel.OperationRoute) (*mmodel.OperationRoute, error) {
 	logger, tracer, _, _ := libCommons.NewTrackingFromContext(ctx)
+
 	operationRouteID := uuid.Nil
 	if operationRoute != nil {
 		operationRouteID = operationRoute.ID
@@ -110,6 +111,7 @@ func (r *OperationRoutePostgreSQLRepository) Create(ctx context.Context, organiz
 
 	ctx, span := tracer.Start(ctx, "postgres.create_operation_route")
 	defer span.End()
+
 	span.SetAttributes(
 		attribute.String("app.request.organization_id", organizationID.String()),
 		attribute.String("app.request.ledger_id", ledgerID.String()),
@@ -149,6 +151,7 @@ func (r *OperationRoutePostgreSQLRepository) Create(ctx context.Context, organiz
 
 		return nil, err
 	}
+
 	logger.Log(ctx, libLog.LevelDebug, "Built create operation route query", libLog.String("query", query))
 
 	_, spanExec := tracer.Start(ctx, "postgres.create.exec")
@@ -191,6 +194,7 @@ func (r *OperationRoutePostgreSQLRepository) Create(ctx context.Context, organiz
 
 		return nil, err
 	}
+
 	spanExec.SetAttributes(attribute.Int64("db.rows_affected", rowsAffected))
 
 	if rowsAffected == 0 {
@@ -215,6 +219,7 @@ func (r *OperationRoutePostgreSQLRepository) FindByID(ctx context.Context, organ
 
 	ctx, span := tracer.Start(ctx, "postgres.find_operation_route")
 	defer span.End()
+
 	span.SetAttributes(
 		attribute.String("app.request.organization_id", organizationID.String()),
 		attribute.String("app.request.ledger_id", ledgerID.String()),
@@ -251,6 +256,7 @@ func (r *OperationRoutePostgreSQLRepository) FindByID(ctx context.Context, organ
 
 		return nil, err
 	}
+
 	logger.Log(ctx, libLog.LevelDebug, "Built find operation route query", libLog.String("query", query))
 
 	operationRoute := &OperationRoutePostgreSQLModel{}
@@ -306,6 +312,7 @@ func (r *OperationRoutePostgreSQLRepository) FindByIDs(ctx context.Context, orga
 
 	ctx, span := tracer.Start(ctx, "postgres.find_operation_routes_by_ids")
 	defer span.End()
+
 	span.SetAttributes(
 		attribute.String("app.request.organization_id", organizationID.String()),
 		attribute.String("app.request.ledger_id", ledgerID.String()),
@@ -347,6 +354,7 @@ func (r *OperationRoutePostgreSQLRepository) FindByIDs(ctx context.Context, orga
 
 		return nil, err
 	}
+
 	logger.Log(ctx, libLog.LevelDebug, "Built find operation routes by IDs query", libLog.String("query", findByIDsSql))
 
 	_, spanQuery := tracer.Start(ctx, "postgres.find_by_ids.query")
@@ -400,6 +408,7 @@ func (r *OperationRoutePostgreSQLRepository) FindByIDs(ctx context.Context, orga
 
 		return nil, err
 	}
+
 	spanQuery.SetAttributes(attribute.Int("db.rows_returned", len(operationRoutes)))
 
 	var missingIDs []string
@@ -433,6 +442,7 @@ func (r *OperationRoutePostgreSQLRepository) Update(ctx context.Context, organiz
 
 	ctx, span := tracer.Start(ctx, "postgres.update_operation_route")
 	defer span.End()
+
 	span.SetAttributes(
 		attribute.String("app.request.organization_id", organizationID.String()),
 		attribute.String("app.request.ledger_id", ledgerID.String()),
@@ -512,6 +522,7 @@ func (r *OperationRoutePostgreSQLRepository) Update(ctx context.Context, organiz
 
 		return nil, err
 	}
+
 	logger.Log(ctx, libLog.LevelDebug, "Built update operation route query", libLog.String("query", query))
 
 	_, spanExec := tracer.Start(ctx, "postgres.update.exec")
@@ -554,6 +565,7 @@ func (r *OperationRoutePostgreSQLRepository) Update(ctx context.Context, organiz
 
 		return nil, err
 	}
+
 	spanExec.SetAttributes(attribute.Int64("db.rows_affected", rowsAffected))
 
 	if rowsAffected == 0 {
@@ -578,6 +590,7 @@ func (r *OperationRoutePostgreSQLRepository) Delete(ctx context.Context, organiz
 
 	ctx, span := tracer.Start(ctx, "postgres.delete_operation_route")
 	defer span.End()
+
 	span.SetAttributes(
 		attribute.String("app.request.organization_id", organizationID.String()),
 		attribute.String("app.request.ledger_id", ledgerID.String()),
@@ -618,6 +631,7 @@ func (r *OperationRoutePostgreSQLRepository) Delete(ctx context.Context, organiz
 
 		return err
 	}
+
 	logger.Log(ctx, libLog.LevelDebug, "Built delete operation route query", libLog.String("query", query))
 
 	_, spanExec := tracer.Start(ctx, "postgres.delete.exec")
@@ -646,6 +660,7 @@ func (r *OperationRoutePostgreSQLRepository) Delete(ctx context.Context, organiz
 
 		return err
 	}
+
 	spanExec.SetAttributes(attribute.Int64("db.rows_affected", rowsAffected))
 
 	if rowsAffected == 0 {
@@ -670,6 +685,7 @@ func (r *OperationRoutePostgreSQLRepository) FindAll(ctx context.Context, organi
 
 	ctx, span := tracer.Start(ctx, "postgres.find_all_operation_routes")
 	defer span.End()
+
 	span.SetAttributes(
 		attribute.String("app.request.organization_id", organizationID.String()),
 		attribute.String("app.request.ledger_id", ledgerID.String()),
@@ -733,6 +749,7 @@ func (r *OperationRoutePostgreSQLRepository) FindAll(ctx context.Context, organi
 
 		return nil, libHTTP.CursorPagination{}, err
 	}
+
 	logger.Log(ctx, libLog.LevelDebug, "Built find all operation routes query", libLog.String("query", query))
 
 	_, spanQuery := tracer.Start(ctx, "postgres.find_all.query")
@@ -780,6 +797,7 @@ func (r *OperationRoutePostgreSQLRepository) FindAll(ctx context.Context, organi
 
 		return nil, libHTTP.CursorPagination{}, err
 	}
+
 	spanQuery.SetAttributes(attribute.Int("db.rows_returned", len(operationRoutes)))
 
 	hasPagination := len(operationRoutes) > filter.Limit
@@ -806,6 +824,7 @@ func (r *OperationRoutePostgreSQLRepository) HasTransactionRouteLinks(ctx contex
 
 	ctx, span := tracer.Start(ctx, "postgres.has_transaction_route_links")
 	defer span.End()
+
 	span.SetAttributes(
 		attribute.String("app.request.organization_id", organizationID.String()),
 		attribute.String("app.request.ledger_id", ledgerID.String()),
@@ -853,6 +872,7 @@ func (r *OperationRoutePostgreSQLRepository) HasTransactionRouteLinks(ctx contex
 
 		return false, err
 	}
+
 	logger.Log(ctx, libLog.LevelDebug, "Built transaction route link query", libLog.String("query", query))
 
 	_, spanQuery := tracer.Start(ctx, "postgres.has_transaction_route_links.query")
@@ -872,6 +892,7 @@ func (r *OperationRoutePostgreSQLRepository) HasTransactionRouteLinks(ctx contex
 
 		return false, err
 	}
+
 	spanQuery.SetAttributes(attribute.Bool("app.operation_route_has_transaction_route_links", exists))
 
 	return exists, nil
@@ -882,6 +903,7 @@ func (r *OperationRoutePostgreSQLRepository) FindTransactionRouteIDs(ctx context
 
 	ctx, span := tracer.Start(ctx, "postgres.find_transaction_route_ids")
 	defer span.End()
+
 	span.SetAttributes(attribute.String("app.request.operation_route_id", operationRouteID.String()))
 
 	if err := ctx.Err(); err != nil {
@@ -918,6 +940,7 @@ func (r *OperationRoutePostgreSQLRepository) FindTransactionRouteIDs(ctx context
 
 		return nil, err
 	}
+
 	logger.Log(ctx, libLog.LevelDebug, "Built transaction route IDs query", libLog.String("query", query))
 
 	_, spanQuery := tracer.Start(ctx, "postgres.find_transaction_route_ids.query")
@@ -965,6 +988,7 @@ func (r *OperationRoutePostgreSQLRepository) FindTransactionRouteIDs(ctx context
 
 		return nil, err
 	}
+
 	spanQuery.SetAttributes(attribute.Int("db.rows_returned", len(transactionRouteIDs)))
 
 	return transactionRouteIDs, nil

--- a/components/ledger/internal/adapters/postgres/operationroute/operationroute.postgresql.go
+++ b/components/ledger/internal/adapters/postgres/operationroute/operationroute.postgresql.go
@@ -10,8 +10,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"reflect"
-	"strconv"
 	"strings"
 	"time"
 
@@ -33,21 +31,28 @@ import (
 	"github.com/lib/pq"
 	"go.opentelemetry.io/otel/attribute"
 
-	// Repository provides an interface for operations related to operation route entities.
-	// It defines methods for creating, retrieving, updating, and deleting operation routes.
-	//
-	//go:generate mockgen --destination=operationroute.postgresql_mock.go --package=operationroute . Repository
 	libLog "github.com/LerianStudio/lib-commons/v5/commons/log"
 )
 
+// Repository provides the persistence contract for operation routes and their transaction-route links.
+//
+//go:generate mockgen --destination=operationroute.postgresql_mock.go --package=operationroute . Repository
 type Repository interface {
+	// Create persists a new operation route in the given organization and ledger.
 	Create(ctx context.Context, organizationID, ledgerID uuid.UUID, operationRoute *mmodel.OperationRoute) (*mmodel.OperationRoute, error)
+	// FindByID returns one active operation route by scoped ID.
 	FindByID(ctx context.Context, organizationID, ledgerID, id uuid.UUID) (*mmodel.OperationRoute, error)
+	// FindByIDs returns active operation routes matching every requested scoped ID.
 	FindByIDs(ctx context.Context, organizationID, ledgerID uuid.UUID, ids []uuid.UUID) ([]*mmodel.OperationRoute, error)
+	// Update applies partial changes to an active operation route by scoped ID.
 	Update(ctx context.Context, organizationID, ledgerID, id uuid.UUID, operationRoute *mmodel.OperationRoute) (*mmodel.OperationRoute, error)
+	// Delete soft-deletes an active operation route by scoped ID.
 	Delete(ctx context.Context, organizationID, ledgerID, id uuid.UUID) error
+	// FindAll returns active operation routes for a ledger using cursor pagination and date filtering.
 	FindAll(ctx context.Context, organizationID, ledgerID uuid.UUID, filter http.Pagination) ([]*mmodel.OperationRoute, libHTTP.CursorPagination, error)
+	// HasTransactionRouteLinks reports whether an active operation route is linked to active transaction routes in the same scope.
 	HasTransactionRouteLinks(ctx context.Context, organizationID, ledgerID, operationRouteID uuid.UUID) (bool, error)
+	// FindTransactionRouteIDs returns active transaction-route IDs linked to an operation route.
 	FindTransactionRouteIDs(ctx context.Context, operationRouteID uuid.UUID) ([]uuid.UUID, error)
 }
 
@@ -96,18 +101,32 @@ func (r *OperationRoutePostgreSQLRepository) getDB(ctx context.Context) (dbresol
 	return r.connection.Resolver(ctx)
 }
 
-// Create creates a new operation route in the database.
 func (r *OperationRoutePostgreSQLRepository) Create(ctx context.Context, organizationID, ledgerID uuid.UUID, operationRoute *mmodel.OperationRoute) (*mmodel.OperationRoute, error) {
 	logger, tracer, _, _ := libCommons.NewTrackingFromContext(ctx)
+	operationRouteID := uuid.Nil
+	if operationRoute != nil {
+		operationRouteID = operationRoute.ID
+	}
 
 	ctx, span := tracer.Start(ctx, "postgres.create_operation_route")
 	defer span.End()
+	span.SetAttributes(
+		attribute.String("app.request.organization_id", organizationID.String()),
+		attribute.String("app.request.ledger_id", ledgerID.String()),
+		attribute.String("app.request.operation_route_id", operationRouteID.String()),
+	)
+
+	if err := ctx.Err(); err != nil {
+		libOpentelemetry.HandleSpanError(span, "Context finished before creating operation route", err)
+
+		return nil, err
+	}
 
 	db, err := r.getDB(ctx)
 	if err != nil {
 		libOpentelemetry.HandleSpanError(span, "Failed to get database connection", err)
 
-		logger.Log(ctx, libLog.LevelError, fmt.Sprintf("Failed to get database connection: %v", err))
+		logger.Log(ctx, libLog.LevelError, "Failed to get database connection", libLog.Err(err))
 
 		return nil, err
 	}
@@ -115,60 +134,75 @@ func (r *OperationRoutePostgreSQLRepository) Create(ctx context.Context, organiz
 	record := &OperationRoutePostgreSQLModel{}
 	record.FromEntity(operationRoute)
 
-	ctx, spanExec := tracer.Start(ctx, "postgres.create.exec")
+	query, args, err := squirrel.Insert(r.tableName).
+		Columns("id", "organization_id", "ledger_id", "title", "description", "code", "operation_type", "account_rule_type", "account_rule_valid_if", "accounting_entries", "created_at", "updated_at").
+		Values(record.ID, record.OrganizationID, record.LedgerID, record.Title, record.Description, record.Code, record.OperationType, record.AccountRuleType, record.AccountRuleValidIf, record.AccountingEntries, record.CreatedAt, record.UpdatedAt).
+		PlaceholderFormat(squirrel.Dollar).
+		ToSql()
+	if err != nil {
+		libOpentelemetry.HandleSpanError(span, "Failed to build create query", err)
 
-	result, err := db.ExecContext(ctx, `INSERT INTO operation_route(
-										id, organization_id, ledger_id, title, description, code, operation_type, account_rule_type, account_rule_valid_if, accounting_entries, created_at, updated_at
-										) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12) RETURNING *`,
-		&record.ID,
-		&record.OrganizationID,
-		&record.LedgerID,
-		&record.Title,
-		&record.Description,
-		&record.Code,
-		&record.OperationType,
-		&record.AccountRuleType,
-		&record.AccountRuleValidIf,
-		&record.AccountingEntries,
-		&record.CreatedAt,
-		&record.UpdatedAt,
-	)
+		logger.Log(ctx, libLog.LevelError, "Failed to build create query",
+			libLog.Err(err),
+			libLog.String("operation_route_id", record.ID.String()),
+		)
+
+		return nil, err
+	}
+	logger.Log(ctx, libLog.LevelDebug, "Built create operation route query", libLog.String("query", query))
+
+	_, spanExec := tracer.Start(ctx, "postgres.create.exec")
+	defer spanExec.End()
+
+	result, err := db.ExecContext(ctx, query, args...)
 	if err != nil {
 		var pgErr *pgconn.PgError
 		if errors.As(err, &pgErr) {
-			err := services.ValidatePGError(pgErr, reflect.TypeOf(mmodel.OperationRoute{}).Name())
+			err := services.ValidatePGError(pgErr, constant.EntityOperationRoute)
 
-			libOpentelemetry.HandleSpanBusinessErrorEvent(spanExec, "Failed to execute update query", err)
+			libOpentelemetry.HandleSpanBusinessErrorEvent(spanExec, "Failed to execute create query", err)
 
-			logger.Log(ctx, libLog.LevelError, fmt.Sprintf("Failed to execute update query: %v", err))
+			logger.Log(ctx, libLog.LevelWarn, "Failed to execute create query",
+				libLog.Err(err),
+				libLog.String("operation_route_id", record.ID.String()),
+			)
 
 			return nil, err
 		}
 
-		libOpentelemetry.HandleSpanError(spanExec, "Failed to execute update query", err)
+		libOpentelemetry.HandleSpanError(spanExec, "Failed to execute create query", err)
 
-		logger.Log(ctx, libLog.LevelError, fmt.Sprintf("Failed to execute update query: %v", err))
+		logger.Log(ctx, libLog.LevelError, "Failed to execute create query",
+			libLog.Err(err),
+			libLog.String("operation_route_id", record.ID.String()),
+		)
 
 		return nil, err
 	}
-
-	spanExec.End()
 
 	rowsAffected, err := result.RowsAffected()
 	if err != nil {
-		libOpentelemetry.HandleSpanError(span, "Failed to get rows affected", err)
+		libOpentelemetry.HandleSpanError(spanExec, "Failed to get rows affected", err)
 
-		logger.Log(ctx, libLog.LevelError, fmt.Sprintf("Failed to get rows affected: %v", err))
+		logger.Log(ctx, libLog.LevelError, "Failed to get rows affected",
+			libLog.Err(err),
+			libLog.String("operation_route_id", record.ID.String()),
+		)
 
 		return nil, err
 	}
+	spanExec.SetAttributes(attribute.Int64("db.rows_affected", rowsAffected))
 
 	if rowsAffected == 0 {
-		err := pkg.ValidateBusinessError(constant.ErrEntityNotFound, reflect.TypeOf(mmodel.OperationRoute{}).Name())
+		err := pkg.ValidateBusinessError(constant.ErrEntityNotFound, constant.EntityOperationRoute)
 
-		libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Failed to create operation route. Rows affected is 0", err)
+		libOpentelemetry.HandleSpanBusinessErrorEvent(spanExec, "Failed to create operation route. Rows affected is 0", err)
 
-		logger.Log(ctx, libLog.LevelWarn, fmt.Sprintf("Failed to create operation route. Rows affected is 0: %v", err))
+		logger.Log(ctx, libLog.LevelWarn, "Operation route not created",
+			libLog.Err(err),
+			libLog.String("operation_route_id", record.ID.String()),
+			libLog.Any("rows_affected", rowsAffected),
+		)
 
 		return nil, err
 	}
@@ -176,35 +210,55 @@ func (r *OperationRoutePostgreSQLRepository) Create(ctx context.Context, organiz
 	return record.ToEntity(), nil
 }
 
-// FindByID retrieves an operation route by its ID.
-// It returns the operation route if found, otherwise it returns an error.
 func (r *OperationRoutePostgreSQLRepository) FindByID(ctx context.Context, organizationID, ledgerID, id uuid.UUID) (*mmodel.OperationRoute, error) {
 	logger, tracer, _, _ := libCommons.NewTrackingFromContext(ctx)
 
 	ctx, span := tracer.Start(ctx, "postgres.find_operation_route")
 	defer span.End()
+	span.SetAttributes(
+		attribute.String("app.request.organization_id", organizationID.String()),
+		attribute.String("app.request.ledger_id", ledgerID.String()),
+		attribute.String("app.request.operation_route_id", id.String()),
+	)
+
+	if err := ctx.Err(); err != nil {
+		libOpentelemetry.HandleSpanError(span, "Context finished before finding operation route", err)
+
+		return nil, err
+	}
 
 	db, err := r.getDB(ctx)
 	if err != nil {
 		libOpentelemetry.HandleSpanError(span, "Failed to get database connection", err)
 
-		logger.Log(ctx, libLog.LevelError, fmt.Sprintf("Failed to get database connection: %v", err))
+		logger.Log(ctx, libLog.LevelError, "Failed to get database connection", libLog.Err(err))
 
 		return nil, err
 	}
 
-	query := `SELECT id, organization_id, ledger_id, title, description, code, operation_type, account_rule_type, account_rule_valid_if, accounting_entries, created_at, updated_at, deleted_at
-		FROM operation_route
-		WHERE organization_id = $1 AND ledger_id = $2 AND id = $3 AND deleted_at IS NULL`
-	args := []any{organizationID, ledgerID, id}
+	query, args, err := squirrel.Select("id", "organization_id", "ledger_id", "title", "description", "code", "operation_type", "account_rule_type", "account_rule_valid_if", "accounting_entries", "created_at", "updated_at", "deleted_at").
+		From(r.tableName).
+		Where(squirrel.Eq{"organization_id": organizationID, "ledger_id": ledgerID, "id": id, "deleted_at": nil}).
+		PlaceholderFormat(squirrel.Dollar).
+		ToSql()
+	if err != nil {
+		libOpentelemetry.HandleSpanError(span, "Failed to build find query", err)
+
+		logger.Log(ctx, libLog.LevelError, "Failed to build find query",
+			libLog.Err(err),
+			libLog.String("operation_route_id", id.String()),
+		)
+
+		return nil, err
+	}
+	logger.Log(ctx, libLog.LevelDebug, "Built find operation route query", libLog.String("query", query))
 
 	operationRoute := &OperationRoutePostgreSQLModel{}
 
-	ctx, spanQuery := tracer.Start(ctx, "postgres.find.query")
+	_, spanQuery := tracer.Start(ctx, "postgres.find.query")
+	defer spanQuery.End()
 
 	row := db.QueryRowContext(ctx, query, args...)
-
-	spanQuery.End()
 
 	if err := row.Scan(
 		&operationRoute.ID,
@@ -222,18 +276,24 @@ func (r *OperationRoutePostgreSQLRepository) FindByID(ctx context.Context, organ
 		&operationRoute.DeletedAt,
 	); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			err := pkg.ValidateBusinessError(constant.ErrOperationRouteNotFound, reflect.TypeOf(mmodel.OperationRoute{}).Name())
+			err := pkg.ValidateBusinessError(constant.ErrOperationRouteNotFound, constant.EntityOperationRoute)
 
-			libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Failed to scan operation route", err)
+			libOpentelemetry.HandleSpanBusinessErrorEvent(spanQuery, "Operation route not found", err)
 
-			logger.Log(ctx, libLog.LevelWarn, fmt.Sprintf("Failed to scan operation route: %v", err))
+			logger.Log(ctx, libLog.LevelWarn, "Operation route not found",
+				libLog.Err(err),
+				libLog.String("operation_route_id", id.String()),
+			)
 
 			return nil, err
 		}
 
-		libOpentelemetry.HandleSpanError(span, "Failed to scan operation route", err)
+		libOpentelemetry.HandleSpanError(spanQuery, "Failed to scan operation route", err)
 
-		logger.Log(ctx, libLog.LevelError, fmt.Sprintf("Failed to scan operation route: %v", err))
+		logger.Log(ctx, libLog.LevelError, "Failed to scan operation route",
+			libLog.Err(err),
+			libLog.String("operation_route_id", id.String()),
+		)
 
 		return nil, err
 	}
@@ -241,13 +301,22 @@ func (r *OperationRoutePostgreSQLRepository) FindByID(ctx context.Context, organ
 	return operationRoute.ToEntity(), nil
 }
 
-// FindByIDs retrieves operation routes by their IDs.
-// It returns the operation routes if found, otherwise it returns an error.
 func (r *OperationRoutePostgreSQLRepository) FindByIDs(ctx context.Context, organizationID, ledgerID uuid.UUID, ids []uuid.UUID) ([]*mmodel.OperationRoute, error) {
 	logger, tracer, _, _ := libCommons.NewTrackingFromContext(ctx)
 
 	ctx, span := tracer.Start(ctx, "postgres.find_operation_routes_by_ids")
 	defer span.End()
+	span.SetAttributes(
+		attribute.String("app.request.organization_id", organizationID.String()),
+		attribute.String("app.request.ledger_id", ledgerID.String()),
+		attribute.Int("app.request.operation_route_ids_count", len(ids)),
+	)
+
+	if err := ctx.Err(); err != nil {
+		libOpentelemetry.HandleSpanError(span, "Context finished before finding operation routes", err)
+
+		return nil, err
+	}
 
 	if len(ids) == 0 {
 		return []*mmodel.OperationRoute{}, nil
@@ -257,13 +326,13 @@ func (r *OperationRoutePostgreSQLRepository) FindByIDs(ctx context.Context, orga
 	if err != nil {
 		libOpentelemetry.HandleSpanError(span, "Failed to get database connection", err)
 
-		logger.Log(ctx, libLog.LevelError, fmt.Sprintf("Failed to get database connection: %v", err))
+		logger.Log(ctx, libLog.LevelError, "Failed to get database connection", libLog.Err(err))
 
 		return nil, err
 	}
 
 	query := squirrel.Select("id", "organization_id", "ledger_id", "title", "description", "code", "operation_type", "account_rule_type", "account_rule_valid_if", "accounting_entries", "created_at", "updated_at", "deleted_at").
-		From("operation_route").
+		From(r.tableName).
 		Where(squirrel.Eq{"organization_id": organizationID}).
 		Where(squirrel.Eq{"ledger_id": ledgerID}).
 		Where(squirrel.Eq{"id": ids}).
@@ -274,22 +343,24 @@ func (r *OperationRoutePostgreSQLRepository) FindByIDs(ctx context.Context, orga
 	if err != nil {
 		libOpentelemetry.HandleSpanError(span, "Failed to build query", err)
 
+		logger.Log(ctx, libLog.LevelError, "Failed to build find by IDs query", libLog.Err(err))
+
 		return nil, err
 	}
+	logger.Log(ctx, libLog.LevelDebug, "Built find operation routes by IDs query", libLog.String("query", findByIDsSql))
 
-	ctx, spanQuery := tracer.Start(ctx, "postgres.find_by_ids.query")
+	_, spanQuery := tracer.Start(ctx, "postgres.find_by_ids.query")
+	defer spanQuery.End()
 
 	rows, err := db.QueryContext(ctx, findByIDsSql, args...)
 	if err != nil {
 		libOpentelemetry.HandleSpanError(spanQuery, "Failed to execute query", err)
 
-		logger.Log(ctx, libLog.LevelError, fmt.Sprintf("Failed to execute query: %v", err))
+		logger.Log(ctx, libLog.LevelError, "Failed to execute query", libLog.Err(err))
 
 		return nil, err
 	}
 	defer rows.Close()
-
-	spanQuery.End()
 
 	var operationRoutes []*mmodel.OperationRoute
 
@@ -313,9 +384,8 @@ func (r *OperationRoutePostgreSQLRepository) FindByIDs(ctx context.Context, orga
 			&operationRoute.UpdatedAt,
 			&operationRoute.DeletedAt,
 		); err != nil {
-			libOpentelemetry.HandleSpanError(span, "Failed to scan operation route", err)
-
-			logger.Log(ctx, libLog.LevelError, fmt.Sprintf("Failed to scan operation route: %v", err))
+			libOpentelemetry.HandleSpanError(spanQuery, "Failed to scan operation route", err)
+			logger.Log(ctx, libLog.LevelError, "Failed to scan operation route", libLog.Err(err))
 
 			return nil, err
 		}
@@ -325,12 +395,12 @@ func (r *OperationRoutePostgreSQLRepository) FindByIDs(ctx context.Context, orga
 	}
 
 	if err := rows.Err(); err != nil {
-		libOpentelemetry.HandleSpanError(span, "Failed to iterate rows", err)
-
-		logger.Log(ctx, libLog.LevelError, fmt.Sprintf("Failed to iterate rows: %v", err))
+		libOpentelemetry.HandleSpanError(spanQuery, "Failed to iterate rows", err)
+		logger.Log(ctx, libLog.LevelError, "Failed to iterate rows", libLog.Err(err))
 
 		return nil, err
 	}
+	spanQuery.SetAttributes(attribute.Int("db.rows_returned", len(operationRoutes)))
 
 	var missingIDs []string
 
@@ -343,11 +413,14 @@ func (r *OperationRoutePostgreSQLRepository) FindByIDs(ctx context.Context, orga
 	if len(missingIDs) > 0 {
 		missingIDsStr := strings.Join(missingIDs, ", ")
 
-		err := pkg.ValidateBusinessError(constant.ErrOperationRouteNotFound, reflect.TypeOf(mmodel.OperationRoute{}).Name(), missingIDsStr)
+		err := pkg.ValidateBusinessError(constant.ErrOperationRouteNotFound, constant.EntityOperationRoute, missingIDsStr)
 
 		libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Operation route(s) not found", err)
 
-		logger.Log(ctx, libLog.LevelWarn, fmt.Sprintf("Operation route(s) not found: %v", missingIDsStr))
+		logger.Log(ctx, libLog.LevelWarn, "Operation routes not found",
+			libLog.Err(err),
+			libLog.Any("missing_operation_route_ids", missingIDs),
+		)
 
 		return nil, err
 	}
@@ -355,19 +428,27 @@ func (r *OperationRoutePostgreSQLRepository) FindByIDs(ctx context.Context, orga
 	return operationRoutes, nil
 }
 
-// Update updates an operation route by its ID.
-// It returns the updated operation route if found, otherwise it returns an error.
 func (r *OperationRoutePostgreSQLRepository) Update(ctx context.Context, organizationID, ledgerID, id uuid.UUID, operationRoute *mmodel.OperationRoute) (*mmodel.OperationRoute, error) {
 	logger, tracer, _, _ := libCommons.NewTrackingFromContext(ctx)
 
 	ctx, span := tracer.Start(ctx, "postgres.update_operation_route")
 	defer span.End()
+	span.SetAttributes(
+		attribute.String("app.request.organization_id", organizationID.String()),
+		attribute.String("app.request.ledger_id", ledgerID.String()),
+		attribute.String("app.request.operation_route_id", id.String()),
+	)
+
+	if err := ctx.Err(); err != nil {
+		libOpentelemetry.HandleSpanError(span, "Context finished before updating operation route", err)
+
+		return nil, err
+	}
 
 	db, err := r.getDB(ctx)
 	if err != nil {
 		libOpentelemetry.HandleSpanError(span, "Failed to get database connection", err)
-
-		logger.Log(ctx, libLog.LevelError, fmt.Sprintf("Failed to get database connection: %v", err))
+		logger.Log(ctx, libLog.LevelError, "Failed to get database connection", libLog.Err(err))
 
 		return nil, err
 	}
@@ -375,34 +456,27 @@ func (r *OperationRoutePostgreSQLRepository) Update(ctx context.Context, organiz
 	record := &OperationRoutePostgreSQLModel{}
 	record.FromEntity(operationRoute)
 
-	var updates []string
-
-	var args []any
+	qb := squirrel.Update(r.tableName)
 
 	if operationRoute.Title != "" {
-		updates = append(updates, "title = $"+strconv.Itoa(len(args)+1))
-		args = append(args, record.Title)
+		qb = qb.Set("title", record.Title)
 	}
 
 	if operationRoute.Description != "" {
-		updates = append(updates, "description = $"+strconv.Itoa(len(args)+1))
-		args = append(args, record.Description)
+		qb = qb.Set("description", record.Description)
 	}
 
 	if operationRoute.Code != "" {
-		updates = append(updates, "code = $"+strconv.Itoa(len(args)+1))
-		args = append(args, record.Code)
+		qb = qb.Set("code", record.Code)
 	}
 
 	if operationRoute.Account != nil {
 		if operationRoute.Account.RuleType != "" {
-			updates = append(updates, "account_rule_type = $"+strconv.Itoa(len(args)+1))
-			args = append(args, record.AccountRuleType)
+			qb = qb.Set("account_rule_type", record.AccountRuleType)
 		}
 
 		if operationRoute.Account.ValidIf != nil {
-			updates = append(updates, "account_rule_valid_if = $"+strconv.Itoa(len(args)+1))
-			args = append(args, record.AccountRuleValidIf)
+			qb = qb.Set("account_rule_valid_if", record.AccountRuleValidIf)
 		}
 	}
 
@@ -410,78 +484,88 @@ func (r *OperationRoutePostgreSQLRepository) Update(ctx context.Context, organiz
 		mergeJSON, removeKeys := splitMergePatch(rawJSON)
 
 		if len(mergeJSON) > 0 {
-			paramIdx := strconv.Itoa(len(args) + 1)
-			expr := "COALESCE(accounting_entries, '{}'::jsonb) || $" + paramIdx + "::jsonb"
-
-			args = append(args, mergeJSON)
-
 			if len(removeKeys) > 0 {
-				expr += " - $" + strconv.Itoa(len(args)+1) + "::text[]"
-				args = append(args, pq.Array(removeKeys))
+				qb = qb.Set("accounting_entries", squirrel.Expr("(COALESCE(accounting_entries, '{}'::jsonb) || ?::jsonb) - ?::text[]", mergeJSON, pq.Array(removeKeys)))
+			} else {
+				qb = qb.Set("accounting_entries", squirrel.Expr("COALESCE(accounting_entries, '{}'::jsonb) || ?::jsonb", mergeJSON))
 			}
-
-			updates = append(updates, "accounting_entries = "+expr)
 		} else if len(removeKeys) > 0 {
-			paramIdx := strconv.Itoa(len(args) + 1)
-			updates = append(updates, "accounting_entries = COALESCE(accounting_entries, '{}'::jsonb) - $"+paramIdx+"::text[]")
-			args = append(args, pq.Array(removeKeys))
+			qb = qb.Set("accounting_entries", squirrel.Expr("COALESCE(accounting_entries, '{}'::jsonb) - ?::text[]", pq.Array(removeKeys)))
 		}
 	} else if record.AccountingEntries != nil {
-		updates = append(updates, "accounting_entries = COALESCE(accounting_entries, '{}'::jsonb) || $"+strconv.Itoa(len(args)+1)+"::jsonb")
-		args = append(args, record.AccountingEntries)
+		qb = qb.Set("accounting_entries", squirrel.Expr("COALESCE(accounting_entries, '{}'::jsonb) || ?::jsonb", record.AccountingEntries))
 	}
 
 	record.UpdatedAt = time.Now()
+	qb = qb.Set("updated_at", record.UpdatedAt).
+		Where(squirrel.Eq{"organization_id": organizationID, "ledger_id": ledgerID, "id": id, "deleted_at": nil}).
+		PlaceholderFormat(squirrel.Dollar)
 
-	updates = append(updates, "updated_at = $"+strconv.Itoa(len(args)+1))
+	query, args, err := qb.ToSql()
+	if err != nil {
+		libOpentelemetry.HandleSpanError(span, "Failed to build update query", err)
 
-	args = append(args, record.UpdatedAt, organizationID, ledgerID, id)
+		logger.Log(ctx, libLog.LevelError, "Failed to build update query",
+			libLog.Err(err),
+			libLog.String("operation_route_id", id.String()),
+		)
 
-	query := `UPDATE operation_route SET ` + strings.Join(updates, ", ") +
-		` WHERE organization_id = $` + strconv.Itoa(len(args)-2) +
-		` AND ledger_id = $` + strconv.Itoa(len(args)-1) +
-		` AND id = $` + strconv.Itoa(len(args)) +
-		` AND deleted_at IS NULL`
+		return nil, err
+	}
+	logger.Log(ctx, libLog.LevelDebug, "Built update operation route query", libLog.String("query", query))
 
-	ctx, spanExec := tracer.Start(ctx, "postgres.update.exec")
+	_, spanExec := tracer.Start(ctx, "postgres.update.exec")
+	defer spanExec.End()
 
 	result, err := db.ExecContext(ctx, query, args...)
 	if err != nil {
 		var pgErr *pgconn.PgError
 		if errors.As(err, &pgErr) {
-			err := services.ValidatePGError(pgErr, reflect.TypeOf(mmodel.OperationRoute{}).Name())
+			err := services.ValidatePGError(pgErr, constant.EntityOperationRoute)
 
 			libOpentelemetry.HandleSpanBusinessErrorEvent(spanExec, "Failed to execute update query", err)
 
-			logger.Log(ctx, libLog.LevelWarn, fmt.Sprintf("Failed to execute update query: %v", err))
+			logger.Log(ctx, libLog.LevelWarn, "Failed to execute update query",
+				libLog.Err(err),
+				libLog.String("operation_route_id", id.String()),
+			)
 
 			return nil, err
 		}
 
 		libOpentelemetry.HandleSpanError(spanExec, "Failed to execute update query", err)
 
-		logger.Log(ctx, libLog.LevelError, fmt.Sprintf("Failed to execute update query: %v", err))
+		logger.Log(ctx, libLog.LevelError, "Failed to execute update query",
+			libLog.Err(err),
+			libLog.String("operation_route_id", id.String()),
+		)
 
 		return nil, err
 	}
-
-	spanExec.End()
 
 	rowsAffected, err := result.RowsAffected()
 	if err != nil {
-		libOpentelemetry.HandleSpanError(span, "Failed to get rows affected", err)
+		libOpentelemetry.HandleSpanError(spanExec, "Failed to get rows affected", err)
 
-		logger.Log(ctx, libLog.LevelError, fmt.Sprintf("Failed to get rows affected: %v", err))
+		logger.Log(ctx, libLog.LevelError, "Failed to get rows affected",
+			libLog.Err(err),
+			libLog.String("operation_route_id", id.String()),
+		)
 
 		return nil, err
 	}
+	spanExec.SetAttributes(attribute.Int64("db.rows_affected", rowsAffected))
 
 	if rowsAffected == 0 {
 		err := services.ErrDatabaseItemNotFound
 
 		libOpentelemetry.HandleSpanBusinessErrorEvent(spanExec, "Failed to update operation route. Rows affected is 0", err)
 
-		logger.Log(ctx, libLog.LevelWarn, fmt.Sprintf("Failed to update operation route. Rows affected is 0: %v", err))
+		logger.Log(ctx, libLog.LevelWarn, "Operation route not found for update",
+			libLog.Err(err),
+			libLog.String("operation_route_id", id.String()),
+			libLog.Any("rows_affected", rowsAffected),
+		)
 
 		return nil, err
 	}
@@ -489,16 +573,15 @@ func (r *OperationRoutePostgreSQLRepository) Update(ctx context.Context, organiz
 	return record.ToEntity(), nil
 }
 
-// Delete soft-deletes an operation route using the provided IDs.
 func (r *OperationRoutePostgreSQLRepository) Delete(ctx context.Context, organizationID, ledgerID, id uuid.UUID) error {
 	logger, tracer, _, _ := libCommons.NewTrackingFromContext(ctx)
 
 	ctx, span := tracer.Start(ctx, "postgres.delete_operation_route")
 	defer span.End()
 	span.SetAttributes(
-		attribute.String("app.organization_id", organizationID.String()),
-		attribute.String("app.ledger_id", ledgerID.String()),
-		attribute.String("app.operation_route_id", id.String()),
+		attribute.String("app.request.organization_id", organizationID.String()),
+		attribute.String("app.request.ledger_id", ledgerID.String()),
+		attribute.String("app.request.operation_route_id", id.String()),
 	)
 
 	if err := ctx.Err(); err != nil {
@@ -582,20 +665,28 @@ func (r *OperationRoutePostgreSQLRepository) Delete(ctx context.Context, organiz
 	return nil
 }
 
-// FindAll retrieves all operation routes with pagination.
-// It returns a list of operation routes, a cursor pagination object, and an error if the operation fails.
-// The function supports filtering by date range and pagination.
 func (r *OperationRoutePostgreSQLRepository) FindAll(ctx context.Context, organizationID, ledgerID uuid.UUID, filter http.Pagination) ([]*mmodel.OperationRoute, libHTTP.CursorPagination, error) {
 	logger, tracer, _, _ := libCommons.NewTrackingFromContext(ctx)
 
 	ctx, span := tracer.Start(ctx, "postgres.find_all_operation_routes")
 	defer span.End()
+	span.SetAttributes(
+		attribute.String("app.request.organization_id", organizationID.String()),
+		attribute.String("app.request.ledger_id", ledgerID.String()),
+		attribute.Int("app.request.query.limit", filter.Limit),
+		attribute.String("app.request.query.cursor", filter.Cursor),
+	)
+
+	if err := ctx.Err(); err != nil {
+		libOpentelemetry.HandleSpanError(span, "Context finished before finding operation routes", err)
+
+		return nil, libHTTP.CursorPagination{}, err
+	}
 
 	db, err := r.getDB(ctx)
 	if err != nil {
 		libOpentelemetry.HandleSpanError(span, "Failed to get database connection", err)
-
-		logger.Log(ctx, libLog.LevelError, fmt.Sprintf("Failed to get database connection: %v", err))
+		logger.Log(ctx, libLog.LevelError, "Failed to get database connection", libLog.Err(err))
 
 		return nil, libHTTP.CursorPagination{}, err
 	}
@@ -609,8 +700,7 @@ func (r *OperationRoutePostgreSQLRepository) FindAll(ctx context.Context, organi
 		decodedCursor, err = libHTTP.DecodeCursor(filter.Cursor)
 		if err != nil {
 			libOpentelemetry.HandleSpanError(span, "Failed to decode cursor", err)
-
-			logger.Log(ctx, libLog.LevelError, fmt.Sprintf("Failed to decode cursor: %v", err))
+			logger.Log(ctx, libLog.LevelError, "Failed to decode cursor", libLog.Err(err))
 
 			return nil, libHTTP.CursorPagination{}, err
 		}
@@ -631,6 +721,7 @@ func (r *OperationRoutePostgreSQLRepository) FindAll(ctx context.Context, organi
 	findAll, err = applyCursorPagination(findAll, decodedCursor, orderDirection, filter.Limit)
 	if err != nil {
 		libOpentelemetry.HandleSpanError(span, "Failed to apply cursor pagination", err)
+		logger.Log(ctx, libLog.LevelError, "Failed to apply cursor pagination", libLog.Err(err))
 
 		return nil, libHTTP.CursorPagination{}, err
 	}
@@ -638,20 +729,19 @@ func (r *OperationRoutePostgreSQLRepository) FindAll(ctx context.Context, organi
 	query, args, err := findAll.ToSql()
 	if err != nil {
 		libOpentelemetry.HandleSpanError(span, "Failed to build query", err)
-
-		logger.Log(ctx, libLog.LevelError, fmt.Sprintf("Failed to build query: %v", err))
+		logger.Log(ctx, libLog.LevelError, "Failed to build query", libLog.Err(err))
 
 		return nil, libHTTP.CursorPagination{}, err
 	}
+	logger.Log(ctx, libLog.LevelDebug, "Built find all operation routes query", libLog.String("query", query))
 
-	ctx, spanQuery := tracer.Start(ctx, "postgres.find_all.query")
+	_, spanQuery := tracer.Start(ctx, "postgres.find_all.query")
 	defer spanQuery.End()
 
 	rows, err := db.QueryContext(ctx, query, args...)
 	if err != nil {
 		libOpentelemetry.HandleSpanError(spanQuery, "Failed to execute query", err)
-
-		logger.Log(ctx, libLog.LevelError, fmt.Sprintf("Failed to execute query: %v", err))
+		logger.Log(ctx, libLog.LevelError, "Failed to execute query", libLog.Err(err))
 
 		return nil, libHTTP.CursorPagination{}, err
 	}
@@ -675,9 +765,8 @@ func (r *OperationRoutePostgreSQLRepository) FindAll(ctx context.Context, organi
 			&operationRoute.DeletedAt,
 			&operationRoute.Code,
 		); err != nil {
-			libOpentelemetry.HandleSpanError(span, "Failed to scan operation route", err)
-
-			logger.Log(ctx, libLog.LevelError, fmt.Sprintf("Failed to scan operation route: %v", err))
+			libOpentelemetry.HandleSpanError(spanQuery, "Failed to scan operation route", err)
+			logger.Log(ctx, libLog.LevelError, "Failed to scan operation route", libLog.Err(err))
 
 			return nil, libHTTP.CursorPagination{}, err
 		}
@@ -686,12 +775,12 @@ func (r *OperationRoutePostgreSQLRepository) FindAll(ctx context.Context, organi
 	}
 
 	if err := rows.Err(); err != nil {
-		libOpentelemetry.HandleSpanError(span, "Failed to iterate rows", err)
-
-		logger.Log(ctx, libLog.LevelError, fmt.Sprintf("Failed to iterate rows: %v", err))
+		libOpentelemetry.HandleSpanError(spanQuery, "Failed to iterate rows", err)
+		logger.Log(ctx, libLog.LevelError, "Failed to iterate rows", libLog.Err(err))
 
 		return nil, libHTTP.CursorPagination{}, err
 	}
+	spanQuery.SetAttributes(attribute.Int("db.rows_returned", len(operationRoutes)))
 
 	hasPagination := len(operationRoutes) > filter.Limit
 	isFirstPage := libCommons.IsNilOrEmpty(&filter.Cursor)
@@ -703,8 +792,7 @@ func (r *OperationRoutePostgreSQLRepository) FindAll(ctx context.Context, organi
 		cur, err = libHTTP.CalculateCursor(isFirstPage, hasPagination, decodedCursor.Direction, operationRoutes[0].ID.String(), operationRoutes[len(operationRoutes)-1].ID.String())
 		if err != nil {
 			libOpentelemetry.HandleSpanError(span, "Failed to calculate cursor", err)
-
-			logger.Log(ctx, libLog.LevelError, fmt.Sprintf("Failed to calculate cursor: %v", err))
+			logger.Log(ctx, libLog.LevelError, "Failed to calculate cursor", libLog.Err(err))
 
 			return nil, libHTTP.CursorPagination{}, err
 		}
@@ -713,17 +801,15 @@ func (r *OperationRoutePostgreSQLRepository) FindAll(ctx context.Context, organi
 	return operationRoutes, cur, nil
 }
 
-// HasTransactionRouteLinks checks if an operation route is linked to any transaction routes.
-// It returns true if the operation route is linked to at least one transaction route, false otherwise.
 func (r *OperationRoutePostgreSQLRepository) HasTransactionRouteLinks(ctx context.Context, organizationID, ledgerID, operationRouteID uuid.UUID) (bool, error) {
 	logger, tracer, _, _ := libCommons.NewTrackingFromContext(ctx)
 
 	ctx, span := tracer.Start(ctx, "postgres.has_transaction_route_links")
 	defer span.End()
 	span.SetAttributes(
-		attribute.String("app.organization_id", organizationID.String()),
-		attribute.String("app.ledger_id", ledgerID.String()),
-		attribute.String("app.operation_route_id", operationRouteID.String()),
+		attribute.String("app.request.organization_id", organizationID.String()),
+		attribute.String("app.request.ledger_id", ledgerID.String()),
+		attribute.String("app.request.operation_route_id", operationRouteID.String()),
 	)
 
 	if err := ctx.Err(); err != nil {
@@ -791,34 +877,60 @@ func (r *OperationRoutePostgreSQLRepository) HasTransactionRouteLinks(ctx contex
 	return exists, nil
 }
 
-// FindTransactionRouteIDs retrieves all transaction route IDs associated with a specific operation route.
-// It returns a slice of transaction route UUIDs that are linked to the given operation route ID.
 func (r *OperationRoutePostgreSQLRepository) FindTransactionRouteIDs(ctx context.Context, operationRouteID uuid.UUID) ([]uuid.UUID, error) {
 	logger, tracer, _, _ := libCommons.NewTrackingFromContext(ctx)
 
 	ctx, span := tracer.Start(ctx, "postgres.find_transaction_route_ids")
 	defer span.End()
+	span.SetAttributes(attribute.String("app.request.operation_route_id", operationRouteID.String()))
+
+	if err := ctx.Err(); err != nil {
+		libOpentelemetry.HandleSpanError(span, "Context finished before finding transaction route IDs", err)
+
+		return nil, err
+	}
 
 	db, err := r.getDB(ctx)
 	if err != nil {
 		libOpentelemetry.HandleSpanError(span, "Failed to get database connection", err)
 
-		logger.Log(ctx, libLog.LevelError, fmt.Sprintf("Failed to get database connection: %v", err))
+		logger.Log(ctx, libLog.LevelError, "Failed to get database connection",
+			libLog.Err(err),
+			libLog.String("operation_route_id", operationRouteID.String()),
+		)
 
 		return nil, err
 	}
 
-	query := `SELECT transaction_route_id FROM operation_transaction_route WHERE operation_route_id = $1 AND deleted_at IS NULL ORDER BY created_at`
-	args := []any{operationRouteID}
+	query, args, err := squirrel.Select("transaction_route_id").
+		From("operation_transaction_route").
+		Where(squirrel.Eq{"operation_route_id": operationRouteID, "deleted_at": nil}).
+		OrderBy("created_at").
+		PlaceholderFormat(squirrel.Dollar).
+		ToSql()
+	if err != nil {
+		libOpentelemetry.HandleSpanError(span, "Failed to build transaction route IDs query", err)
 
-	ctx, spanQuery := tracer.Start(ctx, "postgres.find_transaction_route_ids.query")
+		logger.Log(ctx, libLog.LevelError, "Failed to build transaction route IDs query",
+			libLog.Err(err),
+			libLog.String("operation_route_id", operationRouteID.String()),
+		)
+
+		return nil, err
+	}
+	logger.Log(ctx, libLog.LevelDebug, "Built transaction route IDs query", libLog.String("query", query))
+
+	_, spanQuery := tracer.Start(ctx, "postgres.find_transaction_route_ids.query")
 	defer spanQuery.End()
 
 	rows, err := db.QueryContext(ctx, query, args...)
 	if err != nil {
 		libOpentelemetry.HandleSpanError(spanQuery, "Failed to execute query", err)
 
-		logger.Log(ctx, libLog.LevelError, fmt.Sprintf("Failed to execute query: %v", err))
+		logger.Log(ctx, libLog.LevelError, "Failed to execute query",
+			libLog.Err(err),
+			libLog.String("operation_route_id", operationRouteID.String()),
+		)
 
 		return nil, err
 	}
@@ -830,9 +942,12 @@ func (r *OperationRoutePostgreSQLRepository) FindTransactionRouteIDs(ctx context
 		var transactionRouteID uuid.UUID
 
 		if err := rows.Scan(&transactionRouteID); err != nil {
-			libOpentelemetry.HandleSpanError(span, "Failed to scan transaction route ID", err)
+			libOpentelemetry.HandleSpanError(spanQuery, "Failed to scan transaction route ID", err)
 
-			logger.Log(ctx, libLog.LevelError, fmt.Sprintf("Failed to scan transaction route ID: %v", err))
+			logger.Log(ctx, libLog.LevelError, "Failed to scan transaction route ID",
+				libLog.Err(err),
+				libLog.String("operation_route_id", operationRouteID.String()),
+			)
 
 			return nil, err
 		}
@@ -841,12 +956,16 @@ func (r *OperationRoutePostgreSQLRepository) FindTransactionRouteIDs(ctx context
 	}
 
 	if err := rows.Err(); err != nil {
-		libOpentelemetry.HandleSpanError(span, "Failed to iterate rows", err)
+		libOpentelemetry.HandleSpanError(spanQuery, "Failed to iterate rows", err)
 
-		logger.Log(ctx, libLog.LevelError, fmt.Sprintf("Failed to iterate rows: %v", err))
+		logger.Log(ctx, libLog.LevelError, "Failed to iterate rows",
+			libLog.Err(err),
+			libLog.String("operation_route_id", operationRouteID.String()),
+		)
 
 		return nil, err
 	}
+	spanQuery.SetAttributes(attribute.Int("db.rows_returned", len(transactionRouteIDs)))
 
 	return transactionRouteIDs, nil
 }

--- a/components/ledger/internal/adapters/postgres/operationroute/operationroute.postgresql.go
+++ b/components/ledger/internal/adapters/postgres/operationroute/operationroute.postgresql.go
@@ -31,6 +31,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/lib/pq"
+	"go.opentelemetry.io/otel/attribute"
 
 	// Repository provides an interface for operations related to operation route entities.
 	// It defines methods for creating, retrieving, updating, and deleting operation routes.
@@ -494,6 +495,11 @@ func (r *OperationRoutePostgreSQLRepository) Delete(ctx context.Context, organiz
 
 	ctx, span := tracer.Start(ctx, "postgres.delete_operation_route")
 	defer span.End()
+	span.SetAttributes(
+		attribute.String("app.organization_id", organizationID.String()),
+		attribute.String("app.ledger_id", ledgerID.String()),
+		attribute.String("app.operation_route_id", id.String()),
+	)
 
 	if err := ctx.Err(); err != nil {
 		libOpentelemetry.HandleSpanError(span, "Context finished before deleting operation route", err)
@@ -504,7 +510,6 @@ func (r *OperationRoutePostgreSQLRepository) Delete(ctx context.Context, organiz
 	db, err := r.getDB(ctx)
 	if err != nil {
 		libOpentelemetry.HandleSpanError(span, "Failed to get database connection", err)
-
 		logger.Log(ctx, libLog.LevelError, "Failed to get database connection", libLog.Err(err))
 
 		return err
@@ -523,10 +528,14 @@ func (r *OperationRoutePostgreSQLRepository) Delete(ctx context.Context, organiz
 	if err != nil {
 		libOpentelemetry.HandleSpanError(span, "Failed to build delete query", err)
 
-		logger.Log(ctx, libLog.LevelError, "Failed to build delete query", libLog.Err(err))
+		logger.Log(ctx, libLog.LevelError, "Failed to build delete query",
+			libLog.Err(err),
+			libLog.String("operation_route_id", id.String()),
+		)
 
 		return err
 	}
+	logger.Log(ctx, libLog.LevelDebug, "Built delete operation route query", libLog.String("query", query))
 
 	_, spanExec := tracer.Start(ctx, "postgres.delete.exec")
 	defer spanExec.End()
@@ -537,8 +546,6 @@ func (r *OperationRoutePostgreSQLRepository) Delete(ctx context.Context, organiz
 
 		logger.Log(ctx, libLog.LevelError, "Failed to execute delete query",
 			libLog.Err(err),
-			libLog.String("organization_id", organizationID.String()),
-			libLog.String("ledger_id", ledgerID.String()),
 			libLog.String("operation_route_id", id.String()),
 		)
 
@@ -547,12 +554,16 @@ func (r *OperationRoutePostgreSQLRepository) Delete(ctx context.Context, organiz
 
 	rowsAffected, err := result.RowsAffected()
 	if err != nil {
-		libOpentelemetry.HandleSpanError(span, "Failed to get rows affected", err)
+		libOpentelemetry.HandleSpanError(spanExec, "Failed to get rows affected", err)
 
-		logger.Log(ctx, libLog.LevelError, "Failed to get rows affected", libLog.Err(err))
+		logger.Log(ctx, libLog.LevelError, "Failed to get rows affected",
+			libLog.Err(err),
+			libLog.String("operation_route_id", id.String()),
+		)
 
 		return err
 	}
+	spanExec.SetAttributes(attribute.Int64("db.rows_affected", rowsAffected))
 
 	if rowsAffected == 0 {
 		err := services.ErrDatabaseItemNotFound
@@ -561,8 +572,6 @@ func (r *OperationRoutePostgreSQLRepository) Delete(ctx context.Context, organiz
 
 		logger.Log(ctx, libLog.LevelWarn, "Operation route not found for delete",
 			libLog.Err(err),
-			libLog.String("organization_id", organizationID.String()),
-			libLog.String("ledger_id", ledgerID.String()),
 			libLog.String("operation_route_id", id.String()),
 			libLog.Any("rows_affected", rowsAffected),
 		)
@@ -711,43 +720,73 @@ func (r *OperationRoutePostgreSQLRepository) HasTransactionRouteLinks(ctx contex
 
 	ctx, span := tracer.Start(ctx, "postgres.has_transaction_route_links")
 	defer span.End()
+	span.SetAttributes(
+		attribute.String("app.organization_id", organizationID.String()),
+		attribute.String("app.ledger_id", ledgerID.String()),
+		attribute.String("app.operation_route_id", operationRouteID.String()),
+	)
+
+	if err := ctx.Err(); err != nil {
+		libOpentelemetry.HandleSpanError(span, "Context finished before checking operation route links", err)
+
+		return false, err
+	}
 
 	db, err := r.getDB(ctx)
 	if err != nil {
 		libOpentelemetry.HandleSpanError(span, "Failed to get database connection", err)
 
-		logger.Log(ctx, libLog.LevelError, fmt.Sprintf("Failed to get database connection: %v", err))
+		logger.Log(ctx, libLog.LevelError, "Failed to get database connection",
+			libLog.Err(err),
+			libLog.String("operation_route_id", operationRouteID.String()),
+		)
 
 		return false, err
 	}
 
-	query := `SELECT EXISTS(
+	query, args, err := squirrel.Select().
+		Column(squirrel.Expr(`EXISTS(
 		SELECT 1
 		FROM operation_transaction_route otr
 		JOIN operation_route opr ON opr.id = otr.operation_route_id
-		WHERE otr.operation_route_id = $1
-		AND opr.organization_id = $2
-		AND opr.ledger_id = $3
+		WHERE otr.operation_route_id = ?
+		AND opr.organization_id = ?
+		AND opr.ledger_id = ?
 		AND otr.deleted_at IS NULL
 		AND opr.deleted_at IS NULL
-	)`
-	args := []any{operationRouteID, organizationID, ledgerID}
+	)`, operationRouteID, organizationID, ledgerID)).
+		PlaceholderFormat(squirrel.Dollar).
+		ToSql()
+	if err != nil {
+		libOpentelemetry.HandleSpanError(span, "Failed to build transaction route link query", err)
 
-	ctx, spanQuery := tracer.Start(ctx, "postgres.has_transaction_route_links.query")
+		logger.Log(ctx, libLog.LevelError, "Failed to build transaction route link query",
+			libLog.Err(err),
+			libLog.String("operation_route_id", operationRouteID.String()),
+		)
+
+		return false, err
+	}
+	logger.Log(ctx, libLog.LevelDebug, "Built transaction route link query", libLog.String("query", query))
+
+	_, spanQuery := tracer.Start(ctx, "postgres.has_transaction_route_links.query")
+	defer spanQuery.End()
 
 	var exists bool
 
 	row := db.QueryRowContext(ctx, query, args...)
 
-	spanQuery.End()
-
 	if err := row.Scan(&exists); err != nil {
-		libOpentelemetry.HandleSpanError(span, "Failed to scan exists result", err)
+		libOpentelemetry.HandleSpanError(spanQuery, "Failed to scan transaction route link result", err)
 
-		logger.Log(ctx, libLog.LevelError, fmt.Sprintf("Failed to scan exists result: %v", err))
+		logger.Log(ctx, libLog.LevelError, "Failed to scan transaction route link result",
+			libLog.Err(err),
+			libLog.String("operation_route_id", operationRouteID.String()),
+		)
 
 		return false, err
 	}
+	spanQuery.SetAttributes(attribute.Bool("app.operation_route_has_transaction_route_links", exists))
 
 	return exists, nil
 }

--- a/components/ledger/internal/adapters/postgres/operationroute/operationroute.postgresql_integration_test.go
+++ b/components/ledger/internal/adapters/postgres/operationroute/operationroute.postgresql_integration_test.go
@@ -721,7 +721,7 @@ func TestIntegration_OperationRouteRepository_HasTransactionRouteLinks_NoLinks(t
 	ctx := context.Background()
 
 	// Act
-	hasLinks, err := repo.HasTransactionRouteLinks(ctx, operationRouteID)
+	hasLinks, err := repo.HasTransactionRouteLinks(ctx, orgID, ledgerID, operationRouteID)
 
 	// Assert
 	require.NoError(t, err, "HasTransactionRouteLinks should not return error")
@@ -747,11 +747,35 @@ func TestIntegration_OperationRouteRepository_HasTransactionRouteLinks_WithLinks
 	ctx := context.Background()
 
 	// Act
-	hasLinks, err := repo.HasTransactionRouteLinks(ctx, operationRouteID)
+	hasLinks, err := repo.HasTransactionRouteLinks(ctx, orgID, ledgerID, operationRouteID)
 
 	// Assert
 	require.NoError(t, err, "HasTransactionRouteLinks should not return error")
 	assert.True(t, hasLinks, "should return true for linked route")
+}
+
+func TestIntegration_OperationRouteRepository_HasTransactionRouteLinks_WrongScope(t *testing.T) {
+	container := pgtestutil.SetupContainer(t)
+	repo := createRepository(t, container)
+
+	orgID := uuid.Must(libCommons.GenerateUUIDv7())
+	ledgerID := uuid.Must(libCommons.GenerateUUIDv7())
+	otherOrgID := uuid.Must(libCommons.GenerateUUIDv7())
+	otherLedgerID := uuid.Must(libCommons.GenerateUUIDv7())
+
+	// Insert linked operation route in the owning organization/ledger.
+	operationRouteID := pgtestutil.CreateTestOperationRouteSimple(t, container.DB, orgID, ledgerID, "Scoped Linked Route", "source")
+	transactionRouteID := pgtestutil.CreateTestTransactionRouteSimple(t, container.DB, orgID, ledgerID, "Scoped Transaction Route")
+	pgtestutil.CreateTestOperationTransactionRouteLink(t, container.DB, operationRouteID, transactionRouteID)
+
+	ctx := context.Background()
+
+	// Act
+	hasLinks, err := repo.HasTransactionRouteLinks(ctx, otherOrgID, otherLedgerID, operationRouteID)
+
+	// Assert
+	require.NoError(t, err, "HasTransactionRouteLinks should not return error")
+	assert.False(t, hasLinks, "should not expose links outside the requested organization/ledger")
 }
 
 func TestIntegration_OperationRouteRepository_HasTransactionRouteLinks_SoftDeletedLink(t *testing.T) {
@@ -774,7 +798,7 @@ func TestIntegration_OperationRouteRepository_HasTransactionRouteLinks_SoftDelet
 	ctx := context.Background()
 
 	// Act
-	hasLinks, err := repo.HasTransactionRouteLinks(ctx, operationRouteID)
+	hasLinks, err := repo.HasTransactionRouteLinks(ctx, orgID, ledgerID, operationRouteID)
 
 	// Assert
 	require.NoError(t, err, "HasTransactionRouteLinks should not return error")

--- a/components/ledger/internal/adapters/postgres/operationroute/operationroute.postgresql_integration_test.go
+++ b/components/ledger/internal/adapters/postgres/operationroute/operationroute.postgresql_integration_test.go
@@ -543,12 +543,29 @@ func TestIntegration_OperationRouteRepository_Delete_AlreadyDeleted(t *testing.T
 	ctx := context.Background()
 
 	// Act - delete already deleted record
-	// Note: The current implementation doesn't check rows affected for delete,
-	// so this will succeed silently (no error returned)
 	err := repo.Delete(ctx, orgID, ledgerID, operationRouteID)
 
-	// Assert - current behavior: no error (DELETE WHERE deleted_at IS NULL affects 0 rows)
-	require.NoError(t, err, "Delete does not return error for already-deleted record (known behavior)")
+	// Assert - already-deleted records are not matched by the soft-delete query
+	require.Error(t, err, "Delete should return error for already-deleted record")
+	assert.ErrorIs(t, err, services.ErrDatabaseItemNotFound, "error should be ErrDatabaseItemNotFound")
+}
+
+func TestIntegration_OperationRouteRepository_Delete_NotFound(t *testing.T) {
+	container := pgtestutil.SetupContainer(t)
+	repo := createRepository(t, container)
+
+	orgID := uuid.Must(libCommons.GenerateUUIDv7())
+	ledgerID := uuid.Must(libCommons.GenerateUUIDv7())
+	nonExistentID := uuid.Must(libCommons.GenerateUUIDv7())
+
+	ctx := context.Background()
+
+	// Act
+	err := repo.Delete(ctx, orgID, ledgerID, nonExistentID)
+
+	// Assert
+	require.Error(t, err, "Delete should return error for non-existent ID")
+	assert.ErrorIs(t, err, services.ErrDatabaseItemNotFound, "error should be ErrDatabaseItemNotFound")
 }
 
 // ============================================================================

--- a/components/ledger/internal/adapters/postgres/operationroute/operationroute.postgresql_mock.go
+++ b/components/ledger/internal/adapters/postgres/operationroute/operationroute.postgresql_mock.go
@@ -134,18 +134,18 @@ func (mr *MockRepositoryMockRecorder) FindTransactionRouteIDs(arg0, arg1 any) *g
 }
 
 // HasTransactionRouteLinks mocks base method.
-func (m *MockRepository) HasTransactionRouteLinks(arg0 context.Context, arg1 uuid.UUID) (bool, error) {
+func (m *MockRepository) HasTransactionRouteLinks(arg0 context.Context, arg1, arg2, arg3 uuid.UUID) (bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "HasTransactionRouteLinks", arg0, arg1)
+	ret := m.ctrl.Call(m, "HasTransactionRouteLinks", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // HasTransactionRouteLinks indicates an expected call of HasTransactionRouteLinks.
-func (mr *MockRepositoryMockRecorder) HasTransactionRouteLinks(arg0, arg1 any) *gomock.Call {
+func (mr *MockRepositoryMockRecorder) HasTransactionRouteLinks(arg0, arg1, arg2, arg3 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasTransactionRouteLinks", reflect.TypeOf((*MockRepository)(nil).HasTransactionRouteLinks), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasTransactionRouteLinks", reflect.TypeOf((*MockRepository)(nil).HasTransactionRouteLinks), arg0, arg1, arg2, arg3)
 }
 
 // Update mocks base method.

--- a/components/ledger/internal/services/command/delete_operation_route.go
+++ b/components/ledger/internal/services/command/delete_operation_route.go
@@ -30,7 +30,7 @@ func (uc *UseCase) DeleteOperationRouteByID(ctx context.Context, organizationID,
 
 	logger.Log(ctx, libLog.LevelInfo, fmt.Sprintf("Remove operation route for id: %s", id.String()))
 
-	hasLinks, err := uc.OperationRouteRepo.HasTransactionRouteLinks(ctx, id)
+	hasLinks, err := uc.OperationRouteRepo.HasTransactionRouteLinks(ctx, organizationID, ledgerID, id)
 	if err != nil {
 		libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Failed to check transaction route links", err)
 

--- a/components/ledger/internal/services/command/delete_operation_route.go
+++ b/components/ledger/internal/services/command/delete_operation_route.go
@@ -7,60 +7,80 @@ package command
 import (
 	"context"
 	"errors"
-	"fmt"
-	"reflect"
 
 	libCommons "github.com/LerianStudio/lib-commons/v5/commons"
+	libLog "github.com/LerianStudio/lib-commons/v5/commons/log"
 	libOpentelemetry "github.com/LerianStudio/lib-commons/v5/commons/opentelemetry"
+	"github.com/google/uuid"
+	"go.opentelemetry.io/otel/attribute"
+
 	"github.com/LerianStudio/midaz/v3/components/ledger/internal/services"
 	"github.com/LerianStudio/midaz/v3/pkg"
 	"github.com/LerianStudio/midaz/v3/pkg/constant"
-	"github.com/LerianStudio/midaz/v3/pkg/mmodel"
-	"github.com/google/uuid"
-
-	// DeleteOperationRouteByID is a method that deletes Operation Route information.
-	libLog "github.com/LerianStudio/lib-commons/v5/commons/log"
 )
 
+// DeleteOperationRouteByID deletes an operation route by ID.
 func (uc *UseCase) DeleteOperationRouteByID(ctx context.Context, organizationID, ledgerID uuid.UUID, id uuid.UUID) error {
 	logger, tracer, _, _ := libCommons.NewTrackingFromContext(ctx)
 
 	ctx, span := tracer.Start(ctx, "command.delete_operation_route_by_id")
 	defer span.End()
 
-	logger.Log(ctx, libLog.LevelInfo, fmt.Sprintf("Remove operation route for id: %s", id.String()))
+	span.SetAttributes(
+		attribute.String("app.request.organization_id", organizationID.String()),
+		attribute.String("app.request.ledger_id", ledgerID.String()),
+		attribute.String("app.request.operation_route_id", id.String()),
+	)
+
+	if err := ctx.Err(); err != nil {
+		libOpentelemetry.HandleSpanError(span, "Context canceled before deleting operation route", err)
+
+		return err
+	}
 
 	hasLinks, err := uc.OperationRouteRepo.HasTransactionRouteLinks(ctx, organizationID, ledgerID, id)
 	if err != nil {
-		libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Failed to check transaction route links", err)
+		libOpentelemetry.HandleSpanError(span, "Failed to check transaction route links", err)
 
-		logger.Log(ctx, libLog.LevelError, fmt.Sprintf("Error checking transaction route links for operation route %s: %v", id.String(), err))
+		logger.Log(ctx, libLog.LevelError, "Failed to check transaction route links",
+			libLog.Err(err),
+			libLog.String("operation_route_id", id.String()),
+		)
 
 		return err
 	}
 
 	if hasLinks {
-		libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Operation Route cannot be deleted because it is linked to transaction routes", nil)
+		err := pkg.ValidateBusinessError(constant.ErrOperationRouteLinkedToTransactionRoutes, constant.EntityOperationRoute)
 
-		logger.Log(ctx, libLog.LevelWarn, fmt.Sprintf("Operation Route ID %s cannot be deleted because it is linked to transaction routes", id.String()))
+		libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Operation route is linked to transaction routes", err)
 
-		return pkg.ValidateBusinessError(constant.ErrOperationRouteLinkedToTransactionRoutes, reflect.TypeOf(mmodel.OperationRoute{}).Name())
+		logger.Log(ctx, libLog.LevelWarn, "Operation route is linked to transaction routes",
+			libLog.String("operation_route_id", id.String()),
+		)
+
+		return err
 	}
 
 	if err := uc.OperationRouteRepo.Delete(ctx, organizationID, ledgerID, id); err != nil {
 		if errors.Is(err, services.ErrDatabaseItemNotFound) {
-			err := pkg.ValidateBusinessError(constant.ErrOperationRouteNotFound, reflect.TypeOf(mmodel.OperationRoute{}).Name())
+			err := pkg.ValidateBusinessError(constant.ErrOperationRouteNotFound, constant.EntityOperationRoute)
 
-			libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Operation Route ID not found", err)
+			libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Operation route not found", err)
 
-			logger.Log(ctx, libLog.LevelWarn, fmt.Sprintf("Operation Route ID not found: %s", id.String()))
+			logger.Log(ctx, libLog.LevelWarn, "Operation route not found",
+				libLog.String("operation_route_id", id.String()),
+			)
 
 			return err
 		}
 
-		libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Failed to delete operation route on repo by id", err)
+		libOpentelemetry.HandleSpanError(span, "Failed to delete operation route", err)
 
-		logger.Log(ctx, libLog.LevelError, fmt.Sprintf("Error deleting operation route: %v", err))
+		logger.Log(ctx, libLog.LevelError, "Failed to delete operation route",
+			libLog.Err(err),
+			libLog.String("operation_route_id", id.String()),
+		)
 
 		return err
 	}

--- a/components/ledger/internal/services/command/delete_operation_route_test.go
+++ b/components/ledger/internal/services/command/delete_operation_route_test.go
@@ -32,7 +32,7 @@ func TestDeleteOperationRouteByIDSuccess(t *testing.T) {
 	}
 
 	mockRepo.EXPECT().
-		HasTransactionRouteLinks(gomock.Any(), operationRouteID).
+		HasTransactionRouteLinks(gomock.Any(), organizationID, ledgerID, operationRouteID).
 		Return(false, nil).
 		Times(1)
 
@@ -61,7 +61,7 @@ func TestDeleteOperationRouteByIDNotFound(t *testing.T) {
 	}
 
 	mockRepo.EXPECT().
-		HasTransactionRouteLinks(gomock.Any(), operationRouteID).
+		HasTransactionRouteLinks(gomock.Any(), organizationID, ledgerID, operationRouteID).
 		Return(false, nil).
 		Times(1)
 
@@ -96,7 +96,7 @@ func TestDeleteOperationRouteByIDError(t *testing.T) {
 	}
 
 	mockRepo.EXPECT().
-		HasTransactionRouteLinks(gomock.Any(), operationRouteID).
+		HasTransactionRouteLinks(gomock.Any(), organizationID, ledgerID, operationRouteID).
 		Return(false, nil).
 		Times(1)
 
@@ -126,7 +126,7 @@ func TestDeleteOperationRouteByIDLinkedToTransactionRoutes(t *testing.T) {
 	}
 
 	mockRepo.EXPECT().
-		HasTransactionRouteLinks(gomock.Any(), operationRouteID).
+		HasTransactionRouteLinks(gomock.Any(), organizationID, ledgerID, operationRouteID).
 		Return(true, nil).
 		Times(1)
 
@@ -161,7 +161,7 @@ func TestDeleteOperationRouteByIDHasLinksCheckError(t *testing.T) {
 	}
 
 	mockRepo.EXPECT().
-		HasTransactionRouteLinks(gomock.Any(), operationRouteID).
+		HasTransactionRouteLinks(gomock.Any(), organizationID, ledgerID, operationRouteID).
 		Return(false, linkCheckError).
 		Times(1)
 

--- a/components/ledger/internal/services/command/delete_operation_route_test.go
+++ b/components/ledger/internal/services/command/delete_operation_route_test.go
@@ -46,6 +46,28 @@ func TestDeleteOperationRouteByIDSuccess(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+// TestDeleteOperationRouteByIDContextCanceled tests deletion with canceled context.
+func TestDeleteOperationRouteByIDContextCanceled(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	operationRouteID := uuid.New()
+	organizationID := uuid.New()
+	ledgerID := uuid.New()
+
+	mockRepo := operationroute.NewMockRepository(ctrl)
+	uc := &UseCase{
+		OperationRouteRepo: mockRepo,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := uc.DeleteOperationRouteByID(ctx, organizationID, ledgerID, operationRouteID)
+
+	assert.ErrorIs(t, err, context.Canceled)
+}
+
 // TestDeleteOperationRouteByIDNotFound tests deletion when operation route is not found
 func TestDeleteOperationRouteByIDNotFound(t *testing.T) {
 	ctrl := gomock.NewController(t)

--- a/pkg/net/http/httputils.go
+++ b/pkg/net/http/httputils.go
@@ -358,16 +358,7 @@ func validateDates(startDate, endDate *time.Time) error {
 	maxDateRangeMonths := libCommons.SafeInt64ToInt(libCommons.GetenvIntOrDefault("MAX_PAGINATION_MONTH_DATE_RANGE", 1))
 
 	if startDate.IsZero() && endDate.IsZero() {
-		now := time.Now()
-
-		defaultStartDate := time.Unix(0, 0).UTC()
-
-		if maxDateRangeMonths != 0 {
-			defaultStartDate = time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC).AddDate(0, -maxDateRangeMonths, 0)
-		}
-
-		*startDate = defaultStartDate
-		*endDate = time.Date(now.Year(), now.Month(), now.Day(), 23, 59, 59, 999999999, time.UTC)
+		*startDate, *endDate = defaultPaginationDateRange(time.Now(), maxDateRangeMonths)
 
 		return nil
 	}
@@ -386,6 +377,19 @@ func validateDates(startDate, endDate *time.Time) error {
 	}
 
 	return nil
+}
+
+func defaultPaginationDateRange(now time.Time, maxDateRangeMonths int) (time.Time, time.Time) {
+	now = now.UTC()
+
+	defaultStartDate := time.Unix(0, 0).UTC()
+	if maxDateRangeMonths != 0 {
+		defaultStartDate = time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC).AddDate(0, -maxDateRangeMonths, 0)
+	}
+
+	defaultEndDate := time.Date(now.Year(), now.Month(), now.Day(), 23, 59, 59, 999999999, time.UTC)
+
+	return defaultStartDate, defaultEndDate
 }
 
 type legacyCursor struct {

--- a/pkg/net/http/httputils_test.go
+++ b/pkg/net/http/httputils_test.go
@@ -321,6 +321,15 @@ func TestValidateDates_WithMaxDateRangeZero(t *testing.T) {
 	assert.Equal(t, int64(0), startDate.Unix())
 }
 
+func TestDefaultPaginationDateRange_UsesUTCDate(t *testing.T) {
+	localTime := time.Date(2026, time.April, 30, 23, 30, 0, 0, time.FixedZone("BRT", -3*60*60))
+
+	startDate, endDate := defaultPaginationDateRange(localTime, 1)
+
+	assert.Equal(t, time.Date(2026, time.April, 1, 0, 0, 0, 0, time.UTC), startDate)
+	assert.Equal(t, time.Date(2026, time.May, 1, 23, 59, 59, 999999999, time.UTC), endDate)
+}
+
 func TestValidatePagination_ValidParams(t *testing.T) {
 	_, err := validatePagination("", "asc", 10)
 


### PR DESCRIPTION
## Summary

- Scope operation route delete link checks by organization and ledger.
- Return not found when deleting missing or already-deleted operation routes.
- Improve operation route repository observability and structured logging.