### PR TITLE
feat(tracer): emit rule and limit lifecycle events via lib-streaming

### DIFF
--- a/components/infra/docker-compose.yml
+++ b/components/infra/docker-compose.yml
@@ -204,6 +204,90 @@ services:
     networks:
       - infra-network
 
+  # One-shot topic provisioner for lib-streaming. lib-streaming v1.6.2 has no
+  # client-side topic auto-create, so every topic the platform emits to must be
+  # pre-created or emits fail on a healthy broker. Runs once after the broker is
+  # healthy, creates every topic idempotently ("|| true"), then exits.
+  #
+  # Topic set is the FULL platform catalog derived from the two canonical
+  # registration functions — DO NOT hand-edit stale entries; keep in sync with:
+  #   - midazEventDefinitions()  (components/ledger/internal/bootstrap/streaming.go) — 48 ledger/CRM/fees topics
+  #   - tracerEventDefinitions() (components/tracer/internal/bootstrap/streaming.go) — 12 rule.*/limit.* topics
+  # Total: 60 topics. Topic name = "lerian.streaming.<resource>.<event>".
+  midaz-redpanda-init:
+    container_name: midaz-redpanda-init
+    image: redpandadata/redpanda:v24.2.7
+    depends_on:
+      midaz-redpanda:
+        condition: service_healthy
+    restart: "no"
+    entrypoint: /bin/sh
+    command:
+      - -c
+      - |
+        rpk topic create lerian.streaming.account.created -r 1 -p 1 --brokers midaz-redpanda:9092 || true
+        rpk topic create lerian.streaming.account.deleted -r 1 -p 1 --brokers midaz-redpanda:9092 || true
+        rpk topic create lerian.streaming.account.updated -r 1 -p 1 --brokers midaz-redpanda:9092 || true
+        rpk topic create lerian.streaming.asset.created -r 1 -p 1 --brokers midaz-redpanda:9092 || true
+        rpk topic create lerian.streaming.asset.deleted -r 1 -p 1 --brokers midaz-redpanda:9092 || true
+        rpk topic create lerian.streaming.asset.updated -r 1 -p 1 --brokers midaz-redpanda:9092 || true
+        rpk topic create lerian.streaming.balance.config-changed -r 1 -p 1 --brokers midaz-redpanda:9092 || true
+        rpk topic create lerian.streaming.balance.created -r 1 -p 1 --brokers midaz-redpanda:9092 || true
+        rpk topic create lerian.streaming.balance.deleted -r 1 -p 1 --brokers midaz-redpanda:9092 || true
+        rpk topic create lerian.streaming.balance.overdraft-cleared -r 1 -p 1 --brokers midaz-redpanda:9092 || true
+        rpk topic create lerian.streaming.balance.overdraft-drawn -r 1 -p 1 --brokers midaz-redpanda:9092 || true
+        rpk topic create lerian.streaming.balance.overdraft-repaid -r 1 -p 1 --brokers midaz-redpanda:9092 || true
+        rpk topic create lerian.streaming.fees.applied -r 1 -p 1 --brokers midaz-redpanda:9092 || true
+        rpk topic create lerian.streaming.fees-billing-package.created -r 1 -p 1 --brokers midaz-redpanda:9092 || true
+        rpk topic create lerian.streaming.fees-billing-package.deleted -r 1 -p 1 --brokers midaz-redpanda:9092 || true
+        rpk topic create lerian.streaming.fees-billing-package.updated -r 1 -p 1 --brokers midaz-redpanda:9092 || true
+        rpk topic create lerian.streaming.fees-package.created -r 1 -p 1 --brokers midaz-redpanda:9092 || true
+        rpk topic create lerian.streaming.fees-package.deleted -r 1 -p 1 --brokers midaz-redpanda:9092 || true
+        rpk topic create lerian.streaming.fees-package.updated -r 1 -p 1 --brokers midaz-redpanda:9092 || true
+        rpk topic create lerian.streaming.holder.created -r 1 -p 1 --brokers midaz-redpanda:9092 || true
+        rpk topic create lerian.streaming.holder.deleted -r 1 -p 1 --brokers midaz-redpanda:9092 || true
+        rpk topic create lerian.streaming.holder.updated -r 1 -p 1 --brokers midaz-redpanda:9092 || true
+        rpk topic create lerian.streaming.instrument.created -r 1 -p 1 --brokers midaz-redpanda:9092 || true
+        rpk topic create lerian.streaming.instrument.deleted -r 1 -p 1 --brokers midaz-redpanda:9092 || true
+        rpk topic create lerian.streaming.instrument.related-party-deleted -r 1 -p 1 --brokers midaz-redpanda:9092 || true
+        rpk topic create lerian.streaming.instrument.updated -r 1 -p 1 --brokers midaz-redpanda:9092 || true
+        rpk topic create lerian.streaming.ledger.created -r 1 -p 1 --brokers midaz-redpanda:9092 || true
+        rpk topic create lerian.streaming.ledger.deleted -r 1 -p 1 --brokers midaz-redpanda:9092 || true
+        rpk topic create lerian.streaming.ledger.updated -r 1 -p 1 --brokers midaz-redpanda:9092 || true
+        rpk topic create lerian.streaming.limit.activated -r 1 -p 1 --brokers midaz-redpanda:9092 || true
+        rpk topic create lerian.streaming.limit.created -r 1 -p 1 --brokers midaz-redpanda:9092 || true
+        rpk topic create lerian.streaming.limit.deactivated -r 1 -p 1 --brokers midaz-redpanda:9092 || true
+        rpk topic create lerian.streaming.limit.deleted -r 1 -p 1 --brokers midaz-redpanda:9092 || true
+        rpk topic create lerian.streaming.limit.drafted -r 1 -p 1 --brokers midaz-redpanda:9092 || true
+        rpk topic create lerian.streaming.limit.updated -r 1 -p 1 --brokers midaz-redpanda:9092 || true
+        rpk topic create lerian.streaming.operation-route.created -r 1 -p 1 --brokers midaz-redpanda:9092 || true
+        rpk topic create lerian.streaming.operation-route.deleted -r 1 -p 1 --brokers midaz-redpanda:9092 || true
+        rpk topic create lerian.streaming.operation-route.updated -r 1 -p 1 --brokers midaz-redpanda:9092 || true
+        rpk topic create lerian.streaming.organization.created -r 1 -p 1 --brokers midaz-redpanda:9092 || true
+        rpk topic create lerian.streaming.organization.deleted -r 1 -p 1 --brokers midaz-redpanda:9092 || true
+        rpk topic create lerian.streaming.organization.updated -r 1 -p 1 --brokers midaz-redpanda:9092 || true
+        rpk topic create lerian.streaming.portfolio.created -r 1 -p 1 --brokers midaz-redpanda:9092 || true
+        rpk topic create lerian.streaming.portfolio.deleted -r 1 -p 1 --brokers midaz-redpanda:9092 || true
+        rpk topic create lerian.streaming.portfolio.updated -r 1 -p 1 --brokers midaz-redpanda:9092 || true
+        rpk topic create lerian.streaming.rule.activated -r 1 -p 1 --brokers midaz-redpanda:9092 || true
+        rpk topic create lerian.streaming.rule.created -r 1 -p 1 --brokers midaz-redpanda:9092 || true
+        rpk topic create lerian.streaming.rule.deactivated -r 1 -p 1 --brokers midaz-redpanda:9092 || true
+        rpk topic create lerian.streaming.rule.deleted -r 1 -p 1 --brokers midaz-redpanda:9092 || true
+        rpk topic create lerian.streaming.rule.drafted -r 1 -p 1 --brokers midaz-redpanda:9092 || true
+        rpk topic create lerian.streaming.rule.updated -r 1 -p 1 --brokers midaz-redpanda:9092 || true
+        rpk topic create lerian.streaming.segment.created -r 1 -p 1 --brokers midaz-redpanda:9092 || true
+        rpk topic create lerian.streaming.segment.deleted -r 1 -p 1 --brokers midaz-redpanda:9092 || true
+        rpk topic create lerian.streaming.segment.updated -r 1 -p 1 --brokers midaz-redpanda:9092 || true
+        rpk topic create lerian.streaming.transaction.canceled -r 1 -p 1 --brokers midaz-redpanda:9092 || true
+        rpk topic create lerian.streaming.transaction.committed -r 1 -p 1 --brokers midaz-redpanda:9092 || true
+        rpk topic create lerian.streaming.transaction.posted -r 1 -p 1 --brokers midaz-redpanda:9092 || true
+        rpk topic create lerian.streaming.transaction.reverted -r 1 -p 1 --brokers midaz-redpanda:9092 || true
+        rpk topic create lerian.streaming.transaction-route.created -r 1 -p 1 --brokers midaz-redpanda:9092 || true
+        rpk topic create lerian.streaming.transaction-route.deleted -r 1 -p 1 --brokers midaz-redpanda:9092 || true
+        rpk topic create lerian.streaming.transaction-route.updated -r 1 -p 1 --brokers midaz-redpanda:9092 || true
+    networks:
+      - infra-network
+
   # HashiCorp Vault for KMS/Transit secrets engine (OPTIONAL)
   # Used by components that need envelope encryption (e.g., CRM with KMS_VENDOR=hashicorp-vault)
   # Start with: docker compose up midaz-hc-vault midaz-hc-vault-init -d

--- a/components/tracer/.env.example
+++ b/components/tracer/.env.example
@@ -363,7 +363,9 @@ STREAMING_ENABLED=false
 # STREAMING_BROKERS=midaz-redpanda:9092
 # Kafka client.id for broker-side diagnostics.
 # STREAMING_CLIENT_ID=midaz-tracer
-# CloudEvents `ce-source` default — required when STREAMING_ENABLED=true.
+# CloudEvents `ce-source` stamped on every emitted event. Read by tracer at
+# bootstrap; when unset, the in-code default lerian.midaz.tracer is used. Set
+# it only to distinguish sources across environments or shadow deployments.
 # STREAMING_CLOUDEVENTS_SOURCE=lerian.midaz.tracer
 # Compression codec: snappy | lz4 | zstd | gzip | none. Default: lz4.
 # STREAMING_COMPRESSION=lz4

--- a/components/tracer/.env.example
+++ b/components/tracer/.env.example
@@ -348,3 +348,54 @@ TRACER_TLS_KEY_FILE=
 # TRACER_TLS_MODE=mtls — without it the server cannot enforce
 # RequireAndVerifyClientCert.
 TRACER_TLS_CLIENT_CA_FILE=
+
+# ============================================================================
+# Streaming (lib-streaming producer)
+# ============================================================================
+# lib-streaming publishes past-tense business events over Kafka/Redpanda.
+# Default is OFF for every existing deployment; flip STREAMING_ENABLED=true and
+# supply STREAMING_BROKERS to enable. When disabled, a NoopEmitter is injected
+# and no broker connection is attempted.
+STREAMING_ENABLED=false
+# Comma-separated Redpanda / Kafka bootstrap list (host:port). From inside the
+# infra-network use the container address midaz-redpanda:9092; from the host use
+# localhost:19092.
+# STREAMING_BROKERS=midaz-redpanda:9092
+# Kafka client.id for broker-side diagnostics.
+# STREAMING_CLIENT_ID=midaz-tracer
+# CloudEvents `ce-source` default — required when STREAMING_ENABLED=true.
+# STREAMING_CLOUDEVENTS_SOURCE=lerian.midaz.tracer
+# Compression codec: snappy | lz4 | zstd | gzip | none. Default: lz4.
+# STREAMING_COMPRESSION=lz4
+# Producer ack policy: all | leader | none. Default: all.
+# STREAMING_REQUIRED_ACKS=all
+# franz-go ProducerLinger in ms. Default: 5.
+# STREAMING_BATCH_LINGER_MS=5
+
+# --- Per-emit timeout (IMPORTANT-posture events) ---
+# Per-call deadline applied around emitter.Emit() for IMPORTANT-posture events.
+# When this fires, the emit is logged as a warning and dropped — durability of
+# IMPORTANT events belongs to PG and (eventually) the outbox subsystem, not to
+# the synchronous broker round-trip.
+#
+# Value is in milliseconds; must be > 0 or the default is used. Default: 5000 (5s).
+# Bump it if your broker is far away (cross-region) or when running end-to-end
+# against a cold/loaded test cluster. Lower it if you want to fail-fast on slow
+# brokers and rely on async/outbox redelivery.
+# STREAMING_IMPORTANT_EMIT_TIMEOUT_MS=5000
+
+# --- SASL/TLS auth ---
+# When STREAMING_SASL_MECHANISM is empty (default) the producer connects to the
+# broker without authentication. Set to PLAIN, SCRAM-SHA-256, or SCRAM-SHA-512
+# to enable SASL; STREAMING_SASL_USERNAME and STREAMING_SASL_PASSWORD then
+# become required.
+# STREAMING_SASL_MECHANISM=
+# STREAMING_SASL_USERNAME=
+# STREAMING_SASL_PASSWORD=
+#
+# SASL without TLS is rejected at bootstrap unless explicitly opted in via
+# STREAMING_ALLOW_PLAINTEXT_SASL=true. Use ONLY for local/dev brokers that don't
+# terminate TLS (e.g. a Redpanda dev container with a SASL_PLAINTEXT listener).
+# NEVER set this in staging or production: SASL credentials would cross the
+# network in cleartext.
+# STREAMING_ALLOW_PLAINTEXT_SASL=false

--- a/components/tracer/internal/bootstrap/config.go
+++ b/components/tracer/internal/bootstrap/config.go
@@ -22,6 +22,7 @@ import (
 	libRuntime "github.com/LerianStudio/lib-observability/runtime"
 	libOtel "github.com/LerianStudio/lib-observability/tracing"
 	libZap "github.com/LerianStudio/lib-observability/zap"
+	libStreaming "github.com/LerianStudio/lib-streaming"
 	"google.golang.org/grpc"
 
 	"github.com/LerianStudio/midaz/v4/components/tracer/internal/adapters/cel"
@@ -233,6 +234,13 @@ type Config struct {
 	// (brokers, compression, acks, linger) are NOT bound here — they are read by
 	// libStreaming.LoadConfig() directly from STREAMING_* env at build time.
 	StreamingEnabled bool `env:"STREAMING_ENABLED"`
+
+	// StreamingCloudEventsSource overrides the CloudEvents `ce-source` stamped
+	// on every event tracer emits. When empty (the default), the in-code
+	// default lerian.midaz.tracer is used, so an existing deployment that never
+	// sets this var keeps the historical source. Operators set it only to
+	// distinguish sources across environments or shadow deployments.
+	StreamingCloudEventsSource string `env:"STREAMING_CLOUDEVENTS_SOURCE"`
 
 	// --- Streaming SASL/TLS auth ---
 	// When STREAMING_SASL_MECHANISM is empty (default) the producer connects
@@ -1493,14 +1501,19 @@ func initWorkers(
 	logger libLog.Logger,
 	clk clock.Clock,
 	mtComponents *componentsMT,
+	streamingEmitter libStreaming.Emitter,
+	streamingClose func() error,
 ) (*Service, error) {
 	svc := &Service{
-		HTTPServer:    serverAPI,
-		grpcServer:    grpcServer,
-		Logger:        logger,
-		postgresConn:  postgresConn,
-		healthChecker: healthChecker,
-		config:        cfg,
+		HTTPServer:       serverAPI,
+		grpcServer:       grpcServer,
+		Logger:           logger,
+		postgresConn:     postgresConn,
+		healthChecker:    healthChecker,
+		config:           cfg,
+		StreamingEmitter: streamingEmitter,
+		StreamingClose:   streamingClose,
+		StreamingEnabled: cfg.StreamingEnabled,
 	}
 
 	if mtComponents != nil {
@@ -1628,8 +1641,11 @@ func conditionalWarmUpCache(
 	return nil
 }
 
-// initCoreInfra initializes logger, validates auth config, and sets up OpenTelemetry.
-func initCoreInfra(ctx context.Context, cfg *Config) (libLog.Logger, *libOtel.Telemetry, error) {
+// initCoreInfra initializes logger, validates auth config, sets up
+// OpenTelemetry, and builds the streaming emitter. The emitter and its close
+// hook are non-nil in every path (NoopEmitter + no-op close when streaming is
+// disabled), so callers can wire them unconditionally.
+func initCoreInfra(ctx context.Context, cfg *Config) (libLog.Logger, *libOtel.Telemetry, libStreaming.Emitter, func() error, error) {
 	zapEnv := libZap.Environment(cfg.OtelDeploymentEnv)
 	if zapEnv == "" {
 		zapEnv = libZap.EnvironmentDevelopment
@@ -1641,30 +1657,30 @@ func initCoreInfra(ctx context.Context, cfg *Config) (libLog.Logger, *libOtel.Te
 		OTelLibraryName: "tracer",
 	})
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to initialize logger: %w", err)
+		return nil, nil, nil, nil, fmt.Errorf("failed to initialize logger: %w", err)
 	}
 
 	var logger libLog.Logger = zapLogger
 
 	// Validate authentication configuration (fail-fast if misconfigured)
 	if err := ValidateAuthConfig(ctx, cfg, logger); err != nil {
-		return nil, nil, fmt.Errorf("invalid auth configuration: %w", err)
+		return nil, nil, nil, nil, fmt.Errorf("invalid auth configuration: %w", err)
 	}
 
 	// Validate Access Manager plugin configuration (fail-fast if misconfigured)
 	if err := ValidateAccessManagerConfig(ctx, cfg, logger); err != nil {
-		return nil, nil, fmt.Errorf("invalid access manager configuration: %w", err)
+		return nil, nil, nil, nil, fmt.Errorf("invalid access manager configuration: %w", err)
 	}
 
 	// Cross-check: at least one auth mechanism must be enabled outside local
 	// deployments (fail-fast; the per-mechanism validators above only Warn)
 	if err := ValidateAuthPresence(ctx, cfg, logger); err != nil {
-		return nil, nil, fmt.Errorf("auth presence: %w", err)
+		return nil, nil, nil, nil, fmt.Errorf("auth presence: %w", err)
 	}
 
 	// Validate multi-tenant configuration (fail-fast if misconfigured)
 	if err := ValidateMultiTenantConfig(ctx, cfg, logger); err != nil {
-		return nil, nil, fmt.Errorf("invalid multi-tenant configuration: %w", err)
+		return nil, nil, nil, nil, fmt.Errorf("invalid multi-tenant configuration: %w", err)
 	}
 
 	// Gate 4: enforce TLS posture for SaaS deployments BEFORE any external
@@ -1673,7 +1689,7 @@ func initCoreInfra(ctx context.Context, cfg *Config) (libLog.Logger, *libOtel.Te
 	// function with one call site — anti-pattern N6 (scattered inline
 	// checks) is structurally absent.
 	if err := ValidateSaaSTLS(cfg); err != nil {
-		return nil, nil, fmt.Errorf("TLS enforcement: %w", err)
+		return nil, nil, nil, nil, fmt.Errorf("TLS enforcement: %w", err)
 	}
 
 	// Init OpenTelemetry via lib-commons helper (per Ring standards)
@@ -1687,7 +1703,7 @@ func initCoreInfra(ctx context.Context, cfg *Config) (libLog.Logger, *libOtel.Te
 		Logger:                    logger,
 	})
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to initialize telemetry: %w", err)
+		return nil, nil, nil, nil, fmt.Errorf("failed to initialize telemetry: %w", err)
 	}
 
 	// C2: arm lib-commons' panic-observability trident so every
@@ -1699,7 +1715,15 @@ func initCoreInfra(ctx context.Context, cfg *Config) (libLog.Logger, *libOtel.Te
 		libRuntime.InitPanicMetrics(telemetry.MetricsFactory, logger)
 	}
 
-	return logger, telemetry, nil
+	// Build the streaming emitter. Disabled (the default) yields a NoopEmitter
+	// plus a no-op close hook — no transport is constructed and no broker
+	// connection is attempted, so an unset STREAMING_* config never breaks boot.
+	streamingEmitter, streamingClose, err := BuildStreamingEmitter(ctx, cfg, logger, telemetry)
+	if err != nil {
+		return nil, nil, nil, nil, fmt.Errorf("failed to build streaming emitter: %w", err)
+	}
+
+	return logger, telemetry, streamingEmitter, streamingClose, nil
 }
 
 // initClock creates a clock instance based on environment configuration.
@@ -1749,7 +1773,11 @@ func InitServers(ctx context.Context) (*Service, error) {
 	// `envDefault` struct tags; this is the single source of truth for defaults.
 	ApplyMultiTenantDefaults(cfg)
 
-	logger, telemetry, err := initCoreInfra(ctx, cfg)
+	// initCoreInfra also builds the streaming emitter once logger + telemetry
+	// are up. Disabled (the default) yields a NoopEmitter plus a no-op close
+	// hook — no transport is constructed and no broker connection is
+	// attempted, so an unset STREAMING_* config never breaks boot.
+	logger, telemetry, streamingEmitter, streamingClose, err := initCoreInfra(ctx, cfg)
 	if err != nil {
 		return nil, err
 	}
@@ -1880,7 +1908,7 @@ func InitServers(ctx context.Context) (*Service, error) {
 	// finalizeStartup also builds the opt-in reservation gRPC server and runs the
 	// startup self-probe BEFORE the HTTP server begins accepting traffic; folded
 	// into one helper to keep InitServers under the gocyclo budget.
-	svc, err := finalizeStartup(ctx, cfg, limitDeps, syncWorker, serverAPI, reservationService, postgresConn, healthChecker, logger, telemetry, clk, mtComponents)
+	svc, err := finalizeStartup(ctx, cfg, limitDeps, syncWorker, serverAPI, reservationService, postgresConn, healthChecker, logger, telemetry, clk, mtComponents, streamingEmitter, streamingClose)
 	if err != nil {
 		return nil, err
 	}
@@ -1963,6 +1991,8 @@ func finalizeStartup(
 	telemetry *libOtel.Telemetry,
 	clk clock.Clock,
 	mtComponents *componentsMT,
+	streamingEmitter libStreaming.Emitter,
+	streamingClose func() error,
 ) (*Service, error) {
 	var pgManager *tmpostgres.Manager
 	if mtComponents != nil {
@@ -1974,7 +2004,7 @@ func finalizeStartup(
 		return nil, err
 	}
 
-	svc, err := initWorkers(ctx, cfg, limitDeps, syncWorker, serverAPI, grpcServer, postgresConn, healthChecker, logger, clk, mtComponents)
+	svc, err := initWorkers(ctx, cfg, limitDeps, syncWorker, serverAPI, grpcServer, postgresConn, healthChecker, logger, clk, mtComponents, streamingEmitter, streamingClose)
 	if err != nil {
 		return nil, err
 	}

--- a/components/tracer/internal/bootstrap/config.go
+++ b/components/tracer/internal/bootstrap/config.go
@@ -956,7 +956,7 @@ func initRuleService(ruleRepo *postgres.Repository, celAdapter *cel.Adapter, aud
 
 	draftRuleCmd.Streaming = streaming
 
-	deleteRuleCmd, err := command.NewDeleteRuleService(ruleRepo, auditWriter, txBeginner)
+	deleteRuleCmd, err := command.NewDeleteRuleService(ruleRepo, auditWriter, clk, txBeginner)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create delete rule service: %w", err)
 	}

--- a/components/tracer/internal/bootstrap/config.go
+++ b/components/tracer/internal/bootstrap/config.go
@@ -917,7 +917,7 @@ func initPostgresConnection(ctx context.Context, cfg *Config, logger libLog.Logg
 // The txBeginner is shared with the limit lifecycle commands and the validation
 // service so the rule lifecycle commands persist the status/update and the
 // audit event atomically via executeInTx.
-func initRuleService(ruleRepo *postgres.Repository, celAdapter *cel.Adapter, auditWriter command.AuditWriter, cacheWriter command.RuleCacheWriter, clk clock.Clock, txBeginner pgdb.TxBeginner) (*services.RuleService, error) {
+func initRuleService(ruleRepo *postgres.Repository, celAdapter *cel.Adapter, auditWriter command.AuditWriter, cacheWriter command.RuleCacheWriter, clk clock.Clock, txBeginner pgdb.TxBeginner, streaming libStreaming.Emitter) (*services.RuleService, error) {
 	celCompiler := &celCompilerAdapter{adapter: celAdapter}
 
 	// Inject audit writer and cache writer into Rule commands
@@ -926,30 +926,42 @@ func initRuleService(ruleRepo *postgres.Repository, celAdapter *cel.Adapter, aud
 		return nil, fmt.Errorf("failed to construct CreateRuleCommand: %w", err)
 	}
 
+	createRuleCmd.Streaming = streaming
+
 	updateRuleCmd, err := command.NewUpdateRuleCommand(ruleRepo, celCompiler, clk, auditWriter, txBeginner)
 	if err != nil {
 		return nil, fmt.Errorf("failed to construct UpdateRuleCommand: %w", err)
 	}
+
+	updateRuleCmd.Streaming = streaming
 
 	activateRuleCmd, err := command.NewActivateRuleService(ruleRepo, celCompiler, clk, auditWriter, cacheWriter, txBeginner)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create activate rule service: %w", err)
 	}
 
+	activateRuleCmd.Streaming = streaming
+
 	deactivateRuleCmd, err := command.NewDeactivateRuleService(ruleRepo, clk, auditWriter, cacheWriter, txBeginner)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create deactivate rule service: %w", err)
 	}
+
+	deactivateRuleCmd.Streaming = streaming
 
 	draftRuleCmd, err := command.NewDraftRuleService(ruleRepo, clk, auditWriter, txBeginner)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create draft rule service: %w", err)
 	}
 
+	draftRuleCmd.Streaming = streaming
+
 	deleteRuleCmd, err := command.NewDeleteRuleService(ruleRepo, auditWriter, txBeginner)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create delete rule service: %w", err)
 	}
+
+	deleteRuleCmd.Streaming = streaming
 
 	getRuleQuery := query.NewGetRuleQuery(ruleRepo)
 	listRulesQuery := query.NewListRulesQuery(ruleRepo)
@@ -1025,7 +1037,7 @@ type limitServiceDeps struct {
 // tenant pool fails fast in MT mode rather than silently using root (M1).
 // The txBeginner is shared with the validation service so the limit lifecycle
 // commands persist the status/update and the audit event atomically.
-func initLimitService(pgConn pgdb.Connection, auditWriter command.AuditWriter, clk clock.Clock, txBeginner pgdb.TxBeginner) (*limitServiceDeps, error) {
+func initLimitService(pgConn pgdb.Connection, auditWriter command.AuditWriter, clk clock.Clock, txBeginner pgdb.TxBeginner, streaming libStreaming.Emitter) (*limitServiceDeps, error) {
 	limitRepo := postgres.NewLimitRepositoryWithConnection(pgConn)
 
 	usageCounterRepo := postgres.NewUsageCounterRepositoryWithConnection(pgConn)
@@ -1035,30 +1047,42 @@ func initLimitService(pgConn pgdb.Connection, auditWriter command.AuditWriter, c
 		return nil, fmt.Errorf("failed to construct CreateLimitCommand: %w", err)
 	}
 
+	createLimitCmd.Streaming = streaming
+
 	updateLimitCmd, err := command.NewUpdateLimitCommand(limitRepo, clk, auditWriter, txBeginner)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create update limit command: %w", err)
 	}
+
+	updateLimitCmd.Streaming = streaming
 
 	activateLimitCmd, err := command.NewActivateLimitCommand(limitRepo, clk, auditWriter, txBeginner)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create activate limit command: %w", err)
 	}
 
+	activateLimitCmd.Streaming = streaming
+
 	deactivateLimitCmd, err := command.NewDeactivateLimitCommand(limitRepo, clk, auditWriter, txBeginner)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create deactivate limit command: %w", err)
 	}
+
+	deactivateLimitCmd.Streaming = streaming
 
 	draftLimitCmd, err := command.NewDraftLimitCommand(limitRepo, clk, auditWriter, txBeginner)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create draft limit command: %w", err)
 	}
 
+	draftLimitCmd.Streaming = streaming
+
 	deleteLimitCmd, err := command.NewDeleteLimitCommand(limitRepo, clk, auditWriter, txBeginner)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create delete limit command: %w", err)
 	}
+
+	deleteLimitCmd.Streaming = streaming
 
 	getLimitQuery := query.NewGetLimitQuery(limitRepo)
 
@@ -1862,7 +1886,7 @@ func InitServers(ctx context.Context) (*Service, error) {
 	}
 
 	// Init Rule service with audit writer and rule cache for synchronous cache updates
-	ruleService, err := initRuleService(ruleRepo, celAdapter, auditWriter, ruleCache, clk, txBeginner)
+	ruleService, err := initRuleService(ruleRepo, celAdapter, auditWriter, ruleCache, clk, txBeginner, streamingEmitter)
 	if err != nil {
 		return nil, err
 	}
@@ -1886,7 +1910,7 @@ func InitServers(ctx context.Context) (*Service, error) {
 	}
 
 	// Init Limit service with audit writer for SOX/GLBA compliance
-	limitDeps, err := initLimitService(pgConn, auditWriter, clk, txBeginner)
+	limitDeps, err := initLimitService(pgConn, auditWriter, clk, txBeginner, streamingEmitter)
 	if err != nil {
 		return nil, err
 	}

--- a/components/tracer/internal/bootstrap/config.go
+++ b/components/tracer/internal/bootstrap/config.go
@@ -224,6 +224,31 @@ type Config struct {
 	// default; bootstrap applies the value via
 	// HealthChecker.SetCacheStalenessThreshold.
 	ReadyzCacheStalenessThresholdSeconds int `env:"READYZ_CACHE_STALENESS_THRESHOLD_SECONDS"`
+
+	// --- Streaming (lib-streaming producer) ---
+	// StreamingEnabled is the master flag. Default OFF (unset bool = false): a
+	// service with STREAMING_ENABLED=false injects a NoopEmitter and never
+	// initialises the underlying transport, so an existing deployment that never
+	// sets these vars is not broken by the new dependency. Transport knobs
+	// (brokers, compression, acks, linger) are NOT bound here — they are read by
+	// libStreaming.LoadConfig() directly from STREAMING_* env at build time.
+	StreamingEnabled bool `env:"STREAMING_ENABLED"`
+
+	// --- Streaming SASL/TLS auth ---
+	// When STREAMING_SASL_MECHANISM is empty (default) the producer connects
+	// without authentication, matching the existing behaviour for local/dev
+	// brokers. When set, the value must be one of PLAIN, SCRAM-SHA-256,
+	// SCRAM-SHA-512 (case-insensitive); USERNAME and PASSWORD are then required.
+	//
+	// SASL without TLS is rejected by lib-streaming with
+	// ErrPlaintextSASLNotAllowed. STREAMING_ALLOW_PLAINTEXT_SASL=true is the
+	// explicit unsafe opt-in for local/dev brokers that do not terminate TLS. It
+	// must NOT be set in production: SASL credentials cross the network in
+	// cleartext.
+	StreamingSASLMechanism      string `env:"STREAMING_SASL_MECHANISM"`
+	StreamingSASLUsername       string `env:"STREAMING_SASL_USERNAME"`
+	StreamingSASLPassword       string `env:"STREAMING_SASL_PASSWORD"`
+	StreamingAllowPlaintextSASL bool   `env:"STREAMING_ALLOW_PLAINTEXT_SASL"`
 }
 
 // minAPIKeyLength is the minimum recommended length for API keys.

--- a/components/tracer/internal/bootstrap/config_streaming_test.go
+++ b/components/tracer/internal/bootstrap/config_streaming_test.go
@@ -1,0 +1,64 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package bootstrap
+
+import (
+	"testing"
+
+	libCommons "github.com/LerianStudio/lib-commons/v5/commons"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// streamingEnvVars is the exact set of STREAMING_* keys the tracer Config binds.
+// Tests clear these to a known baseline so a leaked env var from the surrounding
+// shell/CI cannot make a default-path assertion flaky.
+var streamingEnvVars = []string{
+	"STREAMING_ENABLED",
+	"STREAMING_SASL_MECHANISM",
+	"STREAMING_SASL_USERNAME",
+	"STREAMING_SASL_PASSWORD",
+	"STREAMING_ALLOW_PLAINTEXT_SASL",
+}
+
+// TestConfig_StreamingDefaults verifies the safe-by-default posture: with every
+// STREAMING_* env var unset (empty), a loaded Config has streaming disabled and
+// all SASL fields empty, so a deployment that never sets these vars is not
+// broken by the new dependency.
+func TestConfig_StreamingDefaults(t *testing.T) {
+	// Setenv every streaming key to empty to exercise the default path
+	// deterministically. t.Setenv restores prior values on cleanup.
+	for _, ev := range streamingEnvVars {
+		t.Setenv(ev, "")
+	}
+
+	cfg := &Config{}
+	require.NoError(t, libCommons.SetConfigFromEnvVars(cfg))
+
+	assert.False(t, cfg.StreamingEnabled, "STREAMING_ENABLED must default to false")
+	assert.Empty(t, cfg.StreamingSASLMechanism, "STREAMING_SASL_MECHANISM must default to empty")
+	assert.Empty(t, cfg.StreamingSASLUsername, "STREAMING_SASL_USERNAME must default to empty")
+	assert.Empty(t, cfg.StreamingSASLPassword, "STREAMING_SASL_PASSWORD must default to empty")
+	assert.False(t, cfg.StreamingAllowPlaintextSASL, "STREAMING_ALLOW_PLAINTEXT_SASL must default to false")
+}
+
+// TestConfig_StreamingParsesEnvVars verifies the five streaming fields are bound
+// from their environment variables via SetConfigFromEnvVars.
+func TestConfig_StreamingParsesEnvVars(t *testing.T) {
+	t.Setenv("STREAMING_ENABLED", "true")
+	t.Setenv("STREAMING_SASL_MECHANISM", "SCRAM-SHA-512")
+	t.Setenv("STREAMING_SASL_USERNAME", "tracer-user")
+	t.Setenv("STREAMING_SASL_PASSWORD", "tracer-secret")
+	t.Setenv("STREAMING_ALLOW_PLAINTEXT_SASL", "true")
+
+	cfg := &Config{}
+	require.NoError(t, libCommons.SetConfigFromEnvVars(cfg))
+
+	assert.True(t, cfg.StreamingEnabled, "STREAMING_ENABLED should parse to true")
+	assert.Equal(t, "SCRAM-SHA-512", cfg.StreamingSASLMechanism)
+	assert.Equal(t, "tracer-user", cfg.StreamingSASLUsername)
+	assert.Equal(t, "tracer-secret", cfg.StreamingSASLPassword)
+	assert.True(t, cfg.StreamingAllowPlaintextSASL, "STREAMING_ALLOW_PLAINTEXT_SASL should parse to true")
+}

--- a/components/tracer/internal/bootstrap/service.go
+++ b/components/tracer/internal/bootstrap/service.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"os"
 	"os/signal"
+	"sync"
 	"syscall"
 	"time"
 
@@ -18,6 +19,7 @@ import (
 	libObservability "github.com/LerianStudio/lib-observability"
 	libLog "github.com/LerianStudio/lib-observability/log"
 	libRuntime "github.com/LerianStudio/lib-observability/runtime"
+	libStreaming "github.com/LerianStudio/lib-streaming"
 
 	"github.com/LerianStudio/midaz/v4/components/tracer/internal/adapters/http/in"
 	"github.com/LerianStudio/midaz/v4/components/tracer/internal/services/workers"
@@ -60,6 +62,20 @@ type Service struct {
 	// single source of truth — env reloads (if ever introduced) propagate
 	// without restarting Service.
 	config *Config
+
+	// StreamingEmitter is the lib-streaming Emitter injected into command
+	// use cases. It is non-nil for both the live producer and the
+	// NoopEmitter (STREAMING_ENABLED=false) so downstream emit sites can
+	// depend on the interface unconditionally.
+	StreamingEmitter libStreaming.Emitter
+	// StreamingClose drains the streaming producer on SIGTERM. Non-nil for
+	// both the live producer and the Noop path; Run() registers it as a
+	// Launcher app only when streaming is enabled (see
+	// shouldRegisterStreamingProducer).
+	StreamingClose func() error
+	// StreamingEnabled mirrors cfg.StreamingEnabled so Run() can decide
+	// whether to register the producer-drain Launcher app.
+	StreamingEnabled bool
 }
 
 // Run starts the application.
@@ -118,6 +134,16 @@ func (app *Service) Run() {
 
 	if app.syncWorker != nil {
 		opts = append(opts, libCommons.RunApp("Rule Sync Worker", app.syncWorker))
+	}
+
+	// Streaming producer drain: register only when streaming is enabled AND a
+	// non-nil close hook is present. The NoopEmitter path (streaming disabled)
+	// registers nothing so the Launcher app list stays lean. The producer drain
+	// touches no DB, so its ordering relative to the DB-backed drains is
+	// immaterial.
+	if shouldRegisterStreamingProducer(app.StreamingEnabled, app.StreamingClose) {
+		opts = append(opts, libCommons.RunApp("Streaming Producer",
+			&streamingProducerRunnable{close: app.StreamingClose, logger: app.Logger}))
 	}
 
 	// Install the drain handler BEFORE the Launcher starts so its
@@ -195,6 +221,57 @@ func (app *Service) installDrainHandler() func() {
 		close(sigCh)
 		<-stopped
 	}
+}
+
+// shouldRegisterStreamingProducer reports whether the streaming producer drain
+// runnable should be registered with the Launcher. It is a pure predicate:
+// registration happens only when streaming is enabled AND a non-nil close hook
+// is present. The disabled path (NoopEmitter) registers nothing.
+func shouldRegisterStreamingProducer(enabled bool, closeHook func() error) bool {
+	return enabled && closeHook != nil
+}
+
+// streamingProducerRunnable adapts the lib-streaming producer's Close hook to
+// the libCommons launcher App interface. It blocks until SIGINT/SIGTERM and
+// then runs the producer's drain/flush close path so buffered records reach the
+// broker before the process exits.
+type streamingProducerRunnable struct {
+	close     func() error
+	logger    libLog.Logger
+	closeOnce sync.Once
+}
+
+// Run blocks until SIGINT/SIGTERM and then drains the producer exactly once.
+func (r *streamingProducerRunnable) Run(_ *libCommons.Launcher) error {
+	if r == nil {
+		return nil
+	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	<-ctx.Done()
+
+	r.drain()
+
+	return nil
+}
+
+// drain invokes the producer close hook at most once (sync.Once) and is
+// nil-safe. A non-nil close error is logged at Warn and not propagated: at
+// shutdown the Launcher cannot meaningfully react.
+func (r *streamingProducerRunnable) drain() {
+	if r == nil || r.close == nil {
+		return
+	}
+
+	r.closeOnce.Do(func() {
+		if err := r.close(); err != nil && r.logger != nil {
+			r.logger.With(
+				libLog.String("error.message", err.Error()),
+			).Log(context.Background(), libLog.LevelWarn, "streaming producer Close returned error")
+		}
+	})
 }
 
 // Shutdown gracefully shuts down the application.

--- a/components/tracer/internal/bootstrap/service_streaming_test.go
+++ b/components/tracer/internal/bootstrap/service_streaming_test.go
@@ -1,0 +1,67 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package bootstrap
+
+import (
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestStreamingProducerRunnable_drain_ClosesOnce verifies that calling drain()
+// multiple times invokes the underlying close hook exactly once (sync.Once).
+func TestStreamingProducerRunnable_drain_ClosesOnce(t *testing.T) {
+	var calls int32
+
+	r := &streamingProducerRunnable{
+		close: func() error {
+			atomic.AddInt32(&calls, 1)
+			return nil
+		},
+	}
+
+	r.drain()
+	r.drain()
+
+	require.Equal(t, int32(1), atomic.LoadInt32(&calls), "close hook must run exactly once across repeated drain() calls")
+}
+
+// TestStreamingProducerRunnable_drain_NilCloseNoPanic verifies drain() is
+// nil-safe: a runnable with a nil close hook must not panic.
+func TestStreamingProducerRunnable_drain_NilCloseNoPanic(t *testing.T) {
+	r := &streamingProducerRunnable{close: nil}
+
+	require.NotPanics(t, func() {
+		r.drain()
+		r.drain()
+	})
+}
+
+// TestShouldRegisterStreamingProducer locks the registration predicate: the
+// producer drain runnable is registered only when streaming is enabled AND the
+// close hook is non-nil.
+func TestShouldRegisterStreamingProducer(t *testing.T) {
+	nonNilClose := func() error { return nil }
+
+	tests := []struct {
+		name    string
+		enabled bool
+		close   func() error
+		want    bool
+	}{
+		{name: "enabled and non-nil close registers", enabled: true, close: nonNilClose, want: true},
+		{name: "disabled registers nothing", enabled: false, close: nonNilClose, want: false},
+		{name: "enabled but nil close registers nothing", enabled: true, close: nil, want: false},
+		{name: "disabled and nil close registers nothing", enabled: false, close: nil, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := shouldRegisterStreamingProducer(tt.enabled, tt.close)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/components/tracer/internal/bootstrap/streaming.go
+++ b/components/tracer/internal/bootstrap/streaming.go
@@ -6,6 +6,7 @@ package bootstrap
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -71,13 +72,15 @@ func noopStreamingCloser() error { return nil }
 //     pilot) the function returns libStreaming.NewNoopEmitter() and a no-op
 //     close hook. No transport client is constructed and no broker
 //     connection is attempted.
-//   - When STREAMING_BROKERS is empty (LoadConfig surfaces this as an empty
-//     Brokers slice) the function ALSO returns a NoopEmitter — the Builder
-//     would otherwise reject construction with a missing-Brokers error.
-//   - When tracerEventDefinitions() is empty (the Phase-1 state: tracer
-//     emits no events yet) the function returns a NoopEmitter. An empty
-//     catalog can never build a live producer, so this is the live path
-//     today and is expected.
+//   - When STREAMING_BROKERS is empty, libStreaming.LoadConfig fails closed
+//     with ErrMissingBrokers. The function treats that as an
+//     operator-correctable misconfiguration and degrades to a NoopEmitter
+//     (no error, Warn logged) rather than aborting bootstrap. Any OTHER
+//     LoadConfig failure propagates as a wrapped error.
+//   - When tracerEventDefinitions() is empty the function returns a
+//     NoopEmitter. An empty catalog can never build a live producer; this
+//     is a defensive guard so a future edit that empties the definition set
+//     degrades to Noop rather than failing bootstrap.
 //   - Otherwise the function builds a single-target catalog-first Producer
 //     via libStreaming.NewBuilder(), wiring the tracer CloudEvents source
 //     onto the Builder and registering all tracer event definitions in the
@@ -102,9 +105,9 @@ func BuildStreamingEmitter(
 		return libStreaming.NewNoopEmitter(), noopStreamingCloser, nil
 	}
 
-	// An empty catalog can never build a live producer. In Phase 1 tracer
-	// emits no events, so this guard is the live path — guarding here keeps
-	// the Builder from being reached with zero routes.
+	// An empty catalog can never build a live producer. Defensive guard so a
+	// future edit that empties the definition set degrades to Noop rather
+	// than reaching the Builder with zero routes.
 	if len(tracerEventDefinitions()) == 0 {
 		if logger != nil {
 			logger.Log(ctx, libLog.LevelInfo,
@@ -120,6 +123,19 @@ func BuildStreamingEmitter(
 	// the zero value of the struct.
 	streamingCfg, warnings, err := libStreaming.LoadConfig()
 	if err != nil {
+		// A missing broker list is an operator-correctable misconfiguration,
+		// not a reason to abort bootstrap: degrade to a NoopEmitter so the
+		// service starts with streaming disabled. Any OTHER LoadConfig
+		// failure is a genuine config error and propagates.
+		if errors.Is(err, libStreaming.ErrMissingBrokers) {
+			if logger != nil {
+				logger.Log(ctx, libLog.LevelWarn,
+					"STREAMING_ENABLED=true but STREAMING_BROKERS is empty; falling back to NoopEmitter")
+			}
+
+			return libStreaming.NewNoopEmitter(), noopStreamingCloser, nil
+		}
+
 		return nil, noopStreamingCloser, fmt.Errorf("failed to load streaming config: %w", err)
 	}
 
@@ -127,15 +143,6 @@ func BuildStreamingEmitter(
 		for _, warning := range warnings {
 			logger.Log(ctx, libLog.LevelWarn, "Streaming config warning: "+warning)
 		}
-	}
-
-	if len(streamingCfg.Brokers) == 0 {
-		if logger != nil {
-			logger.Log(ctx, libLog.LevelWarn,
-				"STREAMING_ENABLED=true but STREAMING_BROKERS is empty; falling back to NoopEmitter")
-		}
-
-		return libStreaming.NewNoopEmitter(), noopStreamingCloser, nil
 	}
 
 	return buildLiveStreamingEmitter(ctx, cfg, logger, streamingCfg)
@@ -281,10 +288,18 @@ func resolveSASLMechanism(cfg *Config) (sasl.Mechanism, string, error) {
 // Kept as a single source of truth so adding a new event is a one-place
 // change.
 //
-// Empty in Phase 1: tracer emits no events yet. Tracer events (e.g.
-// validation/rule/limit lifecycle) are added here in later phases (2/3).
+// Registers the Rule lifecycle events (created, updated, activated,
+// deactivated, drafted, deleted). Limit lifecycle events land here in a
+// later phase.
 func tracerEventDefinitions() []events.Definition {
-	return []events.Definition{}
+	return []events.Definition{
+		events.RuleCreatedDefinition,
+		events.RuleUpdatedDefinition,
+		events.RuleActivatedDefinition,
+		events.RuleDeactivatedDefinition,
+		events.RuleDraftedDefinition,
+		events.RuleDeletedDefinition,
+	}
 }
 
 // buildCatalog constructs the immutable lib-streaming Catalog from

--- a/components/tracer/internal/bootstrap/streaming.go
+++ b/components/tracer/internal/bootstrap/streaming.go
@@ -13,10 +13,11 @@ import (
 	libLog "github.com/LerianStudio/lib-observability/log"
 	libOtel "github.com/LerianStudio/lib-observability/tracing"
 	libStreaming "github.com/LerianStudio/lib-streaming"
-	"github.com/LerianStudio/midaz/v4/pkg/streaming/events"
 	"github.com/twmb/franz-go/pkg/sasl"
 	"github.com/twmb/franz-go/pkg/sasl/plain"
 	"github.com/twmb/franz-go/pkg/sasl/scram"
+
+	"github.com/LerianStudio/midaz/v4/pkg/streaming/events"
 )
 
 // SASL mechanism names accepted by STREAMING_SASL_MECHANISM. Compared
@@ -93,6 +94,10 @@ func BuildStreamingEmitter(
 ) (libStreaming.Emitter, func() error, error) {
 	if cfg == nil {
 		return nil, noopStreamingCloser, fmt.Errorf("BuildStreamingEmitter: nil config")
+	}
+
+	if err := ctx.Err(); err != nil {
+		return nil, noopStreamingCloser, err
 	}
 
 	_ = telemetry

--- a/components/tracer/internal/bootstrap/streaming.go
+++ b/components/tracer/internal/bootstrap/streaming.go
@@ -36,10 +36,26 @@ const streamingPrimaryTargetName = "primary"
 // Topic names take the shape "lerian.streaming.<resource>.<event>".
 const streamingTopicPrefix = "lerian.streaming."
 
-// streamingSource is the CloudEvents source stamped on every event tracer
-// emits. Distinct from the ledger component's source so downstream
-// consumers can attribute events to the emitting service.
+// streamingSource is the default CloudEvents source stamped on every event
+// tracer emits. Distinct from the ledger component's source so downstream
+// consumers can attribute events to the emitting service. Overridable via
+// STREAMING_CLOUDEVENTS_SOURCE (see resolveStreamingSource).
 const streamingSource = "lerian.midaz.tracer"
+
+// resolveStreamingSource returns the CloudEvents source to stamp on emitted
+// events. The configured STREAMING_CLOUDEVENTS_SOURCE value wins when set
+// (after trimming surrounding whitespace); otherwise the in-code default
+// streamingSource is used so an unset var never breaks the historical
+// behaviour.
+func resolveStreamingSource(cfg *Config) string {
+	if cfg != nil {
+		if source := strings.TrimSpace(cfg.StreamingCloudEventsSource); source != "" {
+			return source
+		}
+	}
+
+	return streamingSource
+}
 
 // noopStreamingCloser is the close hook returned by BuildStreamingEmitter
 // when streaming is disabled. It exists only so callers can append a single
@@ -149,8 +165,10 @@ func buildLiveStreamingEmitter(
 	// canonical "lerian.streaming.<resource>.<event>" topic name.
 	routes := buildRoutes(streamingPrimaryTargetName)
 
+	source := resolveStreamingSource(cfg)
+
 	builder := libStreaming.NewBuilder().
-		Source(streamingSource).
+		Source(source).
 		Catalog(catalog).
 		Routes(routes...).
 		Target(libStreaming.TargetConfig{
@@ -199,7 +217,7 @@ func buildLiveStreamingEmitter(
 		logger.Log(ctx, libLog.LevelInfo, "Streaming emitter constructed",
 			libLog.String("brokers", strings.Join(streamingCfg.Brokers, ",")),
 			libLog.String("client_id", streamingCfg.ClientID),
-			libLog.String("ce_source", streamingSource),
+			libLog.String("ce_source", source),
 			libLog.String("auth", authMode),
 			libLog.Int("catalog_size", catalog.Len()),
 			libLog.Int("routes", len(routes)),

--- a/components/tracer/internal/bootstrap/streaming.go
+++ b/components/tracer/internal/bootstrap/streaming.go
@@ -288,9 +288,8 @@ func resolveSASLMechanism(cfg *Config) (sasl.Mechanism, string, error) {
 // Kept as a single source of truth so adding a new event is a one-place
 // change.
 //
-// Registers the Rule lifecycle events (created, updated, activated,
-// deactivated, drafted, deleted). Limit lifecycle events land here in a
-// later phase.
+// Registers the full Rule and Limit lifecycle events (created, updated,
+// activated, deactivated, drafted, deleted) — six per resource, twelve total.
 func tracerEventDefinitions() []events.Definition {
 	return []events.Definition{
 		events.RuleCreatedDefinition,
@@ -299,6 +298,12 @@ func tracerEventDefinitions() []events.Definition {
 		events.RuleDeactivatedDefinition,
 		events.RuleDraftedDefinition,
 		events.RuleDeletedDefinition,
+		events.LimitCreatedDefinition,
+		events.LimitUpdatedDefinition,
+		events.LimitActivatedDefinition,
+		events.LimitDeactivatedDefinition,
+		events.LimitDraftedDefinition,
+		events.LimitDeletedDefinition,
 	}
 }
 

--- a/components/tracer/internal/bootstrap/streaming.go
+++ b/components/tracer/internal/bootstrap/streaming.go
@@ -1,0 +1,317 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package bootstrap
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	libLog "github.com/LerianStudio/lib-observability/log"
+	libOtel "github.com/LerianStudio/lib-observability/tracing"
+	libStreaming "github.com/LerianStudio/lib-streaming"
+	"github.com/LerianStudio/midaz/v4/pkg/streaming/events"
+	"github.com/twmb/franz-go/pkg/sasl"
+	"github.com/twmb/franz-go/pkg/sasl/plain"
+	"github.com/twmb/franz-go/pkg/sasl/scram"
+)
+
+// SASL mechanism names accepted by STREAMING_SASL_MECHANISM. Compared
+// case-insensitively at parse time so operators can write any casing.
+const (
+	saslMechanismPlain    = "PLAIN"
+	saslMechanismScram256 = "SCRAM-SHA-256"
+	saslMechanismScram512 = "SCRAM-SHA-512"
+)
+
+// streamingPrimaryTargetName is the canonical name for tracer's single
+// streaming target. Lives as a const so the Builder.Target call, the
+// RouteDefinition.Target field, and the route-key suffix all stay in
+// sync.
+const streamingPrimaryTargetName = "primary"
+
+// streamingTopicPrefix is the canonical prefix every topic name uses.
+// Topic names take the shape "lerian.streaming.<resource>.<event>".
+const streamingTopicPrefix = "lerian.streaming."
+
+// streamingSource is the CloudEvents source stamped on every event tracer
+// emits. Distinct from the ledger component's source so downstream
+// consumers can attribute events to the emitting service.
+const streamingSource = "lerian.midaz.tracer"
+
+// noopStreamingCloser is the close hook returned by BuildStreamingEmitter
+// when streaming is disabled. It exists only so callers can append a single
+// uniform cleanup callback to their existing chain.
+func noopStreamingCloser() error { return nil }
+
+// BuildStreamingEmitter returns the lib-streaming Emitter the tracer
+// component should inject into its command UseCase, plus a close hook the
+// caller must run on shutdown (or on bootstrap failure).
+//
+// Behaviour:
+//   - When cfg.StreamingEnabled is false (the documented default for this
+//     pilot) the function returns libStreaming.NewNoopEmitter() and a no-op
+//     close hook. No transport client is constructed and no broker
+//     connection is attempted.
+//   - When STREAMING_BROKERS is empty (LoadConfig surfaces this as an empty
+//     Brokers slice) the function ALSO returns a NoopEmitter — the Builder
+//     would otherwise reject construction with a missing-Brokers error.
+//   - When tracerEventDefinitions() is empty (the Phase-1 state: tracer
+//     emits no events yet) the function returns a NoopEmitter. An empty
+//     catalog can never build a live producer, so this is the live path
+//     today and is expected.
+//   - Otherwise the function builds a single-target catalog-first Producer
+//     via libStreaming.NewBuilder(), wiring the tracer CloudEvents source
+//     onto the Builder and registering all tracer event definitions in the
+//     Catalog with a matching RouteDefinition per event.
+func BuildStreamingEmitter(
+	ctx context.Context,
+	cfg *Config,
+	logger libLog.Logger,
+	telemetry *libOtel.Telemetry,
+) (libStreaming.Emitter, func() error, error) {
+	if cfg == nil {
+		return nil, noopStreamingCloser, fmt.Errorf("BuildStreamingEmitter: nil config")
+	}
+
+	_ = telemetry
+
+	if !cfg.StreamingEnabled {
+		if logger != nil {
+			logger.Log(ctx, libLog.LevelInfo, "Streaming disabled (STREAMING_ENABLED=false); using NoopEmitter")
+		}
+
+		return libStreaming.NewNoopEmitter(), noopStreamingCloser, nil
+	}
+
+	// An empty catalog can never build a live producer. In Phase 1 tracer
+	// emits no events, so this guard is the live path — guarding here keeps
+	// the Builder from being reached with zero routes.
+	if len(tracerEventDefinitions()) == 0 {
+		if logger != nil {
+			logger.Log(ctx, libLog.LevelInfo,
+				"Streaming enabled but no tracer events are registered yet; using NoopEmitter")
+		}
+
+		return libStreaming.NewNoopEmitter(), noopStreamingCloser, nil
+	}
+
+	// Delegate env-var loading + defaulting to libStreaming.LoadConfig so
+	// every STREAMING_* knob (MaxBufferedRecords, BatchMaxBytes, CB
+	// ratios, CloseTimeout, etc.) gets its documented default rather than
+	// the zero value of the struct.
+	streamingCfg, warnings, err := libStreaming.LoadConfig()
+	if err != nil {
+		return nil, noopStreamingCloser, fmt.Errorf("failed to load streaming config: %w", err)
+	}
+
+	if logger != nil {
+		for _, warning := range warnings {
+			logger.Log(ctx, libLog.LevelWarn, "Streaming config warning: "+warning)
+		}
+	}
+
+	if len(streamingCfg.Brokers) == 0 {
+		if logger != nil {
+			logger.Log(ctx, libLog.LevelWarn,
+				"STREAMING_ENABLED=true but STREAMING_BROKERS is empty; falling back to NoopEmitter")
+		}
+
+		return libStreaming.NewNoopEmitter(), noopStreamingCloser, nil
+	}
+
+	return buildLiveStreamingEmitter(ctx, cfg, logger, streamingCfg)
+}
+
+// buildLiveStreamingEmitter constructs the single-target, catalog-first
+// Producer once BuildStreamingEmitter's early-return guards have passed.
+// Split out so the guard-heavy entry point stays within the package
+// cyclomatic-complexity budget.
+func buildLiveStreamingEmitter(
+	ctx context.Context,
+	cfg *Config,
+	logger libLog.Logger,
+	streamingCfg libStreaming.Config,
+) (libStreaming.Emitter, func() error, error) {
+	// Build the immutable Catalog of every event tracer emits. Catalog
+	// lookup at emit time resolves ResourceType/EventType/SchemaVersion
+	// from these entries via the EmitRequest.DefinitionKey, so the
+	// Catalog and the per-event Definition vars in pkg/streaming/events
+	// MUST stay in sync (the test suite locks the key strings).
+	catalog, err := buildCatalog()
+	if err != nil {
+		return nil, noopStreamingCloser, fmt.Errorf("failed to build streaming catalog: %w", err)
+	}
+
+	// Build the route table. One required route per event keyed to the
+	// canonical "lerian.streaming.<resource>.<event>" topic name.
+	routes := buildRoutes(streamingPrimaryTargetName)
+
+	builder := libStreaming.NewBuilder().
+		Source(streamingSource).
+		Catalog(catalog).
+		Routes(routes...).
+		Target(libStreaming.TargetConfig{
+			Name:    streamingPrimaryTargetName,
+			Kind:    libStreaming.TransportKafkaLike,
+			Brokers: streamingCfg.Brokers,
+		})
+
+	// Apply SASL/TLS auth knobs from cfg. resolveSASLMechanism returns a
+	// nil mechanism (and an empty mechanism name) when SASL is disabled,
+	// in which case the Builder is left untouched and the producer dials
+	// the broker without authentication — matching the historical local/dev
+	// behaviour. When SASL is enabled but TLS is not, lib-streaming
+	// rejects construction with ErrPlaintextSASLNotAllowed unless the
+	// caller also opts into AllowPlaintextSASL — gated behind
+	// STREAMING_ALLOW_PLAINTEXT_SASL=true for dev brokers.
+	mechanism, mechanismName, err := resolveSASLMechanism(cfg)
+	if err != nil {
+		return nil, noopStreamingCloser, fmt.Errorf("failed to resolve streaming SASL mechanism: %w", err)
+	}
+
+	if mechanism != nil {
+		builder = builder.SASL(mechanism)
+
+		if cfg.StreamingAllowPlaintextSASL {
+			builder = builder.AllowPlaintextSASL()
+		}
+	}
+
+	emitter, err := builder.Build(ctx)
+	if err != nil {
+		return nil, noopStreamingCloser, fmt.Errorf("failed to construct streaming emitter: %w", err)
+	}
+
+	if logger != nil {
+		// NOTE: only mechanism name is logged. Username and password are
+		// NEVER logged, even at debug level.
+		authMode := "none"
+		if mechanismName != "" {
+			authMode = mechanismName
+			if cfg.StreamingAllowPlaintextSASL {
+				authMode += " (plaintext)"
+			}
+		}
+
+		logger.Log(ctx, libLog.LevelInfo, "Streaming emitter constructed",
+			libLog.String("brokers", strings.Join(streamingCfg.Brokers, ",")),
+			libLog.String("client_id", streamingCfg.ClientID),
+			libLog.String("ce_source", streamingSource),
+			libLog.String("auth", authMode),
+			libLog.Int("catalog_size", catalog.Len()),
+			libLog.Int("routes", len(routes)),
+		)
+	}
+
+	return emitter, emitter.Close, nil
+}
+
+// resolveSASLMechanism inspects the streaming SASL knobs on cfg and
+// returns the matching franz-go sasl.Mechanism plus its canonical name.
+//
+// Behaviour:
+//   - StreamingSASLMechanism empty (after trimming) → returns (nil, "", nil).
+//     The Builder stays unauthenticated, matching the existing local/dev
+//     default.
+//   - StreamingSASLMechanism set but USERNAME or PASSWORD empty → returns
+//     a config error. SASL with empty credentials would either be rejected
+//     by the broker after I/O (PLAIN) or panic inside franz-go's SCRAM
+//     handshake; failing closed at bootstrap is the safer contract.
+//   - StreamingSASLMechanism unrecognised → returns a config error
+//     enumerating the accepted values.
+//
+// The mechanism name returned is the canonical upper-case form
+// ("PLAIN", "SCRAM-SHA-256", "SCRAM-SHA-512") — used for the bootstrap
+// log line. Username and password are NEVER returned to the caller and
+// never logged.
+func resolveSASLMechanism(cfg *Config) (sasl.Mechanism, string, error) {
+	raw := strings.TrimSpace(cfg.StreamingSASLMechanism)
+	if raw == "" {
+		return nil, "", nil
+	}
+
+	mechanism := strings.ToUpper(raw)
+
+	user := cfg.StreamingSASLUsername
+	pass := cfg.StreamingSASLPassword
+
+	if user == "" || pass == "" {
+		return nil, "", fmt.Errorf(
+			"STREAMING_SASL_MECHANISM=%q requires STREAMING_SASL_USERNAME and STREAMING_SASL_PASSWORD",
+			mechanism)
+	}
+
+	switch mechanism {
+	case saslMechanismPlain:
+		return plain.Auth{User: user, Pass: pass}.AsMechanism(), saslMechanismPlain, nil
+	case saslMechanismScram256:
+		return scram.Auth{User: user, Pass: pass}.AsSha256Mechanism(), saslMechanismScram256, nil
+	case saslMechanismScram512:
+		return scram.Auth{User: user, Pass: pass}.AsSha512Mechanism(), saslMechanismScram512, nil
+	default:
+		return nil, "", fmt.Errorf(
+			"STREAMING_SASL_MECHANISM=%q is not supported (accepted: %s, %s, %s)",
+			raw, saslMechanismPlain, saslMechanismScram256, saslMechanismScram512)
+	}
+}
+
+// tracerEventDefinitions returns the canonical, ordered list of tracer
+// event Definitions registered into both the Catalog and the Routes.
+// Kept as a single source of truth so adding a new event is a one-place
+// change.
+//
+// Empty in Phase 1: tracer emits no events yet. Tracer events (e.g.
+// validation/rule/limit lifecycle) are added here in later phases (2/3).
+func tracerEventDefinitions() []events.Definition {
+	return []events.Definition{}
+}
+
+// buildCatalog constructs the immutable lib-streaming Catalog from
+// tracer's event Definitions. Every entry maps the canonical
+// "<resource>.<event>" key to its ResourceType / EventType /
+// SchemaVersion triple.
+func buildCatalog() (libStreaming.Catalog, error) {
+	defs := tracerEventDefinitions()
+	entries := make([]libStreaming.EventDefinition, 0, len(defs))
+
+	for _, d := range defs {
+		entries = append(entries, libStreaming.EventDefinition{
+			Key:           d.Key(),
+			ResourceType:  d.ResourceType,
+			EventType:     d.EventType,
+			SchemaVersion: d.SchemaVersion,
+		})
+	}
+
+	return libStreaming.NewCatalog(entries...)
+}
+
+// buildRoutes constructs one RouteRequired route per tracer event,
+// targeting the single broker named targetName. Topic names are
+// "lerian.streaming.<resource>.<event>".
+//
+// Route Keys are composed as "<definition-key>.<target-name>" (e.g.
+// "validation.evaluated.primary") — Route.Key must match a lower-case
+// dot-delimited pattern, and the target-name suffix guarantees uniqueness
+// when the same event is later routed to multiple targets (e.g. a parallel
+// shadow route).
+func buildRoutes(targetName string) []libStreaming.RouteDefinition {
+	defs := tracerEventDefinitions()
+	routes := make([]libStreaming.RouteDefinition, 0, len(defs))
+
+	for _, d := range defs {
+		key := d.Key()
+		routes = append(routes, libStreaming.RouteDefinition{
+			Key:           key + "." + targetName,
+			DefinitionKey: key,
+			Target:        targetName,
+			Destination:   libStreaming.KafkaTopic(streamingTopicPrefix + key),
+			Requirement:   libStreaming.RouteRequired,
+		})
+	}
+
+	return routes
+}

--- a/components/tracer/internal/bootstrap/streaming_integration_test.go
+++ b/components/tracer/internal/bootstrap/streaming_integration_test.go
@@ -1,0 +1,475 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+//go:build integration
+
+package bootstrap
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	libStreaming "github.com/LerianStudio/lib-streaming"
+	"github.com/LerianStudio/midaz/v4/components/tracer/pkg/model"
+	"github.com/LerianStudio/midaz/v4/pkg/streaming/events"
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/require"
+	"github.com/twmb/franz-go/pkg/kadm"
+	"github.com/twmb/franz-go/pkg/kgo"
+)
+
+// defaultSmokeBroker is the host-facing Redpanda listener the local
+// components/infra stack advertises (external://localhost:19092). Overridable
+// via STREAMING_BROKERS so CI can target another broker.
+const defaultSmokeBroker = "localhost:19092"
+
+// smokeDeadline bounds the whole emit+consume round-trip so a wedged broker
+// can never hang the suite. Generous because a cold Redpanda + first-write
+// topic-leader election can take a few seconds.
+const smokeDeadline = 45 * time.Second
+
+// ceType/ceSubject/ceTenantID are the CloudEvents binary-mode header keys
+// lib-streaming stamps on every record. Asserted per-record after consume.
+const (
+	headerCEType     = "ce-type"
+	headerCESubject  = "ce-subject"
+	headerCETenantID = "ce-tenantid"
+)
+
+// forbiddenPayloadKeys are the fenced fields that must NEVER appear on any
+// tracer event payload — free text and financial detail. Asserted absent at
+// top level AND inside every nested scope object.
+var forbiddenPayloadKeys = []string{"name", "description", "expression", "maxAmount", "compiledProgram"}
+
+// smokeEvent pairs an EmitRequest with the ce-type it must surface once
+// consumed back, so the assertion loop can look each record up by subject.
+type smokeEvent struct {
+	subject    string // aggregate UUID (ce-subject)
+	wantCEType string // "studio.lerian.<resource>.<event>"
+	request    libStreaming.EmitRequest
+}
+
+// TestStreamingSmoke drives the REAL tracer emitter end-to-end against a live
+// Redpanda broker: it ensures the 12 tracer topics exist, emits all 12
+// rule/limit lifecycle events with the forbidden fields deliberately populated
+// on the domain fixtures, then CONSUMES the records back and asserts the
+// CloudEvents headers and the payload fence for each one. This is the core
+// contract check — not merely "emit returned no error".
+//
+// The test skips (never fails) when no broker is reachable, so a unit-only CI
+// run without infra stays green. It runs under the `integration` build tag so
+// `make test-unit` excludes it.
+func TestStreamingSmoke(t *testing.T) {
+	broker := strings.TrimSpace(os.Getenv("STREAMING_BROKERS"))
+	if broker == "" {
+		broker = defaultSmokeBroker
+	}
+
+	// First broker in a comma list is enough for a single-node dev cluster.
+	broker = strings.Split(broker, ",")[0]
+
+	ctx, cancel := context.WithTimeout(context.Background(), smokeDeadline)
+	defer cancel()
+
+	skipIfBrokerUnreachable(ctx, t, broker)
+
+	// Unique per-run identifiers so repeat runs never read each other's
+	// records. tenant is stamped into every event and matched on consume.
+	runID := uuid.NewString()
+	tenant := "smoke-" + runID
+
+	smokeEvents := buildSmokeEvents(t, tenant)
+	require.Len(t, smokeEvents, 12, "expected exactly 12 tracer lifecycle events")
+
+	topics := smokeTopics(smokeEvents)
+	ensureTopics(ctx, t, broker, topics)
+
+	emitter := buildSmokeEmitter(ctx, t, broker)
+	defer func() {
+		require.NoError(t, emitter.Close(), "emitter Close must drain cleanly")
+	}()
+
+	emitAll(ctx, t, emitter, smokeEvents)
+
+	consumed := consumeRecords(ctx, t, broker, topics, tenant, len(smokeEvents))
+	assertConsumed(t, tenant, smokeEvents, consumed)
+}
+
+// skipIfBrokerUnreachable probes the broker's metadata once. An unreachable
+// broker means "no infra" -> t.Skip (safe for unit CI). A reachable broker
+// means the smoke MUST run.
+func skipIfBrokerUnreachable(ctx context.Context, t *testing.T, broker string) {
+	t.Helper()
+
+	cl, err := kgo.NewClient(kgo.SeedBrokers(broker))
+	if err != nil {
+		t.Skipf("streaming smoke skipped: cannot build probe client for %q: %v", broker, err)
+	}
+
+	defer cl.Close()
+
+	pingCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	if err := cl.Ping(pingCtx); err != nil {
+		t.Skipf("streaming smoke skipped: broker %q unreachable: %v", broker, err)
+	}
+}
+
+// buildSmokeEmitter constructs the production emitter via BuildStreamingEmitter
+// with a non-empty catalog so the live producer path (not Noop) is taken.
+func buildSmokeEmitter(ctx context.Context, t *testing.T, broker string) libStreaming.Emitter {
+	t.Helper()
+
+	t.Setenv("STREAMING_ENABLED", "true")
+	t.Setenv("STREAMING_BROKERS", broker)
+	t.Setenv("STREAMING_CLOUDEVENTS_SOURCE", "lerian.midaz.tracer")
+
+	cfg := &Config{
+		StreamingEnabled:           true,
+		StreamingCloudEventsSource: "lerian.midaz.tracer",
+	}
+
+	emitter, closeFn, err := BuildStreamingEmitter(ctx, cfg, nil, nil)
+	require.NoError(t, err, "BuildStreamingEmitter must succeed against a live broker")
+	require.NotNil(t, emitter)
+	require.NotNil(t, closeFn)
+
+	// A live producer must NOT be the Noop fallback: assert the concrete live
+	// type positively rather than DeepEqual against an empty Noop struct.
+	require.IsType(t, &libStreaming.Producer{}, emitter,
+		"expected a live *libStreaming.Producer, got the NoopEmitter fallback")
+
+	// And it must report healthy against the reachable broker.
+	require.NoError(t, emitter.Healthy(ctx), "live emitter must be healthy against the broker")
+
+	return emitter
+}
+
+// buildSmokeEvents constructs the 12 domain fixtures with name/description/
+// expression/maxAmount populated ON PURPOSE, runs them through the events.New*
+// constructors, and assembles the EmitRequests. Deterministic where it matters:
+// the subject UUIDs and timestamps are fixed per event; only the run tenant is
+// unique.
+func buildSmokeEvents(t *testing.T, tenant string) []smokeEvent {
+	t.Helper()
+
+	ts := time.Date(2026, 7, 3, 12, 0, 0, 0, time.UTC)
+
+	rule := newSmokeRule(ts)
+	limit := newSmokeLimit(t, ts)
+
+	// reqFn defers the ToEmitRequest call so the two-value return can be
+	// unpacked and its error checked in one place per event.
+	type reqFn func(tenant string, ts time.Time) (libStreaming.EmitRequest, error)
+
+	specs := []struct {
+		subject    string
+		wantCEType string
+		ts         time.Time
+		build      reqFn
+	}{
+		{rule.ID.String(), "studio.lerian.rule.created", rule.CreatedAt, events.NewRuleCreated(rule).ToEmitRequest},
+		{rule.ID.String(), "studio.lerian.rule.updated", rule.UpdatedAt, events.NewRuleUpdated(rule).ToEmitRequest},
+		{rule.ID.String(), "studio.lerian.rule.activated", rule.UpdatedAt, events.NewRuleActivated(rule).ToEmitRequest},
+		{rule.ID.String(), "studio.lerian.rule.deactivated", rule.UpdatedAt, events.NewRuleDeactivated(rule).ToEmitRequest},
+		{rule.ID.String(), "studio.lerian.rule.drafted", rule.UpdatedAt, events.NewRuleDrafted(rule).ToEmitRequest},
+		{rule.ID.String(), "studio.lerian.rule.deleted", ts, events.NewRuleDeleted(rule.ID, ts).ToEmitRequest},
+		{limit.ID.String(), "studio.lerian.limit.created", limit.CreatedAt, events.NewLimitCreated(limit).ToEmitRequest},
+		{limit.ID.String(), "studio.lerian.limit.updated", limit.UpdatedAt, events.NewLimitUpdated(limit).ToEmitRequest},
+		{limit.ID.String(), "studio.lerian.limit.activated", limit.UpdatedAt, events.NewLimitActivated(limit).ToEmitRequest},
+		{limit.ID.String(), "studio.lerian.limit.deactivated", limit.UpdatedAt, events.NewLimitDeactivated(limit).ToEmitRequest},
+		{limit.ID.String(), "studio.lerian.limit.drafted", limit.UpdatedAt, events.NewLimitDrafted(limit).ToEmitRequest},
+		{limit.ID.String(), "studio.lerian.limit.deleted", ts, events.NewLimitDeleted(limit).ToEmitRequest},
+	}
+
+	out := make([]smokeEvent, 0, len(specs))
+
+	for _, s := range specs {
+		req, err := s.build(tenant, s.ts)
+		require.NoErrorf(t, err, "ToEmitRequest failed for %s", s.wantCEType)
+
+		out = append(out, smokeEvent{
+			subject:    s.subject,
+			wantCEType: s.wantCEType,
+			request:    req,
+		})
+	}
+
+	return out
+}
+
+// newSmokeRule builds a Rule with the fenced fields (Name, Description,
+// Expression, CompiledProgram) deliberately populated, plus a fully populated
+// scope, so the payload-fence assertion proves those never reach the wire.
+func newSmokeRule(ts time.Time) *model.Rule {
+	desc := "fenced description that must never hit the wire"
+	activated := ts
+	deactivated := ts
+
+	return &model.Rule{
+		ID:              uuid.New(),
+		Name:            "fenced rule name",
+		Description:     &desc,
+		Expression:      "transaction.amount > 1000",
+		Action:          model.DecisionDeny,
+		Scopes:          []model.Scope{fencedScope()},
+		Status:          model.RuleStatusActive,
+		CreatedAt:       ts,
+		UpdatedAt:       ts,
+		ActivatedAt:     &activated,
+		DeactivatedAt:   &deactivated,
+		CompiledProgram: struct{ compiled bool }{compiled: true},
+	}
+}
+
+// newSmokeLimit builds a Limit with the fenced fields (Name, Description,
+// MaxAmount) deliberately populated so the payload-fence assertion proves the
+// financial value and free text never reach the wire.
+func newSmokeLimit(t *testing.T, ts time.Time) *model.Limit {
+	t.Helper()
+
+	desc := "fenced limit description"
+
+	start, err := model.NewTimeOfDay("09:00")
+	require.NoError(t, err)
+
+	end, err := model.NewTimeOfDay("17:00")
+	require.NoError(t, err)
+
+	resetAt := ts.Add(24 * time.Hour)
+
+	return &model.Limit{
+		ID:              uuid.New(),
+		Name:            "fenced limit name",
+		Description:     &desc,
+		LimitType:       model.LimitTypeDaily,
+		MaxAmount:       decimal.RequireFromString("1000.00"),
+		Currency:        "USD",
+		Scopes:          []model.Scope{fencedScope()},
+		Status:          model.LimitStatusActive,
+		ActiveTimeStart: &start,
+		ActiveTimeEnd:   &end,
+		ResetAt:         &resetAt,
+		CreatedAt:       ts,
+		UpdatedAt:       ts,
+	}
+}
+
+// fencedScope returns a fully populated scope so the nested-scope fence check
+// runs against real values rather than nils.
+func fencedScope() model.Scope {
+	segment := uuid.New()
+	portfolio := uuid.New()
+	account := uuid.New()
+	merchant := uuid.New()
+	txType := model.TransactionTypeCard
+	subType := "purchase"
+
+	return model.Scope{
+		SegmentID:       &segment,
+		PortfolioID:     &portfolio,
+		AccountID:       &account,
+		MerchantID:      &merchant,
+		TransactionType: &txType,
+		SubType:         &subType,
+	}
+}
+
+// smokeTopics maps each event's ce-type back to its canonical topic name
+// "lerian.streaming.<resource>.<event>".
+func smokeTopics(evs []smokeEvent) []string {
+	out := make([]string, 0, len(evs))
+
+	for _, e := range evs {
+		key := strings.TrimPrefix(e.wantCEType, "studio.lerian.")
+		out = append(out, "lerian.streaming."+key)
+	}
+
+	return out
+}
+
+// ensureTopics idempotently creates the given topics (1 partition, RF 1) via
+// a kadm admin client. Already-exists is not an error.
+func ensureTopics(ctx context.Context, t *testing.T, broker string, topics []string) {
+	t.Helper()
+
+	cl, err := kgo.NewClient(kgo.SeedBrokers(broker))
+	require.NoError(t, err)
+
+	defer cl.Close()
+
+	admin := kadm.NewClient(cl)
+
+	createCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
+	defer cancel()
+
+	resp, err := admin.CreateTopics(createCtx, 1, 1, nil, topics...)
+	require.NoError(t, err, "CreateTopics call must not fail at the RPC level")
+
+	for _, ct := range resp.Sorted() {
+		if ct.Err != nil && !strings.Contains(ct.Err.Error(), "already exists") {
+			t.Fatalf("failed to ensure topic %q: %v", ct.Topic, ct.Err)
+		}
+	}
+}
+
+// emitAll emits every event through the real producer. Each Emit must succeed;
+// the whole point of the smoke test is that the live path works.
+func emitAll(ctx context.Context, t *testing.T, emitter libStreaming.Emitter, evs []smokeEvent) {
+	t.Helper()
+
+	for _, e := range evs {
+		require.NoErrorf(t, emitter.Emit(ctx, e.request), "Emit failed for %s", e.wantCEType)
+	}
+}
+
+// consumedRecord is the decoded shape used by the assertion loop.
+type consumedRecord struct {
+	ceType   string
+	subject  string
+	tenantID string
+	value    []byte
+}
+
+// consumeRecords reads from the given topics at the start of each partition
+// until `want` records CARRYING THIS RUN'S TENANT are collected or the context
+// deadline fires. A fresh consumer group per run guarantees AtStart reads every
+// record. The tenant filter lives inside the collection predicate so leftover
+// records from prior runs on a reused broker never fill this run's budget —
+// only this run's tenant-matching records count, keeping the smoke re-runnable.
+func consumeRecords(ctx context.Context, t *testing.T, broker string, topics []string, tenant string, want int) []consumedRecord {
+	t.Helper()
+
+	group := "smoke-consumer-" + uuid.NewString()
+
+	cl, err := kgo.NewClient(
+		kgo.SeedBrokers(broker),
+		kgo.ConsumeTopics(topics...),
+		kgo.ConsumerGroup(group),
+		kgo.ConsumeResetOffset(kgo.NewOffset().AtStart()),
+	)
+	require.NoError(t, err)
+
+	defer cl.Close()
+
+	collected := make([]consumedRecord, 0, want)
+
+	for len(collected) < want {
+		if err := ctx.Err(); err != nil {
+			t.Fatalf("deadline reached with only %d/%d tenant-matching records consumed: %v", len(collected), want, err)
+		}
+
+		pollCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		fetches := cl.PollFetches(pollCtx)
+		cancel()
+
+		for _, fe := range fetches.Errors() {
+			// The deadline path (ctx.Err() != nil) is the normal per-poll
+			// termination between batches; keep looping. Any other fetch error
+			// on a live broker is a real fault — fail fast with its cause.
+			if fe.Err != nil && ctx.Err() == nil {
+				t.Fatalf("fetch error on topic %q: %v", fe.Topic, fe.Err)
+			}
+		}
+
+		fetches.EachRecord(func(r *kgo.Record) {
+			rec := decodeRecord(r)
+			if rec.tenantID != tenant {
+				return
+			}
+
+			collected = append(collected, rec)
+		})
+	}
+
+	return collected
+}
+
+// decodeRecord pulls the CloudEvents binary-mode headers off a kgo record and
+// keeps the raw JSON value for the fence check.
+func decodeRecord(r *kgo.Record) consumedRecord {
+	cr := consumedRecord{value: r.Value}
+
+	for _, h := range r.Headers {
+		switch h.Key {
+		case headerCEType:
+			cr.ceType = string(h.Value)
+		case headerCESubject:
+			cr.subject = string(h.Value)
+		case headerCETenantID:
+			cr.tenantID = string(h.Value)
+		}
+	}
+
+	return cr
+}
+
+// assertConsumed verifies that each emitted event was read back with the
+// correct ce-type / ce-subject / ce-tenantid and a fenced payload. Only records
+// carrying this run's tenant are considered, so leftover topic data from other
+// runs is ignored.
+func assertConsumed(t *testing.T, tenant string, evs []smokeEvent, consumed []consumedRecord) {
+	t.Helper()
+
+	byType := make(map[string]consumedRecord, len(consumed))
+
+	for _, c := range consumed {
+		if c.tenantID != tenant {
+			continue
+		}
+
+		byType[c.ceType] = c
+	}
+
+	for _, e := range evs {
+		got, ok := byType[e.wantCEType]
+		require.Truef(t, ok, "no consumed record for %s (tenant %s)", e.wantCEType, tenant)
+
+		require.Equal(t, e.wantCEType, got.ceType, "ce-type mismatch")
+		require.Equal(t, e.subject, got.subject, "ce-subject must be the aggregate UUID for %s", e.wantCEType)
+		require.NotEmpty(t, got.tenantID, "ce-tenantid must be present for %s", e.wantCEType)
+
+		assertPayloadFenced(t, e.wantCEType, got.value)
+	}
+}
+
+// assertPayloadFenced unmarshals the record value and asserts none of the
+// forbidden keys appear at top level or inside any nested scope object.
+func assertPayloadFenced(t *testing.T, ceType string, value []byte) {
+	t.Helper()
+
+	var payload map[string]any
+	require.NoErrorf(t, json.Unmarshal(value, &payload), "payload for %s must be valid JSON", ceType)
+
+	assertNoForbiddenKeys(t, ceType, "<top-level>", payload)
+
+	// Scopes are the only nested objects on tracer payloads. Descend into each.
+	if rawScopes, ok := payload["scopes"]; ok {
+		scopes, isSlice := rawScopes.([]any)
+		require.Truef(t, isSlice, "scopes must be an array for %s", ceType)
+
+		for i, rawScope := range scopes {
+			scope, isMap := rawScope.(map[string]any)
+			require.Truef(t, isMap, "scope[%d] must be an object for %s", i, ceType)
+			assertNoForbiddenKeys(t, ceType, fmt.Sprintf("scopes[%d]", i), scope)
+		}
+	}
+}
+
+// assertNoForbiddenKeys fails if any fenced key is present in the given object.
+func assertNoForbiddenKeys(t *testing.T, ceType, scope string, obj map[string]any) {
+	t.Helper()
+
+	for _, k := range forbiddenPayloadKeys {
+		_, present := obj[k]
+		require.Falsef(t, present, "forbidden key %q leaked into %s of %s", k, scope, ceType)
+	}
+}

--- a/components/tracer/internal/bootstrap/streaming_test.go
+++ b/components/tracer/internal/bootstrap/streaming_test.go
@@ -1,0 +1,316 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package bootstrap
+
+import (
+	"context"
+	"testing"
+
+	libStreaming "github.com/LerianStudio/lib-streaming"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// noopEmitterReference is a NoopEmitter constructed independently of the
+// code under test. Its concrete type is what BuildStreamingEmitter must
+// return on every disabled/fallback branch, so tests assert type identity
+// against it rather than dialling a broker or inspecting private state.
+var noopEmitterReference = libStreaming.NewNoopEmitter()
+
+// TestTracerEventDefinitions_EmptyInPhase1 locks the Phase-1 contract:
+// Tracer emits no events yet, so the catalog source is empty. This is the
+// guard that forces BuildStreamingEmitter onto the NoopEmitter path even
+// when streaming is enabled with valid brokers — an empty catalog can
+// never build a live producer.
+func TestTracerEventDefinitions_EmptyInPhase1(t *testing.T) {
+	t.Parallel()
+
+	assert.Empty(t, tracerEventDefinitions(),
+		"tracerEventDefinitions must be empty in Phase 1; Tracer events land in Phases 2/3")
+}
+
+// TestBuildStreamingEmitter covers the three NoopEmitter fallback branches.
+// None of them opens a broker connection, so the test runs without any
+// local Kafka/Redpanda dependency.
+func TestBuildStreamingEmitter(t *testing.T) {
+	cases := []struct {
+		name    string
+		envVars map[string]string
+		cfg     *Config
+	}{
+		{
+			// Branch 1: master flag off. Returns the noop without loading
+			// libStreaming.LoadConfig or touching env.
+			name: "disabled returns noop",
+			envVars: map[string]string{
+				"STREAMING_ENABLED": "false",
+			},
+			cfg: &Config{
+				StreamingEnabled: false,
+				// SASL fields ignored when disabled.
+				StreamingSASLMechanism: "PLAIN",
+				StreamingSASLUsername:  "u",
+				StreamingSASLPassword:  "p",
+			},
+		},
+		{
+			// Branch 2: enabled but STREAMING_BROKERS empty after
+			// LoadConfig — the Builder would reject construction, so we
+			// fall back to the noop.
+			name: "enabled with empty brokers returns noop",
+			envVars: map[string]string{
+				"STREAMING_ENABLED":            "true",
+				"STREAMING_BROKERS":            "",
+				"STREAMING_CLOUDEVENTS_SOURCE": "lerian.midaz.tracer.test",
+			},
+			cfg: &Config{
+				StreamingEnabled: true,
+			},
+		},
+		{
+			// Branch 3: enabled with valid brokers, but the empty
+			// tracerEventDefinitions() catalog guard short-circuits to the
+			// noop. This is the live Phase-1 path.
+			name: "enabled with brokers but empty catalog returns noop",
+			envVars: map[string]string{
+				"STREAMING_ENABLED":            "true",
+				"STREAMING_BROKERS":            "127.0.0.1:0",
+				"STREAMING_CLOUDEVENTS_SOURCE": "lerian.midaz.tracer.test",
+			},
+			cfg: &Config{
+				StreamingEnabled: true,
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// t.Setenv forbids t.Parallel — these mutate process env.
+			for k, v := range tc.envVars {
+				t.Setenv(k, v)
+			}
+
+			emitter, closer, err := BuildStreamingEmitter(context.Background(), tc.cfg, nil, nil)
+			require.NoError(t, err)
+			require.NotNil(t, emitter)
+			require.NotNil(t, closer)
+
+			// Every fallback path returns the concrete NoopEmitter type.
+			assert.IsType(t, noopEmitterReference, emitter,
+				"expected NoopEmitter on the fallback path")
+
+			// The noop closer never errors and never blocks.
+			assert.NoError(t, closer())
+		})
+	}
+}
+
+// TestBuildStreamingEmitter_NilConfig documents the nil-guard contract:
+// BuildStreamingEmitter must return an error (never panic) and a non-nil
+// closer that is safe to invoke.
+func TestBuildStreamingEmitter_NilConfig(t *testing.T) {
+	t.Parallel()
+
+	emitter, closer, err := BuildStreamingEmitter(context.Background(), nil, nil, nil)
+	require.Error(t, err)
+	assert.Nil(t, emitter)
+	require.NotNil(t, closer)
+	assert.NoError(t, closer())
+}
+
+// TestBuildLiveStreamingEmitter_EmptyCatalogFailsClosed proves why the
+// empty-catalog guard in BuildStreamingEmitter is load-bearing: if the
+// live-producer path is ever reached with the Phase-1 (empty) catalog,
+// lib-streaming's Builder rejects construction rather than silently
+// producing a dead emitter. The test calls the helper directly (the public
+// entry point short-circuits to Noop before reaching it) and asserts a
+// wrapped error plus a safe closer — never a panic.
+func TestBuildLiveStreamingEmitter_EmptyCatalogFailsClosed(t *testing.T) {
+	t.Setenv("STREAMING_ENABLED", "true")
+	t.Setenv("STREAMING_BROKERS", "127.0.0.1:0")
+	t.Setenv("STREAMING_CLOUDEVENTS_SOURCE", "lerian.midaz.tracer.test")
+
+	streamingCfg, _, err := libStreaming.LoadConfig()
+	require.NoError(t, err)
+	require.NotEmpty(t, streamingCfg.Brokers)
+
+	cfg := &Config{StreamingEnabled: true}
+
+	emitter, closer, err := buildLiveStreamingEmitter(context.Background(), cfg, nil, streamingCfg)
+	require.Error(t, err)
+	assert.Nil(t, emitter)
+	require.NotNil(t, closer)
+	assert.NoError(t, closer())
+}
+
+// TestBuildCatalog_EmptyInPhase1 exercises buildCatalog against the empty
+// Phase-1 definition set: it must succeed and produce a zero-length
+// catalog. This is the helper the live path uses once tracer events land,
+// so keeping it green now guards against Catalog construction regressions.
+func TestBuildCatalog_EmptyInPhase1(t *testing.T) {
+	t.Parallel()
+
+	catalog, err := buildCatalog()
+	require.NoError(t, err)
+	require.NotNil(t, catalog)
+	assert.Equal(t, 0, catalog.Len(), "Phase-1 catalog must be empty")
+}
+
+// TestBuildRoutes_EmptyInPhase1 exercises buildRoutes against the empty
+// Phase-1 definition set: one route per event, so zero events yields zero
+// routes. Locks the route-derivation shape ahead of Phase 2/3 events.
+func TestBuildRoutes_EmptyInPhase1(t *testing.T) {
+	t.Parallel()
+
+	routes := buildRoutes(streamingPrimaryTargetName)
+	assert.Empty(t, routes, "Phase-1 route table must be empty")
+}
+
+// TestResolveSASLMechanism_Disabled covers the default code path: an empty
+// (or whitespace) STREAMING_SASL_MECHANISM yields a nil mechanism and
+// empty name so the Builder is left unauthenticated — the back-compat
+// contract for local/dev brokers running without auth.
+func TestResolveSASLMechanism_Disabled(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		cfg  *Config
+	}{
+		{name: "empty", cfg: &Config{}},
+		{name: "whitespace only", cfg: &Config{StreamingSASLMechanism: "   \t  "}},
+		{
+			name: "credentials without mechanism",
+			cfg: &Config{
+				StreamingSASLUsername: "u",
+				StreamingSASLPassword: "p",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			mech, name, err := resolveSASLMechanism(tc.cfg)
+			require.NoError(t, err)
+			assert.Nil(t, mech)
+			assert.Empty(t, name)
+		})
+	}
+}
+
+// TestResolveSASLMechanism_Supported covers every accepted mechanism
+// string, including case-insensitive matching, and asserts the returned
+// canonical name matches the upper-case form used in the bootstrap log.
+func TestResolveSASLMechanism_Supported(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		input        string
+		expectedName string
+	}{
+		{input: "PLAIN", expectedName: saslMechanismPlain},
+		{input: "plain", expectedName: saslMechanismPlain},
+		{input: "  PLAIN  ", expectedName: saslMechanismPlain},
+		{input: "SCRAM-SHA-256", expectedName: saslMechanismScram256},
+		{input: "scram-sha-256", expectedName: saslMechanismScram256},
+		{input: "SCRAM-SHA-512", expectedName: saslMechanismScram512},
+		{input: "scram-sha-512", expectedName: saslMechanismScram512},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.input, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := &Config{
+				StreamingSASLMechanism: tc.input,
+				StreamingSASLUsername:  "tracer-prod",
+				StreamingSASLPassword:  "s3cret",
+			}
+
+			mech, name, err := resolveSASLMechanism(cfg)
+			require.NoError(t, err)
+			require.NotNil(t, mech)
+			assert.Equal(t, tc.expectedName, name)
+			assert.Equal(t, tc.expectedName, mech.Name())
+		})
+	}
+}
+
+// TestResolveSASLMechanism_MissingCredentials guarantees the resolver
+// fails closed when MECHANISM is set but USERNAME or PASSWORD is empty.
+func TestResolveSASLMechanism_MissingCredentials(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		cfg  *Config
+	}{
+		{name: "missing both", cfg: &Config{StreamingSASLMechanism: "PLAIN"}},
+		{
+			name: "missing username",
+			cfg: &Config{
+				StreamingSASLMechanism: "SCRAM-SHA-256",
+				StreamingSASLPassword:  "p",
+			},
+		},
+		{
+			name: "missing password",
+			cfg: &Config{
+				StreamingSASLMechanism: "SCRAM-SHA-512",
+				StreamingSASLUsername:  "u",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			mech, name, err := resolveSASLMechanism(tc.cfg)
+			require.Error(t, err)
+			assert.Nil(t, mech)
+			assert.Empty(t, name)
+			assert.Contains(t, err.Error(), "STREAMING_SASL_USERNAME")
+			assert.Contains(t, err.Error(), "STREAMING_SASL_PASSWORD")
+		})
+	}
+}
+
+// TestResolveSASLMechanism_Unsupported guards against typos and
+// unsupported mechanisms; the error must enumerate the accepted values.
+func TestResolveSASLMechanism_Unsupported(t *testing.T) {
+	t.Parallel()
+
+	cases := []string{
+		"OAUTHBEARER",
+		"GSSAPI",
+		"SCRAM",
+		"SCRAM-SHA-1",
+		"plain-sha-256",
+		"unknown",
+	}
+
+	for _, input := range cases {
+		t.Run(input, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := &Config{
+				StreamingSASLMechanism: input,
+				StreamingSASLUsername:  "u",
+				StreamingSASLPassword:  "p",
+			}
+
+			mech, name, err := resolveSASLMechanism(cfg)
+			require.Error(t, err)
+			assert.Nil(t, mech)
+			assert.Empty(t, name)
+			assert.Contains(t, err.Error(), saslMechanismPlain)
+			assert.Contains(t, err.Error(), saslMechanismScram256)
+			assert.Contains(t, err.Error(), saslMechanismScram512)
+		})
+	}
+}

--- a/components/tracer/internal/bootstrap/streaming_test.go
+++ b/components/tracer/internal/bootstrap/streaming_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	libStreaming "github.com/LerianStudio/lib-streaming"
+	"github.com/LerianStudio/midaz/v4/pkg/streaming/events"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -19,92 +20,115 @@ import (
 // against it rather than dialling a broker or inspecting private state.
 var noopEmitterReference = libStreaming.NewNoopEmitter()
 
-// TestTracerEventDefinitions_EmptyInPhase1 locks the Phase-1 contract:
-// Tracer emits no events yet, so the catalog source is empty. This is the
-// guard that forces BuildStreamingEmitter onto the NoopEmitter path even
-// when streaming is enabled with valid brokers — an empty catalog can
-// never build a live producer.
-func TestTracerEventDefinitions_EmptyInPhase1(t *testing.T) {
-	t.Parallel()
-
-	assert.Empty(t, tracerEventDefinitions(),
-		"tracerEventDefinitions must be empty in Phase 1; Tracer events land in Phases 2/3")
+// expectedRuleEventKeys is the canonical set of event keys tracer registers
+// for the Rule lifecycle (Phase 2). Limit events (Phase 3) extend this set.
+var expectedRuleEventKeys = []string{
+	"rule.created",
+	"rule.updated",
+	"rule.activated",
+	"rule.deactivated",
+	"rule.drafted",
+	"rule.deleted",
 }
 
-// TestBuildStreamingEmitter covers the three NoopEmitter fallback branches.
-// None of them opens a broker connection, so the test runs without any
-// local Kafka/Redpanda dependency.
-func TestBuildStreamingEmitter(t *testing.T) {
-	cases := []struct {
-		name    string
-		envVars map[string]string
-		cfg     *Config
-	}{
-		{
-			// Branch 1: master flag off. Returns the noop without loading
-			// libStreaming.LoadConfig or touching env.
-			name: "disabled returns noop",
-			envVars: map[string]string{
-				"STREAMING_ENABLED": "false",
-			},
-			cfg: &Config{
-				StreamingEnabled: false,
-				// SASL fields ignored when disabled.
-				StreamingSASLMechanism: "PLAIN",
-				StreamingSASLUsername:  "u",
-				StreamingSASLPassword:  "p",
-			},
-		},
-		{
-			// Branch 2: enabled but STREAMING_BROKERS empty after
-			// LoadConfig — the Builder would reject construction, so we
-			// fall back to the noop.
-			name: "enabled with empty brokers returns noop",
-			envVars: map[string]string{
-				"STREAMING_ENABLED":            "true",
-				"STREAMING_BROKERS":            "",
-				"STREAMING_CLOUDEVENTS_SOURCE": "lerian.midaz.tracer.test",
-			},
-			cfg: &Config{
-				StreamingEnabled: true,
-			},
-		},
-		{
-			// Branch 3: enabled with valid brokers, but the empty
-			// tracerEventDefinitions() catalog guard short-circuits to the
-			// noop. This is the live Phase-1 path.
-			name: "enabled with brokers but empty catalog returns noop",
-			envVars: map[string]string{
-				"STREAMING_ENABLED":            "true",
-				"STREAMING_BROKERS":            "127.0.0.1:0",
-				"STREAMING_CLOUDEVENTS_SOURCE": "lerian.midaz.tracer.test",
-			},
-			cfg: &Config{
-				StreamingEnabled: true,
-			},
-		},
+// TestTracerEventDefinitions_CoversRuleLifecycle locks the Phase-2 contract:
+// tracerEventDefinitions() registers exactly the six Rule lifecycle events,
+// in the fixed order, with no extra and none missing. This is the single
+// source of truth that feeds both the catalog and the routes.
+func TestTracerEventDefinitions_CoversRuleLifecycle(t *testing.T) {
+	t.Parallel()
+
+	defs := tracerEventDefinitions()
+	require.Len(t, defs, len(expectedRuleEventKeys),
+		"tracerEventDefinitions must register exactly the six Rule lifecycle events")
+
+	actualKeys := make([]string, 0, len(defs))
+	for _, d := range defs {
+		actualKeys = append(actualKeys, d.Key())
 	}
 
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			// t.Setenv forbids t.Parallel — these mutate process env.
-			for k, v := range tc.envVars {
-				t.Setenv(k, v)
-			}
+	// Order is part of the contract (created, updated, activated,
+	// deactivated, drafted, deleted).
+	assert.Equal(t, expectedRuleEventKeys, actualKeys,
+		"tracerEventDefinitions must return the Rule events in the fixed order")
+}
 
-			emitter, closer, err := BuildStreamingEmitter(context.Background(), tc.cfg, nil, nil)
-			require.NoError(t, err)
-			require.NotNil(t, emitter)
-			require.NotNil(t, closer)
+// TestBuildStreamingEmitter_DisabledReturnsNoop covers the master-flag-off
+// branch: BuildStreamingEmitter returns the concrete NoopEmitter without
+// loading libStreaming.LoadConfig or touching a broker. SASL fields are
+// ignored on this path.
+func TestBuildStreamingEmitter_DisabledReturnsNoop(t *testing.T) {
+	t.Setenv("STREAMING_ENABLED", "false")
 
-			// Every fallback path returns the concrete NoopEmitter type.
-			assert.IsType(t, noopEmitterReference, emitter,
-				"expected NoopEmitter on the fallback path")
-
-			// The noop closer never errors and never blocks.
-			assert.NoError(t, closer())
-		})
+	cfg := &Config{
+		StreamingEnabled: false,
+		// SASL fields ignored when disabled.
+		StreamingSASLMechanism: "PLAIN",
+		StreamingSASLUsername:  "u",
+		StreamingSASLPassword:  "p",
 	}
+
+	emitter, closer, err := BuildStreamingEmitter(context.Background(), cfg, nil, nil)
+	require.NoError(t, err)
+	require.NotNil(t, emitter)
+	require.NotNil(t, closer)
+
+	assert.IsType(t, noopEmitterReference, emitter,
+		"disabled streaming must return the NoopEmitter")
+	assert.NoError(t, closer())
+}
+
+// TestBuildStreamingEmitter_EnabledMissingBrokersDegradesToNoop asserts the
+// graceful-degradation contract: with STREAMING_ENABLED=true and no
+// STREAMING_BROKERS, libStreaming.LoadConfig returns ErrMissingBrokers, which
+// BuildStreamingEmitter recognises as a caller-correctable misconfiguration
+// and degrades to a NoopEmitter (no error, safe closer) rather than aborting
+// bootstrap. A missing broker list is an operator-fixable condition, not a
+// reason to prevent the service from starting; the Warn log records the
+// degradation. Any OTHER LoadConfig failure still propagates as a wrapped
+// error.
+func TestBuildStreamingEmitter_EnabledMissingBrokersDegradesToNoop(t *testing.T) {
+	t.Setenv("STREAMING_ENABLED", "true")
+	t.Setenv("STREAMING_BROKERS", "")
+	t.Setenv("STREAMING_CLOUDEVENTS_SOURCE", "lerian.midaz.tracer.test")
+
+	cfg := &Config{StreamingEnabled: true}
+
+	emitter, closer, err := BuildStreamingEmitter(context.Background(), cfg, nil, nil)
+	require.NoError(t, err)
+	require.NotNil(t, emitter)
+	require.NotNil(t, closer)
+
+	assert.IsType(t, noopEmitterReference, emitter,
+		"missing brokers must degrade to the NoopEmitter, not fail closed")
+	assert.NoError(t, closer())
+}
+
+// TestBuildStreamingEmitter_EnabledWithRuleCatalogBuildsLive proves that once
+// the Rule catalog is populated, an enabled + brokered config no longer
+// short-circuits to the noop: BuildStreamingEmitter constructs a real
+// producer (not a NoopEmitter) and returns a working closer. The broker
+// address is intentionally unresolvable (127.0.0.1:0); lib-streaming dials
+// asynchronously, so Build succeeds without a live broker and no real
+// network I/O occurs during the test.
+func TestBuildStreamingEmitter_EnabledWithRuleCatalogBuildsLive(t *testing.T) {
+	t.Setenv("STREAMING_ENABLED", "true")
+	t.Setenv("STREAMING_BROKERS", "127.0.0.1:0")
+	t.Setenv("STREAMING_CLOUDEVENTS_SOURCE", "lerian.midaz.tracer.test")
+
+	cfg := &Config{StreamingEnabled: true}
+
+	emitter, closer, err := BuildStreamingEmitter(context.Background(), cfg, nil, nil)
+	require.NoError(t, err)
+	require.NotNil(t, emitter)
+	require.NotNil(t, closer)
+
+	// With the Rule catalog populated the emitter must be a real producer,
+	// never the NoopEmitter fallback.
+	assert.NotEqual(t, noopEmitterReference, emitter,
+		"expected a live emitter once the Rule catalog is populated")
+
+	assert.NoError(t, closer())
 }
 
 // TestBuildStreamingEmitter_NilConfig documents the nil-guard contract:
@@ -120,14 +144,13 @@ func TestBuildStreamingEmitter_NilConfig(t *testing.T) {
 	assert.NoError(t, closer())
 }
 
-// TestBuildLiveStreamingEmitter_EmptyCatalogFailsClosed proves why the
-// empty-catalog guard in BuildStreamingEmitter is load-bearing: if the
-// live-producer path is ever reached with the Phase-1 (empty) catalog,
-// lib-streaming's Builder rejects construction rather than silently
-// producing a dead emitter. The test calls the helper directly (the public
-// entry point short-circuits to Noop before reaching it) and asserts a
-// wrapped error plus a safe closer — never a panic.
-func TestBuildLiveStreamingEmitter_EmptyCatalogFailsClosed(t *testing.T) {
+// TestBuildLiveStreamingEmitter_BuildsWithRuleCatalog proves the live path
+// constructs a real producer once the Rule catalog is populated. The helper
+// derives its catalog from tracerEventDefinitions() internally, so this
+// asserts the six-event catalog builds a non-nil emitter without a panic and
+// with a safe closer. The unresolvable broker address (127.0.0.1:0) keeps
+// the dial asynchronous so no real network I/O occurs.
+func TestBuildLiveStreamingEmitter_BuildsWithRuleCatalog(t *testing.T) {
 	t.Setenv("STREAMING_ENABLED", "true")
 	t.Setenv("STREAMING_BROKERS", "127.0.0.1:0")
 	t.Setenv("STREAMING_CLOUDEVENTS_SOURCE", "lerian.midaz.tracer.test")
@@ -139,33 +162,121 @@ func TestBuildLiveStreamingEmitter_EmptyCatalogFailsClosed(t *testing.T) {
 	cfg := &Config{StreamingEnabled: true}
 
 	emitter, closer, err := buildLiveStreamingEmitter(context.Background(), cfg, nil, streamingCfg)
-	require.Error(t, err)
-	assert.Nil(t, emitter)
+	require.NoError(t, err)
+	require.NotNil(t, emitter)
 	require.NotNil(t, closer)
+	assert.NotEqual(t, noopEmitterReference, emitter,
+		"live path must return a real producer, not the NoopEmitter")
 	assert.NoError(t, closer())
 }
 
-// TestBuildCatalog_EmptyInPhase1 exercises buildCatalog against the empty
-// Phase-1 definition set: it must succeed and produce a zero-length
-// catalog. This is the helper the live path uses once tracer events land,
-// so keeping it green now guards against Catalog construction regressions.
-func TestBuildCatalog_EmptyInPhase1(t *testing.T) {
+// TestBuildCatalog_CoversRuleLifecycle exercises buildCatalog against the
+// populated Rule definition set: it must succeed and register exactly one
+// entry per Rule event, each looked up by its canonical key.
+func TestBuildCatalog_CoversRuleLifecycle(t *testing.T) {
 	t.Parallel()
 
 	catalog, err := buildCatalog()
 	require.NoError(t, err)
 	require.NotNil(t, catalog)
-	assert.Equal(t, 0, catalog.Len(), "Phase-1 catalog must be empty")
+	assert.Equal(t, len(expectedRuleEventKeys), catalog.Len(),
+		"catalog must hold one entry per Rule event")
+
+	for _, key := range expectedRuleEventKeys {
+		_, ok := catalog.Lookup(key)
+		assert.Truef(t, ok, "catalog must register key %q", key)
+	}
 }
 
-// TestBuildRoutes_EmptyInPhase1 exercises buildRoutes against the empty
-// Phase-1 definition set: one route per event, so zero events yields zero
-// routes. Locks the route-derivation shape ahead of Phase 2/3 events.
-func TestBuildRoutes_EmptyInPhase1(t *testing.T) {
+// TestBuildRoutes_CoversRuleLifecycle exercises buildRoutes against the
+// populated Rule definition set: one required route per event, each keyed
+// "<event>.<target>" and pointing at the canonical
+// "lerian.streaming.<event>" Kafka topic.
+func TestBuildRoutes_CoversRuleLifecycle(t *testing.T) {
 	t.Parallel()
 
 	routes := buildRoutes(streamingPrimaryTargetName)
-	assert.Empty(t, routes, "Phase-1 route table must be empty")
+	require.Len(t, routes, len(expectedRuleEventKeys),
+		"one route per Rule event")
+
+	byDefKey := make(map[string]libStreaming.RouteDefinition, len(routes))
+	for _, r := range routes {
+		byDefKey[r.DefinitionKey] = r
+	}
+
+	for _, key := range expectedRuleEventKeys {
+		r, ok := byDefKey[key]
+		require.Truef(t, ok, "missing route for %q", key)
+		assert.Equal(t, key+"."+streamingPrimaryTargetName, r.Key,
+			"route Key must be <event>.<target>")
+		assert.Equal(t, streamingPrimaryTargetName, r.Target)
+		assert.Equal(t, libStreaming.RouteRequired, r.Requirement)
+		assert.Equal(t, libStreaming.KafkaTopic(streamingTopicPrefix+key), r.Destination,
+			"route Destination must be the canonical Kafka topic")
+	}
+}
+
+// TestTracerCatalog_CoversAllEmittedEvents is the drift lock: it asserts an
+// exact 1:1:1 bijection between the registered event definitions, the
+// catalog entries, and the route table — no event registered without a
+// route, no route pointing at an unregistered event (ghost topic), and no
+// count drift between the three. Phase 3 extends this to all 12 events.
+func TestTracerCatalog_CoversAllEmittedEvents(t *testing.T) {
+	t.Parallel()
+
+	defs := tracerEventDefinitions()
+	require.NotEmpty(t, defs, "tracer must register at least the Rule events")
+
+	catalog, err := buildCatalog()
+	require.NoError(t, err)
+
+	routes := buildRoutes(streamingPrimaryTargetName)
+
+	// (a) count parity across all three views.
+	assert.Equal(t, len(defs), catalog.Len(),
+		"catalog entry count must equal definition count")
+	assert.Equal(t, len(defs), len(routes),
+		"route count must equal definition count")
+
+	// Definition key set (the source of truth).
+	defKeys := make(map[string]struct{}, len(defs))
+	for _, d := range defs {
+		defKeys[d.Key()] = struct{}{}
+	}
+
+	require.Lenf(t, defKeys, len(defs),
+		"definition keys must be unique (found %d unique of %d defs)", len(defKeys), len(defs))
+
+	// (b) every definition resolves to a catalog entry.
+	for key := range defKeys {
+		_, ok := catalog.Lookup(key)
+		assert.Truef(t, ok, "catalog is missing a definition-registered key %q", key)
+	}
+
+	// (c) route set is a bijection with the definition set: every route
+	// targets a registered definition (no ghost topics) and every
+	// definition has exactly one route.
+	routeKeys := make(map[string]struct{}, len(routes))
+	for _, r := range routes {
+		_, dup := routeKeys[r.DefinitionKey]
+		require.Falsef(t, dup, "duplicate route for definition key %q", r.DefinitionKey)
+
+		routeKeys[r.DefinitionKey] = struct{}{}
+
+		_, registered := defKeys[r.DefinitionKey]
+		assert.Truef(t, registered,
+			"route %q points at an unregistered event (ghost topic)", r.DefinitionKey)
+
+		// (d) destination topic derives from the definition key.
+		assert.Equal(t, libStreaming.KafkaTopic(streamingTopicPrefix+r.DefinitionKey), r.Destination,
+			"route Destination must be lerian.streaming.<key>")
+	}
+
+	assert.Equal(t, defKeys, routeKeys,
+		"route definition-key set must exactly equal the registered definition-key set")
+
+	// Guard against a stale reference to the events package import.
+	assert.Equal(t, "rule.created", events.RuleCreatedDefinition.Key())
 }
 
 // TestResolveStreamingSource locks the CloudEvents source resolution

--- a/components/tracer/internal/bootstrap/streaming_test.go
+++ b/components/tracer/internal/bootstrap/streaming_test.go
@@ -168,6 +168,55 @@ func TestBuildRoutes_EmptyInPhase1(t *testing.T) {
 	assert.Empty(t, routes, "Phase-1 route table must be empty")
 }
 
+// TestResolveStreamingSource locks the CloudEvents source resolution
+// contract: a trimmed, non-empty STREAMING_CLOUDEVENTS_SOURCE value wins;
+// an empty, whitespace-only, or nil config falls back to the in-code
+// streamingSource default so an unset var never changes historical
+// behaviour.
+func TestResolveStreamingSource(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		cfg      *Config
+		expected string
+	}{
+		{
+			name:     "nil config falls back to default",
+			cfg:      nil,
+			expected: streamingSource,
+		},
+		{
+			name:     "empty value falls back to default",
+			cfg:      &Config{StreamingCloudEventsSource: ""},
+			expected: streamingSource,
+		},
+		{
+			name:     "whitespace-only value falls back to default",
+			cfg:      &Config{StreamingCloudEventsSource: "  \t  "},
+			expected: streamingSource,
+		},
+		{
+			name:     "configured value wins",
+			cfg:      &Config{StreamingCloudEventsSource: "lerian.midaz.tracer.staging"},
+			expected: "lerian.midaz.tracer.staging",
+		},
+		{
+			name:     "configured value is trimmed",
+			cfg:      &Config{StreamingCloudEventsSource: "  lerian.midaz.tracer.shadow  "},
+			expected: "lerian.midaz.tracer.shadow",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tc.expected, resolveStreamingSource(tc.cfg))
+		})
+	}
+}
+
 // TestResolveSASLMechanism_Disabled covers the default code path: an empty
 // (or whitespace) STREAMING_SASL_MECHANISM yields a nil mechanism and
 // empty name so the Builder is left unauthenticated — the back-compat

--- a/components/tracer/internal/bootstrap/streaming_test.go
+++ b/components/tracer/internal/bootstrap/streaming_test.go
@@ -21,7 +21,7 @@ import (
 var noopEmitterReference = libStreaming.NewNoopEmitter()
 
 // expectedRuleEventKeys is the canonical set of event keys tracer registers
-// for the Rule lifecycle (Phase 2). Limit events (Phase 3) extend this set.
+// for the Rule lifecycle (Phase 2).
 var expectedRuleEventKeys = []string{
 	"rule.created",
 	"rule.updated",
@@ -31,26 +31,44 @@ var expectedRuleEventKeys = []string{
 	"rule.deleted",
 }
 
-// TestTracerEventDefinitions_CoversRuleLifecycle locks the Phase-2 contract:
-// tracerEventDefinitions() registers exactly the six Rule lifecycle events,
-// in the fixed order, with no extra and none missing. This is the single
-// source of truth that feeds both the catalog and the routes.
-func TestTracerEventDefinitions_CoversRuleLifecycle(t *testing.T) {
+// expectedLimitEventKeys is the canonical set of event keys tracer registers
+// for the Limit lifecycle (Phase 3).
+var expectedLimitEventKeys = []string{
+	"limit.created",
+	"limit.updated",
+	"limit.activated",
+	"limit.deactivated",
+	"limit.drafted",
+	"limit.deleted",
+}
+
+// expectedAllEventKeys is the full ordered set of the twelve lifecycle events
+// tracer registers (six Rule, then six Limit). This is the drift lock the
+// catalog/routes/bijection tests assert against.
+var expectedAllEventKeys = append(append([]string{}, expectedRuleEventKeys...), expectedLimitEventKeys...)
+
+// TestTracerEventDefinitions_CoversAllLifecycles locks the Phase-3 contract:
+// tracerEventDefinitions() registers exactly the twelve lifecycle events (six
+// Rule, then six Limit), in the fixed order, with no extra and none missing.
+// This is the single source of truth that feeds both the catalog and the
+// routes.
+func TestTracerEventDefinitions_CoversAllLifecycles(t *testing.T) {
 	t.Parallel()
 
 	defs := tracerEventDefinitions()
-	require.Len(t, defs, len(expectedRuleEventKeys),
-		"tracerEventDefinitions must register exactly the six Rule lifecycle events")
+	require.Len(t, defs, len(expectedAllEventKeys),
+		"tracerEventDefinitions must register exactly the twelve lifecycle events")
 
 	actualKeys := make([]string, 0, len(defs))
 	for _, d := range defs {
 		actualKeys = append(actualKeys, d.Key())
 	}
 
-	// Order is part of the contract (created, updated, activated,
-	// deactivated, drafted, deleted).
-	assert.Equal(t, expectedRuleEventKeys, actualKeys,
-		"tracerEventDefinitions must return the Rule events in the fixed order")
+	// Order is part of the contract: six Rule events (created, updated,
+	// activated, deactivated, drafted, deleted) then six Limit events in the
+	// same order.
+	assert.Equal(t, expectedAllEventKeys, actualKeys,
+		"tracerEventDefinitions must return the Rule then Limit events in the fixed order")
 }
 
 // TestBuildStreamingEmitter_DisabledReturnsNoop covers the master-flag-off
@@ -170,41 +188,41 @@ func TestBuildLiveStreamingEmitter_BuildsWithRuleCatalog(t *testing.T) {
 	assert.NoError(t, closer())
 }
 
-// TestBuildCatalog_CoversRuleLifecycle exercises buildCatalog against the
-// populated Rule definition set: it must succeed and register exactly one
-// entry per Rule event, each looked up by its canonical key.
-func TestBuildCatalog_CoversRuleLifecycle(t *testing.T) {
+// TestBuildCatalog_CoversAllLifecycles exercises buildCatalog against the
+// populated Rule + Limit definition set: it must succeed and register exactly
+// one entry per event, each looked up by its canonical key.
+func TestBuildCatalog_CoversAllLifecycles(t *testing.T) {
 	t.Parallel()
 
 	catalog, err := buildCatalog()
 	require.NoError(t, err)
 	require.NotNil(t, catalog)
-	assert.Equal(t, len(expectedRuleEventKeys), catalog.Len(),
-		"catalog must hold one entry per Rule event")
+	assert.Equal(t, len(expectedAllEventKeys), catalog.Len(),
+		"catalog must hold one entry per lifecycle event")
 
-	for _, key := range expectedRuleEventKeys {
+	for _, key := range expectedAllEventKeys {
 		_, ok := catalog.Lookup(key)
 		assert.Truef(t, ok, "catalog must register key %q", key)
 	}
 }
 
-// TestBuildRoutes_CoversRuleLifecycle exercises buildRoutes against the
-// populated Rule definition set: one required route per event, each keyed
-// "<event>.<target>" and pointing at the canonical
+// TestBuildRoutes_CoversAllLifecycles exercises buildRoutes against the
+// populated Rule + Limit definition set: one required route per event, each
+// keyed "<event>.<target>" and pointing at the canonical
 // "lerian.streaming.<event>" Kafka topic.
-func TestBuildRoutes_CoversRuleLifecycle(t *testing.T) {
+func TestBuildRoutes_CoversAllLifecycles(t *testing.T) {
 	t.Parallel()
 
 	routes := buildRoutes(streamingPrimaryTargetName)
-	require.Len(t, routes, len(expectedRuleEventKeys),
-		"one route per Rule event")
+	require.Len(t, routes, len(expectedAllEventKeys),
+		"one route per lifecycle event")
 
 	byDefKey := make(map[string]libStreaming.RouteDefinition, len(routes))
 	for _, r := range routes {
 		byDefKey[r.DefinitionKey] = r
 	}
 
-	for _, key := range expectedRuleEventKeys {
+	for _, key := range expectedAllEventKeys {
 		r, ok := byDefKey[key]
 		require.Truef(t, ok, "missing route for %q", key)
 		assert.Equal(t, key+"."+streamingPrimaryTargetName, r.Key,
@@ -220,12 +238,14 @@ func TestBuildRoutes_CoversRuleLifecycle(t *testing.T) {
 // exact 1:1:1 bijection between the registered event definitions, the
 // catalog entries, and the route table — no event registered without a
 // route, no route pointing at an unregistered event (ghost topic), and no
-// count drift between the three. Phase 3 extends this to all 12 events.
+// count drift between the three. It locks all twelve events (six Rule, six
+// Limit).
 func TestTracerCatalog_CoversAllEmittedEvents(t *testing.T) {
 	t.Parallel()
 
 	defs := tracerEventDefinitions()
-	require.NotEmpty(t, defs, "tracer must register at least the Rule events")
+	require.Len(t, defs, len(expectedAllEventKeys),
+		"tracer must register all twelve lifecycle events")
 
 	catalog, err := buildCatalog()
 	require.NoError(t, err)
@@ -277,6 +297,7 @@ func TestTracerCatalog_CoversAllEmittedEvents(t *testing.T) {
 
 	// Guard against a stale reference to the events package import.
 	assert.Equal(t, "rule.created", events.RuleCreatedDefinition.Key())
+	assert.Equal(t, "limit.created", events.LimitCreatedDefinition.Key())
 }
 
 // TestResolveStreamingSource locks the CloudEvents source resolution

--- a/components/tracer/internal/services/command/activate_limit.go
+++ b/components/tracer/internal/services/command/activate_limit.go
@@ -13,6 +13,7 @@ import (
 	libObservability "github.com/LerianStudio/lib-observability"
 	libLog "github.com/LerianStudio/lib-observability/log"
 	libOpentelemetry "github.com/LerianStudio/lib-observability/tracing"
+	libStreaming "github.com/LerianStudio/lib-streaming"
 	"github.com/google/uuid"
 	"go.opentelemetry.io/otel/attribute"
 
@@ -31,6 +32,11 @@ type ActivateLimitCommand struct {
 	clock       clock.Clock
 	auditWriter AuditWriter
 	txBeginner  pgdb.TxBeginner
+
+	// Streaming is the lib-streaming Emitter used to publish past-tense domain
+	// events; nil disables emission and never fails the request. Set
+	// post-construction at bootstrap.
+	Streaming libStreaming.Emitter
 }
 
 // NewActivateLimitCommand creates a new ActivateLimitCommand with dependencies.

--- a/components/tracer/internal/services/command/activate_limit.go
+++ b/components/tracer/internal/services/command/activate_limit.go
@@ -16,6 +16,7 @@ import (
 	libStreaming "github.com/LerianStudio/lib-streaming"
 	"github.com/google/uuid"
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 
 	pgdb "github.com/LerianStudio/midaz/v4/components/tracer/internal/adapters/postgres/db"
 	"github.com/LerianStudio/midaz/v4/components/tracer/pkg/clock"
@@ -23,6 +24,8 @@ import (
 	"github.com/LerianStudio/midaz/v4/components/tracer/pkg/model"
 	"github.com/LerianStudio/midaz/v4/pkg"
 	"github.com/LerianStudio/midaz/v4/pkg/constant"
+	pkgStreaming "github.com/LerianStudio/midaz/v4/pkg/streaming"
+	"github.com/LerianStudio/midaz/v4/pkg/streaming/events"
 	"github.com/LerianStudio/midaz/v4/pkg/utils"
 )
 
@@ -212,5 +215,17 @@ func (c *ActivateLimitCommand) Execute(ctx context.Context, id uuid.UUID) (_ *mo
 		return nil, fmt.Errorf("failed to activate limit: %w", txErr)
 	}
 
+	c.emitLimitActivatedEvent(ctx, span, logger, limit)
+
 	return limit, nil
+}
+
+// emitLimitActivatedEvent publishes the limit.activated event post-commit. It is
+// not called on the idempotent already-active no-op (which skips the tx).
+// IMPORTANT posture: emit failures never fail the request.
+func (c *ActivateLimitCommand) emitLimitActivatedEvent(ctx context.Context, span trace.Span, logger libLog.Logger, limit *model.Limit) {
+	pkgStreaming.EmitImportant(ctx, span, logger, c.Streaming, events.LimitActivatedDefinition.Key(),
+		func(tenantID string) (libStreaming.EmitRequest, error) {
+			return events.NewLimitActivated(limit).ToEmitRequest(tenantID, limit.UpdatedAt)
+		})
 }

--- a/components/tracer/internal/services/command/activate_rule.go
+++ b/components/tracer/internal/services/command/activate_rule.go
@@ -13,6 +13,7 @@ import (
 	libObservability "github.com/LerianStudio/lib-observability"
 	libLog "github.com/LerianStudio/lib-observability/log"
 	libOpentelemetry "github.com/LerianStudio/lib-observability/tracing"
+	libStreaming "github.com/LerianStudio/lib-streaming"
 	"github.com/google/uuid"
 	"go.opentelemetry.io/otel/attribute"
 
@@ -47,6 +48,11 @@ type ActivateRuleService struct {
 	auditWriter        AuditWriter
 	cacheWriter        RuleCacheWriter
 	txBeginner         pgdb.TxBeginner
+
+	// Streaming is the lib-streaming Emitter used to publish past-tense domain
+	// events; nil disables emission and never fails the request. Set
+	// post-construction at bootstrap.
+	Streaming libStreaming.Emitter
 }
 
 // NewActivateRuleService creates a new ActivateRuleService.

--- a/components/tracer/internal/services/command/activate_rule.go
+++ b/components/tracer/internal/services/command/activate_rule.go
@@ -16,6 +16,7 @@ import (
 	libStreaming "github.com/LerianStudio/lib-streaming"
 	"github.com/google/uuid"
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 
 	pgdb "github.com/LerianStudio/midaz/v4/components/tracer/internal/adapters/postgres/db"
 	"github.com/LerianStudio/midaz/v4/components/tracer/pkg/clock"
@@ -23,6 +24,8 @@ import (
 	"github.com/LerianStudio/midaz/v4/components/tracer/pkg/model"
 	"github.com/LerianStudio/midaz/v4/pkg"
 	"github.com/LerianStudio/midaz/v4/pkg/constant"
+	pkgStreaming "github.com/LerianStudio/midaz/v4/pkg/streaming"
+	"github.com/LerianStudio/midaz/v4/pkg/streaming/events"
 	"github.com/LerianStudio/midaz/v4/pkg/utils"
 )
 
@@ -313,5 +316,16 @@ func (s *ActivateRuleService) Execute(ctx context.Context, ruleID uuid.UUID) (_ 
 		}()
 	}
 
+	s.emitRuleActivatedEvent(ctx, span, logger, rule)
+
 	return rule, nil
+}
+
+// emitRuleActivatedEvent publishes the rule.activated event post-commit.
+// IMPORTANT posture: emit failures never fail the request.
+func (s *ActivateRuleService) emitRuleActivatedEvent(ctx context.Context, span trace.Span, logger libLog.Logger, rule *model.Rule) {
+	pkgStreaming.EmitImportant(ctx, span, logger, s.Streaming, events.RuleActivatedDefinition.Key(),
+		func(tenantID string) (libStreaming.EmitRequest, error) {
+			return events.NewRuleActivated(rule).ToEmitRequest(tenantID, rule.UpdatedAt)
+		})
 }

--- a/components/tracer/internal/services/command/audit_recording_test.go
+++ b/components/tracer/internal/services/command/audit_recording_test.go
@@ -210,7 +210,7 @@ func TestAuditEventRecording_DeleteRule(t *testing.T) {
 		mockTx.EXPECT().Commit().Return(nil),
 	)
 
-	service, err := NewDeleteRuleService(mockRepo, auditWriter, txBeginner)
+	service, err := NewDeleteRuleService(mockRepo, auditWriter, testutil.NewDefaultMockClock(), txBeginner)
 	require.NoError(t, err)
 	err = service.Execute(context.Background(), ruleID)
 	require.NoError(t, err)

--- a/components/tracer/internal/services/command/create_limit.go
+++ b/components/tracer/internal/services/command/create_limit.go
@@ -14,6 +14,7 @@ import (
 	libObservability "github.com/LerianStudio/lib-observability"
 	libLog "github.com/LerianStudio/lib-observability/log"
 	libOpentelemetry "github.com/LerianStudio/lib-observability/tracing"
+	libStreaming "github.com/LerianStudio/lib-streaming"
 	"github.com/shopspring/decimal"
 	"go.opentelemetry.io/otel/attribute"
 
@@ -75,6 +76,11 @@ type CreateLimitCommand struct {
 	clock       clock.Clock
 	auditWriter AuditWriter
 	txBeginner  pgdb.TxBeginner
+
+	// Streaming is the lib-streaming Emitter used to publish past-tense domain
+	// events; nil disables emission and never fails the request. Set
+	// post-construction at bootstrap.
+	Streaming libStreaming.Emitter
 }
 
 // NewCreateLimitCommand creates a new CreateLimitCommand with dependencies.

--- a/components/tracer/internal/services/command/create_limit.go
+++ b/components/tracer/internal/services/command/create_limit.go
@@ -18,11 +18,15 @@ import (
 	"github.com/shopspring/decimal"
 	"go.opentelemetry.io/otel/attribute"
 
+	"go.opentelemetry.io/otel/trace"
+
 	pgdb "github.com/LerianStudio/midaz/v4/components/tracer/internal/adapters/postgres/db"
 	"github.com/LerianStudio/midaz/v4/components/tracer/pkg/clock"
 	"github.com/LerianStudio/midaz/v4/components/tracer/pkg/logging"
 	"github.com/LerianStudio/midaz/v4/components/tracer/pkg/model"
 	"github.com/LerianStudio/midaz/v4/pkg/constant"
+	pkgStreaming "github.com/LerianStudio/midaz/v4/pkg/streaming"
+	"github.com/LerianStudio/midaz/v4/pkg/streaming/events"
 	"github.com/LerianStudio/midaz/v4/pkg/utils"
 )
 
@@ -323,5 +327,17 @@ func (c *CreateLimitCommand) Execute(ctx context.Context, input *CreateLimitInpu
 		return nil, fmt.Errorf("failed to create limit: %w", txErr)
 	}
 
+	c.emitLimitCreatedEvent(ctx, span, logger, limit)
+
 	return limit, nil
+}
+
+// emitLimitCreatedEvent publishes the limit.created event post-commit. IMPORTANT
+// posture: EmitImportant nil-guards the emitter, bounds the emit, and never
+// propagates build/emit failures — so this never fails the request.
+func (c *CreateLimitCommand) emitLimitCreatedEvent(ctx context.Context, span trace.Span, logger libLog.Logger, limit *model.Limit) {
+	pkgStreaming.EmitImportant(ctx, span, logger, c.Streaming, events.LimitCreatedDefinition.Key(),
+		func(tenantID string) (libStreaming.EmitRequest, error) {
+			return events.NewLimitCreated(limit).ToEmitRequest(tenantID, limit.CreatedAt)
+		})
 }

--- a/components/tracer/internal/services/command/create_rule.go
+++ b/components/tracer/internal/services/command/create_rule.go
@@ -19,11 +19,15 @@ import (
 	libOpentelemetry "github.com/LerianStudio/lib-observability/tracing"
 	libStreaming "github.com/LerianStudio/lib-streaming"
 
+	"go.opentelemetry.io/otel/trace"
+
 	pgdb "github.com/LerianStudio/midaz/v4/components/tracer/internal/adapters/postgres/db"
 	"github.com/LerianStudio/midaz/v4/components/tracer/pkg/clock"
 	"github.com/LerianStudio/midaz/v4/components/tracer/pkg/logging"
 	"github.com/LerianStudio/midaz/v4/components/tracer/pkg/model"
 	"github.com/LerianStudio/midaz/v4/pkg/constant"
+	pkgStreaming "github.com/LerianStudio/midaz/v4/pkg/streaming"
+	"github.com/LerianStudio/midaz/v4/pkg/streaming/events"
 	"github.com/LerianStudio/midaz/v4/pkg/utils"
 )
 
@@ -268,5 +272,17 @@ func (c *CreateRuleCommand) Execute(ctx context.Context, input *CreateRuleInput)
 		return nil, fmt.Errorf("failed to create rule: %w", txErr)
 	}
 
+	c.emitRuleCreatedEvent(ctx, span, logger, result)
+
 	return result, nil
+}
+
+// emitRuleCreatedEvent publishes the rule.created event post-commit. IMPORTANT
+// posture: EmitImportant nil-guards the emitter, bounds the emit, and never
+// propagates build/emit failures — so this never fails the request.
+func (c *CreateRuleCommand) emitRuleCreatedEvent(ctx context.Context, span trace.Span, logger libLog.Logger, rule *model.Rule) {
+	pkgStreaming.EmitImportant(ctx, span, logger, c.Streaming, events.RuleCreatedDefinition.Key(),
+		func(tenantID string) (libStreaming.EmitRequest, error) {
+			return events.NewRuleCreated(rule).ToEmitRequest(tenantID, rule.CreatedAt)
+		})
 }

--- a/components/tracer/internal/services/command/create_rule.go
+++ b/components/tracer/internal/services/command/create_rule.go
@@ -17,6 +17,7 @@ import (
 	libObservability "github.com/LerianStudio/lib-observability"
 	libLog "github.com/LerianStudio/lib-observability/log"
 	libOpentelemetry "github.com/LerianStudio/lib-observability/tracing"
+	libStreaming "github.com/LerianStudio/lib-streaming"
 
 	pgdb "github.com/LerianStudio/midaz/v4/components/tracer/internal/adapters/postgres/db"
 	"github.com/LerianStudio/midaz/v4/components/tracer/pkg/clock"
@@ -88,6 +89,12 @@ type CreateRuleCommand struct {
 	clock       clock.Clock
 	auditWriter AuditWriter
 	txBeginner  pgdb.TxBeginner
+
+	// Streaming publishes past-tense domain events to external consumers. It
+	// holds the Emitter interface (never *libStreaming.Producer) so unit tests
+	// substitute a mock or noop emitter without a broker. optional; nil disables
+	// emission and never fails the request. Set post-construction at bootstrap.
+	Streaming libStreaming.Emitter
 }
 
 // NewCreateRuleCommand creates a new CreateRuleCommand instance.

--- a/components/tracer/internal/services/command/deactivate_limit.go
+++ b/components/tracer/internal/services/command/deactivate_limit.go
@@ -16,6 +16,7 @@ import (
 	libStreaming "github.com/LerianStudio/lib-streaming"
 	"github.com/google/uuid"
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 
 	pgdb "github.com/LerianStudio/midaz/v4/components/tracer/internal/adapters/postgres/db"
 	"github.com/LerianStudio/midaz/v4/components/tracer/pkg/clock"
@@ -23,6 +24,8 @@ import (
 	"github.com/LerianStudio/midaz/v4/components/tracer/pkg/model"
 	"github.com/LerianStudio/midaz/v4/pkg"
 	"github.com/LerianStudio/midaz/v4/pkg/constant"
+	pkgStreaming "github.com/LerianStudio/midaz/v4/pkg/streaming"
+	"github.com/LerianStudio/midaz/v4/pkg/streaming/events"
 	"github.com/LerianStudio/midaz/v4/pkg/utils"
 )
 
@@ -212,5 +215,17 @@ func (c *DeactivateLimitCommand) Execute(ctx context.Context, id uuid.UUID) (_ *
 		return nil, fmt.Errorf("failed to deactivate limit: %w", txErr)
 	}
 
+	c.emitLimitDeactivatedEvent(ctx, span, logger, limit)
+
 	return limit, nil
+}
+
+// emitLimitDeactivatedEvent publishes the limit.deactivated event post-commit.
+// It is not called on the idempotent already-inactive no-op (which skips the
+// tx). IMPORTANT posture: emit failures never fail the request.
+func (c *DeactivateLimitCommand) emitLimitDeactivatedEvent(ctx context.Context, span trace.Span, logger libLog.Logger, limit *model.Limit) {
+	pkgStreaming.EmitImportant(ctx, span, logger, c.Streaming, events.LimitDeactivatedDefinition.Key(),
+		func(tenantID string) (libStreaming.EmitRequest, error) {
+			return events.NewLimitDeactivated(limit).ToEmitRequest(tenantID, limit.UpdatedAt)
+		})
 }

--- a/components/tracer/internal/services/command/deactivate_limit.go
+++ b/components/tracer/internal/services/command/deactivate_limit.go
@@ -13,6 +13,7 @@ import (
 	libObservability "github.com/LerianStudio/lib-observability"
 	libLog "github.com/LerianStudio/lib-observability/log"
 	libOpentelemetry "github.com/LerianStudio/lib-observability/tracing"
+	libStreaming "github.com/LerianStudio/lib-streaming"
 	"github.com/google/uuid"
 	"go.opentelemetry.io/otel/attribute"
 
@@ -31,6 +32,11 @@ type DeactivateLimitCommand struct {
 	clock       clock.Clock
 	auditWriter AuditWriter
 	txBeginner  pgdb.TxBeginner
+
+	// Streaming is the lib-streaming Emitter used to publish past-tense domain
+	// events; nil disables emission and never fails the request. Set
+	// post-construction at bootstrap.
+	Streaming libStreaming.Emitter
 }
 
 // NewDeactivateLimitCommand creates a new DeactivateLimitCommand with dependencies.

--- a/components/tracer/internal/services/command/deactivate_rule.go
+++ b/components/tracer/internal/services/command/deactivate_rule.go
@@ -13,6 +13,7 @@ import (
 	libObservability "github.com/LerianStudio/lib-observability"
 	libLog "github.com/LerianStudio/lib-observability/log"
 	libOpentelemetry "github.com/LerianStudio/lib-observability/tracing"
+	libStreaming "github.com/LerianStudio/lib-streaming"
 	"github.com/google/uuid"
 	"go.opentelemetry.io/otel/attribute"
 
@@ -45,6 +46,11 @@ type DeactivateRuleService struct {
 	auditWriter AuditWriter
 	cacheWriter RuleCacheWriter
 	txBeginner  pgdb.TxBeginner
+
+	// Streaming is the lib-streaming Emitter used to publish past-tense domain
+	// events; nil disables emission and never fails the request. Set
+	// post-construction at bootstrap.
+	Streaming libStreaming.Emitter
 }
 
 // NewDeactivateRuleService creates a new DeactivateRuleService.

--- a/components/tracer/internal/services/command/deactivate_rule.go
+++ b/components/tracer/internal/services/command/deactivate_rule.go
@@ -16,6 +16,7 @@ import (
 	libStreaming "github.com/LerianStudio/lib-streaming"
 	"github.com/google/uuid"
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 
 	pgdb "github.com/LerianStudio/midaz/v4/components/tracer/internal/adapters/postgres/db"
 	"github.com/LerianStudio/midaz/v4/components/tracer/pkg/clock"
@@ -23,6 +24,8 @@ import (
 	"github.com/LerianStudio/midaz/v4/components/tracer/pkg/model"
 	"github.com/LerianStudio/midaz/v4/pkg"
 	"github.com/LerianStudio/midaz/v4/pkg/constant"
+	pkgStreaming "github.com/LerianStudio/midaz/v4/pkg/streaming"
+	"github.com/LerianStudio/midaz/v4/pkg/streaming/events"
 	"github.com/LerianStudio/midaz/v4/pkg/utils"
 )
 
@@ -264,5 +267,16 @@ func (s *DeactivateRuleService) Execute(ctx context.Context, ruleID uuid.UUID) (
 		}()
 	}
 
+	s.emitRuleDeactivatedEvent(ctx, span, logger, rule)
+
 	return rule, nil
+}
+
+// emitRuleDeactivatedEvent publishes the rule.deactivated event post-commit.
+// IMPORTANT posture: emit failures never fail the request.
+func (s *DeactivateRuleService) emitRuleDeactivatedEvent(ctx context.Context, span trace.Span, logger libLog.Logger, rule *model.Rule) {
+	pkgStreaming.EmitImportant(ctx, span, logger, s.Streaming, events.RuleDeactivatedDefinition.Key(),
+		func(tenantID string) (libStreaming.EmitRequest, error) {
+			return events.NewRuleDeactivated(rule).ToEmitRequest(tenantID, rule.UpdatedAt)
+		})
 }

--- a/components/tracer/internal/services/command/delete_limit.go
+++ b/components/tracer/internal/services/command/delete_limit.go
@@ -13,6 +13,7 @@ import (
 	libObservability "github.com/LerianStudio/lib-observability"
 	libLog "github.com/LerianStudio/lib-observability/log"
 	libOpentelemetry "github.com/LerianStudio/lib-observability/tracing"
+	libStreaming "github.com/LerianStudio/lib-streaming"
 	"github.com/google/uuid"
 	"go.opentelemetry.io/otel/attribute"
 
@@ -31,6 +32,11 @@ type DeleteLimitCommand struct {
 	clock       clock.Clock
 	auditWriter AuditWriter
 	txBeginner  pgdb.TxBeginner
+
+	// Streaming is the lib-streaming Emitter used to publish past-tense domain
+	// events; nil disables emission and never fails the request. Set
+	// post-construction at bootstrap.
+	Streaming libStreaming.Emitter
 }
 
 // NewDeleteLimitCommand creates a new DeleteLimitCommand with dependencies.

--- a/components/tracer/internal/services/command/delete_limit.go
+++ b/components/tracer/internal/services/command/delete_limit.go
@@ -224,8 +224,6 @@ func (c *DeleteLimitCommand) Execute(ctx context.Context, id uuid.UUID) (retErr 
 
 // emitLimitDeletedEvent publishes the limit.deleted event post-commit. It is
 // not called on the idempotent already-deleted no-op (which skips the tx).
-// The domain constructor reads limit.DeletedAt, populated by SetStatus(DELETED)
-// before the tx; ts is limit.UpdatedAt, which SetStatus set to the same instant.
 // IMPORTANT posture: emit failures never fail the request.
 func (c *DeleteLimitCommand) emitLimitDeletedEvent(ctx context.Context, span trace.Span, logger libLog.Logger, limit *model.Limit) {
 	pkgStreaming.EmitImportant(ctx, span, logger, c.Streaming, events.LimitDeletedDefinition.Key(),

--- a/components/tracer/internal/services/command/delete_limit.go
+++ b/components/tracer/internal/services/command/delete_limit.go
@@ -16,6 +16,7 @@ import (
 	libStreaming "github.com/LerianStudio/lib-streaming"
 	"github.com/google/uuid"
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 
 	pgdb "github.com/LerianStudio/midaz/v4/components/tracer/internal/adapters/postgres/db"
 	"github.com/LerianStudio/midaz/v4/components/tracer/pkg/clock"
@@ -23,6 +24,8 @@ import (
 	"github.com/LerianStudio/midaz/v4/components/tracer/pkg/model"
 	"github.com/LerianStudio/midaz/v4/pkg"
 	"github.com/LerianStudio/midaz/v4/pkg/constant"
+	pkgStreaming "github.com/LerianStudio/midaz/v4/pkg/streaming"
+	"github.com/LerianStudio/midaz/v4/pkg/streaming/events"
 	"github.com/LerianStudio/midaz/v4/pkg/utils"
 )
 
@@ -214,5 +217,19 @@ func (c *DeleteLimitCommand) Execute(ctx context.Context, id uuid.UUID) (retErr 
 		return fmt.Errorf("failed to delete limit: %w", txErr)
 	}
 
+	c.emitLimitDeletedEvent(ctx, span, logger, limit)
+
 	return nil
+}
+
+// emitLimitDeletedEvent publishes the limit.deleted event post-commit. It is
+// not called on the idempotent already-deleted no-op (which skips the tx).
+// The domain constructor reads limit.DeletedAt, populated by SetStatus(DELETED)
+// before the tx; ts is limit.UpdatedAt, which SetStatus set to the same instant.
+// IMPORTANT posture: emit failures never fail the request.
+func (c *DeleteLimitCommand) emitLimitDeletedEvent(ctx context.Context, span trace.Span, logger libLog.Logger, limit *model.Limit) {
+	pkgStreaming.EmitImportant(ctx, span, logger, c.Streaming, events.LimitDeletedDefinition.Key(),
+		func(tenantID string) (libStreaming.EmitRequest, error) {
+			return events.NewLimitDeleted(limit).ToEmitRequest(tenantID, limit.UpdatedAt)
+		})
 }

--- a/components/tracer/internal/services/command/delete_rule.go
+++ b/components/tracer/internal/services/command/delete_rule.go
@@ -16,12 +16,16 @@ import (
 	libStreaming "github.com/LerianStudio/lib-streaming"
 	"github.com/google/uuid"
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 
 	pgdb "github.com/LerianStudio/midaz/v4/components/tracer/internal/adapters/postgres/db"
+	"github.com/LerianStudio/midaz/v4/components/tracer/pkg/clock"
 	"github.com/LerianStudio/midaz/v4/components/tracer/pkg/logging"
 	"github.com/LerianStudio/midaz/v4/components/tracer/pkg/model"
 	"github.com/LerianStudio/midaz/v4/pkg"
 	"github.com/LerianStudio/midaz/v4/pkg/constant"
+	pkgStreaming "github.com/LerianStudio/midaz/v4/pkg/streaming"
+	"github.com/LerianStudio/midaz/v4/pkg/streaming/events"
 	"github.com/LerianStudio/midaz/v4/pkg/utils"
 )
 
@@ -36,6 +40,7 @@ type DeleteRuleService struct {
 	repository  RuleRepository
 	auditWriter AuditWriter
 	txBeginner  pgdb.TxBeginner
+	clock       clock.Clock
 
 	// Streaming is the lib-streaming Emitter used to publish past-tense domain
 	// events; nil disables emission and never fails the request. Set
@@ -49,9 +54,12 @@ var (
 )
 
 // NewDeleteRuleService creates a new DeleteRuleService.
+// The clock supplies the delete-moment timestamp carried on the rule.deleted
+// streaming event (the DB/audit remain the source of truth for persisted
+// timestamps).
 // txBeginner may be nil — in that case Execute will surface pgdb.ErrNilConnection
 // when it attempts to start the persistence transaction.
-func NewDeleteRuleService(repository RuleRepository, auditWriter AuditWriter, txBeginner pgdb.TxBeginner) (*DeleteRuleService, error) {
+func NewDeleteRuleService(repository RuleRepository, auditWriter AuditWriter, clk clock.Clock, txBeginner pgdb.TxBeginner) (*DeleteRuleService, error) {
 	if repository == nil {
 		return nil, ErrNilDeleteRuleRepository
 	}
@@ -60,10 +68,15 @@ func NewDeleteRuleService(repository RuleRepository, auditWriter AuditWriter, tx
 		return nil, ErrNilAuditWriter
 	}
 
+	if clk == nil {
+		return nil, ErrNilClock
+	}
+
 	return &DeleteRuleService{
 		repository:  repository,
 		auditWriter: auditWriter,
 		txBeginner:  txBeginner,
+		clock:       clk,
 	}, nil
 }
 
@@ -147,6 +160,12 @@ func (s *DeleteRuleService) Execute(ctx context.Context, ruleID uuid.UUID) (retE
 		return err
 	}
 
+	// Capture the delete moment for the rule.deleted streaming payload. The
+	// delete use case returns no post-delete entity to read DeletedAt from, so
+	// the clock provides a deterministic, request-monotonic timestamp used only
+	// for the event (persisted timestamps remain DB/audit-owned).
+	deletedAt := s.clock.Now().UTC()
+
 	// Capture "before" state for audit (after idempotency + transition checks,
 	// before the soft-delete mutates the rule row).
 	beforeState := RuleToMap(rule)
@@ -214,5 +233,17 @@ func (s *DeleteRuleService) Execute(ctx context.Context, ruleID uuid.UUID) (retE
 		return fmt.Errorf("failed to delete rule: %w", txErr)
 	}
 
+	s.emitRuleDeletedEvent(ctx, span, logger, ruleID, deletedAt)
+
 	return nil
+}
+
+// emitRuleDeletedEvent publishes the rule.deleted event post-commit. IMPORTANT
+// posture: emit failures never fail the request. deletedAt is the delete moment
+// captured before the transaction.
+func (s *DeleteRuleService) emitRuleDeletedEvent(ctx context.Context, span trace.Span, logger libLog.Logger, ruleID uuid.UUID, deletedAt time.Time) {
+	pkgStreaming.EmitImportant(ctx, span, logger, s.Streaming, events.RuleDeletedDefinition.Key(),
+		func(tenantID string) (libStreaming.EmitRequest, error) {
+			return events.NewRuleDeleted(ruleID, deletedAt).ToEmitRequest(tenantID, deletedAt)
+		})
 }

--- a/components/tracer/internal/services/command/delete_rule.go
+++ b/components/tracer/internal/services/command/delete_rule.go
@@ -13,6 +13,7 @@ import (
 	libObservability "github.com/LerianStudio/lib-observability"
 	libLog "github.com/LerianStudio/lib-observability/log"
 	libOpentelemetry "github.com/LerianStudio/lib-observability/tracing"
+	libStreaming "github.com/LerianStudio/lib-streaming"
 	"github.com/google/uuid"
 	"go.opentelemetry.io/otel/attribute"
 
@@ -35,6 +36,11 @@ type DeleteRuleService struct {
 	repository  RuleRepository
 	auditWriter AuditWriter
 	txBeginner  pgdb.TxBeginner
+
+	// Streaming is the lib-streaming Emitter used to publish past-tense domain
+	// events; nil disables emission and never fails the request. Set
+	// post-construction at bootstrap.
+	Streaming libStreaming.Emitter
 }
 
 var (

--- a/components/tracer/internal/services/command/delete_rule_test.go
+++ b/components/tracer/internal/services/command/delete_rule_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 func TestNewDeleteRuleService_NilRepository(t *testing.T) {
-	service, err := NewDeleteRuleService(nil, nil, nil)
+	service, err := NewDeleteRuleService(nil, nil, nil, nil)
 
 	require.Error(t, err)
 	assert.ErrorIs(t, err, ErrNilDeleteRuleRepository)
@@ -31,7 +31,7 @@ func TestNewDeleteRuleService_NilAuditWriter(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockRepo := NewMockRuleRepository(ctrl)
 
-	service, err := NewDeleteRuleService(mockRepo, nil, nil)
+	service, err := NewDeleteRuleService(mockRepo, nil, nil, nil)
 
 	require.Error(t, err)
 	assert.ErrorIs(t, err, ErrNilAuditWriter)
@@ -88,7 +88,7 @@ func TestDeleteRule_Success_FromInactive(t *testing.T) {
 		mockTx.EXPECT().Commit().Return(nil),
 	)
 
-	service, err := NewDeleteRuleService(mockRepo, auditWriter, txBeginner)
+	service, err := NewDeleteRuleService(mockRepo, auditWriter, testutil.NewDefaultMockClock(), txBeginner)
 	require.NoError(t, err)
 
 	err = service.Execute(ctx, ruleID)
@@ -145,7 +145,7 @@ func TestDeleteRule_Success_FromDraft(t *testing.T) {
 		mockTx.EXPECT().Commit().Return(nil),
 	)
 
-	service, err := NewDeleteRuleService(mockRepo, auditWriter, txBeginner)
+	service, err := NewDeleteRuleService(mockRepo, auditWriter, testutil.NewDefaultMockClock(), txBeginner)
 	require.NoError(t, err)
 
 	err = service.Execute(ctx, ruleID)
@@ -172,7 +172,7 @@ func TestDeleteRule_RuleNotFound(t *testing.T) {
 		RecordRuleEventWithTx(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 		Times(0)
 
-	service, err := NewDeleteRuleService(mockRepo, auditWriter, txBeginner)
+	service, err := NewDeleteRuleService(mockRepo, auditWriter, testutil.NewDefaultMockClock(), txBeginner)
 	require.NoError(t, err)
 
 	err = service.Execute(ctx, ruleID)
@@ -207,7 +207,7 @@ func TestDeleteRule_NilRuleFromRepo(t *testing.T) {
 		RecordRuleEventWithTx(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 		Times(0)
 
-	service, err := NewDeleteRuleService(mockRepo, auditWriter, txBeginner)
+	service, err := NewDeleteRuleService(mockRepo, auditWriter, testutil.NewDefaultMockClock(), txBeginner)
 	require.NoError(t, err)
 
 	err = service.Execute(ctx, ruleID)
@@ -243,7 +243,7 @@ func TestDeleteRule_AlreadyDeleted_Idempotent(t *testing.T) {
 		RecordRuleEventWithTx(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 		Times(0)
 
-	service, err := NewDeleteRuleService(mockRepo, auditWriter, txBeginner)
+	service, err := NewDeleteRuleService(mockRepo, auditWriter, testutil.NewDefaultMockClock(), txBeginner)
 	require.NoError(t, err)
 
 	err = service.Execute(ctx, ruleID)
@@ -292,7 +292,7 @@ func TestDeleteRule_InvalidTransition(t *testing.T) {
 				RecordRuleEventWithTx(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 				Times(0)
 
-			service, err := NewDeleteRuleService(mockRepo, auditWriter, txBeginner)
+			service, err := NewDeleteRuleService(mockRepo, auditWriter, testutil.NewDefaultMockClock(), txBeginner)
 			require.NoError(t, err)
 
 			err = service.Execute(ctx, ruleID)
@@ -328,7 +328,7 @@ func TestDeleteRule_GetByIDError(t *testing.T) {
 		RecordRuleEventWithTx(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 		Times(0)
 
-	service, err := NewDeleteRuleService(mockRepo, auditWriter, txBeginner)
+	service, err := NewDeleteRuleService(mockRepo, auditWriter, testutil.NewDefaultMockClock(), txBeginner)
 	require.NoError(t, err)
 
 	err = service.Execute(ctx, ruleID)
@@ -379,7 +379,7 @@ func TestDeleteRule_DeleteError(t *testing.T) {
 		RecordRuleEventWithTx(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 		Times(0)
 
-	service, err := NewDeleteRuleService(mockRepo, auditWriter, txBeginner)
+	service, err := NewDeleteRuleService(mockRepo, auditWriter, testutil.NewDefaultMockClock(), txBeginner)
 	require.NoError(t, err)
 
 	err = service.Execute(ctx, ruleID)
@@ -427,7 +427,7 @@ func TestDeleteRule_BeginTxError(t *testing.T) {
 		RecordRuleEventWithTx(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 		Times(0)
 
-	service, err := NewDeleteRuleService(mockRepo, auditWriter, txBeginner)
+	service, err := NewDeleteRuleService(mockRepo, auditWriter, testutil.NewDefaultMockClock(), txBeginner)
 	require.NoError(t, err)
 
 	err = service.Execute(ctx, ruleID)
@@ -484,7 +484,7 @@ func TestDeleteRule_AuditError_Rollback(t *testing.T) {
 	)
 	mockTx.EXPECT().Commit().Times(0)
 
-	service, err := NewDeleteRuleService(mockRepo, auditWriter, txBeginner)
+	service, err := NewDeleteRuleService(mockRepo, auditWriter, testutil.NewDefaultMockClock(), txBeginner)
 	require.NoError(t, err)
 
 	err = service.Execute(ctx, ruleID)
@@ -541,7 +541,7 @@ func TestDeleteRule_CommitError(t *testing.T) {
 		mockTx.EXPECT().Rollback().Return(nil),
 	)
 
-	service, err := NewDeleteRuleService(mockRepo, auditWriter, txBeginner)
+	service, err := NewDeleteRuleService(mockRepo, auditWriter, testutil.NewDefaultMockClock(), txBeginner)
 	require.NoError(t, err)
 
 	err = service.Execute(ctx, ruleID)

--- a/components/tracer/internal/services/command/draft_limit.go
+++ b/components/tracer/internal/services/command/draft_limit.go
@@ -13,6 +13,7 @@ import (
 	libObservability "github.com/LerianStudio/lib-observability"
 	libLog "github.com/LerianStudio/lib-observability/log"
 	libOpentelemetry "github.com/LerianStudio/lib-observability/tracing"
+	libStreaming "github.com/LerianStudio/lib-streaming"
 	"github.com/google/uuid"
 	"go.opentelemetry.io/otel/attribute"
 
@@ -33,6 +34,11 @@ type DraftLimitCommand struct {
 	clock       clock.Clock
 	auditWriter AuditWriter
 	txBeginner  pgdb.TxBeginner
+
+	// Streaming is the lib-streaming Emitter used to publish past-tense domain
+	// events; nil disables emission and never fails the request. Set
+	// post-construction at bootstrap.
+	Streaming libStreaming.Emitter
 }
 
 // NewDraftLimitCommand creates a new DraftLimitCommand with dependencies.

--- a/components/tracer/internal/services/command/draft_limit.go
+++ b/components/tracer/internal/services/command/draft_limit.go
@@ -16,6 +16,7 @@ import (
 	libStreaming "github.com/LerianStudio/lib-streaming"
 	"github.com/google/uuid"
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 
 	pgdb "github.com/LerianStudio/midaz/v4/components/tracer/internal/adapters/postgres/db"
 	"github.com/LerianStudio/midaz/v4/components/tracer/pkg/clock"
@@ -23,6 +24,8 @@ import (
 	"github.com/LerianStudio/midaz/v4/components/tracer/pkg/model"
 	"github.com/LerianStudio/midaz/v4/pkg"
 	"github.com/LerianStudio/midaz/v4/pkg/constant"
+	pkgStreaming "github.com/LerianStudio/midaz/v4/pkg/streaming"
+	"github.com/LerianStudio/midaz/v4/pkg/streaming/events"
 	"github.com/LerianStudio/midaz/v4/pkg/utils"
 )
 
@@ -214,5 +217,17 @@ func (c *DraftLimitCommand) Execute(ctx context.Context, id uuid.UUID) (_ *model
 		return nil, fmt.Errorf("failed to transition limit to draft: %w", txErr)
 	}
 
+	c.emitLimitDraftedEvent(ctx, span, logger, limit)
+
 	return limit, nil
+}
+
+// emitLimitDraftedEvent publishes the limit.drafted event post-commit. It is
+// not called on the idempotent already-draft no-op (which skips the tx).
+// IMPORTANT posture: emit failures never fail the request.
+func (c *DraftLimitCommand) emitLimitDraftedEvent(ctx context.Context, span trace.Span, logger libLog.Logger, limit *model.Limit) {
+	pkgStreaming.EmitImportant(ctx, span, logger, c.Streaming, events.LimitDraftedDefinition.Key(),
+		func(tenantID string) (libStreaming.EmitRequest, error) {
+			return events.NewLimitDrafted(limit).ToEmitRequest(tenantID, limit.UpdatedAt)
+		})
 }

--- a/components/tracer/internal/services/command/draft_rule.go
+++ b/components/tracer/internal/services/command/draft_rule.go
@@ -13,6 +13,7 @@ import (
 	libObservability "github.com/LerianStudio/lib-observability"
 	libLog "github.com/LerianStudio/lib-observability/log"
 	libOpentelemetry "github.com/LerianStudio/lib-observability/tracing"
+	libStreaming "github.com/LerianStudio/lib-streaming"
 	"github.com/google/uuid"
 	"go.opentelemetry.io/otel/attribute"
 
@@ -40,6 +41,11 @@ type DraftRuleService struct {
 	clock       clock.Clock
 	auditWriter AuditWriter
 	txBeginner  pgdb.TxBeginner
+
+	// Streaming is the lib-streaming Emitter used to publish past-tense domain
+	// events; nil disables emission and never fails the request. Set
+	// post-construction at bootstrap.
+	Streaming libStreaming.Emitter
 }
 
 // NewDraftRuleService creates a new DraftRuleService with dependencies.

--- a/components/tracer/internal/services/command/draft_rule.go
+++ b/components/tracer/internal/services/command/draft_rule.go
@@ -16,6 +16,7 @@ import (
 	libStreaming "github.com/LerianStudio/lib-streaming"
 	"github.com/google/uuid"
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 
 	pgdb "github.com/LerianStudio/midaz/v4/components/tracer/internal/adapters/postgres/db"
 	"github.com/LerianStudio/midaz/v4/components/tracer/pkg/clock"
@@ -23,6 +24,8 @@ import (
 	"github.com/LerianStudio/midaz/v4/components/tracer/pkg/model"
 	"github.com/LerianStudio/midaz/v4/pkg"
 	"github.com/LerianStudio/midaz/v4/pkg/constant"
+	pkgStreaming "github.com/LerianStudio/midaz/v4/pkg/streaming"
+	"github.com/LerianStudio/midaz/v4/pkg/streaming/events"
 	"github.com/LerianStudio/midaz/v4/pkg/utils"
 )
 
@@ -234,5 +237,16 @@ func (s *DraftRuleService) Execute(ctx context.Context, ruleID uuid.UUID) (_ *mo
 		return nil, fmt.Errorf("failed to transition rule to draft: %w", txErr)
 	}
 
+	s.emitRuleDraftedEvent(ctx, span, logger, rule)
+
 	return rule, nil
+}
+
+// emitRuleDraftedEvent publishes the rule.drafted event post-commit. IMPORTANT
+// posture: emit failures never fail the request.
+func (s *DraftRuleService) emitRuleDraftedEvent(ctx context.Context, span trace.Span, logger libLog.Logger, rule *model.Rule) {
+	pkgStreaming.EmitImportant(ctx, span, logger, s.Streaming, events.RuleDraftedDefinition.Key(),
+		func(tenantID string) (libStreaming.EmitRequest, error) {
+			return events.NewRuleDrafted(rule).ToEmitRequest(tenantID, rule.UpdatedAt)
+		})
 }

--- a/components/tracer/internal/services/command/limit_streaming_test.go
+++ b/components/tracer/internal/services/command/limit_streaming_test.go
@@ -1,0 +1,731 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package command
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	libStreaming "github.com/LerianStudio/lib-streaming"
+
+	pgdbMocks "github.com/LerianStudio/midaz/v4/components/tracer/internal/adapters/postgres/db/mocks"
+	"github.com/LerianStudio/midaz/v4/components/tracer/internal/testutil"
+	"github.com/LerianStudio/midaz/v4/components/tracer/pkg/model"
+	pkgStreaming "github.com/LerianStudio/midaz/v4/pkg/streaming"
+	"github.com/LerianStudio/midaz/v4/pkg/streaming/events"
+)
+
+// limitFixture builds a limit in the given pre-transition status with fixed
+// times, usable as the repository GetByID return for the status-transition and
+// delete streaming tests. Times come from the fixed test clock, never
+// time.Now().
+func limitFixture(id, scopeSeed int64, status model.LimitStatus) *model.Limit {
+	return &model.Limit{
+		ID:        testutil.MustDeterministicUUID(id),
+		Name:      "Streaming Limit",
+		LimitType: model.LimitTypeDaily,
+		MaxAmount: decimal.RequireFromString("1000"),
+		Currency:  "USD",
+		Status:    status,
+		Scopes: []model.Scope{
+			{AccountID: testutil.UUIDPtr(testutil.MustDeterministicUUID(scopeSeed))},
+		},
+		CreatedAt: testutil.FixedTime(),
+		UpdatedAt: testutil.FixedTime(),
+	}
+}
+
+// assertLimitFenceClean fails if any forbidden free-text / financial key appears
+// at the top level of the wire payload.
+func assertLimitFenceClean(t *testing.T, raw []byte) {
+	t.Helper()
+
+	var m map[string]any
+	require.NoError(t, json.Unmarshal(raw, &m))
+
+	for _, forbidden := range []string{"name", "description", "maxAmount"} {
+		_, present := m[forbidden]
+		assert.Falsef(t, present, "forbidden key %q must never appear on the wire", forbidden)
+	}
+}
+
+// ── limit.created ─────────────────────────────────────────────────────────────
+
+func TestCreateLimit_EmitsLimitCreated(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	mockRepo := NewMockLimitRepository(ctrl)
+	auditWriter := NewMockAuditWriter(ctrl)
+	txBeginner := pgdbMocks.NewMockTxBeginner(ctrl)
+	mockTx := pgdbMocks.NewMockTx(ctrl)
+	emitter := pkgStreaming.NewMockEmitter()
+
+	expectLimitCreateTxSuccess(t, txBeginner, mockTx, mockRepo, auditWriter,
+		model.AuditEventLimitCreated, model.AuditActionCreate, "Limit created via API")
+
+	cmd, err := NewCreateLimitCommand(mockRepo, testutil.NewDefaultMockClock(), auditWriter, txBeginner)
+	require.NoError(t, err)
+	cmd.Streaming = emitter
+
+	input := &CreateLimitInput{
+		Name:        "Daily Card Limit",
+		Description: testutil.StringPtr("Daily spending limit"),
+		LimitType:   model.LimitTypeDaily,
+		MaxAmount:   decimal.RequireFromString("1000"),
+		Currency:    "USD",
+		Scopes:      []model.Scope{{AccountID: testutil.UUIDPtr(testutil.MustDeterministicUUID(1))}},
+	}
+
+	result, err := cmd.Execute(context.Background(), input)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	emitted := emitter.Events()
+	require.Len(t, emitted, 1)
+	assert.Equal(t, "limit.created", emitted[0].DefinitionKey)
+	assert.Equal(t, result.ID.String(), emitted[0].Subject)
+
+	var payload events.LimitCreatedPayload
+	require.NoError(t, json.Unmarshal(emitted[0].Payload, &payload))
+	assert.Equal(t, result.ID.String(), payload.ID)
+	assert.Equal(t, "DRAFT", payload.Status)
+	assert.Equal(t, "DAILY", payload.LimitType)
+	assert.Equal(t, "USD", payload.Currency)
+	require.Len(t, payload.Scopes, 1)
+
+	assertLimitFenceClean(t, emitted[0].Payload)
+}
+
+func TestCreateLimit_NilEmitter_NoEmit_NoPanic(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	mockRepo := NewMockLimitRepository(ctrl)
+	auditWriter := NewMockAuditWriter(ctrl)
+	txBeginner := pgdbMocks.NewMockTxBeginner(ctrl)
+	mockTx := pgdbMocks.NewMockTx(ctrl)
+
+	expectLimitCreateTxSuccess(t, txBeginner, mockTx, mockRepo, auditWriter,
+		model.AuditEventLimitCreated, model.AuditActionCreate, "Limit created via API")
+
+	cmd, err := NewCreateLimitCommand(mockRepo, testutil.NewDefaultMockClock(), auditWriter, txBeginner)
+	require.NoError(t, err)
+	// Streaming left nil.
+
+	input := &CreateLimitInput{
+		Name: "Daily Card Limit", LimitType: model.LimitTypeDaily,
+		MaxAmount: decimal.RequireFromString("1000"), Currency: "USD",
+		Scopes: []model.Scope{{AccountID: testutil.UUIDPtr(testutil.MustDeterministicUUID(1))}},
+	}
+
+	result, err := cmd.Execute(context.Background(), input)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+}
+
+func TestCreateLimit_NoopEmitter_Succeeds(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	mockRepo := NewMockLimitRepository(ctrl)
+	auditWriter := NewMockAuditWriter(ctrl)
+	txBeginner := pgdbMocks.NewMockTxBeginner(ctrl)
+	mockTx := pgdbMocks.NewMockTx(ctrl)
+
+	expectLimitCreateTxSuccess(t, txBeginner, mockTx, mockRepo, auditWriter,
+		model.AuditEventLimitCreated, model.AuditActionCreate, "Limit created via API")
+
+	cmd, err := NewCreateLimitCommand(mockRepo, testutil.NewDefaultMockClock(), auditWriter, txBeginner)
+	require.NoError(t, err)
+	cmd.Streaming = libStreaming.NewNoopEmitter()
+
+	input := &CreateLimitInput{
+		Name: "Daily Card Limit", LimitType: model.LimitTypeDaily,
+		MaxAmount: decimal.RequireFromString("1000"), Currency: "USD",
+		Scopes: []model.Scope{{AccountID: testutil.UUIDPtr(testutil.MustDeterministicUUID(1))}},
+	}
+
+	result, err := cmd.Execute(context.Background(), input)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+}
+
+func TestCreateLimit_EmitFailure_RequestStillSucceeds(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	mockRepo := NewMockLimitRepository(ctrl)
+	auditWriter := NewMockAuditWriter(ctrl)
+	txBeginner := pgdbMocks.NewMockTxBeginner(ctrl)
+	mockTx := pgdbMocks.NewMockTx(ctrl)
+	emitter := pkgStreaming.NewMockEmitter()
+	emitter.SetError(errors.New("broker down"))
+
+	expectLimitCreateTxSuccess(t, txBeginner, mockTx, mockRepo, auditWriter,
+		model.AuditEventLimitCreated, model.AuditActionCreate, "Limit created via API")
+
+	cmd, err := NewCreateLimitCommand(mockRepo, testutil.NewDefaultMockClock(), auditWriter, txBeginner)
+	require.NoError(t, err)
+	cmd.Streaming = emitter
+
+	input := &CreateLimitInput{
+		Name: "Daily Card Limit", LimitType: model.LimitTypeDaily,
+		MaxAmount: decimal.RequireFromString("1000"), Currency: "USD",
+		Scopes: []model.Scope{{AccountID: testutil.UUIDPtr(testutil.MustDeterministicUUID(1))}},
+	}
+
+	result, err := cmd.Execute(context.Background(), input)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Empty(t, emitter.Events(), "failed emits are not captured")
+}
+
+// ── limit.updated ─────────────────────────────────────────────────────────────
+
+func TestUpdateLimit_EmitsLimitUpdated(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	limitID := testutil.MustDeterministicUUID(10)
+	existing := limitFixture(10, 11, model.LimitStatusDraft)
+
+	mockRepo := NewMockLimitRepository(ctrl)
+	auditWriter := NewMockAuditWriter(ctrl)
+	txBeginner := pgdbMocks.NewMockTxBeginner(ctrl)
+	mockTx := pgdbMocks.NewMockTx(ctrl)
+	emitter := pkgStreaming.NewMockEmitter()
+
+	mockRepo.EXPECT().GetByID(gomock.Any(), limitID).Return(existing, nil)
+	gomock.InOrder(
+		txBeginner.EXPECT().BeginTx(gomock.Any(), nil).Return(mockTx, nil),
+		mockRepo.EXPECT().UpdateWithTx(gomock.Any(), gomock.AssignableToTypeOf(mockTx), gomock.Any()).Return(nil),
+		auditWriter.EXPECT().RecordLimitEventWithTx(
+			gomock.Any(), gomock.AssignableToTypeOf(mockTx),
+			model.AuditEventLimitUpdated, model.AuditActionUpdate, limitID,
+			gomock.Any(), gomock.Any(), "Limit updated via API",
+		).Return(nil),
+		mockTx.EXPECT().Commit().Return(nil),
+	)
+
+	cmd, err := NewUpdateLimitCommand(mockRepo, testutil.NewDefaultMockClock(), auditWriter, txBeginner)
+	require.NoError(t, err)
+	cmd.Streaming = emitter
+
+	result, err := cmd.Execute(context.Background(), limitID, &UpdateLimitInput{Name: testutil.StringPtr("Updated Name")})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	emitted := emitter.Events()
+	require.Len(t, emitted, 1)
+	assert.Equal(t, "limit.updated", emitted[0].DefinitionKey)
+	assert.Equal(t, limitID.String(), emitted[0].Subject)
+
+	var payload events.LimitUpdatedPayload
+	require.NoError(t, json.Unmarshal(emitted[0].Payload, &payload))
+	assert.Equal(t, limitID.String(), payload.ID)
+	assert.Equal(t, "DRAFT", payload.Status)
+	assert.Equal(t, testutil.FixedTime().Format("2006-01-02T15:04:05Z07:00"), payload.UpdatedAt)
+	assertLimitFenceClean(t, emitted[0].Payload)
+}
+
+func TestUpdateLimit_NoChange_EmitsNothing(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	limitID := testutil.MustDeterministicUUID(10)
+	existing := limitFixture(10, 11, model.LimitStatusDraft)
+
+	mockRepo := NewMockLimitRepository(ctrl)
+	auditWriter := NewMockAuditWriter(ctrl)
+	txBeginner := pgdbMocks.NewMockTxBeginner(ctrl)
+	emitter := pkgStreaming.NewMockEmitter()
+
+	mockRepo.EXPECT().GetByID(gomock.Any(), limitID).Return(existing, nil)
+	// No fields to change → no tx, no emit.
+	txBeginner.EXPECT().BeginTx(gomock.Any(), gomock.Any()).Times(0)
+
+	cmd, err := NewUpdateLimitCommand(mockRepo, testutil.NewDefaultMockClock(), auditWriter, txBeginner)
+	require.NoError(t, err)
+	cmd.Streaming = emitter
+
+	result, err := cmd.Execute(context.Background(), limitID, &UpdateLimitInput{})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Empty(t, emitter.Events(), "no-change update must not emit")
+}
+
+func TestUpdateLimit_NilEmitter_NoPanic(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	limitID := testutil.MustDeterministicUUID(10)
+	existing := limitFixture(10, 11, model.LimitStatusDraft)
+
+	mockRepo := NewMockLimitRepository(ctrl)
+	auditWriter := NewMockAuditWriter(ctrl)
+	txBeginner := pgdbMocks.NewMockTxBeginner(ctrl)
+	mockTx := pgdbMocks.NewMockTx(ctrl)
+
+	mockRepo.EXPECT().GetByID(gomock.Any(), limitID).Return(existing, nil)
+	gomock.InOrder(
+		txBeginner.EXPECT().BeginTx(gomock.Any(), nil).Return(mockTx, nil),
+		mockRepo.EXPECT().UpdateWithTx(gomock.Any(), gomock.AssignableToTypeOf(mockTx), gomock.Any()).Return(nil),
+		auditWriter.EXPECT().RecordLimitEventWithTx(
+			gomock.Any(), gomock.AssignableToTypeOf(mockTx),
+			model.AuditEventLimitUpdated, model.AuditActionUpdate, limitID,
+			gomock.Any(), gomock.Any(), "Limit updated via API",
+		).Return(nil),
+		mockTx.EXPECT().Commit().Return(nil),
+	)
+
+	cmd, err := NewUpdateLimitCommand(mockRepo, testutil.NewDefaultMockClock(), auditWriter, txBeginner)
+	require.NoError(t, err)
+
+	result, err := cmd.Execute(context.Background(), limitID, &UpdateLimitInput{Name: testutil.StringPtr("Updated Name")})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+}
+
+func TestUpdateLimit_EmitFailure_RequestStillSucceeds(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	limitID := testutil.MustDeterministicUUID(10)
+	existing := limitFixture(10, 11, model.LimitStatusDraft)
+
+	mockRepo := NewMockLimitRepository(ctrl)
+	auditWriter := NewMockAuditWriter(ctrl)
+	txBeginner := pgdbMocks.NewMockTxBeginner(ctrl)
+	mockTx := pgdbMocks.NewMockTx(ctrl)
+	emitter := pkgStreaming.NewMockEmitter()
+	emitter.SetError(errors.New("broker down"))
+
+	mockRepo.EXPECT().GetByID(gomock.Any(), limitID).Return(existing, nil)
+	gomock.InOrder(
+		txBeginner.EXPECT().BeginTx(gomock.Any(), nil).Return(mockTx, nil),
+		mockRepo.EXPECT().UpdateWithTx(gomock.Any(), gomock.AssignableToTypeOf(mockTx), gomock.Any()).Return(nil),
+		auditWriter.EXPECT().RecordLimitEventWithTx(
+			gomock.Any(), gomock.AssignableToTypeOf(mockTx),
+			model.AuditEventLimitUpdated, model.AuditActionUpdate, limitID,
+			gomock.Any(), gomock.Any(), "Limit updated via API",
+		).Return(nil),
+		mockTx.EXPECT().Commit().Return(nil),
+	)
+
+	cmd, err := NewUpdateLimitCommand(mockRepo, testutil.NewDefaultMockClock(), auditWriter, txBeginner)
+	require.NoError(t, err)
+	cmd.Streaming = emitter
+
+	result, err := cmd.Execute(context.Background(), limitID, &UpdateLimitInput{Name: testutil.StringPtr("Updated Name")})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Empty(t, emitter.Events(), "failed emits are not captured")
+}
+
+// ── limit.activated ───────────────────────────────────────────────────────────
+
+func TestActivateLimit_EmitsLimitActivated(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	limitID := testutil.MustDeterministicUUID(20)
+	inputLimit := limitFixture(20, 21, model.LimitStatusInactive)
+
+	mockRepo := NewMockLimitRepository(ctrl)
+	auditWriter := NewMockAuditWriter(ctrl)
+	txBeginner := pgdbMocks.NewMockTxBeginner(ctrl)
+	mockTx := pgdbMocks.NewMockTx(ctrl)
+	emitter := pkgStreaming.NewMockEmitter()
+
+	mockRepo.EXPECT().GetByID(gomock.Any(), limitID).Return(inputLimit, nil)
+	expectLimitStatusTxSuccess(t, txBeginner, mockTx, mockRepo, auditWriter,
+		limitID, model.LimitStatusActive, model.AuditEventLimitActivated, model.AuditActionActivate,
+		"Limit activated via API", gomock.Any())
+
+	cmd, err := NewActivateLimitCommand(mockRepo, testutil.NewDefaultMockClock(), auditWriter, txBeginner)
+	require.NoError(t, err)
+	cmd.Streaming = emitter
+
+	result, err := cmd.Execute(context.Background(), limitID)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	emitted := emitter.Events()
+	require.Len(t, emitted, 1)
+	assert.Equal(t, "limit.activated", emitted[0].DefinitionKey)
+	assert.Equal(t, limitID.String(), emitted[0].Subject)
+
+	var payload events.LimitActivatedPayload
+	require.NoError(t, json.Unmarshal(emitted[0].Payload, &payload))
+	assert.Equal(t, limitID.String(), payload.ID)
+	assert.Equal(t, "ACTIVE", payload.Status)
+	assert.NotEmpty(t, payload.UpdatedAt)
+}
+
+func TestActivateLimit_Idempotent_EmitsNothing(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	limitID := testutil.MustDeterministicUUID(20)
+	inputLimit := limitFixture(20, 21, model.LimitStatusActive)
+
+	mockRepo := NewMockLimitRepository(ctrl)
+	auditWriter := NewMockAuditWriter(ctrl)
+	txBeginner := pgdbMocks.NewMockTxBeginner(ctrl)
+	emitter := pkgStreaming.NewMockEmitter()
+
+	mockRepo.EXPECT().GetByID(gomock.Any(), limitID).Return(inputLimit, nil)
+	txBeginner.EXPECT().BeginTx(gomock.Any(), gomock.Any()).Times(0)
+
+	cmd, err := NewActivateLimitCommand(mockRepo, testutil.NewDefaultMockClock(), auditWriter, txBeginner)
+	require.NoError(t, err)
+	cmd.Streaming = emitter
+
+	result, err := cmd.Execute(context.Background(), limitID)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Empty(t, emitter.Events(), "idempotent no-op must not emit")
+}
+
+func TestActivateLimit_NilEmitter_NoPanic(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	limitID := testutil.MustDeterministicUUID(20)
+	inputLimit := limitFixture(20, 21, model.LimitStatusInactive)
+
+	mockRepo := NewMockLimitRepository(ctrl)
+	auditWriter := NewMockAuditWriter(ctrl)
+	txBeginner := pgdbMocks.NewMockTxBeginner(ctrl)
+	mockTx := pgdbMocks.NewMockTx(ctrl)
+
+	mockRepo.EXPECT().GetByID(gomock.Any(), limitID).Return(inputLimit, nil)
+	expectLimitStatusTxSuccess(t, txBeginner, mockTx, mockRepo, auditWriter,
+		limitID, model.LimitStatusActive, model.AuditEventLimitActivated, model.AuditActionActivate,
+		"Limit activated via API", gomock.Any())
+
+	cmd, err := NewActivateLimitCommand(mockRepo, testutil.NewDefaultMockClock(), auditWriter, txBeginner)
+	require.NoError(t, err)
+
+	result, err := cmd.Execute(context.Background(), limitID)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+}
+
+func TestActivateLimit_EmitFailure_RequestStillSucceeds(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	limitID := testutil.MustDeterministicUUID(20)
+	inputLimit := limitFixture(20, 21, model.LimitStatusInactive)
+
+	mockRepo := NewMockLimitRepository(ctrl)
+	auditWriter := NewMockAuditWriter(ctrl)
+	txBeginner := pgdbMocks.NewMockTxBeginner(ctrl)
+	mockTx := pgdbMocks.NewMockTx(ctrl)
+	emitter := pkgStreaming.NewMockEmitter()
+	emitter.SetError(errors.New("broker down"))
+
+	mockRepo.EXPECT().GetByID(gomock.Any(), limitID).Return(inputLimit, nil)
+	expectLimitStatusTxSuccess(t, txBeginner, mockTx, mockRepo, auditWriter,
+		limitID, model.LimitStatusActive, model.AuditEventLimitActivated, model.AuditActionActivate,
+		"Limit activated via API", gomock.Any())
+
+	cmd, err := NewActivateLimitCommand(mockRepo, testutil.NewDefaultMockClock(), auditWriter, txBeginner)
+	require.NoError(t, err)
+	cmd.Streaming = emitter
+
+	result, err := cmd.Execute(context.Background(), limitID)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Empty(t, emitter.Events(), "failed emits are not captured")
+}
+
+// ── limit.deactivated ─────────────────────────────────────────────────────────
+
+func TestDeactivateLimit_EmitsLimitDeactivated(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	limitID := testutil.MustDeterministicUUID(30)
+	inputLimit := limitFixture(30, 31, model.LimitStatusActive)
+
+	mockRepo := NewMockLimitRepository(ctrl)
+	auditWriter := NewMockAuditWriter(ctrl)
+	txBeginner := pgdbMocks.NewMockTxBeginner(ctrl)
+	mockTx := pgdbMocks.NewMockTx(ctrl)
+	emitter := pkgStreaming.NewMockEmitter()
+
+	mockRepo.EXPECT().GetByID(gomock.Any(), limitID).Return(inputLimit, nil)
+	expectLimitStatusTxSuccess(t, txBeginner, mockTx, mockRepo, auditWriter,
+		limitID, model.LimitStatusInactive, model.AuditEventLimitDeactivated, model.AuditActionDeactivate,
+		"Limit deactivated via API", gomock.Any())
+
+	cmd, err := NewDeactivateLimitCommand(mockRepo, testutil.NewDefaultMockClock(), auditWriter, txBeginner)
+	require.NoError(t, err)
+	cmd.Streaming = emitter
+
+	result, err := cmd.Execute(context.Background(), limitID)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	emitted := emitter.Events()
+	require.Len(t, emitted, 1)
+	assert.Equal(t, "limit.deactivated", emitted[0].DefinitionKey)
+	assert.Equal(t, limitID.String(), emitted[0].Subject)
+
+	var payload events.LimitDeactivatedPayload
+	require.NoError(t, json.Unmarshal(emitted[0].Payload, &payload))
+	assert.Equal(t, "INACTIVE", payload.Status)
+	assert.NotEmpty(t, payload.UpdatedAt)
+}
+
+func TestDeactivateLimit_Idempotent_EmitsNothing(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	limitID := testutil.MustDeterministicUUID(30)
+	inputLimit := limitFixture(30, 31, model.LimitStatusInactive)
+
+	mockRepo := NewMockLimitRepository(ctrl)
+	auditWriter := NewMockAuditWriter(ctrl)
+	txBeginner := pgdbMocks.NewMockTxBeginner(ctrl)
+	emitter := pkgStreaming.NewMockEmitter()
+
+	mockRepo.EXPECT().GetByID(gomock.Any(), limitID).Return(inputLimit, nil)
+	txBeginner.EXPECT().BeginTx(gomock.Any(), gomock.Any()).Times(0)
+
+	cmd, err := NewDeactivateLimitCommand(mockRepo, testutil.NewDefaultMockClock(), auditWriter, txBeginner)
+	require.NoError(t, err)
+	cmd.Streaming = emitter
+
+	result, err := cmd.Execute(context.Background(), limitID)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Empty(t, emitter.Events())
+}
+
+func TestDeactivateLimit_EmitFailure_RequestStillSucceeds(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	limitID := testutil.MustDeterministicUUID(30)
+	inputLimit := limitFixture(30, 31, model.LimitStatusActive)
+
+	mockRepo := NewMockLimitRepository(ctrl)
+	auditWriter := NewMockAuditWriter(ctrl)
+	txBeginner := pgdbMocks.NewMockTxBeginner(ctrl)
+	mockTx := pgdbMocks.NewMockTx(ctrl)
+	emitter := pkgStreaming.NewMockEmitter()
+	emitter.SetError(errors.New("broker down"))
+
+	mockRepo.EXPECT().GetByID(gomock.Any(), limitID).Return(inputLimit, nil)
+	expectLimitStatusTxSuccess(t, txBeginner, mockTx, mockRepo, auditWriter,
+		limitID, model.LimitStatusInactive, model.AuditEventLimitDeactivated, model.AuditActionDeactivate,
+		"Limit deactivated via API", gomock.Any())
+
+	cmd, err := NewDeactivateLimitCommand(mockRepo, testutil.NewDefaultMockClock(), auditWriter, txBeginner)
+	require.NoError(t, err)
+	cmd.Streaming = emitter
+
+	result, err := cmd.Execute(context.Background(), limitID)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Empty(t, emitter.Events(), "failed emits are not captured")
+}
+
+// ── limit.drafted ─────────────────────────────────────────────────────────────
+
+func TestDraftLimit_EmitsLimitDrafted(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	limitID := testutil.MustDeterministicUUID(40)
+	inputLimit := limitFixture(40, 41, model.LimitStatusInactive)
+
+	mockRepo := NewMockLimitRepository(ctrl)
+	auditWriter := NewMockAuditWriter(ctrl)
+	txBeginner := pgdbMocks.NewMockTxBeginner(ctrl)
+	mockTx := pgdbMocks.NewMockTx(ctrl)
+	emitter := pkgStreaming.NewMockEmitter()
+
+	mockRepo.EXPECT().GetByID(gomock.Any(), limitID).Return(inputLimit, nil)
+	expectLimitStatusTxSuccess(t, txBeginner, mockTx, mockRepo, auditWriter,
+		limitID, model.LimitStatusDraft, model.AuditEventLimitDrafted, model.AuditActionDraft,
+		"Limit transitioned to draft via API", gomock.Any())
+
+	cmd, err := NewDraftLimitCommand(mockRepo, testutil.NewDefaultMockClock(), auditWriter, txBeginner)
+	require.NoError(t, err)
+	cmd.Streaming = emitter
+
+	result, err := cmd.Execute(context.Background(), limitID)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	emitted := emitter.Events()
+	require.Len(t, emitted, 1)
+	assert.Equal(t, "limit.drafted", emitted[0].DefinitionKey)
+	assert.Equal(t, limitID.String(), emitted[0].Subject)
+
+	var payload events.LimitDraftedPayload
+	require.NoError(t, json.Unmarshal(emitted[0].Payload, &payload))
+	assert.Equal(t, "DRAFT", payload.Status)
+	assert.NotEmpty(t, payload.UpdatedAt)
+}
+
+func TestDraftLimit_Idempotent_EmitsNothing(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	limitID := testutil.MustDeterministicUUID(40)
+	inputLimit := limitFixture(40, 41, model.LimitStatusDraft)
+
+	mockRepo := NewMockLimitRepository(ctrl)
+	auditWriter := NewMockAuditWriter(ctrl)
+	txBeginner := pgdbMocks.NewMockTxBeginner(ctrl)
+	emitter := pkgStreaming.NewMockEmitter()
+
+	mockRepo.EXPECT().GetByID(gomock.Any(), limitID).Return(inputLimit, nil)
+	txBeginner.EXPECT().BeginTx(gomock.Any(), gomock.Any()).Times(0)
+
+	cmd, err := NewDraftLimitCommand(mockRepo, testutil.NewDefaultMockClock(), auditWriter, txBeginner)
+	require.NoError(t, err)
+	cmd.Streaming = emitter
+
+	result, err := cmd.Execute(context.Background(), limitID)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Empty(t, emitter.Events())
+}
+
+func TestDraftLimit_EmitFailure_RequestStillSucceeds(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	limitID := testutil.MustDeterministicUUID(40)
+	inputLimit := limitFixture(40, 41, model.LimitStatusInactive)
+
+	mockRepo := NewMockLimitRepository(ctrl)
+	auditWriter := NewMockAuditWriter(ctrl)
+	txBeginner := pgdbMocks.NewMockTxBeginner(ctrl)
+	mockTx := pgdbMocks.NewMockTx(ctrl)
+	emitter := pkgStreaming.NewMockEmitter()
+	emitter.SetError(errors.New("broker down"))
+
+	mockRepo.EXPECT().GetByID(gomock.Any(), limitID).Return(inputLimit, nil)
+	expectLimitStatusTxSuccess(t, txBeginner, mockTx, mockRepo, auditWriter,
+		limitID, model.LimitStatusDraft, model.AuditEventLimitDrafted, model.AuditActionDraft,
+		"Limit transitioned to draft via API", gomock.Any())
+
+	cmd, err := NewDraftLimitCommand(mockRepo, testutil.NewDefaultMockClock(), auditWriter, txBeginner)
+	require.NoError(t, err)
+	cmd.Streaming = emitter
+
+	result, err := cmd.Execute(context.Background(), limitID)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Empty(t, emitter.Events(), "failed emits are not captured")
+}
+
+// ── limit.deleted ─────────────────────────────────────────────────────────────
+
+func TestDeleteLimit_EmitsLimitDeleted(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	limitID := testutil.MustDeterministicUUID(50)
+	inputLimit := limitFixture(50, 51, model.LimitStatusInactive)
+
+	mockRepo := NewMockLimitRepository(ctrl)
+	auditWriter := NewMockAuditWriter(ctrl)
+	txBeginner := pgdbMocks.NewMockTxBeginner(ctrl)
+	mockTx := pgdbMocks.NewMockTx(ctrl)
+	emitter := pkgStreaming.NewMockEmitter()
+
+	mockRepo.EXPECT().GetByID(gomock.Any(), limitID).Return(inputLimit, nil)
+	expectLimitStatusTxSuccess(t, txBeginner, mockTx, mockRepo, auditWriter,
+		limitID, model.LimitStatusDeleted, model.AuditEventLimitDeleted, model.AuditActionDelete,
+		"Limit deleted via API", gomock.Nil())
+
+	cmd, err := NewDeleteLimitCommand(mockRepo, testutil.NewDefaultMockClock(), auditWriter, txBeginner)
+	require.NoError(t, err)
+	cmd.Streaming = emitter
+
+	err = cmd.Execute(context.Background(), limitID)
+	require.NoError(t, err)
+
+	emitted := emitter.Events()
+	require.Len(t, emitted, 1)
+	assert.Equal(t, "limit.deleted", emitted[0].DefinitionKey)
+	assert.Equal(t, limitID.String(), emitted[0].Subject)
+
+	var payload events.LimitDeletedPayload
+	require.NoError(t, json.Unmarshal(emitted[0].Payload, &payload))
+	assert.Equal(t, limitID.String(), payload.ID)
+	// Fixed clock: SetStatus(DELETED) stamps DeletedAt at the clock time.
+	assert.Equal(t, testutil.FixedTime().Format("2006-01-02T15:04:05Z07:00"), payload.DeletedAt)
+}
+
+func TestDeleteLimit_Idempotent_EmitsNothing(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	limitID := testutil.MustDeterministicUUID(50)
+	inputLimit := limitFixture(50, 51, model.LimitStatusDeleted)
+
+	mockRepo := NewMockLimitRepository(ctrl)
+	auditWriter := NewMockAuditWriter(ctrl)
+	txBeginner := pgdbMocks.NewMockTxBeginner(ctrl)
+	emitter := pkgStreaming.NewMockEmitter()
+
+	mockRepo.EXPECT().GetByID(gomock.Any(), limitID).Return(inputLimit, nil)
+	txBeginner.EXPECT().BeginTx(gomock.Any(), gomock.Any()).Times(0)
+
+	cmd, err := NewDeleteLimitCommand(mockRepo, testutil.NewDefaultMockClock(), auditWriter, txBeginner)
+	require.NoError(t, err)
+	cmd.Streaming = emitter
+
+	err = cmd.Execute(context.Background(), limitID)
+	require.NoError(t, err)
+	assert.Empty(t, emitter.Events())
+}
+
+func TestDeleteLimit_NilEmitter_NoPanic(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	limitID := testutil.MustDeterministicUUID(50)
+	inputLimit := limitFixture(50, 51, model.LimitStatusInactive)
+
+	mockRepo := NewMockLimitRepository(ctrl)
+	auditWriter := NewMockAuditWriter(ctrl)
+	txBeginner := pgdbMocks.NewMockTxBeginner(ctrl)
+	mockTx := pgdbMocks.NewMockTx(ctrl)
+
+	mockRepo.EXPECT().GetByID(gomock.Any(), limitID).Return(inputLimit, nil)
+	expectLimitStatusTxSuccess(t, txBeginner, mockTx, mockRepo, auditWriter,
+		limitID, model.LimitStatusDeleted, model.AuditEventLimitDeleted, model.AuditActionDelete,
+		"Limit deleted via API", gomock.Nil())
+
+	cmd, err := NewDeleteLimitCommand(mockRepo, testutil.NewDefaultMockClock(), auditWriter, txBeginner)
+	require.NoError(t, err)
+
+	err = cmd.Execute(context.Background(), limitID)
+	require.NoError(t, err)
+}
+
+func TestDeleteLimit_EmitFailure_RequestStillSucceeds(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	limitID := testutil.MustDeterministicUUID(50)
+	inputLimit := limitFixture(50, 51, model.LimitStatusInactive)
+
+	mockRepo := NewMockLimitRepository(ctrl)
+	auditWriter := NewMockAuditWriter(ctrl)
+	txBeginner := pgdbMocks.NewMockTxBeginner(ctrl)
+	mockTx := pgdbMocks.NewMockTx(ctrl)
+	emitter := pkgStreaming.NewMockEmitter()
+	emitter.SetError(errors.New("broker down"))
+
+	mockRepo.EXPECT().GetByID(gomock.Any(), limitID).Return(inputLimit, nil)
+	expectLimitStatusTxSuccess(t, txBeginner, mockTx, mockRepo, auditWriter,
+		limitID, model.LimitStatusDeleted, model.AuditEventLimitDeleted, model.AuditActionDelete,
+		"Limit deleted via API", gomock.Nil())
+
+	cmd, err := NewDeleteLimitCommand(mockRepo, testutil.NewDefaultMockClock(), auditWriter, txBeginner)
+	require.NoError(t, err)
+	cmd.Streaming = emitter
+
+	err = cmd.Execute(context.Background(), limitID)
+	require.NoError(t, err)
+	assert.Empty(t, emitter.Events(), "failed emits are not captured")
+}

--- a/components/tracer/internal/services/command/rule_streaming_test.go
+++ b/components/tracer/internal/services/command/rule_streaming_test.go
@@ -1,0 +1,693 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package command
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	libStreaming "github.com/LerianStudio/lib-streaming"
+
+	pgdbMocks "github.com/LerianStudio/midaz/v4/components/tracer/internal/adapters/postgres/db/mocks"
+	"github.com/LerianStudio/midaz/v4/components/tracer/internal/testutil"
+	"github.com/LerianStudio/midaz/v4/components/tracer/pkg/model"
+	pkgStreaming "github.com/LerianStudio/midaz/v4/pkg/streaming"
+	"github.com/LerianStudio/midaz/v4/pkg/streaming/events"
+)
+
+// draftRuleFixture builds an INACTIVE rule usable as the pre-transition state
+// for activate/deactivate/draft/delete streaming tests. Times come from the
+// fixed test clock, never time.Now().
+func inactiveRuleFixture(id, seed int64) *model.Rule {
+	ruleID := testutil.MustDeterministicUUID(id)
+	return &model.Rule{
+		ID:         ruleID,
+		Name:       "Streaming Rule",
+		Status:     model.RuleStatusInactive,
+		Expression: "amount > 1000",
+		Action:     model.DecisionDeny,
+		Scopes: []model.Scope{
+			{AccountID: testutil.UUIDPtr(testutil.MustDeterministicUUID(seed))},
+		},
+		CreatedAt: testutil.FixedTime(),
+		UpdatedAt: testutil.FixedTime(),
+	}
+}
+
+// ── rule.created ────────────────────────────────────────────────────────────
+
+func TestCreateRule_EmitsRuleCreated(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	mockRepo := NewMockRuleRepository(ctrl)
+	mockCEL := NewMockExpressionCompiler(ctrl)
+	auditWriter := NewMockAuditWriter(ctrl)
+	txBeginner := pgdbMocks.NewMockTxBeginner(ctrl)
+	mockTx := pgdbMocks.NewMockTx(ctrl)
+	emitter := pkgStreaming.NewMockEmitter()
+
+	mockCEL.EXPECT().Compile(gomock.Any(), "amount > 1000000").Return(nil, nil)
+	expectRuleCreateTxSuccess(t, txBeginner, mockTx, mockRepo, auditWriter,
+		model.AuditEventRuleCreated, model.AuditActionCreate, "Rule created via API")
+
+	cmd, err := NewCreateRuleCommand(mockRepo, mockCEL, testutil.NewDefaultMockClock(), auditWriter, txBeginner)
+	require.NoError(t, err)
+	cmd.Streaming = emitter
+
+	input := &CreateRuleInput{
+		Name:        "High Value Transaction Rule",
+		Description: "Blocks transactions over $10,000",
+		Expression:  "amount > 1000000",
+		Action:      model.DecisionDeny,
+		Scopes:      []model.Scope{{AccountID: testutil.UUIDPtr(testutil.MustDeterministicUUID(1))}},
+	}
+
+	result, err := cmd.Execute(context.Background(), input)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	emitted := emitter.Events()
+	require.Len(t, emitted, 1)
+	assert.Equal(t, "rule.created", emitted[0].DefinitionKey)
+	assert.Equal(t, result.ID.String(), emitted[0].Subject)
+
+	var payload events.RuleCreatedPayload
+	require.NoError(t, json.Unmarshal(emitted[0].Payload, &payload))
+	assert.Equal(t, result.ID.String(), payload.ID)
+	assert.Equal(t, "DRAFT", payload.Status)
+	assert.Equal(t, "DENY", payload.Action)
+	require.Len(t, payload.Scopes, 1)
+
+	// Fence: free-text / rule-logic keys must never appear on the wire.
+	assertRuleFenceClean(t, emitted[0].Payload)
+}
+
+func TestCreateRule_NilEmitter_NoEmit_NoPanic(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	mockRepo := NewMockRuleRepository(ctrl)
+	mockCEL := NewMockExpressionCompiler(ctrl)
+	auditWriter := NewMockAuditWriter(ctrl)
+	txBeginner := pgdbMocks.NewMockTxBeginner(ctrl)
+	mockTx := pgdbMocks.NewMockTx(ctrl)
+
+	mockCEL.EXPECT().Compile(gomock.Any(), "amount > 1000000").Return(nil, nil)
+	expectRuleCreateTxSuccess(t, txBeginner, mockTx, mockRepo, auditWriter,
+		model.AuditEventRuleCreated, model.AuditActionCreate, "Rule created via API")
+
+	cmd, err := NewCreateRuleCommand(mockRepo, mockCEL, testutil.NewDefaultMockClock(), auditWriter, txBeginner)
+	require.NoError(t, err)
+	// Streaming left nil.
+
+	input := &CreateRuleInput{
+		Name:       "Global Rule",
+		Expression: "amount > 1000000",
+		Action:     model.DecisionDeny,
+	}
+
+	result, err := cmd.Execute(context.Background(), input)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+}
+
+func TestCreateRule_NoopEmitter_Succeeds(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	mockRepo := NewMockRuleRepository(ctrl)
+	mockCEL := NewMockExpressionCompiler(ctrl)
+	auditWriter := NewMockAuditWriter(ctrl)
+	txBeginner := pgdbMocks.NewMockTxBeginner(ctrl)
+	mockTx := pgdbMocks.NewMockTx(ctrl)
+
+	mockCEL.EXPECT().Compile(gomock.Any(), "amount > 1000000").Return(nil, nil)
+	expectRuleCreateTxSuccess(t, txBeginner, mockTx, mockRepo, auditWriter,
+		model.AuditEventRuleCreated, model.AuditActionCreate, "Rule created via API")
+
+	cmd, err := NewCreateRuleCommand(mockRepo, mockCEL, testutil.NewDefaultMockClock(), auditWriter, txBeginner)
+	require.NoError(t, err)
+	cmd.Streaming = libStreaming.NewNoopEmitter()
+
+	input := &CreateRuleInput{Name: "Global Rule", Expression: "amount > 1000000", Action: model.DecisionDeny}
+
+	result, err := cmd.Execute(context.Background(), input)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+}
+
+func TestCreateRule_EmitFailure_RequestStillSucceeds(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	mockRepo := NewMockRuleRepository(ctrl)
+	mockCEL := NewMockExpressionCompiler(ctrl)
+	auditWriter := NewMockAuditWriter(ctrl)
+	txBeginner := pgdbMocks.NewMockTxBeginner(ctrl)
+	mockTx := pgdbMocks.NewMockTx(ctrl)
+	emitter := pkgStreaming.NewMockEmitter()
+	emitter.SetError(errors.New("broker down"))
+
+	mockCEL.EXPECT().Compile(gomock.Any(), "amount > 1000000").Return(nil, nil)
+	expectRuleCreateTxSuccess(t, txBeginner, mockTx, mockRepo, auditWriter,
+		model.AuditEventRuleCreated, model.AuditActionCreate, "Rule created via API")
+
+	cmd, err := NewCreateRuleCommand(mockRepo, mockCEL, testutil.NewDefaultMockClock(), auditWriter, txBeginner)
+	require.NoError(t, err)
+	cmd.Streaming = emitter
+
+	input := &CreateRuleInput{Name: "Global Rule", Expression: "amount > 1000000", Action: model.DecisionDeny}
+
+	result, err := cmd.Execute(context.Background(), input)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Empty(t, emitter.Events(), "failed emits are not captured")
+}
+
+// ── rule.updated ────────────────────────────────────────────────────────────
+
+func TestUpdateRule_EmitsRuleUpdated(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	ruleID := testutil.MustDeterministicUUID(10)
+	existing := &model.Rule{
+		ID:         ruleID,
+		Name:       "existing rule",
+		Expression: "amount > 1000",
+		Action:     model.DecisionDeny,
+		Status:     model.RuleStatusDraft,
+		CreatedAt:  testutil.FixedTime(),
+		UpdatedAt:  testutil.FixedTime(),
+	}
+
+	mockRepo := NewMockRuleRepository(ctrl)
+	mockCEL := NewMockExpressionCompiler(ctrl)
+	auditWriter := NewMockAuditWriter(ctrl)
+	txBeginner := pgdbMocks.NewMockTxBeginner(ctrl)
+	mockTx := pgdbMocks.NewMockTx(ctrl)
+	emitter := pkgStreaming.NewMockEmitter()
+
+	mockRepo.EXPECT().GetByID(gomock.Any(), ruleID).Return(existing, nil)
+	expectRuleUpdateTxSuccess(t, txBeginner, mockTx, mockRepo, auditWriter,
+		ruleID, model.AuditEventRuleUpdated, model.AuditActionUpdate, "Rule updated via API")
+
+	cmd, err := NewUpdateRuleCommand(mockRepo, mockCEL, testutil.NewDefaultMockClock(), auditWriter, txBeginner)
+	require.NoError(t, err)
+	cmd.Streaming = emitter
+
+	result, err := cmd.Execute(context.Background(), ruleID, &UpdateRuleInput{Name: testutil.StringPtr("Updated Name")})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	emitted := emitter.Events()
+	require.Len(t, emitted, 1)
+	assert.Equal(t, "rule.updated", emitted[0].DefinitionKey)
+	assert.Equal(t, ruleID.String(), emitted[0].Subject)
+
+	var payload events.RuleUpdatedPayload
+	require.NoError(t, json.Unmarshal(emitted[0].Payload, &payload))
+	assert.Equal(t, ruleID.String(), payload.ID)
+	assert.Equal(t, "DRAFT", payload.Status)
+	assert.Equal(t, testutil.FixedTime().Format("2006-01-02T15:04:05Z07:00"), payload.UpdatedAt)
+	assertRuleFenceClean(t, emitted[0].Payload)
+}
+
+func TestUpdateRule_NilEmitter_NoPanic(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	ruleID := testutil.MustDeterministicUUID(10)
+	existing := &model.Rule{
+		ID: ruleID, Name: "existing rule", Expression: "amount > 1000",
+		Action: model.DecisionDeny, Status: model.RuleStatusDraft,
+		CreatedAt: testutil.FixedTime(), UpdatedAt: testutil.FixedTime(),
+	}
+
+	mockRepo := NewMockRuleRepository(ctrl)
+	mockCEL := NewMockExpressionCompiler(ctrl)
+	auditWriter := NewMockAuditWriter(ctrl)
+	txBeginner := pgdbMocks.NewMockTxBeginner(ctrl)
+	mockTx := pgdbMocks.NewMockTx(ctrl)
+
+	mockRepo.EXPECT().GetByID(gomock.Any(), ruleID).Return(existing, nil)
+	expectRuleUpdateTxSuccess(t, txBeginner, mockTx, mockRepo, auditWriter,
+		ruleID, model.AuditEventRuleUpdated, model.AuditActionUpdate, "Rule updated via API")
+
+	cmd, err := NewUpdateRuleCommand(mockRepo, mockCEL, testutil.NewDefaultMockClock(), auditWriter, txBeginner)
+	require.NoError(t, err)
+
+	result, err := cmd.Execute(context.Background(), ruleID, &UpdateRuleInput{Name: testutil.StringPtr("Updated Name")})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+}
+
+func TestUpdateRule_EmitFailure_RequestStillSucceeds(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	ruleID := testutil.MustDeterministicUUID(10)
+	existing := &model.Rule{
+		ID: ruleID, Name: "existing rule", Expression: "amount > 1000",
+		Action: model.DecisionDeny, Status: model.RuleStatusDraft,
+		CreatedAt: testutil.FixedTime(), UpdatedAt: testutil.FixedTime(),
+	}
+
+	mockRepo := NewMockRuleRepository(ctrl)
+	mockCEL := NewMockExpressionCompiler(ctrl)
+	auditWriter := NewMockAuditWriter(ctrl)
+	txBeginner := pgdbMocks.NewMockTxBeginner(ctrl)
+	mockTx := pgdbMocks.NewMockTx(ctrl)
+	emitter := pkgStreaming.NewMockEmitter()
+	emitter.SetError(errors.New("broker down"))
+
+	mockRepo.EXPECT().GetByID(gomock.Any(), ruleID).Return(existing, nil)
+	expectRuleUpdateTxSuccess(t, txBeginner, mockTx, mockRepo, auditWriter,
+		ruleID, model.AuditEventRuleUpdated, model.AuditActionUpdate, "Rule updated via API")
+
+	cmd, err := NewUpdateRuleCommand(mockRepo, mockCEL, testutil.NewDefaultMockClock(), auditWriter, txBeginner)
+	require.NoError(t, err)
+	cmd.Streaming = emitter
+
+	result, err := cmd.Execute(context.Background(), ruleID, &UpdateRuleInput{Name: testutil.StringPtr("Updated Name")})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Empty(t, emitter.Events(), "failed emits are not captured")
+}
+
+// ── rule.activated ──────────────────────────────────────────────────────────
+
+func TestActivateRule_EmitsRuleActivated(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	ruleID := testutil.MustDeterministicUUID(20)
+	inputRule := &model.Rule{
+		ID: ruleID, Name: "Test Rule", Status: model.RuleStatusDraft,
+		Expression: "amount > 1000", Action: model.DecisionDeny,
+		CreatedAt: testutil.FixedTime(), UpdatedAt: testutil.FixedTime(),
+	}
+
+	mockRepo := NewMockRuleRepository(ctrl)
+	mockExprCompiler := NewMockExpressionCompiler(ctrl)
+	auditWriter := NewMockAuditWriter(ctrl)
+	txBeginner := pgdbMocks.NewMockTxBeginner(ctrl)
+	mockTx := pgdbMocks.NewMockTx(ctrl)
+	emitter := pkgStreaming.NewMockEmitter()
+
+	mockRepo.EXPECT().GetByID(gomock.Any(), ruleID).Return(inputRule, nil)
+	mockExprCompiler.EXPECT().Compile(gomock.Any(), inputRule.Expression).Return(struct{}{}, nil)
+	expectRuleUpdateTxSuccess(t, txBeginner, mockTx, mockRepo, auditWriter,
+		ruleID, model.AuditEventRuleActivated, model.AuditActionActivate, "Rule activated via API")
+
+	service, err := NewActivateRuleService(mockRepo, mockExprCompiler, testutil.NewDefaultMockClock(), auditWriter, nil, txBeginner)
+	require.NoError(t, err)
+	service.Streaming = emitter
+
+	result, err := service.Execute(context.Background(), ruleID)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	emitted := emitter.Events()
+	require.Len(t, emitted, 1)
+	assert.Equal(t, "rule.activated", emitted[0].DefinitionKey)
+	assert.Equal(t, ruleID.String(), emitted[0].Subject)
+
+	var payload events.RuleActivatedPayload
+	require.NoError(t, json.Unmarshal(emitted[0].Payload, &payload))
+	assert.Equal(t, ruleID.String(), payload.ID)
+	assert.Equal(t, "ACTIVE", payload.Status)
+	require.NotNil(t, payload.ActivatedAt, "activatedAt populated after a real transition")
+}
+
+func TestActivateRule_Idempotent_EmitsNothing(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	ruleID := testutil.MustDeterministicUUID(20)
+	inputRule := &model.Rule{
+		ID: ruleID, Name: "Test Rule", Status: model.RuleStatusActive,
+		Expression: "amount > 1000", Action: model.DecisionDeny,
+		CreatedAt: testutil.FixedTime(), UpdatedAt: testutil.FixedTime(),
+	}
+
+	mockRepo := NewMockRuleRepository(ctrl)
+	mockExprCompiler := NewMockExpressionCompiler(ctrl)
+	auditWriter := NewMockAuditWriter(ctrl)
+	txBeginner := pgdbMocks.NewMockTxBeginner(ctrl)
+	emitter := pkgStreaming.NewMockEmitter()
+
+	mockRepo.EXPECT().GetByID(gomock.Any(), ruleID).Return(inputRule, nil)
+	txBeginner.EXPECT().BeginTx(gomock.Any(), gomock.Any()).Times(0)
+
+	service, err := NewActivateRuleService(mockRepo, mockExprCompiler, testutil.NewDefaultMockClock(), auditWriter, nil, txBeginner)
+	require.NoError(t, err)
+	service.Streaming = emitter
+
+	result, err := service.Execute(context.Background(), ruleID)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Empty(t, emitter.Events(), "idempotent no-op must not emit")
+}
+
+func TestActivateRule_EmitFailure_RequestStillSucceeds(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	ruleID := testutil.MustDeterministicUUID(20)
+	inputRule := &model.Rule{
+		ID: ruleID, Name: "Test Rule", Status: model.RuleStatusDraft,
+		Expression: "amount > 1000", Action: model.DecisionDeny,
+		CreatedAt: testutil.FixedTime(), UpdatedAt: testutil.FixedTime(),
+	}
+
+	mockRepo := NewMockRuleRepository(ctrl)
+	mockExprCompiler := NewMockExpressionCompiler(ctrl)
+	auditWriter := NewMockAuditWriter(ctrl)
+	txBeginner := pgdbMocks.NewMockTxBeginner(ctrl)
+	mockTx := pgdbMocks.NewMockTx(ctrl)
+	emitter := pkgStreaming.NewMockEmitter()
+	emitter.SetError(errors.New("broker down"))
+
+	mockRepo.EXPECT().GetByID(gomock.Any(), ruleID).Return(inputRule, nil)
+	mockExprCompiler.EXPECT().Compile(gomock.Any(), inputRule.Expression).Return(struct{}{}, nil)
+	expectRuleUpdateTxSuccess(t, txBeginner, mockTx, mockRepo, auditWriter,
+		ruleID, model.AuditEventRuleActivated, model.AuditActionActivate, "Rule activated via API")
+
+	service, err := NewActivateRuleService(mockRepo, mockExprCompiler, testutil.NewDefaultMockClock(), auditWriter, nil, txBeginner)
+	require.NoError(t, err)
+	service.Streaming = emitter
+
+	result, err := service.Execute(context.Background(), ruleID)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Empty(t, emitter.Events(), "failed emits are not captured")
+}
+
+// ── rule.deactivated ────────────────────────────────────────────────────────
+
+func TestDeactivateRule_EmitsRuleDeactivated(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	ruleID := testutil.MustDeterministicUUID(30)
+	inputRule := &model.Rule{
+		ID: ruleID, Name: "Test Rule", Status: model.RuleStatusActive,
+		Expression: "amount > 1000", Action: model.DecisionDeny,
+		CreatedAt: testutil.FixedTime(), UpdatedAt: testutil.FixedTime(),
+	}
+
+	mockRepo := NewMockRuleRepository(ctrl)
+	auditWriter := NewMockAuditWriter(ctrl)
+	txBeginner := pgdbMocks.NewMockTxBeginner(ctrl)
+	mockTx := pgdbMocks.NewMockTx(ctrl)
+	emitter := pkgStreaming.NewMockEmitter()
+
+	mockRepo.EXPECT().GetByID(gomock.Any(), ruleID).Return(inputRule, nil)
+	expectRuleUpdateTxSuccess(t, txBeginner, mockTx, mockRepo, auditWriter,
+		ruleID, model.AuditEventRuleDeactivated, model.AuditActionDeactivate, "Rule deactivated via API")
+
+	service, err := NewDeactivateRuleService(mockRepo, testutil.NewDefaultMockClock(), auditWriter, nil, txBeginner)
+	require.NoError(t, err)
+	service.Streaming = emitter
+
+	result, err := service.Execute(context.Background(), ruleID)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	emitted := emitter.Events()
+	require.Len(t, emitted, 1)
+	assert.Equal(t, "rule.deactivated", emitted[0].DefinitionKey)
+	assert.Equal(t, ruleID.String(), emitted[0].Subject)
+
+	var payload events.RuleDeactivatedPayload
+	require.NoError(t, json.Unmarshal(emitted[0].Payload, &payload))
+	assert.Equal(t, "INACTIVE", payload.Status)
+	require.NotNil(t, payload.DeactivatedAt)
+}
+
+func TestDeactivateRule_Idempotent_EmitsNothing(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	ruleID := testutil.MustDeterministicUUID(30)
+	inputRule := &model.Rule{
+		ID: ruleID, Name: "Test Rule", Status: model.RuleStatusInactive,
+		Expression: "amount > 1000", Action: model.DecisionDeny,
+		CreatedAt: testutil.FixedTime(), UpdatedAt: testutil.FixedTime(),
+	}
+
+	mockRepo := NewMockRuleRepository(ctrl)
+	auditWriter := NewMockAuditWriter(ctrl)
+	txBeginner := pgdbMocks.NewMockTxBeginner(ctrl)
+	emitter := pkgStreaming.NewMockEmitter()
+
+	mockRepo.EXPECT().GetByID(gomock.Any(), ruleID).Return(inputRule, nil)
+	txBeginner.EXPECT().BeginTx(gomock.Any(), gomock.Any()).Times(0)
+
+	service, err := NewDeactivateRuleService(mockRepo, testutil.NewDefaultMockClock(), auditWriter, nil, txBeginner)
+	require.NoError(t, err)
+	service.Streaming = emitter
+
+	result, err := service.Execute(context.Background(), ruleID)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Empty(t, emitter.Events())
+}
+
+func TestDeactivateRule_EmitFailure_RequestStillSucceeds(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	ruleID := testutil.MustDeterministicUUID(30)
+	inputRule := &model.Rule{
+		ID: ruleID, Name: "Test Rule", Status: model.RuleStatusActive,
+		Expression: "amount > 1000", Action: model.DecisionDeny,
+		CreatedAt: testutil.FixedTime(), UpdatedAt: testutil.FixedTime(),
+	}
+
+	mockRepo := NewMockRuleRepository(ctrl)
+	auditWriter := NewMockAuditWriter(ctrl)
+	txBeginner := pgdbMocks.NewMockTxBeginner(ctrl)
+	mockTx := pgdbMocks.NewMockTx(ctrl)
+	emitter := pkgStreaming.NewMockEmitter()
+	emitter.SetError(errors.New("broker down"))
+
+	mockRepo.EXPECT().GetByID(gomock.Any(), ruleID).Return(inputRule, nil)
+	expectRuleUpdateTxSuccess(t, txBeginner, mockTx, mockRepo, auditWriter,
+		ruleID, model.AuditEventRuleDeactivated, model.AuditActionDeactivate, "Rule deactivated via API")
+
+	service, err := NewDeactivateRuleService(mockRepo, testutil.NewDefaultMockClock(), auditWriter, nil, txBeginner)
+	require.NoError(t, err)
+	service.Streaming = emitter
+
+	result, err := service.Execute(context.Background(), ruleID)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Empty(t, emitter.Events(), "failed emits are not captured")
+}
+
+// ── rule.drafted ────────────────────────────────────────────────────────────
+
+func TestDraftRule_EmitsRuleDrafted(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	ruleID := testutil.MustDeterministicUUID(40)
+	inputRule := inactiveRuleFixture(40, 41)
+
+	mockRepo := NewMockRuleRepository(ctrl)
+	auditWriter := NewMockAuditWriter(ctrl)
+	txBeginner := pgdbMocks.NewMockTxBeginner(ctrl)
+	mockTx := pgdbMocks.NewMockTx(ctrl)
+	emitter := pkgStreaming.NewMockEmitter()
+
+	mockRepo.EXPECT().GetByID(gomock.Any(), ruleID).Return(inputRule, nil)
+	expectRuleUpdateTxSuccess(t, txBeginner, mockTx, mockRepo, auditWriter,
+		ruleID, model.AuditEventRuleDrafted, model.AuditActionDraft, "Rule transitioned to draft via API")
+
+	service, err := NewDraftRuleService(mockRepo, testutil.NewDefaultMockClock(), auditWriter, txBeginner)
+	require.NoError(t, err)
+	service.Streaming = emitter
+
+	result, err := service.Execute(context.Background(), ruleID)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	emitted := emitter.Events()
+	require.Len(t, emitted, 1)
+	assert.Equal(t, "rule.drafted", emitted[0].DefinitionKey)
+	assert.Equal(t, ruleID.String(), emitted[0].Subject)
+
+	var payload events.RuleDraftedPayload
+	require.NoError(t, json.Unmarshal(emitted[0].Payload, &payload))
+	assert.Equal(t, "DRAFT", payload.Status)
+}
+
+func TestDraftRule_Idempotent_EmitsNothing(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	ruleID := testutil.MustDeterministicUUID(40)
+	inputRule := &model.Rule{
+		ID: ruleID, Name: "Test Rule", Status: model.RuleStatusDraft,
+		Expression: "amount > 1000", Action: model.DecisionDeny,
+		CreatedAt: testutil.FixedTime(), UpdatedAt: testutil.FixedTime(),
+	}
+
+	mockRepo := NewMockRuleRepository(ctrl)
+	auditWriter := NewMockAuditWriter(ctrl)
+	txBeginner := pgdbMocks.NewMockTxBeginner(ctrl)
+	emitter := pkgStreaming.NewMockEmitter()
+
+	mockRepo.EXPECT().GetByID(gomock.Any(), ruleID).Return(inputRule, nil)
+	txBeginner.EXPECT().BeginTx(gomock.Any(), gomock.Any()).Times(0)
+
+	service, err := NewDraftRuleService(mockRepo, testutil.NewDefaultMockClock(), auditWriter, txBeginner)
+	require.NoError(t, err)
+	service.Streaming = emitter
+
+	result, err := service.Execute(context.Background(), ruleID)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Empty(t, emitter.Events())
+}
+
+func TestDraftRule_EmitFailure_RequestStillSucceeds(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	ruleID := testutil.MustDeterministicUUID(40)
+	inputRule := inactiveRuleFixture(40, 41)
+
+	mockRepo := NewMockRuleRepository(ctrl)
+	auditWriter := NewMockAuditWriter(ctrl)
+	txBeginner := pgdbMocks.NewMockTxBeginner(ctrl)
+	mockTx := pgdbMocks.NewMockTx(ctrl)
+	emitter := pkgStreaming.NewMockEmitter()
+	emitter.SetError(errors.New("broker down"))
+
+	mockRepo.EXPECT().GetByID(gomock.Any(), ruleID).Return(inputRule, nil)
+	expectRuleUpdateTxSuccess(t, txBeginner, mockTx, mockRepo, auditWriter,
+		ruleID, model.AuditEventRuleDrafted, model.AuditActionDraft, "Rule transitioned to draft via API")
+
+	service, err := NewDraftRuleService(mockRepo, testutil.NewDefaultMockClock(), auditWriter, txBeginner)
+	require.NoError(t, err)
+	service.Streaming = emitter
+
+	result, err := service.Execute(context.Background(), ruleID)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Empty(t, emitter.Events(), "failed emits are not captured")
+}
+
+// ── rule.deleted ────────────────────────────────────────────────────────────
+
+func TestDeleteRule_EmitsRuleDeleted(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	ruleID := testutil.MustDeterministicUUID(50)
+	rule := &model.Rule{
+		ID: ruleID, Name: "Test Rule", Status: model.RuleStatusInactive,
+		Expression: "amount > 1000",
+	}
+
+	mockRepo := NewMockRuleRepository(ctrl)
+	auditWriter := NewMockAuditWriter(ctrl)
+	txBeginner := pgdbMocks.NewMockTxBeginner(ctrl)
+	mockTx := pgdbMocks.NewMockTx(ctrl)
+	emitter := pkgStreaming.NewMockEmitter()
+
+	mockRepo.EXPECT().GetByID(gomock.Any(), ruleID).Return(rule, nil)
+	gomock.InOrder(
+		txBeginner.EXPECT().BeginTx(gomock.Any(), nil).Return(mockTx, nil),
+		mockRepo.EXPECT().DeleteWithTx(gomock.Any(), gomock.AssignableToTypeOf(mockTx), ruleID).Return(nil),
+		auditWriter.EXPECT().RecordRuleEventWithTx(
+			gomock.Any(), gomock.AssignableToTypeOf(mockTx),
+			model.AuditEventRuleDeleted, model.AuditActionDelete, ruleID,
+			gomock.Any(), gomock.Nil(), "Rule deleted via API",
+		).Return(nil),
+		mockTx.EXPECT().Commit().Return(nil),
+	)
+
+	service, err := NewDeleteRuleService(mockRepo, auditWriter, testutil.NewDefaultMockClock(), txBeginner)
+	require.NoError(t, err)
+	service.Streaming = emitter
+
+	err = service.Execute(context.Background(), ruleID)
+	require.NoError(t, err)
+
+	emitted := emitter.Events()
+	require.Len(t, emitted, 1)
+	assert.Equal(t, "rule.deleted", emitted[0].DefinitionKey)
+	assert.Equal(t, ruleID.String(), emitted[0].Subject)
+
+	var payload events.RuleDeletedPayload
+	require.NoError(t, json.Unmarshal(emitted[0].Payload, &payload))
+	assert.Equal(t, ruleID.String(), payload.ID)
+	assert.Equal(t, testutil.FixedTime().Format("2006-01-02T15:04:05Z07:00"), payload.DeletedAt)
+}
+
+func TestDeleteRule_Idempotent_EmitsNothing(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	ruleID := testutil.MustDeterministicUUID(50)
+	rule := &model.Rule{ID: ruleID, Name: "Test Rule", Status: model.RuleStatusDeleted, Expression: "amount > 1000"}
+
+	mockRepo := NewMockRuleRepository(ctrl)
+	auditWriter := NewMockAuditWriter(ctrl)
+	txBeginner := pgdbMocks.NewMockTxBeginner(ctrl)
+	emitter := pkgStreaming.NewMockEmitter()
+
+	mockRepo.EXPECT().GetByID(gomock.Any(), ruleID).Return(rule, nil)
+	txBeginner.EXPECT().BeginTx(gomock.Any(), gomock.Any()).Times(0)
+
+	service, err := NewDeleteRuleService(mockRepo, auditWriter, testutil.NewDefaultMockClock(), txBeginner)
+	require.NoError(t, err)
+	service.Streaming = emitter
+
+	err = service.Execute(context.Background(), ruleID)
+	require.NoError(t, err)
+	assert.Empty(t, emitter.Events())
+}
+
+func TestDeleteRule_EmitFailure_RequestStillSucceeds(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	ruleID := testutil.MustDeterministicUUID(50)
+	rule := &model.Rule{ID: ruleID, Name: "Test Rule", Status: model.RuleStatusInactive, Expression: "amount > 1000"}
+
+	mockRepo := NewMockRuleRepository(ctrl)
+	auditWriter := NewMockAuditWriter(ctrl)
+	txBeginner := pgdbMocks.NewMockTxBeginner(ctrl)
+	mockTx := pgdbMocks.NewMockTx(ctrl)
+	emitter := pkgStreaming.NewMockEmitter()
+	emitter.SetError(errors.New("broker down"))
+
+	mockRepo.EXPECT().GetByID(gomock.Any(), ruleID).Return(rule, nil)
+	gomock.InOrder(
+		txBeginner.EXPECT().BeginTx(gomock.Any(), nil).Return(mockTx, nil),
+		mockRepo.EXPECT().DeleteWithTx(gomock.Any(), gomock.AssignableToTypeOf(mockTx), ruleID).Return(nil),
+		auditWriter.EXPECT().RecordRuleEventWithTx(
+			gomock.Any(), gomock.AssignableToTypeOf(mockTx),
+			model.AuditEventRuleDeleted, model.AuditActionDelete, ruleID,
+			gomock.Any(), gomock.Nil(), "Rule deleted via API",
+		).Return(nil),
+		mockTx.EXPECT().Commit().Return(nil),
+	)
+
+	service, err := NewDeleteRuleService(mockRepo, auditWriter, testutil.NewDefaultMockClock(), txBeginner)
+	require.NoError(t, err)
+	service.Streaming = emitter
+
+	err = service.Execute(context.Background(), ruleID)
+	require.NoError(t, err)
+	assert.Empty(t, emitter.Events(), "failed emits are not captured")
+}
+
+// assertRuleFenceClean fails if any forbidden free-text / rule-logic key
+// appears at the top level of the wire payload.
+func assertRuleFenceClean(t *testing.T, raw []byte) {
+	t.Helper()
+
+	var m map[string]any
+	require.NoError(t, json.Unmarshal(raw, &m))
+
+	for _, forbidden := range []string{"name", "description", "expression", "compiledProgram"} {
+		_, present := m[forbidden]
+		assert.Falsef(t, present, "forbidden key %q must never appear on the wire", forbidden)
+	}
+}

--- a/components/tracer/internal/services/command/streaming_field_test.go
+++ b/components/tracer/internal/services/command/streaming_field_test.go
@@ -1,0 +1,90 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package command
+
+import (
+	"testing"
+
+	"go.uber.org/mock/gomock"
+
+	libStreaming "github.com/LerianStudio/lib-streaming"
+	pgdbMocks "github.com/LerianStudio/midaz/v4/components/tracer/internal/adapters/postgres/db/mocks"
+	"github.com/LerianStudio/midaz/v4/components/tracer/internal/testutil"
+	pkgStreaming "github.com/LerianStudio/midaz/v4/pkg/streaming"
+)
+
+// TestCommandStructs_StreamingFieldSettable asserts that every rule and limit
+// command struct carries an exported Streaming field of type
+// libStreaming.Emitter that accepts a mock emitter. The field is left
+// zero-valued (nil) by the New* constructors — nil disables emission — and is
+// set post-construction by the bootstrap wiring, mirroring how fees inject the
+// emitter onto the ledger UseCase.
+func TestCommandStructs_StreamingFieldSettable(t *testing.T) {
+	t.Parallel()
+
+	mock := pkgStreaming.NewMockEmitter()
+
+	// Compile-time + runtime proof that each struct exposes a settable
+	// Streaming field of the Emitter interface type. If any struct lacks the
+	// field (or names/types it differently) this file fails to compile.
+	fields := []libStreaming.Emitter{
+		CreateRuleCommand{Streaming: mock}.Streaming,
+		UpdateRuleCommand{Streaming: mock}.Streaming,
+		ActivateRuleService{Streaming: mock}.Streaming,
+		DeactivateRuleService{Streaming: mock}.Streaming,
+		DraftRuleService{Streaming: mock}.Streaming,
+		DeleteRuleService{Streaming: mock}.Streaming,
+		CreateLimitCommand{Streaming: mock}.Streaming,
+		UpdateLimitCommand{Streaming: mock}.Streaming,
+		ActivateLimitCommand{Streaming: mock}.Streaming,
+		DeactivateLimitCommand{Streaming: mock}.Streaming,
+		DraftLimitCommand{Streaming: mock}.Streaming,
+		DeleteLimitCommand{Streaming: mock}.Streaming,
+	}
+
+	if len(fields) != 12 {
+		t.Fatalf("expected 12 command structs to carry a Streaming field, got %d", len(fields))
+	}
+
+	for i, f := range fields {
+		if f != mock {
+			t.Errorf("command struct #%d: Streaming field not settable to the mock emitter", i)
+		}
+	}
+}
+
+// TestNewCommandConstructors_LeaveStreamingNil asserts the New* constructors
+// leave Streaming zero-valued (nil), so existing command tests keep passing
+// and nil-emitter call sites treat the field as "streaming disabled".
+func TestNewCommandConstructors_LeaveStreamingNil(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+
+	ruleRepo := NewMockRuleRepository(ctrl)
+	cel := NewMockExpressionCompiler(ctrl)
+	limitRepo := NewMockLimitRepository(ctrl)
+	audit := NewMockAuditWriter(ctrl)
+	tx := pgdbMocks.NewMockTxBeginner(ctrl)
+	clk := testutil.NewDefaultMockClock()
+
+	createRule, err := NewCreateRuleCommand(ruleRepo, cel, clk, audit, tx)
+	if err != nil {
+		t.Fatalf("NewCreateRuleCommand returned error: %v", err)
+	}
+
+	if createRule.Streaming != nil {
+		t.Errorf("NewCreateRuleCommand: expected Streaming nil by default, got non-nil")
+	}
+
+	createLimit, err := NewCreateLimitCommand(limitRepo, clk, audit, tx)
+	if err != nil {
+		t.Fatalf("NewCreateLimitCommand returned error: %v", err)
+	}
+
+	if createLimit.Streaming != nil {
+		t.Errorf("NewCreateLimitCommand: expected Streaming nil by default, got non-nil")
+	}
+}

--- a/components/tracer/internal/services/command/update_limit.go
+++ b/components/tracer/internal/services/command/update_limit.go
@@ -26,6 +26,8 @@ import (
 	"github.com/LerianStudio/midaz/v4/components/tracer/pkg/logging"
 	"github.com/LerianStudio/midaz/v4/components/tracer/pkg/model"
 	"github.com/LerianStudio/midaz/v4/pkg/constant"
+	pkgStreaming "github.com/LerianStudio/midaz/v4/pkg/streaming"
+	"github.com/LerianStudio/midaz/v4/pkg/streaming/events"
 	"github.com/LerianStudio/midaz/v4/pkg/utils"
 )
 
@@ -258,7 +260,20 @@ func (c *UpdateLimitCommand) Execute(ctx context.Context, id uuid.UUID, input *U
 		return nil, fmt.Errorf("failed to update limit: %w", txErr)
 	}
 
+	c.emitLimitUpdatedEvent(ctx, span, logger, limit)
+
 	return limit, nil
+}
+
+// emitLimitUpdatedEvent publishes the limit.updated event post-commit. It is
+// called only at the committed-mutation return, never at the no-change
+// short-circuit (which skips the tx), so a no-op update emits nothing.
+// IMPORTANT posture: emit failures never fail the request.
+func (c *UpdateLimitCommand) emitLimitUpdatedEvent(ctx context.Context, span trace.Span, logger libLog.Logger, limit *model.Limit) {
+	pkgStreaming.EmitImportant(ctx, span, logger, c.Streaming, events.LimitUpdatedDefinition.Key(),
+		func(tenantID string) (libStreaming.EmitRequest, error) {
+			return events.NewLimitUpdated(limit).ToEmitRequest(tenantID, limit.UpdatedAt)
+		})
 }
 
 func (c *UpdateLimitCommand) validateInput(span trace.Span, id uuid.UUID, input *UpdateLimitInput) error {

--- a/components/tracer/internal/services/command/update_limit.go
+++ b/components/tracer/internal/services/command/update_limit.go
@@ -19,6 +19,7 @@ import (
 	libObservability "github.com/LerianStudio/lib-observability"
 	libLog "github.com/LerianStudio/lib-observability/log"
 	libOpentelemetry "github.com/LerianStudio/lib-observability/tracing"
+	libStreaming "github.com/LerianStudio/lib-streaming"
 
 	pgdb "github.com/LerianStudio/midaz/v4/components/tracer/internal/adapters/postgres/db"
 	"github.com/LerianStudio/midaz/v4/components/tracer/pkg/clock"
@@ -58,6 +59,11 @@ type UpdateLimitCommand struct {
 	clock       clock.Clock
 	auditWriter AuditWriter
 	txBeginner  pgdb.TxBeginner
+
+	// Streaming is the lib-streaming Emitter used to publish past-tense domain
+	// events; nil disables emission and never fails the request. Set
+	// post-construction at bootstrap.
+	Streaming libStreaming.Emitter
 }
 
 // NewUpdateLimitCommand creates a new UpdateLimitCommand with dependencies.

--- a/components/tracer/internal/services/command/update_rule.go
+++ b/components/tracer/internal/services/command/update_rule.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"go.opentelemetry.io/otel/trace"
 
 	libObservability "github.com/LerianStudio/lib-observability"
 	libLog "github.com/LerianStudio/lib-observability/log"
@@ -22,6 +23,8 @@ import (
 	"github.com/LerianStudio/midaz/v4/components/tracer/pkg/logging"
 	"github.com/LerianStudio/midaz/v4/components/tracer/pkg/model"
 	"github.com/LerianStudio/midaz/v4/pkg/constant"
+	pkgStreaming "github.com/LerianStudio/midaz/v4/pkg/streaming"
+	"github.com/LerianStudio/midaz/v4/pkg/streaming/events"
 	"github.com/LerianStudio/midaz/v4/pkg/utils"
 )
 
@@ -272,5 +275,16 @@ func (c *UpdateRuleCommand) Execute(ctx context.Context, id uuid.UUID, input *Up
 		return nil, fmt.Errorf("failed to update rule: %w", txErr)
 	}
 
+	c.emitRuleUpdatedEvent(ctx, span, logger, rule)
+
 	return rule, nil
+}
+
+// emitRuleUpdatedEvent publishes the rule.updated event post-commit. IMPORTANT
+// posture: emit failures never fail the request.
+func (c *UpdateRuleCommand) emitRuleUpdatedEvent(ctx context.Context, span trace.Span, logger libLog.Logger, rule *model.Rule) {
+	pkgStreaming.EmitImportant(ctx, span, logger, c.Streaming, events.RuleUpdatedDefinition.Key(),
+		func(tenantID string) (libStreaming.EmitRequest, error) {
+			return events.NewRuleUpdated(rule).ToEmitRequest(tenantID, rule.UpdatedAt)
+		})
 }

--- a/components/tracer/internal/services/command/update_rule.go
+++ b/components/tracer/internal/services/command/update_rule.go
@@ -15,6 +15,7 @@ import (
 	libObservability "github.com/LerianStudio/lib-observability"
 	libLog "github.com/LerianStudio/lib-observability/log"
 	libOpentelemetry "github.com/LerianStudio/lib-observability/tracing"
+	libStreaming "github.com/LerianStudio/lib-streaming"
 
 	pgdb "github.com/LerianStudio/midaz/v4/components/tracer/internal/adapters/postgres/db"
 	"github.com/LerianStudio/midaz/v4/components/tracer/pkg/clock"
@@ -71,6 +72,11 @@ type UpdateRuleCommand struct {
 	clock       clock.Clock
 	auditWriter AuditWriter
 	txBeginner  pgdb.TxBeginner
+
+	// Streaming is the lib-streaming Emitter used to publish past-tense domain
+	// events; nil disables emission and never fails the request. Set
+	// post-construction at bootstrap.
+	Streaming libStreaming.Emitter
 }
 
 // NewUpdateRuleCommand creates a new UpdateRuleCommand instance.

--- a/docs/streaming/tracer-events.md
+++ b/docs/streaming/tracer-events.md
@@ -1,0 +1,416 @@
+# Tracer Streaming Event Catalog
+
+Canonical reference for every streaming event the **tracer** component
+(`components/tracer`, :4020) emits. It complements — does not duplicate — the
+producer conventions in `CLAUDE.md` (Streaming section) and
+`docs/PROJECT_RULES.md`.
+
+> **Drift discipline.** This document, the Payload structs in
+> `pkg/streaming/events/{rule,limit}_*.go`, and the field-count assertions in the
+> matching `*_test.go` JSONShape tests are ONE contract. A wire change updates
+> all three in the same PR. When this doc and the code disagree, the code wins.
+
+## Overview
+
+- **Producer:** [`github.com/LerianStudio/lib-streaming`](https://github.com/LerianStudio/lib-streaming) v1.6.2.
+- **Wire format:** CloudEvents 1.0, binary mode, over Kafka/Redpanda.
+- **Component:** tracer (`components/tracer`). Tracer is a standalone Go service
+  (like CRM in structure, unlike fees which is folded into ledger); it owns its
+  own self-contained emitter bootstrap at
+  `components/tracer/internal/bootstrap/streaming.go`.
+- **CloudEvents source (`ce-source`):** `lerian.midaz.tracer` (set on the
+  producer Builder at construction; there is no per-emit source).
+- **Posture:** all 12 events are **IMPORTANT** — direct-emit, synchronous, via
+  `pkgStreaming.EmitImportant`. Emit is best-effort at the post-commit slot in
+  the command use case: a build/emit failure logs a Warn and is recorded on the
+  span, but **never fails the request**. Durability of the mutation itself is
+  owned by the database write, not by the emit.
+- **No outbox.** Emission is direct-emit only. When an outbox lands, only the
+  emit call sites change; the Definitions and payload contracts below stay put.
+- **Master flag:** `STREAMING_ENABLED` (default `false`). When disabled — or
+  when `STREAMING_BROKERS` is empty, or no events are registered — bootstrap
+  injects a `NoopEmitter` and no broker connection is attempted.
+- **No `organizationId` / `ledgerId` on the wire.** Those dimensions do not
+  exist anywhere in Tracer's domain. Tenant isolation travels only in the
+  `ce-tenantid` header (see [ce-tenantid](#ce-tenantid)).
+
+Routing constants are assembled from `Definition{ResourceType, EventType,
+SchemaVersion}` (`pkg/streaming/events/events.go`) and registered exactly once
+in `tracerEventDefinitions()`
+(`components/tracer/internal/bootstrap/streaming.go`), which feeds both the
+Catalog (`buildCatalog`) and the route table (`buildRoutes`):
+
+- **Event key** = `<resourceType>.<eventType>` via `Definition.Key()` (e.g.
+  `rule.created`). `resource` ∈ {`rule`, `limit`}; `event` ∈ {`created`,
+  `updated`, `activated`, `deactivated`, `drafted`, `deleted`}.
+- **`ce-type`** = lib-streaming auto-prefixes the key: `studio.lerian.<key>`.
+- **Kafka topic** = `streamingTopicPrefix` + key = `lerian.streaming.<key>`.
+- **`ce-subject`** = the aggregate ID (`EmitRequest.Subject`) — the rule UUID or
+  limit UUID.
+- **`ce-tenantid`** = `EmitRequest.TenantID`, resolved by
+  `pkgStreaming.ResolveTenantID(ctx)` inside `EmitImportant`.
+
+## Conventions
+
+| Aspect | Rule |
+|--------|------|
+| Event key | `<resource>.<event>`, lowercase; tokens are single words (no separator); underscores are rejected by the route-key validator |
+| Kafka topic | `lerian.streaming.<resource>.<event>` |
+| `ce-type` | `studio.lerian.<resource>.<event>` (auto-prefixed by lib-streaming) |
+| `ce-source` | `lerian.midaz.tracer` |
+| `ce-subject` | aggregate ID — rule UUID or limit UUID |
+| `ce-tenantid` | `pkgStreaming.ResolveTenantID(ctx)`, falls back to `"default"` |
+| Schema version | `1.0.0` (all 12 events) |
+
+## Event catalog
+
+All 12 events carry `SchemaVersion = 1.0.0`.
+
+| Event key | `ce-type` | Kafka topic | `ce-subject` | Schema version |
+|-----------|-----------|-------------|--------------|----------------|
+| `rule.created` | `studio.lerian.rule.created` | `lerian.streaming.rule.created` | rule ID | `1.0.0` |
+| `rule.updated` | `studio.lerian.rule.updated` | `lerian.streaming.rule.updated` | rule ID | `1.0.0` |
+| `rule.activated` | `studio.lerian.rule.activated` | `lerian.streaming.rule.activated` | rule ID | `1.0.0` |
+| `rule.deactivated` | `studio.lerian.rule.deactivated` | `lerian.streaming.rule.deactivated` | rule ID | `1.0.0` |
+| `rule.drafted` | `studio.lerian.rule.drafted` | `lerian.streaming.rule.drafted` | rule ID | `1.0.0` |
+| `rule.deleted` | `studio.lerian.rule.deleted` | `lerian.streaming.rule.deleted` | rule ID | `1.0.0` |
+| `limit.created` | `studio.lerian.limit.created` | `lerian.streaming.limit.created` | limit ID | `1.0.0` |
+| `limit.updated` | `studio.lerian.limit.updated` | `lerian.streaming.limit.updated` | limit ID | `1.0.0` |
+| `limit.activated` | `studio.lerian.limit.activated` | `lerian.streaming.limit.activated` | limit ID | `1.0.0` |
+| `limit.deactivated` | `studio.lerian.limit.deactivated` | `lerian.streaming.limit.deactivated` | limit ID | `1.0.0` |
+| `limit.drafted` | `studio.lerian.limit.drafted` | `lerian.streaming.limit.drafted` | limit ID | `1.0.0` |
+| `limit.deleted` | `studio.lerian.limit.deleted` | `lerian.streaming.limit.deleted` | limit ID | `1.0.0` |
+
+## Shared `scopes[]` nested shape
+
+Both `rule.created`/`rule.updated` and `limit.created`/`limit.updated` carry a
+`scopes[]` array. Every element is the same `RuleScopePayload`
+(`pkg/streaming/events/rule_scope.go`) — six structural identifiers/enums, each
+`*string` on the wire so JSON `null` distinguishes "unset" from empty. An empty
+domain scope slice serializes as `"scopes": []` (non-null).
+
+```jsonc
+{
+  "segmentId":       "uuid | null",
+  "portfolioId":     "uuid | null",
+  "accountId":       "uuid | null",
+  "merchantId":      "uuid | null",
+  "transactionType": "CARD | WIRE | PIX | CRYPTO | null",
+  "subType":         "string | null"
+}
+```
+
+The nested object is locked to exactly **6 keys**. `subType` is a structural
+sub-classifier and is deliberately INCLUDED; no free text otherwise appears in
+a scope.
+
+## Payload contracts
+
+The wire keys below are the exact JSON field set produced by the Payload structs
+in `pkg/streaming/events/`. The "field count" is the number the JSONShape test
+locks.
+
+### `rule.created` / `rule.updated` — 6 fields
+
+Source: `pkg/streaming/events/rule_created.go`, `rule_updated.go`.
+`ce-subject` = rule ID.
+
+```jsonc
+{
+  "id":        "uuid",
+  "status":    "DRAFT | ACTIVE | INACTIVE | DELETED",
+  "action":    "ALLOW | DENY | REVIEW",
+  "scopes":    [ { /* RuleScopePayload — 6 keys */ } ],
+  "createdAt": "RFC3339",
+  "updatedAt": "RFC3339"
+}
+```
+
+| Key | Type | Notes |
+|-----|------|-------|
+| `id` | string | Rule ID. |
+| `status` | string | `DRAFT` / `ACTIVE` / `INACTIVE` / `DELETED`. |
+| `action` | string | Decision: `ALLOW` / `DENY` / `REVIEW`. |
+| `scopes` | array | Shared `RuleScopePayload` elements (6 keys each); `[]` when empty. |
+| `createdAt` | string | RFC3339. |
+| `updatedAt` | string | RFC3339. |
+
+**Excluded / never on the wire** — the JSONShape test explicitly asserts `name`,
+`description`, `expression`, and `compiledProgram` are absent at the top level,
+and additionally asserts `name`, `description`, and `expression` are absent
+inside each `scopes` element.
+
+### `rule.activated` — 4 fields
+
+Source: `pkg/streaming/events/rule_activated.go`. `ce-subject` = rule ID.
+
+```jsonc
+{
+  "id":          "uuid",
+  "status":      "DRAFT | ACTIVE | INACTIVE | DELETED",
+  "activatedAt": "RFC3339 | null",
+  "updatedAt":   "RFC3339"
+}
+```
+
+`activatedAt` is `*string`: the key is always present (not `omitempty`); a
+defensive nil serializes as JSON `null`. In practice `Rule.SetStatus(ACTIVE)`
+guarantees it non-nil at the emit site.
+
+**Excluded / not present on the wire:** `action`, `scopes`, `name`,
+`description`, `expression`, `compiledProgram`, `deactivatedAt`. The JSONShape
+test names `name`, `description`, `expression`, `action`, and `scopes` in an
+explicit forbidden-key check; `compiledProgram` and `deactivatedAt` are kept off
+the wire by the exact-key-set + field-count lock (not a dedicated NotContains).
+
+### `rule.deactivated` — 4 fields
+
+Source: `pkg/streaming/events/rule_deactivated.go`. `ce-subject` = rule ID.
+
+```jsonc
+{
+  "id":            "uuid",
+  "status":        "DRAFT | ACTIVE | INACTIVE | DELETED",
+  "deactivatedAt": "RFC3339 | null",
+  "updatedAt":     "RFC3339"
+}
+```
+
+`deactivatedAt` is `*string` with the same key-always-present / nil-guard
+treatment as `rule.activated`.
+
+**Excluded / not present on the wire:** `action`, `scopes`, `name`,
+`description`, `expression`, `compiledProgram`, `activatedAt`. The JSONShape test
+names `name`, `description`, `expression`, `action`, `scopes`, and `activatedAt`
+in an explicit forbidden-key check; `compiledProgram` is kept off the wire by the
+exact-key-set + field-count lock (not a dedicated NotContains).
+
+### `rule.drafted` — 3 fields
+
+Source: `pkg/streaming/events/rule_drafted.go`. `ce-subject` = rule ID.
+
+```jsonc
+{
+  "id":        "uuid",
+  "status":    "DRAFT | ACTIVE | INACTIVE | DELETED",
+  "updatedAt": "RFC3339"
+}
+```
+
+`activatedAt` and `deactivatedAt` are deliberately omitted:
+`Rule.SetStatus(DRAFT)` nils both, so carrying them would emit `null` noise. The
+drafted contract stays minimal.
+
+**Excluded:** `action`, `scopes`, `activatedAt`, `deactivatedAt`, `name`,
+`description`, `expression`, `compiledProgram`.
+
+### `rule.deleted` — 2 fields
+
+Source: `pkg/streaming/events/rule_deleted.go`. `ce-subject` = rule ID.
+
+```jsonc
+{
+  "id":        "uuid",
+  "deletedAt": "RFC3339"
+}
+```
+
+The delete use case returns no entity, so the payload is built from a
+primitive-arg constructor `NewRuleDeleted(id, deletedAt)`. No `status` field.
+
+**Excluded** (asserted absent by the JSONShape test): `status`, `name`,
+`description`, `expression`, `scopes`, `action`.
+
+### `limit.created` / `limit.updated` — 12 fields
+
+Source: `pkg/streaming/events/limit_created.go`, `limit_updated.go`.
+`ce-subject` = limit ID.
+
+```jsonc
+{
+  "id":              "uuid",
+  "status":          "DRAFT | ACTIVE | INACTIVE | DELETED",
+  "limitType":       "DAILY | WEEKLY | MONTHLY | CUSTOM | PER_TRANSACTION",
+  "currency":        "ISO-4217",
+  "scopes":          [ { /* RuleScopePayload — 6 keys */ } ],
+  "activeTimeStart": "HH:MM | null",
+  "activeTimeEnd":   "HH:MM | null",
+  "customStartDate": "RFC3339 | null",
+  "customEndDate":   "RFC3339 | null",
+  "resetAt":         "RFC3339 | null",
+  "createdAt":       "RFC3339",
+  "updatedAt":       "RFC3339"
+}
+```
+
+| Key | Type | Notes |
+|-----|------|-------|
+| `id` | string | Limit ID. |
+| `status` | string | `DRAFT` / `ACTIVE` / `INACTIVE` / `DELETED`. |
+| `limitType` | string | `DAILY` / `WEEKLY` / `MONTHLY` / `CUSTOM` / `PER_TRANSACTION`. |
+| `currency` | string | ISO-4217 code. |
+| `scopes` | array | Shared `RuleScopePayload` elements (6 keys each); `[]` when empty. |
+| `activeTimeStart` | string \| null | Time-of-day window start (`HH:MM`), `null` when unset. |
+| `activeTimeEnd` | string \| null | Time-of-day window end (`HH:MM`), `null` when unset. |
+| `customStartDate` | string \| null | RFC3339, `null` unless the period is `CUSTOM`. |
+| `customEndDate` | string \| null | RFC3339, `null` unless the period is `CUSTOM`. |
+| `resetAt` | string \| null | RFC3339 next-reset time, `null` when unset. |
+| `createdAt` | string | RFC3339. |
+| `updatedAt` | string | RFC3339. |
+
+**Excluded / never on the wire** (asserted absent by the JSONShape test):
+`name`, `description`, `maxAmount`.
+
+### `limit.activated` / `limit.deactivated` / `limit.drafted` — 3 fields each
+
+Source: `pkg/streaming/events/limit_activated.go`, `limit_deactivated.go`,
+`limit_drafted.go`. `ce-subject` = limit ID.
+
+```jsonc
+{
+  "id":        "uuid",
+  "status":    "DRAFT | ACTIVE | INACTIVE | DELETED",
+  "updatedAt": "RFC3339"
+}
+```
+
+Unlike Rule, the Limit domain model has no `ActivatedAt` / `DeactivatedAt`
+fields, so all three status-transition events carry the same minimal shape.
+
+**Excluded:** `limitType`, `currency`, `scopes`, all time-window fields,
+`name`, `description`, `maxAmount`.
+
+### `limit.deleted` — 2 fields
+
+Source: `pkg/streaming/events/limit_deleted.go`. `ce-subject` = limit ID.
+
+```jsonc
+{
+  "id":        "uuid",
+  "deletedAt": "RFC3339"
+}
+```
+
+**Excluded:** `status`, `limitType`, `currency`, `scopes`, all time-window
+fields, `name`, `description`, `maxAmount`.
+
+## What is deliberately off the wire, and why
+
+Every payload carries only stable identifiers, classifier enums, structural
+scope references, time-window/period fields, and timestamps. The following are
+**deliberately excluded** from every event body and are asserted absent by the
+JSONShape tests. Consumers that need any of these fetch the full record by `id`.
+
+| Field | Aggregate | Reason for exclusion |
+|-------|-----------|----------------------|
+| `name` | rule, limit | Free text — human-facing label, not needed for routing. |
+| `description` | rule, limit | Free text — narrative, not needed for routing. |
+| `expression` | rule | Rule logic (CEL body). Business logic does not belong on a lifecycle event. |
+| `compiledProgram` | rule | Transient compiled artifact of `expression`; never persisted meaning on the wire. |
+| `maxAmount` | limit | **Monetary value.** Excluded to keep financial values off the wire, mirroring the ledger's "no monetary values on the wire" fence. Consumers fetch the amount by `id`. |
+
+**Enforcement.** Two mechanisms back these guarantees, and the first is what
+makes them airtight. First, the `JSONShape` unit test in each event's `*_test.go`
+pins the EXACT present-key set and the field COUNT (`Lenf(..., N)`). Together
+these reject ANY top-level key that is not in the documented shape — which is
+what guarantees `compiledProgram`, `deactivatedAt`, and any other stray field
+never leak, even though those two are not named in an explicit forbidden-key
+check on the `activated` / `deactivated` events. Any excluded field added to a
+payload changes the key set or count and fails that test.
+
+Second, and in addition, each `JSONShape` test carries explicit forbidden-key
+assertions (`assert.False` / `NotContains`) over a subset of the shared
+high-risk fields — the free-text, rule-logic, and monetary fields (`name`,
+`description`, `expression`, `compiledProgram` for rule; `name`, `description`,
+`maxAmount` for limit). The fixtures deliberately POPULATE those fields
+(`minimalRule()` sets `Name`, `Description`, `Expression`, and `CompiledProgram`
+to non-empty values) so the tests prove those specific fields are dropped even
+when set upstream. The subset checked explicitly varies per event; the exact
+key-set + count lock above covers the remainder.
+
+## `ce-tenantid`
+
+Every emission carries a `ce-tenantid` header sourced from
+`pkgStreaming.ResolveTenantID(ctx)`:
+
+- **Multi-tenant deployments:** the resolved tenant ID from the lib-commons
+  multitenancy middleware (JWT auth or the `X-Tenant-Id` seam header).
+- **Single-tenant deployments and tenantless paths** (e.g. workers): the literal
+  `"default"` (`pkgStreaming.DefaultTenantID`). lib-streaming requires a
+  non-empty tenant ID, so the fallback guarantees a valid header.
+
+Tracer has no `organizationId` / `ledgerId` dimension, so tenant isolation lives
+solely in this header.
+
+## A real consumed event
+
+A `rule.created` emission, as a consumer sees it (CloudEvents 1.0 binary mode —
+metadata in Kafka headers, payload in the record value):
+
+**Headers**
+
+```
+ce-specversion: 1.0
+ce-type:        studio.lerian.rule.created
+ce-source:      lerian.midaz.tracer
+ce-id:          0f9c1a3e-6b2d-4e7f-9a10-2c8d5f4b1a22
+ce-subject:     7b3e2c14-9d5a-4f61-8c2b-1e0a9d7f4c33
+ce-tenantid:    default
+ce-time:        2026-07-03T14:22:07Z
+content-type:   application/json
+```
+
+**Payload (record value)**
+
+```json
+{
+  "id": "7b3e2c14-9d5a-4f61-8c2b-1e0a9d7f4c33",
+  "status": "DRAFT",
+  "action": "DENY",
+  "scopes": [
+    {
+      "segmentId": "3a1f8b02-4c6d-4e90-a2b7-9f0c1d2e3a4b",
+      "portfolioId": null,
+      "accountId": null,
+      "merchantId": "c4d5e6f7-8a9b-40c1-92d3-e4f5a6b7c8d9",
+      "transactionType": "PIX",
+      "subType": "instant"
+    }
+  ],
+  "createdAt": "2026-07-03T14:22:07Z",
+  "updatedAt": "2026-07-03T14:22:07Z"
+}
+```
+
+`ce-type` is the auto-prefixed key (`studio.lerian.` + `rule.created`);
+`ce-subject` is the rule UUID and matches the payload `id`; the payload carries
+no `name`, `description`, or `expression`. All UUIDs above are illustrative
+placeholders.
+
+## Local testing
+
+To exercise the real emit path against a broker, run a Redpanda instance and
+point tracer at it:
+
+- Bind the broker on host port `19092`; join `infra-network` so it is reachable
+  from both host (`localhost:19092`) and containers (`<container>:9092`).
+- Set `STREAMING_ENABLED=true`, `STREAMING_BROKERS=localhost:19092`, and
+  `STREAMING_CLOUDEVENTS_SOURCE=lerian.midaz.tracer`.
+- Pre-provision the 12 `lerian.streaming.{rule,limit}.*` topics explicitly; do
+  not rely on auto-create.
+
+The default unit suite never touches a broker — the JSONShape and mapping tests
+in `pkg/streaming/events/` marshal payloads in memory. See the `CLAUDE.md`
+Streaming → Local testing section for the broker/environment conventions.
+
+## Canonical code locations
+
+- **Wire structs + JSONShape tests:** `pkg/streaming/events/{rule,limit}_*.go`
+  and the matching `*_test.go`.
+- **Shared scope shape:** `pkg/streaming/events/rule_scope.go`
+  (`RuleScopePayload`, `newRuleScopePayloads`).
+- **Event registry (single source of truth for catalog + routes):**
+  `tracerEventDefinitions()` in
+  `components/tracer/internal/bootstrap/streaming.go`.
+- **Emit helpers (post-commit):** `emit<Event>Event` on each command in
+  `components/tracer/internal/services/command/`.

--- a/docs/streaming/tracer-events.md
+++ b/docs/streaming/tracer-events.md
@@ -15,8 +15,7 @@ producer conventions in `CLAUDE.md` (Streaming section) and
 - **Producer:** [`github.com/LerianStudio/lib-streaming`](https://github.com/LerianStudio/lib-streaming) v1.6.2.
 - **Wire format:** CloudEvents 1.0, binary mode, over Kafka/Redpanda.
 - **Component:** tracer (`components/tracer`). Tracer is a standalone Go service
-  (like CRM in structure, unlike fees which is folded into ledger); it owns its
-  own self-contained emitter bootstrap at
+  with its own self-contained emitter bootstrap at
   `components/tracer/internal/bootstrap/streaming.go`.
 - **CloudEvents source (`ce-source`):** `lerian.midaz.tracer` (set on the
   producer Builder at construction; there is no per-emit source).

--- a/go.mod
+++ b/go.mod
@@ -106,6 +106,7 @@ require (
 	github.com/testcontainers/testcontainers-go/modules/toxiproxy v0.42.0
 	github.com/tink-crypto/tink-go/v2 v2.7.0
 	github.com/twmb/franz-go v1.21.3
+	github.com/twmb/franz-go/pkg/kadm v1.18.0
 	github.com/twmb/franz-go/pkg/kmsg v1.13.1
 	go.mongodb.org/mongo-driver/v2 v2.6.0
 	go.opentelemetry.io/otel/exporters/prometheus v0.66.0

--- a/pkg/streaming/events/limit_activated.go
+++ b/pkg/streaming/events/limit_activated.go
@@ -1,0 +1,59 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package events
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	libStreaming "github.com/LerianStudio/lib-streaming"
+
+	"github.com/LerianStudio/midaz/v4/components/tracer/pkg/model"
+)
+
+// LimitActivatedDefinition is the routing contract for limit.activated.
+// Subject (ce-subject) is the limit ID.
+var LimitActivatedDefinition = Definition{
+	ResourceType:  "limit",
+	EventType:     "activated",
+	SchemaVersion: "1.0.0",
+}
+
+// LimitActivatedPayload is the minimal wire payload for limit.activated.
+// model.Limit has no ActivatedAt/DeactivatedAt fields (unlike model.Rule), so
+// the transition events carry only identity, status, and the update time.
+type LimitActivatedPayload struct {
+	ID        string `json:"id"`
+	Status    string `json:"status"`
+	UpdatedAt string `json:"updatedAt"`
+}
+
+// NewLimitActivated maps a limit into the limit.activated wire payload. Status
+// is mapped via a plain string conversion (LimitStatus has no String()).
+func NewLimitActivated(limit *model.Limit) LimitActivatedPayload {
+	return LimitActivatedPayload{
+		ID:        limit.ID.String(),
+		Status:    string(limit.Status),
+		UpdatedAt: limit.UpdatedAt.Format(time.RFC3339),
+	}
+}
+
+// ToEmitRequest assembles a libStreaming.EmitRequest; ts is typically the
+// persisted UpdatedAt for this event.
+func (p LimitActivatedPayload) ToEmitRequest(tenantID string, ts time.Time) (libStreaming.EmitRequest, error) {
+	data, err := json.Marshal(p)
+	if err != nil {
+		return libStreaming.EmitRequest{}, fmt.Errorf("marshal %s payload: %w", LimitActivatedDefinition.Key(), err)
+	}
+
+	return libStreaming.EmitRequest{
+		DefinitionKey: LimitActivatedDefinition.Key(),
+		TenantID:      tenantID,
+		Subject:       p.ID,
+		Timestamp:     ts,
+		Payload:       data,
+	}, nil
+}

--- a/pkg/streaming/events/limit_activated_test.go
+++ b/pkg/streaming/events/limit_activated_test.go
@@ -1,0 +1,89 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package events_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/LerianStudio/midaz/v4/components/tracer/pkg/model"
+	"github.com/LerianStudio/midaz/v4/pkg/streaming/events"
+)
+
+func TestLimitActivatedDefinition_Key(t *testing.T) {
+	assert.Equal(t, "limit.activated", events.LimitActivatedDefinition.Key())
+	assert.Equal(t, "limit", events.LimitActivatedDefinition.ResourceType)
+	assert.Equal(t, "activated", events.LimitActivatedDefinition.EventType)
+	assert.Equal(t, "1.0.0", events.LimitActivatedDefinition.SchemaVersion)
+}
+
+func TestNewLimitActivated_MapsLimit(t *testing.T) {
+	limit := minimalLimit()
+	limit.Status = model.LimitStatusActive
+
+	payload := events.NewLimitActivated(limit)
+
+	assert.Equal(t, fixedLimitUUID.String(), payload.ID)
+	assert.Equal(t, "ACTIVE", payload.Status)
+	assert.Equal(t, "2026-05-13T12:34:56Z", payload.UpdatedAt)
+}
+
+func TestLimitActivatedPayload_ToEmitRequest(t *testing.T) {
+	limit := minimalLimit()
+	limit.Status = model.LimitStatusActive
+
+	payload := events.NewLimitActivated(limit)
+
+	req, err := payload.ToEmitRequest("tenant-1", fixedTime)
+	require.NoError(t, err)
+
+	assert.Equal(t, events.LimitActivatedDefinition.Key(), req.DefinitionKey)
+	assert.Equal(t, "tenant-1", req.TenantID)
+	assert.Equal(t, payload.ID, req.Subject)
+	assert.Equal(t, fixedTime, req.Timestamp)
+
+	var roundTrip events.LimitActivatedPayload
+	require.NoError(t, json.Unmarshal(req.Payload, &roundTrip))
+	assert.Equal(t, payload, roundTrip)
+}
+
+func TestLimitActivatedPayload_JSONShape(t *testing.T) {
+	limit := minimalLimit()
+	limit.Status = model.LimitStatusActive
+
+	data, err := json.Marshal(events.NewLimitActivated(limit))
+	require.NoError(t, err)
+
+	var generic map[string]any
+	require.NoError(t, json.Unmarshal(data, &generic))
+
+	expectedKeys := map[string]struct{}{
+		"id":        {},
+		"status":    {},
+		"updatedAt": {},
+	}
+
+	for key := range generic {
+		_, ok := expectedKeys[key]
+		assert.Truef(t, ok, "unexpected top-level key %q (drift?)", key)
+	}
+
+	for key := range expectedKeys {
+		_, ok := generic[key]
+		assert.Truef(t, ok, "must include %q", key)
+	}
+
+	for _, forbidden := range []string{
+		"activatedAt", "deactivatedAt", "limitType", "currency", "scopes", "maxAmount", "name", "description",
+	} {
+		_, present := generic[forbidden]
+		assert.Falsef(t, present, "field %q must NOT appear", forbidden)
+	}
+
+	assert.Lenf(t, generic, 3, "expected 3 top-level fields, got %d (drift?)", len(generic))
+}

--- a/pkg/streaming/events/limit_created.go
+++ b/pkg/streaming/events/limit_created.go
@@ -1,0 +1,100 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package events
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	libStreaming "github.com/LerianStudio/lib-streaming"
+
+	"github.com/LerianStudio/midaz/v4/components/tracer/pkg/model"
+)
+
+// formatOptionalTimeOfDay formats an optional TimeOfDay as an "HH:MM" *string,
+// returning nil when the input is nil so the wire serializes JSON null. A
+// non-nil but zero-value TimeOfDay stringifies to "" (never panics); the domain
+// validates windows at construction so that cannot occur post-NewLimit.
+func formatOptionalTimeOfDay(t *model.TimeOfDay) *string {
+	if t == nil {
+		return nil
+	}
+
+	s := t.String()
+
+	return &s
+}
+
+// LimitCreatedDefinition is the routing contract for limit.created.
+// Subject (ce-subject) is the limit ID. IMPORTANT posture: emit failures
+// MUST NOT fail the request.
+var LimitCreatedDefinition = Definition{
+	ResourceType:  "limit",
+	EventType:     "created",
+	SchemaVersion: "1.0.0",
+}
+
+// LimitCreatedPayload is the wire payload for limit.created. Fields are typed
+// independently of model.Limit so domain evolution does not leak onto the
+// wire. The payload fence EXCLUDES name, description (free text), and maxAmount
+// (a financial value — consumers fetch the amount by id). The nested Scopes
+// reuse RuleScopePayload since model.Limit.Scopes is the same []model.Scope
+// type as model.Rule.Scopes.
+type LimitCreatedPayload struct {
+	ID              string             `json:"id"`
+	Status          string             `json:"status"`
+	LimitType       string             `json:"limitType"`
+	Currency        string             `json:"currency"`
+	Scopes          []RuleScopePayload `json:"scopes"`
+	ActiveTimeStart *string            `json:"activeTimeStart"`
+	ActiveTimeEnd   *string            `json:"activeTimeEnd"`
+	CustomStartDate *string            `json:"customStartDate"`
+	CustomEndDate   *string            `json:"customEndDate"`
+	ResetAt         *string            `json:"resetAt"`
+	CreatedAt       string             `json:"createdAt"`
+	UpdatedAt       string             `json:"updatedAt"`
+}
+
+// NewLimitCreated maps a persisted limit into the wire payload. Status and
+// LimitType are mapped via a plain string conversion (LimitStatus/LimitType
+// have no String() method, unlike RuleStatus). Every field must be assigned
+// here; the JSONShape test locks the field count so drift surfaces at test
+// time.
+func NewLimitCreated(limit *model.Limit) LimitCreatedPayload {
+	return LimitCreatedPayload{
+		ID:              limit.ID.String(),
+		Status:          string(limit.Status),
+		LimitType:       string(limit.LimitType),
+		Currency:        limit.Currency,
+		Scopes:          newRuleScopePayloads(limit.Scopes),
+		ActiveTimeStart: formatOptionalTimeOfDay(limit.ActiveTimeStart),
+		ActiveTimeEnd:   formatOptionalTimeOfDay(limit.ActiveTimeEnd),
+		CustomStartDate: formatOptionalRFC3339(limit.CustomStartDate),
+		CustomEndDate:   formatOptionalRFC3339(limit.CustomEndDate),
+		ResetAt:         formatOptionalRFC3339(limit.ResetAt),
+		CreatedAt:       limit.CreatedAt.Format(time.RFC3339),
+		UpdatedAt:       limit.UpdatedAt.Format(time.RFC3339),
+	}
+}
+
+// ToEmitRequest assembles a libStreaming.EmitRequest. tenantID comes from
+// pkgStreaming.ResolveTenantID(ctx); ts is the ce-time — typically the
+// persisted CreatedAt for this event. Returns a wrapped json.Marshal error
+// so IMPORTANT-posture callers can log Warn without failing the request.
+func (p LimitCreatedPayload) ToEmitRequest(tenantID string, ts time.Time) (libStreaming.EmitRequest, error) {
+	data, err := json.Marshal(p)
+	if err != nil {
+		return libStreaming.EmitRequest{}, fmt.Errorf("marshal %s payload: %w", LimitCreatedDefinition.Key(), err)
+	}
+
+	return libStreaming.EmitRequest{
+		DefinitionKey: LimitCreatedDefinition.Key(),
+		TenantID:      tenantID,
+		Subject:       p.ID,
+		Timestamp:     ts,
+		Payload:       data,
+	}, nil
+}

--- a/pkg/streaming/events/limit_created_test.go
+++ b/pkg/streaming/events/limit_created_test.go
@@ -1,0 +1,217 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package events_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/LerianStudio/midaz/v4/components/tracer/pkg/model"
+	"github.com/LerianStudio/midaz/v4/pkg/streaming/events"
+)
+
+// fixedLimitUUID is a deterministic UUID used across limit event tests so
+// subject/payload assertions match by exact value.
+var fixedLimitUUID = uuid.MustParse("018f5e2a-1c3d-7a4b-9e6f-0a1b2c3daaaa")
+
+// limitFenceName/Description are deliberately populated on fixtures so tests
+// prove the fence keeps free text off the wire.
+const (
+	limitFenceName        = "Daily USD spending cap"
+	limitFenceDescription = "Caps daily USD outflows for retail accounts"
+)
+
+// mustTimeOfDay builds a TimeOfDay from "HH:MM" for test fixtures, failing the
+// test if the format is invalid.
+func mustTimeOfDay(t *testing.T, s string) model.TimeOfDay {
+	t.Helper()
+
+	tod, err := model.NewTimeOfDay(s)
+	require.NoError(t, err)
+
+	return tod
+}
+
+// minimalLimit returns the smallest Limit that satisfies the limit.created
+// contract with all nullable time fields nil and no scopes. The fenced fields
+// (Name, Description, MaxAmount) are populated on purpose to prove they never
+// leak onto the wire.
+func minimalLimit() *model.Limit {
+	desc := limitFenceDescription
+
+	return &model.Limit{
+		ID:          fixedLimitUUID,
+		Name:        limitFenceName,
+		Description: &desc,
+		LimitType:   model.LimitTypeDaily,
+		MaxAmount:   decimal.RequireFromString("1000.00"),
+		Currency:    "USD",
+		Scopes:      nil,
+		Status:      model.LimitStatusDraft,
+		CreatedAt:   fixedTime,
+		UpdatedAt:   fixedTime,
+	}
+}
+
+// fullLimit returns a Limit with every optional field populated so tests prove
+// the nullable keys serialize their values (not null) and scopes map through.
+func fullLimit(t *testing.T) *model.Limit {
+	t.Helper()
+
+	limit := minimalLimit()
+	limit.LimitType = model.LimitTypeCustom
+	limit.Status = model.LimitStatusActive
+
+	start := mustTimeOfDay(t, "09:00")
+	end := mustTimeOfDay(t, "17:00")
+	limit.ActiveTimeStart = &start
+	limit.ActiveTimeEnd = &end
+
+	customStart := fixedTime
+	customEnd := fixedTime
+	resetAt := fixedTime
+	limit.CustomStartDate = &customStart
+	limit.CustomEndDate = &customEnd
+	limit.ResetAt = &resetAt
+
+	txType := model.TransactionTypeCard
+	limit.Scopes = []model.Scope{{SegmentID: &scopeSegmentID, TransactionType: &txType}}
+
+	return limit
+}
+
+func TestLimitCreatedDefinition_Key(t *testing.T) {
+	assert.Equal(t, "limit.created", events.LimitCreatedDefinition.Key())
+	assert.Equal(t, "limit", events.LimitCreatedDefinition.ResourceType)
+	assert.Equal(t, "created", events.LimitCreatedDefinition.EventType)
+	assert.Equal(t, "1.0.0", events.LimitCreatedDefinition.SchemaVersion)
+}
+
+func TestNewLimitCreated_MapsMinimalLimit(t *testing.T) {
+	payload := events.NewLimitCreated(minimalLimit())
+
+	assert.Equal(t, fixedLimitUUID.String(), payload.ID)
+	assert.Equal(t, "DRAFT", payload.Status)
+	assert.Equal(t, "DAILY", payload.LimitType)
+	assert.Equal(t, "USD", payload.Currency)
+	require.NotNil(t, payload.Scopes)
+	assert.Len(t, payload.Scopes, 0)
+	assert.Nil(t, payload.ActiveTimeStart)
+	assert.Nil(t, payload.ActiveTimeEnd)
+	assert.Nil(t, payload.CustomStartDate)
+	assert.Nil(t, payload.CustomEndDate)
+	assert.Nil(t, payload.ResetAt)
+	assert.Equal(t, "2026-05-13T12:34:56Z", payload.CreatedAt)
+	assert.Equal(t, "2026-05-13T12:34:56Z", payload.UpdatedAt)
+}
+
+func TestNewLimitCreated_MapsAllOptionalFields(t *testing.T) {
+	payload := events.NewLimitCreated(fullLimit(t))
+
+	assert.Equal(t, "ACTIVE", payload.Status)
+	assert.Equal(t, "CUSTOM", payload.LimitType)
+
+	require.NotNil(t, payload.ActiveTimeStart)
+	assert.Equal(t, "09:00", *payload.ActiveTimeStart)
+	require.NotNil(t, payload.ActiveTimeEnd)
+	assert.Equal(t, "17:00", *payload.ActiveTimeEnd)
+
+	require.NotNil(t, payload.CustomStartDate)
+	assert.Equal(t, "2026-05-13T12:34:56Z", *payload.CustomStartDate)
+	require.NotNil(t, payload.CustomEndDate)
+	assert.Equal(t, "2026-05-13T12:34:56Z", *payload.CustomEndDate)
+	require.NotNil(t, payload.ResetAt)
+	assert.Equal(t, "2026-05-13T12:34:56Z", *payload.ResetAt)
+
+	require.Len(t, payload.Scopes, 1)
+	require.NotNil(t, payload.Scopes[0].SegmentID)
+	assert.Equal(t, scopeSegmentID.String(), *payload.Scopes[0].SegmentID)
+	require.NotNil(t, payload.Scopes[0].TransactionType)
+	assert.Equal(t, "CARD", *payload.Scopes[0].TransactionType)
+}
+
+func TestLimitCreatedPayload_ToEmitRequest(t *testing.T) {
+	payload := events.NewLimitCreated(fullLimit(t))
+
+	req, err := payload.ToEmitRequest("tenant-1", fixedTime)
+	require.NoError(t, err)
+
+	assert.Equal(t, events.LimitCreatedDefinition.Key(), req.DefinitionKey)
+	assert.Equal(t, "tenant-1", req.TenantID)
+	assert.Equal(t, payload.ID, req.Subject)
+	assert.Equal(t, fixedTime, req.Timestamp)
+
+	var roundTrip events.LimitCreatedPayload
+	require.NoError(t, json.Unmarshal(req.Payload, &roundTrip))
+	assert.Equal(t, payload, roundTrip)
+}
+
+func TestLimitCreatedPayload_JSONShape(t *testing.T) {
+	// fullLimit populates Name/Description/MaxAmount on purpose to prove the
+	// fence keeps them off the wire.
+	data, err := json.Marshal(events.NewLimitCreated(fullLimit(t)))
+	require.NoError(t, err)
+
+	var generic map[string]any
+	require.NoError(t, json.Unmarshal(data, &generic))
+
+	expectedKeys := map[string]struct{}{
+		"id":              {},
+		"status":          {},
+		"limitType":       {},
+		"currency":        {},
+		"scopes":          {},
+		"activeTimeStart": {},
+		"activeTimeEnd":   {},
+		"customStartDate": {},
+		"customEndDate":   {},
+		"resetAt":         {},
+		"createdAt":       {},
+		"updatedAt":       {},
+	}
+
+	for key := range generic {
+		_, ok := expectedKeys[key]
+		assert.Truef(t, ok, "wire payload has unexpected top-level key %q (drift?)", key)
+	}
+
+	for key := range expectedKeys {
+		_, ok := generic[key]
+		assert.Truef(t, ok, "wire payload must include %q", key)
+	}
+
+	// Fence: free text and the financial value MUST NOT appear.
+	for _, forbidden := range []string{"name", "description", "maxAmount"} {
+		_, present := generic[forbidden]
+		assert.Falsef(t, present, "fenced field %q must NOT appear on the wire", forbidden)
+	}
+
+	assert.Lenf(t, generic, 12, "expected 12 top-level fields, got %d (drift?)", len(generic))
+}
+
+func TestLimitCreatedPayload_JSONShape_NullableKeysPresentWhenUnset(t *testing.T) {
+	data, err := json.Marshal(events.NewLimitCreated(minimalLimit()))
+	require.NoError(t, err)
+
+	var generic map[string]any
+	require.NoError(t, json.Unmarshal(data, &generic))
+
+	// Nullable keys must be present with a null value (never omitempty).
+	for _, key := range []string{"activeTimeStart", "activeTimeEnd", "customStartDate", "customEndDate", "resetAt"} {
+		val, present := generic[key]
+		require.Truef(t, present, "%q key must be present even when unset", key)
+		assert.Nilf(t, val, "%q must serialize null when unset", key)
+	}
+
+	// scopes must serialize as [] (non-nil), not null.
+	scopes, present := generic["scopes"]
+	require.True(t, present)
+	assert.NotNil(t, scopes, "scopes must serialize as [] not null")
+}

--- a/pkg/streaming/events/limit_deactivated.go
+++ b/pkg/streaming/events/limit_deactivated.go
@@ -1,0 +1,58 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package events
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	libStreaming "github.com/LerianStudio/lib-streaming"
+
+	"github.com/LerianStudio/midaz/v4/components/tracer/pkg/model"
+)
+
+// LimitDeactivatedDefinition is the routing contract for limit.deactivated.
+// Subject (ce-subject) is the limit ID.
+var LimitDeactivatedDefinition = Definition{
+	ResourceType:  "limit",
+	EventType:     "deactivated",
+	SchemaVersion: "1.0.0",
+}
+
+// LimitDeactivatedPayload is the minimal wire payload for limit.deactivated.
+// model.Limit has no DeactivatedAt field, so the payload carries only
+// identity, status, and the update time.
+type LimitDeactivatedPayload struct {
+	ID        string `json:"id"`
+	Status    string `json:"status"`
+	UpdatedAt string `json:"updatedAt"`
+}
+
+// NewLimitDeactivated maps a limit into the limit.deactivated wire payload.
+func NewLimitDeactivated(limit *model.Limit) LimitDeactivatedPayload {
+	return LimitDeactivatedPayload{
+		ID:        limit.ID.String(),
+		Status:    string(limit.Status),
+		UpdatedAt: limit.UpdatedAt.Format(time.RFC3339),
+	}
+}
+
+// ToEmitRequest assembles a libStreaming.EmitRequest; ts is typically the
+// persisted UpdatedAt for this event.
+func (p LimitDeactivatedPayload) ToEmitRequest(tenantID string, ts time.Time) (libStreaming.EmitRequest, error) {
+	data, err := json.Marshal(p)
+	if err != nil {
+		return libStreaming.EmitRequest{}, fmt.Errorf("marshal %s payload: %w", LimitDeactivatedDefinition.Key(), err)
+	}
+
+	return libStreaming.EmitRequest{
+		DefinitionKey: LimitDeactivatedDefinition.Key(),
+		TenantID:      tenantID,
+		Subject:       p.ID,
+		Timestamp:     ts,
+		Payload:       data,
+	}, nil
+}

--- a/pkg/streaming/events/limit_deactivated_test.go
+++ b/pkg/streaming/events/limit_deactivated_test.go
@@ -1,0 +1,89 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package events_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/LerianStudio/midaz/v4/components/tracer/pkg/model"
+	"github.com/LerianStudio/midaz/v4/pkg/streaming/events"
+)
+
+func TestLimitDeactivatedDefinition_Key(t *testing.T) {
+	assert.Equal(t, "limit.deactivated", events.LimitDeactivatedDefinition.Key())
+	assert.Equal(t, "limit", events.LimitDeactivatedDefinition.ResourceType)
+	assert.Equal(t, "deactivated", events.LimitDeactivatedDefinition.EventType)
+	assert.Equal(t, "1.0.0", events.LimitDeactivatedDefinition.SchemaVersion)
+}
+
+func TestNewLimitDeactivated_MapsLimit(t *testing.T) {
+	limit := minimalLimit()
+	limit.Status = model.LimitStatusInactive
+
+	payload := events.NewLimitDeactivated(limit)
+
+	assert.Equal(t, fixedLimitUUID.String(), payload.ID)
+	assert.Equal(t, "INACTIVE", payload.Status)
+	assert.Equal(t, "2026-05-13T12:34:56Z", payload.UpdatedAt)
+}
+
+func TestLimitDeactivatedPayload_ToEmitRequest(t *testing.T) {
+	limit := minimalLimit()
+	limit.Status = model.LimitStatusInactive
+
+	payload := events.NewLimitDeactivated(limit)
+
+	req, err := payload.ToEmitRequest("tenant-3", fixedTime)
+	require.NoError(t, err)
+
+	assert.Equal(t, events.LimitDeactivatedDefinition.Key(), req.DefinitionKey)
+	assert.Equal(t, "tenant-3", req.TenantID)
+	assert.Equal(t, payload.ID, req.Subject)
+	assert.Equal(t, fixedTime, req.Timestamp)
+
+	var roundTrip events.LimitDeactivatedPayload
+	require.NoError(t, json.Unmarshal(req.Payload, &roundTrip))
+	assert.Equal(t, payload, roundTrip)
+}
+
+func TestLimitDeactivatedPayload_JSONShape(t *testing.T) {
+	limit := minimalLimit()
+	limit.Status = model.LimitStatusInactive
+
+	data, err := json.Marshal(events.NewLimitDeactivated(limit))
+	require.NoError(t, err)
+
+	var generic map[string]any
+	require.NoError(t, json.Unmarshal(data, &generic))
+
+	expectedKeys := map[string]struct{}{
+		"id":        {},
+		"status":    {},
+		"updatedAt": {},
+	}
+
+	for key := range generic {
+		_, ok := expectedKeys[key]
+		assert.Truef(t, ok, "unexpected top-level key %q (drift?)", key)
+	}
+
+	for key := range expectedKeys {
+		_, ok := generic[key]
+		assert.Truef(t, ok, "must include %q", key)
+	}
+
+	for _, forbidden := range []string{
+		"activatedAt", "deactivatedAt", "limitType", "currency", "scopes", "maxAmount", "name", "description",
+	} {
+		_, present := generic[forbidden]
+		assert.Falsef(t, present, "field %q must NOT appear", forbidden)
+	}
+
+	assert.Lenf(t, generic, 3, "expected 3 top-level fields, got %d (drift?)", len(generic))
+}

--- a/pkg/streaming/events/limit_deleted.go
+++ b/pkg/streaming/events/limit_deleted.go
@@ -1,0 +1,68 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package events
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	libStreaming "github.com/LerianStudio/lib-streaming"
+
+	"github.com/LerianStudio/midaz/v4/components/tracer/pkg/model"
+)
+
+// LimitDeletedDefinition is the routing contract for limit.deleted.
+// Subject (ce-subject) is the limit ID.
+var LimitDeletedDefinition = Definition{
+	ResourceType:  "limit",
+	EventType:     "deleted",
+	SchemaVersion: "1.0.0",
+}
+
+// LimitDeletedPayload is the leanest limit wire payload: just the identity and
+// the soft-delete timestamp. No status — deletion is terminal.
+type LimitDeletedPayload struct {
+	ID        string `json:"id"`
+	DeletedAt string `json:"deletedAt"`
+}
+
+// NewLimitDeleted maps a soft-deleted limit into the wire payload.
+//
+// Unlike NewRuleDeleted, which takes primitives because the rule delete use
+// case returns no entity, the limit delete command mutates the in-memory
+// entity's DeletedAt (via SetStatus(DELETED, now)) before the tx, so this
+// domain constructor reads limit.DeletedAt directly. The nil-guard is
+// defensive: after SetStatus(DELETED) DeletedAt is always non-nil, but a nil
+// value must never panic — it falls back to an empty deletedAt.
+func NewLimitDeleted(limit *model.Limit) LimitDeletedPayload {
+	deletedAt := ""
+	if limit.DeletedAt != nil {
+		deletedAt = limit.DeletedAt.Format(time.RFC3339)
+	}
+
+	return LimitDeletedPayload{
+		ID:        limit.ID.String(),
+		DeletedAt: deletedAt,
+	}
+}
+
+// ToEmitRequest assembles a libStreaming.EmitRequest; ts is typically the
+// limit's delete time (DeletedAt/UpdatedAt, which SetStatus(DELETED) set to the
+// same instant).
+func (p LimitDeletedPayload) ToEmitRequest(tenantID string, ts time.Time) (libStreaming.EmitRequest, error) {
+	data, err := json.Marshal(p)
+	if err != nil {
+		return libStreaming.EmitRequest{}, fmt.Errorf("marshal %s payload: %w", LimitDeletedDefinition.Key(), err)
+	}
+
+	return libStreaming.EmitRequest{
+		DefinitionKey: LimitDeletedDefinition.Key(),
+		TenantID:      tenantID,
+		Subject:       p.ID,
+		Timestamp:     ts,
+		Payload:       data,
+	}, nil
+}

--- a/pkg/streaming/events/limit_deleted.go
+++ b/pkg/streaming/events/limit_deleted.go
@@ -29,14 +29,8 @@ type LimitDeletedPayload struct {
 	DeletedAt string `json:"deletedAt"`
 }
 
-// NewLimitDeleted maps a soft-deleted limit into the wire payload.
-//
-// Unlike NewRuleDeleted, which takes primitives because the rule delete use
-// case returns no entity, the limit delete command mutates the in-memory
-// entity's DeletedAt (via SetStatus(DELETED, now)) before the tx, so this
-// domain constructor reads limit.DeletedAt directly. The nil-guard is
-// defensive: after SetStatus(DELETED) DeletedAt is always non-nil, but a nil
-// value must never panic — it falls back to an empty deletedAt.
+// NewLimitDeleted maps a soft-deleted limit into the wire payload. A nil
+// DeletedAt falls back to an empty deletedAt rather than panicking.
 func NewLimitDeleted(limit *model.Limit) LimitDeletedPayload {
 	deletedAt := ""
 	if limit.DeletedAt != nil {
@@ -49,9 +43,8 @@ func NewLimitDeleted(limit *model.Limit) LimitDeletedPayload {
 	}
 }
 
-// ToEmitRequest assembles a libStreaming.EmitRequest; ts is typically the
-// limit's delete time (DeletedAt/UpdatedAt, which SetStatus(DELETED) set to the
-// same instant).
+// ToEmitRequest assembles a libStreaming.EmitRequest; ts is the limit's delete
+// timestamp.
 func (p LimitDeletedPayload) ToEmitRequest(tenantID string, ts time.Time) (libStreaming.EmitRequest, error) {
 	data, err := json.Marshal(p)
 	if err != nil {

--- a/pkg/streaming/events/limit_deleted_test.go
+++ b/pkg/streaming/events/limit_deleted_test.go
@@ -1,0 +1,101 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package events_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/LerianStudio/midaz/v4/components/tracer/pkg/model"
+	"github.com/LerianStudio/midaz/v4/pkg/streaming/events"
+)
+
+func TestLimitDeletedDefinition_Key(t *testing.T) {
+	assert.Equal(t, "limit.deleted", events.LimitDeletedDefinition.Key())
+	assert.Equal(t, "limit", events.LimitDeletedDefinition.ResourceType)
+	assert.Equal(t, "deleted", events.LimitDeletedDefinition.EventType)
+	assert.Equal(t, "1.0.0", events.LimitDeletedDefinition.SchemaVersion)
+}
+
+func TestNewLimitDeleted_MapsDomain(t *testing.T) {
+	limit := minimalLimit()
+	deletedAt := fixedTime
+	limit.Status = model.LimitStatusDeleted
+	limit.DeletedAt = &deletedAt
+
+	payload := events.NewLimitDeleted(limit)
+
+	assert.Equal(t, fixedLimitUUID.String(), payload.ID)
+	assert.Equal(t, "2026-05-13T12:34:56Z", payload.DeletedAt)
+}
+
+func TestNewLimitDeleted_NilDeletedAtDoesNotPanic(t *testing.T) {
+	limit := minimalLimit()
+	limit.DeletedAt = nil
+
+	payload := events.NewLimitDeleted(limit)
+
+	assert.Equal(t, fixedLimitUUID.String(), payload.ID)
+	assert.Equal(t, "", payload.DeletedAt)
+}
+
+func TestLimitDeletedPayload_ToEmitRequest(t *testing.T) {
+	limit := minimalLimit()
+	deletedAt := fixedTime
+	limit.DeletedAt = &deletedAt
+
+	payload := events.NewLimitDeleted(limit)
+
+	req, err := payload.ToEmitRequest("tenant-1", fixedTime)
+	require.NoError(t, err)
+
+	assert.Equal(t, events.LimitDeletedDefinition.Key(), req.DefinitionKey)
+	assert.Equal(t, "tenant-1", req.TenantID)
+	assert.Equal(t, payload.ID, req.Subject)
+	assert.Equal(t, fixedTime, req.Timestamp)
+
+	var roundTrip events.LimitDeletedPayload
+	require.NoError(t, json.Unmarshal(req.Payload, &roundTrip))
+	assert.Equal(t, payload, roundTrip)
+}
+
+func TestLimitDeletedPayload_JSONShape(t *testing.T) {
+	limit := minimalLimit()
+	deletedAt := fixedTime
+	limit.DeletedAt = &deletedAt
+
+	data, err := json.Marshal(events.NewLimitDeleted(limit))
+	require.NoError(t, err)
+
+	var generic map[string]any
+	require.NoError(t, json.Unmarshal(data, &generic))
+
+	expectedKeys := map[string]struct{}{
+		"id":        {},
+		"deletedAt": {},
+	}
+
+	for key := range generic {
+		_, ok := expectedKeys[key]
+		assert.Truef(t, ok, "unexpected top-level key %q (drift?)", key)
+	}
+
+	for key := range expectedKeys {
+		_, ok := generic[key]
+		assert.Truef(t, ok, "must include %q", key)
+	}
+
+	for _, forbidden := range []string{
+		"status", "name", "description", "maxAmount", "limitType", "currency", "scopes",
+	} {
+		_, present := generic[forbidden]
+		assert.Falsef(t, present, "field %q must NOT appear", forbidden)
+	}
+
+	assert.Lenf(t, generic, 2, "expected 2 top-level fields, got %d (drift?)", len(generic))
+}

--- a/pkg/streaming/events/limit_drafted.go
+++ b/pkg/streaming/events/limit_drafted.go
@@ -1,0 +1,58 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package events
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	libStreaming "github.com/LerianStudio/lib-streaming"
+
+	"github.com/LerianStudio/midaz/v4/components/tracer/pkg/model"
+)
+
+// LimitDraftedDefinition is the routing contract for limit.drafted.
+// Subject (ce-subject) is the limit ID.
+var LimitDraftedDefinition = Definition{
+	ResourceType:  "limit",
+	EventType:     "drafted",
+	SchemaVersion: "1.0.0",
+}
+
+// LimitDraftedPayload is the minimal wire payload for limit.drafted. model.Limit
+// has no transition-timestamp fields, so the payload carries only identity,
+// status, and the update time.
+type LimitDraftedPayload struct {
+	ID        string `json:"id"`
+	Status    string `json:"status"`
+	UpdatedAt string `json:"updatedAt"`
+}
+
+// NewLimitDrafted maps a limit into the limit.drafted wire payload.
+func NewLimitDrafted(limit *model.Limit) LimitDraftedPayload {
+	return LimitDraftedPayload{
+		ID:        limit.ID.String(),
+		Status:    string(limit.Status),
+		UpdatedAt: limit.UpdatedAt.Format(time.RFC3339),
+	}
+}
+
+// ToEmitRequest assembles a libStreaming.EmitRequest; ts is typically the
+// persisted UpdatedAt for this event.
+func (p LimitDraftedPayload) ToEmitRequest(tenantID string, ts time.Time) (libStreaming.EmitRequest, error) {
+	data, err := json.Marshal(p)
+	if err != nil {
+		return libStreaming.EmitRequest{}, fmt.Errorf("marshal %s payload: %w", LimitDraftedDefinition.Key(), err)
+	}
+
+	return libStreaming.EmitRequest{
+		DefinitionKey: LimitDraftedDefinition.Key(),
+		TenantID:      tenantID,
+		Subject:       p.ID,
+		Timestamp:     ts,
+		Payload:       data,
+	}, nil
+}

--- a/pkg/streaming/events/limit_drafted_test.go
+++ b/pkg/streaming/events/limit_drafted_test.go
@@ -1,0 +1,85 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package events_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/LerianStudio/midaz/v4/components/tracer/pkg/model"
+	"github.com/LerianStudio/midaz/v4/pkg/streaming/events"
+)
+
+func TestLimitDraftedDefinition_Key(t *testing.T) {
+	assert.Equal(t, "limit.drafted", events.LimitDraftedDefinition.Key())
+	assert.Equal(t, "limit", events.LimitDraftedDefinition.ResourceType)
+	assert.Equal(t, "drafted", events.LimitDraftedDefinition.EventType)
+	assert.Equal(t, "1.0.0", events.LimitDraftedDefinition.SchemaVersion)
+}
+
+func TestNewLimitDrafted_MapsLimit(t *testing.T) {
+	limit := minimalLimit()
+	limit.Status = model.LimitStatusDraft
+
+	payload := events.NewLimitDrafted(limit)
+
+	assert.Equal(t, fixedLimitUUID.String(), payload.ID)
+	assert.Equal(t, "DRAFT", payload.Status)
+	assert.Equal(t, "2026-05-13T12:34:56Z", payload.UpdatedAt)
+}
+
+func TestLimitDraftedPayload_ToEmitRequest(t *testing.T) {
+	limit := minimalLimit()
+
+	payload := events.NewLimitDrafted(limit)
+
+	req, err := payload.ToEmitRequest("tenant-x", fixedTime)
+	require.NoError(t, err)
+
+	assert.Equal(t, events.LimitDraftedDefinition.Key(), req.DefinitionKey)
+	assert.Equal(t, "tenant-x", req.TenantID)
+	assert.Equal(t, payload.ID, req.Subject)
+	assert.Equal(t, fixedTime, req.Timestamp)
+
+	var roundTrip events.LimitDraftedPayload
+	require.NoError(t, json.Unmarshal(req.Payload, &roundTrip))
+	assert.Equal(t, payload, roundTrip)
+}
+
+func TestLimitDraftedPayload_JSONShape(t *testing.T) {
+	data, err := json.Marshal(events.NewLimitDrafted(minimalLimit()))
+	require.NoError(t, err)
+
+	var generic map[string]any
+	require.NoError(t, json.Unmarshal(data, &generic))
+
+	expectedKeys := map[string]struct{}{
+		"id":        {},
+		"status":    {},
+		"updatedAt": {},
+	}
+
+	for key := range generic {
+		_, ok := expectedKeys[key]
+		assert.Truef(t, ok, "unexpected top-level key %q (drift?)", key)
+	}
+
+	for key := range expectedKeys {
+		_, ok := generic[key]
+		assert.Truef(t, ok, "must include %q", key)
+	}
+
+	for _, forbidden := range []string{
+		"activatedAt", "deactivatedAt", "limitType", "currency", "scopes", "maxAmount", "name", "description",
+	} {
+		_, present := generic[forbidden]
+		assert.Falsef(t, present, "field %q must NOT appear", forbidden)
+	}
+
+	assert.Lenf(t, generic, 3, "expected 3 top-level fields, got %d (drift?)", len(generic))
+}

--- a/pkg/streaming/events/limit_updated.go
+++ b/pkg/streaming/events/limit_updated.go
@@ -1,0 +1,77 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package events
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	libStreaming "github.com/LerianStudio/lib-streaming"
+
+	"github.com/LerianStudio/midaz/v4/components/tracer/pkg/model"
+)
+
+// LimitUpdatedDefinition is the routing contract for limit.updated.
+// Subject (ce-subject) is the limit ID.
+var LimitUpdatedDefinition = Definition{
+	ResourceType:  "limit",
+	EventType:     "updated",
+	SchemaVersion: "1.0.0",
+}
+
+// LimitUpdatedPayload is the wire payload for limit.updated. It carries the
+// same twelve-field shape as LimitCreatedPayload; the fence EXCLUDES name,
+// description, and maxAmount.
+type LimitUpdatedPayload struct {
+	ID              string             `json:"id"`
+	Status          string             `json:"status"`
+	LimitType       string             `json:"limitType"`
+	Currency        string             `json:"currency"`
+	Scopes          []RuleScopePayload `json:"scopes"`
+	ActiveTimeStart *string            `json:"activeTimeStart"`
+	ActiveTimeEnd   *string            `json:"activeTimeEnd"`
+	CustomStartDate *string            `json:"customStartDate"`
+	CustomEndDate   *string            `json:"customEndDate"`
+	ResetAt         *string            `json:"resetAt"`
+	CreatedAt       string             `json:"createdAt"`
+	UpdatedAt       string             `json:"updatedAt"`
+}
+
+// NewLimitUpdated maps a persisted limit into the wire payload. Status and
+// LimitType are mapped via a plain string conversion.
+func NewLimitUpdated(limit *model.Limit) LimitUpdatedPayload {
+	return LimitUpdatedPayload{
+		ID:              limit.ID.String(),
+		Status:          string(limit.Status),
+		LimitType:       string(limit.LimitType),
+		Currency:        limit.Currency,
+		Scopes:          newRuleScopePayloads(limit.Scopes),
+		ActiveTimeStart: formatOptionalTimeOfDay(limit.ActiveTimeStart),
+		ActiveTimeEnd:   formatOptionalTimeOfDay(limit.ActiveTimeEnd),
+		CustomStartDate: formatOptionalRFC3339(limit.CustomStartDate),
+		CustomEndDate:   formatOptionalRFC3339(limit.CustomEndDate),
+		ResetAt:         formatOptionalRFC3339(limit.ResetAt),
+		CreatedAt:       limit.CreatedAt.Format(time.RFC3339),
+		UpdatedAt:       limit.UpdatedAt.Format(time.RFC3339),
+	}
+}
+
+// ToEmitRequest assembles a libStreaming.EmitRequest; ts is typically the
+// persisted UpdatedAt for this event.
+func (p LimitUpdatedPayload) ToEmitRequest(tenantID string, ts time.Time) (libStreaming.EmitRequest, error) {
+	data, err := json.Marshal(p)
+	if err != nil {
+		return libStreaming.EmitRequest{}, fmt.Errorf("marshal %s payload: %w", LimitUpdatedDefinition.Key(), err)
+	}
+
+	return libStreaming.EmitRequest{
+		DefinitionKey: LimitUpdatedDefinition.Key(),
+		TenantID:      tenantID,
+		Subject:       p.ID,
+		Timestamp:     ts,
+		Payload:       data,
+	}, nil
+}

--- a/pkg/streaming/events/limit_updated_test.go
+++ b/pkg/streaming/events/limit_updated_test.go
@@ -1,0 +1,104 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package events_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/LerianStudio/midaz/v4/pkg/streaming/events"
+)
+
+func TestLimitUpdatedDefinition_Key(t *testing.T) {
+	assert.Equal(t, "limit.updated", events.LimitUpdatedDefinition.Key())
+	assert.Equal(t, "limit", events.LimitUpdatedDefinition.ResourceType)
+	assert.Equal(t, "updated", events.LimitUpdatedDefinition.EventType)
+	assert.Equal(t, "1.0.0", events.LimitUpdatedDefinition.SchemaVersion)
+}
+
+func TestNewLimitUpdated_MapsMinimalLimit(t *testing.T) {
+	payload := events.NewLimitUpdated(minimalLimit())
+
+	assert.Equal(t, fixedLimitUUID.String(), payload.ID)
+	assert.Equal(t, "DRAFT", payload.Status)
+	assert.Equal(t, "DAILY", payload.LimitType)
+	assert.Equal(t, "USD", payload.Currency)
+	require.NotNil(t, payload.Scopes)
+	assert.Len(t, payload.Scopes, 0)
+	assert.Nil(t, payload.ActiveTimeStart)
+	assert.Nil(t, payload.ResetAt)
+	assert.Equal(t, "2026-05-13T12:34:56Z", payload.UpdatedAt)
+}
+
+func TestNewLimitUpdated_MapsAllOptionalFields(t *testing.T) {
+	payload := events.NewLimitUpdated(fullLimit(t))
+
+	assert.Equal(t, "ACTIVE", payload.Status)
+	assert.Equal(t, "CUSTOM", payload.LimitType)
+	require.NotNil(t, payload.ActiveTimeStart)
+	assert.Equal(t, "09:00", *payload.ActiveTimeStart)
+	require.NotNil(t, payload.ResetAt)
+	assert.Equal(t, "2026-05-13T12:34:56Z", *payload.ResetAt)
+	require.Len(t, payload.Scopes, 1)
+}
+
+func TestLimitUpdatedPayload_ToEmitRequest(t *testing.T) {
+	payload := events.NewLimitUpdated(fullLimit(t))
+
+	req, err := payload.ToEmitRequest("tenant-2", fixedTime)
+	require.NoError(t, err)
+
+	assert.Equal(t, events.LimitUpdatedDefinition.Key(), req.DefinitionKey)
+	assert.Equal(t, "tenant-2", req.TenantID)
+	assert.Equal(t, payload.ID, req.Subject)
+	assert.Equal(t, fixedTime, req.Timestamp)
+
+	var roundTrip events.LimitUpdatedPayload
+	require.NoError(t, json.Unmarshal(req.Payload, &roundTrip))
+	assert.Equal(t, payload, roundTrip)
+}
+
+func TestLimitUpdatedPayload_JSONShape(t *testing.T) {
+	data, err := json.Marshal(events.NewLimitUpdated(fullLimit(t)))
+	require.NoError(t, err)
+
+	var generic map[string]any
+	require.NoError(t, json.Unmarshal(data, &generic))
+
+	expectedKeys := map[string]struct{}{
+		"id":              {},
+		"status":          {},
+		"limitType":       {},
+		"currency":        {},
+		"scopes":          {},
+		"activeTimeStart": {},
+		"activeTimeEnd":   {},
+		"customStartDate": {},
+		"customEndDate":   {},
+		"resetAt":         {},
+		"createdAt":       {},
+		"updatedAt":       {},
+	}
+
+	for key := range generic {
+		_, ok := expectedKeys[key]
+		assert.Truef(t, ok, "wire payload has unexpected top-level key %q (drift?)", key)
+	}
+
+	for key := range expectedKeys {
+		_, ok := generic[key]
+		assert.Truef(t, ok, "wire payload must include %q", key)
+	}
+
+	for _, forbidden := range []string{"name", "description", "maxAmount"} {
+		_, present := generic[forbidden]
+		assert.Falsef(t, present, "fenced field %q must NOT appear on the wire", forbidden)
+	}
+
+	assert.Lenf(t, generic, 12, "expected 12 top-level fields, got %d (drift?)", len(generic))
+}

--- a/pkg/streaming/events/rule_activated.go
+++ b/pkg/streaming/events/rule_activated.go
@@ -1,0 +1,76 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package events
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	libStreaming "github.com/LerianStudio/lib-streaming"
+
+	"github.com/LerianStudio/midaz/v4/components/tracer/pkg/model"
+)
+
+// formatOptionalRFC3339 formats an optional timestamp as an RFC3339 *string,
+// returning nil when the input is nil so the wire serializes JSON null. Used
+// by rule status-transition payloads whose transition timestamp fields are
+// optional but must always be present as a key (never omitempty).
+func formatOptionalRFC3339(ts *time.Time) *string {
+	if ts == nil {
+		return nil
+	}
+
+	s := ts.Format(time.RFC3339)
+
+	return &s
+}
+
+// RuleActivatedDefinition is the routing contract for rule.activated.
+// Subject (ce-subject) is the rule ID.
+var RuleActivatedDefinition = Definition{
+	ResourceType:  "rule",
+	EventType:     "activated",
+	SchemaVersion: "1.0.0",
+}
+
+// RuleActivatedPayload is the wire payload for rule.activated. ActivatedAt is
+// a *string so a defensive nil serializes as JSON null; the key is always
+// present (NOT omitempty) per the locked contract.
+type RuleActivatedPayload struct {
+	ID          string  `json:"id"`
+	Status      string  `json:"status"`
+	ActivatedAt *string `json:"activatedAt"`
+	UpdatedAt   string  `json:"updatedAt"`
+}
+
+// NewRuleActivated maps a rule into the rule.activated wire payload. After a
+// real ACTIVE transition rule.ActivatedAt is non-nil, but the mapping is
+// nil-guarded defensively.
+func NewRuleActivated(rule *model.Rule) RuleActivatedPayload {
+	return RuleActivatedPayload{
+		ID:          rule.ID.String(),
+		Status:      rule.Status.String(),
+		ActivatedAt: formatOptionalRFC3339(rule.ActivatedAt),
+		UpdatedAt:   rule.UpdatedAt.Format(time.RFC3339),
+	}
+}
+
+// ToEmitRequest assembles a libStreaming.EmitRequest; ts is typically the
+// persisted UpdatedAt for this event.
+func (p RuleActivatedPayload) ToEmitRequest(tenantID string, ts time.Time) (libStreaming.EmitRequest, error) {
+	data, err := json.Marshal(p)
+	if err != nil {
+		return libStreaming.EmitRequest{}, fmt.Errorf("marshal %s payload: %w", RuleActivatedDefinition.Key(), err)
+	}
+
+	return libStreaming.EmitRequest{
+		DefinitionKey: RuleActivatedDefinition.Key(),
+		TenantID:      tenantID,
+		Subject:       p.ID,
+		Timestamp:     ts,
+		Payload:       data,
+	}, nil
+}

--- a/pkg/streaming/events/rule_activated_test.go
+++ b/pkg/streaming/events/rule_activated_test.go
@@ -1,0 +1,109 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package events_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/LerianStudio/midaz/v4/components/tracer/pkg/model"
+	"github.com/LerianStudio/midaz/v4/pkg/streaming/events"
+)
+
+func TestRuleActivatedDefinition_Key(t *testing.T) {
+	assert.Equal(t, "rule.activated", events.RuleActivatedDefinition.Key())
+	assert.Equal(t, "rule", events.RuleActivatedDefinition.ResourceType)
+	assert.Equal(t, "activated", events.RuleActivatedDefinition.EventType)
+	assert.Equal(t, "1.0.0", events.RuleActivatedDefinition.SchemaVersion)
+}
+
+func TestNewRuleActivated_MapsWithTimestamp(t *testing.T) {
+	activatedAt := fixedTime
+	rule := minimalRule()
+	rule.Status = model.RuleStatusActive
+	rule.ActivatedAt = &activatedAt
+
+	payload := events.NewRuleActivated(rule)
+
+	assert.Equal(t, fixedRuleUUID.String(), payload.ID)
+	assert.Equal(t, "ACTIVE", payload.Status)
+	require.NotNil(t, payload.ActivatedAt)
+	assert.Equal(t, "2026-05-13T12:34:56Z", *payload.ActivatedAt)
+	assert.Equal(t, "2026-05-13T12:34:56Z", payload.UpdatedAt)
+}
+
+func TestNewRuleActivated_NilTimestamp(t *testing.T) {
+	rule := minimalRule()
+	rule.Status = model.RuleStatusActive
+	rule.ActivatedAt = nil
+
+	payload := events.NewRuleActivated(rule)
+
+	assert.Nil(t, payload.ActivatedAt)
+}
+
+func TestRuleActivatedPayload_ToEmitRequest(t *testing.T) {
+	activatedAt := fixedTime
+	rule := minimalRule()
+	rule.ActivatedAt = &activatedAt
+
+	payload := events.NewRuleActivated(rule)
+
+	req, err := payload.ToEmitRequest("tenant-1", fixedTime)
+	require.NoError(t, err)
+
+	assert.Equal(t, events.RuleActivatedDefinition.Key(), req.DefinitionKey)
+	assert.Equal(t, "tenant-1", req.TenantID)
+	assert.Equal(t, payload.ID, req.Subject)
+	assert.Equal(t, fixedTime, req.Timestamp)
+
+	var roundTrip events.RuleActivatedPayload
+	require.NoError(t, json.Unmarshal(req.Payload, &roundTrip))
+	assert.Equal(t, payload, roundTrip)
+}
+
+func TestRuleActivatedPayload_JSONShape(t *testing.T) {
+	// Nil timestamp path: key must still be present with value null.
+	rule := minimalRule()
+	rule.ActivatedAt = nil
+
+	data, err := json.Marshal(events.NewRuleActivated(rule))
+	require.NoError(t, err)
+
+	var generic map[string]any
+	require.NoError(t, json.Unmarshal(data, &generic))
+
+	expectedKeys := map[string]struct{}{
+		"id":          {},
+		"status":      {},
+		"activatedAt": {},
+		"updatedAt":   {},
+	}
+
+	for key := range generic {
+		_, ok := expectedKeys[key]
+		assert.Truef(t, ok, "unexpected top-level key %q (drift?)", key)
+	}
+
+	for key := range expectedKeys {
+		_, ok := generic[key]
+		assert.Truef(t, ok, "must include %q", key)
+	}
+
+	// activatedAt key present even when nil (NOT omitempty), value null.
+	val, present := generic["activatedAt"]
+	require.True(t, present)
+	assert.Nil(t, val, "activatedAt must serialize null when unset")
+
+	for _, forbidden := range []string{"name", "description", "expression", "action", "scopes"} {
+		_, present := generic[forbidden]
+		assert.Falsef(t, present, "fenced/absent field %q must NOT appear", forbidden)
+	}
+
+	assert.Lenf(t, generic, 4, "expected 4 top-level fields, got %d (drift?)", len(generic))
+}

--- a/pkg/streaming/events/rule_created.go
+++ b/pkg/streaming/events/rule_created.go
@@ -1,0 +1,70 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package events
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	libStreaming "github.com/LerianStudio/lib-streaming"
+
+	"github.com/LerianStudio/midaz/v4/components/tracer/pkg/model"
+)
+
+// RuleCreatedDefinition is the routing contract for rule.created.
+// Subject (ce-subject) is the rule ID. IMPORTANT posture: emit failures
+// MUST NOT fail the request.
+var RuleCreatedDefinition = Definition{
+	ResourceType:  "rule",
+	EventType:     "created",
+	SchemaVersion: "1.0.0",
+}
+
+// RuleCreatedPayload is the wire payload for rule.created. Fields are typed
+// independently of model.Rule so domain evolution does not leak onto the
+// wire. The payload fence EXCLUDES name, description, expression, and the
+// transient compiledProgram — those never appear on the wire.
+type RuleCreatedPayload struct {
+	ID        string             `json:"id"`
+	Status    string             `json:"status"`
+	Action    string             `json:"action"`
+	Scopes    []RuleScopePayload `json:"scopes"`
+	CreatedAt string             `json:"createdAt"`
+	UpdatedAt string             `json:"updatedAt"`
+}
+
+// NewRuleCreated maps a persisted rule into the wire payload. Every field
+// on RuleCreatedPayload must be assigned here; the JSONShape test locks the
+// field count so additions and deletions surface at test time.
+func NewRuleCreated(rule *model.Rule) RuleCreatedPayload {
+	return RuleCreatedPayload{
+		ID:        rule.ID.String(),
+		Status:    rule.Status.String(),
+		Action:    string(rule.Action),
+		Scopes:    newRuleScopePayloads(rule.Scopes),
+		CreatedAt: rule.CreatedAt.Format(time.RFC3339),
+		UpdatedAt: rule.UpdatedAt.Format(time.RFC3339),
+	}
+}
+
+// ToEmitRequest assembles a libStreaming.EmitRequest. tenantID comes from
+// pkgStreaming.ResolveTenantID(ctx); ts is the ce-time — typically the
+// persisted CreatedAt for this event. Returns a wrapped json.Marshal error
+// so IMPORTANT-posture callers can log Warn without failing the request.
+func (p RuleCreatedPayload) ToEmitRequest(tenantID string, ts time.Time) (libStreaming.EmitRequest, error) {
+	data, err := json.Marshal(p)
+	if err != nil {
+		return libStreaming.EmitRequest{}, fmt.Errorf("marshal %s payload: %w", RuleCreatedDefinition.Key(), err)
+	}
+
+	return libStreaming.EmitRequest{
+		DefinitionKey: RuleCreatedDefinition.Key(),
+		TenantID:      tenantID,
+		Subject:       p.ID,
+		Timestamp:     ts,
+		Payload:       data,
+	}, nil
+}

--- a/pkg/streaming/events/rule_created_test.go
+++ b/pkg/streaming/events/rule_created_test.go
@@ -1,0 +1,141 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package events_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/LerianStudio/midaz/v4/components/tracer/pkg/model"
+	"github.com/LerianStudio/midaz/v4/pkg/streaming/events"
+)
+
+// ruleFenceDescription/Expression/Name/CompiledProgram are deliberately
+// populated on fixtures to prove the fence keeps them off the wire.
+const (
+	fenceName       = "Block high-value checking transactions"
+	fenceExpression = "transaction.amount > 1000 && account.type == 'checking'"
+)
+
+// minimalRule returns the smallest Rule that satisfies the rule.created
+// contract, with the fenced free-text fields populated on purpose so tests
+// prove none of them leak onto the wire.
+func minimalRule() *model.Rule {
+	desc := "Denies transactions over $1000"
+
+	return &model.Rule{
+		ID:              fixedRuleUUID,
+		Name:            fenceName,
+		Description:     &desc,
+		Expression:      fenceExpression,
+		Action:          model.DecisionDeny,
+		Scopes:          nil,
+		Status:          model.RuleStatusDraft,
+		CreatedAt:       fixedTime,
+		UpdatedAt:       fixedTime,
+		CompiledProgram: "COMPILED",
+	}
+}
+
+func TestRuleCreatedDefinition_Key(t *testing.T) {
+	assert.Equal(t, "rule.created", events.RuleCreatedDefinition.Key())
+	assert.Equal(t, "rule", events.RuleCreatedDefinition.ResourceType)
+	assert.Equal(t, "created", events.RuleCreatedDefinition.EventType)
+	assert.Equal(t, "1.0.0", events.RuleCreatedDefinition.SchemaVersion)
+}
+
+func TestNewRuleCreated_MapsMinimalRule(t *testing.T) {
+	payload := events.NewRuleCreated(minimalRule())
+
+	assert.Equal(t, fixedRuleUUID.String(), payload.ID)
+	assert.Equal(t, "DRAFT", payload.Status)
+	assert.Equal(t, "DENY", payload.Action)
+	require.NotNil(t, payload.Scopes)
+	assert.Len(t, payload.Scopes, 0)
+	assert.Equal(t, "2026-05-13T12:34:56Z", payload.CreatedAt)
+	assert.Equal(t, "2026-05-13T12:34:56Z", payload.UpdatedAt)
+}
+
+func TestNewRuleCreated_MapsScopes(t *testing.T) {
+	txType := model.TransactionTypeCard
+	rule := minimalRule()
+	rule.Scopes = []model.Scope{{SegmentID: &scopeSegmentID, TransactionType: &txType}}
+
+	payload := events.NewRuleCreated(rule)
+
+	require.Len(t, payload.Scopes, 1)
+	require.NotNil(t, payload.Scopes[0].SegmentID)
+	assert.Equal(t, scopeSegmentID.String(), *payload.Scopes[0].SegmentID)
+}
+
+func TestRuleCreatedPayload_ToEmitRequest(t *testing.T) {
+	payload := events.NewRuleCreated(minimalRule())
+
+	req, err := payload.ToEmitRequest("tenant-1", fixedTime)
+	require.NoError(t, err)
+
+	assert.Equal(t, events.RuleCreatedDefinition.Key(), req.DefinitionKey)
+	assert.Equal(t, "tenant-1", req.TenantID)
+	assert.Equal(t, payload.ID, req.Subject)
+	assert.Equal(t, fixedTime, req.Timestamp)
+
+	var roundTrip events.RuleCreatedPayload
+	require.NoError(t, json.Unmarshal(req.Payload, &roundTrip))
+	assert.Equal(t, payload, roundTrip)
+}
+
+func TestRuleCreatedPayload_JSONShape(t *testing.T) {
+	txType := model.TransactionTypeCard
+	rule := minimalRule()
+	rule.Scopes = []model.Scope{{AccountID: &scopeAccountID, TransactionType: &txType}}
+
+	data, err := json.Marshal(events.NewRuleCreated(rule))
+	require.NoError(t, err)
+
+	var generic map[string]any
+	require.NoError(t, json.Unmarshal(data, &generic))
+
+	expectedKeys := map[string]struct{}{
+		"id":        {},
+		"status":    {},
+		"action":    {},
+		"scopes":    {},
+		"createdAt": {},
+		"updatedAt": {},
+	}
+
+	for key := range generic {
+		_, ok := expectedKeys[key]
+		assert.Truef(t, ok, "wire payload has unexpected top-level key %q (drift?)", key)
+	}
+
+	for key := range expectedKeys {
+		_, ok := generic[key]
+		assert.Truef(t, ok, "wire payload must include %q", key)
+	}
+
+	// Fence: free text and rule logic MUST NOT appear.
+	for _, forbidden := range []string{"name", "description", "expression", "compiledProgram"} {
+		_, present := generic[forbidden]
+		assert.Falsef(t, present, "fenced field %q must NOT appear on the wire", forbidden)
+	}
+
+	// Nested scope has exactly the six structural keys, no free text.
+	scopesRaw, ok := generic["scopes"].([]any)
+	require.True(t, ok)
+	require.Len(t, scopesRaw, 1)
+	scope, ok := scopesRaw[0].(map[string]any)
+	require.True(t, ok, "scope must serialize as an object")
+	assert.Lenf(t, scope, 6, "nested scope must have 6 keys, got %d", len(scope))
+	for _, forbidden := range []string{"name", "description", "expression"} {
+		_, present := scope[forbidden]
+		assert.Falsef(t, present, "scope must not carry %q", forbidden)
+	}
+
+	assert.Lenf(t, generic, 6, "expected 6 top-level fields, got %d (drift?)", len(generic))
+}

--- a/pkg/streaming/events/rule_deactivated.go
+++ b/pkg/streaming/events/rule_deactivated.go
@@ -1,0 +1,62 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package events
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	libStreaming "github.com/LerianStudio/lib-streaming"
+
+	"github.com/LerianStudio/midaz/v4/components/tracer/pkg/model"
+)
+
+// RuleDeactivatedDefinition is the routing contract for rule.deactivated.
+// Subject (ce-subject) is the rule ID.
+var RuleDeactivatedDefinition = Definition{
+	ResourceType:  "rule",
+	EventType:     "deactivated",
+	SchemaVersion: "1.0.0",
+}
+
+// RuleDeactivatedPayload is the wire payload for rule.deactivated.
+// DeactivatedAt is a *string so a defensive nil serializes as JSON null; the
+// key is always present (NOT omitempty) per the locked contract.
+type RuleDeactivatedPayload struct {
+	ID            string  `json:"id"`
+	Status        string  `json:"status"`
+	DeactivatedAt *string `json:"deactivatedAt"`
+	UpdatedAt     string  `json:"updatedAt"`
+}
+
+// NewRuleDeactivated maps a rule into the rule.deactivated wire payload.
+// After a real INACTIVE transition rule.DeactivatedAt is non-nil, but the
+// mapping is nil-guarded defensively.
+func NewRuleDeactivated(rule *model.Rule) RuleDeactivatedPayload {
+	return RuleDeactivatedPayload{
+		ID:            rule.ID.String(),
+		Status:        rule.Status.String(),
+		DeactivatedAt: formatOptionalRFC3339(rule.DeactivatedAt),
+		UpdatedAt:     rule.UpdatedAt.Format(time.RFC3339),
+	}
+}
+
+// ToEmitRequest assembles a libStreaming.EmitRequest; ts is typically the
+// persisted UpdatedAt for this event.
+func (p RuleDeactivatedPayload) ToEmitRequest(tenantID string, ts time.Time) (libStreaming.EmitRequest, error) {
+	data, err := json.Marshal(p)
+	if err != nil {
+		return libStreaming.EmitRequest{}, fmt.Errorf("marshal %s payload: %w", RuleDeactivatedDefinition.Key(), err)
+	}
+
+	return libStreaming.EmitRequest{
+		DefinitionKey: RuleDeactivatedDefinition.Key(),
+		TenantID:      tenantID,
+		Subject:       p.ID,
+		Timestamp:     ts,
+		Payload:       data,
+	}, nil
+}

--- a/pkg/streaming/events/rule_deactivated_test.go
+++ b/pkg/streaming/events/rule_deactivated_test.go
@@ -1,0 +1,107 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package events_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/LerianStudio/midaz/v4/components/tracer/pkg/model"
+	"github.com/LerianStudio/midaz/v4/pkg/streaming/events"
+)
+
+func TestRuleDeactivatedDefinition_Key(t *testing.T) {
+	assert.Equal(t, "rule.deactivated", events.RuleDeactivatedDefinition.Key())
+	assert.Equal(t, "rule", events.RuleDeactivatedDefinition.ResourceType)
+	assert.Equal(t, "deactivated", events.RuleDeactivatedDefinition.EventType)
+	assert.Equal(t, "1.0.0", events.RuleDeactivatedDefinition.SchemaVersion)
+}
+
+func TestNewRuleDeactivated_MapsWithTimestamp(t *testing.T) {
+	deactivatedAt := fixedTime
+	rule := minimalRule()
+	rule.Status = model.RuleStatusInactive
+	rule.DeactivatedAt = &deactivatedAt
+
+	payload := events.NewRuleDeactivated(rule)
+
+	assert.Equal(t, fixedRuleUUID.String(), payload.ID)
+	assert.Equal(t, "INACTIVE", payload.Status)
+	require.NotNil(t, payload.DeactivatedAt)
+	assert.Equal(t, "2026-05-13T12:34:56Z", *payload.DeactivatedAt)
+	assert.Equal(t, "2026-05-13T12:34:56Z", payload.UpdatedAt)
+}
+
+func TestNewRuleDeactivated_NilTimestamp(t *testing.T) {
+	rule := minimalRule()
+	rule.Status = model.RuleStatusInactive
+	rule.DeactivatedAt = nil
+
+	payload := events.NewRuleDeactivated(rule)
+
+	assert.Nil(t, payload.DeactivatedAt)
+}
+
+func TestRuleDeactivatedPayload_ToEmitRequest(t *testing.T) {
+	deactivatedAt := fixedTime
+	rule := minimalRule()
+	rule.DeactivatedAt = &deactivatedAt
+
+	payload := events.NewRuleDeactivated(rule)
+
+	req, err := payload.ToEmitRequest("tenant-9", fixedTime)
+	require.NoError(t, err)
+
+	assert.Equal(t, events.RuleDeactivatedDefinition.Key(), req.DefinitionKey)
+	assert.Equal(t, "tenant-9", req.TenantID)
+	assert.Equal(t, payload.ID, req.Subject)
+	assert.Equal(t, fixedTime, req.Timestamp)
+
+	var roundTrip events.RuleDeactivatedPayload
+	require.NoError(t, json.Unmarshal(req.Payload, &roundTrip))
+	assert.Equal(t, payload, roundTrip)
+}
+
+func TestRuleDeactivatedPayload_JSONShape(t *testing.T) {
+	rule := minimalRule()
+	rule.DeactivatedAt = nil
+
+	data, err := json.Marshal(events.NewRuleDeactivated(rule))
+	require.NoError(t, err)
+
+	var generic map[string]any
+	require.NoError(t, json.Unmarshal(data, &generic))
+
+	expectedKeys := map[string]struct{}{
+		"id":            {},
+		"status":        {},
+		"deactivatedAt": {},
+		"updatedAt":     {},
+	}
+
+	for key := range generic {
+		_, ok := expectedKeys[key]
+		assert.Truef(t, ok, "unexpected top-level key %q (drift?)", key)
+	}
+
+	for key := range expectedKeys {
+		_, ok := generic[key]
+		assert.Truef(t, ok, "must include %q", key)
+	}
+
+	val, present := generic["deactivatedAt"]
+	require.True(t, present)
+	assert.Nil(t, val, "deactivatedAt must serialize null when unset")
+
+	for _, forbidden := range []string{"name", "description", "expression", "action", "scopes", "activatedAt"} {
+		_, present := generic[forbidden]
+		assert.Falsef(t, present, "fenced/absent field %q must NOT appear", forbidden)
+	}
+
+	assert.Lenf(t, generic, 4, "expected 4 top-level fields, got %d (drift?)", len(generic))
+}

--- a/pkg/streaming/events/rule_deleted.go
+++ b/pkg/streaming/events/rule_deleted.go
@@ -1,0 +1,61 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package events
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	libStreaming "github.com/LerianStudio/lib-streaming"
+	"github.com/google/uuid"
+)
+
+// RuleDeletedDefinition is the routing contract for rule.deleted.
+// Subject (ce-subject) is the rule ID.
+var RuleDeletedDefinition = Definition{
+	ResourceType:  "rule",
+	EventType:     "deleted",
+	SchemaVersion: "1.0.0",
+}
+
+// RuleDeletedPayload is the leanest rule wire payload: just the identity and
+// the soft-delete timestamp. No status — deletion is terminal.
+type RuleDeletedPayload struct {
+	ID        string `json:"id"`
+	DeletedAt string `json:"deletedAt"`
+}
+
+// NewRuleDeleted maps the identity and delete timestamp into the wire
+// payload.
+//
+// Deviation from the New<Event>(domain) template: the tracer delete use case
+// returns no entity (it soft-deletes by ID and returns only error), so there
+// is no post-delete Rule to read DeletedAt from. The constructor therefore
+// takes primitives — the caller captures deletedAt at the delete site and
+// passes it here.
+func NewRuleDeleted(id uuid.UUID, deletedAt time.Time) RuleDeletedPayload {
+	return RuleDeletedPayload{
+		ID:        id.String(),
+		DeletedAt: deletedAt.Format(time.RFC3339),
+	}
+}
+
+// ToEmitRequest assembles a libStreaming.EmitRequest; ts is typically the
+// same captured deletedAt passed to the constructor.
+func (p RuleDeletedPayload) ToEmitRequest(tenantID string, ts time.Time) (libStreaming.EmitRequest, error) {
+	data, err := json.Marshal(p)
+	if err != nil {
+		return libStreaming.EmitRequest{}, fmt.Errorf("marshal %s payload: %w", RuleDeletedDefinition.Key(), err)
+	}
+
+	return libStreaming.EmitRequest{
+		DefinitionKey: RuleDeletedDefinition.Key(),
+		TenantID:      tenantID,
+		Subject:       p.ID,
+		Timestamp:     ts,
+		Payload:       data,
+	}, nil
+}

--- a/pkg/streaming/events/rule_deleted_test.go
+++ b/pkg/streaming/events/rule_deleted_test.go
@@ -1,0 +1,75 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package events_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/LerianStudio/midaz/v4/pkg/streaming/events"
+)
+
+func TestRuleDeletedDefinition_Key(t *testing.T) {
+	assert.Equal(t, "rule.deleted", events.RuleDeletedDefinition.Key())
+	assert.Equal(t, "rule", events.RuleDeletedDefinition.ResourceType)
+	assert.Equal(t, "deleted", events.RuleDeletedDefinition.EventType)
+	assert.Equal(t, "1.0.0", events.RuleDeletedDefinition.SchemaVersion)
+}
+
+func TestNewRuleDeleted_MapsPrimitives(t *testing.T) {
+	payload := events.NewRuleDeleted(fixedRuleUUID, fixedTime)
+
+	assert.Equal(t, fixedRuleUUID.String(), payload.ID)
+	assert.Equal(t, "2026-05-13T12:34:56Z", payload.DeletedAt)
+}
+
+func TestRuleDeletedPayload_ToEmitRequest(t *testing.T) {
+	payload := events.NewRuleDeleted(fixedRuleUUID, fixedTime)
+
+	req, err := payload.ToEmitRequest("tenant-1", fixedTime)
+	require.NoError(t, err)
+
+	assert.Equal(t, events.RuleDeletedDefinition.Key(), req.DefinitionKey)
+	assert.Equal(t, "tenant-1", req.TenantID)
+	assert.Equal(t, payload.ID, req.Subject)
+	assert.Equal(t, fixedTime, req.Timestamp)
+
+	var roundTrip events.RuleDeletedPayload
+	require.NoError(t, json.Unmarshal(req.Payload, &roundTrip))
+	assert.Equal(t, payload, roundTrip)
+}
+
+func TestRuleDeletedPayload_JSONShape(t *testing.T) {
+	data, err := json.Marshal(events.NewRuleDeleted(fixedRuleUUID, fixedTime))
+	require.NoError(t, err)
+
+	var generic map[string]any
+	require.NoError(t, json.Unmarshal(data, &generic))
+
+	expectedKeys := map[string]struct{}{
+		"id":        {},
+		"deletedAt": {},
+	}
+
+	for key := range generic {
+		_, ok := expectedKeys[key]
+		assert.Truef(t, ok, "unexpected top-level key %q (drift?)", key)
+	}
+
+	for key := range expectedKeys {
+		_, ok := generic[key]
+		assert.Truef(t, ok, "must include %q", key)
+	}
+
+	for _, forbidden := range []string{"status", "name", "description", "expression", "scopes", "action"} {
+		_, present := generic[forbidden]
+		assert.Falsef(t, present, "field %q must NOT appear", forbidden)
+	}
+
+	assert.Lenf(t, generic, 2, "expected 2 top-level fields, got %d (drift?)", len(generic))
+}

--- a/pkg/streaming/events/rule_drafted.go
+++ b/pkg/streaming/events/rule_drafted.go
@@ -1,0 +1,58 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package events
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	libStreaming "github.com/LerianStudio/lib-streaming"
+
+	"github.com/LerianStudio/midaz/v4/components/tracer/pkg/model"
+)
+
+// RuleDraftedDefinition is the routing contract for rule.drafted.
+// Subject (ce-subject) is the rule ID.
+var RuleDraftedDefinition = Definition{
+	ResourceType:  "rule",
+	EventType:     "drafted",
+	SchemaVersion: "1.0.0",
+}
+
+// RuleDraftedPayload is the minimal wire payload for rule.drafted. It omits
+// activatedAt and deactivatedAt because SetStatus(DRAFT) clears both — the
+// contract keeps drafted lean rather than emitting null noise.
+type RuleDraftedPayload struct {
+	ID        string `json:"id"`
+	Status    string `json:"status"`
+	UpdatedAt string `json:"updatedAt"`
+}
+
+// NewRuleDrafted maps a rule into the rule.drafted wire payload.
+func NewRuleDrafted(rule *model.Rule) RuleDraftedPayload {
+	return RuleDraftedPayload{
+		ID:        rule.ID.String(),
+		Status:    rule.Status.String(),
+		UpdatedAt: rule.UpdatedAt.Format(time.RFC3339),
+	}
+}
+
+// ToEmitRequest assembles a libStreaming.EmitRequest; ts is typically the
+// persisted UpdatedAt for this event.
+func (p RuleDraftedPayload) ToEmitRequest(tenantID string, ts time.Time) (libStreaming.EmitRequest, error) {
+	data, err := json.Marshal(p)
+	if err != nil {
+		return libStreaming.EmitRequest{}, fmt.Errorf("marshal %s payload: %w", RuleDraftedDefinition.Key(), err)
+	}
+
+	return libStreaming.EmitRequest{
+		DefinitionKey: RuleDraftedDefinition.Key(),
+		TenantID:      tenantID,
+		Subject:       p.ID,
+		Timestamp:     ts,
+		Payload:       data,
+	}, nil
+}

--- a/pkg/streaming/events/rule_drafted_test.go
+++ b/pkg/streaming/events/rule_drafted_test.go
@@ -1,0 +1,81 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package events_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/LerianStudio/midaz/v4/components/tracer/pkg/model"
+	"github.com/LerianStudio/midaz/v4/pkg/streaming/events"
+)
+
+func TestRuleDraftedDefinition_Key(t *testing.T) {
+	assert.Equal(t, "rule.drafted", events.RuleDraftedDefinition.Key())
+	assert.Equal(t, "rule", events.RuleDraftedDefinition.ResourceType)
+	assert.Equal(t, "drafted", events.RuleDraftedDefinition.EventType)
+	assert.Equal(t, "1.0.0", events.RuleDraftedDefinition.SchemaVersion)
+}
+
+func TestNewRuleDrafted_MapsRule(t *testing.T) {
+	rule := minimalRule()
+	rule.Status = model.RuleStatusDraft
+
+	payload := events.NewRuleDrafted(rule)
+
+	assert.Equal(t, fixedRuleUUID.String(), payload.ID)
+	assert.Equal(t, "DRAFT", payload.Status)
+	assert.Equal(t, "2026-05-13T12:34:56Z", payload.UpdatedAt)
+}
+
+func TestRuleDraftedPayload_ToEmitRequest(t *testing.T) {
+	payload := events.NewRuleDrafted(minimalRule())
+
+	req, err := payload.ToEmitRequest("tenant-x", fixedTime)
+	require.NoError(t, err)
+
+	assert.Equal(t, events.RuleDraftedDefinition.Key(), req.DefinitionKey)
+	assert.Equal(t, "tenant-x", req.TenantID)
+	assert.Equal(t, payload.ID, req.Subject)
+	assert.Equal(t, fixedTime, req.Timestamp)
+
+	var roundTrip events.RuleDraftedPayload
+	require.NoError(t, json.Unmarshal(req.Payload, &roundTrip))
+	assert.Equal(t, payload, roundTrip)
+}
+
+func TestRuleDraftedPayload_JSONShape(t *testing.T) {
+	data, err := json.Marshal(events.NewRuleDrafted(minimalRule()))
+	require.NoError(t, err)
+
+	var generic map[string]any
+	require.NoError(t, json.Unmarshal(data, &generic))
+
+	expectedKeys := map[string]struct{}{
+		"id":        {},
+		"status":    {},
+		"updatedAt": {},
+	}
+
+	for key := range generic {
+		_, ok := expectedKeys[key]
+		assert.Truef(t, ok, "unexpected top-level key %q (drift?)", key)
+	}
+
+	for key := range expectedKeys {
+		_, ok := generic[key]
+		assert.Truef(t, ok, "must include %q", key)
+	}
+
+	for _, forbidden := range []string{"name", "description", "expression", "action", "scopes", "activatedAt", "deactivatedAt"} {
+		_, present := generic[forbidden]
+		assert.Falsef(t, present, "fenced/absent field %q must NOT appear", forbidden)
+	}
+
+	assert.Lenf(t, generic, 3, "expected 3 top-level fields, got %d (drift?)", len(generic))
+}

--- a/pkg/streaming/events/rule_scope.go
+++ b/pkg/streaming/events/rule_scope.go
@@ -1,0 +1,74 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package events
+
+import (
+	"github.com/LerianStudio/midaz/v4/components/tracer/pkg/model"
+)
+
+// RuleScopePayload is the nested scope object shared by every rule event
+// that carries scopes (rule.created, rule.updated). It mirrors the six
+// structural fields of model.Scope, typed independently so domain evolution
+// does not silently shift the wire contract.
+//
+// Every field is a *string so JSON null distinguishes "unset" from an empty
+// value. The fence keeps this shape to structural identifiers and enums only:
+// no free text beyond subType, which is a structural sub-classifier.
+type RuleScopePayload struct {
+	SegmentID       *string `json:"segmentId"`
+	PortfolioID     *string `json:"portfolioId"`
+	AccountID       *string `json:"accountId"`
+	MerchantID      *string `json:"merchantId"`
+	TransactionType *string `json:"transactionType"`
+	SubType         *string `json:"subType"`
+}
+
+// newRuleScopePayloads maps a domain scope slice into the wire scope slice.
+// It always returns a non-nil slice so the wire serializes "scopes": [] and
+// never null when there are no scopes. Each domain pointer is dereferenced
+// under its own nil-guard, so a scope with any nil field cannot panic.
+func newRuleScopePayloads(scopes []model.Scope) []RuleScopePayload {
+	payloads := make([]RuleScopePayload, 0, len(scopes))
+
+	for i := range scopes {
+		scope := scopes[i]
+
+		var p RuleScopePayload
+
+		if scope.SegmentID != nil {
+			s := scope.SegmentID.String()
+			p.SegmentID = &s
+		}
+
+		if scope.PortfolioID != nil {
+			s := scope.PortfolioID.String()
+			p.PortfolioID = &s
+		}
+
+		if scope.AccountID != nil {
+			s := scope.AccountID.String()
+			p.AccountID = &s
+		}
+
+		if scope.MerchantID != nil {
+			s := scope.MerchantID.String()
+			p.MerchantID = &s
+		}
+
+		if scope.TransactionType != nil {
+			s := scope.TransactionType.String()
+			p.TransactionType = &s
+		}
+
+		if scope.SubType != nil {
+			s := *scope.SubType
+			p.SubType = &s
+		}
+
+		payloads = append(payloads, p)
+	}
+
+	return payloads
+}

--- a/pkg/streaming/events/rule_scope_test.go
+++ b/pkg/streaming/events/rule_scope_test.go
@@ -1,0 +1,193 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package events_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/LerianStudio/midaz/v4/components/tracer/pkg/model"
+	"github.com/LerianStudio/midaz/v4/pkg/streaming/events"
+)
+
+// fixedRuleUUID is a deterministic UUID used across rule event tests so
+// subject/payload assertions match by exact value.
+var fixedRuleUUID = uuid.MustParse("018f5e2a-1c3d-7a4b-9e6f-0a1b2c3d4e5f")
+
+// ruleScopeIDs are deterministic UUIDs used to populate scope fields.
+var (
+	scopeSegmentID   = uuid.MustParse("111e5e2a-1c3d-7a4b-9e6f-0a1b2c3d4e01")
+	scopePortfolioID = uuid.MustParse("222e5e2a-1c3d-7a4b-9e6f-0a1b2c3d4e02")
+	scopeAccountID   = uuid.MustParse("333e5e2a-1c3d-7a4b-9e6f-0a1b2c3d4e03")
+	scopeMerchantID  = uuid.MustParse("444e5e2a-1c3d-7a4b-9e6f-0a1b2c3d4e04")
+)
+
+// TestNewRuleScopePayloads_EmptySliceIsNonNil proves the mapper returns a
+// non-nil empty slice for an empty input so the wire always serializes
+// "scopes": [] and never null.
+func TestNewRuleScopePayloads_EmptySliceIsNonNil(t *testing.T) {
+	rule := &model.Rule{
+		ID:     fixedRuleUUID,
+		Status: model.RuleStatusDraft,
+		Action: model.DecisionDeny,
+		Scopes: nil,
+	}
+
+	payload := events.NewRuleCreated(rule)
+
+	require.NotNil(t, payload.Scopes)
+	assert.Len(t, payload.Scopes, 0)
+
+	data, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	var generic map[string]any
+	require.NoError(t, json.Unmarshal(data, &generic))
+
+	scopes, ok := generic["scopes"]
+	require.True(t, ok, "scopes key must be present")
+	assert.NotNil(t, scopes, "scopes must serialize as [] not null")
+}
+
+// TestNewRuleScopePayloads_PopulatedScope verifies each domain pointer maps
+// to its string form when non-nil, and unset fields stay nil (JSON null).
+func TestNewRuleScopePayloads_PopulatedScope(t *testing.T) {
+	txType := model.TransactionTypeCard
+	subType := "purchase"
+
+	rule := &model.Rule{
+		ID:     fixedRuleUUID,
+		Status: model.RuleStatusActive,
+		Action: model.DecisionAllow,
+		Scopes: []model.Scope{
+			{
+				SegmentID:       &scopeSegmentID,
+				TransactionType: &txType,
+				SubType:         &subType,
+			},
+		},
+	}
+
+	payload := events.NewRuleCreated(rule)
+
+	require.Len(t, payload.Scopes, 1)
+	sc := payload.Scopes[0]
+
+	require.NotNil(t, sc.SegmentID)
+	assert.Equal(t, scopeSegmentID.String(), *sc.SegmentID)
+
+	require.NotNil(t, sc.TransactionType)
+	assert.Equal(t, "CARD", *sc.TransactionType)
+
+	require.NotNil(t, sc.SubType)
+	assert.Equal(t, "purchase", *sc.SubType)
+
+	// Unset fields remain nil.
+	assert.Nil(t, sc.PortfolioID)
+	assert.Nil(t, sc.AccountID)
+	assert.Nil(t, sc.MerchantID)
+}
+
+// TestNewRuleScopePayloads_AllFieldsSet verifies a scope with every field set
+// maps each pointer without panic.
+func TestNewRuleScopePayloads_AllFieldsSet(t *testing.T) {
+	txType := model.TransactionTypePix
+	subType := "transfer"
+
+	rule := &model.Rule{
+		ID:     fixedRuleUUID,
+		Status: model.RuleStatusActive,
+		Action: model.DecisionReview,
+		Scopes: []model.Scope{
+			{
+				SegmentID:       &scopeSegmentID,
+				PortfolioID:     &scopePortfolioID,
+				AccountID:       &scopeAccountID,
+				MerchantID:      &scopeMerchantID,
+				TransactionType: &txType,
+				SubType:         &subType,
+			},
+		},
+	}
+
+	payload := events.NewRuleCreated(rule)
+
+	require.Len(t, payload.Scopes, 1)
+	sc := payload.Scopes[0]
+
+	require.NotNil(t, sc.SegmentID)
+	assert.Equal(t, scopeSegmentID.String(), *sc.SegmentID)
+	require.NotNil(t, sc.PortfolioID)
+	assert.Equal(t, scopePortfolioID.String(), *sc.PortfolioID)
+	require.NotNil(t, sc.AccountID)
+	assert.Equal(t, scopeAccountID.String(), *sc.AccountID)
+	require.NotNil(t, sc.MerchantID)
+	assert.Equal(t, scopeMerchantID.String(), *sc.MerchantID)
+	require.NotNil(t, sc.TransactionType)
+	assert.Equal(t, "PIX", *sc.TransactionType)
+	require.NotNil(t, sc.SubType)
+	assert.Equal(t, "transfer", *sc.SubType)
+}
+
+// TestRuleScopePayload_JSONShape locks the nested scope object to exactly six
+// keys and asserts no rule free-text leaks into a scope.
+func TestRuleScopePayload_JSONShape(t *testing.T) {
+	txType := model.TransactionTypeWire
+	subType := "b2b"
+
+	rule := &model.Rule{
+		ID:     fixedRuleUUID,
+		Status: model.RuleStatusActive,
+		Action: model.DecisionAllow,
+		Scopes: []model.Scope{
+			{
+				SegmentID:       &scopeSegmentID,
+				PortfolioID:     &scopePortfolioID,
+				AccountID:       &scopeAccountID,
+				MerchantID:      &scopeMerchantID,
+				TransactionType: &txType,
+				SubType:         &subType,
+			},
+		},
+	}
+
+	data, err := json.Marshal(events.NewRuleCreated(rule))
+	require.NoError(t, err)
+
+	var generic map[string]any
+	require.NoError(t, json.Unmarshal(data, &generic))
+
+	scopesRaw, ok := generic["scopes"].([]any)
+	require.True(t, ok, "scopes must serialize as an array")
+	require.Len(t, scopesRaw, 1)
+
+	scope, ok := scopesRaw[0].(map[string]any)
+	require.True(t, ok, "scope must serialize as an object")
+
+	expectedKeys := map[string]struct{}{
+		"segmentId":       {},
+		"portfolioId":     {},
+		"accountId":       {},
+		"merchantId":      {},
+		"transactionType": {},
+		"subType":         {},
+	}
+
+	for key := range scope {
+		_, allowed := expectedKeys[key]
+		assert.Truef(t, allowed, "scope has unexpected key %q (drift?)", key)
+	}
+
+	for key := range expectedKeys {
+		_, present := scope[key]
+		assert.Truef(t, present, "scope must include %q", key)
+	}
+
+	assert.Lenf(t, scope, 6, "expected 6 scope keys, got %d (drift?)", len(scope))
+}

--- a/pkg/streaming/events/rule_updated.go
+++ b/pkg/streaming/events/rule_updated.go
@@ -1,0 +1,64 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package events
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	libStreaming "github.com/LerianStudio/lib-streaming"
+
+	"github.com/LerianStudio/midaz/v4/components/tracer/pkg/model"
+)
+
+// RuleUpdatedDefinition is the routing contract for rule.updated.
+// Subject (ce-subject) is the rule ID.
+var RuleUpdatedDefinition = Definition{
+	ResourceType:  "rule",
+	EventType:     "updated",
+	SchemaVersion: "1.0.0",
+}
+
+// RuleUpdatedPayload is the wire payload for rule.updated. It shares the
+// full rule shape with rule.created and honors the same fence (no name,
+// description, expression, or compiledProgram).
+type RuleUpdatedPayload struct {
+	ID        string             `json:"id"`
+	Status    string             `json:"status"`
+	Action    string             `json:"action"`
+	Scopes    []RuleScopePayload `json:"scopes"`
+	CreatedAt string             `json:"createdAt"`
+	UpdatedAt string             `json:"updatedAt"`
+}
+
+// NewRuleUpdated maps a persisted rule into the rule.updated wire payload.
+func NewRuleUpdated(rule *model.Rule) RuleUpdatedPayload {
+	return RuleUpdatedPayload{
+		ID:        rule.ID.String(),
+		Status:    rule.Status.String(),
+		Action:    string(rule.Action),
+		Scopes:    newRuleScopePayloads(rule.Scopes),
+		CreatedAt: rule.CreatedAt.Format(time.RFC3339),
+		UpdatedAt: rule.UpdatedAt.Format(time.RFC3339),
+	}
+}
+
+// ToEmitRequest assembles a libStreaming.EmitRequest; ts is typically the
+// persisted UpdatedAt for this event.
+func (p RuleUpdatedPayload) ToEmitRequest(tenantID string, ts time.Time) (libStreaming.EmitRequest, error) {
+	data, err := json.Marshal(p)
+	if err != nil {
+		return libStreaming.EmitRequest{}, fmt.Errorf("marshal %s payload: %w", RuleUpdatedDefinition.Key(), err)
+	}
+
+	return libStreaming.EmitRequest{
+		DefinitionKey: RuleUpdatedDefinition.Key(),
+		TenantID:      tenantID,
+		Subject:       p.ID,
+		Timestamp:     ts,
+		Payload:       data,
+	}, nil
+}

--- a/pkg/streaming/events/rule_updated_test.go
+++ b/pkg/streaming/events/rule_updated_test.go
@@ -1,0 +1,162 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package events_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/LerianStudio/midaz/v4/components/tracer/pkg/model"
+	"github.com/LerianStudio/midaz/v4/pkg/streaming/events"
+)
+
+func TestRuleUpdatedDefinition_Key(t *testing.T) {
+	assert.Equal(t, "rule.updated", events.RuleUpdatedDefinition.Key())
+	assert.Equal(t, "rule", events.RuleUpdatedDefinition.ResourceType)
+	assert.Equal(t, "updated", events.RuleUpdatedDefinition.EventType)
+	assert.Equal(t, "1.0.0", events.RuleUpdatedDefinition.SchemaVersion)
+}
+
+func TestNewRuleUpdated_MapsMinimalRule(t *testing.T) {
+	rule := minimalRule()
+	rule.Status = model.RuleStatusActive
+	rule.Action = model.DecisionAllow
+
+	payload := events.NewRuleUpdated(rule)
+
+	assert.Equal(t, fixedRuleUUID.String(), payload.ID)
+	assert.Equal(t, "ACTIVE", payload.Status)
+	assert.Equal(t, "ALLOW", payload.Action)
+	require.NotNil(t, payload.Scopes)
+	assert.Len(t, payload.Scopes, 0)
+	assert.Equal(t, "2026-05-13T12:34:56Z", payload.CreatedAt)
+	assert.Equal(t, "2026-05-13T12:34:56Z", payload.UpdatedAt)
+}
+
+func TestNewRuleUpdated_MapsScopes(t *testing.T) {
+	subType := "purchase"
+	rule := minimalRule()
+	rule.Scopes = []model.Scope{{MerchantID: &scopeMerchantID, SubType: &subType}}
+
+	payload := events.NewRuleUpdated(rule)
+
+	require.Len(t, payload.Scopes, 1)
+	require.NotNil(t, payload.Scopes[0].MerchantID)
+	assert.Equal(t, scopeMerchantID.String(), *payload.Scopes[0].MerchantID)
+	require.NotNil(t, payload.Scopes[0].SubType)
+	assert.Equal(t, "purchase", *payload.Scopes[0].SubType)
+}
+
+func TestRuleUpdatedPayload_ToEmitRequest(t *testing.T) {
+	payload := events.NewRuleUpdated(minimalRule())
+
+	req, err := payload.ToEmitRequest("tenant-2", fixedTime)
+	require.NoError(t, err)
+
+	assert.Equal(t, events.RuleUpdatedDefinition.Key(), req.DefinitionKey)
+	assert.Equal(t, "tenant-2", req.TenantID)
+	assert.Equal(t, payload.ID, req.Subject)
+	assert.Equal(t, fixedTime, req.Timestamp)
+
+	var roundTrip events.RuleUpdatedPayload
+	require.NoError(t, json.Unmarshal(req.Payload, &roundTrip))
+	assert.Equal(t, payload, roundTrip)
+}
+
+func TestRuleUpdatedPayload_JSONShape(t *testing.T) {
+	data, err := json.Marshal(events.NewRuleUpdated(minimalRule()))
+	require.NoError(t, err)
+
+	var generic map[string]any
+	require.NoError(t, json.Unmarshal(data, &generic))
+
+	expectedKeys := map[string]struct{}{
+		"id":        {},
+		"status":    {},
+		"action":    {},
+		"scopes":    {},
+		"createdAt": {},
+		"updatedAt": {},
+	}
+
+	for key := range generic {
+		_, ok := expectedKeys[key]
+		assert.Truef(t, ok, "wire payload has unexpected top-level key %q (drift?)", key)
+	}
+
+	for key := range expectedKeys {
+		_, ok := generic[key]
+		assert.Truef(t, ok, "wire payload must include %q", key)
+	}
+
+	for _, forbidden := range []string{"name", "description", "expression", "compiledProgram"} {
+		_, present := generic[forbidden]
+		assert.Falsef(t, present, "fenced field %q must NOT appear on the wire", forbidden)
+	}
+
+	assert.Lenf(t, generic, 6, "expected 6 top-level fields, got %d (drift?)", len(generic))
+}
+
+// TestRuleUpdatedPayload_JSONShape_PopulatedScope locks the nested scope
+// object on the rule.updated path to exactly the six structural keys and
+// asserts no rule free-text leaks into a scope (parity with rule.created).
+func TestRuleUpdatedPayload_JSONShape_PopulatedScope(t *testing.T) {
+	txType := model.TransactionTypePix
+	subType := "transfer"
+
+	rule := minimalRule()
+	rule.Scopes = []model.Scope{
+		{
+			SegmentID:       &scopeSegmentID,
+			PortfolioID:     &scopePortfolioID,
+			AccountID:       &scopeAccountID,
+			MerchantID:      &scopeMerchantID,
+			TransactionType: &txType,
+			SubType:         &subType,
+		},
+	}
+
+	data, err := json.Marshal(events.NewRuleUpdated(rule))
+	require.NoError(t, err)
+
+	var generic map[string]any
+	require.NoError(t, json.Unmarshal(data, &generic))
+
+	scopesRaw, ok := generic["scopes"].([]any)
+	require.True(t, ok, "scopes must serialize as an array")
+	require.Len(t, scopesRaw, 1)
+
+	scope, ok := scopesRaw[0].(map[string]any)
+	require.True(t, ok, "scope must serialize as an object")
+
+	expectedKeys := map[string]struct{}{
+		"segmentId":       {},
+		"portfolioId":     {},
+		"accountId":       {},
+		"merchantId":      {},
+		"transactionType": {},
+		"subType":         {},
+	}
+
+	for key := range scope {
+		_, allowed := expectedKeys[key]
+		assert.Truef(t, allowed, "scope has unexpected key %q (drift?)", key)
+	}
+
+	for key := range expectedKeys {
+		_, present := scope[key]
+		assert.Truef(t, present, "scope must include %q", key)
+	}
+
+	for _, forbidden := range []string{"name", "description", "expression"} {
+		_, present := scope[forbidden]
+		assert.Falsef(t, present, "scope must not carry %q", forbidden)
+	}
+
+	assert.Lenf(t, scope, 6, "expected 6 scope keys, got %d (drift?)", len(scope))
+}


### PR DESCRIPTION
<table border="0" cellspacing="0" cellpadding="0">
  <tr>
    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
    <td><h1>Midaz</h1></td>
  </tr>
</table>

---

## Description

Wires **lib-streaming** into the **Tracer** service (`:4020`) so it emits its full rule and limit lifecycle as CloudEvents 1.0 (binary mode) over Redpanda/Kafka, strictly mirroring the existing ledger/fees streaming implementation.

Twelve events are modeled and emitted post-commit: `rule.{created,updated,activated,deactivated,drafted,deleted}` and `limit.{created,updated,activated,deactivated,drafted,deleted}`. Each is defined once in `pkg/streaming/events/` (Definition + wire-typed Payload + `New<Event>` constructor + `ToEmitRequest`) and emitted through a private `emit<Event>Event` helper that calls `pkgStreaming.EmitImportant` — IMPORTANT posture: nil-emitter guard, tenant resolution via `ResolveTenantID`, bounded emit timeout, Warn-on-failure, and **the request never fails on a streaming error**. No outbox (matches current ledger state).

Key properties:
- **Opt-in and safe by default.** `STREAMING_ENABLED=false` injects a NoopEmitter; empty brokers degrade to Noop with a Warn rather than failing startup. Zero behavior change when disabled.
- **Emitter is self-contained** in the tracer bootstrap (source `lerian.midaz.tracer`), built once, registered as a SIGTERM-drained runnable.
- **Contract locked three ways:** Definition key, per-event `JSONShape` test (exact key-set + pinned field count + explicit PII/financial fence), and a catalog↔definitions↔routes bijection test covering all 12 events.
- **Payload fence:** free text (`name`, `description`), rule logic (`expression`, `compiledProgram`), and monetary values (`maxAmount`) are deliberately kept off the wire — only stable identifiers, classifier enums, structural scope references, time-window fields, and timestamps are emitted. Consumers fetch full records by `id`.
- **Verified end-to-end** against a live broker: a build-tagged integration smoke emits all 12 events and consumes them back from Redpanda, asserting `ce-type`/`ce-subject`/`ce-tenantid` and the PII/`maxAmount` fence on the wire.
- **Topic provisioning** added via `midaz-redpanda-init` (full platform set: ledger/CRM/fees + the 12 tracer topics).

## Type of Change

- [x] `feat`: New feature or capability
- [ ] `fix`: Bug fix
- [ ] `perf`: Performance improvement
- [ ] `refactor`: Internal restructuring with no behavior change
- [x] `docs`: Documentation only
- [ ] `style`: Formatting, whitespace, naming (no logic change)
- [x] `test`: Adding or updating tests
- [ ] `ci`: CI pipeline or workflow changes
- [ ] `build`: Build system, Dockerfile, Go module dependencies
- [ ] `chore`: Maintenance, config, tooling
- [ ] `revert`: Reverts a previous commit
- [ ] `BREAKING CHANGE`: Consumers must update their integration

## Breaking Changes

None. Streaming is opt-in (`STREAMING_ENABLED`, default `false` → NoopEmitter), additive only. No changes to public HTTP APIs, config keys (all new `STREAMING_*` vars have safe backwards-compatible defaults), exported types, storage formats, or existing message schemas. The 12 event schemas are new and versioned (`1.0.0`). Rolling updates are safe: with streaming disabled the code path is inert.

## Testing

- [x] `make test` passes (unit tests GREEN with `-race` across all epics; 89–100% coverage on substantive units)
- [x] `make test-int` passes if integration paths are exercised (build-tagged `TestStreamingSmoke` ran GREEN against a live Redpanda on `localhost:19092`; 12 events consumed back)
- [x] `make lint` passes (golangci-lint v2, 0 issues on changed files)
- [ ] `make sec` and `make vulncheck` pass

**Test evidence / Actions run:** Unit + `-race` per epic (Gate 0); live-broker smoke round-trip with `rpk`-confirmed CloudEvents (`rule.created`, `limit.created`, `rule.deleted`) showing correct ce-headers and the PII/`maxAmount` fence on the wire.

## Architectural Checklist

- [x] No `panic()` in production paths
- [x] Timestamps use `time.Now().UTC()`
- [x] Errors wrapped with `%w`
- [x] Handlers stay thin (parse, validate, call service) — events emit post-commit inside command use cases, never at HTTP handlers
- [x] Infrastructure concerns kept in `internal/bootstrap` (emitter construction, catalog, routes, SIGTERM drain)

## Related Issues
N/A

