### PR TITLE
revert(ci): unblock develop — drop e2e wiring, bump shared workflow to v1.46.4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   pipeline:
-    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/go-release.yml@feat/midaz-e2e-tests
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/go-release.yml@v1.46.4
     with:
       enable_changelog: ${{ github.ref == 'refs/heads/main' }}
       release_single_app: true
@@ -36,12 +36,5 @@ jobs:
       helm_values_key_mappings: '{"midaz-crm": "crm", "midaz-ledger": "ledger"}'
       gitops_yaml_key_mappings: '{"midaz-crm.tag": ".crm.image.tag", "midaz-ledger.tag": ".ledger.image.tag"}'
       enable_apidog_e2e: true
-      enable_e2e_tests: true
-      e2e_modules: "midaz-ledger,midaz-crm"
-      e2e_tenancy: st
-      s3_uploads: >-
-        [
-          {"s3_bucket":"lerian-migration-files","file_pattern":"components/ledger/migrations/onboarding/*.sql","s3_prefix":"ledger/onboarding/postgresql","strip_prefix":"components/ledger/migrations/onboarding","flatten":false},
-          {"s3_bucket":"lerian-migration-files","file_pattern":"components/ledger/migrations/transaction/*.sql","s3_prefix":"ledger/transaction/postgresql","strip_prefix":"components/ledger/migrations/transaction","flatten":false}
-        ]
+      s3_uploads: '[{"s3_bucket":"lerian-migration-files","file_pattern":"components/ledger/migrations/onboarding/*.sql","s3_prefix":"ledger/onboarding/postgresql","strip_prefix":"components/ledger/migrations/onboarding","flatten":false},{"s3_bucket":"lerian-migration-files","file_pattern":"components/ledger/migrations/transaction/*.sql","s3_prefix":"ledger/transaction/postgresql","strip_prefix":"components/ledger/migrations/transaction","flatten":false}]'
     secrets: inherit


### PR DESCRIPTION
## Description

Unblocks the `develop` release pipeline by reverting the e2e wiring introduced in #2209.

That PR pointed the release job at the `feat/midaz-e2e-tests` **branch** of the shared workflow (`go-release.yml`), whose new e2e step currently fails (pending token/config work — the deployed env is on internal runners and the `E2E_REPO_TOKEN` is still being sorted out). As a result, every Release run on `develop` goes red.

This PR restores `.github/workflows/release.yml` and `Makefile` to their pre-#2209 state, keeping **only** the CI reference bumped to the latest released shared-workflow tag:

- `uses: .../go-release.yml@feat/midaz-e2e-tests` → `@v1.46.4`
- Removes `enable_e2e_tests` / `e2e_modules` / `e2e_tenancy`
- Reverts the `s3_uploads` reformatting back to the original single line
- Restores the `Makefile` trailing newline touch

## Why not just fix forward

The e2e work is not lost — it lives in `LerianStudio/github-actions-shared-workflows#583` and will be re-wired here via a follow-up PR once that ships in a released tag. For now `develop` needs to be green.

## Type of Change

- [x] `revert`: revert a previous change

🤖 Generated with [Claude Code](https://claude.com/claude-code)