### PR TITLE
chore(ci): wire e2e against the fuzzing environment (single-tenant)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   pipeline:
-    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/go-release.yml@v1.46.4
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/go-release.yml@feat/midaz-e2e-tests
     with:
       enable_changelog: ${{ github.ref == 'refs/heads/main' }}
       release_single_app: true
@@ -36,5 +36,8 @@ jobs:
       helm_values_key_mappings: '{"midaz-crm": "crm", "midaz-ledger": "ledger"}'
       gitops_yaml_key_mappings: '{"midaz-crm.tag": ".crm.image.tag", "midaz-ledger.tag": ".ledger.image.tag"}'
       enable_apidog_e2e: true
+      enable_e2e_tests: true
+      e2e_modules: "midaz-ledger,midaz-crm"
+      e2e_tenancy: st
       s3_uploads: '[{"s3_bucket":"lerian-migration-files","file_pattern":"components/ledger/migrations/onboarding/*.sql","s3_prefix":"ledger/onboarding/postgresql","strip_prefix":"components/ledger/migrations/onboarding","flatten":false},{"s3_bucket":"lerian-migration-files","file_pattern":"components/ledger/migrations/transaction/*.sql","s3_prefix":"ledger/transaction/postgresql","strip_prefix":"components/ledger/migrations/transaction","flatten":false}]'
     secrets: inherit

--- a/Makefile
+++ b/Makefile
@@ -647,3 +647,4 @@ migrate-create:
 	@echo "  4. Follow the guidelines in scripts/migration_linter/docs/MIGRATION_GUIDELINES.md"
 
 
+


### PR DESCRIPTION
## Description

Re-enables the e2e job (reverted in #2220 to unblock develop), now targeting the **fuzzing** environment single-tenant, to avoid the `dev-st` rate limiter that failed the last run (~330 HTTP 429s).

- `uses: .../go-release.yml@feat/midaz-e2e-tests`
- `enable_e2e_tests: true`, `e2e_modules: "midaz-ledger,midaz-crm"`, `e2e_tenancy: st`
- **No `e2e_service_domain`** here — the shared workflow now defaults it to `fuzzing.lerian.net`, so URLs resolve to `<app>.dev-st.fuzzing.lerian.net`.
- Makefile touch (shared_path) so merging cuts a beta and builds both components.

## Already in place
- Runner DNS: `/etc/hosts` on the e2e LXC runners (411–416) resolves `*.dev-st.fuzzing.lerian.net` → the fuzzing ingress `10.123.10.11` (validated: resolves + connects).
- AWS CLI install + tenant-cred secret names — fixed in shared-workflows #583.
- Tenant-1 creds already registered (st needs no tenant-2).

## Notes
- Points at a mutable branch (temporary, for validation); to be pinned to a released tag once shared-workflows #583 ships.
- Prior blockers cleared in order: token → DNS → AWS CLI → auth (tenant creds) → rate limit (this PR moves off the rate-limited env).

## Type of Change
- [x] `chore`: CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)