### PR TITLE
chore: bump env examples to v3.8.0

### DIFF
--- a/components/crm/.env.example
+++ b/components/crm/.env.example
@@ -11,7 +11,7 @@ ENV_NAME=development
 #
 # This setting controls the ValidateSaaSTLS() check at bootstrap.
 DEPLOYMENT_MODE=local
-VERSION=v3.7.2
+VERSION=v3.8.0
 SERVER_PORT=4003
 SERVER_ADDRESS=:${SERVER_PORT}
 

--- a/components/ledger/.env.example
+++ b/components/ledger/.env.example
@@ -7,7 +7,7 @@
 # DEFAULT local
 ENV_NAME=development
 
-VERSION=v3.7.2
+VERSION=v3.8.0
 
 # DEPLOYMENT MODE (controls TLS enforcement)
 # Valid values:


### PR DESCRIPTION
## Summary
- Bump CRM and Ledger `.env.example` VERSION values to `v3.8.0` to force a build after merge-back.

## Tests
- Not run (env example only).

Requested by: @ClaraTersi