### PR TITLE
feat(crm): ensure holder and alias index create once

### DIFF
--- a/components/crm/internal/adapters/mongodb/alias/alias.mongodb.go
+++ b/components/crm/internal/adapters/mongodb/alias/alias.mongodb.go
@@ -108,7 +108,7 @@ func (am *MongoDBRepository) Create(ctx context.Context, organizationID string, 
 
 	coll := db.Collection(strings.ToLower("aliases_" + organizationID))
 
-	err = createIndexes(ctx, coll)
+	err = ensureIndexes(ctx, coll)
 	if err != nil {
 		libOpenTelemetry.HandleSpanError(span, "Failed to create indexes", err)
 

--- a/components/crm/internal/adapters/mongodb/alias/alias.mongodb_integration_test.go
+++ b/components/crm/internal/adapters/mongodb/alias/alias.mongodb_integration_test.go
@@ -11,7 +11,9 @@ import (
 	"fmt"
 	"slices"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/LerianStudio/midaz/v3/components/crm/internal/services/encryption"
 	"github.com/LerianStudio/midaz/v3/pkg"
@@ -29,8 +31,12 @@ import (
 // Test Helpers
 // ============================================================================
 
-// createRepository creates a MongoDBRepository for integration testing.
-func createRepository(t *testing.T, container *mongotestutil.ContainerResult) *MongoDBRepository {
+// createRepository creates a MongoDBRepository for integration testing and resets the
+// process-global index tracker for the given org's collection. The tracker is a process-global;
+// a prior test that already built indexes for the same "dbName:collection" key would leave
+// done=true and cause the guard to skip creation. Resetting the exact key the collection will
+// produce keeps each fresh container deterministic.
+func createRepository(t *testing.T, container *mongotestutil.ContainerResult, organizationID string) *MongoDBRepository {
 	t.Helper()
 
 	conn := mongotestutil.CreateConnection(t, container.URI, container.DBName)
@@ -46,6 +52,8 @@ func createRepository(t *testing.T, container *mongotestutil.ContainerResult) *M
 	repo, err := NewMongoDBRepository(conn, fe)
 	require.NoError(t, err)
 
+	globalIndexTracker.reset(container.DBName + ":" + strings.ToLower("aliases_"+organizationID))
+
 	return repo
 }
 
@@ -56,10 +64,9 @@ func createRepository(t *testing.T, container *mongotestutil.ContainerResult) *M
 func TestIntegration_AliasRepo_Create(t *testing.T) {
 	// Arrange
 	container := mongotestutil.SetupContainer(t)
-	repo := createRepository(t, container)
-	ctx := context.Background()
-
 	organizationID := "org-" + uuid.New().String()[:8]
+	repo := createRepository(t, container, organizationID)
+	ctx := context.Background()
 	holderID := uuid.New()
 	originalDocument := "12345678901"
 
@@ -83,10 +90,9 @@ func TestIntegration_AliasRepo_Create(t *testing.T) {
 func TestIntegration_AliasRepo_Create_EncryptsData(t *testing.T) {
 	// Arrange
 	container := mongotestutil.SetupContainer(t)
-	repo := createRepository(t, container)
-	ctx := context.Background()
-
 	organizationID := "org-encrypt-" + uuid.New().String()[:8]
+	repo := createRepository(t, container, organizationID)
+	ctx := context.Background()
 	holderID := uuid.New()
 	originalDocument := "99988877766"
 
@@ -126,10 +132,9 @@ func TestIntegration_AliasRepo_Create_EncryptsData(t *testing.T) {
 func TestIntegration_AliasRepo_Create_DuplicateAccount(t *testing.T) {
 	// Arrange
 	container := mongotestutil.SetupContainer(t)
-	repo := createRepository(t, container)
-	ctx := context.Background()
-
 	organizationID := "org-dup-" + uuid.New().String()[:8]
+	repo := createRepository(t, container, organizationID)
+	ctx := context.Background()
 	holderID := uuid.New()
 	sharedAccountID := "account-duplicate-test"
 
@@ -156,10 +161,9 @@ func TestIntegration_AliasRepo_Create_DuplicateAccount(t *testing.T) {
 func TestIntegration_AliasRepo_Find(t *testing.T) {
 	// Arrange
 	container := mongotestutil.SetupContainer(t)
-	repo := createRepository(t, container)
-	ctx := context.Background()
-
 	organizationID := "org-find-" + uuid.New().String()[:8]
+	repo := createRepository(t, container, organizationID)
+	ctx := context.Background()
 	holderID := uuid.New()
 	originalDocument := "44455566677"
 
@@ -182,10 +186,9 @@ func TestIntegration_AliasRepo_Find(t *testing.T) {
 func TestIntegration_AliasRepo_Find_NotFound(t *testing.T) {
 	// Arrange
 	container := mongotestutil.SetupContainer(t)
-	repo := createRepository(t, container)
-	ctx := context.Background()
-
 	organizationID := "org-notfound-" + uuid.New().String()[:8]
+	repo := createRepository(t, container, organizationID)
+	ctx := context.Background()
 	holderID := uuid.New()
 	nonExistentID := uuid.New()
 
@@ -201,10 +204,9 @@ func TestIntegration_AliasRepo_Find_NotFound(t *testing.T) {
 func TestIntegration_AliasRepo_Find_ExcludesDeleted(t *testing.T) {
 	// Arrange
 	container := mongotestutil.SetupContainer(t)
-	repo := createRepository(t, container)
-	ctx := context.Background()
-
 	organizationID := "org-deleted-" + uuid.New().String()[:8]
+	repo := createRepository(t, container, organizationID)
+	ctx := context.Background()
 	holderID := uuid.New()
 
 	alias := mongotestutil.CreateTestAliasSimple(t, holderID, "account-deleted-1", "77788899900")
@@ -227,10 +229,9 @@ func TestIntegration_AliasRepo_Find_ExcludesDeleted(t *testing.T) {
 func TestIntegration_AliasRepo_Find_IncludesDeleted(t *testing.T) {
 	// Arrange
 	container := mongotestutil.SetupContainer(t)
-	repo := createRepository(t, container)
-	ctx := context.Background()
-
 	organizationID := "org-incldel-" + uuid.New().String()[:8]
+	repo := createRepository(t, container, organizationID)
+	ctx := context.Background()
 	holderID := uuid.New()
 
 	alias := mongotestutil.CreateTestAliasSimple(t, holderID, "account-incldel-1", "66655544433")
@@ -257,10 +258,9 @@ func TestIntegration_AliasRepo_Find_IncludesDeleted(t *testing.T) {
 func TestIntegration_AliasRepo_FindAll(t *testing.T) {
 	// Arrange
 	container := mongotestutil.SetupContainer(t)
-	repo := createRepository(t, container)
-	ctx := context.Background()
-
 	organizationID := "org-findall-" + uuid.New().String()[:8]
+	repo := createRepository(t, container, organizationID)
+	ctx := context.Background()
 	holderID := uuid.New()
 
 	// Create multiple aliases
@@ -284,10 +284,9 @@ func TestIntegration_AliasRepo_FindAll(t *testing.T) {
 func TestIntegration_AliasRepo_FindAll_Pagination(t *testing.T) {
 	// Arrange
 	container := mongotestutil.SetupContainer(t)
-	repo := createRepository(t, container)
-	ctx := context.Background()
-
 	organizationID := "org-page-" + uuid.New().String()[:8]
+	repo := createRepository(t, container, organizationID)
+	ctx := context.Background()
 	holderID := uuid.New()
 
 	// Create 5 aliases
@@ -328,10 +327,9 @@ func TestIntegration_AliasRepo_FindAll_Pagination(t *testing.T) {
 func TestIntegration_AliasRepo_FindAll_FilterByDocument(t *testing.T) {
 	// Arrange
 	container := mongotestutil.SetupContainer(t)
-	repo := createRepository(t, container)
-	ctx := context.Background()
-
 	organizationID := "org-filterdoc-" + uuid.New().String()[:8]
+	repo := createRepository(t, container, organizationID)
+	ctx := context.Background()
 	holderID := uuid.New()
 	targetDocument := "33344455566"
 
@@ -361,10 +359,9 @@ func TestIntegration_AliasRepo_FindAll_FilterByDocument(t *testing.T) {
 func TestIntegration_AliasRepo_FindAll_FilterByAccountID(t *testing.T) {
 	// Arrange
 	container := mongotestutil.SetupContainer(t)
-	repo := createRepository(t, container)
-	ctx := context.Background()
-
 	organizationID := "org-filteracc-" + uuid.New().String()[:8]
+	repo := createRepository(t, container, organizationID)
+	ctx := context.Background()
 	holderID := uuid.New()
 	targetAccountID := "account-target-xyz"
 
@@ -394,10 +391,9 @@ func TestIntegration_AliasRepo_FindAll_FilterByAccountID(t *testing.T) {
 func TestIntegration_AliasRepo_FindAll_ReturnsEmpty(t *testing.T) {
 	// Arrange
 	container := mongotestutil.SetupContainer(t)
-	repo := createRepository(t, container)
-	ctx := context.Background()
-
 	organizationID := "org-empty-" + uuid.New().String()[:8]
+	repo := createRepository(t, container, organizationID)
+	ctx := context.Background()
 	holderID := uuid.New()
 
 	// Act - Query empty collection
@@ -416,10 +412,9 @@ func TestIntegration_AliasRepo_FindAll_ReturnsEmpty(t *testing.T) {
 func TestIntegration_AliasRepo_Update(t *testing.T) {
 	// Arrange
 	container := mongotestutil.SetupContainer(t)
-	repo := createRepository(t, container)
-	ctx := context.Background()
-
 	organizationID := "org-update-" + uuid.New().String()[:8]
+	repo := createRepository(t, container, organizationID)
+	ctx := context.Background()
 	holderID := uuid.New()
 
 	alias := mongotestutil.CreateTestAliasSimple(t, holderID, "account-update-1", "88899900011")
@@ -443,10 +438,9 @@ func TestIntegration_AliasRepo_Update(t *testing.T) {
 func TestIntegration_AliasRepo_Update_NotFound(t *testing.T) {
 	// Arrange
 	container := mongotestutil.SetupContainer(t)
-	repo := createRepository(t, container)
-	ctx := context.Background()
-
 	organizationID := "org-upnotfound-" + uuid.New().String()[:8]
+	repo := createRepository(t, container, organizationID)
+	ctx := context.Background()
 	holderID := uuid.New()
 	nonExistentID := uuid.New()
 
@@ -463,10 +457,9 @@ func TestIntegration_AliasRepo_Update_NotFound(t *testing.T) {
 func TestIntegration_AliasRepo_Update_FieldsToRemove(t *testing.T) {
 	// Arrange
 	container := mongotestutil.SetupContainer(t)
-	repo := createRepository(t, container)
-	ctx := context.Background()
-
 	organizationID := "org-remove-" + uuid.New().String()[:8]
+	repo := createRepository(t, container, organizationID)
+	ctx := context.Background()
 	holderID := uuid.New()
 
 	alias := mongotestutil.CreateTestAliasWithBanking(t, holderID, "account-remove-1", "77766655544")
@@ -491,10 +484,9 @@ func TestIntegration_AliasRepo_Update_FieldsToRemove(t *testing.T) {
 func TestIntegration_AliasRepo_Delete_Soft(t *testing.T) {
 	// Arrange
 	container := mongotestutil.SetupContainer(t)
-	repo := createRepository(t, container)
-	ctx := context.Background()
-
 	organizationID := "org-softdel-" + uuid.New().String()[:8]
+	repo := createRepository(t, container, organizationID)
+	ctx := context.Background()
 	holderID := uuid.New()
 
 	alias := mongotestutil.CreateTestAliasSimple(t, holderID, "account-softdel-1", "55544433322")
@@ -517,10 +509,9 @@ func TestIntegration_AliasRepo_Delete_Soft(t *testing.T) {
 func TestIntegration_AliasRepo_Delete_Hard(t *testing.T) {
 	// Arrange
 	container := mongotestutil.SetupContainer(t)
-	repo := createRepository(t, container)
-	ctx := context.Background()
-
 	organizationID := "org-harddel-" + uuid.New().String()[:8]
+	repo := createRepository(t, container, organizationID)
+	ctx := context.Background()
 	holderID := uuid.New()
 
 	alias := mongotestutil.CreateTestAliasSimple(t, holderID, "account-harddel-1", "22211100099")
@@ -542,10 +533,9 @@ func TestIntegration_AliasRepo_Delete_Hard(t *testing.T) {
 func TestIntegration_AliasRepo_Delete_NotFound(t *testing.T) {
 	// Arrange
 	container := mongotestutil.SetupContainer(t)
-	repo := createRepository(t, container)
-	ctx := context.Background()
-
 	organizationID := "org-delnotfound-" + uuid.New().String()[:8]
+	repo := createRepository(t, container, organizationID)
+	ctx := context.Background()
 	holderID := uuid.New()
 	nonExistentID := uuid.New()
 
@@ -564,10 +554,9 @@ func TestIntegration_AliasRepo_Delete_NotFound(t *testing.T) {
 func TestIntegration_AliasRepo_Count(t *testing.T) {
 	// Arrange
 	container := mongotestutil.SetupContainer(t)
-	repo := createRepository(t, container)
-	ctx := context.Background()
-
 	organizationID := "org-count-" + uuid.New().String()[:8]
+	repo := createRepository(t, container, organizationID)
+	ctx := context.Background()
 	holderID := uuid.New()
 
 	// Create 3 aliases
@@ -590,10 +579,9 @@ func TestIntegration_AliasRepo_Count(t *testing.T) {
 func TestIntegration_AliasRepo_Count_ExcludesDeleted(t *testing.T) {
 	// Arrange
 	container := mongotestutil.SetupContainer(t)
-	repo := createRepository(t, container)
-	ctx := context.Background()
-
 	organizationID := "org-countdel-" + uuid.New().String()[:8]
+	repo := createRepository(t, container, organizationID)
+	ctx := context.Background()
 	holderID := uuid.New()
 
 	// Create 3 aliases
@@ -622,10 +610,9 @@ func TestIntegration_AliasRepo_Count_ExcludesDeleted(t *testing.T) {
 func TestIntegration_AliasRepo_Count_ReturnsZero(t *testing.T) {
 	// Arrange
 	container := mongotestutil.SetupContainer(t)
-	repo := createRepository(t, container)
-	ctx := context.Background()
-
 	organizationID := "org-countzero-" + uuid.New().String()[:8]
+	repo := createRepository(t, container, organizationID)
+	ctx := context.Background()
 	holderID := uuid.New()
 
 	// Act - Count empty collection
@@ -643,10 +630,9 @@ func TestIntegration_AliasRepo_Count_ReturnsZero(t *testing.T) {
 func TestIntegration_AliasRepo_EncryptionRoundTrip(t *testing.T) {
 	// Arrange
 	container := mongotestutil.SetupContainer(t)
-	repo := createRepository(t, container)
-	ctx := context.Background()
-
 	organizationID := "org-roundtrip-" + uuid.New().String()[:8]
+	repo := createRepository(t, container, organizationID)
+	ctx := context.Background()
 	holderID := uuid.New()
 	relatedPartyID := uuid.New()
 
@@ -695,4 +681,89 @@ func TestIntegration_AliasRepo_EncryptionRoundTrip(t *testing.T) {
 	assert.Equal(t, originalRelatedPartyDoc, result.RelatedParties[0].Document, "related party document should decrypt correctly")
 	assert.Equal(t, "Test Related Party", result.RelatedParties[0].Name)
 	assert.Equal(t, "PRIMARY_HOLDER", result.RelatedParties[0].Role)
+}
+
+// ============================================================================
+// Concurrent Index-Build Guard Tests
+// ============================================================================
+
+// TestAliasRepository_Create_ConcurrentBurst_SingleIndexBuild reproduces the production symptom:
+// a concurrent burst of Create() calls against a brand-new aliases_<orgID> collection used to
+// storm collection.Indexes().CreateMany() on every insert, serializing on MongoDB's index build
+// and producing context-deadline-exceeded 500s. With the ensureOnce guard the build collapses to
+// one execution, so the whole burst succeeds well within the per-call 5s budget and the collection
+// ends up correctly indexed.
+func TestAliasRepository_Create_ConcurrentBurst_SingleIndexBuild(t *testing.T) {
+	// Arrange - fresh container, one new org, tracker reset for that exact collection key.
+	container := mongotestutil.SetupContainer(t)
+
+	organizationID := "org-burst-" + uuid.New().String()[:8]
+	repo := createRepository(t, container, organizationID)
+
+	const goroutines = 10
+
+	var wg sync.WaitGroup
+
+	// Buffered so no goroutine blocks on send; sized to the worst case (every goroutine errors).
+	errCh := make(chan error, goroutines)
+
+	// Act - launch the burst. Each goroutine gets its OWN context.Background() so one failure
+	// cannot cancel siblings, and DISTINCT _id (fresh per fixture), holder_id, account_id, and
+	// ledger_id (fresh per DefaultAliasParams) so the three unique partial indexes —
+	// (_id, holder_id), account_id, and (ledger_id, account_id) — are never the source of an error.
+	start := time.Now().UTC()
+
+	wg.Add(goroutines)
+
+	for i := 0; i < goroutines; i++ {
+		go func(i int) {
+			defer wg.Done()
+
+			ctx := context.Background()
+
+			holderID := uuid.New()
+
+			alias := mongotestutil.CreateTestAliasSimple(
+				t,
+				holderID,
+				fmt.Sprintf("account-burst-%02d", i),
+				fmt.Sprintf("900000000%02d", i),
+			)
+
+			if _, err := repo.Create(ctx, organizationID, alias); err != nil {
+				errCh <- err
+			}
+		}(i)
+	}
+
+	wg.Wait()
+	close(errCh)
+
+	elapsed := time.Since(start)
+
+	// Assert - every Create() succeeded (no context-deadline-exceeded).
+	var errs []error
+	for err := range errCh {
+		errs = append(errs, err)
+	}
+
+	require.Empty(t, errs, "all concurrent Create() calls must succeed; got errors: %v", errs)
+
+	// Coarse wall-clock ceiling: a regression to serialized per-insert index builds would blow
+	// past the per-call 5s budget. This is intentionally generous to stay machine-independent.
+	assert.Less(t, elapsed, 5*time.Second,
+		"concurrent burst must complete well under the per-call 5s index-build budget")
+
+	// The guard must have built the full index set exactly once for the collection.
+	collName := strings.ToLower("aliases_" + organizationID)
+
+	cursor, err := container.Database.Collection(collName).Indexes().List(context.Background())
+	require.NoError(t, err)
+
+	var indexes []bson.M
+	require.NoError(t, cursor.All(context.Background(), &indexes))
+
+	// indexModels() defines 11 indexes; MongoDB adds the implicit _id_ index, for 12 total.
+	assert.Len(t, indexes, len(indexModels())+1,
+		"collection should have the 11 modeled indexes plus the implicit _id_ index")
 }

--- a/components/crm/internal/adapters/mongodb/alias/alias_maintenance.mongodb.go
+++ b/components/crm/internal/adapters/mongodb/alias/alias_maintenance.mongodb.go
@@ -157,6 +157,17 @@ func indexModels() []mongo.IndexModel {
 	}
 }
 
+// ensureIndexes ensures indexes exist for the alias collection.
+// Uses per-collection tracking to handle multi-tenant/per-org collections correctly.
+// Retries on failure — indexes are only marked as done after successful creation.
+func ensureIndexes(ctx context.Context, collection *mongo.Collection) error {
+	key := collection.Database().Name() + ":" + collection.Name()
+
+	return globalIndexTracker.ensureOnce(key, func() error {
+		return createIndexes(ctx, collection)
+	})
+}
+
 // createIndexes creates indexes for specific fields, if it not exists.
 func createIndexes(ctx context.Context, collection *mongo.Collection) error {
 	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)

--- a/components/crm/internal/adapters/mongodb/alias/index_tracker.go
+++ b/components/crm/internal/adapters/mongodb/alias/index_tracker.go
@@ -12,9 +12,13 @@ type indexState struct {
 	done bool
 }
 
-// indexTracker manages per-database index creation state.
-// In multi-tenant mode, each tenant database needs its own indexes.
-// This tracker ensures indexes are created exactly once per database, with retry on failure.
+// indexTracker manages index-creation state per (database, collection) pair.
+// In multi-tenant mode each tenant database needs its own indexes, and alias
+// collections are per-organization (aliases_<orgID>), so one entry accumulates
+// per (tenant database, organization). Entries are never evicted in production:
+// the map grows with the distinct collection count, bounded by the org/tenant
+// scale — an intentional, create-once-per-collection cache (reset is test-only).
+// Indexes are created once per key, with retry on failure.
 type indexTracker struct {
 	states sync.Map // key: "dbName:collection" -> *indexState
 }
@@ -49,6 +53,6 @@ func (t *indexTracker) reset(key string) {
 	t.states.Delete(key)
 }
 
-// globalIndexTracker is shared across all audit repository instances.
-// This ensures indexes are created once per database even if multiple repository instances exist.
+// globalIndexTracker is shared across all alias repository instances, so indexes
+// are created once per (database, collection) even when multiple instances exist.
 var globalIndexTracker = &indexTracker{}

--- a/components/crm/internal/adapters/mongodb/alias/index_tracker.go
+++ b/components/crm/internal/adapters/mongodb/alias/index_tracker.go
@@ -1,0 +1,54 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package alias
+
+import "sync"
+
+// indexState tracks whether indexes have been successfully created for a specific database/collection pair.
+type indexState struct {
+	mu   sync.Mutex
+	done bool
+}
+
+// indexTracker manages per-database index creation state.
+// In multi-tenant mode, each tenant database needs its own indexes.
+// This tracker ensures indexes are created exactly once per database, with retry on failure.
+type indexTracker struct {
+	states sync.Map // key: "dbName:collection" -> *indexState
+}
+
+// ensureOnce executes fn exactly once per key, but only marks as done on success.
+// If fn returns an error, subsequent calls will retry.
+func (t *indexTracker) ensureOnce(key string, fn func() error) error {
+	v, _ := t.states.LoadOrStore(key, &indexState{})
+	state := v.(*indexState)
+
+	state.mu.Lock()
+	defer state.mu.Unlock()
+
+	if state.done {
+		return nil
+	}
+
+	if err := fn(); err != nil {
+		return err
+	}
+
+	state.done = true
+
+	return nil
+}
+
+// reset clears the state for a specific key. Used in integration tests to ensure fresh state
+// when each test runs with a new MongoDB container.
+//
+//nolint:unused // used in *_integration_test.go files (build tag: integration)
+func (t *indexTracker) reset(key string) {
+	t.states.Delete(key)
+}
+
+// globalIndexTracker is shared across all audit repository instances.
+// This ensures indexes are created once per database even if multiple repository instances exist.
+var globalIndexTracker = &indexTracker{}

--- a/components/crm/internal/adapters/mongodb/holder/holder.mongodb.go
+++ b/components/crm/internal/adapters/mongodb/holder/holder.mongodb.go
@@ -113,7 +113,7 @@ func (hm *MongoDBRepository) Create(ctx context.Context, organizationID string, 
 
 	coll := db.Collection(strings.ToLower("holders_" + organizationID))
 
-	err = createIndexes(ctx, coll)
+	err = ensureIndexes(ctx, coll)
 	if err != nil {
 		libOpenTelemetry.HandleSpanError(span, "Failed to create indexes", err)
 

--- a/components/crm/internal/adapters/mongodb/holder/holder.mongodb_integration_test.go
+++ b/components/crm/internal/adapters/mongodb/holder/holder.mongodb_integration_test.go
@@ -11,7 +11,9 @@ import (
 	"fmt"
 	"slices"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/LerianStudio/midaz/v3/components/crm/internal/services/encryption"
 	"github.com/LerianStudio/midaz/v3/pkg"
@@ -29,8 +31,12 @@ import (
 // Test Helpers
 // ============================================================================
 
-// createRepository creates a MongoDBRepository for integration testing.
-func createRepository(t *testing.T, container *mongotestutil.ContainerResult) *MongoDBRepository {
+// createRepository creates a MongoDBRepository for integration testing and resets the
+// process-global index tracker for the given org's collection. The tracker is a process-global;
+// a prior test that already built indexes for the same "dbName:collection" key would leave
+// done=true and cause the guard to skip creation. Resetting the exact key the collection will
+// produce keeps each fresh container deterministic.
+func createRepository(t *testing.T, container *mongotestutil.ContainerResult, organizationID string) *MongoDBRepository {
 	t.Helper()
 
 	conn := mongotestutil.CreateConnection(t, container.URI, container.DBName)
@@ -46,6 +52,8 @@ func createRepository(t *testing.T, container *mongotestutil.ContainerResult) *M
 	repo, err := NewMongoDBRepository(conn, fe)
 	require.NoError(t, err)
 
+	globalIndexTracker.reset(container.DBName + ":" + strings.ToLower("holders_"+organizationID))
+
 	return repo
 }
 
@@ -56,10 +64,10 @@ func createRepository(t *testing.T, container *mongotestutil.ContainerResult) *M
 func TestIntegration_HolderRepo_Create(t *testing.T) {
 	// Arrange
 	container := mongotestutil.SetupContainer(t)
-	repo := createRepository(t, container)
+	organizationID := "org-" + uuid.New().String()[:8]
+	repo := createRepository(t, container, organizationID)
 	ctx := context.Background()
 
-	organizationID := "org-" + uuid.New().String()[:8]
 	originalName := "John Doe"
 	originalDocument := "12345678901"
 
@@ -84,10 +92,10 @@ func TestIntegration_HolderRepo_Create(t *testing.T) {
 func TestIntegration_HolderRepo_Create_EncryptsData(t *testing.T) {
 	// Arrange
 	container := mongotestutil.SetupContainer(t)
-	repo := createRepository(t, container)
+	organizationID := "org-encrypt-" + uuid.New().String()[:8]
+	repo := createRepository(t, container, organizationID)
 	ctx := context.Background()
 
-	organizationID := "org-encrypt-" + uuid.New().String()[:8]
 	originalName := "Encrypted User"
 	originalDocument := "99988877766"
 
@@ -132,10 +140,10 @@ func TestIntegration_HolderRepo_Create_EncryptsData(t *testing.T) {
 func TestIntegration_HolderRepo_Create_DuplicateDocument(t *testing.T) {
 	// Arrange
 	container := mongotestutil.SetupContainer(t)
-	repo := createRepository(t, container)
+	organizationID := "org-dup-" + uuid.New().String()[:8]
+	repo := createRepository(t, container, organizationID)
 	ctx := context.Background()
 
-	organizationID := "org-dup-" + uuid.New().String()[:8]
 	sharedDocument := "11111111111"
 
 	// Create first holder
@@ -157,10 +165,9 @@ func TestIntegration_HolderRepo_Create_DuplicateDocument(t *testing.T) {
 func TestIntegration_HolderRepo_Create_WithAllFields(t *testing.T) {
 	// Arrange
 	container := mongotestutil.SetupContainer(t)
-	repo := createRepository(t, container)
-	ctx := context.Background()
-
 	organizationID := "org-complete-" + uuid.New().String()[:8]
+	repo := createRepository(t, container, organizationID)
+	ctx := context.Background()
 
 	holder := mongotestutil.CreateCompleteTestHolder(t, "Complete User", "55566677788")
 
@@ -195,10 +202,9 @@ func TestIntegration_HolderRepo_Create_WithAllFields(t *testing.T) {
 func TestIntegration_HolderRepo_Create_WithLegalPerson(t *testing.T) {
 	// Arrange
 	container := mongotestutil.SetupContainer(t)
-	repo := createRepository(t, container)
-	ctx := context.Background()
-
 	organizationID := "org-legal-" + uuid.New().String()[:8]
+	repo := createRepository(t, container, organizationID)
+	ctx := context.Background()
 
 	holder := mongotestutil.CreateTestHolderWithLegalPerson(t, "ACME Corp", "12345678000199")
 
@@ -228,10 +234,10 @@ func TestIntegration_HolderRepo_Create_WithLegalPerson(t *testing.T) {
 func TestIntegration_HolderRepo_Find(t *testing.T) {
 	// Arrange
 	container := mongotestutil.SetupContainer(t)
-	repo := createRepository(t, container)
+	organizationID := "org-find-" + uuid.New().String()[:8]
+	repo := createRepository(t, container, organizationID)
 	ctx := context.Background()
 
-	organizationID := "org-find-" + uuid.New().String()[:8]
 	originalName := "Find Test User"
 	originalDocument := "44455566677"
 
@@ -254,10 +260,10 @@ func TestIntegration_HolderRepo_Find(t *testing.T) {
 func TestIntegration_HolderRepo_Find_NotFound(t *testing.T) {
 	// Arrange
 	container := mongotestutil.SetupContainer(t)
-	repo := createRepository(t, container)
+	organizationID := "org-notfound-" + uuid.New().String()[:8]
+	repo := createRepository(t, container, organizationID)
 	ctx := context.Background()
 
-	organizationID := "org-notfound-" + uuid.New().String()[:8]
 	nonExistentID := uuid.New()
 
 	// Act
@@ -272,10 +278,9 @@ func TestIntegration_HolderRepo_Find_NotFound(t *testing.T) {
 func TestIntegration_HolderRepo_Find_ExcludesDeleted(t *testing.T) {
 	// Arrange
 	container := mongotestutil.SetupContainer(t)
-	repo := createRepository(t, container)
-	ctx := context.Background()
-
 	organizationID := "org-deleted-" + uuid.New().String()[:8]
+	repo := createRepository(t, container, organizationID)
+	ctx := context.Background()
 
 	holder := mongotestutil.CreateTestHolderSimple(t, "Deleted User", "77788899900")
 	_, err := repo.Create(ctx, organizationID, holder)
@@ -297,10 +302,9 @@ func TestIntegration_HolderRepo_Find_ExcludesDeleted(t *testing.T) {
 func TestIntegration_HolderRepo_Find_IncludesDeleted(t *testing.T) {
 	// Arrange
 	container := mongotestutil.SetupContainer(t)
-	repo := createRepository(t, container)
-	ctx := context.Background()
-
 	organizationID := "org-incldel-" + uuid.New().String()[:8]
+	repo := createRepository(t, container, organizationID)
+	ctx := context.Background()
 
 	holder := mongotestutil.CreateTestHolderSimple(t, "Include Deleted User", "66655544433")
 	_, err := repo.Create(ctx, organizationID, holder)
@@ -326,10 +330,9 @@ func TestIntegration_HolderRepo_Find_IncludesDeleted(t *testing.T) {
 func TestIntegration_HolderRepo_FindAll(t *testing.T) {
 	// Arrange
 	container := mongotestutil.SetupContainer(t)
-	repo := createRepository(t, container)
-	ctx := context.Background()
-
 	organizationID := "org-findall-" + uuid.New().String()[:8]
+	repo := createRepository(t, container, organizationID)
+	ctx := context.Background()
 
 	// Create multiple holders
 	for i := 0; i < 5; i++ {
@@ -350,10 +353,9 @@ func TestIntegration_HolderRepo_FindAll(t *testing.T) {
 func TestIntegration_HolderRepo_FindAll_Pagination(t *testing.T) {
 	// Arrange
 	container := mongotestutil.SetupContainer(t)
-	repo := createRepository(t, container)
-	ctx := context.Background()
-
 	organizationID := "org-page-" + uuid.New().String()[:8]
+	repo := createRepository(t, container, organizationID)
+	ctx := context.Background()
 
 	// Create 5 holders
 	for i := 0; i < 5; i++ {
@@ -391,10 +393,10 @@ func TestIntegration_HolderRepo_FindAll_Pagination(t *testing.T) {
 func TestIntegration_HolderRepo_FindAll_FilterByExternalID(t *testing.T) {
 	// Arrange
 	container := mongotestutil.SetupContainer(t)
-	repo := createRepository(t, container)
+	organizationID := "org-filterext-" + uuid.New().String()[:8]
+	repo := createRepository(t, container, organizationID)
 	ctx := context.Background()
 
-	organizationID := "org-filterext-" + uuid.New().String()[:8]
 	targetExternalID := "EXT-TARGET-123"
 
 	// Create holders with different external IDs
@@ -423,10 +425,10 @@ func TestIntegration_HolderRepo_FindAll_FilterByExternalID(t *testing.T) {
 func TestIntegration_HolderRepo_FindAll_FilterByDocument(t *testing.T) {
 	// Arrange
 	container := mongotestutil.SetupContainer(t)
-	repo := createRepository(t, container)
+	organizationID := "org-filterdoc-" + uuid.New().String()[:8]
+	repo := createRepository(t, container, organizationID)
 	ctx := context.Background()
 
-	organizationID := "org-filterdoc-" + uuid.New().String()[:8]
 	targetDocument := "55566677788"
 
 	// Create holders with different documents
@@ -455,10 +457,9 @@ func TestIntegration_HolderRepo_FindAll_FilterByDocument(t *testing.T) {
 func TestIntegration_HolderRepo_FindAll_FilterByMetadata(t *testing.T) {
 	// Arrange
 	container := mongotestutil.SetupContainer(t)
-	repo := createRepository(t, container)
-	ctx := context.Background()
-
 	organizationID := "org-filtermeta-" + uuid.New().String()[:8]
+	repo := createRepository(t, container, organizationID)
+	ctx := context.Background()
 
 	// Create holder with specific metadata
 	holder1 := mongotestutil.CreateTestHolderSimple(t, "Metadata User 1", "77788899900")
@@ -490,10 +491,9 @@ func TestIntegration_HolderRepo_FindAll_FilterByMetadata(t *testing.T) {
 func TestIntegration_HolderRepo_FindAll_ReturnsEmpty(t *testing.T) {
 	// Arrange
 	container := mongotestutil.SetupContainer(t)
-	repo := createRepository(t, container)
-	ctx := context.Background()
-
 	organizationID := "org-empty-" + uuid.New().String()[:8]
+	repo := createRepository(t, container, organizationID)
+	ctx := context.Background()
 
 	// Act - Query empty collection
 	filter := http.QueryHeader{Limit: 10, Page: 1}
@@ -507,10 +507,9 @@ func TestIntegration_HolderRepo_FindAll_ReturnsEmpty(t *testing.T) {
 func TestIntegration_HolderRepo_FindAll_ExcludesDeleted(t *testing.T) {
 	// Arrange
 	container := mongotestutil.SetupContainer(t)
-	repo := createRepository(t, container)
-	ctx := context.Background()
-
 	organizationID := "org-findalldel-" + uuid.New().String()[:8]
+	repo := createRepository(t, container, organizationID)
+	ctx := context.Background()
 
 	// Create holders
 	holder1 := mongotestutil.CreateTestHolderSimple(t, "Delete Test User 1", "44455566677")
@@ -542,10 +541,9 @@ func TestIntegration_HolderRepo_FindAll_ExcludesDeleted(t *testing.T) {
 func TestIntegration_HolderRepo_Update(t *testing.T) {
 	// Arrange
 	container := mongotestutil.SetupContainer(t)
-	repo := createRepository(t, container)
-	ctx := context.Background()
-
 	organizationID := "org-update-" + uuid.New().String()[:8]
+	repo := createRepository(t, container, organizationID)
+	ctx := context.Background()
 
 	holder := mongotestutil.CreateTestHolderSimple(t, "Original Name", "88899900011")
 	_, err := repo.Create(ctx, organizationID, holder)
@@ -567,10 +565,9 @@ func TestIntegration_HolderRepo_Update(t *testing.T) {
 func TestIntegration_HolderRepo_Update_FieldsToRemove(t *testing.T) {
 	// Arrange
 	container := mongotestutil.SetupContainer(t)
-	repo := createRepository(t, container)
-	ctx := context.Background()
-
 	organizationID := "org-remove-" + uuid.New().String()[:8]
+	repo := createRepository(t, container, organizationID)
+	ctx := context.Background()
 
 	holder := mongotestutil.CreateTestHolderSimple(t, "Remove Fields User", "77766655544")
 	holder.Metadata = map[string]any{"key1": "value1", "key2": "value2", "key3": "value3"}
@@ -592,10 +589,10 @@ func TestIntegration_HolderRepo_Update_FieldsToRemove(t *testing.T) {
 func TestIntegration_HolderRepo_Update_NotFound(t *testing.T) {
 	// Arrange
 	container := mongotestutil.SetupContainer(t)
-	repo := createRepository(t, container)
+	organizationID := "org-updatenotfound-" + uuid.New().String()[:8]
+	repo := createRepository(t, container, organizationID)
 	ctx := context.Background()
 
-	organizationID := "org-updatenotfound-" + uuid.New().String()[:8]
 	nonExistentID := uuid.New()
 
 	// Act - Try to update non-existent holder
@@ -620,10 +617,9 @@ func TestIntegration_HolderRepo_Update_NotFound(t *testing.T) {
 func TestIntegration_HolderRepo_Delete_Soft(t *testing.T) {
 	// Arrange
 	container := mongotestutil.SetupContainer(t)
-	repo := createRepository(t, container)
-	ctx := context.Background()
-
 	organizationID := "org-softdel-" + uuid.New().String()[:8]
+	repo := createRepository(t, container, organizationID)
+	ctx := context.Background()
 
 	holder := mongotestutil.CreateTestHolderSimple(t, "Soft Delete User", "55544433322")
 	_, err := repo.Create(ctx, organizationID, holder)
@@ -645,10 +641,9 @@ func TestIntegration_HolderRepo_Delete_Soft(t *testing.T) {
 func TestIntegration_HolderRepo_Delete_Hard(t *testing.T) {
 	// Arrange
 	container := mongotestutil.SetupContainer(t)
-	repo := createRepository(t, container)
-	ctx := context.Background()
-
 	organizationID := "org-harddel-" + uuid.New().String()[:8]
+	repo := createRepository(t, container, organizationID)
+	ctx := context.Background()
 
 	holder := mongotestutil.CreateTestHolderSimple(t, "Hard Delete User", "22211100099")
 	_, err := repo.Create(ctx, organizationID, holder)
@@ -669,10 +664,10 @@ func TestIntegration_HolderRepo_Delete_Hard(t *testing.T) {
 func TestIntegration_HolderRepo_Delete_NotFound(t *testing.T) {
 	// Arrange
 	container := mongotestutil.SetupContainer(t)
-	repo := createRepository(t, container)
+	organizationID := "org-delnotfound-" + uuid.New().String()[:8]
+	repo := createRepository(t, container, organizationID)
 	ctx := context.Background()
 
-	organizationID := "org-delnotfound-" + uuid.New().String()[:8]
 	nonExistentID := uuid.New()
 
 	// Act
@@ -686,10 +681,9 @@ func TestIntegration_HolderRepo_Delete_NotFound(t *testing.T) {
 func TestIntegration_HolderRepo_Delete_AlreadyDeleted(t *testing.T) {
 	// Arrange
 	container := mongotestutil.SetupContainer(t)
-	repo := createRepository(t, container)
-	ctx := context.Background()
-
 	organizationID := "org-delalready-" + uuid.New().String()[:8]
+	repo := createRepository(t, container, organizationID)
+	ctx := context.Background()
 
 	holder := mongotestutil.CreateTestHolderSimple(t, "Already Deleted User", "99900011122")
 	_, err := repo.Create(ctx, organizationID, holder)
@@ -714,10 +708,9 @@ func TestIntegration_HolderRepo_Delete_AlreadyDeleted(t *testing.T) {
 func TestIntegration_HolderRepo_EncryptionRoundTrip(t *testing.T) {
 	// Arrange
 	container := mongotestutil.SetupContainer(t)
-	repo := createRepository(t, container)
-	ctx := context.Background()
-
 	organizationID := "org-roundtrip-" + uuid.New().String()[:8]
+	repo := createRepository(t, container, organizationID)
+	ctx := context.Background()
 
 	// Original values
 	originalName := "Round Trip Test User"
@@ -758,10 +751,9 @@ func TestIntegration_HolderRepo_EncryptionRoundTrip(t *testing.T) {
 func TestIntegration_HolderRepo_EncryptionRoundTrip_LegalPerson(t *testing.T) {
 	// Arrange
 	container := mongotestutil.SetupContainer(t)
-	repo := createRepository(t, container)
-	ctx := context.Background()
-
 	organizationID := "org-roundtrip-legal-" + uuid.New().String()[:8]
+	repo := createRepository(t, container, organizationID)
+	ctx := context.Background()
 
 	// Original values
 	originalName := "Legal Round Trip Corp"
@@ -801,19 +793,23 @@ func TestIntegration_HolderRepo_EncryptionRoundTrip_LegalPerson(t *testing.T) {
 func TestIntegration_HolderRepo_Create_SameDocumentDifferentOrganizations(t *testing.T) {
 	// Arrange
 	container := mongotestutil.SetupContainer(t)
-	repo := createRepository(t, container)
+	org1 := "org-1-" + uuid.New().String()[:8]
+	repo := createRepository(t, container, org1)
 	ctx := context.Background()
 
 	sharedDocument := "33344455566"
 
 	// Create holder in first organization
-	org1 := "org-1-" + uuid.New().String()[:8]
 	holder1 := mongotestutil.CreateTestHolderSimple(t, "Org1 User", sharedDocument)
 	_, err := repo.Create(ctx, org1, holder1)
 	require.NoError(t, err, "first org create should succeed")
 
-	// Act - Create holder with same document in different organization
+	// Act - Create holder with same document in different organization. This test uses a second
+	// org against the same repo, so reset the tracker for org2's collection too (createRepository
+	// only resets the primary org's key).
 	org2 := "org-2-" + uuid.New().String()[:8]
+	globalIndexTracker.reset(container.DBName + ":" + strings.ToLower("holders_"+org2))
+
 	holder2 := mongotestutil.CreateTestHolderSimple(t, "Org2 User", sharedDocument)
 	_, err = repo.Create(ctx, org2, holder2)
 
@@ -824,10 +820,10 @@ func TestIntegration_HolderRepo_Create_SameDocumentDifferentOrganizations(t *tes
 func TestIntegration_HolderRepo_Create_ReuseSoftDeletedDocument(t *testing.T) {
 	// Arrange
 	container := mongotestutil.SetupContainer(t)
-	repo := createRepository(t, container)
+	organizationID := "org-reuse-" + uuid.New().String()[:8]
+	repo := createRepository(t, container, organizationID)
 	ctx := context.Background()
 
-	organizationID := "org-reuse-" + uuid.New().String()[:8]
 	reusedDocument := "77788899900"
 
 	// Create and soft delete first holder
@@ -845,4 +841,85 @@ func TestIntegration_HolderRepo_Create_ReuseSoftDeletedDocument(t *testing.T) {
 	// Assert - Should succeed since first was soft deleted
 	// (partial filter expression on index excludes deleted records)
 	require.NoError(t, err, "reusing document from soft-deleted holder should succeed")
+}
+
+// ============================================================================
+// Concurrent Index-Build Guard Tests
+// ============================================================================
+
+// TestHolderRepository_Create_ConcurrentBurst_SingleIndexBuild reproduces the production symptom:
+// a concurrent burst of Create() calls against a brand-new holders_<orgID> collection used to
+// storm collection.Indexes().CreateMany() on every insert, serializing on MongoDB's index build
+// and producing context-deadline-exceeded 500s. With the ensureOnce guard the build collapses to
+// one execution, so the whole burst succeeds well within the per-call 5s budget and the collection
+// ends up correctly indexed.
+func TestHolderRepository_Create_ConcurrentBurst_SingleIndexBuild(t *testing.T) {
+	// Arrange - fresh container, one new org, tracker reset for that exact collection key.
+	container := mongotestutil.SetupContainer(t)
+
+	organizationID := "org-burst-" + uuid.New().String()[:8]
+	repo := createRepository(t, container, organizationID)
+
+	const goroutines = 10
+
+	var wg sync.WaitGroup
+
+	// Buffered so no goroutine blocks on send; sized to the worst case (every goroutine errors).
+	errCh := make(chan error, goroutines)
+
+	// Act - launch the burst. Each goroutine gets its OWN context.Background() so one failure
+	// cannot cancel siblings, and distinct document values so the unique partial index on
+	// search.document (holder_maintenance.mongodb.go) is never the source of an error.
+	start := time.Now().UTC()
+
+	wg.Add(goroutines)
+
+	for i := 0; i < goroutines; i++ {
+		go func(i int) {
+			defer wg.Done()
+
+			ctx := context.Background()
+
+			holder := mongotestutil.CreateTestHolderSimple(
+				t,
+				fmt.Sprintf("Burst User %d", i),
+				fmt.Sprintf("900000000%02d", i),
+			)
+
+			if _, err := repo.Create(ctx, organizationID, holder); err != nil {
+				errCh <- err
+			}
+		}(i)
+	}
+
+	wg.Wait()
+	close(errCh)
+
+	elapsed := time.Since(start)
+
+	// Assert - every Create() succeeded (no context-deadline-exceeded).
+	var errs []error
+	for err := range errCh {
+		errs = append(errs, err)
+	}
+
+	require.Empty(t, errs, "all concurrent Create() calls must succeed; got errors: %v", errs)
+
+	// Coarse wall-clock ceiling: a regression to serialized per-insert index builds would blow
+	// past the per-call 5s budget. This is intentionally generous to stay machine-independent.
+	assert.Less(t, elapsed, 5*time.Second,
+		"concurrent burst must complete well under the per-call 5s index-build budget")
+
+	// The guard must have built the full index set exactly once for the collection.
+	collName := strings.ToLower("holders_" + organizationID)
+
+	cursor, err := container.Database.Collection(collName).Indexes().List(context.Background())
+	require.NoError(t, err)
+
+	var indexes []bson.M
+	require.NoError(t, cursor.All(context.Background(), &indexes))
+
+	// indexModels() defines 5 indexes; MongoDB adds the implicit _id_ index, for 6 total.
+	assert.Len(t, indexes, len(indexModels())+1,
+		"collection should have the 5 modeled indexes plus the implicit _id_ index")
 }

--- a/components/crm/internal/adapters/mongodb/holder/holder_maintenance.mongodb.go
+++ b/components/crm/internal/adapters/mongodb/holder/holder_maintenance.mongodb.go
@@ -53,6 +53,17 @@ func indexModels() []mongo.IndexModel {
 	}
 }
 
+// ensureIndexes ensures indexes exist for the holder collection.
+// Uses per-collection tracking to handle multi-tenant/per-org collections correctly.
+// Retries on failure — indexes are only marked as done after successful creation.
+func ensureIndexes(ctx context.Context, collection *mongo.Collection) error {
+	key := collection.Database().Name() + ":" + collection.Name()
+
+	return globalIndexTracker.ensureOnce(key, func() error {
+		return createIndexes(ctx, collection)
+	})
+}
+
 // createIndexes creates indexes for specific fields, if it not exists.
 func createIndexes(ctx context.Context, collection *mongo.Collection) error {
 	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)

--- a/components/crm/internal/adapters/mongodb/holder/index_tracker.go
+++ b/components/crm/internal/adapters/mongodb/holder/index_tracker.go
@@ -12,9 +12,13 @@ type indexState struct {
 	done bool
 }
 
-// indexTracker manages per-database index creation state.
-// In multi-tenant mode, each tenant database needs its own indexes.
-// This tracker ensures indexes are created exactly once per database, with retry on failure.
+// indexTracker manages index-creation state per (database, collection) pair.
+// In multi-tenant mode each tenant database needs its own indexes, and holder
+// collections are per-organization (holders_<orgID>), so one entry accumulates
+// per (tenant database, organization). Entries are never evicted in production:
+// the map grows with the distinct collection count, bounded by the org/tenant
+// scale — an intentional, create-once-per-collection cache (reset is test-only).
+// Indexes are created once per key, with retry on failure.
 type indexTracker struct {
 	states sync.Map // key: "dbName:collection" -> *indexState
 }
@@ -49,6 +53,6 @@ func (t *indexTracker) reset(key string) {
 	t.states.Delete(key)
 }
 
-// globalIndexTracker is shared across all audit repository instances.
-// This ensures indexes are created once per database even if multiple repository instances exist.
+// globalIndexTracker is shared across all holder repository instances, so indexes
+// are created once per (database, collection) even when multiple instances exist.
 var globalIndexTracker = &indexTracker{}

--- a/components/crm/internal/adapters/mongodb/holder/index_tracker.go
+++ b/components/crm/internal/adapters/mongodb/holder/index_tracker.go
@@ -1,0 +1,54 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package holder
+
+import "sync"
+
+// indexState tracks whether indexes have been successfully created for a specific database/collection pair.
+type indexState struct {
+	mu   sync.Mutex
+	done bool
+}
+
+// indexTracker manages per-database index creation state.
+// In multi-tenant mode, each tenant database needs its own indexes.
+// This tracker ensures indexes are created exactly once per database, with retry on failure.
+type indexTracker struct {
+	states sync.Map // key: "dbName:collection" -> *indexState
+}
+
+// ensureOnce executes fn exactly once per key, but only marks as done on success.
+// If fn returns an error, subsequent calls will retry.
+func (t *indexTracker) ensureOnce(key string, fn func() error) error {
+	v, _ := t.states.LoadOrStore(key, &indexState{})
+	state := v.(*indexState)
+
+	state.mu.Lock()
+	defer state.mu.Unlock()
+
+	if state.done {
+		return nil
+	}
+
+	if err := fn(); err != nil {
+		return err
+	}
+
+	state.done = true
+
+	return nil
+}
+
+// reset clears the state for a specific key. Used in integration tests to ensure fresh state
+// when each test runs with a new MongoDB container.
+//
+//nolint:unused // used in *_integration_test.go files (build tag: integration)
+func (t *indexTracker) reset(key string) {
+	t.states.Delete(key)
+}
+
+// globalIndexTracker is shared across all audit repository instances.
+// This ensures indexes are created once per database even if multiple repository instances exist.
+var globalIndexTracker = &indexTracker{}


### PR DESCRIPTION
<table border="0" cellspacing="0" cellpadding="0">
  <tr>
    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
    <td><h1>Midaz</h1></td>
  </tr>
</table>

---

## Description

CRM's holder and alias MongoDB repositories called `collection.Indexes().CreateMany()` on **every** insert, with no guard. Under a concurrent burst to a fresh per-org collection (`holders_<orgID>` / `aliases_<orgID>`), those calls serialized on MongoDB's index build — producing 2–4s stalls and `context deadline exceeded` 500s on `POST /v1/holders` and `POST /v1/aliases`.

This routes index creation through an `ensureOnce` guard keyed by `database:collection`, mirroring the pattern already shipping in the `audit` and `encryption` adapters. The first insert per collection builds the indexes once; subsequent inserts skip MongoDB entirely. A failed or timed-out build leaves the flag unset so the next request retries. Because CRM collections are per-org, a burst to one org collapses to a single build while other orgs and tenants stay fully parallel.

No index shapes, routes, exported signatures, or stored formats change — this is a non-breaking internal fix.

## Type of Change

- [x] `feat`: New feature or capability
- [x] `fix`: Bug fix
- [ ] `perf`: Performance improvement
- [ ] `refactor`: Internal restructuring with no behavior change
- [ ] `docs`: Documentation only
- [ ] `style`: Formatting, whitespace, naming (no logic change)
- [ ] `test`: Adding or updating tests
- [ ] `ci`: CI pipeline or workflow changes
- [ ] `build`: Build system, Dockerfile, Go module dependencies
- [ ] `chore`: Maintenance, config, tooling
- [ ] `revert`: Reverts a previous commit
- [ ] `BREAKING CHANGE`: Consumers must update their integration

## Breaking Changes

None.

## Testing

- [x] `make test` passes
- [x] `make test-int` passes if integration paths are exercised
- [x] `make lint` passes

**Test evidence / Actions run:** Integration suites run against testcontainers MongoDB with `ALLOW_INSECURE_TLS=true` (testcontainers are plaintext; `go test` does not source `.env`).
- Holder: 68 PASS, 0 FAIL. `TestHolderRepository_Create_ConcurrentBurst_SingleIndexBuild` — 10 concurrent `Create()` to a fresh collection, **1.11s** (under the 5s deadline).
- Alias: 54 PASS, 0 FAIL. `TestAliasRepository_Create_ConcurrentBurst_SingleIndexBuild` — 10 concurrent `Create()`, distinct keys clearing all 3 unique partial indexes, **1.17s**.
- No `context deadline` / `incomplete read` / `DATA RACE` / `panic` signatures in either run.
- `golangci-lint` (v2): 0 issues on the changed packages, both default and `-tags integration`.
- `make sec` / `make vulncheck` not run in this session.

## Architectural Checklist

- [x] No `panic()` in production paths
- [x] Timestamps use `time.Now().UTC()` (no new timestamps introduced)
- [x] Errors wrapped with `%w` (guard passes repository errors through unchanged)
- [x] Handlers stay thin (parse, validate, call service — no handler changes)
- [x] Infrastructure concerns kept in the adapter layer (index management stays in the MongoDB repository adapters; no bootstrap changes)

## Related Issues
N/A
