### PR TITLE
fix(ci): upgrade shared-workflows to v1.37.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   pipeline:
-    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/go-release.yml@v1.36.6
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/go-release.yml@v1.37.0
     with:
       enable_changelog: ${{ github.ref == 'refs/heads/main' }}
       release_single_app: true

--- a/Makefile
+++ b/Makefile
@@ -645,5 +645,3 @@ migrate-create:
 	@echo "  2. Edit the .down.sql file with the rollback"
 	@echo "  3. Run 'make migrate-lint' to validate"
 	@echo "  4. Follow the guidelines in scripts/migration_linter/docs/MIGRATION_GUIDELINES.md"
-
-


### PR DESCRIPTION
<table border="0" cellspacing="0" cellpadding="0">
  <tr>
    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
    <td><h1>Midaz</h1></td>
  </tr>
</table>

---

## Description

Upgrades `go-release.yml` from `@v1.36.6` to `@v1.37.0`.

Key changes included in v1.37.0:
- `env_contexts` + `env_suffixes` support for anacleto cluster (chaos/fuzzing × dev-st/dev-mt)
- `GITOPS_REPOSITORY`, `GITOPS_RUNNERS`, `ARGOCD_URL` resolved from org-level variables
- `update_sandbox` boolean (default `false`)
- `ARGOCD_TOKEN` rename (was `ARGOCD_GHUSER_TOKEN`)
- yq and argocd install without sudo

## Type of Change

- [ ] `feat`: New feature or capability
- [ ] `fix`: Bug fix
- [ ] `perf`: Performance improvement
- [ ] `refactor`: Internal restructuring with no behavior change
- [ ] `docs`: Documentation only
- [ ] `style`: Formatting, whitespace, naming (no logic change)
- [ ] `test`: Adding or updating tests
- [x] `ci`: CI pipeline or workflow changes
- [ ] `build`: Build system, Dockerfile, Go module dependencies
- [ ] `chore`: Maintenance, config, tooling
- [ ] `revert`: Reverts a previous commit
- [ ] `BREAKING CHANGE`: Consumers must update their integration

## Breaking Changes

- `ARGOCD_GHUSER_TOKEN` secret renamed to `ARGOCD_TOKEN`
- `ARGOCD_URL` moved from secret to org variable (`vars.ARGOCD_URL`)
- `GITOPS_REPOSITORY` and `GITOPS_RUNNERS` must be set as org variables

## Testing

- [ ] `make test` passes
- [ ] `make lint` passes

## Related Issues

Closes #