### PR TITLE
refactor(ledger): extract overdraft event env-var names to constants

### DIFF
--- a/components/ledger/internal/services/command/send_overdraft_events.go
+++ b/components/ledger/internal/services/command/send_overdraft_events.go
@@ -43,6 +43,19 @@ const (
 	OverdraftActionCleared = "overdraft.cleared"
 )
 
+// Environment variable names read by the overdraft-event flow. Extracted to
+// constants so the names have a single source of truth instead of being
+// repeated as inline string literals across the file.
+const (
+	// envOverdraftEventsEnabled toggles overdraft-event emission. Enabled unless
+	// explicitly set to "false".
+	envOverdraftEventsEnabled = "RABBITMQ_OVERDRAFT_EVENTS_ENABLED"
+
+	// envOverdraftEventsExchange is the RabbitMQ exchange the legacy overdraft
+	// events are published to.
+	envOverdraftEventsExchange = "RABBITMQ_OVERDRAFT_EVENTS_EXCHANGE"
+)
+
 // OverdraftEventPayload carries the business fields for an overdraft
 // lifecycle event. It is marshalled as the Payload field inside mmodel.Event.
 type OverdraftEventPayload struct {
@@ -100,7 +113,7 @@ func (uc *UseCase) SendOverdraftEvents(ctx context.Context, tran *transaction.Tr
 
 	if !isOverdraftEventEnabled() {
 		logger.Log(ctx, libLog.LevelInfo, "Overdraft events not enabled",
-			libLog.String("RABBITMQ_OVERDRAFT_EVENTS_ENABLED", os.Getenv("RABBITMQ_OVERDRAFT_EVENTS_ENABLED")))
+			libLog.String(envOverdraftEventsEnabled, os.Getenv(envOverdraftEventsEnabled)))
 
 		return
 	}
@@ -113,7 +126,7 @@ func (uc *UseCase) SendOverdraftEvents(ctx context.Context, tran *transaction.Tr
 	ctxSend, span := tracer.Start(ctx, "command.send_overdraft_events_async")
 	defer span.End()
 
-	exchange := os.Getenv("RABBITMQ_OVERDRAFT_EVENTS_EXCHANGE")
+	exchange := os.Getenv(envOverdraftEventsExchange)
 
 	for _, ep := range payloads {
 		raw, err := json.Marshal(ep.payload)
@@ -356,6 +369,6 @@ func overdraftBalanceAfter(op *operation.Operation) decimal.Decimal {
 // Unset or any other value means enabled — consistent with the transaction
 // event flag pattern.
 func isOverdraftEventEnabled() bool {
-	envValue := strings.ToLower(strings.TrimSpace(os.Getenv("RABBITMQ_OVERDRAFT_EVENTS_ENABLED")))
+	envValue := strings.ToLower(strings.TrimSpace(os.Getenv(envOverdraftEventsEnabled)))
 	return envValue != "false"
 }


### PR DESCRIPTION
## What

Standardizes `send_overdraft_events.go`: the `RABBITMQ_OVERDRAFT_EVENTS_ENABLED` / `RABBITMQ_OVERDRAFT_EVENTS_EXCHANGE` env-var names were repeated as inline string literals (the ENABLED one twice). Extracted to named constants (`envOverdraftEventsEnabled` / `envOverdraftEventsExchange`) so the names have a single source of truth.

No behavior change. `go build`/`go vet`/unit tests green.

## Base branch

Targets the integration branch `feature/account-block-transaction-block` (consistent with keeping Midaz adjustments off develop during sisbajud testing). Retarget to develop if you'd prefer this cleanup lands independently.