### PR TITLE
chore(workflows): restrict release trigger to maintenance/v3.6.* branches

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,9 +3,7 @@ name: Release
 on:
   push:
     branches:
-      - develop
-      - release-candidate
-      - main
+      - 'maintenance/v3.6.*'
     paths-ignore:
       - '.gitignore'
       - '**/*.env'   # Ignores all .env files


### PR DESCRIPTION
# Midaz Pull Request Checklist

## Pull Request Type

- [x] Pipeline

## Checklist

- [x] I have tested these changes locally.
- [x] I have ensured that my changes adhere to the project's coding standards.
- [x] I have checked for any potential security issues.
- [x] I have confirmed this code is ready for review.

## Additional Notes

Restringe o trigger do workflow `release.yml` para rodar **apenas** em pushes para branches `maintenance/v3.6.*` (glob), removendo `develop`, `release-candidate` e `main`.

Padrão `maintenance/v3.6.*` é interpretado como glob pelo GitHub Actions (casa `maintenance/v3.6.1`, `maintenance/v3.6.x`, etc.), evitando hardcode do patch version.