### PR TITLE
feat(deps): adopt lib-streaming v1.9.0 TLS/SASL

### DIFF
--- a/components/crm/.env.example
+++ b/components/crm/.env.example
@@ -247,6 +247,10 @@ STREAMING_ENABLED=false
 # STREAMING_IMPORTANT_EMIT_TIMEOUT_MS=5000
 
 # --- SASL/TLS auth ---
+# SASL and TLS are owned by lib-streaming: it reads the STREAMING_SASL_* and
+# STREAMING_TLS_* env vars below via LoadConfig and wires the broker dial
+# itself. midaz no longer parses these knobs.
+#
 # When STREAMING_SASL_MECHANISM is empty (default) the producer connects to the
 # broker without authentication. Set to PLAIN, SCRAM-SHA-256, or SCRAM-SHA-512
 # to enable SASL; STREAMING_SASL_USERNAME and STREAMING_SASL_PASSWORD then
@@ -255,8 +259,15 @@ STREAMING_ENABLED=false
 # STREAMING_SASL_USERNAME=
 # STREAMING_SASL_PASSWORD=
 #
-# SASL without TLS is rejected at bootstrap unless explicitly opted in via
-# STREAMING_ALLOW_PLAINTEXT_SASL=true. Use ONLY for local/dev brokers that
+# SASL without TLS is rejected by lib-streaming unless explicitly opted in via
+# STREAMING_SASL_ALLOW_PLAINTEXT=true. Use ONLY for local/dev brokers that
 # don't terminate TLS. NEVER set this in staging or production: SASL
 # credentials would cross the network in cleartext.
-# STREAMING_ALLOW_PLAINTEXT_SASL=false
+# STREAMING_SASL_ALLOW_PLAINTEXT=false
+#
+# TLS for the broker connection. Off by default so plaintext dev brokers are
+# unaffected. Set STREAMING_TLS_ENABLED=true to dial the broker over TLS.
+# STREAMING_TLS_CA_CERT takes a base64-encoded PEM CA bundle for private-CA
+# brokers; leave it empty to verify against the system trust pool.
+# STREAMING_TLS_ENABLED=false
+# STREAMING_TLS_CA_CERT=

--- a/components/crm/internal/bootstrap/config.go
+++ b/components/crm/internal/bootstrap/config.go
@@ -88,24 +88,6 @@ type Config struct {
 	// are consumed by libStreaming.LoadConfig() inside BuildStreamingEmitter, not
 	// from this struct — so they have no field here.
 	StreamingEnabled bool `env:"STREAMING_ENABLED"`
-
-	// --- Streaming SASL/TLS auth ---
-	// When STREAMING_SASL_MECHANISM is empty (default) the producer connects
-	// without authentication, matching the existing behaviour for local/dev
-	// brokers. When set, the value must be one of PLAIN, SCRAM-SHA-256,
-	// SCRAM-SHA-512 (case-insensitive); USERNAME and PASSWORD are then
-	// required and BuildStreamingEmitter wires the matching franz-go
-	// sasl.Mechanism into the lib-streaming Builder.
-	//
-	// SASL without TLS is rejected by lib-streaming with
-	// ErrPlaintextSASLNotAllowed. STREAMING_ALLOW_PLAINTEXT_SASL=true is the
-	// explicit unsafe opt-in for local/dev brokers that do not terminate
-	// TLS. It must NOT be set in production: SASL credentials cross the
-	// network in cleartext.
-	StreamingSASLMechanism      string `env:"STREAMING_SASL_MECHANISM"`
-	StreamingSASLUsername       string `env:"STREAMING_SASL_USERNAME"`
-	StreamingSASLPassword       string `env:"STREAMING_SASL_PASSWORD"`
-	StreamingAllowPlaintextSASL bool   `env:"STREAMING_ALLOW_PLAINTEXT_SASL"`
 }
 
 // Options contains optional dependencies that can be injected by callers.

--- a/components/crm/internal/bootstrap/streaming.go
+++ b/components/crm/internal/bootstrap/streaming.go
@@ -13,17 +13,6 @@ import (
 	libOpentelemetry "github.com/LerianStudio/lib-observability/tracing"
 	libStreaming "github.com/LerianStudio/lib-streaming"
 	"github.com/LerianStudio/midaz/v3/pkg/streaming/events"
-	"github.com/twmb/franz-go/pkg/sasl"
-	"github.com/twmb/franz-go/pkg/sasl/plain"
-	"github.com/twmb/franz-go/pkg/sasl/scram"
-)
-
-// SASL mechanism names accepted by STREAMING_SASL_MECHANISM. Compared
-// case-insensitively at parse time so operators can write any casing.
-const (
-	saslMechanismPlain    = "PLAIN"
-	saslMechanismScram256 = "SCRAM-SHA-256"
-	saslMechanismScram512 = "SCRAM-SHA-512"
 )
 
 // streamingPrimaryTargetName is the canonical name for CRM's single streaming
@@ -137,25 +126,16 @@ func BuildStreamingEmitter(
 			Brokers: streamingCfg.Brokers,
 		})
 
-	// Apply SASL/TLS auth knobs from cfg. resolveSASLMechanism returns a nil
-	// mechanism (and an empty mechanism name) when SASL is disabled, in which
-	// case the Builder is left untouched and the producer dials the broker
-	// without authentication. When SASL is enabled but TLS is not, lib-streaming
-	// rejects construction with ErrPlaintextSASLNotAllowed unless the caller
-	// also opts into AllowPlaintextSASL — gated behind
-	// STREAMING_ALLOW_PLAINTEXT_SASL=true for dev brokers.
-	mechanism, mechanismName, err := resolveSASLMechanism(cfg)
-	if err != nil {
-		return nil, noopStreamingCloser, fmt.Errorf("failed to resolve streaming SASL mechanism: %w", err)
-	}
+	// Apply TLS from STREAMING_TLS_* env. No-op when STREAMING_TLS_ENABLED=false,
+	// so plaintext dev brokers are unaffected. When enabled, the private-CA dial
+	// is built from STREAMING_TLS_CA_CERT inside lib-streaming.
+	builder = builder.TLSFromConfig(streamingCfg)
 
-	if mechanism != nil {
-		builder = builder.SASL(mechanism)
-
-		if cfg.StreamingAllowPlaintextSASL {
-			builder = builder.AllowPlaintextSASL()
-		}
-	}
+	// Apply SASL from STREAMING_SASL_* env via lib-streaming (SASLFromConfig).
+	// No-op when STREAMING_SASL_MECHANISM is empty. SASL over plaintext needs
+	// STREAMING_SASL_ALLOW_PLAINTEXT=true (dev brokers only); otherwise
+	// lib-streaming pairs SASL with TLS and fails closed at Build.
+	builder = builder.SASLFromConfig(streamingCfg)
 
 	emitter, err := builder.Build(ctx)
 	if err != nil {
@@ -166,9 +146,9 @@ func BuildStreamingEmitter(
 		// NOTE: only the mechanism name is logged. Username and password are
 		// NEVER logged, even at debug level.
 		authMode := "none"
-		if mechanismName != "" {
-			authMode = mechanismName
-			if cfg.StreamingAllowPlaintextSASL {
+		if streamingCfg.SASLMechanism != "" {
+			authMode = streamingCfg.SASLMechanism
+			if streamingCfg.SASLAllowPlaintext {
 				authMode += " (plaintext)"
 			}
 		}
@@ -185,56 +165,6 @@ func BuildStreamingEmitter(
 	}
 
 	return emitter, emitter.Close, nil
-}
-
-// resolveSASLMechanism inspects the streaming SASL knobs on cfg and returns the
-// matching franz-go sasl.Mechanism plus its canonical name.
-//
-// Behaviour:
-//   - StreamingSASLMechanism empty (after trimming) → returns (nil, "", nil).
-//     The Builder stays unauthenticated, matching the existing local/dev
-//     default.
-//   - StreamingSASLMechanism set but USERNAME or PASSWORD empty → returns a
-//     config error. SASL with empty credentials would either be rejected by
-//     the broker after I/O (PLAIN) or panic inside franz-go's SCRAM handshake;
-//     failing closed at bootstrap is the safer contract.
-//   - StreamingSASLMechanism unrecognised → returns a config error enumerating
-//     the accepted values.
-//
-// The mechanism name returned is the canonical upper-case form ("PLAIN",
-// "SCRAM-SHA-256", "SCRAM-SHA-512") — used for the bootstrap log line. Username
-// and password are NEVER returned to the caller and never logged.
-func resolveSASLMechanism(cfg *Config) (sasl.Mechanism, string, error) {
-	raw := strings.TrimSpace(cfg.StreamingSASLMechanism)
-	if raw == "" {
-		return nil, "", nil
-	}
-
-	mechanism := strings.ToUpper(raw)
-
-	user := cfg.StreamingSASLUsername
-	pass := cfg.StreamingSASLPassword
-
-	if user == "" || pass == "" {
-		return nil, "", fmt.Errorf(
-			"STREAMING_SASL_MECHANISM=%q requires STREAMING_SASL_USERNAME and STREAMING_SASL_PASSWORD",
-			mechanism,
-		)
-	}
-
-	switch mechanism {
-	case saslMechanismPlain:
-		return plain.Auth{User: user, Pass: pass}.AsMechanism(), saslMechanismPlain, nil
-	case saslMechanismScram256:
-		return scram.Auth{User: user, Pass: pass}.AsSha256Mechanism(), saslMechanismScram256, nil
-	case saslMechanismScram512:
-		return scram.Auth{User: user, Pass: pass}.AsSha512Mechanism(), saslMechanismScram512, nil
-	default:
-		return nil, "", fmt.Errorf(
-			"STREAMING_SASL_MECHANISM=%q is not supported (accepted: %s, %s, %s)",
-			raw, saslMechanismPlain, saslMechanismScram256, saslMechanismScram512,
-		)
-	}
 }
 
 // crmEventDefinitions returns the canonical, ordered list of CRM event

--- a/components/crm/internal/bootstrap/streaming_test.go
+++ b/components/crm/internal/bootstrap/streaming_test.go
@@ -6,7 +6,6 @@ package bootstrap
 
 import (
 	"context"
-	"errors"
 	"strings"
 	"testing"
 
@@ -15,162 +14,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-// TestResolveSASLMechanism_Disabled covers the default code path: when
-// STREAMING_SASL_MECHANISM is empty (or whitespace) the resolver returns a
-// nil mechanism and an empty name, signalling that the Builder should be
-// left unauthenticated. This is the back-compat contract for local/dev
-// brokers still running without auth.
-func TestResolveSASLMechanism_Disabled(t *testing.T) {
-	t.Parallel()
-
-	cases := []struct {
-		name string
-		cfg  *Config
-	}{
-		{name: "empty", cfg: &Config{}},
-		{name: "whitespace only", cfg: &Config{StreamingSASLMechanism: "   \t  "}},
-		{
-			// USERNAME/PASSWORD set without a MECHANISM is also treated as
-			// disabled — operators who half-configure SASL from the bottom up
-			// shouldn't accidentally activate auth.
-			name: "credentials without mechanism",
-			cfg: &Config{
-				StreamingSASLUsername: "u",
-				StreamingSASLPassword: "p",
-			},
-		},
-	}
-
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-
-			mech, name, err := resolveSASLMechanism(tc.cfg)
-			require.NoError(t, err)
-			assert.Nil(t, mech)
-			assert.Empty(t, name)
-		})
-	}
-}
-
-// TestResolveSASLMechanism_Supported covers every accepted mechanism string,
-// including case-insensitive matching, and asserts that the returned
-// canonical name matches the upper-case form used in the bootstrap log line.
-func TestResolveSASLMechanism_Supported(t *testing.T) {
-	t.Parallel()
-
-	cases := []struct {
-		input        string
-		expectedName string
-	}{
-		{input: "PLAIN", expectedName: saslMechanismPlain},
-		{input: "plain", expectedName: saslMechanismPlain},
-		{input: "  PLAIN  ", expectedName: saslMechanismPlain},
-		{input: "SCRAM-SHA-256", expectedName: saslMechanismScram256},
-		{input: "scram-sha-256", expectedName: saslMechanismScram256},
-		{input: "SCRAM-SHA-512", expectedName: saslMechanismScram512},
-		{input: "scram-sha-512", expectedName: saslMechanismScram512},
-	}
-
-	for _, tc := range cases {
-		t.Run(tc.input, func(t *testing.T) {
-			t.Parallel()
-
-			cfg := &Config{
-				StreamingSASLMechanism: tc.input,
-				StreamingSASLUsername:  "crm-prod",
-				StreamingSASLPassword:  "s3cret",
-			}
-
-			mech, name, err := resolveSASLMechanism(cfg)
-			require.NoError(t, err)
-			require.NotNil(t, mech)
-			assert.Equal(t, tc.expectedName, name)
-			// franz-go's Mechanism.Name() returns the wire-format mechanism
-			// string, which should match the canonical name 1:1.
-			assert.Equal(t, tc.expectedName, mech.Name())
-		})
-	}
-}
-
-// TestResolveSASLMechanism_MissingCredentials guarantees the resolver fails
-// closed when MECHANISM is set but USERNAME or PASSWORD is empty.
-func TestResolveSASLMechanism_MissingCredentials(t *testing.T) {
-	t.Parallel()
-
-	cases := []struct {
-		name string
-		cfg  *Config
-	}{
-		{
-			name: "missing both",
-			cfg:  &Config{StreamingSASLMechanism: "PLAIN"},
-		},
-		{
-			name: "missing username",
-			cfg: &Config{
-				StreamingSASLMechanism: "SCRAM-SHA-256",
-				StreamingSASLPassword:  "p",
-			},
-		},
-		{
-			name: "missing password",
-			cfg: &Config{
-				StreamingSASLMechanism: "SCRAM-SHA-512",
-				StreamingSASLUsername:  "u",
-			},
-		},
-	}
-
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-
-			mech, name, err := resolveSASLMechanism(tc.cfg)
-			require.Error(t, err)
-			assert.Nil(t, mech)
-			assert.Empty(t, name)
-			assert.Contains(t, err.Error(), "STREAMING_SASL_USERNAME")
-			assert.Contains(t, err.Error(), "STREAMING_SASL_PASSWORD")
-		})
-	}
-}
-
-// TestResolveSASLMechanism_Unsupported guards against typos and unsupported
-// mechanisms. The error message must enumerate the accepted values.
-func TestResolveSASLMechanism_Unsupported(t *testing.T) {
-	t.Parallel()
-
-	cases := []string{
-		"OAUTHBEARER",
-		"GSSAPI",
-		"SCRAM",         // missing -SHA-xxx suffix
-		"SCRAM-SHA-1",   // not supported by franz-go
-		"plain-sha-256", // mangled
-		"unknown",
-	}
-
-	for _, input := range cases {
-		t.Run(input, func(t *testing.T) {
-			t.Parallel()
-
-			cfg := &Config{
-				StreamingSASLMechanism: input,
-				StreamingSASLUsername:  "u",
-				StreamingSASLPassword:  "p",
-			}
-
-			mech, name, err := resolveSASLMechanism(cfg)
-			require.Error(t, err)
-			assert.Nil(t, mech)
-			assert.Empty(t, name)
-			assert.Contains(t, err.Error(), saslMechanismPlain)
-			assert.Contains(t, err.Error(), saslMechanismScram256)
-			assert.Contains(t, err.Error(), saslMechanismScram512)
-		})
-	}
-}
 
 // TestBuildStreamingEmitter_NilConfig documents the nil-guard contract:
 // BuildStreamingEmitter must never panic on a nil config and always returns a
@@ -187,17 +30,14 @@ func TestBuildStreamingEmitter_NilConfig(t *testing.T) {
 
 // TestBuildStreamingEmitter_DisabledReturnsNoop covers the default pilot path:
 // STREAMING_ENABLED is false, so the emitter is the no-op, a non-nil no-op
-// closer is returned, and no broker connection is attempted regardless of the
-// SASL config. This is the contract that keeps CRM behaving exactly as today.
+// closer is returned, and no broker connection is attempted. This is the
+// contract that keeps CRM behaving exactly as today.
 func TestBuildStreamingEmitter_DisabledReturnsNoop(t *testing.T) {
 	// t.Setenv prevents t.Parallel — we mutate process env.
 	t.Setenv("STREAMING_ENABLED", "false")
 
 	cfg := &Config{
-		StreamingEnabled:       false,
-		StreamingSASLMechanism: "PLAIN", // ignored when disabled
-		StreamingSASLUsername:  "u",
-		StreamingSASLPassword:  "p",
+		StreamingEnabled: false,
 	}
 
 	emitter, closer, err := BuildStreamingEmitter(context.Background(), cfg, nil, nil)
@@ -349,29 +189,50 @@ func TestCRMCatalog_CoversAllEmittedEvents(t *testing.T) {
 	assert.Equal(t, "alias.related-party-deleted", events.AliasRelatedPartyDeletedDefinition.Key())
 }
 
-// TestBuildStreamingEmitter_SASLWithoutTLSFailsClosed is the integration guard:
-// when SASL is enabled but neither TLS nor AllowPlaintextSASL is set,
-// lib-streaming must reject construction with ErrPlaintextSASLNotAllowed. This
-// locks the contract that CRM never silently downgrades a SASL config to
-// plaintext without explicit opt-in.
+// TestBuildStreamingEmitter_SASLWithoutTLSFailsClosed locks the security
+// contract at CRM's wiring seam: with SASL configured, TLS disabled, and no
+// plaintext opt-in, BuildStreamingEmitter must fail closed rather than dial the
+// broker with credentials in cleartext. This guards that the
+// builder.SASLFromConfig call stays wired — drop it and the build would succeed
+// unauthenticated, which this test would catch.
 func TestBuildStreamingEmitter_SASLWithoutTLSFailsClosed(t *testing.T) {
+	// t.Setenv prevents t.Parallel — lib-streaming's LoadConfig reads process env.
 	t.Setenv("STREAMING_ENABLED", "true")
-	t.Setenv("STREAMING_BROKERS", "127.0.0.1:0")
+	t.Setenv("STREAMING_BROKERS", "127.0.0.1:9092")
 	t.Setenv("STREAMING_CLOUDEVENTS_SOURCE", "lerian.midaz.crm.test")
+	t.Setenv("STREAMING_SASL_MECHANISM", "PLAIN")
+	t.Setenv("STREAMING_SASL_USERNAME", "u")
+	t.Setenv("STREAMING_SASL_PASSWORD", "p")
+	// Pin TLS off and plaintext-SASL not permitted, so the fail-closed assertion
+	// does not depend on ambient STREAMING_* env leaking into the test.
+	t.Setenv("STREAMING_TLS_ENABLED", "false")
+	t.Setenv("STREAMING_SASL_ALLOW_PLAINTEXT", "false")
 
-	cfg := &Config{
-		StreamingEnabled:       true,
-		StreamingSASLMechanism: "PLAIN",
-		StreamingSASLUsername:  "u",
-		StreamingSASLPassword:  "p",
-		// StreamingAllowPlaintextSASL intentionally false.
-	}
-
-	emitter, closer, err := BuildStreamingEmitter(context.Background(), cfg, nil, nil)
+	emitter, closer, err := BuildStreamingEmitter(context.Background(), &Config{StreamingEnabled: true}, nil, nil)
 	require.Error(t, err)
+	assert.ErrorIs(t, err, libStreaming.ErrPlaintextSASLNotAllowed)
 	assert.Nil(t, emitter)
 	require.NotNil(t, closer)
 	assert.NoError(t, closer())
-	assert.True(t, errors.Is(err, libStreaming.ErrPlaintextSASLNotAllowed),
-		"expected ErrPlaintextSASLNotAllowed, got %v", err)
+}
+
+// TestBuildStreamingEmitter_EnabledBuildsAndCloses exercises the enabled happy
+// path through the builder — catalog + routes + target + SASL-over-plaintext
+// (dev opt-in) + Build — guarding the otherwise-untested assembly and proving
+// the TLS/SASL delegation produces a working, closeable emitter.
+func TestBuildStreamingEmitter_EnabledBuildsAndCloses(t *testing.T) {
+	t.Setenv("STREAMING_ENABLED", "true")
+	t.Setenv("STREAMING_BROKERS", "127.0.0.1:9092")
+	t.Setenv("STREAMING_CLOUDEVENTS_SOURCE", "lerian.midaz.crm.test")
+	t.Setenv("STREAMING_SASL_MECHANISM", "PLAIN")
+	t.Setenv("STREAMING_SASL_USERNAME", "u")
+	t.Setenv("STREAMING_SASL_PASSWORD", "p")
+	t.Setenv("STREAMING_TLS_ENABLED", "false")
+	t.Setenv("STREAMING_SASL_ALLOW_PLAINTEXT", "true")
+
+	emitter, closer, err := BuildStreamingEmitter(context.Background(), &Config{StreamingEnabled: true}, nil, nil)
+	require.NoError(t, err)
+	require.NotNil(t, emitter)
+	require.NotNil(t, closer)
+	t.Cleanup(func() { _ = closer() })
 }

--- a/components/ledger/.env.example
+++ b/components/ledger/.env.example
@@ -375,6 +375,10 @@ STREAMING_ENABLED=false
 # STREAMING_IMPORTANT_EMIT_TIMEOUT_MS=5000
 
 # --- SASL/TLS auth ---
+# SASL and TLS are owned by lib-streaming: it reads the STREAMING_SASL_* and
+# STREAMING_TLS_* env vars below via LoadConfig and wires the broker dial
+# itself. midaz no longer parses these knobs.
+#
 # When STREAMING_SASL_MECHANISM is empty (default) the producer connects to
 # the broker without authentication. Set to PLAIN, SCRAM-SHA-256, or
 # SCRAM-SHA-512 to enable SASL; STREAMING_SASL_USERNAME and
@@ -383,9 +387,16 @@ STREAMING_ENABLED=false
 # STREAMING_SASL_USERNAME=
 # STREAMING_SASL_PASSWORD=
 #
-# SASL without TLS is rejected at bootstrap unless explicitly opted in via
-# STREAMING_ALLOW_PLAINTEXT_SASL=true. Use ONLY for local/dev brokers that
+# SASL without TLS is rejected by lib-streaming unless explicitly opted in via
+# STREAMING_SASL_ALLOW_PLAINTEXT=true. Use ONLY for local/dev brokers that
 # don't terminate TLS (e.g. a Redpanda dev container with a SASL_PLAINTEXT
 # listener). NEVER set this in staging or production: SASL credentials
 # would cross the network in cleartext.
-# STREAMING_ALLOW_PLAINTEXT_SASL=false
+# STREAMING_SASL_ALLOW_PLAINTEXT=false
+#
+# TLS for the broker connection. Off by default so plaintext dev brokers are
+# unaffected. Set STREAMING_TLS_ENABLED=true to dial the broker over TLS.
+# STREAMING_TLS_CA_CERT takes a base64-encoded PEM CA bundle for private-CA
+# brokers; leave it empty to verify against the system trust pool.
+# STREAMING_TLS_ENABLED=false
+# STREAMING_TLS_CA_CERT=

--- a/components/ledger/internal/bootstrap/config.go
+++ b/components/ledger/internal/bootstrap/config.go
@@ -219,24 +219,6 @@ type Config struct {
 	StreamingCompression       string `env:"STREAMING_COMPRESSION"`
 	StreamingRequiredAcks      string `env:"STREAMING_REQUIRED_ACKS"`
 	StreamingBatchLingerMs     int    `env:"STREAMING_BATCH_LINGER_MS"`
-
-	// --- Streaming SASL/TLS auth ---
-	// When STREAMING_SASL_MECHANISM is empty (default) the producer connects
-	// without authentication, matching the existing behaviour for local/dev
-	// brokers. When set, the value must be one of PLAIN, SCRAM-SHA-256,
-	// SCRAM-SHA-512 (case-insensitive); USERNAME and PASSWORD are then
-	// required and BuildStreamingEmitter wires the matching franz-go
-	// sasl.Mechanism into the lib-streaming Builder.
-	//
-	// SASL without TLS is rejected by lib-streaming with
-	// ErrPlaintextSASLNotAllowed. STREAMING_ALLOW_PLAINTEXT_SASL=true is the
-	// explicit unsafe opt-in for local/dev brokers that do not terminate
-	// TLS. It must NOT be set in production: SASL credentials cross the
-	// network in cleartext.
-	StreamingSASLMechanism      string `env:"STREAMING_SASL_MECHANISM"`
-	StreamingSASLUsername       string `env:"STREAMING_SASL_USERNAME"`
-	StreamingSASLPassword       string `env:"STREAMING_SASL_PASSWORD"`
-	StreamingAllowPlaintextSASL bool   `env:"STREAMING_ALLOW_PLAINTEXT_SASL"`
 }
 
 // Options contains optional dependencies that can be injected by callers.

--- a/components/ledger/internal/bootstrap/streaming.go
+++ b/components/ledger/internal/bootstrap/streaming.go
@@ -13,17 +13,6 @@ import (
 	libOpentelemetry "github.com/LerianStudio/lib-observability/tracing"
 	libStreaming "github.com/LerianStudio/lib-streaming"
 	"github.com/LerianStudio/midaz/v3/pkg/streaming/events"
-	"github.com/twmb/franz-go/pkg/sasl"
-	"github.com/twmb/franz-go/pkg/sasl/plain"
-	"github.com/twmb/franz-go/pkg/sasl/scram"
-)
-
-// SASL mechanism names accepted by STREAMING_SASL_MECHANISM. Compared
-// case-insensitively at parse time so operators can write any casing.
-const (
-	saslMechanismPlain    = "PLAIN"
-	saslMechanismScram256 = "SCRAM-SHA-256"
-	saslMechanismScram512 = "SCRAM-SHA-512"
 )
 
 // streamingPrimaryTargetName is the canonical name for midaz's single
@@ -125,26 +114,16 @@ func BuildStreamingEmitter(
 			Brokers: streamingCfg.Brokers,
 		})
 
-	// Apply SASL/TLS auth knobs from cfg. resolveSASLMechanism returns a
-	// nil mechanism (and an empty mechanism name) when SASL is disabled,
-	// in which case the Builder is left untouched and the producer dials
-	// the broker without authentication — matching the historical local/dev
-	// behaviour. When SASL is enabled but TLS is not, lib-streaming
-	// rejects construction with ErrPlaintextSASLNotAllowed unless the
-	// caller also opts into AllowPlaintextSASL — gated behind
-	// STREAMING_ALLOW_PLAINTEXT_SASL=true for dev brokers.
-	mechanism, mechanismName, err := resolveSASLMechanism(cfg)
-	if err != nil {
-		return nil, noopStreamingCloser, fmt.Errorf("failed to resolve streaming SASL mechanism: %w", err)
-	}
+	// Apply TLS from STREAMING_TLS_* env. No-op when STREAMING_TLS_ENABLED=false,
+	// so plaintext dev brokers are unaffected. When enabled, the private-CA dial
+	// is built from STREAMING_TLS_CA_CERT inside lib-streaming.
+	builder = builder.TLSFromConfig(streamingCfg)
 
-	if mechanism != nil {
-		builder = builder.SASL(mechanism)
-
-		if cfg.StreamingAllowPlaintextSASL {
-			builder = builder.AllowPlaintextSASL()
-		}
-	}
+	// Apply SASL from STREAMING_SASL_* env via lib-streaming (SASLFromConfig).
+	// No-op when STREAMING_SASL_MECHANISM is empty. SASL over plaintext needs
+	// STREAMING_SASL_ALLOW_PLAINTEXT=true (dev brokers only); otherwise
+	// lib-streaming pairs SASL with TLS and fails closed at Build.
+	builder = builder.SASLFromConfig(streamingCfg)
 
 	emitter, err := builder.Build(ctx)
 	if err != nil {
@@ -155,9 +134,9 @@ func BuildStreamingEmitter(
 		// NOTE: only mechanism name is logged. Username and password are
 		// NEVER logged, even at debug level.
 		authMode := "none"
-		if mechanismName != "" {
-			authMode = mechanismName
-			if cfg.StreamingAllowPlaintextSASL {
+		if streamingCfg.SASLMechanism != "" {
+			authMode = streamingCfg.SASLMechanism
+			if streamingCfg.SASLAllowPlaintext {
 				authMode += " (plaintext)"
 			}
 		}
@@ -174,57 +153,6 @@ func BuildStreamingEmitter(
 	}
 
 	return emitter, emitter.Close, nil
-}
-
-// resolveSASLMechanism inspects the streaming SASL knobs on cfg and
-// returns the matching franz-go sasl.Mechanism plus its canonical name.
-//
-// Behaviour:
-//   - StreamingSASLMechanism empty (after trimming) → returns (nil, "", nil).
-//     The Builder stays unauthenticated, matching the existing local/dev
-//     default.
-//   - StreamingSASLMechanism set but USERNAME or PASSWORD empty → returns
-//     a config error. SASL with empty credentials would either be rejected
-//     by the broker after I/O (PLAIN) or panic inside franz-go's SCRAM
-//     handshake; failing closed at bootstrap is the safer contract.
-//   - StreamingSASLMechanism unrecognised → returns a config error
-//     enumerating the accepted values.
-//
-// The mechanism name returned is the canonical upper-case form
-// ("PLAIN", "SCRAM-SHA-256", "SCRAM-SHA-512") — used for the bootstrap
-// log line. Username and password are NEVER returned to the caller and
-// never logged.
-func resolveSASLMechanism(cfg *Config) (sasl.Mechanism, string, error) {
-	raw := strings.TrimSpace(cfg.StreamingSASLMechanism)
-	if raw == "" {
-		return nil, "", nil
-	}
-
-	mechanism := strings.ToUpper(raw)
-
-	user := cfg.StreamingSASLUsername
-	pass := cfg.StreamingSASLPassword
-
-	if user == "" || pass == "" {
-		return nil, "", fmt.Errorf(
-			"STREAMING_SASL_MECHANISM=%q requires STREAMING_SASL_USERNAME and STREAMING_SASL_PASSWORD",
-			mechanism,
-		)
-	}
-
-	switch mechanism {
-	case saslMechanismPlain:
-		return plain.Auth{User: user, Pass: pass}.AsMechanism(), saslMechanismPlain, nil
-	case saslMechanismScram256:
-		return scram.Auth{User: user, Pass: pass}.AsSha256Mechanism(), saslMechanismScram256, nil
-	case saslMechanismScram512:
-		return scram.Auth{User: user, Pass: pass}.AsSha512Mechanism(), saslMechanismScram512, nil
-	default:
-		return nil, "", fmt.Errorf(
-			"STREAMING_SASL_MECHANISM=%q is not supported (accepted: %s, %s, %s)",
-			raw, saslMechanismPlain, saslMechanismScram256, saslMechanismScram512,
-		)
-	}
 }
 
 // midazEventDefinitions returns the canonical, ordered list of midaz

--- a/components/ledger/internal/bootstrap/streaming_test.go
+++ b/components/ledger/internal/bootstrap/streaming_test.go
@@ -6,176 +6,12 @@ package bootstrap
 
 import (
 	"context"
-	"errors"
-	"strings"
 	"testing"
 
 	libStreaming "github.com/LerianStudio/lib-streaming"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-// TestResolveSASLMechanism_Disabled covers the default code path: when
-// STREAMING_SASL_MECHANISM is empty (or whitespace) the resolver returns a
-// nil mechanism and an empty name, signalling that the Builder should be
-// left unauthenticated. This is the back-compat contract for local/dev
-// brokers that are still running without auth.
-func TestResolveSASLMechanism_Disabled(t *testing.T) {
-	t.Parallel()
-
-	cases := []struct {
-		name string
-		cfg  *Config
-	}{
-		{name: "empty", cfg: &Config{}},
-		{name: "whitespace only", cfg: &Config{StreamingSASLMechanism: "   \t  "}},
-		{
-			// Ensure that USERNAME/PASSWORD set without a MECHANISM is also
-			// treated as disabled — operators who half-configure SASL from
-			// the bottom up shouldn't accidentally activate auth.
-			name: "credentials without mechanism",
-			cfg: &Config{
-				StreamingSASLUsername: "u",
-				StreamingSASLPassword: "p",
-			},
-		},
-	}
-
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-
-			mech, name, err := resolveSASLMechanism(tc.cfg)
-			require.NoError(t, err)
-			assert.Nil(t, mech)
-			assert.Empty(t, name)
-		})
-	}
-}
-
-// TestResolveSASLMechanism_Supported covers every accepted mechanism
-// string, including case-insensitive matching, and asserts that the
-// returned canonical name matches the upper-case form used in the
-// bootstrap log line.
-func TestResolveSASLMechanism_Supported(t *testing.T) {
-	t.Parallel()
-
-	cases := []struct {
-		input        string
-		expectedName string
-	}{
-		{input: "PLAIN", expectedName: saslMechanismPlain},
-		{input: "plain", expectedName: saslMechanismPlain},
-		{input: "  PLAIN  ", expectedName: saslMechanismPlain},
-		{input: "SCRAM-SHA-256", expectedName: saslMechanismScram256},
-		{input: "scram-sha-256", expectedName: saslMechanismScram256},
-		{input: "SCRAM-SHA-512", expectedName: saslMechanismScram512},
-		{input: "scram-sha-512", expectedName: saslMechanismScram512},
-	}
-
-	for _, tc := range cases {
-		t.Run(tc.input, func(t *testing.T) {
-			t.Parallel()
-
-			cfg := &Config{
-				StreamingSASLMechanism: tc.input,
-				StreamingSASLUsername:  "ledger-prod",
-				StreamingSASLPassword:  "s3cret",
-			}
-
-			mech, name, err := resolveSASLMechanism(cfg)
-			require.NoError(t, err)
-			require.NotNil(t, mech)
-			assert.Equal(t, tc.expectedName, name)
-			// franz-go's Mechanism.Name() returns the wire-format mechanism
-			// string, which should match the canonical name 1:1.
-			assert.Equal(t, tc.expectedName, mech.Name())
-		})
-	}
-}
-
-// TestResolveSASLMechanism_MissingCredentials guarantees the resolver
-// fails closed when MECHANISM is set but USERNAME or PASSWORD is empty.
-// SASL with empty credentials would either be rejected by the broker
-// after I/O (PLAIN) or panic deep inside franz-go's SCRAM handshake;
-// failing at bootstrap is the safer contract.
-func TestResolveSASLMechanism_MissingCredentials(t *testing.T) {
-	t.Parallel()
-
-	cases := []struct {
-		name string
-		cfg  *Config
-	}{
-		{
-			name: "missing both",
-			cfg:  &Config{StreamingSASLMechanism: "PLAIN"},
-		},
-		{
-			name: "missing username",
-			cfg: &Config{
-				StreamingSASLMechanism: "SCRAM-SHA-256",
-				StreamingSASLPassword:  "p",
-			},
-		},
-		{
-			name: "missing password",
-			cfg: &Config{
-				StreamingSASLMechanism: "SCRAM-SHA-512",
-				StreamingSASLUsername:  "u",
-			},
-		},
-	}
-
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-
-			mech, name, err := resolveSASLMechanism(tc.cfg)
-			require.Error(t, err)
-			assert.Nil(t, mech)
-			assert.Empty(t, name)
-			assert.Contains(t, err.Error(), "STREAMING_SASL_USERNAME")
-			assert.Contains(t, err.Error(), "STREAMING_SASL_PASSWORD")
-		})
-	}
-}
-
-// TestResolveSASLMechanism_Unsupported guards against typos and
-// unsupported mechanisms (OAUTHBEARER, GSSAPI, etc). The error message
-// must enumerate the accepted values so an operator can fix it without
-// reading the source.
-func TestResolveSASLMechanism_Unsupported(t *testing.T) {
-	t.Parallel()
-
-	cases := []string{
-		"OAUTHBEARER",
-		"GSSAPI",
-		"SCRAM",         // missing -SHA-xxx suffix
-		"SCRAM-SHA-1",   // not supported by franz-go
-		"plain-sha-256", // mangled
-		"unknown",
-	}
-
-	for _, input := range cases {
-		t.Run(input, func(t *testing.T) {
-			t.Parallel()
-
-			cfg := &Config{
-				StreamingSASLMechanism: input,
-				StreamingSASLUsername:  "u",
-				StreamingSASLPassword:  "p",
-			}
-
-			mech, name, err := resolveSASLMechanism(cfg)
-			require.Error(t, err)
-			assert.Nil(t, mech)
-			assert.Empty(t, name)
-			assert.Contains(t, err.Error(), saslMechanismPlain)
-			assert.Contains(t, err.Error(), saslMechanismScram256)
-			assert.Contains(t, err.Error(), saslMechanismScram512)
-		})
-	}
-}
 
 // TestBuildStreamingEmitter_NilConfig keeps the existing nil-guard
 // contract documented as a unit test: BuildStreamingEmitter must never
@@ -192,16 +28,13 @@ func TestBuildStreamingEmitter_NilConfig(t *testing.T) {
 
 // TestBuildStreamingEmitter_DisabledReturnsNoop covers the default
 // pilot path: STREAMING_ENABLED is false, the emitter is the no-op,
-// and no broker connection is attempted regardless of the SASL config.
+// and no broker connection is attempted.
 func TestBuildStreamingEmitter_DisabledReturnsNoop(t *testing.T) {
 	// t.Setenv prevents t.Parallel — we mutate process env.
 	t.Setenv("STREAMING_ENABLED", "false")
 
 	cfg := &Config{
-		StreamingEnabled:       false,
-		StreamingSASLMechanism: "PLAIN", // ignored when disabled
-		StreamingSASLUsername:  "u",
-		StreamingSASLPassword:  "p",
+		StreamingEnabled: false,
 	}
 
 	emitter, closer, err := BuildStreamingEmitter(context.Background(), cfg, nil, nil)
@@ -209,90 +42,6 @@ func TestBuildStreamingEmitter_DisabledReturnsNoop(t *testing.T) {
 	require.NotNil(t, emitter)
 	require.NotNil(t, closer)
 	t.Cleanup(func() { _ = closer() })
-}
-
-// TestBuildStreamingEmitter_SASLWithoutTLSFailsClosed is the integration
-// guard: when SASL is enabled but neither TLS nor AllowPlaintextSASL is
-// set, lib-streaming must reject construction with
-// ErrPlaintextSASLNotAllowed. This locks the contract that midaz never
-// silently downgrades a SASL config to plaintext without explicit opt-in.
-//
-// The test does NOT dial the broker — Build() validates the option
-// combination before any network I/O, so STREAMING_BROKERS can point at
-// a non-routable host.
-func TestBuildStreamingEmitter_SASLWithoutTLSFailsClosed(t *testing.T) {
-	t.Setenv("STREAMING_ENABLED", "true")
-	t.Setenv("STREAMING_BROKERS", "127.0.0.1:0")
-	t.Setenv("STREAMING_CLOUDEVENTS_SOURCE", "lerian.midaz.ledger.test")
-
-	cfg := &Config{
-		StreamingEnabled:       true,
-		StreamingSASLMechanism: "PLAIN",
-		StreamingSASLUsername:  "u",
-		StreamingSASLPassword:  "p",
-		// StreamingAllowPlaintextSASL intentionally false.
-	}
-
-	emitter, closer, err := BuildStreamingEmitter(context.Background(), cfg, nil, nil)
-	require.Error(t, err)
-	assert.Nil(t, emitter)
-	require.NotNil(t, closer)
-	assert.NoError(t, closer())
-	assert.True(t, errors.Is(err, libStreaming.ErrPlaintextSASLNotAllowed),
-		"expected ErrPlaintextSASLNotAllowed, got %v", err)
-}
-
-// TestBuildStreamingEmitter_SASLWithAllowPlaintextSucceeds is the
-// dev-broker happy path: SASL enabled + AllowPlaintextSASL=true + no TLS
-// builds an emitter without dialling the broker. The emitter is closed
-// by t.Cleanup so franz-go's background goroutines do not leak into
-// other tests in this package.
-func TestBuildStreamingEmitter_SASLWithAllowPlaintextSucceeds(t *testing.T) {
-	t.Setenv("STREAMING_ENABLED", "true")
-	t.Setenv("STREAMING_BROKERS", "127.0.0.1:0")
-	t.Setenv("STREAMING_CLOUDEVENTS_SOURCE", "lerian.midaz.ledger.test")
-
-	cfg := &Config{
-		StreamingEnabled:            true,
-		StreamingSASLMechanism:      "SCRAM-SHA-256",
-		StreamingSASLUsername:       "u",
-		StreamingSASLPassword:       "p",
-		StreamingAllowPlaintextSASL: true,
-	}
-
-	emitter, closer, err := BuildStreamingEmitter(context.Background(), cfg, nil, nil)
-	require.NoError(t, err)
-	require.NotNil(t, emitter)
-	require.NotNil(t, closer)
-	t.Cleanup(func() { _ = closer() })
-}
-
-// TestBuildStreamingEmitter_UnsupportedMechanismFailsClosed verifies
-// that resolveSASLMechanism's unsupported-mechanism error propagates
-// out of BuildStreamingEmitter rather than getting masked by a downstream
-// builder error.
-func TestBuildStreamingEmitter_UnsupportedMechanismFailsClosed(t *testing.T) {
-	t.Setenv("STREAMING_ENABLED", "true")
-	t.Setenv("STREAMING_BROKERS", "127.0.0.1:0")
-	t.Setenv("STREAMING_CLOUDEVENTS_SOURCE", "lerian.midaz.ledger.test")
-
-	cfg := &Config{
-		StreamingEnabled:            true,
-		StreamingSASLMechanism:      "OAUTHBEARER", // not on the allow-list
-		StreamingSASLUsername:       "u",
-		StreamingSASLPassword:       "p",
-		StreamingAllowPlaintextSASL: true,
-	}
-
-	emitter, closer, err := BuildStreamingEmitter(context.Background(), cfg, nil, nil)
-	require.Error(t, err)
-	assert.Nil(t, emitter)
-	require.NotNil(t, closer)
-	assert.NoError(t, closer())
-	assert.True(t,
-		strings.Contains(err.Error(), "OAUTHBEARER") ||
-			strings.Contains(err.Error(), "not supported"),
-		"expected unsupported-mechanism error, got %v", err)
 }
 
 // TestMidazEventDefinitions_IncludesBalanceChanged asserts the generic
@@ -329,4 +78,52 @@ func TestBuildRoutes_BalanceChangedTopic(t *testing.T) {
 		}
 	}
 	assert.Equal(t, "lerian.streaming.balance.changed", dest)
+}
+
+// TestBuildStreamingEmitter_SASLWithoutTLSFailsClosed locks the security
+// contract at midaz's wiring seam: with SASL configured, TLS disabled, and no
+// plaintext opt-in, BuildStreamingEmitter must fail closed rather than dial the
+// broker with credentials in cleartext. This guards that the
+// builder.SASLFromConfig call stays wired — drop it and the build would succeed
+// unauthenticated, which this test would catch.
+func TestBuildStreamingEmitter_SASLWithoutTLSFailsClosed(t *testing.T) {
+	// t.Setenv prevents t.Parallel — lib-streaming's LoadConfig reads process env.
+	t.Setenv("STREAMING_ENABLED", "true")
+	t.Setenv("STREAMING_BROKERS", "127.0.0.1:9092")
+	t.Setenv("STREAMING_CLOUDEVENTS_SOURCE", "lerian.midaz.ledger.test")
+	t.Setenv("STREAMING_SASL_MECHANISM", "PLAIN")
+	t.Setenv("STREAMING_SASL_USERNAME", "u")
+	t.Setenv("STREAMING_SASL_PASSWORD", "p")
+	// Pin TLS off and plaintext-SASL not permitted, so the fail-closed assertion
+	// does not depend on ambient STREAMING_* env leaking into the test.
+	t.Setenv("STREAMING_TLS_ENABLED", "false")
+	t.Setenv("STREAMING_SASL_ALLOW_PLAINTEXT", "false")
+
+	emitter, closer, err := BuildStreamingEmitter(context.Background(), &Config{StreamingEnabled: true}, nil, nil)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, libStreaming.ErrPlaintextSASLNotAllowed)
+	assert.Nil(t, emitter)
+	require.NotNil(t, closer)
+	assert.NoError(t, closer())
+}
+
+// TestBuildStreamingEmitter_EnabledBuildsAndCloses exercises the enabled happy
+// path through the builder — catalog + routes + target + SASL-over-plaintext
+// (dev opt-in) + Build — guarding the otherwise-untested assembly and proving
+// the TLS/SASL delegation produces a working, closeable emitter.
+func TestBuildStreamingEmitter_EnabledBuildsAndCloses(t *testing.T) {
+	t.Setenv("STREAMING_ENABLED", "true")
+	t.Setenv("STREAMING_BROKERS", "127.0.0.1:9092")
+	t.Setenv("STREAMING_CLOUDEVENTS_SOURCE", "lerian.midaz.ledger.test")
+	t.Setenv("STREAMING_SASL_MECHANISM", "PLAIN")
+	t.Setenv("STREAMING_SASL_USERNAME", "u")
+	t.Setenv("STREAMING_SASL_PASSWORD", "p")
+	t.Setenv("STREAMING_TLS_ENABLED", "false")
+	t.Setenv("STREAMING_SASL_ALLOW_PLAINTEXT", "true")
+
+	emitter, closer, err := BuildStreamingEmitter(context.Background(), &Config{StreamingEnabled: true}, nil, nil)
+	require.NoError(t, err)
+	require.NotNil(t, emitter)
+	require.NotNil(t, closer)
+	t.Cleanup(func() { _ = closer() })
 }


### PR DESCRIPTION
## Description

Adopts **lib-streaming v1.9.0** and delegates streaming transport auth (TLS + SASL) to its Builder in both the `ledger` and `crm` bootstrap, via `TLSFromConfig` / `SASLFromConfig`.

This unblocks emitting events to brokers that require **TLS with a private CA** (task #3154): the old bootstrap never configured a `tls.Config`, so it could only dial plaintext and was rejected by the TLS-only broker. TLS is now enabled purely via env (`STREAMING_TLS_ENABLED` + `STREAMING_TLS_CA_CERT`), with the shared lib owning cert validation (rejects `InsecureSkipVerify`, floors TLS 1.2).

It also removes midaz's hand-rolled SASL wiring (`resolveSASLMechanism`, the `franz-go/pkg/sasl{,/plain,/scram}` imports, and the `StreamingSASL*` `Config` fields); mechanism resolution and the SASL-requires-TLS fail-closed contract now live in lib-streaming. `.env.example` moves to the canonical `STREAMING_SASL_ALLOW_PLAINTEXT` and documents the new `STREAMING_TLS_*` vars.

Net: ~160 insertions / ~667 deletions — a maintainability win that removes reinvented, security-adjacent code in favor of the shared library.

## Type of Change

- [x] `feat`: New feature or capability
- [ ] `fix`: Bug fix
- [ ] `perf`: Performance improvement
- [ ] `refactor`: Internal restructuring with no behavior change
- [ ] `docs`: Documentation only
- [ ] `style`: Formatting, whitespace, naming (no logic change)
- [x] `test`: Adding or updating tests
- [ ] `ci`: CI pipeline or workflow changes
- [x] `build`: Build system, Dockerfile, Go module dependencies
- [ ] `chore`: Maintenance, config, tooling
- [ ] `revert`: Reverts a previous commit
- [ ] `BREAKING CHANGE`: Consumers must update their integration

## Breaking Changes

None. Streaming stays OFF by default (`STREAMING_ENABLED=false` → NoopEmitter). The env rename is backward-compatible: lib-streaming still accepts the old `STREAMING_ALLOW_PLAINTEXT_SASL` as a deprecation-warned alias, so existing deployments are unaffected.

## Testing

- [x] `make test` passes (bootstrap unit tests green: nil-guard, disabled→noop, catalog/routes, and the new wiring-seam tests)
- [ ] `make test-int` passes if integration paths are exercised
- [ ] `make lint` passes
- [ ] `make sec` and `make vulncheck` pass

**Test evidence / Actions run:**
- New env-driven wiring tests added to both components (`TestBuildStreamingEmitter_SASLWithoutTLSFailsClosed`, `TestBuildStreamingEmitter_EnabledBuildsAndCloses`). The fail-closed test is mutation-proven: removing the `SASLFromConfig` call makes it fail.
- Ran the full Ring Gate-8 review (11 reviewers): 9 PASS; the test-reviewer FAIL (missing wiring coverage) is resolved by the tests above; the beta-pin note is resolved by shipping stable `v1.9.0`.
- Validated end-to-end locally with the stack + a Redpanda broker: `account.created` (ledger) and `holder.created` / `alias.created` (crm) land on the topics with correct CloudEvents envelopes; and against a real TLS broker (private CA) + SASL.

## Architectural Checklist

- [x] No `panic()` in production paths
- [x] Timestamps use `time.Now().UTC()`
- [x] Errors wrapped with `%w`
- [x] Handlers stay thin (parse, validate, call service)
- [x] Infrastructure concerns kept in `internal/bootstrap`

## Related Issues

Lerian Map task **#3154** — streaming de eventos para midaz ledger e crm em ambientes single-tenant. (Deploy steps — real CA into Vault, GitOps enablement — are ops follow-ups outside this PR.)
