### PR TITLE
chore: add DeepWiki badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![License: Elastic-2.0](https://img.shields.io/badge/License-Elastic_2.0-blue.svg)](https://github.com/LerianStudio/midaz/blob/main/LICENSE)
 [![Go Report](https://goreportcard.com/badge/github.com/lerianstudio/midaz)](https://goreportcard.com/report/github.com/lerianstudio/midaz)
 [![Discord](https://img.shields.io/badge/Discord-Lerian%20Studio-%237289da.svg?logo=discord)](https://discord.gg/DnhqKwkGv3)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/LerianStudio/midaz)
 
 </div>
 


### PR DESCRIPTION
## What

Replicates onto `hotfix/overdraft-outflow` the DeepWiki badge added in #2098 (commit 3280872) so the badge survives when this hotfix is merged into main.

## Why `chore:` prefix

#2098 was committed as `feat:`, which would bump the minor version. This hotfix needs to stay at patch level, so the same change is committed here as `chore:` to avoid the minor bump on merge.

## Changes

- `README.md`: add `[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/LerianStudio/midaz)` right after the Discord badge.

Requested by: @ClaraTersi