### PR TITLE
chore: bump lib-streaming version to 1.8.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -102,7 +102,7 @@ require (
 	github.com/LerianStudio/lib-commons/v5 v5.8.0
 	github.com/LerianStudio/lib-observability v1.1.0
 	github.com/LerianStudio/lib-service-discovery v0.6.0
-	github.com/LerianStudio/lib-streaming v1.7.0
+	github.com/LerianStudio/lib-streaming v1.8.0
 	github.com/Shopify/toxiproxy/v2 v2.12.0
 	github.com/docker/go-connections v0.7.0
 	github.com/hashicorp/vault/api v1.23.0

--- a/go.sum
+++ b/go.sum
@@ -26,8 +26,8 @@ github.com/LerianStudio/lib-observability v1.1.0 h1:e/OrIoTKo8gI1RKXgKDyDDKcrddR
 github.com/LerianStudio/lib-observability v1.1.0/go.mod h1:PBtmXygWXmcsTnyNLBetyYb/OtsWq6WT9fSJvoppeUQ=
 github.com/LerianStudio/lib-service-discovery v0.6.0 h1:24om6ckDkgQbvdz0AK2rkhCX285o4tMMLmVuoAEWbNw=
 github.com/LerianStudio/lib-service-discovery v0.6.0/go.mod h1:SB8TAfQEfhG4PJKJgzNsrQ6a/BPhswlTRmFc9YTGTq4=
-github.com/LerianStudio/lib-streaming v1.7.0 h1:p/98R+41/29RDF428gop1eo2szye16AEq9A9ETNmaHk=
-github.com/LerianStudio/lib-streaming v1.7.0/go.mod h1:UnwYshbihsneUHsBjjDOqzHrF/Iq7u6Vv1IhFv4e8pM=
+github.com/LerianStudio/lib-streaming v1.8.0 h1:b/xkNuIZQueC2dfRVXHZpuQ311eoN7fLnA9m+oLTK9Y=
+github.com/LerianStudio/lib-streaming v1.8.0/go.mod h1:UnwYshbihsneUHsBjjDOqzHrF/Iq7u6Vv1IhFv4e8pM=
 github.com/Masterminds/squirrel v1.5.4 h1:uUcX/aBc8O7Fg9kaISIUsHXdKuqehiXAMQTYX8afzqM=
 github.com/Masterminds/squirrel v1.5.4/go.mod h1:NNaOrjSoIDfDA40n7sr2tPNZRfjzjA400rg+riTZj10=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=


### PR DESCRIPTION
<table border="0" cellspacing="0" cellpadding="0">
  <tr>
    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
    <td><h1>Midaz</h1></td>
  </tr>
</table>

---

## Description

Bumps `lib-streaming` from v1.7.0 to v1.8.0. Updates `go.mod` and `go.sum` with the new module hash. No production code changes.

## Type of Change

- [ ] `feat`: New feature or capability
- [ ] `fix`: Bug fix
- [ ] `perf`: Performance improvement
- [ ] `refactor`: Internal restructuring with no behavior change
- [ ] `docs`: Documentation only
- [ ] `style`: Formatting, whitespace, naming (no logic change)
- [ ] `test`: Adding or updating tests
- [ ] `ci`: CI pipeline or workflow changes
- [x] `build`: Build system, Dockerfile, Go module dependencies
- [x] `chore`: Maintenance, config, tooling
- [ ] `revert`: Reverts a previous commit
- [ ] `BREAKING CHANGE`: Consumers must update their integration

## Breaking Changes

None.

## Testing

- [ ] `make test` passes
- [ ] `make test-int` passes if integration paths are exercised
- [ ] `make lint` passes
- [ ] `make sec` and `make vulncheck` pass

**Test evidence / Actions run:** <!-- Optional: link to a CI run or screenshot -->

## Architectural Checklist

- [x] No `panic()` in production paths
- [x] Timestamps use `time.Now().UTC()`
- [x] Errors wrapped with `%w`
- [x] Handlers stay thin (parse, validate, call service)
- [x] Infrastructure concerns kept in `internal/bootstrap`

## Related Issues

Closes #
