### PR TITLE
feat(ledger): emit generic balance.changed streaming event

### DIFF
--- a/components/ledger/internal/bootstrap/streaming.go
+++ b/components/ledger/internal/bootstrap/streaming.go
@@ -162,7 +162,8 @@ func BuildStreamingEmitter(
 			}
 		}
 
-		logger.Log(ctx, libLog.LevelInfo, "Streaming emitter constructed",
+		logger.Log(
+			ctx, libLog.LevelInfo, "Streaming emitter constructed",
 			libLog.String("brokers", strings.Join(streamingCfg.Brokers, ",")),
 			libLog.String("client_id", streamingCfg.ClientID),
 			libLog.String("ce_source", streamingCfg.CloudEventsSource),
@@ -207,7 +208,8 @@ func resolveSASLMechanism(cfg *Config) (sasl.Mechanism, string, error) {
 	if user == "" || pass == "" {
 		return nil, "", fmt.Errorf(
 			"STREAMING_SASL_MECHANISM=%q requires STREAMING_SASL_USERNAME and STREAMING_SASL_PASSWORD",
-			mechanism)
+			mechanism,
+		)
 	}
 
 	switch mechanism {
@@ -220,7 +222,8 @@ func resolveSASLMechanism(cfg *Config) (sasl.Mechanism, string, error) {
 	default:
 		return nil, "", fmt.Errorf(
 			"STREAMING_SASL_MECHANISM=%q is not supported (accepted: %s, %s, %s)",
-			raw, saslMechanismPlain, saslMechanismScram256, saslMechanismScram512)
+			raw, saslMechanismPlain, saslMechanismScram256, saslMechanismScram512,
+		)
 	}
 }
 
@@ -258,6 +261,7 @@ func midazEventDefinitions() []events.Definition {
 		events.TransactionRouteUpdatedDefinition,
 		events.TransactionRouteDeletedDefinition,
 		events.BalanceCreatedDefinition,
+		events.BalanceChangedDefinition,
 		events.BalanceConfigChangedDefinition,
 		events.BalanceDeletedDefinition,
 		events.BalanceOverdraftDrawnDefinition,

--- a/components/ledger/internal/bootstrap/streaming_test.go
+++ b/components/ledger/internal/bootstrap/streaming_test.go
@@ -294,3 +294,39 @@ func TestBuildStreamingEmitter_UnsupportedMechanismFailsClosed(t *testing.T) {
 			strings.Contains(err.Error(), "not supported"),
 		"expected unsupported-mechanism error, got %v", err)
 }
+
+// TestMidazEventDefinitions_IncludesBalanceChanged asserts the generic
+// balance.changed event is registered in the single-source-of-truth
+// definition list, so it flows into both the Catalog and the Routes.
+func TestMidazEventDefinitions_IncludesBalanceChanged(t *testing.T) {
+	t.Parallel()
+
+	defs := midazEventDefinitions()
+
+	found := false
+	for _, d := range defs {
+		if d.Key() == "balance.changed" {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "balance.changed must be registered in midazEventDefinitions")
+}
+
+// TestBuildRoutes_BalanceChangedTopic asserts the balance.changed route
+// resolves to the canonical lerian.streaming.balance.changed Kafka topic.
+func TestBuildRoutes_BalanceChangedTopic(t *testing.T) {
+	t.Parallel()
+
+	routes := buildRoutes(streamingPrimaryTargetName)
+
+	var dest string
+	for _, r := range routes {
+		if r.DefinitionKey == "balance.changed" {
+			// KafkaTopic stores the topic string in Destination.Name
+			// (Destination is a struct, not a string).
+			dest = r.Destination.Name
+		}
+	}
+	assert.Equal(t, "lerian.streaming.balance.changed", dest)
+}

--- a/components/ledger/internal/services/command/create_balance_transaction_operations_async.go
+++ b/components/ledger/internal/services/command/create_balance_transaction_operations_async.go
@@ -149,6 +149,7 @@ func (uc *UseCase) CreateBalanceTransactionOperationsAsync(ctx context.Context, 
 
 	go uc.SendTransactionEvents(ctx, tran, phase)
 	go uc.SendOverdraftEvents(ctx, tran)
+	go uc.SendBalanceChangedEvents(ctx, tran)
 
 	logger.Log(ctx, libLog.LevelInfo, fmt.Sprintf("Backup queue: cleaning up transaction %s after successful processing", tran.ID))
 
@@ -484,7 +485,8 @@ func (uc *UseCase) UpdateTransactionBackupOperations(ctx context.Context, organi
 func validateOperationDirection(ctx context.Context, logger libLog.Logger, oper *operation.Operation) error {
 	if oper.Direction == "" {
 		logger.Log(ctx, libLog.LevelWarn, fmt.Sprintf(
-			"Operation %s has empty direction, may be from pre-migration message", oper.ID))
+			"Operation %s has empty direction, may be from pre-migration message", oper.ID,
+		))
 
 		return nil
 	}

--- a/components/ledger/internal/services/command/create_bulk_transaction_operations_async.go
+++ b/components/ledger/internal/services/command/create_bulk_transaction_operations_async.go
@@ -108,7 +108,8 @@ func (uc *UseCase) CreateBulkTransactionOperationsAsync(
 
 			logger.Log(ctx, libLog.LevelWarn, fmt.Sprintf(
 				"Legacy payload detected (no Version field) for transaction %s, calling UpdateBalances",
-				p.Transaction.ID))
+				p.Transaction.ID,
+			))
 
 			if err := uc.UpdateBalances(ctx, orgID, ledgerID, *p.Validate, p.Balances, p.BalancesAfter); err != nil {
 				logger.Log(ctx, libLog.LevelError, fmt.Sprintf("Failed to update balances for legacy payload %s: %v", p.Transaction.ID, err))
@@ -542,7 +543,8 @@ func (uc *UseCase) processMetadataAndEvents(
 		if len(insertedTxIDs) > 0 {
 			if _, wasInserted := insertedTxIDs[tx.ID]; !wasInserted {
 				logger.Log(ctx, libLog.LevelDebug, fmt.Sprintf(
-					"Skipping events for duplicate transaction %s", tx.ID))
+					"Skipping events for duplicate transaction %s", tx.ID,
+				))
 
 				continue
 			}
@@ -580,6 +582,7 @@ func (uc *UseCase) processMetadataAndEvents(
 
 			uc.SendTransactionEvents(opCtx, tx, phase)
 			uc.SendOverdraftEvents(opCtx, tx)
+			uc.SendBalanceChangedEvents(opCtx, tx)
 		}(phase)
 	}
 }

--- a/components/ledger/internal/services/command/send_balance_changed_events.go
+++ b/components/ledger/internal/services/command/send_balance_changed_events.go
@@ -1,0 +1,127 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package command
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	libObs "github.com/LerianStudio/lib-observability"
+	libStreaming "github.com/LerianStudio/lib-streaming"
+	"github.com/LerianStudio/midaz/v3/components/ledger/internal/adapters/postgres/transaction"
+	"github.com/LerianStudio/midaz/v3/pkg/constant"
+	pkgStreaming "github.com/LerianStudio/midaz/v3/pkg/streaming"
+	"github.com/LerianStudio/midaz/v3/pkg/streaming/events"
+	"github.com/shopspring/decimal"
+)
+
+// SendBalanceChangedEvents emits one generic, domain-agnostic balance.changed
+// event per balance-affecting operation of a committed transaction.
+//
+// Fire-and-forget: launched as a goroutine alongside SendTransactionEvents /
+// SendOverdraftEvents. Emission failures are logged/span-recorded but never
+// propagate — this MUST NOT fail the parent transaction (mirrors the
+// EmitImportant contract). Emission happens whenever streaming is enabled:
+// when STREAMING_ENABLED=false the streaming client is a NoopEmitter, so this
+// simply becomes a no-op — the same posture as balance.created.
+//
+// The event carries only Midaz identities + a generic Reason. It carries NO
+// consumer-domain fields — the consumer (e.g. the br-sisbajud Connector) maps
+// accountId -> its own domain key and produces its own trigger.
+func (uc *UseCase) SendBalanceChangedEvents(ctx context.Context, tran *transaction.Transaction) {
+	logger, tracer, _, _ := libObs.NewTrackingFromContext(ctx)
+
+	if uc.Streaming == nil {
+		return
+	}
+
+	if tran == nil || len(tran.Operations) == 0 {
+		return
+	}
+
+	ctxSend, span := tracer.Start(ctx, "command.send_balance_changed_events_async")
+	defer span.End()
+
+	occurredAt := time.Now().UTC()
+
+	for _, op := range tran.Operations {
+		if op == nil || !op.BalanceAffected {
+			continue
+		}
+
+		// src is declared INSIDE the loop so each buildFn closure captures its
+		// own copy — avoids the classic loop-variable capture bug.
+		src := events.BalanceChangedSource{
+			OrganizationID: tran.OrganizationID,
+			LedgerID:       tran.LedgerID,
+			AccountID:      op.AccountID,
+			BalanceID:      op.BalanceID,
+			Alias:          op.AccountAlias,
+			AssetCode:      op.AssetCode,
+			BalanceKey:     op.BalanceKey,
+			Available:      decimalOrZero(op.BalanceAfter.Available),
+			OnHold:         decimalOrZero(op.BalanceAfter.OnHold),
+			Version:        int64OrZero(op.BalanceAfter.Version),
+			Reason:         reasonForOperation(op.Type),
+			OperationType:  op.Type,
+			Direction:      op.Direction,
+			Amount:         decimalOrZero(op.Amount.Value),
+			TransactionID:  tran.ID,
+			OperationID:    op.ID,
+			OccurredAt:     occurredAt,
+		}
+
+		buildFn := func(tenantID string) (libStreaming.EmitRequest, error) {
+			return events.NewBalanceChanged(src).ToEmitRequest(tenantID, src.OccurredAt)
+		}
+
+		pkgStreaming.EmitImportant(ctxSend, span, logger, uc.Streaming, events.BalanceChangedDefinition.Key(), buildFn)
+	}
+}
+
+// decimalOrZero dereferences a *decimal.Decimal, treating nil as zero.
+func decimalOrZero(d *decimal.Decimal) decimal.Decimal {
+	if d == nil {
+		return decimal.Zero
+	}
+
+	return *d
+}
+
+// int64OrZero dereferences a *int64, treating nil as zero.
+func int64OrZero(v *int64) int64 {
+	if v == nil {
+		return 0
+	}
+
+	return *v
+}
+
+// reasonForOperation maps a Midaz Operation.Type into the generic,
+// domain-agnostic balance.changed Reason discriminator. Unknown types fall back
+// to "adjust" so the event stays emittable for any future op type without a
+// code change (the consumer treats "adjust" as "generic mutation"). The op-type
+// labels are the canonical values exported by pkg/constant.
+func reasonForOperation(opType string) string {
+	switch strings.ToUpper(strings.TrimSpace(opType)) {
+	case constant.CREDIT:
+		return events.BalanceChangeReasonCredit
+	case constant.DEBIT:
+		return events.BalanceChangeReasonDebit
+	case constant.BLOCK:
+		return events.BalanceChangeReasonBlock
+	case constant.UNBLOCK:
+		return events.BalanceChangeReasonUnblock
+	case constant.ONHOLD:
+		return events.BalanceChangeReasonHold
+	case constant.RELEASE:
+		return events.BalanceChangeReasonRelease
+	case constant.OVERDRAFT:
+		return events.BalanceChangeReasonOverdraft
+	default:
+		return events.BalanceChangeReasonAdjust
+	}
+}

--- a/components/ledger/internal/services/command/send_balance_changed_events_streaming_test.go
+++ b/components/ledger/internal/services/command/send_balance_changed_events_streaming_test.go
@@ -1,0 +1,78 @@
+//go:build unit
+
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package command
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/LerianStudio/midaz/v3/components/ledger/internal/adapters/postgres/operation"
+	"github.com/LerianStudio/midaz/v3/components/ledger/internal/adapters/postgres/transaction"
+	pkgStreaming "github.com/LerianStudio/midaz/v3/pkg/streaming"
+	"github.com/LerianStudio/midaz/v3/pkg/streaming/events"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSendBalanceChangedEvents_PayloadRoundTrip drives one balance-affecting
+// BLOCK operation through the emit path and round-trips the recorded wire
+// payload back into BalanceChangedPayload. It deliberately uses a BLOCK op with
+// Direction "debit": the classifier maps Type "BLOCK" -> reason "block"
+// regardless of direction, so this locks reason != direction (a wire-contract
+// property the CREDIT/DEBIT cases in send_balance_changed_events_test.go cannot
+// observe, since there reason and direction coincide).
+func TestSendBalanceChangedEvents_PayloadRoundTrip(t *testing.T) {
+	rec := pkgStreaming.NewMockEmitter()
+	uc := &UseCase{Streaming: rec}
+
+	avail := decimal.NewFromInt(900)
+	onHold := decimal.NewFromInt(100)
+	amt := decimal.NewFromInt(50)
+	ver := int64(3)
+
+	tran := &transaction.Transaction{
+		ID:             "txn-9",
+		OrganizationID: "org-9",
+		LedgerID:       "led-9",
+		Operations: []*operation.Operation{
+			{
+				ID:              "op-9",
+				AccountID:       "acc-9",
+				BalanceID:       "bal-9",
+				AccountAlias:    "@a9",
+				AssetCode:       "BRL",
+				BalanceKey:      "default",
+				Type:            "BLOCK",
+				Direction:       "debit",
+				BalanceAffected: true,
+				Amount:          operation.Amount{Value: &amt},
+				BalanceAfter:    operation.Balance{Available: &avail, OnHold: &onHold, Version: &ver},
+			},
+		},
+	}
+
+	uc.SendBalanceChangedEvents(context.Background(), tran)
+
+	reqs := rec.Events()
+	require.Len(t, reqs, 1)
+	assert.Equal(t, "balance.changed", reqs[0].DefinitionKey)
+	assert.Equal(t, "txn-9:op-9", reqs[0].Subject)
+
+	var p events.BalanceChangedPayload
+	require.NoError(t, json.Unmarshal(reqs[0].Payload, &p))
+
+	assert.Equal(t, "acc-9", p.AccountID)
+	// reason is driven by Operation.Type, NOT by Direction: BLOCK -> "block"
+	// even though Direction is "debit". This locks reason != direction.
+	assert.Equal(t, events.BalanceChangeReasonBlock, p.Reason)
+	assert.Equal(t, "BLOCK", p.OperationType)
+	assert.Equal(t, "debit", p.Direction)
+	assert.True(t, decimal.NewFromInt(900).Equal(p.Available), "available: got %s", p.Available)
+	assert.Equal(t, int64(3), p.Version)
+}

--- a/components/ledger/internal/services/command/send_balance_changed_events_test.go
+++ b/components/ledger/internal/services/command/send_balance_changed_events_test.go
@@ -1,0 +1,160 @@
+//go:build unit
+
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package command
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/LerianStudio/midaz/v3/components/ledger/internal/adapters/postgres/operation"
+	"github.com/LerianStudio/midaz/v3/components/ledger/internal/adapters/postgres/transaction"
+	pkgStreaming "github.com/LerianStudio/midaz/v3/pkg/streaming"
+	"github.com/LerianStudio/midaz/v3/pkg/streaming/events"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReasonForOperation(t *testing.T) {
+	cases := []struct {
+		name     string
+		opType   string
+		expected string
+	}{
+		{"credit", "CREDIT", events.BalanceChangeReasonCredit},
+		{"debit", "DEBIT", events.BalanceChangeReasonDebit},
+		{"block", "BLOCK", events.BalanceChangeReasonBlock},
+		{"unblock", "UNBLOCK", events.BalanceChangeReasonUnblock},
+		{"hold", "ON_HOLD", events.BalanceChangeReasonHold},
+		{"release", "RELEASE", events.BalanceChangeReasonRelease},
+		{"overdraft", "OVERDRAFT", events.BalanceChangeReasonOverdraft},
+		{"unknown falls back to adjust", "SOMETHING_NEW", events.BalanceChangeReasonAdjust},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, reasonForOperation(tc.opType))
+		})
+	}
+}
+
+func TestSendBalanceChangedEvents_EmitsPerBalanceAffectingOperation(t *testing.T) {
+	// GIVEN a recording emitter capturing EmitRequests.
+	rec := pkgStreaming.NewMockEmitter()
+	uc := &UseCase{Streaming: rec}
+
+	avail := decimal.NewFromInt(1500)
+	onHold := decimal.NewFromInt(0)
+	amt := decimal.NewFromInt(100)
+	ver := int64(7)
+
+	avail2 := decimal.NewFromInt(900)
+	onHold2 := decimal.NewFromInt(0)
+	amt2 := decimal.NewFromInt(600)
+	ver2 := int64(8)
+
+	tran := &transaction.Transaction{
+		ID:             "txn-1",
+		OrganizationID: "org-1",
+		LedgerID:       "led-1",
+		Operations: []*operation.Operation{
+			{
+				ID:              "op-1",
+				AccountID:       "acc-1",
+				BalanceID:       "bal-1",
+				AccountAlias:    "@person1",
+				AssetCode:       "BRL",
+				BalanceKey:      "default",
+				Type:            "CREDIT",
+				Direction:       "credit",
+				BalanceAffected: true,
+				Amount:          operation.Amount{Value: &amt},
+				BalanceAfter:    operation.Balance{Available: &avail, OnHold: &onHold, Version: &ver},
+			},
+			{
+				// Second balance-affecting op — proves one event PER operation.
+				ID:              "op-2",
+				AccountID:       "acc-2",
+				BalanceID:       "bal-2",
+				AccountAlias:    "@person2",
+				AssetCode:       "BRL",
+				BalanceKey:      "default",
+				Type:            "DEBIT",
+				Direction:       "debit",
+				BalanceAffected: true,
+				Amount:          operation.Amount{Value: &amt2},
+				BalanceAfter:    operation.Balance{Available: &avail2, OnHold: &onHold2, Version: &ver2},
+			},
+			{
+				ID:              "op-3",
+				BalanceAffected: false, // must not emit
+				AccountID:       "acc-3",
+				Type:            "DEBIT",
+			},
+		},
+	}
+
+	uc.SendBalanceChangedEvents(context.Background(), tran)
+
+	// M1: exactly one event per balance-affecting op, two DISTINCT subjects.
+	reqs := rec.Events()
+	require.Len(t, reqs, 2)
+	assert.Equal(t, "balance.changed", reqs[0].DefinitionKey)
+	assert.Equal(t, "balance.changed", reqs[1].DefinitionKey)
+	assert.Equal(t, "txn-1:op-1", reqs[0].Subject)
+	assert.Equal(t, "txn-1:op-2", reqs[1].Subject)
+
+	// H1 + M2: decode the first op's wire payload and assert the full
+	// operation -> payload mapping so a field-swap regression fails here.
+	var payload events.BalanceChangedPayload
+	require.NoError(t, json.Unmarshal(reqs[0].Payload, &payload))
+
+	assert.Equal(t, "acc-1", payload.AccountID)
+	assert.Equal(t, "bal-1", payload.BalanceID)
+	assert.Equal(t, "BRL", payload.AssetCode)
+	assert.Equal(t, "default", payload.BalanceKey)
+	assert.Equal(t, "@person1", payload.Alias)
+	assert.Equal(t, events.BalanceChangeReasonCredit, payload.Reason)
+	assert.Equal(t, "CREDIT", payload.OperationType)
+	assert.Equal(t, "credit", payload.Direction)
+	assert.True(t, decimal.NewFromInt(1500).Equal(payload.Available), "available: got %s", payload.Available)
+	assert.True(t, decimal.NewFromInt(0).Equal(payload.OnHold), "onHold: got %s", payload.OnHold)
+	assert.True(t, decimal.NewFromInt(100).Equal(payload.Amount), "amount: got %s", payload.Amount)
+	assert.Equal(t, int64(7), payload.Version)
+}
+
+func TestSendBalanceChangedEvents_NilSafe(t *testing.T) {
+	uc := &UseCase{Streaming: nil}
+	// nil Streaming → no emit / no panic.
+	uc.SendBalanceChangedEvents(context.Background(), nil)
+	uc.SendBalanceChangedEvents(context.Background(), &transaction.Transaction{ID: "txn-1"})
+
+	// A nil operation / nil balance pointers inside a live transaction must
+	// also be nil-safe once Streaming is present.
+	rec := pkgStreaming.NewMockEmitter()
+	uc2 := &UseCase{Streaming: rec}
+	uc2.SendBalanceChangedEvents(context.Background(), &transaction.Transaction{
+		ID: "txn-2",
+		Operations: []*operation.Operation{
+			nil,
+			{ID: "op-1", Type: "CREDIT", BalanceAffected: true}, // nil Amount/Balance pointers
+		},
+	})
+	// nil op skipped; the second op has nil Amount.Value + nil BalanceAfter
+	// pointers but still emits (values default to zero) without panicking.
+	reqs := rec.Events()
+	require.Len(t, reqs, 1)
+
+	// The nil->zero conversions (decimalOrZero / int64OrZero) must reach the
+	// wire as decimal.Zero / version 0, not as absent or garbage values.
+	var payload events.BalanceChangedPayload
+	require.NoError(t, json.Unmarshal(reqs[0].Payload, &payload))
+	assert.True(t, payload.Available.Equal(decimal.Zero), "available: got %s", payload.Available)
+	assert.True(t, payload.OnHold.Equal(decimal.Zero), "onHold: got %s", payload.OnHold)
+	assert.True(t, payload.Amount.Equal(decimal.Zero), "amount: got %s", payload.Amount)
+	assert.Equal(t, int64(0), payload.Version)
+}

--- a/pkg/streaming/events/balance_changed.go
+++ b/pkg/streaming/events/balance_changed.go
@@ -1,0 +1,152 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package events
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	libStreaming "github.com/LerianStudio/lib-streaming"
+	"github.com/shopspring/decimal"
+)
+
+// Reason values stamped onto BalanceChangedPayload.Reason. Domain-agnostic,
+// wire-stable discriminators of WHAT changed the balance. Consumers switch on
+// these. NO third-party domain semantics belong here — the Midaz ledger only
+// announces "the balance moved, and generically why".
+const (
+	BalanceChangeReasonCredit    = "credit"
+	BalanceChangeReasonDebit     = "debit"
+	BalanceChangeReasonBlock     = "block"
+	BalanceChangeReasonUnblock   = "unblock"
+	BalanceChangeReasonHold      = "hold"
+	BalanceChangeReasonRelease   = "release"
+	BalanceChangeReasonOverdraft = "overdraft"
+	BalanceChangeReasonAdjust    = "adjust"
+)
+
+// BalanceChangedDefinition is the routing contract for balance.changed.
+//
+// Emission anchor: components/ledger/internal/services/command/send_balance_changed_events.go,
+// inside SendBalanceChangedEvents, launched as a goroutine alongside
+// SendTransactionEvents / SendOverdraftEvents from
+// create_balance_transaction_operations_async.go and
+// create_bulk_transaction_operations_async.go. One balance.changed is emitted
+// per balance-affecting operation of the committed transaction.
+//
+// Design intent: this event is INTENTIONALLY generic and domain-agnostic. It
+// carries only Midaz identities (org/ledger/account/balance/asset) plus a
+// generic Reason discriminator. It carries NO consumer-domain fields (no
+// cpf_hash, no judicial-order id, nothing SISBAJUD-specific). Translating this
+// generic signal into a domain trigger is the consumer's job.
+//
+// Relationship to balance.created: COMPLEMENTARY, not a replacement.
+// balance.created fires only on CreateAdditionalBalance (lifecycle create);
+// balance.changed fires on transaction-driven mutations of an existing balance.
+//
+// IMPORTANT posture: emit failures MUST NOT fail the parent transaction.
+// EventType "changed" is a single word — no underscore/hyphen concern with the
+// lib-streaming route-key regex. Wire topic: lerian.streaming.balance.changed.
+var BalanceChangedDefinition = Definition{
+	ResourceType:  "balance",
+	EventType:     "changed",
+	SchemaVersion: "1.0.0",
+}
+
+// BalanceChangedPayload is the wire payload for balance.changed.
+//
+// Available/OnHold/Amount are decimal.Decimal so the wire encodes them as JSON
+// numbers (matching the HTTP balance contract). They reflect the state AFTER
+// the operation.
+//
+// Scale is intentionally OMITTED: it is an asset-level property, not a
+// balance-level one (see balance_created.go). Consumers needing scale should
+// join against the corresponding asset.created event. Version IS included so
+// consumers can order/dedup mutations of the same balance.
+type BalanceChangedPayload struct {
+	OrganizationID string          `json:"organizationId"`
+	LedgerID       string          `json:"ledgerId"`
+	AccountID      string          `json:"accountId"`
+	BalanceID      string          `json:"balanceId"`
+	Alias          string          `json:"alias,omitempty"`
+	AssetCode      string          `json:"assetCode"`
+	BalanceKey     string          `json:"balanceKey"`
+	Available      decimal.Decimal `json:"available"`
+	OnHold         decimal.Decimal `json:"onHold"`
+	Version        int64           `json:"version"`
+	Reason         string          `json:"reason"`
+	OperationType  string          `json:"operationType"`
+	Direction      string          `json:"direction,omitempty"`
+	Amount         decimal.Decimal `json:"amount"`
+	TransactionID  string          `json:"transactionId"`
+	OperationID    string          `json:"operationId"`
+	OccurredAt     string          `json:"occurredAt"`
+}
+
+// BalanceChangedSource carries the identifiers + amounts the constructor needs
+// to assemble a payload. The use case populates this from one operation + its
+// parent transaction. Keeping it a struct keeps the constructor from growing
+// into positional-argument territory (mirrors BalanceOverdraftSource).
+type BalanceChangedSource struct {
+	OrganizationID string
+	LedgerID       string
+	AccountID      string
+	BalanceID      string
+	Alias          string
+	AssetCode      string
+	BalanceKey     string
+	Available      decimal.Decimal
+	OnHold         decimal.Decimal
+	Version        int64
+	Reason         string
+	OperationType  string
+	Direction      string
+	Amount         decimal.Decimal
+	TransactionID  string
+	OperationID    string
+	OccurredAt     time.Time
+}
+
+// NewBalanceChanged maps the source into the wire payload.
+func NewBalanceChanged(src BalanceChangedSource) BalanceChangedPayload {
+	return BalanceChangedPayload{
+		OrganizationID: src.OrganizationID,
+		LedgerID:       src.LedgerID,
+		AccountID:      src.AccountID,
+		BalanceID:      src.BalanceID,
+		Alias:          src.Alias,
+		AssetCode:      src.AssetCode,
+		BalanceKey:     src.BalanceKey,
+		Available:      src.Available,
+		OnHold:         src.OnHold,
+		Version:        src.Version,
+		Reason:         src.Reason,
+		OperationType:  src.OperationType,
+		Direction:      src.Direction,
+		Amount:         src.Amount,
+		TransactionID:  src.TransactionID,
+		OperationID:    src.OperationID,
+		OccurredAt:     src.OccurredAt.Format(time.RFC3339),
+	}
+}
+
+// ToEmitRequest assembles a libStreaming.EmitRequest ready for the Emitter.
+// Subject combines transactionId + operationId so consumers safe-deduping on
+// Subject match the canonical idempotency key for this event.
+func (p BalanceChangedPayload) ToEmitRequest(tenantID string, ts time.Time) (libStreaming.EmitRequest, error) {
+	data, err := json.Marshal(p)
+	if err != nil {
+		return libStreaming.EmitRequest{}, fmt.Errorf("marshal %s payload: %w", BalanceChangedDefinition.Key(), err)
+	}
+
+	return libStreaming.EmitRequest{
+		DefinitionKey: BalanceChangedDefinition.Key(),
+		TenantID:      tenantID,
+		Subject:       p.TransactionID + ":" + p.OperationID,
+		Timestamp:     ts,
+		Payload:       data,
+	}, nil
+}

--- a/pkg/streaming/events/balance_changed_test.go
+++ b/pkg/streaming/events/balance_changed_test.go
@@ -1,0 +1,118 @@
+//go:build unit
+
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package events
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBalanceChangedDefinition_Key(t *testing.T) {
+	assert.Equal(t, "balance.changed", BalanceChangedDefinition.Key())
+	assert.Equal(t, "balance", BalanceChangedDefinition.ResourceType)
+	assert.Equal(t, "changed", BalanceChangedDefinition.EventType)
+	assert.Equal(t, "1.0.0", BalanceChangedDefinition.SchemaVersion)
+}
+
+func TestNewBalanceChanged_MapsAllFields(t *testing.T) {
+	ts := time.Date(2026, 7, 3, 12, 0, 0, 0, time.UTC)
+	src := BalanceChangedSource{
+		OrganizationID: "org-1",
+		LedgerID:       "led-1",
+		AccountID:      "acc-1",
+		BalanceID:      "bal-1",
+		Alias:          "@person1",
+		AssetCode:      "BRL",
+		BalanceKey:     "default",
+		Available:      decimal.NewFromInt(1500),
+		OnHold:         decimal.NewFromInt(500),
+		Version:        42,
+		Reason:         BalanceChangeReasonCredit,
+		OperationType:  "CREDIT",
+		Direction:      "credit",
+		Amount:         decimal.NewFromInt(100),
+		TransactionID:  "txn-1",
+		OperationID:    "op-1",
+		OccurredAt:     ts,
+	}
+
+	p := NewBalanceChanged(src)
+
+	assert.Equal(t, "acc-1", p.AccountID)
+	assert.Equal(t, "bal-1", p.BalanceID)
+	assert.Equal(t, "credit", p.Reason)
+	assert.Equal(t, "CREDIT", p.OperationType)
+	assert.True(t, decimal.NewFromInt(1500).Equal(p.Available))
+	assert.Equal(t, int64(42), p.Version)
+	assert.Equal(t, "2026-07-03T12:00:00Z", p.OccurredAt)
+}
+
+func TestBalanceChangedPayload_ToEmitRequest(t *testing.T) {
+	ts := time.Date(2026, 7, 3, 12, 0, 0, 0, time.UTC)
+	p := NewBalanceChanged(BalanceChangedSource{
+		TransactionID: "txn-1",
+		OperationID:   "op-1",
+		Reason:        BalanceChangeReasonDebit,
+		OccurredAt:    ts,
+	})
+
+	req, err := p.ToEmitRequest("tenant-1", ts)
+	require.NoError(t, err)
+	assert.Equal(t, "balance.changed", req.DefinitionKey)
+	assert.Equal(t, "tenant-1", req.TenantID)
+	assert.Equal(t, "txn-1:op-1", req.Subject)
+	assert.Equal(t, ts, req.Timestamp)
+	assert.NotEmpty(t, req.Payload)
+}
+
+// JSONShape locks the wire field count and names (v1.0.0 contract).
+func TestBalanceChangedPayload_JSONShape(t *testing.T) {
+	p := NewBalanceChanged(BalanceChangedSource{
+		OrganizationID: "org-1",
+		LedgerID:       "led-1",
+		AccountID:      "acc-1",
+		BalanceID:      "bal-1",
+		Alias:          "@person1",
+		AssetCode:      "BRL",
+		BalanceKey:     "default",
+		Available:      decimal.NewFromInt(1500),
+		OnHold:         decimal.NewFromInt(500),
+		Version:        42,
+		Reason:         BalanceChangeReasonCredit,
+		OperationType:  "CREDIT",
+		Direction:      "credit",
+		Amount:         decimal.NewFromInt(100),
+		TransactionID:  "txn-1",
+		OperationID:    "op-1",
+		OccurredAt:     time.Now().UTC(),
+	})
+
+	raw, err := json.Marshal(p)
+	require.NoError(t, err)
+
+	var m map[string]any
+	require.NoError(t, json.Unmarshal(raw, &m))
+
+	// 17 wire fields (alias and direction are omitempty but present here,
+	// since every field is set in this test).
+	for _, k := range []string{
+		"organizationId", "ledgerId", "accountId", "balanceId", "alias",
+		"assetCode", "balanceKey", "available", "onHold", "version",
+		"reason", "operationType", "direction", "amount", "transactionId",
+		"operationId", "occurredAt",
+	} {
+		_, ok := m[k]
+		assert.Truef(t, ok, "missing wire field: %s", k)
+	}
+	assert.Len(t, m, 17, "payload must have exactly 17 wire fields")
+	assert.NotContains(t, m, "scale", "scale is asset-level; it must not be in the payload")
+}


### PR DESCRIPTION
## What

Adds a generic, domain-agnostic `balance.changed` lib-streaming event, emitted per balance-affecting operation after a transaction is committed (mirrors the `SendOverdraftEvents`/`SendTransactionEvents` pattern, same async/bulk call site, fire-and-forget). The event carries only Midaz identities (org/ledger/account/balance/asset) plus a generic `reason` discriminator — **no consumer-domain fields**; consumers map `accountId` to their own domain key.

- Topic: `lerian.streaming.balance.changed` · CloudEvents 1.0 binary · `ce-tenantid` header.
- Emission point is post-Redis (balance already sensitized by the Lua atomic op) and post-approval (transaction APPROVED + persisted); `op.BalanceAfter` reflects the real sensitized balance.
- Gated only by the master `STREAMING_ENABLED` (NoopEmitter when off) — consistent with the other pure lib-streaming events (`balance.created`, CRUD). No dedicated per-event flag.
- Complementary to (not replacing) `balance.created`.

## Base branch — NOT develop

Targets the integration branch `feature/account-block-transaction-block`, which accumulates the Midaz-side adjustments for the br-sisbajud judicial-block feature and stays **off develop** until sisbajud end-to-end testing is complete.

## Notes

- 3 signed commits, additive (+686/-6, 9 files). `go build`/`go vet`/`make lint`/unit tests green.
- `make check-tests` (coverage 80%) fails on the pre-existing repo-wide baseline (ledger ~48%), unrelated to this additive change.