### PR TITLE
fix(ci): upgrade shared-workflows to v1.39.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   pipeline:
-    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/go-release.yml@v1.37.0
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/go-release.yml@v1.40.3
     with:
       enable_changelog: ${{ github.ref == 'refs/heads/main' }}
       release_single_app: true

--- a/Makefile
+++ b/Makefile
@@ -645,3 +645,4 @@ migrate-create:
 	@echo "  2. Edit the .down.sql file with the rollback"
 	@echo "  3. Run 'make migrate-lint' to validate"
 	@echo "  4. Follow the guidelines in scripts/migration_linter/docs/MIGRATION_GUIDELINES.md"
+


### PR DESCRIPTION
Upgrades go-release.yml to @v1.39.0. Includes fix for normalize_to_filter boolean type mismatch in extra_build, env_contexts/env_suffixes for anacleto, org-level vars for GITOPS_REPOSITORY/GITOPS_RUNNERS/ARGOCD_URL, and ARGOCD_TOKEN rename.