### PR TITLE
feat(pkg): add Service Discovery metrics via MetricsFactory

### DIFF
--- a/components/crm/internal/bootstrap/config.go
+++ b/components/crm/internal/bootstrap/config.go
@@ -313,8 +313,7 @@ type serviceDiscoveryWiring struct {
 // The metrics recorder is built AFTER BuildManager reports enabled so it is a
 // NopMetricsRecorder whenever discovery is disabled: with SD off, resolve (and
 // every downstream SD metric) emits nothing, even though metricsFactory is
-// non-nil. When enabled it is the OTel-backed recorder (a nil factory still
-// degrades to a no-op via NewMetricsFactoryRecorder).
+// non-nil. When enabled it is the OTel-backed recorder.
 func wireServiceDiscovery(cfg *Config, logger libLog.Logger, metricsFactory *metrics.MetricsFactory) (serviceDiscoveryWiring, error) {
 	manager, enabled, err := pkgsd.BuildManager(logger)
 	if err != nil {

--- a/components/crm/internal/bootstrap/config.go
+++ b/components/crm/internal/bootstrap/config.go
@@ -152,17 +152,8 @@ func InitServersWithOptions(opts *Options) (*Service, error) {
 		return nil, fmt.Errorf("MULTI_TENANT_ENABLED=true requires PLUGIN_AUTH_ENABLED=true")
 	}
 
-	// Build service discovery before the streaming emitter so a misconfigured
-	// SD (fail-fast) returns before anything requiring drain is constructed. The
-	// helper also parses the advertised port (fail-fast on a malformed
-	// SERVER_ADDRESS), builds this instance's descriptor, and resolves the
-	// plugin-auth host.
-	sd, err := wireServiceDiscovery(cfg, logger)
-	if err != nil {
-		return nil, err
-	}
-
-	// Init Open telemetry to control logs and flows
+	// Init Open telemetry to control logs and flows. Built before service
+	// discovery so the metrics factory is available to back the SD recorder.
 	telemetry, err := libOpentelemetry.NewTelemetry(libOpentelemetry.TelemetryConfig{
 		LibraryName:               cfg.OtelLibraryName,
 		ServiceName:               cfg.OtelServiceName,
@@ -183,10 +174,21 @@ func InitServersWithOptions(opts *Options) (*Service, error) {
 	}
 
 	// Extract the metrics factory ONCE (nil when telemetry disabled) and reuse it
-	// for both encryption metrics and readyz metrics emission.
+	// for the SD recorder, encryption metrics, and readyz metrics emission.
 	var metricsFactory *metrics.MetricsFactory
 	if telemetry != nil {
 		metricsFactory = telemetry.MetricsFactory
+	}
+
+	// Build service discovery before the streaming emitter so a misconfigured
+	// SD (fail-fast) returns before anything requiring drain is constructed. The
+	// helper also parses the advertised port (fail-fast on a malformed
+	// SERVER_ADDRESS), builds this instance's descriptor, and resolves the
+	// plugin-auth host. The recorder is a no-op unless discovery is enabled, so
+	// SD off emits zero SD metrics.
+	sd, err := wireServiceDiscovery(cfg, logger, metricsFactory)
+	if err != nil {
+		return nil, err
 	}
 
 	mongoConnection, err := initMongoConnection(cfg, logger)
@@ -278,18 +280,23 @@ func InitServersWithOptions(opts *Options) (*Service, error) {
 		ServiceDiscovery:        sd.manager,
 		ServiceDiscoveryEnabled: sd.enabled,
 		ServiceDescriptor:       sd.descriptor,
+		ServiceDiscoveryMetrics: sd.recorder,
 		Logger:                  logger,
 	}, nil
 }
 
 // serviceDiscoveryWiring holds the service-discovery outputs consumed by the
 // composition root: the Manager, whether discovery is enabled, the descriptor to
-// register, and the plugin-auth host resolved (or degraded) via discovery.
+// register, the plugin-auth host resolved (or degraded) via discovery, and the
+// metrics recorder threaded through the SD call paths. The recorder is a no-op
+// unless discovery is enabled, upholding the invariant that SD off emits zero
+// SD metrics.
 type serviceDiscoveryWiring struct {
 	manager    *libsd.Manager
 	enabled    bool
 	descriptor libsd.Service
 	authHost   string
+	recorder   pkgsd.MetricsRecorder
 }
 
 // wireServiceDiscovery builds the discovery Manager (fail-fast on
@@ -302,10 +309,21 @@ type serviceDiscoveryWiring struct {
 // only when enabled), so a malformed SERVER_ADDRESS must not abort boot with
 // discovery off. The resolve timeout is created only when auth is enabled, since
 // ResolveAuthHost returns the static host without touching the context otherwise.
-func wireServiceDiscovery(cfg *Config, logger libLog.Logger) (serviceDiscoveryWiring, error) {
+//
+// The metrics recorder is built AFTER BuildManager reports enabled so it is a
+// NopMetricsRecorder whenever discovery is disabled: with SD off, resolve (and
+// every downstream SD metric) emits nothing, even though metricsFactory is
+// non-nil. When enabled it is the OTel-backed recorder (a nil factory still
+// degrades to a no-op via NewMetricsFactoryRecorder).
+func wireServiceDiscovery(cfg *Config, logger libLog.Logger, metricsFactory *metrics.MetricsFactory) (serviceDiscoveryWiring, error) {
 	manager, enabled, err := pkgsd.BuildManager(logger)
 	if err != nil {
 		return serviceDiscoveryWiring{}, err
+	}
+
+	recorder := pkgsd.MetricsRecorder(pkgsd.NopMetricsRecorder{})
+	if enabled {
+		recorder = pkgsd.NewMetricsFactoryRecorder(metricsFactory, logger)
 	}
 
 	var descriptor libsd.Service
@@ -322,7 +340,7 @@ func wireServiceDiscovery(cfg *Config, logger libLog.Logger) (serviceDiscoveryWi
 	authHost := cfg.AuthAddress
 	if cfg.AuthEnabled {
 		resolveCtx, cancel := context.WithTimeout(context.Background(), pkgsd.ResolveTimeout)
-		authHost = pkgsd.ResolveAuthHost(resolveCtx, manager, cfg.AuthEnabled, cfg.AuthAddress, nil)
+		authHost = pkgsd.ResolveAuthHost(resolveCtx, manager, cfg.AuthEnabled, cfg.AuthAddress, recorder)
 
 		cancel()
 	}
@@ -332,6 +350,7 @@ func wireServiceDiscovery(cfg *Config, logger libLog.Logger) (serviceDiscoveryWi
 		enabled:    enabled,
 		descriptor: descriptor,
 		authHost:   authHost,
+		recorder:   recorder,
 	}, nil
 }
 

--- a/components/crm/internal/bootstrap/config.go
+++ b/components/crm/internal/bootstrap/config.go
@@ -322,7 +322,7 @@ func wireServiceDiscovery(cfg *Config, logger libLog.Logger) (serviceDiscoveryWi
 	authHost := cfg.AuthAddress
 	if cfg.AuthEnabled {
 		resolveCtx, cancel := context.WithTimeout(context.Background(), pkgsd.ResolveTimeout)
-		authHost = pkgsd.ResolveAuthHost(resolveCtx, manager, cfg.AuthEnabled, cfg.AuthAddress)
+		authHost = pkgsd.ResolveAuthHost(resolveCtx, manager, cfg.AuthEnabled, cfg.AuthAddress, nil)
 
 		cancel()
 	}

--- a/components/crm/internal/bootstrap/service.go
+++ b/components/crm/internal/bootstrap/service.go
@@ -97,7 +97,7 @@ func (app *Service) launcherApps() []launcherApp {
 	if app.ServiceDiscoveryEnabled {
 		apps = append(apps, launcherApp{
 			"Service Discovery",
-			pkgsd.NewRunnable(app.ServiceDiscovery, app.ServiceDescriptor, app.Logger),
+			pkgsd.NewRunnable(app.ServiceDiscovery, app.ServiceDescriptor, app.Logger, nil),
 		})
 	}
 

--- a/components/crm/internal/bootstrap/service.go
+++ b/components/crm/internal/bootstrap/service.go
@@ -58,6 +58,10 @@ type Service struct {
 	ServiceDiscovery        *libsd.Manager
 	ServiceDiscoveryEnabled bool
 	ServiceDescriptor       libsd.Service
+	// ServiceDiscoveryMetrics records SD register/deregister metrics through the
+	// discovery runnable. It is a NopMetricsRecorder when discovery is disabled,
+	// so no SD metrics are emitted with SD off.
+	ServiceDiscoveryMetrics pkgsd.MetricsRecorder
 
 	libLog.Logger
 }
@@ -97,7 +101,7 @@ func (app *Service) launcherApps() []launcherApp {
 	if app.ServiceDiscoveryEnabled {
 		apps = append(apps, launcherApp{
 			"Service Discovery",
-			pkgsd.NewRunnable(app.ServiceDiscovery, app.ServiceDescriptor, app.Logger, nil),
+			pkgsd.NewRunnable(app.ServiceDiscovery, app.ServiceDescriptor, app.Logger, app.ServiceDiscoveryMetrics),
 		})
 	}
 

--- a/components/crm/internal/bootstrap/service_discovery_test.go
+++ b/components/crm/internal/bootstrap/service_discovery_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	libLog "github.com/LerianStudio/lib-observability/log"
+	"github.com/LerianStudio/lib-observability/metrics"
 	pkgsd "github.com/LerianStudio/midaz/v3/pkg/servicediscovery"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -40,6 +41,7 @@ func TestService_launcherApps_ServiceDiscoveryGuard(t *testing.T) {
 	enabled := &Service{
 		ServiceDiscoveryEnabled: true,
 		ServiceDescriptor:       pkgsd.BuildServiceDescriptor("midaz-crm", 4003),
+		ServiceDiscoveryMetrics: pkgsd.NewMetricsFactoryRecorder(metrics.NewNopFactory(), libLog.NewNop()),
 	}
 	assert.Contains(t, launcherAppNames(enabled), "Service Discovery",
 		"enabled service must register the Service Discovery app")
@@ -54,7 +56,7 @@ func TestWireServiceDiscovery_DisabledIgnoresMalformedServerAddress(t *testing.T
 
 	cfg := &Config{ServerAddress: "not-a-valid-address", AuthEnabled: false, AuthAddress: "http://plugin-auth:4000"}
 
-	sd, err := wireServiceDiscovery(cfg, libLog.NewNop())
+	sd, err := wireServiceDiscovery(cfg, libLog.NewNop(), metrics.NewNopFactory())
 
 	require.NoError(t, err, "malformed SERVER_ADDRESS must not fail boot when discovery is disabled")
 	require.False(t, sd.enabled)
@@ -74,11 +76,72 @@ func TestWireServiceDiscovery_AuthEnabledDiscoveryDisabledFallsBackToStaticHost(
 
 	cfg := &Config{ServerAddress: ":4003", AuthEnabled: true, AuthAddress: "http://plugin-auth:4000"}
 
-	sd, err := wireServiceDiscovery(cfg, libLog.NewNop())
+	sd, err := wireServiceDiscovery(cfg, libLog.NewNop(), metrics.NewNopFactory())
 
 	require.NoError(t, err)
 	require.False(t, sd.enabled, "discovery must stay disabled when SD_ENABLED is unset")
 	require.NotNil(t, sd.manager)
 	assert.Equal(t, "http://plugin-auth:4000", sd.authHost,
 		"auth enabled + discovery disabled must fall back to the static host")
+}
+
+// TestWireServiceDiscovery_DisabledUsesNopRecorder locks the SD metrics INVARIANT:
+// when discovery is disabled, wireServiceDiscovery must forward a
+// NopMetricsRecorder — even though a real MetricsFactory is available — so that
+// the resolve path (and every downstream SD metric) emits nothing with SD off.
+func TestWireServiceDiscovery_DisabledUsesNopRecorder(t *testing.T) {
+	t.Setenv("SD_ENABLED", "")
+	t.Setenv("SERVICE_DISCOVERY_ENABLED", "")
+
+	cfg := &Config{ServerAddress: ":4003", AuthEnabled: true, AuthAddress: "http://plugin-auth:4000"}
+
+	sd, err := wireServiceDiscovery(cfg, libLog.NewNop(), metrics.NewNopFactory())
+
+	require.NoError(t, err)
+	require.False(t, sd.enabled)
+
+	_, isNop := sd.recorder.(pkgsd.NopMetricsRecorder)
+	assert.True(t, isNop,
+		"SD disabled must yield a NopMetricsRecorder so zero SD metrics are emitted")
+}
+
+// TestWireServiceDiscovery_EnabledUsesRealRecorder asserts that when discovery is
+// enabled with a real MetricsFactory the wiring carries the OTel-backed recorder
+// (not the no-op), so register/deregister/resolve metrics actually flow.
+func TestWireServiceDiscovery_EnabledUsesRealRecorder(t *testing.T) {
+	t.Setenv("SD_ENABLED", "true")
+	t.Setenv("SD_ADVERTISE_ADDRESS", "midaz-crm")
+
+	// AuthEnabled=false so ResolveAuthHost is skipped and the test never dials a
+	// registry; the recorder posture is what is under test.
+	cfg := &Config{ServerAddress: ":4003", AuthEnabled: false, AuthAddress: "http://plugin-auth:4000"}
+
+	sd, err := wireServiceDiscovery(cfg, libLog.NewNop(), metrics.NewNopFactory())
+
+	require.NoError(t, err)
+	require.True(t, sd.enabled)
+	require.NotNil(t, sd.recorder)
+
+	_, isNop := sd.recorder.(pkgsd.NopMetricsRecorder)
+	assert.False(t, isNop,
+		"SD enabled with a real factory must yield the OTel-backed recorder")
+}
+
+// TestWireServiceDiscovery_EnabledNilFactoryDegradesToNop asserts that when SD is
+// enabled but telemetry is off (nil factory), the recorder degrades to a no-op via
+// NewMetricsFactoryRecorder — safe, and never a nil deref at the call sites.
+func TestWireServiceDiscovery_EnabledNilFactoryDegradesToNop(t *testing.T) {
+	t.Setenv("SD_ENABLED", "true")
+	t.Setenv("SD_ADVERTISE_ADDRESS", "midaz-crm")
+
+	cfg := &Config{ServerAddress: ":4003", AuthEnabled: false, AuthAddress: "http://plugin-auth:4000"}
+
+	sd, err := wireServiceDiscovery(cfg, libLog.NewNop(), nil)
+
+	require.NoError(t, err)
+	require.True(t, sd.enabled)
+	require.NotNil(t, sd.recorder)
+
+	_, isNop := sd.recorder.(pkgsd.NopMetricsRecorder)
+	assert.True(t, isNop, "nil factory must degrade to a NopMetricsRecorder")
 }

--- a/components/ledger/internal/bootstrap/config.go
+++ b/components/ledger/internal/bootstrap/config.go
@@ -716,10 +716,18 @@ func InitServersWithOptions(opts *Options) (*Service, error) {
 		TransactionMongoManager: txnMgo.mongoManager,
 	}
 
+	// Extract the metrics factory ONCE (nil when telemetry disabled) so it can
+	// back both the service-discovery recorder below and the readyz handler.
+	var metricsFactory *metrics.MetricsFactory
+	if telemetry != nil {
+		metricsFactory = telemetry.MetricsFactory
+	}
+
 	// Service discovery: build the Manager (no-op when disabled), parse the
 	// advertised port + descriptor (gated on enabled), and resolve plugin-auth
-	// through discovery — all in one helper mirrored on the CRM side.
-	sd, err := wireServiceDiscovery(cfg, logger)
+	// through discovery — all in one helper mirrored on the CRM side. The recorder
+	// is a no-op unless discovery is enabled, so SD off emits zero SD metrics.
+	sd, err := wireServiceDiscovery(cfg, logger, metricsFactory)
 	if err != nil {
 		doCleanup()
 
@@ -752,12 +760,7 @@ func InitServersWithOptions(opts *Options) (*Service, error) {
 
 	// === Readyz handler ===
 
-	// Get metricsFactory from telemetry (nil-safe: checked inside handler)
-	var metricsFactory *metrics.MetricsFactory
-	if telemetry != nil {
-		metricsFactory = telemetry.MetricsFactory
-	}
-
+	// metricsFactory was extracted above (nil-safe: checked inside handler).
 	readyzHandler, err := buildReadyzHandler(cfg, logger, redisConnection, onbPG, txnPG, onbMgo, txnMgo, rmq, metricsFactory)
 	if err != nil {
 		doCleanup()
@@ -822,17 +825,22 @@ func InitServersWithOptions(opts *Options) (*Service, error) {
 		ServiceDiscovery:         sd.manager,
 		ServiceDiscoveryEnabled:  sd.enabled,
 		ServiceDescriptor:        sd.descriptor,
+		ServiceDiscoveryMetrics:  sd.recorder,
 	}, nil
 }
 
 // serviceDiscoveryWiring holds the service-discovery outputs consumed by the
 // composition root: the Manager, whether discovery is enabled, the descriptor to
-// register, and the plugin-auth host resolved (or degraded) via discovery.
+// register, the plugin-auth host resolved (or degraded) via discovery, and the
+// metrics recorder threaded through the SD call paths. The recorder is a no-op
+// unless discovery is enabled, upholding the invariant that SD off emits zero
+// SD metrics.
 type serviceDiscoveryWiring struct {
 	manager    *libsd.Manager
 	enabled    bool
 	descriptor libsd.Service
 	authHost   string
+	recorder   pkgsd.MetricsRecorder
 }
 
 // wireServiceDiscovery builds the discovery Manager (fail-fast on
@@ -845,10 +853,21 @@ type serviceDiscoveryWiring struct {
 // only when enabled), so a malformed SERVER_ADDRESS must not abort boot with
 // discovery off. The resolve timeout is created only when auth is enabled, since
 // ResolveAuthHost returns the static host without touching the context otherwise.
-func wireServiceDiscovery(cfg *Config, logger libLog.Logger) (serviceDiscoveryWiring, error) {
+//
+// The metrics recorder is built AFTER BuildManager reports enabled so it is a
+// NopMetricsRecorder whenever discovery is disabled: with SD off, resolve (and
+// every downstream SD metric) emits nothing, even though metricsFactory is
+// non-nil. When enabled it is the OTel-backed recorder (a nil factory still
+// degrades to a no-op via NewMetricsFactoryRecorder).
+func wireServiceDiscovery(cfg *Config, logger libLog.Logger, metricsFactory *metrics.MetricsFactory) (serviceDiscoveryWiring, error) {
 	manager, enabled, err := pkgsd.BuildManager(logger)
 	if err != nil {
 		return serviceDiscoveryWiring{}, err
+	}
+
+	recorder := pkgsd.MetricsRecorder(pkgsd.NopMetricsRecorder{})
+	if enabled {
+		recorder = pkgsd.NewMetricsFactoryRecorder(metricsFactory, logger)
 	}
 
 	var descriptor libsd.Service
@@ -865,7 +884,7 @@ func wireServiceDiscovery(cfg *Config, logger libLog.Logger) (serviceDiscoveryWi
 	authHost := cfg.AuthHost
 	if cfg.AuthEnabled {
 		resolveCtx, cancel := context.WithTimeout(context.Background(), pkgsd.ResolveTimeout)
-		authHost = pkgsd.ResolveAuthHost(resolveCtx, manager, cfg.AuthEnabled, cfg.AuthHost, nil)
+		authHost = pkgsd.ResolveAuthHost(resolveCtx, manager, cfg.AuthEnabled, cfg.AuthHost, recorder)
 
 		cancel()
 	}
@@ -875,6 +894,7 @@ func wireServiceDiscovery(cfg *Config, logger libLog.Logger) (serviceDiscoveryWi
 		enabled:    enabled,
 		descriptor: descriptor,
 		authHost:   authHost,
+		recorder:   recorder,
 	}, nil
 }
 

--- a/components/ledger/internal/bootstrap/config.go
+++ b/components/ledger/internal/bootstrap/config.go
@@ -857,8 +857,7 @@ type serviceDiscoveryWiring struct {
 // The metrics recorder is built AFTER BuildManager reports enabled so it is a
 // NopMetricsRecorder whenever discovery is disabled: with SD off, resolve (and
 // every downstream SD metric) emits nothing, even though metricsFactory is
-// non-nil. When enabled it is the OTel-backed recorder (a nil factory still
-// degrades to a no-op via NewMetricsFactoryRecorder).
+// non-nil. When enabled it is the OTel-backed recorder.
 func wireServiceDiscovery(cfg *Config, logger libLog.Logger, metricsFactory *metrics.MetricsFactory) (serviceDiscoveryWiring, error) {
 	manager, enabled, err := pkgsd.BuildManager(logger)
 	if err != nil {

--- a/components/ledger/internal/bootstrap/config.go
+++ b/components/ledger/internal/bootstrap/config.go
@@ -865,7 +865,7 @@ func wireServiceDiscovery(cfg *Config, logger libLog.Logger) (serviceDiscoveryWi
 	authHost := cfg.AuthHost
 	if cfg.AuthEnabled {
 		resolveCtx, cancel := context.WithTimeout(context.Background(), pkgsd.ResolveTimeout)
-		authHost = pkgsd.ResolveAuthHost(resolveCtx, manager, cfg.AuthEnabled, cfg.AuthHost)
+		authHost = pkgsd.ResolveAuthHost(resolveCtx, manager, cfg.AuthEnabled, cfg.AuthHost, nil)
 
 		cancel()
 	}

--- a/components/ledger/internal/bootstrap/service.go
+++ b/components/ledger/internal/bootstrap/service.go
@@ -96,7 +96,7 @@ func (s *Service) launcherApps() []launcherApp {
 	if s.ServiceDiscoveryEnabled {
 		apps = append(apps, launcherApp{
 			"Service Discovery",
-			pkgsd.NewRunnable(s.ServiceDiscovery, s.ServiceDescriptor, s.Logger),
+			pkgsd.NewRunnable(s.ServiceDiscovery, s.ServiceDescriptor, s.Logger, nil),
 		})
 	}
 

--- a/components/ledger/internal/bootstrap/service.go
+++ b/components/ledger/internal/bootstrap/service.go
@@ -57,6 +57,10 @@ type Service struct {
 	// SERVER_ADDRESS never aborts boot with discovery off) and reused by the
 	// service-discovery runnable. It is zero-value when discovery is disabled.
 	ServiceDescriptor libsd.Service
+	// ServiceDiscoveryMetrics records SD register/deregister metrics through the
+	// discovery runnable. It is a NopMetricsRecorder when discovery is disabled,
+	// so no SD metrics are emitted with SD off.
+	ServiceDiscoveryMetrics pkgsd.MetricsRecorder
 }
 
 // Run starts the unified ledger service with all APIs on a single port.
@@ -96,7 +100,7 @@ func (s *Service) launcherApps() []launcherApp {
 	if s.ServiceDiscoveryEnabled {
 		apps = append(apps, launcherApp{
 			"Service Discovery",
-			pkgsd.NewRunnable(s.ServiceDiscovery, s.ServiceDescriptor, s.Logger, nil),
+			pkgsd.NewRunnable(s.ServiceDiscovery, s.ServiceDescriptor, s.Logger, s.ServiceDiscoveryMetrics),
 		})
 	}
 

--- a/components/ledger/internal/bootstrap/service_discovery_test.go
+++ b/components/ledger/internal/bootstrap/service_discovery_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	libLog "github.com/LerianStudio/lib-observability/log"
+	"github.com/LerianStudio/lib-observability/metrics"
 	pkgsd "github.com/LerianStudio/midaz/v3/pkg/servicediscovery"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -40,6 +41,7 @@ func TestService_launcherApps_ServiceDiscoveryGuard(t *testing.T) {
 	enabled := &Service{
 		ServiceDiscoveryEnabled: true,
 		ServiceDescriptor:       pkgsd.BuildServiceDescriptor("midaz-ledger", 3002),
+		ServiceDiscoveryMetrics: pkgsd.NewMetricsFactoryRecorder(metrics.NewNopFactory(), libLog.NewNop()),
 	}
 	assert.Contains(t, launcherAppNames(enabled), "Service Discovery",
 		"enabled service must register the Service Discovery app")
@@ -54,7 +56,7 @@ func TestWireServiceDiscovery_DisabledIgnoresMalformedServerAddress(t *testing.T
 
 	cfg := &Config{ServerAddress: "not-a-valid-address", AuthEnabled: false, AuthHost: "http://plugin-auth:4000"}
 
-	sd, err := wireServiceDiscovery(cfg, libLog.NewNop())
+	sd, err := wireServiceDiscovery(cfg, libLog.NewNop(), metrics.NewNopFactory())
 
 	require.NoError(t, err, "malformed SERVER_ADDRESS must not fail boot when discovery is disabled")
 	require.False(t, sd.enabled)
@@ -74,11 +76,72 @@ func TestWireServiceDiscovery_AuthEnabledDiscoveryDisabledFallsBackToStaticHost(
 
 	cfg := &Config{ServerAddress: ":3002", AuthEnabled: true, AuthHost: "http://plugin-auth:4000"}
 
-	sd, err := wireServiceDiscovery(cfg, libLog.NewNop())
+	sd, err := wireServiceDiscovery(cfg, libLog.NewNop(), metrics.NewNopFactory())
 
 	require.NoError(t, err)
 	require.False(t, sd.enabled, "discovery must stay disabled when SD_ENABLED is unset")
 	require.NotNil(t, sd.manager)
 	assert.Equal(t, "http://plugin-auth:4000", sd.authHost,
 		"auth enabled + discovery disabled must fall back to the static host")
+}
+
+// TestWireServiceDiscovery_DisabledUsesNopRecorder locks the SD metrics INVARIANT:
+// when discovery is disabled, wireServiceDiscovery must forward a
+// NopMetricsRecorder — even though a real MetricsFactory is available — so that
+// the resolve path (and every downstream SD metric) emits nothing with SD off.
+func TestWireServiceDiscovery_DisabledUsesNopRecorder(t *testing.T) {
+	t.Setenv("SD_ENABLED", "")
+	t.Setenv("SERVICE_DISCOVERY_ENABLED", "")
+
+	cfg := &Config{ServerAddress: ":3002", AuthEnabled: true, AuthHost: "http://plugin-auth:4000"}
+
+	sd, err := wireServiceDiscovery(cfg, libLog.NewNop(), metrics.NewNopFactory())
+
+	require.NoError(t, err)
+	require.False(t, sd.enabled)
+
+	_, isNop := sd.recorder.(pkgsd.NopMetricsRecorder)
+	assert.True(t, isNop,
+		"SD disabled must yield a NopMetricsRecorder so zero SD metrics are emitted")
+}
+
+// TestWireServiceDiscovery_EnabledUsesRealRecorder asserts that when discovery is
+// enabled with a real MetricsFactory the wiring carries the OTel-backed recorder
+// (not the no-op), so register/deregister/resolve metrics actually flow.
+func TestWireServiceDiscovery_EnabledUsesRealRecorder(t *testing.T) {
+	t.Setenv("SD_ENABLED", "true")
+	t.Setenv("SD_ADVERTISE_ADDRESS", "midaz-ledger")
+
+	// AuthEnabled=false so ResolveAuthHost is skipped and the test never dials a
+	// registry; the recorder posture is what is under test.
+	cfg := &Config{ServerAddress: ":3002", AuthEnabled: false, AuthHost: "http://plugin-auth:4000"}
+
+	sd, err := wireServiceDiscovery(cfg, libLog.NewNop(), metrics.NewNopFactory())
+
+	require.NoError(t, err)
+	require.True(t, sd.enabled)
+	require.NotNil(t, sd.recorder)
+
+	_, isNop := sd.recorder.(pkgsd.NopMetricsRecorder)
+	assert.False(t, isNop,
+		"SD enabled with a real factory must yield the OTel-backed recorder")
+}
+
+// TestWireServiceDiscovery_EnabledNilFactoryDegradesToNop asserts that when SD is
+// enabled but telemetry is off (nil factory), the recorder degrades to a no-op via
+// NewMetricsFactoryRecorder — safe, and never a nil deref at the call sites.
+func TestWireServiceDiscovery_EnabledNilFactoryDegradesToNop(t *testing.T) {
+	t.Setenv("SD_ENABLED", "true")
+	t.Setenv("SD_ADVERTISE_ADDRESS", "midaz-ledger")
+
+	cfg := &Config{ServerAddress: ":3002", AuthEnabled: false, AuthHost: "http://plugin-auth:4000"}
+
+	sd, err := wireServiceDiscovery(cfg, libLog.NewNop(), nil)
+
+	require.NoError(t, err)
+	require.True(t, sd.enabled)
+	require.NotNil(t, sd.recorder)
+
+	_, isNop := sd.recorder.(pkgsd.NopMetricsRecorder)
+	assert.True(t, isNop, "nil factory must degrade to a NopMetricsRecorder")
 }

--- a/pkg/servicediscovery/auth_host_resolver.go
+++ b/pkg/servicediscovery/auth_host_resolver.go
@@ -7,7 +7,17 @@ package servicediscovery
 import (
 	"context"
 	"strings"
+	"time"
 )
+
+// authServiceName is the registry name plugin-auth is resolved by, and the
+// service label attached to the resolve metric.
+const authServiceName = "plugin-auth"
+
+// sinceFn measures elapsed time for the resolve-duration metric. It is a package
+// var so tests can freeze it deterministically (mirrors the hostnameFn seam);
+// production uses time.Since.
+var sinceFn = time.Since
 
 // AuthHostResolver resolves a service host, returning the fallback verbatim when
 // discovery is disabled or fails. *libsd.Manager satisfies this contract.
@@ -19,16 +29,42 @@ type AuthHostResolver interface {
 // It only resolves when auth is enabled (no point resolving a downstream we
 // won't call) and always degrades to the static host on resolve error so a
 // discovery outage never fails boot.
-func ResolveAuthHost(ctx context.Context, r AuthHostResolver, authEnabled bool, staticHost string) string {
+//
+// It passes an EMPTY fallback to r.Resolve so the return distinguishes a
+// consul-resolved host from a fell-back one: on error libsd returns the error
+// rather than swallowing it into the fallback, letting this function label the
+// resolve outcome (resolved/fallback/error) for the metric. The returned host is
+// byte-identical to feeding the static host as the fallback: on success it is the
+// same consul value scheme-normalized; on error it is the static host verbatim.
+func ResolveAuthHost(ctx context.Context, r AuthHostResolver, authEnabled bool, staticHost string, recorder MetricsRecorder) string {
 	if !authEnabled {
 		return staticHost
 	}
 
-	if resolved, err := r.Resolve(ctx, "plugin-auth", staticHost); err == nil {
-		return withFallbackScheme(resolved, staticHost)
+	start := time.Now()
+	resolved, err := r.Resolve(ctx, authServiceName, "")
+	durationMs := sinceFn(start).Milliseconds()
+
+	var (
+		authHost string
+		result   string
+	)
+
+	switch {
+	case err == nil:
+		result = ResultResolved
+		authHost = withFallbackScheme(resolved, staticHost)
+	case staticHost != "":
+		result = ResultFallback
+		authHost = staticHost
+	default:
+		result = ResultError
+		authHost = staticHost
 	}
 
-	return staticHost
+	orNop(recorder).ResolveResult(ctx, authServiceName, result, durationMs)
+
+	return authHost
 }
 
 // withFallbackScheme returns resolved unchanged if it already carries a scheme

--- a/pkg/servicediscovery/auth_host_resolver_test.go
+++ b/pkg/servicediscovery/auth_host_resolver_test.go
@@ -8,23 +8,44 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
 
-// stubAuthHostResolver records how many times Resolve was called and returns a
-// fixed result, so tests can assert both the returned host and that resolution
-// is skipped when auth is disabled.
+// stubAuthHostResolver mimics the libsd Manager.Resolve fallback contract so tests
+// exercise the same source-classification the production resolver relies on:
+// on a consul error it returns the caller-supplied fallback verbatim (nil err)
+// when that fallback is non-empty, and the consul error otherwise. This is what
+// lets ResolveAuthHost distinguish resolved-from-consul from fell-back once it
+// starts passing an EMPTY fallback.
 type stubAuthHostResolver struct {
-	calls    int
-	resolved string
-	err      error
+	calls     int
+	resolved  string
+	consulErr error
 }
 
-func (s *stubAuthHostResolver) Resolve(_ context.Context, _, _ string) (string, error) {
+func (s *stubAuthHostResolver) Resolve(_ context.Context, _, fallback string) (string, error) {
 	s.calls++
 
-	return s.resolved, s.err
+	if s.consulErr == nil {
+		return s.resolved, nil
+	}
+
+	if fallback != "" {
+		return fallback, nil
+	}
+
+	return "", s.consulErr
+}
+
+// stubElapsed freezes the resolve-duration seam so tests observe a fixed elapsed
+// time regardless of wall clock. It returns a restore func to reset the seam.
+func stubElapsed(d time.Duration) func() {
+	orig := sinceFn
+	sinceFn = func(time.Time) time.Duration { return d }
+
+	return func() { sinceFn = orig }
 }
 
 func TestResolveAuthHost(t *testing.T) {
@@ -35,92 +56,146 @@ func TestResolveAuthHost(t *testing.T) {
 	resolveErr := errors.New("consul unavailable")
 
 	tests := []struct {
-		name          string
-		authEnabled   bool
-		staticHost    string
-		stubResolved  string
-		stubErr       error
-		expectedHost  string
-		expectedCalls int
+		name           string
+		authEnabled    bool
+		staticHost     string
+		stubResolved   string
+		stubConsulErr  error
+		expectedHost   string
+		expectedCalls  int
+		expectRecorded bool
+		expectedResult string
 	}{
 		{
-			name:          "auth disabled returns static host without resolving",
-			authEnabled:   false,
-			stubResolved:  "should-not-be-used:9999",
-			stubErr:       nil,
-			expectedHost:  staticHost,
-			expectedCalls: 0,
+			name:           "auth disabled returns static host without resolving or recording",
+			authEnabled:    false,
+			stubResolved:   "should-not-be-used:9999",
+			stubConsulErr:  nil,
+			expectedHost:   staticHost,
+			expectedCalls:  0,
+			expectRecorded: false,
 		},
 		{
-			name:          "auth enabled uses resolved host on success",
-			authEnabled:   true,
-			stubResolved:  "consul-host:4000",
-			stubErr:       nil,
-			expectedHost:  "consul-host:4000",
-			expectedCalls: 1,
+			name:           "auth enabled uses resolved host on success and records resolved",
+			authEnabled:    true,
+			stubResolved:   "consul-host:4000",
+			stubConsulErr:  nil,
+			expectedHost:   "consul-host:4000",
+			expectedCalls:  1,
+			expectRecorded: true,
+			expectedResult: ResultResolved,
 		},
 		{
-			name:          "auth enabled falls back to static host on resolve error",
-			authEnabled:   true,
-			stubResolved:  "",
-			stubErr:       resolveErr,
-			expectedHost:  staticHost,
-			expectedCalls: 1,
+			name:           "auth enabled falls back to static host on resolve error and records fallback",
+			authEnabled:    true,
+			stubResolved:   "",
+			stubConsulErr:  resolveErr,
+			expectedHost:   staticHost,
+			expectedCalls:  1,
+			expectRecorded: true,
+			expectedResult: ResultFallback,
 		},
 		{
-			name:          "auth enabled degrades to static host on resolve deadline exceeded",
-			authEnabled:   true,
-			stubResolved:  "",
-			stubErr:       context.DeadlineExceeded,
-			expectedHost:  staticHost,
-			expectedCalls: 1,
+			name:           "auth enabled degrades to static host on resolve deadline exceeded and records fallback",
+			authEnabled:    true,
+			stubResolved:   "",
+			stubConsulErr:  context.DeadlineExceeded,
+			expectedHost:   staticHost,
+			expectedCalls:  1,
+			expectRecorded: true,
+			expectedResult: ResultFallback,
 		},
 		{
-			name:          "auth enabled borrows fallback scheme when resolved host lacks one",
-			authEnabled:   true,
-			staticHost:    "http://plugin-auth:4000",
-			stubResolved:  "plugin-auth:4000",
-			stubErr:       nil,
-			expectedHost:  "http://plugin-auth:4000",
-			expectedCalls: 1,
+			name:           "auth enabled with empty static host on error returns empty and records error",
+			authEnabled:    true,
+			staticHost:     " ", // sentinel meaning "force empty static host" (see below)
+			stubResolved:   "",
+			stubConsulErr:  resolveErr,
+			expectedHost:   "",
+			expectedCalls:  1,
+			expectRecorded: true,
+			expectedResult: ResultError,
 		},
 		{
-			name:          "auth enabled keeps resolved scheme without double-prefixing",
-			authEnabled:   true,
-			staticHost:    "http://x:4000",
-			stubResolved:  "https://x:4000",
-			stubErr:       nil,
-			expectedHost:  "https://x:4000",
-			expectedCalls: 1,
+			name:           "auth enabled borrows fallback scheme when resolved host lacks one",
+			authEnabled:    true,
+			staticHost:     "http://plugin-auth:4000",
+			stubResolved:   "plugin-auth:4000",
+			stubConsulErr:  nil,
+			expectedHost:   "http://plugin-auth:4000",
+			expectedCalls:  1,
+			expectRecorded: true,
+			expectedResult: ResultResolved,
 		},
 		{
-			name:          "auth enabled leaves scheme-less resolved host untouched when fallback has none",
-			authEnabled:   true,
-			staticHost:    "x:4000",
-			stubResolved:  "x:4000",
-			stubErr:       nil,
-			expectedHost:  "x:4000",
-			expectedCalls: 1,
+			name:           "auth enabled keeps resolved scheme without double-prefixing",
+			authEnabled:    true,
+			staticHost:     "http://x:4000",
+			stubResolved:   "https://x:4000",
+			stubConsulErr:  nil,
+			expectedHost:   "https://x:4000",
+			expectedCalls:  1,
+			expectRecorded: true,
+			expectedResult: ResultResolved,
+		},
+		{
+			name:           "auth enabled leaves scheme-less resolved host untouched when fallback has none",
+			authEnabled:    true,
+			staticHost:     "x:4000",
+			stubResolved:   "x:4000",
+			stubConsulErr:  nil,
+			expectedHost:   "x:4000",
+			expectedCalls:  1,
+			expectRecorded: true,
+			expectedResult: ResultResolved,
 		},
 	}
+
+	// Freeze the duration seam once for the whole table so elapsed is exactly 5ms.
+	// Subtests are not run in parallel here because they share this seam.
+	restore := stubElapsed(5 * time.Millisecond)
+	defer restore()
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-
-			stub := &stubAuthHostResolver{resolved: tc.stubResolved, err: tc.stubErr}
+			stub := &stubAuthHostResolver{resolved: tc.stubResolved, consulErr: tc.stubConsulErr}
+			recorder := &stubRecorder{}
 
 			static := staticHost
-			if tc.staticHost != "" {
+			if tc.staticHost == " " {
+				static = ""
+			} else if tc.staticHost != "" {
 				static = tc.staticHost
 			}
 
-			host := ResolveAuthHost(context.Background(), stub, tc.authEnabled, static)
+			host := ResolveAuthHost(context.Background(), stub, tc.authEnabled, static, recorder)
 
 			require.Equal(t, tc.expectedHost, host)
 			require.Equal(t, tc.expectedCalls, stub.calls)
+
+			if !tc.expectRecorded {
+				require.Empty(t, recorder.resolveResults, "no resolve metric expected when resolution not attempted")
+				return
+			}
+
+			require.Len(t, recorder.resolveResults, 1)
+			require.Equal(t, "plugin-auth", recorder.resolveResults[0].service)
+			require.Equal(t, tc.expectedResult, recorder.resolveResults[0].result)
+			require.Equal(t, int64(5), recorder.resolveResults[0].durationMs)
 		})
 	}
+}
+
+func TestResolveAuthHostNilRecorderDoesNotPanic(t *testing.T) {
+	restore := stubElapsed(5 * time.Millisecond)
+	defer restore()
+
+	stub := &stubAuthHostResolver{resolved: "consul-host:4000"}
+
+	require.NotPanics(t, func() {
+		host := ResolveAuthHost(context.Background(), stub, true, "plugin-auth:4000", nil)
+		require.Equal(t, "consul-host:4000", host)
+	})
 }
 
 func TestWithFallbackScheme(t *testing.T) {

--- a/pkg/servicediscovery/metrics.go
+++ b/pkg/servicediscovery/metrics.go
@@ -1,0 +1,58 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package servicediscovery
+
+import "context"
+
+// Result labels attached to Service Discovery metrics. They are the single source
+// of truth for both call sites and the OTel-backed recorder implementation.
+const (
+	ResultOK       = "ok"
+	ResultError    = "error"
+	ResultResolved = "resolved"
+	ResultFallback = "fallback"
+)
+
+// MetricsRecorder records Service Discovery metrics. Implementations are optional;
+// a nil recorder is treated as a no-op via orNop. The interface is intentionally
+// decoupled from OTel/lib-observability so call sites stay unit-testable with a
+// plain stub.
+type MetricsRecorder interface {
+	// RegisterInitiated records that a service registration was initiated
+	// (registration is fire-and-forget, so only initiations are observable).
+	RegisterInitiated(ctx context.Context)
+	// DeregisterResult records a synchronous deregistration outcome
+	// (result: ResultOK|ResultError).
+	DeregisterResult(ctx context.Context, result string)
+	// ResolveResult records a resolve outcome for a service
+	// (result: ResultResolved|ResultFallback|ResultError) together with its
+	// duration in milliseconds.
+	ResolveResult(ctx context.Context, service, result string, durationMs int64)
+}
+
+// NopMetricsRecorder is a zero-size MetricsRecorder whose methods do nothing. It
+// backs orNop so call sites never need a nil check.
+type NopMetricsRecorder struct{}
+
+var _ MetricsRecorder = NopMetricsRecorder{}
+
+func (NopMetricsRecorder) RegisterInitiated(_ context.Context) {}
+
+func (NopMetricsRecorder) DeregisterResult(_ context.Context, _ string) {}
+
+func (NopMetricsRecorder) ResolveResult(_ context.Context, _, _ string, _ int64) {}
+
+// orNop returns r, or a NopMetricsRecorder when r is nil, so callers can invoke
+// recorder methods unconditionally. It is the nil-guard the register/deregister/
+// resolve call sites route every recorder through once they adopt the seam.
+//
+//nolint:unused // consumed by the SD call sites wired in a follow-up task.
+func orNop(r MetricsRecorder) MetricsRecorder {
+	if r == nil {
+		return NopMetricsRecorder{}
+	}
+
+	return r
+}

--- a/pkg/servicediscovery/metrics.go
+++ b/pkg/servicediscovery/metrics.go
@@ -46,9 +46,7 @@ func (NopMetricsRecorder) ResolveResult(_ context.Context, _, _ string, _ int64)
 
 // orNop returns r, or a NopMetricsRecorder when r is nil, so callers can invoke
 // recorder methods unconditionally. It is the nil-guard the register/deregister/
-// resolve call sites route every recorder through once they adopt the seam.
-//
-//nolint:unused // consumed by the SD call sites wired in a follow-up task.
+// resolve call sites route every recorder through.
 func orNop(r MetricsRecorder) MetricsRecorder {
 	if r == nil {
 		return NopMetricsRecorder{}

--- a/pkg/servicediscovery/metrics_factory.go
+++ b/pkg/servicediscovery/metrics_factory.go
@@ -37,7 +37,17 @@ var (
 		Name:        "sd_resolve_duration_milliseconds",
 		Unit:        "ms",
 		Description: "Service Discovery resolve duration in milliseconds.",
+		// Explicit millisecond boundaries. Without them, MetricsFactory.Histogram
+		// auto-selects DefaultLatencyBuckets (seconds, 0.001-10) for any "duration"
+		// metric, collapsing every ms observation into the +Inf bucket. These bounds
+		// match the declared "ms" unit and the int64 ms values ResolveResult records.
+		Buckets: sdResolveDurationMsBuckets,
 	}
+
+	// sdResolveDurationMsBuckets are the explicit ms bucket boundaries locked to
+	// the "ms" unit of sdResolveDurationMs. Kept as a package var so tests can
+	// assert the descriptor and the emitted histogram share the same scale.
+	sdResolveDurationMsBuckets = []float64{1, 2, 5, 10, 25, 50, 100, 250, 500, 1000, 2500, 5000}
 )
 
 // metricsFactoryRecorder is the OTel-backed MetricsRecorder. It records SD metrics

--- a/pkg/servicediscovery/metrics_factory.go
+++ b/pkg/servicediscovery/metrics_factory.go
@@ -1,0 +1,121 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package servicediscovery
+
+import (
+	"context"
+
+	libLog "github.com/LerianStudio/lib-observability/log"
+	"github.com/LerianStudio/lib-observability/metrics"
+	"go.opentelemetry.io/otel/attribute"
+)
+
+// Service Discovery metric descriptors. They are the single registration point
+// for the SD telemetry surface and back the MetricsFactory recorder below.
+var (
+	sdRegisterTotal = metrics.Metric{
+		Name:        "sd_register_total",
+		Unit:        "1",
+		Description: "Total Service Discovery registrations initiated.",
+	}
+
+	sdDeregisterTotal = metrics.Metric{
+		Name:        "sd_deregister_total",
+		Unit:        "1",
+		Description: "Total Service Discovery deregistrations by result.",
+	}
+
+	sdResolveTotal = metrics.Metric{
+		Name:        "sd_resolve_total",
+		Unit:        "1",
+		Description: "Total Service Discovery resolutions by service and result.",
+	}
+
+	sdResolveDurationMs = metrics.Metric{
+		Name:        "sd_resolve_duration_milliseconds",
+		Unit:        "ms",
+		Description: "Service Discovery resolve duration in milliseconds.",
+	}
+)
+
+// metricsFactoryRecorder is the OTel-backed MetricsRecorder. It records SD metrics
+// through a lib-observability MetricsFactory. Recording is best-effort: builder or
+// record errors are logged at Warn and never propagated, so telemetry cannot affect
+// the register/deregister/resolve call sites.
+type metricsFactoryRecorder struct {
+	factory *metrics.MetricsFactory
+	logger  libLog.Logger
+}
+
+var _ MetricsRecorder = (*metricsFactoryRecorder)(nil)
+
+// NewMetricsFactoryRecorder builds a MetricsRecorder backed by factory. A nil
+// factory (telemetry or SD disabled) yields a NopMetricsRecorder so call sites
+// pay zero overhead and never need a nil check.
+func NewMetricsFactoryRecorder(factory *metrics.MetricsFactory, logger libLog.Logger) MetricsRecorder {
+	if factory == nil {
+		return NopMetricsRecorder{}
+	}
+
+	return &metricsFactoryRecorder{factory: factory, logger: logger}
+}
+
+func (r *metricsFactoryRecorder) RegisterInitiated(ctx context.Context) {
+	r.addOne(ctx, sdRegisterTotal)
+}
+
+func (r *metricsFactoryRecorder) DeregisterResult(ctx context.Context, result string) {
+	r.addOne(ctx, sdDeregisterTotal, attribute.String("result", result))
+}
+
+func (r *metricsFactoryRecorder) ResolveResult(ctx context.Context, service, result string, durationMs int64) {
+	r.addOne(ctx, sdResolveTotal,
+		attribute.String("service", service),
+		attribute.String("result", result))
+
+	r.record(ctx, sdResolveDurationMs, durationMs, attribute.String("service", service))
+}
+
+// addOne increments the named counter by one with the given attributes. Builder
+// and add errors are logged at Warn and swallowed; recording never affects the
+// caller.
+func (r *metricsFactoryRecorder) addOne(ctx context.Context, m metrics.Metric, attrs ...attribute.KeyValue) {
+	counter, err := r.factory.Counter(m)
+	if err != nil {
+		r.warn(ctx, "failed to build service discovery counter", err)
+
+		return
+	}
+
+	if err := counter.WithAttributes(attrs...).AddOne(ctx); err != nil {
+		r.warn(ctx, "failed to record service discovery counter", err)
+	}
+}
+
+// record observes value on the named histogram with the given attributes. Builder
+// and record errors are logged at Warn and swallowed; recording never affects the
+// caller.
+func (r *metricsFactoryRecorder) record(ctx context.Context, m metrics.Metric, value int64, attrs ...attribute.KeyValue) {
+	histogram, err := r.factory.Histogram(m)
+	if err != nil {
+		r.warn(ctx, "failed to build service discovery histogram", err)
+
+		return
+	}
+
+	if err := histogram.WithAttributes(attrs...).Record(ctx, value); err != nil {
+		r.warn(ctx, "failed to record service discovery histogram", err)
+	}
+}
+
+// warn logs a recording failure at Warn when a logger is present. It never carries
+// metric values or attributes, only the error, so no PII or financial data leaks.
+func (r *metricsFactoryRecorder) warn(ctx context.Context, msg string, err error) {
+	if r.logger == nil {
+		return
+	}
+
+	r.logger.Log(ctx, libLog.LevelWarn, msg, libLog.Err(err))
+}

--- a/pkg/servicediscovery/metrics_factory_test.go
+++ b/pkg/servicediscovery/metrics_factory_test.go
@@ -1,0 +1,165 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package servicediscovery
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	libLog "github.com/LerianStudio/lib-observability/log"
+	"github.com/LerianStudio/lib-observability/metrics"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+)
+
+// newTestMetricsFactory builds a real *metrics.MetricsFactory backed by an
+// in-memory OTel meter provider (no exporter), mirroring the repo's bootstrap
+// tests. It lets the factory-backed recorder exercise the real Counter/Histogram
+// paths without a live telemetry pipeline.
+func newTestMetricsFactory(t *testing.T) *metrics.MetricsFactory {
+	t.Helper()
+
+	mp := sdkmetric.NewMeterProvider()
+	meter := mp.Meter("servicediscovery_test")
+
+	factory, err := metrics.NewMetricsFactory(meter, nil)
+	if err != nil {
+		t.Fatalf("NewMetricsFactory returned error: %v", err)
+	}
+
+	return factory
+}
+
+func TestNewMetricsFactoryRecorder_NilFactoryReturnsNop(t *testing.T) {
+	r := NewMetricsFactoryRecorder(nil, libLog.NewNop())
+	if r == nil {
+		t.Fatal("NewMetricsFactoryRecorder(nil, ...) returned nil; want non-nil no-op recorder")
+	}
+
+	if _, ok := r.(NopMetricsRecorder); !ok {
+		t.Fatalf("NewMetricsFactoryRecorder(nil, ...) returned %T; want NopMetricsRecorder", r)
+	}
+
+	// The returned no-op recorder must be callable without panic.
+	ctx := context.Background()
+	r.RegisterInitiated(ctx)
+	r.DeregisterResult(ctx, ResultError)
+	r.ResolveResult(ctx, "plugin-auth", ResultFallback, 3)
+}
+
+func TestNewMetricsFactoryRecorder_NonNilFactoryImplementsRecorder(t *testing.T) {
+	factory := newTestMetricsFactory(t)
+
+	r := NewMetricsFactoryRecorder(factory, libLog.NewNop())
+	if r == nil {
+		t.Fatal("NewMetricsFactoryRecorder(factory, ...) returned nil; want a recorder")
+	}
+
+	if _, ok := r.(NopMetricsRecorder); ok {
+		t.Fatal("NewMetricsFactoryRecorder(factory, ...) returned NopMetricsRecorder; want the factory-backed recorder")
+	}
+}
+
+func TestMetricsFactoryRecorder_MethodsRecordWithoutPanic(t *testing.T) {
+	factory := newTestMetricsFactory(t)
+	r := NewMetricsFactoryRecorder(factory, libLog.NewNop())
+	ctx := context.Background()
+
+	// All three interface methods must record against the real factory and
+	// return normally (recording MUST NOT affect the caller).
+	r.RegisterInitiated(ctx)
+	r.DeregisterResult(ctx, ResultOK)
+	r.DeregisterResult(ctx, ResultError)
+	r.ResolveResult(ctx, "plugin-auth", ResultResolved, 12)
+	r.ResolveResult(ctx, "plugin-auth", ResultFallback, 0)
+	r.ResolveResult(ctx, "plugin-auth", ResultError, 999)
+}
+
+func TestMetricsFactoryRecorder_NilLoggerDoesNotPanic(t *testing.T) {
+	factory := newTestMetricsFactory(t)
+
+	// A nil logger must not cause a panic on the happy path (the factory paths
+	// succeed, so the logger is never invoked). This guards the construction
+	// contract without depending on unreachable error branches.
+	r := NewMetricsFactoryRecorder(factory, nil)
+	ctx := context.Background()
+
+	r.RegisterInitiated(ctx)
+	r.DeregisterResult(ctx, ResultOK)
+	r.ResolveResult(ctx, "plugin-auth", ResultResolved, 5)
+}
+
+func TestMetricsFactoryRecorder_SatisfiesInterface(t *testing.T) {
+	var _ MetricsRecorder = (*metricsFactoryRecorder)(nil)
+}
+
+// TestMetricsFactoryRecorder_Warn exercises the Warn logging helper directly. The
+// counter/histogram builder error branches are unreachable with a valid factory
+// (factory.Counter/Histogram only error on meter-creation failure), so warn is
+// tested via its own reachable branches: nil logger (no-op) and real logger.
+func TestMetricsFactoryRecorder_Warn(t *testing.T) {
+	factory := newTestMetricsFactory(t)
+	ctx := context.Background()
+	err := errors.New("boom")
+
+	// Nil logger must short-circuit without panic.
+	nilLoggerRec := &metricsFactoryRecorder{factory: factory, logger: nil}
+	nilLoggerRec.warn(ctx, "should be dropped", err)
+
+	// Real logger must accept the Warn call without panic.
+	realLoggerRec := &metricsFactoryRecorder{factory: factory, logger: libLog.NewNop()}
+	realLoggerRec.warn(ctx, "recorded at warn", err)
+}
+
+func TestSDMetricDescriptors(t *testing.T) {
+	tests := []struct {
+		name     string
+		gotName  string
+		gotUnit  string
+		wantName string
+		wantUnit string
+	}{
+		{
+			name:     "register_total",
+			gotName:  sdRegisterTotal.Name,
+			gotUnit:  sdRegisterTotal.Unit,
+			wantName: "sd_register_total",
+			wantUnit: "1",
+		},
+		{
+			name:     "deregister_total",
+			gotName:  sdDeregisterTotal.Name,
+			gotUnit:  sdDeregisterTotal.Unit,
+			wantName: "sd_deregister_total",
+			wantUnit: "1",
+		},
+		{
+			name:     "resolve_total",
+			gotName:  sdResolveTotal.Name,
+			gotUnit:  sdResolveTotal.Unit,
+			wantName: "sd_resolve_total",
+			wantUnit: "1",
+		},
+		{
+			name:     "resolve_duration_milliseconds",
+			gotName:  sdResolveDurationMs.Name,
+			gotUnit:  sdResolveDurationMs.Unit,
+			wantName: "sd_resolve_duration_milliseconds",
+			wantUnit: "ms",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.gotName != tt.wantName {
+				t.Errorf("Name = %q; want %q", tt.gotName, tt.wantName)
+			}
+
+			if tt.gotUnit != tt.wantUnit {
+				t.Errorf("Unit = %q; want %q", tt.gotUnit, tt.wantUnit)
+			}
+		})
+	}
+}

--- a/pkg/servicediscovery/metrics_factory_test.go
+++ b/pkg/servicediscovery/metrics_factory_test.go
@@ -7,11 +7,14 @@ package servicediscovery
 import (
 	"context"
 	"errors"
+	"reflect"
 	"testing"
 
 	libLog "github.com/LerianStudio/lib-observability/log"
 	"github.com/LerianStudio/lib-observability/metrics"
+	"go.opentelemetry.io/otel/attribute"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 )
 
 // newTestMetricsFactory builds a real *metrics.MetricsFactory backed by an
@@ -30,6 +33,106 @@ func newTestMetricsFactory(t *testing.T) *metrics.MetricsFactory {
 	}
 
 	return factory
+}
+
+// newReaderBackedFactory builds a *metrics.MetricsFactory whose meter is wired to
+// a ManualReader, so tests can Collect and assert on the emitted metricdata.
+// Mirrors the repo pattern of driving a factory over an in-memory meter provider.
+func newReaderBackedFactory(t *testing.T) (*metrics.MetricsFactory, *sdkmetric.ManualReader) {
+	t.Helper()
+
+	reader := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	meter := mp.Meter("servicediscovery_observe_test")
+
+	factory, err := metrics.NewMetricsFactory(meter, nil)
+	if err != nil {
+		t.Fatalf("NewMetricsFactory returned error: %v", err)
+	}
+
+	return factory, reader
+}
+
+// collect gathers the current metrics from the reader and returns them keyed by
+// metric name for assertion.
+func collect(t *testing.T, reader *sdkmetric.ManualReader) map[string]metricdata.Metrics {
+	t.Helper()
+
+	var rm metricdata.ResourceMetrics
+	if err := reader.Collect(context.Background(), &rm); err != nil {
+		t.Fatalf("reader.Collect returned error: %v", err)
+	}
+
+	out := make(map[string]metricdata.Metrics)
+
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			out[m.Name] = m
+		}
+	}
+
+	return out
+}
+
+// attrValue returns the string value of key in the datapoint's attribute set,
+// and whether it was present.
+func attrValue(set attribute.Set, key string) (string, bool) {
+	v, ok := set.Value(attribute.Key(key))
+	return v.AsString(), ok
+}
+
+// requireSumDataPoint returns the single int64 Sum datapoint for the named metric,
+// failing if the metric is absent, not a Sum, or does not have exactly one point.
+func requireSumDataPoint(t *testing.T, metricsByName map[string]metricdata.Metrics, name string) metricdata.DataPoint[int64] {
+	t.Helper()
+
+	m, ok := metricsByName[name]
+	if !ok {
+		t.Fatalf("metric %q not emitted; got %v", name, metricNames(metricsByName))
+	}
+
+	sum, ok := m.Data.(metricdata.Sum[int64])
+	if !ok {
+		t.Fatalf("metric %q has data type %T; want metricdata.Sum[int64]", name, m.Data)
+	}
+
+	if len(sum.DataPoints) != 1 {
+		t.Fatalf("metric %q has %d datapoints; want exactly 1", name, len(sum.DataPoints))
+	}
+
+	return sum.DataPoints[0]
+}
+
+// requireHistogramDataPoint returns the single int64 Histogram datapoint for the
+// named metric, failing if the metric is absent, not a Histogram, or does not
+// have exactly one point.
+func requireHistogramDataPoint(t *testing.T, metricsByName map[string]metricdata.Metrics, name string) metricdata.HistogramDataPoint[int64] {
+	t.Helper()
+
+	m, ok := metricsByName[name]
+	if !ok {
+		t.Fatalf("metric %q not emitted; got %v", name, metricNames(metricsByName))
+	}
+
+	hist, ok := m.Data.(metricdata.Histogram[int64])
+	if !ok {
+		t.Fatalf("metric %q has data type %T; want metricdata.Histogram[int64]", name, m.Data)
+	}
+
+	if len(hist.DataPoints) != 1 {
+		t.Fatalf("metric %q has %d datapoints; want exactly 1", name, len(hist.DataPoints))
+	}
+
+	return hist.DataPoints[0]
+}
+
+func metricNames(metricsByName map[string]metricdata.Metrics) []string {
+	names := make([]string, 0, len(metricsByName))
+	for n := range metricsByName {
+		names = append(names, n)
+	}
+
+	return names
 }
 
 func TestNewMetricsFactoryRecorder_NilFactoryReturnsNop(t *testing.T) {
@@ -62,19 +165,136 @@ func TestNewMetricsFactoryRecorder_NonNilFactoryImplementsRecorder(t *testing.T)
 	}
 }
 
-func TestMetricsFactoryRecorder_MethodsRecordWithoutPanic(t *testing.T) {
-	factory := newTestMetricsFactory(t)
+func TestMetricsFactoryRecorder_RegisterInitiated_EmitsCounter(t *testing.T) {
+	factory, reader := newReaderBackedFactory(t)
 	r := NewMetricsFactoryRecorder(factory, libLog.NewNop())
 	ctx := context.Background()
 
-	// All three interface methods must record against the real factory and
-	// return normally (recording MUST NOT affect the caller).
 	r.RegisterInitiated(ctx)
-	r.DeregisterResult(ctx, ResultOK)
-	r.DeregisterResult(ctx, ResultError)
-	r.ResolveResult(ctx, "plugin-auth", ResultResolved, 12)
-	r.ResolveResult(ctx, "plugin-auth", ResultFallback, 0)
-	r.ResolveResult(ctx, "plugin-auth", ResultError, 999)
+
+	dp := requireSumDataPoint(t, collect(t, reader), "sd_register_total")
+
+	if dp.Value != 1 {
+		t.Errorf("sd_register_total value = %d; want 1", dp.Value)
+	}
+
+	if dp.Attributes.Len() != 0 {
+		t.Errorf("sd_register_total has %d attributes; want 0 (register is unlabeled)", dp.Attributes.Len())
+	}
+}
+
+func TestMetricsFactoryRecorder_DeregisterResult_EmitsLabeledCounter(t *testing.T) {
+	tests := []struct {
+		name   string
+		result string
+	}{
+		{name: "ok", result: ResultOK},
+		{name: "error", result: ResultError},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			factory, reader := newReaderBackedFactory(t)
+			r := NewMetricsFactoryRecorder(factory, libLog.NewNop())
+
+			r.DeregisterResult(context.Background(), tt.result)
+
+			dp := requireSumDataPoint(t, collect(t, reader), "sd_deregister_total")
+
+			if dp.Value != 1 {
+				t.Errorf("sd_deregister_total value = %d; want 1", dp.Value)
+			}
+
+			got, ok := attrValue(dp.Attributes, "result")
+			if !ok {
+				t.Fatalf("sd_deregister_total datapoint missing %q attribute", "result")
+			}
+
+			if got != tt.result {
+				t.Errorf("sd_deregister_total result = %q; want %q", got, tt.result)
+			}
+		})
+	}
+}
+
+func TestMetricsFactoryRecorder_ResolveResult_EmitsCounterAndHistogram(t *testing.T) {
+	const (
+		service    = "plugin-auth"
+		durationMs = int64(12)
+	)
+
+	factory, reader := newReaderBackedFactory(t)
+	r := NewMetricsFactoryRecorder(factory, libLog.NewNop())
+
+	r.ResolveResult(context.Background(), service, ResultResolved, durationMs)
+
+	metricsByName := collect(t, reader)
+
+	// Counter: sd_resolve_total{service,result} == 1
+	countDP := requireSumDataPoint(t, metricsByName, "sd_resolve_total")
+
+	if countDP.Value != 1 {
+		t.Errorf("sd_resolve_total value = %d; want 1", countDP.Value)
+	}
+
+	if got, ok := attrValue(countDP.Attributes, "service"); !ok || got != service {
+		t.Errorf("sd_resolve_total service = %q (present=%t); want %q", got, ok, service)
+	}
+
+	if got, ok := attrValue(countDP.Attributes, "result"); !ok || got != ResultResolved {
+		t.Errorf("sd_resolve_total result = %q (present=%t); want %q", got, ok, ResultResolved)
+	}
+
+	// Histogram: sd_resolve_duration_milliseconds{service} count==1, sum==durationMs
+	histDP := requireHistogramDataPoint(t, metricsByName, "sd_resolve_duration_milliseconds")
+
+	if histDP.Count != 1 {
+		t.Errorf("sd_resolve_duration_milliseconds count = %d; want 1", histDP.Count)
+	}
+
+	if histDP.Sum != durationMs {
+		t.Errorf("sd_resolve_duration_milliseconds sum = %d; want %d", histDP.Sum, durationMs)
+	}
+
+	if got, ok := attrValue(histDP.Attributes, "service"); !ok || got != service {
+		t.Errorf("sd_resolve_duration_milliseconds service = %q (present=%t); want %q", got, ok, service)
+	}
+
+	if _, ok := attrValue(histDP.Attributes, "result"); ok {
+		t.Errorf("sd_resolve_duration_milliseconds must not carry a %q attribute", "result")
+	}
+
+	// Lock the ms/seconds contract: emitted bucket boundaries must match the
+	// explicit ms buckets on the descriptor (not the seconds-scaled defaults).
+	if !reflect.DeepEqual(histDP.Bounds, sdResolveDurationMsBuckets) {
+		t.Errorf("sd_resolve_duration_milliseconds bounds = %v; want ms buckets %v", histDP.Bounds, sdResolveDurationMsBuckets)
+	}
+}
+
+func TestMetricsFactoryRecorder_ResolveResult_LabelVariants(t *testing.T) {
+	tests := []struct {
+		name   string
+		result string
+	}{
+		{name: "resolved", result: ResultResolved},
+		{name: "fallback", result: ResultFallback},
+		{name: "error", result: ResultError},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			factory, reader := newReaderBackedFactory(t)
+			r := NewMetricsFactoryRecorder(factory, libLog.NewNop())
+
+			r.ResolveResult(context.Background(), "midaz-ledger", tt.result, 5)
+
+			dp := requireSumDataPoint(t, collect(t, reader), "sd_resolve_total")
+
+			if got, ok := attrValue(dp.Attributes, "result"); !ok || got != tt.result {
+				t.Errorf("sd_resolve_total result = %q (present=%t); want %q", got, ok, tt.result)
+			}
+		})
+	}
 }
 
 func TestMetricsFactoryRecorder_NilLoggerDoesNotPanic(t *testing.T) {
@@ -116,36 +336,31 @@ func TestMetricsFactoryRecorder_Warn(t *testing.T) {
 func TestSDMetricDescriptors(t *testing.T) {
 	tests := []struct {
 		name     string
-		gotName  string
-		gotUnit  string
+		desc     metrics.Metric
 		wantName string
 		wantUnit string
 	}{
 		{
 			name:     "register_total",
-			gotName:  sdRegisterTotal.Name,
-			gotUnit:  sdRegisterTotal.Unit,
+			desc:     sdRegisterTotal,
 			wantName: "sd_register_total",
 			wantUnit: "1",
 		},
 		{
 			name:     "deregister_total",
-			gotName:  sdDeregisterTotal.Name,
-			gotUnit:  sdDeregisterTotal.Unit,
+			desc:     sdDeregisterTotal,
 			wantName: "sd_deregister_total",
 			wantUnit: "1",
 		},
 		{
 			name:     "resolve_total",
-			gotName:  sdResolveTotal.Name,
-			gotUnit:  sdResolveTotal.Unit,
+			desc:     sdResolveTotal,
 			wantName: "sd_resolve_total",
 			wantUnit: "1",
 		},
 		{
 			name:     "resolve_duration_milliseconds",
-			gotName:  sdResolveDurationMs.Name,
-			gotUnit:  sdResolveDurationMs.Unit,
+			desc:     sdResolveDurationMs,
 			wantName: "sd_resolve_duration_milliseconds",
 			wantUnit: "ms",
 		},
@@ -153,13 +368,36 @@ func TestSDMetricDescriptors(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if tt.gotName != tt.wantName {
-				t.Errorf("Name = %q; want %q", tt.gotName, tt.wantName)
+			if tt.desc.Name != tt.wantName {
+				t.Errorf("Name = %q; want %q", tt.desc.Name, tt.wantName)
 			}
 
-			if tt.gotUnit != tt.wantUnit {
-				t.Errorf("Unit = %q; want %q", tt.gotUnit, tt.wantUnit)
+			if tt.desc.Unit != tt.wantUnit {
+				t.Errorf("Unit = %q; want %q", tt.desc.Unit, tt.wantUnit)
+			}
+
+			if tt.desc.Description == "" {
+				t.Errorf("Description is empty; want a non-empty descriptor comment")
 			}
 		})
+	}
+}
+
+// TestSDResolveDurationBuckets locks the resolve-duration histogram to explicit
+// millisecond boundaries. Without them, MetricsFactory.selectDefaultBuckets picks
+// seconds-scaled DefaultLatencyBuckets for any "duration" metric, so ms values
+// collapse into +Inf and the distribution becomes unobservable.
+func TestSDResolveDurationBuckets(t *testing.T) {
+	wantBuckets := []float64{1, 2, 5, 10, 25, 50, 100, 250, 500, 1000, 2500, 5000}
+
+	if !reflect.DeepEqual(sdResolveDurationMs.Buckets, wantBuckets) {
+		t.Errorf("sdResolveDurationMs.Buckets = %v; want ms buckets %v", sdResolveDurationMs.Buckets, wantBuckets)
+	}
+
+	// The other descriptors are counters and must not carry histogram buckets.
+	for _, m := range []metrics.Metric{sdRegisterTotal, sdDeregisterTotal, sdResolveTotal} {
+		if m.Buckets != nil {
+			t.Errorf("counter descriptor %q has Buckets %v; want nil", m.Name, m.Buckets)
+		}
 	}
 }

--- a/pkg/servicediscovery/metrics_test.go
+++ b/pkg/servicediscovery/metrics_test.go
@@ -1,0 +1,89 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package servicediscovery
+
+import (
+	"context"
+	"testing"
+)
+
+// stubRecorder is a local white-box stub used to assert orNop identity passthrough
+// and that call sites can drive a plain (non-OTel) MetricsRecorder.
+type stubRecorder struct {
+	called bool
+}
+
+func (s *stubRecorder) RegisterInitiated(_ context.Context) { s.called = true }
+
+func (s *stubRecorder) DeregisterResult(_ context.Context, _ string) { s.called = true }
+
+func (s *stubRecorder) ResolveResult(_ context.Context, _, _ string, _ int64) { s.called = true }
+
+func TestNopMetricsRecorder_SatisfiesInterfaceAndDoesNotPanic(t *testing.T) {
+	var r MetricsRecorder = NopMetricsRecorder{}
+	ctx := context.Background()
+
+	// All methods must be callable without panic.
+	r.RegisterInitiated(ctx)
+	r.DeregisterResult(ctx, ResultOK)
+	r.ResolveResult(ctx, "midaz-ledger", ResultResolved, 42)
+}
+
+func TestOrNop_NilReturnsNopRecorder(t *testing.T) {
+	r := orNop(nil)
+	if r == nil {
+		t.Fatal("orNop(nil) returned nil; want non-nil no-op recorder")
+	}
+
+	if _, ok := r.(NopMetricsRecorder); !ok {
+		t.Fatalf("orNop(nil) returned %T; want NopMetricsRecorder", r)
+	}
+
+	ctx := context.Background()
+	r.RegisterInitiated(ctx)
+	r.DeregisterResult(ctx, ResultError)
+	r.ResolveResult(ctx, "midaz-crm", ResultFallback, 7)
+}
+
+func TestOrNop_NonNilReturnsSameRecorder(t *testing.T) {
+	stub := &stubRecorder{}
+
+	got := orNop(stub)
+
+	gotStub, ok := got.(*stubRecorder)
+	if !ok {
+		t.Fatalf("orNop(stub) returned %T; want *stubRecorder", got)
+	}
+
+	if gotStub != stub {
+		t.Fatal("orNop(stub) returned a different recorder; want the same instance")
+	}
+
+	got.RegisterInitiated(context.Background())
+	if !stub.called {
+		t.Fatal("call through orNop(stub) did not reach the underlying recorder")
+	}
+}
+
+func TestMetricsResultConstants(t *testing.T) {
+	tests := []struct {
+		name string
+		got  string
+		want string
+	}{
+		{name: "ResultOK", got: ResultOK, want: "ok"},
+		{name: "ResultError", got: ResultError, want: "error"},
+		{name: "ResultResolved", got: ResultResolved, want: "resolved"},
+		{name: "ResultFallback", got: ResultFallback, want: "fallback"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.got != tt.want {
+				t.Errorf("%s = %q; want %q", tt.name, tt.got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/servicediscovery/metrics_test.go
+++ b/pkg/servicediscovery/metrics_test.go
@@ -10,16 +10,30 @@ import (
 )
 
 // stubRecorder is a local white-box stub used to assert orNop identity passthrough
-// and that call sites can drive a plain (non-OTel) MetricsRecorder.
+// and that call sites can drive a plain (non-OTel) MetricsRecorder. It tracks each
+// method independently so future call-site tests can assert which method fired and
+// with what arguments.
 type stubRecorder struct {
-	called bool
+	registerInitiatedCalls int
+	deregisterResults      []string
+	resolveResults         []resolveCall
 }
 
-func (s *stubRecorder) RegisterInitiated(_ context.Context) { s.called = true }
+type resolveCall struct {
+	service    string
+	result     string
+	durationMs int64
+}
 
-func (s *stubRecorder) DeregisterResult(_ context.Context, _ string) { s.called = true }
+func (s *stubRecorder) RegisterInitiated(_ context.Context) { s.registerInitiatedCalls++ }
 
-func (s *stubRecorder) ResolveResult(_ context.Context, _, _ string, _ int64) { s.called = true }
+func (s *stubRecorder) DeregisterResult(_ context.Context, result string) {
+	s.deregisterResults = append(s.deregisterResults, result)
+}
+
+func (s *stubRecorder) ResolveResult(_ context.Context, service, result string, durationMs int64) {
+	s.resolveResults = append(s.resolveResults, resolveCall{service: service, result: result, durationMs: durationMs})
+}
 
 func TestNopMetricsRecorder_SatisfiesInterfaceAndDoesNotPanic(t *testing.T) {
 	var r MetricsRecorder = NopMetricsRecorder{}
@@ -61,9 +75,22 @@ func TestOrNop_NonNilReturnsSameRecorder(t *testing.T) {
 		t.Fatal("orNop(stub) returned a different recorder; want the same instance")
 	}
 
-	got.RegisterInitiated(context.Background())
-	if !stub.called {
-		t.Fatal("call through orNop(stub) did not reach the underlying recorder")
+	ctx := context.Background()
+	got.RegisterInitiated(ctx)
+	got.DeregisterResult(ctx, ResultError)
+	got.ResolveResult(ctx, "plugin-auth", ResultFallback, 7)
+
+	if stub.registerInitiatedCalls != 1 {
+		t.Errorf("RegisterInitiated calls = %d; want 1 (call must reach the same instance)", stub.registerInitiatedCalls)
+	}
+
+	if len(stub.deregisterResults) != 1 || stub.deregisterResults[0] != ResultError {
+		t.Errorf("DeregisterResult calls = %v; want [%q]", stub.deregisterResults, ResultError)
+	}
+
+	wantResolve := resolveCall{service: "plugin-auth", result: ResultFallback, durationMs: 7}
+	if len(stub.resolveResults) != 1 || stub.resolveResults[0] != wantResolve {
+		t.Errorf("ResolveResult calls = %v; want [%+v]", stub.resolveResults, wantResolve)
 	}
 }
 

--- a/pkg/servicediscovery/runnable.go
+++ b/pkg/servicediscovery/runnable.go
@@ -24,6 +24,7 @@ type Runnable struct {
 	manager *libsd.Manager
 	svc     libsd.Service
 	logger  libLog.Logger
+	metrics MetricsRecorder
 
 	// notifyContext builds the signal-scoped context that gates the runnable's
 	// lifetime. It defaults to signal.NotifyContext in production; tests inject a
@@ -32,9 +33,10 @@ type Runnable struct {
 }
 
 // NewRunnable builds a Runnable that registers svc against manager on start and
-// deregisters it on SIGINT/SIGTERM.
-func NewRunnable(manager *libsd.Manager, svc libsd.Service, logger libLog.Logger) *Runnable {
-	return &Runnable{manager: manager, svc: svc, logger: logger}
+// deregisters it on SIGINT/SIGTERM. A nil recorder is safe: it is replaced by a
+// no-op recorder so the lifecycle never dereferences nil.
+func NewRunnable(manager *libsd.Manager, svc libsd.Service, logger libLog.Logger, recorder MetricsRecorder) *Runnable {
+	return &Runnable{manager: manager, svc: svc, logger: logger, metrics: orNop(recorder)}
 }
 
 // Run registers the service asynchronously against the signal-scoped context,
@@ -53,24 +55,35 @@ func (r *Runnable) Run(_ *libCommons.Launcher) error {
 	sigCtx, stop := notify(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
+	metrics := orNop(r.metrics)
+
 	// RegisterAsync is non-blocking and retries in the background until sigCtx
 	// is cancelled. It needs the app-lifetime (signal) context, not a
 	// request-scoped one.
 	r.manager.RegisterAsync(sigCtx, r.svc)
+	metrics.RegisterInitiated(sigCtx)
 
 	<-sigCtx.Done()
 
 	ctx, cancel := context.WithTimeout(context.Background(), DeregisterTimeout)
 	defer cancel()
 
-	if err := r.manager.Deregister(ctx, r.svc.ID); err != nil && r.logger != nil {
-		r.logger.Log(
-			context.Background(), libLog.LevelWarn,
-			"service discovery deregister returned error",
-			libLog.String("service_id", r.svc.ID),
-			libLog.Err(err),
-		)
+	result := ResultOK
+
+	if err := r.manager.Deregister(ctx, r.svc.ID); err != nil {
+		result = ResultError
+
+		if r.logger != nil {
+			r.logger.Log(
+				context.Background(), libLog.LevelWarn,
+				"service discovery deregister returned error",
+				libLog.String("service_id", r.svc.ID),
+				libLog.Err(err),
+			)
+		}
 	}
+
+	metrics.DeregisterResult(ctx, result)
 
 	return nil
 }

--- a/pkg/servicediscovery/runnable_test.go
+++ b/pkg/servicediscovery/runnable_test.go
@@ -103,13 +103,15 @@ func newStubManager(t *testing.T, stub libsd.Registry) *libsd.Manager {
 // TestRunnable_Lifecycle exercises the full register/deregister path of Run
 // without a real Consul: RegisterAsync must record a Register with the
 // descriptor's ID/Name/Port/TTL, and simulated SIGTERM (context cancel) must
-// trigger a Deregister with the SAME ID.
+// trigger a Deregister with the SAME ID. It also asserts the metrics recorder
+// observes exactly one register-initiated and one deregister-OK over the cycle.
 func TestRunnable_Lifecycle(t *testing.T) {
 	t.Parallel()
 
 	stub := &stubRegistry{registeredCh: make(chan struct{}, 1)}
 	mgr := newStubManager(t, stub)
 	svc := BuildServiceDescriptor("midaz-ledger", 3002)
+	recorder := &stubRecorder{}
 
 	sigCtx, cancel := context.WithCancel(context.Background())
 
@@ -117,6 +119,7 @@ func TestRunnable_Lifecycle(t *testing.T) {
 		manager: mgr,
 		svc:     svc,
 		logger:  libLog.NewNop(),
+		metrics: recorder,
 		notifyContext: func(context.Context, ...os.Signal) (context.Context, context.CancelFunc) {
 			return sigCtx, func() {}
 		},
@@ -153,10 +156,14 @@ func TestRunnable_Lifecycle(t *testing.T) {
 	deregistered := stub.deregisteredIDs()
 	require.Len(t, deregistered, 1)
 	assert.Equal(t, svc.ID, deregistered[0])
+
+	assert.Equal(t, 1, recorder.registerInitiatedCalls, "exactly one register-initiated over the cycle")
+	assert.Equal(t, []string{ResultOK}, recorder.deregisterResults, "clean shutdown records deregister OK")
 }
 
 // TestRunnable_DeregisterErrorSwallowed verifies a deregister failure is logged
-// at Warn and NOT propagated: Run still returns nil.
+// at Warn and NOT propagated: Run still returns nil. The failure path must also
+// record a single deregister-error metric.
 func TestRunnable_DeregisterErrorSwallowed(t *testing.T) {
 	t.Parallel()
 
@@ -166,6 +173,7 @@ func TestRunnable_DeregisterErrorSwallowed(t *testing.T) {
 	}
 	mgr := newStubManager(t, stub)
 	svc := BuildServiceDescriptor("midaz-crm", 4003)
+	recorder := &stubRecorder{}
 
 	sigCtx, cancel := context.WithCancel(context.Background())
 
@@ -173,6 +181,7 @@ func TestRunnable_DeregisterErrorSwallowed(t *testing.T) {
 		manager: mgr,
 		svc:     svc,
 		logger:  libLog.NewNop(),
+		metrics: recorder,
 		notifyContext: func(context.Context, ...os.Signal) (context.Context, context.CancelFunc) {
 			return sigCtx, func() {}
 		},
@@ -192,6 +201,42 @@ func TestRunnable_DeregisterErrorSwallowed(t *testing.T) {
 
 	require.NoError(t, <-done, "deregister error must be swallowed, not propagated")
 	assert.Equal(t, []string{svc.ID}, stub.deregisteredIDs())
+
+	assert.Equal(t, 1, recorder.registerInitiatedCalls, "exactly one register-initiated over the cycle")
+	assert.Equal(t, []string{ResultError}, recorder.deregisterResults, "deregister failure records error result")
+}
+
+// TestRunnable_NilRecorderNoOp verifies passing a nil recorder to NewRunnable
+// does not panic across a full register/deregister lifecycle: orNop must
+// substitute the no-op recorder at construction.
+func TestRunnable_NilRecorderNoOp(t *testing.T) {
+	t.Parallel()
+
+	stub := &stubRegistry{registeredCh: make(chan struct{}, 1)}
+	mgr := newStubManager(t, stub)
+	svc := BuildServiceDescriptor("midaz-ledger", 3002)
+
+	r := NewRunnable(mgr, svc, libLog.NewNop(), nil)
+
+	sigCtx, cancel := context.WithCancel(context.Background())
+	r.notifyContext = func(context.Context, ...os.Signal) (context.Context, context.CancelFunc) {
+		return sigCtx, func() {}
+	}
+
+	done := make(chan error, 1)
+
+	go func() { done <- r.Run(nil) }()
+
+	select {
+	case <-stub.registeredCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("RegisterAsync did not call Register within timeout")
+	}
+
+	cancel()
+
+	require.NoError(t, <-done, "nil recorder must be safe across the full lifecycle")
+	assert.Equal(t, []string{svc.ID}, stub.deregisteredIDs())
 }
 
 // TestRunnable_NilManagerNoOp verifies the runnable returns immediately when the
@@ -206,8 +251,9 @@ func TestRunnable_NilManagerNoOp(t *testing.T) {
 	require.NoError(t, r.Run(nil))
 }
 
-// TestNewRunnable verifies the constructor wires the manager, descriptor, and
-// logger, leaving notifyContext nil so production uses signal.NotifyContext.
+// TestNewRunnable verifies the constructor wires the manager, descriptor,
+// logger, and recorder, leaving notifyContext nil so production uses
+// signal.NotifyContext.
 func TestNewRunnable(t *testing.T) {
 	t.Parallel()
 
@@ -215,11 +261,30 @@ func TestNewRunnable(t *testing.T) {
 	mgr := newStubManager(t, stub)
 	svc := BuildServiceDescriptor("midaz-ledger", 3002)
 	logger := libLog.NewNop()
+	recorder := &stubRecorder{}
 
-	r := NewRunnable(mgr, svc, logger)
+	r := NewRunnable(mgr, svc, logger, recorder)
 
 	require.NotNil(t, r)
 	assert.Same(t, mgr, r.manager)
 	assert.Equal(t, svc, r.svc)
+	assert.Same(t, recorder, r.metrics)
 	assert.Nil(t, r.notifyContext)
+}
+
+// TestNewRunnable_NilRecorderStoresNop verifies a nil recorder is replaced by
+// the no-op recorder at construction, so Run never dereferences nil.
+func TestNewRunnable_NilRecorderStoresNop(t *testing.T) {
+	t.Parallel()
+
+	stub := &stubRegistry{}
+	mgr := newStubManager(t, stub)
+	svc := BuildServiceDescriptor("midaz-ledger", 3002)
+
+	r := NewRunnable(mgr, svc, libLog.NewNop(), nil)
+
+	require.NotNil(t, r)
+	require.NotNil(t, r.metrics)
+	_, ok := r.metrics.(NopMetricsRecorder)
+	assert.True(t, ok, "nil recorder must be stored as NopMetricsRecorder")
 }


### PR DESCRIPTION
## Description

Adds Service Discovery **metrics** via the existing `lib-observability` `MetricsFactory`, in the shared `pkg/servicediscovery`, wired into both the `ledger` and `crm` bootstraps. Follow-up to the SD adoption (#2191).

**No-op when Service Discovery is disabled** (`SD_ENABLED=false`, the default) — zero overhead, no metric registration. Emission is a side-channel: recording failures are logged at `Warn` and never affect the request/boot path.

Metrics emitted (bounded label cardinality — no host/address/error-detail labels):

| Metric | Type | Labels | Unit |
|--------|------|--------|------|
| `sd_register_total` | Counter | — (registration initiations) | 1 |
| `sd_deregister_total` | Counter | `result` (ok\|error) | 1 |
| `sd_resolve_total` | Counter | `service`, `result` (resolved\|fallback\|error) | 1 |
| `sd_resolve_duration_milliseconds` | Histogram | `service` | ms |

Design notes:
- A `MetricsRecorder` interface (decoupled from OTel) + a `NopMetricsRecorder` default keep the SD call sites unit-testable and zero-cost when disabled; a `MetricsFactory`-backed recorder satisfies it.
- `sd_register_total` counts registration **initiations** only — `RegisterAsync` is fire-and-forget with no success hook, so a success `result` would be dishonest.
- `ResolveAuthHost` now passes an **empty fallback** to the registry so a consul hit, a static fallback, and an error are distinguishable (`resolved`/`fallback`/`error`). The returned auth host is **byte-identical** to prior behavior.
- The resolve histogram sets **explicit millisecond buckets** — the factory's name-based auto-bucketing yields seconds-scaled buckets for `*duration*` metrics, which would otherwise send ms values to the overflow bucket.

## Type of Change

- [x] `feat`: New feature or capability

## Breaking Changes

None. Opt-in / no-op by default; the auth-host resolution result is byte-identical to prior behavior.

## Testing

- [x] `make test` passes
- [x] `make test-int` passes (except 1 pre-existing, unrelated failure: `TestIntegration_AuditRepo_Create_BuildsAllSixIndexes` in `crm/mongodb/audit`, a mongo-driver-v2 bson-decode issue — verified failing identically on clean `develop`; that package is not in this diff)
- [x] `make lint` passes (golangci-lint v2.4.0, 0 issues)
- [x] `go vet` / `go mod verify` clean
- [x] e2e (Postman collection) run against a rebuilt stack — no regression from this branch (diff touches no HTTP/route/handler/DTO code)

**Test evidence / Actions run:** Full Ring dev-cycle — Gate 0 (TDD RED→GREEN, coverage 88.9–91.1%), Gate 8 (10 reviewers incl. obs), Gate 9 (acceptance).

## Architectural Checklist

- [x] No `panic()` in production paths
- [x] Errors wrapped with `%w`
- [x] Handlers stay thin (parse, validate, call service)
- [x] Infrastructure concerns kept in `internal/bootstrap`

## Related Issues

Closes #
