### PR TITLE
fix(ledger): scope default date filter to txns/ops

### DIFF
--- a/components/ledger/internal/adapters/postgres/account/account.postgresql.go
+++ b/components/ledger/internal/adapters/postgres/account/account.postgresql.go
@@ -310,9 +310,13 @@ func (r *AccountPostgreSQLRepository) FindAll(ctx context.Context, organizationI
 		)
 	}
 
-	findAll = findAll.OrderBy("created_at " + strings.ToUpper(filter.SortOrder)).
-		Where(squirrel.GtOrEq{"created_at": libCommons.NormalizeDateTime(filter.StartDate, libPointers.Int(0), false)}).
-		Where(squirrel.LtOrEq{"created_at": libCommons.NormalizeDateTime(filter.EndDate, libPointers.Int(0), true)})
+	findAll = findAll.OrderBy("created_at " + strings.ToUpper(filter.SortOrder))
+
+	if !filter.StartDate.IsZero() {
+		findAll = findAll.
+			Where(squirrel.GtOrEq{"created_at": libCommons.NormalizeDateTime(filter.StartDate, libPointers.Int(0), false)}).
+			Where(squirrel.LtOrEq{"created_at": libCommons.NormalizeDateTime(filter.EndDate, libPointers.Int(0), true)})
+	}
 
 	findAll = findAll.Limit(libCommons.SafeIntToUint64(filter.Limit)).
 		Offset(libCommons.SafeIntToUint64((filter.Page - 1) * filter.Limit)).

--- a/components/ledger/internal/adapters/postgres/accounttype/accounttype.postgresql.go
+++ b/components/ledger/internal/adapters/postgres/accounttype/accounttype.postgresql.go
@@ -438,9 +438,13 @@ func (r *AccountTypePostgreSQLRepository) FindAll(ctx context.Context, organizat
 		Where(squirrel.Eq{"organization_id": organizationID}).
 		Where(squirrel.Eq{"ledger_id": ledgerID}).
 		Where(squirrel.Eq{"deleted_at": nil}).
-		Where(squirrel.GtOrEq{"created_at": libCommons.NormalizeDateTime(pagination.StartDate, libPointers.Int(0), false)}).
-		Where(squirrel.LtOrEq{"created_at": libCommons.NormalizeDateTime(pagination.EndDate, libPointers.Int(0), true)}).
 		PlaceholderFormat(squirrel.Dollar)
+
+	if !pagination.StartDate.IsZero() {
+		findAll = findAll.
+			Where(squirrel.GtOrEq{"created_at": libCommons.NormalizeDateTime(pagination.StartDate, libPointers.Int(0), false)}).
+			Where(squirrel.LtOrEq{"created_at": libCommons.NormalizeDateTime(pagination.EndDate, libPointers.Int(0), true)})
+	}
 
 	// Filter by entity IDs when provided (metadata composition)
 	if len(filter.EntityIDs) > 0 {

--- a/components/ledger/internal/adapters/postgres/asset/asset.postgresql.go
+++ b/components/ledger/internal/adapters/postgres/asset/asset.postgresql.go
@@ -259,10 +259,15 @@ func (r *AssetPostgreSQLRepository) FindAll(ctx context.Context, organizationID,
 		From(r.tableName).
 		Where(squirrel.Eq{"deleted_at": nil}).
 		Where(squirrel.Expr("organization_id = ?", organizationID)).
-		Where(squirrel.Expr("ledger_id = ?", ledgerID)).
-		Where(squirrel.GtOrEq{"created_at": libCommons.NormalizeDateTime(filter.StartDate, libPointers.Int(0), false)}).
-		Where(squirrel.LtOrEq{"created_at": libCommons.NormalizeDateTime(filter.EndDate, libPointers.Int(0), true)}).
-		OrderBy("id " + strings.ToUpper(filter.SortOrder)).
+		Where(squirrel.Expr("ledger_id = ?", ledgerID))
+
+	if !filter.StartDate.IsZero() {
+		findAll = findAll.
+			Where(squirrel.GtOrEq{"created_at": libCommons.NormalizeDateTime(filter.StartDate, libPointers.Int(0), false)}).
+			Where(squirrel.LtOrEq{"created_at": libCommons.NormalizeDateTime(filter.EndDate, libPointers.Int(0), true)})
+	}
+
+	findAll = findAll.OrderBy("id " + strings.ToUpper(filter.SortOrder)).
 		Limit(libCommons.SafeIntToUint64(filter.Limit)).
 		Offset(libCommons.SafeIntToUint64((filter.Page - 1) * filter.Limit)).
 		PlaceholderFormat(squirrel.Dollar)

--- a/components/ledger/internal/adapters/postgres/assetrate/assetrate.postgresql.go
+++ b/components/ledger/internal/adapters/postgres/assetrate/assetrate.postgresql.go
@@ -366,9 +366,13 @@ func (r *AssetRatePostgreSQLRepository) FindAllByAssetCodes(ctx context.Context,
 		Where(squirrel.Expr("organization_id = ?", organizationID)).
 		Where(squirrel.Expr("ledger_id = ?", ledgerID)).
 		Where(squirrel.Expr(`"from" = ?`, fromAssetCode)).
-		Where(squirrel.GtOrEq{"created_at": libCommons.NormalizeDateTime(filter.StartDate, libPointers.Int(0), false)}).
-		Where(squirrel.LtOrEq{"created_at": libCommons.NormalizeDateTime(filter.EndDate, libPointers.Int(0), true)}).
 		PlaceholderFormat(squirrel.Dollar)
+
+	if !filter.StartDate.IsZero() {
+		findAll = findAll.
+			Where(squirrel.GtOrEq{"created_at": libCommons.NormalizeDateTime(filter.StartDate, libPointers.Int(0), false)}).
+			Where(squirrel.LtOrEq{"created_at": libCommons.NormalizeDateTime(filter.EndDate, libPointers.Int(0), true)})
+	}
 
 	if toAssetCodes != nil {
 		findAll.Where(squirrel.Eq{`"to"`: toAssetCodes})

--- a/components/ledger/internal/adapters/postgres/balance/balance.postgresql.go
+++ b/components/ledger/internal/adapters/postgres/balance/balance.postgresql.go
@@ -438,9 +438,13 @@ func (r *BalancePostgreSQLRepository) ListAll(ctx context.Context, organizationI
 		Where(squirrel.Expr("organization_id = ?", organizationID)).
 		Where(squirrel.Expr("ledger_id = ?", ledgerID)).
 		Where(squirrel.Eq{"deleted_at": nil}).
-		Where(squirrel.GtOrEq{"created_at": libCommons.NormalizeDateTime(filter.StartDate, libPointers.Int(0), false)}).
-		Where(squirrel.LtOrEq{"created_at": libCommons.NormalizeDateTime(filter.EndDate, libPointers.Int(0), true)}).
 		PlaceholderFormat(squirrel.Dollar)
+
+	if !filter.StartDate.IsZero() {
+		findAll = findAll.
+			Where(squirrel.GtOrEq{"created_at": libCommons.NormalizeDateTime(filter.StartDate, libPointers.Int(0), false)}).
+			Where(squirrel.LtOrEq{"created_at": libCommons.NormalizeDateTime(filter.EndDate, libPointers.Int(0), true)})
+	}
 
 	findAll, err = applyCursorPagination(findAll, decodedCursor, orderDirection, filter.Limit)
 	if err != nil {
@@ -571,9 +575,13 @@ func (r *BalancePostgreSQLRepository) ListAllByAccountID(ctx context.Context, or
 		Where(squirrel.Expr("ledger_id = ?", ledgerID)).
 		Where(squirrel.Expr("account_id = ?", accountID)).
 		Where(squirrel.Eq{"deleted_at": nil}).
-		Where(squirrel.GtOrEq{"created_at": libCommons.NormalizeDateTime(filter.StartDate, libPointers.Int(0), false)}).
-		Where(squirrel.LtOrEq{"created_at": libCommons.NormalizeDateTime(filter.EndDate, libPointers.Int(0), true)}).
 		PlaceholderFormat(squirrel.Dollar)
+
+	if !filter.StartDate.IsZero() {
+		findAll = findAll.
+			Where(squirrel.GtOrEq{"created_at": libCommons.NormalizeDateTime(filter.StartDate, libPointers.Int(0), false)}).
+			Where(squirrel.LtOrEq{"created_at": libCommons.NormalizeDateTime(filter.EndDate, libPointers.Int(0), true)})
+	}
 
 	findAll, err = applyCursorPagination(findAll, decodedCursor, orderDirection, filter.Limit)
 	if err != nil {

--- a/components/ledger/internal/adapters/postgres/ledger/ledger.postgresql.go
+++ b/components/ledger/internal/adapters/postgres/ledger/ledger.postgresql.go
@@ -352,10 +352,15 @@ func (r *LedgerPostgreSQLRepository) FindAll(ctx context.Context, organizationID
 	findAll := squirrel.Select(ledgerColumnList...).
 		From(r.tableName).
 		Where(squirrel.Expr("organization_id = ?", organizationID)).
-		Where(squirrel.Eq{"deleted_at": nil}).
-		Where(squirrel.GtOrEq{"created_at": libCommons.NormalizeDateTime(pagination.StartDate, libPointers.Int(0), false)}).
-		Where(squirrel.LtOrEq{"created_at": libCommons.NormalizeDateTime(pagination.EndDate, libPointers.Int(0), true)}).
-		OrderBy("id " + strings.ToUpper(pagination.SortOrder)).
+		Where(squirrel.Eq{"deleted_at": nil})
+
+	if !pagination.StartDate.IsZero() {
+		findAll = findAll.
+			Where(squirrel.GtOrEq{"created_at": libCommons.NormalizeDateTime(pagination.StartDate, libPointers.Int(0), false)}).
+			Where(squirrel.LtOrEq{"created_at": libCommons.NormalizeDateTime(pagination.EndDate, libPointers.Int(0), true)})
+	}
+
+	findAll = findAll.OrderBy("id " + strings.ToUpper(pagination.SortOrder)).
 		Limit(libCommons.SafeIntToUint64(pagination.Limit)).
 		Offset(libCommons.SafeIntToUint64((pagination.Page - 1) * pagination.Limit)).
 		PlaceholderFormat(squirrel.Dollar)

--- a/components/ledger/internal/adapters/postgres/operation/operation.postgresql.go
+++ b/components/ledger/internal/adapters/postgres/operation/operation.postgresql.go
@@ -553,9 +553,13 @@ func (r *OperationPostgreSQLRepository) FindAll(ctx context.Context, organizatio
 		Where(squirrel.Expr("ledger_id = ?", ledgerID)).
 		Where(squirrel.Expr("transaction_id = ?", transactionID)).
 		Where(squirrel.Eq{"deleted_at": nil}).
-		Where(squirrel.GtOrEq{"created_at": libCommons.NormalizeDateTime(filter.StartDate, libPointers.Int(0), false)}).
-		Where(squirrel.LtOrEq{"created_at": libCommons.NormalizeDateTime(filter.EndDate, libPointers.Int(0), true)}).
 		PlaceholderFormat(squirrel.Dollar)
+
+	if !filter.StartDate.IsZero() {
+		findAll = findAll.
+			Where(squirrel.GtOrEq{"created_at": libCommons.NormalizeDateTime(filter.StartDate, libPointers.Int(0), false)}).
+			Where(squirrel.LtOrEq{"created_at": libCommons.NormalizeDateTime(filter.EndDate, libPointers.Int(0), true)})
+	}
 
 	findAll, err = applyCursorPagination(findAll, decodedCursor, orderDirection, filter.Limit)
 	if err != nil {
@@ -1177,9 +1181,13 @@ func (r *OperationPostgreSQLRepository) FindAllByAccount(ctx context.Context, or
 		Where(squirrel.Expr("ledger_id = ?", ledgerID)).
 		Where(squirrel.Expr("account_id = ?", accountID)).
 		Where(squirrel.Eq{"deleted_at": nil}).
-		Where(squirrel.GtOrEq{"created_at": libCommons.NormalizeDateTime(filter.StartDate, libPointers.Int(0), false)}).
-		Where(squirrel.LtOrEq{"created_at": libCommons.NormalizeDateTime(filter.EndDate, libPointers.Int(0), true)}).
 		PlaceholderFormat(squirrel.Dollar)
+
+	if !filter.StartDate.IsZero() {
+		findAll = findAll.
+			Where(squirrel.GtOrEq{"created_at": libCommons.NormalizeDateTime(filter.StartDate, libPointers.Int(0), false)}).
+			Where(squirrel.LtOrEq{"created_at": libCommons.NormalizeDateTime(filter.EndDate, libPointers.Int(0), true)})
+	}
 
 	if !libCommons.IsNilOrEmpty(opFilter.OperationType) {
 		findAll = findAll.Where(squirrel.Expr("type = ?", *opFilter.OperationType))

--- a/components/ledger/internal/adapters/postgres/operationroute/operationroute.postgresql.go
+++ b/components/ledger/internal/adapters/postgres/operationroute/operationroute.postgresql.go
@@ -745,9 +745,13 @@ func (r *OperationRoutePostgreSQLRepository) FindAll(ctx context.Context, organi
 		Where(squirrel.Eq{"organization_id": organizationID}).
 		Where(squirrel.Eq{"ledger_id": ledgerID}).
 		Where(squirrel.Eq{"deleted_at": nil}).
-		Where(squirrel.GtOrEq{"created_at": libCommons.NormalizeDateTime(filter.StartDate, libPointers.Int(0), false)}).
-		Where(squirrel.LtOrEq{"created_at": libCommons.NormalizeDateTime(filter.EndDate, libPointers.Int(0), true)}).
 		PlaceholderFormat(squirrel.Dollar)
+
+	if !filter.StartDate.IsZero() {
+		findAll = findAll.
+			Where(squirrel.GtOrEq{"created_at": libCommons.NormalizeDateTime(filter.StartDate, libPointers.Int(0), false)}).
+			Where(squirrel.LtOrEq{"created_at": libCommons.NormalizeDateTime(filter.EndDate, libPointers.Int(0), true)})
+	}
 
 	findAll, err = applyCursorPagination(findAll, decodedCursor, orderDirection, filter.Limit)
 	if err != nil {

--- a/components/ledger/internal/adapters/postgres/organization/organization.postgresql.go
+++ b/components/ledger/internal/adapters/postgres/organization/organization.postgresql.go
@@ -418,10 +418,15 @@ func (r *OrganizationPostgreSQLRepository) FindAll(ctx context.Context, filter h
 
 	findAll := squirrel.Select(organizationColumnList...).
 		From(r.tableName).
-		Where(squirrel.Eq{"deleted_at": nil}).
-		Where(squirrel.GtOrEq{"created_at": libCommons.NormalizeDateTime(pagination.StartDate, libPointers.Int(0), false)}).
-		Where(squirrel.LtOrEq{"created_at": libCommons.NormalizeDateTime(pagination.EndDate, libPointers.Int(0), true)}).
-		OrderBy("id " + strings.ToUpper(pagination.SortOrder)).
+		Where(squirrel.Eq{"deleted_at": nil})
+
+	if !pagination.StartDate.IsZero() {
+		findAll = findAll.
+			Where(squirrel.GtOrEq{"created_at": libCommons.NormalizeDateTime(pagination.StartDate, libPointers.Int(0), false)}).
+			Where(squirrel.LtOrEq{"created_at": libCommons.NormalizeDateTime(pagination.EndDate, libPointers.Int(0), true)})
+	}
+
+	findAll = findAll.OrderBy("id " + strings.ToUpper(pagination.SortOrder)).
 		Limit(libCommons.SafeIntToUint64(pagination.Limit)).
 		Offset(libCommons.SafeIntToUint64((pagination.Page - 1) * pagination.Limit)).
 		PlaceholderFormat(squirrel.Dollar)

--- a/components/ledger/internal/adapters/postgres/portfolio/portfolio.postgresql.go
+++ b/components/ledger/internal/adapters/postgres/portfolio/portfolio.postgresql.go
@@ -267,10 +267,15 @@ func (r *PortfolioPostgreSQLRepository) FindAll(ctx context.Context, organizatio
 		From(r.tableName).
 		Where(squirrel.Expr("organization_id = ?", organizationID)).
 		Where(squirrel.Expr("ledger_id = ?", ledgerID)).
-		Where(squirrel.Eq{"deleted_at": nil}).
-		Where(squirrel.GtOrEq{"created_at": libCommons.NormalizeDateTime(pagination.StartDate, libPointers.Int(0), false)}).
-		Where(squirrel.LtOrEq{"created_at": libCommons.NormalizeDateTime(pagination.EndDate, libPointers.Int(0), true)}).
-		OrderBy("id " + strings.ToUpper(pagination.SortOrder)).
+		Where(squirrel.Eq{"deleted_at": nil})
+
+	if !pagination.StartDate.IsZero() {
+		findAll = findAll.
+			Where(squirrel.GtOrEq{"created_at": libCommons.NormalizeDateTime(pagination.StartDate, libPointers.Int(0), false)}).
+			Where(squirrel.LtOrEq{"created_at": libCommons.NormalizeDateTime(pagination.EndDate, libPointers.Int(0), true)})
+	}
+
+	findAll = findAll.OrderBy("id " + strings.ToUpper(pagination.SortOrder)).
 		Limit(libCommons.SafeIntToUint64(pagination.Limit)).
 		Offset(libCommons.SafeIntToUint64((pagination.Page - 1) * pagination.Limit)).
 		PlaceholderFormat(squirrel.Dollar)

--- a/components/ledger/internal/adapters/postgres/segment/segment.postgresql.go
+++ b/components/ledger/internal/adapters/postgres/segment/segment.postgresql.go
@@ -278,10 +278,15 @@ func (p *SegmentPostgreSQLRepository) FindAll(ctx context.Context, organizationI
 		From(p.tableName).
 		Where(squirrel.Eq{"organization_id": organizationID}).
 		Where(squirrel.Eq{"ledger_id": ledgerID}).
-		Where(squirrel.Eq{"deleted_at": nil}).
-		Where(squirrel.GtOrEq{"created_at": libCommons.NormalizeDateTime(filter.StartDate, libPointers.Int(0), false)}).
-		Where(squirrel.LtOrEq{"created_at": libCommons.NormalizeDateTime(filter.EndDate, libPointers.Int(0), true)}).
-		OrderBy("id " + strings.ToUpper(filter.SortOrder)).
+		Where(squirrel.Eq{"deleted_at": nil})
+
+	if !filter.StartDate.IsZero() {
+		findAll = findAll.
+			Where(squirrel.GtOrEq{"created_at": libCommons.NormalizeDateTime(filter.StartDate, libPointers.Int(0), false)}).
+			Where(squirrel.LtOrEq{"created_at": libCommons.NormalizeDateTime(filter.EndDate, libPointers.Int(0), true)})
+	}
+
+	findAll = findAll.OrderBy("id " + strings.ToUpper(filter.SortOrder)).
 		Limit(libCommons.SafeIntToUint64(filter.Limit)).
 		Offset(libCommons.SafeIntToUint64((filter.Page - 1) * filter.Limit)).
 		PlaceholderFormat(squirrel.Dollar)

--- a/components/ledger/internal/adapters/postgres/transaction/transaction.postgresql.go
+++ b/components/ledger/internal/adapters/postgres/transaction/transaction.postgresql.go
@@ -725,9 +725,9 @@ func (r *TransactionPostgreSQLRepository) FindAll(ctx context.Context, organizat
 		Where(squirrel.Expr("organization_id = ?", organizationID)).
 		Where(squirrel.Expr("ledger_id = ?", ledgerID)).
 		Where(squirrel.Eq{"deleted_at": nil}).
-		Where(squirrel.GtOrEq{"created_at": libCommons.NormalizeDateTime(filter.StartDate, libPointers.Int(0), false)}).
-		Where(squirrel.LtOrEq{"created_at": libCommons.NormalizeDateTime(filter.EndDate, libPointers.Int(0), true)}).
 		PlaceholderFormat(squirrel.Dollar)
+
+	findAll = applyCreatedAtRange(findAll, filter)
 
 	findAll, err = applyCursorPagination(findAll, decodedCursor, orderDirection, filter.Limit)
 	if err != nil {
@@ -1437,9 +1437,9 @@ func (r *TransactionPostgreSQLRepository) FindOrListAllWithOperations(ctx contex
 		Where(squirrel.Expr("organization_id = ?", organizationID)).
 		Where(squirrel.Expr("ledger_id = ?", ledgerID)).
 		Where(squirrel.Eq{"deleted_at": nil}).
-		Where(squirrel.GtOrEq{"created_at": libCommons.NormalizeDateTime(filter.StartDate, libPointers.Int(0), false)}).
-		Where(squirrel.LtOrEq{"created_at": libCommons.NormalizeDateTime(filter.EndDate, libPointers.Int(0), true)}).
 		PlaceholderFormat(squirrel.Dollar)
+
+	subQuery = applyCreatedAtRange(subQuery, filter)
 
 	if len(ids) > 0 {
 		subQuery = subQuery.Where(squirrel.Expr("id = ANY(?)", pq.Array(ids)))
@@ -1717,6 +1717,19 @@ func (r *TransactionPostgreSQLRepository) CountByFilters(ctx context.Context, or
 	}
 
 	return count, nil
+}
+
+// applyCreatedAtRange appends the created_at range clauses only when the caller
+// provided a start date. A zero StartDate means no date filter was requested, so
+// the query must return the full set instead of an empty (zero-bounded) window.
+func applyCreatedAtRange(builder squirrel.SelectBuilder, pagination http.Pagination) squirrel.SelectBuilder {
+	if pagination.StartDate.IsZero() {
+		return builder
+	}
+
+	return builder.
+		Where(squirrel.GtOrEq{"created_at": libCommons.NormalizeDateTime(pagination.StartDate, libPointers.Int(0), false)}).
+		Where(squirrel.LtOrEq{"created_at": libCommons.NormalizeDateTime(pagination.EndDate, libPointers.Int(0), true)})
 }
 
 // derefString safely dereferences a *string, returning "" if nil.

--- a/components/ledger/internal/adapters/postgres/transactionroute/transactionroute.postgresql.go
+++ b/components/ledger/internal/adapters/postgres/transactionroute/transactionroute.postgresql.go
@@ -660,9 +660,13 @@ func (r *TransactionRoutePostgreSQLRepository) FindAll(ctx context.Context, orga
 		Where(squirrel.Eq{"organization_id": organizationID}).
 		Where(squirrel.Eq{"ledger_id": ledgerID}).
 		Where(squirrel.Eq{"deleted_at": nil}).
-		Where(squirrel.GtOrEq{"created_at": libCommons.NormalizeDateTime(filter.StartDate, libPointers.Int(0), false)}).
-		Where(squirrel.LtOrEq{"created_at": libCommons.NormalizeDateTime(filter.EndDate, libPointers.Int(0), true)}).
 		PlaceholderFormat(squirrel.Dollar)
+
+	if !filter.StartDate.IsZero() {
+		findAll = findAll.
+			Where(squirrel.GtOrEq{"created_at": libCommons.NormalizeDateTime(filter.StartDate, libPointers.Int(0), false)}).
+			Where(squirrel.LtOrEq{"created_at": libCommons.NormalizeDateTime(filter.EndDate, libPointers.Int(0), true)})
+	}
 
 	findAll, err = applyCursorPagination(findAll, decodedCursor, orderDirection, filter.Limit)
 	if err != nil {

--- a/components/ledger/internal/services/query/get_all_metadata_operations.go
+++ b/components/ledger/internal/services/query/get_all_metadata_operations.go
@@ -32,6 +32,8 @@ func (uc *UseCase) GetAllMetadataOperations(ctx context.Context, organizationID,
 
 	logger.Log(ctx, libLog.LevelInfo, "Retrieving operations")
 
+	filter.ApplyDefaultDateRange()
+
 	metadata, err := uc.TransactionMetadataRepo.FindList(ctx, constant.EntityOperation, filter)
 	if err != nil || metadata == nil {
 		err := pkg.ValidateBusinessError(constant.ErrNoOperationsFound, constant.EntityOperation)

--- a/components/ledger/internal/services/query/get_all_metadata_operations_test.go
+++ b/components/ledger/internal/services/query/get_all_metadata_operations_test.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	libHTTP "github.com/LerianStudio/lib-commons/v5/commons/net/http"
 	mongodb "github.com/LerianStudio/midaz/v3/components/ledger/internal/adapters/mongodb/transaction"
@@ -84,10 +85,14 @@ func TestGetAllMetadataOperationsWithOperations(t *testing.T) {
 	ledgerID, _ := uuid.Parse(ledgerIDStr)
 	accountID, _ := uuid.Parse(accountIDStr)
 
+	// Explicit non-zero dates so ApplyDefaultDateRange is a no-op and the
+	// strict filter expectations below match unchanged.
 	filter := http.QueryHeader{
-		Metadata: &bson.M{"key": "value"},
-		Limit:    10,
-		Page:     1,
+		Metadata:  &bson.M{"key": "value"},
+		Limit:     10,
+		Page:      1,
+		StartDate: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		EndDate:   time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC),
 	}
 
 	metadataList := []*mongodb.Metadata{
@@ -163,9 +168,11 @@ func TestGetAllMetadataOperationsMetadataNotFound(t *testing.T) {
 	accountID := uuid.New()
 
 	filter := http.QueryHeader{
-		Metadata: &bson.M{"key": "value"},
-		Limit:    10,
-		Page:     1,
+		Metadata:  &bson.M{"key": "value"},
+		Limit:     10,
+		Page:      1,
+		StartDate: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		EndDate:   time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC),
 	}
 
 	mockMetadataRepo.EXPECT().
@@ -197,9 +204,11 @@ func TestGetAllMetadataOperationsOperationNotFound(t *testing.T) {
 	accountID := uuid.New()
 
 	filter := http.QueryHeader{
-		Metadata: &bson.M{"key": "value"},
-		Limit:    10,
-		Page:     1,
+		Metadata:  &bson.M{"key": "value"},
+		Limit:     10,
+		Page:      1,
+		StartDate: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		EndDate:   time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC),
 	}
 
 	metadataList := []*mongodb.Metadata{
@@ -243,9 +252,11 @@ func TestGetAllMetadataOperationsOperationRepoError(t *testing.T) {
 	accountID := uuid.New()
 
 	filter := http.QueryHeader{
-		Metadata: &bson.M{"key": "value"},
-		Limit:    10,
-		Page:     1,
+		Metadata:  &bson.M{"key": "value"},
+		Limit:     10,
+		Page:      1,
+		StartDate: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		EndDate:   time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC),
 	}
 
 	metadataList := []*mongodb.Metadata{
@@ -276,4 +287,60 @@ func TestGetAllMetadataOperationsOperationRepoError(t *testing.T) {
 	assert.Error(t, err)
 	assert.Nil(t, result)
 	assert.Equal(t, repoError, err)
+}
+
+// TestGetAllMetadataOperations_AppliesDefaultDateRange ensures that when the
+// caller passes no date window, GetAllMetadataOperations applies the default
+// window before reaching the protected operation repository, so the repo never
+// receives a zero-date (unbounded) filter.
+func TestGetAllMetadataOperations_AppliesDefaultDateRange(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockMetadataRepo := mongodb.NewMockRepository(ctrl)
+	mockOperationRepo := operation.NewMockRepository(ctrl)
+
+	orgID := uuid.New()
+	ledgerID := uuid.New()
+	accountID := uuid.New()
+	opID := uuid.New()
+
+	// No StartDate/EndDate: the use case must inject the default window.
+	filter := http.QueryHeader{
+		Metadata: &bson.M{"key": "value"},
+		Limit:    10,
+		Page:     1,
+	}
+
+	metadataList := []*mongodb.Metadata{
+		{
+			ID:       primitive.NewObjectID(),
+			EntityID: opID.String(),
+			Data:     map[string]any{"key": "value"},
+		},
+	}
+
+	// FindList must receive a windowed QueryHeader (non-zero, ordered dates).
+	mockMetadataRepo.EXPECT().
+		FindList(gomock.Any(), constant.EntityOperation, gomock.Cond(func(qh http.QueryHeader) bool {
+			return isWindowed(qh.StartDate, qh.EndDate)
+		})).
+		Return(metadataList, nil)
+
+	// FindAllByAccount must receive the same windowed pagination.
+	mockOperationRepo.EXPECT().
+		FindAllByAccount(gomock.Any(), orgID, ledgerID, accountID, gomock.Any(), gomock.Cond(func(p http.Pagination) bool {
+			return isWindowed(p.StartDate, p.EndDate)
+		})).
+		Return([]*operation.Operation{{ID: opID.String()}}, libHTTP.CursorPagination{}, nil)
+
+	uc := &UseCase{
+		TransactionMetadataRepo: mockMetadataRepo,
+		OperationRepo:           mockOperationRepo,
+	}
+
+	result, _, err := uc.GetAllMetadataOperations(context.Background(), orgID, ledgerID, accountID, filter)
+
+	assert.NoError(t, err)
+	assert.Len(t, result, 1)
 }

--- a/components/ledger/internal/services/query/get_all_metadata_operations_test.go
+++ b/components/ledger/internal/services/query/get_all_metadata_operations_test.go
@@ -314,7 +314,7 @@ func TestGetAllMetadataOperations_AppliesDefaultDateRange(t *testing.T) {
 
 	metadataList := []*mongodb.Metadata{
 		{
-			ID:       primitive.NewObjectID(),
+			ID:       bson.NewObjectID(),
 			EntityID: opID.String(),
 			Data:     map[string]any{"key": "value"},
 		},

--- a/components/ledger/internal/services/query/get_all_metadata_transactions.go
+++ b/components/ledger/internal/services/query/get_all_metadata_transactions.go
@@ -33,6 +33,8 @@ func (uc *UseCase) GetAllMetadataTransactions(ctx context.Context, organizationI
 
 	logger.Log(ctx, libLog.LevelInfo, "Retrieving transactions")
 
+	filter.ApplyDefaultDateRange()
+
 	metadata, err := uc.TransactionMetadataRepo.FindList(ctx, constant.EntityTransaction, filter)
 	if err != nil || metadata == nil {
 		err := pkg.ValidateBusinessError(constant.ErrNoTransactionsFound, constant.EntityTransaction)

--- a/components/ledger/internal/services/query/get_all_metadata_transactions_test.go
+++ b/components/ledger/internal/services/query/get_all_metadata_transactions_test.go
@@ -254,7 +254,7 @@ func TestGetAllMetadataTransactions_AppliesDefaultDateRange(t *testing.T) {
 
 	metadataList := []*mongodb.Metadata{
 		{
-			ID:       primitive.NewObjectID(),
+			ID:       bson.NewObjectID(),
 			EntityID: txID.String(),
 			Data:     map[string]any{"key": "value"},
 		},

--- a/components/ledger/internal/services/query/get_all_metadata_transactions_test.go
+++ b/components/ledger/internal/services/query/get_all_metadata_transactions_test.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	libHTTP "github.com/LerianStudio/lib-commons/v5/commons/net/http"
 	mongodb "github.com/LerianStudio/midaz/v3/components/ledger/internal/adapters/mongodb/transaction"
@@ -84,10 +85,14 @@ func TestGetAllMetadataTransactionsWithOperations(t *testing.T) {
 	txID1, _ := uuid.Parse(txID1Str)
 	txID2, _ := uuid.Parse(txID2Str)
 
+	// Explicit non-zero dates so ApplyDefaultDateRange is a no-op and the
+	// strict filter expectations below match unchanged.
 	filter := http.QueryHeader{
-		Metadata: &bson.M{"key": "value"},
-		Limit:    10,
-		Page:     1,
+		Metadata:  &bson.M{"key": "value"},
+		Limit:     10,
+		Page:      1,
+		StartDate: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		EndDate:   time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC),
 	}
 
 	metadataList := []*mongodb.Metadata{
@@ -201,9 +206,11 @@ func TestGetAllMetadataTransactions_NoMetadata(t *testing.T) {
 
 	collection := constant.EntityTransaction
 	filter := http.QueryHeader{
-		Metadata: &bson.M{"k": "v"},
-		Limit:    10,
-		Page:     1,
+		Metadata:  &bson.M{"k": "v"},
+		Limit:     10,
+		Page:      1,
+		StartDate: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		EndDate:   time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC),
 	}
 
 	// Return an empty, non-nil slice to hit the early-return branch.
@@ -221,4 +228,70 @@ func TestGetAllMetadataTransactions_NoMetadata(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Nil(t, result)
 	assert.Equal(t, libHTTP.CursorPagination{}, cur)
+}
+
+// TestGetAllMetadataTransactions_AppliesDefaultDateRange ensures that when the
+// caller passes no date window, GetAllMetadataTransactions applies the default
+// window before reaching the protected transaction repository, so the repo never
+// receives a zero-date (unbounded) filter.
+func TestGetAllMetadataTransactions_AppliesDefaultDateRange(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockMetadataRepo := mongodb.NewMockRepository(ctrl)
+	mockTransactionRepo := transaction.NewMockRepository(ctrl)
+
+	orgID := uuid.New()
+	ledgerID := uuid.New()
+	txID := uuid.New()
+
+	// No StartDate/EndDate: the use case must inject the default window.
+	filter := http.QueryHeader{
+		Metadata: &bson.M{"key": "value"},
+		Limit:    10,
+		Page:     1,
+	}
+
+	metadataList := []*mongodb.Metadata{
+		{
+			ID:       primitive.NewObjectID(),
+			EntityID: txID.String(),
+			Data:     map[string]any{"key": "value"},
+		},
+	}
+
+	// FindList must receive a windowed QueryHeader (non-zero, ordered dates).
+	mockMetadataRepo.EXPECT().
+		FindList(gomock.Any(), constant.EntityTransaction, gomock.Cond(func(qh http.QueryHeader) bool {
+			return isWindowed(qh.StartDate, qh.EndDate)
+		})).
+		Return(metadataList, nil)
+
+	// FindOrListAllWithOperations must receive the same windowed pagination.
+	mockTransactionRepo.EXPECT().
+		FindOrListAllWithOperations(gomock.Any(), orgID, ledgerID, []uuid.UUID{txID}, gomock.Cond(func(p http.Pagination) bool {
+			return isWindowed(p.StartDate, p.EndDate)
+		})).
+		Return([]*transaction.Transaction{{ID: txID.String()}}, libHTTP.CursorPagination{}, nil)
+
+	mockMetadataRepo.EXPECT().
+		FindByEntityIDs(gomock.Any(), constant.EntityOperation, gomock.Any()).
+		Return(nil, nil).
+		AnyTimes()
+
+	uc := &UseCase{
+		TransactionMetadataRepo: mockMetadataRepo,
+		TransactionRepo:         mockTransactionRepo,
+	}
+
+	result, _, err := uc.GetAllMetadataTransactions(context.Background(), orgID, ledgerID, filter)
+
+	assert.NoError(t, err)
+	assert.Len(t, result, 1)
+}
+
+// isWindowed reports whether a date window is non-zero and correctly ordered.
+// It avoids asserting against time.Now() directly.
+func isWindowed(start, end time.Time) bool {
+	return !start.IsZero() && !end.IsZero() && !start.After(end)
 }

--- a/components/ledger/internal/services/query/get_all_operations_account.go
+++ b/components/ledger/internal/services/query/get_all_operations_account.go
@@ -30,6 +30,8 @@ func (uc *UseCase) GetAllOperationsByAccount(ctx context.Context, organizationID
 
 	logger.Log(ctx, libLog.LevelInfo, "Retrieving operations by account")
 
+	filter.ApplyDefaultDateRange()
+
 	opFilter := operation.OperationFilter{
 		OperationType: &filter.OperationType,
 		Direction:     filter.Direction,

--- a/components/ledger/internal/services/query/get_all_transactions.go
+++ b/components/ledger/internal/services/query/get_all_transactions.go
@@ -33,6 +33,8 @@ func (uc *UseCase) GetAllTransactions(ctx context.Context, organizationID, ledge
 
 	logger.Log(ctx, libLog.LevelInfo, "Retrieving transactions")
 
+	filter.ApplyDefaultDateRange()
+
 	trans, cur, err := uc.TransactionRepo.FindOrListAllWithOperations(ctx, organizationID, ledgerID, []uuid.UUID{}, filter.ToCursorPagination())
 	if err != nil {
 		logger.Log(ctx, libLog.LevelError, fmt.Sprintf("Error getting transactions on repo: %v", err))

--- a/pkg/net/http/httputils.go
+++ b/pkg/net/http/httputils.go
@@ -361,19 +361,15 @@ func ValidateParameters(params map[string]string) (*QueryHeader, error) {
 	return query, nil
 }
 
-// validateDates validates and normalizes start/end date range for pagination queries.
-// Mutates the provided pointers to apply defaults when both dates are zero.
-// Default range: last N months (via MAX_PAGINATION_MONTH_DATE_RANGE env var, default=1).
-// Set MAX_PAGINATION_MONTH_DATE_RANGE=0 for unlimited range (since epoch).
+// validateDates validates an explicit start/end date range for pagination queries.
+// It no longer applies any default window: when both dates are zero the caller
+// supplied neither, so it returns nil without mutating the pointers. The default
+// protection window is applied separately, and only for high-volume endpoints,
+// via (*QueryHeader).ApplyDefaultDateRange.
 // Enforces all-or-nothing: both dates required if any provided.
 // Returns error if dates are invalid, out of order, or only one is provided.
 func validateDates(startDate, endDate *time.Time) error {
-	// Limits query range to prevent expensive DB operations on large datasets
-	maxDateRangeMonths := libCommons.SafeInt64ToInt(libCommons.GetenvIntOrDefault("MAX_PAGINATION_MONTH_DATE_RANGE", 1))
-
 	if startDate.IsZero() && endDate.IsZero() {
-		*startDate, *endDate = defaultPaginationDateRange(time.Now(), maxDateRangeMonths)
-
 		return nil
 	}
 
@@ -391,6 +387,19 @@ func validateDates(startDate, endDate *time.Time) error {
 	}
 
 	return nil
+}
+
+// ApplyDefaultDateRange fills StartDate/EndDate with the default protection
+// window (MAX_PAGINATION_MONTH_DATE_RANGE) when the caller provided neither
+// date. No-op when either date was supplied explicitly. Used only by
+// high-volume list endpoints (transactions, operations) to bound table scans.
+func (q *QueryHeader) ApplyDefaultDateRange() {
+	if !q.StartDate.IsZero() || !q.EndDate.IsZero() {
+		return
+	}
+
+	maxDateRangeMonths := libCommons.SafeInt64ToInt(libCommons.GetenvIntOrDefault("MAX_PAGINATION_MONTH_DATE_RANGE", 1))
+	q.StartDate, q.EndDate = defaultPaginationDateRange(time.Now(), maxDateRangeMonths)
 }
 
 func defaultPaginationDateRange(now time.Time, maxDateRangeMonths int) (time.Time, time.Time) {

--- a/pkg/net/http/httputils.go
+++ b/pkg/net/http/httputils.go
@@ -399,6 +399,12 @@ func (q *QueryHeader) ApplyDefaultDateRange() {
 	}
 
 	maxDateRangeMonths := libCommons.SafeInt64ToInt(libCommons.GetenvIntOrDefault("MAX_PAGINATION_MONTH_DATE_RANGE", 1))
+	if maxDateRangeMonths < 0 {
+		// A negative configured value would push StartDate ahead of EndDate,
+		// silently yielding empty results. Treat it as 0 (unbounded start).
+		maxDateRangeMonths = 0
+	}
+
 	q.StartDate, q.EndDate = defaultPaginationDateRange(time.Now(), maxDateRangeMonths)
 }
 

--- a/pkg/net/http/httputils_test.go
+++ b/pkg/net/http/httputils_test.go
@@ -341,19 +341,13 @@ func TestValidateDates_BothZero(t *testing.T) {
 	startDate := time.Time{}
 	endDate := time.Time{}
 	err := validateDates(&startDate, &endDate)
+
+	// validateDates no longer fabricates a default window: when both dates are
+	// zero it returns nil and leaves the pointers untouched. The default window
+	// is applied separately via (*QueryHeader).ApplyDefaultDateRange.
 	require.NoError(t, err)
-	assert.False(t, startDate.IsZero())
-	assert.False(t, endDate.IsZero())
-
-	assert.Equal(t, 0, startDate.Hour())
-	assert.Equal(t, 0, startDate.Minute())
-	assert.Equal(t, 0, startDate.Second())
-
-	assert.Equal(t, 23, endDate.Hour())
-	assert.Equal(t, 59, endDate.Minute())
-	assert.Equal(t, 59, endDate.Second())
-
-	assert.True(t, endDate.After(startDate) || endDate.Equal(startDate))
+	assert.True(t, startDate.IsZero())
+	assert.True(t, endDate.IsZero())
 }
 
 func TestValidateDates_OnlyStartDateProvided(t *testing.T) {
@@ -392,17 +386,47 @@ func TestValidateDates_ValidDateRange(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestValidateDates_WithMaxDateRangeZero(t *testing.T) {
+func TestApplyDefaultDateRange_BothZeroAppliesWindow(t *testing.T) {
+	q := &QueryHeader{}
+
+	q.ApplyDefaultDateRange()
+
+	assert.False(t, q.StartDate.IsZero())
+	assert.False(t, q.EndDate.IsZero())
+	assert.True(t, q.EndDate.After(q.StartDate))
+}
+
+func TestApplyDefaultDateRange_WithMaxDateRangeZero(t *testing.T) {
 	t.Setenv("MAX_PAGINATION_MONTH_DATE_RANGE", "0")
 
-	startDate := time.Time{}
-	endDate := time.Time{}
+	q := &QueryHeader{}
 
-	err := validateDates(&startDate, &endDate)
+	q.ApplyDefaultDateRange()
 
-	require.NoError(t, err)
-	// When max is 0, startDate should be epoch
-	assert.Equal(t, int64(0), startDate.Unix())
+	// When max is 0, StartDate falls back to epoch (effectively unbounded start).
+	assert.Equal(t, int64(0), q.StartDate.Unix())
+	assert.False(t, q.EndDate.IsZero())
+}
+
+func TestApplyDefaultDateRange_ExplicitDatesNoOp(t *testing.T) {
+	start := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	end := time.Date(2024, 1, 31, 23, 59, 59, 0, time.UTC)
+	q := &QueryHeader{StartDate: start, EndDate: end}
+
+	q.ApplyDefaultDateRange()
+
+	assert.Equal(t, start, q.StartDate)
+	assert.Equal(t, end, q.EndDate)
+}
+
+func TestApplyDefaultDateRange_OnlyStartProvidedNoOp(t *testing.T) {
+	start := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	q := &QueryHeader{StartDate: start}
+
+	q.ApplyDefaultDateRange()
+
+	assert.Equal(t, start, q.StartDate)
+	assert.True(t, q.EndDate.IsZero())
 }
 
 func TestDefaultPaginationDateRange_UsesUTCDate(t *testing.T) {


### PR DESCRIPTION
The implicit created_at default window (MAX_PAGINATION_MONTH_DATE_RANGE) is no longer applied to every list endpoint. validateDates now only validates explicit dates; the default window is applied via QueryHeader.ApplyDefaultDateRange in the transaction and operation list use cases (both the normal and metadata-filtered paths).

All list repositories guard the created_at range behind a non-zero StartDate check, so low-cardinality endpoints return the full tenant set when no dates are supplied. Explicit start_date/end_date keep working on every endpoint. Fixes silent empty-list results for records aged beyond the default window (e.g. organizations).

X-Lerian-Ref: 0x1

# Midaz Pull Request Checklist

## Pull Request Type
[//]: # (Check the appropriate box for the type of pull request.)

- [ ] Documentation
- [ ] Pipeline
- [ ] Infra
- [x] Ledger
- [ ] Onboarding
- [ ] Transaction
- [ ] CRM
- [ ] Tests

## Checklist
Check each item after completion.

- [x] I have tested these changes locally.
- [ ] I have updated the documentation accordingly.
- [x] I have added necessary comments to the code, especially in complex areas.
- [x] I have ensured that my changes adhere to the project's coding standards.
- [x] I have checked for any potential security issues.
- [x] I have ensured that all tests pass.
- [ ] I have updated the version appropriately (if applicable).
- [x] I have confirmed this code is ready for review.

**Important:** Always target your PR to the develop branch instead of main.
## Additional Notes
[//]: # (Add any additional notes, context, or explanation that could be helpful for reviewers.)
