### PR TITLE
fix(ci): bump shared workflows to v1.46.2

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   validate:
-    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/go-pr-validation.yml@v1.46.1
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/go-pr-validation.yml@v1.46.2
     with:
       enforce_source_branches: true
       allowed_source_branches: 'hotfix/*|release-candidate'

--- a/.github/workflows/release-notification.yml
+++ b/.github/workflows/release-notification.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   notify:
-    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/release-notification.yml@v1.36.6
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/release-notification.yml@v1.46.2
     with:
       product_name: "Midaz"
       slack_channel: "lerian-product-release"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   pipeline:
-    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/go-release.yml@v1.46.1
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/go-release.yml@v1.46.2
     with:
       enable_changelog: ${{ github.ref == 'refs/heads/main' }}
       release_single_app: true

--- a/.github/workflows/routine.yml
+++ b/.github/workflows/routine.yml
@@ -35,7 +35,7 @@ permissions:
 
 jobs:
   routine:
-    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/routine.yml@v1.46.1
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/routine.yml@v1.46.2
     with:
       routine: ${{ inputs.routine || 'all' }}
       dry_run: ${{ inputs.dry_run || false }}


### PR DESCRIPTION
## Description

Bumps all `LerianStudio/github-actions-shared-workflows` references (pr-validation, release-notification, routine, release) to `v1.46.2`, picking up:

- ArgoCD application wait timeout made configurable with retry backoff (GitOps update)
- Ungoliant `curl-timeout` default increased from 300s to 900s
- Tag sorting fix (`versionsort.suffix`) prioritizing stable releases over prereleases
- Release process fix for the develop -> main transition

See: https://github.com/LerianStudio/github-actions-shared-workflows/releases/tag/v1.46.2

## Type of Change

- ci: CI pipeline or workflow changes

## Breaking Changes

None.