### PR TITLE
fix(ci): bump shared-workflows to v1.46.1 and enable ungoliant release-diff

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   validate:
-    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/go-pr-validation.yml@v1.36.6
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/go-pr-validation.yml@v1.46.1
     with:
       pr_title_scopes: |
         crm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   pipeline:
-    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/go-release.yml@v1.40.3
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/go-release.yml@v1.46.1
     with:
       enable_changelog: ${{ github.ref == 'refs/heads/main' }}
       release_single_app: true
@@ -28,6 +28,9 @@ jobs:
         pkg/
         Makefile
       enable_gitops_artifacts: true
+      enable_ungoliant_release_diff: true
+      ungoliant_env_type: chaos
+      ungoliant_tenancy: st
       enable_helm_dispatch: true
       helm_chart: "midaz"
       helm_values_key_mappings: '{"midaz-crm": "crm", "midaz-ledger": "ledger"}'

--- a/.github/workflows/routine.yml
+++ b/.github/workflows/routine.yml
@@ -35,7 +35,7 @@ permissions:
 
 jobs:
   routine:
-    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/routine.yml@v1.36.6
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/routine.yml@v1.46.1
     with:
       routine: ${{ inputs.routine || 'all' }}
       dry_run: ${{ inputs.dry_run || false }}

--- a/Makefile
+++ b/Makefile
@@ -646,3 +646,4 @@ migrate-create:
 	@echo "  3. Run 'make migrate-lint' to validate"
 	@echo "  4. Follow the guidelines in scripts/migration_linter/docs/MIGRATION_GUIDELINES.md"
 
+


### PR DESCRIPTION
## Description

Bumps `github-actions-shared-workflows` to v1.46.1 (fixes a bug in the prerelease-check input description) in `release.yml`, `pr-validation.yml` and `routine.yml`, and enables the Ungoliant release-diff trigger in `release.yml` (`ungoliant_env_type: chaos`, `ungoliant_tenancy: st`), following the pattern already in place in [reporter](https://github.com/LerianStudio/reporter/blob/develop/.github/workflows/release.yml#L23-L25).

## Type of Change

- [x] `ci`: CI pipeline or workflow changes

## Breaking Changes

None.

## Testing

- [ ] `make test` passes
- [ ] `make lint` passes

**Test evidence / Actions run:** N/A (CI-only change; verify on this PR's own workflow runs)

## Related Issues

