### PR TITLE
fix(ledger): pin runtime WORKDIR to / so migrations resolve

### DIFF
--- a/components/ledger/Dockerfile
+++ b/components/ledger/Dockerfile
@@ -29,6 +29,11 @@ LABEL org.opencontainers.image.licenses="Elastic-2.0"
 LABEL org.opencontainers.image.version="${VERSION}"
 LABEL org.opencontainers.image.created="${BUILD_DATE}"
 
+# The :nonroot base defaults WORKDIR to /home/nonroot, but the ledger resolves
+# its migration source from the CWD-relative "components/ledger/migrations/...".
+# Pin WORKDIR to / so that relative path resolves to the staged files below.
+WORKDIR /
+
 COPY --from=builder /app /app
 COPY --from=builder /ledger-app/components/ledger/migrations/onboarding /components/ledger/migrations/onboarding
 COPY --from=builder /ledger-app/components/ledger/migrations/transaction /components/ledger/migrations/transaction


### PR DESCRIPTION
<table border="0" cellspacing="0" cellpadding="0">
  <tr>
    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
    <td><h1>Midaz</h1></td>
  </tr>
</table>

---

## Description

PR #2159 switched the ledger runtime base image to
`gcr.io/distroless/static-debian12:nonroot`. That tag changes the default
`WORKDIR` from `/` to `/home/nonroot`. The migrator resolves its source from the
CWD-relative path `components/ledger/migrations/{onboarding,transaction}` (see
`config.postgres.onboarding.go` / `config.postgres.transaction.go`), while the
image stages those files at the absolute `/components/ledger/migrations/...`.

Under the new WORKDIR the relative path resolved to
`/home/nonroot/components/ledger/migrations/onboarding`, which does not exist, so
`migrate` failed with `open .: permission denied` and the ledger pod crash-looped
on startup. Local docker-compose masked the regression via a `working_dir: /`
override the Kubernetes deployment never had.

This pins `WORKDIR /` in the runtime stage so the CWD-relative path realigns with
the staged files. Fix is Dockerfile-only; the migrator path stays relative.

## Type of Change

- [ ] `feat`: New feature or capability
- [x] `fix`: Bug fix
- [ ] `perf`: Performance improvement
- [ ] `refactor`: Internal restructuring with no behavior change
- [ ] `docs`: Documentation only
- [ ] `style`: Formatting, whitespace, naming (no logic change)
- [ ] `test`: Adding or updating tests
- [ ] `ci`: CI pipeline or workflow changes
- [ ] `build`: Build system, Dockerfile, Go module dependencies
- [ ] `chore`: Maintenance, config, tooling
- [ ] `revert`: Reverts a previous commit
- [ ] `BREAKING CHANGE`: Consumers must update their integration

## Breaking Changes

None. The migrations are staged at the same absolute path as before; only the
runtime WORKDIR changes. The redundant `working_dir: /` in
`components/ledger/docker-compose.yml` remains consistent.

## Testing

- [ ] `make test` passes
- [ ] `make test-int` passes if integration paths are exercised
- [ ] `make lint` passes
- [ ] `make sec` and `make vulncheck` pass

**Test evidence / Actions run:** Dockerfile-only change, validated at the
container level: `docker build` and `docker compose build` both succeed; image
inspect confirms `WorkingDir=/` and migrations staged at
`/components/ledger/migrations/{onboarding,transaction}`. Full stack brought up
via `make up` against a wiped Postgres volume — migrations applied cleanly
(`schema_migrations` version 19, `dirty=f`), container stayed `Up` (no
crash-loop), and zero `permission denied` lines in the ledger logs.

## Architectural Checklist

- [x] No `panic()` in production paths
- [x] Timestamps use `time.Now().UTC()`
- [x] Errors wrapped with `%w`
- [x] Handlers stay thin (parse, validate, call service)
- [x] Infrastructure concerns kept in `internal/bootstrap`

## Related Issues

Closes #
