### PR TITLE
fix: persist balances in multi-tenant balance-sync (double-namespacing) + bump Go to 1.26.4

### DIFF
--- a/.github/workflows/go-combined-analysis.yml
+++ b/.github/workflows/go-combined-analysis.yml
@@ -31,7 +31,7 @@ jobs:
       filter_paths: '["components/crm", "components/ledger"]'
       path_level: 2
       app_name_prefix: "midaz"
-      go_version: "1.26.3"
+      go_version: "1.26.4"
       golangci_lint_version: "v2.4.0"
       golangci_lint_args: "--timeout=5m"
       coverage_threshold: 85

--- a/components/crm/Dockerfile
+++ b/components/crm/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.4
 
-FROM --platform=$BUILDPLATFORM golang:1.26.3-alpine AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.4-alpine AS builder
 
 WORKDIR /crm-app
 

--- a/components/ledger/Dockerfile
+++ b/components/ledger/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.26.3-alpine AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.4-alpine AS builder
 
 WORKDIR /ledger-app
 

--- a/components/ledger/internal/adapters/http/in/observability.go
+++ b/components/ledger/internal/adapters/http/in/observability.go
@@ -90,7 +90,7 @@ func resolvePayloadValue(payload any) reflect.Value {
 		return v
 	}
 
-	for v.Kind() == reflect.Ptr {
+	for v.Kind() == reflect.Pointer {
 		if v.IsNil() {
 			return reflect.Value{}
 		}

--- a/components/ledger/internal/adapters/redis/transaction/balance/aggregation.go
+++ b/components/ledger/internal/adapters/redis/transaction/balance/aggregation.go
@@ -40,28 +40,60 @@ func (k BalanceCompositeKey) String() string {
 
 // BalanceCompositeKeyFromRedisKey extracts a composite key from a Redis balance key.
 // Redis key format: "balance:{transactions}:orgID:ledgerID:alias#partitionKey"
-// Note: alias may contain colons (e.g., "test:account:100"), so we join parts[4:] before splitting by #
+//
+// In multi-tenant mode the claimed ZSET members handed to the flush pipeline are
+// tenant-namespaced exactly once at write time, i.e.
+// "tenant:{tenantID}:balance:{transactions}:orgID:ledgerID:alias#partitionKey".
+// The parser must therefore be prefix-tolerant: orgID and ledgerID are located as the
+// first two colon-separated 36-character UUID segments (position-independent), mirroring
+// BalanceSyncWorker.extractIDsFromMember. A positional parse (parts[2]/parts[3]) would
+// reject the namespaced key as a parse error, causing the balance to be treated as an
+// orphan and silently dropped — never persisting to PostgreSQL.
+//
+// Note: alias may contain colons (e.g., "test:account:100"); everything after the
+// ledgerID segment is treated as "alias#partitionKey".
 func BalanceCompositeKeyFromRedisKey(redisKey string) (BalanceCompositeKey, error) {
-	// Expected format: balance:{transactions}:orgID:ledgerID:alias#key
-	// Note: alias may contain colons, so we need at least 5 parts but may have more
 	parts := strings.Split(redisKey, ":")
-	if len(parts) < 5 {
-		return BalanceCompositeKey{}, fmt.Errorf("invalid redis key format: expected at least 5 parts, got %d", len(parts))
+
+	// Locate the first two parseable 36-char UUID segments: orgID then ledgerID.
+	// This is robust to any leading prefix (e.g. the tenant namespace) the key may carry.
+	var (
+		orgID       uuid.UUID
+		ledgerID    uuid.UUID
+		haveOrg     bool
+		ledgerIndex = -1
+	)
+
+	for i, seg := range parts {
+		if len(seg) != 36 {
+			continue
+		}
+
+		u, err := uuid.Parse(seg)
+		if err != nil {
+			continue
+		}
+
+		if !haveOrg {
+			orgID = u
+			haveOrg = true
+
+			continue
+		}
+
+		ledgerID = u
+		ledgerIndex = i
+
+		break
 	}
 
-	// Parts: [balance, {transactions}, orgID, ledgerID, alias...#key]
-	orgID, err := uuid.Parse(parts[2])
-	if err != nil {
-		return BalanceCompositeKey{}, fmt.Errorf("invalid organization ID in redis key %q: %w", redisKey, err)
+	if !haveOrg || ledgerIndex == -1 {
+		return BalanceCompositeKey{}, fmt.Errorf("invalid redis key format: missing two UUIDs (orgID, ledgerID): %q", redisKey)
 	}
 
-	ledgerID, err := uuid.Parse(parts[3])
-	if err != nil {
-		return BalanceCompositeKey{}, fmt.Errorf("invalid ledger ID in redis key %q: %w", redisKey, err)
-	}
-
-	// Join all parts from index 4 onwards to handle aliases with colons (e.g., "test:account:100#other")
-	aliasAndKey := strings.Join(parts[4:], ":")
+	// Everything after the ledgerID segment is "alias#key" (alias may contain colons,
+	// e.g. "test:account:100#other"), so rejoin the remaining segments with ":".
+	aliasAndKey := strings.Join(parts[ledgerIndex+1:], ":")
 	aliasParts := strings.Split(aliasAndKey, "#")
 
 	alias := aliasParts[0]

--- a/components/ledger/internal/adapters/redis/transaction/balance/aggregation.go
+++ b/components/ledger/internal/adapters/redis/transaction/balance/aggregation.go
@@ -39,19 +39,14 @@ func (k BalanceCompositeKey) String() string {
 }
 
 // BalanceCompositeKeyFromRedisKey extracts a composite key from a Redis balance key.
-// Redis key format: "balance:{transactions}:orgID:ledgerID:alias#partitionKey"
 //
-// In multi-tenant mode the claimed ZSET members handed to the flush pipeline are
-// tenant-namespaced exactly once at write time, i.e.
-// "tenant:{tenantID}:balance:{transactions}:orgID:ledgerID:alias#partitionKey".
-// The parser must therefore be prefix-tolerant: orgID and ledgerID are located as the
-// first two colon-separated 36-character UUID segments (position-independent), mirroring
-// BalanceSyncWorker.extractIDsFromMember. A positional parse (parts[2]/parts[3]) would
-// reject the namespaced key as a parse error, causing the balance to be treated as an
-// orphan and silently dropped — never persisting to PostgreSQL.
+// Base key format: "balance:{transactions}:orgID:ledgerID:alias#partitionKey".
+// The key may carry a leading namespace prefix (e.g. "tenant:{tenantID}:") so parsing is
+// position-independent: orgID and ledgerID are the first two colon-separated 36-character
+// UUID segments, and everything after the ledgerID segment is "alias#partitionKey".
+// The alias itself may contain colons (e.g. "test:account:100").
 //
-// Note: alias may contain colons (e.g., "test:account:100"); everything after the
-// ledgerID segment is treated as "alias#partitionKey".
+// Returns an error if two UUID segments cannot be found.
 func BalanceCompositeKeyFromRedisKey(redisKey string) (BalanceCompositeKey, error) {
 	parts := strings.Split(redisKey, ":")
 

--- a/components/ledger/internal/adapters/redis/transaction/balance/aggregation_test.go
+++ b/components/ledger/internal/adapters/redis/transaction/balance/aggregation_test.go
@@ -108,6 +108,27 @@ func TestBalanceCompositeKeyFromRedisKey(t *testing.T) {
 			wantErr:     false,
 		},
 		{
+			// Regression: multi-tenant claimed members are namespaced once at write time.
+			// The parser must skip the "tenant:{id}:" prefix and still find orgID/ledgerID,
+			// otherwise the balance is rejected as a parse error and silently dropped.
+			name:        "multi-tenant namespaced key with partition",
+			redisKey:    "tenant:acme:balance:{transactions}:11111111-1111-1111-1111-111111111111:22222222-2222-2222-2222-222222222222:@account#default",
+			wantOrgID:   uuid.MustParse("11111111-1111-1111-1111-111111111111"),
+			wantLedger:  uuid.MustParse("22222222-2222-2222-2222-222222222222"),
+			wantAccount: "@account",
+			wantPartKey: "default",
+			wantErr:     false,
+		},
+		{
+			name:        "multi-tenant namespaced key with alias containing colons",
+			redisKey:    "tenant:acme:balance:{transactions}:11111111-1111-1111-1111-111111111111:22222222-2222-2222-2222-222222222222:test:account:100#other",
+			wantOrgID:   uuid.MustParse("11111111-1111-1111-1111-111111111111"),
+			wantLedger:  uuid.MustParse("22222222-2222-2222-2222-222222222222"),
+			wantAccount: "test:account:100",
+			wantPartKey: "other",
+			wantErr:     false,
+		},
+		{
 			name:        "valid key format with alias containing colons",
 			redisKey:    "balance:{transactions}:11111111-1111-1111-1111-111111111111:22222222-2222-2222-2222-222222222222:test:account:100#other",
 			wantOrgID:   uuid.MustParse("11111111-1111-1111-1111-111111111111"),

--- a/components/ledger/internal/adapters/redis/transaction/consumer.redis.go
+++ b/components/ledger/internal/adapters/redis/transaction/consumer.redis.go
@@ -1617,11 +1617,9 @@ func (rr *RedisConsumerRepository) UpdateBalanceCacheSettings(ctx context.Contex
 // This is used by the aggregation engine to fetch current balance states in batch.
 // Large inputs are processed in chunks of maxRedisBatchSize to prevent oversized payloads.
 //
-// CONTRACT: keys must be fully-qualified Redis keys, i.e. already tenant-namespaced
-// when running multi-tenant. The sole caller (SyncBalancesBatch) passes the ZSET
-// members claimed from the balance-sync schedule, which are already namespaced once
-// at write time. This method therefore performs NO tenant namespacing — doing so would
-// double-prefix the keys and cause every MGET to miss.
+// Keys must be fully-qualified Redis keys (already tenant-namespaced in multi-tenant
+// mode). This method performs no tenant namespacing; tenant isolation comes from the
+// per-tenant connection resolved by conn.GetClient(ctx).
 func (rr *RedisConsumerRepository) GetBalancesByKeys(ctx context.Context, keys []string) (map[string]*mmodel.BalanceRedis, error) {
 	if len(keys) == 0 {
 		return make(map[string]*mmodel.BalanceRedis), nil
@@ -1642,21 +1640,7 @@ func (rr *RedisConsumerRepository) GetBalancesByKeys(ctx context.Context, keys [
 		return nil, err
 	}
 
-	// The keys passed here are already fully-qualified Redis keys. In multi-tenant
-	// mode they are the tenant-namespaced ZSET members claimed from the balance-sync
-	// schedule — written exactly once as "tenant:{id}:balance:..." by
-	// balance_atomic_operation.lua (SET value + ZADD member share the same key) and
-	// returned verbatim by GetBalanceSyncKeys.
-	//
-	// They MUST NOT be namespaced again here. Re-prefixing would produce
-	// "tenant:{id}:tenant:{id}:balance:..." so every MGET would miss; the sync worker
-	// would then treat live balances as orphaned (expired TTL) and silently drop the
-	// pending write — the balance never reaches PostgreSQL and the bug is
-	// self-perpetuating as each new mutation re-schedules the same doomed key.
-	//
-	// Tenant isolation on this read path is enforced by rr.conn.GetClient(ctx), which
-	// resolves the correct per-tenant connection pool — not by key prefixing.
-	//
+	// Keys are used as-is (already namespaced); see the method contract above.
 	// Process in chunks to prevent oversized payloads.
 	for start := 0; start < len(keys); start += maxRedisBatchSize {
 		end := min(start+maxRedisBatchSize, len(keys))

--- a/components/ledger/internal/adapters/redis/transaction/consumer.redis.go
+++ b/components/ledger/internal/adapters/redis/transaction/consumer.redis.go
@@ -113,6 +113,9 @@ type RedisRepository interface {
 	// GetBalancesByKeys retrieves multiple balance values by their Redis keys using MGET.
 	// Returns a map of key -> *mmodel.BalanceRedis (nil if key does not exist).
 	// This enables batch retrieval for the aggregation engine.
+	//
+	// Keys must be fully-qualified Redis keys (already tenant-namespaced in
+	// multi-tenant mode); this method does not apply tenant namespacing.
 	GetBalancesByKeys(ctx context.Context, keys []string) (map[string]*mmodel.BalanceRedis, error)
 	// RemoveBalanceSyncKeysBatch conditionally removes keys from the sync schedule.
 	// Only removes a member if its current ZSET score matches the claimed score,
@@ -1613,6 +1616,12 @@ func (rr *RedisConsumerRepository) UpdateBalanceCacheSettings(ctx context.Contex
 // Returns a map where each key maps to its BalanceRedis value, or nil if the key does not exist.
 // This is used by the aggregation engine to fetch current balance states in batch.
 // Large inputs are processed in chunks of maxRedisBatchSize to prevent oversized payloads.
+//
+// CONTRACT: keys must be fully-qualified Redis keys, i.e. already tenant-namespaced
+// when running multi-tenant. The sole caller (SyncBalancesBatch) passes the ZSET
+// members claimed from the balance-sync schedule, which are already namespaced once
+// at write time. This method therefore performs NO tenant namespacing — doing so would
+// double-prefix the keys and cause every MGET to miss.
 func (rr *RedisConsumerRepository) GetBalancesByKeys(ctx context.Context, keys []string) (map[string]*mmodel.BalanceRedis, error) {
 	if len(keys) == 0 {
 		return make(map[string]*mmodel.BalanceRedis), nil
@@ -1633,21 +1642,25 @@ func (rr *RedisConsumerRepository) GetBalancesByKeys(ctx context.Context, keys [
 		return nil, err
 	}
 
-	prefixedKeys, err := tenantKeysFromContext(ctx, keys)
-	if err != nil {
-		libOpentelemetry.HandleSpanError(span, "Failed to namespace redis keys", err)
-		logger.Log(ctx, libLog.LevelError, "Failed to namespace redis keys", libLog.Err(err))
-
-		return nil, err
-	}
-
+	// The keys passed here are already fully-qualified Redis keys. In multi-tenant
+	// mode they are the tenant-namespaced ZSET members claimed from the balance-sync
+	// schedule — written exactly once as "tenant:{id}:balance:..." by
+	// balance_atomic_operation.lua (SET value + ZADD member share the same key) and
+	// returned verbatim by GetBalanceSyncKeys.
+	//
+	// They MUST NOT be namespaced again here. Re-prefixing would produce
+	// "tenant:{id}:tenant:{id}:balance:..." so every MGET would miss; the sync worker
+	// would then treat live balances as orphaned (expired TTL) and silently drop the
+	// pending write — the balance never reaches PostgreSQL and the bug is
+	// self-perpetuating as each new mutation re-schedules the same doomed key.
+	//
+	// Tenant isolation on this read path is enforced by rr.conn.GetClient(ctx), which
+	// resolves the correct per-tenant connection pool — not by key prefixing.
+	//
 	// Process in chunks to prevent oversized payloads.
-	// chunk (prefixed) is sent to Redis; originalKeysChunk (unprefixed) is used as
-	// map keys in the result so callers can look up by the keys they know.
-	for start := 0; start < len(prefixedKeys); start += maxRedisBatchSize {
-		end := min(start+maxRedisBatchSize, len(prefixedKeys))
-		chunk := prefixedKeys[start:end]
-		originalKeysChunk := keys[start:end]
+	for start := 0; start < len(keys); start += maxRedisBatchSize {
+		end := min(start+maxRedisBatchSize, len(keys))
+		chunk := keys[start:end]
 
 		values, err := client.MGet(ctx, chunk...).Result()
 		if err != nil {
@@ -1657,7 +1670,7 @@ func (rr *RedisConsumerRepository) GetBalancesByKeys(ctx context.Context, keys [
 			return nil, err
 		}
 
-		for i, key := range originalKeysChunk {
+		for i, key := range chunk {
 			if values[i] == nil {
 				result[key] = nil
 

--- a/components/ledger/internal/adapters/redis/transaction/consumer.redis_atomic_state_test.go
+++ b/components/ledger/internal/adapters/redis/transaction/consumer.redis_atomic_state_test.go
@@ -90,14 +90,32 @@ func TestKeyNamespacing_MalformedTenantID_FailsClosedBalanceSyncScripts(t *testi
 
 }
 
-func TestKeyNamespacing_MalformedTenantID_FailsClosedGetBalancesByKeys(t *testing.T) {
+// TestGetBalancesByKeys_MultiTenant_NoDoubleNamespacing is a regression test for the
+// balance-sync multi-tenant bug where the flush/read path re-namespaced keys that were
+// already tenant-namespaced at write/claim time, producing "tenant:{id}:tenant:{id}:..."
+// and causing every MGET to miss (live balances silently dropped as orphans).
+//
+// The keys handed to GetBalancesByKeys are the claimed ZSET members — already
+// fully-qualified Redis keys — so they must reach MGET verbatim, even with a tenant
+// in context.
+func TestGetBalancesByKeys_MultiTenant_NoDoubleNamespacing(t *testing.T) {
 	t.Parallel()
 
-	mockClient := &mockMGetClient{
-		mGetFunc: func(_ context.Context, _ ...string) *redis.SliceCmd {
-			t.Fatal("GetBalancesByKeys must fail closed before calling MGet")
+	// Member as written once by balance_atomic_operation.lua: prefixed exactly one time.
+	const namespacedMember = "tenant:acme:balance:{transactions}:org:ledger:@alias#default"
 
-			return nil
+	validJSON := `{"id":"uuid-mt","alias":"@alias","key":"default","accountId":"acc-mt","assetCode":"USD","available":"42.00","onHold":"0","version":1,"accountType":"deposit","allowSending":1,"allowReceiving":1}`
+
+	var capturedKeys []string
+
+	mockClient := &mockMGetClient{
+		mGetFunc: func(_ context.Context, keys ...string) *redis.SliceCmd {
+			capturedKeys = append(capturedKeys, keys...)
+
+			cmd := redis.NewSliceCmd(context.Background())
+			cmd.SetVal([]any{validJSON})
+
+			return cmd
 		},
 	}
 
@@ -105,8 +123,18 @@ func TestKeyNamespacing_MalformedTenantID_FailsClosedGetBalancesByKeys(t *testin
 		conn: newMockMGetConnection(mockClient),
 	}
 
-	_, err := repo.GetBalancesByKeys(tmcore.ContextWithTenantID(context.Background(), "tenant:invalid"), []string{"key1", "key2"})
-	require.Error(t, err)
+	ctx := tmcore.ContextWithTenantID(context.Background(), "acme")
+
+	result, err := repo.GetBalancesByKeys(ctx, []string{namespacedMember})
+	require.NoError(t, err)
+
+	// MGET must receive the already-namespaced key unchanged (NOT double-prefixed).
+	require.Equal(t, []string{namespacedMember}, capturedKeys,
+		"claimed member must reach MGET verbatim; re-prefixing would cause a miss")
+
+	// The value must be found (no false orphan) and keyed by the input member.
+	require.NotNil(t, result[namespacedMember], "balance value must be found for the namespaced key")
+	assert.Equal(t, "uuid-mt", result[namespacedMember].ID)
 }
 
 func TestKeyNamespacing_MalformedTenantID_FailsClosedBatchScheduleAndRemove(t *testing.T) {

--- a/components/ledger/internal/adapters/redis/transaction/consumer.redis_get_balances_test.go
+++ b/components/ledger/internal/adapters/redis/transaction/consumer.redis_get_balances_test.go
@@ -282,6 +282,40 @@ func TestGetBalancesByKeys_AllKeysNotFound(t *testing.T) {
 	assert.Nil(t, result["key3"])
 }
 
+// TestGetBalancesByKeys_SingleTenant_KeyReachesMGetUnchanged proves the single-tenant
+// path is unaffected by the multi-tenant double-namespacing fix: with no tenant in
+// context, the key must reach MGET exactly as provided and the value must be found.
+func TestGetBalancesByKeys_SingleTenant_KeyReachesMGetUnchanged(t *testing.T) {
+	const plainKey = "balance:{transactions}:org:ledger:@alias#default"
+
+	validJSON := `{"id":"uuid-st","alias":"@alias","key":"default","accountId":"acc-st","assetCode":"USD","available":"7.00","onHold":"0","version":1,"accountType":"deposit","allowSending":1,"allowReceiving":1}`
+
+	var capturedKeys []string
+
+	mockClient := &mockMGetClient{
+		mGetFunc: func(_ context.Context, keys ...string) *redis.SliceCmd {
+			capturedKeys = append(capturedKeys, keys...)
+
+			cmd := redis.NewSliceCmd(context.Background())
+			cmd.SetVal([]any{validJSON})
+
+			return cmd
+		},
+	}
+
+	repo := &RedisConsumerRepository{
+		conn: newMockMGetConnection(mockClient),
+	}
+
+	// context.Background() carries no tenant — single-tenant / default mode.
+	result, err := repo.GetBalancesByKeys(context.Background(), []string{plainKey})
+	require.NoError(t, err)
+
+	require.Equal(t, []string{plainKey}, capturedKeys, "single-tenant key must reach MGET unchanged")
+	require.NotNil(t, result[plainKey], "balance value must be found in single-tenant mode")
+	assert.Equal(t, "uuid-st", result[plainKey].ID)
+}
+
 func TestGetBalancesByKeys_InterfaceCompliance(t *testing.T) {
 	// Type assertion to verify method exists with correct signature
 	type BalanceGetter interface {

--- a/components/ledger/internal/services/command/send_overdraft_events.go
+++ b/components/ledger/internal/services/command/send_overdraft_events.go
@@ -203,7 +203,6 @@ func buildOverdraftEvents(tran *transaction.Transaction) []overdraftEventItem {
 		return nil
 	}
 
-	//nolint:prealloc // contract: return nil (not empty slice) when no operation qualifies; tests assert nil.
 	var items []overdraftEventItem
 
 	for _, op := range tran.Operations {

--- a/components/ledger/internal/services/command/sync_balances_batch_test.go
+++ b/components/ledger/internal/services/command/sync_balances_batch_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	libCommons "github.com/LerianStudio/lib-commons/v5/commons"
+	tmcore "github.com/LerianStudio/lib-commons/v5/commons/tenant-manager/core"
 	"github.com/LerianStudio/midaz/v3/components/ledger/internal/adapters/postgres/balance"
 	redis "github.com/LerianStudio/midaz/v3/components/ledger/internal/adapters/redis/transaction"
 	"github.com/LerianStudio/midaz/v3/pkg/mmodel"
@@ -844,6 +845,84 @@ func TestSyncBalancesBatch_MalformedKeyWithTrailingHash(t *testing.T) {
 	assert.Equal(t, 1, result.BalancesAggregated)
 	assert.Equal(t, int64(1), result.BalancesSynced)
 	assert.Equal(t, int64(1), result.KeysRemoved, "Malformed key must be removed to break sync loop")
+}
+
+// TestSyncBalancesBatch_MultiTenant_PresentValuePersistsNotOrphaned is the use-case-level
+// regression for the multi-tenant balance-sync bug. With a tenant in context and already
+// tenant-namespaced claimed members, the (now-fixed) read returns the live balance value.
+// The flush MUST persist it to the database (UpdateMany called) and remove it as a *synced*
+// key — it must NOT be treated as an orphan and silently dropped. Before the fix, the read
+// double-namespaced the key, MGET missed, and the balance was dropped as a false orphan.
+func TestSyncBalancesBatch_MultiTenant_PresentValuePersistsNotOrphaned(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	organizationID := uuid.Must(libCommons.GenerateUUIDv7())
+	ledgerID := uuid.Must(libCommons.GenerateUUIDv7())
+	balanceID := uuid.Must(libCommons.GenerateUUIDv7())
+
+	// Claimed ZSET member: tenant-namespaced exactly once (as written by the Lua script).
+	namespacedKey := "tenant:acme:balance:{transactions}:" + organizationID.String() + ":" + ledgerID.String() + ":@acc1#default"
+
+	keys := []string{namespacedKey}
+
+	// The fixed read finds the value for the namespaced key (no double-prefix miss).
+	balanceData := map[string]*mmodel.BalanceRedis{
+		namespacedKey: {
+			ID:        balanceID.String(),
+			Alias:     "@acc1",
+			AssetCode: "USD",
+			Version:   1,
+			Available: decimal.NewFromInt(1000),
+		},
+	}
+
+	mockRedis := redis.NewMockRedisRepository(ctrl)
+	mockBalance := balance.NewMockRepository(ctrl)
+
+	mockRedis.EXPECT().
+		GetBalancesByKeys(gomock.Any(), keys).
+		Return(balanceData, nil).
+		Times(1)
+
+	// Must persist to DB — proves the value was NOT discarded as an orphan.
+	mockBalance.EXPECT().
+		UpdateMany(gomock.Any(), organizationID, ledgerID, gomock.Any()).
+		DoAndReturn(func(_ context.Context, _, _ uuid.UUID, balances []mmodel.BalanceRedis) (int64, error) {
+			assert.Len(t, balances, 1, "the present balance must be queued for persistence")
+			assert.Equal(t, balanceID.String(), balances[0].ID)
+			assert.Equal(t, int64(1), balances[0].Version)
+			return 1, nil
+		}).
+		Times(1)
+
+	// The key is removed as a synced key (after a successful DB write), carrying its
+	// claimed score — not via the orphan-only cleanup path.
+	mockRedis.EXPECT().
+		RemoveBalanceSyncKeysBatch(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, keysToRemove []redis.SyncKey) (int64, error) {
+			assert.Len(t, keysToRemove, 1)
+			assert.Equal(t, namespacedKey, keysToRemove[0].Key, "namespaced key must be removed verbatim")
+			assert.Equal(t, syncKeyScore(0), keysToRemove[0].Score, "claimed score must be preserved")
+			return 1, nil
+		}).
+		Times(1)
+
+	uc := UseCase{
+		TransactionRedisRepo: mockRedis,
+		BalanceRepo:          mockBalance,
+	}
+
+	ctx := tmcore.ContextWithTenantID(context.Background(), "acme")
+
+	result, err := uc.SyncBalancesBatch(ctx, organizationID, ledgerID, toSyncKeys(keys))
+
+	assert.NoError(t, err)
+	assert.NotNil(t, result)
+	assert.Equal(t, 1, result.KeysProcessed)
+	assert.Equal(t, 1, result.BalancesAggregated, "present value must aggregate, not be orphaned")
+	assert.Equal(t, int64(1), result.BalancesSynced, "balance must be persisted to PostgreSQL")
+	assert.Equal(t, int64(1), result.KeysRemoved)
 }
 
 // TestSyncBalancesBatch_MalformedKeyFallbackToDefault verifies that when parsed partition

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/LerianStudio/midaz/v3
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/LerianStudio/lib-auth/v2 v2.8.0

--- a/pkg/net/http/withBody.go
+++ b/pkg/net/http/withBody.go
@@ -185,7 +185,7 @@ func ValidateStruct(s any) error {
 	v, trans := newValidator()
 
 	k := reflect.ValueOf(s).Kind()
-	if k == reflect.Ptr {
+	if k == reflect.Pointer {
 		k = reflect.ValueOf(s).Elem().Kind()
 	}
 
@@ -637,7 +637,7 @@ func collectNullByteViolations(rv reflect.Value, jsonPath string, out pkg.FieldV
 	}
 
 	switch rv.Kind() {
-	case reflect.Ptr:
+	case reflect.Pointer:
 		collectNullBytesFromPtr(rv, jsonPath, out, state)
 	case reflect.Struct:
 		collectNullBytesFromStruct(rv, out, state)
@@ -771,7 +771,7 @@ func jsonFieldName(f reflect.StructField) string {
 // parseMetadata For compliance with RFC7396 JSON Merge Patch
 func parseMetadata(s any, originalMap map[string]any) {
 	val := reflect.ValueOf(s)
-	if val.Kind() != reflect.Ptr || val.Elem().Kind() != reflect.Struct {
+	if val.Kind() != reflect.Pointer || val.Elem().Kind() != reflect.Struct {
 		return
 	}
 
@@ -800,7 +800,7 @@ func populateNullFields(s any, originalMap map[string]any) {
 	}
 
 	val := reflect.ValueOf(s)
-	if val.Kind() != reflect.Ptr || val.IsNil() {
+	if val.Kind() != reflect.Pointer || val.IsNil() {
 		return
 	}
 


### PR DESCRIPTION
**Summary**

In multi-tenant mode the balance was mutated in Redis (version incremented, e.g. v1) but the Postgres balance row stayed at version 0. Single-tenant/default mode was unaffected.

Root cause: the sync/flush read path re-applied the tenant namespace to keys that were already namespaced, so every lookup missed and the worker treated live balances as expired "orphans", silently dropping the pending write. Because each new mutation re-scheduled the same key, the bug was self-perpetuating (synced=0 every batch, balance_synced_total empty).

This PR fixes the read path to target the same key the value was written under, with no change to the Redis key format. It also bumps the Go toolchain to 1.26.4 to clear two stdlib vulnerabilities flagged by govulncheck.

**Background**

Balance keys are tenant-namespaced once at write time as tenant:{tenantID}:balance:{transactions}:<org>:<ledger>:<alias>#<key> (via tmvalkey.GetKeyContext). In single-tenant mode there is no tenant in context, so keys are returned unchanged — which is why only multi-tenant broke.
- WRITE (consumer.redis.go:658) namespaces the key once and the Lua script (balance_atomic_operation.lua) uses that same key for both the SET value and the schedule ZADD member — correct (prefixed 1×).
- CLAIM (GetBalanceSyncKeys, claim_balance_sync_keys.lua) returns those members verbatim (still 1×).
- READ/FLUSH (the bug): SyncBalancesBatch → GetBalancesByKeys called tenantKeysFromContext(ctx, keys), turning tenant:{id}:balance:… into tenant:{id}:tenant:{id}:balance:… → MGET miss → false orphan → entry removed from the schedule → never persisted.

**Changes**

Bug fix (read/flush path only — Redis key format unchanged):
- GetBalancesByKeys (consumer.redis.go): no longer re-namespaces keys. The claimed members are already fully-qualified Redis keys, so MGET uses them verbatim. Tenant isolation on this path is enforced by the per-tenant connection pool (conn.GetClient(ctx)), not by key prefixing. Interface + method doc comments updated to state the contract.
- BalanceCompositeKeyFromRedisKey (balance/aggregation.go): made prefix-tolerant. It previously parsed org/ledger positionally (parts[2]/parts[3]), which rejected namespaced keys as a parse error → another false-orphan drop after the MGET fix. It now locates org/ledger as the first two parseable UUID segments, consistent with the worker's existing extractIDsFromMember.
Toolchain bump (separate, repo-wide):
- go.mod: go 1.26.3 → 1.26.4
- .github/workflows/go-combined-analysis.yml: go_version: "1.26.3" → "1.26.4"
- Fixes GO-2026-5039 (net/textproto) and GO-2026-5037 (crypto/x509). Stdlib-only; no application code change required.
Self-review of related paths (same double-namespacing premise)
- Claim and Remove (RemoveBalanceSyncKeysBatch / remove_balance_sync_keys_batch.lua): schedule key namespaced once; ZSET members passed as-is (not re-namespaced); lock key = lockPrefix .. member, symmetric between claim and remove. Verified correct — no change needed.
- Worker grouping (extractIDsFromMember): already prefix-tolerant. No change needed.

**Tests**

- aggregation_test.go: added multi-tenant namespaced-key cases (with partition + alias-containing-colons) to the parser table.
- consumer.redis_get_balances_test.go: single-tenant test asserting the key reaches MGET unchanged and the value is found (proves single-tenant unaffected).
- consumer.redis_atomic_state_test.go: TestGetBalancesByKeys_MultiTenant_NoDoubleNamespacing — tenant in context + already-namespaced member reaches MGET verbatim and the value is found.
- sync_balances_batch_test.go: TestSyncBalancesBatch_MultiTenant_PresentValuePersistsNotOrphaned — present value is persisted via UpdateMany and removed as a synced key (with its claimed score), not dropped as an orphan. Existing orphan-handling tests (nil value still treated as orphan) remain green.
All affected packages pass (redis/transaction, redis/transaction/balance, services/command, bootstrap); make sec passes (gosec: 0 issues, govulncheck: No vulnerabilities found).

**Known limitation (pre-existing, out of scope)**

Both the parser and the worker's extractIDsFromMember assume the tenant ID is not a 36-char UUID; a UUID tenant ID would be mis-read as orgID. This predates these changes and affects the worker equally — flagging for a separate follow-up.

**Risk**

- Behavior is identical in single-tenant/default mode.
- No Redis key-format change; no data migration.