### PR TITLE
fix(ledger): place migrations at /home/nonroot for UserHomeDir resolution

### DIFF
--- a/components/ledger/Dockerfile
+++ b/components/ledger/Dockerfile
@@ -29,14 +29,13 @@ LABEL org.opencontainers.image.licenses="Elastic-2.0"
 LABEL org.opencontainers.image.version="${VERSION}"
 LABEL org.opencontainers.image.created="${BUILD_DATE}"
 
-# The :nonroot base defaults WORKDIR to /home/nonroot, but the ledger resolves
-# its migration source from the CWD-relative "components/ledger/migrations/...".
-# Pin WORKDIR to / so that relative path resolves to the staged files below.
-WORKDIR /
-
+# The ledger resolves its migration source from os.UserHomeDir(), which for the
+# nonroot user is always /home/nonroot regardless of WORKDIR. Stage the
+# migrations under /home/nonroot/components/ledger/migrations/... so the code
+# finds them.
 COPY --from=builder /app /app
-COPY --from=builder /ledger-app/components/ledger/migrations/onboarding /components/ledger/migrations/onboarding
-COPY --from=builder /ledger-app/components/ledger/migrations/transaction /components/ledger/migrations/transaction
+COPY --chown=nonroot:nonroot --from=builder /ledger-app/components/ledger/migrations/onboarding /home/nonroot/components/ledger/migrations/onboarding
+COPY --chown=nonroot:nonroot --from=builder /ledger-app/components/ledger/migrations/transaction /home/nonroot/components/ledger/migrations/transaction
 
 EXPOSE 3002
 


### PR DESCRIPTION
## Root cause

PR #2239 tried to fix the ledger migrations bug with `WORKDIR /`, but it did not work. The error persists in `4.0.0-beta.2`:

```
failed to open source, 'file:///home/nonroot/components/ledger/migrations/onboarding': open .: permission denied
```

The ledger builds the migration source path from `os.UserHomeDir()` (not `os.Getwd()`). For the `nonroot` user, `UserHomeDir()` is **always** `/home/nonroot`, regardless of the `WORKDIR` set in the Dockerfile. So the `WORKDIR /` approach can never resolve the path — the code always looks under `/home/nonroot/components/ledger/migrations/...`.

## Fix

In `components/ledger/Dockerfile` (final stage):
- Remove the ineffective `WORKDIR /`.
- Copy the migrations to `/home/nonroot/components/ledger/migrations/...` (where the code actually looks), with `--chown=nonroot:nonroot` so the nonroot user can read them.

## Notes
Requested by: Ygohr
