### PR TITLE
fix(events): subscribe to env-scoped tenant-events channel

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -100,7 +100,7 @@ require (
 )
 
 require (
-	github.com/LerianStudio/lib-commons/v5 v5.1.0
+	github.com/LerianStudio/lib-commons/v5 v5.1.2
 	github.com/Shopify/toxiproxy/v2 v2.12.0
 	github.com/docker/go-connections v0.7.0
 	github.com/moby/moby/api v1.54.1

--- a/go.sum
+++ b/go.sum
@@ -19,8 +19,8 @@ github.com/KyleBanks/depth v1.2.1 h1:5h8fQADFrWtarTdtDudMmGsC7GPbOAu6RVB3ffsVFHc
 github.com/KyleBanks/depth v1.2.1/go.mod h1:jzSb9d0L43HxTQfT+oSA1EEp2q+ne2uh6XgeJcm8brE=
 github.com/LerianStudio/lib-auth/v2 v2.7.0 h1:y8S89ilWfU1qnag66QluXIsFkavK4JnvGqaPB0a2lZU=
 github.com/LerianStudio/lib-auth/v2 v2.7.0/go.mod h1:KQHyqkKGDneetVsVOpb4oX6rjHSr8gaOUI1eqM48RDY=
-github.com/LerianStudio/lib-commons/v5 v5.1.0 h1:ORsQGox4YqxeqG6BqcJrBI+4zorw+OYmJxzZUpPq2SY=
-github.com/LerianStudio/lib-commons/v5 v5.1.0/go.mod h1:2Snd37QiChK5NwyHcqcO/QbAJRd0mS/7X/F7rmhTZ/E=
+github.com/LerianStudio/lib-commons/v5 v5.1.2 h1:qhwfvaTaEtfJM33Cu+M0KuyUL5Wl66C8nN7K/ar1O8o=
+github.com/LerianStudio/lib-commons/v5 v5.1.2/go.mod h1:2Snd37QiChK5NwyHcqcO/QbAJRd0mS/7X/F7rmhTZ/E=
 github.com/Masterminds/squirrel v1.5.4 h1:uUcX/aBc8O7Fg9kaISIUsHXdKuqehiXAMQTYX8afzqM=
 github.com/Masterminds/squirrel v1.5.4/go.mod h1:NNaOrjSoIDfDA40n7sr2tPNZRfjzjA400rg+riTZj10=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=


### PR DESCRIPTION
## Summary
- Bumps `lib-commons/v5` `v5.1.0 → v5.1.2` (backport on the 5.1 line). The v5.1.2 `TenantEventListener` subscribes to the **env-scoped** `tenant-events:{env}:` channel via `commons.CurrentEnv()` instead of the global `tenant-events:*` wildcard — closing the cross-env tenant-events leak in production.
- **ledger and crm** consume the shared `tmevent` listener; **no subscribe wiring changed** (the fix lives inside lib-commons).
- **No observability / mongo-driver migration**: v5.1.2 keeps the pre-split `commons/{log,opentelemetry,zap}` packages, so this is a contained patch bump (`go.mod`/`go.sum` only).

## Operator note
- Requires `ENV_NAME` (`staging`|`production`) on the pod — already set in the `midaz-mt` gitops values, so no deploy-config change is needed.
- The 5.1 line does NOT carry the v5.4.0 TLS-by-default / rate-limit-default changes, so `ALLOW_INSECURE_TLS` / `RATE_LIMIT_ENABLED` are not required here.

## Test plan
- `go build ./...` ✅ · `go vet ./...` ✅ · `go test ./... -short -count=1` ✅ (39 packages, 0 failures)
- Mongo integration suite intentionally not run (no driver change on the 5.1 line).

## Links
- lib-commons v5.1.2 (backport): https://github.com/LerianStudio/lib-commons/releases/tag/v5.1.2
- tenant-manager dual-channel publisher: https://github.com/LerianStudio/tenant-manager/pull/356