### PR TITLE
fix: authorize all ledger routes under the midaz service :bug:

### DIFF
--- a/components/ledger/.env.example
+++ b/components/ledger/.env.example
@@ -7,7 +7,7 @@
 # DEFAULT local
 ENV_NAME=development
 
-VERSION=v3.7.6
+VERSION=v3.7.7
 
 # DEPLOYMENT MODE (controls TLS enforcement)
 # Valid values:

--- a/components/ledger/internal/adapters/http/in/routes.go
+++ b/components/ledger/internal/adapters/http/in/routes.go
@@ -21,10 +21,7 @@ import (
 	fiberSwagger "github.com/swaggo/fiber-swagger"
 )
 
-const (
-	midazName   = "midaz"
-	routingName = "routing"
-)
+const midazName = "midaz"
 
 // SettingsMaxPayloadSize defines the maximum payload size for settings endpoints (64KB).
 const SettingsMaxPayloadSize = 64 * 1024
@@ -67,23 +64,20 @@ func NewRouter(lg libLog.Logger, tl *libOpentelemetry.Telemetry, auth *middlewar
 func RegisterMetadataRoutesToApp(f fiber.Router, auth *middleware.AuthClient, mdi *MetadataIndexHandler, routeOptions *http.ProtectedRouteOptions) {
 	// Metadata Indexes
 	f.Post("/v1/settings/metadata-indexes/entities/:entity_name",
-		http.ProtectedRouteChain(
-			auth.Authorize(midazName, "settings", "post"),
-			routeOptions,
+		protectedMidaz(
+			auth, "settings", "post", routeOptions,
 			http.WithBody(new(mmodel.CreateMetadataIndexInput), mdi.CreateMetadataIndex),
 		)...)
 
 	f.Get("/v1/settings/metadata-indexes",
-		http.ProtectedRouteChain(
-			auth.Authorize(midazName, "settings", "get"),
-			routeOptions,
+		protectedMidaz(
+			auth, "settings", "get", routeOptions,
 			mdi.GetAllMetadataIndexes,
 		)...)
 
 	f.Delete("/v1/settings/metadata-indexes/entities/:entity_name/key/:index_key",
-		http.ProtectedRouteChain(
-			auth.Authorize(midazName, "settings", "delete"),
-			routeOptions,
+		protectedMidaz(
+			auth, "settings", "delete", routeOptions,
 			mdi.DeleteMetadataIndex,
 		)...)
 }
@@ -153,11 +147,11 @@ func RegisterOnboardingRoutesToApp(f fiber.Router, auth *middleware.AuthClient, 
 	f.Head("/v1/organizations/:organization_id/ledgers/:ledger_id/accounts/metrics/count", protectedMidaz(auth, "accounts", "head", routeOptions, http.ParseUUIDPathParameters("account"), ah.CountAccounts)...)
 
 	// Account Types
-	f.Post("/v1/organizations/:organization_id/ledgers/:ledger_id/account-types", protectedRouting(auth, "account-types", "post", routeOptions, http.ParseUUIDPathParameters("account_type"), http.WithBody(new(mmodel.CreateAccountTypeInput), ath.CreateAccountType))...)
-	f.Patch("/v1/organizations/:organization_id/ledgers/:ledger_id/account-types/:id", protectedRouting(auth, "account-types", "patch", routeOptions, http.ParseUUIDPathParameters("account_type"), http.WithBody(new(mmodel.UpdateAccountTypeInput), ath.UpdateAccountType))...)
-	f.Get("/v1/organizations/:organization_id/ledgers/:ledger_id/account-types/:id", protectedRouting(auth, "account-types", "get", routeOptions, http.ParseUUIDPathParameters("account_type"), ath.GetAccountTypeByID)...)
-	f.Get("/v1/organizations/:organization_id/ledgers/:ledger_id/account-types", protectedRouting(auth, "account-types", "get", routeOptions, http.ParseUUIDPathParameters("account_type"), ath.GetAllAccountTypes)...)
-	f.Delete("/v1/organizations/:organization_id/ledgers/:ledger_id/account-types/:id", protectedRouting(auth, "account-types", "delete", routeOptions, http.ParseUUIDPathParameters("account_type"), ath.DeleteAccountTypeByID)...)
+	f.Post("/v1/organizations/:organization_id/ledgers/:ledger_id/account-types", protectedMidaz(auth, "account-types", "post", routeOptions, http.ParseUUIDPathParameters("account_type"), http.WithBody(new(mmodel.CreateAccountTypeInput), ath.CreateAccountType))...)
+	f.Patch("/v1/organizations/:organization_id/ledgers/:ledger_id/account-types/:id", protectedMidaz(auth, "account-types", "patch", routeOptions, http.ParseUUIDPathParameters("account_type"), http.WithBody(new(mmodel.UpdateAccountTypeInput), ath.UpdateAccountType))...)
+	f.Get("/v1/organizations/:organization_id/ledgers/:ledger_id/account-types/:id", protectedMidaz(auth, "account-types", "get", routeOptions, http.ParseUUIDPathParameters("account_type"), ath.GetAccountTypeByID)...)
+	f.Get("/v1/organizations/:organization_id/ledgers/:ledger_id/account-types", protectedMidaz(auth, "account-types", "get", routeOptions, http.ParseUUIDPathParameters("account_type"), ath.GetAllAccountTypes)...)
+	f.Delete("/v1/organizations/:organization_id/ledgers/:ledger_id/account-types/:id", protectedMidaz(auth, "account-types", "delete", routeOptions, http.ParseUUIDPathParameters("account_type"), ath.DeleteAccountTypeByID)...)
 }
 
 // RegisterTransactionRoutesToApp registers transaction routes to an existing Fiber app.
@@ -205,24 +199,20 @@ func RegisterTransactionRoutesToApp(f fiber.Router, auth *middleware.AuthClient,
 	f.Post("/v1/organizations/:organization_id/ledgers/:ledger_id/accounts/:account_id/balances", protectedMidaz(auth, "balances", "post", routeOptions, http.ParseUUIDPathParameters("balance"), http.WithBody(new(mmodel.CreateAdditionalBalance), bh.CreateAdditionalBalance))...)
 
 	// Operation-route
-	f.Post("/v1/organizations/:organization_id/ledgers/:ledger_id/operation-routes", protectedRouting(auth, "operation-routes", "post", routeOptions, http.ParseUUIDPathParameters("operation_route"), http.WithBody(new(mmodel.CreateOperationRouteInput), orh.CreateOperationRoute))...)
-	f.Get("/v1/organizations/:organization_id/ledgers/:ledger_id/operation-routes/:operation_route_id", protectedRouting(auth, "operation-routes", "get", routeOptions, http.ParseUUIDPathParameters("operation_route"), orh.GetOperationRouteByID)...)
-	f.Patch("/v1/organizations/:organization_id/ledgers/:ledger_id/operation-routes/:operation_route_id", protectedRouting(auth, "operation-routes", "patch", routeOptions, http.ParseUUIDPathParameters("operation_route"), http.WithBody(new(mmodel.UpdateOperationRouteInput), orh.UpdateOperationRoute))...)
-	f.Delete("/v1/organizations/:organization_id/ledgers/:ledger_id/operation-routes/:operation_route_id", protectedRouting(auth, "operation-routes", "delete", routeOptions, http.ParseUUIDPathParameters("operation_route"), orh.DeleteOperationRouteByID)...)
-	f.Get("/v1/organizations/:organization_id/ledgers/:ledger_id/operation-routes", protectedRouting(auth, "operation-routes", "get", routeOptions, http.ParseUUIDPathParameters("operation_route"), orh.GetAllOperationRoutes)...)
+	f.Post("/v1/organizations/:organization_id/ledgers/:ledger_id/operation-routes", protectedMidaz(auth, "operation-routes", "post", routeOptions, http.ParseUUIDPathParameters("operation_route"), http.WithBody(new(mmodel.CreateOperationRouteInput), orh.CreateOperationRoute))...)
+	f.Get("/v1/organizations/:organization_id/ledgers/:ledger_id/operation-routes/:operation_route_id", protectedMidaz(auth, "operation-routes", "get", routeOptions, http.ParseUUIDPathParameters("operation_route"), orh.GetOperationRouteByID)...)
+	f.Patch("/v1/organizations/:organization_id/ledgers/:ledger_id/operation-routes/:operation_route_id", protectedMidaz(auth, "operation-routes", "patch", routeOptions, http.ParseUUIDPathParameters("operation_route"), http.WithBody(new(mmodel.UpdateOperationRouteInput), orh.UpdateOperationRoute))...)
+	f.Delete("/v1/organizations/:organization_id/ledgers/:ledger_id/operation-routes/:operation_route_id", protectedMidaz(auth, "operation-routes", "delete", routeOptions, http.ParseUUIDPathParameters("operation_route"), orh.DeleteOperationRouteByID)...)
+	f.Get("/v1/organizations/:organization_id/ledgers/:ledger_id/operation-routes", protectedMidaz(auth, "operation-routes", "get", routeOptions, http.ParseUUIDPathParameters("operation_route"), orh.GetAllOperationRoutes)...)
 
 	// Transaction-route
-	f.Post("/v1/organizations/:organization_id/ledgers/:ledger_id/transaction-routes", protectedRouting(auth, "transaction-routes", "post", routeOptions, http.ParseUUIDPathParameters("transaction_route"), http.WithBody(new(mmodel.CreateTransactionRouteInput), trh.CreateTransactionRoute))...)
-	f.Get("/v1/organizations/:organization_id/ledgers/:ledger_id/transaction-routes/:transaction_route_id", protectedRouting(auth, "transaction-routes", "get", routeOptions, http.ParseUUIDPathParameters("transaction_route"), trh.GetTransactionRouteByID)...)
-	f.Patch("/v1/organizations/:organization_id/ledgers/:ledger_id/transaction-routes/:transaction_route_id", protectedRouting(auth, "transaction-routes", "patch", routeOptions, http.ParseUUIDPathParameters("transaction_route"), http.WithBody(new(mmodel.UpdateTransactionRouteInput), trh.UpdateTransactionRoute))...)
-	f.Delete("/v1/organizations/:organization_id/ledgers/:ledger_id/transaction-routes/:transaction_route_id", protectedRouting(auth, "transaction-routes", "delete", routeOptions, http.ParseUUIDPathParameters("transaction_route"), trh.DeleteTransactionRouteByID)...)
-	f.Get("/v1/organizations/:organization_id/ledgers/:ledger_id/transaction-routes", protectedRouting(auth, "transaction-routes", "get", routeOptions, http.ParseUUIDPathParameters("transaction_route"), trh.GetAllTransactionRoutes)...)
+	f.Post("/v1/organizations/:organization_id/ledgers/:ledger_id/transaction-routes", protectedMidaz(auth, "transaction-routes", "post", routeOptions, http.ParseUUIDPathParameters("transaction_route"), http.WithBody(new(mmodel.CreateTransactionRouteInput), trh.CreateTransactionRoute))...)
+	f.Get("/v1/organizations/:organization_id/ledgers/:ledger_id/transaction-routes/:transaction_route_id", protectedMidaz(auth, "transaction-routes", "get", routeOptions, http.ParseUUIDPathParameters("transaction_route"), trh.GetTransactionRouteByID)...)
+	f.Patch("/v1/organizations/:organization_id/ledgers/:ledger_id/transaction-routes/:transaction_route_id", protectedMidaz(auth, "transaction-routes", "patch", routeOptions, http.ParseUUIDPathParameters("transaction_route"), http.WithBody(new(mmodel.UpdateTransactionRouteInput), trh.UpdateTransactionRoute))...)
+	f.Delete("/v1/organizations/:organization_id/ledgers/:ledger_id/transaction-routes/:transaction_route_id", protectedMidaz(auth, "transaction-routes", "delete", routeOptions, http.ParseUUIDPathParameters("transaction_route"), trh.DeleteTransactionRouteByID)...)
+	f.Get("/v1/organizations/:organization_id/ledgers/:ledger_id/transaction-routes", protectedMidaz(auth, "transaction-routes", "get", routeOptions, http.ParseUUIDPathParameters("transaction_route"), trh.GetAllTransactionRoutes)...)
 }
 
 func protectedMidaz(auth *middleware.AuthClient, resource, action string, routeOptions *http.ProtectedRouteOptions, handlers ...fiber.Handler) []fiber.Handler {
 	return http.ProtectedRouteChain(auth.Authorize(midazName, resource, action), routeOptions, handlers...)
-}
-
-func protectedRouting(auth *middleware.AuthClient, resource, action string, routeOptions *http.ProtectedRouteOptions, handlers ...fiber.Handler) []fiber.Handler {
-	return http.ProtectedRouteChain(auth.Authorize(routingName, resource, action), routeOptions, handlers...)
 }


### PR DESCRIPTION
# Midaz Pull Request Checklist

## Pull Request Type
[//]: # (Check the appropriate box for the type of pull request.)

- [ ] Documentation
- [ ] Pipeline
- [ ] Infra
- [x] Ledger
- [ ] Onboarding
- [ ] Transaction
- [ ] CRM
- [ ] Tests

## Checklist
Check each item after completion.

- [x] I have tested these changes locally.
- [ ] I have updated the documentation accordingly.
- [x] I have added necessary comments to the code, especially in complex areas.
- [x] I have ensured that my changes adhere to the project's coding standards.
- [x] I have checked for any potential security issues.
- [x] I have ensured that all tests pass.
- [ ] I have updated the version appropriately (if applicable).
- [x] I have confirmed this code is ready for review.

**Important:** Always target your PR to the develop branch instead of main.
## Additional Notes
[//]: # (Add any additional notes, context, or explanation that could be helpful for reviewers.)

### What

Authorize **all** ledger routes under the `midaz` service. Removes the
`protectedRouting` helper and the `routingName` (`"routing"`) constant from
`components/ledger/internal/adapters/http/in/routes.go`; the accounting routes
that used it — **account-types**, **operation-routes**, **transaction-routes** —
now go through `protectedMidaz`, and the metadata-index routes were folded onto
the same helper for consistency. Every route now authorizes under a single
service name (`midaz`).

### Why

These routes were the only ones still authorizing under a separate `routing`
service, which split the RBAC surface for no functional reason. Consolidating
them under `midaz` makes authorization uniform across the ledger and removes a
dead authorization scope.

### Behavior / scope

- No change to paths, payloads, methods, handlers, or persistence — only the
  service name passed to the auth middleware (`routing` → `midaz`).
- `fix:` (patch): an internal authorization-wiring correction, not a new feature.

### ⚠️ Deployment dependency (Access Manager)

For **M2M tokens**, lib-auth maps the service name to `<owner>/<service>-editor-role`,
so authorizing under `midaz` requires the `midaz` roles to grant these resources.
That is handled by the companion **Plugin Access Manager** PR
(`fix: grant midaz roles access to accounting resources`), which adds
`account-types`, `transaction-routes` and `operation-routes` to the
`midaz-editor/contributor/viewer` permissions:
- `init_data.json` for fresh installs;
- migration `30_add_accounting_to_midaz_permissions` for existing deployments.

**Deploy the Access Manager change first (or together)** so M2M callers keep
access to these routes. For normal users, casbin matches on `(resource, action)`
and the service name is not part of the request, so they are unaffected.

### Testing

- Full local stack (ledger + plugin-auth + plugin-identity) with
  `PLUGIN_AUTH_ENABLED=true`; `go build` / `go vet` clean on the routes package.
- Protected route without a token → `401`; with token → authorized.