### PR TITLE
fix(ci): restrict PR source branches to hotfix and release-candidate

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -17,6 +17,9 @@ jobs:
   validate:
     uses: LerianStudio/github-actions-shared-workflows/.github/workflows/go-pr-validation.yml@v1.46.1
     with:
+      enforce_source_branches: true
+      allowed_source_branches: 'hotfix/*|release-candidate'
+      target_branches_for_source_check: 'main'
       pr_title_scopes: |
         crm
         ledger


### PR DESCRIPTION
## Description

Sets `enforce_source_branches: true` and restricts `allowed_source_branches` to `hotfix/*|release-candidate` for PRs targeting `main`. This input was previously unset, defaulting to a wider allowlist that included `develop`.

## Type of Change

- ci: CI pipeline or workflow changes

## Breaking Changes

None.