### PR TITLE
fix(crm): align tenant-manager module name with provisioning (crm → crm-api)

### DIFF
--- a/components/crm/internal/bootstrap/config.tenant.go
+++ b/components/crm/internal/bootstrap/config.tenant.go
@@ -26,7 +26,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 )
 
-const moduleName = "crm"
+const moduleName = "crm-api"
 
 // initTenantMiddleware creates the tenant middleware for multi-tenant mode.
 // Returns (nil, nil, nil) when multi-tenant is disabled or the URL is not configured.


### PR DESCRIPTION
## Summary
- CRM was registering with tenant-manager using `moduleName = "crm"` (`components/crm/internal/bootstrap/config.tenant.go:29`), but tenant databases are provisioned under module `crm-api`.
- This caused runtime failures in multi-tenant mode:
  `no MongoDB config for tenant <id> service plugin-crm module crm`
- Fix: change the constant to `"crm-api"` so the module identity matches what tenant-manager has provisioned for the service.

## Scope
Single one-line change. Service name (`plugin-crm`) and OTel resource name (`crm`) intentionally left untouched — only the multi-tenant identifier moves.

## Test plan
- [ ] Deploy in a multi-tenant environment and confirm `tmmongo` resolves a tenant DB config for module `crm-api` (no more "no MongoDB config for tenant" error)
- [ ] Verify single-tenant mode is unaffected (the constant is only consumed inside `initTenantMiddleware`, which is a no-op when `MULTI_TENANT_ENABLED=false`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)