### PR TITLE
refactor(ledger): prefix streaming topics with service name

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -166,7 +166,7 @@ spanExec.SetAttributes(attribute.Int64("db.rows_affected", rowsAffected))
 
 ## Streaming (lib-streaming events)
 
-Producer is `github.com/LerianStudio/lib-streaming`. Wire format: CloudEvents 1.0 binary mode on Kafka. Topic: `midaz.<resource>.<event>`. ce-type is auto-prefixed by lib-streaming as `studio.lerian.<resource>.<event>`. The canonical wire contract lives in code under `pkg/streaming/events/`; the JSONShape unit test in that package locks it against drift.
+Producer is `github.com/LerianStudio/lib-streaming`. Wire format: CloudEvents 1.0 binary mode on Kafka. Topic: `lerian.streaming.<service>_<resource>.<event>` (service = component: `ledger` or `crm`; hyphens in the resource/event become underscores in the topic name only). ce-type is auto-prefixed by lib-streaming as `studio.lerian.<resource>.<event>`. The route key / DefinitionKey and ce-type stay hyphenated (e.g. `operation-route`, `related-party-deleted`); only the Kafka topic uses underscores. The canonical wire contract lives in code under `pkg/streaming/events/`; the JSONShape unit test in that package locks it against drift.
 
 ### Producer conventions
 

--- a/components/crm/internal/bootstrap/streaming.go
+++ b/components/crm/internal/bootstrap/streaming.go
@@ -21,8 +21,15 @@ import (
 const streamingPrimaryTargetName = "primary"
 
 // streamingTopicPrefix is the canonical prefix every topic name uses. Topic
-// names take the shape "midaz.<resource>.<event>".
-const streamingTopicPrefix = "midaz."
+// names take the shape "lerian.streaming.<service>_<resource>.<event>", where
+// <service> is streamingServiceName and hyphens in the <resource>.<event>
+// route key are converted to underscores in the topic name only (the route key
+// and ce-type stay hyphenated).
+const streamingTopicPrefix = "lerian.streaming."
+
+// streamingServiceName is the component service segment embedded in every topic
+// name (e.g. "crm" -> lerian.streaming.crm_<resource>.<event>).
+const streamingServiceName = "crm"
 
 // noopStreamingCloser is the close hook returned by BuildStreamingEmitter when
 // streaming is disabled. It exists only so callers can append a single uniform
@@ -113,7 +120,7 @@ func BuildStreamingEmitter(
 	}
 
 	// Build the route table. One required route per event keyed to the
-	// canonical "midaz.<resource>.<event>" topic name.
+	// canonical "lerian.streaming.<service>_<resource>.<event>" topic name.
 	routes := buildRoutes(streamingPrimaryTargetName)
 
 	builder := libStreaming.NewBuilder().
@@ -203,7 +210,10 @@ func buildCatalog() (libStreaming.Catalog, error) {
 
 // buildRoutes constructs one RouteRequired route per CRM event, targeting the
 // single broker named targetName. Topic names are
-// "midaz.<resource>.<event>".
+// "lerian.streaming.<service>_<resource>.<event>" — hyphens in the route key
+// are converted to underscores in the topic name ONLY; the route Key and
+// DefinitionKey stay hyphenated (the lib-streaming route-key regex rejects
+// underscores).
 //
 // Route Keys are composed as "<definition-key>.<target-name>" (e.g.
 // "holder.created.primary") — Route.Key must match a lower-case dot-delimited
@@ -215,11 +225,12 @@ func buildRoutes(targetName string) []libStreaming.RouteDefinition {
 
 	for _, d := range defs {
 		key := d.Key()
+		topic := streamingTopicPrefix + streamingServiceName + "_" + strings.ReplaceAll(key, "-", "_")
 		routes = append(routes, libStreaming.RouteDefinition{
 			Key:           key + "." + targetName,
 			DefinitionKey: key,
 			Target:        targetName,
-			Destination:   libStreaming.KafkaTopic(streamingTopicPrefix + key),
+			Destination:   libStreaming.KafkaTopic(topic),
 			Requirement:   libStreaming.RouteRequired,
 		})
 	}

--- a/components/crm/internal/bootstrap/streaming.go
+++ b/components/crm/internal/bootstrap/streaming.go
@@ -225,15 +225,29 @@ func buildRoutes(targetName string) []libStreaming.RouteDefinition {
 
 	for _, d := range defs {
 		key := d.Key()
-		topic := streamingTopicPrefix + streamingServiceName + "_" + strings.ReplaceAll(key, "-", "_")
 		routes = append(routes, libStreaming.RouteDefinition{
 			Key:           key + "." + targetName,
 			DefinitionKey: key,
 			Target:        targetName,
-			Destination:   libStreaming.KafkaTopic(topic),
+			Destination:   libStreaming.KafkaTopic(streamingTopicName(key)),
 			Requirement:   libStreaming.RouteRequired,
 		})
 	}
 
 	return routes
+}
+
+// streamingTopicName renders the consumer-facing Kafka topic name for a
+// definition key ("<resource>.<event>").
+//
+// The streaming-hub ingest consumer subscribes via kgo.ConsumeRegex to
+// ^lerian.streaming.<seg>.<seg>$ over the [a-z0-9_] charset — exactly two
+// segments, no hyphen. To satisfy that grammar while still namespacing topics by
+// producing service, the service is folded into the first segment
+// ("<service>_<resource>") and hyphens are normalized to underscores. The route
+// Key and the CloudEvents type keep their hyphens: lib-streaming's route-key
+// grammar requires hyphens and rejects "_", so the underscore form lives ONLY on
+// the wire topic name, not on the event identity.
+func streamingTopicName(key string) string {
+	return streamingTopicPrefix + streamingServiceName + "_" + strings.ReplaceAll(key, "-", "_")
 }

--- a/components/crm/internal/bootstrap/streaming_test.go
+++ b/components/crm/internal/bootstrap/streaming_test.go
@@ -158,8 +158,9 @@ func TestCRMCatalog_CoversAllEmittedEvents(t *testing.T) {
 		assert.False(t, dup, "duplicate route for DefinitionKey %q", r.DefinitionKey)
 		routeKeys[r.DefinitionKey] = struct{}{}
 
-		assert.Equal(t, streamingTopicPrefix+r.DefinitionKey, r.Destination.Name,
-			"route for %q must target topic %q", r.DefinitionKey, streamingTopicPrefix+r.DefinitionKey)
+		expectedTopic := streamingTopicPrefix + "crm_" + strings.ReplaceAll(r.DefinitionKey, "-", "_")
+		assert.Equal(t, expectedTopic, r.Destination.Name,
+			"route for %q must target topic %q", r.DefinitionKey, expectedTopic)
 	}
 
 	// Bijection both directions: every emitted key has a route, every route has
@@ -182,7 +183,7 @@ func TestCRMCatalog_CoversAllEmittedEvents(t *testing.T) {
 	}
 
 	require.NotNil(t, hyphenatedRoute, "route for %q must exist", hyphenatedKey)
-	assert.Equal(t, "midaz.alias.related-party-deleted", hyphenatedRoute.Destination.Name)
+	assert.Equal(t, "lerian.streaming.crm_alias.related_party_deleted", hyphenatedRoute.Destination.Name)
 
 	// The canonical set must match the events.*Definition vars the helpers use,
 	// so a Definition var mis-keyed away from the literal above is also caught.

--- a/components/ledger/internal/bootstrap/streaming.go
+++ b/components/ledger/internal/bootstrap/streaming.go
@@ -22,8 +22,15 @@ import (
 const streamingPrimaryTargetName = "primary"
 
 // streamingTopicPrefix is the canonical prefix every topic name uses.
-// Topic names take the shape "midaz.<resource>.<event>".
-const streamingTopicPrefix = "midaz."
+// Topic names take the shape "lerian.streaming.<service>_<resource>.<event>",
+// where <service> is streamingServiceName and hyphens in the
+// <resource>.<event> route key are converted to underscores in the topic
+// name only (the route key and ce-type stay hyphenated).
+const streamingTopicPrefix = "lerian.streaming."
+
+// streamingServiceName is the component service segment embedded in every
+// topic name (e.g. "ledger" -> lerian.streaming.ledger_<resource>.<event>).
+const streamingServiceName = "ledger"
 
 // noopStreamingCloser is the close hook returned by BuildStreamingEmitter
 // when streaming is disabled. It exists only so callers can append a single
@@ -101,7 +108,7 @@ func BuildStreamingEmitter(
 	}
 
 	// Build the route table. One required route per event keyed to the
-	// canonical "midaz.<resource>.<event>" topic name.
+	// canonical "lerian.streaming.<service>_<resource>.<event>" topic name.
 	routes := buildRoutes(streamingPrimaryTargetName)
 
 	builder := libStreaming.NewBuilder().
@@ -224,7 +231,10 @@ func buildCatalog() (libStreaming.Catalog, error) {
 
 // buildRoutes constructs one RouteRequired route per midaz event,
 // targeting the single broker named targetName. Topic names are
-// "midaz.<resource>.<event>".
+// "lerian.streaming.<service>_<resource>.<event>" — hyphens in the route
+// key are converted to underscores in the topic name ONLY; the route Key
+// and DefinitionKey stay hyphenated (the lib-streaming route-key regex
+// rejects underscores).
 //
 // Route Keys are composed as "<definition-key>.<target-name>" (e.g.
 // "account.created.primary") — Route.Key must match a lower-case
@@ -237,11 +247,12 @@ func buildRoutes(targetName string) []libStreaming.RouteDefinition {
 
 	for _, d := range defs {
 		key := d.Key()
+		topic := streamingTopicPrefix + streamingServiceName + "_" + strings.ReplaceAll(key, "-", "_")
 		routes = append(routes, libStreaming.RouteDefinition{
 			Key:           key + "." + targetName,
 			DefinitionKey: key,
 			Target:        targetName,
-			Destination:   libStreaming.KafkaTopic(streamingTopicPrefix + key),
+			Destination:   libStreaming.KafkaTopic(topic),
 			Requirement:   libStreaming.RouteRequired,
 		})
 	}

--- a/components/ledger/internal/bootstrap/streaming.go
+++ b/components/ledger/internal/bootstrap/streaming.go
@@ -247,15 +247,29 @@ func buildRoutes(targetName string) []libStreaming.RouteDefinition {
 
 	for _, d := range defs {
 		key := d.Key()
-		topic := streamingTopicPrefix + streamingServiceName + "_" + strings.ReplaceAll(key, "-", "_")
 		routes = append(routes, libStreaming.RouteDefinition{
 			Key:           key + "." + targetName,
 			DefinitionKey: key,
 			Target:        targetName,
-			Destination:   libStreaming.KafkaTopic(topic),
+			Destination:   libStreaming.KafkaTopic(streamingTopicName(key)),
 			Requirement:   libStreaming.RouteRequired,
 		})
 	}
 
 	return routes
+}
+
+// streamingTopicName renders the consumer-facing Kafka topic name for a
+// definition key ("<resource>.<event>").
+//
+// The streaming-hub ingest consumer subscribes via kgo.ConsumeRegex to
+// ^lerian.streaming.<seg>.<seg>$ over the [a-z0-9_] charset — exactly two
+// segments, no hyphen. To satisfy that grammar while still namespacing topics by
+// producing service, the service is folded into the first segment
+// ("<service>_<resource>") and hyphens are normalized to underscores. The route
+// Key and the CloudEvents type keep their hyphens: lib-streaming's route-key
+// grammar requires hyphens and rejects "_", so the underscore form lives ONLY on
+// the wire topic name, not on the event identity.
+func streamingTopicName(key string) string {
+	return streamingTopicPrefix + streamingServiceName + "_" + strings.ReplaceAll(key, "-", "_")
 }

--- a/components/ledger/internal/bootstrap/streaming_test.go
+++ b/components/ledger/internal/bootstrap/streaming_test.go
@@ -63,7 +63,7 @@ func TestMidazEventDefinitions_IncludesBalanceChanged(t *testing.T) {
 }
 
 // TestBuildRoutes_BalanceChangedTopic asserts the balance.changed route
-// resolves to the canonical midaz.balance.changed Kafka topic.
+// resolves to the canonical lerian.streaming.ledger_balance.changed Kafka topic.
 func TestBuildRoutes_BalanceChangedTopic(t *testing.T) {
 	t.Parallel()
 
@@ -77,7 +77,7 @@ func TestBuildRoutes_BalanceChangedTopic(t *testing.T) {
 			dest = r.Destination.Name
 		}
 	}
-	assert.Equal(t, "midaz.balance.changed", dest)
+	assert.Equal(t, "lerian.streaming.ledger_balance.changed", dest)
 }
 
 // TestBuildStreamingEmitter_SASLWithoutTLSFailsClosed locks the security

--- a/docs/streaming/crm-events.md
+++ b/docs/streaming/crm-events.md
@@ -36,7 +36,10 @@ which feeds both the Catalog and the route table:
 
 - **Event key** = `<resourceType>.<eventType>` (e.g. `holder.created`).
 - **`ce-type`** = lib-streaming auto-prefixes the key: `studio.lerian.<key>`.
-- **Kafka topic** = `midaz.<key>`.
+- **Kafka topic** = `lerian.streaming.crm_<key>`, with hyphens in `<key>`
+  converted to underscores in the topic name only (e.g.
+  `lerian.streaming.crm_alias.related_party_deleted`). The event key and
+  `ce-type` keep the hyphen.
 - **`ce-subject`** = the aggregate ID (`EmitRequest.Subject`).
 - **`ce-tenantid`** = `EmitRequest.TenantID`, resolved by
   `pkgStreaming.ResolveTenantID(ctx)` (see [ce-tenantid](#ce-tenantid)).
@@ -47,17 +50,18 @@ All 7 events carry `SchemaVersion = 1.0.0`.
 
 | Event key | Resource / Event | `ce-type` | Kafka topic | `ce-subject` | Trigger (use case) |
 |-----------|------------------|-----------|-------------|--------------|--------------------|
-| `holder.created` | holder / created | `studio.lerian.holder.created` | `midaz.holder.created` | holder ID | `CreateHolder` |
-| `holder.updated` | holder / updated | `studio.lerian.holder.updated` | `midaz.holder.updated` | holder ID | `UpdateHolderByID` |
-| `holder.deleted` | holder / deleted | `studio.lerian.holder.deleted` | `midaz.holder.deleted` | holder ID | `DeleteHolderByID` |
-| `alias.created` | alias / created | `studio.lerian.alias.created` | `midaz.alias.created` | alias ID | `CreateAlias` |
-| `alias.updated` | alias / updated | `studio.lerian.alias.updated` | `midaz.alias.updated` | alias ID | `UpdateAliasByID` |
-| `alias.deleted` | alias / deleted | `studio.lerian.alias.deleted` | `midaz.alias.deleted` | alias ID | `DeleteAliasByID` |
-| `alias.related-party-deleted` | alias / related-party-deleted | `studio.lerian.alias.related-party-deleted` | `midaz.alias.related-party-deleted` | **alias ID** (not the related-party ID) | `DeleteRelatedPartyByID` |
+| `holder.created` | holder / created | `studio.lerian.holder.created` | `lerian.streaming.crm_holder.created` | holder ID | `CreateHolder` |
+| `holder.updated` | holder / updated | `studio.lerian.holder.updated` | `lerian.streaming.crm_holder.updated` | holder ID | `UpdateHolderByID` |
+| `holder.deleted` | holder / deleted | `studio.lerian.holder.deleted` | `lerian.streaming.crm_holder.deleted` | holder ID | `DeleteHolderByID` |
+| `alias.created` | alias / created | `studio.lerian.alias.created` | `lerian.streaming.crm_alias.created` | alias ID | `CreateAlias` |
+| `alias.updated` | alias / updated | `studio.lerian.alias.updated` | `lerian.streaming.crm_alias.updated` | alias ID | `UpdateAliasByID` |
+| `alias.deleted` | alias / deleted | `studio.lerian.alias.deleted` | `lerian.streaming.crm_alias.deleted` | alias ID | `DeleteAliasByID` |
+| `alias.related-party-deleted` | alias / related-party-deleted | `studio.lerian.alias.related-party-deleted` | `lerian.streaming.crm_alias.related_party_deleted` | **alias ID** (not the related-party ID) | `DeleteRelatedPartyByID` |
 
 > **Hyphen, not underscore.** The `alias.related-party-deleted` event type is
 > hyphenated. The lib-streaming route-key validator rejects underscores, so the
-> key, topic, and `ce-type` all keep the hyphen.
+> key and `ce-type` keep the hyphen. The Kafka topic is the only place hyphens
+> become underscores: `lerian.streaming.crm_alias.related_party_deleted`.
 
 > **`ce-subject` on `alias.related-party-deleted`.** The aggregate is the alias,
 > so `ce-subject` is the **alias ID**, and the removed party's ID travels in the

--- a/pkg/streaming/events/balance_changed.go
+++ b/pkg/streaming/events/balance_changed.go
@@ -45,7 +45,7 @@ const (
 //
 // IMPORTANT posture: emit failures MUST NOT fail the parent transaction.
 // EventType "changed" is a single word — no underscore/hyphen concern with the
-// lib-streaming route-key regex. Wire topic: midaz.balance.changed.
+// lib-streaming route-key regex. Wire topic: lerian.streaming.ledger_balance.changed.
 var BalanceChangedDefinition = Definition{
 	ResourceType:  "balance",
 	EventType:     "changed",

--- a/pkg/streaming/events/balance_config_changed.go
+++ b/pkg/streaming/events/balance_config_changed.go
@@ -63,7 +63,8 @@ const (
 // EventType uses the HYPHEN form `config-changed` because the
 // lib-streaming route-key regex `^[a-z0-9][a-z0-9-]*(\.[a-z0-9][a-z0-9-]*)+$`
 // rejects underscores. The wire topic is
-// `midaz.balance.config-changed`. Payload field VALUES
+// `lerian.streaming.ledger_balance.config_changed` (hyphens in the route
+// key become underscores in the topic name only). Payload field VALUES
 // (e.g. changeType="settings_updated") may keep snake_case because
 // they are payload data, not routing identifiers.
 var BalanceConfigChangedDefinition = Definition{

--- a/pkg/streaming/events/balance_overdraft.go
+++ b/pkg/streaming/events/balance_overdraft.go
@@ -42,7 +42,8 @@ const (
 // IMPORTANT posture: emit failures MUST NOT fail the parent transaction.
 // EventType uses the HYPHEN form `overdraft-drawn` because the
 // lib-streaming route-key regex rejects underscores. Wire topic:
-// `midaz.balance.overdraft-drawn`. The Action payload field
+// `lerian.streaming.ledger_balance.overdraft_drawn` (hyphens in the route
+// key become underscores in the topic name only). The Action payload field
 // keeps the unsuffixed value "drawn" (consumers can match on either
 // the topic or the action field).
 var BalanceOverdraftDrawnDefinition = Definition{


### PR DESCRIPTION
## Description

Renames the lib-streaming producer **topic Destination** names for ledger and crm from
`midaz.<resource>.<event>` to `lerian.streaming.<service>_<resource>.<event>`
(service = `ledger` / `crm`). Hyphens inside the resource/event are converted to
underscores **in the topic name only**.

Examples:
- `lerian.streaming.ledger_organization.created`
- `lerian.streaming.ledger_operation_route.created`
- `lerian.streaming.ledger_balance.overdraft_drawn`
- `lerian.streaming.crm_holder.created`
- `lerian.streaming.crm_alias.related_party_deleted`

**Why:** the platform consumer (streaming-hub) subscribes via `kgo.ConsumeRegex`
to `^lerian\.streaming\.[a-z0-9_]+\.[a-z0-9_]+(\.v[0-9]+)?$`. The previous
`midaz.` prefix did not match, so events were produced but never consumed. This
restores the `lerian.streaming.` prefix, embeds the service segment, and (by
underscoring hyphens) makes **every** event match the consumer regex — including
the previously-unconsumed hyphenated ones (operation-route, related-party-deleted,
config-changed, overdraft-*).

## Changes

- `streamingTopicPrefix` back to `lerian.streaming.` + new `streamingServiceName`
  const in `components/{ledger,crm}/internal/bootstrap/streaming.go`; `buildRoutes`
  derives the topic as `prefix + service + "_" + ReplaceAll(key, "-", "_")`.
- Route `Key`/`DefinitionKey` and all `ResourceType`/`EventType` values are
  **unchanged** (still hyphenated — lib-streaming's route-key regex rejects `_`).
- Test assertion literals in both `streaming_test.go`.
- Event doc comments (`pkg/streaming/events/balance_*`), `CLAUDE.md`, `docs/streaming/crm-events.md`.

## Type of Change

- [x] `refactor`: Internal restructuring with no behavior change

## Breaking Changes

Topic names change. Ops: provision the new `lerian.streaming.<service>_*` topics in
each environment and repoint any topic-scoped config before rolling this image;
the interim `midaz.*` topics become orphaned.

## Testing

- [x] `go test` green: `components/ledger/internal/bootstrap`, `components/crm/internal/bootstrap`, `pkg/streaming/events`
- [x] `go build` clean; lint passed on push

## Related Issues

Streaming producer/consumer topic-name alignment.
