### PR TITLE
refactor(crm): enhance KMS integration with base mount path resolution

### DIFF
--- a/components/crm/.env.example
+++ b/components/crm/.env.example
@@ -71,7 +71,9 @@ KMS_VENDOR=none
 #
 # REQUIRED SETTINGS (all deployment modes):
 #   - KMS_VAULT_ADDR: Vault server address
-#   - KMS_VAULT_MOUNT_PATH: Transit secrets engine mount path
+#
+# OPTIONAL SETTINGS (all deployment modes):
+#   - KMS_VAULT_MOUNT_PATH: BASE Transit mount (defaults to "transit" if unset; safe to omit)
 #
 # VAULT AUTHENTICATION
 # The auth method is automatically selected based on DEPLOYMENT_MODE:
@@ -79,11 +81,12 @@ KMS_VENDOR=none
 # LOCAL/DEVELOPMENT MODE (DEPLOYMENT_MODE=local or empty):
 #   - Uses Token auth with hardcoded root token ("root")
 #   - AppRole credentials (if provided) are ignored for simplicity
-#   - REQUIRED: KMS_VAULT_ADDR and KMS_VAULT_MOUNT_PATH must be set
+#   - REQUIRED: KMS_VAULT_ADDR must be set (KMS_VAULT_MOUNT_PATH is optional; defaults to "transit")
 #
 # SAAS/BYOC MODE (DEPLOYMENT_MODE=saas or byoc):
 #   - Uses AppRole auth exclusively (more secure)
-#   - REQUIRES: KMS_VAULT_ROLE_ID, KMS_VAULT_SECRET_ID, KMS_VAULT_ADDR, KMS_VAULT_MOUNT_PATH
+#   - REQUIRES: KMS_VAULT_ROLE_ID, KMS_VAULT_SECRET_ID, KMS_VAULT_ADDR
+#     (KMS_VAULT_MOUNT_PATH is optional; defaults to base "transit")
 #   - Token auth is NOT available in saas/byoc mode
 #   - Service fails to start if any required credential is missing
 #
@@ -100,14 +103,22 @@ KMS_VENDOR=none
 # KMS_VAULT_ROLE_ID=
 # KMS_VAULT_SECRET_ID=
 #
-# TRANSIT MOUNT PATH (REQUIRED for envelope mode)
-# KMS_VAULT_MOUNT_PATH: Transit secrets engine mount path (no default - must be set)
-#   Use a dedicated mount per application for namespace isolation.
-#   Transit key convention: org/{organization_id}
-#   Example: crm-transit/encrypt/org/550e8400-e29b-41d4-a716-446655440000
+# TRANSIT BASE MOUNT PATH (OPTIONAL for envelope mode; defaults to "transit")
+# KMS_VAULT_MOUNT_PATH: BASE Transit secrets engine mount path.
+#   - Safe to omit: unset or empty falls back to the base "transit" (no crash).
+#   - This is the BASE mount only. Per-tenant mounts are derived as {base}/{tenantID}
+#     and are provisioned out-of-band (Terraform/operator), not by CRM at runtime.
+#   - MUTUALLY EXCLUSIVE topology: Vault mount paths are hierarchical, so an engine at
+#     the bare base ("transit") and per-tenant sub-mounts ("transit/{tenantID}") cannot
+#     coexist under the same base. A deployment is EITHER flat single-tenant (engine at
+#     the base) OR multi-tenant (per-tenant engines, with NO engine at the bare base).
+#   - Use a dedicated base mount per application for namespace isolation.
+#   Transit key convention: org/{organization_id} under the resolved per-tenant mount
+#   Example: transit/{tenantID}/encrypt/org/550e8400-e29b-41d4-a716-446655440000
 #
-#   LOCAL DEV: vault-init service automatically enables Transit at this path
-#   SAAS/BYOC: Ensure Transit is enabled at this path before starting CRM
+#   LOCAL DEV: vault-init service enables Transit at the base mount
+#   SAAS/BYOC: Ensure each per-tenant mount ({base}/{tenantID}) is enabled out-of-band
+#              (Terraform/operator) before that tenant encrypts
 # KMS_VAULT_MOUNT_PATH=transit
 #
 # KEY AUTO-CREATION

--- a/components/crm/api/docs.go
+++ b/components/crm/api/docs.go
@@ -963,6 +963,12 @@ const docTemplate = `{
                             "$ref": "#/definitions/pkg.HTTPError"
                         }
                     },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/pkg.HTTPError"
+                        }
+                    },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
@@ -1002,6 +1008,101 @@ const docTemplate = `{
                         "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/ProvisioningStatusResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/pkg.HTTPError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/pkg.HTTPError"
+                        }
+                    }
+                }
+            }
+        },
+        "/v1/organizations/{organization_id}/protection/audit": {
+            "get": {
+                "description": "Returns the protection audit events for an organization, filtered by action, actor, outcome, and time range, with cursor pagination.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Protection"
+                ],
+                "summary": "List Protection Audit Events",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "The authorization token in the 'Bearer\taccess_token' format. Only required when auth plugin is enabled.",
+                        "name": "Authorization",
+                        "in": "header"
+                    },
+                    {
+                        "type": "string",
+                        "description": "The unique identifier of the Organization.",
+                        "name": "organization_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Maximum number of events to return (default 20).",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Opaque pagination cursor.",
+                        "name": "cursor",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Sort order: asc or desc (default desc).",
+                        "name": "sort_order",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by action.",
+                        "name": "action",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by actor.",
+                        "name": "actor",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by outcome: success, failure, or already_exists.",
+                        "name": "outcome",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Inclusive lower time bound (yyyy-mm-dd or RFC3339).",
+                        "name": "start_date",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Inclusive upper time bound (yyyy-mm-dd or RFC3339).",
+                        "name": "end_date",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/internal_adapters_http_in.auditEventsEnvelope"
                         }
                     },
                     "400": {
@@ -1743,6 +1844,61 @@ const docTemplate = `{
                 },
                 "page": {
                     "type": "integer"
+                },
+                "prev_cursor": {
+                    "type": "string"
+                }
+            }
+        },
+        "internal_adapters_http_in.auditEventResponse": {
+            "type": "object",
+            "properties": {
+                "action": {
+                    "type": "string"
+                },
+                "actor": {
+                    "type": "string"
+                },
+                "from_status": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "outcome": {
+                    "type": "string"
+                },
+                "reason": {
+                    "type": "string"
+                },
+                "request_id": {
+                    "type": "string"
+                },
+                "timestamp": {
+                    "type": "string"
+                },
+                "to_status": {
+                    "type": "string"
+                }
+            }
+        },
+        "internal_adapters_http_in.auditEventsEnvelope": {
+            "type": "object",
+            "properties": {
+                "items": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/internal_adapters_http_in.auditEventResponse"
+                    }
+                },
+                "limit": {
+                    "type": "integer"
+                },
+                "next_cursor": {
+                    "type": "string"
+                },
+                "organization_id": {
+                    "type": "string"
                 },
                 "prev_cursor": {
                     "type": "string"

--- a/components/crm/api/openapi.yaml
+++ b/components/crm/api/openapi.yaml
@@ -801,6 +801,12 @@ paths:
               schema:
                 $ref: '#/components/schemas/pkg.HTTPError'
           description: Conflict
+        "422":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/pkg.HTTPError'
+          description: Unprocessable Entity
         "500":
           content:
             application/json:
@@ -850,6 +856,85 @@ paths:
       summary: Get Provisioning Status
       tags:
       - Encryption
+  /v1/organizations/{organization_id}/protection/audit:
+    get:
+      description: Returns the protection audit events for an organization, filtered
+        by action, actor, outcome, and time range, with cursor pagination.
+      parameters:
+      - description: "The authorization token in the 'Bearer\taccess_token' format.\
+          \ Only required when auth plugin is enabled."
+        in: header
+        name: Authorization
+        schema:
+          type: string
+      - description: The unique identifier of the Organization.
+        in: path
+        name: organization_id
+        required: true
+        schema:
+          type: string
+      - description: Maximum number of events to return (default 20).
+        in: query
+        name: limit
+        schema:
+          type: integer
+      - description: Opaque pagination cursor.
+        in: query
+        name: cursor
+        schema:
+          type: string
+      - description: 'Sort order: asc or desc (default desc).'
+        in: query
+        name: sort_order
+        schema:
+          type: string
+      - description: Filter by action.
+        in: query
+        name: action
+        schema:
+          type: string
+      - description: Filter by actor.
+        in: query
+        name: actor
+        schema:
+          type: string
+      - description: 'Filter by outcome: success, failure, or already_exists.'
+        in: query
+        name: outcome
+        schema:
+          type: string
+      - description: Inclusive lower time bound (yyyy-mm-dd or RFC3339).
+        in: query
+        name: start_date
+        schema:
+          type: string
+      - description: Inclusive upper time bound (yyyy-mm-dd or RFC3339).
+        in: query
+        name: end_date
+        schema:
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/internal_adapters_http_in.auditEventsEnvelope'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/pkg.HTTPError'
+          description: Bad Request
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/pkg.HTTPError'
+          description: Internal Server Error
+      summary: List Protection Audit Events
+      tags:
+      - Protection
 components:
   schemas:
     Address:
@@ -1684,6 +1769,76 @@ components:
           type: string
         page:
           type: integer
+        prev_cursor:
+          type: string
+      type: object
+    internal_adapters_http_in.auditEventResponse:
+      example:
+        actor: actor
+        reason: reason
+        to_status: to_status
+        action: action
+        from_status: from_status
+        id: id
+        request_id: request_id
+        outcome: outcome
+        timestamp: timestamp
+      properties:
+        action:
+          type: string
+        actor:
+          type: string
+        from_status:
+          type: string
+        id:
+          type: string
+        outcome:
+          type: string
+        reason:
+          type: string
+        request_id:
+          type: string
+        timestamp:
+          type: string
+        to_status:
+          type: string
+      type: object
+    internal_adapters_http_in.auditEventsEnvelope:
+      example:
+        prev_cursor: prev_cursor
+        next_cursor: next_cursor
+        organization_id: organization_id
+        limit: 0
+        items:
+        - actor: actor
+          reason: reason
+          to_status: to_status
+          action: action
+          from_status: from_status
+          id: id
+          request_id: request_id
+          outcome: outcome
+          timestamp: timestamp
+        - actor: actor
+          reason: reason
+          to_status: to_status
+          action: action
+          from_status: from_status
+          id: id
+          request_id: request_id
+          outcome: outcome
+          timestamp: timestamp
+      properties:
+        items:
+          items:
+            $ref: '#/components/schemas/internal_adapters_http_in.auditEventResponse'
+          type: array
+        limit:
+          type: integer
+        next_cursor:
+          type: string
+        organization_id:
+          type: string
         prev_cursor:
           type: string
       type: object

--- a/components/crm/api/swagger.json
+++ b/components/crm/api/swagger.json
@@ -960,6 +960,12 @@
                             "$ref": "#/definitions/pkg.HTTPError"
                         }
                     },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/pkg.HTTPError"
+                        }
+                    },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
@@ -999,6 +1005,101 @@
                         "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/ProvisioningStatusResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/pkg.HTTPError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/pkg.HTTPError"
+                        }
+                    }
+                }
+            }
+        },
+        "/v1/organizations/{organization_id}/protection/audit": {
+            "get": {
+                "description": "Returns the protection audit events for an organization, filtered by action, actor, outcome, and time range, with cursor pagination.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Protection"
+                ],
+                "summary": "List Protection Audit Events",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "The authorization token in the 'Bearer\taccess_token' format. Only required when auth plugin is enabled.",
+                        "name": "Authorization",
+                        "in": "header"
+                    },
+                    {
+                        "type": "string",
+                        "description": "The unique identifier of the Organization.",
+                        "name": "organization_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Maximum number of events to return (default 20).",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Opaque pagination cursor.",
+                        "name": "cursor",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Sort order: asc or desc (default desc).",
+                        "name": "sort_order",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by action.",
+                        "name": "action",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by actor.",
+                        "name": "actor",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by outcome: success, failure, or already_exists.",
+                        "name": "outcome",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Inclusive lower time bound (yyyy-mm-dd or RFC3339).",
+                        "name": "start_date",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Inclusive upper time bound (yyyy-mm-dd or RFC3339).",
+                        "name": "end_date",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/internal_adapters_http_in.auditEventsEnvelope"
                         }
                     },
                     "400": {
@@ -1740,6 +1841,61 @@
                 },
                 "page": {
                     "type": "integer"
+                },
+                "prev_cursor": {
+                    "type": "string"
+                }
+            }
+        },
+        "internal_adapters_http_in.auditEventResponse": {
+            "type": "object",
+            "properties": {
+                "action": {
+                    "type": "string"
+                },
+                "actor": {
+                    "type": "string"
+                },
+                "from_status": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "outcome": {
+                    "type": "string"
+                },
+                "reason": {
+                    "type": "string"
+                },
+                "request_id": {
+                    "type": "string"
+                },
+                "timestamp": {
+                    "type": "string"
+                },
+                "to_status": {
+                    "type": "string"
+                }
+            }
+        },
+        "internal_adapters_http_in.auditEventsEnvelope": {
+            "type": "object",
+            "properties": {
+                "items": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/internal_adapters_http_in.auditEventResponse"
+                    }
+                },
+                "limit": {
+                    "type": "integer"
+                },
+                "next_cursor": {
+                    "type": "string"
+                },
+                "organization_id": {
+                    "type": "string"
                 },
                 "prev_cursor": {
                     "type": "string"

--- a/components/crm/api/swagger.yaml
+++ b/components/crm/api/swagger.yaml
@@ -568,6 +568,42 @@ definitions:
       prev_cursor:
         type: string
     type: object
+  internal_adapters_http_in.auditEventResponse:
+    properties:
+      action:
+        type: string
+      actor:
+        type: string
+      from_status:
+        type: string
+      id:
+        type: string
+      outcome:
+        type: string
+      reason:
+        type: string
+      request_id:
+        type: string
+      timestamp:
+        type: string
+      to_status:
+        type: string
+    type: object
+  internal_adapters_http_in.auditEventsEnvelope:
+    properties:
+      items:
+        items:
+          $ref: '#/definitions/internal_adapters_http_in.auditEventResponse'
+        type: array
+      limit:
+        type: integer
+      next_cursor:
+        type: string
+      organization_id:
+        type: string
+      prev_cursor:
+        type: string
+    type: object
   pkg.HTTPError:
     properties:
       code:
@@ -1260,6 +1296,10 @@ paths:
           description: Conflict
           schema:
             $ref: '#/definitions/pkg.HTTPError'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/pkg.HTTPError'
         "500":
           description: Internal Server Error
           schema:
@@ -1300,6 +1340,71 @@ paths:
       summary: Get Provisioning Status
       tags:
       - Encryption
+  /v1/organizations/{organization_id}/protection/audit:
+    get:
+      description: Returns the protection audit events for an organization, filtered
+        by action, actor, outcome, and time range, with cursor pagination.
+      parameters:
+      - description: "The authorization token in the 'Bearer\taccess_token' format.
+          Only required when auth plugin is enabled."
+        in: header
+        name: Authorization
+        type: string
+      - description: The unique identifier of the Organization.
+        in: path
+        name: organization_id
+        required: true
+        type: string
+      - description: Maximum number of events to return (default 20).
+        in: query
+        name: limit
+        type: integer
+      - description: Opaque pagination cursor.
+        in: query
+        name: cursor
+        type: string
+      - description: 'Sort order: asc or desc (default desc).'
+        in: query
+        name: sort_order
+        type: string
+      - description: Filter by action.
+        in: query
+        name: action
+        type: string
+      - description: Filter by actor.
+        in: query
+        name: actor
+        type: string
+      - description: 'Filter by outcome: success, failure, or already_exists.'
+        in: query
+        name: outcome
+        type: string
+      - description: Inclusive lower time bound (yyyy-mm-dd or RFC3339).
+        in: query
+        name: start_date
+        type: string
+      - description: Inclusive upper time bound (yyyy-mm-dd or RFC3339).
+        in: query
+        name: end_date
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/internal_adapters_http_in.auditEventsEnvelope'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/pkg.HTTPError'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/pkg.HTTPError'
+      summary: List Protection Audit Events
+      tags:
+      - Protection
 schemes:
 - http
 securityDefinitions:

--- a/components/crm/internal/adapters/http/in/encryption.go
+++ b/components/crm/internal/adapters/http/in/encryption.go
@@ -5,7 +5,6 @@
 package in
 
 import (
-	tmcore "github.com/LerianStudio/lib-commons/v5/commons/tenant-manager/core"
 	"github.com/LerianStudio/midaz/v3/components/crm/internal/services/encryption"
 	cn "github.com/LerianStudio/midaz/v3/pkg/constant"
 	"github.com/LerianStudio/midaz/v3/pkg/mmodel"
@@ -36,6 +35,7 @@ type EncryptionHandler struct {
 //	@Success		201					{object}	mmodel.ProvisionEncryptionResponse
 //	@Failure		400					{object}	pkg.HTTPError
 //	@Failure		409					{object}	pkg.HTTPError
+//	@Failure		422					{object}	pkg.HTTPError
 //	@Failure		500					{object}	pkg.HTTPError
 //	@Router			/v1/organizations/{organization_id}/encryption/provision [post]
 func (handler *EncryptionHandler) Provision(p any, c *fiber.Ctx) error {
@@ -69,10 +69,23 @@ func (handler *EncryptionHandler) Provision(p any, c *fiber.Ctx) error {
 		return http.WithError(c, err)
 	}
 
-	// Get tenant ID from context (defaults to "default" for single-tenant mode)
-	tenantID := tmcore.GetTenantIDContext(ctx)
-	if tenantID == "" {
-		tenantID = "default"
+	// Resolve tenant ID through the shared guard.
+	//
+	// In single-tenant mode the tenant middleware does not run, so the context
+	// carries no tenant id (empty) and the helper substitutes the reserved
+	// "default" flat-base sentinel. In multi-tenant mode the middleware always
+	// populates a non-empty tenant id from the JWT; a real tenant literally named
+	// "default" would collide with the single-tenant sentinel and resolve to the
+	// flat base mount, breaking tenant isolation, so the helper rejects it with
+	// ErrReservedTenantID. The lazy autoProvision path uses the same helper, so
+	// both ingress points share one source of truth.
+	tenantID, err := encryption.ResolveProvisionTenantID(ctx)
+	if err != nil {
+		libOpenTelemetry.HandleSpanError(span, "reserved tenant id supplied", err)
+
+		logger.Log(ctx, libLog.LevelWarn, "reserved tenant id supplied")
+
+		return http.WithError(c, err)
 	}
 
 	input := encryption.ProvisionInput{

--- a/components/crm/internal/adapters/http/in/encryption_test.go
+++ b/components/crm/internal/adapters/http/in/encryption_test.go
@@ -14,6 +14,7 @@ import (
 	"reflect"
 	"testing"
 
+	tmcore "github.com/LerianStudio/lib-commons/v5/commons/tenant-manager/core"
 	"github.com/LerianStudio/midaz/v3/components/crm/internal/services/encryption"
 	pkg "github.com/LerianStudio/midaz/v3/pkg"
 	"github.com/LerianStudio/midaz/v3/pkg/constant"
@@ -31,6 +32,7 @@ func TestEncryption_Provision(t *testing.T) {
 	tests := []struct {
 		name           string
 		organizationID string
+		tenantID       string
 		jsonBody       string
 		setupMocks     func(mockService *MockProvisioningService, orgID string)
 		expectedStatus int
@@ -150,6 +152,61 @@ func TestEncryption_Provision(t *testing.T) {
 			expectedStatus: 500,
 			validateBody:   nil, // Error format handled by http.WithError middleware
 		},
+		{
+			// Multi-tenant mode: the tenant middleware populated a real, non-empty
+			// tenant id literally equal to "default" from the JWT. This collides
+			// with the single-tenant flat-base sentinel, so it MUST be rejected
+			// before reaching the provisioning service (no Provision call).
+			name:           "real tenant named default returns 422",
+			organizationID: uuid.New().String(),
+			tenantID:       "default",
+			jsonBody: `{
+				"actor": "admin@example.com",
+				"reason": "Initial encryption setup"
+			}`,
+			setupMocks: func(mockService *MockProvisioningService, orgID string) {
+				// No mock expectations: rejection happens before the service call.
+			},
+			expectedStatus: 422,
+			validateBody: func(t *testing.T, body []byte) {
+				var errResp map[string]any
+				err := json.Unmarshal(body, &errResp)
+				require.NoError(t, err)
+
+				assert.Equal(t, constant.ErrReservedTenantID.Error(), errResp["code"],
+					"reserved tenant id rejection should map to ErrReservedTenantID code")
+			},
+		},
+		{
+			// Single-tenant sentinel path: no tenant middleware ran, so the
+			// context carries no tenant id (empty). The handler substitutes the
+			// "default" flat-base sentinel and provisioning proceeds normally.
+			name:           "single-tenant default sentinel still provisions",
+			organizationID: uuid.New().String(),
+			tenantID:       "", // empty context => single-tenant sentinel path
+			jsonBody: `{
+				"actor": "admin@example.com",
+				"reason": "Initial encryption setup"
+			}`,
+			setupMocks: func(mockService *MockProvisioningService, orgID string) {
+				mockService.EXPECT().
+					Provision(gomock.Any(), gomock.Cond(func(x any) bool {
+						req, ok := x.(encryption.ProvisionInput)
+						if !ok {
+							return false
+						}
+						return req.OrganizationID == orgID && req.TenantID == "default"
+					})).
+					Return(encryption.ProvisionResult{
+						OrganizationID: orgID,
+						KEKPath:        "transit/keys/org-" + orgID,
+						RegistryStatus: mmodel.RegistryStatusActive,
+					}, nil).
+					Times(1)
+			},
+			expectedStatus: 201,
+			validateBody:   nil,
+		},
 	}
 
 	for _, tt := range tests {
@@ -164,10 +221,18 @@ func TestEncryption_Provision(t *testing.T) {
 				ProvisioningService: mockService,
 			}
 
+			tenantID := tt.tenantID
+
 			app := fiber.New()
 			app.Post("/v1/organizations/:organization_id/encryption/provision",
 				func(c *fiber.Ctx) error {
 					c.Locals("organization_id", uuid.MustParse(tt.organizationID))
+					// Simulate the tenant middleware: in multi-tenant mode it
+					// stores a non-empty tenant id; in single-tenant mode it does
+					// not run, so the context carries no tenant id.
+					if tenantID != "" {
+						c.SetUserContext(tmcore.ContextWithTenantID(c.UserContext(), tenantID))
+					}
 					return c.Next()
 				},
 				http.WithBody(new(mmodel.ProvisionEncryptionInput), handler.Provision),

--- a/components/crm/internal/adapters/mongodb/encryption/keyset.go
+++ b/components/crm/internal/adapters/mongodb/encryption/keyset.go
@@ -15,6 +15,7 @@ type KeysetMongoDBModel struct {
 	TenantID          string          `bson:"tenant_id,omitempty"`
 	OrganizationID    string          `bson:"organization_id"`
 	KEKPath           string          `bson:"kek_path"`
+	KEKMountPath      string          `bson:"kek_mount_path,omitempty"`
 	WrappedKeyset     string          `bson:"wrapped_keyset"`
 	KeysetInfo        KeysetInfoModel `bson:"keyset_info"`
 	WrappedHMACKeyset string          `bson:"wrapped_hmac_keyset,omitempty"`
@@ -48,6 +49,7 @@ func KeysetFromEntity(k *mmodel.OrganizationKeyset) *KeysetMongoDBModel {
 		TenantID:          k.TenantID,
 		OrganizationID:    k.OrganizationID,
 		KEKPath:           k.KEKPath,
+		KEKMountPath:      k.KEKMountPath,
 		WrappedKeyset:     k.WrappedKeyset,
 		KeysetInfo:        keysetInfoFromEntity(k.KeysetInfo),
 		WrappedHMACKeyset: k.WrappedHMACKeyset,
@@ -68,6 +70,7 @@ func (m *KeysetMongoDBModel) ToEntity() *mmodel.OrganizationKeyset {
 		TenantID:          m.TenantID,
 		OrganizationID:    m.OrganizationID,
 		KEKPath:           m.KEKPath,
+		KEKMountPath:      m.KEKMountPath,
 		WrappedKeyset:     m.WrappedKeyset,
 		KeysetInfo:        m.KeysetInfo.toEntity(),
 		WrappedHMACKeyset: m.WrappedHMACKeyset,

--- a/components/crm/internal/adapters/mongodb/encryption/keyset.mongodb_integration_test.go
+++ b/components/crm/internal/adapters/mongodb/encryption/keyset.mongodb_integration_test.go
@@ -47,6 +47,7 @@ func createValidKeyset(organizationID string) *mmodel.OrganizationKeyset {
 	return &mmodel.OrganizationKeyset{
 		OrganizationID: organizationID,
 		KEKPath:        "transit/keys/crm-" + organizationID,
+		KEKMountPath:   "transit",
 		WrappedKeyset:  "vault:v1:encrypted-dek-" + uuid.New().String()[:8],
 		KeysetInfo: mmodel.KeysetInfo{
 			PrimaryKeyID: 1,
@@ -519,6 +520,7 @@ func TestIntegration_KeysetRepo_RoundTrip(t *testing.T) {
 
 	assert.Equal(t, original.OrganizationID, result.OrganizationID)
 	assert.Equal(t, original.KEKPath, result.KEKPath)
+	assert.Equal(t, original.KEKMountPath, result.KEKMountPath)
 	assert.Equal(t, original.WrappedKeyset, result.WrappedKeyset)
 	assert.Equal(t, original.WrappedHMACKeyset, result.WrappedHMACKeyset)
 	assert.Equal(t, original.KeysetInfo.PrimaryKeyID, result.KeysetInfo.PrimaryKeyID)

--- a/components/crm/internal/adapters/mongodb/encryption/keyset.mongodb_test.go
+++ b/components/crm/internal/adapters/mongodb/encryption/keyset.mongodb_test.go
@@ -85,16 +85,29 @@ func TestKeysetMongoDBRepository_Save_ValidationError(t *testing.T) {
 			keyset: &mmodel.OrganizationKeyset{
 				OrganizationID: "org-a",
 				KEKPath:        "transit/keys/test",
+				KEKMountPath:   "transit",
 				WrappedKeyset:  "",
 				KeysetInfo:     mmodel.KeysetInfo{PrimaryKeyID: 1},
 			},
 			wantErrMsg: "wrapped_keyset is required",
 		},
 		{
+			name: "empty kek_mount_path",
+			keyset: &mmodel.OrganizationKeyset{
+				OrganizationID: "org-a",
+				KEKPath:        "transit/keys/test",
+				KEKMountPath:   "",
+				WrappedKeyset:  "vault:v1:dek",
+				KeysetInfo:     mmodel.KeysetInfo{PrimaryKeyID: 1},
+			},
+			wantErrMsg: "kek_mount_path is required",
+		},
+		{
 			name: "zero primary_key_id",
 			keyset: &mmodel.OrganizationKeyset{
 				OrganizationID: "org-a",
 				KEKPath:        "transit/keys/test",
+				KEKMountPath:   "transit",
 				WrappedKeyset:  "vault:v1:dek",
 				KeysetInfo:     mmodel.KeysetInfo{PrimaryKeyID: 0},
 			},
@@ -318,6 +331,7 @@ func validTestKeyset() *mmodel.OrganizationKeyset {
 	return &mmodel.OrganizationKeyset{
 		OrganizationID:    "org-test",
 		KEKPath:           "transit/keys/crm-org-test",
+		KEKMountPath:      "transit",
 		WrappedKeyset:     "vault:v1:encrypted-dek",
 		WrappedHMACKeyset: "vault:v1:encrypted-hmac",
 		KeysetInfo: mmodel.KeysetInfo{

--- a/components/crm/internal/adapters/mongodb/encryption/keyset_test.go
+++ b/components/crm/internal/adapters/mongodb/encryption/keyset_test.go
@@ -23,6 +23,7 @@ func TestKeysetFromEntity(t *testing.T) {
 		TenantID:       "tenant-a",
 		OrganizationID: "org-a",
 		KEKPath:        "transit/keys/org-123",
+		KEKMountPath:   "transit/tenant-a",
 		WrappedKeyset:  "vault:v1:encrypted-dek",
 		KeysetInfo: mmodel.KeysetInfo{
 			PrimaryKeyID: 2,
@@ -44,6 +45,7 @@ func TestKeysetFromEntity(t *testing.T) {
 	assert.Equal(t, entity.TenantID, model.TenantID)
 	assert.Equal(t, entity.OrganizationID, model.OrganizationID)
 	assert.Equal(t, entity.KEKPath, model.KEKPath)
+	assert.Equal(t, entity.KEKMountPath, model.KEKMountPath)
 	assert.Equal(t, entity.WrappedKeyset, model.WrappedKeyset)
 	assert.Equal(t, entity.KeysetInfo.PrimaryKeyID, model.KeysetInfo.PrimaryKeyID)
 	assert.Len(t, model.KeysetInfo.Keys, 2)
@@ -71,6 +73,7 @@ func TestKeysetMongoDBModel_ToEntity(t *testing.T) {
 		TenantID:       "tenant-a",
 		OrganizationID: "org-a",
 		KEKPath:        "transit/keys/org-123",
+		KEKMountPath:   "transit/tenant-a",
 		WrappedKeyset:  "vault:v1:encrypted-dek",
 		KeysetInfo: KeysetInfoModel{
 			PrimaryKeyID: 2,
@@ -92,6 +95,7 @@ func TestKeysetMongoDBModel_ToEntity(t *testing.T) {
 	assert.Equal(t, model.TenantID, entity.TenantID)
 	assert.Equal(t, model.OrganizationID, entity.OrganizationID)
 	assert.Equal(t, model.KEKPath, entity.KEKPath)
+	assert.Equal(t, model.KEKMountPath, entity.KEKMountPath)
 	assert.Equal(t, model.WrappedKeyset, entity.WrappedKeyset)
 	assert.Equal(t, model.KeysetInfo.PrimaryKeyID, entity.KeysetInfo.PrimaryKeyID)
 	assert.Len(t, entity.KeysetInfo.Keys, 2)
@@ -120,6 +124,7 @@ func TestKeysetConversion_RoundTrip(t *testing.T) {
 		TenantID:       "tenant-a",
 		OrganizationID: "org-a",
 		KEKPath:        "transit/keys/org-123",
+		KEKMountPath:   "transit/tenant-a",
 		WrappedKeyset:  "vault:v1:encrypted-dek",
 		KeysetInfo: mmodel.KeysetInfo{
 			PrimaryKeyID: 2,
@@ -141,6 +146,7 @@ func TestKeysetConversion_RoundTrip(t *testing.T) {
 	assert.Equal(t, original.TenantID, recovered.TenantID)
 	assert.Equal(t, original.OrganizationID, recovered.OrganizationID)
 	assert.Equal(t, original.KEKPath, recovered.KEKPath)
+	assert.Equal(t, original.KEKMountPath, recovered.KEKMountPath)
 	assert.Equal(t, original.WrappedKeyset, recovered.WrappedKeyset)
 	assert.Equal(t, original.KeysetInfo.PrimaryKeyID, recovered.KeysetInfo.PrimaryKeyID)
 	assert.Equal(t, len(original.KeysetInfo.Keys), len(recovered.KeysetInfo.Keys))

--- a/components/crm/internal/bootstrap/encryption.go
+++ b/components/crm/internal/bootstrap/encryption.go
@@ -20,6 +20,21 @@ import (
 // defaultKEKMountPath is the default Vault Transit mount path for KEK operations.
 const defaultKEKMountPath = "transit"
 
+// resolveBaseMountPath resolves the base Vault Transit mount from the configured
+// KMS_VAULT_MOUNT_PATH. Unset/empty values (including whitespace-only and
+// slash-only inputs such as "/") fall back to the safe default "transit" so
+// single-tenant deployments and missing config never crash or produce a
+// degenerate leading-slash mount. Per-tenant sub-mounts ({base}/{tenantID}) are
+// resolved downstream from this base. The returned base is never blank.
+func resolveBaseMountPath(configured string) string {
+	base := strings.TrimSpace(configured)
+	if strings.Trim(configured, "/ \t") == "" {
+		return defaultKEKMountPath
+	}
+
+	return base
+}
+
 // wireEncryptionServicesInput contains all dependencies for wiring encryption services.
 // For testing with mocks, use testWireEncryptionServicesWithMocks in encryption_test.go.
 type wireEncryptionServicesInput struct {
@@ -114,11 +129,8 @@ func wireEncryptionServices(input wireEncryptionServicesInput) wireEncryptionSer
 		}
 	}
 
-	// Resolve Vault mount path with default
-	vaultMountPath := input.vaultMountPath
-	if vaultMountPath == "" {
-		vaultMountPath = defaultKEKMountPath
-	}
+	// Resolve the base Vault Transit mount once (see resolveBaseMountPath).
+	baseMountPath := resolveBaseMountPath(input.vaultMountPath)
 
 	// Wire ProtectionStateResolver with RegistryRepository
 	protectionStateResolver := encryption.NewProtectionStateResolver(input.registryRepo, pm)
@@ -136,18 +148,22 @@ func wireEncryptionServices(input wireEncryptionServicesInput) wireEncryptionSer
 		input.keysetRepo,
 		input.registryRepo,
 		&keysetGeneratorAdapter{factory: keysetFactory},
-		encryption.ProvisioningConfig{KEKMountPath: vaultMountPath},
+		encryption.ProvisioningConfig{KEKMountPath: baseMountPath},
 		input.auditWriter,
 		pm,
 	)
 
-	// Wire KeysetManager with KeysetRepository, VaultKeysetUnwrapper, and ProvisioningService
-	// Tenant ID for auto-provisioning is obtained from context
+	// Wire KeysetManager with KeysetRepository, VaultKeysetUnwrapper, and ProvisioningService.
+	// Tenant ID for auto-provisioning is obtained from context. The base mount is
+	// injected so per-tenant sub-mounts resolve consistently with provisioning.
+	keysetManagerConfig := encryption.DefaultKeysetManagerConfig()
+	keysetManagerConfig.BaseMountPath = baseMountPath
+
 	keysetManager := encryption.NewKeysetManager(
 		input.keysetRepo,
 		keysetWrapper,
 		provisioningService,
-		encryption.DefaultKeysetManagerConfig(),
+		keysetManagerConfig,
 		pm,
 	)
 
@@ -180,11 +196,13 @@ type keysetGeneratorAdapter struct {
 }
 
 // GenerateAEADKeyset generates a new AEAD keyset and wraps it with the KMS.
-func (a *keysetGeneratorAdapter) GenerateAEADKeyset(ctx context.Context, keyName string) (tink.KeysetBundle, error) {
-	return a.factory.GenerateAEADKeyset(ctx, keyName)
+// The per-tenant mountPath is forwarded verbatim to the underlying factory.
+func (a *keysetGeneratorAdapter) GenerateAEADKeyset(ctx context.Context, mountPath, keyName string) (tink.KeysetBundle, error) {
+	return a.factory.GenerateAEADKeyset(ctx, mountPath, keyName)
 }
 
 // GenerateMACKeyset generates a new MAC keyset and wraps it with the KMS.
-func (a *keysetGeneratorAdapter) GenerateMACKeyset(ctx context.Context, keyName string) (tink.KeysetBundle, error) {
-	return a.factory.GenerateMACKeyset(ctx, keyName)
+// The per-tenant mountPath is forwarded verbatim to the underlying factory.
+func (a *keysetGeneratorAdapter) GenerateMACKeyset(ctx context.Context, mountPath, keyName string) (tink.KeysetBundle, error) {
+	return a.factory.GenerateMACKeyset(ctx, mountPath, keyName)
 }

--- a/components/crm/internal/bootstrap/encryption.go
+++ b/components/crm/internal/bootstrap/encryption.go
@@ -20,9 +20,12 @@ import (
 // defaultKEKMountPath is the default Vault Transit mount path for KEK operations.
 const defaultKEKMountPath = "transit"
 
-// resolveBaseMountPath resolves the base Vault Transit mount, trimming surrounding
-// slashes/whitespace so the returned base equals the effective mount used downstream.
-// Empty/whitespace/slash-only input falls back to the default "transit"; never blank.
+// resolveBaseMountPath is the SINGLE base-mount normalizer: base normalization
+// lives here, not in resolveMount. It resolves the base Vault Transit mount,
+// trimming surrounding slashes/whitespace so the returned base equals the effective
+// mount used downstream. Empty/whitespace/slash-only input falls back to the default
+// "transit"; never blank. Callers inject the result as the pre-normalized base that
+// resolveMount consumes verbatim.
 func resolveBaseMountPath(configured string) string {
 	// One cutset for guard and returned value so they cannot drift.
 	const cut = "/ \t\n"

--- a/components/crm/internal/bootstrap/encryption.go
+++ b/components/crm/internal/bootstrap/encryption.go
@@ -20,19 +20,19 @@ import (
 // defaultKEKMountPath is the default Vault Transit mount path for KEK operations.
 const defaultKEKMountPath = "transit"
 
-// resolveBaseMountPath resolves the base Vault Transit mount from the configured
-// KMS_VAULT_MOUNT_PATH. Unset/empty values (including whitespace-only and
-// slash-only inputs such as "/") fall back to the safe default "transit" so
-// single-tenant deployments and missing config never crash or produce a
-// degenerate leading-slash mount. Per-tenant sub-mounts ({base}/{tenantID}) are
-// resolved downstream from this base. The returned base is never blank.
+// resolveBaseMountPath resolves the base Vault Transit mount, trimming surrounding
+// slashes/whitespace so the returned base equals the effective mount used downstream.
+// Empty/whitespace/slash-only input falls back to the default "transit"; never blank.
 func resolveBaseMountPath(configured string) string {
-	base := strings.TrimSpace(configured)
-	if strings.Trim(configured, "/ \t") == "" {
+	// One cutset for guard and returned value so they cannot drift.
+	const cut = "/ \t\n"
+
+	trimmed := strings.Trim(configured, cut)
+	if trimmed == "" {
 		return defaultKEKMountPath
 	}
 
-	return base
+	return trimmed
 }
 
 // wireEncryptionServicesInput contains all dependencies for wiring encryption services.

--- a/components/crm/internal/bootstrap/encryption_test.go
+++ b/components/crm/internal/bootstrap/encryption_test.go
@@ -385,6 +385,11 @@ func TestResolveBaseMountPath(t *testing.T) {
 			configured: "  transit  ",
 			want:       "transit",
 		},
+		{
+			name:       "surrounding newlines and slashes are trimmed to the effective mount",
+			configured: "\n/transit/\n",
+			want:       "transit",
+		},
 	}
 
 	for _, tt := range tests {

--- a/components/crm/internal/bootstrap/encryption_test.go
+++ b/components/crm/internal/bootstrap/encryption_test.go
@@ -361,6 +361,16 @@ func TestResolveBaseMountPath(t *testing.T) {
 			want:       defaultKEKMountPath,
 		},
 		{
+			name:       "surrounding slashes are trimmed to the effective mount",
+			configured: "/transit/",
+			want:       "transit",
+		},
+		{
+			name:       "surrounding slashes and whitespace are trimmed to the effective mount",
+			configured: " /transit/ ",
+			want:       "transit",
+		},
+		{
 			name:       "real value is preserved",
 			configured: "transit",
 			want:       "transit",
@@ -629,71 +639,60 @@ func newWiringVaultClient(t *testing.T) *vault.Client {
 	return client
 }
 
-// TestWireEncryptionServices_DefaultsBaseMountWhenUnset asserts the production
-// wiring computes the base mount with a safe default ("transit") when
-// VaultMountPath is unset/empty and wires services without error.
-func TestWireEncryptionServices_DefaultsBaseMountWhenUnset(t *testing.T) {
-	t.Parallel()
-
-	result := wireEncryptionServices(wireEncryptionServicesInput{
-		mode:           encryptionModeEnvelope,
-		vaultClient:    newWiringVaultClient(t),
-		keysetRepo:     &mockKeysetRepo{},
-		registryRepo:   &mockRegistryRepo{},
-		auditWriter:    stubAuditWriter{},
-		vaultMountPath: "", // unset -> base "transit"
-	})
-
-	require.NoError(t, result.err,
-		"wireEncryptionServices must default base mount safely when VaultMountPath is unset")
-	require.NotNil(t, result.provisioningService,
-		"ProvisioningService must be wired (base mount reaches KEKMountPath)")
-	require.NotNil(t, result.keysetManager,
-		"KeysetManager must be wired (base mount reaches BaseMountPath)")
-}
-
-// TestWireEncryptionServices_InjectsCustomBaseMount asserts a custom base mount
-// is accepted and the wiring succeeds, exercising the same injection path into
+// TestWireEncryptionServices_BaseMountResolution asserts the production wiring
+// resolves the configured VaultMountPath into the base mount and injects it into
 // both the provisioning service (KEKMountPath) and the keyset manager
-// (BaseMountPath).
-func TestWireEncryptionServices_InjectsCustomBaseMount(t *testing.T) {
+// (BaseMountPath). Each row varies only the configured VaultMountPath; the
+// resolution itself (default/trim/normalize) is unit-tested in
+// TestResolveBaseMountPath, so here we assert the wiring succeeds end-to-end for
+// every input shape that reaches production.
+func TestWireEncryptionServices_BaseMountResolution(t *testing.T) {
 	t.Parallel()
 
-	result := wireEncryptionServices(wireEncryptionServicesInput{
-		mode:           encryptionModeEnvelope,
-		vaultClient:    newWiringVaultClient(t),
-		keysetRepo:     &mockKeysetRepo{},
-		registryRepo:   &mockRegistryRepo{},
-		auditWriter:    stubAuditWriter{},
-		vaultMountPath: "crm-transit",
-	})
+	tests := []struct {
+		name           string
+		vaultMountPath string
+	}{
+		{
+			name:           "unset defaults to transit",
+			vaultMountPath: "", // unset -> base "transit"
+		},
+		{
+			name:           "custom base mount is injected",
+			vaultMountPath: "crm-transit",
+		},
+		{
+			name:           "whitespace-only defaults to transit",
+			vaultMountPath: "   ", // whitespace-only -> base "transit"
+		},
+		{
+			name:           "slash-wrapped normalizes to transit",
+			vaultMountPath: "/transit/", // slash-wrapped -> base "transit"
+		},
+	}
 
-	require.NoError(t, result.err,
-		"wireEncryptionServices must accept a custom base mount")
-	require.NotNil(t, result.provisioningService,
-		"ProvisioningService must be wired with the custom base mount")
-	require.NotNil(t, result.keysetManager,
-		"KeysetManager must be wired with the custom base mount")
-}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
-// TestWireEncryptionServices_TrimsWhitespaceBaseMount asserts a whitespace-only
-// VaultMountPath is treated as unset and defaults to "transit" without error.
-func TestWireEncryptionServices_TrimsWhitespaceBaseMount(t *testing.T) {
-	t.Parallel()
+			result := wireEncryptionServices(wireEncryptionServicesInput{
+				mode:           encryptionModeEnvelope,
+				vaultClient:    newWiringVaultClient(t),
+				keysetRepo:     &mockKeysetRepo{},
+				registryRepo:   &mockRegistryRepo{},
+				auditWriter:    stubAuditWriter{},
+				vaultMountPath: tt.vaultMountPath,
+			})
 
-	result := wireEncryptionServices(wireEncryptionServicesInput{
-		mode:           encryptionModeEnvelope,
-		vaultClient:    newWiringVaultClient(t),
-		keysetRepo:     &mockKeysetRepo{},
-		registryRepo:   &mockRegistryRepo{},
-		auditWriter:    stubAuditWriter{},
-		vaultMountPath: "   ", // whitespace-only -> base "transit"
-	})
-
-	require.NoError(t, result.err,
-		"wireEncryptionServices must treat whitespace-only mount as unset and default safely")
-	require.NotNil(t, result.keysetManager,
-		"KeysetManager must be wired with the defaulted base mount")
+			require.NoError(t, result.err,
+				"wireEncryptionServices must resolve VaultMountPath %q and wire without error",
+				tt.vaultMountPath)
+			require.NotNil(t, result.provisioningService,
+				"ProvisioningService must be wired (base mount reaches KEKMountPath)")
+			require.NotNil(t, result.keysetManager,
+				"KeysetManager must be wired (base mount reaches BaseMountPath)")
+		})
+	}
 }
 
 // =============================================================================

--- a/components/crm/internal/bootstrap/encryption_test.go
+++ b/components/crm/internal/bootstrap/encryption_test.go
@@ -13,6 +13,7 @@ import (
 	mongoEncryption "github.com/LerianStudio/midaz/v3/components/crm/internal/adapters/mongodb/encryption"
 	"github.com/LerianStudio/midaz/v3/components/crm/internal/services/encryption"
 	"github.com/LerianStudio/midaz/v3/pkg/crypto"
+	"github.com/LerianStudio/midaz/v3/pkg/crypto/kms/vault"
 	"github.com/LerianStudio/midaz/v3/pkg/crypto/tink"
 	"github.com/LerianStudio/midaz/v3/pkg/mmodel"
 	"github.com/stretchr/testify/assert"
@@ -331,6 +332,63 @@ func TestWireEncryptionServices_DefaultsVaultMountPathToTransit(t *testing.T) {
 		"ProvisioningService must be wired with default vault mount path")
 }
 
+func TestResolveBaseMountPath(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		configured string
+		want       string
+	}{
+		{
+			name:       "empty falls back to default",
+			configured: "",
+			want:       defaultKEKMountPath,
+		},
+		{
+			name:       "whitespace-only falls back to default",
+			configured: "  ",
+			want:       defaultKEKMountPath,
+		},
+		{
+			name:       "slash-only falls back to default",
+			configured: "/",
+			want:       defaultKEKMountPath,
+		},
+		{
+			name:       "slashes and whitespace fall back to default",
+			configured: " // ",
+			want:       defaultKEKMountPath,
+		},
+		{
+			name:       "real value is preserved",
+			configured: "transit",
+			want:       "transit",
+		},
+		{
+			name:       "custom value is preserved",
+			configured: "crm-transit",
+			want:       "crm-transit",
+		},
+		{
+			name:       "surrounding whitespace is trimmed but value kept",
+			configured: "  transit  ",
+			want:       "transit",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := resolveBaseMountPath(tt.configured)
+			assert.Equal(t, tt.want, got,
+				"resolveBaseMountPath(%q) must resolve to %q (never blank or a leading-slash mount)",
+				tt.configured, tt.want)
+		})
+	}
+}
+
 // =============================================================================
 // Graceful Degradation Tests
 // =============================================================================
@@ -477,6 +535,165 @@ func (m *mockLegacyCrypto) Decrypt(_ *string) (*string, error) {
 
 func (m *mockLegacyCrypto) GenerateHash(_ *string) string {
 	return m.hashResult
+}
+
+// =============================================================================
+// keysetGeneratorAdapter Tests (base-mount forwarding)
+// =============================================================================
+
+// recordingKMSClient implements tink.KMSClient and records the mountPath it
+// receives, letting the test observe that the adapter forwards the per-call
+// mount verbatim through the production factory path.
+type recordingKMSClient struct {
+	gotMountPath string
+	gotKeyName   string
+}
+
+func (r *recordingKMSClient) Encrypt(_ context.Context, mountPath, keyName string, _ []byte) (string, error) {
+	r.gotMountPath = mountPath
+	r.gotKeyName = keyName
+
+	return "vault:v1:stub", nil
+}
+
+func (r *recordingKMSClient) Decrypt(_ context.Context, _, _ string, _ string) ([]byte, error) {
+	return []byte("stub"), nil
+}
+
+// TestKeysetGeneratorAdapter_ImplementsKeysetGenerator asserts the bootstrap
+// adapter satisfies the encryption.KeysetGenerator contract. This is the
+// compile-level RED that blocked the whole package after the E-1.4 refactor.
+func TestKeysetGeneratorAdapter_ImplementsKeysetGenerator(t *testing.T) {
+	t.Parallel()
+
+	var _ encryption.KeysetGenerator = (*keysetGeneratorAdapter)(nil)
+
+	adapter := &keysetGeneratorAdapter{factory: tink.NewKeysetFactory(&recordingKMSClient{})}
+	assert.Implements(t, (*encryption.KeysetGenerator)(nil), adapter,
+		"keysetGeneratorAdapter must implement encryption.KeysetGenerator")
+}
+
+// TestKeysetGeneratorAdapter_ForwardsMountPath asserts the adapter forwards the
+// per-call mountPath (resolved per-tenant by the provisioning service) straight
+// to the tink.KeysetFactory, which forwards it verbatim to the KMS Encrypt call.
+func TestKeysetGeneratorAdapter_ForwardsMountPath(t *testing.T) {
+	t.Parallel()
+
+	t.Run("AEAD forwards mountPath to KMS", func(t *testing.T) {
+		t.Parallel()
+
+		kms := &recordingKMSClient{}
+		adapter := &keysetGeneratorAdapter{factory: tink.NewKeysetFactory(kms)}
+
+		_, err := adapter.GenerateAEADKeyset(context.Background(), "transit/tenant-x", "org-123")
+		require.NoError(t, err)
+
+		assert.Equal(t, "transit/tenant-x", kms.gotMountPath,
+			"adapter must forward the per-call mountPath to the KMS")
+		assert.Equal(t, "org-123", kms.gotKeyName)
+	})
+
+	t.Run("MAC forwards mountPath to KMS", func(t *testing.T) {
+		t.Parallel()
+
+		kms := &recordingKMSClient{}
+		adapter := &keysetGeneratorAdapter{factory: tink.NewKeysetFactory(kms)}
+
+		_, err := adapter.GenerateMACKeyset(context.Background(), "transit/tenant-y", "org-456")
+		require.NoError(t, err)
+
+		assert.Equal(t, "transit/tenant-y", kms.gotMountPath,
+			"adapter must forward the per-call mountPath to the KMS")
+		assert.Equal(t, "org-456", kms.gotKeyName)
+	})
+}
+
+// =============================================================================
+// Base Mount Injection Tests (production wireEncryptionServices)
+// =============================================================================
+
+// newWiringVaultClient builds a real, unauthenticated vault.Client suitable for
+// wiring tests. NewClient validates config and constructs the API client but
+// performs no network I/O until Login/Encrypt is called, so it is safe to use
+// in a unit test that only exercises construction/wiring.
+func newWiringVaultClient(t *testing.T) *vault.Client {
+	t.Helper()
+
+	client, err := vault.NewClient(vault.Config{
+		Addr:       "https://vault.example.com:8200",
+		AuthMethod: vault.AuthMethodToken,
+		Token:      "test-token",
+	})
+	require.NoError(t, err)
+
+	return client
+}
+
+// TestWireEncryptionServices_DefaultsBaseMountWhenUnset asserts the production
+// wiring computes the base mount with a safe default ("transit") when
+// VaultMountPath is unset/empty and wires services without error.
+func TestWireEncryptionServices_DefaultsBaseMountWhenUnset(t *testing.T) {
+	t.Parallel()
+
+	result := wireEncryptionServices(wireEncryptionServicesInput{
+		mode:           encryptionModeEnvelope,
+		vaultClient:    newWiringVaultClient(t),
+		keysetRepo:     &mockKeysetRepo{},
+		registryRepo:   &mockRegistryRepo{},
+		auditWriter:    stubAuditWriter{},
+		vaultMountPath: "", // unset -> base "transit"
+	})
+
+	require.NoError(t, result.err,
+		"wireEncryptionServices must default base mount safely when VaultMountPath is unset")
+	require.NotNil(t, result.provisioningService,
+		"ProvisioningService must be wired (base mount reaches KEKMountPath)")
+	require.NotNil(t, result.keysetManager,
+		"KeysetManager must be wired (base mount reaches BaseMountPath)")
+}
+
+// TestWireEncryptionServices_InjectsCustomBaseMount asserts a custom base mount
+// is accepted and the wiring succeeds, exercising the same injection path into
+// both the provisioning service (KEKMountPath) and the keyset manager
+// (BaseMountPath).
+func TestWireEncryptionServices_InjectsCustomBaseMount(t *testing.T) {
+	t.Parallel()
+
+	result := wireEncryptionServices(wireEncryptionServicesInput{
+		mode:           encryptionModeEnvelope,
+		vaultClient:    newWiringVaultClient(t),
+		keysetRepo:     &mockKeysetRepo{},
+		registryRepo:   &mockRegistryRepo{},
+		auditWriter:    stubAuditWriter{},
+		vaultMountPath: "crm-transit",
+	})
+
+	require.NoError(t, result.err,
+		"wireEncryptionServices must accept a custom base mount")
+	require.NotNil(t, result.provisioningService,
+		"ProvisioningService must be wired with the custom base mount")
+	require.NotNil(t, result.keysetManager,
+		"KeysetManager must be wired with the custom base mount")
+}
+
+// TestWireEncryptionServices_TrimsWhitespaceBaseMount asserts a whitespace-only
+// VaultMountPath is treated as unset and defaults to "transit" without error.
+func TestWireEncryptionServices_TrimsWhitespaceBaseMount(t *testing.T) {
+	t.Parallel()
+
+	result := wireEncryptionServices(wireEncryptionServicesInput{
+		mode:           encryptionModeEnvelope,
+		vaultClient:    newWiringVaultClient(t),
+		keysetRepo:     &mockKeysetRepo{},
+		registryRepo:   &mockRegistryRepo{},
+		auditWriter:    stubAuditWriter{},
+		vaultMountPath: "   ", // whitespace-only -> base "transit"
+	})
+
+	require.NoError(t, result.err,
+		"wireEncryptionServices must treat whitespace-only mount as unset and default safely")
+	require.NotNil(t, result.keysetManager,
+		"KeysetManager must be wired with the defaulted base mount")
 }
 
 // =============================================================================
@@ -653,13 +870,13 @@ func testWireEncryptionServicesWithMocks(input testWireEncryptionServicesInput) 
 type mockEncryptionVaultClient struct{}
 
 // UnwrapKeyset satisfies the encryption.KeysetUnwrapper interface.
-func (m *mockEncryptionVaultClient) UnwrapKeyset(_ context.Context, _ string, _ string) ([]byte, error) {
+func (m *mockEncryptionVaultClient) UnwrapKeyset(_ context.Context, _, _, _ string) ([]byte, error) {
 	// Return a minimal valid Tink keyset handle bytes (placeholder)
 	return []byte("mock-keyset-bytes"), nil
 }
 
 // GenerateAEADKeyset satisfies the encryption.KeysetGenerator interface.
-func (m *mockEncryptionVaultClient) GenerateAEADKeyset(_ context.Context, _ string) (tink.KeysetBundle, error) {
+func (m *mockEncryptionVaultClient) GenerateAEADKeyset(_ context.Context, _, _ string) (tink.KeysetBundle, error) {
 	return tink.KeysetBundle{
 		Wrapped: tink.WrappedKeyset{
 			WrappedData: "mock-wrapped-aead",
@@ -675,7 +892,7 @@ func (m *mockEncryptionVaultClient) GenerateAEADKeyset(_ context.Context, _ stri
 }
 
 // GenerateMACKeyset satisfies the encryption.KeysetGenerator interface.
-func (m *mockEncryptionVaultClient) GenerateMACKeyset(_ context.Context, _ string) (tink.KeysetBundle, error) {
+func (m *mockEncryptionVaultClient) GenerateMACKeyset(_ context.Context, _, _ string) (tink.KeysetBundle, error) {
 	return tink.KeysetBundle{
 		Wrapped: tink.WrappedKeyset{
 			WrappedData: "mock-wrapped-mac",

--- a/components/crm/internal/bootstrap/kms.go
+++ b/components/crm/internal/bootstrap/kms.go
@@ -13,7 +13,6 @@ import (
 	libLog "github.com/LerianStudio/lib-commons/v5/commons/log"
 	"github.com/LerianStudio/midaz/v3/pkg/crypto"
 	"github.com/LerianStudio/midaz/v3/pkg/crypto/kms/vault"
-	"github.com/google/uuid"
 )
 
 // KMSResult contains the results of KMS initialization.
@@ -66,8 +65,13 @@ func initVaultClient(ctx context.Context, cfg *Config, logger libLog.Logger) (*v
 		return nil, fmt.Errorf("failed to authenticate with vault: %w", err)
 	}
 
+	// Log the RESOLVED base mount (the same base bootstrap injects into
+	// provisioning/keyset_manager), not the raw config value. KMS_VAULT_MOUNT_PATH
+	// is optional, so the raw value is frequently empty/misleading; resolve it to
+	// the safe default so the logged base always matches what is actually wired
+	// downstream and is never blank.
 	logger.Log(ctx, libLog.LevelInfo, "Vault client initialized",
-		libLog.String("mount_path", cfg.VaultMountPath))
+		libLog.String("base_mount_path", resolveBaseMountPath(cfg.VaultMountPath)))
 
 	return client, nil
 }
@@ -140,7 +144,6 @@ func buildVaultConfig(cfg *Config) vault.Config {
 		Addr:       cfg.VaultAddr,
 		RoleID:     cfg.VaultRoleID,
 		SecretID:   cfg.VaultSecretID,
-		MountPath:  cfg.VaultMountPath,
 		Token:      token,
 		AuthMethod: authMethod,
 	}
@@ -167,15 +170,4 @@ func resolveVaultAuth(deploymentMode string, hasAppRole bool) (vault.AuthMethod,
 
 	// Local/development: always use hardcoded root token
 	return vault.AuthMethodToken, DefaultVaultDevToken
-}
-
-// buildTransitKeyName constructs the transit key name for an organization.
-// Key name convention: org/{organization_id}
-// Example: org/550e8400-e29b-41d4-a716-446655440000
-//
-// Keys are auto-created on first use per organization in Vault Transit.
-//
-//nolint:unused // Prepared for Phase 1 envelope encryption; will be used when Vault operations are implemented.
-func buildTransitKeyName(organizationID uuid.UUID) string {
-	return fmt.Sprintf("org/%s", organizationID.String())
 }

--- a/components/crm/internal/bootstrap/kms_integration_test.go
+++ b/components/crm/internal/bootstrap/kms_integration_test.go
@@ -352,7 +352,7 @@ func TestIntegration_BuildVaultConfig_BYOCMode_UsesAppRole(t *testing.T) {
 func TestIntegration_VaultClient_Authentication(t *testing.T) {
 	// Arrange
 	vaultContainer := vaulttestutil.SetupContainer(t)
-	client := vaulttestutil.CreateClient(t, vaultContainer, "transit")
+	client := vaulttestutil.CreateClient(t, vaultContainer)
 
 	// Assert
 	assert.True(t, client.IsAuthenticated(), "client should be authenticated after login")
@@ -397,7 +397,7 @@ func TestIntegration_VaultClient_IsAuthenticated_AfterLogin(t *testing.T) {
 func TestIntegration_VaultChecker_WithRealClient(t *testing.T) {
 	// Arrange
 	vaultContainer := vaulttestutil.SetupContainer(t)
-	client := vaulttestutil.CreateClient(t, vaultContainer, "transit")
+	client := vaulttestutil.CreateClient(t, vaultContainer)
 
 	checker := NewVaultChecker("vault", client, vaultContainer.Address)
 
@@ -439,7 +439,7 @@ func TestIntegration_VaultChecker_TLSDetection_HTTPS(t *testing.T) {
 func TestIntegration_Readyz_WithVaultChecker(t *testing.T) {
 	// Arrange
 	vaultContainer := vaulttestutil.SetupContainer(t)
-	client := vaulttestutil.CreateClient(t, vaultContainer, "transit")
+	client := vaulttestutil.CreateClient(t, vaultContainer)
 
 	checkers := []DependencyChecker{
 		NewVaultChecker("vault", client, vaultContainer.Address),
@@ -469,7 +469,7 @@ func TestIntegration_Readyz_WithVaultChecker(t *testing.T) {
 func TestIntegration_Readyz_MixedCheckers_MongoAndVault(t *testing.T) {
 	// Arrange
 	vaultContainer := vaulttestutil.SetupContainer(t)
-	client := vaulttestutil.CreateClient(t, vaultContainer, "transit")
+	client := vaulttestutil.CreateClient(t, vaultContainer)
 
 	// Mix of VaultChecker (up) and NAChecker (n/a for mongo)
 	checkers := []DependencyChecker{

--- a/components/crm/internal/bootstrap/kms_test.go
+++ b/components/crm/internal/bootstrap/kms_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/LerianStudio/midaz/v3/pkg/crypto"
 	"github.com/LerianStudio/midaz/v3/pkg/crypto/kms/vault"
-	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -319,7 +318,9 @@ func TestBuildVaultConfig(t *testing.T) {
 	assert.Equal(t, cfg.VaultAddr, vaultCfg.Addr)
 	assert.Equal(t, cfg.VaultRoleID, vaultCfg.RoleID)
 	assert.Equal(t, cfg.VaultSecretID, vaultCfg.SecretID)
-	assert.Equal(t, cfg.VaultMountPath, vaultCfg.MountPath)
+	// vault.Config no longer carries a MountPath: the base mount lives on the
+	// bootstrap Config (VaultMountPath) and is resolved per-tenant downstream,
+	// not at vault client construction time.
 }
 
 func TestResolveEncryptionMode_FromEnvironment(t *testing.T) {
@@ -391,58 +392,6 @@ func TestBuildVaultConfig_ReturnsVaultConfigType(t *testing.T) {
 
 	// Type assertion to verify the return type
 	var _ vault.Config = vaultCfg
-}
-
-func TestBuildTransitKeyName(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name           string
-		orgID          uuid.UUID
-		expectedResult string
-	}{
-		{
-			name:           "generates correct key name for organization",
-			orgID:          uuid.MustParse("550e8400-e29b-41d4-a716-446655440000"),
-			expectedResult: "org/550e8400-e29b-41d4-a716-446655440000",
-		},
-		{
-			name:           "works with different organization ID",
-			orgID:          uuid.MustParse("123e4567-e89b-12d3-a456-426614174000"),
-			expectedResult: "org/123e4567-e89b-12d3-a456-426614174000",
-		},
-		{
-			name:           "handles nil UUID (zero value)",
-			orgID:          uuid.Nil,
-			expectedResult: "org/00000000-0000-0000-0000-000000000000",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			result := buildTransitKeyName(tt.orgID)
-
-			assert.Equal(t, tt.expectedResult, result)
-		})
-	}
-}
-
-func TestBuildTransitKeyName_KeyNameConvention(t *testing.T) {
-	t.Parallel()
-
-	t.Run("key name follows convention: org/{org_id}", func(t *testing.T) {
-		t.Parallel()
-
-		orgID := uuid.MustParse("550e8400-e29b-41d4-a716-446655440000")
-
-		keyName := buildTransitKeyName(orgID)
-
-		assert.Equal(t, "org/550e8400-e29b-41d4-a716-446655440000", keyName)
-		assert.Contains(t, keyName, "org/")
-		assert.Contains(t, keyName, orgID.String())
-	})
 }
 
 func TestDefaultVaultDevToken(t *testing.T) {

--- a/components/crm/internal/services/encryption/encryption_test.go
+++ b/components/crm/internal/services/encryption/encryption_test.go
@@ -85,7 +85,7 @@ type serviceTestKeysetUnwrapper struct {
 	err        error
 }
 
-func (f *serviceTestKeysetUnwrapper) UnwrapKeyset(_ context.Context, _ string, wrappedKeyset string) ([]byte, error) {
+func (f *serviceTestKeysetUnwrapper) UnwrapKeyset(_ context.Context, _ string, _ string, wrappedKeyset string) ([]byte, error) {
 	if f.err != nil {
 		return nil, f.err
 	}

--- a/components/crm/internal/services/encryption/field_encryptor.go
+++ b/components/crm/internal/services/encryption/field_encryptor.go
@@ -6,8 +6,12 @@ package encryption
 
 import (
 	"context"
+	"strings"
 
 	tmcore "github.com/LerianStudio/lib-commons/v5/commons/tenant-manager/core"
+
+	"github.com/LerianStudio/midaz/v3/pkg"
+	"github.com/LerianStudio/midaz/v3/pkg/constant"
 )
 
 // EncryptionContext provides the context for field encryption operations.
@@ -19,12 +23,32 @@ type EncryptionContext struct {
 }
 
 // ExtractTenantID extracts tenant ID from context or returns "default" for single-tenant mode.
+// "default" is a reserved sentinel mapping to the flat-base mount; externally supplied
+// "default" is rejected at the provisioning boundary to avoid collision.
 func ExtractTenantID(ctx context.Context) string {
 	if tenantID := tmcore.GetTenantIDContext(ctx); tenantID != "" {
 		return tenantID
 	}
 
 	return "default"
+}
+
+// ResolveProvisionTenantID resolves the tenant id for provisioning. It rejects an
+// externally-supplied "default" (the reserved single-tenant sentinel) with
+// ErrReservedTenantID; an empty context maps to the "default" sentinel. Shared by the
+// HTTP handler and lazy autoProvision so the rule is single-sourced.
+func ResolveProvisionTenantID(ctx context.Context) (string, error) {
+	raw := strings.Trim(tmcore.GetTenantIDContext(ctx), "/ \t")
+
+	if raw == "default" {
+		return "", pkg.ValidateBusinessError(constant.ErrReservedTenantID, EntityOrganizationEncryption)
+	}
+
+	if raw == "" {
+		return "default", nil
+	}
+
+	return raw, nil
 }
 
 // FieldEncryptor provides field-level encryption for repository adapters.

--- a/components/crm/internal/services/encryption/keyset_manager.go
+++ b/components/crm/internal/services/encryption/keyset_manager.go
@@ -25,8 +25,10 @@ import (
 // KeysetUnwrapper defines the interface for unwrapping keysets.
 // Compatible with KeysetWrapper from pkg/crypto/tink.
 //
-// mountPath is the resolved Vault Transit mount for the keyset's tenant; it is
-// derived from the stored keyset tenant at unwrap time so reads are self-contained.
+// mountPath is the resolved Vault Transit mount for the keyset. At unwrap time it
+// is read from the keyset's stored KEKMountPath (the wrap-time mount), falling back
+// to deriving it from the stored tenant only for legacy records, so reads are
+// self-contained and independent of live config.
 type KeysetUnwrapper interface {
 	UnwrapKeyset(ctx context.Context, mountPath, keyName, wrappedKeyset string) ([]byte, error)
 }
@@ -259,10 +261,12 @@ func (km *KeysetManager) fetchAndCache(ctx context.Context, cacheKey, organizati
 		return nil, err
 	}
 
-	// Resolve the Vault Transit mount from the STORED keyset tenant (not ctx) so
-	// reads are self-contained: flat base for single-tenant ("" or "default"),
-	// per-tenant sub-mount otherwise. The same mount serves both AEAD and MAC.
-	mount := resolveMount(km.baseMountPath, keyset.TenantID)
+	// Prefer the stored KEKMountPath so reads are config-independent; fall back to
+	// deriving from the stored tenant for legacy records.
+	mount := keyset.KEKMountPath
+	if mount == "" {
+		mount = resolveMount(km.baseMountPath, keyset.TenantID)
+	}
 
 	// app.protection.mount_path is the resolved mount, not a secret.
 	_, tracer, _, _ := libCommons.NewTrackingFromContext(ctx) //nolint:dogsled // NewTrackingFromContext returns 4 values; only the tracer is needed here
@@ -347,17 +351,20 @@ func (km *KeysetManager) fetchAndCache(ctx context.Context, cacheKey, organizati
 	return cached, nil
 }
 
-// autoProvision provisions an organization using the injected provisioner.
-// Tenant ID is extracted from context, defaulting to "default" for single-tenant mode.
+// autoProvision provisions an organization using the injected provisioner. The tenant
+// is resolved via ResolveProvisionTenantID (rejects reserved "default" before
+// provisioning, fail-closed); an empty context maps to the single-tenant sentinel.
 func (km *KeysetManager) autoProvision(ctx context.Context, organizationID string) error {
 	if km.provisioner == nil {
 		return fmt.Errorf("provisioner not configured")
 	}
 
-	// Use ExtractTenantID which defaults to "default" for single-tenant mode
-	tenantID := ExtractTenantID(ctx)
+	tenantID, err := ResolveProvisionTenantID(ctx)
+	if err != nil {
+		return err
+	}
 
-	_, err := km.provisioner.Provision(ctx, ProvisionInput{
+	_, err = km.provisioner.Provision(ctx, ProvisionInput{
 		TenantID:       tenantID,
 		OrganizationID: organizationID,
 		Actor:          "system:auto-provision",

--- a/components/crm/internal/services/encryption/keyset_manager.go
+++ b/components/crm/internal/services/encryption/keyset_manager.go
@@ -11,16 +11,24 @@ import (
 	"sync"
 	"time"
 
+	libCommons "github.com/LerianStudio/lib-commons/v5/commons"
+	libOpenTelemetry "github.com/LerianStudio/lib-commons/v5/commons/opentelemetry"
+
 	mongoEncryption "github.com/LerianStudio/midaz/v3/components/crm/internal/adapters/mongodb/encryption"
 	"github.com/LerianStudio/midaz/v3/pkg/constant"
 	"github.com/LerianStudio/midaz/v3/pkg/crypto/tink"
 	"github.com/LerianStudio/midaz/v3/pkg/mmodel"
+
+	"go.opentelemetry.io/otel/attribute"
 )
 
 // KeysetUnwrapper defines the interface for unwrapping keysets.
 // Compatible with KeysetWrapper from pkg/crypto/tink.
+//
+// mountPath is the resolved Vault Transit mount for the keyset's tenant; it is
+// derived from the stored keyset tenant at unwrap time so reads are self-contained.
 type KeysetUnwrapper interface {
-	UnwrapKeyset(ctx context.Context, keyName string, wrappedKeyset string) ([]byte, error)
+	UnwrapKeyset(ctx context.Context, mountPath, keyName, wrappedKeyset string) ([]byte, error)
 }
 
 // CachedPrimitives holds the unwrapped AEAD and MAC primitives for an organization.
@@ -40,6 +48,11 @@ func (cp *CachedPrimitives) IsExpired() bool {
 // KeysetManagerConfig holds configuration for KeysetManager.
 type KeysetManagerConfig struct {
 	CacheTTL time.Duration // Default: 5 minutes
+
+	// BaseMountPath is the Vault Transit base mount used to resolve per-tenant
+	// sub-mounts at unwrap time. Empty defaults to "transit" so single-tenant
+	// deployments are unaffected.
+	BaseMountPath string
 }
 
 // DefaultKeysetManagerConfig returns the default configuration.
@@ -61,13 +74,14 @@ func DefaultKeysetManagerConfig() KeysetManagerConfig {
 // Cache keys are scoped by tenant to prevent cross-tenant cache collisions.
 // Format: "tenantID:organizationID"
 type KeysetManager struct {
-	keysetRepo  mongoEncryption.KeysetRepository
-	unwrapper   KeysetUnwrapper
-	provisioner ProvisioningService // Required: enables lazy provisioning on first access
-	metrics     *protectionMetrics
-	cacheTTL    time.Duration
-	cache       map[string]*CachedPrimitives // Key: "tenantID:organizationID"
-	mu          sync.RWMutex
+	keysetRepo    mongoEncryption.KeysetRepository
+	unwrapper     KeysetUnwrapper
+	provisioner   ProvisioningService // Required: enables lazy provisioning on first access
+	metrics       *protectionMetrics
+	cacheTTL      time.Duration
+	baseMountPath string                       // Vault Transit base mount for per-tenant resolution
+	cache         map[string]*CachedPrimitives // Key: "tenantID:organizationID"
+	mu            sync.RWMutex
 
 	// Per-tenant-organization locks to prevent concurrent fetches for the same tenant+org.
 	// This avoids cache stampede without blocking unrelated tenant-organizations.
@@ -92,18 +106,24 @@ func NewKeysetManager(
 		ttl = 5 * time.Minute
 	}
 
+	mountPath := config.BaseMountPath
+	if mountPath == "" {
+		mountPath = "transit"
+	}
+
 	if metrics == nil {
 		metrics = NewProtectionMetrics(nil)
 	}
 
 	return &KeysetManager{
-		keysetRepo:  keysetRepo,
-		unwrapper:   unwrapper,
-		provisioner: provisioner,
-		metrics:     metrics,
-		cacheTTL:    ttl,
-		cache:       make(map[string]*CachedPrimitives),
-		fetching:    make(map[string]*sync.Mutex),
+		keysetRepo:    keysetRepo,
+		unwrapper:     unwrapper,
+		provisioner:   provisioner,
+		metrics:       metrics,
+		cacheTTL:      ttl,
+		baseMountPath: mountPath,
+		cache:         make(map[string]*CachedPrimitives),
+		fetching:      make(map[string]*sync.Mutex),
 	}
 }
 
@@ -239,16 +259,31 @@ func (km *KeysetManager) fetchAndCache(ctx context.Context, cacheKey, organizati
 		return nil, err
 	}
 
+	// Resolve the Vault Transit mount from the STORED keyset tenant (not ctx) so
+	// reads are self-contained: flat base for single-tenant ("" or "default"),
+	// per-tenant sub-mount otherwise. The same mount serves both AEAD and MAC.
+	mount := resolveMount(km.baseMountPath, keyset.TenantID)
+
+	// app.protection.mount_path is the resolved mount, not a secret.
+	_, tracer, _, _ := libCommons.NewTrackingFromContext(ctx) //nolint:dogsled // NewTrackingFromContext returns 4 values; only the tracer is needed here
+
+	ctx, span := tracer.Start(ctx, "service.protection.keyset_manager.unwrap")
+	defer span.End()
+
+	span.SetAttributes(attribute.String("app.protection.mount_path", mount))
+
 	// Unwrap AEAD keyset. Provider is "vault" today (envelope encryption is
 	// Vault-only); this becomes dynamic when other KMS providers land.
 	// Provider operation timing is recorded even when the unwrap fails.
 	aeadStart := time.Now()
-	aeadBytes, err := km.unwrapper.UnwrapKeyset(ctx, keyset.KEKPath, keyset.WrappedKeyset)
+	aeadBytes, err := km.unwrapper.UnwrapKeyset(ctx, mount, keyset.KEKPath, keyset.WrappedKeyset)
 	km.metrics.recordProviderOperation(ctx, providerOperationUnwrap, providerVault, time.Since(aeadStart).Milliseconds())
 
 	if err != nil {
 		km.metrics.recordProviderFailure(ctx, providerOperationUnwrap, errorCodeUnwrapAEADFailed)
+		libOpenTelemetry.HandleSpanError(span, "failed to unwrap AEAD keyset", err)
 
+		// Wrap with %w so callers can errors.Is(vault.ErrMountNotFound) (fail-closed).
 		return nil, fmt.Errorf("failed to unwrap AEAD keyset: %w", err)
 	}
 
@@ -263,14 +298,17 @@ func (km *KeysetManager) fetchAndCache(ctx context.Context, cacheKey, organizati
 		return nil, err
 	}
 
-	// Unwrap MAC keyset. Provider operation timing is recorded even on failure.
+	// Unwrap MAC keyset using the same resolved mount. Provider operation timing
+	// is recorded even on failure.
 	macStart := time.Now()
-	macBytes, err := km.unwrapper.UnwrapKeyset(ctx, keyset.KEKPath, keyset.WrappedHMACKeyset)
+	macBytes, err := km.unwrapper.UnwrapKeyset(ctx, mount, keyset.KEKPath, keyset.WrappedHMACKeyset)
 	km.metrics.recordProviderOperation(ctx, providerOperationUnwrap, providerVault, time.Since(macStart).Milliseconds())
 
 	if err != nil {
 		km.metrics.recordProviderFailure(ctx, providerOperationUnwrap, errorCodeUnwrapMACFailed)
+		libOpenTelemetry.HandleSpanError(span, "failed to unwrap MAC keyset", err)
 
+		// Wrap with %w so callers can errors.Is(vault.ErrMountNotFound) (fail-closed).
 		return nil, fmt.Errorf("failed to unwrap MAC keyset: %w", err)
 	}
 

--- a/components/crm/internal/services/encryption/keyset_manager_test.go
+++ b/components/crm/internal/services/encryption/keyset_manager_test.go
@@ -15,6 +15,7 @@ import (
 	tmcore "github.com/LerianStudio/lib-commons/v5/commons/tenant-manager/core"
 
 	"github.com/LerianStudio/midaz/v3/pkg/constant"
+	"github.com/LerianStudio/midaz/v3/pkg/crypto/kms/vault"
 	"github.com/LerianStudio/midaz/v3/pkg/crypto/tink"
 	"github.com/LerianStudio/midaz/v3/pkg/mmodel"
 )
@@ -58,13 +59,15 @@ type fakeKeysetUnwrapper struct {
 	macKeyset  []byte
 	err        error
 	calls      int
+	mountPaths []string // Records the mountPath received on each call.
 }
 
-func (f *fakeKeysetUnwrapper) UnwrapKeyset(_ context.Context, _ string, wrappedKeyset string) ([]byte, error) {
+func (f *fakeKeysetUnwrapper) UnwrapKeyset(_ context.Context, mountPath, _ string, wrappedKeyset string) ([]byte, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 
 	f.calls++
+	f.mountPaths = append(f.mountPaths, mountPath)
 
 	if f.err != nil {
 		return nil, f.err
@@ -87,6 +90,16 @@ func (f *fakeKeysetUnwrapper) getCalls() int {
 	defer f.mu.Unlock()
 
 	return f.calls
+}
+
+func (f *fakeKeysetUnwrapper) getMountPaths() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	out := make([]string, len(f.mountPaths))
+	copy(out, f.mountPaths)
+
+	return out
 }
 
 // generateTestKeysets creates real Tink keysets for testing.
@@ -1671,5 +1684,131 @@ func TestKeysetManager_fetchAndCache_MultiKeyMAC_StrictErrorMode(t *testing.T) {
 
 	if ok {
 		t.Error("cache entry should NOT exist after fetchAndCache failure")
+	}
+}
+
+// TestKeysetManager_GetPrimitives_UnwrapMount_DefaultTenant_Flat verifies that a stored
+// keyset with TenantID "default" resolves to the flat base mount ("transit") for both the
+// AEAD and MAC unwrap calls. The mount is derived from the STORED keyset.TenantID, not ctx.
+func TestKeysetManager_GetPrimitives_UnwrapMount_DefaultTenant_Flat(t *testing.T) {
+	t.Parallel()
+
+	aeadBytes, macBytes := generateTestKeysets(t)
+
+	reader := &fakeKeysetRepo{
+		keyset: &mmodel.OrganizationKeyset{
+			TenantID:          "default",
+			OrganizationID:    "org-flat",
+			KEKPath:           "crm/org-flat",
+			WrappedKeyset:     "wrapped-aead",
+			WrappedHMACKeyset: "wrapped-mac",
+		},
+	}
+
+	unwrapper := &fakeKeysetUnwrapper{
+		aeadKeyset: aeadBytes,
+		macKeyset:  macBytes,
+	}
+
+	config := KeysetManagerConfig{BaseMountPath: "transit"}
+	manager := NewKeysetManager(reader, unwrapper, nil, config, NewProtectionMetrics(nil))
+
+	_, _, _, _, err := manager.GetPrimitives(context.Background(), "org-flat")
+	if err != nil {
+		t.Fatalf("GetPrimitives() error = %v", err)
+	}
+
+	mounts := unwrapper.getMountPaths()
+	if len(mounts) != 2 {
+		t.Fatalf("unwrapper mountPaths len = %d, want 2", len(mounts))
+	}
+
+	for i, got := range mounts {
+		if got != "transit" {
+			t.Errorf("unwrap call %d mountPath = %q, want %q", i, got, "transit")
+		}
+	}
+}
+
+// TestKeysetManager_GetPrimitives_UnwrapMount_NonDefaultTenant_SubMount verifies that a
+// stored keyset with a non-default TenantID resolves to a per-tenant sub-mount
+// "transit/<tenant>" for both AEAD and MAC unwrap calls, derived from the STORED tenant.
+func TestKeysetManager_GetPrimitives_UnwrapMount_NonDefaultTenant_SubMount(t *testing.T) {
+	t.Parallel()
+
+	aeadBytes, macBytes := generateTestKeysets(t)
+
+	const tenant = "11111111-2222-3333-4444-555555555555"
+
+	reader := &fakeKeysetRepo{
+		keyset: &mmodel.OrganizationKeyset{
+			TenantID:          tenant,
+			OrganizationID:    "org-sub",
+			KEKPath:           "crm/org-sub",
+			WrappedKeyset:     "wrapped-aead",
+			WrappedHMACKeyset: "wrapped-mac",
+		},
+	}
+
+	unwrapper := &fakeKeysetUnwrapper{
+		aeadKeyset: aeadBytes,
+		macKeyset:  macBytes,
+	}
+
+	config := KeysetManagerConfig{BaseMountPath: "transit"}
+	manager := NewKeysetManager(reader, unwrapper, nil, config, NewProtectionMetrics(nil))
+
+	// ctx carries a DIFFERENT tenant to prove the mount comes from the stored keyset, not ctx.
+	ctx := tmcore.ContextWithTenantID(context.Background(), "ctx-tenant-should-be-ignored")
+
+	_, _, _, _, err := manager.GetPrimitives(ctx, "org-sub")
+	if err != nil {
+		t.Fatalf("GetPrimitives() error = %v", err)
+	}
+
+	want := "transit/" + tenant
+
+	mounts := unwrapper.getMountPaths()
+	if len(mounts) != 2 {
+		t.Fatalf("unwrapper mountPaths len = %d, want 2", len(mounts))
+	}
+
+	for i, got := range mounts {
+		if got != want {
+			t.Errorf("unwrap call %d mountPath = %q, want %q", i, got, want)
+		}
+	}
+}
+
+// TestKeysetManager_GetPrimitives_MountNotFound_FailsClosed verifies that when the
+// unwrapper returns vault.ErrMountNotFound, GetPrimitives propagates an error that is
+// errors.Is(vault.ErrMountNotFound) — fail-closed, no fallback to the base mount.
+func TestKeysetManager_GetPrimitives_MountNotFound_FailsClosed(t *testing.T) {
+	t.Parallel()
+
+	reader := &fakeKeysetRepo{
+		keyset: &mmodel.OrganizationKeyset{
+			TenantID:          "11111111-2222-3333-4444-555555555555",
+			OrganizationID:    "org-no-mount",
+			KEKPath:           "crm/org-no-mount",
+			WrappedKeyset:     "wrapped-aead",
+			WrappedHMACKeyset: "wrapped-mac",
+		},
+	}
+
+	unwrapper := &fakeKeysetUnwrapper{
+		err: vault.ErrMountNotFound,
+	}
+
+	config := KeysetManagerConfig{BaseMountPath: "transit"}
+	manager := NewKeysetManager(reader, unwrapper, nil, config, NewProtectionMetrics(nil))
+
+	_, _, _, _, err := manager.GetPrimitives(context.Background(), "org-no-mount")
+	if err == nil {
+		t.Fatal("GetPrimitives() expected error, got nil")
+	}
+
+	if !errors.Is(err, vault.ErrMountNotFound) {
+		t.Errorf("GetPrimitives() error = %v, want errors.Is(vault.ErrMountNotFound)", err)
 	}
 }

--- a/components/crm/internal/services/encryption/keyset_manager_test.go
+++ b/components/crm/internal/services/encryption/keyset_manager_test.go
@@ -7,6 +7,7 @@ package encryption
 import (
 	"context"
 	"errors"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -1164,6 +1165,53 @@ func TestKeysetManager_autoProvision_UsesTenantFromContext(t *testing.T) {
 	}
 }
 
+func TestKeysetManager_autoProvision_RejectsReservedTenantID(t *testing.T) {
+	t.Parallel()
+
+	// Multi-tenant mode: the tenant middleware populated a real, non-empty tenant
+	// id literally equal to "default" from the JWT. Resolving it to the flat-base
+	// mount would break KEK isolation, so auto-provisioning MUST be refused. The
+	// keyset is missing, so without the guard this would auto-provision under the
+	// flat base.
+	reader := &fakeKeysetRepo{
+		keyset: nil,
+		err:    constant.ErrKeysetNotFound,
+	}
+
+	unwrapper := &fakeKeysetUnwrapper{}
+
+	provisioner := &fakeProvisioningService{}
+
+	manager := NewKeysetManager(reader, unwrapper, provisioner, DefaultKeysetManagerConfig(), NewProtectionMetrics(nil))
+
+	// Non-empty tenant id of "default" supplied via context (multi-tenant).
+	ctx := tmcore.ContextWithTenantID(context.Background(), "default")
+
+	_, _, _, _, err := manager.GetPrimitives(ctx, "org-reserved")
+	if err == nil {
+		t.Fatal("GetPrimitives() expected error for reserved tenant id, got nil")
+	}
+
+	// The reserved-tenant rejection surfaces as the ErrReservedTenantID business
+	// error (code ENC-0013), %w-wrapped through fetchAndCache. The typed
+	// UnprocessableOperationError has no Unwrap, so assert on its code string,
+	// matching the handler test which checks the JSON "code" field.
+	if !strings.Contains(err.Error(), constant.ErrReservedTenantID.Error()) {
+		t.Errorf("GetPrimitives() error = %v, want error carrying code %q", err, constant.ErrReservedTenantID.Error())
+	}
+
+	// The provisioner MUST NOT be called: rejection happens before provisioning
+	// (fail-closed, no keyset written under the flat base).
+	if provisioner.getCalls() != 0 {
+		t.Errorf("GetPrimitives() provisioner calls = %d, want 0 (no provisioning under flat base)", provisioner.getCalls())
+	}
+
+	// The unwrapper MUST NOT be called either (no keyset to unwrap).
+	if unwrapper.getCalls() != 0 {
+		t.Errorf("GetPrimitives() unwrapper calls = %d, want 0", unwrapper.getCalls())
+	}
+}
+
 func TestKeysetManager_autoProvision_DefaultsTenantWhenMissing(t *testing.T) {
 	t.Parallel()
 
@@ -1810,5 +1858,162 @@ func TestKeysetManager_GetPrimitives_MountNotFound_FailsClosed(t *testing.T) {
 
 	if !errors.Is(err, vault.ErrMountNotFound) {
 		t.Errorf("GetPrimitives() error = %v, want errors.Is(vault.ErrMountNotFound)", err)
+	}
+}
+
+// TestKeysetManager_GetPrimitives_StoredMountWins verifies that when the fetched
+// keyset carries a stored KEKMountPath, unwrap uses that mount for BOTH AEAD and
+// MAC, even when the manager's BaseMountPath would derive a different value.
+func TestKeysetManager_GetPrimitives_StoredMountWins(t *testing.T) {
+	t.Parallel()
+
+	aeadBytes, macBytes := generateTestKeysets(t)
+
+	const storedMount = "transit/tenant-x"
+
+	reader := &fakeKeysetRepo{
+		keyset: &mmodel.OrganizationKeyset{
+			TenantID:          "tenant-x",
+			OrganizationID:    "org-stored",
+			KEKPath:           "crm/org-stored",
+			KEKMountPath:      storedMount,
+			WrappedKeyset:     "wrapped-aead",
+			WrappedHMACKeyset: "wrapped-mac",
+		},
+	}
+
+	unwrapper := &fakeKeysetUnwrapper{
+		aeadKeyset: aeadBytes,
+		macKeyset:  macBytes,
+	}
+
+	// BaseMountPath deliberately differs from the stored mount's base.
+	config := KeysetManagerConfig{BaseMountPath: "other-base"}
+	manager := NewKeysetManager(reader, unwrapper, nil, config, NewProtectionMetrics(nil))
+
+	_, _, _, _, err := manager.GetPrimitives(context.Background(), "org-stored")
+	if err != nil {
+		t.Fatalf("GetPrimitives() error = %v", err)
+	}
+
+	mounts := unwrapper.getMountPaths()
+	if len(mounts) != 2 {
+		t.Fatalf("unwrapper mountPaths len = %d, want 2", len(mounts))
+	}
+
+	for i, got := range mounts {
+		if got != storedMount {
+			t.Errorf("unwrap call %d mountPath = %q, want stored %q", i, got, storedMount)
+		}
+	}
+}
+
+// TestKeysetManager_GetPrimitives_ConfigBaseChanged_UsesStoredMount is the #3
+// regression: a keyset provisioned under "transit" must still unwrap under
+// "transit" even after KMS_VAULT_MOUNT_PATH (BaseMountPath) is changed to a new
+// value. Before the read-side fix, unwrap derived the mount from the live config
+// and would have targeted the CHANGED base, stranding existing keysets.
+func TestKeysetManager_GetPrimitives_ConfigBaseChanged_UsesStoredMount(t *testing.T) {
+	t.Parallel()
+
+	aeadBytes, macBytes := generateTestKeysets(t)
+
+	const provisionedMount = "transit"
+
+	reader := &fakeKeysetRepo{
+		keyset: &mmodel.OrganizationKeyset{
+			TenantID:          "default",
+			OrganizationID:    "org-config-changed",
+			KEKPath:           "crm/org-config-changed",
+			KEKMountPath:      provisionedMount,
+			WrappedKeyset:     "wrapped-aead",
+			WrappedHMACKeyset: "wrapped-mac",
+		},
+	}
+
+	unwrapper := &fakeKeysetUnwrapper{
+		aeadKeyset: aeadBytes,
+		macKeyset:  macBytes,
+	}
+
+	// Live config base changed after provisioning.
+	config := KeysetManagerConfig{BaseMountPath: "CHANGED-BASE"}
+	manager := NewKeysetManager(reader, unwrapper, nil, config, NewProtectionMetrics(nil))
+
+	_, _, _, _, err := manager.GetPrimitives(context.Background(), "org-config-changed")
+	if err != nil {
+		t.Fatalf("GetPrimitives() error = %v", err)
+	}
+
+	mounts := unwrapper.getMountPaths()
+	if len(mounts) != 2 {
+		t.Fatalf("unwrapper mountPaths len = %d, want 2", len(mounts))
+	}
+
+	for i, got := range mounts {
+		if got != provisionedMount {
+			t.Errorf("unwrap call %d mountPath = %q, want stored %q (NOT derived from CHANGED-BASE)", i, got, provisionedMount)
+		}
+	}
+}
+
+// TestKeysetManager_GetPrimitives_LegacyEmptyMount_FallsBackToDerived verifies the
+// back-compat path: a keyset with no stored KEKMountPath derives the mount from the
+// manager BaseMountPath and the stored tenant. "default"/"" tenant -> flat base;
+// a real tenant -> per-tenant sub-mount.
+func TestKeysetManager_GetPrimitives_LegacyEmptyMount_FallsBackToDerived(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		tenantID string
+		want     string
+	}{
+		{name: "default tenant -> flat base", tenantID: "default", want: "transit"},
+		{name: "real tenant -> sub-mount", tenantID: "t1", want: "transit/t1"},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			aeadBytes, macBytes := generateTestKeysets(t)
+
+			reader := &fakeKeysetRepo{
+				keyset: &mmodel.OrganizationKeyset{
+					TenantID:          tt.tenantID,
+					OrganizationID:    "org-legacy",
+					KEKPath:           "crm/org-legacy",
+					KEKMountPath:      "", // legacy record predating the stored mount
+					WrappedKeyset:     "wrapped-aead",
+					WrappedHMACKeyset: "wrapped-mac",
+				},
+			}
+
+			unwrapper := &fakeKeysetUnwrapper{
+				aeadKeyset: aeadBytes,
+				macKeyset:  macBytes,
+			}
+
+			config := KeysetManagerConfig{BaseMountPath: "transit"}
+			manager := NewKeysetManager(reader, unwrapper, nil, config, NewProtectionMetrics(nil))
+
+			_, _, _, _, err := manager.GetPrimitives(context.Background(), "org-legacy")
+			if err != nil {
+				t.Fatalf("GetPrimitives() error = %v", err)
+			}
+
+			mounts := unwrapper.getMountPaths()
+			if len(mounts) != 2 {
+				t.Fatalf("unwrapper mountPaths len = %d, want 2", len(mounts))
+			}
+
+			for i, got := range mounts {
+				if got != tt.want {
+					t.Errorf("unwrap call %d mountPath = %q, want derived %q", i, got, tt.want)
+				}
+			}
+		})
 	}
 }

--- a/components/crm/internal/services/encryption/mount.go
+++ b/components/crm/internal/services/encryption/mount.go
@@ -6,12 +6,13 @@ package encryption
 
 import "strings"
 
-// resolveMount derives the Vault Transit mount path for a tenant.
-// The base is normalized by trimming surrounding slashes. For empty or
-// "default" tenants it returns the flat base (single-tenant unchanged);
-// otherwise it returns a per-tenant sub-mount of the form base/tenantID.
+// resolveMount derives the Vault Transit mount for a tenant: flat base for
+// empty/"default" (single-tenant), else base/tenantID. Base and tenant are
+// trimmed of surrounding slashes/whitespace.
+
 func resolveMount(base, tenantID string) string {
 	normalized := strings.Trim(base, "/")
+	tenantID = strings.Trim(tenantID, "/ \t")
 
 	if tenantID == "" || tenantID == "default" {
 		return normalized

--- a/components/crm/internal/services/encryption/mount.go
+++ b/components/crm/internal/services/encryption/mount.go
@@ -7,16 +7,18 @@ package encryption
 import "strings"
 
 // resolveMount derives the Vault Transit mount for a tenant: flat base for
-// empty/"default" (single-tenant), else base/tenantID. Base and tenant are
-// trimmed of surrounding slashes/whitespace.
-
+// empty/"default" (single-tenant), else base/tenantID.
+//
+// Contract: base MUST already be normalized by resolveBaseMountPath (the single
+// base-mount normalizer, in bootstrap). resolveMount uses base verbatim and only
+// resolves the tenant segment, defensively trimming surrounding slashes/whitespace
+// off the tenant. The strings import remains in use for that tenant trim.
 func resolveMount(base, tenantID string) string {
-	normalized := strings.Trim(base, "/")
 	tenantID = strings.Trim(tenantID, "/ \t")
 
 	if tenantID == "" || tenantID == "default" {
-		return normalized
+		return base
 	}
 
-	return normalized + "/" + tenantID
+	return base + "/" + tenantID
 }

--- a/components/crm/internal/services/encryption/mount.go
+++ b/components/crm/internal/services/encryption/mount.go
@@ -1,0 +1,21 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package encryption
+
+import "strings"
+
+// resolveMount derives the Vault Transit mount path for a tenant.
+// The base is normalized by trimming surrounding slashes. For empty or
+// "default" tenants it returns the flat base (single-tenant unchanged);
+// otherwise it returns a per-tenant sub-mount of the form base/tenantID.
+func resolveMount(base, tenantID string) string {
+	normalized := strings.Trim(base, "/")
+
+	if tenantID == "" || tenantID == "default" {
+		return normalized
+	}
+
+	return normalized + "/" + tenantID
+}

--- a/components/crm/internal/services/encryption/mount_test.go
+++ b/components/crm/internal/services/encryption/mount_test.go
@@ -11,6 +11,10 @@ import (
 func TestResolveMount(t *testing.T) {
 	t.Parallel()
 
+	// Contract: base is ALWAYS pre-normalized by resolveBaseMountPath (the single
+	// base-mount normalizer in bootstrap). resolveMount uses base verbatim and only
+	// resolves/defensively trims the tenant segment. Base-normalization coverage
+	// lives in TestResolveBaseMountPath, not here.
 	tests := []struct {
 		name     string
 		base     string
@@ -30,22 +34,22 @@ func TestResolveMount(t *testing.T) {
 			want:     "transit",
 		},
 		{
-			name:     "real tenant returns sub-mount",
+			name:     "clean base with uuid tenant returns sub-mount",
 			base:     "transit",
 			tenantID: "9b2e4c1a-7f60-4d3e-8a21-1c5b0e7d9f44",
 			want:     "transit/9b2e4c1a-7f60-4d3e-8a21-1c5b0e7d9f44",
 		},
 		{
-			name:     "normalizes surrounding slashes with empty tenant",
-			base:     "/transit/",
-			tenantID: "",
-			want:     "transit",
+			name:     "custom clean base with uuid tenant returns sub-mount",
+			base:     "crm-transit",
+			tenantID: "9b2e4c1a-7f60-4d3e-8a21-1c5b0e7d9f44",
+			want:     "crm-transit/9b2e4c1a-7f60-4d3e-8a21-1c5b0e7d9f44",
 		},
 		{
-			name:     "normalizes surrounding slashes with real tenant",
+			name:     "slash-wrapped base is NOT normalized by resolveMount (moved to resolveBaseMountPath)",
 			base:     "/transit/",
 			tenantID: "9b2e4c1a-7f60-4d3e-8a21-1c5b0e7d9f44",
-			want:     "transit/9b2e4c1a-7f60-4d3e-8a21-1c5b0e7d9f44",
+			want:     "/transit//9b2e4c1a-7f60-4d3e-8a21-1c5b0e7d9f44",
 		},
 		{
 			name:     "padded default sentinel resolves to flat base",

--- a/components/crm/internal/services/encryption/mount_test.go
+++ b/components/crm/internal/services/encryption/mount_test.go
@@ -47,6 +47,24 @@ func TestResolveMount(t *testing.T) {
 			tenantID: "9b2e4c1a-7f60-4d3e-8a21-1c5b0e7d9f44",
 			want:     "transit/9b2e4c1a-7f60-4d3e-8a21-1c5b0e7d9f44",
 		},
+		{
+			name:     "padded default sentinel resolves to flat base",
+			base:     "transit",
+			tenantID: " default ",
+			want:     "transit",
+		},
+		{
+			name:     "trims surrounding slashes on tenant segment",
+			base:     "transit",
+			tenantID: "/weird/",
+			want:     "transit/weird",
+		},
+		{
+			name:     "preserves interior slash in tenant segment",
+			base:     "transit",
+			tenantID: "a/b",
+			want:     "transit/a/b",
+		},
 	}
 
 	for _, tt := range tests {

--- a/components/crm/internal/services/encryption/mount_test.go
+++ b/components/crm/internal/services/encryption/mount_test.go
@@ -1,0 +1,62 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package encryption
+
+import (
+	"testing"
+)
+
+func TestResolveMount(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		base     string
+		tenantID string
+		want     string
+	}{
+		{
+			name:     "empty tenant returns flat base",
+			base:     "transit",
+			tenantID: "",
+			want:     "transit",
+		},
+		{
+			name:     "default tenant returns flat base",
+			base:     "transit",
+			tenantID: "default",
+			want:     "transit",
+		},
+		{
+			name:     "real tenant returns sub-mount",
+			base:     "transit",
+			tenantID: "9b2e4c1a-7f60-4d3e-8a21-1c5b0e7d9f44",
+			want:     "transit/9b2e4c1a-7f60-4d3e-8a21-1c5b0e7d9f44",
+		},
+		{
+			name:     "normalizes surrounding slashes with empty tenant",
+			base:     "/transit/",
+			tenantID: "",
+			want:     "transit",
+		},
+		{
+			name:     "normalizes surrounding slashes with real tenant",
+			base:     "/transit/",
+			tenantID: "9b2e4c1a-7f60-4d3e-8a21-1c5b0e7d9f44",
+			want:     "transit/9b2e4c1a-7f60-4d3e-8a21-1c5b0e7d9f44",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := resolveMount(tt.base, tt.tenantID)
+			if got != tt.want {
+				t.Errorf("resolveMount(%q, %q) = %q, want %q", tt.base, tt.tenantID, got, tt.want)
+			}
+		})
+	}
+}

--- a/components/crm/internal/services/encryption/provider_metrics_test.go
+++ b/components/crm/internal/services/encryption/provider_metrics_test.go
@@ -30,7 +30,7 @@ type scriptedUnwrapper struct {
 	calls      int
 }
 
-func (s *scriptedUnwrapper) UnwrapKeyset(_ context.Context, _ string, _ string) ([]byte, error) {
+func (s *scriptedUnwrapper) UnwrapKeyset(_ context.Context, _ string, _ string, _ string) ([]byte, error) {
 	s.calls++
 
 	if s.calls == 1 {

--- a/components/crm/internal/services/encryption/provisioning.go
+++ b/components/crm/internal/services/encryption/provisioning.go
@@ -228,14 +228,11 @@ func (s *provisioningService) provision(ctx context.Context, req ProvisionInput)
 		return result, mmodel.AuditOutcomeAlreadyExists, nil
 	}
 
-	// Generate KEK path (key NAME) for this organization. The mount is resolved
-	// separately from the request tenant: flat base for single-tenant ("" or
-	// "default"), per-tenant sub-mount otherwise. The key name is unchanged.
+	// KEK path is the key name; mount is resolved per-tenant (flat base for single-tenant).
 	kekPath := s.buildKEKPath(req.OrganizationID)
 	mount := resolveMount(s.kekMountPath, req.TenantID)
 
-	// app.protection.mount_path is the resolved mount, not a secret. Unwrap re-derives
-	// it from the stored tenant_id, so it is intentionally NOT persisted here.
+	// app.protection.mount_path is the resolved mount (not a secret), persisted on the keyset.
 	span.SetAttributes(attribute.String("app.protection.mount_path", mount))
 
 	// Generate AEAD keyset. The KMS wrap happens inside the generator; provider
@@ -276,6 +273,7 @@ func (s *provisioningService) provision(ctx context.Context, req ProvisionInput)
 		TenantID:          req.TenantID,
 		OrganizationID:    req.OrganizationID,
 		KEKPath:           kekPath,
+		KEKMountPath:      mount,
 		WrappedKeyset:     aeadBundle.Wrapped.WrappedData,
 		KeysetInfo:        convertKeysetInfo(aeadBundle.Wrapped.Info),
 		WrappedHMACKeyset: macBundle.Wrapped.WrappedData,

--- a/components/crm/internal/services/encryption/provisioning.go
+++ b/components/crm/internal/services/encryption/provisioning.go
@@ -12,11 +12,15 @@ import (
 
 	libCommons "github.com/LerianStudio/lib-commons/v5/commons"
 	libLog "github.com/LerianStudio/lib-commons/v5/commons/log"
+	libOpenTelemetry "github.com/LerianStudio/lib-commons/v5/commons/opentelemetry"
 	mongoEncryption "github.com/LerianStudio/midaz/v3/components/crm/internal/adapters/mongodb/encryption"
 	pkg "github.com/LerianStudio/midaz/v3/pkg"
 	"github.com/LerianStudio/midaz/v3/pkg/constant"
+	"github.com/LerianStudio/midaz/v3/pkg/crypto/kms/vault"
 	"github.com/LerianStudio/midaz/v3/pkg/crypto/tink"
 	"github.com/LerianStudio/midaz/v3/pkg/mmodel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 )
 
 // defaultAuditActor is the ActorID recorded when the provision request omits an
@@ -40,10 +44,12 @@ const (
 const EntityOrganizationEncryption = "OrganizationEncryption"
 
 // KeysetGenerator defines the interface for generating and wrapping keysets.
-// Compatible with pkg/crypto/tink.KeysetFactory.
+// Compatible with pkg/crypto/tink.KeysetFactory. mountPath is the resolved Vault
+// Transit mount (flat base for single-tenant, base/tenant for multi-tenant);
+// keyName is the per-organization KEK key name (org-{id}).
 type KeysetGenerator interface {
-	GenerateAEADKeyset(ctx context.Context, keyName string) (tink.KeysetBundle, error)
-	GenerateMACKeyset(ctx context.Context, keyName string) (tink.KeysetBundle, error)
+	GenerateAEADKeyset(ctx context.Context, mountPath, keyName string) (tink.KeysetBundle, error)
+	GenerateMACKeyset(ctx context.Context, mountPath, keyName string) (tink.KeysetBundle, error)
 }
 
 // ProvisioningConfig holds configuration for the ProvisioningService.
@@ -188,6 +194,13 @@ func (s *provisioningService) Provision(ctx context.Context, req ProvisionInput)
 // point so the exported Provision can emit exactly one audit event. The helpers
 // return their own outcome; this method never emits.
 func (s *provisioningService) provision(ctx context.Context, req ProvisionInput) (ProvisionResult, mmodel.AuditOutcome, error) {
+	_, tracer, _, _ := libCommons.NewTrackingFromContext(ctx) //nolint:dogsled // NewTrackingFromContext returns 4 values; only the tracer is needed here
+
+	ctx, span := tracer.Start(ctx, "service.protection.provision")
+	defer span.End()
+
+	span.SetAttributes(attribute.String("app.request.organization_id", req.OrganizationID))
+
 	// Check context before any work
 	if err := ctx.Err(); err != nil {
 		return ProvisionResult{}, mmodel.AuditOutcomeFailure, err
@@ -195,6 +208,8 @@ func (s *provisioningService) provision(ctx context.Context, req ProvisionInput)
 
 	// Validate request
 	if err := req.Validate(); err != nil {
+		libOpenTelemetry.HandleSpanError(span, "invalid provision request", err)
+
 		return ProvisionResult{}, mmodel.AuditOutcomeFailure, fmt.Errorf("invalid provision request: %w", err)
 	}
 
@@ -213,8 +228,15 @@ func (s *provisioningService) provision(ctx context.Context, req ProvisionInput)
 		return result, mmodel.AuditOutcomeAlreadyExists, nil
 	}
 
-	// Generate KEK path for this organization
+	// Generate KEK path (key NAME) for this organization. The mount is resolved
+	// separately from the request tenant: flat base for single-tenant ("" or
+	// "default"), per-tenant sub-mount otherwise. The key name is unchanged.
 	kekPath := s.buildKEKPath(req.OrganizationID)
+	mount := resolveMount(s.kekMountPath, req.TenantID)
+
+	// app.protection.mount_path is the resolved mount, not a secret. Unwrap re-derives
+	// it from the stored tenant_id, so it is intentionally NOT persisted here.
+	span.SetAttributes(attribute.String("app.protection.mount_path", mount))
 
 	// Generate AEAD keyset. The KMS wrap happens inside the generator; provider
 	// timing is measured here at the service boundary (pkg/crypto/tink MUST NOT
@@ -222,13 +244,13 @@ func (s *provisioningService) provision(ctx context.Context, req ProvisionInput)
 	// becomes dynamic when other KMS providers land. Timing is recorded even on
 	// failure.
 	aeadWrapStart := time.Now()
-	aeadBundle, err := s.keysetGenerator.GenerateAEADKeyset(ctx, kekPath)
+	aeadBundle, err := s.keysetGenerator.GenerateAEADKeyset(ctx, mount, kekPath)
 	s.metrics.recordProviderOperation(ctx, providerOperationWrap, providerVault, time.Since(aeadWrapStart).Milliseconds())
 
 	if err != nil {
 		s.metrics.recordProviderFailure(ctx, providerOperationWrap, errorCodeWrapAEADFailed)
 
-		return ProvisionResult{}, mmodel.AuditOutcomeFailure, pkg.ValidateBusinessError(constant.ErrProvisioningFailed, EntityOrganizationEncryption)
+		return ProvisionResult{}, mmodel.AuditOutcomeFailure, s.wrapProvisionError(span, err)
 	}
 
 	// Check context before generating MAC keyset
@@ -239,13 +261,13 @@ func (s *provisioningService) provision(ctx context.Context, req ProvisionInput)
 	// Generate MAC keyset. Provider timing is measured here at the service
 	// boundary and recorded even on failure.
 	macWrapStart := time.Now()
-	macBundle, err := s.keysetGenerator.GenerateMACKeyset(ctx, kekPath)
+	macBundle, err := s.keysetGenerator.GenerateMACKeyset(ctx, mount, kekPath)
 	s.metrics.recordProviderOperation(ctx, providerOperationWrap, providerVault, time.Since(macWrapStart).Milliseconds())
 
 	if err != nil {
 		s.metrics.recordProviderFailure(ctx, providerOperationWrap, errorCodeWrapMACFailed)
 
-		return ProvisionResult{}, mmodel.AuditOutcomeFailure, pkg.ValidateBusinessError(constant.ErrProvisioningFailed, EntityOrganizationEncryption)
+		return ProvisionResult{}, mmodel.AuditOutcomeFailure, s.wrapProvisionError(span, err)
 	}
 
 	// Build organization keyset
@@ -515,6 +537,26 @@ func (s *provisioningService) IsActive(ctx context.Context, organizationID strin
 	}
 
 	return *status == mmodel.RegistryStatusActive, nil
+}
+
+// wrapProvisionError maps a keyset wrap failure to the provisioning error.
+//
+// A missing per-tenant Vault Transit mount (vault.ErrMountNotFound) must fail
+// provisioning closed: it is surfaced clearly and kept Is-comparable via %w so
+// callers can distinguish "tenant not bootstrapped" from a generic failure. Any
+// other wrap failure maps to the opaque provisioning business error, which never
+// exposes internal technical detail to API clients.
+func (s *provisioningService) wrapProvisionError(span trace.Span, err error) error {
+	if errors.Is(err, vault.ErrMountNotFound) {
+		wrapped := fmt.Errorf("provision: tenant transit mount missing: %w", err)
+		libOpenTelemetry.HandleSpanError(span, "tenant transit mount missing", wrapped)
+
+		return wrapped
+	}
+
+	libOpenTelemetry.HandleSpanError(span, "failed to wrap keyset", err)
+
+	return pkg.ValidateBusinessError(constant.ErrProvisioningFailed, EntityOrganizationEncryption)
 }
 
 // buildKEKPath constructs the KEK key name for an organization.

--- a/components/crm/internal/services/encryption/provisioning_test.go
+++ b/components/crm/internal/services/encryption/provisioning_test.go
@@ -391,10 +391,12 @@ func TestProvisioningService_Provision_SingleTenant_FlatMount(t *testing.T) {
 	assert.Equal(t, "transit", keysetGenerator.aeadMountPath, "AEAD wrap must use flat base mount for default tenant")
 	assert.Equal(t, "transit", keysetGenerator.macMountPath, "MAC wrap must use flat base mount for default tenant")
 
-	// The mount must NOT be stored on the keyset record (unwrap re-derives it).
+	// The resolved mount IS stored on the keyset record so unwrap is independent
+	// of live config; for the "default"/single-tenant case it is the flat base.
 	savedKeyset := keysetRepo.keysets["org-456"]
 	require.NotNil(t, savedKeyset)
 	assert.Equal(t, "org-org-456", savedKeyset.KEKPath, "key name stays org-{id}, unchanged by mount resolution")
+	assert.Equal(t, "transit", savedKeyset.KEKMountPath, "resolved flat-base mount must be persisted on the keyset")
 }
 
 func TestProvisioningService_Provision_MultiTenant_SubMount(t *testing.T) {
@@ -425,10 +427,12 @@ func TestProvisioningService_Provision_MultiTenant_SubMount(t *testing.T) {
 	assert.Equal(t, want, keysetGenerator.aeadMountPath, "AEAD wrap must use per-tenant sub-mount")
 	assert.Equal(t, want, keysetGenerator.macMountPath, "MAC wrap must use per-tenant sub-mount")
 
-	// Key name remains org-{id}; mount is not part of it and not stored on the record.
+	// Key name remains org-{id}; the resolved per-tenant sub-mount IS persisted on
+	// the record so unwrap does not depend on live KMS_VAULT_MOUNT_PATH config.
 	savedKeyset := keysetRepo.keysets["org-456"]
 	require.NotNil(t, savedKeyset)
 	assert.Equal(t, "org-org-456", savedKeyset.KEKPath)
+	assert.Equal(t, want, savedKeyset.KEKMountPath, "resolved per-tenant sub-mount must be persisted on the keyset")
 }
 
 func TestProvisioningService_Provision_MountNotFound_FailsClosed(t *testing.T) {

--- a/components/crm/internal/services/encryption/provisioning_test.go
+++ b/components/crm/internal/services/encryption/provisioning_test.go
@@ -7,9 +7,11 @@ package encryption
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 
 	pkg "github.com/LerianStudio/midaz/v3/pkg"
+	"github.com/LerianStudio/midaz/v3/pkg/crypto/kms/vault"
 	"github.com/LerianStudio/midaz/v3/pkg/crypto/tink"
 	"github.com/LerianStudio/midaz/v3/pkg/mmodel"
 	"github.com/stretchr/testify/assert"
@@ -144,6 +146,8 @@ type fakeKeysetGenerator struct {
 	macErr        error
 	aeadCalled    int
 	macCalled     int
+	aeadMountPath string // records the mountPath received by GenerateAEADKeyset
+	macMountPath  string // records the mountPath received by GenerateMACKeyset
 	nextKeyID     uint32
 	callSequencer int
 }
@@ -154,9 +158,10 @@ func newFakeKeysetGenerator() *fakeKeysetGenerator {
 	}
 }
 
-func (f *fakeKeysetGenerator) GenerateAEADKeyset(_ context.Context, _ string) (tink.KeysetBundle, error) {
+func (f *fakeKeysetGenerator) GenerateAEADKeyset(_ context.Context, mountPath, _ string) (tink.KeysetBundle, error) {
 	f.aeadCalled++
 	f.callSequencer++
+	f.aeadMountPath = mountPath
 
 	if f.aeadErr != nil {
 		return tink.KeysetBundle{}, f.aeadErr
@@ -190,9 +195,10 @@ func (f *fakeKeysetGenerator) GenerateAEADKeyset(_ context.Context, _ string) (t
 	}, nil
 }
 
-func (f *fakeKeysetGenerator) GenerateMACKeyset(_ context.Context, _ string) (tink.KeysetBundle, error) {
+func (f *fakeKeysetGenerator) GenerateMACKeyset(_ context.Context, mountPath, _ string) (tink.KeysetBundle, error) {
 	f.macCalled++
 	f.callSequencer++
+	f.macMountPath = mountPath
 
 	if f.macErr != nil {
 		return tink.KeysetBundle{}, f.macErr
@@ -358,6 +364,99 @@ func TestProvisioningService_Provision_Success(t *testing.T) {
 	// Verify generators were called
 	assert.Equal(t, 1, keysetGenerator.aeadCalled)
 	assert.Equal(t, 1, keysetGenerator.macCalled)
+}
+
+func TestProvisioningService_Provision_SingleTenant_FlatMount(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	keysetRepo := newFakeKeysetRepoForProv()
+	registryRepo := newFakeRegistryRepoForProv()
+	keysetGenerator := newFakeKeysetGenerator()
+
+	svc := NewProvisioningService(keysetRepo, registryRepo, keysetGenerator,
+		ProvisioningConfig{KEKMountPath: "transit"}, newSpyAuditWriter(), NewProtectionMetrics(nil))
+
+	req := ProvisionInput{
+		TenantID:       "default",
+		OrganizationID: "org-456",
+		Actor:          "admin@example.com",
+		Reason:         "Initial provisioning",
+	}
+
+	_, err := svc.Provision(ctx, req)
+	require.NoError(t, err)
+
+	// Single-tenant ("default") resolves to the flat base mount for both wrap calls.
+	assert.Equal(t, "transit", keysetGenerator.aeadMountPath, "AEAD wrap must use flat base mount for default tenant")
+	assert.Equal(t, "transit", keysetGenerator.macMountPath, "MAC wrap must use flat base mount for default tenant")
+
+	// The mount must NOT be stored on the keyset record (unwrap re-derives it).
+	savedKeyset := keysetRepo.keysets["org-456"]
+	require.NotNil(t, savedKeyset)
+	assert.Equal(t, "org-org-456", savedKeyset.KEKPath, "key name stays org-{id}, unchanged by mount resolution")
+}
+
+func TestProvisioningService_Provision_MultiTenant_SubMount(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	keysetRepo := newFakeKeysetRepoForProv()
+	registryRepo := newFakeRegistryRepoForProv()
+	keysetGenerator := newFakeKeysetGenerator()
+
+	svc := NewProvisioningService(keysetRepo, registryRepo, keysetGenerator,
+		ProvisioningConfig{KEKMountPath: "transit"}, newSpyAuditWriter(), NewProtectionMetrics(nil))
+
+	const tenantID = "11111111-2222-3333-4444-555555555555"
+
+	req := ProvisionInput{
+		TenantID:       tenantID,
+		OrganizationID: "org-456",
+		Actor:          "admin@example.com",
+		Reason:         "Initial provisioning",
+	}
+
+	_, err := svc.Provision(ctx, req)
+	require.NoError(t, err)
+
+	// Multi-tenant resolves to a per-tenant sub-mount for both wrap calls.
+	want := "transit/" + tenantID
+	assert.Equal(t, want, keysetGenerator.aeadMountPath, "AEAD wrap must use per-tenant sub-mount")
+	assert.Equal(t, want, keysetGenerator.macMountPath, "MAC wrap must use per-tenant sub-mount")
+
+	// Key name remains org-{id}; mount is not part of it and not stored on the record.
+	savedKeyset := keysetRepo.keysets["org-456"]
+	require.NotNil(t, savedKeyset)
+	assert.Equal(t, "org-org-456", savedKeyset.KEKPath)
+}
+
+func TestProvisioningService_Provision_MountNotFound_FailsClosed(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	keysetRepo := newFakeKeysetRepoForProv()
+	registryRepo := newFakeRegistryRepoForProv()
+	keysetGenerator := newFakeKeysetGenerator()
+	keysetGenerator.aeadErr = fmt.Errorf("wrap aead: %w", vault.ErrMountNotFound)
+
+	svc := NewProvisioningService(keysetRepo, registryRepo, keysetGenerator,
+		ProvisioningConfig{KEKMountPath: "transit"}, newSpyAuditWriter(), NewProtectionMetrics(nil))
+
+	req := ProvisionInput{
+		TenantID:       "11111111-2222-3333-4444-555555555555",
+		OrganizationID: "org-456",
+		Actor:          "admin@example.com",
+		Reason:         "Initial provisioning",
+	}
+
+	_, err := svc.Provision(ctx, req)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, vault.ErrMountNotFound, "missing per-tenant mount must fail provisioning closed")
+
+	// No keyset/registry should be persisted on a failed-closed provision.
+	assert.Empty(t, keysetRepo.keysets, "no keyset should be saved when mount is missing")
+	assert.Empty(t, registryRepo.records, "no registry should be saved when mount is missing")
 }
 
 func TestProvisioningService_Provision_AlreadyProvisioned(t *testing.T) {

--- a/pkg/constant/errors.go
+++ b/pkg/constant/errors.go
@@ -263,4 +263,5 @@ var (
 	ErrProvisioningFailed           = errors.New("ENC-0010")
 	ErrAuditEventRequired           = errors.New("ENC-0011")
 	ErrAuditWriteFailed             = errors.New("ENC-0012")
+	ErrReservedTenantID             = errors.New("ENC-0013")
 )

--- a/pkg/crypto/kms/vault/client.go
+++ b/pkg/crypto/kms/vault/client.go
@@ -167,11 +167,6 @@ func (c *Client) Close() error {
 	return nil
 }
 
-// MountPath returns the configured Transit secrets engine mount path.
-func (c *Client) MountPath() string {
-	return c.config.MountPath
-}
-
 // AuthMethod returns the effective authentication method being used.
 func (c *Client) AuthMethod() AuthMethod {
 	return c.config.EffectiveAuthMethod()

--- a/pkg/crypto/kms/vault/client_test.go
+++ b/pkg/crypto/kms/vault/client_test.go
@@ -27,7 +27,6 @@ func TestNewClient(t *testing.T) {
 			name: "valid approle config creates client",
 			config: Config{
 				Addr:       "https://vault.example.com:8200",
-				MountPath:  "transit",
 				AuthMethod: AuthMethodAppRole,
 				RoleID:     "role-123",
 				SecretID:   "secret-456",
@@ -38,7 +37,6 @@ func TestNewClient(t *testing.T) {
 			name: "valid token config creates client",
 			config: Config{
 				Addr:       "https://vault.example.com:8200",
-				MountPath:  "transit",
 				AuthMethod: AuthMethodToken,
 				Token:      "hvs.test-token",
 			},
@@ -48,7 +46,6 @@ func TestNewClient(t *testing.T) {
 			name: "invalid config returns error",
 			config: Config{
 				Addr:       "",
-				MountPath:  "transit",
 				AuthMethod: AuthMethodAppRole,
 				RoleID:     "role-123",
 				SecretID:   "secret-456",
@@ -101,7 +98,6 @@ func TestClient_Login_AppRole(t *testing.T) {
 
 		client, err := NewClient(Config{
 			Addr:       server.URL,
-			MountPath:  "transit",
 			AuthMethod: AuthMethodAppRole,
 			RoleID:     "role-123",
 			SecretID:   "secret-456",
@@ -127,7 +123,6 @@ func TestClient_Login_AppRole(t *testing.T) {
 
 		client, err := NewClient(Config{
 			Addr:       server.URL,
-			MountPath:  "transit",
 			AuthMethod: AuthMethodAppRole,
 			RoleID:     "invalid-role",
 			SecretID:   "invalid-secret",
@@ -151,7 +146,6 @@ func TestClient_Login_AppRole(t *testing.T) {
 
 		client, err := NewClient(Config{
 			Addr:       server.URL,
-			MountPath:  "transit",
 			AuthMethod: AuthMethodAppRole,
 			RoleID:     "role-123",
 			SecretID:   "secret-456",
@@ -174,7 +168,6 @@ func TestClient_Login_Token(t *testing.T) {
 		// Token auth doesn't make any HTTP calls during login
 		client, err := NewClient(Config{
 			Addr:       "https://vault.example.com:8200",
-			MountPath:  "transit",
 			AuthMethod: AuthMethodToken,
 			Token:      "hvs.test-token-123",
 		})
@@ -195,7 +188,6 @@ func TestClient_AuthMethod(t *testing.T) {
 
 		client, err := NewClient(Config{
 			Addr:       "https://vault.example.com:8200",
-			MountPath:  "transit",
 			AuthMethod: AuthMethodAppRole,
 			RoleID:     "role-123",
 			SecretID:   "secret-456",
@@ -210,7 +202,6 @@ func TestClient_AuthMethod(t *testing.T) {
 
 		client, err := NewClient(Config{
 			Addr:       "https://vault.example.com:8200",
-			MountPath:  "transit",
 			AuthMethod: AuthMethodToken,
 			Token:      "hvs.test-token",
 		})
@@ -223,10 +214,9 @@ func TestClient_AuthMethod(t *testing.T) {
 		t.Parallel()
 
 		client, err := NewClient(Config{
-			Addr:      "https://vault.example.com:8200",
-			MountPath: "transit",
-			RoleID:    "role-123",
-			SecretID:  "secret-456",
+			Addr:     "https://vault.example.com:8200",
+			RoleID:   "role-123",
+			SecretID: "secret-456",
 		})
 		require.NoError(t, err)
 
@@ -254,7 +244,6 @@ func TestClient_Close(t *testing.T) {
 
 		client, err := NewClient(Config{
 			Addr:       server.URL,
-			MountPath:  "transit",
 			AuthMethod: AuthMethodAppRole,
 			RoleID:     "role-123",
 			SecretID:   "secret-456",
@@ -276,7 +265,6 @@ func TestClient_Close(t *testing.T) {
 
 		client, err := NewClient(Config{
 			Addr:       "https://vault.example.com:8200",
-			MountPath:  "transit",
 			AuthMethod: AuthMethodToken,
 			Token:      "hvs.test-token",
 		})
@@ -291,21 +279,6 @@ func TestClient_Close(t *testing.T) {
 		require.NoError(t, err)
 		assert.False(t, client.isLoggedIn)
 	})
-}
-
-func TestClient_MountPath(t *testing.T) {
-	t.Parallel()
-
-	client, err := NewClient(Config{
-		Addr:       "https://vault.example.com:8200",
-		MountPath:  "crm-transit",
-		AuthMethod: AuthMethodAppRole,
-		RoleID:     "role-123",
-		SecretID:   "secret-456",
-	})
-	require.NoError(t, err)
-
-	assert.Equal(t, "crm-transit", client.MountPath())
 }
 
 func TestIsPermissionDenied(t *testing.T) {

--- a/pkg/crypto/kms/vault/config.go
+++ b/pkg/crypto/kms/vault/config.go
@@ -23,10 +23,6 @@ type Config struct {
 	// Addr is the Vault server address (e.g., "https://vault.example.com:8200").
 	Addr string
 
-	// MountPath is the Transit secrets engine mount path (e.g., "crm-transit").
-	// Use a dedicated mount per application for namespace isolation.
-	MountPath string
-
 	// AuthMethod specifies which authentication method to use.
 	// Supported values: "approle", "token". Defaults to "approle" if empty.
 	AuthMethod AuthMethod
@@ -52,10 +48,6 @@ func (c Config) Validate() error {
 
 	if strings.TrimSpace(c.Addr) == "" {
 		missing = append(missing, "addr")
-	}
-
-	if strings.TrimSpace(c.MountPath) == "" {
-		missing = append(missing, "mount_path")
 	}
 
 	if len(missing) > 0 {
@@ -94,7 +86,6 @@ func (c Config) EffectiveAuthMethod() AuthMethod {
 // IsEmpty returns true if all configuration fields are empty or contain only whitespace.
 func (c Config) IsEmpty() bool {
 	return strings.TrimSpace(c.Addr) == "" &&
-		strings.TrimSpace(c.MountPath) == "" &&
 		strings.TrimSpace(c.RoleID) == "" &&
 		strings.TrimSpace(c.SecretID) == "" &&
 		strings.TrimSpace(c.Token) == ""

--- a/pkg/crypto/kms/vault/config_test.go
+++ b/pkg/crypto/kms/vault/config_test.go
@@ -24,7 +24,6 @@ func TestConfig_Validate_AppRole(t *testing.T) {
 			name: "valid approle config with explicit method",
 			config: Config{
 				Addr:       "https://vault.example.com:8200",
-				MountPath:  "transit",
 				AuthMethod: AuthMethodAppRole,
 				RoleID:     "role-123",
 				SecretID:   "secret-456",
@@ -34,10 +33,9 @@ func TestConfig_Validate_AppRole(t *testing.T) {
 		{
 			name: "valid approle config with default method (empty)",
 			config: Config{
-				Addr:      "https://vault.example.com:8200",
-				MountPath: "transit",
-				RoleID:    "role-123",
-				SecretID:  "secret-456",
+				Addr:     "https://vault.example.com:8200",
+				RoleID:   "role-123",
+				SecretID: "secret-456",
 			},
 			expectError: false,
 		},
@@ -45,7 +43,6 @@ func TestConfig_Validate_AppRole(t *testing.T) {
 			name: "missing addr returns error",
 			config: Config{
 				Addr:       "",
-				MountPath:  "transit",
 				AuthMethod: AuthMethodAppRole,
 				RoleID:     "role-123",
 				SecretID:   "secret-456",
@@ -54,22 +51,9 @@ func TestConfig_Validate_AppRole(t *testing.T) {
 			errorContains: "addr",
 		},
 		{
-			name: "missing mount_path returns error",
-			config: Config{
-				Addr:       "https://vault.example.com:8200",
-				MountPath:  "",
-				AuthMethod: AuthMethodAppRole,
-				RoleID:     "role-123",
-				SecretID:   "secret-456",
-			},
-			expectError:   true,
-			errorContains: "mount_path",
-		},
-		{
 			name: "missing role_id returns error",
 			config: Config{
 				Addr:       "https://vault.example.com:8200",
-				MountPath:  "transit",
 				AuthMethod: AuthMethodAppRole,
 				RoleID:     "",
 				SecretID:   "secret-456",
@@ -81,7 +65,6 @@ func TestConfig_Validate_AppRole(t *testing.T) {
 			name: "missing secret_id returns error",
 			config: Config{
 				Addr:       "https://vault.example.com:8200",
-				MountPath:  "transit",
 				AuthMethod: AuthMethodAppRole,
 				RoleID:     "role-123",
 				SecretID:   "",
@@ -120,7 +103,6 @@ func TestConfig_Validate_Token(t *testing.T) {
 			name: "valid token config",
 			config: Config{
 				Addr:       "https://vault.example.com:8200",
-				MountPath:  "transit",
 				AuthMethod: AuthMethodToken,
 				Token:      "hvs.test-token-123",
 			},
@@ -130,7 +112,6 @@ func TestConfig_Validate_Token(t *testing.T) {
 			name: "token auth missing token returns error",
 			config: Config{
 				Addr:       "https://vault.example.com:8200",
-				MountPath:  "transit",
 				AuthMethod: AuthMethodToken,
 				Token:      "",
 			},
@@ -141,7 +122,6 @@ func TestConfig_Validate_Token(t *testing.T) {
 			name: "token auth with whitespace-only token returns error",
 			config: Config{
 				Addr:       "https://vault.example.com:8200",
-				MountPath:  "transit",
 				AuthMethod: AuthMethodToken,
 				Token:      "   ",
 			},
@@ -171,7 +151,6 @@ func TestConfig_Validate_InvalidAuthMethod(t *testing.T) {
 
 	config := Config{
 		Addr:       "https://vault.example.com:8200",
-		MountPath:  "transit",
 		AuthMethod: "invalid",
 		RoleID:     "role-123",
 		SecretID:   "secret-456",
@@ -235,11 +214,10 @@ func TestConfig_IsEmpty(t *testing.T) {
 		{
 			name: "config with only whitespace returns true",
 			config: Config{
-				Addr:      "   ",
-				MountPath: "   ",
-				RoleID:    "   ",
-				SecretID:  "   ",
-				Token:     "   ",
+				Addr:     "   ",
+				RoleID:   "   ",
+				SecretID: "   ",
+				Token:    "   ",
 			},
 			expected: true,
 		},
@@ -261,7 +239,6 @@ func TestConfig_IsEmpty(t *testing.T) {
 			name: "fully populated approle config returns false",
 			config: Config{
 				Addr:       "https://vault.example.com:8200",
-				MountPath:  "transit",
 				AuthMethod: AuthMethodAppRole,
 				RoleID:     "role-123",
 				SecretID:   "secret-456",
@@ -272,7 +249,6 @@ func TestConfig_IsEmpty(t *testing.T) {
 			name: "fully populated token config returns false",
 			config: Config{
 				Addr:       "https://vault.example.com:8200",
-				MountPath:  "transit",
 				AuthMethod: AuthMethodToken,
 				Token:      "hvs.token",
 			},

--- a/pkg/crypto/kms/vault/errors.go
+++ b/pkg/crypto/kms/vault/errors.go
@@ -1,0 +1,12 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package vault
+
+import "errors"
+
+// ErrMountNotFound indicates that a tenant's Vault Transit mount is absent.
+// Callers can match it with errors.Is to surface a typed error instead of
+// silently falling back when the Transit engine has no handler for the route.
+var ErrMountNotFound = errors.New("vault transit mount not found")

--- a/pkg/crypto/kms/vault/errors_test.go
+++ b/pkg/crypto/kms/vault/errors_test.go
@@ -1,0 +1,19 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package vault
+
+import (
+	"testing"
+)
+
+func TestErrMountNotFound_Sentinel(t *testing.T) {
+	if ErrMountNotFound == nil {
+		t.Fatal("expected ErrMountNotFound to be non-nil")
+	}
+
+	if got, want := ErrMountNotFound.Error(), "vault transit mount not found"; got != want {
+		t.Errorf("unexpected error message: got %q, want %q", got, want)
+	}
+}

--- a/pkg/crypto/kms/vault/transit.go
+++ b/pkg/crypto/kms/vault/transit.go
@@ -7,20 +7,31 @@ package vault
 import (
 	"context"
 	"encoding/base64"
+	"errors"
 	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/hashicorp/vault/api"
 )
 
 // Encrypt encrypts plaintext using the Vault Transit secrets engine.
+// The mountPath selects the Transit mount for the request (e.g. "transit"
+// or "transit/tenant-x") and must be non-empty.
 // The keyName should follow the convention: org/{organization_id}
 // Keys are auto-created on first use if the AppRole has create permissions.
 //
 // Returns the ciphertext in Vault's format: vault:v1:base64-encoded-ciphertext
-func (c *Client) Encrypt(ctx context.Context, keyName string, plaintext []byte) (string, error) {
+func (c *Client) Encrypt(ctx context.Context, mountPath, keyName string, plaintext []byte) (string, error) {
+	if mountPath == "" {
+		return "", fmt.Errorf("vault: empty mount path for key %q", keyName)
+	}
+
 	if err := c.ensureAuthenticated(ctx); err != nil {
 		return "", fmt.Errorf("authentication failed: %w", err)
 	}
 
-	ciphertext, err := c.encryptInternal(ctx, keyName, plaintext)
+	ciphertext, err := c.encryptInternal(ctx, mountPath, keyName, plaintext)
 	if err != nil {
 		// Re-authenticate and retry once on permission denied (token expired)
 		if isPermissionDenied(err) {
@@ -28,18 +39,25 @@ func (c *Client) Encrypt(ctx context.Context, keyName string, plaintext []byte) 
 				return "", fmt.Errorf("re-authentication failed: %w", reAuthErr)
 			}
 
-			return c.encryptInternal(ctx, keyName, plaintext)
+			ciphertext, err = c.encryptInternal(ctx, mountPath, keyName, plaintext)
+			if err != nil {
+				return "", c.mapMountErr(mountPath, err)
+			}
+
+			return ciphertext, nil
 		}
 
-		return "", err
+		// Fail closed when the Transit mount is absent: surface a typed error
+		// instead of falling back to a different mount.
+		return "", c.mapMountErr(mountPath, err)
 	}
 
 	return ciphertext, nil
 }
 
 // encryptInternal performs the actual encryption call to Vault.
-func (c *Client) encryptInternal(ctx context.Context, keyName string, plaintext []byte) (string, error) {
-	path := fmt.Sprintf("%s/encrypt/%s", c.config.MountPath, keyName)
+func (c *Client) encryptInternal(ctx context.Context, mountPath, keyName string, plaintext []byte) (string, error) {
+	path := fmt.Sprintf("%s/encrypt/%s", mountPath, keyName)
 
 	data := map[string]any{
 		"plaintext": base64.StdEncoding.EncodeToString(plaintext),
@@ -63,15 +81,21 @@ func (c *Client) encryptInternal(ctx context.Context, keyName string, plaintext 
 }
 
 // Decrypt decrypts ciphertext using the Vault Transit secrets engine.
+// The mountPath selects the Transit mount for the request (e.g. "transit"
+// or "transit/tenant-x") and must be non-empty.
 // The ciphertext must be in Vault's format: vault:v1:base64-encoded-ciphertext
 //
 // Returns the original plaintext bytes.
-func (c *Client) Decrypt(ctx context.Context, keyName string, ciphertext string) ([]byte, error) {
+func (c *Client) Decrypt(ctx context.Context, mountPath, keyName, ciphertext string) ([]byte, error) {
+	if mountPath == "" {
+		return nil, fmt.Errorf("vault: empty mount path for key %q", keyName)
+	}
+
 	if err := c.ensureAuthenticated(ctx); err != nil {
 		return nil, fmt.Errorf("authentication failed: %w", err)
 	}
 
-	plaintext, err := c.decryptInternal(ctx, keyName, ciphertext)
+	plaintext, err := c.decryptInternal(ctx, mountPath, keyName, ciphertext)
 	if err != nil {
 		// Re-authenticate and retry once on permission denied (token expired)
 		if isPermissionDenied(err) {
@@ -79,18 +103,25 @@ func (c *Client) Decrypt(ctx context.Context, keyName string, ciphertext string)
 				return nil, fmt.Errorf("re-authentication failed: %w", reAuthErr)
 			}
 
-			return c.decryptInternal(ctx, keyName, ciphertext)
+			plaintext, err = c.decryptInternal(ctx, mountPath, keyName, ciphertext)
+			if err != nil {
+				return nil, c.mapMountErr(mountPath, err)
+			}
+
+			return plaintext, nil
 		}
 
-		return nil, err
+		// Fail closed when the Transit mount is absent: surface a typed error
+		// instead of falling back to a different mount.
+		return nil, c.mapMountErr(mountPath, err)
 	}
 
 	return plaintext, nil
 }
 
 // decryptInternal performs the actual decryption call to Vault.
-func (c *Client) decryptInternal(ctx context.Context, keyName string, ciphertext string) ([]byte, error) {
-	path := fmt.Sprintf("%s/decrypt/%s", c.config.MountPath, keyName)
+func (c *Client) decryptInternal(ctx context.Context, mountPath, keyName, ciphertext string) ([]byte, error) {
+	path := fmt.Sprintf("%s/decrypt/%s", mountPath, keyName)
 
 	data := map[string]any{
 		"ciphertext": ciphertext,
@@ -116,4 +147,37 @@ func (c *Client) decryptInternal(ctx context.Context, keyName string, ciphertext
 	}
 
 	return plaintext, nil
+}
+
+// mapMountErr translates a missing-Transit-mount error into the typed
+// ErrMountNotFound (wrapped with the mount path for context), so callers can
+// match it with errors.Is and fail closed. Non-mount errors pass through
+// unchanged.
+func (c *Client) mapMountErr(mountPath string, err error) error {
+	if isMountNotFound(err) {
+		return fmt.Errorf("%w: %s", ErrMountNotFound, mountPath)
+	}
+
+	return err
+}
+
+// isMountNotFound reports whether err indicates that the targeted Transit mount
+// does not exist. Vault surfaces a missing mount as an HTTP 404 *api.ResponseError,
+// with a body that varies across versions ("no handler for route ..." on newer
+// builds, "unsupported path" on older ones). The substring check is a
+// belt-and-suspenders fallback for clients that do not expose the typed error.
+func isMountNotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	var respErr *api.ResponseError
+	if errors.As(err, &respErr) && respErr.StatusCode == http.StatusNotFound {
+		return true
+	}
+
+	msg := strings.ToLower(err.Error())
+
+	return strings.Contains(msg, "no handler for route") ||
+		strings.Contains(msg, "unsupported path")
 }

--- a/pkg/crypto/kms/vault/transit_test.go
+++ b/pkg/crypto/kms/vault/transit_test.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"sync/atomic"
@@ -82,14 +83,13 @@ func TestClient_Encrypt(t *testing.T) {
 
 		client, err := NewClient(Config{
 			Addr:       server.URL,
-			MountPath:  "transit",
 			AuthMethod: AuthMethodAppRole,
 			RoleID:     "role-123",
 			SecretID:   "secret-456",
 		})
 		require.NoError(t, err)
 
-		ciphertext, err := client.Encrypt(context.Background(), "org/test-org-id", plaintext)
+		ciphertext, err := client.Encrypt(context.Background(), "transit", "org/test-org-id", plaintext)
 
 		require.NoError(t, err)
 		assert.Equal(t, expectedCiphertext, ciphertext)
@@ -128,14 +128,13 @@ func TestClient_Encrypt(t *testing.T) {
 
 		client, err := NewClient(Config{
 			Addr:       server.URL,
-			MountPath:  "transit",
 			AuthMethod: AuthMethodAppRole,
 			RoleID:     "role-123",
 			SecretID:   "secret-456",
 		})
 		require.NoError(t, err)
 
-		ciphertext, err := client.Encrypt(context.Background(), "org/test-org-id", []byte("data"))
+		ciphertext, err := client.Encrypt(context.Background(), "transit", "org/test-org-id", []byte("data"))
 
 		require.NoError(t, err)
 		assert.Equal(t, "vault:v1:retry-success", ciphertext)
@@ -155,14 +154,13 @@ func TestClient_Encrypt(t *testing.T) {
 
 		client, err := NewClient(Config{
 			Addr:       server.URL,
-			MountPath:  "transit",
 			AuthMethod: AuthMethodAppRole,
 			RoleID:     "role-123",
 			SecretID:   "secret-456",
 		})
 		require.NoError(t, err)
 
-		_, err = client.Encrypt(context.Background(), "org/test-org-id", []byte("data"))
+		_, err = client.Encrypt(context.Background(), "transit", "org/test-org-id", []byte("data"))
 
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "empty response")
@@ -186,14 +184,13 @@ func TestClient_Encrypt(t *testing.T) {
 
 		client, err := NewClient(Config{
 			Addr:       server.URL,
-			MountPath:  "transit",
 			AuthMethod: AuthMethodAppRole,
 			RoleID:     "role-123",
 			SecretID:   "secret-456",
 		})
 		require.NoError(t, err)
 
-		_, err = client.Encrypt(context.Background(), "org/test-org-id", []byte("data"))
+		_, err = client.Encrypt(context.Background(), "transit", "org/test-org-id", []byte("data"))
 
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "missing ciphertext")
@@ -232,14 +229,13 @@ func TestClient_Decrypt(t *testing.T) {
 
 		client, err := NewClient(Config{
 			Addr:       server.URL,
-			MountPath:  "transit",
 			AuthMethod: AuthMethodAppRole,
 			RoleID:     "role-123",
 			SecretID:   "secret-456",
 		})
 		require.NoError(t, err)
 
-		plaintext, err := client.Decrypt(context.Background(), "org/test-org-id", ciphertext)
+		plaintext, err := client.Decrypt(context.Background(), "transit", "org/test-org-id", ciphertext)
 
 		require.NoError(t, err)
 		assert.Equal(t, expectedPlaintext, plaintext)
@@ -279,14 +275,13 @@ func TestClient_Decrypt(t *testing.T) {
 
 		client, err := NewClient(Config{
 			Addr:       server.URL,
-			MountPath:  "transit",
 			AuthMethod: AuthMethodAppRole,
 			RoleID:     "role-123",
 			SecretID:   "secret-456",
 		})
 		require.NoError(t, err)
 
-		plaintext, err := client.Decrypt(context.Background(), "org/test-org-id", "vault:v1:data")
+		plaintext, err := client.Decrypt(context.Background(), "transit", "org/test-org-id", "vault:v1:data")
 
 		require.NoError(t, err)
 		assert.Equal(t, expectedPlaintext, plaintext)
@@ -306,14 +301,13 @@ func TestClient_Decrypt(t *testing.T) {
 
 		client, err := NewClient(Config{
 			Addr:       server.URL,
-			MountPath:  "transit",
 			AuthMethod: AuthMethodAppRole,
 			RoleID:     "role-123",
 			SecretID:   "secret-456",
 		})
 		require.NoError(t, err)
 
-		_, err = client.Decrypt(context.Background(), "org/test-org-id", "vault:v1:data")
+		_, err = client.Decrypt(context.Background(), "transit", "org/test-org-id", "vault:v1:data")
 
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "empty response")
@@ -337,17 +331,300 @@ func TestClient_Decrypt(t *testing.T) {
 
 		client, err := NewClient(Config{
 			Addr:       server.URL,
-			MountPath:  "transit",
 			AuthMethod: AuthMethodAppRole,
 			RoleID:     "role-123",
 			SecretID:   "secret-456",
 		})
 		require.NoError(t, err)
 
-		_, err = client.Decrypt(context.Background(), "org/test-org-id", "vault:v1:data")
+		_, err = client.Decrypt(context.Background(), "transit", "org/test-org-id", "vault:v1:data")
 
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "decode plaintext")
+	})
+}
+
+func TestClient_Encrypt_MountPathDrivesPath(t *testing.T) {
+	t.Parallel()
+
+	t.Run("supplied mount path is used in the request URL", func(t *testing.T) {
+		t.Parallel()
+
+		var capturedPath atomic.Value
+
+		server := newTestServer(t, map[string]http.HandlerFunc{
+			"/v1/transit/tenant-x/encrypt/org/test-org-id": func(w http.ResponseWriter, r *http.Request) {
+				capturedPath.Store(r.URL.Path)
+
+				resp := map[string]any{
+					"data": map[string]any{
+						"ciphertext": "vault:v1:tenant-x-ciphertext",
+					},
+				}
+				w.Header().Set("Content-Type", "application/json")
+				json.NewEncoder(w).Encode(resp)
+			},
+		})
+		defer server.Close()
+
+		client, err := NewClient(Config{
+			Addr:       server.URL,
+			AuthMethod: AuthMethodAppRole,
+			RoleID:     "role-123",
+			SecretID:   "secret-456",
+		})
+		require.NoError(t, err)
+
+		ciphertext, err := client.Encrypt(context.Background(), "transit/tenant-x", "org/test-org-id", []byte("data"))
+
+		require.NoError(t, err)
+		assert.Equal(t, "vault:v1:tenant-x-ciphertext", ciphertext)
+		assert.Equal(t, "/v1/transit/tenant-x/encrypt/org/test-org-id", capturedPath.Load())
+	})
+
+	t.Run("empty mount path returns guard error", func(t *testing.T) {
+		t.Parallel()
+
+		client, err := NewClient(Config{
+			Addr:       "https://vault.example.com:8200",
+			AuthMethod: AuthMethodToken,
+			Token:      "hvs.test-token",
+		})
+		require.NoError(t, err)
+
+		_, err = client.Encrypt(context.Background(), "", "org/test-org-id", []byte("data"))
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "empty mount path")
+	})
+}
+
+func TestClient_Decrypt_MountPathDrivesPath(t *testing.T) {
+	t.Parallel()
+
+	t.Run("supplied mount path is used in the request URL", func(t *testing.T) {
+		t.Parallel()
+
+		expectedPlaintext := []byte("tenant data")
+		var capturedPath atomic.Value
+
+		server := newTestServer(t, map[string]http.HandlerFunc{
+			"/v1/transit/tenant-x/decrypt/org/test-org-id": func(w http.ResponseWriter, r *http.Request) {
+				capturedPath.Store(r.URL.Path)
+
+				resp := map[string]any{
+					"data": map[string]any{
+						"plaintext": base64.StdEncoding.EncodeToString(expectedPlaintext),
+					},
+				}
+				w.Header().Set("Content-Type", "application/json")
+				json.NewEncoder(w).Encode(resp)
+			},
+		})
+		defer server.Close()
+
+		client, err := NewClient(Config{
+			Addr:       server.URL,
+			AuthMethod: AuthMethodAppRole,
+			RoleID:     "role-123",
+			SecretID:   "secret-456",
+		})
+		require.NoError(t, err)
+
+		plaintext, err := client.Decrypt(context.Background(), "transit/tenant-x", "org/test-org-id", "vault:v1:data")
+
+		require.NoError(t, err)
+		assert.Equal(t, expectedPlaintext, plaintext)
+		assert.Equal(t, "/v1/transit/tenant-x/decrypt/org/test-org-id", capturedPath.Load())
+	})
+
+	t.Run("empty mount path returns guard error", func(t *testing.T) {
+		t.Parallel()
+
+		client, err := NewClient(Config{
+			Addr:       "https://vault.example.com:8200",
+			AuthMethod: AuthMethodToken,
+			Token:      "hvs.test-token",
+		})
+		require.NoError(t, err)
+
+		_, err = client.Decrypt(context.Background(), "", "org/test-org-id", "vault:v1:data")
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "empty mount path")
+	})
+}
+
+func TestClient_Encrypt_MissingMount(t *testing.T) {
+	t.Parallel()
+
+	t.Run("404 no handler for route maps to ErrMountNotFound", func(t *testing.T) {
+		t.Parallel()
+
+		server := newTestServer(t, map[string]http.HandlerFunc{
+			"/v1/transit/missing/encrypt/org/x": func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusNotFound)
+				json.NewEncoder(w).Encode(map[string]any{
+					"errors": []string{`no handler for route "transit/missing/encrypt/org/x". route entry not found.`},
+				})
+			},
+		})
+		defer server.Close()
+
+		client, err := NewClient(Config{
+			Addr:       server.URL,
+			AuthMethod: AuthMethodAppRole,
+			RoleID:     "role-123",
+			SecretID:   "secret-456",
+		})
+		require.NoError(t, err)
+
+		_, err = client.Encrypt(context.Background(), "transit/missing", "org/x", []byte("data"))
+
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, ErrMountNotFound), "expected ErrMountNotFound, got %v", err)
+		assert.Contains(t, err.Error(), "transit/missing", "mount path should be included in error")
+	})
+
+	t.Run("404 unsupported path maps to ErrMountNotFound", func(t *testing.T) {
+		t.Parallel()
+
+		server := newTestServer(t, map[string]http.HandlerFunc{
+			"/v1/transit/missing/encrypt/org/x": func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusNotFound)
+				json.NewEncoder(w).Encode(map[string]any{
+					"errors": []string{"unsupported path"},
+				})
+			},
+		})
+		defer server.Close()
+
+		client, err := NewClient(Config{
+			Addr:       server.URL,
+			AuthMethod: AuthMethodAppRole,
+			RoleID:     "role-123",
+			SecretID:   "secret-456",
+		})
+		require.NoError(t, err)
+
+		_, err = client.Encrypt(context.Background(), "transit/missing", "org/x", []byte("data"))
+
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, ErrMountNotFound), "expected ErrMountNotFound, got %v", err)
+	})
+
+	t.Run("500 server error is not misclassified as ErrMountNotFound", func(t *testing.T) {
+		t.Parallel()
+
+		server := newTestServer(t, map[string]http.HandlerFunc{
+			"/v1/transit/encrypt/org/test-org-id": func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusInternalServerError)
+				json.NewEncoder(w).Encode(map[string]any{
+					"errors": []string{"internal server error"},
+				})
+			},
+		})
+		defer server.Close()
+
+		client, err := NewClient(Config{
+			Addr:       server.URL,
+			AuthMethod: AuthMethodAppRole,
+			RoleID:     "role-123",
+			SecretID:   "secret-456",
+		})
+		require.NoError(t, err)
+
+		_, err = client.Encrypt(context.Background(), "transit", "org/test-org-id", []byte("data"))
+
+		require.Error(t, err)
+		assert.False(t, errors.Is(err, ErrMountNotFound), "500 must not be ErrMountNotFound, got %v", err)
+	})
+}
+
+func TestClient_Decrypt_MissingMount(t *testing.T) {
+	t.Parallel()
+
+	t.Run("404 no handler for route maps to ErrMountNotFound", func(t *testing.T) {
+		t.Parallel()
+
+		server := newTestServer(t, map[string]http.HandlerFunc{
+			"/v1/transit/missing/decrypt/org/x": func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusNotFound)
+				json.NewEncoder(w).Encode(map[string]any{
+					"errors": []string{`no handler for route "transit/missing/decrypt/org/x". route entry not found.`},
+				})
+			},
+		})
+		defer server.Close()
+
+		client, err := NewClient(Config{
+			Addr:       server.URL,
+			AuthMethod: AuthMethodAppRole,
+			RoleID:     "role-123",
+			SecretID:   "secret-456",
+		})
+		require.NoError(t, err)
+
+		_, err = client.Decrypt(context.Background(), "transit/missing", "org/x", "vault:v1:data")
+
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, ErrMountNotFound), "expected ErrMountNotFound, got %v", err)
+		assert.Contains(t, err.Error(), "transit/missing", "mount path should be included in error")
+	})
+
+	t.Run("404 unsupported path maps to ErrMountNotFound", func(t *testing.T) {
+		t.Parallel()
+
+		server := newTestServer(t, map[string]http.HandlerFunc{
+			"/v1/transit/missing/decrypt/org/x": func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusNotFound)
+				json.NewEncoder(w).Encode(map[string]any{
+					"errors": []string{"unsupported path"},
+				})
+			},
+		})
+		defer server.Close()
+
+		client, err := NewClient(Config{
+			Addr:       server.URL,
+			AuthMethod: AuthMethodAppRole,
+			RoleID:     "role-123",
+			SecretID:   "secret-456",
+		})
+		require.NoError(t, err)
+
+		_, err = client.Decrypt(context.Background(), "transit/missing", "org/x", "vault:v1:data")
+
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, ErrMountNotFound), "expected ErrMountNotFound, got %v", err)
+	})
+
+	t.Run("403 permission denied is not misclassified as ErrMountNotFound", func(t *testing.T) {
+		t.Parallel()
+
+		// Always return 403 so the single re-auth retry also fails with 403.
+		server := newTestServer(t, map[string]http.HandlerFunc{
+			"/v1/transit/decrypt/org/test-org-id": func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusForbidden)
+				json.NewEncoder(w).Encode(map[string]any{
+					"errors": []string{"permission denied"},
+				})
+			},
+		})
+		defer server.Close()
+
+		client, err := NewClient(Config{
+			Addr:       server.URL,
+			AuthMethod: AuthMethodAppRole,
+			RoleID:     "role-123",
+			SecretID:   "secret-456",
+		})
+		require.NoError(t, err)
+
+		_, err = client.Decrypt(context.Background(), "transit", "org/test-org-id", "vault:v1:data")
+
+		require.Error(t, err)
+		assert.False(t, errors.Is(err, ErrMountNotFound), "403 must not be ErrMountNotFound, got %v", err)
 	})
 }
 
@@ -398,7 +675,6 @@ func TestClient_EncryptDecrypt_RoundTrip(t *testing.T) {
 
 		client, err := NewClient(Config{
 			Addr:       server.URL,
-			MountPath:  "transit",
 			AuthMethod: AuthMethodAppRole,
 			RoleID:     "role-123",
 			SecretID:   "secret-456",
@@ -406,13 +682,13 @@ func TestClient_EncryptDecrypt_RoundTrip(t *testing.T) {
 		require.NoError(t, err)
 
 		// Encrypt
-		ciphertext, err := client.Encrypt(context.Background(), "org/test-org-id", originalData)
+		ciphertext, err := client.Encrypt(context.Background(), "transit", "org/test-org-id", originalData)
 		require.NoError(t, err)
 		assert.NotEmpty(t, ciphertext)
 		assert.NotEqual(t, string(originalData), ciphertext)
 
 		// Decrypt
-		decrypted, err := client.Decrypt(context.Background(), "org/test-org-id", ciphertext)
+		decrypted, err := client.Decrypt(context.Background(), "transit", "org/test-org-id", ciphertext)
 		require.NoError(t, err)
 
 		// Verify round-trip

--- a/pkg/crypto/tink/wrapper.go
+++ b/pkg/crypto/tink/wrapper.go
@@ -16,18 +16,15 @@ import (
 // Implementations must handle authentication and connection management internally.
 // Callers should not need to manage KMS credentials after client construction.
 type KMSClient interface {
-	// Encrypt encrypts plaintext using the key identified by keyName.
-	// The keyName format is provider-specific and determined by the caller.
+	// Encrypt encrypts plaintext using the key identified by keyName under the
+	// given mountPath. Both mountPath and keyName are provider-specific and
+	// determined by the caller.
 	// Returns the ciphertext in provider-specific format (e.g., "vault:v1:..." for Vault).
-	Encrypt(ctx context.Context, keyName string, plaintext []byte) (string, error)
+	Encrypt(ctx context.Context, mountPath, keyName string, plaintext []byte) (string, error)
 
-	// Decrypt decrypts ciphertext using the key identified by keyName.
-	// The ciphertext format is provider-specific.
-	Decrypt(ctx context.Context, keyName string, ciphertext string) ([]byte, error)
-
-	// MountPath returns the KMS mount path (e.g., "transit" for Vault Transit).
-	// Used by callers to construct full key paths if needed.
-	MountPath() string
+	// Decrypt decrypts ciphertext using the key identified by keyName under the
+	// given mountPath. The ciphertext format is provider-specific.
+	Decrypt(ctx context.Context, mountPath, keyName string, ciphertext string) ([]byte, error)
 }
 
 // KeysetWrapper handles wrapping and unwrapping of Tink keysets using a KMS.
@@ -47,14 +44,16 @@ func NewKeysetWrapper(kms KMSClient) *KeysetWrapper {
 }
 
 // WrapKeyset encrypts a serialized keyset using the KMS.
-// The keyName format is determined by the caller (e.g., "tenant/org-123", "keys/mykey").
+// The mountPath and keyName are determined by the caller (e.g., mount
+// "transit/tenant-x" with key "tenant/org-123"). They are forwarded verbatim
+// to the KMS; this wrapper performs no mount resolution.
 // Returns the wrapped keyset in provider-specific ciphertext format.
-func (w *KeysetWrapper) WrapKeyset(ctx context.Context, keyName string, keyset []byte) (string, error) {
+func (w *KeysetWrapper) WrapKeyset(ctx context.Context, mountPath, keyName string, keyset []byte) (string, error) {
 	if len(keyset) == 0 {
 		return "", fmt.Errorf("cannot wrap empty keyset")
 	}
 
-	ciphertext, err := w.kms.Encrypt(ctx, keyName, keyset)
+	ciphertext, err := w.kms.Encrypt(ctx, mountPath, keyName, keyset)
 	if err != nil {
 		return "", fmt.Errorf("failed to wrap keyset with KMS: %w", err)
 	}
@@ -63,25 +62,20 @@ func (w *KeysetWrapper) WrapKeyset(ctx context.Context, keyName string, keyset [
 }
 
 // UnwrapKeyset decrypts a wrapped keyset using the KMS.
-// The keyName must match the key used during wrapping.
+// The mountPath and keyName must match those used during wrapping; both are
+// forwarded verbatim to the KMS.
 // Returns the serialized keyset bytes that can be parsed into primitives.
-func (w *KeysetWrapper) UnwrapKeyset(ctx context.Context, keyName string, wrappedKeyset string) ([]byte, error) {
+func (w *KeysetWrapper) UnwrapKeyset(ctx context.Context, mountPath, keyName string, wrappedKeyset string) ([]byte, error) {
 	if wrappedKeyset == "" {
 		return nil, fmt.Errorf("cannot unwrap empty ciphertext")
 	}
 
-	plaintext, err := w.kms.Decrypt(ctx, keyName, wrappedKeyset)
+	plaintext, err := w.kms.Decrypt(ctx, mountPath, keyName, wrappedKeyset)
 	if err != nil {
 		return nil, fmt.Errorf("failed to unwrap keyset with KMS: %w", err)
 	}
 
 	return plaintext, nil
-}
-
-// MountPath returns the KMS mount path from the underlying client.
-// Useful for callers that need to construct full key paths.
-func (w *KeysetWrapper) MountPath() string {
-	return w.kms.MountPath()
 }
 
 // KeysetBundle contains a generated keyset with its wrapped form and metadata.
@@ -120,9 +114,10 @@ func NewKeysetFactory(kms KMSClient) *KeysetFactory {
 }
 
 // GenerateAEADKeyset creates a new AES256-GCM keyset and wraps it with the KMS.
-// The keyName is caller-defined and should follow the caller's naming convention.
+// The mountPath and keyName are caller-defined and should follow the caller's
+// naming convention; both are forwarded verbatim to the wrapper.
 // Returns a bundle containing both the wrapped keyset and raw bytes for immediate use.
-func (f *KeysetFactory) GenerateAEADKeyset(ctx context.Context, keyName string) (KeysetBundle, error) {
+func (f *KeysetFactory) GenerateAEADKeyset(ctx context.Context, mountPath, keyName string) (KeysetBundle, error) {
 	handle, rawKeyset, err := f.aeadGenerator.Generate()
 	if err != nil {
 		return KeysetBundle{}, fmt.Errorf("failed to generate AEAD keyset: %w", err)
@@ -133,7 +128,7 @@ func (f *KeysetFactory) GenerateAEADKeyset(ctx context.Context, keyName string) 
 		return KeysetBundle{}, fmt.Errorf("failed to extract AEAD keyset info: %w", err)
 	}
 
-	wrappedData, err := f.wrapper.WrapKeyset(ctx, keyName, rawKeyset)
+	wrappedData, err := f.wrapper.WrapKeyset(ctx, mountPath, keyName, rawKeyset)
 	if err != nil {
 		return KeysetBundle{}, fmt.Errorf("failed to wrap AEAD keyset: %w", err)
 	}
@@ -145,9 +140,10 @@ func (f *KeysetFactory) GenerateAEADKeyset(ctx context.Context, keyName string) 
 }
 
 // GenerateMACKeyset creates a new HMAC-SHA256 keyset and wraps it with the KMS.
-// The keyName is caller-defined and should follow the caller's naming convention.
+// The mountPath and keyName are caller-defined and should follow the caller's
+// naming convention; both are forwarded verbatim to the wrapper.
 // Returns a bundle containing both the wrapped keyset and raw bytes for immediate use.
-func (f *KeysetFactory) GenerateMACKeyset(ctx context.Context, keyName string) (KeysetBundle, error) {
+func (f *KeysetFactory) GenerateMACKeyset(ctx context.Context, mountPath, keyName string) (KeysetBundle, error) {
 	handle, rawKeyset, err := f.macGenerator.Generate()
 	if err != nil {
 		return KeysetBundle{}, fmt.Errorf("failed to generate MAC keyset: %w", err)
@@ -158,7 +154,7 @@ func (f *KeysetFactory) GenerateMACKeyset(ctx context.Context, keyName string) (
 		return KeysetBundle{}, fmt.Errorf("failed to extract MAC keyset info: %w", err)
 	}
 
-	wrappedData, err := f.wrapper.WrapKeyset(ctx, keyName, rawKeyset)
+	wrappedData, err := f.wrapper.WrapKeyset(ctx, mountPath, keyName, rawKeyset)
 	if err != nil {
 		return KeysetBundle{}, fmt.Errorf("failed to wrap MAC keyset: %w", err)
 	}
@@ -170,9 +166,9 @@ func (f *KeysetFactory) GenerateMACKeyset(ctx context.Context, keyName string) (
 }
 
 // UnwrapAEAD unwraps a keyset and returns an AEAD primitive ready for use.
-// The keyName must match the key used during wrapping.
-func (f *KeysetFactory) UnwrapAEAD(ctx context.Context, keyName string, wrapped WrappedKeyset) (*AEADPrimitive, error) {
-	keysetBytes, err := f.wrapper.UnwrapKeyset(ctx, keyName, wrapped.WrappedData)
+// The mountPath and keyName must match those used during wrapping.
+func (f *KeysetFactory) UnwrapAEAD(ctx context.Context, mountPath, keyName string, wrapped WrappedKeyset) (*AEADPrimitive, error) {
+	keysetBytes, err := f.wrapper.UnwrapKeyset(ctx, mountPath, keyName, wrapped.WrappedData)
 	if err != nil {
 		return nil, fmt.Errorf("failed to unwrap AEAD keyset: %w", err)
 	}
@@ -186,9 +182,9 @@ func (f *KeysetFactory) UnwrapAEAD(ctx context.Context, keyName string, wrapped 
 }
 
 // UnwrapMAC unwraps a keyset and returns a MAC primitive ready for use.
-// The keyName must match the key used during wrapping.
-func (f *KeysetFactory) UnwrapMAC(ctx context.Context, keyName string, wrapped WrappedKeyset) (*MACPrimitive, error) {
-	keysetBytes, err := f.wrapper.UnwrapKeyset(ctx, keyName, wrapped.WrappedData)
+// The mountPath and keyName must match those used during wrapping.
+func (f *KeysetFactory) UnwrapMAC(ctx context.Context, mountPath, keyName string, wrapped WrappedKeyset) (*MACPrimitive, error) {
+	keysetBytes, err := f.wrapper.UnwrapKeyset(ctx, mountPath, keyName, wrapped.WrappedData)
 	if err != nil {
 		return nil, fmt.Errorf("failed to unwrap MAC keyset: %w", err)
 	}

--- a/pkg/crypto/tink/wrapper_test.go
+++ b/pkg/crypto/tink/wrapper_test.go
@@ -15,19 +15,23 @@ import (
 )
 
 // mockKMSClient implements KMSClient for testing.
+// It records the mountPath received on the most recent Encrypt/Decrypt call
+// so tests can assert that the mountPath is forwarded verbatim.
 type mockKMSClient struct {
-	mountPath  string
 	encryptErr error
 	decryptErr error
+
+	gotEncryptMount string
+	gotDecryptMount string
 }
 
 func newMockKMSClient() *mockKMSClient {
-	return &mockKMSClient{
-		mountPath: "transit",
-	}
+	return &mockKMSClient{}
 }
 
-func (m *mockKMSClient) Encrypt(_ context.Context, _ string, plaintext []byte) (string, error) {
+func (m *mockKMSClient) Encrypt(_ context.Context, mountPath, _ string, plaintext []byte) (string, error) {
+	m.gotEncryptMount = mountPath
+
 	if m.encryptErr != nil {
 		return "", m.encryptErr
 	}
@@ -39,7 +43,9 @@ func (m *mockKMSClient) Encrypt(_ context.Context, _ string, plaintext []byte) (
 	return ciphertext, nil
 }
 
-func (m *mockKMSClient) Decrypt(_ context.Context, _ string, ciphertext string) ([]byte, error) {
+func (m *mockKMSClient) Decrypt(_ context.Context, mountPath, _ string, ciphertext string) ([]byte, error) {
+	m.gotDecryptMount = mountPath
+
 	if m.decryptErr != nil {
 		return nil, m.decryptErr
 	}
@@ -58,10 +64,6 @@ func (m *mockKMSClient) Decrypt(_ context.Context, _ string, ciphertext string) 
 	return decoded, nil
 }
 
-func (m *mockKMSClient) MountPath() string {
-	return m.mountPath
-}
-
 func TestKeysetWrapper_WrapKeyset(t *testing.T) {
 	t.Parallel()
 
@@ -73,10 +75,22 @@ func TestKeysetWrapper_WrapKeyset(t *testing.T) {
 
 		keyset := []byte("serialized keyset data")
 
-		wrapped, err := wrapper.WrapKeyset(context.Background(), "my-key", keyset)
+		wrapped, err := wrapper.WrapKeyset(context.Background(), "transit/tenant-x", "my-key", keyset)
 
 		require.NoError(t, err)
 		assert.Contains(t, wrapped, "vault:v1:")
+	})
+
+	t.Run("forwards mountPath verbatim to KMS", func(t *testing.T) {
+		t.Parallel()
+
+		kms := newMockKMSClient()
+		wrapper := NewKeysetWrapper(kms)
+
+		_, err := wrapper.WrapKeyset(context.Background(), "transit/tenant-x", "my-key", []byte("keyset"))
+
+		require.NoError(t, err)
+		assert.Equal(t, "transit/tenant-x", kms.gotEncryptMount)
 	})
 
 	t.Run("fails on empty keyset", func(t *testing.T) {
@@ -85,7 +99,7 @@ func TestKeysetWrapper_WrapKeyset(t *testing.T) {
 		kms := newMockKMSClient()
 		wrapper := NewKeysetWrapper(kms)
 
-		_, err := wrapper.WrapKeyset(context.Background(), "my-key", []byte{})
+		_, err := wrapper.WrapKeyset(context.Background(), "transit/tenant-x", "my-key", []byte{})
 
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "empty keyset")
@@ -98,7 +112,7 @@ func TestKeysetWrapper_WrapKeyset(t *testing.T) {
 		kms.encryptErr = fmt.Errorf("KMS unavailable")
 		wrapper := NewKeysetWrapper(kms)
 
-		_, err := wrapper.WrapKeyset(context.Background(), "my-key", []byte("keyset"))
+		_, err := wrapper.WrapKeyset(context.Background(), "transit/tenant-x", "my-key", []byte("keyset"))
 
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "KMS")
@@ -117,14 +131,26 @@ func TestKeysetWrapper_UnwrapKeyset(t *testing.T) {
 		originalKeyset := []byte("original keyset data")
 
 		// Wrap first
-		wrapped, err := wrapper.WrapKeyset(context.Background(), "my-key", originalKeyset)
+		wrapped, err := wrapper.WrapKeyset(context.Background(), "transit/tenant-x", "my-key", originalKeyset)
 		require.NoError(t, err)
 
 		// Unwrap
-		unwrapped, err := wrapper.UnwrapKeyset(context.Background(), "my-key", wrapped)
+		unwrapped, err := wrapper.UnwrapKeyset(context.Background(), "transit/tenant-x", "my-key", wrapped)
 
 		require.NoError(t, err)
 		assert.Equal(t, originalKeyset, unwrapped)
+	})
+
+	t.Run("forwards mountPath verbatim to KMS", func(t *testing.T) {
+		t.Parallel()
+
+		kms := newMockKMSClient()
+		wrapper := NewKeysetWrapper(kms)
+
+		_, err := wrapper.UnwrapKeyset(context.Background(), "transit/tenant-x", "my-key", "vault:v1:c29tZWRhdGE=")
+
+		require.NoError(t, err)
+		assert.Equal(t, "transit/tenant-x", kms.gotDecryptMount)
 	})
 
 	t.Run("fails on empty ciphertext", func(t *testing.T) {
@@ -133,7 +159,7 @@ func TestKeysetWrapper_UnwrapKeyset(t *testing.T) {
 		kms := newMockKMSClient()
 		wrapper := NewKeysetWrapper(kms)
 
-		_, err := wrapper.UnwrapKeyset(context.Background(), "my-key", "")
+		_, err := wrapper.UnwrapKeyset(context.Background(), "transit/tenant-x", "my-key", "")
 
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "empty ciphertext")
@@ -146,23 +172,11 @@ func TestKeysetWrapper_UnwrapKeyset(t *testing.T) {
 		kms.decryptErr = fmt.Errorf("permission denied")
 		wrapper := NewKeysetWrapper(kms)
 
-		_, err := wrapper.UnwrapKeyset(context.Background(), "my-key", "vault:v1:somedata")
+		_, err := wrapper.UnwrapKeyset(context.Background(), "transit/tenant-x", "my-key", "vault:v1:somedata")
 
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "KMS")
 	})
-}
-
-func TestKeysetWrapper_MountPath(t *testing.T) {
-	t.Parallel()
-
-	kms := newMockKMSClient()
-	kms.mountPath = "crm-transit"
-	wrapper := NewKeysetWrapper(kms)
-
-	path := wrapper.MountPath()
-
-	assert.Equal(t, "crm-transit", path)
 }
 
 func TestKeysetFactory_GenerateAEADKeyset(t *testing.T) {
@@ -174,7 +188,7 @@ func TestKeysetFactory_GenerateAEADKeyset(t *testing.T) {
 		kms := newMockKMSClient()
 		factory := NewKeysetFactory(kms)
 
-		bundle, err := factory.GenerateAEADKeyset(context.Background(), "test-key")
+		bundle, err := factory.GenerateAEADKeyset(context.Background(), "transit/tenant-x", "test-key")
 
 		require.NoError(t, err)
 		assert.NotEmpty(t, bundle.Wrapped.WrappedData)
@@ -183,6 +197,7 @@ func TestKeysetFactory_GenerateAEADKeyset(t *testing.T) {
 		assert.Len(t, bundle.Wrapped.Info.Keys, 1)
 		assert.Equal(t, KeyTypeAES256GCM, bundle.Wrapped.Info.Keys[0].Type)
 		assert.False(t, bundle.Wrapped.LegacyKeyImported)
+		assert.Equal(t, "transit/tenant-x", kms.gotEncryptMount)
 	})
 
 	t.Run("fails on KMS encryption error", func(t *testing.T) {
@@ -192,7 +207,7 @@ func TestKeysetFactory_GenerateAEADKeyset(t *testing.T) {
 		kms.encryptErr = fmt.Errorf("KMS unavailable")
 		factory := NewKeysetFactory(kms)
 
-		_, err := factory.GenerateAEADKeyset(context.Background(), "test-key")
+		_, err := factory.GenerateAEADKeyset(context.Background(), "transit/tenant-x", "test-key")
 
 		require.Error(t, err)
 	})
@@ -207,7 +222,7 @@ func TestKeysetFactory_GenerateMACKeyset(t *testing.T) {
 		kms := newMockKMSClient()
 		factory := NewKeysetFactory(kms)
 
-		bundle, err := factory.GenerateMACKeyset(context.Background(), "test-key")
+		bundle, err := factory.GenerateMACKeyset(context.Background(), "transit/tenant-x", "test-key")
 
 		require.NoError(t, err)
 		assert.NotEmpty(t, bundle.Wrapped.WrappedData)
@@ -216,6 +231,7 @@ func TestKeysetFactory_GenerateMACKeyset(t *testing.T) {
 		assert.Len(t, bundle.Wrapped.Info.Keys, 1)
 		assert.Equal(t, KeyTypeHMACSHA256, bundle.Wrapped.Info.Keys[0].Type)
 		assert.False(t, bundle.Wrapped.LegacyKeyImported)
+		assert.Equal(t, "transit/tenant-x", kms.gotEncryptMount)
 	})
 
 	t.Run("fails on KMS encryption error", func(t *testing.T) {
@@ -225,7 +241,7 @@ func TestKeysetFactory_GenerateMACKeyset(t *testing.T) {
 		kms.encryptErr = fmt.Errorf("KMS unavailable")
 		factory := NewKeysetFactory(kms)
 
-		_, err := factory.GenerateMACKeyset(context.Background(), "test-key")
+		_, err := factory.GenerateMACKeyset(context.Background(), "transit/tenant-x", "test-key")
 
 		require.Error(t, err)
 	})
@@ -241,12 +257,13 @@ func TestKeysetFactory_UnwrapAEAD(t *testing.T) {
 		factory := NewKeysetFactory(kms)
 
 		// Generate keyset first
-		bundle, err := factory.GenerateAEADKeyset(context.Background(), "test-key")
+		bundle, err := factory.GenerateAEADKeyset(context.Background(), "transit/tenant-x", "test-key")
 		require.NoError(t, err)
 
 		// Unwrap AEAD keyset
-		primitive, err := factory.UnwrapAEAD(context.Background(), "test-key", bundle.Wrapped)
+		primitive, err := factory.UnwrapAEAD(context.Background(), "transit/tenant-x", "test-key", bundle.Wrapped)
 		require.NoError(t, err)
+		assert.Equal(t, "transit/tenant-x", kms.gotDecryptMount)
 
 		// Test that primitive works
 		plaintext := []byte("test encryption")
@@ -270,7 +287,7 @@ func TestKeysetFactory_UnwrapAEAD(t *testing.T) {
 
 		kms.decryptErr = fmt.Errorf("permission denied")
 
-		_, err := factory.UnwrapAEAD(context.Background(), "test-key", wrapped)
+		_, err := factory.UnwrapAEAD(context.Background(), "transit/tenant-x", "test-key", wrapped)
 
 		require.Error(t, err)
 	})
@@ -286,12 +303,13 @@ func TestKeysetFactory_UnwrapMAC(t *testing.T) {
 		factory := NewKeysetFactory(kms)
 
 		// Generate keyset first
-		bundle, err := factory.GenerateMACKeyset(context.Background(), "test-key")
+		bundle, err := factory.GenerateMACKeyset(context.Background(), "transit/tenant-x", "test-key")
 		require.NoError(t, err)
 
 		// Unwrap MAC keyset
-		primitive, err := factory.UnwrapMAC(context.Background(), "test-key", bundle.Wrapped)
+		primitive, err := factory.UnwrapMAC(context.Background(), "transit/tenant-x", "test-key", bundle.Wrapped)
 		require.NoError(t, err)
+		assert.Equal(t, "transit/tenant-x", kms.gotDecryptMount)
 
 		// Test that primitive works
 		data := []byte("data to mac")
@@ -314,7 +332,7 @@ func TestKeysetFactory_UnwrapMAC(t *testing.T) {
 
 		kms.decryptErr = fmt.Errorf("permission denied")
 
-		_, err := factory.UnwrapMAC(context.Background(), "test-key", wrapped)
+		_, err := factory.UnwrapMAC(context.Background(), "transit/tenant-x", "test-key", wrapped)
 
 		require.Error(t, err)
 	})
@@ -329,7 +347,6 @@ func TestKeysetFactory_Wrapper(t *testing.T) {
 	wrapper := factory.Wrapper()
 
 	assert.NotNil(t, wrapper)
-	assert.Equal(t, "transit", wrapper.MountPath())
 }
 
 func TestKeysetFactory_EndToEnd(t *testing.T) {
@@ -341,13 +358,14 @@ func TestKeysetFactory_EndToEnd(t *testing.T) {
 		kms := newMockKMSClient()
 		factory := NewKeysetFactory(kms)
 
-		// Generate AEAD keyset with caller-defined key name
+		// Generate AEAD keyset with caller-defined mount and key name
+		mountPath := "transit/tenant-abc"
 		keyName := "tenant/abc/entity/123"
-		bundle, err := factory.GenerateAEADKeyset(context.Background(), keyName)
+		bundle, err := factory.GenerateAEADKeyset(context.Background(), mountPath, keyName)
 		require.NoError(t, err)
 
 		// Unwrap and use for encryption
-		aeadPrimitive, err := factory.UnwrapAEAD(context.Background(), keyName, bundle.Wrapped)
+		aeadPrimitive, err := factory.UnwrapAEAD(context.Background(), mountPath, keyName, bundle.Wrapped)
 		require.NoError(t, err)
 
 		// Encrypt sensitive data
@@ -360,7 +378,7 @@ func TestKeysetFactory_EndToEnd(t *testing.T) {
 		// Simulate storage and retrieval...
 
 		// Unwrap AEAD again (simulating different request)
-		aeadPrimitive2, err := factory.UnwrapAEAD(context.Background(), keyName, bundle.Wrapped)
+		aeadPrimitive2, err := factory.UnwrapAEAD(context.Background(), mountPath, keyName, bundle.Wrapped)
 		require.NoError(t, err)
 
 		// Decrypt
@@ -376,12 +394,13 @@ func TestKeysetFactory_EndToEnd(t *testing.T) {
 		factory := NewKeysetFactory(kms)
 
 		// Generate MAC keyset
+		mountPath := "transit/tenant-abc"
 		keyName := "tenant/abc/entity/123"
-		bundle, err := factory.GenerateMACKeyset(context.Background(), keyName)
+		bundle, err := factory.GenerateMACKeyset(context.Background(), mountPath, keyName)
 		require.NoError(t, err)
 
 		// Unwrap MAC for search tokens
-		macPrimitive, err := factory.UnwrapMAC(context.Background(), keyName, bundle.Wrapped)
+		macPrimitive, err := factory.UnwrapMAC(context.Background(), mountPath, keyName, bundle.Wrapped)
 		require.NoError(t, err)
 
 		// Generate search token for email

--- a/pkg/errors.go
+++ b/pkg/errors.go
@@ -1436,6 +1436,13 @@ func ValidateBusinessError(err error, entityType string, args ...any) error {
 			Message:    "Your request is missing one or more required fields. Please refer to the documentation to ensure all necessary fields are included in your request.",
 			Err:        constant.ErrAuditEventRequired,
 		},
+		constant.ErrReservedTenantID: UnprocessableOperationError{
+			EntityType: entityType,
+			Code:       constant.ErrReservedTenantID.Error(),
+			Title:      "Reserved Tenant ID",
+			Message:    "The tenant id \"default\" is reserved for internal single-tenant use and cannot be used as a tenant identifier. Please use a different tenant id and try again.",
+			Err:        constant.ErrReservedTenantID,
+		},
 	}
 
 	if mappedError, found := errorMap[err]; found {

--- a/pkg/mmodel/organization_keyset.go
+++ b/pkg/mmodel/organization_keyset.go
@@ -22,9 +22,12 @@ var (
 // OrganizationKeyset stores wrapped keyset metadata for an organization.
 // Wrapped keysets are encrypted by a KEK in the KMS provider.
 type OrganizationKeyset struct {
-	TenantID          string
-	OrganizationID    string
-	KEKPath           string
+	TenantID       string
+	OrganizationID string
+	KEKPath        string
+	// KEKMountPath is the resolved Vault Transit mount the wrapped keysets were created
+	// under (e.g. "transit" or "transit/{tenant}"); persisted so unwrap ignores live config.
+	KEKMountPath      string
 	WrappedKeyset     string
 	KeysetInfo        KeysetInfo
 	WrappedHMACKeyset string
@@ -58,6 +61,12 @@ func (k *OrganizationKeyset) Validate() error {
 		return fmt.Errorf("kek_path is required")
 	}
 
+	// Required on write (Save/Update call Validate); the read/unwrap path tolerates
+	// legacy records lacking it via fallback. A legacy record must backfill this before re-save.
+	if k.KEKMountPath == "" {
+		return fmt.Errorf("kek_mount_path is required")
+	}
+
 	if k.WrappedKeyset == "" {
 		return fmt.Errorf("wrapped_keyset is required")
 	}
@@ -80,6 +89,7 @@ func (k *OrganizationKeyset) SafeView() OrganizationKeyset {
 		TenantID:          k.TenantID,
 		OrganizationID:    k.OrganizationID,
 		KEKPath:           k.KEKPath,
+		KEKMountPath:      k.KEKMountPath,
 		WrappedKeyset:     "[REDACTED]",
 		KeysetInfo:        k.KeysetInfo,
 		WrappedHMACKeyset: "[REDACTED]",

--- a/pkg/mmodel/organization_keyset_test.go
+++ b/pkg/mmodel/organization_keyset_test.go
@@ -25,10 +25,22 @@ func TestOrganizationKeyset_Validate(t *testing.T) {
 			keyset: OrganizationKeyset{
 				OrganizationID: "org-a",
 				KEKPath:        "transit/keys/test",
+				KEKMountPath:   "transit",
 				WrappedKeyset:  "vault:v1:encrypted",
 				KeysetInfo:     KeysetInfo{PrimaryKeyID: 1},
 			},
 			wantErrMsg: "",
+		},
+		{
+			name: "empty kek_mount_path",
+			keyset: OrganizationKeyset{
+				OrganizationID: "org-a",
+				KEKPath:        "transit/keys/test",
+				KEKMountPath:   "",
+				WrappedKeyset:  "vault:v1:encrypted",
+				KeysetInfo:     KeysetInfo{PrimaryKeyID: 1},
+			},
+			wantErrMsg: "kek_mount_path is required",
 		},
 		{
 			name: "empty organization_id",
@@ -55,6 +67,7 @@ func TestOrganizationKeyset_Validate(t *testing.T) {
 			keyset: OrganizationKeyset{
 				OrganizationID: "org-a",
 				KEKPath:        "transit/keys/test",
+				KEKMountPath:   "transit",
 				WrappedKeyset:  "",
 				KeysetInfo:     KeysetInfo{PrimaryKeyID: 1},
 			},
@@ -65,6 +78,7 @@ func TestOrganizationKeyset_Validate(t *testing.T) {
 			keyset: OrganizationKeyset{
 				OrganizationID: "org-a",
 				KEKPath:        "transit/keys/test",
+				KEKMountPath:   "transit",
 				WrappedKeyset:  "vault:v1:encrypted",
 				KeysetInfo:     KeysetInfo{PrimaryKeyID: 0},
 			},
@@ -75,6 +89,7 @@ func TestOrganizationKeyset_Validate(t *testing.T) {
 			keyset: OrganizationKeyset{
 				OrganizationID:    "org-a",
 				KEKPath:           "transit/keys/test",
+				KEKMountPath:      "transit",
 				WrappedKeyset:     "vault:v1:encrypted",
 				KeysetInfo:        KeysetInfo{PrimaryKeyID: 1},
 				WrappedHMACKeyset: "vault:v1:hmac-encrypted",
@@ -87,6 +102,7 @@ func TestOrganizationKeyset_Validate(t *testing.T) {
 			keyset: OrganizationKeyset{
 				OrganizationID:    "org-a",
 				KEKPath:           "transit/keys/test",
+				KEKMountPath:      "transit",
 				WrappedKeyset:     "vault:v1:encrypted",
 				KeysetInfo:        KeysetInfo{PrimaryKeyID: 1},
 				WrappedHMACKeyset: "vault:v1:hmac-encrypted",
@@ -120,6 +136,7 @@ func TestOrganizationKeyset_SafeView(t *testing.T) {
 		TenantID:          "tenant-a",
 		OrganizationID:    "org-a",
 		KEKPath:           "transit/keys/test",
+		KEKMountPath:      "transit",
 		WrappedKeyset:     "vault:v1:secret-dek-material",
 		WrappedHMACKeyset: "vault:v1:secret-hmac-material",
 		KeysetInfo:        KeysetInfo{PrimaryKeyID: 1},
@@ -138,6 +155,7 @@ func TestOrganizationKeyset_SafeView(t *testing.T) {
 	assert.Equal(t, keyset.TenantID, safe.TenantID)
 	assert.Equal(t, keyset.OrganizationID, safe.OrganizationID)
 	assert.Equal(t, keyset.KEKPath, safe.KEKPath)
+	assert.Equal(t, keyset.KEKMountPath, safe.KEKMountPath, "non-secret mount path must remain visible in SafeView")
 	assert.Equal(t, keyset.KeysetInfo, safe.KeysetInfo)
 	assert.Equal(t, keyset.HMACKeysetInfo, safe.HMACKeysetInfo)
 	assert.Equal(t, keyset.Revision, safe.Revision)

--- a/tests/utils/vault/vault.go
+++ b/tests/utils/vault/vault.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/LerianStudio/midaz/v3/pkg/crypto/kms/vault"
+	vaultapi "github.com/hashicorp/vault/api"
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/wait"
 )
@@ -80,13 +81,12 @@ func SetupContainer(t *testing.T) *ContainerResult {
 }
 
 // CreateClient creates a Vault client connected to the test container.
-func CreateClient(t *testing.T, container *ContainerResult, mountPath string) *vault.Client {
+func CreateClient(t *testing.T, container *ContainerResult) *vault.Client {
 	t.Helper()
 
 	cfg := vault.Config{
 		Addr:       container.Address,
 		Token:      container.Token,
-		MountPath:  mountPath,
 		AuthMethod: vault.AuthMethodToken,
 	}
 
@@ -106,32 +106,26 @@ func CreateClient(t *testing.T, container *ContainerResult, mountPath string) *v
 	return client
 }
 
-// EnableTransitEngine enables the Transit secrets engine at the specified path.
-func EnableTransitEngine(t *testing.T, container *ContainerResult, mountPath string) {
+// EnableTransitMount enables a Transit secrets engine at mountPath in the test
+// container's Vault. Callers enable a single path per call (e.g. "transit" or
+// "transit/<tenantUUID>"); mounting the same path twice is an error in Vault.
+// It builds its own raw api.Client from the container address and root token so
+// it does not depend on the vault.Client unexported internals. No cleanup is
+// registered: the container teardown from SetupContainer disposes the Vault.
+func EnableTransitMount(t *testing.T, container *ContainerResult, mountPath string) {
 	t.Helper()
+
+	client, err := vaultapi.NewClient(&vaultapi.Config{Address: container.Address})
+	if err != nil {
+		t.Fatalf("failed to create vault api client: %v", err)
+	}
+
+	client.SetToken(container.Token)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	// Create a temporary client to enable the engine
-	cfg := vault.Config{
-		Addr:       container.Address,
-		Token:      container.Token,
-		MountPath:  mountPath,
-		AuthMethod: vault.AuthMethodToken,
+	if err := client.Sys().MountWithContext(ctx, mountPath, &vaultapi.MountInput{Type: "transit"}); err != nil {
+		t.Fatalf("failed to enable transit mount at %q: %v", mountPath, err)
 	}
-
-	client, err := vault.NewClient(cfg)
-	if err != nil {
-		t.Fatalf("failed to create vault client for transit setup: %v", err)
-	}
-
-	if err := client.Login(ctx); err != nil {
-		t.Fatalf("failed to login for transit setup: %v", err)
-	}
-
-	// Note: In dev mode, Transit is not enabled by default.
-	// For full integration tests, you would need to enable it via the API.
-	// This is left as a placeholder for future enhancement.
-	_ = ctx
 }


### PR DESCRIPTION
## Summary

Makes the CRM Vault Transit **mount path** tenant-scoped (`{base}/{tenantID}`), resolved at runtime, so each tenant's KEKs live in a separate Transit engine. The mount stops being a single static string on the shared `vault.Client` and becomes an **explicit per-call parameter** threaded service → tink → vault via a pure `resolveMount(base, tenantID)` helper (`""`/`"default"` → flat base, single-tenant unchanged). A missing per-tenant mount **fails closed** with typed `ErrMountNotFound` (never falls back to base). On top of that, a review round added three correctness/security hardenings: the reserved `"default"` tenant id is rejected on **every** provisioning ingress (closing a latent cross-tenant KEK-isolation gap), and the resolved mount is **persisted on the keyset** so unwrap is independent of live config.

## Motivation

Per-tenant KEK isolation: each tenant's key-encryption keys should live in a dedicated Vault Transit engine, which the prior single static `MountPath` could not express. Mounts are created **out-of-band** (Terraform/operator); CRM never mounts engines and must fail closed when a tenant's mount is absent rather than silently using the wrong/shared KEK.

The review round addressed two findings that matter once this is deployed:
- **Cross-tenant KEK isolation gap (security):** the reserved-`"default"` guard initially covered only the HTTP provision endpoint; the lazy auto-provisioning path (first encrypted-field access) was a second, unguarded ingress through which a multi-tenant tenant literally named `"default"` would provision under the shared flat-base mount.
- **Config-change footgun (operational):** re-deriving the mount from live `KMS_VAULT_MOUNT_PATH` on read meant changing that env var after provisioning would strand existing keysets (fail-closed, unrecoverable). The mount is now persisted per keyset.

**Production impact:** this encryption flow is **not yet used in production**, so there is no impact on a running system today. The fixes are pre-deployment hardening; the schema addition is free now (no data to migrate) and would be costly post-launch.

## Semantic Decision

- **Type:** `refactor` + a security/correctness hardening. Conventional-commit scope `crm` / `pkg/crypto`.
- **Breaking changes are internal-only:** `vault.Config.MountPath`, `vault.Client.MountPath()`, `tink.KMSClient.MountPath()` removed; `Encrypt`/`Decrypt`/`Wrap`/`Unwrap`/`Generate*` gained a per-call `mountPath`. These are unexported/internal `pkg/crypto` contracts, all call sites updated.
- **Backward-compatible config:** `KMS_VAULT_MOUNT_PATH` is now **optional** with a safe default (`transit`), where it was required.
- **New persisted field `kek_mount_path`** on the keyset (decision A1). This **reopened the original plan's locked "no new schema field" decision** — justified: pre-production, no existing data to migrate; recorded in the plan's `## Deviations`. `bson:"...,omitempty"` + a read-path empty-fallback keep it backward-compatible for any record written before the field existed.
- **New typed error `ENC-0013` (`ErrReservedTenantID`)** → HTTP 422 (`UnprocessableOperationError`), a post-auth business-validation rejection.
- **Operational constraint (documented in `.env.example`):** Vault mount paths are hierarchical, so a flat base engine (`transit`) and per-tenant sub-mounts (`transit/{tenant}`) are mutually exclusive under one base — a deployment is *either* flat single-tenant *or* multi-tenant.

## Changes

### New Files
| File | Purpose |
|------|---------|
| `components/crm/internal/services/encryption/mount.go` | Pure `resolveMount(base, tenantID)` — flat base for `""`/`"default"`, `base/{tenantID}` otherwise; trims surrounding slashes (base) and the tenant segment. |
| `components/crm/internal/services/encryption/mount_test.go` | `resolveMount` branch + edge-case tests (slashed/padded tenant, interior slash). |
| `pkg/crypto/kms/vault/errors.go` | Typed `ErrMountNotFound` sentinel for fail-closed missing-mount detection. |
| `pkg/crypto/kms/vault/errors_test.go` | Sentinel identity test. |

### Environment Variables — Tenant-Scoped KEK Mount
| Variable | Type | Default | Description |
|----------|------|---------|-------------|
| `KMS_VAULT_MOUNT_PATH` | string | `transit` | **BASE** Transit mount (no longer required). Per-tenant mounts derived as `{base}/{tenantID}`, provisioned out-of-band. Empty/whitespace/slash-only → `transit`. Single-tenant (`""`/`"default"`) uses the flat base. |

(No new env var was added by the review round.)

### Refactored Code
| Before | After |
|--------|-------|
| `vault.Config.MountPath` field + required validation; `Client.MountPath()` | Removed; mount no longer stored on client/config |
| `Client.Encrypt(ctx, keyName, …)` / `Decrypt(...)` | `Encrypt(ctx, mountPath, keyName, …)` / `Decrypt(ctx, mountPath, keyName, …)` |
| Raw Vault 404 surfaced generically | Mapped to typed `ErrMountNotFound` via shared `mapMountErr` (Encrypt/Decrypt incl. post-reauth retry); fail-closed, no base fallback |
| `tink.KMSClient.MountPath()`; wrapper/factory carried `keyName` only | `MountPath()` removed; `mountPath` threaded pass-through through `KMSClient`, `KeysetWrapper`, `KeysetFactory` |
| `ProvisioningConfig.KEKMountPath` dead | Live **base** mount; wrap = `resolveMount(base, req.TenantID)` |
| `KeysetManager` had no base mount | New `KeysetManagerConfig.BaseMountPath`; unwrap prefers stored `keyset.KEKMountPath`, falls back to `resolveMount(base, keyset.TenantID)` only when empty |
| Reserved-`"default"` rejected only at the HTTP provision handler | Shared `ResolveProvisionTenantID(ctx)` rejects a non-empty `"default"` at **both** ingresses (handler + lazy `autoProvision`); single-tenant empty-ctx sentinel preserved |
| `resolveBaseMountPath` returned an un-normalized base (logged ≠ effective mount) | Returns the slash+whitespace-normalized base (shared cutset); logged/injected base == effective mount |
| 3 near-identical `wireEncryptionServices` base-mount tests | One table-test |
| `tests/utils/vault.CreateClient(t, container, mountPath)`; `EnableTransitEngine` stub | `CreateClient(t, container)`; new `EnableTransitMount(t, container, mountPath)` |

### Error Codes
| Code | Sentinel | HTTP | Meaning |
|------|----------|------|---------|
| `ENC-0013` | `constant.ErrReservedTenantID` | 422 | An externally-supplied tenant id equals the reserved single-tenant sentinel `"default"`. |

### Persisted Schema (MongoDB `organization_keyset`)
| Field | bson | Purpose |
|-------|------|---------|
| `KEKMountPath` | `kek_mount_path,omitempty` | The resolved Vault mount the keyset was wrapped under; read at unwrap so decryption is independent of live `KMS_VAULT_MOUNT_PATH`. Required on write; read path tolerates legacy empties via fallback. |

### OpenTelemetry (spans / attributes)
No new metrics. Two operation spans carry a non-secret resolved-mount attribute:
| Span | Attribute | Description |
|------|-----------|-------------|
| `service.protection.provision` | `app.protection.mount_path` | Resolved Vault mount at wrap time |
| `service.protection.keyset_manager.unwrap` | `app.protection.mount_path` | Resolved Vault mount at unwrap time (from stored `KEKMountPath`) |

## Test Plan

- [x] Unit tests across changed packages; production-code coverage ≥ 85% (`resolveMount` all branches incl. slashed/`default`; `resolveBaseMountPath` normalization; fail-closed `ErrMountNotFound`; tink/vault pass-through; reserved-`"default"` rejected at HTTP handler **and** lazy `autoProvision`; single-tenant sentinel preserved; stored-`KEKMountPath` wins over derived; config-base-changed-still-unwraps regression; legacy empty-mount fallback).
- [x] Integration tests (testcontainers `hashicorp/vault:1.15` + MongoDB, `//go:build integration`): flat + per-tenant `provision → unwrap → AEAD` round-trips; missing-mount fail-closed; live Vault 404 wording confirmed.
- [x] `golangci-lint` v2 + `go vet` clean on changed files (default + `integration` tags); only the pre-existing, out-of-scope `components/crm/internal/bootstrap/config.go:90` gocyclo remains.
- [x] `go build ./...` and `go build -tags integration ./...` clean; `go test -race` green (unit + integration) — no data race / deadlock / goroutine leak / mutex misuse.
- [x] Manual Docker testing (rebuilt image, real stack): **envelope** mode (org provisioned, fields stored with `tink:v{keyID}:` marker keyed to the provisioned AEAD key, decrypt round-trips) and **legacy** mode (`KMS_VENDOR=none`, unmarked ciphertext, decrypt round-trips); single-tenant resolves to flat `transit`.
- [x] Gate-8 multi-reviewer pass (security/tenancy/logic/code-quality/nil/test/dead-code/perf/commons/obs): the lazy-autoProvision isolation gap was caught and fixed, then confirmed RESOLVED on re-review.
