### PR TITLE
chore(ci): re-wire e2e against the fuzzing environment (single-tenant)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   pipeline:
-    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/go-release.yml@v1.46.4
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/go-release.yml@feat/midaz-e2e-tests
     with:
       enable_changelog: ${{ github.ref == 'refs/heads/main' }}
       release_single_app: true
@@ -36,5 +36,8 @@ jobs:
       helm_values_key_mappings: '{"midaz-crm": "crm", "midaz-ledger": "ledger"}'
       gitops_yaml_key_mappings: '{"midaz-crm.tag": ".crm.image.tag", "midaz-ledger.tag": ".ledger.image.tag"}'
       enable_apidog_e2e: true
+      enable_e2e_tests: true
+      e2e_modules: "midaz-ledger,midaz-crm"
+      e2e_tenancy: st
       s3_uploads: '[{"s3_bucket":"lerian-migration-files","file_pattern":"components/ledger/migrations/onboarding/*.sql","s3_prefix":"ledger/onboarding/postgresql","strip_prefix":"components/ledger/migrations/onboarding","flatten":false},{"s3_bucket":"lerian-migration-files","file_pattern":"components/ledger/migrations/transaction/*.sql","s3_prefix":"ledger/transaction/postgresql","strip_prefix":"components/ledger/migrations/transaction","flatten":false}]'
     secrets: inherit

--- a/Makefile
+++ b/Makefile
@@ -648,3 +648,4 @@ migrate-create:
 
 
 
+


### PR DESCRIPTION
## Description

Re-enables the e2e job (reverted in #2222 to unblock develop) to run against the **fuzzing** environment single-tenant, now that the blockers are resolved:

- Access-manager rate limits raised on fuzzing (gitops LerianStudio/lerian-internal-gitops#1649, merged) — fixes the ~330 HTTP 429s.
- `LEDGER_URL` now provided to the crm module in the shared workflow — fixes the crm setup hitting `localhost:3002` (connection refused).

Config:
- `uses: .../go-release.yml@feat/midaz-e2e-tests`
- `enable_e2e_tests: true`, `e2e_modules: "midaz-ledger,midaz-crm"`, `e2e_tenancy: st`
- No `e2e_service_domain` — the shared workflow now defaults to `fuzzing.lerian.net`.
- Makefile touch (shared_path) so merging cuts a beta and builds both components.

## Testing
- Last fuzzing run (beta.41): ledger 1263 tests / 76 failures (rate limit gone, real test failures remain to triage), crm blocked by the localhost fallback (fixed here). This run should exercise both modules end-to-end.

## Notes
- Points at a mutable branch (temporary); to be pinned to a released tag once shared-workflows #583 ships.

## Type of Change
- [x] `chore`: CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)