### PR TITLE
refactor(crm): version-aware envelope routing

### DIFF
--- a/components/crm/internal/adapters/mongodb/encryption/keyset.go
+++ b/components/crm/internal/adapters/mongodb/encryption/keyset.go
@@ -14,6 +14,7 @@ import (
 type KeysetMongoDBModel struct {
 	TenantID          string          `bson:"tenant_id,omitempty"`
 	OrganizationID    string          `bson:"organization_id"`
+	Version           int             `bson:"version"`
 	KEKPath           string          `bson:"kek_path"`
 	KEKMountPath      string          `bson:"kek_mount_path,omitempty"`
 	WrappedKeyset     string          `bson:"wrapped_keyset"`
@@ -48,6 +49,7 @@ func KeysetFromEntity(k *mmodel.OrganizationKeyset) *KeysetMongoDBModel {
 	return &KeysetMongoDBModel{
 		TenantID:          k.TenantID,
 		OrganizationID:    k.OrganizationID,
+		Version:           k.Version,
 		KEKPath:           k.KEKPath,
 		KEKMountPath:      k.KEKMountPath,
 		WrappedKeyset:     k.WrappedKeyset,
@@ -69,6 +71,7 @@ func (m *KeysetMongoDBModel) ToEntity() *mmodel.OrganizationKeyset {
 	return &mmodel.OrganizationKeyset{
 		TenantID:          m.TenantID,
 		OrganizationID:    m.OrganizationID,
+		Version:           m.Version,
 		KEKPath:           m.KEKPath,
 		KEKMountPath:      m.KEKMountPath,
 		WrappedKeyset:     m.WrappedKeyset,

--- a/components/crm/internal/adapters/mongodb/encryption/keyset.mongodb.go
+++ b/components/crm/internal/adapters/mongodb/encryption/keyset.mongodb.go
@@ -28,6 +28,8 @@ const keysetCollection = "organization_keyset"
 type KeysetRepository interface {
 	Save(ctx context.Context, keyset *mmodel.OrganizationKeyset) error
 	Get(ctx context.Context, organizationID string) (*mmodel.OrganizationKeyset, error)
+	GetByVersion(ctx context.Context, organizationID string, version int) (*mmodel.OrganizationKeyset, error)
+	GetActive(ctx context.Context, organizationID string) (*mmodel.OrganizationKeyset, error)
 	Update(ctx context.Context, keyset *mmodel.OrganizationKeyset, expectedRevision int64) error
 }
 
@@ -96,8 +98,10 @@ func (r *KeysetMongoDBRepository) Save(ctx context.Context, keyset *mmodel.Organ
 
 	model := KeysetFromEntity(keyset)
 
-	// Database isolation handles multi-tenancy - filter by organization_id only
-	filter := bson.M{"organization_id": keyset.OrganizationID}
+	// Database isolation handles multi-tenancy - filter by organization_id and
+	// version so each keyset version is an independent document (storage is
+	// version-keyed).
+	filter := bson.M{"organization_id": keyset.OrganizationID, "version": keyset.Version}
 	update := bson.M{"$setOnInsert": model}
 
 	result, err := collection.UpdateOne(ctx, filter, update, options.Update().SetUpsert(true))
@@ -150,6 +154,85 @@ func (r *KeysetMongoDBRepository) Get(ctx context.Context, organizationID string
 	return model.ToEntity(), nil
 }
 
+// GetByVersion returns the keyset document for an organization at an exact version.
+func (r *KeysetMongoDBRepository) GetByVersion(ctx context.Context, organizationID string, version int) (*mmodel.OrganizationKeyset, error) {
+	_, tracer, _, _ := libCommons.NewTrackingFromContext(ctx) //nolint:dogsled // consistent with codebase pattern
+
+	ctx, span := tracer.Start(ctx, "mongodb.keyset.get_by_version")
+	defer span.End()
+
+	tenantID := extractTenantID(ctx)
+
+	span.SetAttributes(
+		attribute.String("app.request.tenant_id", tenantID),
+		attribute.String("app.request.organization_id", organizationID),
+		attribute.Int("app.request.version", version),
+	)
+
+	collection, err := r.collection(ctx)
+	if err != nil {
+		libOpenTelemetry.HandleSpanError(span, "Failed to get collection", err)
+		return nil, err
+	}
+
+	var model KeysetMongoDBModel
+
+	// Database isolation handles multi-tenancy - filter by organization_id and version.
+	filter := bson.M{"organization_id": organizationID, "version": version}
+
+	if err := collection.FindOne(ctx, filter).Decode(&model); err != nil {
+		if errors.Is(err, mongo.ErrNoDocuments) {
+			return nil, mmodel.ErrKeysetNotFound
+		}
+
+		libOpenTelemetry.HandleSpanError(span, "Failed to get organization keyset by version", err)
+
+		return nil, fmt.Errorf("get organization keyset by version: %w", err)
+	}
+
+	return model.ToEntity(), nil
+}
+
+// GetActive returns the highest-version keyset document for an organization.
+func (r *KeysetMongoDBRepository) GetActive(ctx context.Context, organizationID string) (*mmodel.OrganizationKeyset, error) {
+	_, tracer, _, _ := libCommons.NewTrackingFromContext(ctx) //nolint:dogsled // consistent with codebase pattern
+
+	ctx, span := tracer.Start(ctx, "mongodb.keyset.get_active")
+	defer span.End()
+
+	tenantID := extractTenantID(ctx)
+
+	span.SetAttributes(
+		attribute.String("app.request.tenant_id", tenantID),
+		attribute.String("app.request.organization_id", organizationID),
+	)
+
+	collection, err := r.collection(ctx)
+	if err != nil {
+		libOpenTelemetry.HandleSpanError(span, "Failed to get collection", err)
+		return nil, err
+	}
+
+	var model KeysetMongoDBModel
+
+	// Database isolation handles multi-tenancy - filter by organization_id, select
+	// the highest version document (descending sort, single result).
+	filter := bson.M{"organization_id": organizationID}
+	opts := options.FindOne().SetSort(bson.D{{Key: "version", Value: -1}})
+
+	if err := collection.FindOne(ctx, filter, opts).Decode(&model); err != nil {
+		if errors.Is(err, mongo.ErrNoDocuments) {
+			return nil, mmodel.ErrKeysetNotFound
+		}
+
+		libOpenTelemetry.HandleSpanError(span, "Failed to get active organization keyset", err)
+
+		return nil, fmt.Errorf("get active organization keyset: %w", err)
+	}
+
+	return model.ToEntity(), nil
+}
+
 func (r *KeysetMongoDBRepository) Update(ctx context.Context, keyset *mmodel.OrganizationKeyset, expectedRevision int64) error {
 	_, tracer, _, _ := libCommons.NewTrackingFromContext(ctx) //nolint:dogsled // consistent with codebase pattern
 
@@ -189,9 +272,11 @@ func (r *KeysetMongoDBRepository) Update(ctx context.Context, keyset *mmodel.Org
 	model := KeysetFromEntity(keyset)
 	model.Revision = expectedRevision + 1
 
-	// Database isolation handles multi-tenancy - filter by organization_id and revision only
+	// Database isolation handles multi-tenancy - filter by organization_id, version
+	// and revision so the optimistic update targets the exact version document.
 	filter := bson.M{
 		"organization_id": keyset.OrganizationID,
+		"version":         keyset.Version,
 		"revision":        expectedRevision,
 	}
 
@@ -253,8 +338,9 @@ func (r *KeysetMongoDBRepository) ensureIndexes(ctx context.Context, collection 
 func (r *KeysetMongoDBRepository) createIndexes(ctx context.Context, collection *mongo.Collection) error {
 	indexModels := []mongo.IndexModel{
 		{
-			// Compound unique index on tenant_id + organization_id for proper tenant isolation
-			Keys:    bson.D{{Key: "tenant_id", Value: 1}, {Key: "organization_id", Value: 1}},
+			// Compound unique index on tenant_id + organization_id + version for
+			// proper tenant isolation and version-keyed keyset storage.
+			Keys:    bson.D{{Key: "tenant_id", Value: 1}, {Key: "organization_id", Value: 1}, {Key: "version", Value: 1}},
 			Options: options.Index().SetUnique(true),
 		},
 	}

--- a/components/crm/internal/adapters/mongodb/encryption/keyset.mongodb_test.go
+++ b/components/crm/internal/adapters/mongodb/encryption/keyset.mongodb_test.go
@@ -74,6 +74,7 @@ func TestKeysetMongoDBRepository_Save_ValidationError(t *testing.T) {
 			name: "empty kek_path",
 			keyset: &mmodel.OrganizationKeyset{
 				OrganizationID: "org-a",
+				Version:        1,
 				KEKPath:        "",
 				WrappedKeyset:  "vault:v1:dek",
 				KeysetInfo:     mmodel.KeysetInfo{PrimaryKeyID: 1},
@@ -84,6 +85,7 @@ func TestKeysetMongoDBRepository_Save_ValidationError(t *testing.T) {
 			name: "empty wrapped_keyset",
 			keyset: &mmodel.OrganizationKeyset{
 				OrganizationID: "org-a",
+				Version:        1,
 				KEKPath:        "transit/keys/test",
 				KEKMountPath:   "transit",
 				WrappedKeyset:  "",
@@ -95,6 +97,7 @@ func TestKeysetMongoDBRepository_Save_ValidationError(t *testing.T) {
 			name: "empty kek_mount_path",
 			keyset: &mmodel.OrganizationKeyset{
 				OrganizationID: "org-a",
+				Version:        1,
 				KEKPath:        "transit/keys/test",
 				KEKMountPath:   "",
 				WrappedKeyset:  "vault:v1:dek",
@@ -106,6 +109,7 @@ func TestKeysetMongoDBRepository_Save_ValidationError(t *testing.T) {
 			name: "zero primary_key_id",
 			keyset: &mmodel.OrganizationKeyset{
 				OrganizationID: "org-a",
+				Version:        1,
 				KEKPath:        "transit/keys/test",
 				KEKMountPath:   "transit",
 				WrappedKeyset:  "vault:v1:dek",
@@ -330,6 +334,7 @@ func validTestKeyset() *mmodel.OrganizationKeyset {
 
 	return &mmodel.OrganizationKeyset{
 		OrganizationID:    "org-test",
+		Version:           1,
 		KEKPath:           "transit/keys/crm-org-test",
 		KEKMountPath:      "transit",
 		WrappedKeyset:     "vault:v1:encrypted-dek",

--- a/components/crm/internal/bootstrap/encryption_test.go
+++ b/components/crm/internal/bootstrap/encryption_test.go
@@ -1079,6 +1079,32 @@ func (m *mockKeysetRepo) Get(_ context.Context, _ string) (*mmodel.OrganizationK
 	}, nil
 }
 
+// GetByVersion satisfies the mongoEncryption.KeysetRepository interface.
+func (m *mockKeysetRepo) GetByVersion(_ context.Context, _ string, version int) (*mmodel.OrganizationKeyset, error) {
+	return &mmodel.OrganizationKeyset{
+		OrganizationID: "test-org",
+		Version:        version,
+		KEKPath:        "transit/keys/test",
+		WrappedKeyset:  "mock-wrapped",
+		KeysetInfo: mmodel.KeysetInfo{
+			PrimaryKeyID: 12345,
+		},
+	}, nil
+}
+
+// GetActive satisfies the mongoEncryption.KeysetRepository interface.
+func (m *mockKeysetRepo) GetActive(_ context.Context, _ string) (*mmodel.OrganizationKeyset, error) {
+	return &mmodel.OrganizationKeyset{
+		OrganizationID: "test-org",
+		Version:        1,
+		KEKPath:        "transit/keys/test",
+		WrappedKeyset:  "mock-wrapped",
+		KeysetInfo: mmodel.KeysetInfo{
+			PrimaryKeyID: 12345,
+		},
+	}, nil
+}
+
 // Save satisfies the mongoEncryption.KeysetRepository interface.
 func (m *mockKeysetRepo) Save(_ context.Context, _ *mmodel.OrganizationKeyset) error {
 	return nil

--- a/components/crm/internal/services/encryption/encryption.go
+++ b/components/crm/internal/services/encryption/encryption.go
@@ -527,8 +527,9 @@ func (s *encryptionService) decryptEnvelope(ctx context.Context, fieldCtx FieldC
 // organization's readable-versions set. An empty/nil set is never readable
 // (fail-closed for legacy/unprovisioned organizations).
 func versionIsReadable(version uint32, readable []int) bool {
+	target := int(version)
 	for _, v := range readable {
-		if v >= 0 && uint32(v) == version {
+		if v == target {
 			return true
 		}
 	}

--- a/components/crm/internal/services/encryption/encryption.go
+++ b/components/crm/internal/services/encryption/encryption.go
@@ -248,7 +248,7 @@ func NewEncryptionService(
 //
 // When encryptionMode is EncryptionModeEnvelope:
 //   - Always uses envelope encryption regardless of per-org registry state
-//   - Triggers lazy provisioning via KeysetManager.GetPrimitives() for non-provisioned orgs
+//   - Triggers lazy provisioning via KeysetManager.GetActivePrimitives() for non-provisioned orgs
 //
 // When encryptionMode is EncryptionModeLegacy (or unset):
 //   - Routes based on per-organization protection state
@@ -257,9 +257,9 @@ func NewEncryptionService(
 //
 // For envelope mode:
 //   - Validates field context
-//   - Gets AEAD primitive from KeysetManager
+//   - Gets the active-version AEAD primitive from KeysetManager
 //   - Encrypts with canonical AAD
-//   - Returns marked ciphertext (tink:v{keyID}:{base64})
+//   - Returns marked ciphertext (tink:v{keysetVersion}:{base64})
 //
 // For legacy mode:
 //   - Uses libCommons crypto.Encrypt
@@ -343,10 +343,10 @@ func (s *encryptionService) resolveEncryptPath(ctx context.Context, organization
 	return protectionPathLegacy, false, nil
 }
 
-// encryptEnvelope performs envelope encryption using Tink AEAD.
+// encryptEnvelope performs envelope encryption using the active keyset's Tink AEAD.
 func (s *encryptionService) encryptEnvelope(ctx context.Context, fieldCtx FieldContext, plaintext string) (string, error) {
-	// Get cached primitives (AEAD and primary key ID, fetched together to avoid redundant DB calls)
-	prims, err := s.keysetManager.GetPrimitives(ctx, fieldCtx.OrganizationID)
+	// Get the active-version primitives (auto-provisions version 1 on first access).
+	prims, err := s.keysetManager.GetActivePrimitives(ctx, fieldCtx.OrganizationID)
 	if err != nil {
 		return "", fmt.Errorf("failed to get AEAD primitive: %w", err)
 	}
@@ -359,8 +359,9 @@ func (s *encryptionService) encryptEnvelope(ctx context.Context, fieldCtx FieldC
 		return "", fmt.Errorf("AEAD encryption failed: %w", err)
 	}
 
-	// Format with envelope marker
-	marked := FormatEnvelopeMarker(prims.PrimaryKeyID, ciphertext)
+	// Stamp the marker with the active keyset VERSION (NOT the Tink primary key id);
+	// decrypt routes on this version.
+	marked := FormatEnvelopeMarker(prims.Version, ciphertext)
 
 	return marked, nil
 }
@@ -393,8 +394,9 @@ func (s *encryptionService) encryptLegacy(ctx context.Context, plaintext string)
 // Routes based on envelope marker presence and organization state.
 //
 // If ciphertext has envelope marker:
-//   - Parse marker to get key ID
-//   - Get AEAD primitive from KeysetManager
+//   - Parse marker to get the keyset version
+//   - Fail closed if the version is not in the org's readable versions
+//   - Load the version-specific AEAD primitive from KeysetManager
 //   - Decrypt with canonical AAD
 //   - Return plaintext
 //
@@ -484,11 +486,27 @@ func classifyLegacyDecryptError(err error) string {
 	return ""
 }
 
-// decryptEnvelope performs envelope decryption using Tink AEAD.
-// Returns ErrEnvelopeDecryptFailed on failure - NO fallback to legacy.
+// decryptEnvelope performs version-routed envelope decryption.
+//
+// The marker carries the organization keyset VERSION that produced the ciphertext.
+// Decrypt resolves the organization's protection state and fails closed when the
+// marker version is not in state.ReadableVersions (no fallback to legacy). It then
+// loads the exact-version primitives via GetPrimitivesForVersion and decrypts. Tink
+// still selects the concrete key internally from the ciphertext prefix; the version
+// only routes which keyset is loaded. Returns ErrEnvelopeDecryptFailed on failure.
 func (s *encryptionService) decryptEnvelope(ctx context.Context, fieldCtx FieldContext, marker EnvelopeMarker) (string, error) {
-	// Get cached primitives (only AEAD is needed; the marker's key ID drives decryption)
-	prims, err := s.keysetManager.GetPrimitives(ctx, fieldCtx.OrganizationID)
+	// Resolve protection state to enforce readable-version routing (fail-closed).
+	state, err := s.stateResolver.Resolve(ctx, fieldCtx.OrganizationID)
+	if err != nil {
+		return "", fmt.Errorf("%w: failed to resolve protection state: %v", ErrEnvelopeDecryptFailed, err)
+	}
+
+	if !versionIsReadable(marker.Version, state.ReadableVersions) {
+		return "", fmt.Errorf("%w: marker version %d is not in the organization's readable versions", ErrEnvelopeDecryptFailed, marker.Version)
+	}
+
+	// Load the primitives for the exact marker version (no auto-provision).
+	prims, err := s.keysetManager.GetPrimitivesForVersion(ctx, fieldCtx.OrganizationID, int(marker.Version))
 	if err != nil {
 		return "", fmt.Errorf("%w: failed to get AEAD primitive: %v", ErrEnvelopeDecryptFailed, err)
 	}
@@ -503,6 +521,19 @@ func (s *encryptionService) decryptEnvelope(ctx context.Context, fieldCtx FieldC
 	}
 
 	return string(plaintext), nil
+}
+
+// versionIsReadable reports whether the marker version is present in the
+// organization's readable-versions set. An empty/nil set is never readable
+// (fail-closed for legacy/unprovisioned organizations).
+func versionIsReadable(version uint32, readable []int) bool {
+	for _, v := range readable {
+		if v >= 0 && uint32(v) == version {
+			return true
+		}
+	}
+
+	return false
 }
 
 // decryptLegacy performs legacy decryption using the LegacyCrypto interface.
@@ -581,7 +612,7 @@ func (s *encryptionService) decryptLegacyFromKeyset(ctx context.Context, fieldCt
 		return "", fmt.Errorf("decode legacy ciphertext: %w", err)
 	}
 
-	prims, err := s.keysetManager.GetPrimitives(ctx, fieldCtx.OrganizationID)
+	prims, err := s.keysetManager.GetActivePrimitives(ctx, fieldCtx.OrganizationID)
 	if err != nil {
 		return "", fmt.Errorf("failed to get AEAD primitive: %w", err)
 	}
@@ -601,7 +632,7 @@ func (s *encryptionService) decryptLegacyFromKeyset(ctx context.Context, fieldCt
 //
 // When encryptionMode is EncryptionModeEnvelope:
 //   - Always uses envelope PRF generation regardless of per-org registry state
-//   - Triggers lazy provisioning via KeysetManager.GetPrimitives() for non-provisioned orgs
+//   - Triggers lazy provisioning via KeysetManager.GetActivePrimitives() for non-provisioned orgs
 //
 // When encryptionMode is EncryptionModeLegacy (or unset):
 //   - Routes based on per-organization protection state
@@ -648,8 +679,8 @@ func (s *encryptionService) GenerateSearchToken(ctx context.Context, searchCtx S
 // generateSearchTokenEnvelope generates a PRF-based search token using Tink and
 // returns the PRF keyset primary key ID it was computed with.
 func (s *encryptionService) generateSearchTokenEnvelope(ctx context.Context, searchCtx SearchTokenContext, normalizedValue string) (string, uint32, error) {
-	// Get cached primitives (only the PRF surface and its primary key ID are needed here).
-	prims, err := s.keysetManager.GetPrimitives(ctx, searchCtx.OrganizationID)
+	// Write path: index with the ACTIVE version's PRF primary key (auto-provisions v1).
+	prims, err := s.keysetManager.GetActivePrimitives(ctx, searchCtx.OrganizationID)
 	if err != nil {
 		return "", 0, fmt.Errorf("failed to get PRF primitive: %w", err)
 	}
@@ -710,8 +741,10 @@ func (s *encryptionService) GenerateSearchTokenCandidates(ctx context.Context, s
 // Envelope-only organizations (LegacyHexTokenPRF nil) never wrote legacy tokens, so no
 // legacy candidate is appended and the process-global legacyCrypto is never consulted.
 func (s *encryptionService) generateSearchTokenCandidatesEnvelope(ctx context.Context, searchCtx SearchTokenContext, normalizedValue string, canReadLegacy bool) ([]string, error) {
-	// Get cached primitives (strict mode: only MultiKeyPRF is needed; error if construction failed)
-	prims, err := s.keysetManager.GetPrimitives(ctx, searchCtx.OrganizationID)
+	// Read path: candidates are generated from the ACTIVE version's MultiKeyPRF.
+	// Multi-version search fan-out (querying older keyset versions after rotation)
+	// is rotation work and is deferred/out of scope here.
+	prims, err := s.keysetManager.GetActivePrimitives(ctx, searchCtx.OrganizationID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get MultiKeyPRF primitive: %w", err)
 	}

--- a/components/crm/internal/services/encryption/encryption_test.go
+++ b/components/crm/internal/services/encryption/encryption_test.go
@@ -70,6 +70,23 @@ func (f *serviceTestKeysetRepo) Get(_ context.Context, organizationID string) (*
 	return keyset, nil
 }
 
+func (f *serviceTestKeysetRepo) GetActive(ctx context.Context, organizationID string) (*mmodel.OrganizationKeyset, error) {
+	return f.Get(ctx, organizationID)
+}
+
+func (f *serviceTestKeysetRepo) GetByVersion(_ context.Context, organizationID string, version int) (*mmodel.OrganizationKeyset, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+
+	keyset, ok := f.keysets[organizationID]
+	if !ok || keyset.Version != version {
+		return nil, mmodel.ErrKeysetNotFound
+	}
+
+	return keyset, nil
+}
+
 func (f *serviceTestKeysetRepo) Save(_ context.Context, _ *mmodel.OrganizationKeyset) error {
 	return nil
 }
@@ -125,9 +142,18 @@ func createEncryptionTestService(t *testing.T, state ProtectionState, legacyKeys
 
 	aeadBytes, prfBytes, aeadKeyID, prfKeyID := generateServiceTestKeysets(t)
 
+	// Default the registry's readable versions to [keysetVersion] so version-routed
+	// decrypt of the active marker passes the fail-closed gate, unless the test set
+	// ReadableVersions explicitly (e.g. to exercise the fail-closed path).
+	readableVersions := state.ReadableVersions
+	if readableVersions == nil && state.CurrentKeysetVersion >= 1 {
+		readableVersions = []int{state.CurrentKeysetVersion}
+	}
+
 	keyset := &mmodel.OrganizationKeyset{
 		TenantID:       state.TenantID,
 		OrganizationID: state.OrganizationID,
+		Version:        1,
 		KEKPath:        "test-kek",
 		WrappedKeyset:  "wrapped-aead",
 		KeysetInfo: mmodel.KeysetInfo{
@@ -155,11 +181,12 @@ func createEncryptionTestService(t *testing.T, state ProtectionState, legacyKeys
 	registryRepo := &serviceTestRegistryRepo{
 		records: map[string]*mmodel.OrganizationRegistryRecord{
 			state.OrganizationID: {
-				TenantID:       state.TenantID,
-				OrganizationID: state.OrganizationID,
-				Status:         mmodel.RegistryStatusActive,
-				LegacyReadable: state.CanReadLegacy,
-				CurrentVersion: state.CurrentKeysetVersion,
+				TenantID:         state.TenantID,
+				OrganizationID:   state.OrganizationID,
+				Status:           mmodel.RegistryStatusActive,
+				LegacyReadable:   state.CanReadLegacy,
+				CurrentVersion:   state.CurrentKeysetVersion,
+				ReadableVersions: readableVersions,
 			},
 		},
 	}
@@ -209,7 +236,8 @@ func TestService_Encrypt_EnvelopeMode(t *testing.T) {
 	marker, hasMarker, err := ParseEnvelopeMarker(ciphertext)
 	require.NoError(t, err)
 	require.True(t, hasMarker)
-	assert.Equal(t, keyset.KeysetInfo.PrimaryKeyID, marker.KeyID)
+	// The marker now carries the keyset VERSION (not the Tink primary key id).
+	assert.Equal(t, uint32(keyset.Version), marker.Version)
 }
 
 func TestService_Encrypt_LegacyMode(t *testing.T) {
@@ -514,8 +542,9 @@ func TestService_Decrypt_EnvelopeFailure_NoFallback(t *testing.T) {
 		FieldName:      "tax_id",
 	}
 
-	// Create a marked ciphertext with bogus payload
-	bogusMarkedCiphertext := FormatEnvelopeMarker(keyset.KeysetInfo.PrimaryKeyID, []byte("invalid-ciphertext"))
+	// Create a marked ciphertext with bogus payload for the active keyset version
+	// (so it passes the readable-version gate and fails on AEAD decrypt instead).
+	bogusMarkedCiphertext := FormatEnvelopeMarker(uint32(keyset.Version), []byte("invalid-ciphertext"))
 
 	// Decryption should fail - NO fallback to legacy
 	_, err := svc.Decrypt(ctx, fieldCtx, bogusMarkedCiphertext)
@@ -1308,6 +1337,19 @@ func (f *serviceTestKeysetRepoWithProvisioning) Get(_ context.Context, organizat
 	keyset, ok := f.keysets[organizationID]
 	if !ok {
 		return nil, constant.ErrKeysetNotFound
+	}
+
+	return keyset, nil
+}
+
+func (f *serviceTestKeysetRepoWithProvisioning) GetActive(ctx context.Context, organizationID string) (*mmodel.OrganizationKeyset, error) {
+	return f.Get(ctx, organizationID)
+}
+
+func (f *serviceTestKeysetRepoWithProvisioning) GetByVersion(_ context.Context, organizationID string, version int) (*mmodel.OrganizationKeyset, error) {
+	keyset, ok := f.keysets[organizationID]
+	if !ok || keyset.Version != version {
+		return nil, mmodel.ErrKeysetNotFound
 	}
 
 	return keyset, nil

--- a/components/crm/internal/services/encryption/keyset_manager.go
+++ b/components/crm/internal/services/encryption/keyset_manager.go
@@ -387,7 +387,7 @@ func (km *KeysetManager) unwrapAndCache(ctx context.Context, cacheKey string, ke
 		LegacyHexTokenPRF: prfSet.legacyHexToken,
 		PrimaryKeyID:      keyset.KeysetInfo.PrimaryKeyID,
 		PRFPrimaryKeyID:   keyset.HMACKeysetInfo.PrimaryKeyID,
-		Version:           uint32(keyset.Version), //nolint:gosec // keyset version is a small positive monotonic counter
+		Version:           uint32(keyset.Version), // #nosec G115 -- keyset version is a small positive monotonic counter
 		ExpiresAt:         time.Now().Add(km.cacheTTL),
 	}
 

--- a/components/crm/internal/services/encryption/keyset_manager.go
+++ b/components/crm/internal/services/encryption/keyset_manager.go
@@ -8,6 +8,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -51,6 +53,7 @@ type CachedPrimitives struct {
 	LegacyHexTokenPRF *tink.LegacyPRFPrimitive
 	PrimaryKeyID      uint32
 	PRFPrimaryKeyID   uint32
+	Version           uint32
 	ExpiresAt         time.Time
 }
 
@@ -141,10 +144,19 @@ func NewKeysetManager(
 	}
 }
 
-// buildCacheKey constructs a tenant-scoped cache key.
+// buildCacheKey constructs a tenant-scoped cache key prefix.
 // Format: "tenantID:organizationID" to prevent cross-tenant cache collisions.
+// Used by the protection-state resolver and as the prefix for version-scoped
+// keyset cache invalidation.
 func buildCacheKey(tenantID, organizationID string) string {
 	return tenantID + ":" + organizationID
+}
+
+// buildVersionedCacheKey constructs a version-scoped keyset cache key.
+// Format: "tenantID:organizationID:version" so each keyset version is cached
+// independently and routed-by-version reads do not collide.
+func buildVersionedCacheKey(tenantID, organizationID string, version int) string {
+	return tenantID + ":" + organizationID + ":" + strconv.Itoa(version)
 }
 
 // getOrgLock returns the mutex for a specific tenant-organization combination.
@@ -162,95 +174,80 @@ func (km *KeysetManager) getOrgLock(cacheKey string) *sync.Mutex {
 	return lock
 }
 
-// GetPrimitives retrieves the cached AEAD, PRF, and PRFMulti primitives for an
-// organization. Returns cached primitives if available and not expired.
-// Otherwise, fetches from repository, unwraps via KMS, caches, and returns.
+// GetActivePrimitives retrieves the cached AEAD, PRF, and PRFMulti primitives for an
+// organization's ACTIVE (highest-version) keyset. It is CACHE-FIRST: the active
+// entry is keyed on the non-versioned cache key (tenantID:organizationID), so a
+// fresh cache hit serves without touching the repository. On a miss it loads the
+// active keyset via repo.GetActive and, when no keyset exists and a provisioner is
+// configured, auto-provisions version 1 before retrying (lazy provisioning).
 //
 // The returned CachedPrimitives carries:
 //   - AEAD primitive for encryption/decryption
 //   - PRF primitive for search token generation (primary key only)
-//   - MultiKeyPRF primitive for search token generation across all keys (for key rotation)
-//   - PrimaryKeyID, the primary AEAD key ID for envelope marker formatting
+//   - MultiKeyPRF primitive for search token generation across all keys
+//   - PrimaryKeyID, the primary AEAD key ID
 //   - PRFPrimaryKeyID, the primary PRF key ID for search-token versioning
+//   - Version, the loaded keyset version, stamped onto envelope markers
 //
-// Uses per-tenant-organization mutexes to deduplicate concurrent requests for the same
-// tenant-organization, preventing cache stampede while allowing concurrent fetches for
-// different tenant-organizations.
-//
-// Cache keys are scoped by tenant ID to prevent cross-tenant cache collisions.
-func (km *KeysetManager) GetPrimitives(ctx context.Context, organizationID string) (*CachedPrimitives, error) {
+// Uses the per-key mutex to deduplicate concurrent loads/unwraps for the same
+// tenant-organization. Cache keys are scoped by tenant to prevent cross-tenant
+// collisions.
+func (km *KeysetManager) GetActivePrimitives(ctx context.Context, organizationID string) (*CachedPrimitives, error) {
 	// Check context before any work
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
 
-	// Extract tenant ID for cache key scoping
 	tenantID := ExtractTenantID(ctx)
 	cacheKey := buildCacheKey(tenantID, organizationID)
 
-	// Fast path: check cache with read lock
-	km.mu.RLock()
-	cached, ok := km.cache[cacheKey]
-	km.mu.RUnlock()
-
-	if ok && !cached.IsExpired() {
-		// Fast-path cache hit: record exactly one hit.
-		km.metrics.recordCache(ctx, "get_primitives", "hit")
-
-		return cached, nil
-	}
-
-	// Cache miss or expired - acquire per-tenant-organization lock
-	orgLock := km.getOrgLock(cacheKey)
-	orgLock.Lock()
-	defer orgLock.Unlock()
-
-	// Double-check cache after acquiring lock (another goroutine may have fetched)
-	km.mu.RLock()
-	cached, ok = km.cache[cacheKey]
-	km.mu.RUnlock()
-
-	if ok && !cached.IsExpired() {
-		// Double-check cache hit: another goroutine populated the cache while we
-		// waited on the lock. Record exactly one hit (no double-count with the
-		// fast path, which already returned for the fast-path-hit case).
-		km.metrics.recordCache(ctx, "get_primitives", "hit")
-
-		return cached, nil
-	}
-
-	// Cache miss: we will fetch and cache. Record exactly one miss per fetch.
-	km.metrics.recordCache(ctx, "get_primitives", "miss")
-
-	// Fetch and cache while holding org lock
-	return km.fetchAndCache(ctx, cacheKey, organizationID)
+	return km.getOrUnwrap(ctx, cacheKey, func(ctx context.Context) (*mmodel.OrganizationKeyset, error) {
+		return km.loadActiveKeyset(ctx, organizationID)
+	})
 }
 
-// fetchAndCache fetches keyset from repository, unwraps via KMS, and caches the primitives.
-// Caller MUST hold the per-tenant-organization lock before calling this method.
-//
-// When a keyset is not found and a Provisioner is configured, this method
-// automatically provisions the organization before retrying the fetch.
-//
-// The cacheKey parameter is the tenant-scoped key (tenantID:organizationID).
-// The organizationID parameter is needed for repository lookups and provisioning.
-func (km *KeysetManager) fetchAndCache(ctx context.Context, cacheKey, organizationID string) (*CachedPrimitives, error) {
-	// Check context before expensive KMS operations
+// GetPrimitivesForVersion retrieves the cached primitives for an organization's
+// keyset at an EXACT version. It is CACHE-FIRST: the entry is keyed on the
+// version-scoped cache key (tenantID:organizationID:version), so a fresh cache hit
+// serves without touching the repository. On a miss it loads via repo.GetByVersion
+// and does NOT auto-provision; a missing version surfaces as ErrKeysetNotFound.
+// Used on the read/decrypt path where the marker selects the version to route to.
+func (km *KeysetManager) GetPrimitivesForVersion(ctx context.Context, organizationID string, version int) (*CachedPrimitives, error) {
+	// Check context before any work
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
 
-	// Fetch keyset from repository (repository extracts tenant from context)
-	keyset, err := km.keysetRepo.Get(ctx, organizationID)
+	tenantID := ExtractTenantID(ctx)
+	cacheKey := buildVersionedCacheKey(tenantID, organizationID, version)
+
+	return km.getOrUnwrap(ctx, cacheKey, func(ctx context.Context) (*mmodel.OrganizationKeyset, error) {
+		keyset, err := km.keysetRepo.GetByVersion(ctx, organizationID, version)
+		if err != nil {
+			return nil, err
+		}
+
+		if keyset == nil {
+			return nil, constant.ErrKeysetNotFound
+		}
+
+		return keyset, nil
+	})
+}
+
+// loadActiveKeyset fetches the organization's active (highest-version) keyset,
+// auto-provisioning version 1 on first access when a provisioner is configured.
+func (km *KeysetManager) loadActiveKeyset(ctx context.Context, organizationID string) (*mmodel.OrganizationKeyset, error) {
+	keyset, err := km.keysetRepo.GetActive(ctx, organizationID)
 	if err != nil {
-		// If keyset not found and provisioner available, try to auto-provision
+		// If keyset not found and provisioner available, try to auto-provision.
 		if km.provisioner != nil && (errors.Is(err, constant.ErrKeysetNotFound) || errors.Is(err, mmodel.ErrKeysetNotFound)) {
 			if provErr := km.autoProvision(ctx, organizationID); provErr != nil {
 				return nil, fmt.Errorf("auto-provision failed: %w", provErr)
 			}
 
-			// Retry fetch after provisioning
-			keyset, err = km.keysetRepo.Get(ctx, organizationID)
+			// Retry fetch after provisioning.
+			keyset, err = km.keysetRepo.GetActive(ctx, organizationID)
 			if err != nil {
 				return nil, fmt.Errorf("failed to get keyset after provisioning: %w", err)
 			}
@@ -259,11 +256,60 @@ func (km *KeysetManager) fetchAndCache(ctx context.Context, cacheKey, organizati
 		}
 	}
 
-	// Guard against nil keyset (repository returned nil without error)
+	// Guard against nil keyset (repository returned nil without error).
 	if keyset == nil {
 		return nil, constant.ErrKeysetNotFound
 	}
 
+	return keyset, nil
+}
+
+// getOrUnwrap returns cached primitives for cacheKey when present and fresh,
+// otherwise loads the keyset via the load closure, unwraps it via KMS, caches, and
+// returns. It is CACHE-FIRST: the cache is consulted before load runs, so a fresh
+// hit serves from cache without any repository call. The per-key mutex (keyed on
+// cacheKey) deduplicates concurrent loads/unwraps without blocking unrelated keys.
+func (km *KeysetManager) getOrUnwrap(ctx context.Context, cacheKey string, load func(context.Context) (*mmodel.OrganizationKeyset, error)) (*CachedPrimitives, error) {
+	// Fast path: check cache with read lock.
+	km.mu.RLock()
+	cached, ok := km.cache[cacheKey]
+	km.mu.RUnlock()
+
+	if ok && !cached.IsExpired() {
+		km.metrics.recordCache(ctx, "get_primitives", "hit")
+
+		return cached, nil
+	}
+
+	// Cache miss or expired - acquire per-key lock.
+	orgLock := km.getOrgLock(cacheKey)
+	orgLock.Lock()
+	defer orgLock.Unlock()
+
+	// Double-check cache after acquiring lock (another goroutine may have unwrapped).
+	km.mu.RLock()
+	cached, ok = km.cache[cacheKey]
+	km.mu.RUnlock()
+
+	if ok && !cached.IsExpired() {
+		km.metrics.recordCache(ctx, "get_primitives", "hit")
+
+		return cached, nil
+	}
+
+	km.metrics.recordCache(ctx, "get_primitives", "miss")
+
+	keyset, err := load(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return km.unwrapAndCache(ctx, cacheKey, keyset)
+}
+
+// unwrapAndCache unwraps the keyset via KMS and caches the primitives under cacheKey.
+// Caller MUST hold the per-tenant-organization-version lock before calling.
+func (km *KeysetManager) unwrapAndCache(ctx context.Context, cacheKey string, keyset *mmodel.OrganizationKeyset) (*CachedPrimitives, error) {
 	// Check context before KMS unwrap
 	if err := ctx.Err(); err != nil {
 		return nil, err
@@ -341,10 +387,11 @@ func (km *KeysetManager) fetchAndCache(ctx context.Context, cacheKey, organizati
 		LegacyHexTokenPRF: prfSet.legacyHexToken,
 		PrimaryKeyID:      keyset.KeysetInfo.PrimaryKeyID,
 		PRFPrimaryKeyID:   keyset.HMACKeysetInfo.PrimaryKeyID,
+		Version:           uint32(keyset.Version), //nolint:gosec // keyset version is a small positive monotonic counter
 		ExpiresAt:         time.Now().Add(km.cacheTTL),
 	}
 
-	// Cache the primitives with write lock using tenant-scoped key
+	// Cache the primitives with write lock using the tenant+version-scoped key
 	km.mu.Lock()
 	km.cache[cacheKey] = cached
 	km.mu.Unlock()
@@ -435,19 +482,35 @@ func (km *KeysetManager) autoProvision(ctx context.Context, organizationID strin
 	return err
 }
 
-// InvalidateCacheForTenant removes the cached primitives for a specific tenant-organization.
-// Call this after key rotation or when keyset is updated.
-// Also removes the per-tenant-organization mutex to prevent unbounded map growth.
+// InvalidateCacheForTenant removes the cached primitives for the ACTIVE keyset and
+// ALL keyset versions of a specific tenant-organization. The active entry is cached
+// under the exact key "tenantID:organizationID" (no version), while version entries
+// are cached under the "tenantID:organizationID:version" prefix; both are removed.
+// Call this after key rotation or when a keyset is updated. Also removes the matching
+// per-key mutexes to prevent unbounded map growth.
 func (km *KeysetManager) InvalidateCacheForTenant(tenantID, organizationID string) {
-	cacheKey := buildCacheKey(tenantID, organizationID)
+	activeKey := buildCacheKey(tenantID, organizationID)
+	prefix := activeKey + ":"
 
 	km.mu.Lock()
-	delete(km.cache, cacheKey)
+	delete(km.cache, activeKey)
+
+	for key := range km.cache {
+		if strings.HasPrefix(key, prefix) {
+			delete(km.cache, key)
+		}
+	}
 	km.mu.Unlock()
 
-	// Clean up per-tenant-org mutex to prevent unbounded growth
+	// Clean up per-key mutexes (active + all versions) to prevent unbounded growth.
 	km.fetchMu.Lock()
-	delete(km.fetching, cacheKey)
+	delete(km.fetching, activeKey)
+
+	for key := range km.fetching {
+		if strings.HasPrefix(key, prefix) {
+			delete(km.fetching, key)
+		}
+	}
 	km.fetchMu.Unlock()
 }
 

--- a/components/crm/internal/services/encryption/keyset_manager_test.go
+++ b/components/crm/internal/services/encryption/keyset_manager_test.go
@@ -40,6 +40,14 @@ func (f *fakeKeysetRepo) Get(_ context.Context, _ string) (*mmodel.OrganizationK
 	return f.keyset, f.err
 }
 
+func (f *fakeKeysetRepo) GetActive(ctx context.Context, organizationID string) (*mmodel.OrganizationKeyset, error) {
+	return f.Get(ctx, organizationID)
+}
+
+func (f *fakeKeysetRepo) GetByVersion(ctx context.Context, organizationID string, _ int) (*mmodel.OrganizationKeyset, error) {
+	return f.Get(ctx, organizationID)
+}
+
 func (f *fakeKeysetRepo) Save(_ context.Context, _ *mmodel.OrganizationKeyset) error {
 	return nil
 }
@@ -135,7 +143,7 @@ func TestKeysetManager_GetPrimitives_CacheMiss_Success(t *testing.T) {
 
 	manager := NewKeysetManager(reader, unwrapper, nil, DefaultKeysetManagerConfig(), NewProtectionMetrics(nil))
 
-	prims, err := manager.GetPrimitives(context.Background(), "org-123")
+	prims, err := manager.GetActivePrimitives(context.Background(), "org-123")
 	aead := prims.AEAD
 	prf := prims.PRF
 	if err != nil {
@@ -181,7 +189,7 @@ func TestKeysetManager_GetPrimitives_CacheHit_ReturnsCached(t *testing.T) {
 	manager := NewKeysetManager(reader, unwrapper, nil, DefaultKeysetManagerConfig(), NewProtectionMetrics(nil))
 
 	// First call - cache miss
-	prims2, err := manager.GetPrimitives(context.Background(), "org-456")
+	prims2, err := manager.GetActivePrimitives(context.Background(), "org-456")
 	aead1 := prims2.AEAD
 	prf1 := prims2.PRF
 	if err != nil {
@@ -189,7 +197,7 @@ func TestKeysetManager_GetPrimitives_CacheHit_ReturnsCached(t *testing.T) {
 	}
 
 	// Second call - should be cache hit
-	prims3, err := manager.GetPrimitives(context.Background(), "org-456")
+	prims3, err := manager.GetActivePrimitives(context.Background(), "org-456")
 	aead2 := prims3.AEAD
 	prf2 := prims3.PRF
 	if err != nil {
@@ -242,7 +250,7 @@ func TestKeysetManager_GetPrimitives_CacheExpired_Refetches(t *testing.T) {
 	manager := NewKeysetManager(reader, unwrapper, nil, config, NewProtectionMetrics(nil))
 
 	// First call - cache miss
-	_, err := manager.GetPrimitives(context.Background(), "org-789")
+	_, err := manager.GetActivePrimitives(context.Background(), "org-789")
 	if err != nil {
 		t.Fatalf("GetPrimitives() first call error = %v", err)
 	}
@@ -251,7 +259,7 @@ func TestKeysetManager_GetPrimitives_CacheExpired_Refetches(t *testing.T) {
 	time.Sleep(20 * time.Millisecond)
 
 	// Second call - cache expired, should refetch
-	_, err = manager.GetPrimitives(context.Background(), "org-789")
+	_, err = manager.GetActivePrimitives(context.Background(), "org-789")
 	if err != nil {
 		t.Fatalf("GetPrimitives() second call error = %v", err)
 	}
@@ -279,7 +287,7 @@ func TestKeysetManager_GetPrimitives_KeysetNotFound_Error(t *testing.T) {
 
 	manager := NewKeysetManager(reader, unwrapper, nil, DefaultKeysetManagerConfig(), NewProtectionMetrics(nil))
 
-	_, err := manager.GetPrimitives(context.Background(), "org-not-found")
+	_, err := manager.GetActivePrimitives(context.Background(), "org-not-found")
 	if err == nil {
 		t.Fatal("GetPrimitives() expected error, got nil")
 	}
@@ -313,7 +321,7 @@ func TestKeysetManager_GetPrimitives_UnwrapError_Propagated(t *testing.T) {
 
 	manager := NewKeysetManager(reader, unwrapper, nil, DefaultKeysetManagerConfig(), NewProtectionMetrics(nil))
 
-	_, err := manager.GetPrimitives(context.Background(), "org-unwrap-fail")
+	_, err := manager.GetActivePrimitives(context.Background(), "org-unwrap-fail")
 	if err == nil {
 		t.Fatal("GetPrimitives() expected error, got nil")
 	}
@@ -343,7 +351,7 @@ func TestKeysetManager_GetPrimitives_ParseError_Propagated(t *testing.T) {
 
 	manager := NewKeysetManager(reader, unwrapper, nil, DefaultKeysetManagerConfig(), NewProtectionMetrics(nil))
 
-	_, err := manager.GetPrimitives(context.Background(), "org-parse-fail")
+	_, err := manager.GetActivePrimitives(context.Background(), "org-parse-fail")
 	if err == nil {
 		t.Fatal("GetPrimitives() expected error for invalid keyset, got nil")
 	}
@@ -382,7 +390,7 @@ func TestKeysetManager_GetPrimitives_ConcurrentAccess_Safe(t *testing.T) {
 		go func() {
 			defer wg.Done()
 
-			prims4, err := manager.GetPrimitives(context.Background(), "org-concurrent")
+			prims4, err := manager.GetActivePrimitives(context.Background(), "org-concurrent")
 			aead := prims4.AEAD
 			prf := prims4.PRF
 			if err != nil {
@@ -423,7 +431,7 @@ func TestKeysetManager_GetPrimitives_ContextCancelled(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	_, err := manager.GetPrimitives(ctx, "org-ctx-cancel")
+	_, err := manager.GetActivePrimitives(ctx, "org-ctx-cancel")
 	if err == nil {
 		t.Fatal("GetPrimitives() expected error for cancelled context, got nil")
 	}
@@ -455,7 +463,7 @@ func TestKeysetManager_InvalidateCache_RemovesEntry(t *testing.T) {
 	manager := NewKeysetManager(reader, unwrapper, nil, DefaultKeysetManagerConfig(), NewProtectionMetrics(nil))
 
 	// First call - cache miss
-	_, err := manager.GetPrimitives(context.Background(), "org-invalidate")
+	_, err := manager.GetActivePrimitives(context.Background(), "org-invalidate")
 	if err != nil {
 		t.Fatalf("GetPrimitives() first call error = %v", err)
 	}
@@ -464,7 +472,7 @@ func TestKeysetManager_InvalidateCache_RemovesEntry(t *testing.T) {
 	manager.InvalidateCache("org-invalidate")
 
 	// Second call - should refetch after invalidation
-	_, err = manager.GetPrimitives(context.Background(), "org-invalidate")
+	_, err = manager.GetActivePrimitives(context.Background(), "org-invalidate")
 	if err != nil {
 		t.Fatalf("GetPrimitives() second call error = %v", err)
 	}
@@ -497,7 +505,7 @@ func TestKeysetManager_ClearCache_RemovesAllEntries(t *testing.T) {
 	manager := NewKeysetManager(reader, unwrapper, nil, DefaultKeysetManagerConfig(), NewProtectionMetrics(nil))
 
 	// First call - cache miss
-	_, err := manager.GetPrimitives(context.Background(), "org-clear")
+	_, err := manager.GetActivePrimitives(context.Background(), "org-clear")
 	if err != nil {
 		t.Fatalf("GetPrimitives() first call error = %v", err)
 	}
@@ -506,7 +514,7 @@ func TestKeysetManager_ClearCache_RemovesAllEntries(t *testing.T) {
 	manager.ClearCache()
 
 	// Second call - should refetch after clear
-	_, err = manager.GetPrimitives(context.Background(), "org-clear")
+	_, err = manager.GetActivePrimitives(context.Background(), "org-clear")
 	if err != nil {
 		t.Fatalf("GetPrimitives() second call error = %v", err)
 	}
@@ -601,7 +609,7 @@ func TestKeysetManager_GetPrimitives_MultipleOrganizations(t *testing.T) {
 		WrappedHMACKeyset: "wrapped-prf",
 	}
 
-	prims5, err := manager.GetPrimitives(context.Background(), "org-1")
+	prims5, err := manager.GetActivePrimitives(context.Background(), "org-1")
 	aead1 := prims5.AEAD
 	prf1 := prims5.PRF
 	if err != nil {
@@ -616,7 +624,7 @@ func TestKeysetManager_GetPrimitives_MultipleOrganizations(t *testing.T) {
 		WrappedHMACKeyset: "wrapped-prf",
 	}
 
-	prims6, err := manager.GetPrimitives(context.Background(), "org-2")
+	prims6, err := manager.GetActivePrimitives(context.Background(), "org-2")
 	aead2 := prims6.AEAD
 	prf2 := prims6.PRF
 	if err != nil {
@@ -667,6 +675,14 @@ func (f *slowKeysetRepo) Get(_ context.Context, _ string) (*mmodel.OrganizationK
 	defer f.mu.Unlock()
 
 	return f.keyset, f.err
+}
+
+func (f *slowKeysetRepo) GetActive(ctx context.Context, organizationID string) (*mmodel.OrganizationKeyset, error) {
+	return f.Get(ctx, organizationID)
+}
+
+func (f *slowKeysetRepo) GetByVersion(ctx context.Context, organizationID string, _ int) (*mmodel.OrganizationKeyset, error) {
+	return f.Get(ctx, organizationID)
 }
 
 func (f *slowKeysetRepo) Save(_ context.Context, _ *mmodel.OrganizationKeyset) error {
@@ -724,7 +740,7 @@ func TestKeysetManager_GetPrimitives_PerOrgMutex_DeduplicatesConcurrentFetches(t
 			// Wait for start signal to ensure concurrent execution
 			<-start
 
-			prims7, err := manager.GetPrimitives(context.Background(), "org-dedup")
+			prims7, err := manager.GetActivePrimitives(context.Background(), "org-dedup")
 			aead := prims7.AEAD
 			prf := prims7.PRF
 			if err != nil {
@@ -791,7 +807,7 @@ func TestKeysetManager_GetPrimitives_NilKeyset_ReturnsError(t *testing.T) {
 
 	manager := NewKeysetManager(reader, unwrapper, nil, DefaultKeysetManagerConfig(), NewProtectionMetrics(nil))
 
-	_, err := manager.GetPrimitives(context.Background(), "org-nil-keyset")
+	_, err := manager.GetActivePrimitives(context.Background(), "org-nil-keyset")
 	if err == nil {
 		t.Fatal("GetPrimitives() expected error for nil keyset, got nil")
 	}
@@ -893,6 +909,14 @@ func (f *fakeKeysetRepoWithProvision) Get(_ context.Context, _ string) (*mmodel.
 	return f.keyset, f.err
 }
 
+func (f *fakeKeysetRepoWithProvision) GetActive(ctx context.Context, organizationID string) (*mmodel.OrganizationKeyset, error) {
+	return f.Get(ctx, organizationID)
+}
+
+func (f *fakeKeysetRepoWithProvision) GetByVersion(ctx context.Context, organizationID string, _ int) (*mmodel.OrganizationKeyset, error) {
+	return f.Get(ctx, organizationID)
+}
+
 func (f *fakeKeysetRepoWithProvision) Save(_ context.Context, _ *mmodel.OrganizationKeyset) error {
 	return nil
 }
@@ -955,7 +979,7 @@ func TestKeysetManager_GetPrimitives_AutoProvisionOnNotFound(t *testing.T) {
 	// Context with tenant ID (required for auto-provisioning)
 	ctx := tmcore.ContextWithTenantID(context.Background(), "test-tenant")
 
-	prims8, err := manager.GetPrimitives(ctx, "org-auto-prov")
+	prims8, err := manager.GetActivePrimitives(ctx, "org-auto-prov")
 	aead := prims8.AEAD
 	prf := prims8.PRF
 	if err != nil {
@@ -1004,7 +1028,7 @@ func TestKeysetManager_GetPrimitives_NoAutoProvisionWhenKeysetExists(t *testing.
 
 	manager := NewKeysetManager(reader, unwrapper, provisioner, DefaultKeysetManagerConfig(), NewProtectionMetrics(nil))
 
-	prims9, err := manager.GetPrimitives(context.Background(), "org-existing")
+	prims9, err := manager.GetActivePrimitives(context.Background(), "org-existing")
 	aead := prims9.AEAD
 	prf := prims9.PRF
 	if err != nil {
@@ -1045,7 +1069,7 @@ func TestKeysetManager_GetPrimitives_AutoProvisionFails(t *testing.T) {
 	// Context with tenant ID (required for auto-provisioning)
 	ctx := tmcore.ContextWithTenantID(context.Background(), "test-tenant")
 
-	_, err := manager.GetPrimitives(ctx, "org-prov-fail")
+	_, err := manager.GetActivePrimitives(ctx, "org-prov-fail")
 	if err == nil {
 		t.Fatal("GetPrimitives() expected error, got nil")
 	}
@@ -1077,7 +1101,7 @@ func TestKeysetManager_GetPrimitives_NoProvisionerConfigured(t *testing.T) {
 	// No provisioner configured (nil)
 	manager := NewKeysetManager(reader, unwrapper, nil, DefaultKeysetManagerConfig(), NewProtectionMetrics(nil))
 
-	_, err := manager.GetPrimitives(context.Background(), "org-no-prov")
+	_, err := manager.GetActivePrimitives(context.Background(), "org-no-prov")
 	if err == nil {
 		t.Fatal("GetPrimitives() expected error, got nil")
 	}
@@ -1110,7 +1134,7 @@ func TestKeysetManager_GetPrimitives_NilKeysetAfterProvision(t *testing.T) {
 	// Context with tenant ID (required for auto-provisioning)
 	ctx := tmcore.ContextWithTenantID(context.Background(), "test-tenant")
 
-	_, err := manager.GetPrimitives(ctx, "org-nil-after")
+	_, err := manager.GetActivePrimitives(ctx, "org-nil-after")
 	if err == nil {
 		t.Fatal("GetPrimitives() expected error for nil keyset after provisioning, got nil")
 	}
@@ -1153,7 +1177,7 @@ func TestKeysetManager_autoProvision_UsesTenantFromContext(t *testing.T) {
 	// Create context with tenant ID using tmcore
 	ctx := tmcore.ContextWithTenantID(context.Background(), "tenant-from-context")
 
-	_, err := manager.GetPrimitives(ctx, "org-tenant-ctx")
+	_, err := manager.GetActivePrimitives(ctx, "org-tenant-ctx")
 	if err != nil {
 		t.Fatalf("GetPrimitives() error = %v", err)
 	}
@@ -1199,7 +1223,7 @@ func TestKeysetManager_autoProvision_RejectsReservedTenantID(t *testing.T) {
 	// Non-empty tenant id of "default" supplied via context (multi-tenant).
 	ctx := tmcore.ContextWithTenantID(context.Background(), "default")
 
-	_, err := manager.GetPrimitives(ctx, "org-reserved")
+	_, err := manager.GetActivePrimitives(ctx, "org-reserved")
 	if err == nil {
 		t.Fatal("GetPrimitives() expected error for reserved tenant id, got nil")
 	}
@@ -1266,7 +1290,7 @@ func TestKeysetManager_autoProvision_DefaultsTenantWhenMissing(t *testing.T) {
 	// Context WITHOUT tenant ID - should default to "default"
 	ctx := context.Background()
 
-	_, err := manager.GetPrimitives(ctx, "org-no-tenant")
+	_, err := manager.GetActivePrimitives(ctx, "org-no-tenant")
 	if err != nil {
 		t.Fatalf("GetPrimitives() unexpected error: %v", err)
 	}
@@ -1326,7 +1350,7 @@ func TestKeysetManager_GetPrimitives_TenantIsolation_CacheKeysScopedByTenant(t *
 	ctxTenantB := tmcore.ContextWithTenantID(context.Background(), "tenant-beta")
 
 	// First call from tenant A - should fetch from repo
-	prims10, err := manager.GetPrimitives(ctxTenantA, "same-org-id")
+	prims10, err := manager.GetActivePrimitives(ctxTenantA, "same-org-id")
 	aeadA := prims10.AEAD
 	prfA := prims10.PRF
 	if err != nil {
@@ -1338,7 +1362,7 @@ func TestKeysetManager_GetPrimitives_TenantIsolation_CacheKeysScopedByTenant(t *
 	readerMu.Unlock()
 
 	// First call from tenant B - should fetch from repo (different cache key)
-	prims11, err := manager.GetPrimitives(ctxTenantB, "same-org-id")
+	prims11, err := manager.GetActivePrimitives(ctxTenantB, "same-org-id")
 	aeadB := prims11.AEAD
 	prfB := prims11.PRF
 	if err != nil {
@@ -1351,7 +1375,7 @@ func TestKeysetManager_GetPrimitives_TenantIsolation_CacheKeysScopedByTenant(t *
 	}
 
 	// Second call from tenant A - should use cache
-	prims12, err := manager.GetPrimitives(ctxTenantA, "same-org-id")
+	prims12, err := manager.GetActivePrimitives(ctxTenantA, "same-org-id")
 	aeadA2 := prims12.AEAD
 	prfA2 := prims12.PRF
 	if err != nil {
@@ -1406,13 +1430,13 @@ func TestKeysetManager_InvalidateCacheForTenant_OnlyAffectsSpecificTenant(t *tes
 	ctxTenantB := tmcore.ContextWithTenantID(context.Background(), "tenant-two")
 
 	// Populate cache for both tenants
-	prims13, err := manager.GetPrimitives(ctxTenantA, "shared-org")
+	prims13, err := manager.GetActivePrimitives(ctxTenantA, "shared-org")
 	aeadA1 := prims13.AEAD
 	if err != nil {
 		t.Fatalf("GetPrimitives(tenant-one) error = %v", err)
 	}
 
-	prims14, err := manager.GetPrimitives(ctxTenantB, "shared-org")
+	prims14, err := manager.GetActivePrimitives(ctxTenantB, "shared-org")
 	aeadB1 := prims14.AEAD
 	if err != nil {
 		t.Fatalf("GetPrimitives(tenant-two) error = %v", err)
@@ -1427,7 +1451,7 @@ func TestKeysetManager_InvalidateCacheForTenant_OnlyAffectsSpecificTenant(t *tes
 	manager.InvalidateCacheForTenant("tenant-one", "shared-org")
 
 	// Tenant A should refetch (cache was invalidated)
-	prims15, err := manager.GetPrimitives(ctxTenantA, "shared-org")
+	prims15, err := manager.GetActivePrimitives(ctxTenantA, "shared-org")
 	aeadA2 := prims15.AEAD
 	if err != nil {
 		t.Fatalf("GetPrimitives(tenant-one, after invalidation) error = %v", err)
@@ -1444,7 +1468,7 @@ func TestKeysetManager_InvalidateCacheForTenant_OnlyAffectsSpecificTenant(t *tes
 	}
 
 	// Tenant B should still use cache (not invalidated)
-	prims16, err := manager.GetPrimitives(ctxTenantB, "shared-org")
+	prims16, err := manager.GetActivePrimitives(ctxTenantB, "shared-org")
 	aeadB2 := prims16.AEAD
 	if err != nil {
 		t.Fatalf("GetPrimitives(tenant-two) error = %v", err)
@@ -1508,7 +1532,7 @@ func TestKeysetManager_GetPrimitives_AutoProvision_RegistryProperties(t *testing
 	// Context with tenant ID (required for auto-provisioning)
 	ctx := tmcore.ContextWithTenantID(context.Background(), "test-tenant")
 
-	prims17, err := manager.GetPrimitives(ctx, "org-registry-test")
+	prims17, err := manager.GetActivePrimitives(ctx, "org-registry-test")
 	aead := prims17.AEAD
 	prf := prims17.PRF
 	if err != nil {
@@ -1654,6 +1678,7 @@ func TestKeysetManager_GetPrimitives_PopulatesMultiKeyPRF(t *testing.T) {
 	reader := &fakeKeysetRepo{
 		keyset: &mmodel.OrganizationKeyset{
 			OrganizationID:    "org-multikey",
+			Version:           1,
 			KEKPath:           "org-org-multikey",
 			WrappedKeyset:     "wrapped-aead",
 			WrappedHMACKeyset: "wrapped-prf",
@@ -1669,7 +1694,7 @@ func TestKeysetManager_GetPrimitives_PopulatesMultiKeyPRF(t *testing.T) {
 	manager := NewKeysetManager(reader, unwrapper, nil, DefaultKeysetManagerConfig(), NewProtectionMetrics(nil))
 
 	// Call GetPrimitives to trigger fetchAndCache
-	prims18, err := manager.GetPrimitives(context.Background(), "org-multikey")
+	prims18, err := manager.GetActivePrimitives(context.Background(), "org-multikey")
 	aead := prims18.AEAD
 	prf := prims18.PRF
 	if err != nil {
@@ -1683,7 +1708,8 @@ func TestKeysetManager_GetPrimitives_PopulatesMultiKeyPRF(t *testing.T) {
 		t.Error("GetPrimitives() PRF is nil")
 	}
 
-	// Verify MultiKeyPRF is populated in the cache
+	// Verify MultiKeyPRF is populated in the cache. The active path caches under the
+	// non-versioned key (the active keyset is looked up by tenant+org, not version).
 	manager.mu.RLock()
 	cacheKey := buildCacheKey("default", "org-multikey")
 	cached, ok := manager.cache[cacheKey]
@@ -1738,7 +1764,7 @@ func TestKeysetManager_fetchAndCache_MultiKeyPRF_StrictErrorMode(t *testing.T) {
 	manager := NewKeysetManager(reader, unwrapper, nil, DefaultKeysetManagerConfig(), NewProtectionMetrics(nil))
 
 	// GetPrimitives should fail due to invalid PRF keyset
-	_, err = manager.GetPrimitives(context.Background(), "org-strict-error")
+	_, err = manager.GetActivePrimitives(context.Background(), "org-strict-error")
 	if err == nil {
 		t.Fatal("GetPrimitives() expected error for invalid PRF keyset, got nil")
 	}
@@ -1780,7 +1806,7 @@ func TestKeysetManager_GetPrimitives_UnwrapMount_DefaultTenant_Flat(t *testing.T
 	config := KeysetManagerConfig{BaseMountPath: "transit"}
 	manager := NewKeysetManager(reader, unwrapper, nil, config, NewProtectionMetrics(nil))
 
-	_, err := manager.GetPrimitives(context.Background(), "org-flat")
+	_, err := manager.GetActivePrimitives(context.Background(), "org-flat")
 	if err != nil {
 		t.Fatalf("GetPrimitives() error = %v", err)
 	}
@@ -1828,7 +1854,7 @@ func TestKeysetManager_GetPrimitives_UnwrapMount_NonDefaultTenant_SubMount(t *te
 	// ctx carries a DIFFERENT tenant to prove the mount comes from the stored keyset, not ctx.
 	ctx := tmcore.ContextWithTenantID(context.Background(), "ctx-tenant-should-be-ignored")
 
-	_, err := manager.GetPrimitives(ctx, "org-sub")
+	_, err := manager.GetActivePrimitives(ctx, "org-sub")
 	if err != nil {
 		t.Fatalf("GetPrimitives() error = %v", err)
 	}
@@ -1870,7 +1896,7 @@ func TestKeysetManager_GetPrimitives_MountNotFound_FailsClosed(t *testing.T) {
 	config := KeysetManagerConfig{BaseMountPath: "transit"}
 	manager := NewKeysetManager(reader, unwrapper, nil, config, NewProtectionMetrics(nil))
 
-	_, err := manager.GetPrimitives(context.Background(), "org-no-mount")
+	_, err := manager.GetActivePrimitives(context.Background(), "org-no-mount")
 	if err == nil {
 		t.Fatal("GetPrimitives() expected error, got nil")
 	}
@@ -1910,7 +1936,7 @@ func TestKeysetManager_GetPrimitives_StoredMountWins(t *testing.T) {
 	config := KeysetManagerConfig{BaseMountPath: "other-base"}
 	manager := NewKeysetManager(reader, unwrapper, nil, config, NewProtectionMetrics(nil))
 
-	_, err := manager.GetPrimitives(context.Background(), "org-stored")
+	_, err := manager.GetActivePrimitives(context.Background(), "org-stored")
 	if err != nil {
 		t.Fatalf("GetPrimitives() error = %v", err)
 	}
@@ -1959,7 +1985,7 @@ func TestKeysetManager_GetPrimitives_ConfigBaseChanged_UsesStoredMount(t *testin
 	config := KeysetManagerConfig{BaseMountPath: "CHANGED-BASE"}
 	manager := NewKeysetManager(reader, unwrapper, nil, config, NewProtectionMetrics(nil))
 
-	_, err := manager.GetPrimitives(context.Background(), "org-config-changed")
+	_, err := manager.GetActivePrimitives(context.Background(), "org-config-changed")
 	if err != nil {
 		t.Fatalf("GetPrimitives() error = %v", err)
 	}
@@ -2018,7 +2044,7 @@ func TestKeysetManager_GetPrimitives_LegacyEmptyMount_FallsBackToDerived(t *test
 			config := KeysetManagerConfig{BaseMountPath: "transit"}
 			manager := NewKeysetManager(reader, unwrapper, nil, config, NewProtectionMetrics(nil))
 
-			_, err := manager.GetPrimitives(context.Background(), "org-legacy")
+			_, err := manager.GetActivePrimitives(context.Background(), "org-legacy")
 			if err != nil {
 				t.Fatalf("GetPrimitives() error = %v", err)
 			}
@@ -2161,7 +2187,7 @@ func TestKeysetManager_GetPrimitives_MixedKeyset_UnwrapsToWorkingPrimitives(t *t
 
 	manager := NewKeysetManager(reader, unwrapper, nil, DefaultKeysetManagerConfig(), NewProtectionMetrics(nil))
 
-	prims, err := manager.GetPrimitives(context.Background(), "org-mixed")
+	prims, err := manager.GetActivePrimitives(context.Background(), "org-mixed")
 	if err != nil {
 		t.Fatalf("GetPrimitives() error = %v", err)
 	}
@@ -2322,7 +2348,7 @@ func TestKeysetManager_GetPrimitives_MigratedKeyset_ExposesLegacyHexTokenPRF(t *
 
 	manager := NewKeysetManager(reader, unwrapper, nil, DefaultKeysetManagerConfig(), NewProtectionMetrics(nil))
 
-	prims, err := manager.GetPrimitives(context.Background(), "org-legacy-prf")
+	prims, err := manager.GetActivePrimitives(context.Background(), "org-legacy-prf")
 	if err != nil {
 		t.Fatalf("GetPrimitives() error = %v", err)
 	}
@@ -2379,7 +2405,7 @@ func TestKeysetManager_GetPrimitives_EnvelopeOnlyKeyset_LegacyHexTokenPRFNil(t *
 
 	manager := NewKeysetManager(reader, unwrapper, nil, DefaultKeysetManagerConfig(), NewProtectionMetrics(nil))
 
-	prims, err := manager.GetPrimitives(context.Background(), "org-envelope-only")
+	prims, err := manager.GetActivePrimitives(context.Background(), "org-envelope-only")
 	if err != nil {
 		t.Fatalf("GetPrimitives() error = %v", err)
 	}
@@ -2424,7 +2450,7 @@ func TestKeysetManager_GetPrimitives_LegacyMetadataButNoHandleKey_FailsClosed(t 
 
 	manager := NewKeysetManager(reader, unwrapper, nil, DefaultKeysetManagerConfig(), NewProtectionMetrics(nil))
 
-	_, err := manager.GetPrimitives(context.Background(), "org-legacy-mismatch")
+	_, err := manager.GetActivePrimitives(context.Background(), "org-legacy-mismatch")
 	if err == nil {
 		t.Fatal("GetPrimitives() expected fail-closed error for legacy-metadata/handle mismatch, got nil")
 	}

--- a/components/crm/internal/services/encryption/marker.go
+++ b/components/crm/internal/services/encryption/marker.go
@@ -15,9 +15,9 @@ import (
 const MarkerPrefix = "tink:v"
 
 // EnvelopeMarker identifies ciphertext encrypted with envelope encryption.
-// Format: "tink:v{keyID}:{base64_payload}"
+// Format: "tink:v{version}:{base64_payload}"
 type EnvelopeMarker struct {
-	KeyID   uint32 // Primary key ID from the keyset
+	Version uint32 // The organization's keyset version that produced the payload
 	Payload []byte // The actual ciphertext (decoded from base64)
 }
 
@@ -32,23 +32,23 @@ func ParseEnvelopeMarker(value string) (EnvelopeMarker, bool, error) {
 	}
 
 	// Remove prefix and split by colon
-	// Format after prefix removal: "{keyID}:{base64_payload}"
+	// Format after prefix removal: "{version}:{base64_payload}"
 	remainder := strings.TrimPrefix(value, MarkerPrefix)
 
-	// Find the first colon that separates key ID from payload
-	keyIDStr, payloadB64, found := strings.Cut(remainder, ":")
+	// Find the first colon that separates the keyset version from the payload
+	versionStr, payloadB64, found := strings.Cut(remainder, ":")
 	if !found {
 		return EnvelopeMarker{}, false, fmt.Errorf("invalid envelope marker format: missing payload separator")
 	}
 
-	// Parse key ID
-	if keyIDStr == "" {
-		return EnvelopeMarker{}, false, fmt.Errorf("invalid key ID: empty")
+	// Parse keyset version
+	if versionStr == "" {
+		return EnvelopeMarker{}, false, fmt.Errorf("invalid keyset version: empty")
 	}
 
-	keyID, err := strconv.ParseUint(keyIDStr, 10, 32)
+	version, err := strconv.ParseUint(versionStr, 10, 32)
 	if err != nil {
-		return EnvelopeMarker{}, false, fmt.Errorf("invalid key ID %q: %w", keyIDStr, err)
+		return EnvelopeMarker{}, false, fmt.Errorf("invalid keyset version %q: %w", versionStr, err)
 	}
 
 	// Decode payload (URL-safe base64)
@@ -58,15 +58,22 @@ func ParseEnvelopeMarker(value string) (EnvelopeMarker, bool, error) {
 	}
 
 	return EnvelopeMarker{
-		KeyID:   uint32(keyID),
+		Version: uint32(version),
 		Payload: payload,
 	}, true, nil
 }
 
-// FormatEnvelopeMarker creates a marked ciphertext string from key ID and payload.
-func FormatEnvelopeMarker(keyID uint32, payload []byte) string {
+// FormatEnvelopeMarker creates a marked ciphertext string from the organization's
+// keyset version and the ciphertext payload. The version is the monotonic
+// per-organization keyset version (NOT the Tink primary key id) and is what
+// decrypt routes on.
+//
+// The payload is encoded with base64 URL-safe (consistent with search tokens),
+// while the legacy on-disk path uses base64 Std for lib-commons compatibility.
+// These two alphabets are intentionally different and MUST NOT be unified.
+func FormatEnvelopeMarker(version uint32, payload []byte) string {
 	payloadB64 := base64.URLEncoding.EncodeToString(payload)
-	return fmt.Sprintf("%s%d:%s", MarkerPrefix, keyID, payloadB64)
+	return fmt.Sprintf("%s%d:%s", MarkerPrefix, version, payloadB64)
 }
 
 // HasEnvelopeMarker returns true if the value starts with the envelope marker prefix.

--- a/components/crm/internal/services/encryption/marker_test.go
+++ b/components/crm/internal/services/encryption/marker_test.go
@@ -28,7 +28,7 @@ func TestParseEnvelopeMarker(t *testing.T) {
 			name:  "valid marker with key ID 1",
 			value: "tink:v1:" + validPayloadB64,
 			wantMarker: EnvelopeMarker{
-				KeyID:   1,
+				Version: 1,
 				Payload: validPayload,
 			},
 			wantHasMarker: true,
@@ -38,7 +38,7 @@ func TestParseEnvelopeMarker(t *testing.T) {
 			name:  "valid marker with large key ID",
 			value: "tink:v4294967295:" + validPayloadB64,
 			wantMarker: EnvelopeMarker{
-				KeyID:   4294967295, // max uint32
+				Version: 4294967295, // max uint32
 				Payload: validPayload,
 			},
 			wantHasMarker: true,
@@ -64,7 +64,7 @@ func TestParseEnvelopeMarker(t *testing.T) {
 			wantMarker:    EnvelopeMarker{},
 			wantHasMarker: false,
 			wantErr:       true,
-			errContains:   "invalid key ID",
+			errContains:   "invalid keyset version",
 		},
 		{
 			name:          "malformed - non-numeric key ID",
@@ -72,7 +72,7 @@ func TestParseEnvelopeMarker(t *testing.T) {
 			wantMarker:    EnvelopeMarker{},
 			wantHasMarker: false,
 			wantErr:       true,
-			errContains:   "invalid key ID",
+			errContains:   "invalid keyset version",
 		},
 		{
 			name:          "malformed - negative key ID",
@@ -80,7 +80,7 @@ func TestParseEnvelopeMarker(t *testing.T) {
 			wantMarker:    EnvelopeMarker{},
 			wantHasMarker: false,
 			wantErr:       true,
-			errContains:   "invalid key ID",
+			errContains:   "invalid keyset version",
 		},
 		{
 			name:          "malformed - key ID exceeds uint32",
@@ -88,7 +88,7 @@ func TestParseEnvelopeMarker(t *testing.T) {
 			wantMarker:    EnvelopeMarker{},
 			wantHasMarker: false,
 			wantErr:       true,
-			errContains:   "invalid key ID",
+			errContains:   "invalid keyset version",
 		},
 		{
 			name:          "malformed - missing payload separator",
@@ -110,7 +110,7 @@ func TestParseEnvelopeMarker(t *testing.T) {
 			name:  "valid marker with empty payload",
 			value: "tink:v1:",
 			wantMarker: EnvelopeMarker{
-				KeyID:   1,
+				Version: 1,
 				Payload: []byte{},
 			},
 			wantHasMarker: true,
@@ -155,8 +155,8 @@ func TestParseEnvelopeMarker(t *testing.T) {
 			}
 
 			if hasMarker {
-				if marker.KeyID != tt.wantMarker.KeyID {
-					t.Errorf("ParseEnvelopeMarker() KeyID = %d, want %d", marker.KeyID, tt.wantMarker.KeyID)
+				if marker.Version != tt.wantMarker.Version {
+					t.Errorf("ParseEnvelopeMarker() Version = %d, want %d", marker.Version, tt.wantMarker.Version)
 				}
 
 				if string(marker.Payload) != string(tt.wantMarker.Payload) {
@@ -172,37 +172,37 @@ func TestFormatEnvelopeMarker(t *testing.T) {
 
 	tests := []struct {
 		name     string
-		keyID    uint32
+		version  uint32
 		payload  []byte
 		expected string
 	}{
 		{
 			name:     "standard key ID and payload",
-			keyID:    1,
+			version:  1,
 			payload:  []byte("encrypted-data"),
 			expected: "tink:v1:" + base64.URLEncoding.EncodeToString([]byte("encrypted-data")),
 		},
 		{
 			name:     "large key ID",
-			keyID:    4294967295,
+			version:  4294967295,
 			payload:  []byte("data"),
 			expected: "tink:v4294967295:" + base64.URLEncoding.EncodeToString([]byte("data")),
 		},
 		{
 			name:     "empty payload",
-			keyID:    42,
+			version:  42,
 			payload:  []byte{},
 			expected: "tink:v42:",
 		},
 		{
 			name:     "zero key ID",
-			keyID:    0,
+			version:  0,
 			payload:  []byte("test"),
 			expected: "tink:v0:" + base64.URLEncoding.EncodeToString([]byte("test")),
 		},
 		{
 			name:     "binary payload",
-			keyID:    123,
+			version:  123,
 			payload:  []byte{0x00, 0x01, 0x02, 0xFF, 0xFE},
 			expected: "tink:v123:" + base64.URLEncoding.EncodeToString([]byte{0x00, 0x01, 0x02, 0xFF, 0xFE}),
 		},
@@ -212,10 +212,10 @@ func TestFormatEnvelopeMarker(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			got := FormatEnvelopeMarker(tt.keyID, tt.payload)
+			got := FormatEnvelopeMarker(tt.version, tt.payload)
 
 			if got != tt.expected {
-				t.Errorf("FormatEnvelopeMarker(%d, %q) = %q, want %q", tt.keyID, string(tt.payload), got, tt.expected)
+				t.Errorf("FormatEnvelopeMarker(%d, %q) = %q, want %q", tt.version, string(tt.payload), got, tt.expected)
 			}
 		})
 	}
@@ -226,27 +226,27 @@ func TestFormatEnvelopeMarker_Roundtrip(t *testing.T) {
 
 	tests := []struct {
 		name    string
-		keyID   uint32
+		version uint32
 		payload []byte
 	}{
 		{
 			name:    "standard roundtrip",
-			keyID:   12345,
+			version: 12345,
 			payload: []byte("some encrypted data here"),
 		},
 		{
 			name:    "max key ID roundtrip",
-			keyID:   4294967295,
+			version: 4294967295,
 			payload: []byte("max key test"),
 		},
 		{
 			name:    "binary data roundtrip",
-			keyID:   99,
+			version: 99,
 			payload: []byte{0x00, 0x01, 0x02, 0x03, 0x04, 0x05},
 		},
 		{
 			name:    "empty payload roundtrip",
-			keyID:   1,
+			version: 1,
 			payload: []byte{},
 		},
 	}
@@ -256,7 +256,7 @@ func TestFormatEnvelopeMarker_Roundtrip(t *testing.T) {
 			t.Parallel()
 
 			// Format the marker
-			formatted := FormatEnvelopeMarker(tt.keyID, tt.payload)
+			formatted := FormatEnvelopeMarker(tt.version, tt.payload)
 
 			// Parse it back
 			marker, hasMarker, err := ParseEnvelopeMarker(formatted)
@@ -270,8 +270,8 @@ func TestFormatEnvelopeMarker_Roundtrip(t *testing.T) {
 				return
 			}
 
-			if marker.KeyID != tt.keyID {
-				t.Errorf("Roundtrip failed: KeyID = %d, want %d", marker.KeyID, tt.keyID)
+			if marker.Version != tt.version {
+				t.Errorf("Roundtrip failed: Version = %d, want %d", marker.Version, tt.version)
 			}
 
 			if string(marker.Payload) != string(tt.payload) {

--- a/components/crm/internal/services/encryption/metrics_test.go
+++ b/components/crm/internal/services/encryption/metrics_test.go
@@ -156,6 +156,6 @@ func TestFetchAndCache_NilFactory_NoPanic(t *testing.T) {
 
 	km := newKeysetManagerForMetrics(&scriptedUnwrapper{aeadKeyset: aeadBytes, prfKeyset: prfBytes}, NewProtectionMetrics(nil))
 
-	_, err := km.GetPrimitives(context.Background(), "org-metrics")
+	_, err := km.GetActivePrimitives(context.Background(), "org-metrics")
 	require.NoError(t, err)
 }

--- a/components/crm/internal/services/encryption/protection_state.go
+++ b/components/crm/internal/services/encryption/protection_state.go
@@ -56,6 +56,10 @@ type ProtectionState struct {
 	CanReadLegacy bool
 	// CurrentKeysetVersion is the keyset version for new encryptions (0 for legacy mode).
 	CurrentKeysetVersion int
+	// ReadableVersions lists the keyset versions whose marked ciphertext may be
+	// decrypted. Decrypt fails closed when a marker's version is not in this set.
+	// Empty/nil for legacy or unprovisioned organizations.
+	ReadableVersions []int
 	// OrganizationID is the resolved organization.
 	OrganizationID string
 	// TenantID is the resolved tenant (from registry record).
@@ -226,6 +230,7 @@ func (r *ProtectionStateResolver) resolveFromRecord(ctx context.Context, logger 
 			Mode:                 mode,
 			CanReadLegacy:        record.LegacyReadable,
 			CurrentKeysetVersion: record.CurrentVersion,
+			ReadableVersions:     record.ReadableVersions,
 			OrganizationID:       record.OrganizationID,
 			TenantID:             record.TenantID,
 		}

--- a/components/crm/internal/services/encryption/protection_state_test.go
+++ b/components/crm/internal/services/encryption/protection_state_test.go
@@ -7,6 +7,7 @@ package encryption
 import (
 	"context"
 	"errors"
+	"reflect"
 	"testing"
 
 	tmcore "github.com/LerianStudio/lib-commons/v5/commons/tenant-manager/core"
@@ -306,7 +307,7 @@ func TestProtectionStateResolver_Resolve_CachesWithinTTL(t *testing.T) {
 		t.Errorf("registry Get calls = %d, want 1 (second resolve must hit the cache)", reader.getCalls)
 	}
 
-	if first != second {
+	if !reflect.DeepEqual(first, second) {
 		t.Errorf("cached resolve returned different state: first=%+v second=%+v", first, second)
 	}
 

--- a/components/crm/internal/services/encryption/provisioning.go
+++ b/components/crm/internal/services/encryption/provisioning.go
@@ -337,6 +337,7 @@ func (s *provisioningService) buildProvisioningKeysets(ctx context.Context, req 
 	return &mmodel.OrganizationKeyset{
 		TenantID:          req.TenantID,
 		OrganizationID:    req.OrganizationID,
+		Version:           1,
 		KEKPath:           kekPath,
 		KEKMountPath:      mount,
 		WrappedKeyset:     aeadBundle.Wrapped.WrappedData,

--- a/components/crm/internal/services/encryption/provisioning_test.go
+++ b/components/crm/internal/services/encryption/provisioning_test.go
@@ -65,6 +65,19 @@ func (f *fakeKeysetRepoForProv) Get(_ context.Context, organizationID string) (*
 	return keyset, nil
 }
 
+func (f *fakeKeysetRepoForProv) GetActive(ctx context.Context, organizationID string) (*mmodel.OrganizationKeyset, error) {
+	return f.Get(ctx, organizationID)
+}
+
+func (f *fakeKeysetRepoForProv) GetByVersion(_ context.Context, organizationID string, version int) (*mmodel.OrganizationKeyset, error) {
+	keyset, ok := f.keysets[organizationID]
+	if !ok || keyset.Version != version {
+		return nil, mmodel.ErrKeysetNotFound
+	}
+
+	return keyset, nil
+}
+
 func (f *fakeKeysetRepoForProv) Update(_ context.Context, _ *mmodel.OrganizationKeyset, _ int64) error {
 	return nil
 }
@@ -2035,6 +2048,14 @@ func (f *fakeKeysetRepoNilNil) Get(_ context.Context, _ string) (*mmodel.Organiz
 	return nil, nil
 }
 
+func (f *fakeKeysetRepoNilNil) GetActive(_ context.Context, _ string) (*mmodel.OrganizationKeyset, error) {
+	return nil, nil
+}
+
+func (f *fakeKeysetRepoNilNil) GetByVersion(_ context.Context, _ string, _ int) (*mmodel.OrganizationKeyset, error) {
+	return nil, nil
+}
+
 func (f *fakeKeysetRepoNilNil) Save(_ context.Context, _ *mmodel.OrganizationKeyset) error {
 	return nil
 }
@@ -2370,10 +2391,19 @@ func (r *raceKeysetRepo) Get(_ context.Context, organizationID string) (*mmodel.
 	return &mmodel.OrganizationKeyset{
 		TenantID:       "tenant-123",
 		OrganizationID: organizationID,
+		Version:        1,
 		KEKPath:        "org-org-456",
 		KeysetInfo:     mmodel.KeysetInfo{PrimaryKeyID: 12345},
 		HMACKeysetInfo: mmodel.KeysetInfo{PrimaryKeyID: 67890},
 	}, nil
+}
+
+func (r *raceKeysetRepo) GetActive(ctx context.Context, organizationID string) (*mmodel.OrganizationKeyset, error) {
+	return r.Get(ctx, organizationID)
+}
+
+func (r *raceKeysetRepo) GetByVersion(ctx context.Context, organizationID string, _ int) (*mmodel.OrganizationKeyset, error) {
+	return r.Get(ctx, organizationID)
 }
 
 func (r *raceKeysetRepo) Update(_ context.Context, _ *mmodel.OrganizationKeyset, _ int64) error {

--- a/pkg/mmodel/organization_keyset.go
+++ b/pkg/mmodel/organization_keyset.go
@@ -22,11 +22,10 @@ var (
 // OrganizationKeyset stores wrapped keyset metadata for an organization.
 // Wrapped keysets are encrypted by a KEK in the KMS provider.
 type OrganizationKeyset struct {
-	TenantID       string
-	OrganizationID string
-	KEKPath        string
-	// KEKMountPath is the resolved Vault Transit mount the wrapped keysets were created
-	// under (e.g. "transit" or "transit/{tenant}"); persisted so unwrap ignores live config.
+	TenantID          string
+	OrganizationID    string
+	Version           int
+	KEKPath           string
 	KEKMountPath      string
 	WrappedKeyset     string
 	KeysetInfo        KeysetInfo
@@ -55,6 +54,10 @@ type KeyInfo struct {
 func (k *OrganizationKeyset) Validate() error {
 	if k.OrganizationID == "" {
 		return fmt.Errorf("organization_id is required")
+	}
+
+	if k.Version < 1 {
+		return fmt.Errorf("version must be >= 1")
 	}
 
 	if k.KEKPath == "" {
@@ -88,6 +91,7 @@ func (k *OrganizationKeyset) SafeView() OrganizationKeyset {
 	return OrganizationKeyset{
 		TenantID:          k.TenantID,
 		OrganizationID:    k.OrganizationID,
+		Version:           k.Version,
 		KEKPath:           k.KEKPath,
 		KEKMountPath:      k.KEKMountPath,
 		WrappedKeyset:     "[REDACTED]",

--- a/pkg/mmodel/organization_keyset_test.go
+++ b/pkg/mmodel/organization_keyset_test.go
@@ -26,6 +26,7 @@ func TestOrganizationKeyset_Validate(t *testing.T) {
 			name: "valid keyset",
 			keyset: OrganizationKeyset{
 				OrganizationID: "org-a",
+				Version:        1,
 				KEKPath:        "transit/keys/test",
 				KEKMountPath:   "transit",
 				WrappedKeyset:  "vault:v1:encrypted",
@@ -37,6 +38,7 @@ func TestOrganizationKeyset_Validate(t *testing.T) {
 			name: "empty kek_mount_path",
 			keyset: OrganizationKeyset{
 				OrganizationID: "org-a",
+				Version:        1,
 				KEKPath:        "transit/keys/test",
 				KEKMountPath:   "",
 				WrappedKeyset:  "vault:v1:encrypted",
@@ -58,6 +60,7 @@ func TestOrganizationKeyset_Validate(t *testing.T) {
 			name: "empty kek_path",
 			keyset: OrganizationKeyset{
 				OrganizationID: "org-a",
+				Version:        1,
 				KEKPath:        "",
 				WrappedKeyset:  "vault:v1:encrypted",
 				KeysetInfo:     KeysetInfo{PrimaryKeyID: 1},
@@ -68,6 +71,7 @@ func TestOrganizationKeyset_Validate(t *testing.T) {
 			name: "empty wrapped_keyset",
 			keyset: OrganizationKeyset{
 				OrganizationID: "org-a",
+				Version:        1,
 				KEKPath:        "transit/keys/test",
 				KEKMountPath:   "transit",
 				WrappedKeyset:  "",
@@ -79,6 +83,7 @@ func TestOrganizationKeyset_Validate(t *testing.T) {
 			name: "zero primary_key_id",
 			keyset: OrganizationKeyset{
 				OrganizationID: "org-a",
+				Version:        1,
 				KEKPath:        "transit/keys/test",
 				KEKMountPath:   "transit",
 				WrappedKeyset:  "vault:v1:encrypted",
@@ -90,6 +95,7 @@ func TestOrganizationKeyset_Validate(t *testing.T) {
 			name: "hmac_keyset_without_hmac_info",
 			keyset: OrganizationKeyset{
 				OrganizationID:    "org-a",
+				Version:           1,
 				KEKPath:           "transit/keys/test",
 				KEKMountPath:      "transit",
 				WrappedKeyset:     "vault:v1:encrypted",
@@ -103,6 +109,7 @@ func TestOrganizationKeyset_Validate(t *testing.T) {
 			name: "valid keyset with hmac",
 			keyset: OrganizationKeyset{
 				OrganizationID:    "org-a",
+				Version:           1,
 				KEKPath:           "transit/keys/test",
 				KEKMountPath:      "transit",
 				WrappedKeyset:     "vault:v1:encrypted",
@@ -226,6 +233,7 @@ func mixedKeyset() OrganizationKeyset {
 	return OrganizationKeyset{
 		TenantID:       "tenant-a",
 		OrganizationID: "org-a",
+		Version:        1,
 		KEKPath:        "transit/keys/test",
 		KEKMountPath:   "transit",
 		WrappedKeyset:  "vault:v1:secret-dek-material",


### PR DESCRIPTION
## Summary

Make the envelope ciphertext marker `tink:v<n>` carry the organization's **monotonic keyset version** instead of the random Tink primary key id, store keysets **version-keyed**, and **route decryption by the marker's version** (fail-closed against the organization's readable versions). This prepares the ground for a future key-rotation flow without implementing rotation itself.


## Motivation

In the envelope marker `tink:v<n>:<payload>`, `<n>` was the random Tink AEAD primary key id (a large opaque number), not a version. Two problems:

- The "version" semantics were misleading: `<n>` looked like a sequential version but was a key id.
- Decryption ignored `<n>` entirely — Tink selected the key internally from the ciphertext prefix, so the marker carried no routing meaning.

To support future DEK rotation (multiple keyset generations per organization), the marker must carry a meaningful, monotonic version, storage must hold one wrapped keyset per version, and decryption must route to the exact version that produced each value. This change delivers that groundwork.

## Semantic Decision

- `<n>` is the organization's **monotonic keyset version** (`organization_registry.current_version`, initialized to 1), not the Tink key id and not a constant. It is intended to increment on rotation.
- **Two-level routing**: the marker version selects which version's keyset to load; Tink still selects the concrete key within that keyset from the ciphertext prefix.
- **Decrypt is fail-closed**: the marker version must be present in the organization's `readable_versions`, otherwise decryption fails (no fallback to legacy).
- **Storage is version-keyed**: the keyset collection is unique on `(tenant_id, organization_id, version)`, so each version is an independent wrapped document. Today only version 1 is written.
- The `KeysetManager` is split into an **active path** (write/encrypt) and a **version path** (read/decrypt), both cache-first to preserve the single-fetch/stampede-dedup guarantee.
- Scope is "prepare the ground": no rotation creation, promotion, or endpoints are added.
- The envelope payload keeps base64 URL-safe encoding (consistent with search tokens); the legacy path keeps base64 Std for lib-commons on-disk compatibility. These are intentionally different and documented inline.

## Changes

### New Files

None. All changes modify existing files.

### Environment Variables

None added or changed.

### Refactored Code

| Before | After |
|--------|-------|
| Marker `tink:v{tinkPrimaryKeyID}:{payload}` (random key id; ignored on decrypt) | Marker `tink:v{keysetVersion}:{payload}` (monotonic org keyset version; routed on decrypt) |
| `EnvelopeMarker.KeyID uint32` | `EnvelopeMarker.Version uint32` |
| `FormatEnvelopeMarker(keyID uint32, payload []byte)` | `FormatEnvelopeMarker(version uint32, payload []byte)` |
| `KeysetManager.GetPrimitives(ctx, orgID)` (single entry, repo read before cache) | `GetActivePrimitives(ctx, orgID)` (write path) + `GetPrimitivesForVersion(ctx, orgID, version)` (read path), both cache-first |
| Cache key `tenantID:organizationID` | Active key `tenantID:organizationID`; version key `tenantID:organizationID:version` |
| `KeysetRepository.Get(ctx, orgID)` only | adds `GetByVersion(ctx, orgID, version)` and `GetActive(ctx, orgID)` |
| Keyset unique index `(tenant_id, organization_id)` | `(tenant_id, organization_id, version)` |
| `decryptEnvelope` always loaded the current keyset | parses marker version, validates against `ReadableVersions` (fail-closed), loads that exact version |
| `mmodel.OrganizationKeyset` had no version | adds `Version int` (validated `>= 1`), persisted and carried in `SafeView` |
| `ProtectionState` exposed only `CurrentKeysetVersion` | adds `ReadableVersions []int` for decrypt-time gating |
| `versionIsReadable` compared via `uint32(v)` (overflow-flagged narrowing) | compares via `int(version)` (safe widening) |

### OpenTelemetry Metrics

None added. Existing protection metrics (`crm.protection.cache.*`, `crm.protection.provider_operation_*`, encrypt/decrypt counters) are unchanged; the cache-first refactor preserves the hit/miss recording semantics.

## Test Plan

- [x] Unit tests for version-keyed storage: `GetByVersion` (hit + not-found) and `GetActive` (highest version), plus the `Version >= 1` model validation.
- [x] Marker tests: `Version` round-trip through `FormatEnvelopeMarker`/`ParseEnvelopeMarker`.
- [x] Encryption service: encrypt stamps the active keyset version into the marker; decrypt is version-routed and fails closed when the marker version is not in `ReadableVersions`; legacy/unmarked path unchanged.
- [x] KeysetManager cache-first behavior: cache hit and concurrent fetches deduplicate to a single repository read; cache keys scoped by tenant and version; version-aware invalidation.
- [x] `go test -race` clean across the encryption service, mongo-encryption, and bootstrap packages.
- [x] `go build ./components/crm/...`, `golangci-lint`, and `gosec` clean on changed files.
- [x] Manual verification in MongoDB: `organization_keyset` document carries `version: 1`, the unique index is `(tenant_id, organization_id, version)`, the registry shows `current_version: 1` / `readable_versions: [1]`, and holder fields carry `tink:v1:` markers.
