### PR TITLE
fix: allow external accounts to hold positive balance

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![License: Elastic-2.0](https://img.shields.io/badge/License-Elastic_2.0-blue.svg)](https://github.com/LerianStudio/midaz/blob/main/LICENSE)
 [![Go Report](https://goreportcard.com/badge/github.com/lerianstudio/midaz)](https://goreportcard.com/report/github.com/lerianstudio/midaz)
 [![Discord](https://img.shields.io/badge/Discord-Lerian%20Studio-%237289da.svg?logo=discord)](https://discord.gg/DnhqKwkGv3)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/LerianStudio/midaz)
 
 </div>
 

--- a/components/ledger/internal/adapters/redis/transaction/consumer.redis.go
+++ b/components/ledger/internal/adapters/redis/transaction/consumer.redis.go
@@ -745,7 +745,7 @@ func (rr *RedisConsumerRepository) buildBalanceAtomicOperationPlan(ctx context.C
 // this mapping must be updated accordingly.
 //
 // Lua error codes emitted by balance_atomic_operation.lua:
-//   - "0018" → ErrInsufficientFunds (negative available on non-external, or positive on external CREDIT)
+//   - "0018" → ErrInsufficientFunds (negative available on non-external credit-direction balance without overdraft fall-through)
 //   - "0098" → ErrOnHoldExternalAccount (external account used in pending source)
 //   - "0139" → ErrTransactionBackupCacheRetrievalFailed (balance key vanished mid-script)
 //   - "0167" → ErrOverdraftLimitExceeded (transaction would push usage past the configured limit)

--- a/components/ledger/internal/adapters/redis/transaction/consumer.redis_integration_test.go
+++ b/components/ledger/internal/adapters/redis/transaction/consumer.redis_integration_test.go
@@ -903,9 +903,20 @@ func TestIntegration_Chaos_Redis_GracefulDegradation(t *testing.T) {
 // INTEGRATION TESTS - EXTERNAL ACCOUNT VALIDATION
 // =============================================================================
 
-// TestIntegration_Redis_ExternalAccountCreditValidation tests that external accounts
-// cannot have positive balance after credit operations.
-// This validates error code 0018 for external destinations in the Lua script.
+// TestIntegration_Redis_ExternalAccountCreditValidation tests the symmetry of
+// CREDIT and DEBIT operations on external accounts: external accounts may
+// hold any sign on Available. The destination-side guard that previously
+// rejected `external + CREDIT → positive result` was removed because the
+// introduction of direction=debit balances made that invariant incompatible
+// with valid customer use cases (notably outflows from a fresh ledger to
+// @external/{asset}).
+//
+// Each sub-test exercises one CREDIT/DEBIT × sign-of-result combination and
+// asserts the Lua script's response. The historical name is preserved for
+// continuity, but the subject under test has shifted from "validating the
+// external-positive guard" to "validating the absence of that guard plus the
+// remaining external-account carve-outs (negative-side debits, internal
+// account positivity, etc.)".
 func TestIntegration_Redis_ExternalAccountCreditValidation(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode")
@@ -918,13 +929,18 @@ func TestIntegration_Redis_ExternalAccountCreditValidation(t *testing.T) {
 	// The Lua script uses SET NX (set if not exists), so sharing keys between tests
 	// would cause the first test's balance to be reused by subsequent tests.
 
-	t.Run("external account with zero balance cannot receive credit", func(t *testing.T) {
+	t.Run("external account with zero balance can receive credit (now goes positive)", func(t *testing.T) {
 		orgID := uuid.New()
 		ledgerID := uuid.New()
 		transactionID := uuid.New()
 
 		// External account with Available = 0
-		// Attempting to credit should fail because result would be positive
+		// Crediting 100 succeeds and the result is +100. Under the previous
+		// rule (removed in 2026-05) this would have failed with 0018; the
+		// destination-side external-positive guard at balance_atomic_operation.lua
+		// line 573-576 was removed because direction=debit balances make a
+		// positive external balance a legitimate state (the ledger has sent
+		// more to the external world than it has received).
 		balanceOps := []mmodel.BalanceOperation{
 			redistestutil.CreateBalanceOperationWithAvailable(
 				orgID, ledgerID, "@external-zero", "USD",
@@ -934,11 +950,16 @@ func TestIntegration_Redis_ExternalAccountCreditValidation(t *testing.T) {
 			),
 		}
 
-		_, err := infra.repo.ProcessBalanceAtomicOperation(ctx, orgID, ledgerID, transactionID, "ACTIVE", false, balanceOps)
+		balances, err := infra.repo.ProcessBalanceAtomicOperation(ctx, orgID, ledgerID, transactionID, "ACTIVE", false, balanceOps)
 
-		// Should fail with error 0018 (insufficient funds / invalid balance state)
-		redistestutil.AssertInsufficientFundsError(t, err)
-		t.Log("External account credit validation passed: zero balance credit blocked")
+		require.NoError(t, err, "credit to external account from zero balance must succeed under the new rules")
+		require.NotNil(t, balances, "should return balances")
+		require.Len(t, balances.After, 1, "should return exactly one post-mutation balance")
+		require.True(t, balances.After[0].Available.Equal(decimal.NewFromInt(100)),
+			"external account Available must equal +100 after CREDIT 100 from 0; got %s",
+			balances.After[0].Available.String())
+
+		t.Log("External account zero-balance credit verified: external can now go positive (Available=+100)")
 	})
 
 	t.Run("external account with negative balance can receive limited credit", func(t *testing.T) {
@@ -965,13 +986,17 @@ func TestIntegration_Redis_ExternalAccountCreditValidation(t *testing.T) {
 		t.Log("External account partial credit validation passed")
 	})
 
-	t.Run("external account credit that would result in positive balance fails", func(t *testing.T) {
+	t.Run("external account credit can cross zero (now allowed)", func(t *testing.T) {
 		orgID := uuid.New()
 		ledgerID := uuid.New()
 		transactionID := uuid.New()
 
 		// External account with Available = -50
-		// Crediting 100 should fail because result would be +50 (positive)
+		// Crediting 100 succeeds and the result is +50. Under the previous
+		// rule (removed in 2026-05) this would have failed with 0018 because
+		// the result crossed zero into positive territory; the destination-side
+		// external-positive guard no longer applies, so the result is
+		// computed straight through: -50 + 100 = +50.
 		balanceOps := []mmodel.BalanceOperation{
 			redistestutil.CreateBalanceOperationWithAvailable(
 				orgID, ledgerID, "@external-overflow", "USD",
@@ -981,11 +1006,16 @@ func TestIntegration_Redis_ExternalAccountCreditValidation(t *testing.T) {
 			),
 		}
 
-		_, err := infra.repo.ProcessBalanceAtomicOperation(ctx, orgID, ledgerID, transactionID, "ACTIVE", false, balanceOps)
+		balances, err := infra.repo.ProcessBalanceAtomicOperation(ctx, orgID, ledgerID, transactionID, "ACTIVE", false, balanceOps)
 
-		// Should fail with error 0018
-		redistestutil.AssertInsufficientFundsError(t, err)
-		t.Log("External account overflow validation passed: positive result blocked")
+		require.NoError(t, err, "credit to external account that crosses zero must succeed under the new rules")
+		require.NotNil(t, balances, "should return balances")
+		require.Len(t, balances.After, 1, "should return exactly one post-mutation balance")
+		require.True(t, balances.After[0].Available.Equal(decimal.NewFromInt(50)),
+			"external account Available must equal +50 after CREDIT 100 from -50; got %s",
+			balances.After[0].Available.String())
+
+		t.Log("External account zero-crossing credit verified: -50 + CREDIT 100 = +50 (no longer blocked)")
 	})
 
 	t.Run("internal account can have positive balance", func(t *testing.T) {
@@ -1035,7 +1065,8 @@ func TestIntegration_Redis_ExternalAccountCreditValidation(t *testing.T) {
 		t.Log("External account debit validation passed - balance became more negative")
 	})
 
-	t.Log("Integration test passed: external account credit validation verified")
+	t.Log("Integration test passed: external account CREDIT/DEBIT symmetry verified " +
+		"(positive results allowed; negative-side debit carve-out preserved; internal accounts unaffected)")
 }
 
 // =============================================================================

--- a/components/ledger/internal/adapters/redis/transaction/scripts/balance_atomic_operation.lua
+++ b/components/ledger/internal/adapters/redis/transaction/scripts/balance_atomic_operation.lua
@@ -282,7 +282,7 @@ local function main()
         --   - Available:   Balance calculations (DEBIT/CREDIT)
         --   - OnHold:      Balance calculations (ON_HOLD/RELEASE)
         --   - Version:     Optimistic concurrency control
-        --   - AccountType: Validation 0018 (external account cannot have positive balance)
+        --   - AccountType: External-account carve-outs (skip overdraft/floor logic)
         --   - AccountID:   Returned to Go for operation tracking
         --   - Direction:   Direction-aware overdraft gating ("credit" vs "debit")
         --   - OverdraftUsed:        Tracked when a debit exceeds Available
@@ -565,14 +565,6 @@ local function main()
                 rollback(rollbackBalances, ttl)
                 return redis.error_reply("0018")
             end
-        end
-
-        -- External accounts cannot have positive balance (they represent debt to external entities)
-        -- This validation MUST be atomic to prevent race conditions where two concurrent
-        -- transactions both credit an external account
-        if operation == "CREDIT" and balance.AccountType == "external" and isPositive(result) then
-            rollback(rollbackBalances, ttl)
-            return redis.error_reply("0018")
         end
 
         -- Only update balance and increment version if there was an actual change.


### PR DESCRIPTION
## Summary
- Removes the Lua atomic script guard that rejected any CREDIT operation on `@external/{asset}` whose post-mutation Available would go positive (`balance_atomic_operation.lua:573-576`). The guard returned error `0018 Insufficient Funds` and made customer outflows to `@external` impossible on a fresh ledger.
- The rule was incompatible with the direction-debit balance model introduced by the overdraft feature: a ledger composed of debit-direction accounts may legitimately send more to the external world than it has received, leaving `@external` net-positive. The remaining external-account carve-outs (`AccountType ~= "external"` checks at lines 487, 515, 526) are unchanged — external accounts still bypass the negative-balance floor on debits.
- Updates the `0018 → ErrInsufficientFunds` mapping comment in `consumer.redis.go:748` to drop the stale `or positive on external CREDIT` clause; the source-side floor at line 566 of the Lua script remains the sole emitter of `0018`.
- Inverts two subtests in `TestIntegration_Redis_ExternalAccountCreditValidation` so they assert success (with the expected post-mutation Available) instead of `0018` rejection. Subtest names and docstrings updated to reflect the new contract; the negative-side carve-out subtests and the internal-account subtest are unchanged.

## User-visible behavior change
- Before: `POST /v1/.../transactions/outflow` (or `/transactions/json` with `distribute.to: @external/{asset}`) from a zero-balance overdraft-enabled account returned `422 / 0018` on a fresh ledger.
- After: same call returns `201` with the overdraft enrichment producing the source default DEBIT, the source overdraft companion DEBIT, and the `@external/{asset}` CREDIT, leaving `@external` at the new positive value.

## Implementation impact
- Lua-only behavioral change; no Go business-logic edits. No schema or data migration required.
- Existing ledgers where `@external` is currently `<= 0` are unaffected. Future transactions on those ledgers can now drive `@external` positive for the first time.
- Operational dashboards or reconciliation jobs that hard-coded `@external.Available <= 0` will need to be reviewed (no internal consumer in this repo asserts that invariant).