### PR TITLE
chore(ci): re-wire end-to-end tests job to validate the pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   pipeline:
-    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/go-release.yml@v1.46.4
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/go-release.yml@feat/midaz-e2e-tests
     with:
       enable_changelog: ${{ github.ref == 'refs/heads/main' }}
       release_single_app: true
@@ -36,5 +36,8 @@ jobs:
       helm_values_key_mappings: '{"midaz-crm": "crm", "midaz-ledger": "ledger"}'
       gitops_yaml_key_mappings: '{"midaz-crm.tag": ".crm.image.tag", "midaz-ledger.tag": ".ledger.image.tag"}'
       enable_apidog_e2e: true
+      enable_e2e_tests: true
+      e2e_modules: "midaz-ledger,midaz-crm"
+      e2e_tenancy: st
       s3_uploads: '[{"s3_bucket":"lerian-migration-files","file_pattern":"components/ledger/migrations/onboarding/*.sql","s3_prefix":"ledger/onboarding/postgresql","strip_prefix":"components/ledger/migrations/onboarding","flatten":false},{"s3_bucket":"lerian-migration-files","file_pattern":"components/ledger/migrations/transaction/*.sql","s3_prefix":"ledger/transaction/postgresql","strip_prefix":"components/ledger/migrations/transaction","flatten":false}]'
     secrets: inherit

--- a/Makefile
+++ b/Makefile
@@ -645,3 +645,4 @@ migrate-create:
 	@echo "  2. Edit the .down.sql file with the rollback"
 	@echo "  3. Run 'make migrate-lint' to validate"
 	@echo "  4. Follow the guidelines in scripts/migration_linter/docs/MIGRATION_GUIDELINES.md"
+


### PR DESCRIPTION
## Description

Re-enables the e2e job (reverted in #2213 to unblock develop) now that the `E2E_REPO_TOKEN` has read access to `LerianStudio/end-to-end` (verified: repo + contents → HTTP 200).

- `uses: .../go-release.yml@feat/midaz-e2e-tests` (branch, to exercise the not-yet-released e2e job)
- `enable_e2e_tests: true`, `e2e_modules: "midaz-ledger,midaz-crm"`, `e2e_tenancy: st`

Merging cuts a beta that runs the e2e end-to-end against the deployed dev env (internal runner), scoped to the component(s) that built.

## ⚠️ Before merging

- Ensure the **`E2E_REPO_TOKEN` secret** holds the working token value (the one now granted access to `end-to-end`). The earlier run failed with 401 because the secret carried a stale/invalid token; the token has since been fixed — the secret must match it.
- This points at a **mutable branch** (temporary, for validation). Once shared-workflows #583 ships a release tag, a follow-up will pin `uses:` to `@vX.Y.Z`.

## Type of Change

- [x] `chore`: CI change

🤖 Generated with [Claude Code](https://claude.com/claude-code)