### PR TITLE
feat(crm): enhance encryption to handle mountPath in mt mode

### DIFF
--- a/components/crm/internal/bootstrap/config.go
+++ b/components/crm/internal/bootstrap/config.go
@@ -304,6 +304,7 @@ func buildEncryptionServices(
 		legacyCrypto:         legacyCrypto,
 		metricsFactory:       metricsFactory,
 		vaultMountPath:       cfg.VaultMountPath,
+		multiTenant:          cfg.MultiTenantEnabled,
 		allowGracefulDegrade: false, // Fail hard if envelope mode requested but dependencies unavailable
 		legacyAESHexKey:      cfg.EncryptSecretKey,
 		legacyHMACSecret:     cfg.HashSecretKey,

--- a/components/crm/internal/bootstrap/encryption.go
+++ b/components/crm/internal/bootstrap/encryption.go
@@ -49,6 +49,7 @@ type wireEncryptionServicesInput struct {
 	legacyCrypto         encryption.LegacyCrypto
 	metricsFactory       *metrics.MetricsFactory
 	vaultMountPath       string
+	multiTenant          bool
 	allowGracefulDegrade bool
 
 	// legacyAESHexKey and legacyHMACSecret are the process-level legacy key
@@ -171,7 +172,7 @@ func wireEncryptionServices(input wireEncryptionServicesInput) wireEncryptionSer
 			legacyAESHexKey:  input.legacyAESHexKey,
 			legacyHMACSecret: input.legacyHMACSecret,
 		},
-		encryption.ProvisioningConfig{KEKMountPath: baseMountPath},
+		encryption.ProvisioningConfig{KEKMountPath: baseMountPath, MultiTenant: input.multiTenant},
 		input.auditWriter,
 		pm,
 		protectionStateResolver,
@@ -182,6 +183,7 @@ func wireEncryptionServices(input wireEncryptionServicesInput) wireEncryptionSer
 	// injected so per-tenant sub-mounts resolve consistently with provisioning.
 	keysetManagerConfig := encryption.DefaultKeysetManagerConfig()
 	keysetManagerConfig.BaseMountPath = baseMountPath
+	keysetManagerConfig.MultiTenant = input.multiTenant
 
 	keysetManager := encryption.NewKeysetManager(
 		input.keysetRepo,

--- a/components/crm/internal/services/encryption/keyset_manager.go
+++ b/components/crm/internal/services/encryption/keyset_manager.go
@@ -70,6 +70,11 @@ type KeysetManagerConfig struct {
 	// sub-mounts at unwrap time. Empty defaults to "transit" so single-tenant
 	// deployments are unaffected.
 	BaseMountPath string
+
+	// MultiTenant enables per-tenant mount resolution for the legacy-record
+	// fallback. When true, the tenant segment is appended and empty/"default"
+	// tenants fail closed. When false (single-tenant), the flat base is used.
+	MultiTenant bool
 }
 
 // DefaultKeysetManagerConfig returns the default configuration.
@@ -96,7 +101,8 @@ type KeysetManager struct {
 	provisioner   ProvisioningService // Required: enables lazy provisioning on first access
 	metrics       *protectionMetrics
 	cacheTTL      time.Duration
-	baseMountPath string                       // Vault Transit base mount for per-tenant resolution
+	baseMountPath string // Vault Transit base mount for per-tenant resolution
+	multiTenant   bool
 	cache         map[string]*CachedPrimitives // Key: "tenantID:organizationID"
 	mu            sync.RWMutex
 
@@ -139,6 +145,7 @@ func NewKeysetManager(
 		metrics:       metrics,
 		cacheTTL:      ttl,
 		baseMountPath: mountPath,
+		multiTenant:   config.MultiTenant,
 		cache:         make(map[string]*CachedPrimitives),
 		fetching:      make(map[string]*sync.Mutex),
 	}
@@ -319,7 +326,12 @@ func (km *KeysetManager) unwrapAndCache(ctx context.Context, cacheKey string, ke
 	// deriving from the stored tenant for legacy records.
 	mount := keyset.KEKMountPath
 	if mount == "" {
-		mount = resolveMount(km.baseMountPath, keyset.TenantID)
+		resolved, err := resolveMount(km.baseMountPath, keyset.TenantID, km.multiTenant)
+		if err != nil {
+			return nil, err
+		}
+
+		mount = resolved
 	}
 
 	// app.protection.mount_path is the resolved mount, not a secret.

--- a/components/crm/internal/services/encryption/keyset_manager_test.go
+++ b/components/crm/internal/services/encryption/keyset_manager_test.go
@@ -1848,7 +1848,7 @@ func TestKeysetManager_GetPrimitives_UnwrapMount_NonDefaultTenant_SubMount(t *te
 		prfKeyset:  prfBytes,
 	}
 
-	config := KeysetManagerConfig{BaseMountPath: "transit"}
+	config := KeysetManagerConfig{BaseMountPath: "transit", MultiTenant: true}
 	manager := NewKeysetManager(reader, unwrapper, nil, config, NewProtectionMetrics(nil))
 
 	// ctx carries a DIFFERENT tenant to prove the mount comes from the stored keyset, not ctx.
@@ -2010,12 +2010,18 @@ func TestKeysetManager_GetPrimitives_LegacyEmptyMount_FallsBackToDerived(t *test
 	t.Parallel()
 
 	tests := []struct {
-		name     string
-		tenantID string
-		want     string
+		name        string
+		tenantID    string
+		multiTenant bool
+		want        string
+		wantErr     bool
 	}{
-		{name: "default tenant -> flat base", tenantID: "default", want: "transit"},
-		{name: "real tenant -> sub-mount", tenantID: "t1", want: "transit/t1"},
+		// Single-tenant: the legacy fallback always derives the flat base.
+		{name: "single-tenant default tenant -> flat base", tenantID: "default", multiTenant: false, want: "transit"},
+		{name: "single-tenant real tenant -> flat base", tenantID: "t1", multiTenant: false, want: "transit"},
+		// Multi-tenant: a real tenant derives a sub-mount; "default" fails closed.
+		{name: "multi-tenant real tenant -> sub-mount", tenantID: "t1", multiTenant: true, want: "transit/t1"},
+		{name: "multi-tenant default tenant -> fail closed", tenantID: "default", multiTenant: true, wantErr: true},
 	}
 
 	for _, tt := range tests {
@@ -2041,10 +2047,18 @@ func TestKeysetManager_GetPrimitives_LegacyEmptyMount_FallsBackToDerived(t *test
 				prfKeyset:  prfBytes,
 			}
 
-			config := KeysetManagerConfig{BaseMountPath: "transit"}
+			config := KeysetManagerConfig{BaseMountPath: "transit", MultiTenant: tt.multiTenant}
 			manager := NewKeysetManager(reader, unwrapper, nil, config, NewProtectionMetrics(nil))
 
 			_, err := manager.GetActivePrimitives(context.Background(), "org-legacy")
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("GetPrimitives() expected error for multi-tenant default tenant, got nil")
+				}
+
+				return
+			}
+
 			if err != nil {
 				t.Fatalf("GetPrimitives() error = %v", err)
 			}

--- a/components/crm/internal/services/encryption/mount.go
+++ b/components/crm/internal/services/encryption/mount.go
@@ -4,21 +4,42 @@
 
 package encryption
 
-import "strings"
+import (
+	"fmt"
+	"strings"
+)
 
-// resolveMount derives the Vault Transit mount for a tenant: flat base for
-// empty/"default" (single-tenant), else base/tenantID.
+// defaultTenantID is the single-tenant sentinel. It mirrors the literal "default"
+// used by ExtractTenantID/ResolveProvisionTenantID in field_encryptor.go: in
+// single-tenant deployments the tenant resolves to this value and the mount stays
+// flat (no tenant segment). In multi-tenant mode it is a reserved, non-routable
+// value that MUST NOT be turned into a real sub-mount.
+const defaultTenantID = "default"
+
+// resolveMount derives the Vault Transit mount for a tenant. It is mode-aware and
+// fails closed in multi-tenant mode:
+//
+//   - Single-tenant (multiTenant == false): always returns the flat base; the
+//     tenant segment is never appended, regardless of tenantID.
+//   - Multi-tenant (multiTenant == true) with a real tenant: returns base/tenantID.
+//   - Multi-tenant with empty or "default" tenant: returns an error. The bare
+//     multi-tenant base has no Transit engine, so resolving to it would silently
+//     route to a non-existent mount. Failing closed here prevents that.
 //
 // Contract: base MUST already be normalized by resolveBaseMountPath (the single
 // base-mount normalizer, in bootstrap). resolveMount uses base verbatim and only
 // resolves the tenant segment, defensively trimming surrounding slashes/whitespace
-// off the tenant. The strings import remains in use for that tenant trim.
-func resolveMount(base, tenantID string) string {
+// off the tenant.
+func resolveMount(base, tenantID string, multiTenant bool) (string, error) {
 	tenantID = strings.Trim(tenantID, "/ \t")
 
-	if tenantID == "" || tenantID == "default" {
-		return base
+	if !multiTenant {
+		return base, nil
 	}
 
-	return base + "/" + tenantID
+	if tenantID == "" || tenantID == defaultTenantID {
+		return "", fmt.Errorf("multi-tenant mount resolution requires a real tenant id, got %q", tenantID)
+	}
+
+	return base + "/" + tenantID, nil
 }

--- a/components/crm/internal/services/encryption/mount_test.go
+++ b/components/crm/internal/services/encryption/mount_test.go
@@ -15,59 +15,91 @@ func TestResolveMount(t *testing.T) {
 	// base-mount normalizer in bootstrap). resolveMount uses base verbatim and only
 	// resolves/defensively trims the tenant segment. Base-normalization coverage
 	// lives in TestResolveBaseMountPath, not here.
+	//
+	// resolveMount is mode-aware:
+	//   - single-tenant (multiTenant == false): flat base, tenant never appended.
+	//   - multi-tenant (multiTenant == true): base/tenant for a real tenant; empty
+	//     or "default" fails closed (no Transit engine on the bare base).
 	tests := []struct {
-		name     string
-		base     string
-		tenantID string
-		want     string
+		name        string
+		base        string
+		tenantID    string
+		multiTenant bool
+		want        string
+		wantErr     bool
 	}{
+		// Single-tenant: flat base regardless of tenant value.
 		{
-			name:     "empty tenant returns flat base",
-			base:     "transit",
-			tenantID: "",
-			want:     "transit",
+			name:        "single-tenant empty tenant returns flat base",
+			base:        "transit",
+			tenantID:    "",
+			multiTenant: false,
+			want:        "transit",
 		},
 		{
-			name:     "default tenant returns flat base",
-			base:     "transit",
-			tenantID: "default",
-			want:     "transit",
+			name:        "single-tenant default tenant returns flat base",
+			base:        "transit",
+			tenantID:    "default",
+			multiTenant: false,
+			want:        "transit",
 		},
 		{
-			name:     "clean base with uuid tenant returns sub-mount",
-			base:     "transit",
-			tenantID: "9b2e4c1a-7f60-4d3e-8a21-1c5b0e7d9f44",
-			want:     "transit/9b2e4c1a-7f60-4d3e-8a21-1c5b0e7d9f44",
+			name:        "single-tenant real tenant still returns flat base",
+			base:        "transit",
+			tenantID:    "9b2e4c1a-7f60-4d3e-8a21-1c5b0e7d9f44",
+			multiTenant: false,
+			want:        "transit",
+		},
+		// Multi-tenant: real tenant resolves to a sub-mount.
+		{
+			name:        "multi-tenant clean base with uuid tenant returns sub-mount",
+			base:        "transit",
+			tenantID:    "9b2e4c1a-7f60-4d3e-8a21-1c5b0e7d9f44",
+			multiTenant: true,
+			want:        "transit/9b2e4c1a-7f60-4d3e-8a21-1c5b0e7d9f44",
 		},
 		{
-			name:     "custom clean base with uuid tenant returns sub-mount",
-			base:     "crm-transit",
-			tenantID: "9b2e4c1a-7f60-4d3e-8a21-1c5b0e7d9f44",
-			want:     "crm-transit/9b2e4c1a-7f60-4d3e-8a21-1c5b0e7d9f44",
+			name:        "multi-tenant custom clean base with uuid tenant returns sub-mount",
+			base:        "crm-transit",
+			tenantID:    "9b2e4c1a-7f60-4d3e-8a21-1c5b0e7d9f44",
+			multiTenant: true,
+			want:        "crm-transit/9b2e4c1a-7f60-4d3e-8a21-1c5b0e7d9f44",
 		},
 		{
-			name:     "slash-wrapped base is NOT normalized by resolveMount (moved to resolveBaseMountPath)",
-			base:     "/transit/",
-			tenantID: "9b2e4c1a-7f60-4d3e-8a21-1c5b0e7d9f44",
-			want:     "/transit//9b2e4c1a-7f60-4d3e-8a21-1c5b0e7d9f44",
+			name:        "multi-tenant trims surrounding slashes on tenant segment",
+			base:        "transit",
+			tenantID:    "/weird/",
+			multiTenant: true,
+			want:        "transit/weird",
 		},
 		{
-			name:     "padded default sentinel resolves to flat base",
-			base:     "transit",
-			tenantID: " default ",
-			want:     "transit",
+			name:        "multi-tenant preserves interior slash in tenant segment",
+			base:        "transit",
+			tenantID:    "a/b",
+			multiTenant: true,
+			want:        "transit/a/b",
+		},
+		// Multi-tenant fail-closed: empty/"default" must NOT resolve to the bare base.
+		{
+			name:        "multi-tenant empty tenant fails closed",
+			base:        "transit",
+			tenantID:    "",
+			multiTenant: true,
+			wantErr:     true,
 		},
 		{
-			name:     "trims surrounding slashes on tenant segment",
-			base:     "transit",
-			tenantID: "/weird/",
-			want:     "transit/weird",
+			name:        "multi-tenant default tenant fails closed",
+			base:        "transit",
+			tenantID:    "default",
+			multiTenant: true,
+			wantErr:     true,
 		},
 		{
-			name:     "preserves interior slash in tenant segment",
-			base:     "transit",
-			tenantID: "a/b",
-			want:     "transit/a/b",
+			name:        "multi-tenant padded default sentinel fails closed",
+			base:        "transit",
+			tenantID:    " default ",
+			multiTenant: true,
+			wantErr:     true,
 		},
 	}
 
@@ -75,9 +107,25 @@ func TestResolveMount(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			got := resolveMount(tt.base, tt.tenantID)
+			got, err := resolveMount(tt.base, tt.tenantID, tt.multiTenant)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("resolveMount(%q, %q, %t) expected error, got nil (result %q)", tt.base, tt.tenantID, tt.multiTenant, got)
+				}
+
+				if got != "" {
+					t.Errorf("resolveMount(%q, %q, %t) on error = %q, want empty string", tt.base, tt.tenantID, tt.multiTenant, got)
+				}
+
+				return
+			}
+
+			if err != nil {
+				t.Errorf("resolveMount(%q, %q, %t) unexpected error: %v", tt.base, tt.tenantID, tt.multiTenant, err)
+			}
+
 			if got != tt.want {
-				t.Errorf("resolveMount(%q, %q) = %q, want %q", tt.base, tt.tenantID, got, tt.want)
+				t.Errorf("resolveMount(%q, %q, %t) = %q, want %q", tt.base, tt.tenantID, tt.multiTenant, got, tt.want)
 			}
 		})
 	}

--- a/components/crm/internal/services/encryption/provisioning.go
+++ b/components/crm/internal/services/encryption/provisioning.go
@@ -68,6 +68,12 @@ type KeysetGenerator interface {
 type ProvisioningConfig struct {
 	// KEKMountPath is the KMS mount path (e.g., "transit" for Vault Transit).
 	KEKMountPath string
+
+	// MultiTenant enables per-tenant mount resolution. When true, the tenant
+	// segment is appended to the base mount and empty/"default" tenants fail
+	// closed (the bare multi-tenant base has no Transit engine). When false
+	// (single-tenant), the flat base is used verbatim.
+	MultiTenant bool
 }
 
 // DefaultProvisioningConfig returns the default configuration.
@@ -100,6 +106,7 @@ type provisioningService struct {
 	registryRepo    mongoEncryption.RegistryRepository
 	keysetGenerator KeysetGenerator
 	kekMountPath    string
+	multiTenant     bool
 	auditWriter     AuditWriter
 	metrics         *protectionMetrics
 	stateResolver   *ProtectionStateResolver
@@ -138,6 +145,7 @@ func NewProvisioningService(
 		registryRepo:    registryRepo,
 		keysetGenerator: keysetGenerator,
 		kekMountPath:    mountPath,
+		multiTenant:     config.MultiTenant,
 		auditWriter:     auditWriter,
 		metrics:         metrics,
 		stateResolver:   stateResolver,
@@ -239,6 +247,16 @@ func (s *provisioningService) provision(ctx context.Context, req ProvisionInput)
 		return ProvisionResult{}, mmodel.AuditOutcomeFailure, fmt.Errorf("invalid provision request: %w", err)
 	}
 
+	// Fail closed before any work: in multi-tenant mode a real tenant id is
+	// required. The reserved "default" (and empty) sentinel would otherwise route
+	// to the bare multi-tenant base, which has no Transit engine.
+	if s.multiTenant && (req.TenantID == "" || req.TenantID == defaultTenantID) {
+		err := pkg.ValidateBusinessError(constant.ErrReservedTenantID, EntityOrganizationEncryption)
+		libOpenTelemetry.HandleSpanError(span, "multi-tenant provisioning requires a real tenant id", err)
+
+		return ProvisionResult{}, mmodel.AuditOutcomeFailure, err
+	}
+
 	// Check if already provisioned (idempotent behavior)
 	provisioned, err := s.IsProvisioned(ctx, req.OrganizationID)
 	if err != nil {
@@ -256,7 +274,13 @@ func (s *provisioningService) provision(ctx context.Context, req ProvisionInput)
 
 	// KEK path is the key name; mount is resolved per-tenant (flat base for single-tenant).
 	kekPath := s.buildKEKPath(req.OrganizationID)
-	mount := resolveMount(s.kekMountPath, req.TenantID)
+
+	mount, err := resolveMount(s.kekMountPath, req.TenantID, s.multiTenant)
+	if err != nil {
+		libOpenTelemetry.HandleSpanError(span, "failed to resolve tenant mount", err)
+
+		return ProvisionResult{}, mmodel.AuditOutcomeFailure, err
+	}
 
 	// app.protection.mount_path is the resolved mount (not a secret), persisted on the keyset.
 	span.SetAttributes(attribute.String("app.protection.mount_path", mount))

--- a/components/crm/internal/services/encryption/provisioning_test.go
+++ b/components/crm/internal/services/encryption/provisioning_test.go
@@ -506,7 +506,9 @@ func TestProvisioningService_buildProvisioningKeysets_EnvelopeOnly_SingleKeyShap
 		importLegacy:   false,
 	}
 
-	mount := resolveMount(concreteSvc.kekMountPath, req.TenantID)
+	mount, err := resolveMount(concreteSvc.kekMountPath, req.TenantID, concreteSvc.multiTenant)
+	require.NoError(t, err)
+
 	kekPath := concreteSvc.buildKEKPath(req.OrganizationID)
 
 	keyset, verbatim, err := concreteSvc.buildProvisioningKeysets(ctx, req, mount, kekPath)
@@ -637,7 +639,7 @@ func TestProvisioningService_Provision_MultiTenant_SubMount(t *testing.T) {
 	keysetGenerator := newFakeKeysetGenerator()
 
 	svc := NewProvisioningService(keysetRepo, registryRepo, keysetGenerator,
-		ProvisioningConfig{KEKMountPath: "transit"}, newSpyAuditWriter(), NewProtectionMetrics(nil), nil)
+		ProvisioningConfig{KEKMountPath: "transit", MultiTenant: true}, newSpyAuditWriter(), NewProtectionMetrics(nil), nil)
 
 	const tenantID = "11111111-2222-3333-4444-555555555555"
 
@@ -1317,7 +1319,9 @@ func TestProvisioningService_buildProvisioningKeysets_Migration_MixedTwoKeyShape
 		importLegacy:   true,
 	}
 
-	mount := resolveMount(concreteSvc.kekMountPath, req.TenantID)
+	mount, err := resolveMount(concreteSvc.kekMountPath, req.TenantID, concreteSvc.multiTenant)
+	require.NoError(t, err)
+
 	kekPath := concreteSvc.buildKEKPath(req.OrganizationID)
 
 	keyset, verbatim, err := concreteSvc.buildProvisioningKeysets(ctx, req, mount, kekPath)


### PR DESCRIPTION
## Summary

Makes CRM envelope-mode mount resolution mode-aware and fail-closed so multi-tenant deployments can never resolve a Vault Transit mount to the engine-less bare base. `resolveMount` now takes an explicit `multiTenant` flag: single-tenant returns the flat base unchanged, multi-tenant with a real tenant returns `base/{tenantID}`, and multi-tenant with an empty or `"default"` tenant returns an error instead of silently routing to a non-existent mount. A second, upstream guard in the provisioning path rejects the same case early with a typed business error.

## Motivation

The Vault topology is mutually exclusive: a single-tenant deployment has a flat Transit engine at the base mount, while a multi-tenant deployment has per-tenant sub-mounts (`{base}/{tenantID}`) and no engine at the bare base. The previous `resolveMount` overloaded "empty/`default` tenant -> return bare base", which is correct for single-tenant but, in multi-tenant mode, silently routed encryption to a base mount that has no engine (a misconfigured or missing tenant context would fail in confusing ways or write to an unintended location). The invariant "in multi-tenant, the tenant is never empty or `default`" must be enforced, not silently absorbed.

## Semantic Decision

- **Defense in depth, two layers.** The chokepoint in `resolveMount` covers every path that builds a mount (provisioning write path and the legacy `kek_mount_path == ""` read fallback in the keyset manager). The upstream guard in `provision()` gives a clear, early `422` on the write path before any Vault/keyset work.
- **`resolveBaseMountPath` left unchanged.** Base normalization is mode-agnostic (the operator already configures the base via `KMS_VAULT_MOUNT_PATH`); the per-call tenant decision is the right place for the mode-aware logic.
- **Backwards compatible.** `multiTenant` is threaded as an additive `MultiTenant bool` on the existing `ProvisioningConfig`/`KeysetManagerConfig` structs (default `false`). Single-tenant flat-mount behavior is byte-for-byte unchanged; existing callers compile and behave as before.
- **Reuse existing error contract.** The upstream guard returns the existing `constant.ErrReservedTenantID` (ENC-0013), which already maps to HTTP `422`; no new sentinel introduced.
- **Sentinel consistency.** The `"default"` literal matches the existing single-tenant sentinel used by `ExtractTenantID` / `ResolveProvisionTenantID`; centralized as a local `defaultTenantID` const in `mount.go` for the new code.

## Changes

### New Files
| File | Purpose |
|------|---------|
| _(none)_ | All changes modify existing files. |

### Environment Variables
| Variable | Type | Default | Description |
|----------|------|---------|-------------|
| _(none new)_ | - | - | Behavior is gated by the existing `MULTI_TENANT_ENABLED`; no new variables. |

### Refactored Code
| Before | After |
|--------|-------|
| `resolveMount(base, tenantID string) string` | `resolveMount(base, tenantID string, multiTenant bool) (string, error)` |
| Empty/`"default"` tenant -> return bare `base` (both modes) | Single-tenant -> flat `base`; multi-tenant + real tenant -> `base/{tenantID}`; multi-tenant + empty/`"default"` -> error (fail closed) |
| `ProvisioningConfig` / `KeysetManagerConfig` mode-agnostic | Each gains `MultiTenant bool`; stored on `provisioningService` / `KeysetManager` and set at wiring from `cfg.MultiTenantEnabled` |
| `provision()` had no tenant-vs-mode guard | After `Validate()`, multi-tenant + empty/`"default"` tenant returns `ErrReservedTenantID` (422) |
| Keyset-manager legacy read fallback called `resolveMount(...)` unchecked | Now checks the returned error and propagates it (no unwrap against an invalid mount) |
| `provision()` / keyset-manager `resolveMount` call sites | Updated to the new checked 3-arg form; `mount`/error handled and span-recorded |

### OpenTelemetry Metrics
| Metric | Type | Description |
|--------|------|-------------|
| _(none new)_ | - | Existing `crm_protection_*` metrics unchanged. |

## Test Plan
- [x] `mount_test.go`: single-tenant returns base for `""`/`"default"`/real tenant; multi-tenant + real tenant -> `base/{tenant}`; multi-tenant + `""`/`"default"` -> non-nil error + empty string
- [x] `provisioning_test.go`: multi-tenant sub-mount test gated on `MultiTenant: true`; `resolveMount` call sites updated to checked form
- [x] `keyset_manager_test.go`: legacy empty-mount fallback parameterized by mode (single-tenant flattens; multi-tenant real -> sub-mount; multi-tenant `default` -> fail-closed)
- [x] `go build ./...` clean
- [x] `go vet ./components/crm/...` clean
- [x] `go test -race -count=1 ./components/crm/internal/services/encryption/... ./components/crm/internal/bootstrap/...` passes
- [x] golangci-lint v2 clean on changed packages (one pre-existing `gocyclo` on `InitServersWithOptions`, not introduced by this change)
