### PR TITLE
feat(pkg): restore per-product streaming topic segments

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -179,7 +179,7 @@ Binding standard: `docs/standards/error-handling.md` (E1–E14). One error platf
 
 ## Streaming (lib-streaming events)
 
-Producer is `github.com/LerianStudio/lib-streaming`. Wire format: CloudEvents 1.0 binary mode on Kafka. Topic: `lerian.streaming.<service>_<resource>.<event>` (service = component: `ledger` or `crm`; hyphens in the resource/event become underscores in the topic name only). ce-type is auto-prefixed by lib-streaming as `studio.lerian.<resource>.<event>`. The route key / DefinitionKey and ce-type stay hyphenated (e.g. `operation-route`, `related-party-deleted`); only the Kafka topic uses underscores. The canonical wire contract lives in code under `pkg/streaming/events/`; the JSONShape unit test in that package locks it against drift.
+Producer is `github.com/LerianStudio/lib-streaming`. Wire format: CloudEvents 1.0 binary mode on Kafka. Topic: `lerian.streaming.<service>_<resource>.<event>` (service = producing product: `ledger` / `fee` / `crm` from the ledger binary, or `tracer` from the tracer service; hyphens in the resource/event become underscores in the topic name only). ce-type is auto-prefixed by lib-streaming as `studio.lerian.<resource>.<event>`. The route key / DefinitionKey and ce-type stay hyphenated (e.g. `operation-route`, `related-party-deleted`); only the Kafka topic uses underscores. The canonical wire contract lives in code under `pkg/streaming/events/`; the JSONShape unit test in that package locks it against drift.
 
 ### Producer conventions
 

--- a/components/infra/docker-compose.yml
+++ b/components/infra/docker-compose.yml
@@ -211,9 +211,9 @@ services:
   #
   # Topic set is the FULL platform catalog derived from the two canonical
   # registration functions — DO NOT hand-edit stale entries; keep in sync with:
-  #   - midazEventDefinitions()  (components/ledger/internal/bootstrap/streaming.go) — 48 ledger/CRM/fees topics
-  #   - tracerEventDefinitions() (components/tracer/internal/bootstrap/streaming.go) — 12 rule.*/limit.* topics
-  # Total: 60 topics. Topic name = "lerian.streaming.<resource>.<event>".
+  #   - midazEventDefinitions()  (components/ledger/internal/bootstrap/streaming.go) — 49 ledger/fee/crm topics
+  #   - tracerEventDefinitions() (components/tracer/internal/bootstrap/streaming.go) — 12 tracer_rule.*/tracer_limit.* topics
+  # Total: 61 topics. Topic name = "lerian.streaming.<service>_<resource>.<event>".
   midaz-redpanda-init:
     container_name: midaz-redpanda-init
     image: redpandadata/redpanda:v24.2.7
@@ -225,66 +225,71 @@ services:
     command:
       - -c
       - |
-        rpk topic create lerian.streaming.account.created -r 1 -p 1 --brokers midaz-redpanda:9092 || true
-        rpk topic create lerian.streaming.account.deleted -r 1 -p 1 --brokers midaz-redpanda:9092 || true
-        rpk topic create lerian.streaming.account.updated -r 1 -p 1 --brokers midaz-redpanda:9092 || true
-        rpk topic create lerian.streaming.asset.created -r 1 -p 1 --brokers midaz-redpanda:9092 || true
-        rpk topic create lerian.streaming.asset.deleted -r 1 -p 1 --brokers midaz-redpanda:9092 || true
-        rpk topic create lerian.streaming.asset.updated -r 1 -p 1 --brokers midaz-redpanda:9092 || true
-        rpk topic create lerian.streaming.balance.config-changed -r 1 -p 1 --brokers midaz-redpanda:9092 || true
-        rpk topic create lerian.streaming.balance.created -r 1 -p 1 --brokers midaz-redpanda:9092 || true
-        rpk topic create lerian.streaming.balance.deleted -r 1 -p 1 --brokers midaz-redpanda:9092 || true
-        rpk topic create lerian.streaming.balance.overdraft-cleared -r 1 -p 1 --brokers midaz-redpanda:9092 || true
-        rpk topic create lerian.streaming.balance.overdraft-drawn -r 1 -p 1 --brokers midaz-redpanda:9092 || true
-        rpk topic create lerian.streaming.balance.overdraft-repaid -r 1 -p 1 --brokers midaz-redpanda:9092 || true
-        rpk topic create lerian.streaming.fees.applied -r 1 -p 1 --brokers midaz-redpanda:9092 || true
-        rpk topic create lerian.streaming.fees-billing-package.created -r 1 -p 1 --brokers midaz-redpanda:9092 || true
-        rpk topic create lerian.streaming.fees-billing-package.deleted -r 1 -p 1 --brokers midaz-redpanda:9092 || true
-        rpk topic create lerian.streaming.fees-billing-package.updated -r 1 -p 1 --brokers midaz-redpanda:9092 || true
-        rpk topic create lerian.streaming.fees-package.created -r 1 -p 1 --brokers midaz-redpanda:9092 || true
-        rpk topic create lerian.streaming.fees-package.deleted -r 1 -p 1 --brokers midaz-redpanda:9092 || true
-        rpk topic create lerian.streaming.fees-package.updated -r 1 -p 1 --brokers midaz-redpanda:9092 || true
-        rpk topic create lerian.streaming.holder.created -r 1 -p 1 --brokers midaz-redpanda:9092 || true
-        rpk topic create lerian.streaming.holder.deleted -r 1 -p 1 --brokers midaz-redpanda:9092 || true
-        rpk topic create lerian.streaming.holder.updated -r 1 -p 1 --brokers midaz-redpanda:9092 || true
-        rpk topic create lerian.streaming.instrument.created -r 1 -p 1 --brokers midaz-redpanda:9092 || true
-        rpk topic create lerian.streaming.instrument.deleted -r 1 -p 1 --brokers midaz-redpanda:9092 || true
-        rpk topic create lerian.streaming.instrument.related-party-deleted -r 1 -p 1 --brokers midaz-redpanda:9092 || true
-        rpk topic create lerian.streaming.instrument.updated -r 1 -p 1 --brokers midaz-redpanda:9092 || true
-        rpk topic create lerian.streaming.ledger.created -r 1 -p 1 --brokers midaz-redpanda:9092 || true
-        rpk topic create lerian.streaming.ledger.deleted -r 1 -p 1 --brokers midaz-redpanda:9092 || true
-        rpk topic create lerian.streaming.ledger.updated -r 1 -p 1 --brokers midaz-redpanda:9092 || true
-        rpk topic create lerian.streaming.limit.activated -r 1 -p 1 --brokers midaz-redpanda:9092 || true
-        rpk topic create lerian.streaming.limit.created -r 1 -p 1 --brokers midaz-redpanda:9092 || true
-        rpk topic create lerian.streaming.limit.deactivated -r 1 -p 1 --brokers midaz-redpanda:9092 || true
-        rpk topic create lerian.streaming.limit.deleted -r 1 -p 1 --brokers midaz-redpanda:9092 || true
-        rpk topic create lerian.streaming.limit.drafted -r 1 -p 1 --brokers midaz-redpanda:9092 || true
-        rpk topic create lerian.streaming.limit.updated -r 1 -p 1 --brokers midaz-redpanda:9092 || true
-        rpk topic create lerian.streaming.operation-route.created -r 1 -p 1 --brokers midaz-redpanda:9092 || true
-        rpk topic create lerian.streaming.operation-route.deleted -r 1 -p 1 --brokers midaz-redpanda:9092 || true
-        rpk topic create lerian.streaming.operation-route.updated -r 1 -p 1 --brokers midaz-redpanda:9092 || true
-        rpk topic create lerian.streaming.organization.created -r 1 -p 1 --brokers midaz-redpanda:9092 || true
-        rpk topic create lerian.streaming.organization.deleted -r 1 -p 1 --brokers midaz-redpanda:9092 || true
-        rpk topic create lerian.streaming.organization.updated -r 1 -p 1 --brokers midaz-redpanda:9092 || true
-        rpk topic create lerian.streaming.portfolio.created -r 1 -p 1 --brokers midaz-redpanda:9092 || true
-        rpk topic create lerian.streaming.portfolio.deleted -r 1 -p 1 --brokers midaz-redpanda:9092 || true
-        rpk topic create lerian.streaming.portfolio.updated -r 1 -p 1 --brokers midaz-redpanda:9092 || true
-        rpk topic create lerian.streaming.rule.activated -r 1 -p 1 --brokers midaz-redpanda:9092 || true
-        rpk topic create lerian.streaming.rule.created -r 1 -p 1 --brokers midaz-redpanda:9092 || true
-        rpk topic create lerian.streaming.rule.deactivated -r 1 -p 1 --brokers midaz-redpanda:9092 || true
-        rpk topic create lerian.streaming.rule.deleted -r 1 -p 1 --brokers midaz-redpanda:9092 || true
-        rpk topic create lerian.streaming.rule.drafted -r 1 -p 1 --brokers midaz-redpanda:9092 || true
-        rpk topic create lerian.streaming.rule.updated -r 1 -p 1 --brokers midaz-redpanda:9092 || true
-        rpk topic create lerian.streaming.segment.created -r 1 -p 1 --brokers midaz-redpanda:9092 || true
-        rpk topic create lerian.streaming.segment.deleted -r 1 -p 1 --brokers midaz-redpanda:9092 || true
-        rpk topic create lerian.streaming.segment.updated -r 1 -p 1 --brokers midaz-redpanda:9092 || true
-        rpk topic create lerian.streaming.transaction.canceled -r 1 -p 1 --brokers midaz-redpanda:9092 || true
-        rpk topic create lerian.streaming.transaction.committed -r 1 -p 1 --brokers midaz-redpanda:9092 || true
-        rpk topic create lerian.streaming.transaction.posted -r 1 -p 1 --brokers midaz-redpanda:9092 || true
-        rpk topic create lerian.streaming.transaction.reverted -r 1 -p 1 --brokers midaz-redpanda:9092 || true
-        rpk topic create lerian.streaming.transaction-route.created -r 1 -p 1 --brokers midaz-redpanda:9092 || true
-        rpk topic create lerian.streaming.transaction-route.deleted -r 1 -p 1 --brokers midaz-redpanda:9092 || true
-        rpk topic create lerian.streaming.transaction-route.updated -r 1 -p 1 --brokers midaz-redpanda:9092 || true
+        # ledger core (35)
+        rpk topic create lerian.streaming.ledger_account.created -r 1 -p 1 --brokers midaz-redpanda:9092 || true
+        rpk topic create lerian.streaming.ledger_account.deleted -r 1 -p 1 --brokers midaz-redpanda:9092 || true
+        rpk topic create lerian.streaming.ledger_account.updated -r 1 -p 1 --brokers midaz-redpanda:9092 || true
+        rpk topic create lerian.streaming.ledger_asset.created -r 1 -p 1 --brokers midaz-redpanda:9092 || true
+        rpk topic create lerian.streaming.ledger_asset.deleted -r 1 -p 1 --brokers midaz-redpanda:9092 || true
+        rpk topic create lerian.streaming.ledger_asset.updated -r 1 -p 1 --brokers midaz-redpanda:9092 || true
+        rpk topic create lerian.streaming.ledger_balance.changed -r 1 -p 1 --brokers midaz-redpanda:9092 || true
+        rpk topic create lerian.streaming.ledger_balance.config_changed -r 1 -p 1 --brokers midaz-redpanda:9092 || true
+        rpk topic create lerian.streaming.ledger_balance.created -r 1 -p 1 --brokers midaz-redpanda:9092 || true
+        rpk topic create lerian.streaming.ledger_balance.deleted -r 1 -p 1 --brokers midaz-redpanda:9092 || true
+        rpk topic create lerian.streaming.ledger_balance.overdraft_cleared -r 1 -p 1 --brokers midaz-redpanda:9092 || true
+        rpk topic create lerian.streaming.ledger_balance.overdraft_drawn -r 1 -p 1 --brokers midaz-redpanda:9092 || true
+        rpk topic create lerian.streaming.ledger_balance.overdraft_repaid -r 1 -p 1 --brokers midaz-redpanda:9092 || true
+        rpk topic create lerian.streaming.ledger_ledger.created -r 1 -p 1 --brokers midaz-redpanda:9092 || true
+        rpk topic create lerian.streaming.ledger_ledger.deleted -r 1 -p 1 --brokers midaz-redpanda:9092 || true
+        rpk topic create lerian.streaming.ledger_ledger.updated -r 1 -p 1 --brokers midaz-redpanda:9092 || true
+        rpk topic create lerian.streaming.ledger_operation_route.created -r 1 -p 1 --brokers midaz-redpanda:9092 || true
+        rpk topic create lerian.streaming.ledger_operation_route.deleted -r 1 -p 1 --brokers midaz-redpanda:9092 || true
+        rpk topic create lerian.streaming.ledger_operation_route.updated -r 1 -p 1 --brokers midaz-redpanda:9092 || true
+        rpk topic create lerian.streaming.ledger_organization.created -r 1 -p 1 --brokers midaz-redpanda:9092 || true
+        rpk topic create lerian.streaming.ledger_organization.deleted -r 1 -p 1 --brokers midaz-redpanda:9092 || true
+        rpk topic create lerian.streaming.ledger_organization.updated -r 1 -p 1 --brokers midaz-redpanda:9092 || true
+        rpk topic create lerian.streaming.ledger_portfolio.created -r 1 -p 1 --brokers midaz-redpanda:9092 || true
+        rpk topic create lerian.streaming.ledger_portfolio.deleted -r 1 -p 1 --brokers midaz-redpanda:9092 || true
+        rpk topic create lerian.streaming.ledger_portfolio.updated -r 1 -p 1 --brokers midaz-redpanda:9092 || true
+        rpk topic create lerian.streaming.ledger_segment.created -r 1 -p 1 --brokers midaz-redpanda:9092 || true
+        rpk topic create lerian.streaming.ledger_segment.deleted -r 1 -p 1 --brokers midaz-redpanda:9092 || true
+        rpk topic create lerian.streaming.ledger_segment.updated -r 1 -p 1 --brokers midaz-redpanda:9092 || true
+        rpk topic create lerian.streaming.ledger_transaction.canceled -r 1 -p 1 --brokers midaz-redpanda:9092 || true
+        rpk topic create lerian.streaming.ledger_transaction.committed -r 1 -p 1 --brokers midaz-redpanda:9092 || true
+        rpk topic create lerian.streaming.ledger_transaction.posted -r 1 -p 1 --brokers midaz-redpanda:9092 || true
+        rpk topic create lerian.streaming.ledger_transaction.reverted -r 1 -p 1 --brokers midaz-redpanda:9092 || true
+        rpk topic create lerian.streaming.ledger_transaction_route.created -r 1 -p 1 --brokers midaz-redpanda:9092 || true
+        rpk topic create lerian.streaming.ledger_transaction_route.deleted -r 1 -p 1 --brokers midaz-redpanda:9092 || true
+        rpk topic create lerian.streaming.ledger_transaction_route.updated -r 1 -p 1 --brokers midaz-redpanda:9092 || true
+        # fees (7) — embedded in the ledger binary, ce-source lerian.midaz.ledger
+        rpk topic create lerian.streaming.fee_billing_packages.created -r 1 -p 1 --brokers midaz-redpanda:9092 || true
+        rpk topic create lerian.streaming.fee_billing_packages.deleted -r 1 -p 1 --brokers midaz-redpanda:9092 || true
+        rpk topic create lerian.streaming.fee_billing_packages.updated -r 1 -p 1 --brokers midaz-redpanda:9092 || true
+        rpk topic create lerian.streaming.fee_charge.applied -r 1 -p 1 --brokers midaz-redpanda:9092 || true
+        rpk topic create lerian.streaming.fee_packages.created -r 1 -p 1 --brokers midaz-redpanda:9092 || true
+        rpk topic create lerian.streaming.fee_packages.deleted -r 1 -p 1 --brokers midaz-redpanda:9092 || true
+        rpk topic create lerian.streaming.fee_packages.updated -r 1 -p 1 --brokers midaz-redpanda:9092 || true
+        # crm (7) — embedded in the ledger binary, ce-source lerian.midaz.ledger
+        rpk topic create lerian.streaming.crm_holder.created -r 1 -p 1 --brokers midaz-redpanda:9092 || true
+        rpk topic create lerian.streaming.crm_holder.deleted -r 1 -p 1 --brokers midaz-redpanda:9092 || true
+        rpk topic create lerian.streaming.crm_holder.updated -r 1 -p 1 --brokers midaz-redpanda:9092 || true
+        rpk topic create lerian.streaming.crm_instrument.created -r 1 -p 1 --brokers midaz-redpanda:9092 || true
+        rpk topic create lerian.streaming.crm_instrument.deleted -r 1 -p 1 --brokers midaz-redpanda:9092 || true
+        rpk topic create lerian.streaming.crm_instrument.related_party_deleted -r 1 -p 1 --brokers midaz-redpanda:9092 || true
+        rpk topic create lerian.streaming.crm_instrument.updated -r 1 -p 1 --brokers midaz-redpanda:9092 || true
+        # tracer (12) — ce-source lerian.midaz.tracer
+        rpk topic create lerian.streaming.tracer_limit.activated -r 1 -p 1 --brokers midaz-redpanda:9092 || true
+        rpk topic create lerian.streaming.tracer_limit.created -r 1 -p 1 --brokers midaz-redpanda:9092 || true
+        rpk topic create lerian.streaming.tracer_limit.deactivated -r 1 -p 1 --brokers midaz-redpanda:9092 || true
+        rpk topic create lerian.streaming.tracer_limit.deleted -r 1 -p 1 --brokers midaz-redpanda:9092 || true
+        rpk topic create lerian.streaming.tracer_limit.drafted -r 1 -p 1 --brokers midaz-redpanda:9092 || true
+        rpk topic create lerian.streaming.tracer_limit.updated -r 1 -p 1 --brokers midaz-redpanda:9092 || true
+        rpk topic create lerian.streaming.tracer_rule.activated -r 1 -p 1 --brokers midaz-redpanda:9092 || true
+        rpk topic create lerian.streaming.tracer_rule.created -r 1 -p 1 --brokers midaz-redpanda:9092 || true
+        rpk topic create lerian.streaming.tracer_rule.deactivated -r 1 -p 1 --brokers midaz-redpanda:9092 || true
+        rpk topic create lerian.streaming.tracer_rule.deleted -r 1 -p 1 --brokers midaz-redpanda:9092 || true
+        rpk topic create lerian.streaming.tracer_rule.drafted -r 1 -p 1 --brokers midaz-redpanda:9092 || true
+        rpk topic create lerian.streaming.tracer_rule.updated -r 1 -p 1 --brokers midaz-redpanda:9092 || true
     networks:
       - infra-network
 

--- a/components/ledger/internal/bootstrap/streaming.go
+++ b/components/ledger/internal/bootstrap/streaming.go
@@ -22,10 +22,24 @@ import (
 // sync.
 const streamingPrimaryTargetName = "primary"
 
-// streamingServiceName is the component service segment folded into every
-// topic name by pkgStreaming.TopicName, yielding
-// "lerian.streaming.<service>_<resource>.<event>".
-const streamingServiceName = "ledger"
+// Per-product service segments folded into topic names by
+// pkgStreaming.TopicName, yielding "lerian.streaming.<service>_<resource>.<event>".
+// The monorepo binary emits events on behalf of three products, each keeping the
+// service segment it had before consolidation: ledger core, fees, and CRM.
+const (
+	serviceLedger = "ledger"
+	serviceFee    = "fee"
+	serviceCRM    = "crm"
+)
+
+// routedDefinition pairs an event's pure wire Definition with the producing
+// service that owns its topic segment. events.Definition is the wire contract
+// and carries no service; the service lives here in the bootstrap registry so
+// routing stays a composition-root concern.
+type routedDefinition struct {
+	def     events.Definition
+	service string
+}
 
 // noopStreamingCloser is the close hook returned by BuildStreamingEmitter
 // when streaming is disabled. It exists only so callers can append a single
@@ -103,7 +117,8 @@ func BuildStreamingEmitter(
 	}
 
 	// Build the route table. One required route per event keyed to the
-	// canonical "lerian.streaming.<service>_<resource>.<event>" topic name.
+	// canonical "lerian.streaming.<service>_<resource>.<event>" topic name,
+	// where <service> is the event's producing product (ledger/fee/crm).
 	routes := buildRoutes(streamingPrimaryTargetName)
 
 	builder := libStreaming.NewBuilder().
@@ -152,66 +167,66 @@ func BuildStreamingEmitter(
 	return emitter, emitter.Close, nil
 }
 
-// midazEventDefinitions returns the canonical, ordered list of midaz
-// event Definitions registered into both the Catalog and the Routes.
-// Kept as a single source of truth so adding a new event is a one-place
-// change.
-func midazEventDefinitions() []events.Definition {
-	return []events.Definition{
-		events.OrganizationCreatedDefinition,
-		events.OrganizationUpdatedDefinition,
-		events.OrganizationDeletedDefinition,
-		events.LedgerCreatedDefinition,
-		events.LedgerUpdatedDefinition,
-		events.LedgerDeletedDefinition,
-		events.AccountCreatedDefinition,
-		events.AccountUpdatedDefinition,
-		events.AccountDeletedDefinition,
-		events.AssetCreatedDefinition,
-		events.AssetUpdatedDefinition,
-		events.AssetDeletedDefinition,
-		events.PortfolioCreatedDefinition,
-		events.PortfolioUpdatedDefinition,
-		events.PortfolioDeletedDefinition,
-		events.SegmentCreatedDefinition,
-		events.SegmentUpdatedDefinition,
-		events.SegmentDeletedDefinition,
+// midazEventDefinitions returns the canonical, ordered list of midaz event
+// Definitions paired with their producing service, registered into both the
+// Catalog (service-agnostic) and the Routes (per-product topic). Kept as a
+// single source of truth so adding a new event is a one-place change.
+func midazEventDefinitions() []routedDefinition {
+	return []routedDefinition{
+		{events.OrganizationCreatedDefinition, serviceLedger},
+		{events.OrganizationUpdatedDefinition, serviceLedger},
+		{events.OrganizationDeletedDefinition, serviceLedger},
+		{events.LedgerCreatedDefinition, serviceLedger},
+		{events.LedgerUpdatedDefinition, serviceLedger},
+		{events.LedgerDeletedDefinition, serviceLedger},
+		{events.AccountCreatedDefinition, serviceLedger},
+		{events.AccountUpdatedDefinition, serviceLedger},
+		{events.AccountDeletedDefinition, serviceLedger},
+		{events.AssetCreatedDefinition, serviceLedger},
+		{events.AssetUpdatedDefinition, serviceLedger},
+		{events.AssetDeletedDefinition, serviceLedger},
+		{events.PortfolioCreatedDefinition, serviceLedger},
+		{events.PortfolioUpdatedDefinition, serviceLedger},
+		{events.PortfolioDeletedDefinition, serviceLedger},
+		{events.SegmentCreatedDefinition, serviceLedger},
+		{events.SegmentUpdatedDefinition, serviceLedger},
+		{events.SegmentDeletedDefinition, serviceLedger},
 		// account_type.* events are intentionally NOT registered:
 		// internal validation config, the type label flows through
 		// account.* events as a string field.
-		events.OperationRouteCreatedDefinition,
-		events.OperationRouteUpdatedDefinition,
-		events.OperationRouteDeletedDefinition,
-		events.TransactionRouteCreatedDefinition,
-		events.TransactionRouteUpdatedDefinition,
-		events.TransactionRouteDeletedDefinition,
-		events.BalanceCreatedDefinition,
-		events.BalanceChangedDefinition,
-		events.BalanceConfigChangedDefinition,
-		events.BalanceDeletedDefinition,
-		events.BalanceOverdraftDrawnDefinition,
-		events.BalanceOverdraftRepaidDefinition,
-		events.BalanceOverdraftClearedDefinition,
-		events.TransactionPostedDefinition,
-		events.TransactionCommittedDefinition,
-		events.TransactionCanceledDefinition,
-		events.TransactionRevertedDefinition,
+		{events.OperationRouteCreatedDefinition, serviceLedger},
+		{events.OperationRouteUpdatedDefinition, serviceLedger},
+		{events.OperationRouteDeletedDefinition, serviceLedger},
+		{events.TransactionRouteCreatedDefinition, serviceLedger},
+		{events.TransactionRouteUpdatedDefinition, serviceLedger},
+		{events.TransactionRouteDeletedDefinition, serviceLedger},
+		{events.BalanceCreatedDefinition, serviceLedger},
+		{events.BalanceChangedDefinition, serviceLedger},
+		{events.BalanceConfigChangedDefinition, serviceLedger},
+		{events.BalanceDeletedDefinition, serviceLedger},
+		{events.BalanceOverdraftDrawnDefinition, serviceLedger},
+		{events.BalanceOverdraftRepaidDefinition, serviceLedger},
+		{events.BalanceOverdraftClearedDefinition, serviceLedger},
+		{events.TransactionPostedDefinition, serviceLedger},
+		{events.TransactionCommittedDefinition, serviceLedger},
+		{events.TransactionCanceledDefinition, serviceLedger},
+		{events.TransactionRevertedDefinition, serviceLedger},
 		// Fees
-		events.FeesPackageCreatedDefinition,
-		events.FeesPackageUpdatedDefinition,
-		events.FeesPackageDeletedDefinition,
-		events.FeesBillingPackageCreatedDefinition,
-		events.FeesBillingPackageUpdatedDefinition,
-		events.FeesBillingPackageDeletedDefinition,
-		events.FeesAppliedDefinition,
+		{events.FeesPackageCreatedDefinition, serviceFee},
+		{events.FeesPackageUpdatedDefinition, serviceFee},
+		{events.FeesPackageDeletedDefinition, serviceFee},
+		{events.FeesBillingPackageCreatedDefinition, serviceFee},
+		{events.FeesBillingPackageUpdatedDefinition, serviceFee},
+		{events.FeesBillingPackageDeletedDefinition, serviceFee},
+		{events.FeesAppliedDefinition, serviceFee},
 		// CRM
-		events.HolderCreatedDefinition,
-		events.HolderUpdatedDefinition,
-		events.HolderDeletedDefinition,
-		events.InstrumentCreatedDefinition,
-		events.InstrumentUpdatedDefinition,
-		events.InstrumentDeletedDefinition,
-		events.InstrumentRelatedPartyDeletedDefinition,
+		{events.HolderCreatedDefinition, serviceCRM},
+		{events.HolderUpdatedDefinition, serviceCRM},
+		{events.HolderDeletedDefinition, serviceCRM},
+		{events.InstrumentCreatedDefinition, serviceCRM},
+		{events.InstrumentUpdatedDefinition, serviceCRM},
+		{events.InstrumentDeletedDefinition, serviceCRM},
+		{events.InstrumentRelatedPartyDeletedDefinition, serviceCRM},
 	}
 }
 
@@ -223,12 +238,12 @@ func buildCatalog() (libStreaming.Catalog, error) {
 	defs := midazEventDefinitions()
 	entries := make([]libStreaming.EventDefinition, 0, len(defs))
 
-	for _, d := range defs {
+	for _, rd := range defs {
 		entries = append(entries, libStreaming.EventDefinition{
-			Key:           d.Key(),
-			ResourceType:  d.ResourceType,
-			EventType:     d.EventType,
-			SchemaVersion: d.SchemaVersion,
+			Key:           rd.def.Key(),
+			ResourceType:  rd.def.ResourceType,
+			EventType:     rd.def.EventType,
+			SchemaVersion: rd.def.SchemaVersion,
 		})
 	}
 
@@ -237,7 +252,9 @@ func buildCatalog() (libStreaming.Catalog, error) {
 
 // buildRoutes constructs one RouteRequired route per midaz event,
 // targeting the single broker named targetName. Topic names are
-// "lerian.streaming.<service>_<resource>.<event>".
+// "lerian.streaming.<service>_<resource>.<event>", where the service segment
+// is the event's producing product (ledger core / fee / crm) from the
+// per-product registry — NOT a single shared segment.
 //
 // Route Keys are composed as "<definition-key>.<target-name>" (e.g.
 // "account.created.primary") — Route.Key must match a lower-case
@@ -248,13 +265,13 @@ func buildRoutes(targetName string) []libStreaming.RouteDefinition {
 	defs := midazEventDefinitions()
 	routes := make([]libStreaming.RouteDefinition, 0, len(defs))
 
-	for _, d := range defs {
-		key := d.Key()
+	for _, rd := range defs {
+		key := rd.def.Key()
 		routes = append(routes, libStreaming.RouteDefinition{
 			Key:           key + "." + targetName,
 			DefinitionKey: key,
 			Target:        targetName,
-			Destination:   libStreaming.KafkaTopic(pkgStreaming.TopicName(streamingServiceName, key)),
+			Destination:   libStreaming.KafkaTopic(pkgStreaming.TopicName(rd.service, key)),
 			Requirement:   libStreaming.RouteRequired,
 		})
 	}

--- a/components/ledger/internal/bootstrap/streaming_catalog_test.go
+++ b/components/ledger/internal/bootstrap/streaming_catalog_test.go
@@ -71,32 +71,104 @@ func TestMidazCatalogRoutesAssembly(t *testing.T) {
 		assert.True(t, ok, "definition %q has no route (unroutable event)", key)
 	}
 
-	// Per-product routing regression lock (#3388): fees route under the "fee"
-	// service segment and CRM under "crm" — NOT the ledger default that the
-	// monorepo-consolidation bug folded onto every event.
-	assertRouteTopic := func(key, service string) {
-		t.Helper()
+	// Per-product routing regression lock (#3388): an INDEPENDENT expected-service
+	// map keyed by Definition.Key() with LITERAL service segments, deliberately
+	// NOT derived from midazEventDefinitions (the code under test). serviceByKey
+	// above is computed from the registry and would tautologically agree with a
+	// wrong-service bug; this map enumerates every event's expected service so a
+	// regression on ANY event — not just a handful of spot-checks — is caught at
+	// unit speed. The literals "ledger"/"fee"/"crm" are intentional (not the
+	// serviceLedger/serviceFee/serviceCRM constants the production code uses).
+	const (
+		wantLedger = "ledger"
+		wantFee    = "fee"
+		wantCRM    = "crm"
+	)
 
-		want := libStreaming.KafkaTopic(pkgStreaming.TopicName(service, key))
-		for _, r := range routes {
-			if r.DefinitionKey == key {
-				assert.Equalf(t, want, r.Destination, "route %q must target %q", key, want)
-				return
-			}
-		}
-
-		t.Fatalf("no route for key %q", key)
+	expectedService := map[string]string{
+		// Ledger core.
+		events.OrganizationCreatedDefinition.Key():     wantLedger,
+		events.OrganizationUpdatedDefinition.Key():     wantLedger,
+		events.OrganizationDeletedDefinition.Key():     wantLedger,
+		events.LedgerCreatedDefinition.Key():           wantLedger,
+		events.LedgerUpdatedDefinition.Key():           wantLedger,
+		events.LedgerDeletedDefinition.Key():           wantLedger,
+		events.AccountCreatedDefinition.Key():          wantLedger,
+		events.AccountUpdatedDefinition.Key():          wantLedger,
+		events.AccountDeletedDefinition.Key():          wantLedger,
+		events.AssetCreatedDefinition.Key():            wantLedger,
+		events.AssetUpdatedDefinition.Key():            wantLedger,
+		events.AssetDeletedDefinition.Key():            wantLedger,
+		events.PortfolioCreatedDefinition.Key():        wantLedger,
+		events.PortfolioUpdatedDefinition.Key():        wantLedger,
+		events.PortfolioDeletedDefinition.Key():        wantLedger,
+		events.SegmentCreatedDefinition.Key():          wantLedger,
+		events.SegmentUpdatedDefinition.Key():          wantLedger,
+		events.SegmentDeletedDefinition.Key():          wantLedger,
+		events.OperationRouteCreatedDefinition.Key():   wantLedger,
+		events.OperationRouteUpdatedDefinition.Key():   wantLedger,
+		events.OperationRouteDeletedDefinition.Key():   wantLedger,
+		events.TransactionRouteCreatedDefinition.Key(): wantLedger,
+		events.TransactionRouteUpdatedDefinition.Key(): wantLedger,
+		events.TransactionRouteDeletedDefinition.Key(): wantLedger,
+		events.BalanceCreatedDefinition.Key():          wantLedger,
+		events.BalanceChangedDefinition.Key():          wantLedger,
+		events.BalanceConfigChangedDefinition.Key():    wantLedger,
+		events.BalanceDeletedDefinition.Key():          wantLedger,
+		events.BalanceOverdraftDrawnDefinition.Key():   wantLedger,
+		events.BalanceOverdraftRepaidDefinition.Key():  wantLedger,
+		events.BalanceOverdraftClearedDefinition.Key(): wantLedger,
+		events.TransactionPostedDefinition.Key():       wantLedger,
+		events.TransactionCommittedDefinition.Key():    wantLedger,
+		events.TransactionCanceledDefinition.Key():     wantLedger,
+		events.TransactionRevertedDefinition.Key():     wantLedger,
+		// Fees.
+		events.FeesPackageCreatedDefinition.Key():        wantFee,
+		events.FeesPackageUpdatedDefinition.Key():        wantFee,
+		events.FeesPackageDeletedDefinition.Key():        wantFee,
+		events.FeesBillingPackageCreatedDefinition.Key(): wantFee,
+		events.FeesBillingPackageUpdatedDefinition.Key(): wantFee,
+		events.FeesBillingPackageDeletedDefinition.Key(): wantFee,
+		events.FeesAppliedDefinition.Key():               wantFee,
+		// CRM.
+		events.HolderCreatedDefinition.Key():                 wantCRM,
+		events.HolderUpdatedDefinition.Key():                 wantCRM,
+		events.HolderDeletedDefinition.Key():                 wantCRM,
+		events.InstrumentCreatedDefinition.Key():             wantCRM,
+		events.InstrumentUpdatedDefinition.Key():             wantCRM,
+		events.InstrumentDeletedDefinition.Key():             wantCRM,
+		events.InstrumentRelatedPartyDeletedDefinition.Key(): wantCRM,
 	}
 
-	assertRouteTopic(events.AccountCreatedDefinition.Key(), serviceLedger)
-	assertRouteTopic(events.FeesPackageCreatedDefinition.Key(), serviceFee)
-	assertRouteTopic(events.FeesAppliedDefinition.Key(), serviceFee)
-	assertRouteTopic(events.HolderCreatedDefinition.Key(), serviceCRM)
-	assertRouteTopic(events.InstrumentCreatedDefinition.Key(), serviceCRM)
+	// The independent map must cover exactly the registry key set: a missing
+	// event would silently skip its service check, an extra key would mask a
+	// dropped registration.
+	assert.Equal(t, len(defKeys), len(expectedService),
+		"expectedService must enumerate every registered event exactly once")
+	for key := range defKeys {
+		_, ok := expectedService[key]
+		assert.Truef(t, ok, "registered event %q missing from independent expectedService map", key)
+	}
+	for key := range expectedService {
+		_, ok := defKeys[key]
+		assert.Truef(t, ok, "expectedService key %q is not present in the registry", key)
+	}
+
+	// Every actual route's topic must match the INDEPENDENT expected service.
+	for _, r := range routes {
+		want, ok := expectedService[r.DefinitionKey]
+		if !assert.Truef(t, ok, "route %q has no independent expected service", r.DefinitionKey) {
+			continue
+		}
+
+		wantTopic := libStreaming.KafkaTopic(pkgStreaming.TopicName(want, r.DefinitionKey))
+		assert.Equalf(t, wantTopic, r.Destination,
+			"route %q must target %q (independent service lock)", r.DefinitionKey, wantTopic)
+	}
 }
 
 // TestFeesEventsRegistered locks the fee events into the assembled catalog: the
-// fee package / billing-package keys plus fees.applied must be a subset of the
+// fee package / billing-package keys plus fee-charge.applied must be a subset of the
 // catalog keys, so a dropped fee registration is caught before it becomes a
 // silent gap.
 func TestFeesEventsRegistered(t *testing.T) {

--- a/components/ledger/internal/bootstrap/streaming_catalog_test.go
+++ b/components/ledger/internal/bootstrap/streaming_catalog_test.go
@@ -16,8 +16,9 @@ import (
 
 // TestMidazCatalogRoutesAssembly locks the catalog/routes assembly path: it
 // must produce exactly one catalog entry and one required route per event
-// definition, each route pointing at the canonical prefixed topic, with no
-// duplicate or orphan keys in either direction (the ghost-topic guard).
+// definition, each route pointing at its PER-PRODUCT topic (ledger core under
+// service "ledger", fees under "fee", CRM under "crm"), with no duplicate or
+// orphan keys in either direction (the ghost-topic guard).
 func TestMidazCatalogRoutesAssembly(t *testing.T) {
 	t.Parallel()
 
@@ -32,32 +33,36 @@ func TestMidazCatalogRoutesAssembly(t *testing.T) {
 	assert.Equal(t, len(defs), catalog.Len(), "catalog entry count must equal definition count")
 	assert.Len(t, routes, len(defs), "route count must equal definition count")
 
-	// The set of definition keys is the source of truth for the bijection.
-	// Key the checks off DefinitionKey (NOT route.Key, which carries the
-	// ".primary" target suffix).
+	// The set of definition keys is the source of truth for the bijection, and
+	// each key carries its producing service so route topics are verified
+	// per-product. Key the checks off DefinitionKey (NOT route.Key, which
+	// carries the ".primary" target suffix).
 	defKeys := make(map[string]struct{}, len(defs))
-	for _, d := range defs {
-		key := d.Key()
+	serviceByKey := make(map[string]string, len(defs))
+
+	for _, rd := range defs {
+		key := rd.def.Key()
 		_, dup := defKeys[key]
 		require.False(t, dup, "duplicate definition key %q in midazEventDefinitions", key)
 		defKeys[key] = struct{}{}
+		serviceByKey[key] = rd.service
 	}
 
 	seenRouteKeys := make(map[string]struct{}, len(routes))
 	for _, r := range routes {
 		assert.Equal(t, libStreaming.RouteRequired, r.Requirement,
 			"route for %q must be RouteRequired", r.DefinitionKey)
-		wantTopic := libStreaming.KafkaTopic(pkgStreaming.TopicName(streamingServiceName, r.DefinitionKey))
+
+		service, ok := serviceByKey[r.DefinitionKey]
+		require.Truef(t, ok, "route DefinitionKey %q has no matching event definition (dead/ghost route)", r.DefinitionKey)
+
+		wantTopic := libStreaming.KafkaTopic(pkgStreaming.TopicName(service, r.DefinitionKey))
 		assert.Equal(t, wantTopic, r.Destination,
 			"route for %q must target topic %q", r.DefinitionKey, wantTopic)
 
 		_, dup := seenRouteKeys[r.DefinitionKey]
 		assert.False(t, dup, "duplicate route for DefinitionKey %q", r.DefinitionKey)
 		seenRouteKeys[r.DefinitionKey] = struct{}{}
-
-		// No orphan route: every route maps to a real definition.
-		_, ok := defKeys[r.DefinitionKey]
-		assert.True(t, ok, "route DefinitionKey %q has no matching event definition (dead/ghost route)", r.DefinitionKey)
 	}
 
 	// No orphan definition: every definition has a route (other direction).
@@ -65,6 +70,29 @@ func TestMidazCatalogRoutesAssembly(t *testing.T) {
 		_, ok := seenRouteKeys[key]
 		assert.True(t, ok, "definition %q has no route (unroutable event)", key)
 	}
+
+	// Per-product routing regression lock (#3388): fees route under the "fee"
+	// service segment and CRM under "crm" — NOT the ledger default that the
+	// monorepo-consolidation bug folded onto every event.
+	assertRouteTopic := func(key, service string) {
+		t.Helper()
+
+		want := libStreaming.KafkaTopic(pkgStreaming.TopicName(service, key))
+		for _, r := range routes {
+			if r.DefinitionKey == key {
+				assert.Equalf(t, want, r.Destination, "route %q must target %q", key, want)
+				return
+			}
+		}
+
+		t.Fatalf("no route for key %q", key)
+	}
+
+	assertRouteTopic(events.AccountCreatedDefinition.Key(), serviceLedger)
+	assertRouteTopic(events.FeesPackageCreatedDefinition.Key(), serviceFee)
+	assertRouteTopic(events.FeesAppliedDefinition.Key(), serviceFee)
+	assertRouteTopic(events.HolderCreatedDefinition.Key(), serviceCRM)
+	assertRouteTopic(events.InstrumentCreatedDefinition.Key(), serviceCRM)
 }
 
 // TestFeesEventsRegistered locks the fee events into the assembled catalog: the
@@ -75,13 +103,13 @@ func TestFeesEventsRegistered(t *testing.T) {
 	t.Parallel()
 
 	expected := []string{
-		"fees-package.created",
-		"fees-package.updated",
-		"fees-package.deleted",
-		"fees-billing-package.created",
-		"fees-billing-package.updated",
-		"fees-billing-package.deleted",
-		"fees.applied",
+		"fee-packages.created",
+		"fee-packages.updated",
+		"fee-packages.deleted",
+		"fee-billing-packages.created",
+		"fee-billing-packages.updated",
+		"fee-billing-packages.deleted",
+		"fee-charge.applied",
 	}
 
 	catalog, err := buildCatalog()
@@ -98,7 +126,7 @@ func TestFeesEventsRegistered(t *testing.T) {
 	}
 
 	// Guard against the key strings drifting from the Definition vars.
-	assert.Equal(t, "fees-package.created", events.FeesPackageCreatedDefinition.Key())
-	assert.Equal(t, "fees-billing-package.deleted", events.FeesBillingPackageDeletedDefinition.Key())
-	assert.Equal(t, "fees.applied", events.FeesAppliedDefinition.Key())
+	assert.Equal(t, "fee-packages.created", events.FeesPackageCreatedDefinition.Key())
+	assert.Equal(t, "fee-billing-packages.deleted", events.FeesBillingPackageDeletedDefinition.Key())
+	assert.Equal(t, "fee-charge.applied", events.FeesAppliedDefinition.Key())
 }

--- a/components/ledger/internal/bootstrap/streaming_integration_test.go
+++ b/components/ledger/internal/bootstrap/streaming_integration_test.go
@@ -208,8 +208,8 @@ func streamingITExpectations() []streamingITExpectation {
 
 	return []streamingITExpectation{
 		{
-			name:       "fees-package.created",
-			topic:      pkgStreaming.TopicName(streamingServiceName, events.FeesPackageCreatedDefinition.Key()),
+			name:       "fee-packages.created",
+			topic:      pkgStreaming.TopicName("fee", events.FeesPackageCreatedDefinition.Key()),
 			ceType:     "studio.lerian." + events.FeesPackageCreatedDefinition.Key(),
 			subject:    packageID,
 			requireKey: []string{"id", "organizationId", "ledgerId", "enable", "createdAt", "updatedAt"},
@@ -219,8 +219,8 @@ func streamingITExpectations() []streamingITExpectation {
 			},
 		},
 		{
-			name:       "fees-package.updated",
-			topic:      pkgStreaming.TopicName(streamingServiceName, events.FeesPackageUpdatedDefinition.Key()),
+			name:       "fee-packages.updated",
+			topic:      pkgStreaming.TopicName("fee", events.FeesPackageUpdatedDefinition.Key()),
 			ceType:     "studio.lerian." + events.FeesPackageUpdatedDefinition.Key(),
 			subject:    packageID,
 			requireKey: []string{"id", "organizationId", "ledgerId", "enable", "createdAt", "updatedAt"},
@@ -230,8 +230,8 @@ func streamingITExpectations() []streamingITExpectation {
 			},
 		},
 		{
-			name:       "fees-package.deleted",
-			topic:      pkgStreaming.TopicName(streamingServiceName, events.FeesPackageDeletedDefinition.Key()),
+			name:       "fee-packages.deleted",
+			topic:      pkgStreaming.TopicName("fee", events.FeesPackageDeletedDefinition.Key()),
 			ceType:     "studio.lerian." + events.FeesPackageDeletedDefinition.Key(),
 			subject:    packageID,
 			requireKey: []string{"id", "organizationId", "ledgerId", "deletedAt"},
@@ -241,8 +241,8 @@ func streamingITExpectations() []streamingITExpectation {
 			},
 		},
 		{
-			name:       "fees-billing-package.created",
-			topic:      pkgStreaming.TopicName(streamingServiceName, events.FeesBillingPackageCreatedDefinition.Key()),
+			name:       "fee-billing-packages.created",
+			topic:      pkgStreaming.TopicName("fee", events.FeesBillingPackageCreatedDefinition.Key()),
 			ceType:     "studio.lerian." + events.FeesBillingPackageCreatedDefinition.Key(),
 			subject:    billingID,
 			requireKey: []string{"id", "organizationId", "ledgerId", "type", "enable", "createdAt", "updatedAt"},
@@ -255,8 +255,8 @@ func streamingITExpectations() []streamingITExpectation {
 			},
 		},
 		{
-			name:       "fees-billing-package.updated",
-			topic:      pkgStreaming.TopicName(streamingServiceName, events.FeesBillingPackageUpdatedDefinition.Key()),
+			name:       "fee-billing-packages.updated",
+			topic:      pkgStreaming.TopicName("fee", events.FeesBillingPackageUpdatedDefinition.Key()),
 			ceType:     "studio.lerian." + events.FeesBillingPackageUpdatedDefinition.Key(),
 			subject:    billingID,
 			requireKey: []string{"id", "organizationId", "ledgerId", "type", "enable", "createdAt", "updatedAt"},
@@ -269,8 +269,8 @@ func streamingITExpectations() []streamingITExpectation {
 			},
 		},
 		{
-			name:       "fees-billing-package.deleted",
-			topic:      pkgStreaming.TopicName(streamingServiceName, events.FeesBillingPackageDeletedDefinition.Key()),
+			name:       "fee-billing-packages.deleted",
+			topic:      pkgStreaming.TopicName("fee", events.FeesBillingPackageDeletedDefinition.Key()),
 			ceType:     "studio.lerian." + events.FeesBillingPackageDeletedDefinition.Key(),
 			subject:    billingID,
 			requireKey: []string{"id", "organizationId", "ledgerId", "deletedAt"},
@@ -281,8 +281,8 @@ func streamingITExpectations() []streamingITExpectation {
 		},
 		{
 			// ce-subject for fees.applied is the TRANSACTION id, not a package id.
-			name:       "fees.applied",
-			topic:      pkgStreaming.TopicName(streamingServiceName, events.FeesAppliedDefinition.Key()),
+			name:       "fee-charge.applied",
+			topic:      pkgStreaming.TopicName("fee", events.FeesAppliedDefinition.Key()),
 			ceType:     "studio.lerian." + events.FeesAppliedDefinition.Key(),
 			subject:    transactionID,
 			requireKey: []string{"transactionId", "organizationId", "ledgerId", "feePackageId", "appliedAt"},

--- a/components/ledger/internal/bootstrap/streaming_integration_test.go
+++ b/components/ledger/internal/bootstrap/streaming_integration_test.go
@@ -280,7 +280,7 @@ func streamingITExpectations() []streamingITExpectation {
 			},
 		},
 		{
-			// ce-subject for fees.applied is the TRANSACTION id, not a package id.
+			// ce-subject for fee-charge.applied is the TRANSACTION id, not a package id.
 			name:       "fee-charge.applied",
 			topic:      pkgStreaming.TopicName("fee", events.FeesAppliedDefinition.Key()),
 			ceType:     "studio.lerian." + events.FeesAppliedDefinition.Key(),

--- a/components/ledger/internal/bootstrap/streaming_test.go
+++ b/components/ledger/internal/bootstrap/streaming_test.go
@@ -54,8 +54,8 @@ func TestMidazEventDefinitions_IncludesBalanceChanged(t *testing.T) {
 	defs := midazEventDefinitions()
 
 	found := false
-	for _, d := range defs {
-		if d.Key() == "balance.changed" {
+	for _, rd := range defs {
+		if rd.def.Key() == "balance.changed" {
 			found = true
 			break
 		}

--- a/components/ledger/internal/services/command/send_transaction_events.go
+++ b/components/ledger/internal/services/command/send_transaction_events.go
@@ -249,8 +249,9 @@ func (uc *UseCase) emitTransactionLifecycleEvent(ctx context.Context, span trace
 // emitFeesAppliedEvent emits fee-charge.applied for a posted transaction that
 // actually charged a fee. It fires only when feeApplied=true and a
 // packageAppliedID are present in metadata (charged-only, set by the fee
-// engine on the real-charge branch); pure exemptions carry neither. IMPORTANT
-// posture: EmitImportant swallows build/emit failures.
+// engine on the real-charge branch); pure exemptions still carry
+// packageAppliedID but omit feeApplied=true, so the feeApplied guard suppresses
+// the emit. IMPORTANT posture: EmitImportant swallows build/emit failures.
 func (uc *UseCase) emitFeesAppliedEvent(ctx context.Context, span trace.Span, logger libLog.Logger, tran *transaction.Transaction) {
 	if applied, _ := tran.Metadata["feeApplied"].(string); applied != "true" {
 		return

--- a/components/ledger/internal/services/command/send_transaction_events.go
+++ b/components/ledger/internal/services/command/send_transaction_events.go
@@ -239,14 +239,14 @@ func (uc *UseCase) emitTransactionLifecycleEvent(ctx context.Context, span trace
 
 	pkgStreaming.EmitImportant(ctx, span, logger, uc.Streaming, definitionKey, buildFn)
 
-	// fees.applied rides alongside transaction.posted only. Commit/cancel/
+	// fee-charge.applied rides alongside transaction.posted only. Commit/cancel/
 	// revert do NOT re-emit it (the fee charge happened once, at post).
 	if posted {
 		uc.emitFeesAppliedEvent(ctx, span, logger, tran)
 	}
 }
 
-// emitFeesAppliedEvent emits fees.applied for a posted transaction that
+// emitFeesAppliedEvent emits fee-charge.applied for a posted transaction that
 // actually charged a fee. It fires only when feeApplied=true and a
 // packageAppliedID are present in metadata (charged-only, set by the fee
 // engine on the real-charge branch); pure exemptions carry neither. IMPORTANT

--- a/components/ledger/internal/services/command/send_transaction_events_fees_applied_test.go
+++ b/components/ledger/internal/services/command/send_transaction_events_fees_applied_test.go
@@ -23,7 +23,7 @@ import (
 // TestSendTransactionEvents_FeesAppliedEmittedOnPostedCharge locks the
 // charged-only + posted-only contract: a POSTED (created + APPROVED + nil
 // parent) transaction carrying feeApplied=true and packageAppliedID emits both
-// transaction.posted AND fees.applied.
+// transaction.posted AND fee-charge.applied.
 func TestSendTransactionEvents_FeesAppliedEmittedOnPostedCharge(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -42,19 +42,19 @@ func TestSendTransactionEvents_FeesAppliedEmittedOnPostedCharge(t *testing.T) {
 	uc.SendTransactionEvents(context.Background(), tran, TransactionLifecyclePhaseCreated)
 
 	pkgStreaming.AssertEventEmitted(t, mockEmitter, "transaction", "posted")
-	pkgStreaming.AssertEventEmitted(t, mockEmitter, "fees", "applied")
+	pkgStreaming.AssertEventEmitted(t, mockEmitter, "fee-charge", "applied")
 
 	var feesApplied *libStreaming.EmitRequest
 	for i := range mockEmitter.Events() {
-		if mockEmitter.Events()[i].DefinitionKey == "fees.applied" {
+		if mockEmitter.Events()[i].DefinitionKey == "fee-charge.applied" {
 			feesApplied = &mockEmitter.Events()[i]
 			break
 		}
 	}
-	require.NotNil(t, feesApplied, "fees.applied request must be present in emitted events")
+	require.NotNil(t, feesApplied, "fee-charge.applied request must be present in emitted events")
 
 	assert.Equal(t, tran.ID, feesApplied.Subject,
-		"fees.applied Subject must be the transaction id")
+		"fee-charge.applied Subject must be the transaction id")
 
 	var payload events.FeesAppliedPayload
 	require.NoError(t, json.Unmarshal(feesApplied.Payload, &payload))
@@ -66,7 +66,7 @@ func TestSendTransactionEvents_FeesAppliedEmittedOnPostedCharge(t *testing.T) {
 
 // TestSendTransactionEvents_FeesAppliedSkippedWhenExemptionOnly locks the
 // charged-only fence: a POSTED transaction with packageAppliedID but WITHOUT
-// feeApplied (exemption-only) emits transaction.posted but NOT fees.applied.
+// feeApplied (exemption-only) emits transaction.posted but NOT fee-charge.applied.
 func TestSendTransactionEvents_FeesAppliedSkippedWhenExemptionOnly(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -84,14 +84,14 @@ func TestSendTransactionEvents_FeesAppliedSkippedWhenExemptionOnly(t *testing.T)
 	pkgStreaming.AssertEventEmitted(t, mockEmitter, "transaction", "posted")
 
 	for _, e := range mockEmitter.Events() {
-		assert.NotEqual(t, "fees.applied", e.DefinitionKey,
-			"exemption-only transaction must not emit fees.applied")
+		assert.NotEqual(t, "fee-charge.applied", e.DefinitionKey,
+			"exemption-only transaction must not emit fee-charge.applied")
 	}
 }
 
 // TestSendTransactionEvents_FeesAppliedSkippedWhenPackageIDEmpty locks the
 // second emit guard: a POSTED transaction with feeApplied=true but an empty
-// packageAppliedID emits transaction.posted but NOT fees.applied.
+// packageAppliedID emits transaction.posted but NOT fee-charge.applied.
 func TestSendTransactionEvents_FeesAppliedSkippedWhenPackageIDEmpty(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -110,14 +110,14 @@ func TestSendTransactionEvents_FeesAppliedSkippedWhenPackageIDEmpty(t *testing.T
 	pkgStreaming.AssertEventEmitted(t, mockEmitter, "transaction", "posted")
 
 	for _, e := range mockEmitter.Events() {
-		assert.NotEqual(t, "fees.applied", e.DefinitionKey,
-			"empty packageAppliedID must not emit fees.applied")
+		assert.NotEqual(t, "fee-charge.applied", e.DefinitionKey,
+			"empty packageAppliedID must not emit fee-charge.applied")
 	}
 }
 
 // TestSendTransactionEvents_FeesAppliedSkippedOnNonPostedPhase locks the
 // posted-only fence: a charged transaction on the updated (committed) phase
-// does NOT re-emit fees.applied.
+// does NOT re-emit fee-charge.applied.
 func TestSendTransactionEvents_FeesAppliedSkippedOnNonPostedPhase(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -136,8 +136,8 @@ func TestSendTransactionEvents_FeesAppliedSkippedOnNonPostedPhase(t *testing.T) 
 	pkgStreaming.AssertEventEmitted(t, mockEmitter, "transaction", "committed")
 
 	for _, e := range mockEmitter.Events() {
-		assert.NotEqual(t, "fees.applied", e.DefinitionKey,
-			"committed (updated) phase must not emit fees.applied")
+		assert.NotEqual(t, "fee-charge.applied", e.DefinitionKey,
+			"committed (updated) phase must not emit fee-charge.applied")
 	}
 }
 

--- a/components/ledger/internal/services/fees/billing-package-service.go
+++ b/components/ledger/internal/services/fees/billing-package-service.go
@@ -434,7 +434,7 @@ func (s *BillingPackageService) DeleteBillingPackage(ctx context.Context, id, or
 	return nil
 }
 
-// emitBillingPackageCreatedEvent publishes fees-billing-package.created. IMPORTANT posture.
+// emitBillingPackageCreatedEvent publishes fee-billing-packages.created. IMPORTANT posture.
 func (s *BillingPackageService) emitBillingPackageCreatedEvent(ctx context.Context, span trace.Span, logger libLog.Logger, bp *model.BillingPackage) {
 	pkgStreaming.EmitImportant(ctx, span, logger, s.Streaming, events.FeesBillingPackageCreatedDefinition.Key(),
 		func(tenantID string) (libStreaming.EmitRequest, error) {
@@ -451,7 +451,7 @@ func (s *BillingPackageService) emitBillingPackageCreatedEvent(ctx context.Conte
 		})
 }
 
-// emitBillingPackageUpdatedEvent publishes fees-billing-package.updated. IMPORTANT posture.
+// emitBillingPackageUpdatedEvent publishes fee-billing-packages.updated. IMPORTANT posture.
 func (s *BillingPackageService) emitBillingPackageUpdatedEvent(ctx context.Context, span trace.Span, logger libLog.Logger, bp *model.BillingPackage) {
 	pkgStreaming.EmitImportant(ctx, span, logger, s.Streaming, events.FeesBillingPackageUpdatedDefinition.Key(),
 		func(tenantID string) (libStreaming.EmitRequest, error) {
@@ -468,7 +468,7 @@ func (s *BillingPackageService) emitBillingPackageUpdatedEvent(ctx context.Conte
 		})
 }
 
-// emitBillingPackageDeletedEvent publishes fees-billing-package.deleted. IMPORTANT posture.
+// emitBillingPackageDeletedEvent publishes fee-billing-packages.deleted. IMPORTANT posture.
 func (s *BillingPackageService) emitBillingPackageDeletedEvent(ctx context.Context, span trace.Span, logger libLog.Logger, id, organizationID, ledgerID string, deletedAt time.Time) {
 	pkgStreaming.EmitImportant(ctx, span, logger, s.Streaming, events.FeesBillingPackageDeletedDefinition.Key(),
 		func(tenantID string) (libStreaming.EmitRequest, error) {

--- a/components/ledger/internal/services/fees/billing-package-streaming_test.go
+++ b/components/ledger/internal/services/fees/billing-package-streaming_test.go
@@ -71,9 +71,9 @@ func TestCreateBillingPackage_EmitsCreatedEvent(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, result)
 
-	pkgStreaming.AssertEventEmitted(t, mock, "fees-billing-package", "created")
+	pkgStreaming.AssertEventEmitted(t, mock, "fee-billing-packages", "created")
 
-	req := findEmittedByKey(t, mock, "fees-billing-package", "created")
+	req := findEmittedByKey(t, mock, "fee-billing-packages", "created")
 	assert.Equal(t, result.ID, req.Subject)
 
 	var payload struct {
@@ -112,9 +112,9 @@ func TestUpdateBillingPackage_EmitsUpdatedEvent(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, result)
 
-	pkgStreaming.AssertEventEmitted(t, mock, "fees-billing-package", "updated")
+	pkgStreaming.AssertEventEmitted(t, mock, "fee-billing-packages", "updated")
 
-	req := findEmittedByKey(t, mock, "fees-billing-package", "updated")
+	req := findEmittedByKey(t, mock, "fee-billing-packages", "updated")
 	assert.Equal(t, bpID.String(), req.Subject)
 
 	var payload struct {
@@ -153,9 +153,9 @@ func TestDeleteBillingPackage_EmitsDeletedEvent(t *testing.T) {
 	err := svc.DeleteBillingPackage(context.Background(), bpID, orgID)
 	require.NoError(t, err)
 
-	pkgStreaming.AssertEventEmitted(t, mock, "fees-billing-package", "deleted")
+	pkgStreaming.AssertEventEmitted(t, mock, "fee-billing-packages", "deleted")
 
-	req := findEmittedByKey(t, mock, "fees-billing-package", "deleted")
+	req := findEmittedByKey(t, mock, "fee-billing-packages", "deleted")
 	assert.Equal(t, bpID.String(), req.Subject)
 
 	var payload struct {

--- a/components/ledger/internal/services/fees/calculate-fee.go
+++ b/components/ledger/internal/services/fees/calculate-fee.go
@@ -263,7 +263,7 @@ func (uc *UseCase) updateFeeMetadataIfNeeded(
 		cf.Transaction.Metadata["packageAppliedID"] = packageID.String()
 
 		// feeApplied marks a real charge (not a pure exemption); it gates
-		// the fees.applied streaming emit downstream.
+		// the fee-charge.applied streaming emit downstream.
 		if feeApplied {
 			cf.Transaction.Metadata["feeApplied"] = "true"
 		}

--- a/components/ledger/internal/services/fees/create-package.go
+++ b/components/ledger/internal/services/fees/create-package.go
@@ -114,7 +114,7 @@ func (uc *UseCase) CreatePackage(ctx context.Context, cpi *model.CreatePackageIn
 	return resultPackModel, nil
 }
 
-// emitFeesPackageCreatedEvent publishes fees-package.created. IMPORTANT posture.
+// emitFeesPackageCreatedEvent publishes fee-packages.created. IMPORTANT posture.
 func (uc *UseCase) emitFeesPackageCreatedEvent(ctx context.Context, span trace.Span, logger libLog.Logger, p *pack.Package, organizationID uuid.UUID) {
 	pkgStreaming.EmitImportant(ctx, span, logger, uc.Streaming, events.FeesPackageCreatedDefinition.Key(),
 		func(tenantID string) (libStreaming.EmitRequest, error) {

--- a/components/ledger/internal/services/fees/create-package_test.go
+++ b/components/ledger/internal/services/fees/create-package_test.go
@@ -313,7 +313,7 @@ func TestCreatePackage(t *testing.T) {
 }
 
 // TestCreatePackage_EmitsFeesPackageCreated asserts a successful create emits
-// the fees-package.created event through the mock emitter.
+// the fee-packages.created event through the mock emitter.
 func TestCreatePackage_EmitsFeesPackageCreated(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -362,7 +362,7 @@ func TestCreatePackage_EmitsFeesPackageCreated(t *testing.T) {
 	_, err := svc.CreatePackage(context.Background(), input, orgID, ledgerID, segID)
 	require.NoError(t, err)
 
-	pkgStreaming.AssertEventEmitted(t, mockEmitter, "fees-package", "created")
+	pkgStreaming.AssertEventEmitted(t, mockEmitter, "fee-packages", "created")
 
 	emitted := mockEmitter.Events()
 	require.Len(t, emitted, 1)

--- a/components/ledger/internal/services/fees/delete-package-by-id.go
+++ b/components/ledger/internal/services/fees/delete-package-by-id.go
@@ -72,7 +72,7 @@ func (uc *UseCase) DeletePackageByID(ctx context.Context, id, organizationID uui
 	return nil
 }
 
-// emitFeesPackageDeletedEvent publishes fees-package.deleted. IMPORTANT posture.
+// emitFeesPackageDeletedEvent publishes fee-packages.deleted. IMPORTANT posture.
 func (uc *UseCase) emitFeesPackageDeletedEvent(ctx context.Context, span trace.Span, logger libLog.Logger, id, organizationID, ledgerID uuid.UUID, deletedAt time.Time) {
 	pkgStreaming.EmitImportant(ctx, span, logger, uc.Streaming, events.FeesPackageDeletedDefinition.Key(),
 		func(tenantID string) (libStreaming.EmitRequest, error) {

--- a/components/ledger/internal/services/fees/delete-package-by-id_test.go
+++ b/components/ledger/internal/services/fees/delete-package-by-id_test.go
@@ -109,7 +109,7 @@ func TestDeletePackageById(t *testing.T) {
 }
 
 // TestDeletePackageByID_EmitsFeesPackageDeleted asserts a successful delete emits
-// the fees-package.deleted event, using the ledger resolved by an independent
+// the fee-packages.deleted event, using the ledger resolved by an independent
 // FindByID call (DECISION 2).
 func TestDeletePackageByID_EmitsFeesPackageDeleted(t *testing.T) {
 	ctrl := gomock.NewController(t)
@@ -139,7 +139,7 @@ func TestDeletePackageByID_EmitsFeesPackageDeleted(t *testing.T) {
 	err := svc.DeletePackageByID(context.Background(), packID, orgID)
 	require.NoError(t, err)
 
-	pkgStreaming.AssertEventEmitted(t, mockEmitter, "fees-package", "deleted")
+	pkgStreaming.AssertEventEmitted(t, mockEmitter, "fee-packages", "deleted")
 
 	emitted := mockEmitter.Events()
 	require.Len(t, emitted, 1)

--- a/components/ledger/internal/services/fees/update-package-by-id.go
+++ b/components/ledger/internal/services/fees/update-package-by-id.go
@@ -92,7 +92,7 @@ func (uc *UseCase) UpdatePackageByID(ctx context.Context, id, organizationID uui
 	return nil
 }
 
-// emitFeesPackageUpdatedEvent publishes fees-package.updated. IMPORTANT posture.
+// emitFeesPackageUpdatedEvent publishes fee-packages.updated. IMPORTANT posture.
 func (uc *UseCase) emitFeesPackageUpdatedEvent(ctx context.Context, span trace.Span, logger libLog.Logger, p *pack.Package, organizationID uuid.UUID) {
 	pkgStreaming.EmitImportant(ctx, span, logger, uc.Streaming, events.FeesPackageUpdatedDefinition.Key(),
 		func(tenantID string) (libStreaming.EmitRequest, error) {
@@ -275,7 +275,8 @@ func (uc *UseCase) SetAmountsDataToUpdate(ctx context.Context, logger libLog.Log
 	// validating max and min amount range of a package
 	if errRange := uc.ValidatePackageMaxAndMinAmountRange(
 		ctx, logger, maxAmount, minAmount, feesAmountData.GetTransactionRoute(),
-		organizationID, feesAmountData.LedgerID, feesAmountData.SegmentID, packageID); errRange != nil {
+		organizationID, feesAmountData.LedgerID, feesAmountData.SegmentID, packageID,
+	); errRange != nil {
 		return errRange
 	}
 

--- a/components/ledger/internal/services/fees/update-package-by-id_test.go
+++ b/components/ledger/internal/services/fees/update-package-by-id_test.go
@@ -343,7 +343,7 @@ func TestUpdatePackageByID_UpdatedAtFieldSet(t *testing.T) {
 }
 
 // TestUpdatePackageByID_EmitsFeesPackageUpdated asserts a successful update emits
-// the fees-package.updated event, built from the entity returned by Update.
+// the fee-packages.updated event, built from the entity returned by Update.
 func TestUpdatePackageByID_EmitsFeesPackageUpdated(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -388,7 +388,7 @@ func TestUpdatePackageByID_EmitsFeesPackageUpdated(t *testing.T) {
 	err := svc.UpdatePackageByID(context.Background(), packID, orgID, input)
 	require.NoError(t, err)
 
-	pkgStreaming.AssertEventEmitted(t, mockEmitter, "fees-package", "updated")
+	pkgStreaming.AssertEventEmitted(t, mockEmitter, "fee-packages", "updated")
 
 	emitted := mockEmitter.Events()
 	require.Len(t, emitted, 1)

--- a/components/tracer/internal/bootstrap/streaming.go
+++ b/components/tracer/internal/bootstrap/streaming.go
@@ -17,6 +17,7 @@ import (
 	"github.com/twmb/franz-go/pkg/sasl/plain"
 	"github.com/twmb/franz-go/pkg/sasl/scram"
 
+	pkgStreaming "github.com/LerianStudio/midaz/v4/pkg/streaming"
 	"github.com/LerianStudio/midaz/v4/pkg/streaming/events"
 )
 
@@ -34,9 +35,10 @@ const (
 // sync.
 const streamingPrimaryTargetName = "primary"
 
-// streamingTopicPrefix is the canonical prefix every topic name uses.
-// Topic names take the shape "lerian.streaming.<resource>.<event>".
-const streamingTopicPrefix = "lerian.streaming."
+// streamingServiceName is the producing-service segment folded into every
+// tracer topic name via pkgStreaming.TopicName. Topic names take the shape
+// "lerian.streaming.<service>_<resource>.<event>" (service = tracer).
+const streamingServiceName = "tracer"
 
 // streamingSource is the default CloudEvents source stamped on every event
 // tracer emits. Distinct from the ledger component's source so downstream
@@ -174,7 +176,8 @@ func buildLiveStreamingEmitter(
 	}
 
 	// Build the route table. One required route per event keyed to the
-	// canonical "lerian.streaming.<resource>.<event>" topic name.
+	// canonical "lerian.streaming.<service>_<resource>.<event>" topic name
+	// (service = tracer).
 	routes := buildRoutes(streamingPrimaryTargetName)
 
 	source := resolveStreamingSource(cfg)
@@ -226,7 +229,8 @@ func buildLiveStreamingEmitter(
 			}
 		}
 
-		logger.Log(ctx, libLog.LevelInfo, "Streaming emitter constructed",
+		logger.Log(
+			ctx, libLog.LevelInfo, "Streaming emitter constructed",
 			libLog.String("brokers", strings.Join(streamingCfg.Brokers, ",")),
 			libLog.String("client_id", streamingCfg.ClientID),
 			libLog.String("ce_source", source),
@@ -271,7 +275,8 @@ func resolveSASLMechanism(cfg *Config) (sasl.Mechanism, string, error) {
 	if user == "" || pass == "" {
 		return nil, "", fmt.Errorf(
 			"STREAMING_SASL_MECHANISM=%q requires STREAMING_SASL_USERNAME and STREAMING_SASL_PASSWORD",
-			mechanism)
+			mechanism,
+		)
 	}
 
 	switch mechanism {
@@ -284,7 +289,8 @@ func resolveSASLMechanism(cfg *Config) (sasl.Mechanism, string, error) {
 	default:
 		return nil, "", fmt.Errorf(
 			"STREAMING_SASL_MECHANISM=%q is not supported (accepted: %s, %s, %s)",
-			raw, saslMechanismPlain, saslMechanismScram256, saslMechanismScram512)
+			raw, saslMechanismPlain, saslMechanismScram256, saslMechanismScram512,
+		)
 	}
 }
 
@@ -334,13 +340,13 @@ func buildCatalog() (libStreaming.Catalog, error) {
 
 // buildRoutes constructs one RouteRequired route per tracer event,
 // targeting the single broker named targetName. Topic names are
-// "lerian.streaming.<resource>.<event>".
+// "lerian.streaming.<service>_<resource>.<event>" (service = tracer),
+// rendered via pkgStreaming.TopicName.
 //
 // Route Keys are composed as "<definition-key>.<target-name>" (e.g.
-// "validation.evaluated.primary") — Route.Key must match a lower-case
-// dot-delimited pattern, and the target-name suffix guarantees uniqueness
-// when the same event is later routed to multiple targets (e.g. a parallel
-// shadow route).
+// "rule.created.primary") — Route.Key must match a lower-case dot-delimited
+// pattern, and the target-name suffix guarantees uniqueness when the same
+// event is later routed to multiple targets (e.g. a parallel shadow route).
 func buildRoutes(targetName string) []libStreaming.RouteDefinition {
 	defs := tracerEventDefinitions()
 	routes := make([]libStreaming.RouteDefinition, 0, len(defs))
@@ -351,7 +357,7 @@ func buildRoutes(targetName string) []libStreaming.RouteDefinition {
 			Key:           key + "." + targetName,
 			DefinitionKey: key,
 			Target:        targetName,
-			Destination:   libStreaming.KafkaTopic(streamingTopicPrefix + key),
+			Destination:   libStreaming.KafkaTopic(pkgStreaming.TopicName(streamingServiceName, key)),
 			Requirement:   libStreaming.RouteRequired,
 		})
 	}

--- a/components/tracer/internal/bootstrap/streaming_integration_test.go
+++ b/components/tracer/internal/bootstrap/streaming_integration_test.go
@@ -17,6 +17,7 @@ import (
 
 	libStreaming "github.com/LerianStudio/lib-streaming"
 	"github.com/LerianStudio/midaz/v4/components/tracer/pkg/model"
+	pkgStreaming "github.com/LerianStudio/midaz/v4/pkg/streaming"
 	"github.com/LerianStudio/midaz/v4/pkg/streaming/events"
 	"github.com/google/uuid"
 	"github.com/shopspring/decimal"
@@ -284,13 +285,14 @@ func fencedScope() model.Scope {
 }
 
 // smokeTopics maps each event's ce-type back to its canonical topic name
-// "lerian.streaming.<resource>.<event>".
+// "lerian.streaming.tracer_<resource>.<event>" (service segment folded into
+// the first topic segment, hyphens normalized to underscores).
 func smokeTopics(evs []smokeEvent) []string {
 	out := make([]string, 0, len(evs))
 
 	for _, e := range evs {
 		key := strings.TrimPrefix(e.wantCEType, "studio.lerian.")
-		out = append(out, "lerian.streaming."+key)
+		out = append(out, pkgStreaming.TopicName("tracer", key))
 	}
 
 	return out

--- a/components/tracer/internal/bootstrap/streaming_test.go
+++ b/components/tracer/internal/bootstrap/streaming_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	libStreaming "github.com/LerianStudio/lib-streaming"
+	pkgStreaming "github.com/LerianStudio/midaz/v4/pkg/streaming"
 	"github.com/LerianStudio/midaz/v4/pkg/streaming/events"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -229,8 +230,8 @@ func TestBuildRoutes_CoversAllLifecycles(t *testing.T) {
 			"route Key must be <event>.<target>")
 		assert.Equal(t, streamingPrimaryTargetName, r.Target)
 		assert.Equal(t, libStreaming.RouteRequired, r.Requirement)
-		assert.Equal(t, libStreaming.KafkaTopic(streamingTopicPrefix+key), r.Destination,
-			"route Destination must be the canonical Kafka topic")
+		assert.Equal(t, libStreaming.KafkaTopic(pkgStreaming.TopicName("tracer", key)), r.Destination,
+			"route Destination must be the canonical tracer-namespaced Kafka topic")
 	}
 }
 
@@ -288,8 +289,8 @@ func TestTracerCatalog_CoversAllEmittedEvents(t *testing.T) {
 			"route %q points at an unregistered event (ghost topic)", r.DefinitionKey)
 
 		// (d) destination topic derives from the definition key.
-		assert.Equal(t, libStreaming.KafkaTopic(streamingTopicPrefix+r.DefinitionKey), r.Destination,
-			"route Destination must be lerian.streaming.<key>")
+		assert.Equal(t, libStreaming.KafkaTopic(pkgStreaming.TopicName("tracer", r.DefinitionKey)), r.Destination,
+			"route Destination must be lerian.streaming.tracer_<resource>.<event>")
 	}
 
 	assert.Equal(t, defKeys, routeKeys,

--- a/docs/streaming/crm-events.md
+++ b/docs/streaming/crm-events.md
@@ -13,8 +13,12 @@ complements — does not duplicate — the producer conventions in `CLAUDE.md`
 
 - **Producer:** [`github.com/LerianStudio/lib-streaming`](https://github.com/LerianStudio/lib-streaming) v1.4.0.
 - **Wire format:** CloudEvents 1.0, binary mode, over Kafka.
-- **Component:** CRM (`components/crm`).
-- **CloudEvents source (`ce-source`):** `lerian.midaz.crm`.
+- **Component:** CRM is embedded in the ledger binary
+  (`components/ledger/internal/crm`); there is no standalone CRM service.
+- **CloudEvents source (`ce-source`):** `lerian.midaz.ledger` — the process-wide
+  source of the ledger binary CRM rides on, NOT `lerian.midaz.crm`. Consumers
+  attribute events to CRM via the `crm_` topic segment and the `holder` /
+  `instrument` resource types, not via `ce-source`.
 - **Posture:** all 7 events are **IMPORTANT** — direct-emit, synchronous, via
   `pkgStreaming.EmitImportant`. Emit is best-effort at the post-commit slot in
   the command use case: a build/emit failure logs a Warn and is recorded on the
@@ -31,14 +35,18 @@ complements — does not duplicate — the producer conventions in `CLAUDE.md`
 
 Routing constants are assembled from `Definition{ResourceType, EventType,
 SchemaVersion}` (`pkg/streaming/events/events.go`) and registered exactly once
-in `crmEventDefinitions()` (`components/crm/internal/bootstrap/streaming.go`),
-which feeds both the Catalog and the route table:
+in `midazEventDefinitions()`
+(`components/ledger/internal/bootstrap/streaming.go`), which feeds both the
+Catalog and the route table:
 
 - **Event key** = `<resourceType>.<eventType>` (e.g. `holder.created`).
 - **`ce-type`** = lib-streaming auto-prefixes the key: `studio.lerian.<key>`.
-- **Kafka topic** = `lerian.streaming.ledger_<key>`, with hyphens in `<key>`
-  converted to underscores in the topic name only (e.g.
-  `lerian.streaming.ledger_instrument.related_party_deleted`). The event key and
+  The resource stays `holder` / `instrument`, so `ce-type` is unchanged by the
+  per-service topic segment (e.g. `studio.lerian.holder.created`).
+- **Kafka topic** = `pkgStreaming.TopicName("crm", key)` =
+  `lerian.streaming.crm_<key>`, with hyphens in `<key>` converted to underscores
+  in the topic name only (e.g.
+  `lerian.streaming.crm_instrument.related_party_deleted`). The event key and
   `ce-type` keep the hyphen.
 - **`ce-subject`** = the aggregate ID (`EmitRequest.Subject`).
 - **`ce-tenantid`** = `EmitRequest.TenantID`, resolved by
@@ -50,18 +58,18 @@ All 7 events carry `SchemaVersion = 1.0.0`.
 
 | Event key | Resource / Event | `ce-type` | Kafka topic | `ce-subject` | Trigger (use case) |
 |-----------|------------------|-----------|-------------|--------------|--------------------|
-| `holder.created` | holder / created | `studio.lerian.holder.created` | `lerian.streaming.ledger_holder.created` | holder ID | `CreateHolder` |
-| `holder.updated` | holder / updated | `studio.lerian.holder.updated` | `lerian.streaming.ledger_holder.updated` | holder ID | `UpdateHolderByID` |
-| `holder.deleted` | holder / deleted | `studio.lerian.holder.deleted` | `lerian.streaming.ledger_holder.deleted` | holder ID | `DeleteHolderByID` |
-| `instrument.created` | instrument / created | `studio.lerian.instrument.created` | `lerian.streaming.ledger_instrument.created` | instrument ID | `CreateInstrument` |
-| `instrument.updated` | instrument / updated | `studio.lerian.instrument.updated` | `lerian.streaming.ledger_instrument.updated` | instrument ID | `UpdateInstrumentByID` |
-| `instrument.deleted` | instrument / deleted | `studio.lerian.instrument.deleted` | `lerian.streaming.ledger_instrument.deleted` | instrument ID | `DeleteInstrumentByID` |
-| `instrument.related-party-deleted` | instrument / related-party-deleted | `studio.lerian.instrument.related-party-deleted` | `lerian.streaming.ledger_instrument.related_party_deleted` | **instrument ID** (not the related-party ID) | `DeleteRelatedPartyByID` |
+| `holder.created` | holder / created | `studio.lerian.holder.created` | `lerian.streaming.crm_holder.created` | holder ID | `CreateHolder` |
+| `holder.updated` | holder / updated | `studio.lerian.holder.updated` | `lerian.streaming.crm_holder.updated` | holder ID | `UpdateHolderByID` |
+| `holder.deleted` | holder / deleted | `studio.lerian.holder.deleted` | `lerian.streaming.crm_holder.deleted` | holder ID | `DeleteHolderByID` |
+| `instrument.created` | instrument / created | `studio.lerian.instrument.created` | `lerian.streaming.crm_instrument.created` | instrument ID | `CreateInstrument` |
+| `instrument.updated` | instrument / updated | `studio.lerian.instrument.updated` | `lerian.streaming.crm_instrument.updated` | instrument ID | `UpdateInstrumentByID` |
+| `instrument.deleted` | instrument / deleted | `studio.lerian.instrument.deleted` | `lerian.streaming.crm_instrument.deleted` | instrument ID | `DeleteInstrumentByID` |
+| `instrument.related-party-deleted` | instrument / related-party-deleted | `studio.lerian.instrument.related-party-deleted` | `lerian.streaming.crm_instrument.related_party_deleted` | **instrument ID** (not the related-party ID) | `DeleteRelatedPartyByID` |
 
 > **Hyphen, not underscore.** The `instrument.related-party-deleted` event type is
 > hyphenated. The lib-streaming route-key validator rejects underscores, so the
 > key and `ce-type` keep the hyphen. The Kafka topic is the only place hyphens
-> become underscores: `lerian.streaming.ledger_instrument.related_party_deleted`.
+> become underscores: `lerian.streaming.crm_instrument.related_party_deleted`.
 
 > **`ce-subject` on `instrument.related-party-deleted`.** The aggregate is the instrument,
 > so `ce-subject` is the **instrument ID**, and the removed party's ID travels in the

--- a/docs/streaming/fees-events.md
+++ b/docs/streaming/fees-events.md
@@ -38,9 +38,15 @@ in `midazEventDefinitions()`
 Catalog (`buildCatalog`) and the route table (`buildRoutes`):
 
 - **Event key** = `<resourceType>.<eventType>` via `Definition.Key()` (e.g.
-  `fees-package.created`).
-- **`ce-type`** = lib-streaming auto-prefixes the key: `studio.lerian.<key>`.
-- **Kafka topic** = `streamingTopicPrefix` + key = `lerian.streaming.<key>`.
+  `fee-packages.created`).
+- **`ce-type`** = lib-streaming auto-prefixes the key: `studio.lerian.<key>`
+  (stays hyphenated, e.g. `studio.lerian.fee-packages.created`).
+- **Kafka topic** = `pkgStreaming.TopicName("fee", key)` =
+  `lerian.streaming.<service>_<resource>.<event>` — the producing-service
+  segment (`fee`) is folded in and hyphens in the resource/event become
+  underscores in the topic name only (e.g. `lerian.streaming.fee_packages.created`).
+  The service segment is `fee` even though fees ride the ledger binary; the
+  process-wide `ce-source` stays `lerian.midaz.ledger`.
 - **`ce-subject`** = the aggregate ID (`EmitRequest.Subject`).
 - **`ce-tenantid`** = `EmitRequest.TenantID`, resolved by
   `pkgStreaming.ResolveTenantID(ctx)` inside `EmitImportant` (see
@@ -52,19 +58,21 @@ All 7 events carry `SchemaVersion = 1.0.0`.
 
 | Event key | Resource / Event | `ce-type` | Kafka topic | `ce-subject` | Trigger (use case) |
 |-----------|------------------|-----------|-------------|--------------|--------------------|
-| `fees-package.created` | fees-package / created | `studio.lerian.fees-package.created` | `lerian.streaming.fees-package.created` | package ID | create fee package |
-| `fees-package.updated` | fees-package / updated | `studio.lerian.fees-package.updated` | `lerian.streaming.fees-package.updated` | package ID | update fee package |
-| `fees-package.deleted` | fees-package / deleted | `studio.lerian.fees-package.deleted` | `lerian.streaming.fees-package.deleted` | package ID | delete fee package |
-| `fees-billing-package.created` | fees-billing-package / created | `studio.lerian.fees-billing-package.created` | `lerian.streaming.fees-billing-package.created` | billing package ID | create billing package |
-| `fees-billing-package.updated` | fees-billing-package / updated | `studio.lerian.fees-billing-package.updated` | `lerian.streaming.fees-billing-package.updated` | billing package ID | update billing package |
-| `fees-billing-package.deleted` | fees-billing-package / deleted | `studio.lerian.fees-billing-package.deleted` | `lerian.streaming.fees-billing-package.deleted` | billing package ID | delete billing package |
-| `fees.applied` | fees / applied | `studio.lerian.fees.applied` | `lerian.streaming.fees.applied` | **transaction ID** | fee charged on a posted transaction |
+| `fee-packages.created` | fee-packages / created | `studio.lerian.fee-packages.created` | `lerian.streaming.fee_packages.created` | package ID | create fee package |
+| `fee-packages.updated` | fee-packages / updated | `studio.lerian.fee-packages.updated` | `lerian.streaming.fee_packages.updated` | package ID | update fee package |
+| `fee-packages.deleted` | fee-packages / deleted | `studio.lerian.fee-packages.deleted` | `lerian.streaming.fee_packages.deleted` | package ID | delete fee package |
+| `fee-billing-packages.created` | fee-billing-packages / created | `studio.lerian.fee-billing-packages.created` | `lerian.streaming.fee_billing_packages.created` | billing package ID | create billing package |
+| `fee-billing-packages.updated` | fee-billing-packages / updated | `studio.lerian.fee-billing-packages.updated` | `lerian.streaming.fee_billing_packages.updated` | billing package ID | update billing package |
+| `fee-billing-packages.deleted` | fee-billing-packages / deleted | `studio.lerian.fee-billing-packages.deleted` | `lerian.streaming.fee_billing_packages.deleted` | billing package ID | delete billing package |
+| `fee-charge.applied` | fee-charge / applied | `studio.lerian.fee-charge.applied` | `lerian.streaming.fee_charge.applied` | **transaction ID** | fee charged on a posted transaction |
 
-> **Hyphen, not underscore.** The `fees-package` and `fees-billing-package`
-> resource types are hyphenated. The lib-streaming route-key validator rejects
-> underscores, so the key, topic, and `ce-type` all keep the hyphen.
+> **Hyphen in the key/ce-type, underscore in the topic.** The `fee-packages`
+> and `fee-billing-packages` resource types are hyphenated. The lib-streaming
+> route-key validator rejects underscores, so the event **key** and **`ce-type`**
+> keep the hyphen; only the derived **Kafka topic** name substitutes underscores
+> for hyphens (and folds in the `fee` service segment).
 
-> **`ce-subject` on `fees.applied`.** The aggregate is the transaction the fee
+> **`ce-subject` on `fee-charge.applied`.** The aggregate is the transaction the fee
 > was charged against, so `ce-subject` is the **transaction ID**, and the
 > charged fee package's ID travels in the body as `feePackageId`. The
 > package/billing-package events use their own record ID as subject.
@@ -75,7 +83,7 @@ The wire keys below are the exact JSON field set produced by the Payload structs
 in `pkg/streaming/events/`. The "field count" is the number the JSONShape test
 locks.
 
-### `fees-package.created` / `fees-package.updated` — 8 fields
+### `fee-packages.created` / `fee-packages.updated` — 8 fields
 
 Source: `pkg/streaming/events/fees_package_created.go`,
 `fees_package_updated.go`.
@@ -95,7 +103,7 @@ Source: `pkg/streaming/events/fees_package_created.go`,
 `feeGroupLabel`, `description`, `minimumAmount`, `maximumAmount`, `fees`,
 `waivedAccounts`.
 
-### `fees-package.deleted` — 4 fields
+### `fee-packages.deleted` — 4 fields
 
 Source: `pkg/streaming/events/fees_package_deleted.go`.
 
@@ -110,7 +118,7 @@ Source: `pkg/streaming/events/fees_package_deleted.go`.
 `feeGroupLabel`, `description`, `minimumAmount`, `maximumAmount`, `fees`,
 `waivedAccounts`, `segmentId`, `transactionRoute`, `enable`.
 
-### `fees-billing-package.created` / `fees-billing-package.updated` — 9 fields
+### `fee-billing-packages.created` / `fee-billing-packages.updated` — 9 fields
 
 Source: `pkg/streaming/events/fees_billing_package_created.go`,
 `fees_billing_package_updated.go`.
@@ -132,7 +140,7 @@ Source: `pkg/streaming/events/fees_billing_package_created.go`,
 `freeQuota`, `eventFilter`, `accountTarget`, `debitAccountAlias`,
 `creditAccountAlias`, `maintenanceCreditAccount`.
 
-### `fees-billing-package.deleted` — 4 fields
+### `fee-billing-packages.deleted` — 4 fields
 
 Source: `pkg/streaming/events/fees_billing_package_deleted.go`.
 
@@ -149,7 +157,7 @@ Source: `pkg/streaming/events/fees_billing_package_deleted.go`.
 `creditAccountAlias`, `maintenanceCreditAccount`, `type`, `pricingModel`,
 `countMode`, `enable`, `createdAt`, `updatedAt`.
 
-### `fees.applied` — 5 fields
+### `fee-charge.applied` — 5 fields
 
 Source: `pkg/streaming/events/fees_applied.go`.
 
@@ -165,9 +173,9 @@ Source: `pkg/streaming/events/fees_applied.go`.
 `amount`, `assetCode`, `source`, `destination`, `metadata`, `operations`,
 `description`, `fees`, `waivedAccounts`.
 
-## `fees.applied` semantics
+## `fee-charge.applied` semantics
 
-`fees.applied` is a charge signal, not a transaction signal:
+`fee-charge.applied` is a charge signal, not a transaction signal:
 
 - **Charged only.** It is emitted only when a fee was actually **charged** —
   `emitFeesAppliedEvent` fires only when `feeApplied=true` and a non-empty

--- a/docs/streaming/fees-events.md
+++ b/docs/streaming/fees-events.md
@@ -180,8 +180,9 @@ Source: `pkg/streaming/events/fees_applied.go`.
 - **Charged only.** It is emitted only when a fee was actually **charged** —
   `emitFeesAppliedEvent` fires only when `feeApplied=true` and a non-empty
   `packageAppliedID` are present in the transaction metadata (set by the fee
-  engine on the real-charge branch). A pure exemption carries neither, so **no
-  event is emitted on exemption**.
+  engine on the real-charge branch). A pure exemption still sets
+  `packageAppliedID` but omits `feeApplied=true`, so the `feeApplied` guard
+  suppresses it — **no event is emitted on exemption**.
 - **Once.** It rides alongside `transaction.posted` only. Commit, cancel, and
   revert do NOT re-emit it — the fee charge happened once, at post.
 

--- a/docs/streaming/tracer-events.md
+++ b/docs/streaming/tracer-events.md
@@ -398,8 +398,22 @@ point tracer at it:
   from both host (`localhost:19092`) and containers (`<container>:9092`).
 - Set `STREAMING_ENABLED=true`, `STREAMING_BROKERS=localhost:19092`, and
   `STREAMING_CLOUDEVENTS_SOURCE=lerian.midaz.tracer`.
-- Pre-provision the 12 `lerian.streaming.tracer_{rule,limit}.*` topics
-  explicitly; do not rely on auto-create.
+- Pre-provision these 12 topics explicitly; do not rely on auto-create:
+
+  ```
+  lerian.streaming.tracer_rule.created
+  lerian.streaming.tracer_rule.updated
+  lerian.streaming.tracer_rule.activated
+  lerian.streaming.tracer_rule.deactivated
+  lerian.streaming.tracer_rule.drafted
+  lerian.streaming.tracer_rule.deleted
+  lerian.streaming.tracer_limit.created
+  lerian.streaming.tracer_limit.updated
+  lerian.streaming.tracer_limit.activated
+  lerian.streaming.tracer_limit.deactivated
+  lerian.streaming.tracer_limit.drafted
+  lerian.streaming.tracer_limit.deleted
+  ```
 
 The default unit suite never touches a broker — the JSONShape and mapping tests
 in `pkg/streaming/events/` marshal payloads in memory. See the `CLAUDE.md`

--- a/docs/streaming/tracer-events.md
+++ b/docs/streaming/tracer-events.md
@@ -42,8 +42,11 @@ Catalog (`buildCatalog`) and the route table (`buildRoutes`):
 - **Event key** = `<resourceType>.<eventType>` via `Definition.Key()` (e.g.
   `rule.created`). `resource` ∈ {`rule`, `limit`}; `event` ∈ {`created`,
   `updated`, `activated`, `deactivated`, `drafted`, `deleted`}.
-- **`ce-type`** = lib-streaming auto-prefixes the key: `studio.lerian.<key>`.
-- **Kafka topic** = `streamingTopicPrefix` + key = `lerian.streaming.<key>`.
+- **`ce-type`** = lib-streaming auto-prefixes the key: `studio.lerian.<key>`
+  (resource unchanged, e.g. `studio.lerian.rule.created`).
+- **Kafka topic** = `pkgStreaming.TopicName("tracer", key)` =
+  `lerian.streaming.tracer_<resource>.<event>` — the producing-service segment
+  (`tracer`) is folded in (e.g. `lerian.streaming.tracer_rule.created`).
 - **`ce-subject`** = the aggregate ID (`EmitRequest.Subject`) — the rule UUID or
   limit UUID.
 - **`ce-tenantid`** = `EmitRequest.TenantID`, resolved by
@@ -54,7 +57,7 @@ Catalog (`buildCatalog`) and the route table (`buildRoutes`):
 | Aspect | Rule |
 |--------|------|
 | Event key | `<resource>.<event>`, lowercase; tokens are single words (no separator); underscores are rejected by the route-key validator |
-| Kafka topic | `lerian.streaming.<resource>.<event>` |
+| Kafka topic | `lerian.streaming.tracer_<resource>.<event>` |
 | `ce-type` | `studio.lerian.<resource>.<event>` (auto-prefixed by lib-streaming) |
 | `ce-source` | `lerian.midaz.tracer` |
 | `ce-subject` | aggregate ID — rule UUID or limit UUID |
@@ -67,18 +70,18 @@ All 12 events carry `SchemaVersion = 1.0.0`.
 
 | Event key | `ce-type` | Kafka topic | `ce-subject` | Schema version |
 |-----------|-----------|-------------|--------------|----------------|
-| `rule.created` | `studio.lerian.rule.created` | `lerian.streaming.rule.created` | rule ID | `1.0.0` |
-| `rule.updated` | `studio.lerian.rule.updated` | `lerian.streaming.rule.updated` | rule ID | `1.0.0` |
-| `rule.activated` | `studio.lerian.rule.activated` | `lerian.streaming.rule.activated` | rule ID | `1.0.0` |
-| `rule.deactivated` | `studio.lerian.rule.deactivated` | `lerian.streaming.rule.deactivated` | rule ID | `1.0.0` |
-| `rule.drafted` | `studio.lerian.rule.drafted` | `lerian.streaming.rule.drafted` | rule ID | `1.0.0` |
-| `rule.deleted` | `studio.lerian.rule.deleted` | `lerian.streaming.rule.deleted` | rule ID | `1.0.0` |
-| `limit.created` | `studio.lerian.limit.created` | `lerian.streaming.limit.created` | limit ID | `1.0.0` |
-| `limit.updated` | `studio.lerian.limit.updated` | `lerian.streaming.limit.updated` | limit ID | `1.0.0` |
-| `limit.activated` | `studio.lerian.limit.activated` | `lerian.streaming.limit.activated` | limit ID | `1.0.0` |
-| `limit.deactivated` | `studio.lerian.limit.deactivated` | `lerian.streaming.limit.deactivated` | limit ID | `1.0.0` |
-| `limit.drafted` | `studio.lerian.limit.drafted` | `lerian.streaming.limit.drafted` | limit ID | `1.0.0` |
-| `limit.deleted` | `studio.lerian.limit.deleted` | `lerian.streaming.limit.deleted` | limit ID | `1.0.0` |
+| `rule.created` | `studio.lerian.rule.created` | `lerian.streaming.tracer_rule.created` | rule ID | `1.0.0` |
+| `rule.updated` | `studio.lerian.rule.updated` | `lerian.streaming.tracer_rule.updated` | rule ID | `1.0.0` |
+| `rule.activated` | `studio.lerian.rule.activated` | `lerian.streaming.tracer_rule.activated` | rule ID | `1.0.0` |
+| `rule.deactivated` | `studio.lerian.rule.deactivated` | `lerian.streaming.tracer_rule.deactivated` | rule ID | `1.0.0` |
+| `rule.drafted` | `studio.lerian.rule.drafted` | `lerian.streaming.tracer_rule.drafted` | rule ID | `1.0.0` |
+| `rule.deleted` | `studio.lerian.rule.deleted` | `lerian.streaming.tracer_rule.deleted` | rule ID | `1.0.0` |
+| `limit.created` | `studio.lerian.limit.created` | `lerian.streaming.tracer_limit.created` | limit ID | `1.0.0` |
+| `limit.updated` | `studio.lerian.limit.updated` | `lerian.streaming.tracer_limit.updated` | limit ID | `1.0.0` |
+| `limit.activated` | `studio.lerian.limit.activated` | `lerian.streaming.tracer_limit.activated` | limit ID | `1.0.0` |
+| `limit.deactivated` | `studio.lerian.limit.deactivated` | `lerian.streaming.tracer_limit.deactivated` | limit ID | `1.0.0` |
+| `limit.drafted` | `studio.lerian.limit.drafted` | `lerian.streaming.tracer_limit.drafted` | limit ID | `1.0.0` |
+| `limit.deleted` | `studio.lerian.limit.deleted` | `lerian.streaming.tracer_limit.deleted` | limit ID | `1.0.0` |
 
 ## Shared `scopes[]` nested shape
 
@@ -395,8 +398,8 @@ point tracer at it:
   from both host (`localhost:19092`) and containers (`<container>:9092`).
 - Set `STREAMING_ENABLED=true`, `STREAMING_BROKERS=localhost:19092`, and
   `STREAMING_CLOUDEVENTS_SOURCE=lerian.midaz.tracer`.
-- Pre-provision the 12 `lerian.streaming.{rule,limit}.*` topics explicitly; do
-  not rely on auto-create.
+- Pre-provision the 12 `lerian.streaming.tracer_{rule,limit}.*` topics
+  explicitly; do not rely on auto-create.
 
 The default unit suite never touches a broker — the JSONShape and mapping tests
 in `pkg/streaming/events/` marshal payloads in memory. See the `CLAUDE.md`

--- a/pkg/streaming/events/fees_applied.go
+++ b/pkg/streaming/events/fees_applied.go
@@ -12,15 +12,15 @@ import (
 	libStreaming "github.com/LerianStudio/lib-streaming"
 )
 
-// FeesAppliedDefinition is the routing contract for fees.applied.
+// FeesAppliedDefinition is the routing contract for fee-charge.applied.
 // IMPORTANT posture: emit failures MUST NOT fail the request.
 var FeesAppliedDefinition = Definition{
-	ResourceType:  "fees",
+	ResourceType:  "fee-charge",
 	EventType:     "applied",
 	SchemaVersion: "1.0.0",
 }
 
-// FeesAppliedPayload is the wire payload for fees.applied. Only the transaction
+// FeesAppliedPayload is the wire payload for fee-charge.applied. Only the transaction
 // identity, org/ledger scope, the applied fee package reference, and the
 // application timestamp cross the wire. Monetary and detail surface (amounts,
 // asset codes, source/destination, operations, metadata, fee lines,

--- a/pkg/streaming/events/fees_applied_test.go
+++ b/pkg/streaming/events/fees_applied_test.go
@@ -32,8 +32,8 @@ const feesAppliedPackageID = "0190d9e1-7c2a-7000-8000-0000000000a4"
 func TestFeesAppliedDefinition_Key(t *testing.T) {
 	t.Parallel()
 
-	assert.Equal(t, "fees.applied", events.FeesAppliedDefinition.Key())
-	assert.Equal(t, "fees", events.FeesAppliedDefinition.ResourceType)
+	assert.Equal(t, "fee-charge.applied", events.FeesAppliedDefinition.Key())
+	assert.Equal(t, "fee-charge", events.FeesAppliedDefinition.ResourceType)
 	assert.Equal(t, "applied", events.FeesAppliedDefinition.EventType)
 	assert.Equal(t, "1.0.0", events.FeesAppliedDefinition.SchemaVersion)
 }

--- a/pkg/streaming/events/fees_applied_test.go
+++ b/pkg/streaming/events/fees_applied_test.go
@@ -14,19 +14,19 @@ import (
 )
 
 // feesAppliedTransactionID is the deterministic aggregate ID reused across
-// fees.applied tests so Subject assertions are exact-match.
+// fee-charge.applied tests so Subject assertions are exact-match.
 const feesAppliedTransactionID = "0190d9e1-7c2a-7000-8000-0000000000a1"
 
-// feesAppliedOrgID is the deterministic organization scope for fees.applied
+// feesAppliedOrgID is the deterministic organization scope for fee-charge.applied
 // event tests.
 const feesAppliedOrgID = "0190d9e1-7c2a-7000-8000-0000000000a3"
 
-// feesAppliedLedgerID is the deterministic ledger scope for fees.applied event
+// feesAppliedLedgerID is the deterministic ledger scope for fee-charge.applied event
 // tests.
 const feesAppliedLedgerID = "0190d9e1-7c2a-7000-8000-0000000000a2"
 
 // feesAppliedPackageID is the deterministic fee package reference for
-// fees.applied event tests.
+// fee-charge.applied event tests.
 const feesAppliedPackageID = "0190d9e1-7c2a-7000-8000-0000000000a4"
 
 func TestFeesAppliedDefinition_Key(t *testing.T) {

--- a/pkg/streaming/events/fees_billing_package_created.go
+++ b/pkg/streaming/events/fees_billing_package_created.go
@@ -13,16 +13,16 @@ import (
 )
 
 // FeesBillingPackageCreatedDefinition is the routing contract for
-// fees-billing-package.created. IMPORTANT posture: emit failures MUST NOT fail
+// fee-billing-packages.created. IMPORTANT posture: emit failures MUST NOT fail
 // the request.
 var FeesBillingPackageCreatedDefinition = Definition{
-	ResourceType:  "fees-billing-package",
+	ResourceType:  "fee-billing-packages",
 	EventType:     "created",
 	SchemaVersion: "1.0.0",
 }
 
 // FeesBillingPackageCreatedPayload is the wire payload for
-// fees-billing-package.created. Only stable identifiers, the org/ledger scope,
+// fee-billing-packages.created. Only stable identifiers, the org/ledger scope,
 // the type/pricing/count classification, the enable flag, and timestamps cross
 // the wire. Fee-detail surface (label, description, assetCode, feeAmount, tiers,
 // discountTiers, freeQuota, eventFilter, accountTarget, account aliases) is

--- a/pkg/streaming/events/fees_billing_package_created_test.go
+++ b/pkg/streaming/events/fees_billing_package_created_test.go
@@ -26,8 +26,8 @@ const (
 
 // TestFeesBillingPackageCreatedDefinition_Key locks the canonical event key.
 func TestFeesBillingPackageCreatedDefinition_Key(t *testing.T) {
-	assert.Equal(t, "fees-billing-package.created", events.FeesBillingPackageCreatedDefinition.Key())
-	assert.Equal(t, "fees-billing-package", events.FeesBillingPackageCreatedDefinition.ResourceType)
+	assert.Equal(t, "fee-billing-packages.created", events.FeesBillingPackageCreatedDefinition.Key())
+	assert.Equal(t, "fee-billing-packages", events.FeesBillingPackageCreatedDefinition.ResourceType)
 	assert.Equal(t, "created", events.FeesBillingPackageCreatedDefinition.EventType)
 	assert.Equal(t, "1.0.0", events.FeesBillingPackageCreatedDefinition.SchemaVersion)
 }

--- a/pkg/streaming/events/fees_billing_package_deleted.go
+++ b/pkg/streaming/events/fees_billing_package_deleted.go
@@ -13,16 +13,16 @@ import (
 )
 
 // FeesBillingPackageDeletedDefinition is the routing contract for
-// fees-billing-package.deleted. IMPORTANT posture: emit failures MUST NOT fail
+// fee-billing-packages.deleted. IMPORTANT posture: emit failures MUST NOT fail
 // the request.
 var FeesBillingPackageDeletedDefinition = Definition{
-	ResourceType:  "fees-billing-package",
+	ResourceType:  "fee-billing-packages",
 	EventType:     "deleted",
 	SchemaVersion: "1.0.0",
 }
 
 // FeesBillingPackageDeletedPayload is the wire payload for
-// fees-billing-package.deleted. Only identifiers, scope, and the deletion
+// fee-billing-packages.deleted. Only identifiers, scope, and the deletion
 // timestamp cross the wire.
 type FeesBillingPackageDeletedPayload struct {
 	ID             string `json:"id"`

--- a/pkg/streaming/events/fees_billing_package_deleted_test.go
+++ b/pkg/streaming/events/fees_billing_package_deleted_test.go
@@ -30,8 +30,8 @@ var billingPkgDeletedTime = time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
 
 // TestFeesBillingPackageDeletedDefinition_Key locks the canonical event key.
 func TestFeesBillingPackageDeletedDefinition_Key(t *testing.T) {
-	assert.Equal(t, "fees-billing-package.deleted", events.FeesBillingPackageDeletedDefinition.Key())
-	assert.Equal(t, "fees-billing-package", events.FeesBillingPackageDeletedDefinition.ResourceType)
+	assert.Equal(t, "fee-billing-packages.deleted", events.FeesBillingPackageDeletedDefinition.Key())
+	assert.Equal(t, "fee-billing-packages", events.FeesBillingPackageDeletedDefinition.ResourceType)
 	assert.Equal(t, "deleted", events.FeesBillingPackageDeletedDefinition.EventType)
 	assert.Equal(t, "1.0.0", events.FeesBillingPackageDeletedDefinition.SchemaVersion)
 }
@@ -40,7 +40,8 @@ func TestFeesBillingPackageDeletedDefinition_Key(t *testing.T) {
 // deleted payload including RFC3339 formatting of the deletion timestamp.
 func TestNewFeesBillingPackageDeleted_Maps(t *testing.T) {
 	payload := events.NewFeesBillingPackageDeleted(
-		billingPkgDeletedID, billingPkgDeletedOrgID, billingPkgDeletedLedgerID, billingPkgDeletedTime)
+		billingPkgDeletedID, billingPkgDeletedOrgID, billingPkgDeletedLedgerID, billingPkgDeletedTime,
+	)
 
 	assert.Equal(t, billingPkgDeletedID, payload.ID)
 	assert.Equal(t, billingPkgDeletedOrgID, payload.OrganizationID)
@@ -52,7 +53,8 @@ func TestNewFeesBillingPackageDeleted_Maps(t *testing.T) {
 // helper composes a fully-populated EmitRequest and round-trips the payload.
 func TestFeesBillingPackageDeletedPayload_ToEmitRequest(t *testing.T) {
 	payload := events.NewFeesBillingPackageDeleted(
-		billingPkgDeletedID, billingPkgDeletedOrgID, billingPkgDeletedLedgerID, billingPkgDeletedTime)
+		billingPkgDeletedID, billingPkgDeletedOrgID, billingPkgDeletedLedgerID, billingPkgDeletedTime,
+	)
 
 	req, err := payload.ToEmitRequest("tenant-1", billingPkgDeletedTime)
 	require.NoError(t, err)
@@ -71,7 +73,8 @@ func TestFeesBillingPackageDeletedPayload_ToEmitRequest(t *testing.T) {
 // asserts every fee-detail / account / monetary field is ABSENT.
 func TestFeesBillingPackageDeletedPayload_JSONShape(t *testing.T) {
 	payload := events.NewFeesBillingPackageDeleted(
-		billingPkgDeletedID, billingPkgDeletedOrgID, billingPkgDeletedLedgerID, billingPkgDeletedTime)
+		billingPkgDeletedID, billingPkgDeletedOrgID, billingPkgDeletedLedgerID, billingPkgDeletedTime,
+	)
 
 	data, err := json.Marshal(payload)
 	require.NoError(t, err)

--- a/pkg/streaming/events/fees_billing_package_updated.go
+++ b/pkg/streaming/events/fees_billing_package_updated.go
@@ -13,16 +13,16 @@ import (
 )
 
 // FeesBillingPackageUpdatedDefinition is the routing contract for
-// fees-billing-package.updated. IMPORTANT posture: emit failures MUST NOT fail
+// fee-billing-packages.updated. IMPORTANT posture: emit failures MUST NOT fail
 // the request.
 var FeesBillingPackageUpdatedDefinition = Definition{
-	ResourceType:  "fees-billing-package",
+	ResourceType:  "fee-billing-packages",
 	EventType:     "updated",
 	SchemaVersion: "1.0.0",
 }
 
 // FeesBillingPackageUpdatedPayload is the wire payload for
-// fees-billing-package.updated. It mirrors the created payload: only
+// fee-billing-packages.updated. It mirrors the created payload: only
 // identifiers, scope, classifications, the enable flag, and timestamps cross
 // the wire. Fee-detail surface is DELIBERATELY ABSENT.
 type FeesBillingPackageUpdatedPayload struct {

--- a/pkg/streaming/events/fees_billing_package_updated_test.go
+++ b/pkg/streaming/events/fees_billing_package_updated_test.go
@@ -16,8 +16,8 @@ import (
 
 // TestFeesBillingPackageUpdatedDefinition_Key locks the canonical event key.
 func TestFeesBillingPackageUpdatedDefinition_Key(t *testing.T) {
-	assert.Equal(t, "fees-billing-package.updated", events.FeesBillingPackageUpdatedDefinition.Key())
-	assert.Equal(t, "fees-billing-package", events.FeesBillingPackageUpdatedDefinition.ResourceType)
+	assert.Equal(t, "fee-billing-packages.updated", events.FeesBillingPackageUpdatedDefinition.Key())
+	assert.Equal(t, "fee-billing-packages", events.FeesBillingPackageUpdatedDefinition.ResourceType)
 	assert.Equal(t, "updated", events.FeesBillingPackageUpdatedDefinition.EventType)
 	assert.Equal(t, "1.0.0", events.FeesBillingPackageUpdatedDefinition.SchemaVersion)
 }

--- a/pkg/streaming/events/fees_package_created.go
+++ b/pkg/streaming/events/fees_package_created.go
@@ -12,15 +12,15 @@ import (
 	libStreaming "github.com/LerianStudio/lib-streaming"
 )
 
-// FeesPackageCreatedDefinition is the routing contract for fees-package.created.
+// FeesPackageCreatedDefinition is the routing contract for fee-packages.created.
 // IMPORTANT posture: emit failures MUST NOT fail the request.
 var FeesPackageCreatedDefinition = Definition{
-	ResourceType:  "fees-package",
+	ResourceType:  "fee-packages",
 	EventType:     "created",
 	SchemaVersion: "1.0.0",
 }
 
-// FeesPackageCreatedPayload is the wire payload for fees-package.created. Only
+// FeesPackageCreatedPayload is the wire payload for fee-packages.created. Only
 // stable identifiers, the org/ledger scope, the segment/route classification,
 // the enable flag, and timestamps cross the wire. Fee-detail surface
 // (feeGroupLabel, description, minimum/maximum amount, fees, waivedAccounts) is

--- a/pkg/streaming/events/fees_package_created_test.go
+++ b/pkg/streaming/events/fees_package_created_test.go
@@ -13,15 +13,15 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// feesPackageID is the deterministic aggregate ID reused across fees-package
+// feesPackageID is the deterministic aggregate ID reused across fee-packages
 // tests so Subject/ID assertions are exact-match.
 const feesPackageID = "0190d9e1-7c2a-7000-8000-0000000000f1"
 
-// feesPackageOrgID is the deterministic organization scope for fees-package
+// feesPackageOrgID is the deterministic organization scope for fee-packages
 // event tests.
 const feesPackageOrgID = "0190d9e1-7c2a-7000-8000-0000000000f3"
 
-// feesPackageLedgerID is the deterministic ledger scope for fees-package event
+// feesPackageLedgerID is the deterministic ledger scope for fee-packages event
 // tests.
 const feesPackageLedgerID = "0190d9e1-7c2a-7000-8000-0000000000f2"
 

--- a/pkg/streaming/events/fees_package_created_test.go
+++ b/pkg/streaming/events/fees_package_created_test.go
@@ -26,8 +26,8 @@ const feesPackageOrgID = "0190d9e1-7c2a-7000-8000-0000000000f3"
 const feesPackageLedgerID = "0190d9e1-7c2a-7000-8000-0000000000f2"
 
 func TestFeesPackageCreatedDefinition_Key(t *testing.T) {
-	assert.Equal(t, "fees-package.created", events.FeesPackageCreatedDefinition.Key())
-	assert.Equal(t, "fees-package", events.FeesPackageCreatedDefinition.ResourceType)
+	assert.Equal(t, "fee-packages.created", events.FeesPackageCreatedDefinition.Key())
+	assert.Equal(t, "fee-packages", events.FeesPackageCreatedDefinition.ResourceType)
 	assert.Equal(t, "created", events.FeesPackageCreatedDefinition.EventType)
 	assert.Equal(t, "1.0.0", events.FeesPackageCreatedDefinition.SchemaVersion)
 }

--- a/pkg/streaming/events/fees_package_deleted.go
+++ b/pkg/streaming/events/fees_package_deleted.go
@@ -12,15 +12,15 @@ import (
 	libStreaming "github.com/LerianStudio/lib-streaming"
 )
 
-// FeesPackageDeletedDefinition is the routing contract for fees-package.deleted.
+// FeesPackageDeletedDefinition is the routing contract for fee-packages.deleted.
 // IMPORTANT posture: emit failures MUST NOT fail the request.
 var FeesPackageDeletedDefinition = Definition{
-	ResourceType:  "fees-package",
+	ResourceType:  "fee-packages",
 	EventType:     "deleted",
 	SchemaVersion: "1.0.0",
 }
 
-// FeesPackageDeletedPayload is the wire payload for fees-package.deleted. Kept
+// FeesPackageDeletedPayload is the wire payload for fee-packages.deleted. Kept
 // minimal: identity, org/ledger scope, and the deletion timestamp. Fee-detail
 // surface never crosses the wire.
 //

--- a/pkg/streaming/events/fees_package_deleted_test.go
+++ b/pkg/streaming/events/fees_package_deleted_test.go
@@ -14,8 +14,8 @@ import (
 )
 
 func TestFeesPackageDeletedDefinition_Key(t *testing.T) {
-	assert.Equal(t, "fees-package.deleted", events.FeesPackageDeletedDefinition.Key())
-	assert.Equal(t, "fees-package", events.FeesPackageDeletedDefinition.ResourceType)
+	assert.Equal(t, "fee-packages.deleted", events.FeesPackageDeletedDefinition.Key())
+	assert.Equal(t, "fee-packages", events.FeesPackageDeletedDefinition.ResourceType)
 	assert.Equal(t, "deleted", events.FeesPackageDeletedDefinition.EventType)
 	assert.Equal(t, "1.0.0", events.FeesPackageDeletedDefinition.SchemaVersion)
 }

--- a/pkg/streaming/events/fees_package_updated.go
+++ b/pkg/streaming/events/fees_package_updated.go
@@ -12,15 +12,15 @@ import (
 	libStreaming "github.com/LerianStudio/lib-streaming"
 )
 
-// FeesPackageUpdatedDefinition is the routing contract for fees-package.updated.
+// FeesPackageUpdatedDefinition is the routing contract for fee-packages.updated.
 // IMPORTANT posture: emit failures MUST NOT fail the request.
 var FeesPackageUpdatedDefinition = Definition{
-	ResourceType:  "fees-package",
+	ResourceType:  "fee-packages",
 	EventType:     "updated",
 	SchemaVersion: "1.0.0",
 }
 
-// FeesPackageUpdatedPayload is the wire payload for fees-package.updated. Only
+// FeesPackageUpdatedPayload is the wire payload for fee-packages.updated. Only
 // stable identifiers, the org/ledger scope, the segment/route classification,
 // the enable flag, and timestamps cross the wire. Fee-detail surface
 // (feeGroupLabel, description, minimum/maximum amount, fees, waivedAccounts) is

--- a/pkg/streaming/events/fees_package_updated_test.go
+++ b/pkg/streaming/events/fees_package_updated_test.go
@@ -14,8 +14,8 @@ import (
 )
 
 func TestFeesPackageUpdatedDefinition_Key(t *testing.T) {
-	assert.Equal(t, "fees-package.updated", events.FeesPackageUpdatedDefinition.Key())
-	assert.Equal(t, "fees-package", events.FeesPackageUpdatedDefinition.ResourceType)
+	assert.Equal(t, "fee-packages.updated", events.FeesPackageUpdatedDefinition.Key())
+	assert.Equal(t, "fee-packages", events.FeesPackageUpdatedDefinition.ResourceType)
 	assert.Equal(t, "updated", events.FeesPackageUpdatedDefinition.EventType)
 	assert.Equal(t, "1.0.0", events.FeesPackageUpdatedDefinition.SchemaVersion)
 }

--- a/pkg/streaming/topic.go
+++ b/pkg/streaming/topic.go
@@ -10,7 +10,8 @@ import "strings"
 const TopicPrefix = "lerian.streaming."
 
 // TopicName renders the consumer-facing Kafka topic name for a producing
-// service ("ledger"/"crm") and a definition key ("<resource>.<event>").
+// service ("ledger"/"crm"/"fee"/"tracer") and a definition key
+// ("<resource>.<event>").
 //
 // The streaming-hub ingest consumer subscribes via kgo.ConsumeRegex to
 // ^lerian.streaming.<seg>.<seg>$ over the [a-z0-9_] charset — exactly two
@@ -21,6 +22,14 @@ const TopicPrefix = "lerian.streaming."
 // hyphens: lib-streaming's route-key grammar requires hyphens and rejects "_",
 // so the underscore form lives ONLY on the wire topic name, not on the event
 // identity.
+//
+// A leading "<service>-" on the key is stripped before the fold. Fee resources
+// carry a "fee-" prefix on their keys ("fee-packages.created"); without the strip
+// the "fee_" service segment would double it into "lerian.streaming.fee_fee_*".
+// Stripping keeps the topic at the required two segments and drops the redundant
+// prefix. The strip is a no-op for services whose keys never begin with
+// "<service>-" (ledger/crm/tracer), so it does not affect existing producers.
 func TopicName(service, key string) string {
+	key = strings.TrimPrefix(key, service+"-")
 	return TopicPrefix + service + "_" + strings.ReplaceAll(key, "-", "_")
 }

--- a/pkg/streaming/topic_test.go
+++ b/pkg/streaming/topic_test.go
@@ -55,6 +55,12 @@ func TestTopicName(t *testing.T) {
 			want:    "lerian.streaming.ledger_account.created",
 		},
 		{
+			name:    "ledger created resource equals service no-op proof",
+			service: "ledger",
+			key:     "ledger.created",
+			want:    "lerian.streaming.ledger_ledger.created",
+		},
+		{
 			name:    "crm multi-hyphen event segment",
 			service: "crm",
 			key:     "alias.related-party-deleted",

--- a/pkg/streaming/topic_test.go
+++ b/pkg/streaming/topic_test.go
@@ -5,16 +5,22 @@
 package streaming_test
 
 import (
+	"regexp"
 	"testing"
 
 	pkgStreaming "github.com/LerianStudio/midaz/v4/pkg/streaming"
 	"github.com/stretchr/testify/assert"
 )
 
+// hubTopicGrammar mirrors the streaming-hub ingest consumer subscription:
+// exactly two [a-z0-9_] segments after the prefix, no hyphen.
+var hubTopicGrammar = regexp.MustCompile(`^lerian\.streaming\.[a-z0-9_]+\.[a-z0-9_]+$`)
+
 // TestTopicName locks the service-folding + hyphen-to-underscore transform that
 // keeps wire topic names inside the streaming-hub consumer regex
 // (^lerian.streaming.<seg>.<seg>$ over [a-z0-9_]) while route keys / ce-type
-// stay hyphenated.
+// stay hyphenated. It also locks the leading-"<service>-" strip that keeps
+// fee-folded topics from becoming "fee_fee_*".
 func TestTopicName(t *testing.T) {
 	t.Parallel()
 
@@ -43,6 +49,12 @@ func TestTopicName(t *testing.T) {
 			want:    "lerian.streaming.ledger_balance.config_changed",
 		},
 		{
+			name:    "ledger account created no-op proof",
+			service: "ledger",
+			key:     "account.created",
+			want:    "lerian.streaming.ledger_account.created",
+		},
+		{
 			name:    "crm multi-hyphen event segment",
 			service: "crm",
 			key:     "alias.related-party-deleted",
@@ -54,13 +66,64 @@ func TestTopicName(t *testing.T) {
 			key:     "holder.created",
 			want:    "lerian.streaming.crm_holder.created",
 		},
+		{
+			name:    "crm instrument multi-hyphen event no-op proof",
+			service: "crm",
+			key:     "instrument.related-party-deleted",
+			want:    "lerian.streaming.crm_instrument.related_party_deleted",
+		},
+		{
+			name:    "fee packages created strips leading service prefix",
+			service: "fee",
+			key:     "fee-packages.created",
+			want:    "lerian.streaming.fee_packages.created",
+		},
+		{
+			name:    "fee packages updated strips leading service prefix",
+			service: "fee",
+			key:     "fee-packages.updated",
+			want:    "lerian.streaming.fee_packages.updated",
+		},
+		{
+			name:    "fee packages deleted strips leading service prefix",
+			service: "fee",
+			key:     "fee-packages.deleted",
+			want:    "lerian.streaming.fee_packages.deleted",
+		},
+		{
+			name:    "fee billing-packages created strips leading service prefix",
+			service: "fee",
+			key:     "fee-billing-packages.created",
+			want:    "lerian.streaming.fee_billing_packages.created",
+		},
+		{
+			name:    "fee charge applied strips leading service prefix",
+			service: "fee",
+			key:     "fee-charge.applied",
+			want:    "lerian.streaming.fee_charge.applied",
+		},
+		{
+			name:    "tracer rule created no strip",
+			service: "tracer",
+			key:     "rule.created",
+			want:    "lerian.streaming.tracer_rule.created",
+		},
+		{
+			name:    "tracer limit deactivated no strip",
+			service: "tracer",
+			key:     "limit.deactivated",
+			want:    "lerian.streaming.tracer_limit.deactivated",
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			assert.Equal(t, tt.want, pkgStreaming.TopicName(tt.service, tt.key))
+			got := pkgStreaming.TopicName(tt.service, tt.key)
+			assert.Equal(t, tt.want, got)
+			assert.Regexp(t, hubTopicGrammar, got,
+				"topic must match the two-segment streaming-hub grammar")
 		})
 	}
 }

--- a/tests/e2e/streaming_events_test.go
+++ b/tests/e2e/streaming_events_test.go
@@ -483,11 +483,11 @@ func TestStreamingHolderCreateEmitsRedacted(t *testing.T) {
 
 	ceType, subject, payload, ok := strmConsumeMatch(t, topic, holderID, 15*time.Second)
 	if !ok {
-		t.Fatalf("no holder.created record with ce-subject=%s on %s within timeout", holderID, topic)
+		t.Fatalf("no holder.created record on %s within timeout", topic)
 	}
 
 	if subject != holderID {
-		t.Errorf("ce-subject = %q, want holder id %q", subject, holderID)
+		t.Errorf("ce-subject does not match the created holder")
 	}
 
 	if want := strmCETypePrefix + "holder.created"; ceType != want {

--- a/tests/e2e/streaming_events_test.go
+++ b/tests/e2e/streaming_events_test.go
@@ -38,9 +38,11 @@ import (
 // host port (CLAUDE.md "Streaming / Local testing": bind 19092).
 const strmDefaultBroker = "localhost:19092"
 
-// strmServiceName mirrors bootstrap/streaming.go streamingServiceName; topics
-// are rendered via pkgStreaming.TopicName and take the shape
-// "lerian.streaming.<service>_<resource>.<event>".
+// strmServiceName is the ledger-core producing service segment; topics are
+// rendered via pkgStreaming.TopicName and take the shape
+// "lerian.streaming.<service>_<resource>.<event>". Fees route under "fee" and
+// CRM under "crm" (see bootstrap/streaming.go per-product registry); those are
+// passed explicitly at their call sites, not via this const.
 const strmServiceName = "ledger"
 
 // strmCEType is the reverse-DNS namespace prepended to every ce-type header by
@@ -433,7 +435,7 @@ func TestStreamingTransactionPostedEmitted(t *testing.T) {
 // TestStreamingHolderCreateEmitsNothing pins the negative contract: holder
 // creation has NO streaming emit (components/ledger/internal/crm/services/
 // create-holder.go contains no Emit call). We create a holder and confirm no
-// record carrying its id surfaces on any lerian.streaming.holder.* topic
+// record carrying its id surfaces on any lerian.streaming.crm_holder.* topic
 // within a short window. The holder-created and holder-updated topics are
 // probed explicitly; both must stay silent. A non-empty match is a regression
 // (an emit was added without a wire-contract event).
@@ -448,7 +450,7 @@ func TestStreamingHolderCreateEmitsNothing(t *testing.T) {
 	// keeps the test fast. If the broker auto-creates the topic, an empty log
 	// simply yields found=false.
 	for _, suffix := range []string{"created", "updated"} {
-		topic := pkgStreaming.TopicName(strmServiceName, "holder."+suffix)
+		topic := pkgStreaming.TopicName("crm", "holder."+suffix)
 
 		_, _, _, found := strmConsumeMatch(t, topic, holderID, 4*time.Second)
 		if found {

--- a/tests/e2e/streaming_events_test.go
+++ b/tests/e2e/streaming_events_test.go
@@ -39,11 +39,8 @@ import (
 // host port (CLAUDE.md "Streaming / Local testing": bind 19092).
 const strmDefaultBroker = "localhost:19092"
 
-// strmServiceName is the ledger-core producing service segment; topics are
-// rendered via pkgStreaming.TopicName and take the shape
-// "lerian.streaming.<service>_<resource>.<event>". Fees route under "fee" and
-// CRM under "crm" (see bootstrap/streaming.go per-product registry); those are
-// passed explicitly at their call sites, not via this const.
+// strmServiceName is the ledger-core service segment used to render topics of
+// the shape "lerian.streaming.<service>_<resource>.<event>".
 const strmServiceName = "ledger"
 
 // strmCEType is the reverse-DNS namespace prepended to every ce-type header by
@@ -96,20 +93,15 @@ var strmTransactionPostedCore = []string{
 }
 
 // strmHolderCreatedKeys is the exact 6-key top-level set of the holder.created
-// wire payload, copied from the JSONShape lock in
-// pkg/streaming/events/holder_created_test.go. Holder is a regulated entity;
-// only stable identifiers, the org scope, the person-type classification, the
-// nullable client externalId, and timestamps cross the wire. Asserted as an
-// exact set (fail-closed): an extra or missing key means wire drift.
+// wire payload, asserted as an exact set (fail-closed): an extra or missing key
+// means wire drift.
 var strmHolderCreatedKeys = map[string]struct{}{
 	"id": {}, "organizationId": {}, "type": {}, "externalId": {},
 	"createdAt": {}, "updatedAt": {},
 }
 
 // strmHolderCreatedForbidden is the PII key set that MUST NEVER appear on the
-// holder.created wire payload — mirrors the forbidden set in the JSONShape unit
-// test. The constructor (pkg/streaming/events/holder_created.go) redacts these
-// at the source; this asserts the redaction holds end-to-end on the broker.
+// holder.created wire payload.
 var strmHolderCreatedForbidden = []string{
 	"name", "document", "cpf", "cnpj",
 	"contact", "addresses", "address",
@@ -463,15 +455,11 @@ func TestStreamingTransactionPostedEmitted(t *testing.T) {
 	}
 }
 
-// TestStreamingHolderCreateEmitsRedacted asserts the holder.created wire
-// contract: creating a holder DOES emit a CloudEvents record on
-// lerian.streaming.crm_holder.created whose ce-subject is the holder id and
-// ce-type is studio.lerian.holder.created. holder.created is a fully-modeled,
-// registered IMPORTANT-posture CRM event (pkg/streaming/events/
-// holder_created.go); the constructor redacts PII, so the payload MUST carry
-// only id/organizationId/type/externalId/timestamps and MUST NOT carry name,
-// document, or any other PII key. This mirrors the JSONShape unit lock in
-// holder_created_test.go end-to-end on the live broker.
+// TestStreamingHolderCreateEmitsRedacted asserts that creating a holder emits a
+// CloudEvents record on crm_holder.created whose ce-subject is the holder id and
+// ce-type is studio.lerian.holder.created, with PII redacted: the payload MUST
+// carry only id/organizationId/type/externalId/timestamps and MUST NOT carry
+// name, document, or any other PII key.
 func TestStreamingHolderCreateEmitsRedacted(t *testing.T) {
 	requireStack(t)
 	strmRequireBroker(t)

--- a/tests/e2e/streaming_events_test.go
+++ b/tests/e2e/streaming_events_test.go
@@ -25,9 +25,10 @@ import (
 
 // Epic 3.1 — streaming events. These tests consume the live Kafka-compatible
 // broker that the ledger emits CloudEvents to and assert the on-wire contract
-// (topic, ce-* headers, payload key set) for account.created and
-// transaction.posted, plus two negative contracts: holder.created emits
-// nothing, and an IMPORTANT-posture emit failure never fails the HTTP request.
+// (topic, ce-* headers, payload key set) for account.created,
+// transaction.posted, and holder.created (a PII-redacted CRM event), plus one
+// negative contract: an IMPORTANT-posture emit failure never fails the HTTP
+// request.
 //
 // The suite self-gates: requireStack skips when the ledger is down,
 // strmRequireBroker skips when no broker is reachable at STREAMING_BROKERS.
@@ -92,6 +93,28 @@ var strmTransactionPostedKeys = map[string]struct{}{
 // freshly-posted transaction created via the inflow/JSON paths.
 var strmTransactionPostedCore = []string{
 	"id", "organizationId", "ledgerId", "status", "operations", "createdAt", "updatedAt",
+}
+
+// strmHolderCreatedKeys is the exact 6-key top-level set of the holder.created
+// wire payload, copied from the JSONShape lock in
+// pkg/streaming/events/holder_created_test.go. Holder is a regulated entity;
+// only stable identifiers, the org scope, the person-type classification, the
+// nullable client externalId, and timestamps cross the wire. Asserted as an
+// exact set (fail-closed): an extra or missing key means wire drift.
+var strmHolderCreatedKeys = map[string]struct{}{
+	"id": {}, "organizationId": {}, "type": {}, "externalId": {},
+	"createdAt": {}, "updatedAt": {},
+}
+
+// strmHolderCreatedForbidden is the PII key set that MUST NEVER appear on the
+// holder.created wire payload — mirrors the forbidden set in the JSONShape unit
+// test. The constructor (pkg/streaming/events/holder_created.go) redacts these
+// at the source; this asserts the redaction holds end-to-end on the broker.
+var strmHolderCreatedForbidden = []string{
+	"name", "document", "cpf", "cnpj",
+	"contact", "addresses", "address",
+	"naturalPerson", "legalPerson", "representative",
+	"metadata", "deletedAt",
 }
 
 // strmBrokers returns the broker address list from STREAMING_BROKERS (comma
@@ -228,6 +251,14 @@ func strmCatalogTopics() []string {
 		for _, e := range events {
 			topics = append(topics, pkgStreaming.TopicName(strmServiceName, resource+"."+e))
 		}
+	}
+
+	// CRM resources (holder/instrument) are folded into the ledger binary but
+	// emit under the "crm" service segment, so their topics carry the "crm_"
+	// prefix. Provision them too so a holder create's IMPORTANT-posture emit has
+	// a live destination and never trips the producer circuit breaker.
+	for _, e := range []string{"created", "updated", "deleted"} {
+		topics = append(topics, pkgStreaming.TopicName("crm", "holder."+e))
 	}
 
 	return topics
@@ -432,29 +463,54 @@ func TestStreamingTransactionPostedEmitted(t *testing.T) {
 	}
 }
 
-// TestStreamingHolderCreateEmitsNothing pins the negative contract: holder
-// creation has NO streaming emit (components/ledger/internal/crm/services/
-// create-holder.go contains no Emit call). We create a holder and confirm no
-// record carrying its id surfaces on any lerian.streaming.crm_holder.* topic
-// within a short window. The holder-created and holder-updated topics are
-// probed explicitly; both must stay silent. A non-empty match is a regression
-// (an emit was added without a wire-contract event).
-func TestStreamingHolderCreateEmitsNothing(t *testing.T) {
+// TestStreamingHolderCreateEmitsRedacted asserts the holder.created wire
+// contract: creating a holder DOES emit a CloudEvents record on
+// lerian.streaming.crm_holder.created whose ce-subject is the holder id and
+// ce-type is studio.lerian.holder.created. holder.created is a fully-modeled,
+// registered IMPORTANT-posture CRM event (pkg/streaming/events/
+// holder_created.go); the constructor redacts PII, so the payload MUST carry
+// only id/organizationId/type/externalId/timestamps and MUST NOT carry name,
+// document, or any other PII key. This mirrors the JSONShape unit lock in
+// holder_created_test.go end-to-end on the live broker.
+func TestStreamingHolderCreateEmitsRedacted(t *testing.T) {
 	requireStack(t)
 	strmRequireBroker(t)
 
 	orgID := createOrg(t)
 	holderID := createHolder(t, orgID)
 
-	// Short window — we are proving ABSENCE, so a brief poll is sufficient and
-	// keeps the test fast. If the broker auto-creates the topic, an empty log
-	// simply yields found=false.
-	for _, suffix := range []string{"created", "updated"} {
-		topic := pkgStreaming.TopicName("crm", "holder."+suffix)
+	topic := pkgStreaming.TopicName("crm", "holder.created")
 
-		_, _, _, found := strmConsumeMatch(t, topic, holderID, 4*time.Second)
-		if found {
-			t.Errorf("holder create emitted an unexpected record on %s (ce-subject=%s); holder.* has no wire-contract event", topic, holderID)
+	ceType, subject, payload, ok := strmConsumeMatch(t, topic, holderID, 15*time.Second)
+	if !ok {
+		t.Fatalf("no holder.created record with ce-subject=%s on %s within timeout", holderID, topic)
+	}
+
+	if subject != holderID {
+		t.Errorf("ce-subject = %q, want holder id %q", subject, holderID)
+	}
+
+	if want := strmCETypePrefix + "holder.created"; ceType != want {
+		t.Errorf("ce-type = %q, want %q", ceType, want)
+	}
+
+	// Exact-set lock (fail-closed) + count, mirroring the JSONShape unit test.
+	strmAssertKeySet(t, "holder.created", payload, strmHolderCreatedKeys)
+
+	for k := range strmHolderCreatedKeys {
+		if _, present := payload[k]; !present {
+			t.Errorf("holder.created payload missing key %q", k)
+		}
+	}
+
+	if len(payload) != len(strmHolderCreatedKeys) {
+		t.Errorf("holder.created payload has %d top-level keys, want %d", len(payload), len(strmHolderCreatedKeys))
+	}
+
+	// PII redaction is the point of this event: no PII key may reach the wire.
+	for _, forbidden := range strmHolderCreatedForbidden {
+		if _, present := payload[forbidden]; present {
+			t.Errorf("holder.created payload leaked PII key %q (must be redacted)", forbidden)
 		}
 	}
 }


### PR DESCRIPTION
<table border="0" cellspacing="0" cellpadding="0">
  <tr>
    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
    <td><h1>Midaz</h1></td>
  </tr>
</table>

---

## Description

The monorepo consolidation (folding `tracer` and `plugin-fees` into midaz) collapsed every product's
streaming Kafka topic `<service>` segment down to `ledger`, and left `tracer` without one — diverging from
the platform convention `lerian.streaming.<service>_<resource>.<event>` and from the topic names already
registered on the brokers. This PR restores per-product service segments so topics are collision-safe,
consistent, and match the registered contract.

| Product | Before (consolidation regression) | After |
|---|---|---|
| **fees** | `ledger_fees_package.*` / `ledger_fees.applied` | `fee_packages.*`, `fee_billing_packages.*`, `fee_charge.applied` |
| **CRM** | `ledger_holder.*` / `ledger_instrument.*` | `crm_holder.*`, `crm_instrument.*`, `crm_instrument.related_party_deleted` |
| **tracer** | `rule.*` / `limit.*` (no service segment) | `tracer_rule.*`, `tracer_limit.*` |
| **ledger core** | `ledger_*` | unchanged |

**Mechanism**
- `pkg/streaming/topic.go` — `TopicName` strips a leading `service+"-"` before folding, so fee keys don't
  double (`fee-packages` → `fee_packages`, not `fee_fee_packages`); provably a no-op for ledger/crm/tracer.
- `components/ledger/internal/bootstrap/streaming.go` — replaces the single `streamingServiceName` const
  with a per-definition paired registry (`routedDefinition{def, service}`): core→`ledger`, fees→`fee`,
  crm→`crm`. The `events.Definition` wire-contract struct is left untouched — service is a routing concern.
- Fees `ResourceType`s restored to the pre-consolidation plural-hyphenated form (`fee-packages`,
  `fee-billing-packages`); the net-new `fees.applied` event is kept but re-homed as `fee-charge` →
  `fee_charge.applied`.
- `components/tracer/internal/bootstrap/streaming.go` — routes through the shared `pkgStreaming.TopicName("tracer", key)`.
- `ce-type` stays hyphenated (`studio.lerian.<resource>.<event>`); the underscore lives only on the topic.
  `ce-source` is process-wide `lerian.midaz.ledger` for fees/CRM (they ride the ledger emitter); tracer
  keeps `lerian.midaz.tracer`.
- `components/infra/docker-compose.yml` topic provisioner regenerated to the exact 61 topics the emitters
  route to; `docs/streaming/{fees,crm,tracer}-events.md` and `CLAUDE.md` `## Streaming` updated.

## Type of Change

- [x] `feat`: New feature or capability
- [x] `fix`: Bug fix
- [ ] `perf`: Performance improvement
- [ ] `refactor`: Internal restructuring with no behavior change
- [ ] `docs`: Documentation only
- [ ] `style`: Formatting, whitespace, naming (no logic change)
- [ ] `test`: Adding or updating tests
- [ ] `ci`: CI pipeline or workflow changes
- [ ] `build`: Build system, Dockerfile, Go module dependencies
- [ ] `chore`: Maintenance, config, tooling
- [ ] `revert`: Reverts a previous commit
- [x] `BREAKING CHANGE`: Consumers must update their integration

## Breaking Changes

Topic names and `ce-type`s for **fees** and **CRM** events change versus the interim consolidation names
(`lerian.streaming.ledger_fees_package.*`, `ledger_holder.*`, `studio.lerian.fees-package.*`). Any consumer
keyed on those interim names must repoint to the `fee_*` / `crm_*` topics (and `studio.lerian.fee-packages.*`
ce-types).

> **Deploy ordering (ops):** the renamed `fee_*` / `crm_*` / `tracer_*` topics and the new
> `fee_charge.applied` topic MUST be provisioned on the target brokers **before** this image rolls. All
> routes are `RouteRequired` and fees/CRM events are IMPORTANT-posture, so a missing topic is a silent drop
> (Warn-logged, request still succeeds). No outbox backing yet.

## Testing

- [x] `make test` passes (full unit suite; enforced by the pre-push hook)
- [x] `make test-int` passes if integration paths are exercised — live-broker smokes: ledger 7 fee events + tracer 12 events (emit → consume → ce-type/topic asserted); e2e: `account.created` and `crm_holder.created` (PII-redacted) verified against a running app
- [x] `make lint` passes (enforced by the pre-push hook)
- [x] `make sec` and `make vulncheck` pass (enforced by the pre-push hook; no dependency change)

**Test evidence / Actions run:** verified locally against Redpanda + a running ledger build; the
`docker-compose` provisioner was confirmed to create the exact 61 topics the emitters route to. A stale e2e
test (`TestStreamingHolderCreateEmitsNothing`) that wrongly claimed holders don't stream was corrected to
assert the redacted `crm_holder.created` emit (`TestStreamingHolderCreateEmitsRedacted`).

## Architectural Checklist

- [x] No `panic()` in production paths
- [x] Timestamps use `time.Now().UTC()`
- [x] Errors wrapped with `%w`
- [x] Handlers stay thin (parse, validate, call service)
- [x] Infrastructure concerns kept in `internal/bootstrap`

## Related Issues

Lerian Map #3388.
