### PR TITLE
chore(ci): bump github-actions-shared-workflows to v1.46.5

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   validate:
-    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/go-pr-validation.yml@v1.46.2
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/go-pr-validation.yml@v1.46.5
     with:
       enforce_source_branches: true
       allowed_source_branches: 'hotfix/*|release-candidate'

--- a/.github/workflows/release-notification.yml
+++ b/.github/workflows/release-notification.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   notify:
-    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/release-notification.yml@v1.46.2
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/release-notification.yml@v1.46.5
     with:
       product_name: "Midaz"
       slack_channel: "lerian-product-release"

--- a/.github/workflows/routine.yml
+++ b/.github/workflows/routine.yml
@@ -35,7 +35,7 @@ permissions:
 
 jobs:
   routine:
-    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/routine.yml@v1.46.2
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/routine.yml@v1.46.5
     with:
       routine: ${{ inputs.routine || 'all' }}
       dry_run: ${{ inputs.dry_run || false }}

--- a/Makefile
+++ b/Makefile
@@ -649,3 +649,4 @@ migrate-create:
 
 
 
+


### PR DESCRIPTION
<table border="0" cellspacing="0" cellpadding="0">
  <tr>
    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
    <td><h1>Midaz</h1></td>
  </tr>
</table>

---

## Description

Bumps the `LerianStudio/github-actions-shared-workflows` reusable-workflow version pins from `v1.46.2` to `v1.46.5` across `.github/workflows/routine.yml`, `.github/workflows/pr-validation.yml`, and `.github/workflows/release-notification.yml`. `release.yml` still references a branch ref (`@feat/midaz-e2e-tests`) and was intentionally left untouched.

## Type of Change

- [ ] `feat`: New feature or capability
- [ ] `fix`: Bug fix
- [ ] `perf`: Performance improvement
- [ ] `refactor`: Internal restructuring with no behavior change
- [ ] `docs`: Documentation only
- [ ] `style`: Formatting, whitespace, naming (no logic change)
- [ ] `test`: Adding or updating tests
- [ ] `ci`: CI pipeline or workflow changes
- [ ] `build`: Build system, Dockerfile, Go module dependencies
- [x] `chore`: Maintenance, config, tooling
- [ ] `revert`: Reverts a previous commit
- [ ] `BREAKING CHANGE`: Consumers must update their integration

## Breaking Changes

None.

## Testing

- [ ] `make test` passes
- [ ] `make test-int` passes if integration paths are exercised
- [ ] `make lint` passes
- [ ] `make sec` and `make vulncheck` pass

**Test evidence / Actions run:** N/A — version pin bump only, no code changes.

## Architectural Checklist

- [ ] No `panic()` in production paths
- [ ] Timestamps use `time.Now().UTC()`
- [ ] Errors wrapped with `%w`
- [ ] Handlers stay thin (parse, validate, call service)
- [ ] Infrastructure concerns kept in `internal/bootstrap`

## Related Issues

Closes #
