### PR TITLE
fix(events): bump lib-commons to v5.1.3 (http/1.1 tmclient transport)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -100,7 +100,7 @@ require (
 )
 
 require (
-	github.com/LerianStudio/lib-commons/v5 v5.1.2
+	github.com/LerianStudio/lib-commons/v5 v5.1.3
 	github.com/Shopify/toxiproxy/v2 v2.12.0
 	github.com/docker/go-connections v0.7.0
 	github.com/moby/moby/api v1.54.1

--- a/go.sum
+++ b/go.sum
@@ -19,8 +19,8 @@ github.com/KyleBanks/depth v1.2.1 h1:5h8fQADFrWtarTdtDudMmGsC7GPbOAu6RVB3ffsVFHc
 github.com/KyleBanks/depth v1.2.1/go.mod h1:jzSb9d0L43HxTQfT+oSA1EEp2q+ne2uh6XgeJcm8brE=
 github.com/LerianStudio/lib-auth/v2 v2.7.0 h1:y8S89ilWfU1qnag66QluXIsFkavK4JnvGqaPB0a2lZU=
 github.com/LerianStudio/lib-auth/v2 v2.7.0/go.mod h1:KQHyqkKGDneetVsVOpb4oX6rjHSr8gaOUI1eqM48RDY=
-github.com/LerianStudio/lib-commons/v5 v5.1.2 h1:qhwfvaTaEtfJM33Cu+M0KuyUL5Wl66C8nN7K/ar1O8o=
-github.com/LerianStudio/lib-commons/v5 v5.1.2/go.mod h1:2Snd37QiChK5NwyHcqcO/QbAJRd0mS/7X/F7rmhTZ/E=
+github.com/LerianStudio/lib-commons/v5 v5.1.3 h1:9vggZDXCgtOSV/enuYnEo0IPHJjbPlp7CHQYRUOVzdI=
+github.com/LerianStudio/lib-commons/v5 v5.1.3/go.mod h1:2Snd37QiChK5NwyHcqcO/QbAJRd0mS/7X/F7rmhTZ/E=
 github.com/Masterminds/squirrel v1.5.4 h1:uUcX/aBc8O7Fg9kaISIUsHXdKuqehiXAMQTYX8afzqM=
 github.com/Masterminds/squirrel v1.5.4/go.mod h1:NNaOrjSoIDfDA40n7sr2tPNZRfjzjA400rg+riTZj10=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=


### PR DESCRIPTION
## Summary
- Bumps `lib-commons/v5` `v5.1.2 → v5.1.3`. **v5.1.3** rebuilds the tenant-manager client's HTTP transport with HTTP/2 disabled (explicit empty `TLSNextProto`), fixing `malformed HTTP response` (HTTP/2 SETTINGS frame) when talking to the tenant-manager over **`https://`** — the cloned `http.DefaultTransport` inherited OpenTelemetry's injected `h2` handler.
- Follow-up to **#2128** (v5.1.2, env-scoped tenant-events listener). ledger and crm consume the shared listener; no subscribe wiring change. `go.mod`/`go.sum` only.

## Why now
midaz-mt **production already runs `https://`** against the tenant-manager but on v5.1.2 (no transport fix) — this de-risks it and lets staging move to https for parity.

## Test plan
- `go build ./...` ✅ · `go vet ./...` ✅ (pre-existing ANTLR `unreachable` warnings only). Full suite in CI.

## Links
- lib-commons v5.1.3: https://github.com/LerianStudio/lib-commons/releases/tag/v5.1.3 (PR #498)