### PR TITLE
feat(ledger): emit balance.changed events per balance-affected operation

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -29,7 +29,7 @@ jobs:
         ci
         docs
         tests
-      go_version: "1.26.4"
+      go_version: "1.26.5"
       golangci_lint_version: "v2.4.0"
       app_name_prefix: "midaz"
       filter_paths: |

--- a/.trivyignore
+++ b/.trivyignore
@@ -3,18 +3,3 @@
 # Not applicable to this Go repository; retained from prior configuration.
 # ---------------------------------------------------------------------------
 CVE-2025-57319
-
-# ---------------------------------------------------------------------------
-# Go stdlib LOW CVEs baked into the compiled binary (built with
-# golang:1.26.4-alpine). No patched Go release (> 1.26.4) is available as of
-# 2026-07-08. Both are LOW severity and are hidden from the CRITICAL/HIGH scan
-# summary, but they flip the PR security-reporter gate's has_findings via the
-# all-severity SARIF, blocking every midaz PR (they surface in both the ledger
-# and crm image scans). Remove once the Go builder image is bumped to a release
-# carrying the fixes.
-# Review by: 2026-09-01
-#   CVE-2026-39822 — os: root escape via symlink plus trailing slash
-#   CVE-2026-42505 — crypto/tls: Encrypted Client Hello privacy leak
-# ---------------------------------------------------------------------------
-CVE-2026-39822
-CVE-2026-42505

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,1 +1,20 @@
+# ---------------------------------------------------------------------------
+# CVE-2025-57319 — withdrawn npm advisory (fast-redact prototype pollution).
+# Not applicable to this Go repository; retained from prior configuration.
+# ---------------------------------------------------------------------------
 CVE-2025-57319
+
+# ---------------------------------------------------------------------------
+# Go stdlib LOW CVEs baked into the compiled binary (built with
+# golang:1.26.4-alpine). No patched Go release (> 1.26.4) is available as of
+# 2026-07-08. Both are LOW severity and are hidden from the CRITICAL/HIGH scan
+# summary, but they flip the PR security-reporter gate's has_findings via the
+# all-severity SARIF, blocking every midaz PR (they surface in both the ledger
+# and crm image scans). Remove once the Go builder image is bumped to a release
+# carrying the fixes.
+# Review by: 2026-09-01
+#   CVE-2026-39822 — os: root escape via symlink plus trailing slash
+#   CVE-2026-42505 — crypto/tls: Encrypted Client Hello privacy leak
+# ---------------------------------------------------------------------------
+CVE-2026-39822
+CVE-2026-42505

--- a/components/crm/Dockerfile
+++ b/components/crm/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.4
 
-FROM --platform=$BUILDPLATFORM golang:1.26.4-alpine AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.5-alpine AS builder
 
 WORKDIR /crm-app
 

--- a/components/ledger/Dockerfile
+++ b/components/ledger/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.26.4-alpine AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.5-alpine AS builder
 
 WORKDIR /ledger-app
 

--- a/components/ledger/internal/bootstrap/streaming.go
+++ b/components/ledger/internal/bootstrap/streaming.go
@@ -162,7 +162,8 @@ func BuildStreamingEmitter(
 			}
 		}
 
-		logger.Log(ctx, libLog.LevelInfo, "Streaming emitter constructed",
+		logger.Log(
+			ctx, libLog.LevelInfo, "Streaming emitter constructed",
 			libLog.String("brokers", strings.Join(streamingCfg.Brokers, ",")),
 			libLog.String("client_id", streamingCfg.ClientID),
 			libLog.String("ce_source", streamingCfg.CloudEventsSource),
@@ -207,7 +208,8 @@ func resolveSASLMechanism(cfg *Config) (sasl.Mechanism, string, error) {
 	if user == "" || pass == "" {
 		return nil, "", fmt.Errorf(
 			"STREAMING_SASL_MECHANISM=%q requires STREAMING_SASL_USERNAME and STREAMING_SASL_PASSWORD",
-			mechanism)
+			mechanism,
+		)
 	}
 
 	switch mechanism {
@@ -220,7 +222,8 @@ func resolveSASLMechanism(cfg *Config) (sasl.Mechanism, string, error) {
 	default:
 		return nil, "", fmt.Errorf(
 			"STREAMING_SASL_MECHANISM=%q is not supported (accepted: %s, %s, %s)",
-			raw, saslMechanismPlain, saslMechanismScram256, saslMechanismScram512)
+			raw, saslMechanismPlain, saslMechanismScram256, saslMechanismScram512,
+		)
 	}
 }
 
@@ -258,6 +261,7 @@ func midazEventDefinitions() []events.Definition {
 		events.TransactionRouteUpdatedDefinition,
 		events.TransactionRouteDeletedDefinition,
 		events.BalanceCreatedDefinition,
+		events.BalanceChangedDefinition,
 		events.BalanceConfigChangedDefinition,
 		events.BalanceDeletedDefinition,
 		events.BalanceOverdraftDrawnDefinition,

--- a/components/ledger/internal/bootstrap/streaming_test.go
+++ b/components/ledger/internal/bootstrap/streaming_test.go
@@ -294,3 +294,39 @@ func TestBuildStreamingEmitter_UnsupportedMechanismFailsClosed(t *testing.T) {
 			strings.Contains(err.Error(), "not supported"),
 		"expected unsupported-mechanism error, got %v", err)
 }
+
+// TestMidazEventDefinitions_IncludesBalanceChanged asserts the generic
+// balance.changed event is registered in the single-source-of-truth
+// definition list, so it flows into both the Catalog and the Routes.
+func TestMidazEventDefinitions_IncludesBalanceChanged(t *testing.T) {
+	t.Parallel()
+
+	defs := midazEventDefinitions()
+
+	found := false
+	for _, d := range defs {
+		if d.Key() == "balance.changed" {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "balance.changed must be registered in midazEventDefinitions")
+}
+
+// TestBuildRoutes_BalanceChangedTopic asserts the balance.changed route
+// resolves to the canonical lerian.streaming.balance.changed Kafka topic.
+func TestBuildRoutes_BalanceChangedTopic(t *testing.T) {
+	t.Parallel()
+
+	routes := buildRoutes(streamingPrimaryTargetName)
+
+	var dest string
+	for _, r := range routes {
+		if r.DefinitionKey == "balance.changed" {
+			// KafkaTopic stores the topic string in Destination.Name
+			// (Destination is a struct, not a string).
+			dest = r.Destination.Name
+		}
+	}
+	assert.Equal(t, "lerian.streaming.balance.changed", dest)
+}

--- a/components/ledger/internal/services/command/create_balance_transaction_operations_async.go
+++ b/components/ledger/internal/services/command/create_balance_transaction_operations_async.go
@@ -147,9 +147,15 @@ func (uc *UseCase) CreateBalanceTransactionOperationsAsync(ctx context.Context, 
 		}
 	}
 
-	go uc.SendTransactionEvents(ctx, tran, phase)
-	go uc.SendOverdraftEvents(ctx, tran)
-	go uc.SendBalanceChangedEvents(ctx, tran)
+	// Send events asynchronously with context that preserves trace but survives parent cancellation
+	go func() {
+		eventCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), asyncOperationTimeout)
+		defer cancel()
+
+		uc.SendTransactionEvents(eventCtx, tran, phase)
+		uc.SendOverdraftEvents(eventCtx, tran)
+		uc.SendBalanceChangedEvents(eventCtx, tran)
+	}()
 
 	logger.Log(ctx, libLog.LevelInfo, fmt.Sprintf("Backup queue: cleaning up transaction %s after successful processing", tran.ID))
 

--- a/components/ledger/internal/services/command/create_balance_transaction_operations_async.go
+++ b/components/ledger/internal/services/command/create_balance_transaction_operations_async.go
@@ -147,14 +147,21 @@ func (uc *UseCase) CreateBalanceTransactionOperationsAsync(ctx context.Context, 
 		}
 	}
 
-	// Send events asynchronously with context that preserves trace but survives parent cancellation
+	// Send events asynchronously with context that preserves trace but survives parent cancellation.
+	// Each emitter gets its own timeout budget so a slow earlier emitter cannot starve later ones.
 	go func() {
-		eventCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), asyncOperationTimeout)
-		defer cancel()
+		base := context.WithoutCancel(ctx)
 
-		uc.SendTransactionEvents(eventCtx, tran, phase)
-		uc.SendOverdraftEvents(eventCtx, tran)
-		uc.SendBalanceChangedEvents(eventCtx, tran)
+		runWithTimeout := func(fn func(context.Context)) {
+			emitCtx, cancel := context.WithTimeout(base, asyncOperationTimeout)
+			defer cancel()
+
+			fn(emitCtx)
+		}
+
+		runWithTimeout(func(c context.Context) { uc.SendTransactionEvents(c, tran, phase) })
+		runWithTimeout(func(c context.Context) { uc.SendOverdraftEvents(c, tran) })
+		runWithTimeout(func(c context.Context) { uc.SendBalanceChangedEvents(c, tran) })
 	}()
 
 	logger.Log(ctx, libLog.LevelInfo, fmt.Sprintf("Backup queue: cleaning up transaction %s after successful processing", tran.ID))
@@ -490,9 +497,8 @@ func (uc *UseCase) UpdateTransactionBackupOperations(ctx context.Context, organi
 // Non-empty direction must be one of the valid values ("debit", "credit").
 func validateOperationDirection(ctx context.Context, logger libLog.Logger, oper *operation.Operation) error {
 	if oper.Direction == "" {
-		logger.Log(ctx, libLog.LevelWarn, fmt.Sprintf(
-			"Operation %s has empty direction, may be from pre-migration message", oper.ID,
-		))
+		logger.Log(ctx, libLog.LevelWarn, "Operation has empty direction, may be from pre-migration message",
+			libLog.String("operation_id", oper.ID))
 
 		return nil
 	}

--- a/components/ledger/internal/services/command/create_balance_transaction_operations_async.go
+++ b/components/ledger/internal/services/command/create_balance_transaction_operations_async.go
@@ -149,6 +149,7 @@ func (uc *UseCase) CreateBalanceTransactionOperationsAsync(ctx context.Context, 
 
 	go uc.SendTransactionEvents(ctx, tran, phase)
 	go uc.SendOverdraftEvents(ctx, tran)
+	go uc.SendBalanceChangedEvents(ctx, tran)
 
 	logger.Log(ctx, libLog.LevelInfo, fmt.Sprintf("Backup queue: cleaning up transaction %s after successful processing", tran.ID))
 
@@ -484,7 +485,8 @@ func (uc *UseCase) UpdateTransactionBackupOperations(ctx context.Context, organi
 func validateOperationDirection(ctx context.Context, logger libLog.Logger, oper *operation.Operation) error {
 	if oper.Direction == "" {
 		logger.Log(ctx, libLog.LevelWarn, fmt.Sprintf(
-			"Operation %s has empty direction, may be from pre-migration message", oper.ID))
+			"Operation %s has empty direction, may be from pre-migration message", oper.ID,
+		))
 
 		return nil
 	}

--- a/components/ledger/internal/services/command/create_balance_transaction_operations_async.go
+++ b/components/ledger/internal/services/command/create_balance_transaction_operations_async.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"sync"
 	"time"
 
 	libObs "github.com/LerianStudio/lib-observability"
@@ -159,9 +160,21 @@ func (uc *UseCase) CreateBalanceTransactionOperationsAsync(ctx context.Context, 
 			fn(emitCtx)
 		}
 
-		runWithTimeout(func(c context.Context) { uc.SendTransactionEvents(c, tran, phase) })
-		runWithTimeout(func(c context.Context) { uc.SendOverdraftEvents(c, tran) })
-		runWithTimeout(func(c context.Context) { uc.SendBalanceChangedEvents(c, tran) })
+		var wg sync.WaitGroup
+
+		wg.Add(3)
+
+		go func() {
+			defer wg.Done()
+			runWithTimeout(func(c context.Context) { uc.SendTransactionEvents(c, tran, phase) })
+		}()
+		go func() { defer wg.Done(); runWithTimeout(func(c context.Context) { uc.SendOverdraftEvents(c, tran) }) }()
+		go func() {
+			defer wg.Done()
+			runWithTimeout(func(c context.Context) { uc.SendBalanceChangedEvents(c, tran) })
+		}()
+
+		wg.Wait()
 	}()
 
 	logger.Log(ctx, libLog.LevelInfo, fmt.Sprintf("Backup queue: cleaning up transaction %s after successful processing", tran.ID))

--- a/components/ledger/internal/services/command/create_bulk_transaction_operations_async.go
+++ b/components/ledger/internal/services/command/create_bulk_transaction_operations_async.go
@@ -575,14 +575,21 @@ func (uc *UseCase) processMetadataAndEvents(
 			}
 		}
 
-		// Send events asynchronously with context that preserves trace but survives parent cancellation
+		// Send events asynchronously with context that preserves trace but survives parent cancellation.
+		// Each emitter gets its own timeout budget so a slow earlier emitter cannot starve later ones.
 		go func(phase string) {
-			opCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), asyncOperationTimeout)
-			defer cancel()
+			base := context.WithoutCancel(ctx)
 
-			uc.SendTransactionEvents(opCtx, tx, phase)
-			uc.SendOverdraftEvents(opCtx, tx)
-			uc.SendBalanceChangedEvents(opCtx, tx)
+			runWithTimeout := func(fn func(context.Context)) {
+				emitCtx, cancel := context.WithTimeout(base, asyncOperationTimeout)
+				defer cancel()
+
+				fn(emitCtx)
+			}
+
+			runWithTimeout(func(c context.Context) { uc.SendTransactionEvents(c, tx, phase) })
+			runWithTimeout(func(c context.Context) { uc.SendOverdraftEvents(c, tx) })
+			runWithTimeout(func(c context.Context) { uc.SendBalanceChangedEvents(c, tx) })
 		}(phase)
 	}
 }

--- a/components/ledger/internal/services/command/create_bulk_transaction_operations_async.go
+++ b/components/ledger/internal/services/command/create_bulk_transaction_operations_async.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	libObs "github.com/LerianStudio/lib-observability"
@@ -587,9 +588,21 @@ func (uc *UseCase) processMetadataAndEvents(
 				fn(emitCtx)
 			}
 
-			runWithTimeout(func(c context.Context) { uc.SendTransactionEvents(c, tx, phase) })
-			runWithTimeout(func(c context.Context) { uc.SendOverdraftEvents(c, tx) })
-			runWithTimeout(func(c context.Context) { uc.SendBalanceChangedEvents(c, tx) })
+			var wg sync.WaitGroup
+
+			wg.Add(3)
+
+			go func() {
+				defer wg.Done()
+				runWithTimeout(func(c context.Context) { uc.SendTransactionEvents(c, tx, phase) })
+			}()
+			go func() { defer wg.Done(); runWithTimeout(func(c context.Context) { uc.SendOverdraftEvents(c, tx) }) }()
+			go func() {
+				defer wg.Done()
+				runWithTimeout(func(c context.Context) { uc.SendBalanceChangedEvents(c, tx) })
+			}()
+
+			wg.Wait()
 		}(phase)
 	}
 }

--- a/components/ledger/internal/services/command/create_bulk_transaction_operations_async.go
+++ b/components/ledger/internal/services/command/create_bulk_transaction_operations_async.go
@@ -108,7 +108,8 @@ func (uc *UseCase) CreateBulkTransactionOperationsAsync(
 
 			logger.Log(ctx, libLog.LevelWarn, fmt.Sprintf(
 				"Legacy payload detected (no Version field) for transaction %s, calling UpdateBalances",
-				p.Transaction.ID))
+				p.Transaction.ID,
+			))
 
 			if err := uc.UpdateBalances(ctx, orgID, ledgerID, *p.Validate, p.Balances, p.BalancesAfter); err != nil {
 				logger.Log(ctx, libLog.LevelError, fmt.Sprintf("Failed to update balances for legacy payload %s: %v", p.Transaction.ID, err))
@@ -542,7 +543,8 @@ func (uc *UseCase) processMetadataAndEvents(
 		if len(insertedTxIDs) > 0 {
 			if _, wasInserted := insertedTxIDs[tx.ID]; !wasInserted {
 				logger.Log(ctx, libLog.LevelDebug, fmt.Sprintf(
-					"Skipping events for duplicate transaction %s", tx.ID))
+					"Skipping events for duplicate transaction %s", tx.ID,
+				))
 
 				continue
 			}
@@ -580,6 +582,7 @@ func (uc *UseCase) processMetadataAndEvents(
 
 			uc.SendTransactionEvents(opCtx, tx, phase)
 			uc.SendOverdraftEvents(opCtx, tx)
+			uc.SendBalanceChangedEvents(opCtx, tx)
 		}(phase)
 	}
 }

--- a/components/ledger/internal/services/command/send_balance_changed_events.go
+++ b/components/ledger/internal/services/command/send_balance_changed_events.go
@@ -1,0 +1,127 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package command
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	libObs "github.com/LerianStudio/lib-observability"
+	libStreaming "github.com/LerianStudio/lib-streaming"
+	"github.com/LerianStudio/midaz/v3/components/ledger/internal/adapters/postgres/transaction"
+	"github.com/LerianStudio/midaz/v3/pkg/constant"
+	pkgStreaming "github.com/LerianStudio/midaz/v3/pkg/streaming"
+	"github.com/LerianStudio/midaz/v3/pkg/streaming/events"
+	"github.com/shopspring/decimal"
+)
+
+// SendBalanceChangedEvents emits one generic, domain-agnostic balance.changed
+// event per balance-affecting operation of a committed transaction.
+//
+// Fire-and-forget: launched as a goroutine alongside SendTransactionEvents /
+// SendOverdraftEvents. Emission failures are logged/span-recorded but never
+// propagate — this MUST NOT fail the parent transaction (mirrors the
+// EmitImportant contract). Emission happens whenever streaming is enabled:
+// when STREAMING_ENABLED=false the streaming client is a NoopEmitter, so this
+// simply becomes a no-op — the same posture as balance.created.
+//
+// The event carries only Midaz identities + a generic Reason. It carries NO
+// consumer-domain fields — the consumer (e.g. the br-sisbajud Connector) maps
+// accountId -> its own domain key and produces its own trigger.
+func (uc *UseCase) SendBalanceChangedEvents(ctx context.Context, tran *transaction.Transaction) {
+	logger, tracer, _, _ := libObs.NewTrackingFromContext(ctx)
+
+	if uc.Streaming == nil {
+		return
+	}
+
+	if tran == nil || len(tran.Operations) == 0 {
+		return
+	}
+
+	ctxSend, span := tracer.Start(ctx, "command.send_balance_changed_events_async")
+	defer span.End()
+
+	occurredAt := time.Now().UTC()
+
+	for _, op := range tran.Operations {
+		if op == nil || !op.BalanceAffected {
+			continue
+		}
+
+		// src is declared INSIDE the loop so each buildFn closure captures its
+		// own copy — avoids the classic loop-variable capture bug.
+		src := events.BalanceChangedSource{
+			OrganizationID: tran.OrganizationID,
+			LedgerID:       tran.LedgerID,
+			AccountID:      op.AccountID,
+			BalanceID:      op.BalanceID,
+			Alias:          op.AccountAlias,
+			AssetCode:      op.AssetCode,
+			BalanceKey:     op.BalanceKey,
+			Available:      decimalOrZero(op.BalanceAfter.Available),
+			OnHold:         decimalOrZero(op.BalanceAfter.OnHold),
+			Version:        int64OrZero(op.BalanceAfter.Version),
+			Reason:         reasonForOperation(op.Type),
+			OperationType:  op.Type,
+			Direction:      op.Direction,
+			Amount:         decimalOrZero(op.Amount.Value),
+			TransactionID:  tran.ID,
+			OperationID:    op.ID,
+			OccurredAt:     occurredAt,
+		}
+
+		buildFn := func(tenantID string) (libStreaming.EmitRequest, error) {
+			return events.NewBalanceChanged(src).ToEmitRequest(tenantID, src.OccurredAt)
+		}
+
+		pkgStreaming.EmitImportant(ctxSend, span, logger, uc.Streaming, events.BalanceChangedDefinition.Key(), buildFn)
+	}
+}
+
+// decimalOrZero dereferences a *decimal.Decimal, treating nil as zero.
+func decimalOrZero(d *decimal.Decimal) decimal.Decimal {
+	if d == nil {
+		return decimal.Zero
+	}
+
+	return *d
+}
+
+// int64OrZero dereferences a *int64, treating nil as zero.
+func int64OrZero(v *int64) int64 {
+	if v == nil {
+		return 0
+	}
+
+	return *v
+}
+
+// reasonForOperation maps a Midaz Operation.Type into the generic,
+// domain-agnostic balance.changed Reason discriminator. Unknown types fall back
+// to "adjust" so the event stays emittable for any future op type without a
+// code change (the consumer treats "adjust" as "generic mutation"). The op-type
+// labels are the canonical values exported by pkg/constant.
+func reasonForOperation(opType string) string {
+	switch strings.ToUpper(strings.TrimSpace(opType)) {
+	case constant.CREDIT:
+		return events.BalanceChangeReasonCredit
+	case constant.DEBIT:
+		return events.BalanceChangeReasonDebit
+	case constant.BLOCK:
+		return events.BalanceChangeReasonBlock
+	case constant.UNBLOCK:
+		return events.BalanceChangeReasonUnblock
+	case constant.ONHOLD:
+		return events.BalanceChangeReasonHold
+	case constant.RELEASE:
+		return events.BalanceChangeReasonRelease
+	case constant.OVERDRAFT:
+		return events.BalanceChangeReasonOverdraft
+	default:
+		return events.BalanceChangeReasonAdjust
+	}
+}

--- a/components/ledger/internal/services/command/send_balance_changed_events.go
+++ b/components/ledger/internal/services/command/send_balance_changed_events.go
@@ -7,7 +7,6 @@ package command
 import (
 	"context"
 	"strings"
-	"time"
 
 	libObs "github.com/LerianStudio/lib-observability"
 	libStreaming "github.com/LerianStudio/lib-streaming"
@@ -21,8 +20,7 @@ import (
 // SendBalanceChangedEvents emits one generic, domain-agnostic balance.changed
 // event per balance-affecting operation of a committed transaction.
 //
-// Fire-and-forget: launched as a goroutine alongside SendTransactionEvents /
-// SendOverdraftEvents. Emission failures are logged/span-recorded but never
+// Fire-and-forget: emission failures are logged/span-recorded but never
 // propagate — this MUST NOT fail the parent transaction (mirrors the
 // EmitImportant contract). Emission happens whenever streaming is enabled:
 // when STREAMING_ENABLED=false the streaming client is a NoopEmitter, so this
@@ -45,7 +43,9 @@ func (uc *UseCase) SendBalanceChangedEvents(ctx context.Context, tran *transacti
 	ctxSend, span := tracer.Start(ctx, "command.send_balance_changed_events_async")
 	defer span.End()
 
-	occurredAt := time.Now().UTC()
+	if ctxSend.Err() != nil {
+		return
+	}
 
 	for _, op := range tran.Operations {
 		if op == nil || !op.BalanceAffected {
@@ -71,7 +71,7 @@ func (uc *UseCase) SendBalanceChangedEvents(ctx context.Context, tran *transacti
 			Amount:         decimalOrZero(op.Amount.Value),
 			TransactionID:  tran.ID,
 			OperationID:    op.ID,
-			OccurredAt:     occurredAt,
+			OccurredAt:     op.CreatedAt,
 		}
 
 		buildFn := func(tenantID string) (libStreaming.EmitRequest, error) {

--- a/components/ledger/internal/services/command/send_balance_changed_events_streaming_test.go
+++ b/components/ledger/internal/services/command/send_balance_changed_events_streaming_test.go
@@ -1,0 +1,78 @@
+//go:build unit
+
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package command
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/LerianStudio/midaz/v3/components/ledger/internal/adapters/postgres/operation"
+	"github.com/LerianStudio/midaz/v3/components/ledger/internal/adapters/postgres/transaction"
+	pkgStreaming "github.com/LerianStudio/midaz/v3/pkg/streaming"
+	"github.com/LerianStudio/midaz/v3/pkg/streaming/events"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSendBalanceChangedEvents_PayloadRoundTrip drives one balance-affecting
+// BLOCK operation through the emit path and round-trips the recorded wire
+// payload back into BalanceChangedPayload. It deliberately uses a BLOCK op with
+// Direction "debit": the classifier maps Type "BLOCK" -> reason "block"
+// regardless of direction, so this locks reason != direction (a wire-contract
+// property the CREDIT/DEBIT cases in send_balance_changed_events_test.go cannot
+// observe, since there reason and direction coincide).
+func TestSendBalanceChangedEvents_PayloadRoundTrip(t *testing.T) {
+	rec := pkgStreaming.NewMockEmitter()
+	uc := &UseCase{Streaming: rec}
+
+	avail := decimal.NewFromInt(900)
+	onHold := decimal.NewFromInt(100)
+	amt := decimal.NewFromInt(50)
+	ver := int64(3)
+
+	tran := &transaction.Transaction{
+		ID:             "txn-9",
+		OrganizationID: "org-9",
+		LedgerID:       "led-9",
+		Operations: []*operation.Operation{
+			{
+				ID:              "op-9",
+				AccountID:       "acc-9",
+				BalanceID:       "bal-9",
+				AccountAlias:    "@a9",
+				AssetCode:       "BRL",
+				BalanceKey:      "default",
+				Type:            "BLOCK",
+				Direction:       "debit",
+				BalanceAffected: true,
+				Amount:          operation.Amount{Value: &amt},
+				BalanceAfter:    operation.Balance{Available: &avail, OnHold: &onHold, Version: &ver},
+			},
+		},
+	}
+
+	uc.SendBalanceChangedEvents(context.Background(), tran)
+
+	reqs := rec.Events()
+	require.Len(t, reqs, 1)
+	assert.Equal(t, "balance.changed", reqs[0].DefinitionKey)
+	assert.Equal(t, "txn-9:op-9", reqs[0].Subject)
+
+	var p events.BalanceChangedPayload
+	require.NoError(t, json.Unmarshal(reqs[0].Payload, &p))
+
+	assert.Equal(t, "acc-9", p.AccountID)
+	// reason is driven by Operation.Type, NOT by Direction: BLOCK -> "block"
+	// even though Direction is "debit". This locks reason != direction.
+	assert.Equal(t, events.BalanceChangeReasonBlock, p.Reason)
+	assert.Equal(t, "BLOCK", p.OperationType)
+	assert.Equal(t, "debit", p.Direction)
+	assert.True(t, decimal.NewFromInt(900).Equal(p.Available), "available: got %s", p.Available)
+	assert.Equal(t, int64(3), p.Version)
+}

--- a/components/ledger/internal/services/command/send_balance_changed_events_test.go
+++ b/components/ledger/internal/services/command/send_balance_changed_events_test.go
@@ -1,0 +1,160 @@
+//go:build unit
+
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package command
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/LerianStudio/midaz/v3/components/ledger/internal/adapters/postgres/operation"
+	"github.com/LerianStudio/midaz/v3/components/ledger/internal/adapters/postgres/transaction"
+	pkgStreaming "github.com/LerianStudio/midaz/v3/pkg/streaming"
+	"github.com/LerianStudio/midaz/v3/pkg/streaming/events"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReasonForOperation(t *testing.T) {
+	cases := []struct {
+		name     string
+		opType   string
+		expected string
+	}{
+		{"credit", "CREDIT", events.BalanceChangeReasonCredit},
+		{"debit", "DEBIT", events.BalanceChangeReasonDebit},
+		{"block", "BLOCK", events.BalanceChangeReasonBlock},
+		{"unblock", "UNBLOCK", events.BalanceChangeReasonUnblock},
+		{"hold", "ON_HOLD", events.BalanceChangeReasonHold},
+		{"release", "RELEASE", events.BalanceChangeReasonRelease},
+		{"overdraft", "OVERDRAFT", events.BalanceChangeReasonOverdraft},
+		{"unknown falls back to adjust", "SOMETHING_NEW", events.BalanceChangeReasonAdjust},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, reasonForOperation(tc.opType))
+		})
+	}
+}
+
+func TestSendBalanceChangedEvents_EmitsPerBalanceAffectingOperation(t *testing.T) {
+	// GIVEN a recording emitter capturing EmitRequests.
+	rec := pkgStreaming.NewMockEmitter()
+	uc := &UseCase{Streaming: rec}
+
+	avail := decimal.NewFromInt(1500)
+	onHold := decimal.NewFromInt(0)
+	amt := decimal.NewFromInt(100)
+	ver := int64(7)
+
+	avail2 := decimal.NewFromInt(900)
+	onHold2 := decimal.NewFromInt(0)
+	amt2 := decimal.NewFromInt(600)
+	ver2 := int64(8)
+
+	tran := &transaction.Transaction{
+		ID:             "txn-1",
+		OrganizationID: "org-1",
+		LedgerID:       "led-1",
+		Operations: []*operation.Operation{
+			{
+				ID:              "op-1",
+				AccountID:       "acc-1",
+				BalanceID:       "bal-1",
+				AccountAlias:    "@person1",
+				AssetCode:       "BRL",
+				BalanceKey:      "default",
+				Type:            "CREDIT",
+				Direction:       "credit",
+				BalanceAffected: true,
+				Amount:          operation.Amount{Value: &amt},
+				BalanceAfter:    operation.Balance{Available: &avail, OnHold: &onHold, Version: &ver},
+			},
+			{
+				// Second balance-affecting op — proves one event PER operation.
+				ID:              "op-2",
+				AccountID:       "acc-2",
+				BalanceID:       "bal-2",
+				AccountAlias:    "@person2",
+				AssetCode:       "BRL",
+				BalanceKey:      "default",
+				Type:            "DEBIT",
+				Direction:       "debit",
+				BalanceAffected: true,
+				Amount:          operation.Amount{Value: &amt2},
+				BalanceAfter:    operation.Balance{Available: &avail2, OnHold: &onHold2, Version: &ver2},
+			},
+			{
+				ID:              "op-3",
+				BalanceAffected: false, // must not emit
+				AccountID:       "acc-3",
+				Type:            "DEBIT",
+			},
+		},
+	}
+
+	uc.SendBalanceChangedEvents(context.Background(), tran)
+
+	// M1: exactly one event per balance-affecting op, two DISTINCT subjects.
+	reqs := rec.Events()
+	require.Len(t, reqs, 2)
+	assert.Equal(t, "balance.changed", reqs[0].DefinitionKey)
+	assert.Equal(t, "balance.changed", reqs[1].DefinitionKey)
+	assert.Equal(t, "txn-1:op-1", reqs[0].Subject)
+	assert.Equal(t, "txn-1:op-2", reqs[1].Subject)
+
+	// H1 + M2: decode the first op's wire payload and assert the full
+	// operation -> payload mapping so a field-swap regression fails here.
+	var payload events.BalanceChangedPayload
+	require.NoError(t, json.Unmarshal(reqs[0].Payload, &payload))
+
+	assert.Equal(t, "acc-1", payload.AccountID)
+	assert.Equal(t, "bal-1", payload.BalanceID)
+	assert.Equal(t, "BRL", payload.AssetCode)
+	assert.Equal(t, "default", payload.BalanceKey)
+	assert.Equal(t, "@person1", payload.Alias)
+	assert.Equal(t, events.BalanceChangeReasonCredit, payload.Reason)
+	assert.Equal(t, "CREDIT", payload.OperationType)
+	assert.Equal(t, "credit", payload.Direction)
+	assert.True(t, decimal.NewFromInt(1500).Equal(payload.Available), "available: got %s", payload.Available)
+	assert.True(t, decimal.NewFromInt(0).Equal(payload.OnHold), "onHold: got %s", payload.OnHold)
+	assert.True(t, decimal.NewFromInt(100).Equal(payload.Amount), "amount: got %s", payload.Amount)
+	assert.Equal(t, int64(7), payload.Version)
+}
+
+func TestSendBalanceChangedEvents_NilSafe(t *testing.T) {
+	uc := &UseCase{Streaming: nil}
+	// nil Streaming → no emit / no panic.
+	uc.SendBalanceChangedEvents(context.Background(), nil)
+	uc.SendBalanceChangedEvents(context.Background(), &transaction.Transaction{ID: "txn-1"})
+
+	// A nil operation / nil balance pointers inside a live transaction must
+	// also be nil-safe once Streaming is present.
+	rec := pkgStreaming.NewMockEmitter()
+	uc2 := &UseCase{Streaming: rec}
+	uc2.SendBalanceChangedEvents(context.Background(), &transaction.Transaction{
+		ID: "txn-2",
+		Operations: []*operation.Operation{
+			nil,
+			{ID: "op-1", Type: "CREDIT", BalanceAffected: true}, // nil Amount/Balance pointers
+		},
+	})
+	// nil op skipped; the second op has nil Amount.Value + nil BalanceAfter
+	// pointers but still emits (values default to zero) without panicking.
+	reqs := rec.Events()
+	require.Len(t, reqs, 1)
+
+	// The nil->zero conversions (decimalOrZero / int64OrZero) must reach the
+	// wire as decimal.Zero / version 0, not as absent or garbage values.
+	var payload events.BalanceChangedPayload
+	require.NoError(t, json.Unmarshal(reqs[0].Payload, &payload))
+	assert.True(t, payload.Available.Equal(decimal.Zero), "available: got %s", payload.Available)
+	assert.True(t, payload.OnHold.Equal(decimal.Zero), "onHold: got %s", payload.OnHold)
+	assert.True(t, payload.Amount.Equal(decimal.Zero), "amount: got %s", payload.Amount)
+	assert.Equal(t, int64(0), payload.Version)
+}

--- a/components/ledger/internal/services/command/send_overdraft_events.go
+++ b/components/ledger/internal/services/command/send_overdraft_events.go
@@ -43,6 +43,19 @@ const (
 	OverdraftActionCleared = "overdraft.cleared"
 )
 
+// Environment variable names read by the overdraft-event flow. Extracted to
+// constants so the names have a single source of truth instead of being
+// repeated as inline string literals across the file.
+const (
+	// envOverdraftEventsEnabled toggles overdraft-event emission. Enabled unless
+	// explicitly set to "false".
+	envOverdraftEventsEnabled = "RABBITMQ_OVERDRAFT_EVENTS_ENABLED"
+
+	// envOverdraftEventsExchange is the RabbitMQ exchange the legacy overdraft
+	// events are published to.
+	envOverdraftEventsExchange = "RABBITMQ_OVERDRAFT_EVENTS_EXCHANGE"
+)
+
 // OverdraftEventPayload carries the business fields for an overdraft
 // lifecycle event. It is marshalled as the Payload field inside mmodel.Event.
 type OverdraftEventPayload struct {
@@ -100,7 +113,7 @@ func (uc *UseCase) SendOverdraftEvents(ctx context.Context, tran *transaction.Tr
 
 	if !isOverdraftEventEnabled() {
 		logger.Log(ctx, libLog.LevelInfo, "Overdraft events not enabled",
-			libLog.String("RABBITMQ_OVERDRAFT_EVENTS_ENABLED", os.Getenv("RABBITMQ_OVERDRAFT_EVENTS_ENABLED")))
+			libLog.String(envOverdraftEventsEnabled, os.Getenv(envOverdraftEventsEnabled)))
 
 		return
 	}
@@ -113,7 +126,7 @@ func (uc *UseCase) SendOverdraftEvents(ctx context.Context, tran *transaction.Tr
 	ctxSend, span := tracer.Start(ctx, "command.send_overdraft_events_async")
 	defer span.End()
 
-	exchange := os.Getenv("RABBITMQ_OVERDRAFT_EVENTS_EXCHANGE")
+	exchange := os.Getenv(envOverdraftEventsExchange)
 
 	for _, ep := range payloads {
 		raw, err := json.Marshal(ep.payload)
@@ -356,6 +369,6 @@ func overdraftBalanceAfter(op *operation.Operation) decimal.Decimal {
 // Unset or any other value means enabled — consistent with the transaction
 // event flag pattern.
 func isOverdraftEventEnabled() bool {
-	envValue := strings.ToLower(strings.TrimSpace(os.Getenv("RABBITMQ_OVERDRAFT_EVENTS_ENABLED")))
+	envValue := strings.ToLower(strings.TrimSpace(os.Getenv(envOverdraftEventsEnabled)))
 	return envValue != "false"
 }

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/LerianStudio/midaz/v3
 
 go 1.26.3
 
-toolchain go1.26.4
+toolchain go1.26.5
 
 require (
 	github.com/LerianStudio/lib-auth/v2 v2.9.0

--- a/pkg/streaming/events/balance_changed.go
+++ b/pkg/streaming/events/balance_changed.go
@@ -30,12 +30,8 @@ const (
 
 // BalanceChangedDefinition is the routing contract for balance.changed.
 //
-// Emission anchor: components/ledger/internal/services/command/send_balance_changed_events.go,
-// inside SendBalanceChangedEvents, launched as a goroutine alongside
-// SendTransactionEvents / SendOverdraftEvents from
-// create_balance_transaction_operations_async.go and
-// create_bulk_transaction_operations_async.go. One balance.changed is emitted
-// per balance-affecting operation of the committed transaction.
+// One balance.changed event is emitted per balance-affecting operation of a
+// committed transaction.
 //
 // Design intent: this event is INTENTIONALLY generic and domain-agnostic. It
 // carries only Midaz identities (org/ledger/account/balance/asset) plus a
@@ -58,9 +54,10 @@ var BalanceChangedDefinition = Definition{
 
 // BalanceChangedPayload is the wire payload for balance.changed.
 //
-// Available/OnHold/Amount are decimal.Decimal so the wire encodes them as JSON
-// numbers (matching the HTTP balance contract). They reflect the state AFTER
-// the operation.
+// Available/OnHold/Amount are decimal.Decimal. shopspring/decimal marshals to
+// quoted JSON strings by default, so these fields travel on the wire as strings
+// (matching the HTTP balance contract). They reflect the state AFTER the
+// operation.
 //
 // Scale is intentionally OMITTED: it is an asset-level property, not a
 // balance-level one (see balance_created.go). Consumers needing scale should

--- a/pkg/streaming/events/balance_changed.go
+++ b/pkg/streaming/events/balance_changed.go
@@ -1,0 +1,152 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package events
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	libStreaming "github.com/LerianStudio/lib-streaming"
+	"github.com/shopspring/decimal"
+)
+
+// Reason values stamped onto BalanceChangedPayload.Reason. Domain-agnostic,
+// wire-stable discriminators of WHAT changed the balance. Consumers switch on
+// these. NO third-party domain semantics belong here — the Midaz ledger only
+// announces "the balance moved, and generically why".
+const (
+	BalanceChangeReasonCredit    = "credit"
+	BalanceChangeReasonDebit     = "debit"
+	BalanceChangeReasonBlock     = "block"
+	BalanceChangeReasonUnblock   = "unblock"
+	BalanceChangeReasonHold      = "hold"
+	BalanceChangeReasonRelease   = "release"
+	BalanceChangeReasonOverdraft = "overdraft"
+	BalanceChangeReasonAdjust    = "adjust"
+)
+
+// BalanceChangedDefinition is the routing contract for balance.changed.
+//
+// Emission anchor: components/ledger/internal/services/command/send_balance_changed_events.go,
+// inside SendBalanceChangedEvents, launched as a goroutine alongside
+// SendTransactionEvents / SendOverdraftEvents from
+// create_balance_transaction_operations_async.go and
+// create_bulk_transaction_operations_async.go. One balance.changed is emitted
+// per balance-affecting operation of the committed transaction.
+//
+// Design intent: this event is INTENTIONALLY generic and domain-agnostic. It
+// carries only Midaz identities (org/ledger/account/balance/asset) plus a
+// generic Reason discriminator. It carries NO consumer-domain fields (no
+// cpf_hash, no judicial-order id, nothing SISBAJUD-specific). Translating this
+// generic signal into a domain trigger is the consumer's job.
+//
+// Relationship to balance.created: COMPLEMENTARY, not a replacement.
+// balance.created fires only on CreateAdditionalBalance (lifecycle create);
+// balance.changed fires on transaction-driven mutations of an existing balance.
+//
+// IMPORTANT posture: emit failures MUST NOT fail the parent transaction.
+// EventType "changed" is a single word — no underscore/hyphen concern with the
+// lib-streaming route-key regex. Wire topic: lerian.streaming.balance.changed.
+var BalanceChangedDefinition = Definition{
+	ResourceType:  "balance",
+	EventType:     "changed",
+	SchemaVersion: "1.0.0",
+}
+
+// BalanceChangedPayload is the wire payload for balance.changed.
+//
+// Available/OnHold/Amount are decimal.Decimal so the wire encodes them as JSON
+// numbers (matching the HTTP balance contract). They reflect the state AFTER
+// the operation.
+//
+// Scale is intentionally OMITTED: it is an asset-level property, not a
+// balance-level one (see balance_created.go). Consumers needing scale should
+// join against the corresponding asset.created event. Version IS included so
+// consumers can order/dedup mutations of the same balance.
+type BalanceChangedPayload struct {
+	OrganizationID string          `json:"organizationId"`
+	LedgerID       string          `json:"ledgerId"`
+	AccountID      string          `json:"accountId"`
+	BalanceID      string          `json:"balanceId"`
+	Alias          string          `json:"alias,omitempty"`
+	AssetCode      string          `json:"assetCode"`
+	BalanceKey     string          `json:"balanceKey"`
+	Available      decimal.Decimal `json:"available"`
+	OnHold         decimal.Decimal `json:"onHold"`
+	Version        int64           `json:"version"`
+	Reason         string          `json:"reason"`
+	OperationType  string          `json:"operationType"`
+	Direction      string          `json:"direction,omitempty"`
+	Amount         decimal.Decimal `json:"amount"`
+	TransactionID  string          `json:"transactionId"`
+	OperationID    string          `json:"operationId"`
+	OccurredAt     string          `json:"occurredAt"`
+}
+
+// BalanceChangedSource carries the identifiers + amounts the constructor needs
+// to assemble a payload. The use case populates this from one operation + its
+// parent transaction. Keeping it a struct keeps the constructor from growing
+// into positional-argument territory (mirrors BalanceOverdraftSource).
+type BalanceChangedSource struct {
+	OrganizationID string
+	LedgerID       string
+	AccountID      string
+	BalanceID      string
+	Alias          string
+	AssetCode      string
+	BalanceKey     string
+	Available      decimal.Decimal
+	OnHold         decimal.Decimal
+	Version        int64
+	Reason         string
+	OperationType  string
+	Direction      string
+	Amount         decimal.Decimal
+	TransactionID  string
+	OperationID    string
+	OccurredAt     time.Time
+}
+
+// NewBalanceChanged maps the source into the wire payload.
+func NewBalanceChanged(src BalanceChangedSource) BalanceChangedPayload {
+	return BalanceChangedPayload{
+		OrganizationID: src.OrganizationID,
+		LedgerID:       src.LedgerID,
+		AccountID:      src.AccountID,
+		BalanceID:      src.BalanceID,
+		Alias:          src.Alias,
+		AssetCode:      src.AssetCode,
+		BalanceKey:     src.BalanceKey,
+		Available:      src.Available,
+		OnHold:         src.OnHold,
+		Version:        src.Version,
+		Reason:         src.Reason,
+		OperationType:  src.OperationType,
+		Direction:      src.Direction,
+		Amount:         src.Amount,
+		TransactionID:  src.TransactionID,
+		OperationID:    src.OperationID,
+		OccurredAt:     src.OccurredAt.Format(time.RFC3339),
+	}
+}
+
+// ToEmitRequest assembles a libStreaming.EmitRequest ready for the Emitter.
+// Subject combines transactionId + operationId so consumers safe-deduping on
+// Subject match the canonical idempotency key for this event.
+func (p BalanceChangedPayload) ToEmitRequest(tenantID string, ts time.Time) (libStreaming.EmitRequest, error) {
+	data, err := json.Marshal(p)
+	if err != nil {
+		return libStreaming.EmitRequest{}, fmt.Errorf("marshal %s payload: %w", BalanceChangedDefinition.Key(), err)
+	}
+
+	return libStreaming.EmitRequest{
+		DefinitionKey: BalanceChangedDefinition.Key(),
+		TenantID:      tenantID,
+		Subject:       p.TransactionID + ":" + p.OperationID,
+		Timestamp:     ts,
+		Payload:       data,
+	}, nil
+}

--- a/pkg/streaming/events/balance_changed_test.go
+++ b/pkg/streaming/events/balance_changed_test.go
@@ -56,6 +56,48 @@ func TestNewBalanceChanged_MapsAllFields(t *testing.T) {
 	assert.Equal(t, "2026-07-03T12:00:00Z", p.OccurredAt)
 }
 
+// Minimal-domain mapping: only the required identifiers are set. Optional
+// fields (Alias, Direction) are left zero and must stay empty after mapping,
+// and their omitempty JSON tags must drop them from the wire payload.
+func TestNewBalanceChanged_MinimalDomain(t *testing.T) {
+	ts := time.Date(2026, 7, 3, 12, 0, 0, 0, time.UTC)
+	src := BalanceChangedSource{
+		OrganizationID: "org-1",
+		LedgerID:       "led-1",
+		AccountID:      "acc-1",
+		BalanceID:      "bal-1",
+		AssetCode:      "BRL",
+		BalanceKey:     "default",
+		Reason:         BalanceChangeReasonAdjust,
+		OperationType:  "CREDIT",
+		TransactionID:  "txn-1",
+		OperationID:    "op-1",
+		OccurredAt:     ts,
+	}
+
+	p := NewBalanceChanged(src)
+
+	assert.Empty(t, p.Alias)
+	assert.Empty(t, p.Direction)
+	assert.True(t, p.Available.IsZero())
+	assert.True(t, p.OnHold.IsZero())
+	assert.True(t, p.Amount.IsZero())
+	assert.Equal(t, int64(0), p.Version)
+
+	raw, err := json.Marshal(p)
+	require.NoError(t, err)
+
+	var m map[string]any
+	require.NoError(t, json.Unmarshal(raw, &m))
+
+	assert.NotContains(t, m, "alias", "empty alias must be dropped by omitempty")
+	assert.NotContains(t, m, "direction", "empty direction must be dropped by omitempty")
+	// Required fields stay on the wire even when zero-valued.
+	assert.Contains(t, m, "available")
+	assert.Contains(t, m, "onHold")
+	assert.Contains(t, m, "version")
+}
+
 func TestBalanceChangedPayload_ToEmitRequest(t *testing.T) {
 	ts := time.Date(2026, 7, 3, 12, 0, 0, 0, time.UTC)
 	p := NewBalanceChanged(BalanceChangedSource{
@@ -93,7 +135,7 @@ func TestBalanceChangedPayload_JSONShape(t *testing.T) {
 		Amount:         decimal.NewFromInt(100),
 		TransactionID:  "txn-1",
 		OperationID:    "op-1",
-		OccurredAt:     time.Now().UTC(),
+		OccurredAt:     time.Date(2026, 7, 3, 12, 0, 0, 0, time.UTC),
 	})
 
 	raw, err := json.Marshal(p)

--- a/pkg/streaming/events/balance_changed_test.go
+++ b/pkg/streaming/events/balance_changed_test.go
@@ -1,0 +1,118 @@
+//go:build unit
+
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package events
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBalanceChangedDefinition_Key(t *testing.T) {
+	assert.Equal(t, "balance.changed", BalanceChangedDefinition.Key())
+	assert.Equal(t, "balance", BalanceChangedDefinition.ResourceType)
+	assert.Equal(t, "changed", BalanceChangedDefinition.EventType)
+	assert.Equal(t, "1.0.0", BalanceChangedDefinition.SchemaVersion)
+}
+
+func TestNewBalanceChanged_MapsAllFields(t *testing.T) {
+	ts := time.Date(2026, 7, 3, 12, 0, 0, 0, time.UTC)
+	src := BalanceChangedSource{
+		OrganizationID: "org-1",
+		LedgerID:       "led-1",
+		AccountID:      "acc-1",
+		BalanceID:      "bal-1",
+		Alias:          "@person1",
+		AssetCode:      "BRL",
+		BalanceKey:     "default",
+		Available:      decimal.NewFromInt(1500),
+		OnHold:         decimal.NewFromInt(500),
+		Version:        42,
+		Reason:         BalanceChangeReasonCredit,
+		OperationType:  "CREDIT",
+		Direction:      "credit",
+		Amount:         decimal.NewFromInt(100),
+		TransactionID:  "txn-1",
+		OperationID:    "op-1",
+		OccurredAt:     ts,
+	}
+
+	p := NewBalanceChanged(src)
+
+	assert.Equal(t, "acc-1", p.AccountID)
+	assert.Equal(t, "bal-1", p.BalanceID)
+	assert.Equal(t, "credit", p.Reason)
+	assert.Equal(t, "CREDIT", p.OperationType)
+	assert.True(t, decimal.NewFromInt(1500).Equal(p.Available))
+	assert.Equal(t, int64(42), p.Version)
+	assert.Equal(t, "2026-07-03T12:00:00Z", p.OccurredAt)
+}
+
+func TestBalanceChangedPayload_ToEmitRequest(t *testing.T) {
+	ts := time.Date(2026, 7, 3, 12, 0, 0, 0, time.UTC)
+	p := NewBalanceChanged(BalanceChangedSource{
+		TransactionID: "txn-1",
+		OperationID:   "op-1",
+		Reason:        BalanceChangeReasonDebit,
+		OccurredAt:    ts,
+	})
+
+	req, err := p.ToEmitRequest("tenant-1", ts)
+	require.NoError(t, err)
+	assert.Equal(t, "balance.changed", req.DefinitionKey)
+	assert.Equal(t, "tenant-1", req.TenantID)
+	assert.Equal(t, "txn-1:op-1", req.Subject)
+	assert.Equal(t, ts, req.Timestamp)
+	assert.NotEmpty(t, req.Payload)
+}
+
+// JSONShape locks the wire field count and names (v1.0.0 contract).
+func TestBalanceChangedPayload_JSONShape(t *testing.T) {
+	p := NewBalanceChanged(BalanceChangedSource{
+		OrganizationID: "org-1",
+		LedgerID:       "led-1",
+		AccountID:      "acc-1",
+		BalanceID:      "bal-1",
+		Alias:          "@person1",
+		AssetCode:      "BRL",
+		BalanceKey:     "default",
+		Available:      decimal.NewFromInt(1500),
+		OnHold:         decimal.NewFromInt(500),
+		Version:        42,
+		Reason:         BalanceChangeReasonCredit,
+		OperationType:  "CREDIT",
+		Direction:      "credit",
+		Amount:         decimal.NewFromInt(100),
+		TransactionID:  "txn-1",
+		OperationID:    "op-1",
+		OccurredAt:     time.Now().UTC(),
+	})
+
+	raw, err := json.Marshal(p)
+	require.NoError(t, err)
+
+	var m map[string]any
+	require.NoError(t, json.Unmarshal(raw, &m))
+
+	// 17 wire fields (alias and direction are omitempty but present here,
+	// since every field is set in this test).
+	for _, k := range []string{
+		"organizationId", "ledgerId", "accountId", "balanceId", "alias",
+		"assetCode", "balanceKey", "available", "onHold", "version",
+		"reason", "operationType", "direction", "amount", "transactionId",
+		"operationId", "occurredAt",
+	} {
+		_, ok := m[k]
+		assert.Truef(t, ok, "missing wire field: %s", k)
+	}
+	assert.Len(t, m, 17, "payload must have exactly 17 wire fields")
+	assert.NotContains(t, m, "scale", "scale is asset-level; it must not be in the payload")
+}


### PR DESCRIPTION
## Description

Emits a generic, domain-agnostic `balance.changed` streaming event for every balance-affecting operation in the ledger, so downstream services can react to individual balance mutations without polling.

- New event definition `pkg/streaming/events/balance_changed.go`: `BalanceChangedPayload` + `NewBalanceChanged` constructor, carrying only Midaz identities (organization, ledger, account, balance, transaction, operation) plus amounts and a generic `reason` discriminator. No consumer-domain fields.
- `reason` values: `credit`, `debit`, `block`, `unblock`, `hold`, `release`, `overdraft`, `adjust` (mapped from operation type via `reasonForOperation`; unknown types fall back to `adjust`).
- `SendBalanceChangedEvents` emits one `balance.changed` per balance-affected operation of a transaction, wired into the async operation paths (`create_balance_transaction_operations_async.go`, `create_bulk_transaction_operations_async.go`).
- Registered in the streaming catalog and routed to the wire topic `lerian.streaming.balance.changed`.
- Overdraft event env-var names extracted to constants for consistency alongside the new emission path.

## Why

This unlocks downstream event-driven consumers that need per-operation balance visibility. Concretely, br-sisbajud's Midaz balance translator consumes `balance.changed` to react to credits (and other reasons) on monitored accounts, rather than reconciling by polling balances. The generic `reason` discriminator lets each consumer filter to the operations it cares about (e.g. `credit` for reiteration triggers, `block`/`unblock` for judicial block lifecycle) while keeping the event contract domain-agnostic.

The `block`/`unblock` reasons build on the block/unblock transaction actions already merged in ledger; this PR is the event-emission layer over those and the standard credit/debit/hold/release flows.

## Type of Change

- [x] `feat`: New feature or capability

## Breaking Changes

None. Emission is gated by `STREAMING_ENABLED`; when disabled (the default) the streaming client is a `NoopEmitter`, so `SendBalanceChangedEvents` is a no-op and existing behavior is unchanged.

## Testing

- Unit tests for the event definition (`pkg/streaming/events/balance_changed_test.go`), the emission use case (`send_balance_changed_events_test.go`), a streaming-tagged emission test (`send_balance_changed_events_streaming_test.go`), and catalog/route registration (`bootstrap/streaming_test.go`).
- [x] `make test` passes
- [x] `make lint` passes

## Architectural Checklist

- [x] No `panic()` in production paths
- [x] Timestamps use `time.Now().UTC()`
- [x] Errors wrapped with `%w`
- [x] Infrastructure concerns kept in `internal/bootstrap`
