### PR TITLE
fix: pagination validation for limit and page fields

### DIFF
--- a/components/crm/internal/adapters/http/in/alias_test.go
+++ b/components/crm/internal/adapters/http/in/alias_test.go
@@ -1109,6 +1109,54 @@ func TestAliasHandler_GetAllAliases(t *testing.T) {
 				assert.Contains(t, errResp, "message", "error response should contain message")
 			},
 		},
+		{
+			name:        "zero limit returns 400",
+			queryParams: "?limit=0",
+			setupMocks: func(aliasRepo *alias.MockRepository, orgID string) {
+			},
+			expectedStatus: 400,
+			validateBody:   assertInvalidQueryParameterResponse,
+		},
+		{
+			name:        "negative limit returns 400",
+			queryParams: "?limit=-1",
+			setupMocks: func(aliasRepo *alias.MockRepository, orgID string) {
+			},
+			expectedStatus: 400,
+			validateBody:   assertInvalidQueryParameterResponse,
+		},
+		{
+			name:        "non-numeric limit returns 400",
+			queryParams: "?limit=abc",
+			setupMocks: func(aliasRepo *alias.MockRepository, orgID string) {
+			},
+			expectedStatus: 400,
+			validateBody:   assertInvalidQueryParameterResponse,
+		},
+		{
+			name:        "zero page returns 400",
+			queryParams: "?page=0",
+			setupMocks: func(aliasRepo *alias.MockRepository, orgID string) {
+			},
+			expectedStatus: 400,
+			validateBody:   assertInvalidQueryParameterResponse,
+		},
+		{
+			name:        "negative page returns 400",
+			queryParams: "?page=-1",
+			setupMocks: func(aliasRepo *alias.MockRepository, orgID string) {
+			},
+			expectedStatus: 400,
+			validateBody:   assertInvalidQueryParameterResponse,
+		},
+		{
+			name:        "non-numeric page returns 400",
+			queryParams: "?page=abc",
+			setupMocks: func(aliasRepo *alias.MockRepository, orgID string) {
+			},
+			expectedStatus: 400,
+			validateBody:   assertInvalidQueryParameterResponse,
+		},
 	}
 
 	for _, tt := range tests {
@@ -1149,4 +1197,16 @@ func TestAliasHandler_GetAllAliases(t *testing.T) {
 			}
 		})
 	}
+}
+
+func assertInvalidQueryParameterResponse(t *testing.T, body []byte) {
+	t.Helper()
+
+	var errResp map[string]any
+	err := json.Unmarshal(body, &errResp)
+	require.NoError(t, err)
+
+	assert.Equal(t, cn.ErrInvalidQueryParameter.Error(), errResp["code"])
+	assert.Equal(t, "Invalid Query Parameter", errResp["title"])
+	assert.Contains(t, errResp["message"], "query parameters")
 }

--- a/components/crm/internal/adapters/http/in/holder_test.go
+++ b/components/crm/internal/adapters/http/in/holder_test.go
@@ -1020,96 +1020,52 @@ func TestHolderHandler_GetAllHolders(t *testing.T) {
 			},
 		},
 		{
-			name:        "zero limit passes through to repository",
+			name:        "zero limit returns 400",
 			queryParams: "?limit=0",
 			setupMocks: func(holderRepo *holder.MockRepository, orgID string) {
-				holderRepo.EXPECT().
-					FindAll(gomock.Any(), orgID, gomock.Cond(func(x any) bool {
-						params, ok := x.(http.QueryHeader)
-						return ok && params.Limit == 0
-					}), false).
-					Return([]*mmodel.Holder{}, nil).
-					Times(1)
 			},
-			expectedStatus: 200,
-			validateBody: func(t *testing.T, body []byte) {
-				var result map[string]any
-				err := json.Unmarshal(body, &result)
-				require.NoError(t, err)
-
-				limit, ok := result["limit"].(float64)
-				require.True(t, ok, "limit should be a number")
-				assert.Equal(t, float64(0), limit)
-			},
+			expectedStatus: 400,
+			validateBody:   assertInvalidQueryParameterResponse,
 		},
 		{
-			name:        "negative limit passes through to repository",
+			name:        "negative limit returns 400",
 			queryParams: "?limit=-5",
 			setupMocks: func(holderRepo *holder.MockRepository, orgID string) {
-				holderRepo.EXPECT().
-					FindAll(gomock.Any(), orgID, gomock.Cond(func(x any) bool {
-						params, ok := x.(http.QueryHeader)
-						return ok && params.Limit == -5
-					}), false).
-					Return([]*mmodel.Holder{}, nil).
-					Times(1)
 			},
-			expectedStatus: 200,
-			validateBody: func(t *testing.T, body []byte) {
-				var result map[string]any
-				err := json.Unmarshal(body, &result)
-				require.NoError(t, err)
-
-				limit, ok := result["limit"].(float64)
-				require.True(t, ok, "limit should be a number")
-				assert.Equal(t, float64(-5), limit)
-			},
+			expectedStatus: 400,
+			validateBody:   assertInvalidQueryParameterResponse,
 		},
 		{
-			name:        "negative page passes through to repository",
+			name:        "zero page returns 400",
+			queryParams: "?page=0",
+			setupMocks: func(holderRepo *holder.MockRepository, orgID string) {
+			},
+			expectedStatus: 400,
+			validateBody:   assertInvalidQueryParameterResponse,
+		},
+		{
+			name:        "negative page returns 400",
 			queryParams: "?page=-1",
 			setupMocks: func(holderRepo *holder.MockRepository, orgID string) {
-				holderRepo.EXPECT().
-					FindAll(gomock.Any(), orgID, gomock.Cond(func(x any) bool {
-						params, ok := x.(http.QueryHeader)
-						return ok && params.Page == -1
-					}), false).
-					Return([]*mmodel.Holder{}, nil).
-					Times(1)
 			},
-			expectedStatus: 200,
-			validateBody: func(t *testing.T, body []byte) {
-				var result map[string]any
-				err := json.Unmarshal(body, &result)
-				require.NoError(t, err)
-
-				page, ok := result["page"].(float64)
-				require.True(t, ok, "page should be a number")
-				assert.Equal(t, float64(-1), page)
-			},
+			expectedStatus: 400,
+			validateBody:   assertInvalidQueryParameterResponse,
 		},
 		{
-			name:        "non-numeric limit becomes zero",
+			name:        "non-numeric page returns 400",
+			queryParams: "?page=abc",
+			setupMocks: func(holderRepo *holder.MockRepository, orgID string) {
+			},
+			expectedStatus: 400,
+			validateBody:   assertInvalidQueryParameterResponse,
+		},
+		{
+			name:        "non-numeric limit returns 400",
 			queryParams: "?limit=abc",
 			setupMocks: func(holderRepo *holder.MockRepository, orgID string) {
-				holderRepo.EXPECT().
-					FindAll(gomock.Any(), orgID, gomock.Cond(func(x any) bool {
-						params, ok := x.(http.QueryHeader)
-						return ok && params.Limit == 0
-					}), false).
-					Return([]*mmodel.Holder{}, nil).
-					Times(1)
 			},
-			expectedStatus: 200,
-			validateBody: func(t *testing.T, body []byte) {
-				var result map[string]any
-				err := json.Unmarshal(body, &result)
-				require.NoError(t, err)
-
-				limit, ok := result["limit"].(float64)
-				require.True(t, ok, "limit should be a number")
-				assert.Equal(t, float64(0), limit)
-			},
+			expectedStatus: 400,
+			validateBody:   assertInvalidQueryParameterResponse,
 		},
 	}
 

--- a/components/ledger/internal/adapters/http/in/account_test.go
+++ b/components/ledger/internal/adapters/http/in/account_test.go
@@ -459,6 +459,54 @@ func TestAccountHandler_GetAllAccounts(t *testing.T) {
 			},
 		},
 		{
+			name:        "zero limit returns 400",
+			queryParams: "?limit=0",
+			setupMocks: func(accountRepo *account.MockRepository, metadataRepo *mongodb.MockRepository, orgID, ledgerID uuid.UUID) {
+			},
+			expectedStatus: 400,
+			validateBody:   assertInvalidQueryParameterResponse,
+		},
+		{
+			name:        "negative limit returns 400",
+			queryParams: "?limit=-1",
+			setupMocks: func(accountRepo *account.MockRepository, metadataRepo *mongodb.MockRepository, orgID, ledgerID uuid.UUID) {
+			},
+			expectedStatus: 400,
+			validateBody:   assertInvalidQueryParameterResponse,
+		},
+		{
+			name:        "non-numeric limit returns 400",
+			queryParams: "?limit=abc",
+			setupMocks: func(accountRepo *account.MockRepository, metadataRepo *mongodb.MockRepository, orgID, ledgerID uuid.UUID) {
+			},
+			expectedStatus: 400,
+			validateBody:   assertInvalidQueryParameterResponse,
+		},
+		{
+			name:        "zero page returns 400",
+			queryParams: "?page=0",
+			setupMocks: func(accountRepo *account.MockRepository, metadataRepo *mongodb.MockRepository, orgID, ledgerID uuid.UUID) {
+			},
+			expectedStatus: 400,
+			validateBody:   assertInvalidQueryParameterResponse,
+		},
+		{
+			name:        "negative page returns 400",
+			queryParams: "?page=-1",
+			setupMocks: func(accountRepo *account.MockRepository, metadataRepo *mongodb.MockRepository, orgID, ledgerID uuid.UUID) {
+			},
+			expectedStatus: 400,
+			validateBody:   assertInvalidQueryParameterResponse,
+		},
+		{
+			name:        "non-numeric page returns 400",
+			queryParams: "?page=abc",
+			setupMocks: func(accountRepo *account.MockRepository, metadataRepo *mongodb.MockRepository, orgID, ledgerID uuid.UUID) {
+			},
+			expectedStatus: 400,
+			validateBody:   assertInvalidQueryParameterResponse,
+		},
+		{
 			name:        "repository error returns 500",
 			queryParams: "",
 			setupMocks: func(accountRepo *account.MockRepository, metadataRepo *mongodb.MockRepository, orgID, ledgerID uuid.UUID) {
@@ -527,6 +575,18 @@ func TestAccountHandler_GetAllAccounts(t *testing.T) {
 			}
 		})
 	}
+}
+
+func assertInvalidQueryParameterResponse(t *testing.T, body []byte) {
+	t.Helper()
+
+	var errResp map[string]any
+	err := json.Unmarshal(body, &errResp)
+	require.NoError(t, err)
+
+	assert.Equal(t, cn.ErrInvalidQueryParameter.Error(), errResp["code"])
+	assert.Equal(t, "Invalid Query Parameter", errResp["title"])
+	assert.Contains(t, errResp["message"], "query parameters")
 }
 
 func TestAccountHandler_GetAccountByID(t *testing.T) {

--- a/components/ledger/internal/adapters/http/in/transaction.go
+++ b/components/ledger/internal/adapters/http/in/transaction.go
@@ -294,7 +294,7 @@ func (handler *TransactionHandler) GetTransaction(c *fiber.Ctx) error {
 	headerParams, err := http.ValidateParameters(c.Queries())
 	if err != nil {
 		libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Failed to validate query parameters", err)
-		logger.Log(ctx, libLog.LevelError, "Failed to validate query parameters", libLog.Err(err))
+		logger.Log(ctx, libLog.LevelWarn, "Failed to validate query parameters", libLog.Err(err))
 
 		return http.WithError(c, err)
 	}

--- a/components/ledger/internal/adapters/http/in/transaction.go
+++ b/components/ledger/internal/adapters/http/in/transaction.go
@@ -291,6 +291,14 @@ func (handler *TransactionHandler) GetTransaction(c *fiber.Ctx) error {
 		return http.WithError(c, err)
 	}
 
+	headerParams, err := http.ValidateParameters(c.Queries())
+	if err != nil {
+		libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Failed to validate query parameters", err)
+		logger.Log(ctx, libLog.LevelError, "Failed to validate query parameters", libLog.Err(err))
+
+		return http.WithError(c, err)
+	}
+
 	if wbTran, wbErr := handler.Query.GetWriteBehindTransaction(ctx, params.OrganizationID, params.LedgerID, params.TransactionID); wbErr == nil {
 		c.Set("X-Cache-Hit", "true")
 
@@ -314,14 +322,6 @@ func (handler *TransactionHandler) GetTransaction(c *fiber.Ctx) error {
 
 	ctxGetTransaction, spanGetTransaction := tracer.Start(ctx, "handler.get_transaction.get_operations")
 	defer spanGetTransaction.End()
-
-	headerParams, err := http.ValidateParameters(c.Queries())
-	if err != nil {
-		libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Failed to validate query parameters", err)
-		logger.Log(ctx, libLog.LevelError, "Failed to validate query parameters", libLog.Err(err))
-
-		return http.WithError(c, err)
-	}
 
 	headerParams.Metadata = &bson.M{}
 

--- a/components/ledger/internal/adapters/http/in/transaction_test.go
+++ b/components/ledger/internal/adapters/http/in/transaction_test.go
@@ -243,6 +243,14 @@ func TestTransactionHandler_GetTransaction(t *testing.T) {
 				assert.Contains(t, errResp, "code", "error response should contain code field")
 			},
 		},
+		{
+			name:        "invalid pagination returns 400 before repository calls",
+			queryParams: "?page=abc",
+			setupMocks: func(transactionRepo *transaction.MockRepository, operationRepo *operation.MockRepository, metadataRepo *mongodb.MockRepository, redisRepo *redis.MockRedisRepository, orgID, ledgerID, transactionID uuid.UUID) {
+			},
+			expectedStatus: 400,
+			validateBody:   assertInvalidQueryParameterResponse,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/mmodel/balance_position.go
+++ b/pkg/mmodel/balance_position.go
@@ -97,6 +97,7 @@ func computePosition(available, onHold, overdraftUsed decimal.Decimal, settings 
 
 	// Overdraft enabled AND limited → headroom = limit − used.
 	var limit decimal.Decimal
+
 	if settings.OverdraftLimit != nil {
 		if parsed, err := decimal.NewFromString(*settings.OverdraftLimit); err == nil {
 			limit = parsed

--- a/pkg/net/http/httputils.go
+++ b/pkg/net/http/httputils.go
@@ -153,10 +153,20 @@ func ValidateParameters(params map[string]string) (*QueryHeader, error) {
 		case strings.Contains(key, "metadata."):
 			metadata = &bson.M{key: value}
 			useMetadata = true
-		case strings.Contains(key, "limit"):
-			limit, _ = strconv.Atoi(value)
-		case strings.Contains(key, "page"):
-			page, _ = strconv.Atoi(value)
+		case key == "limit":
+			parsedLimit, err := strconv.Atoi(value)
+			if err != nil {
+				return nil, pkg.ValidateBusinessError(constant.ErrInvalidQueryParameter, "", "limit")
+			}
+
+			limit = parsedLimit
+		case key == "page":
+			parsedPage, err := strconv.Atoi(value)
+			if err != nil {
+				return nil, pkg.ValidateBusinessError(constant.ErrInvalidQueryParameter, "", "page")
+			}
+
+			page = parsedPage
 		case strings.Contains(key, "cursor"):
 			cursor = value
 		case strings.Contains(key, "sort_order"):
@@ -265,6 +275,10 @@ func ValidateParameters(params map[string]string) (*QueryHeader, error) {
 	err := validateDates(&startDate, &endDate)
 	if err != nil {
 		return nil, err
+	}
+
+	if page <= 0 {
+		return nil, pkg.ValidateBusinessError(constant.ErrInvalidQueryParameter, "", "page")
 	}
 
 	cursor, err = validatePagination(cursor, sortOrder, limit)
@@ -400,6 +414,10 @@ type legacyCursor struct {
 // ValidatePagination validate pagination parameters
 func validatePagination(cursor, sortOrder string, limit int) (string, error) {
 	maxPaginationLimit := libCommons.SafeInt64ToInt(libCommons.GetenvIntOrDefault("MAX_PAGINATION_LIMIT", 100))
+
+	if limit <= 0 {
+		return "", pkg.ValidateBusinessError(constant.ErrInvalidQueryParameter, "", "limit")
+	}
 
 	if limit > maxPaginationLimit {
 		return "", pkg.ValidateBusinessError(constant.ErrPaginationLimitExceeded, "", maxPaginationLimit)

--- a/pkg/net/http/httputils_test.go
+++ b/pkg/net/http/httputils_test.go
@@ -16,6 +16,7 @@ import (
 
 	libConstants "github.com/LerianStudio/lib-commons/v5/commons/constants"
 	libHTTP "github.com/LerianStudio/lib-commons/v5/commons/net/http"
+	cn "github.com/LerianStudio/midaz/v3/pkg/constant"
 	"github.com/gofiber/fiber/v2"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
@@ -49,6 +50,41 @@ func TestValidateParameters_WithLimit(t *testing.T) {
 	assert.Equal(t, 50, result.Limit)
 }
 
+func TestValidateParameters_WithInvalidLimit(t *testing.T) {
+	tests := []struct {
+		name  string
+		limit string
+	}{
+		{
+			name:  "zero limit",
+			limit: "0",
+		},
+		{
+			name:  "negative limit",
+			limit: "-1",
+		},
+		{
+			name:  "non-numeric limit",
+			limit: "abc",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			params := map[string]string{
+				"limit": tt.limit,
+			}
+
+			result, err := ValidateParameters(params)
+
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), cn.ErrInvalidQueryParameter.Error())
+			assert.Contains(t, err.Error(), "limit")
+			assert.Nil(t, result)
+		})
+	}
+}
+
 func TestValidateParameters_WithPage(t *testing.T) {
 	params := map[string]string{
 		"page": "5",
@@ -58,6 +94,54 @@ func TestValidateParameters_WithPage(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Equal(t, 5, result.Page)
+}
+
+func TestValidateParameters_WithInvalidPage(t *testing.T) {
+	tests := []struct {
+		name string
+		page string
+	}{
+		{
+			name: "zero page",
+			page: "0",
+		},
+		{
+			name: "negative page",
+			page: "-1",
+		},
+		{
+			name: "non-numeric page",
+			page: "abc",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			params := map[string]string{
+				"page": tt.page,
+			}
+
+			result, err := ValidateParameters(params)
+
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), cn.ErrInvalidQueryParameter.Error())
+			assert.Contains(t, err.Error(), "page")
+			assert.Nil(t, result)
+		})
+	}
+}
+
+func TestValidateParameters_IgnoresNonPaginationKeysContainingPaginationTerms(t *testing.T) {
+	params := map[string]string{
+		"homepage":   "abc",
+		"rate_limit": "abc",
+	}
+
+	result, err := ValidateParameters(params)
+
+	require.NoError(t, err)
+	assert.Equal(t, 10, result.Limit)
+	assert.Equal(t, 1, result.Page)
 }
 
 func TestValidateParameters_WithCursor(t *testing.T) {
@@ -354,6 +438,30 @@ func TestValidatePagination_LimitExceeded(t *testing.T) {
 	_, err := validatePagination("", "asc", 150)
 
 	assert.Error(t, err)
+}
+
+func TestValidatePagination_InvalidLimit(t *testing.T) {
+	tests := []struct {
+		name  string
+		limit int
+	}{
+		{
+			name:  "zero limit",
+			limit: 0,
+		},
+		{
+			name:  "negative limit",
+			limit: -1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := validatePagination("", "asc", tt.limit)
+
+			assert.Error(t, err)
+		})
+	}
 }
 
 func TestValidatePagination_InvalidCursor(t *testing.T) {


### PR DESCRIPTION
## Summary

- Validates `limit` and `page` query parameters before handlers execute repository lookups.
- Returns `ErrInvalidQueryParameter` for non-numeric, zero, or negative pagination values.
- Adds unit coverage for CRM alias and holder pagination, Ledger account and transaction pagination, and shared HTTP query validation.

## Motivation

Invalid pagination input could be silently converted or passed through to repositories, creating inconsistent API behavior. This change fails fast with a deterministic 400 validation response for malformed pagination requests.

## Semantic Decision

Pagination query values are valid only when `limit > 0` and `page > 0`. The parser now matches `limit` and `page` as exact query keys so unrelated keys like `homepage` or `rate_limit` are not interpreted as pagination controls. `GetTransaction` validates query parameters before write-behind and repository lookups so invalid requests stop before downstream calls.

## Changes

- Updated `pkg/net/http/httputils.go` to return `ErrInvalidQueryParameter` when `limit` or `page` cannot be parsed or is less than one.
- Changed pagination key matching from substring checks to exact `limit` and `page` checks.
- Moved Ledger transaction query parameter validation before write-behind transaction lookup.
- Added and updated handler tests for invalid pagination in CRM aliases, CRM holders, Ledger accounts, and Ledger transactions.
- Added shared HTTP utility tests for invalid pagination values and query keys that merely contain pagination terms.
- Includes a formatting-only whitespace change in `pkg/mmodel/balance_position.go`.

### New Files
| File | Purpose |
|------|---------|
| None | No new source files were added. |

### Environment Variables - Pagination Validation
| Variable | Type | Default | Description |
|----------|------|---------|-------------|
| None | N/A | N/A | No environment variables were added or changed. |

### Refactored Code
| Before | After |
|--------|-------|
| `limit` and `page` parsing ignored `strconv.Atoi` errors. | Invalid numeric parsing returns `ErrInvalidQueryParameter`. |
| Zero or negative `limit` values could pass into pagination flow. | `limit <= 0` returns `ErrInvalidQueryParameter`. |
| Zero or negative `page` values could pass into query headers. | `page <= 0` returns `ErrInvalidQueryParameter`. |
| Query keys containing `limit` or `page` substrings were treated as pagination parameters. | Only exact `limit` and `page` keys are treated as pagination parameters. |
| Transaction query validation happened after write-behind lookup. | Transaction query validation happens before downstream lookups. |


## Test Plan
- [x] Added shared unit tests for invalid `limit` and `page` values in `pkg/net/http/httputils_test.go`.
- [x] Added shared unit test coverage proving non-pagination query keys containing pagination terms are ignored.
- [x] Added handler test coverage for invalid pagination in CRM alias and holder list endpoints.
- [x] Added handler test coverage for invalid pagination in Ledger account list and transaction detail endpoints.

