### PR TITLE
feat(tracer): extend /readyz with redis, tenant-manager, streaming

### DIFF
--- a/components/tracer/api/types.go
+++ b/components/tracer/api/types.go
@@ -24,15 +24,23 @@ type ReadyzResponse struct {
 // concept (e.g. an in-process cache) — distinct from "tls=false" (configured
 // without TLS).
 //
-// Reason and BreakerState fields are intentionally absent. The struct
-// previously declared them, but no producer in the readyz pipeline ever
-// populated them — advertising fields in the OpenAPI spec that no code emits
-// is worse than not advertising them at all, because external SDK consumers
-// would build dashboards on data that never arrives. Re-add only when a
-// producer lands.
+// Reason carries a short, operator-facing explanation that has no natural home
+// in Error — it is populated on the non-failing branches where a bare Error
+// would be misleading: skipped probes (why the dependency was not checked, e.g.
+// "MULTI_TENANT_ENABLED=false") and degraded probes (why the dependency is
+// serving but impaired, e.g. "circuit breaker open"). The redis / tenant_manager
+// / streaming probes are the producers that made this field earn its place;
+// down probes still surface a canonical error code via Error, not Reason.
+//
+// BreakerState is intentionally still absent. No probe exposes a reliable
+// breaker-state signal — the tenant-manager client's circuit breaker is private
+// and lib-streaming does not surface one — so advertising the field in the
+// OpenAPI spec would mean SDK consumers building dashboards on data that never
+// arrives. Re-add only when a producer lands.
 type ReadyzCheck struct {
 	Status    string `json:"status" example:"up" enums:"up,down,degraded,skipped,n/a"`
 	LatencyMs int64  `json:"latency_ms,omitempty" example:"3"`
 	TLS       *bool  `json:"tls,omitempty" example:"true"`
+	Reason    string `json:"reason,omitempty" example:"MULTI_TENANT_ENABLED=false"`
 	Error     string `json:"error,omitempty"`
 }

--- a/components/tracer/internal/adapters/http/in/health.go
+++ b/components/tracer/internal/adapters/http/in/health.go
@@ -32,6 +32,11 @@ var (
 	ErrDependenciesUnhealthy    = constant.ErrReadyzDependenciesUnhealthy
 	ErrCacheNotReady            = constant.ErrReadyzCacheNotReady
 	ErrCacheStale               = constant.ErrReadyzCacheStale
+
+	ErrRedisConnectionNotEstablished = constant.ErrReadyzRedisConnectionNotEstablished
+	ErrRedisPingFailed               = constant.ErrReadyzRedisPingFailed
+	ErrTenantManagerUnavailable      = constant.ErrReadyzTenantManagerUnavailable
+	ErrStreamingUnhealthy            = constant.ErrReadyzStreamingUnhealthy
 )
 
 // Default health check configuration values.
@@ -55,6 +60,41 @@ type RuleCacheHealthProvider interface {
 type PostgresDBProvider interface {
 	GetDB(ctx context.Context) (*sql.DB, error)
 	IsConnected() bool
+}
+
+// RedisPinger probes the multi-tenant Redis Pub/Sub client for the /readyz
+// redis check. It is a binary liveness signal (ping works or it does not), so
+// unlike the tenant-manager / streaming probers it returns a raw error and the
+// probe owns the up/down mapping — mirroring PostgresDBProvider. The bootstrap
+// adapter wraps the raw go-redis UniversalClient so this package stays free of
+// the go-redis import.
+type RedisPinger interface {
+	Ping(ctx context.Context) error
+}
+
+// TenantManagerProber reports tenant-manager HTTP client readiness for the
+// /readyz tenant_manager check. The tenant-manager client exposes no
+// Ping/HealthCheck and its circuit breaker is private, so the only viable
+// signal is a functional call whose error must be classified against the
+// tenant-manager circuit-breaker-open sentinel. That classification needs the
+// concrete lib-commons error type, so it is done in the bootstrap adapter and
+// this interface returns a status already in the closed /readyz vocabulary
+// (StatusUp / StatusDegraded / StatusDown) plus the sanitized cause for span
+// attribution. Returning the pre-classified status keeps this package free of
+// the tenant-manager import.
+type TenantManagerProber interface {
+	Probe(ctx context.Context) (status string, err error)
+}
+
+// StreamingHealthProber reports streaming / RedPanda producer readiness for the
+// /readyz streaming check. lib-streaming's Emitter.Healthy returns a tri-state
+// HealthError whose .State() distinguishes healthy / degraded / down; decoding
+// it needs the concrete lib-streaming type, so — same rationale as
+// TenantManagerProber — the bootstrap adapter classifies at the boundary and
+// this interface returns a status already in the closed /readyz vocabulary plus
+// the sanitized cause for span attribution.
+type StreamingHealthProber interface {
+	Probe(ctx context.Context) (status string, err error)
 }
 
 // postgresConnectionAdapter adapts *libPostgres.Client to PostgresDBProvider.
@@ -163,6 +203,28 @@ type HealthChecker struct {
 	// series surface on /metrics that the legacy raw-Prometheus emitter
 	// produced (preserving the canonical contract).
 	readyzRecorder *observability.Recorder
+
+	// redisPinger + tenantManagerProber probe the multi-tenant-only deps. They
+	// stay nil in single-tenant mode (bootstrap only wires them when
+	// mtComponents is non-nil), so the corresponding probes report StatusSkipped
+	// rather than dereferencing a nil provider. Set once at bootstrap before the
+	// HTTP server accepts traffic — no race with /readyz reads.
+	redisPinger         RedisPinger
+	tenantManagerProber TenantManagerProber
+
+	// redisTLSEnabled mirrors cfg.MultiTenantRedisTLS. A *bool so "not wired"
+	// (single-tenant) is distinct from an explicit false; when set, the redis
+	// probe echoes it into ReadyzCheck.TLS. Populated from config (no reflection
+	// on the live connection — anti-pattern N4/N5).
+	redisTLSEnabled *bool
+
+	// streamingProber probes the streaming/RedPanda producer. Always wired at
+	// bootstrap (the emitter is a NoopEmitter when streaming is disabled), but
+	// the probe short-circuits to StatusSkipped when streamingEnabled is false —
+	// reporting "skipped" is more honest than probing a Noop that always
+	// reports healthy.
+	streamingProber  StreamingHealthProber
+	streamingEnabled bool
 }
 
 // NewHealthChecker creates a new HealthChecker instance with connection pools.
@@ -241,6 +303,60 @@ func (h *HealthChecker) SetReadyzRecorder(r *observability.Recorder) {
 	}
 
 	h.readyzRecorder = r
+}
+
+// SetRedisPinger wires the multi-tenant Redis Pub/Sub pinger used by the redis
+// /readyz probe. Bootstrap calls this only in multi-tenant mode; in
+// single-tenant mode it is never called and the probe reports StatusSkipped.
+func (h *HealthChecker) SetRedisPinger(p RedisPinger) {
+	if h == nil {
+		return
+	}
+
+	h.redisPinger = p
+}
+
+// SetRedisTLS records the configured Redis TLS posture (cfg.MultiTenantRedisTLS)
+// so the redis probe can populate ReadyzCheck.TLS without reflecting on the live
+// connection. Bootstrap calls this only in multi-tenant mode.
+func (h *HealthChecker) SetRedisTLS(enabled bool) {
+	if h == nil {
+		return
+	}
+
+	h.redisTLSEnabled = &enabled
+}
+
+// SetTenantManagerProber wires the tenant-manager readiness prober used by the
+// tenant_manager /readyz probe. Bootstrap calls this only in multi-tenant mode;
+// in single-tenant mode the probe reports StatusSkipped.
+func (h *HealthChecker) SetTenantManagerProber(p TenantManagerProber) {
+	if h == nil {
+		return
+	}
+
+	h.tenantManagerProber = p
+}
+
+// SetStreamingProber wires the streaming/RedPanda readiness prober used by the
+// streaming /readyz probe. Always wired at bootstrap; the probe still reports
+// StatusSkipped when SetStreamingEnabled(false).
+func (h *HealthChecker) SetStreamingProber(p StreamingHealthProber) {
+	if h == nil {
+		return
+	}
+
+	h.streamingProber = p
+}
+
+// SetStreamingEnabled records the master streaming flag (cfg.StreamingEnabled)
+// so the streaming probe can report StatusSkipped when streaming is disabled.
+func (h *HealthChecker) SetStreamingEnabled(enabled bool) {
+	if h == nil {
+		return
+	}
+
+	h.streamingEnabled = enabled
 }
 
 // ReadyzRecorder exposes the wired metrics recorder so the bootstrap-time

--- a/components/tracer/internal/adapters/http/in/health_mock.go
+++ b/components/tracer/internal/adapters/http/in/health_mock.go
@@ -122,3 +122,119 @@ func (mr *MockPostgresDBProviderMockRecorder) IsConnected() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsConnected", reflect.TypeOf((*MockPostgresDBProvider)(nil).IsConnected))
 }
+
+// MockRedisPinger is a mock of RedisPinger interface.
+type MockRedisPinger struct {
+	ctrl     *gomock.Controller
+	recorder *MockRedisPingerMockRecorder
+	isgomock struct{}
+}
+
+// MockRedisPingerMockRecorder is the mock recorder for MockRedisPinger.
+type MockRedisPingerMockRecorder struct {
+	mock *MockRedisPinger
+}
+
+// NewMockRedisPinger creates a new mock instance.
+func NewMockRedisPinger(ctrl *gomock.Controller) *MockRedisPinger {
+	mock := &MockRedisPinger{ctrl: ctrl}
+	mock.recorder = &MockRedisPingerMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockRedisPinger) EXPECT() *MockRedisPingerMockRecorder {
+	return m.recorder
+}
+
+// Ping mocks base method.
+func (m *MockRedisPinger) Ping(ctx context.Context) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Ping", ctx)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Ping indicates an expected call of Ping.
+func (mr *MockRedisPingerMockRecorder) Ping(ctx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Ping", reflect.TypeOf((*MockRedisPinger)(nil).Ping), ctx)
+}
+
+// MockTenantManagerProber is a mock of TenantManagerProber interface.
+type MockTenantManagerProber struct {
+	ctrl     *gomock.Controller
+	recorder *MockTenantManagerProberMockRecorder
+	isgomock struct{}
+}
+
+// MockTenantManagerProberMockRecorder is the mock recorder for MockTenantManagerProber.
+type MockTenantManagerProberMockRecorder struct {
+	mock *MockTenantManagerProber
+}
+
+// NewMockTenantManagerProber creates a new mock instance.
+func NewMockTenantManagerProber(ctrl *gomock.Controller) *MockTenantManagerProber {
+	mock := &MockTenantManagerProber{ctrl: ctrl}
+	mock.recorder = &MockTenantManagerProberMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockTenantManagerProber) EXPECT() *MockTenantManagerProberMockRecorder {
+	return m.recorder
+}
+
+// Probe mocks base method.
+func (m *MockTenantManagerProber) Probe(ctx context.Context) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Probe", ctx)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Probe indicates an expected call of Probe.
+func (mr *MockTenantManagerProberMockRecorder) Probe(ctx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Probe", reflect.TypeOf((*MockTenantManagerProber)(nil).Probe), ctx)
+}
+
+// MockStreamingHealthProber is a mock of StreamingHealthProber interface.
+type MockStreamingHealthProber struct {
+	ctrl     *gomock.Controller
+	recorder *MockStreamingHealthProberMockRecorder
+	isgomock struct{}
+}
+
+// MockStreamingHealthProberMockRecorder is the mock recorder for MockStreamingHealthProber.
+type MockStreamingHealthProberMockRecorder struct {
+	mock *MockStreamingHealthProber
+}
+
+// NewMockStreamingHealthProber creates a new mock instance.
+func NewMockStreamingHealthProber(ctrl *gomock.Controller) *MockStreamingHealthProber {
+	mock := &MockStreamingHealthProber{ctrl: ctrl}
+	mock.recorder = &MockStreamingHealthProberMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockStreamingHealthProber) EXPECT() *MockStreamingHealthProberMockRecorder {
+	return m.recorder
+}
+
+// Probe mocks base method.
+func (m *MockStreamingHealthProber) Probe(ctx context.Context) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Probe", ctx)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Probe indicates an expected call of Probe.
+func (mr *MockStreamingHealthProberMockRecorder) Probe(ctx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Probe", reflect.TypeOf((*MockStreamingHealthProber)(nil).Probe), ctx)
+}

--- a/components/tracer/internal/adapters/http/in/readyz.go
+++ b/components/tracer/internal/adapters/http/in/readyz.go
@@ -41,11 +41,14 @@ func (h *HealthChecker) emitReadyzMetrics(ctx context.Context, dep, status strin
 
 // Status vocabulary — closed set per the canonical /readyz contract. Any
 // other value is non-compliant. Aggregation: top-level "healthy" iff every
-// check is in {up, skipped, n/a}; any "down" or "degraded" forces 503.
+// GATING check is in {up, skipped, n/a}; any "down" or "degraded" gating check
+// forces 503. Advisory checks (see advisoryChecks — currently streaming) are
+// excluded from the aggregate.
 //
-// StatusSkipped and StatusNA remain part of the package's public API even
-// though Tracer's single-tenant /readyz cycle never emits them — downstream
-// consumers depend on the canonical 5-value vocabulary.
+// StatusSkipped and StatusNA are emitted by the multi-tenant-gated probes
+// (redis / tenant_manager report "skipped" in single-tenant mode; rule_cache
+// reports "n/a" in multi-tenant mode) and streaming reports "skipped" when
+// disabled — downstream consumers depend on the canonical 5-value vocabulary.
 const (
 	StatusUp       = "up"
 	StatusDown     = "down"
@@ -67,6 +70,26 @@ const (
 	probeTimeoutPostgres = 2 * time.Second
 	// Rule cache is in-process; "0" timeout means we skip context.WithTimeout
 	// entirely. The cache health provider returns synchronously.
+
+	// probeTimeoutRedis bounds the multi-tenant Redis Pub/Sub PING. Tighter
+	// than the DB budget — a Pub/Sub PING is a single round-trip.
+	probeTimeoutRedis = 1 * time.Second
+	// probeTimeoutTenantManager bounds the tenant-manager functional probe
+	// (GetActiveTenantsByService), which is an outbound HTTP call.
+	probeTimeoutTenantManager = 2 * time.Second
+	// probeTimeoutStreaming bounds the streaming producer Healthy() call, which
+	// may touch the broker adapter.
+	probeTimeoutStreaming = 2 * time.Second
+)
+
+// Skip reasons surfaced in ReadyzCheck.Reason when a probe is short-circuited.
+// Mirror the exact env-var spelling so operators can grep the response straight
+// back to the toggle that produced it.
+const (
+	reasonMultiTenantDisabled = "MULTI_TENANT_ENABLED=false"
+	reasonStreamingDisabled   = "STREAMING_ENABLED=false"
+	reasonCircuitBreakerOpen  = "circuit breaker open"
+	reasonStreamingDegraded   = "streaming degraded"
 )
 
 // ReadyzHandler returns the canonical readiness handler per the Lerian
@@ -74,8 +97,10 @@ const (
 // timeout, aggregates results into ReadyzResponse, and returns 200 only
 // when every check is in {up, skipped, n/a}.
 //
-// The /readyz cycle for Tracer is intentionally single-tenant: postgres +
-// rule_cache only.
+// The /readyz cycle probes five dependencies: postgres and rule_cache always
+// run; redis and tenant_manager are multi-tenant-gated (report "skipped" in
+// single-tenant mode); streaming is advisory and gated by STREAMING_ENABLED.
+// All but streaming gate the top-level status.
 //
 // MUST be registered on the public path tree, BEFORE any auth middleware —
 // K8s probes are unauthenticated and a 401 here would be interpreted by
@@ -98,7 +123,7 @@ func (h *HealthChecker) ReadyzHandler() fiber.Handler {
 		// to the non-drain path.
 		draining := h.IsDraining()
 
-		// Run the two probes concurrently. Each probe creates its own child
+		// Run the five probes concurrently. Each probe creates its own child
 		// span from the inherited ctx and enforces its own per-dep timeout via
 		// context.WithTimeout — parallelism is safe here. Worst-case latency
 		// drops from sum(timeouts) to max(timeouts) under partial outage.
@@ -110,11 +135,12 @@ func (h *HealthChecker) ReadyzHandler() fiber.Handler {
 		// KeepRunning policy: a crashing probe MUST NOT crashloop the pod —
 		// the readiness signal recovers naturally via the next probe cycle.
 		var (
-			pgCheck, rcCheck api.ReadyzCheck
-			wg               sync.WaitGroup
+			pgCheck, rcCheck                 api.ReadyzCheck
+			redisCheck, tmCheck, streamCheck api.ReadyzCheck
+			wg                               sync.WaitGroup
 		)
 
-		wg.Add(2)
+		wg.Add(5)
 
 		libRuntime.SafeGoWithContextAndComponent(
 			ctx,
@@ -142,11 +168,53 @@ func (h *HealthChecker) ReadyzHandler() fiber.Handler {
 			},
 		)
 
+		libRuntime.SafeGoWithContextAndComponent(
+			ctx,
+			logger,
+			"readyz",
+			"probe-redis",
+			libRuntime.KeepRunning,
+			func(probeCtx context.Context) {
+				defer wg.Done()
+
+				redisCheck = h.probeReadyzRedis(probeCtx)
+			},
+		)
+
+		libRuntime.SafeGoWithContextAndComponent(
+			ctx,
+			logger,
+			"readyz",
+			"probe-tenant_manager",
+			libRuntime.KeepRunning,
+			func(probeCtx context.Context) {
+				defer wg.Done()
+
+				tmCheck = h.probeReadyzTenantManager(probeCtx)
+			},
+		)
+
+		libRuntime.SafeGoWithContextAndComponent(
+			ctx,
+			logger,
+			"readyz",
+			"probe-streaming",
+			libRuntime.KeepRunning,
+			func(probeCtx context.Context) {
+				defer wg.Done()
+
+				streamCheck = h.probeReadyzStreaming(probeCtx)
+			},
+		)
+
 		wg.Wait()
 
 		checks := map[string]api.ReadyzCheck{
-			"postgres":   pgCheck,
-			"rule_cache": rcCheck,
+			"postgres":       pgCheck,
+			"rule_cache":     rcCheck,
+			"redis":          redisCheck,
+			"tenant_manager": tmCheck,
+			"streaming":      streamCheck,
 		}
 
 		response := api.ReadyzResponse{
@@ -180,17 +248,265 @@ func (h *HealthChecker) ReadyzHandler() fiber.Handler {
 	}
 }
 
-// aggregateStatus implements the canonical aggregation rule: top-level
-// "healthy" iff every check is in {up, skipped, n/a}. Any "down" or
-// "degraded" forces "unhealthy".
+// spanCause chooses the error recorded on a probe's span: the sanitized cause
+// from the boundary adapter when present, otherwise the canonical sentinel.
+// The wire-facing ReadyzCheck.Error always uses the sentinel — this only
+// enriches telemetry.
+func spanCause(cause, fallback error) error {
+	if cause != nil {
+		return cause
+	}
+
+	return fallback
+}
+
+// probeReadyzRedis pings the multi-tenant Redis Pub/Sub client within the
+// per-dep timeout. Redis is multi-tenant-only: in single-tenant mode the probe
+// reports "skipped" and never touches the pinger. On any ping failure it
+// returns "down" with a canonical sentinel code — the raw go-redis error is
+// never surfaced on the wire.
 //
-// Fails CLOSED on unknown probe states: a probe that returns a Status outside
-// the canonical 5-value vocabulary ("", "OK", "READY", a typo) is treated as
-// "unhealthy" and forces 503. Without this default, a buggy probe that
-// returned an empty string would silently aggregate to "healthy" — fail-OPEN,
-// which is the dangerous direction for a readiness signal.
+// The `tls` field is populated from the configured cfg.MultiTenantRedisTLS bool
+// (SetRedisTLS) — never by reflecting on the live connection (anti-pattern
+// N4/N5).
+func (h *HealthChecker) probeReadyzRedis(ctx context.Context) api.ReadyzCheck {
+	//nolint:dogsled // tracker tuple unused in readyz probes; only the tracer is required for child spans
+	_, tracer, _, _ := libObservability.NewTrackingFromContext(ctx)
+
+	ctx, span := tracer.Start(ctx, "readyz.probe.redis")
+	defer span.End()
+
+	start := time.Now().UTC()
+
+	if !h.multiTenantEnabled {
+		elapsed := time.Since(start)
+
+		h.emitReadyzMetrics(ctx, "redis", StatusSkipped, elapsed)
+
+		return api.ReadyzCheck{
+			Status:    StatusSkipped,
+			LatencyMs: elapsed.Milliseconds(),
+			Reason:    reasonMultiTenantDisabled,
+		}
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, probeTimeoutRedis)
+	defer cancel()
+
+	if h.redisPinger == nil {
+		elapsed := time.Since(start)
+
+		libOtel.HandleSpanError(span, "redis readyz: connection not established", ErrRedisConnectionNotEstablished)
+		h.emitReadyzMetrics(ctx, "redis", StatusDown, elapsed)
+
+		return api.ReadyzCheck{
+			Status:    StatusDown,
+			LatencyMs: elapsed.Milliseconds(),
+			Error:     ErrRedisConnectionNotEstablished.Error(),
+		}
+	}
+
+	if err := h.redisPinger.Ping(ctx); err != nil {
+		elapsed := time.Since(start)
+
+		libOtel.HandleSpanError(span, "redis readyz: ping failed", ErrRedisPingFailed)
+		h.emitReadyzMetrics(ctx, "redis", StatusDown, elapsed)
+
+		return api.ReadyzCheck{
+			Status:    StatusDown,
+			LatencyMs: elapsed.Milliseconds(),
+			Error:     ErrRedisPingFailed.Error(),
+		}
+	}
+
+	elapsed := time.Since(start)
+
+	h.emitReadyzMetrics(ctx, "redis", StatusUp, elapsed)
+
+	return api.ReadyzCheck{
+		Status:    StatusUp,
+		LatencyMs: elapsed.Milliseconds(),
+		TLS:       h.redisTLSEnabled,
+	}
+}
+
+// probeReadyzTenantManager reports tenant-manager HTTP client readiness. The
+// tenant-manager client exposes no dedicated health signal, so the bootstrap
+// adapter runs a functional call and classifies its outcome into the tri-state
+// {up, degraded, down} — degraded specifically when the client's circuit
+// breaker is open. Tenant manager is multi-tenant-only: single-tenant reports
+// "skipped".
+func (h *HealthChecker) probeReadyzTenantManager(ctx context.Context) api.ReadyzCheck {
+	//nolint:dogsled // tracker tuple unused in readyz probes; only the tracer is required for child spans
+	_, tracer, _, _ := libObservability.NewTrackingFromContext(ctx)
+
+	ctx, span := tracer.Start(ctx, "readyz.probe.tenant_manager")
+	defer span.End()
+
+	start := time.Now().UTC()
+
+	if !h.multiTenantEnabled {
+		elapsed := time.Since(start)
+
+		h.emitReadyzMetrics(ctx, "tenant_manager", StatusSkipped, elapsed)
+
+		return api.ReadyzCheck{
+			Status:    StatusSkipped,
+			LatencyMs: elapsed.Milliseconds(),
+			Reason:    reasonMultiTenantDisabled,
+		}
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, probeTimeoutTenantManager)
+	defer cancel()
+
+	if h.tenantManagerProber == nil {
+		elapsed := time.Since(start)
+
+		libOtel.HandleSpanError(span, "tenant_manager readyz: prober not configured", ErrTenantManagerUnavailable)
+		h.emitReadyzMetrics(ctx, "tenant_manager", StatusDown, elapsed)
+
+		return api.ReadyzCheck{
+			Status:    StatusDown,
+			LatencyMs: elapsed.Milliseconds(),
+			Error:     ErrTenantManagerUnavailable.Error(),
+		}
+	}
+
+	status, probeErr := h.tenantManagerProber.Probe(ctx)
+	elapsed := time.Since(start)
+
+	switch status {
+	case StatusUp:
+		h.emitReadyzMetrics(ctx, "tenant_manager", StatusUp, elapsed)
+
+		return api.ReadyzCheck{Status: StatusUp, LatencyMs: elapsed.Milliseconds()}
+	case StatusDegraded:
+		libOtel.HandleSpanError(span, "tenant_manager readyz: degraded",
+			spanCause(probeErr, ErrTenantManagerUnavailable))
+		h.emitReadyzMetrics(ctx, "tenant_manager", StatusDegraded, elapsed)
+
+		return api.ReadyzCheck{
+			Status:    StatusDegraded,
+			LatencyMs: elapsed.Milliseconds(),
+			Reason:    reasonCircuitBreakerOpen,
+		}
+	default:
+		// Fail closed: StatusDown and any unexpected value collapse to "down".
+		libOtel.HandleSpanError(span, "tenant_manager readyz: down",
+			spanCause(probeErr, ErrTenantManagerUnavailable))
+		h.emitReadyzMetrics(ctx, "tenant_manager", StatusDown, elapsed)
+
+		return api.ReadyzCheck{
+			Status:    StatusDown,
+			LatencyMs: elapsed.Milliseconds(),
+			Error:     ErrTenantManagerUnavailable.Error(),
+		}
+	}
+}
+
+// probeReadyzStreaming reports streaming/RedPanda producer readiness via the
+// bootstrap adapter over lib-streaming's Emitter.Healthy tri-state. Independent
+// of multi-tenancy: gated by the STREAMING_ENABLED master flag, reporting
+// "skipped" when disabled (more honest than probing a NoopEmitter that always
+// reports healthy).
+func (h *HealthChecker) probeReadyzStreaming(ctx context.Context) api.ReadyzCheck {
+	//nolint:dogsled // tracker tuple unused in readyz probes; only the tracer is required for child spans
+	_, tracer, _, _ := libObservability.NewTrackingFromContext(ctx)
+
+	ctx, span := tracer.Start(ctx, "readyz.probe.streaming")
+	defer span.End()
+
+	start := time.Now().UTC()
+
+	if !h.streamingEnabled {
+		elapsed := time.Since(start)
+
+		h.emitReadyzMetrics(ctx, "streaming", StatusSkipped, elapsed)
+
+		return api.ReadyzCheck{
+			Status:    StatusSkipped,
+			LatencyMs: elapsed.Milliseconds(),
+			Reason:    reasonStreamingDisabled,
+		}
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, probeTimeoutStreaming)
+	defer cancel()
+
+	if h.streamingProber == nil {
+		elapsed := time.Since(start)
+
+		libOtel.HandleSpanError(span, "streaming readyz: prober not configured", ErrStreamingUnhealthy)
+		h.emitReadyzMetrics(ctx, "streaming", StatusDown, elapsed)
+
+		return api.ReadyzCheck{
+			Status:    StatusDown,
+			LatencyMs: elapsed.Milliseconds(),
+			Error:     ErrStreamingUnhealthy.Error(),
+		}
+	}
+
+	status, probeErr := h.streamingProber.Probe(ctx)
+	elapsed := time.Since(start)
+
+	switch status {
+	case StatusUp:
+		h.emitReadyzMetrics(ctx, "streaming", StatusUp, elapsed)
+
+		return api.ReadyzCheck{Status: StatusUp, LatencyMs: elapsed.Milliseconds()}
+	case StatusDegraded:
+		libOtel.HandleSpanError(span, "streaming readyz: degraded",
+			spanCause(probeErr, ErrStreamingUnhealthy))
+		h.emitReadyzMetrics(ctx, "streaming", StatusDegraded, elapsed)
+
+		return api.ReadyzCheck{
+			Status:    StatusDegraded,
+			LatencyMs: elapsed.Milliseconds(),
+			Reason:    reasonStreamingDegraded,
+		}
+	default:
+		// Fail closed: StatusDown and any unexpected value collapse to "down".
+		libOtel.HandleSpanError(span, "streaming readyz: down",
+			spanCause(probeErr, ErrStreamingUnhealthy))
+		h.emitReadyzMetrics(ctx, "streaming", StatusDown, elapsed)
+
+		return api.ReadyzCheck{
+			Status:    StatusDown,
+			LatencyMs: elapsed.Milliseconds(),
+			Error:     ErrStreamingUnhealthy.Error(),
+		}
+	}
+}
+
+// advisoryChecks are checks that appear in the response `checks` map (with
+// their real status and metrics) but do NOT contribute to the top-level
+// aggregate / HTTP status. Streaming is IMPORTANT-posture and non-blocking: a
+// broker hiccup must never pull the pod from rotation, so its up/down/degraded
+// status is informational only.
+var advisoryChecks = map[string]struct{}{
+	"streaming": {},
+}
+
+// aggregateStatus implements the canonical aggregation rule: top-level
+// "healthy" iff every GATING check is in {up, skipped, n/a}. Any "down" or
+// "degraded" gating check forces "unhealthy".
+//
+// Advisory checks (see advisoryChecks) are skipped entirely: they still appear
+// verbatim in the response `checks` map, but their status never influences the
+// aggregate or the HTTP code.
+//
+// Fails CLOSED on unknown probe states: a gating probe that returns a Status
+// outside the canonical 5-value vocabulary ("", "OK", "READY", a typo) is
+// treated as "unhealthy" and forces 503. Without this default, a buggy probe
+// that returned an empty string would silently aggregate to "healthy" —
+// fail-OPEN, which is the dangerous direction for a readiness signal.
 func aggregateStatus(checks map[string]api.ReadyzCheck) string {
-	for _, c := range checks {
+	for name, c := range checks {
+		if _, advisory := advisoryChecks[name]; advisory {
+			continue
+		}
+
 		switch c.Status {
 		case StatusUp, StatusSkipped, StatusNA:
 			// Healthy contribution — keep walking.

--- a/components/tracer/internal/adapters/http/in/readyz_test.go
+++ b/components/tracer/internal/adapters/http/in/readyz_test.go
@@ -80,8 +80,10 @@ func newReadyzCheckerWithDB(t *testing.T, version, deploymentMode string) (*Heal
 // healthy-shape contract: 200, top-level "healthy", every check has a status
 // from the closed vocabulary, and version + deployment_mode are echoed back.
 //
-// The single-tenant /readyz cycle returns exactly two checks: postgres +
-// rule_cache. tenant_manager/tenant_pubsub were stripped at Gate-strip.
+// The single-tenant /readyz cycle returns five checks: postgres + rule_cache
+// are live; redis + tenant_manager report "skipped" (multi-tenant-only) and
+// streaming reports "skipped" (STREAMING_ENABLED=false). tenant_pubsub is not
+// a probe. All in {up, skipped} ⇒ healthy.
 func TestReadyzHandler_AllUp_Returns200WithHealthyShape(t *testing.T) {
 	testutil.SetupTestTracing(t)
 
@@ -116,8 +118,9 @@ func TestReadyzHandler_AllUp_Returns200WithHealthyShape(t *testing.T) {
 	assert.Equal(t, "saas", response.DeploymentMode)
 	assert.False(t, response.Draining, "draining must be false (and omitted from JSON) in normal operation")
 
-	// Exactly two checks — postgres + rule_cache. No tenant_* checks.
-	assert.Len(t, response.Checks, 2, "single-tenant /readyz cycle returns exactly two checks")
+	// Five checks — postgres + rule_cache live, redis + tenant_manager +
+	// streaming skipped in single-tenant / streaming-off mode.
+	assert.Len(t, response.Checks, 5, "grown /readyz fan-out returns five checks")
 
 	// Postgres must be present and "up", with tls=true populated by the detector.
 	pg, ok := response.Checks["postgres"]
@@ -132,12 +135,26 @@ func TestReadyzHandler_AllUp_Returns200WithHealthyShape(t *testing.T) {
 	assert.Equal(t, StatusUp, rc.Status)
 	assert.Nil(t, rc.TLS, "rule_cache has no TLS concept — field must be omitted")
 
-	// tenant_manager + tenant_pubsub must NOT appear in the response.
-	_, hasTM := response.Checks["tenant_manager"]
-	assert.False(t, hasTM, "tenant_manager check must not appear in single-tenant /readyz response")
+	// redis + tenant_manager are multi-tenant-only ⇒ skipped in single-tenant.
+	redis, ok := response.Checks["redis"]
+	require.True(t, ok, "redis check missing")
+	assert.Equal(t, StatusSkipped, redis.Status)
+	assert.Equal(t, reasonMultiTenantDisabled, redis.Reason)
 
+	tm, ok := response.Checks["tenant_manager"]
+	require.True(t, ok, "tenant_manager check missing")
+	assert.Equal(t, StatusSkipped, tm.Status)
+	assert.Equal(t, reasonMultiTenantDisabled, tm.Reason)
+
+	// streaming disabled (STREAMING_ENABLED unset) ⇒ skipped.
+	stream, ok := response.Checks["streaming"]
+	require.True(t, ok, "streaming check missing")
+	assert.Equal(t, StatusSkipped, stream.Status)
+	assert.Equal(t, reasonStreamingDisabled, stream.Reason)
+
+	// tenant_pubsub is not a probe and must never appear.
 	_, hasPS := response.Checks["tenant_pubsub"]
-	assert.False(t, hasPS, "tenant_pubsub check must not appear in single-tenant /readyz response")
+	assert.False(t, hasPS, "tenant_pubsub is not a /readyz probe")
 }
 
 // stubPostgresTLSDetector returns a function-form detector that ignores its
@@ -264,8 +281,8 @@ func TestReadyzHandler_Draining_Returns503EvenIfAllDepsUp(t *testing.T) {
 	// Canonical-shape preservation: the per-dep checks map must be populated
 	// during drain, NOT empty. Operators rely on this to see snapshot health
 	// at drain time.
-	assert.Len(t, response.Checks, 2,
-		"drain must preserve canonical checks shape (postgres + rule_cache)")
+	assert.Len(t, response.Checks, 5,
+		"drain must preserve canonical checks shape (all five probes)")
 
 	pg, ok := response.Checks["postgres"]
 	require.True(t, ok, "postgres check must be present during drain")
@@ -781,6 +798,17 @@ func TestReadyzHandler_MultiTenant_SkipsRuleCacheProbe(t *testing.T) {
 	hc.SetCacheHealthProvider(&mockCacheHealth{ready: false})
 	hc.SetMultiTenantEnabled(true)
 
+	// Wire the multi-tenant-only probes as up so this test isolates the
+	// rule_cache gate — redis/tenant_manager health is exercised elsewhere.
+	ctrl := gomock.NewController(t)
+	redis := NewMockRedisPinger(ctrl)
+	redis.EXPECT().Ping(gomock.Any()).Return(nil).AnyTimes()
+	hc.SetRedisPinger(redis)
+
+	tm := NewMockTenantManagerProber(ctrl)
+	tm.EXPECT().Probe(gomock.Any()).Return(StatusUp, nil).AnyTimes()
+	hc.SetTenantManagerProber(tm)
+
 	app := createReadyzTestApp(hc)
 	req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
 
@@ -903,4 +931,475 @@ func TestHealthChecker_SetCacheStalenessThreshold_NonPositiveIgnored(t *testing.
 	hc.SetCacheStalenessThreshold(2 * time.Minute)
 	assert.Equal(t, 2*time.Minute, hc.CacheStalenessThreshold(),
 		"positive override must land")
+}
+
+// readyzTracerCtx returns a context carrying a no-op tracer so the probe child
+// spans have something to start against, matching production middleware order.
+func readyzTracerCtx() context.Context {
+	return libObservability.ContextWithTracer(context.Background(), otel.Tracer("tracer-readyz-probe-test"))
+}
+
+// TestReadyzProbe_Redis covers the redis probe across up / down / skipped /
+// not-wired, and the TLS-posture echo. Redis is multi-tenant-only: with MT off
+// the probe MUST report skipped and MUST NOT touch the pinger.
+func TestReadyzProbe_Redis(t *testing.T) {
+	testutil.SetupTestTracing(t)
+
+	t.Run("skipped_when_multitenant_off", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		pinger := NewMockRedisPinger(ctrl)
+		// No Ping expectation: the MT gate must short-circuit before the pinger.
+
+		hc := NewTestableHealthChecker(nil)
+		hc.SetRedisPinger(pinger)
+		// multiTenantEnabled defaults to false.
+
+		check := hc.probeReadyzRedis(readyzTracerCtx())
+
+		assert.Equal(t, StatusSkipped, check.Status)
+		assert.Equal(t, reasonMultiTenantDisabled, check.Reason)
+		assert.Empty(t, check.Error, "skipped probe must not surface an error")
+		assert.Nil(t, check.TLS, "skipped probe must not populate TLS")
+	})
+
+	t.Run("up_with_tls_true", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		pinger := NewMockRedisPinger(ctrl)
+		pinger.EXPECT().Ping(gomock.Any()).Return(nil)
+
+		hc := NewTestableHealthChecker(nil)
+		hc.SetMultiTenantEnabled(true)
+		hc.SetRedisPinger(pinger)
+		hc.SetRedisTLS(true)
+
+		check := hc.probeReadyzRedis(readyzTracerCtx())
+
+		assert.Equal(t, StatusUp, check.Status)
+		require.NotNil(t, check.TLS, "redis TLS posture must be echoed when configured")
+		assert.True(t, *check.TLS)
+		assert.GreaterOrEqual(t, check.LatencyMs, int64(0))
+	})
+
+	t.Run("down_on_ping_error", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		pinger := NewMockRedisPinger(ctrl)
+		pinger.EXPECT().Ping(gomock.Any()).Return(errors.New("dial tcp: connection refused"))
+
+		hc := NewTestableHealthChecker(nil)
+		hc.SetMultiTenantEnabled(true)
+		hc.SetRedisPinger(pinger)
+		hc.SetRedisTLS(false)
+
+		check := hc.probeReadyzRedis(readyzTracerCtx())
+
+		assert.Equal(t, StatusDown, check.Status)
+		assert.Equal(t, ErrRedisPingFailed.Error(), check.Error,
+			"down probe must surface the canonical sentinel code, not the raw client error")
+		assert.NotContains(t, check.Error, "connection refused", "raw client error must never leak")
+	})
+
+	t.Run("down_when_not_wired", func(t *testing.T) {
+		hc := NewTestableHealthChecker(nil)
+		hc.SetMultiTenantEnabled(true)
+		// Deliberately never call SetRedisPinger.
+
+		check := hc.probeReadyzRedis(readyzTracerCtx())
+
+		assert.Equal(t, StatusDown, check.Status)
+		assert.Equal(t, ErrRedisConnectionNotEstablished.Error(), check.Error)
+	})
+}
+
+// TestReadyzProbe_TenantManager covers the tenant_manager probe. Tenant manager
+// is multi-tenant-only, and its tri-state comes pre-classified from the
+// bootstrap adapter (up / degraded / down).
+func TestReadyzProbe_TenantManager(t *testing.T) {
+	testutil.SetupTestTracing(t)
+
+	t.Run("skipped_when_multitenant_off", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		prober := NewMockTenantManagerProber(ctrl)
+		// No Probe expectation — MT gate short-circuits.
+
+		hc := NewTestableHealthChecker(nil)
+		hc.SetTenantManagerProber(prober)
+
+		check := hc.probeReadyzTenantManager(readyzTracerCtx())
+
+		assert.Equal(t, StatusSkipped, check.Status)
+		assert.Equal(t, reasonMultiTenantDisabled, check.Reason)
+		assert.Empty(t, check.Error)
+	})
+
+	t.Run("up", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		prober := NewMockTenantManagerProber(ctrl)
+		prober.EXPECT().Probe(gomock.Any()).Return(StatusUp, nil)
+
+		hc := NewTestableHealthChecker(nil)
+		hc.SetMultiTenantEnabled(true)
+		hc.SetTenantManagerProber(prober)
+
+		check := hc.probeReadyzTenantManager(readyzTracerCtx())
+
+		assert.Equal(t, StatusUp, check.Status)
+		assert.Empty(t, check.Error)
+		assert.GreaterOrEqual(t, check.LatencyMs, int64(0))
+	})
+
+	t.Run("degraded_on_circuit_breaker_open", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		prober := NewMockTenantManagerProber(ctrl)
+		prober.EXPECT().Probe(gomock.Any()).Return(StatusDegraded, errors.New("circuit breaker open"))
+
+		hc := NewTestableHealthChecker(nil)
+		hc.SetMultiTenantEnabled(true)
+		hc.SetTenantManagerProber(prober)
+
+		check := hc.probeReadyzTenantManager(readyzTracerCtx())
+
+		assert.Equal(t, StatusDegraded, check.Status)
+		assert.Equal(t, reasonCircuitBreakerOpen, check.Reason)
+		assert.Empty(t, check.Error, "degraded surfaces Reason, not Error")
+	})
+
+	t.Run("down", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		prober := NewMockTenantManagerProber(ctrl)
+		prober.EXPECT().Probe(gomock.Any()).Return(StatusDown, errors.New("500 internal"))
+
+		hc := NewTestableHealthChecker(nil)
+		hc.SetMultiTenantEnabled(true)
+		hc.SetTenantManagerProber(prober)
+
+		check := hc.probeReadyzTenantManager(readyzTracerCtx())
+
+		assert.Equal(t, StatusDown, check.Status)
+		assert.Equal(t, ErrTenantManagerUnavailable.Error(), check.Error)
+		assert.NotContains(t, check.Error, "internal", "raw client error must never leak")
+	})
+
+	t.Run("down_when_not_wired", func(t *testing.T) {
+		hc := NewTestableHealthChecker(nil)
+		hc.SetMultiTenantEnabled(true)
+
+		check := hc.probeReadyzTenantManager(readyzTracerCtx())
+
+		assert.Equal(t, StatusDown, check.Status)
+		assert.Equal(t, ErrTenantManagerUnavailable.Error(), check.Error)
+	})
+}
+
+// TestReadyzProbe_Streaming covers the streaming probe. Streaming is
+// independent of multi-tenancy and gated by its own master flag.
+func TestReadyzProbe_Streaming(t *testing.T) {
+	testutil.SetupTestTracing(t)
+
+	t.Run("skipped_when_streaming_off", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		prober := NewMockStreamingHealthProber(ctrl)
+		// No Probe expectation — the disabled gate short-circuits.
+
+		hc := NewTestableHealthChecker(nil)
+		hc.SetStreamingProber(prober)
+		// streamingEnabled defaults to false.
+
+		check := hc.probeReadyzStreaming(readyzTracerCtx())
+
+		assert.Equal(t, StatusSkipped, check.Status)
+		assert.Equal(t, reasonStreamingDisabled, check.Reason)
+		assert.Empty(t, check.Error)
+	})
+
+	t.Run("up", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		prober := NewMockStreamingHealthProber(ctrl)
+		prober.EXPECT().Probe(gomock.Any()).Return(StatusUp, nil)
+
+		hc := NewTestableHealthChecker(nil)
+		hc.SetStreamingEnabled(true)
+		hc.SetStreamingProber(prober)
+
+		check := hc.probeReadyzStreaming(readyzTracerCtx())
+
+		assert.Equal(t, StatusUp, check.Status)
+		assert.Empty(t, check.Error)
+	})
+
+	t.Run("degraded", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		prober := NewMockStreamingHealthProber(ctrl)
+		prober.EXPECT().Probe(gomock.Any()).Return(StatusDegraded, errors.New("broker unreachable"))
+
+		hc := NewTestableHealthChecker(nil)
+		hc.SetStreamingEnabled(true)
+		hc.SetStreamingProber(prober)
+
+		check := hc.probeReadyzStreaming(readyzTracerCtx())
+
+		assert.Equal(t, StatusDegraded, check.Status)
+		assert.Equal(t, reasonStreamingDegraded, check.Reason)
+		assert.Empty(t, check.Error)
+	})
+
+	t.Run("down", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		prober := NewMockStreamingHealthProber(ctrl)
+		prober.EXPECT().Probe(gomock.Any()).Return(StatusDown, errors.New("broker down"))
+
+		hc := NewTestableHealthChecker(nil)
+		hc.SetStreamingEnabled(true)
+		hc.SetStreamingProber(prober)
+
+		check := hc.probeReadyzStreaming(readyzTracerCtx())
+
+		assert.Equal(t, StatusDown, check.Status)
+		assert.Equal(t, ErrStreamingUnhealthy.Error(), check.Error)
+		assert.NotContains(t, check.Error, "broker", "raw client error must never leak")
+	})
+
+	t.Run("down_when_not_wired", func(t *testing.T) {
+		hc := NewTestableHealthChecker(nil)
+		hc.SetStreamingEnabled(true)
+
+		check := hc.probeReadyzStreaming(readyzTracerCtx())
+
+		assert.Equal(t, StatusDown, check.Status)
+		assert.Equal(t, ErrStreamingUnhealthy.Error(), check.Error)
+	})
+}
+
+// wireFiveCheckHandler builds a HealthChecker with all five deps wired and up,
+// in multi-tenant + streaming-enabled mode. Returns the checker and a cleanup
+// the caller must defer.
+func wireFiveCheckHandler(t *testing.T, redisStatus error, tmStatus, streamStatus string) (*HealthChecker, func()) {
+	t.Helper()
+
+	ctrl := gomock.NewController(t)
+	db, mock, err := sqlmock.New(sqlmock.MonitorPingsOption(true))
+	require.NoError(t, err)
+
+	mock.ExpectPing()
+
+	provider := NewMockPostgresDBProvider(ctrl)
+	provider.EXPECT().IsConnected().Return(true).AnyTimes()
+	provider.EXPECT().GetDB(gomock.Any()).Return(db, nil).AnyTimes()
+
+	redis := NewMockRedisPinger(ctrl)
+	redis.EXPECT().Ping(gomock.Any()).Return(redisStatus).AnyTimes()
+
+	tm := NewMockTenantManagerProber(ctrl)
+	tm.EXPECT().Probe(gomock.Any()).Return(tmStatus, nil).AnyTimes()
+
+	stream := NewMockStreamingHealthProber(ctrl)
+	stream.EXPECT().Probe(gomock.Any()).Return(streamStatus, nil).AnyTimes()
+
+	hc := NewTestableHealthCheckerWithMeta(provider, "1.2.3", "saas")
+	hc.SetMultiTenantEnabled(true)
+	hc.SetCacheHealthProvider(&mockCacheHealth{ready: true, staleness: time.Second, size: 1})
+	hc.SetRedisPinger(redis)
+	hc.SetRedisTLS(true)
+	hc.SetTenantManagerProber(tm)
+	hc.SetStreamingEnabled(true)
+	hc.SetStreamingProber(stream)
+
+	cleanup := func() {
+		mock.ExpectClose()
+		require.NoError(t, db.Close())
+		require.NoError(t, mock.ExpectationsWereMet())
+	}
+
+	return hc, cleanup
+}
+
+// TestReadyzHandler_AllFiveChecks_PresentAndHealthy asserts the grown fan-out:
+// the checks map carries all five keys, and with every dep up (rule_cache is
+// n/a in MT mode) the aggregate is healthy / 200.
+func TestReadyzHandler_AllFiveChecks_PresentAndHealthy(t *testing.T) {
+	testutil.SetupTestTracing(t)
+
+	hc, cleanup := wireFiveCheckHandler(t, nil, StatusUp, StatusUp)
+	defer cleanup()
+
+	app := createReadyzTestApp(hc)
+	req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+
+	resp, err := app.Test(req, -1)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	var response api.ReadyzResponse
+	require.NoError(t, json.Unmarshal(body, &response))
+
+	assert.Equal(t, StatusHealthy, response.Status)
+	assert.Len(t, response.Checks, 5, "grown fan-out must return exactly five checks")
+
+	for _, key := range []string{"postgres", "rule_cache", "redis", "tenant_manager", "streaming"} {
+		_, ok := response.Checks[key]
+		assert.Truef(t, ok, "checks map must contain %q", key)
+	}
+
+	assert.Equal(t, StatusUp, response.Checks["redis"].Status)
+	assert.Equal(t, StatusUp, response.Checks["tenant_manager"].Status)
+	assert.Equal(t, StatusUp, response.Checks["streaming"].Status)
+	assert.Equal(t, StatusNA, response.Checks["rule_cache"].Status, "rule_cache is n/a in MT mode")
+}
+
+// TestReadyzHandler_NewDepDown_Returns503 asserts a down on any of the GATING
+// multi-tenant deps (redis, tenant_manager) flips the aggregate to unhealthy /
+// 503. Streaming is advisory and is covered by the advisory tests above — it is
+// intentionally absent here.
+func TestReadyzHandler_NewDepDown_Returns503(t *testing.T) {
+	testutil.SetupTestTracing(t)
+
+	tests := []struct {
+		name        string
+		redisErr    error
+		tmStatus    string
+		streamState string
+		wantDownKey string
+	}{
+		{name: "redis_down", redisErr: errors.New("refused"), tmStatus: StatusUp, streamState: StatusUp, wantDownKey: "redis"},
+		{name: "tenant_manager_down", redisErr: nil, tmStatus: StatusDown, streamState: StatusUp, wantDownKey: "tenant_manager"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hc, cleanup := wireFiveCheckHandler(t, tt.redisErr, tt.tmStatus, tt.streamState)
+			defer cleanup()
+
+			app := createReadyzTestApp(hc)
+			req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+
+			resp, err := app.Test(req, -1)
+			require.NoError(t, err)
+			defer resp.Body.Close()
+
+			assert.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
+
+			body, err := io.ReadAll(resp.Body)
+			require.NoError(t, err)
+
+			var response api.ReadyzResponse
+			require.NoError(t, json.Unmarshal(body, &response))
+
+			assert.Equal(t, StatusUnhealthy, response.Status)
+			assert.Len(t, response.Checks, 5)
+			assert.Contains(t, []string{StatusDown, StatusDegraded}, response.Checks[tt.wantDownKey].Status)
+		})
+	}
+}
+
+// TestReadyzHandler_StreamingAdvisory_DownDoesNotGate asserts the A-decision:
+// streaming is advisory. With every gating dep up/skipped and streaming DOWN,
+// /readyz must still return 200 + healthy, while the streaming check still
+// appears verbatim in the checks map with its real "down" status. A broker
+// hiccup must never pull the pod from rotation.
+func TestReadyzHandler_StreamingAdvisory_DownDoesNotGate(t *testing.T) {
+	testutil.SetupTestTracing(t)
+
+	hc, cleanup := wireFiveCheckHandler(t, nil, StatusUp, StatusDown)
+	defer cleanup()
+
+	app := createReadyzTestApp(hc)
+	req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+
+	resp, err := app.Test(req, -1)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode,
+		"advisory streaming=down must NOT force 503")
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	var response api.ReadyzResponse
+	require.NoError(t, json.Unmarshal(body, &response))
+
+	assert.Equal(t, StatusHealthy, response.Status,
+		"advisory streaming=down must NOT flip the top-level status")
+	assert.Equal(t, StatusDown, response.Checks["streaming"].Status,
+		"streaming check must still appear verbatim with its real status")
+}
+
+// TestReadyzHandler_StreamingAdvisory_DegradedDoesNotGate is the symmetric
+// advisory case for a degraded streaming producer.
+func TestReadyzHandler_StreamingAdvisory_DegradedDoesNotGate(t *testing.T) {
+	testutil.SetupTestTracing(t)
+
+	hc, cleanup := wireFiveCheckHandler(t, nil, StatusUp, StatusDegraded)
+	defer cleanup()
+
+	app := createReadyzTestApp(hc)
+	req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+
+	resp, err := app.Test(req, -1)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode,
+		"advisory streaming=degraded must NOT force 503")
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	var response api.ReadyzResponse
+	require.NoError(t, json.Unmarshal(body, &response))
+
+	assert.Equal(t, StatusHealthy, response.Status)
+	assert.Equal(t, StatusDegraded, response.Checks["streaming"].Status)
+}
+
+// TestReadyzHandler_PostgresDown_StillGatesWithAdvisoryStreaming guards against
+// over-skipping: a real gating dep (postgres) down must still force 503 even
+// while streaming (advisory) is up. Confirms the advisory-skip is scoped only
+// to the advisoryChecks set.
+func TestReadyzHandler_PostgresDown_StillGatesWithAdvisoryStreaming(t *testing.T) {
+	testutil.SetupTestTracing(t)
+
+	ctrl := gomock.NewController(t)
+
+	provider := NewMockPostgresDBProvider(ctrl)
+	provider.EXPECT().IsConnected().Return(false).AnyTimes()
+
+	redis := NewMockRedisPinger(ctrl)
+	redis.EXPECT().Ping(gomock.Any()).Return(nil).AnyTimes()
+
+	tm := NewMockTenantManagerProber(ctrl)
+	tm.EXPECT().Probe(gomock.Any()).Return(StatusUp, nil).AnyTimes()
+
+	stream := NewMockStreamingHealthProber(ctrl)
+	stream.EXPECT().Probe(gomock.Any()).Return(StatusUp, nil).AnyTimes()
+
+	hc := NewTestableHealthCheckerWithMeta(provider, "1.2.3", "saas")
+	hc.SetMultiTenantEnabled(true)
+	hc.SetCacheHealthProvider(&mockCacheHealth{ready: true, staleness: time.Second, size: 1})
+	hc.SetRedisPinger(redis)
+	hc.SetTenantManagerProber(tm)
+	hc.SetStreamingEnabled(true)
+	hc.SetStreamingProber(stream)
+
+	app := createReadyzTestApp(hc)
+	req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+
+	resp, err := app.Test(req, -1)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusServiceUnavailable, resp.StatusCode,
+		"a real gating dep (postgres) down must still force 503 — advisory-skip must not over-skip")
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	var response api.ReadyzResponse
+	require.NoError(t, json.Unmarshal(body, &response))
+	assert.Equal(t, StatusUnhealthy, response.Status)
+	assert.Equal(t, StatusDown, response.Checks["postgres"].Status)
 }

--- a/components/tracer/internal/bootstrap/config.go
+++ b/components/tracer/internal/bootstrap/config.go
@@ -765,7 +765,8 @@ func ValidateAuthConfig(ctx context.Context, cfg *Config, logger libLog.Logger) 
 		return fmt.Errorf(
 			"API_KEY_ENABLED=true is incompatible with CORS_ALLOWED_ORIGINS=\"*\": " +
 				"any malicious website can invoke authenticated API calls once the key leaks. " +
-				"Restrict CORS_ALLOWED_ORIGINS to a concrete allow-list (e.g. https://app.example.com)")
+				"Restrict CORS_ALLOWED_ORIGINS to a concrete allow-list (e.g. https://app.example.com)",
+		)
 	}
 
 	return nil
@@ -819,7 +820,8 @@ func buildPostgresDSN(cfg *Config) string {
 		sslMode = "disable" // Default for local development; use "require" in production
 	}
 
-	return fmt.Sprintf("host=%s user=%s password=%s dbname=%s port=%s sslmode=%s",
+	return fmt.Sprintf(
+		"host=%s user=%s password=%s dbname=%s port=%s sslmode=%s",
 		quoteLibpqValue(cfg.DBHost),
 		quoteLibpqValue(cfg.DBUser),
 		quoteLibpqValue(cfg.DBPassword),
@@ -1443,7 +1445,8 @@ func initMultiTenant(
 	// (per-tenant sync + cleanup) that run on their own goroutine schedules
 	// and own their own ctx lifetime; threading boot ctx in is conceptually
 	// wrong (the workers must outlive boot).
-	components, err := buildComponentsMT(cfg, logger,
+	components, err := buildComponentsMT(
+		cfg, logger,
 		wiringDepsMT{
 			SyncRepo:             ruleSyncRepo,
 			UsageRepo:            limitDeps.usageCounterRepo,
@@ -1831,12 +1834,14 @@ func InitServers(ctx context.Context) (*Service, error) {
 		}
 	}()
 
-	// Init health checker for readiness probe. The /readyz cycle is single-
-	// tenant only — the cache probe always runs the global staleness/ready
-	// check. In multi-tenant deployments per-tenant cache health is surfaced
-	// via the tenant_consumers_active metric, NOT /readyz. version +
-	// deploymentMode are echoed in /readyz responses; deploymentMode defaults
-	// to "local" when unset (used for SaaS TLS enforcement).
+	// Init health checker for readiness probe. The /readyz cycle probes five
+	// deps: postgres + rule_cache always; redis + tenant_manager are gated to
+	// multi-tenant mode; streaming is advisory (STREAMING_ENABLED-gated, never
+	// forces 503). The rule_cache probe reports "n/a" in multi-tenant mode —
+	// per-tenant cache health is surfaced via the tenant_consumers_active
+	// metric there, NOT /readyz. version + deploymentMode are echoed in /readyz
+	// responses; deploymentMode defaults to "local" when unset (used for SaaS
+	// TLS enforcement).
 	healthChecker := buildHealthChecker(cfg, postgresConn)
 
 	// Build the OTel-backed metrics recorder for /readyz + selfprobe and wire
@@ -1850,6 +1855,12 @@ func InitServers(ctx context.Context) (*Service, error) {
 	// only metric emission is silenced.
 	readyzRecorder := buildReadyzRecorder(ctx, logger)
 	healthChecker.SetReadyzRecorder(readyzRecorder)
+
+	// Wire the streaming /readyz probe. The emitter is always non-nil (a
+	// NoopEmitter when streaming is disabled); the probe reports "skipped"
+	// when StreamingEnabled is false rather than probing the Noop.
+	healthChecker.SetStreamingEnabled(cfg.StreamingEnabled)
+	healthChecker.SetStreamingProber(newStreamingHealthProber(streamingEmitter))
 
 	// Build the single pgdb.Connection adapter and toggle strict MT mode ONCE.
 	// every repository now shares this adapter, so tenant resolution lives in
@@ -1918,6 +1929,16 @@ func InitServers(ctx context.Context) (*Service, error) {
 	mtComponents, mtMetrics, err := buildMultiTenantStack(ctx, cfg, logger, telemetry, ruleCache, ruleSyncRepo, limitDeps, celAdapter, clk)
 	if err != nil {
 		return nil, err
+	}
+
+	// Wire the multi-tenant-only /readyz probes. mtComponents is nil in
+	// single-tenant mode, in which case the probes report "skipped" via their
+	// multiTenantEnabled gate. The Redis TLS posture is read from config, never
+	// reflected off the live connection.
+	if mtComponents != nil {
+		healthChecker.SetRedisPinger(newRedisPinger(mtComponents.redisClient))
+		healthChecker.SetRedisTLS(cfg.MultiTenantRedisTLS)
+		healthChecker.SetTenantManagerProber(newTenantManagerHealthProber(mtComponents.tmClient, cfg.ApplicationName))
 	}
 
 	// Init HTTP server with all services. mtComponents is nil in single-tenant

--- a/components/tracer/internal/bootstrap/config_multitenant_wiring.go
+++ b/components/tracer/internal/bootstrap/config_multitenant_wiring.go
@@ -15,6 +15,7 @@ import (
 	tmpostgres "github.com/LerianStudio/lib-commons/v5/commons/tenant-manager/postgres"
 	tmredis "github.com/LerianStudio/lib-commons/v5/commons/tenant-manager/redis"
 	libLog "github.com/LerianStudio/lib-observability/log"
+	"github.com/redis/go-redis/v9"
 
 	"github.com/LerianStudio/midaz/v4/components/tracer/internal/adapters/cel"
 	"github.com/LerianStudio/midaz/v4/components/tracer/internal/services/workers"
@@ -25,11 +26,13 @@ import (
 // them into Service and to write unit tests for the wiring helper without
 // standing up a real PostgreSQL pool.
 //
-// The /readyz cycle is single-tenant only — the redisClient and tmBaseURL
-// fields used to surface the Tenant Manager + Pub/Sub readyz adapters were
-// removed when the cycle scope was reduced to postgres + rule_cache.
+// redisClient is retained (not just handed to the tenant event listener) so
+// the /readyz redis probe can PING it directly. tmClient is likewise the
+// signal source for the /readyz tenant_manager probe. Both are wired into the
+// HealthChecker in the multi-tenant bootstrap path.
 type componentsMT struct {
 	tmClient      *tmclient.Client
+	redisClient   redis.UniversalClient
 	pgManager     *tmpostgres.Manager
 	supervisor    *workers.WorkerSupervisor
 	eventListener *tenantListenerApp
@@ -257,6 +260,7 @@ func buildComponentsMT(
 
 	return &componentsMT{
 		tmClient:      tmClient,
+		redisClient:   redisClient,
 		pgManager:     pgManager,
 		supervisor:    supervisor,
 		eventListener: listenerApp,
@@ -337,7 +341,8 @@ func buildTMClientOptions(cfg *Config, logger libLog.Logger) ([]tmclient.ClientO
 			return nil, fmt.Errorf(
 				"multi-tenant config: MULTI_TENANT_URL uses http:// but MULTI_TENANT_ALLOW_INSECURE_HTTP is false. " +
 					"Set MULTI_TENANT_ALLOW_INSECURE_HTTP=true to explicitly opt in (NOT for production — " +
-					"credentials travel in cleartext)")
+					"credentials travel in cleartext)",
+			)
 		}
 
 		logger.With(

--- a/components/tracer/internal/bootstrap/readyz_probers.go
+++ b/components/tracer/internal/bootstrap/readyz_probers.go
@@ -1,0 +1,221 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package bootstrap
+
+import (
+	"context"
+	"errors"
+	"strconv"
+	"strings"
+
+	tmclient "github.com/LerianStudio/lib-commons/v5/commons/tenant-manager/client"
+	tmcore "github.com/LerianStudio/lib-commons/v5/commons/tenant-manager/core"
+	libStreaming "github.com/LerianStudio/lib-streaming"
+	"github.com/redis/go-redis/v9"
+
+	"github.com/LerianStudio/midaz/v4/components/tracer/internal/adapters/http/in"
+)
+
+// These generic sentinels are recorded on the probe spans (never on the wire —
+// the /readyz handler surfaces canonical numeric codes). They carry no client
+// detail so nothing sensitive leaks even into telemetry.
+var (
+	errTenantManagerNotWired = errors.New("tenant manager client not wired")
+	errTenantManagerProbe    = errors.New("tenant manager probe failed")
+	errStreamingNotWired     = errors.New("streaming emitter not wired")
+	errStreamingProbe        = errors.New("streaming probe failed")
+)
+
+// redisPingerAdapter adapts the raw go-redis UniversalClient to in.RedisPinger.
+// Kept in the bootstrap package so the http/in package stays free of the
+// go-redis import — the interface is the only coupling point.
+type redisPingerAdapter struct {
+	client redis.UniversalClient
+}
+
+// newRedisPinger wraps the multi-tenant Pub/Sub client for the redis /readyz
+// probe. Returns a nil in.RedisPinger when the client is nil so the probe's
+// nil-guard reports "connection not established" rather than dereferencing.
+func newRedisPinger(client redis.UniversalClient) in.RedisPinger {
+	if client == nil {
+		return nil
+	}
+
+	return &redisPingerAdapter{client: client}
+}
+
+// Ping issues a single go-redis PING and returns its error verbatim; the probe
+// maps a non-nil error to the canonical sentinel, so no raw client text reaches
+// the wire.
+func (a *redisPingerAdapter) Ping(ctx context.Context) error {
+	if a == nil || a.client == nil {
+		return in.ErrRedisConnectionNotEstablished
+	}
+
+	return a.client.Ping(ctx).Err()
+}
+
+// activeTenantsGetter is the minimal slice of *tmclient.Client the readiness
+// probe depends on. Narrowing to this interface (rather than the concrete
+// client) lets the classification logic be unit-tested with a fake — the real
+// *tmclient.Client satisfies it.
+type activeTenantsGetter interface {
+	GetActiveTenantsByService(ctx context.Context, service string) ([]*tmclient.TenantSummary, error)
+}
+
+// tenantManagerHealthProber adapts the tenant-manager HTTP client to
+// in.TenantManagerProber. The client has no dedicated health signal, so the
+// probe uses GetActiveTenantsByService as a functional check and classifies its
+// error against the tenant-manager circuit-breaker sentinel here — keeping the
+// tenant-manager import out of the http/in package.
+type tenantManagerHealthProber struct {
+	client  activeTenantsGetter
+	service string
+}
+
+// newTenantManagerHealthProber wires the tenant-manager readiness prober.
+// Returns a nil in.TenantManagerProber when the client is nil so the probe
+// reports "down" via its nil-guard.
+func newTenantManagerHealthProber(client *tmclient.Client, service string) in.TenantManagerProber {
+	if client == nil {
+		return nil
+	}
+
+	return &tenantManagerHealthProber{client: client, service: service}
+}
+
+// tmStatusMessagePrefix is the fixed leader of the tenant-manager client's
+// non-2xx error message. lib-commons v5.10.0
+// GetActiveTenantsByService returns a plain
+// fmt.Errorf("tenant manager returned status %d for service %s", ...) for every
+// non-2xx round-trip — there is no typed error, exported sentinel, or status
+// accessor to key off (the exported core.Err* sentinels are only wrapped by
+// GetTenantConfig, not this call). Distinguishing a reachable 4xx from a 5xx
+// therefore requires reading the status code out of that message. This couples
+// the probe to the client's message shape; if lib-commons ever exposes a typed
+// status error, switch to it and delete this.
+const tmStatusMessagePrefix = "tenant manager returned status "
+
+// Probe classifies the tenant-manager readiness into the closed /readyz
+// vocabulary:
+//
+//   - nil error                        => up
+//   - core.ErrCircuitBreakerOpen       => degraded (client is serving fail-fast)
+//   - reachable 4xx (client answered)  => up   (the service IS up; only its
+//     answer is a client error — e.g. a rotated service key or unknown service)
+//   - 5xx / transport / read failure   => down
+//
+// Tenant Manager stays a HARD /readyz gate, so only a genuinely unreachable or
+// server-erroring dependency flips it down.
+//
+// ACCEPTED COUPLING: this functional probe drives the SAME production circuit
+// breaker as live tenant resolution (GetActiveTenantsByService internally calls
+// recordSuccess/recordFailure), because the tenant-manager client exposes no
+// read-only health surface. A reachable 4xx resets the failure counter
+// (recordSuccess) client-side, consistent with classifying it as "up" here.
+//
+// The returned error is generic (never the raw client error) so span
+// attribution stays free of internal detail.
+func (p *tenantManagerHealthProber) Probe(ctx context.Context) (string, error) {
+	if p == nil || p.client == nil {
+		return in.StatusDown, errTenantManagerNotWired
+	}
+
+	_, err := p.client.GetActiveTenantsByService(ctx, p.service)
+
+	switch {
+	case err == nil:
+		return in.StatusUp, nil
+	case errors.Is(err, tmcore.ErrCircuitBreakerOpen):
+		return in.StatusDegraded, tmcore.ErrCircuitBreakerOpen
+	default:
+		if code, ok := tmHTTPStatusFromError(err); ok && code >= 400 && code < 500 {
+			return in.StatusUp, nil
+		}
+
+		return in.StatusDown, errTenantManagerProbe
+	}
+}
+
+// tmHTTPStatusFromError extracts the HTTP status code the tenant-manager client
+// reported on a non-2xx round-trip. It matches only on the exact message prefix
+// (see tmStatusMessagePrefix) so transport / read / parse failures — which use
+// different message shapes — never match and correctly fall through to "down".
+// Returns (code, true) only when a numeric code follows the prefix.
+func tmHTTPStatusFromError(err error) (int, bool) {
+	if err == nil {
+		return 0, false
+	}
+
+	idx := strings.Index(err.Error(), tmStatusMessagePrefix)
+	if idx < 0 {
+		return 0, false
+	}
+
+	fields := strings.Fields(err.Error()[idx+len(tmStatusMessagePrefix):])
+	if len(fields) == 0 {
+		return 0, false
+	}
+
+	code, convErr := strconv.Atoi(fields[0])
+	if convErr != nil {
+		return 0, false
+	}
+
+	return code, true
+}
+
+// streamingHealthProber adapts a lib-streaming Emitter to in.StreamingHealthProber.
+// Emitter.Healthy returns a tri-state HealthError; decoding its .State() needs
+// the concrete lib-streaming type, so the classification lives here and the
+// http/in package sees only the resolved status.
+type streamingHealthProber struct {
+	emitter libStreaming.Emitter
+}
+
+// newStreamingHealthProber wires the streaming readiness prober. The emitter is
+// always non-nil in bootstrap (a NoopEmitter when streaming is disabled), but
+// the nil-guard keeps the adapter safe if that ever changes.
+func newStreamingHealthProber(emitter libStreaming.Emitter) in.StreamingHealthProber {
+	if emitter == nil {
+		return nil
+	}
+
+	return &streamingHealthProber{emitter: emitter}
+}
+
+// Probe classifies the streaming producer readiness into the closed /readyz
+// vocabulary. lib-streaming's HealthState maps directly: Healthy=>up,
+// Degraded=>degraded, Down=>down; a non-HealthError failure fails closed to
+// down. The returned error is lib-streaming's HealthError, whose message is
+// already broker-URL-sanitized, so it is safe for span attribution.
+func (p *streamingHealthProber) Probe(ctx context.Context) (string, error) {
+	if p == nil || p.emitter == nil {
+		return in.StatusDown, errStreamingNotWired
+	}
+
+	err := p.emitter.Healthy(ctx)
+	if err == nil {
+		return in.StatusUp, nil
+	}
+
+	var he *libStreaming.HealthError
+	if errors.As(err, &he) {
+		switch he.State() {
+		case libStreaming.Healthy:
+			return in.StatusUp, nil
+		case libStreaming.Degraded:
+			return in.StatusDegraded, err
+		case libStreaming.Down:
+			return in.StatusDown, err
+		}
+	}
+
+	// Unclassifiable failure (not a *HealthError) — fail closed to down and
+	// return the generic sentinel so no raw broker/topology detail reaches the
+	// probe span. Mirrors the tenant_manager prober; the confirmed HealthError
+	// branches above are already broker-URL-sanitized and safe to surface.
+	return in.StatusDown, errStreamingProbe
+}

--- a/components/tracer/internal/bootstrap/readyz_probers.go
+++ b/components/tracer/internal/bootstrap/readyz_probers.go
@@ -54,6 +54,10 @@ func (a *redisPingerAdapter) Ping(ctx context.Context) error {
 		return in.ErrRedisConnectionNotEstablished
 	}
 
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
 	return a.client.Ping(ctx).Err()
 }
 
@@ -121,6 +125,10 @@ const tmStatusMessagePrefix = "tenant manager returned status "
 func (p *tenantManagerHealthProber) Probe(ctx context.Context) (string, error) {
 	if p == nil || p.client == nil {
 		return in.StatusDown, errTenantManagerNotWired
+	}
+
+	if ctx.Err() != nil {
+		return in.StatusDown, errTenantManagerProbe
 	}
 
 	_, err := p.client.GetActiveTenantsByService(ctx, p.service)
@@ -194,6 +202,10 @@ func newStreamingHealthProber(emitter libStreaming.Emitter) in.StreamingHealthPr
 func (p *streamingHealthProber) Probe(ctx context.Context) (string, error) {
 	if p == nil || p.emitter == nil {
 		return in.StatusDown, errStreamingNotWired
+	}
+
+	if ctx.Err() != nil {
+		return in.StatusDown, errStreamingProbe
 	}
 
 	err := p.emitter.Healthy(ctx)

--- a/components/tracer/internal/bootstrap/readyz_probers_test.go
+++ b/components/tracer/internal/bootstrap/readyz_probers_test.go
@@ -1,0 +1,239 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package bootstrap
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	tmclient "github.com/LerianStudio/lib-commons/v5/commons/tenant-manager/client"
+	tmcore "github.com/LerianStudio/lib-commons/v5/commons/tenant-manager/core"
+	libStreaming "github.com/LerianStudio/lib-streaming"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/LerianStudio/midaz/v4/components/tracer/internal/adapters/http/in"
+)
+
+// fakeActiveTenantsGetter drives the tenant-manager probe classification with a
+// controllable error, standing in for the real *tmclient.Client.
+type fakeActiveTenantsGetter struct {
+	err error
+}
+
+func (f fakeActiveTenantsGetter) GetActiveTenantsByService(_ context.Context, _ string) ([]*tmclient.TenantSummary, error) {
+	return nil, f.err
+}
+
+// fakeEmitter drives the streaming probe classification with a controllable
+// Healthy() error.
+type fakeEmitter struct {
+	healthyErr error
+}
+
+func (f fakeEmitter) Emit(_ context.Context, _ libStreaming.EmitRequest) error { return nil }
+func (f fakeEmitter) Close() error                                             { return nil }
+func (f fakeEmitter) Healthy(_ context.Context) error                          { return f.healthyErr }
+
+func TestRedisPingerAdapter(t *testing.T) {
+	t.Parallel()
+
+	assert.Nil(t, newRedisPinger(nil), "nil client must yield a nil in.RedisPinger so the probe reports not-established")
+
+	var adapter *redisPingerAdapter
+
+	assert.ErrorIs(t, adapter.Ping(context.Background()), in.ErrRedisConnectionNotEstablished,
+		"nil adapter must report connection-not-established, not panic")
+
+	assert.ErrorIs(t, (&redisPingerAdapter{}).Ping(context.Background()), in.ErrRedisConnectionNotEstablished,
+		"nil underlying client must report connection-not-established")
+}
+
+func TestTenantManagerHealthProber_Probe(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		err        error
+		wantStatus string
+	}{
+		{name: "up_on_success", err: nil, wantStatus: in.StatusUp},
+		{name: "degraded_on_circuit_breaker_open", err: tmcore.ErrCircuitBreakerOpen, wantStatus: in.StatusDegraded},
+		{
+			name:       "degraded_on_wrapped_circuit_breaker_open",
+			err:        fmt.Errorf("get active tenants: %w", tmcore.ErrCircuitBreakerOpen),
+			wantStatus: in.StatusDegraded,
+		},
+		{name: "down_on_other_error", err: errors.New("500 internal server error at https://tm.internal/x"), wantStatus: in.StatusDown},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			prober := &tenantManagerHealthProber{client: fakeActiveTenantsGetter{err: tt.err}, service: "tracer"}
+
+			status, probeErr := prober.Probe(context.Background())
+			assert.Equal(t, tt.wantStatus, status)
+
+			if tt.wantStatus == in.StatusDown {
+				assert.ErrorIs(t, probeErr, errTenantManagerProbe,
+					"down must return the generic sentinel, never the raw client error")
+				assert.NotContains(t, probeErr.Error(), "tm.internal", "raw client detail must not leak even to the span")
+			}
+		})
+	}
+}
+
+// TestTenantManagerHealthProber_ClassifiesByStatusClass asserts the B-decision:
+// a reachable 4xx round-trip means the tenant-manager service IS up (only its
+// answer is a client error), while 5xx / transport / read failures are "down".
+// CB-open stays "degraded" and nil stays "up".
+func TestTenantManagerHealthProber_ClassifiesByStatusClass(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		err        error
+		wantStatus string
+	}{
+		{name: "nil_is_up", err: nil, wantStatus: in.StatusUp},
+		{name: "circuit_breaker_open_is_degraded", err: tmcore.ErrCircuitBreakerOpen, wantStatus: in.StatusDegraded},
+		{
+			name:       "reachable_400_is_up",
+			err:        fmt.Errorf("tenant manager returned status 400 for service tracer"),
+			wantStatus: in.StatusUp,
+		},
+		{
+			name:       "reachable_403_is_up",
+			err:        fmt.Errorf("tenant manager returned status 403 for service tracer"),
+			wantStatus: in.StatusUp,
+		},
+		{
+			name:       "reachable_404_is_up",
+			err:        fmt.Errorf("tenant manager returned status 404 for service tracer"),
+			wantStatus: in.StatusUp,
+		},
+		{
+			name:       "server_500_is_down",
+			err:        fmt.Errorf("tenant manager returned status 500 for service tracer"),
+			wantStatus: in.StatusDown,
+		},
+		{
+			name:       "server_503_is_down",
+			err:        fmt.Errorf("tenant manager returned status 503 for service tracer"),
+			wantStatus: in.StatusDown,
+		},
+		{
+			name:       "transport_failure_is_down",
+			err:        fmt.Errorf("failed to execute request: %w", context.DeadlineExceeded),
+			wantStatus: in.StatusDown,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			prober := &tenantManagerHealthProber{client: fakeActiveTenantsGetter{err: tt.err}, service: "tracer"}
+
+			status, probeErr := prober.Probe(context.Background())
+			assert.Equal(t, tt.wantStatus, status)
+
+			switch tt.wantStatus {
+			case in.StatusUp:
+				assert.NoError(t, probeErr, "up must carry no error")
+			case in.StatusDown:
+				assert.ErrorIs(t, probeErr, errTenantManagerProbe,
+					"down must return the generic sentinel, never the raw client error")
+			}
+		})
+	}
+}
+
+func TestTenantManagerHealthProber_NotWired(t *testing.T) {
+	t.Parallel()
+
+	assert.Nil(t, newTenantManagerHealthProber(nil, "tracer"),
+		"nil client must yield a nil in.TenantManagerProber so the probe reports down")
+
+	prober := &tenantManagerHealthProber{client: nil, service: "tracer"}
+
+	status, probeErr := prober.Probe(context.Background())
+	assert.Equal(t, in.StatusDown, status)
+	assert.ErrorIs(t, probeErr, errTenantManagerNotWired)
+}
+
+func TestStreamingHealthProber_Probe(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		healthyErr error
+		wantStatus string
+	}{
+		{name: "up_on_nil", healthyErr: nil, wantStatus: in.StatusUp},
+		{
+			name:       "up_on_healthy_state_error",
+			healthyErr: libStreaming.NewHealthError(libStreaming.Healthy, nil),
+			wantStatus: in.StatusUp,
+		},
+		{
+			name:       "degraded_on_degraded_state",
+			healthyErr: libStreaming.NewHealthError(libStreaming.Degraded, errors.New("broker slow")),
+			wantStatus: in.StatusDegraded,
+		},
+		{
+			name:       "down_on_down_state",
+			healthyErr: libStreaming.NewHealthError(libStreaming.Down, errors.New("broker unreachable")),
+			wantStatus: in.StatusDown,
+		},
+		{name: "down_on_non_health_error", healthyErr: errors.New("unexpected"), wantStatus: in.StatusDown},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			prober := &streamingHealthProber{emitter: fakeEmitter{healthyErr: tt.healthyErr}}
+
+			status, _ := prober.Probe(context.Background())
+			assert.Equal(t, tt.wantStatus, status)
+		})
+	}
+}
+
+// TestStreamingHealthProber_NonHealthErrorIsSanitized asserts that the
+// unclassifiable-failure fallback (a non-*HealthError from Emitter.Healthy)
+// does NOT surface the raw error onto the probe span — only a generic sentinel
+// leaves the boundary, mirroring the tenant_manager prober.
+func TestStreamingHealthProber_NonHealthErrorIsSanitized(t *testing.T) {
+	t.Parallel()
+
+	raw := errors.New("broker topology kafka-internal-9092 unreachable")
+	prober := &streamingHealthProber{emitter: fakeEmitter{healthyErr: raw}}
+
+	status, probeErr := prober.Probe(context.Background())
+
+	assert.Equal(t, in.StatusDown, status)
+	assert.ErrorIs(t, probeErr, errStreamingProbe,
+		"non-HealthError fallback must return the generic sentinel, not the raw error")
+	assert.NotContains(t, probeErr.Error(), "kafka-internal-9092",
+		"raw broker/topology detail must never reach the probe span")
+}
+
+func TestStreamingHealthProber_NotWired(t *testing.T) {
+	t.Parallel()
+
+	assert.Nil(t, newStreamingHealthProber(nil),
+		"nil emitter must yield a nil in.StreamingHealthProber so the probe reports down")
+
+	prober := &streamingHealthProber{emitter: nil}
+
+	status, probeErr := prober.Probe(context.Background())
+	assert.Equal(t, in.StatusDown, status)
+	assert.ErrorIs(t, probeErr, errStreamingNotWired)
+}

--- a/components/tracer/internal/bootstrap/readyz_probers_test.go
+++ b/components/tracer/internal/bootstrap/readyz_probers_test.go
@@ -13,6 +13,7 @@ import (
 	tmclient "github.com/LerianStudio/lib-commons/v5/commons/tenant-manager/client"
 	tmcore "github.com/LerianStudio/lib-commons/v5/commons/tenant-manager/core"
 	libStreaming "github.com/LerianStudio/lib-streaming"
+	"github.com/redis/go-redis/v9"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/LerianStudio/midaz/v4/components/tracer/internal/adapters/http/in"
@@ -38,6 +39,49 @@ func (f fakeEmitter) Emit(_ context.Context, _ libStreaming.EmitRequest) error {
 func (f fakeEmitter) Close() error                                             { return nil }
 func (f fakeEmitter) Healthy(_ context.Context) error                          { return f.healthyErr }
 
+// recordingRedisClient records whether Ping reached the external client. It
+// embeds redis.UniversalClient so it satisfies the interface without stubbing
+// every method; only Ping is overridden, and no other method is exercised.
+type recordingRedisClient struct {
+	redis.UniversalClient
+
+	pingCalled bool
+}
+
+func (c *recordingRedisClient) Ping(ctx context.Context) *redis.StatusCmd {
+	c.pingCalled = true
+
+	return redis.NewStatusCmd(ctx)
+}
+
+// recordingTenantsGetter records whether the external tenant-manager call ran,
+// so a short-circuit on a canceled context can be asserted.
+type recordingTenantsGetter struct {
+	called bool
+	err    error
+}
+
+func (r *recordingTenantsGetter) GetActiveTenantsByService(_ context.Context, _ string) ([]*tmclient.TenantSummary, error) {
+	r.called = true
+
+	return nil, r.err
+}
+
+// recordingEmitter records whether Healthy reached the external emitter, so a
+// short-circuit on a canceled context can be asserted.
+type recordingEmitter struct {
+	healthyErr    error
+	healthyCalled bool
+}
+
+func (r *recordingEmitter) Emit(_ context.Context, _ libStreaming.EmitRequest) error { return nil }
+func (r *recordingEmitter) Close() error                                             { return nil }
+func (r *recordingEmitter) Healthy(_ context.Context) error {
+	r.healthyCalled = true
+
+	return r.healthyErr
+}
+
 func TestRedisPingerAdapter(t *testing.T) {
 	t.Parallel()
 
@@ -50,6 +94,23 @@ func TestRedisPingerAdapter(t *testing.T) {
 
 	assert.ErrorIs(t, (&redisPingerAdapter{}).Ping(context.Background()), in.ErrRedisConnectionNotEstablished,
 		"nil underlying client must report connection-not-established")
+}
+
+// TestRedisPingerAdapter_CanceledContext asserts that a canceled context
+// short-circuits before the external PING: the adapter returns the ctx error
+// (probe layer maps it to down) and the underlying client is never touched.
+func TestRedisPingerAdapter_CanceledContext(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	client := &recordingRedisClient{}
+	adapter := &redisPingerAdapter{client: client}
+
+	err := adapter.Ping(ctx)
+	assert.ErrorIs(t, err, context.Canceled, "canceled context must be returned before the external PING")
+	assert.False(t, client.pingCalled, "external PING must not run once the context is canceled")
 }
 
 func TestTenantManagerHealthProber_Probe(t *testing.T) {
@@ -154,6 +215,26 @@ func TestTenantManagerHealthProber_ClassifiesByStatusClass(t *testing.T) {
 	}
 }
 
+// TestTenantManagerHealthProber_Probe_CanceledContext asserts that a canceled
+// context short-circuits to down with the generic sentinel before the external
+// tenant-manager call runs — preserving the "nothing sensitive on the wire/span"
+// discipline (the raw ctx error is not surfaced).
+func TestTenantManagerHealthProber_Probe_CanceledContext(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	getter := &recordingTenantsGetter{}
+	prober := &tenantManagerHealthProber{client: getter, service: "tracer"}
+
+	status, probeErr := prober.Probe(ctx)
+	assert.Equal(t, in.StatusDown, status)
+	assert.ErrorIs(t, probeErr, errTenantManagerProbe,
+		"canceled context must yield the generic down sentinel, never the raw ctx error")
+	assert.False(t, getter.called, "external tenant-manager call must not run once the context is canceled")
+}
+
 func TestTenantManagerHealthProber_NotWired(t *testing.T) {
 	t.Parallel()
 
@@ -223,6 +304,25 @@ func TestStreamingHealthProber_NonHealthErrorIsSanitized(t *testing.T) {
 		"non-HealthError fallback must return the generic sentinel, not the raw error")
 	assert.NotContains(t, probeErr.Error(), "kafka-internal-9092",
 		"raw broker/topology detail must never reach the probe span")
+}
+
+// TestStreamingHealthProber_Probe_CanceledContext asserts that a canceled
+// context short-circuits to down with the generic sentinel before Emitter.Healthy
+// runs — same sanitization discipline as the tenant_manager prober.
+func TestStreamingHealthProber_Probe_CanceledContext(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	emitter := &recordingEmitter{}
+	prober := &streamingHealthProber{emitter: emitter}
+
+	status, probeErr := prober.Probe(ctx)
+	assert.Equal(t, in.StatusDown, status)
+	assert.ErrorIs(t, probeErr, errStreamingProbe,
+		"canceled context must yield the generic down sentinel")
+	assert.False(t, emitter.healthyCalled, "external Healthy call must not run once the context is canceled")
 }
 
 func TestStreamingHealthProber_NotWired(t *testing.T) {

--- a/components/tracer/internal/observability/recorder.go
+++ b/components/tracer/internal/observability/recorder.go
@@ -10,8 +10,8 @@
 //   - readyz_check_status      (Counter,   labels: dep, status) — per-outcome count
 //   - selfprobe_result         (Gauge,     labels: dep)         — startup probe (1=up,0=down)
 //
-// Cardinality is bounded: dep ∈ {postgres, rule_cache},
-// status ∈ {up, down, degraded, skipped, n/a}. No per-tenant labels.
+// Cardinality is bounded: dep ∈ {postgres, rule_cache, redis, tenant_manager,
+// streaming}, status ∈ {up, down, degraded, skipped, n/a}. No per-tenant labels.
 //
 // The metrics are exposed on /metrics via an OpenTelemetry Prometheus exporter
 // bridge wired in bootstrap (see prometheus_factory.go): metrics are recorded
@@ -36,8 +36,11 @@ import (
 // documented at the top of this file.
 var (
 	allowedDeps = map[string]struct{}{
-		"postgres":   {},
-		"rule_cache": {},
+		"postgres":       {},
+		"rule_cache":     {},
+		"redis":          {},
+		"tenant_manager": {},
+		"streaming":      {},
 	}
 
 	allowedStatuses = map[string]struct{}{

--- a/components/tracer/internal/observability/recorder_test.go
+++ b/components/tracer/internal/observability/recorder_test.go
@@ -297,6 +297,36 @@ func TestMetrics_HistogramBuckets(t *testing.T) {
 		"histogram bucket boundaries must match the canonical contract")
 }
 
+// TestEmitMetrics_AcceptsNewDependencyLabels asserts that the three deps added
+// by the five-probe /readyz fan-out (redis, tenant_manager, streaming) are in
+// the bounded-cardinality allow-list, so EmitCheckDuration / EmitCheckStatus
+// actually record instead of being silently dropped by isValidDep.
+func TestEmitMetrics_AcceptsNewDependencyLabels(t *testing.T) {
+	newDeps := []string{"redis", "tenant_manager", "streaming"}
+
+	for _, dep := range newDeps {
+		t.Run(dep, func(t *testing.T) {
+			r, reg := newRecorderWithRegistry(t)
+			ctx := context.Background()
+
+			r.EmitCheckDuration(ctx, dep, "up", 3*time.Millisecond)
+			r.EmitCheckStatus(ctx, dep, "up")
+
+			families := gather(t, reg)
+
+			histMF, ok := families["readyz_check_duration_ms"]
+			require.Truef(t, ok, "%s: duration histogram missing — dep dropped by isValidDep", dep)
+			assert.EqualValuesf(t, 1, findHistogramSampleCount(histMF, dep, "up"),
+				"%s: duration observation must be recorded, not dropped", dep)
+
+			statusMF, ok := families["readyz_check_status"]
+			require.Truef(t, ok, "%s: status counter missing — dep dropped by isValidDep", dep)
+			assert.EqualValuesf(t, 1, findCounterValue(statusMF, dep, "up"),
+				"%s: status counter must be incremented, not dropped", dep)
+		})
+	}
+}
+
 // TestNilRecorder_NoOps verifies that a nil-receiver Recorder silently
 // drops every emission. This is the contract the call sites depend on:
 // HealthChecker / RunSelfProbe can be exercised in unit tests without

--- a/pkg/constant/errors.go
+++ b/pkg/constant/errors.go
@@ -468,6 +468,10 @@ var (
 	ErrInstrumentAccountReferenceNotFound     = errors.New("0489")
 	ErrSkipNotPermitted                       = errors.New("0490")
 	ErrHolderRequired                         = errors.New("0491")
+	ErrReadyzRedisConnectionNotEstablished    = errors.New("0493")
+	ErrReadyzRedisPingFailed                  = errors.New("0494")
+	ErrReadyzTenantManagerUnavailable         = errors.New("0495")
+	ErrReadyzStreamingUnhealthy               = errors.New("0496")
 )
 
 // List of CRM domain errors.

--- a/pkg/errors.go
+++ b/pkg/errors.go
@@ -2693,6 +2693,30 @@ func ValidateBusinessError(err error, entityType string, args ...any) error {
 			Title:      "Readyz Cache Stale",
 			Message:    "Rule_cache readyz: cache data stale.",
 		},
+		constant.ErrReadyzRedisConnectionNotEstablished: ServiceUnavailableError{
+			EntityType: entityType,
+			Code:       constant.ErrReadyzRedisConnectionNotEstablished.Error(),
+			Title:      "Readyz Redis Connection Not Established",
+			Message:    "Redis readyz: connection not established.",
+		},
+		constant.ErrReadyzRedisPingFailed: ServiceUnavailableError{
+			EntityType: entityType,
+			Code:       constant.ErrReadyzRedisPingFailed.Error(),
+			Title:      "Readyz Redis Ping Failed",
+			Message:    "Redis readyz: ping failed.",
+		},
+		constant.ErrReadyzTenantManagerUnavailable: ServiceUnavailableError{
+			EntityType: entityType,
+			Code:       constant.ErrReadyzTenantManagerUnavailable.Error(),
+			Title:      "Readyz Tenant Manager Unavailable",
+			Message:    "Tenant_manager readyz: service unavailable.",
+		},
+		constant.ErrReadyzStreamingUnhealthy: ServiceUnavailableError{
+			EntityType: entityType,
+			Code:       constant.ErrReadyzStreamingUnhealthy.Error(),
+			Title:      "Readyz Streaming Unhealthy",
+			Message:    "Streaming readyz: producer unhealthy.",
+		},
 		constant.ErrSupervisorShuttingDown: ServiceUnavailableError{
 			EntityType: entityType,
 			Code:       constant.ErrSupervisorShuttingDown.Error(),


### PR DESCRIPTION
## Description

Extends the tracer `/readyz` readiness endpoint from **2 probes** (postgres, rule_cache) to **5** by adding `redis`, `tenant_manager` and `streaming`, and re-adds the `reason` contract field.

The existing endpoint was already canonical; this PR grows probe coverage while preserving the established pattern (concurrent probes via `SafeGoWithContextAndComponent`, fail-closed aggregation, per-dep timeouts, metrics on every path).

**New probes**

| Probe | Availability | Signal | Gates readiness? |
|-------|--------------|--------|------------------|
| `redis` | multi-tenant only | `redis.UniversalClient.Ping` | yes (hard gate) — `skipped` when `MULTI_TENANT_ENABLED=false` |
| `tenant_manager` | multi-tenant only | `GetActiveTenantsByService` | yes (hard gate) — `skipped` in single-tenant |
| `streaming` | always | `libStreaming.Emitter.Healthy` + `.State()` | **no — advisory** (visible in `checks` + metrics, never forces 503) |

**Design decisions (from review)**

- **Streaming is advisory.** A broker hiccup must not pull the whole fleet out of rotation — streaming is non-blocking/IMPORTANT-posture in Midaz. It appears in the `checks` map with its real status and still emits metrics, but it never gates the HTTP 200/503 (implemented via an `advisoryChecks` set skipped by `aggregateStatus`).
- **Tenant-manager 4xx is `up`, not `down`.** A reachable-but-4xx response (e.g. 403 rotated service key) means the service is up; only 5xx/transport failures map to `down`, and circuit-breaker-open maps to `degraded`. Accepted/documented coupling: this functional probe feeds the shared production circuit breaker because tenant-manager exposes no read-only health surface.
- **`reason` field re-added** to `api.ReadyzCheck` (now has producers: the `skipped`/`degraded` paths). `breaker_state` deliberately not re-added (no reliable producer).
- New readyz dep labels (`redis`, `tenant_manager`, `streaming`) registered in the observability recorder's `allowedDeps` so their metrics are not silently dropped.

Reviewed by 6 specialists (code, logic, nil-safety, streaming, tenancy, observability); all findings addressed.

## Type of Change

- [x] `feat`: New feature or capability

## Breaking Changes

None. `reason` is an additive, `omitempty` response field.

## Testing

- [x] `make test` passes (unit: 4785 tests, race detector; `in` package 90.6% coverage)
- [ ] `make test-int` passes — **see Known issues** (tracer integration suite is baseline-red for unrelated reasons; 0 readyz failures)
- [x] `make lint` passes
- [x] Live `/readyz` verified (single-tenant): HTTP 200, `postgres`/`rule_cache` up, `redis`/`tenant_manager`/`streaming` skipped with `reason`, top-level `healthy`

**Test evidence:** live single-tenant `/readyz` returns the canonical 5-check body; `go build`/`go vet` clean.

## Architectural Checklist

- [x] No `panic()` in production paths (probes nil-guard + `SafeGo` recovery; verified by nil-safety review)
- [x] Timestamps use `time.Now().UTC()`
- [x] Errors wrapped with `%w`
- [x] Handlers stay thin (probes delegate classification to boundary adapters in `internal/bootstrap/readyz_probers.go`)
- [x] Infrastructure concerns kept in `internal/bootstrap`

## Known issues / before merge

- ✅ **CI `check-docs`: no action needed.** Verified `make generate-docs` produces zero diff — the tracer's `/readyz`/`/health`/`/version` are plain Fiber routes outside the Huma OpenAPI contract, so the `reason` field touches no generated artifact.
- ℹ️ **Tracer integration suite is baseline-red (pre-existing, NOT this PR):** `./tests/integration/...` has 459 failing assertions from the Huma / RFC 9457 (`problem+json`) migration drift (tests expect old `400`/titles; API returns `422`/new titles). **Zero** failures are in readyz/health, and this PR's diff adds none of the drifted titles/codes. Also: the `make test-integration` target has a `/bin/sh` syntax bug; ran via `go test -tags=integration,testhooks` directly.
- Full write-up (with evidence, impact, and follow-ups): `docs/tracer/readyz-extend-known-issues.md` (on `develop`).

## Related Issues

Closes #
