### PR TITLE
refactor(crm): update auto-provisioning logic

### DIFF
--- a/components/crm/internal/services/encryption/keyset_manager.go
+++ b/components/crm/internal/services/encryption/keyset_manager.go
@@ -473,10 +473,10 @@ func (km *KeysetManager) autoProvision(ctx context.Context, organizationID strin
 		TenantID:       tenantID,
 		OrganizationID: organizationID,
 		Actor:          "system:auto-provision",
-		Reason:         "Auto-provisioned on first encrypted field access",
-		// Lazy provisioning is always envelope-only: a new org accessed for the
-		// first time has no legacy key material to import.
-		envelopeOnly: true,
+		Reason:         "Lazy migration: imported legacy key material on first encrypted field access",
+		// Lazy provisioning migrates an existing organization: it imports the
+		// legacy key material (envelope PRIMARY + legacy ENABLED).
+		importLegacy: true,
 	})
 
 	return err

--- a/components/crm/internal/services/encryption/keyset_manager_test.go
+++ b/components/crm/internal/services/encryption/keyset_manager_test.go
@@ -1196,8 +1196,8 @@ func TestKeysetManager_autoProvision_UsesTenantFromContext(t *testing.T) {
 		t.Errorf("autoProvision() actor = %q, want %q", lastReq.Actor, "system:auto-provision")
 	}
 
-	if lastReq.Reason != "Auto-provisioned on first encrypted field access" {
-		t.Errorf("autoProvision() reason = %q, want %q", lastReq.Reason, "Auto-provisioned on first encrypted field access")
+	if lastReq.Reason != "Lazy migration: imported legacy key material on first encrypted field access" {
+		t.Errorf("autoProvision() reason = %q, want %q", lastReq.Reason, "Lazy migration: imported legacy key material on first encrypted field access")
 	}
 }
 
@@ -2063,12 +2063,12 @@ func TestKeysetManager_GetPrimitives_LegacyEmptyMount_FallsBackToDerived(t *test
 	}
 }
 
-// TestKeysetManager_autoProvision_SetsEnvelopeOnly verifies that lazy
-// auto-provisioning takes the envelope-only path by setting the internal
-// ProvisionInput.envelopeOnly marker to true, without relying on audit fields
-// (Actor/Reason). Envelope-only provisioning is the correct path for brand-new
-// organizations that have no legacy key material to import.
-func TestKeysetManager_autoProvision_SetsEnvelopeOnly(t *testing.T) {
+// TestKeysetManager_autoProvision_SetsImportLegacy verifies that lazy
+// auto-provisioning takes the migration path by setting the internal
+// ProvisionInput.importLegacy marker to true, without relying on audit fields
+// (Actor/Reason). Lazy provisioning migrates an existing organization by
+// importing its legacy key material (envelope PRIMARY + legacy ENABLED).
+func TestKeysetManager_autoProvision_SetsImportLegacy(t *testing.T) {
 	t.Parallel()
 
 	provisioner := &fakeProvisioningService{}
@@ -2083,13 +2083,13 @@ func TestKeysetManager_autoProvision_SetsEnvelopeOnly(t *testing.T) {
 
 	ctx := tmcore.ContextWithTenantID(context.Background(), "tenant-envelope")
 
-	if err := manager.autoProvision(ctx, "org-envelope-only"); err != nil {
+	if err := manager.autoProvision(ctx, "org-migrate"); err != nil {
 		t.Fatalf("autoProvision() error = %v", err)
 	}
 
 	got := provisioner.getLastRequest()
-	if !got.envelopeOnly {
-		t.Errorf("autoProvision() envelopeOnly = %v, want true", got.envelopeOnly)
+	if !got.importLegacy {
+		t.Errorf("autoProvision() importLegacy = %v, want true", got.importLegacy)
 	}
 }
 

--- a/components/crm/internal/services/encryption/provisioning.go
+++ b/components/crm/internal/services/encryption/provisioning.go
@@ -54,15 +54,13 @@ type KeysetGenerator interface {
 	// GenerateMixedAEADKeyset builds a composite AEAD keyset: a fresh AES-256-GCM
 	// primary key plus the imported legacy AES-GCM key (legacyHexKey) as an
 	// enabled, non-primary entry, KMS-wrapped as one keyset. It fails closed when
-	// legacy material is missing or invalid. Used only by the manual migration
-	// path; T-1.2.2 routes provision() to it.
+	// legacy material is missing or invalid. Used by the lazy migration path.
 	GenerateMixedAEADKeyset(ctx context.Context, mountPath, keyName, legacyHexKey string) (tink.KeysetBundle, error)
 
 	// GenerateMixedPRFKeyset builds a composite PRF keyset: a fresh HMAC-PRF
 	// primary key plus the imported legacy HMAC-SHA256 key (legacySecret) as an
 	// enabled, non-primary entry, KMS-wrapped as one keyset. It fails closed when
-	// legacy material is missing. Used only by the manual migration path; T-1.2.2
-	// routes provision() to it.
+	// legacy material is missing. Used by the lazy migration path.
 	GenerateMixedPRFKeyset(ctx context.Context, mountPath, keyName, legacySecret string) (tink.KeysetBundle, error)
 }
 
@@ -153,13 +151,13 @@ type ProvisionInput struct {
 	Actor          string // Who initiated the provisioning
 	Reason         string // Why provisioning was requested
 
-	// envelopeOnly selects the lazy, envelope-only provisioning path for brand-new
-	// organizations with no legacy key material to import. It is unexported on
-	// purpose: it is an internal service-package decision, not an HTTP API
-	// contract, so external callers (e.g. adapters/http/in) cannot set it. The
-	// zero value (false) is the default manual migration provisioning path.
+	// importLegacy selects the lazy migration path: import the organization's
+	// legacy key material (envelope PRIMARY + legacy ENABLED) for an existing org.
+	// It is unexported on purpose: an internal service-package decision, not an
+	// HTTP API contract, so external callers (e.g. adapters/http/in) cannot set it.
+	// The zero value (false) is the default envelope-only path for new orgs.
 	// It MUST NOT be inferred from the Actor or Reason audit fields.
-	envelopeOnly bool
+	importLegacy bool
 }
 
 // Validate validates the provision request.
@@ -296,11 +294,11 @@ func (s *provisioningService) provision(ctx context.Context, req ProvisionInput)
 // the single internal branching point between envelope-only and migration
 // keyset construction.
 //
-// envelopeOnly == true selects the lazy path for brand-new organizations with no
-// legacy material: one fresh AEAD keyset plus one fresh PRF keyset. The default
-// (envelopeOnly == false) selects manual migration: it composes the imported
-// legacy key material with a fresh envelope PRIMARY, yielding a two-key keyset per
-// slot (fresh envelope PRIMARY + imported legacy ENABLED non-primary).
+// The default (importLegacy == false) selects the envelope-only path for new
+// organizations: one fresh AEAD keyset plus one fresh PRF keyset. importLegacy ==
+// true selects the lazy migration path: it composes the imported legacy key
+// material with a fresh envelope PRIMARY, yielding a two-key keyset per slot
+// (fresh envelope PRIMARY + imported legacy ENABLED non-primary).
 //
 // The context is checked before generating the PRF keyset. Provider timing is
 // measured at this service boundary (pkg/crypto/tink MUST NOT emit metrics) and
@@ -316,14 +314,13 @@ func (s *provisioningService) buildProvisioningKeysets(ctx context.Context, req 
 		err        error
 	)
 
-	if req.envelopeOnly {
-		aeadBundle, prfBundle, verbatim, err = s.generateFreshKeysets(ctx, mount, kekPath)
-	} else {
+	if req.importLegacy {
 		// Migration mode: compose the imported legacy key material with a fresh
-		// envelope PRIMARY into a single keyset per slot. It is a deliberate seam:
-		// do not collapse it into the envelope-only arm. The fresh envelope keys
+		// envelope PRIMARY into a single keyset per slot. The fresh envelope keys
 		// stay primary, so the returned primary IDs match the envelope-only shape.
 		aeadBundle, prfBundle, verbatim, err = s.generateMixedKeysets(ctx, mount, kekPath)
+	} else {
+		aeadBundle, prfBundle, verbatim, err = s.generateFreshKeysets(ctx, mount, kekPath)
 	}
 
 	if err != nil {
@@ -366,7 +363,7 @@ func (s *provisioningService) generateFreshKeysets(ctx context.Context, mount, k
 }
 
 // generateMixedKeysets generates one composite AEAD keyset and one composite PRF
-// keyset for the manual migration path, each wrapping a fresh envelope PRIMARY
+// keyset for the lazy migration path, each wrapping a fresh envelope PRIMARY
 // plus the imported legacy key as an enabled non-primary entry. It is the
 // migration arm; it delegates the shared scaffolding to generateKeysetPair,
 // supplying the two mixed generator calls.

--- a/components/crm/internal/services/encryption/provisioning_test.go
+++ b/components/crm/internal/services/encryption/provisioning_test.go
@@ -455,12 +455,12 @@ func TestProvisionRequest_Validate(t *testing.T) {
 	}
 }
 
-// TestProvisionInput_EnvelopeOnly_DefaultsFalse verifies that a ProvisionInput
-// built without the internal marker (the manual migration provisioning path used
-// by HTTP handlers) defaults envelopeOnly to false. The marker is unexported on
-// purpose: external packages cannot set it, so manual provisioning always takes
-// the default (migration) path. The mode MUST NOT be inferred from audit fields.
-func TestProvisionInput_EnvelopeOnly_DefaultsFalse(t *testing.T) {
+// TestProvisionInput_ImportLegacy_DefaultsFalse verifies that a ProvisionInput
+// built without the internal marker (the manual provisioning path used by HTTP
+// handlers) defaults importLegacy to false, i.e. the envelope-only path for new
+// organizations. The marker is unexported on purpose: external packages cannot
+// set it. The mode MUST NOT be inferred from audit fields.
+func TestProvisionInput_ImportLegacy_DefaultsFalse(t *testing.T) {
 	t.Parallel()
 
 	req := ProvisionInput{
@@ -470,8 +470,8 @@ func TestProvisionInput_EnvelopeOnly_DefaultsFalse(t *testing.T) {
 		Reason:         "Initial provisioning",
 	}
 
-	if req.envelopeOnly {
-		t.Errorf("ProvisionInput.envelopeOnly = %v, want false (manual provisioning default)", req.envelopeOnly)
+	if req.importLegacy {
+		t.Errorf("ProvisionInput.importLegacy = %v, want false (manual provisioning default)", req.importLegacy)
 	}
 }
 
@@ -484,7 +484,7 @@ func TestProvisionInput_EnvelopeOnly_DefaultsFalse(t *testing.T) {
 // envelope-only path: it constructs one fresh AEAD keyset and one fresh PRF
 // keyset, each with a non-zero PrimaryKeyID and exactly one enabled key, and
 // returns the assembled OrganizationKeyset carrying that single-key metadata.
-// This characterizes the branch reached when envelopeOnly == true.
+// This characterizes the branch reached when importLegacy == false (the default).
 func TestProvisioningService_buildProvisioningKeysets_EnvelopeOnly_SingleKeyShape(t *testing.T) {
 	t.Parallel()
 
@@ -502,7 +502,7 @@ func TestProvisioningService_buildProvisioningKeysets_EnvelopeOnly_SingleKeyShap
 		OrganizationID: "org-456",
 		Actor:          "admin@example.com",
 		Reason:         "Initial provisioning",
-		envelopeOnly:   true,
+		importLegacy:   false,
 	}
 
 	mount := resolveMount(concreteSvc.kekMountPath, req.TenantID)
@@ -1040,6 +1040,7 @@ func TestProvisioningService_Provision_RecoveryFromPartialFailure_MixedKeyset(t 
 		OrganizationID: "org-456",
 		Actor:          "admin@example.com",
 		Reason:         "Recovery from partial failure",
+		importLegacy:   true,
 	}
 
 	result, err := svc.Provision(ctx, req)
@@ -1289,7 +1290,7 @@ func (g *cancelAfterAEADGenerator) GenerateMixedPRFKeyset(ctx context.Context, m
 }
 
 // TestProvisioningService_buildProvisioningKeysets_Migration_MixedTwoKeyShape
-// pins the T-1.2.2 contract for the manual migration arm (envelopeOnly == false):
+// pins the contract for the lazy migration arm (importLegacy == true):
 // it MUST route to the mixed AEAD/PRF generators and assemble a composite keyset
 // holding TWO keys per slot — a fresh envelope PRIMARY key plus the imported
 // legacy ENABLED non-primary key — persisted into the existing
@@ -1312,7 +1313,7 @@ func TestProvisioningService_buildProvisioningKeysets_Migration_MixedTwoKeyShape
 		OrganizationID: "org-456",
 		Actor:          "admin@example.com",
 		Reason:         "Initial provisioning",
-		envelopeOnly:   false,
+		importLegacy:   true,
 	}
 
 	mount := resolveMount(concreteSvc.kekMountPath, req.TenantID)
@@ -2198,8 +2199,10 @@ func TestProvisioningService_Provision_NeverExposesRawLegacySecret(t *testing.T)
 
 	svc := NewProvisioningService(keysetRepo, registryRepo, keysetGenerator, DefaultProvisioningConfig(), spy, NewProtectionMetrics(nil), nil)
 
-	// envelopeOnly defaults to false => manual migration path => mixed generators.
-	result, err := svc.Provision(ctx, newProvisionReq())
+	// importLegacy => lazy migration path => mixed generators import legacy material.
+	req := newProvisionReq()
+	req.importLegacy = true
+	result, err := svc.Provision(ctx, req)
 	require.NoError(t, err)
 	assert.Equal(t, mmodel.RegistryStatusActive, result.RegistryStatus)
 


### PR DESCRIPTION
## Summary

Invert the auto/manual provisioning semantics so they match the intended operational model:

- **Lazy / auto-provisioning** (triggered on an organization's first encrypted write, with no prior provision) now **migrates an existing organization**: it builds a **mixed keyset** (fresh envelope PRIMARY + imported legacy key ENABLED) using `LCRYPTO_ENCRYPT_SECRET_KEY` / `LCRYPTO_HASH_SECRET_KEY`.
- **Manual provisioning** (`POST /v1/organizations/{id}/encryption/provision`) now creates an **envelope-only keyset** for a **new organization** (no legacy import).

## Motivation

The previous mapping was the inverse of the intended model: lazy/auto produced an envelope-only keyset and manual produced a mixed (legacy-importing) keyset. The correct model is:

- New organizations are explicitly provisioned (envelope-only) — they have no legacy data to import.
- Existing organizations migrate lazily on first access — importing their legacy key material so historical (legacy-encrypted) data remains readable while new writes use the envelope PRIMARY.

This change flips which trigger imports legacy material so the keyset shape matches the organization's lifecycle.

## Semantic Decision

- The unexported selector `ProvisionInput.envelopeOnly` is renamed to **`importLegacy`** with inverted meaning: the zero value (`false`) is the envelope-only path (the default for the manual/new-org route, which external HTTP callers cannot override), and `true` selects the lazy migration path that imports legacy key material.
- `KeysetManager.autoProvision` now sets `importLegacy: true`, so the lazy path produces a mixed keyset.
- **Operational contract** (confirmed): manual provisioning of a new organization is the client's responsibility and must happen **before** its first write. The lazy path cannot distinguish a new organization from an existing one, so it always migrates (imports legacy). An unprovisioned new org whose first write precedes a manual provision would receive a mixed keyset (legacy imported but unused); provisioning is idempotent, so the first path wins.
- The legacy material is sourced from the process-level `LCRYPTO_*` secrets via the bootstrap keyset-generator adapter (no request-body input). The mixed generators fail closed when this material is absent.
- The lazy-path audit `Reason` is updated to reflect migration with legacy import.

## Changes

### New Files

None. The change modifies existing files only.

### Environment Variables

No new variables. Behavioral note: in envelope mode (`KMS_VENDOR=hashicorp-vault`), `LCRYPTO_ENCRYPT_SECRET_KEY` and `LCRYPTO_HASH_SECRET_KEY` are now effectively **required** for the lazy migration path — the mixed keyset generation fails closed without them. They are already loaded by bootstrap for the legacy decrypt path.

### Refactored Code

| Before | After |
|--------|-------|
| `ProvisionInput.envelopeOnly bool` (zero value = mixed/migration) | `ProvisionInput.importLegacy bool` (zero value = envelope-only) |
| `buildProvisioningKeysets`: `if envelopeOnly { fresh } else { mixed }` | `if importLegacy { mixed } else { fresh }` |
| `autoProvision` set `envelopeOnly: true` (envelope-only keyset) | `autoProvision` sets `importLegacy: true` (mixed/migration keyset) |
| Lazy / auto result: envelope-only keyset (1 key per slot) | Lazy / auto result: mixed keyset (2 keys per slot: envelope PRIMARY + legacy ENABLED) |
| Manual `POST .../provision` result: mixed keyset | Manual `POST .../provision` result: envelope-only keyset |
| Lazy audit `Reason`: "Auto-provisioned on first encrypted field access" | "Lazy migration: imported legacy key material on first encrypted field access" |

The HTTP handler and the `ProvisionEncryptionInput` API model are unchanged: manual provisioning becomes envelope-only automatically because external callers cannot set the unexported selector (it stays at its zero value).

### OpenTelemetry Metrics

None added or changed.

## Test Plan

- [x] `buildProvisioningKeysets` branch tests: envelope-only shape under `importLegacy == false`; mixed two-key shape under `importLegacy == true`.
- [x] `autoProvision` now sets `importLegacy: true` (migration path), verified without relying on audit fields; updated audit `Reason` assertion.
- [x] Manual/default path defaults to `importLegacy == false` (envelope-only).
- [x] Migration-specific tests (legacy material never persisted in cleartext; partial-failure recovery from an existing mixed keyset) updated to the migration flag.
- [x] `go test -race` clean across the encryption service, mongo-encryption, and bootstrap packages.
- [x] `go build ./components/crm/...` and `golangci-lint` clean on changed files.
- [x] Manual verification in MongoDB: a fresh organization written via the lazy path produces a mixed `organization_keyset` (AEAD: `AES256_GCM` PRIMARY + `LEGACY_AES_GCM` ENABLED non-primary at key id `4294967295`; PRF: `HMAC_PRF` PRIMARY + `LEGACY_HMAC_SHA256` ENABLED non-primary), `legacy_readable: true`. An organization provisioned manually keeps a single key per slot (envelope-only).
