### PR TITLE
fix(ledger): stage migrations at /home/nonroot to match CWD

### DIFF
--- a/components/ledger/Dockerfile
+++ b/components/ledger/Dockerfile
@@ -29,14 +29,18 @@ LABEL org.opencontainers.image.licenses="Elastic-2.0"
 LABEL org.opencontainers.image.version="${VERSION}"
 LABEL org.opencontainers.image.created="${BUILD_DATE}"
 
-# The :nonroot base defaults WORKDIR to /home/nonroot, but the ledger resolves
-# its migration source from the CWD-relative "components/ledger/migrations/...".
-# Pin WORKDIR to / so that relative path resolves to the staged files below.
-WORKDIR /
+# The migrator resolves its source via filepath.Abs(os.Getwd()) applied to the
+# CWD-relative "components/ledger/migrations/...". The :nonroot base runs with
+# CWD /home/nonroot, so stage the migrations there and pin WORKDIR to match.
+WORKDIR /home/nonroot
 
 COPY --from=builder /app /app
-COPY --from=builder /ledger-app/components/ledger/migrations/onboarding /components/ledger/migrations/onboarding
-COPY --from=builder /ledger-app/components/ledger/migrations/transaction /components/ledger/migrations/transaction
+COPY --chown=nonroot:nonroot --from=builder \
+  /ledger-app/components/ledger/migrations/onboarding \
+  /home/nonroot/components/ledger/migrations/onboarding
+COPY --chown=nonroot:nonroot --from=builder \
+  /ledger-app/components/ledger/migrations/transaction \
+  /home/nonroot/components/ledger/migrations/transaction
 
 EXPOSE 3002
 

--- a/components/ledger/docker-compose.yml
+++ b/components/ledger/docker-compose.yml
@@ -2,12 +2,6 @@ services:
   ledger:
     container_name: midaz-ledger
     restart: always
-    # The distroless runtime defaults WORKDIR to /home/nonroot, but the ledger
-    # resolves its migration source from the relative path
-    # "components/ledger/migrations/{onboarding,transaction}" which the Dockerfile
-    # stages at the absolute /components/ledger/migrations/... . Pin working_dir to
-    # / so the relative path resolves to the staged files.
-    working_dir: /
     build:
       context: ../../
       dockerfile: ./components/ledger/Dockerfile


### PR DESCRIPTION
<table border="0" cellspacing="0" cellpadding="0">
  <tr>
    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
    <td><h1>Midaz</h1></td>
  </tr>
</table>

---

## Description

The ledger crash-loops on startup with
`failed to open source, "file:///home/nonroot/components/ledger/migrations/onboarding": open .: permission denied`.

The migrator (lib-commons v5.10.0) resolves its source via
`filepath.Abs(os.Getwd())` applied to the CWD-relative
`components/ledger/migrations/{onboarding,transaction}`. The
`distroless/static-debian12:nonroot` base runs with CWD `/home/nonroot`, so the
relative path resolves to `/home/nonroot/components/ledger/migrations/...` — where
nothing was staged (the image staged them at `/components/ledger/migrations/...`).

The prior fix in #2159's follow-up (#2239) set `WORKDIR /`, but the running
process CWD stays `/home/nonroot`, so it did not realign resolution. This PR
stages the migrations under `/home/nonroot/components/ledger/migrations/...`
(with `--chown=nonroot:nonroot`), pins `WORKDIR /home/nonroot` to match, and
drops the now-incorrect `working_dir: /` override in the ledger docker-compose so
local and container resolution agree.

Supersedes #2239 — its `WORKDIR /` is intentionally reverted here.

## Type of Change

- [ ] `feat`: New feature or capability
- [x] `fix`: Bug fix
- [ ] `perf`: Performance improvement
- [ ] `refactor`: Internal restructuring with no behavior change
- [ ] `docs`: Documentation only
- [ ] `style`: Formatting, whitespace, naming (no logic change)
- [ ] `test`: Adding or updating tests
- [ ] `ci`: CI pipeline or workflow changes
- [x] `build`: Build system, Dockerfile, Go module dependencies
- [ ] `chore`: Maintenance, config, tooling
- [ ] `revert`: Reverts a previous commit
- [ ] `BREAKING CHANGE`: Consumers must update their integration

## Breaking Changes

None. Reverts the `WORKDIR /` from #2239; migration staging moves from
`/components/...` to `/home/nonroot/components/...`. No runtime API/config surface
changes.

## Testing

- [ ] `make test` passes
- [ ] `make test-int` passes if integration paths are exercised
- [ ] `make lint` passes
- [ ] `make sec` and `make vulncheck` pass

**Test evidence / Actions run:** Dockerfile/compose-only change, validated at the
container level. `docker compose build` succeeds; image inspect confirms
`WorkingDir=/home/nonroot`, `User=nonroot:nonroot`, and migrations staged at
`/home/nonroot/components/ledger/migrations/{onboarding,transaction}` owned by
`nonroot` (uid 65532). Full stack via `make up` against a wiped Postgres volume:
migrations applied cleanly (`schema_migrations` version 19, `dirty=f`, 8 onboarding
tables), container stayed `Up` with zero `permission denied` lines.

## Architectural Checklist

- [x] No `panic()` in production paths
- [x] Timestamps use `time.Now().UTC()`
- [x] Errors wrapped with `%w`
- [x] Handlers stay thin (parse, validate, call service)
- [x] Infrastructure concerns kept in `internal/bootstrap`

## Related Issues

Closes #
