### PR TITLE
chore(ci): trigger a shared-path release to run the e2e end-to-end

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -646,3 +646,4 @@ migrate-create:
 	@echo "  3. Run 'make migrate-lint' to validate"
 	@echo "  4. Follow the guidelines in scripts/migration_linter/docs/MIGRATION_GUIDELINES.md"
 
+


### PR DESCRIPTION
## Description

Trigger-only PR: touches the `Makefile` (a `shared_path`) to cut a fresh beta so the e2e job runs with the latest fixes now in place.

No `release.yml` change — develop is already wired for e2e (`@feat/midaz-e2e-tests` + `enable_e2e_tests`). This just triggers a release (the change-gate ignores `.github/*`, so a workflow-only change wouldn't fire) and, being a shared_path, builds **both** components so both e2e modules run.

## What this validates

Both prior blockers are fixed:
- **DNS**: the e2e runners (raimundo LXC 411–416) now resolve `*.dev-st.lerian.net` via `/etc/hosts` (they already routed to the ingress).
- **AWS CLI**: `end-to-end-tests.yml` now installs the AWS CLI on demand before the S3 upload (self-hosted runners don't ship it).

A fresh run is required (not a re-run) so the reusable workflow resolves `feat/midaz-e2e-tests` at its current tip, which includes the AWS CLI install step.

## Type of Change

- [x] `chore`: CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)