### PR TITLE
refactor(pkg): centralize streaming topic naming, address PR #2216 review

### DIFF
--- a/components/crm/internal/bootstrap/streaming.go
+++ b/components/crm/internal/bootstrap/streaming.go
@@ -12,6 +12,7 @@ import (
 	libLog "github.com/LerianStudio/lib-observability/log"
 	libOpentelemetry "github.com/LerianStudio/lib-observability/tracing"
 	libStreaming "github.com/LerianStudio/lib-streaming"
+	pkgStreaming "github.com/LerianStudio/midaz/v3/pkg/streaming"
 	"github.com/LerianStudio/midaz/v3/pkg/streaming/events"
 )
 
@@ -19,13 +20,6 @@ import (
 // target. Lives as a const so the Builder.Target call, the
 // RouteDefinition.Target field, and the route-key suffix all stay in sync.
 const streamingPrimaryTargetName = "primary"
-
-// streamingTopicPrefix is the canonical prefix every topic name uses. Topic
-// names take the shape "lerian.streaming.<service>_<resource>.<event>", where
-// <service> is streamingServiceName and hyphens in the <resource>.<event>
-// route key are converted to underscores in the topic name only (the route key
-// and ce-type stay hyphenated).
-const streamingTopicPrefix = "lerian.streaming."
 
 // streamingServiceName is the component service segment embedded in every topic
 // name (e.g. "crm" -> lerian.streaming.crm_<resource>.<event>).
@@ -229,25 +223,10 @@ func buildRoutes(targetName string) []libStreaming.RouteDefinition {
 			Key:           key + "." + targetName,
 			DefinitionKey: key,
 			Target:        targetName,
-			Destination:   libStreaming.KafkaTopic(streamingTopicName(key)),
+			Destination:   libStreaming.KafkaTopic(pkgStreaming.TopicName(streamingServiceName, key)),
 			Requirement:   libStreaming.RouteRequired,
 		})
 	}
 
 	return routes
-}
-
-// streamingTopicName renders the consumer-facing Kafka topic name for a
-// definition key ("<resource>.<event>").
-//
-// The streaming-hub ingest consumer subscribes via kgo.ConsumeRegex to
-// ^lerian.streaming.<seg>.<seg>$ over the [a-z0-9_] charset — exactly two
-// segments, no hyphen. To satisfy that grammar while still namespacing topics by
-// producing service, the service is folded into the first segment
-// ("<service>_<resource>") and hyphens are normalized to underscores. The route
-// Key and the CloudEvents type keep their hyphens: lib-streaming's route-key
-// grammar requires hyphens and rejects "_", so the underscore form lives ONLY on
-// the wire topic name, not on the event identity.
-func streamingTopicName(key string) string {
-	return streamingTopicPrefix + streamingServiceName + "_" + strings.ReplaceAll(key, "-", "_")
 }

--- a/components/crm/internal/bootstrap/streaming_integration_test.go
+++ b/components/crm/internal/bootstrap/streaming_integration_test.go
@@ -189,7 +189,7 @@ func streamingITExpectations() []streamingITExpectation {
 	return []streamingITExpectation{
 		{
 			name:       "holder.created",
-			topic:      streamingTopicPrefix + events.HolderCreatedDefinition.Key(),
+			topic:      pkgStreaming.TopicName(streamingServiceName, events.HolderCreatedDefinition.Key()),
 			ceType:     "studio.lerian." + events.HolderCreatedDefinition.Key(),
 			subject:    holderID.String(),
 			requireKey: []string{"id", "organizationId", "type", "createdAt", "updatedAt"},
@@ -199,7 +199,7 @@ func streamingITExpectations() []streamingITExpectation {
 		},
 		{
 			name:       "holder.updated",
-			topic:      streamingTopicPrefix + events.HolderUpdatedDefinition.Key(),
+			topic:      pkgStreaming.TopicName(streamingServiceName, events.HolderUpdatedDefinition.Key()),
 			ceType:     "studio.lerian." + events.HolderUpdatedDefinition.Key(),
 			subject:    holderID.String(),
 			requireKey: []string{"id", "organizationId", "type", "createdAt", "updatedAt"},
@@ -209,7 +209,7 @@ func streamingITExpectations() []streamingITExpectation {
 		},
 		{
 			name:       "holder.deleted",
-			topic:      streamingTopicPrefix + events.HolderDeletedDefinition.Key(),
+			topic:      pkgStreaming.TopicName(streamingServiceName, events.HolderDeletedDefinition.Key()),
 			ceType:     "studio.lerian." + events.HolderDeletedDefinition.Key(),
 			subject:    holderID.String(),
 			requireKey: []string{"id", "organizationId", "deletionType", "deletedAt"},
@@ -220,7 +220,7 @@ func streamingITExpectations() []streamingITExpectation {
 		},
 		{
 			name:       "alias.created",
-			topic:      streamingTopicPrefix + events.AliasCreatedDefinition.Key(),
+			topic:      pkgStreaming.TopicName(streamingServiceName, events.AliasCreatedDefinition.Key()),
 			ceType:     "studio.lerian." + events.AliasCreatedDefinition.Key(),
 			subject:    aliasID.String(),
 			requireKey: []string{"id", "holderId", "organizationId", "ledgerId", "accountId", "type", "relatedParties"},
@@ -230,7 +230,7 @@ func streamingITExpectations() []streamingITExpectation {
 		},
 		{
 			name:       "alias.updated",
-			topic:      streamingTopicPrefix + events.AliasUpdatedDefinition.Key(),
+			topic:      pkgStreaming.TopicName(streamingServiceName, events.AliasUpdatedDefinition.Key()),
 			ceType:     "studio.lerian." + events.AliasUpdatedDefinition.Key(),
 			subject:    aliasID.String(),
 			requireKey: []string{"id", "holderId", "organizationId", "ledgerId", "accountId", "type", "relatedParties"},
@@ -240,7 +240,7 @@ func streamingITExpectations() []streamingITExpectation {
 		},
 		{
 			name:       "alias.deleted",
-			topic:      streamingTopicPrefix + events.AliasDeletedDefinition.Key(),
+			topic:      pkgStreaming.TopicName(streamingServiceName, events.AliasDeletedDefinition.Key()),
 			ceType:     "studio.lerian." + events.AliasDeletedDefinition.Key(),
 			subject:    aliasID.String(),
 			requireKey: []string{"id", "holderId", "organizationId", "deletionType", "deletedAt"},
@@ -253,7 +253,7 @@ func streamingITExpectations() []streamingITExpectation {
 			// The hyphenated key AND the subject-is-alias-id subtlety live here:
 			// ce-subject MUST be the alias id, NOT the related-party id.
 			name:       "alias.related-party-deleted",
-			topic:      streamingTopicPrefix + events.AliasRelatedPartyDeletedDefinition.Key(),
+			topic:      pkgStreaming.TopicName(streamingServiceName, events.AliasRelatedPartyDeletedDefinition.Key()),
 			ceType:     "studio.lerian." + events.AliasRelatedPartyDeletedDefinition.Key(),
 			subject:    aliasID.String(),
 			requireKey: []string{"aliasId", "holderId", "organizationId", "relatedPartyId", "deletedAt"},

--- a/components/crm/internal/bootstrap/streaming_test.go
+++ b/components/crm/internal/bootstrap/streaming_test.go
@@ -6,10 +6,12 @@ package bootstrap
 
 import (
 	"context"
+	"regexp"
 	"strings"
 	"testing"
 
 	libStreaming "github.com/LerianStudio/lib-streaming"
+	pkgStreaming "github.com/LerianStudio/midaz/v3/pkg/streaming"
 	"github.com/LerianStudio/midaz/v3/pkg/streaming/events"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -93,8 +95,8 @@ func TestCRMCatalogRoutesAssembly(t *testing.T) {
 	// shared primary target so the wiring stays consistent once events land.
 	for _, r := range routes {
 		assert.Equal(t, streamingPrimaryTargetName, r.Target)
-		assert.True(t, strings.HasPrefix(r.Destination.Name, streamingTopicPrefix),
-			"route destination %q must start with %q", r.Destination.Name, streamingTopicPrefix)
+		assert.True(t, strings.HasPrefix(r.Destination.Name, pkgStreaming.TopicPrefix),
+			"route destination %q must start with %q", r.Destination.Name, pkgStreaming.TopicPrefix)
 	}
 }
 
@@ -158,7 +160,7 @@ func TestCRMCatalog_CoversAllEmittedEvents(t *testing.T) {
 		assert.False(t, dup, "duplicate route for DefinitionKey %q", r.DefinitionKey)
 		routeKeys[r.DefinitionKey] = struct{}{}
 
-		expectedTopic := streamingTopicPrefix + "crm_" + strings.ReplaceAll(r.DefinitionKey, "-", "_")
+		expectedTopic := pkgStreaming.TopicName("crm", r.DefinitionKey)
 		assert.Equal(t, expectedTopic, r.Destination.Name,
 			"route for %q must target topic %q", r.DefinitionKey, expectedTopic)
 	}
@@ -188,6 +190,23 @@ func TestCRMCatalog_CoversAllEmittedEvents(t *testing.T) {
 	// The canonical set must match the events.*Definition vars the helpers use,
 	// so a Definition var mis-keyed away from the literal above is also caught.
 	assert.Equal(t, "alias.related-party-deleted", events.AliasRelatedPartyDeletedDefinition.Key())
+}
+
+// TestBuildRoutes_TopicsMatchConsumerRegex asserts every CRM route destination
+// stays inside the streaming-hub ingest consumer's subscription grammar
+// (^lerian.streaming.<seg>.<seg>(\.vN)?$ over [a-z0-9_]) and carries no hyphen —
+// a hyphen on the wire topic would silently fall outside the consumer regex.
+func TestBuildRoutes_TopicsMatchConsumerRegex(t *testing.T) {
+	t.Parallel()
+
+	consumerRegex := regexp.MustCompile(`^lerian\.streaming\.[a-z0-9_]+\.[a-z0-9_]+(\.v[0-9]+)?$`)
+
+	for _, r := range buildRoutes(streamingPrimaryTargetName) {
+		assert.Regexp(t, consumerRegex, r.Destination.Name,
+			"topic %q must match the streaming-hub consumer regex", r.Destination.Name)
+		assert.NotContains(t, r.Destination.Name, "-",
+			"topic %q must not contain a hyphen (folded to underscore on the wire)", r.Destination.Name)
+	}
 }
 
 // TestBuildStreamingEmitter_SASLWithoutTLSFailsClosed locks the security

--- a/components/ledger/internal/bootstrap/streaming.go
+++ b/components/ledger/internal/bootstrap/streaming.go
@@ -12,6 +12,7 @@ import (
 	libLog "github.com/LerianStudio/lib-observability/log"
 	libOpentelemetry "github.com/LerianStudio/lib-observability/tracing"
 	libStreaming "github.com/LerianStudio/lib-streaming"
+	pkgStreaming "github.com/LerianStudio/midaz/v3/pkg/streaming"
 	"github.com/LerianStudio/midaz/v3/pkg/streaming/events"
 )
 
@@ -20,13 +21,6 @@ import (
 // RouteDefinition.Target field, and the route-key suffix all stay in
 // sync.
 const streamingPrimaryTargetName = "primary"
-
-// streamingTopicPrefix is the canonical prefix every topic name uses.
-// Topic names take the shape "lerian.streaming.<service>_<resource>.<event>",
-// where <service> is streamingServiceName and hyphens in the
-// <resource>.<event> route key are converted to underscores in the topic
-// name only (the route key and ce-type stay hyphenated).
-const streamingTopicPrefix = "lerian.streaming."
 
 // streamingServiceName is the component service segment embedded in every
 // topic name (e.g. "ledger" -> lerian.streaming.ledger_<resource>.<event>).
@@ -251,25 +245,10 @@ func buildRoutes(targetName string) []libStreaming.RouteDefinition {
 			Key:           key + "." + targetName,
 			DefinitionKey: key,
 			Target:        targetName,
-			Destination:   libStreaming.KafkaTopic(streamingTopicName(key)),
+			Destination:   libStreaming.KafkaTopic(pkgStreaming.TopicName(streamingServiceName, key)),
 			Requirement:   libStreaming.RouteRequired,
 		})
 	}
 
 	return routes
-}
-
-// streamingTopicName renders the consumer-facing Kafka topic name for a
-// definition key ("<resource>.<event>").
-//
-// The streaming-hub ingest consumer subscribes via kgo.ConsumeRegex to
-// ^lerian.streaming.<seg>.<seg>$ over the [a-z0-9_] charset — exactly two
-// segments, no hyphen. To satisfy that grammar while still namespacing topics by
-// producing service, the service is folded into the first segment
-// ("<service>_<resource>") and hyphens are normalized to underscores. The route
-// Key and the CloudEvents type keep their hyphens: lib-streaming's route-key
-// grammar requires hyphens and rejects "_", so the underscore form lives ONLY on
-// the wire topic name, not on the event identity.
-func streamingTopicName(key string) string {
-	return streamingTopicPrefix + streamingServiceName + "_" + strings.ReplaceAll(key, "-", "_")
 }

--- a/components/ledger/internal/bootstrap/streaming_test.go
+++ b/components/ledger/internal/bootstrap/streaming_test.go
@@ -6,6 +6,7 @@ package bootstrap
 
 import (
 	"context"
+	"regexp"
 	"testing"
 
 	libStreaming "github.com/LerianStudio/lib-streaming"
@@ -78,6 +79,49 @@ func TestBuildRoutes_BalanceChangedTopic(t *testing.T) {
 		}
 	}
 	assert.Equal(t, "lerian.streaming.ledger_balance.changed", dest)
+}
+
+// TestBuildRoutes_HyphenatedTopics pins the wire topic names for the ledger
+// event keys whose <resource> or <event> segment is hyphenated — exactly the
+// keys where the hyphen-to-underscore fold on the topic name (but NOT on the
+// route Key / ce-type) is easiest to get wrong.
+func TestBuildRoutes_HyphenatedTopics(t *testing.T) {
+	t.Parallel()
+
+	want := map[string]string{
+		"operation-route.created": "lerian.streaming.ledger_operation_route.created",
+		"balance.config-changed":  "lerian.streaming.ledger_balance.config_changed",
+		"balance.overdraft-drawn": "lerian.streaming.ledger_balance.overdraft_drawn",
+	}
+
+	got := make(map[string]string, len(want))
+	for _, r := range buildRoutes(streamingPrimaryTargetName) {
+		if _, ok := want[r.DefinitionKey]; ok {
+			got[r.DefinitionKey] = r.Destination.Name
+		}
+	}
+
+	for key, topic := range want {
+		assert.Equal(t, topic, got[key], "route for %q must target topic %q", key, topic)
+	}
+}
+
+// TestBuildRoutes_TopicsMatchConsumerRegex asserts every ledger route
+// destination stays inside the streaming-hub ingest consumer's subscription
+// grammar (^lerian.streaming.<seg>.<seg>(\.vN)?$ over [a-z0-9_]) and carries no
+// hyphen — a hyphen on the wire topic would silently fall outside the consumer
+// regex.
+func TestBuildRoutes_TopicsMatchConsumerRegex(t *testing.T) {
+	t.Parallel()
+
+	consumerRegex := regexp.MustCompile(`^lerian\.streaming\.[a-z0-9_]+\.[a-z0-9_]+(\.v[0-9]+)?$`)
+
+	for _, r := range buildRoutes(streamingPrimaryTargetName) {
+		assert.Regexp(t, consumerRegex, r.Destination.Name,
+			"topic %q must match the streaming-hub consumer regex", r.Destination.Name)
+		assert.NotContains(t, r.Destination.Name, "-",
+			"topic %q must not contain a hyphen (folded to underscore on the wire)", r.Destination.Name)
+	}
 }
 
 // TestBuildStreamingEmitter_SASLWithoutTLSFailsClosed locks the security

--- a/docs/streaming/ledger-events.md
+++ b/docs/streaming/ledger-events.md
@@ -39,7 +39,10 @@ which feeds both the Catalog and the route table:
 
 - **Event key** = `<resourceType>.<eventType>` (e.g. `balance.changed`).
 - **`ce-type`** = lib-streaming auto-prefixes the key: `studio.lerian.<key>`.
-- **Kafka topic** = `midaz.<key>`.
+- **Kafka topic** = `lerian.streaming.ledger_<key>`, with hyphens in `<key>`
+  converted to underscores in the topic name only (e.g.
+  `lerian.streaming.ledger_operation_route.created`). The event key and
+  `ce-type` keep the hyphen.
 - **`ce-subject`** = the aggregate ID (`EmitRequest.Subject`). Five exceptions
   exist — see [ce-subject](#ce-subject).
 - **`ce-tenantid`** = `EmitRequest.TenantID`, resolved by
@@ -53,41 +56,41 @@ as a string field.
 
 | Event key | Resource / Event | `ce-type` | Kafka topic | `ce-subject` | Trigger (use case) |
 |-----------|------------------|-----------|-------------|--------------|--------------------|
-| `organization.created` | organization / created | `studio.lerian.organization.created` | `midaz.organization.created` | org ID | `CreateOrganization` |
-| `organization.updated` | organization / updated | `studio.lerian.organization.updated` | `midaz.organization.updated` | org ID | `UpdateOrganizationByID` |
-| `organization.deleted` | organization / deleted | `studio.lerian.organization.deleted` | `midaz.organization.deleted` | org ID | `DeleteOrganizationByID` |
-| `ledger.created` | ledger / created | `studio.lerian.ledger.created` | `midaz.ledger.created` | ledger ID | `CreateLedger` |
-| `ledger.updated` | ledger / updated | `studio.lerian.ledger.updated` | `midaz.ledger.updated` | ledger ID | `UpdateLedgerByID` |
-| `ledger.deleted` | ledger / deleted | `studio.lerian.ledger.deleted` | `midaz.ledger.deleted` | ledger ID | `DeleteLedgerByID` |
-| `account.created` | account / created | `studio.lerian.account.created` | `midaz.account.created` | account ID | `CreateAccount` |
-| `account.updated` | account / updated | `studio.lerian.account.updated` | `midaz.account.updated` | account ID | `UpdateAccount` |
-| `account.deleted` | account / deleted | `studio.lerian.account.deleted` | `midaz.account.deleted` | account ID | `DeleteAccountByID` |
-| `asset.created` | asset / created | `studio.lerian.asset.created` | `midaz.asset.created` | asset ID | `CreateAsset` |
-| `asset.updated` | asset / updated | `studio.lerian.asset.updated` | `midaz.asset.updated` | asset ID | `UpdateAssetByID` |
-| `asset.deleted` | asset / deleted | `studio.lerian.asset.deleted` | `midaz.asset.deleted` | asset ID | `DeleteAssetByID` |
-| `portfolio.created` | portfolio / created | `studio.lerian.portfolio.created` | `midaz.portfolio.created` | portfolio ID | `CreatePortfolio` |
-| `portfolio.updated` | portfolio / updated | `studio.lerian.portfolio.updated` | `midaz.portfolio.updated` | portfolio ID | `UpdatePortfolioByID` |
-| `portfolio.deleted` | portfolio / deleted | `studio.lerian.portfolio.deleted` | `midaz.portfolio.deleted` | portfolio ID | `DeletePortfolioByID` |
-| `segment.created` | segment / created | `studio.lerian.segment.created` | `midaz.segment.created` | segment ID | `CreateSegment` |
-| `segment.updated` | segment / updated | `studio.lerian.segment.updated` | `midaz.segment.updated` | segment ID | `UpdateSegmentByID` |
-| `segment.deleted` | segment / deleted | `studio.lerian.segment.deleted` | `midaz.segment.deleted` | segment ID | `DeleteSegmentByID` |
-| `operation-route.created` | operation-route / created | `studio.lerian.operation-route.created` | `midaz.operation-route.created` | op-route ID | `CreateOperationRoute` |
-| `operation-route.updated` | operation-route / updated | `studio.lerian.operation-route.updated` | `midaz.operation-route.updated` | op-route ID | `UpdateOperationRoute` |
-| `operation-route.deleted` | operation-route / deleted | `studio.lerian.operation-route.deleted` | `midaz.operation-route.deleted` | op-route ID | `DeleteOperationRouteByID` |
-| `transaction-route.created` | transaction-route / created | `studio.lerian.transaction-route.created` | `midaz.transaction-route.created` | txn-route ID | `CreateTransactionRoute` |
-| `transaction-route.updated` | transaction-route / updated | `studio.lerian.transaction-route.updated` | `midaz.transaction-route.updated` | txn-route ID | `UpdateTransactionRoute` |
-| `transaction-route.deleted` | transaction-route / deleted | `studio.lerian.transaction-route.deleted` | `midaz.transaction-route.deleted` | txn-route ID | `DeleteTransactionRouteByID` |
-| `balance.created` | balance / created | `studio.lerian.balance.created` | `midaz.balance.created` | balance ID | `CreateAdditionalBalance` |
-| `balance.changed` | balance / changed | `studio.lerian.balance.changed` | `midaz.balance.changed` | **`transactionId:operationId`** | `SendBalanceChangedEvents` (per op, post-commit) |
-| `balance.config-changed` | balance / config-changed | `studio.lerian.balance.config-changed` | `midaz.balance.config-changed` | balance ID† | `UseCase.Update` (`settings_updated`) + `ensureOverdraftBalance` (`overdraft_enabled`) |
-| `balance.deleted` | balance / deleted | `studio.lerian.balance.deleted` | `midaz.balance.deleted` | balance ID | `DeleteBalance` |
-| `balance.overdraft-drawn` | balance / overdraft-drawn | `studio.lerian.balance.overdraft-drawn` | `midaz.balance.overdraft-drawn` | **`transactionId:operationId`** | `SendOverdraftEvents` (per companion op) |
-| `balance.overdraft-repaid` | balance / overdraft-repaid | `studio.lerian.balance.overdraft-repaid` | `midaz.balance.overdraft-repaid` | **`transactionId:operationId`** | `SendOverdraftEvents` |
-| `balance.overdraft-cleared` | balance / overdraft-cleared | `studio.lerian.balance.overdraft-cleared` | `midaz.balance.overdraft-cleared` | **`transactionId:operationId`** | `SendOverdraftEvents` |
-| `transaction.posted` | transaction / posted | `studio.lerian.transaction.posted` | `midaz.transaction.posted` | transaction ID | `SendTransactionEvents` (created, APPROVED, no parent) |
-| `transaction.committed` | transaction / committed | `studio.lerian.transaction.committed` | `midaz.transaction.committed` | transaction ID | `SendTransactionEvents` (updated, APPROVED) |
-| `transaction.canceled` | transaction / canceled | `studio.lerian.transaction.canceled` | `midaz.transaction.canceled` | transaction ID | `SendTransactionEvents` (updated, CANCELED) |
-| `transaction.reverted` | transaction / reverted | `studio.lerian.transaction.reverted` | `midaz.transaction.reverted` | **child** transaction ID | `SendTransactionEvents` (created, APPROVED, parent non-nil) |
+| `organization.created` | organization / created | `studio.lerian.organization.created` | `lerian.streaming.ledger_organization.created` | org ID | `CreateOrganization` |
+| `organization.updated` | organization / updated | `studio.lerian.organization.updated` | `lerian.streaming.ledger_organization.updated` | org ID | `UpdateOrganizationByID` |
+| `organization.deleted` | organization / deleted | `studio.lerian.organization.deleted` | `lerian.streaming.ledger_organization.deleted` | org ID | `DeleteOrganizationByID` |
+| `ledger.created` | ledger / created | `studio.lerian.ledger.created` | `lerian.streaming.ledger_ledger.created` | ledger ID | `CreateLedger` |
+| `ledger.updated` | ledger / updated | `studio.lerian.ledger.updated` | `lerian.streaming.ledger_ledger.updated` | ledger ID | `UpdateLedgerByID` |
+| `ledger.deleted` | ledger / deleted | `studio.lerian.ledger.deleted` | `lerian.streaming.ledger_ledger.deleted` | ledger ID | `DeleteLedgerByID` |
+| `account.created` | account / created | `studio.lerian.account.created` | `lerian.streaming.ledger_account.created` | account ID | `CreateAccount` |
+| `account.updated` | account / updated | `studio.lerian.account.updated` | `lerian.streaming.ledger_account.updated` | account ID | `UpdateAccount` |
+| `account.deleted` | account / deleted | `studio.lerian.account.deleted` | `lerian.streaming.ledger_account.deleted` | account ID | `DeleteAccountByID` |
+| `asset.created` | asset / created | `studio.lerian.asset.created` | `lerian.streaming.ledger_asset.created` | asset ID | `CreateAsset` |
+| `asset.updated` | asset / updated | `studio.lerian.asset.updated` | `lerian.streaming.ledger_asset.updated` | asset ID | `UpdateAssetByID` |
+| `asset.deleted` | asset / deleted | `studio.lerian.asset.deleted` | `lerian.streaming.ledger_asset.deleted` | asset ID | `DeleteAssetByID` |
+| `portfolio.created` | portfolio / created | `studio.lerian.portfolio.created` | `lerian.streaming.ledger_portfolio.created` | portfolio ID | `CreatePortfolio` |
+| `portfolio.updated` | portfolio / updated | `studio.lerian.portfolio.updated` | `lerian.streaming.ledger_portfolio.updated` | portfolio ID | `UpdatePortfolioByID` |
+| `portfolio.deleted` | portfolio / deleted | `studio.lerian.portfolio.deleted` | `lerian.streaming.ledger_portfolio.deleted` | portfolio ID | `DeletePortfolioByID` |
+| `segment.created` | segment / created | `studio.lerian.segment.created` | `lerian.streaming.ledger_segment.created` | segment ID | `CreateSegment` |
+| `segment.updated` | segment / updated | `studio.lerian.segment.updated` | `lerian.streaming.ledger_segment.updated` | segment ID | `UpdateSegmentByID` |
+| `segment.deleted` | segment / deleted | `studio.lerian.segment.deleted` | `lerian.streaming.ledger_segment.deleted` | segment ID | `DeleteSegmentByID` |
+| `operation-route.created` | operation-route / created | `studio.lerian.operation-route.created` | `lerian.streaming.ledger_operation_route.created` | op-route ID | `CreateOperationRoute` |
+| `operation-route.updated` | operation-route / updated | `studio.lerian.operation-route.updated` | `lerian.streaming.ledger_operation_route.updated` | op-route ID | `UpdateOperationRoute` |
+| `operation-route.deleted` | operation-route / deleted | `studio.lerian.operation-route.deleted` | `lerian.streaming.ledger_operation_route.deleted` | op-route ID | `DeleteOperationRouteByID` |
+| `transaction-route.created` | transaction-route / created | `studio.lerian.transaction-route.created` | `lerian.streaming.ledger_transaction_route.created` | txn-route ID | `CreateTransactionRoute` |
+| `transaction-route.updated` | transaction-route / updated | `studio.lerian.transaction-route.updated` | `lerian.streaming.ledger_transaction_route.updated` | txn-route ID | `UpdateTransactionRoute` |
+| `transaction-route.deleted` | transaction-route / deleted | `studio.lerian.transaction-route.deleted` | `lerian.streaming.ledger_transaction_route.deleted` | txn-route ID | `DeleteTransactionRouteByID` |
+| `balance.created` | balance / created | `studio.lerian.balance.created` | `lerian.streaming.ledger_balance.created` | balance ID | `CreateAdditionalBalance` |
+| `balance.changed` | balance / changed | `studio.lerian.balance.changed` | `lerian.streaming.ledger_balance.changed` | **`transactionId:operationId`** | `SendBalanceChangedEvents` (per op, post-commit) |
+| `balance.config-changed` | balance / config-changed | `studio.lerian.balance.config-changed` | `lerian.streaming.ledger_balance.config_changed` | balance ID† | `UseCase.Update` (`settings_updated`) + `ensureOverdraftBalance` (`overdraft_enabled`) |
+| `balance.deleted` | balance / deleted | `studio.lerian.balance.deleted` | `lerian.streaming.ledger_balance.deleted` | balance ID | `DeleteBalance` |
+| `balance.overdraft-drawn` | balance / overdraft-drawn | `studio.lerian.balance.overdraft-drawn` | `lerian.streaming.ledger_balance.overdraft_drawn` | **`transactionId:operationId`** | `SendOverdraftEvents` (per companion op) |
+| `balance.overdraft-repaid` | balance / overdraft-repaid | `studio.lerian.balance.overdraft-repaid` | `lerian.streaming.ledger_balance.overdraft_repaid` | **`transactionId:operationId`** | `SendOverdraftEvents` |
+| `balance.overdraft-cleared` | balance / overdraft-cleared | `studio.lerian.balance.overdraft-cleared` | `lerian.streaming.ledger_balance.overdraft_cleared` | **`transactionId:operationId`** | `SendOverdraftEvents` |
+| `transaction.posted` | transaction / posted | `studio.lerian.transaction.posted` | `lerian.streaming.ledger_transaction.posted` | transaction ID | `SendTransactionEvents` (created, APPROVED, no parent) |
+| `transaction.committed` | transaction / committed | `studio.lerian.transaction.committed` | `lerian.streaming.ledger_transaction.committed` | transaction ID | `SendTransactionEvents` (updated, APPROVED) |
+| `transaction.canceled` | transaction / canceled | `studio.lerian.transaction.canceled` | `lerian.streaming.ledger_transaction.canceled` | transaction ID | `SendTransactionEvents` (updated, CANCELED) |
+| `transaction.reverted` | transaction / reverted | `studio.lerian.transaction.reverted` | `lerian.streaming.ledger_transaction.reverted` | **child** transaction ID | `SendTransactionEvents` (created, APPROVED, parent non-nil) |
 
 † On `balance.config-changed` the `ce-subject` is the companion overdraft
 balance's ID in the `overdraft_enabled` branch, not the parent's.

--- a/pkg/streaming/topic.go
+++ b/pkg/streaming/topic.go
@@ -1,0 +1,26 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package streaming
+
+import "strings"
+
+// TopicPrefix is the canonical prefix every streaming Kafka topic name uses.
+const TopicPrefix = "lerian.streaming."
+
+// TopicName renders the consumer-facing Kafka topic name for a producing
+// service ("ledger"/"crm") and a definition key ("<resource>.<event>").
+//
+// The streaming-hub ingest consumer subscribes via kgo.ConsumeRegex to
+// ^lerian.streaming.<seg>.<seg>$ over the [a-z0-9_] charset — exactly two
+// segments, no hyphen. To satisfy that grammar while still namespacing topics by
+// producing service, the service is folded into the first segment
+// ("<service>_<resource>") and hyphens are normalized to underscores. The route
+// Key/DefinitionKey/ResourceType/EventType and the CloudEvents type keep their
+// hyphens: lib-streaming's route-key grammar requires hyphens and rejects "_",
+// so the underscore form lives ONLY on the wire topic name, not on the event
+// identity.
+func TopicName(service, key string) string {
+	return TopicPrefix + service + "_" + strings.ReplaceAll(key, "-", "_")
+}

--- a/pkg/streaming/topic_test.go
+++ b/pkg/streaming/topic_test.go
@@ -1,0 +1,74 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package streaming_test
+
+import (
+	"testing"
+
+	pkgStreaming "github.com/LerianStudio/midaz/v3/pkg/streaming"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestTopicName locks the service-folding + hyphen-to-underscore transform that
+// keeps wire topic names inside the streaming-hub consumer regex
+// (^lerian.streaming.<seg>.<seg>$ over [a-z0-9_]) while route keys / ce-type
+// stay hyphenated.
+func TestTopicName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		service string
+		key     string
+		want    string
+	}{
+		{
+			name:    "ledger no-hyphen key",
+			service: "ledger",
+			key:     "balance.changed",
+			want:    "lerian.streaming.ledger_balance.changed",
+		},
+		{
+			name:    "ledger single-hyphen resource",
+			service: "ledger",
+			key:     "operation-route.created",
+			want:    "lerian.streaming.ledger_operation_route.created",
+		},
+		{
+			name:    "ledger hyphen in event segment",
+			service: "ledger",
+			key:     "balance.config-changed",
+			want:    "lerian.streaming.ledger_balance.config_changed",
+		},
+		{
+			name:    "crm multi-hyphen event segment",
+			service: "crm",
+			key:     "alias.related-party-deleted",
+			want:    "lerian.streaming.crm_alias.related_party_deleted",
+		},
+		{
+			name:    "crm no-hyphen key",
+			service: "crm",
+			key:     "holder.created",
+			want:    "lerian.streaming.crm_holder.created",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tt.want, pkgStreaming.TopicName(tt.service, tt.key))
+		})
+	}
+}
+
+// TestTopicPrefix pins the exported prefix constant so callers that build or
+// assert topic names against it cannot drift from the wire contract.
+func TestTopicPrefix(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "lerian.streaming.", pkgStreaming.TopicPrefix)
+}


### PR DESCRIPTION
## Description

Follow-up to the 10-reviewer Ring review of #2216 (streaming topic rename to
`lerian.streaming.<service>_<resource>.<event>`). Addresses the findings that
survived review.

## Changes

- **De-duplication (M1):** hoist the `streamingTopicName` helper + prefix const
  into `pkg/streaming` (`TopicName(service, key)` / `TopicPrefix`); ledger and crm
  bootstrap now call `pkgStreaming.TopicName(streamingServiceName, key)`. Removes
  the verbatim helper/const/comment duplicated across both components.
- **Stale integration test (H1):** `components/crm/internal/bootstrap/streaming_integration_test.go`
  expectations still asserted the old `lerian.streaming.<key>` topics — now derived
  via `pkgStreaming.TopicName`, so e.g. `alias.related-party-deleted` →
  `lerian.streaming.crm_alias.related_party_deleted`.
- **Stale doc (M2):** `docs/streaming/ledger-events.md` still documented `midaz.*`
  topics (the crm sibling was already updated). Rewritten to the new scheme.
- **Test coverage (H2/H3/M3/L1):** direct `TestTopicName` in `pkg/streaming`;
  ledger hyphenated-topic literals (`operation-route`, `balance.config-changed`,
  `balance.overdraft-drawn`); a consumer-regex + no-hyphen invariant loop over all
  routes in both ledger and crm; the crm bijection test now calls the helper
  instead of recomputing the transform inline.

## Type of Change

- [x] `refactor`: Internal restructuring with no behavior change
- [x] `test`: Adding or updating tests
- [x] `docs`: Documentation only

## Breaking Changes

None. Behavior (emitted topic names) is identical to #2216; this only removes
duplication, fixes stale test/doc expectations, and adds coverage.

## Testing

- [x] `go test` green: `pkg/streaming`, `components/ledger/internal/bootstrap`, `components/crm/internal/bootstrap`
- [x] integration test compiles with `-tags integration`
- [x] `go build` clean; gofmt clean; lint passed on push

## Related Issues

Review follow-up for #2216 (streaming topic service-prefix rename).
