### PR TITLE
chore(ci): wire end-to-end tests job reporting to Palantir

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,11 @@ permissions:
 
 jobs:
   pipeline:
-    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/go-release.yml@v1.46.2
+    # TODO: pin back to a released tag (e.g. @v1.47.0) once
+    # https://github.com/LerianStudio/github-actions-shared-workflows/pull/583
+    # merges and cuts a release. Points at the PR branch for now so the new
+    # e2e_tests job can be validated end-to-end.
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/go-release.yml@feat/midaz-e2e-tests
     with:
       enable_changelog: ${{ github.ref == 'refs/heads/main' }}
       release_single_app: true
@@ -36,5 +40,8 @@ jobs:
       helm_values_key_mappings: '{"midaz-crm": "crm", "midaz-ledger": "ledger"}'
       gitops_yaml_key_mappings: '{"midaz-crm.tag": ".crm.image.tag", "midaz-ledger.tag": ".ledger.image.tag"}'
       enable_apidog_e2e: true
+      enable_e2e_tests: true
+      e2e_modules: "midaz-ledger,midaz-crm"
+      e2e_tenancy: st
       s3_uploads: '[{"s3_bucket":"lerian-migration-files","file_pattern":"components/ledger/migrations/onboarding/*.sql","s3_prefix":"ledger/onboarding/postgresql","strip_prefix":"components/ledger/migrations/onboarding","flatten":false},{"s3_bucket":"lerian-migration-files","file_pattern":"components/ledger/migrations/transaction/*.sql","s3_prefix":"ledger/transaction/postgresql","strip_prefix":"components/ledger/migrations/transaction","flatten":false}]'
     secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,10 +14,6 @@ permissions:
 
 jobs:
   pipeline:
-    # TODO: pin back to a released tag (e.g. @v1.47.0) once
-    # https://github.com/LerianStudio/github-actions-shared-workflows/pull/583
-    # merges and cuts a release. Points at the PR branch for now so the new
-    # e2e_tests job can be validated end-to-end.
     uses: LerianStudio/github-actions-shared-workflows/.github/workflows/go-release.yml@feat/midaz-e2e-tests
     with:
       enable_changelog: ${{ github.ref == 'refs/heads/main' }}
@@ -43,5 +39,9 @@ jobs:
       enable_e2e_tests: true
       e2e_modules: "midaz-ledger,midaz-crm"
       e2e_tenancy: st
-      s3_uploads: '[{"s3_bucket":"lerian-migration-files","file_pattern":"components/ledger/migrations/onboarding/*.sql","s3_prefix":"ledger/onboarding/postgresql","strip_prefix":"components/ledger/migrations/onboarding","flatten":false},{"s3_bucket":"lerian-migration-files","file_pattern":"components/ledger/migrations/transaction/*.sql","s3_prefix":"ledger/transaction/postgresql","strip_prefix":"components/ledger/migrations/transaction","flatten":false}]'
+      s3_uploads: >-
+        [
+          {"s3_bucket":"lerian-migration-files","file_pattern":"components/ledger/migrations/onboarding/*.sql","s3_prefix":"ledger/onboarding/postgresql","strip_prefix":"components/ledger/migrations/onboarding","flatten":false},
+          {"s3_bucket":"lerian-migration-files","file_pattern":"components/ledger/migrations/transaction/*.sql","s3_prefix":"ledger/transaction/postgresql","strip_prefix":"components/ledger/migrations/transaction","flatten":false}
+        ]
     secrets: inherit

--- a/Makefile
+++ b/Makefile
@@ -645,5 +645,3 @@ migrate-create:
 	@echo "  2. Edit the .down.sql file with the rollback"
 	@echo "  3. Run 'make migrate-lint' to validate"
 	@echo "  4. Follow the guidelines in scripts/migration_linter/docs/MIGRATION_GUIDELINES.md"
-
-


### PR DESCRIPTION
## Description

Enables the new opt-in `e2e_tests` job on `go-release.yml` for `midaz-ledger`
and `midaz-crm` (single-tenant): after a tag push and a successful
`update_gitops`, it runs the `LerianStudio/end-to-end` suite against the
just-deployed environment and uploads the Allure report to
`s3://lerian-e2e-artifacts/midaz/<channel>/<tag>/<module>/` — the same S3
bucket/role the JS products (e.g. product-console) already upload to, read by
Palantir (self-service-testing)'s E2E page.

The run is scoped to only the component(s) this tag actually rebuilt: a
ledger-only change runs only `midaz-ledger`, a crm-only change runs only
`midaz-crm`, and a change touching both (or a `shared_paths` hit) runs both.

**Dependency:** the `uses:` reference temporarily points at the
`feat/midaz-e2e-tests` branch of `github-actions-shared-workflows`
(LerianStudio/github-actions-shared-workflows#583, not yet merged/tagged).
Once that PR merges and cuts a release, a follow-up PR will pin this back to
the released tag (e.g. `@v1.47.0`).

**Also needs** (org/repo secrets, not part of this PR): `E2E_REPO_TOKEN` (read
access to the private `end-to-end` repo), `AWS_E2E_ARTIFACTS_ROLE_ARN` (write
access to `lerian-e2e-artifacts`), `E2E_ADMIN_TENANT_1_USERNAME`/`PASSWORD`.

## Type of Change

- [x] `chore`: Tooling/CI change with no application behavior change

## Test plan

- [ ] Trigger a beta tag on `develop` and confirm the `e2e_tests` job runs
      post-`update_gitops` on eveo-lxc-runners
- [ ] Confirm `aws s3 ls s3://lerian-e2e-artifacts/midaz/beta/<tag>/` shows a
      `midaz-ledger/` and/or `midaz-crm/` folder depending on what changed
- [ ] Swap the `uses:` ref back to a released tag once
      LerianStudio/github-actions-shared-workflows#583 ships

🤖 Generated with [Claude Code](https://claude.com/claude-code)