### PR TITLE
fix(ci): pin shared workflow ref to v1.46.5

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   pipeline:
-    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/go-release.yml@feat/midaz-e2e-tests
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/go-release.yml@v1.46.5
     with:
       enable_changelog: ${{ github.ref == 'refs/heads/main' }}
       release_single_app: true


### PR DESCRIPTION
A causa raiz: o `.github/workflows/release.yml` referenciava a shared workflow via `@feat/midaz-e2e-tests`, um branch que NÃO existe no repo `LerianStudio/github-actions-shared-workflows`. Isso fez a run #29855703077 falhar com "workflow file issue".

Fix aplicado: trocada a única linha `uses:` para fixar a ref em `@v1.46.5`.

Requested by: Ygohr