### PR TITLE
revert(ci): unblock develop — drop e2e wiring, keep shared workflow at v1.46.4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   pipeline:
-    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/go-release.yml@feat/midaz-e2e-tests
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/go-release.yml@v1.46.4
     with:
       enable_changelog: ${{ github.ref == 'refs/heads/main' }}
       release_single_app: true
@@ -36,8 +36,5 @@ jobs:
       helm_values_key_mappings: '{"midaz-crm": "crm", "midaz-ledger": "ledger"}'
       gitops_yaml_key_mappings: '{"midaz-crm.tag": ".crm.image.tag", "midaz-ledger.tag": ".ledger.image.tag"}'
       enable_apidog_e2e: true
-      enable_e2e_tests: true
-      e2e_modules: "midaz-ledger,midaz-crm"
-      e2e_tenancy: st
       s3_uploads: '[{"s3_bucket":"lerian-migration-files","file_pattern":"components/ledger/migrations/onboarding/*.sql","s3_prefix":"ledger/onboarding/postgresql","strip_prefix":"components/ledger/migrations/onboarding","flatten":false},{"s3_bucket":"lerian-migration-files","file_pattern":"components/ledger/migrations/transaction/*.sql","s3_prefix":"ledger/transaction/postgresql","strip_prefix":"components/ledger/migrations/transaction","flatten":false}]'
     secrets: inherit


### PR DESCRIPTION
## Description

Unblocks the `develop` release pipeline by reverting the e2e wiring (re-added in #2214).

The e2e job points the release at the `feat/midaz-e2e-tests` shared-workflow branch, whose suite step still fails (tenant-auth / config work in progress), so every Release run on `develop` goes red. This restores `release.yml` to the clean state — CI on the latest released shared-workflow tag, no e2e:

- `uses: .../go-release.yml@feat/midaz-e2e-tests` → `@v1.46.4`
- Removes `enable_e2e_tests` / `e2e_modules` / `e2e_tenancy`

Only `release.yml` is touched (Makefile untouched).

## Not lost

The e2e work lives in `LerianStudio/github-actions-shared-workflows#583` and will be re-wired here via a follow-up PR once it ships in a released tag. Infra fixes already applied out-of-band: runner DNS (`/etc/hosts` on the e2e LXC runners) and AWS CLI install in the reusable workflow.

## Type of Change

- [x] `revert`

🤖 Generated with [Claude Code](https://claude.com/claude-code)