### PR TITLE
fix(tracer): correct HTTP status mapping and re-sync integration tests to RFC 9457

### DIFF
--- a/components/tracer/internal/adapters/http/in/limit_handler.go
+++ b/components/tracer/internal/adapters/http/in/limit_handler.go
@@ -482,6 +482,14 @@ func (h *LimitHandler) getLimitUsage(ctx context.Context, idParam string) (*mode
 // field/status/code/type-identical envelopes. The errors.Is cascade and the
 // canonical mapping are preserved verbatim from the pre-Huma handler.
 func classifyLimitServiceError(span trace.Span, err error) error {
+	// Services pre-classify domain failures into typed business errors via
+	// pkg.ValidateBusinessError (leaving Err nil, so errors.Is on the raw
+	// sentinel below cannot re-match them). Pass those through unchanged so the
+	// service's status/code survives instead of collapsing to a 500.
+	if pkg.IsBusinessError(err) {
+		return err
+	}
+
 	switch {
 	case errors.Is(err, constant.ErrLimitNameAlreadyExists):
 		libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Limit name already exists", err)

--- a/components/tracer/internal/adapters/http/in/middleware/fault_injection.go
+++ b/components/tracer/internal/adapters/http/in/middleware/fault_injection.go
@@ -40,7 +40,7 @@ func DefaultFaultInjectionConfig() FaultInjectionConfig {
 //
 // Usage in tests:
 //
-//	req.Header.Set("X-Test-Fault-Injection", "timeout")     // timeout error (503)
+//	req.Header.Set("X-Test-Fault-Injection", "timeout")     // gateway timeout (504)
 //	req.Header.Set("X-Test-Fault-Injection", "unavailable") // service unavailable (503)
 func FaultInjection(config ...FaultInjectionConfig) fiber.Handler {
 	cfg := DefaultFaultInjectionConfig()

--- a/components/tracer/internal/adapters/http/in/reservation_handler.go
+++ b/components/tracer/internal/adapters/http/in/reservation_handler.go
@@ -89,6 +89,7 @@ func (h *ReservationHandler) reserve(ctx context.Context, rawBody []byte) (*Rese
 
 	logger = logging.WithTrace(ctx, logger)
 
+	// Check payload size (413 is a client/business error - use HandleSpanBusinessErrorEvent)
 	if len(rawBody) > maxPayloadSize {
 		logger.With(
 			libLog.String("operation", "handler.reservations.reserve"),
@@ -96,9 +97,14 @@ func (h *ReservationHandler) reserve(ctx context.Context, rawBody []byte) (*Rese
 			libLog.Int("max_size", maxPayloadSize),
 		).Log(ctx, libLog.LevelWarn, "Payload too large")
 
-		libOpentelemetry.HandleSpanError(span, "Payload exceeds size limit", constant.ErrPayloadTooLarge)
+		libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Payload exceeds size limit", constant.ErrPayloadTooLarge)
 
-		return nil, pkg.ValidateBusinessError(constant.ErrPayloadTooLarge, constant.EntityReservation)
+		return nil, pkg.PayloadTooLargeError{
+			EntityType: constant.EntityReservation,
+			Code:       constant.ErrPayloadTooLarge.Error(),
+			Title:      "Payload Too Large",
+			Message:    payloadTooLargeMessage,
+		}
 	}
 
 	var request ReserveRequest

--- a/components/tracer/internal/adapters/http/in/rule_handler.go
+++ b/components/tracer/internal/adapters/http/in/rule_handler.go
@@ -454,6 +454,14 @@ func classifyLifecycleError(span trace.Span, err error) error {
 // JSON parser). The errors.Is cascade and the canonical mapping are preserved
 // verbatim from the pre-Huma handler.
 func classifyServiceError(span trace.Span, err error) error {
+	// Services pre-classify domain failures into typed business errors via
+	// pkg.ValidateBusinessError (leaving Err nil, so errors.Is on the raw
+	// sentinel below cannot re-match them). Pass those through unchanged so the
+	// service's status/code survives instead of collapsing to a 500.
+	if pkg.IsBusinessError(err) {
+		return err
+	}
+
 	switch {
 	case errors.Is(err, constant.ErrRuleNameAlreadyExistsInCtx):
 		libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Rule name already exists in this context", err)

--- a/components/tracer/internal/adapters/http/in/tracer_error_contract_test.go
+++ b/components/tracer/internal/adapters/http/in/tracer_error_contract_test.go
@@ -170,20 +170,20 @@ func TestTracerErrorContract(t *testing.T) {
 			expectedCode:   "0432",
 			expectedTitle:  "Transaction Validation Not Found",
 		},
-		// --- timeout / cancelled (503) ---
+		// --- timeout (504) / cancelled (503) ---
 		{
-			name:           "validation timeout -> 0422 / 503",
+			name:           "validation timeout -> 0422 / 504",
 			err:            pkg.ValidateBusinessError(constant.ErrValidationTimeout, constant.EntityValidationRequest),
-			expectedStatus: 503,
+			expectedStatus: 504,
 			expectedCode:   "0422",
-			expectedTitle:  "Service Unavailable", // >=500: title scrubbed to status text (RFC 9457)
+			expectedTitle:  "Gateway Timeout", // >=500: title scrubbed to status text (RFC 9457) == "Gateway Timeout"
 		},
 		{
-			name:           "list validations timeout -> 0433 / 503",
+			name:           "list validations timeout -> 0433 / 504",
 			err:            pkg.ValidateBusinessError(constant.ErrListValidationsTimeout, constant.EntityTransactionValidation),
-			expectedStatus: 503,
+			expectedStatus: 504,
 			expectedCode:   "0433",
-			expectedTitle:  "Service Unavailable", // >=500: title scrubbed to status text (RFC 9457)
+			expectedTitle:  "Gateway Timeout", // >=500: title scrubbed to status text (RFC 9457) == "Gateway Timeout"
 		},
 		{
 			name:           "context cancelled -> 0330 / 503",

--- a/components/tracer/internal/adapters/http/in/validation_handler.go
+++ b/components/tracer/internal/adapters/http/in/validation_handler.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 
 	libObservability "github.com/LerianStudio/lib-observability"
 	libLog "github.com/LerianStudio/lib-observability/log"
@@ -29,6 +30,12 @@ import (
 
 // maxPayloadSize is the maximum allowed request body size in bytes (100KB).
 const maxPayloadSize = 100 * 1024
+
+// payloadTooLargeMessage is the shared HTTP 413 detail for an oversized request
+// body. It is derived from maxPayloadSize so the stated limit can never drift
+// from the enforced one, and is shared by the validation and reservation
+// handlers so both emit an identical message.
+var payloadTooLargeMessage = fmt.Sprintf("payload too large: exceeds %dKB limit", maxPayloadSize/1024)
 
 // ValidationService defines the interface for validation operations.
 // Interface defined locally per Ring pattern.
@@ -96,7 +103,7 @@ func (h *ValidationHandler) validate(ctx context.Context, rawBody []byte) (*serv
 
 	logger = logging.WithTrace(ctx, logger)
 
-	// Check payload size (technical error - use HandleSpanError)
+	// Check payload size (413 is a client/business error - use HandleSpanBusinessErrorEvent)
 	if len(rawBody) > maxPayloadSize {
 		logger.With(
 			libLog.String("operation", "handler.validations.validate"),
@@ -104,13 +111,13 @@ func (h *ValidationHandler) validate(ctx context.Context, rawBody []byte) (*serv
 			libLog.Int("max_size", maxPayloadSize),
 		).Log(ctx, libLog.LevelWarn, "Payload too large")
 
-		libOpentelemetry.HandleSpanError(span, "Payload exceeds size limit", constant.ErrPayloadTooLarge)
+		libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Payload exceeds size limit", constant.ErrPayloadTooLarge)
 
 		return nil, pkg.PayloadTooLargeError{
 			EntityType: constant.EntityValidationRequest,
 			Code:       constant.ErrPayloadTooLarge.Error(),
 			Title:      "Payload Too Large",
-			Message:    "payload too large: exceeds 100KB limit",
+			Message:    payloadTooLargeMessage,
 		}
 	}
 

--- a/components/tracer/internal/adapters/http/in/validation_handler.go
+++ b/components/tracer/internal/adapters/http/in/validation_handler.go
@@ -106,7 +106,12 @@ func (h *ValidationHandler) validate(ctx context.Context, rawBody []byte) (*serv
 
 		libOpentelemetry.HandleSpanError(span, "Payload exceeds size limit", constant.ErrPayloadTooLarge)
 
-		return nil, pkg.ValidateBusinessError(constant.ErrPayloadTooLarge, constant.EntityValidationRequest)
+		return nil, pkg.PayloadTooLargeError{
+			EntityType: constant.EntityValidationRequest,
+			Code:       constant.ErrPayloadTooLarge.Error(),
+			Title:      "Payload Too Large",
+			Message:    "payload too large: exceeds 100KB limit",
+		}
 	}
 
 	var request model.ValidationRequest

--- a/components/tracer/internal/adapters/http/in/validation_handler_test.go
+++ b/components/tracer/internal/adapters/http/in/validation_handler_test.go
@@ -178,7 +178,7 @@ func TestValidationHandler_Validate(t *testing.T) {
 				// Service should NOT be called when payload is too large
 				return mocks.NewMockValidationService(ctrl)
 			},
-			expectedStatus: http.StatusBadRequest,
+			expectedStatus: http.StatusRequestEntityTooLarge,
 			expectedBody: func(t *testing.T, body []byte) {
 				// Verify standardized response format
 				assert.Contains(t, string(body), "0143")
@@ -347,7 +347,7 @@ func TestValidationHandler_Validate(t *testing.T) {
 					Return(nil, constant.ErrValidationTimeout)
 				return mockService
 			},
-			expectedStatus: http.StatusServiceUnavailable,
+			expectedStatus: http.StatusGatewayTimeout,
 			expectedBody: func(t *testing.T, body []byte) {
 			},
 		},
@@ -517,7 +517,7 @@ func TestValidationHandler_Validate_PayloadSizeCheck(t *testing.T) {
 		{
 			name:           "payload over limit (100KB+1) is rejected",
 			payloadSize:    100*1024 + 1, // 100KB + 1 byte
-			expectedStatus: http.StatusBadRequest,
+			expectedStatus: http.StatusRequestEntityTooLarge,
 		},
 	}
 

--- a/components/tracer/internal/services/command/activate_rule.go
+++ b/components/tracer/internal/services/command/activate_rule.go
@@ -174,15 +174,18 @@ func (s *ActivateRuleService) Execute(ctx context.Context, ruleID uuid.UUID) (_ 
 	// the post-commit cache update below.
 	program, err := s.expressionCompiler.Compile(ctx, rule.Expression)
 	if err != nil {
-		businessErr := pkg.ValidateBusinessError(constant.ErrExpressionSyntax, constant.EntityRule)
-		libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Expression compilation failed", businessErr)
+		// Propagate the raw compiler sentinel (ErrExpressionSyntax /
+		// ErrExpressionType) unchanged, mirroring create_rule.go. Collapsing it
+		// into a single fixed sentinel here loses the syntax-vs-type distinction
+		// (0340 vs 0341) that classifyServiceError maps to 400.
+		libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Expression compilation failed", err)
 		logger.With(
 			libLog.String("operation", "service.rule.activate"),
 			libLog.String("rule.id", ruleID.String()),
 			libLog.String("error.message", err.Error()),
 		).Log(ctx, libLog.LevelWarn, "Expression validation failed")
 
-		return nil, businessErr
+		return nil, err
 	}
 
 	// Capture "before" state for audit AFTER idempotency / expression checks

--- a/components/tracer/internal/testutil/integration_helpers.go
+++ b/components/tracer/internal/testutil/integration_helpers.go
@@ -770,6 +770,7 @@ func ListValidationsWithoutAuth(t *testing.T, queryParams string) (*http.Respons
 type ErrorResponse struct {
 	Code    string `json:"code"`
 	Title   string `json:"title"`
+	Detail  string `json:"detail"`
 	Message string `json:"message"`
 }
 

--- a/components/tracer/mk/tests.mk
+++ b/components/tracer/mk/tests.mk
@@ -90,7 +90,10 @@ define integ_discover
 endef
 
 # Tracer's integration suite has no CHAOS notion — suppress the root chaos notice.
-integ_chaos_notice =
+# Must expand to a shell no-op (`:`), not empty: the root recipe uses it as
+# `$(integ_chaos_notice); \`, so an empty value leaves a bare `;` that aborts
+# the recipe under /bin/sh with "syntax error near unexpected token ';'".
+integ_chaos_notice = :
 
 # ------------------------------------------------------
 # Test tooling configuration

--- a/components/tracer/tests/integration/01_validation_1140_1154_test.go
+++ b/components/tracer/tests/integration/01_validation_1140_1154_test.go
@@ -617,7 +617,7 @@ func TestValidation_1_1_46_LimitUsageUpdatedOnlyOnAllow(t *testing.T) {
 // The CEL expression engine converts decimal amounts to float64, which loses precision
 // beyond 2^53. The precision guard rejects such amounts to prevent silent rounding errors.
 // A rule must be active so the amount goes through CEL evaluation (no rules → no CEL).
-// Returns HTTP 400 Bad Request with error code TRC-0089.
+// Returns HTTP 422 Unprocessable Entity with error code 0346 (Amount Exceeds Precision).
 func TestValidation_1_1_47_RejectsAmountExceedingCELPrecision(t *testing.T) {
 	// Create and activate a rule so the validation path invokes CEL.
 	// The expression "amount > 0" matches any positive amount, forcing CEL evaluation.
@@ -654,13 +654,13 @@ func TestValidation_1_1_47_RejectsAmountExceedingCELPrecision(t *testing.T) {
 	body, err := io.ReadAll(resp.Body)
 	require.NoError(t, err)
 
-	require.Equal(t, http.StatusBadRequest, resp.StatusCode,
-		"Amount exceeding CEL precision (2^53) should return 400: %s", string(body))
+	require.Equal(t, http.StatusUnprocessableEntity, resp.StatusCode,
+		"Amount exceeding CEL precision (2^53) should return 422: %s", string(body))
 
 	var errResp map[string]interface{}
 	require.NoError(t, json.Unmarshal(body, &errResp), "Response body should be valid JSON")
-	assert.Equal(t, "0346", errResp["code"], "Error code should be TRC-0089 (amount exceeds precision)")
-	assert.Equal(t, "Bad Request", errResp["title"])
+	assert.Equal(t, "0346", errResp["code"], "Error code should be 0346 (amount exceeds precision)")
+	assert.Equal(t, "Amount Exceeds Precision", errResp["title"])
 }
 
 // Test 1.1.47b: Validation accepts the maximum safe amount for CEL evaluation (2^53).
@@ -840,8 +840,8 @@ func TestValidation_1_1_51_LowercaseCurrencyRejected(t *testing.T) {
 	// Verify structured error response
 	errResp := testutil.ParseErrorResponse(t, body)
 	assert.Equal(t, "0417", errResp.Code, "Error response should have invalid currency error code")
-	assert.Equal(t, "Validation Error", errResp.Title, "Error response should have validation error title")
-	assert.Equal(t, "currency must be valid ISO 4217 code (e.g., BRL, USD)", errResp.Message, "Error message should indicate valid currency format")
+	assert.Equal(t, "Validation Invalid Currency", errResp.Title, "Error response should have invalid currency title")
+	assert.Empty(t, errResp.Message, "RFC 9457 carries the human message in detail, not message")
 }
 
 // Test 1.1.52: Duplicate requestId returns cached response (idempotent behavior)

--- a/components/tracer/tests/integration/01_validation_1140_1154_test.go
+++ b/components/tracer/tests/integration/01_validation_1140_1154_test.go
@@ -657,7 +657,7 @@ func TestValidation_1_1_47_RejectsAmountExceedingCELPrecision(t *testing.T) {
 	require.Equal(t, http.StatusUnprocessableEntity, resp.StatusCode,
 		"Amount exceeding CEL precision (2^53) should return 422: %s", string(body))
 
-	var errResp map[string]interface{}
+	var errResp map[string]any
 	require.NoError(t, json.Unmarshal(body, &errResp), "Response body should be valid JSON")
 	assert.Equal(t, "0346", errResp["code"], "Error code should be 0346 (amount exceeds precision)")
 	assert.Equal(t, "Amount Exceeds Precision", errResp["title"])
@@ -842,6 +842,7 @@ func TestValidation_1_1_51_LowercaseCurrencyRejected(t *testing.T) {
 	assert.Equal(t, "0417", errResp.Code, "Error response should have invalid currency error code")
 	assert.Equal(t, "Validation Invalid Currency", errResp.Title, "Error response should have invalid currency title")
 	assert.Empty(t, errResp.Message, "RFC 9457 carries the human message in detail, not message")
+	assert.Equal(t, "Currency must be valid ISO 4217.", errResp.Detail, "RFC 9457 detail carries the human-readable currency validation message")
 }
 
 // Test 1.1.52: Duplicate requestId returns cached response (idempotent behavior)

--- a/components/tracer/tests/integration/01_validation_get_error_codes_test.go
+++ b/components/tracer/tests/integration/01_validation_get_error_codes_test.go
@@ -887,9 +887,9 @@ func TestListTransactionValidations_InvalidSortBy_TRC0043(t *testing.T) {
 // - Error Title: "Gateway Timeout"
 // - Error Message: mentions "query" to distinguish from the POST validation timeout
 //
-// KNOWN BUG (not synced): the endpoint currently returns 503 "Service Unavailable"
-// with detail "internal error" instead of 504 "Gateway Timeout". Assertions are
-// left expecting the correct 504 contract.
+// The endpoint returns 504 "Gateway Timeout" with the human-readable text in the
+// top-level "message" field; the RFC 9457 "detail" is scrubbed to "internal error"
+// for >=500 responses, so the query-specific text is asserted against message.
 func TestListTransactionValidations_Timeout_ReturnsTRC0252(t *testing.T) {
 	// Use fault injection to simulate timeout scenario
 	resp, respBody := testutil.ListValidationsWithFaultInjection(t, "", testutil.FaultTimeout)
@@ -918,10 +918,9 @@ func TestListTransactionValidations_Timeout_ReturnsTRC0252(t *testing.T) {
 }
 
 // TestListTransactionValidations_Timeout_WithFilters_ReturnsTRC0252 verifies timeout handling
-// when complex filters are used (which might cause slower queries).
-//
-// Same KNOWN BUG as TestListTransactionValidations_Timeout_ReturnsTRC0252: the endpoint
-// currently returns 503 "Service Unavailable" instead of the expected 504 "Gateway Timeout".
+// when complex filters are used (which might cause slower queries). Like
+// TestListTransactionValidations_Timeout_ReturnsTRC0252, the endpoint returns 504
+// "Gateway Timeout" with code 0433.
 func TestListTransactionValidations_Timeout_WithFilters_ReturnsTRC0252(t *testing.T) {
 	// Use filters that might cause a complex query
 	queryParams := "decision=ALLOW&transaction_type=CARD&sort_by=processing_time_ms&sort_order=DESC"

--- a/components/tracer/tests/integration/01_validation_get_error_codes_test.go
+++ b/components/tracer/tests/integration/01_validation_get_error_codes_test.go
@@ -21,19 +21,20 @@ import (
 // Error Code Tests for Transaction Validation Handler
 // =============================================================================
 //
-// These tests document the current error handling behavior for the transaction
+// These tests document the error handling behavior for the transaction
 // validation endpoints (GET /v1/validations and GET /v1/validations/{id}).
 //
-// Current Behavior:
-// - Invalid path parameter (UUID) returns TRC-0007 (ErrInvalidPathParameter)
-//   with title "Invalid Path Parameter"
-// - Invalid query parameter (non-numeric, malformed) returns TRC-0006
-//   (ErrInvalidQueryParameter) with title "Invalid Query Parameter"
-// - Invalid filter values (out of range, invalid enum) returns TRC-0250
-//   (ErrInvalidTransactionValidationFilters) with title "Invalid Transaction Validation Filters"
-//
-// NOTE: These tests document CURRENT behavior to establish a baseline for
-// future error code improvements. Update expected codes when the handler is fixed.
+// Errors follow the RFC 9457 (application/problem+json) envelope with a numeric
+// `code`, a specific `title`, and a `detail`. Each error code carries its own
+// title:
+// - Invalid path parameter (UUID): code 0065, title "Invalid Path Parameter".
+// - Invalid query parameter (non-numeric, malformed): code 0082, title
+//   "Invalid Query Parameter".
+// - Pagination/sort/filter validation: per-error codes and titles, e.g. 0331
+//   "Pagination Limit Invalid", 0080 "Pagination Limit Exceeded", 0332 "Invalid
+//   Sort Column", 0081 "Invalid Sort Order", 0334 "Cursor With Sort Params",
+//   0077 "Invalid Date Format Error", 0083 "Invalid Date Range Error", 0431
+//   "Invalid Transaction Validation Filters".
 // =============================================================================
 
 // =============================================================================
@@ -41,7 +42,7 @@ import (
 // =============================================================================
 
 // TestGetTransactionValidation_InvalidID_ReturnsError verifies invalid UUID handling in path parameter.
-// Returns TRC-0007 for invalid path parameters
+// Returns code 0065 (title "Invalid Path Parameter") for invalid path parameters.
 func TestGetTransactionValidation_InvalidID_ReturnsError(t *testing.T) {
 	baseURL := testutil.GetBaseURL()
 	apiKey := testutil.GetAPIKey()
@@ -56,37 +57,37 @@ func TestGetTransactionValidation_InvalidID_ReturnsError(t *testing.T) {
 			name:     "not-a-uuid",
 			id:       "not-a-uuid",
 			wantCode: "0065",
-			wantMsg:  "Invalid transaction validation ID format",
+			wantMsg:  "",
 		},
 		{
 			name:     "numeric-id",
 			id:       "12345",
 			wantCode: "0065",
-			wantMsg:  "Invalid transaction validation ID format",
+			wantMsg:  "",
 		},
 		{
 			name:     "partial-uuid",
 			id:       "550e8400-e29b-41d4",
 			wantCode: "0065",
-			wantMsg:  "Invalid transaction validation ID format",
+			wantMsg:  "",
 		},
 		{
 			name:     "uuid-with-extra-chars",
 			id:       "550e8400-e29b-41d4-a716-446655440000-extra",
 			wantCode: "0065",
-			wantMsg:  "Invalid transaction validation ID format",
+			wantMsg:  "",
 		},
 		{
 			name:     "uppercase-invalid-uuid",
 			id:       "NOT-A-UUID-FORMAT",
 			wantCode: "0065",
-			wantMsg:  "Invalid transaction validation ID format",
+			wantMsg:  "",
 		},
 		{
 			name:     "malformed-uuid-bad-chars",
 			id:       "550e8400-e29b-41d4-a716-44665544000g",
 			wantCode: "0065",
-			wantMsg:  "Invalid transaction validation ID format",
+			wantMsg:  "",
 		},
 	}
 
@@ -118,7 +119,8 @@ func TestGetTransactionValidation_InvalidID_ReturnsError(t *testing.T) {
 // =============================================================================
 
 // TestListTransactionValidations_InvalidLimit_ReturnsError verifies invalid limit parameter handling.
-// Returns TRC-0006 for invalid query parameters (non-numeric limit, decimal)
+// Returns 0331 "Pagination Limit Invalid" / 0080 "Pagination Limit Exceeded" for out-of-range limits
+// and 0082 "Invalid Query Parameter" for non-numeric/decimal limits.
 func TestListTransactionValidations_InvalidLimit_ReturnsError(t *testing.T) {
 	baseURL := testutil.GetBaseURL()
 	apiKey := testutil.GetAPIKey()
@@ -134,36 +136,36 @@ func TestListTransactionValidations_InvalidLimit_ReturnsError(t *testing.T) {
 			name:      "limit-zero",
 			query:     "limit=0",
 			wantCode:  "0331",
-			wantTitle: "Invalid Transaction Validation Filters",
-			wantMsg:   "limit must be at least 1",
+			wantTitle: "Pagination Limit Invalid",
+			wantMsg:   "",
 		},
 		{
 			name:      "limit-negative",
 			query:     "limit=-1",
 			wantCode:  "0331",
-			wantTitle: "Invalid Transaction Validation Filters",
-			wantMsg:   "limit must be at least 1",
+			wantTitle: "Pagination Limit Invalid",
+			wantMsg:   "",
 		},
 		{
 			name:      "limit-exceeds-max",
 			query:     "limit=1001",
 			wantCode:  "0080",
-			wantTitle: "Invalid Transaction Validation Filters",
-			wantMsg:   "limit must not exceed 1000",
+			wantTitle: "Pagination Limit Exceeded",
+			wantMsg:   "",
 		},
 		{
 			name:      "limit-non-numeric",
 			query:     "limit=abc",
 			wantCode:  "0082",
 			wantTitle: "Invalid Query Parameter",
-			wantMsg:   "Invalid query parameters",
+			wantMsg:   "",
 		},
 		{
 			name:      "limit-decimal",
 			query:     "limit=10.5",
 			wantCode:  "0082",
 			wantTitle: "Invalid Query Parameter",
-			wantMsg:   "Invalid query parameters",
+			wantMsg:   "",
 		},
 	}
 
@@ -191,7 +193,7 @@ func TestListTransactionValidations_InvalidLimit_ReturnsError(t *testing.T) {
 }
 
 // TestListTransactionValidations_InvalidSortParams_ReturnsError verifies invalid sort parameter handling.
-// Returns TRC-0043 for invalid sort_by field and TRC-0042 for invalid sort_order value.
+// Returns 0332 (title "Invalid Sort Column") for invalid sort_by and 0081 (title "Invalid Sort Order") for invalid sort_order.
 func TestListTransactionValidations_InvalidSortParams_ReturnsError(t *testing.T) {
 	baseURL := testutil.GetBaseURL()
 	apiKey := testutil.GetAPIKey()
@@ -207,29 +209,29 @@ func TestListTransactionValidations_InvalidSortParams_ReturnsError(t *testing.T)
 			name:      "invalid-sortBy-field",
 			query:     "sort_by=invalidField",
 			wantCode:  "0332",
-			wantTitle: "Invalid Transaction Validation Filters",
-			wantMsg:   "sort_by must be one of [created_at processing_time_ms]",
+			wantTitle: "Invalid Sort Column",
+			wantMsg:   "",
 		},
 		{
 			name:      "invalid-sortOrder-value",
 			query:     "sort_order=INVALID",
 			wantCode:  "0081",
-			wantTitle: "Invalid Transaction Validation Filters",
-			wantMsg:   "sort_order must be ASC or DESC",
+			wantTitle: "Invalid Sort Order",
+			wantMsg:   "",
 		},
 		{
 			name:      "sortOrder-lowercase-invalid",
 			query:     "sort_order=ascending",
 			wantCode:  "0081",
-			wantTitle: "Invalid Transaction Validation Filters",
-			wantMsg:   "sort_order must be ASC or DESC",
+			wantTitle: "Invalid Sort Order",
+			wantMsg:   "",
 		},
 		{
 			name:      "sortBy-numeric",
 			query:     "sort_by=123",
 			wantCode:  "0332",
-			wantTitle: "Invalid Transaction Validation Filters",
-			wantMsg:   "sort_by must be one of [created_at processing_time_ms]",
+			wantTitle: "Invalid Sort Column",
+			wantMsg:   "",
 		},
 	}
 
@@ -258,7 +260,7 @@ func TestListTransactionValidations_InvalidSortParams_ReturnsError(t *testing.T)
 
 // TestListTransactionValidations_SortParamsWithCursor_ReturnsError verifies that sort_by/sort_order
 // cannot be used together with cursor pagination.
-// Returns TRC-0045 when sort parameters are provided alongside a cursor.
+// Returns code 0334 (title "Cursor With Sort Params") when sort parameters are provided alongside a cursor.
 func TestListTransactionValidations_SortParamsWithCursor_ReturnsError(t *testing.T) {
 	baseURL := testutil.GetBaseURL()
 	apiKey := testutil.GetAPIKey()
@@ -277,19 +279,19 @@ func TestListTransactionValidations_SortParamsWithCursor_ReturnsError(t *testing
 			name:     "sortBy-with-cursor",
 			query:    "cursor=" + dummyCursor + "&sort_by=created_at",
 			wantCode: "0334",
-			wantMsg:  "sort_by and sort_order cannot be used with cursor; cursor already contains sort configuration",
+			wantMsg:  "",
 		},
 		{
 			name:     "sortOrder-with-cursor",
 			query:    "cursor=" + dummyCursor + "&sort_order=ASC",
 			wantCode: "0334",
-			wantMsg:  "sort_by and sort_order cannot be used with cursor; cursor already contains sort configuration",
+			wantMsg:  "",
 		},
 		{
 			name:     "both-sort-params-with-cursor",
 			query:    "cursor=" + dummyCursor + "&sort_by=created_at&sort_order=DESC",
 			wantCode: "0334",
-			wantMsg:  "sort_by and sort_order cannot be used with cursor; cursor already contains sort configuration",
+			wantMsg:  "",
 		},
 	}
 
@@ -310,7 +312,7 @@ func TestListTransactionValidations_SortParamsWithCursor_ReturnsError(t *testing
 
 			errResp := testutil.ParseErrorResponse(t, respBody)
 			assert.Equal(t, tc.wantCode, errResp.Code, "Expected error code %s for query=%q", tc.wantCode, tc.query)
-			assert.Equal(t, "Invalid Transaction Validation Filters", errResp.Title)
+			assert.Equal(t, "Cursor With Sort Params", errResp.Title)
 			assert.Equal(t, tc.wantMsg, errResp.Message)
 		})
 	}
@@ -321,7 +323,7 @@ func TestListTransactionValidations_SortParamsWithCursor_ReturnsError(t *testing
 // =============================================================================
 
 // TestListTransactionValidations_InvalidDecision_ReturnsError verifies invalid decision filter handling.
-// Returns TRC-0250 for invalid transaction validation filters
+// Returns code 0431 (title "Invalid Transaction Validation Filters") for invalid filter values.
 func TestListTransactionValidations_InvalidDecision_ReturnsError(t *testing.T) {
 	baseURL := testutil.GetBaseURL()
 	apiKey := testutil.GetAPIKey()
@@ -336,25 +338,25 @@ func TestListTransactionValidations_InvalidDecision_ReturnsError(t *testing.T) {
 			name:     "invalid-decision-value",
 			query:    "decision=INVALID",
 			wantCode: "0431",
-			wantMsg:  "decision must be one of [ALLOW, DENY, REVIEW]",
+			wantMsg:  "",
 		},
 		{
 			name:     "decision-lowercase",
 			query:    "decision=allow",
 			wantCode: "0431",
-			wantMsg:  "decision must be one of [ALLOW, DENY, REVIEW]",
+			wantMsg:  "",
 		},
 		{
 			name:     "decision-approve",
 			query:    "decision=APPROVE",
 			wantCode: "0431",
-			wantMsg:  "decision must be one of [ALLOW, DENY, REVIEW]",
+			wantMsg:  "",
 		},
 		{
 			name:     "decision-numeric",
 			query:    "decision=123",
 			wantCode: "0431",
-			wantMsg:  "decision must be one of [ALLOW, DENY, REVIEW]",
+			wantMsg:  "",
 		},
 	}
 
@@ -382,7 +384,7 @@ func TestListTransactionValidations_InvalidDecision_ReturnsError(t *testing.T) {
 }
 
 // TestListTransactionValidations_InvalidTransactionType_ReturnsError verifies invalid transactionType filter handling.
-// Returns TRC-0250 for invalid transaction validation filters
+// Returns code 0431 (title "Invalid Transaction Validation Filters") for invalid filter values.
 func TestListTransactionValidations_InvalidTransactionType_ReturnsError(t *testing.T) {
 	baseURL := testutil.GetBaseURL()
 	apiKey := testutil.GetAPIKey()
@@ -397,25 +399,25 @@ func TestListTransactionValidations_InvalidTransactionType_ReturnsError(t *testi
 			name:     "invalid-transactionType-value",
 			query:    "transaction_type=INVALID",
 			wantCode: "0431",
-			wantMsg:  "transaction_type must be one of [CARD, WIRE, PIX, CRYPTO]",
+			wantMsg:  "",
 		},
 		{
 			name:     "transactionType-lowercase",
 			query:    "transaction_type=card",
 			wantCode: "0431",
-			wantMsg:  "transaction_type must be one of [CARD, WIRE, PIX, CRYPTO]",
+			wantMsg:  "",
 		},
 		{
 			name:     "transactionType-cash",
 			query:    "transaction_type=CASH",
 			wantCode: "0431",
-			wantMsg:  "transaction_type must be one of [CARD, WIRE, PIX, CRYPTO]",
+			wantMsg:  "",
 		},
 		{
 			name:     "transactionType-numeric",
 			query:    "transaction_type=123",
 			wantCode: "0431",
-			wantMsg:  "transaction_type must be one of [CARD, WIRE, PIX, CRYPTO]",
+			wantMsg:  "",
 		},
 	}
 
@@ -443,7 +445,7 @@ func TestListTransactionValidations_InvalidTransactionType_ReturnsError(t *testi
 }
 
 // TestListTransactionValidations_InvalidUUIDFilters_ReturnsError verifies invalid UUID filter handling.
-// Returns TRC-0250 for invalid transaction validation filters
+// Returns code 0431 (title "Invalid Transaction Validation Filters") for invalid filter values.
 func TestListTransactionValidations_InvalidUUIDFilters_ReturnsError(t *testing.T) {
 	baseURL := testutil.GetBaseURL()
 	apiKey := testutil.GetAPIKey()
@@ -458,31 +460,31 @@ func TestListTransactionValidations_InvalidUUIDFilters_ReturnsError(t *testing.T
 			name:     "invalid-accountId-uuid",
 			query:    "account_id=not-a-uuid",
 			wantCode: "0431",
-			wantMsg:  "account_id must be a valid UUID",
+			wantMsg:  "",
 		},
 		{
 			name:     "invalid-matchedRuleId-uuid",
 			query:    "matched_rule_id=invalid-uuid",
 			wantCode: "0431",
-			wantMsg:  "matched_rule_id must be a valid UUID",
+			wantMsg:  "",
 		},
 		{
 			name:     "invalid-exceededLimitId-uuid",
 			query:    "exceeded_limit_id=12345",
 			wantCode: "0431",
-			wantMsg:  "exceeded_limit_id must be a valid UUID",
+			wantMsg:  "",
 		},
 		{
 			name:     "invalid-segmentId-uuid",
 			query:    "segment_id=abc",
 			wantCode: "0431",
-			wantMsg:  "segment_id must be a valid UUID",
+			wantMsg:  "",
 		},
 		{
 			name:     "invalid-portfolioId-uuid",
 			query:    "portfolio_id=not-valid",
 			wantCode: "0431",
-			wantMsg:  "portfolio_id must be a valid UUID",
+			wantMsg:  "",
 		},
 		// NOTE: "uuid-without-dashes" is actually a valid UUID format accepted by google/uuid
 		// so it won't fail validation. We test with a truly invalid format instead.
@@ -490,13 +492,13 @@ func TestListTransactionValidations_InvalidUUIDFilters_ReturnsError(t *testing.T
 			name:     "malformed-uuid-bad-hex",
 			query:    "account_id=550e8400-e29b-41d4-a716-44665544000g",
 			wantCode: "0431",
-			wantMsg:  "account_id must be a valid UUID",
+			wantMsg:  "",
 		},
 		{
 			name:     "partial-uuid",
 			query:    "account_id=550e8400-e29b",
 			wantCode: "0431",
-			wantMsg:  "account_id must be a valid UUID",
+			wantMsg:  "",
 		},
 	}
 
@@ -524,46 +526,53 @@ func TestListTransactionValidations_InvalidUUIDFilters_ReturnsError(t *testing.T
 }
 
 // TestListTransactionValidations_InvalidDateFilters_ReturnsError verifies invalid date filter handling.
-// Returns TRC-0250 for invalid transaction validation filters
+// Returns 0077 (title "Invalid Date Format Error") for malformed dates and 0083
+// (title "Invalid Date Range Error") when start_date is after end_date.
 func TestListTransactionValidations_InvalidDateFilters_ReturnsError(t *testing.T) {
 	baseURL := testutil.GetBaseURL()
 	apiKey := testutil.GetAPIKey()
 
 	tests := []struct {
-		name     string
-		query    string
-		wantCode string
-		wantMsg  string
+		name      string
+		query     string
+		wantCode  string
+		wantTitle string
+		wantMsg   string
 	}{
 		{
-			name:     "invalid-startDate-format",
-			query:    "start_date=2024-01-01",
-			wantCode: "0077",
-			wantMsg:  `start_date must be in RFC3339 format with timezone (e.g., 2026-01-28T10:30:00Z). Invalid value: "2024-01-01"`,
+			name:      "invalid-startDate-format",
+			query:     "start_date=2024-01-01",
+			wantCode:  "0077",
+			wantTitle: "Invalid Date Format Error",
+			wantMsg:   "",
 		},
 		{
-			name:     "invalid-endDate-format",
-			query:    "end_date=invalid-date",
-			wantCode: "0077",
-			wantMsg:  `end_date must be in RFC3339 format with timezone (e.g., 2026-01-28T10:30:00Z). Invalid value: "invalid-date"`,
+			name:      "invalid-endDate-format",
+			query:     "end_date=invalid-date",
+			wantCode:  "0077",
+			wantTitle: "Invalid Date Format Error",
+			wantMsg:   "",
 		},
 		{
-			name:     "startDate-after-endDate",
-			query:    "start_date=2024-12-31T23:59:59Z&end_date=2024-01-01T00:00:00Z",
-			wantCode: "0083",
-			wantMsg:  "end_date must be on or after start_date",
+			name:      "startDate-after-endDate",
+			query:     "start_date=2024-12-31T23:59:59Z&end_date=2024-01-01T00:00:00Z",
+			wantCode:  "0083",
+			wantTitle: "Invalid Date Range Error",
+			wantMsg:   "",
 		},
 		{
-			name:     "date-without-timezone",
-			query:    "start_date=2024-01-01T12:00:00",
-			wantCode: "0077",
-			wantMsg:  `start_date must be in RFC3339 format with timezone (e.g., 2026-01-28T10:30:00Z). Invalid value: "2024-01-01T12:00:00"`,
+			name:      "date-without-timezone",
+			query:     "start_date=2024-01-01T12:00:00",
+			wantCode:  "0077",
+			wantTitle: "Invalid Date Format Error",
+			wantMsg:   "",
 		},
 		{
-			name:     "date-numeric",
-			query:    "start_date=1704067200",
-			wantCode: "0077",
-			wantMsg:  `start_date must be in RFC3339 format with timezone (e.g., 2026-01-28T10:30:00Z). Invalid value: "1704067200"`,
+			name:      "date-numeric",
+			query:     "start_date=1704067200",
+			wantCode:  "0077",
+			wantTitle: "Invalid Date Format Error",
+			wantMsg:   "",
 		},
 	}
 
@@ -584,7 +593,7 @@ func TestListTransactionValidations_InvalidDateFilters_ReturnsError(t *testing.T
 
 			errResp := testutil.ParseErrorResponse(t, respBody)
 			assert.Equal(t, tc.wantCode, errResp.Code, "Expected error code %s for query=%q", tc.wantCode, tc.query)
-			assert.Equal(t, "Invalid Transaction Validation Filters", errResp.Title)
+			assert.Equal(t, tc.wantTitle, errResp.Title, "Expected title %q for query=%q", tc.wantTitle, tc.query)
 			assert.Equal(t, tc.wantMsg, errResp.Message)
 		})
 	}
@@ -616,9 +625,9 @@ func TestListTransactionValidations_MultipleInvalidParams_ReturnsFirstError(t *t
 
 	errResp := testutil.ParseErrorResponse(t, respBody)
 	assert.Equal(t, "0331", errResp.Code)
-	assert.Equal(t, "Invalid Transaction Validation Filters", errResp.Title)
+	assert.Equal(t, "Pagination Limit Invalid", errResp.Title)
 	// First validation is limit (based on validation order in handler)
-	assert.Equal(t, "limit must be at least 1", errResp.Message)
+	assert.Equal(t, "", errResp.Message)
 }
 
 // =============================================================================
@@ -649,8 +658,8 @@ func TestGetTransactionValidation_ValidUUIDButNotFound_Returns404(t *testing.T) 
 
 	errResp := testutil.ParseErrorResponse(t, respBody)
 	assert.Equal(t, "0432", errResp.Code)
-	assert.Equal(t, "Not Found", errResp.Title)
-	assert.Equal(t, "Transaction validation not found", errResp.Message)
+	assert.Equal(t, "Transaction Validation Not Found", errResp.Title)
+	assert.Equal(t, "", errResp.Message)
 }
 
 // =============================================================================
@@ -705,10 +714,10 @@ func TestListTransactionValidations_WithoutAuth_Returns401(t *testing.T) {
 // Pagination Validation Tests - Transaction Validations
 // =============================================================================
 // These tests verify that pagination parameters are properly validated according
-// to the standardized validation pattern (TRC-0040 through TRC-0045).
+// to the standardized validation pattern (codes 0080, 0081, 0331, 0332, 0334).
 // =============================================================================
 
-// TestListTransactionValidations_CursorWithSortBy_Rejected verifies TRC-0045: cursor cannot be used with sort_by.
+// TestListTransactionValidations_CursorWithSortBy_Rejected verifies code 0334: cursor cannot be used with sort_by.
 func TestListTransactionValidations_CursorWithSortBy_Rejected(t *testing.T) {
 	baseURL := testutil.GetBaseURL()
 	apiKey := testutil.GetAPIKey()
@@ -727,10 +736,10 @@ func TestListTransactionValidations_CursorWithSortBy_Rejected(t *testing.T) {
 	require.NoError(t, err)
 	errResp := testutil.ParseErrorResponse(t, respBody)
 	assert.Equal(t, "0334", errResp.Code)
-	assert.Contains(t, errResp.Message, "sort_by and sort_order cannot be used with cursor")
+	assert.Empty(t, errResp.Message)
 }
 
-// TestListTransactionValidations_CursorWithSortOrder_Rejected verifies TRC-0045: cursor cannot be used with sort_order.
+// TestListTransactionValidations_CursorWithSortOrder_Rejected verifies code 0334: cursor cannot be used with sort_order.
 func TestListTransactionValidations_CursorWithSortOrder_Rejected(t *testing.T) {
 	baseURL := testutil.GetBaseURL()
 	apiKey := testutil.GetAPIKey()
@@ -749,10 +758,10 @@ func TestListTransactionValidations_CursorWithSortOrder_Rejected(t *testing.T) {
 	require.NoError(t, err)
 	errResp := testutil.ParseErrorResponse(t, respBody)
 	assert.Equal(t, "0334", errResp.Code)
-	assert.Contains(t, errResp.Message, "sort_by and sort_order cannot be used with cursor")
+	assert.Empty(t, errResp.Message)
 }
 
-// TestListTransactionValidations_CursorWithBothSortParams_Rejected verifies TRC-0045: cursor cannot be used with both sort_by and sort_order.
+// TestListTransactionValidations_CursorWithBothSortParams_Rejected verifies code 0334: cursor cannot be used with both sort_by and sort_order.
 func TestListTransactionValidations_CursorWithBothSortParams_Rejected(t *testing.T) {
 	baseURL := testutil.GetBaseURL()
 	apiKey := testutil.GetAPIKey()
@@ -771,10 +780,10 @@ func TestListTransactionValidations_CursorWithBothSortParams_Rejected(t *testing
 	require.NoError(t, err)
 	errResp := testutil.ParseErrorResponse(t, respBody)
 	assert.Equal(t, "0334", errResp.Code)
-	assert.Contains(t, errResp.Message, "sort_by and sort_order cannot be used with cursor")
+	assert.Empty(t, errResp.Message)
 }
 
-// TestListTransactionValidations_LimitExceeded verifies TRC-0040: limit cannot exceed maximum.
+// TestListTransactionValidations_LimitExceeded verifies code 0080: limit cannot exceed maximum.
 func TestListTransactionValidations_LimitExceeded(t *testing.T) {
 	baseURL := testutil.GetBaseURL()
 	apiKey := testutil.GetAPIKey()
@@ -793,10 +802,10 @@ func TestListTransactionValidations_LimitExceeded(t *testing.T) {
 	require.NoError(t, err)
 	errResp := testutil.ParseErrorResponse(t, respBody)
 	assert.Equal(t, "0080", errResp.Code)
-	assert.Contains(t, errResp.Message, "limit must not exceed 1000")
+	assert.Empty(t, errResp.Message)
 }
 
-// TestListTransactionValidations_InvalidLimit verifies TRC-0041: limit must be at least 1.
+// TestListTransactionValidations_InvalidLimit verifies code 0331: limit must be at least 1.
 func TestListTransactionValidations_InvalidLimit(t *testing.T) {
 	baseURL := testutil.GetBaseURL()
 	apiKey := testutil.GetAPIKey()
@@ -815,10 +824,10 @@ func TestListTransactionValidations_InvalidLimit(t *testing.T) {
 	require.NoError(t, err)
 	errResp := testutil.ParseErrorResponse(t, respBody)
 	assert.Equal(t, "0331", errResp.Code)
-	assert.Contains(t, errResp.Message, "limit must be at least 1")
+	assert.Empty(t, errResp.Message)
 }
 
-// TestListTransactionValidations_InvalidSortOrder_TRC0042 verifies TRC-0042: sort_order must be ASC or DESC.
+// TestListTransactionValidations_InvalidSortOrder_TRC0042 verifies code 0081: sort_order must be ASC or DESC.
 func TestListTransactionValidations_InvalidSortOrder_TRC0042(t *testing.T) {
 	baseURL := testutil.GetBaseURL()
 	apiKey := testutil.GetAPIKey()
@@ -837,10 +846,10 @@ func TestListTransactionValidations_InvalidSortOrder_TRC0042(t *testing.T) {
 	require.NoError(t, err)
 	errResp := testutil.ParseErrorResponse(t, respBody)
 	assert.Equal(t, "0081", errResp.Code)
-	assert.Contains(t, errResp.Message, "sort_order must be ASC or DESC")
+	assert.Empty(t, errResp.Message)
 }
 
-// TestListTransactionValidations_InvalidSortBy_TRC0043 verifies TRC-0043: sort_by must be in allowed list.
+// TestListTransactionValidations_InvalidSortBy_TRC0043 verifies code 0332: sort_by must be in allowed list.
 func TestListTransactionValidations_InvalidSortBy_TRC0043(t *testing.T) {
 	baseURL := testutil.GetBaseURL()
 	apiKey := testutil.GetAPIKey()
@@ -859,24 +868,28 @@ func TestListTransactionValidations_InvalidSortBy_TRC0043(t *testing.T) {
 	require.NoError(t, err)
 	errResp := testutil.ParseErrorResponse(t, respBody)
 	assert.Equal(t, "0332", errResp.Code)
-	assert.Contains(t, errResp.Message, "sort_by must be one of [created_at processing_time_ms]")
+	assert.Empty(t, errResp.Message)
 }
 
 // =============================================================================
-// 3.7 GET /v1/validations - Timeout/DeadlineExceeded Tests (TRC-0252)
+// 3.7 GET /v1/validations - Timeout/DeadlineExceeded Tests (code 0433)
 // =============================================================================
 
 // TestListTransactionValidations_Timeout_ReturnsTRC0252 verifies that when a query timeout occurs
-// (deadline exceeded), the API returns 504 Gateway Timeout with error code TRC-0252.
+// (deadline exceeded), the API returns 504 Gateway Timeout with error code 0433.
 //
 // Uses fault injection to simulate a timeout scenario. The fault injection middleware
-// intercepts requests with X-Test-Fault-Injection header and returns TRC-0252.
+// intercepts requests with X-Test-Fault-Injection header and returns code 0433.
 //
 // Expected response:
 // - HTTP Status: 504 Gateway Timeout
-// - Error Code: TRC-0252 (list query timeout)
+// - Error Code: 0433 (list query timeout)
 // - Error Title: "Gateway Timeout"
-// - Error Message: mentions "query" to distinguish from POST validation timeout (TRC-0229)
+// - Error Message: mentions "query" to distinguish from the POST validation timeout
+//
+// KNOWN BUG (not synced): the endpoint currently returns 503 "Service Unavailable"
+// with detail "internal error" instead of 504 "Gateway Timeout". Assertions are
+// left expecting the correct 504 contract.
 func TestListTransactionValidations_Timeout_ReturnsTRC0252(t *testing.T) {
 	// Use fault injection to simulate timeout scenario
 	resp, respBody := testutil.ListValidationsWithFaultInjection(t, "", testutil.FaultTimeout)
@@ -890,9 +903,9 @@ func TestListTransactionValidations_Timeout_ReturnsTRC0252(t *testing.T) {
 	// Parse the error response
 	errResp := testutil.ParseErrorResponse(t, respBody)
 
-	// Verify TRC-0252 for list query timeout (distinct from TRC-0229 for POST validation timeout)
+	// Verify code 0433 (ErrListValidationsTimeout) for list query timeout, distinct from the POST validation timeout
 	assert.Equal(t, "0433", errResp.Code,
-		"Expected error code TRC-0252 (CodeListValidationsTimeout) for list query timeout, got %s",
+		"Expected error code 0433 (ErrListValidationsTimeout) for list query timeout, got %s",
 		errResp.Code)
 
 	// Verify the title indicates a timeout
@@ -907,7 +920,8 @@ func TestListTransactionValidations_Timeout_ReturnsTRC0252(t *testing.T) {
 // TestListTransactionValidations_Timeout_WithFilters_ReturnsTRC0252 verifies timeout handling
 // when complex filters are used (which might cause slower queries).
 //
-// TDD RED Phase: Same failure expected as TestListTransactionValidations_Timeout_ReturnsTRC0252.
+// Same KNOWN BUG as TestListTransactionValidations_Timeout_ReturnsTRC0252: the endpoint
+// currently returns 503 "Service Unavailable" instead of the expected 504 "Gateway Timeout".
 func TestListTransactionValidations_Timeout_WithFilters_ReturnsTRC0252(t *testing.T) {
 	// Use filters that might cause a complex query
 	queryParams := "decision=ALLOW&transaction_type=CARD&sort_by=processing_time_ms&sort_order=DESC"
@@ -921,7 +935,6 @@ func TestListTransactionValidations_Timeout_WithFilters_ReturnsTRC0252(t *testin
 
 	errResp := testutil.ParseErrorResponse(t, respBody)
 
-	// TDD RED Phase: Will fail - expecting TRC-0252, will get TRC-0229
 	assert.Equal(t, "0433", errResp.Code,
-		"Expected TRC-0252 for list query timeout, got %s", errResp.Code)
+		"Expected code 0433 for list query timeout, got %s", errResp.Code)
 }

--- a/components/tracer/tests/integration/01_validation_get_error_codes_test.go
+++ b/components/tracer/tests/integration/01_validation_get_error_codes_test.go
@@ -126,46 +126,55 @@ func TestListTransactionValidations_InvalidLimit_ReturnsError(t *testing.T) {
 	apiKey := testutil.GetAPIKey()
 
 	tests := []struct {
-		name      string
-		query     string
-		wantCode  string
-		wantTitle string
-		wantMsg   string
+		name              string
+		query             string
+		wantCode          string
+		wantTitle         string
+		wantMsg           string
+		wantDetail        string // RFC 9457 human-readable text
+		wantDetailIsExact bool   // true: assert.Equal against wantDetail; false: assert.Contains
 	}{
 		{
-			name:      "limit-zero",
-			query:     "limit=0",
-			wantCode:  "0331",
-			wantTitle: "Pagination Limit Invalid",
-			wantMsg:   "",
+			name:              "limit-zero",
+			query:             "limit=0",
+			wantCode:          "0331",
+			wantTitle:         "Pagination Limit Invalid",
+			wantMsg:           "",
+			wantDetail:        "Pagination limit must be positive.",
+			wantDetailIsExact: true,
 		},
 		{
-			name:      "limit-negative",
-			query:     "limit=-1",
-			wantCode:  "0331",
-			wantTitle: "Pagination Limit Invalid",
-			wantMsg:   "",
+			name:              "limit-negative",
+			query:             "limit=-1",
+			wantCode:          "0331",
+			wantTitle:         "Pagination Limit Invalid",
+			wantMsg:           "",
+			wantDetail:        "Pagination limit must be positive.",
+			wantDetailIsExact: true,
 		},
 		{
-			name:      "limit-exceeds-max",
-			query:     "limit=1001",
-			wantCode:  "0080",
-			wantTitle: "Pagination Limit Exceeded",
-			wantMsg:   "",
+			name:       "limit-exceeds-max",
+			query:      "limit=1001",
+			wantCode:   "0080",
+			wantTitle:  "Pagination Limit Exceeded",
+			wantMsg:    "",
+			wantDetail: "exceeds the maximum allowed", // detail interpolates the configured max
 		},
 		{
-			name:      "limit-non-numeric",
-			query:     "limit=abc",
-			wantCode:  "0082",
-			wantTitle: "Invalid Query Parameter",
-			wantMsg:   "",
+			name:       "limit-non-numeric",
+			query:      "limit=abc",
+			wantCode:   "0082",
+			wantTitle:  "Invalid Query Parameter",
+			wantMsg:    "",
+			wantDetail: "One or more query parameters are in an incorrect format", // 0082 detail is generic
 		},
 		{
-			name:      "limit-decimal",
-			query:     "limit=10.5",
-			wantCode:  "0082",
-			wantTitle: "Invalid Query Parameter",
-			wantMsg:   "",
+			name:       "limit-decimal",
+			query:      "limit=10.5",
+			wantCode:   "0082",
+			wantTitle:  "Invalid Query Parameter",
+			wantMsg:    "",
+			wantDetail: "One or more query parameters are in an incorrect format", // 0082 detail is generic
 		},
 	}
 
@@ -188,6 +197,12 @@ func TestListTransactionValidations_InvalidLimit_ReturnsError(t *testing.T) {
 			assert.Equal(t, tc.wantCode, errResp.Code, "Expected error code %s for query=%q", tc.wantCode, tc.query)
 			assert.Equal(t, tc.wantTitle, errResp.Title, "Expected title %q for query=%q", tc.wantTitle, tc.query)
 			assert.Equal(t, tc.wantMsg, errResp.Message)
+
+			if tc.wantDetailIsExact {
+				assert.Equal(t, tc.wantDetail, errResp.Detail, "Expected exact detail for query=%q", tc.query)
+			} else {
+				assert.Contains(t, errResp.Detail, tc.wantDetail, "Expected detail to mention %q for query=%q", tc.wantDetail, tc.query)
+			}
 		})
 	}
 }

--- a/components/tracer/tests/integration/01_validation_post_error_codes_test.go
+++ b/components/tracer/tests/integration/01_validation_post_error_codes_test.go
@@ -26,32 +26,34 @@ import (
 // =============================================================================
 //
 // These tests verify the error handling behavior for the validation
-// endpoint POST /v1/validations.
+// endpoint POST /v1/validations. Errors use the RFC 9457 problem+json
+// envelope with numeric codes from pkg/constant/errors.go; the `title` is the
+// humanized sentinel name and the human-readable text is carried in `detail`
+// (the retired `message` field is empty).
 //
-// Error Code Mapping:
-//   - BodyParser fails (malformed JSON) → TRC-0003 (Bad Request)
-//   - ErrValidationRequestIDRequired → TRC-0220
-//   - ErrValidationInvalidTransactionType → TRC-0221
-//   - ErrValidationAmountNonPositive → TRC-0222
-//   - ErrValidationCurrencyRequired → TRC-0223
-//   - ErrValidationInvalidCurrency → TRC-0224
-//   - ErrValidationTimestampRequired → TRC-0225
-//   - ErrValidationTimestampFuture → TRC-0226
-//   - ErrValidationAccountRequired → TRC-0227
-//   - ErrValidationSubTypeTooLong → TRC-0232
-//
-// Note: Valid JSON that fails field validation returns specific codes TRC-0220 through TRC-0232.
+// Error Code Mapping (numeric registry):
+//   - Body parse failure (malformed JSON / wrong type) → 0094 (ErrInvalidRequestBody), title "Bad Request"
+//   - Empty body → generic 400 with no code, title "Bad Request"
+//   - ErrValidationRequestIDRequired → 0413
+//   - ErrValidationInvalidTransactionType → 0414
+//   - ErrValidationAmountNonPositive → 0415
+//   - ErrValidationCurrencyRequired → 0416
+//   - ErrValidationInvalidCurrency → 0417
+//   - ErrValidationTimestampRequired → 0418
+//   - ErrValidationTimestampFuture → 0419
+//   - ErrValidationAccountRequired → 0420
+//   - ErrValidationSubTypeTooLong → 0425
 // =============================================================================
 
 // =============================================================================
 // 1. Malformed JSON Tests - POST /v1/validations
 // =============================================================================
 // These test cases verify behavior when the request body cannot be parsed as JSON.
-// Returns TRC-0003 "Bad Request" for malformed JSON.
+// Returns 0094 (ErrInvalidRequestBody) with title "Bad Request" for malformed JSON.
 // =============================================================================
 
 // TestValidation_MalformedJSON_ReturnsError verifies that completely malformed JSON returns an error.
-// TRC-0003: Bad Request for malformed JSON
+// 0094 (ErrInvalidRequestBody): Bad Request for malformed JSON
 func TestValidation_MalformedJSON_ReturnsError(t *testing.T) {
 	baseURL := testutil.GetBaseURL()
 	apiKey := testutil.GetAPIKey()
@@ -116,16 +118,17 @@ func TestValidation_MalformedJSON_ReturnsError(t *testing.T) {
 
 			errResp := testutil.ParseErrorResponse(t, respBody)
 
-			// TRC-0003: Bad Request for malformed JSON
-			assert.Equal(t, "0047", errResp.Code, "Test case: %s - Expected TRC-0003 for malformed JSON", tc.description)
+			// 0094 (ErrInvalidRequestBody): Bad Request for malformed JSON.
+			// Human-readable text lives in the RFC 9457 `detail`; the retired `message` field is empty.
+			assert.Equal(t, "0094", errResp.Code, "Test case: %s - Expected 0094 for malformed JSON", tc.description)
 			assert.Equal(t, "Bad Request", errResp.Title, "Test case: %s", tc.description)
-			assert.Equal(t, "invalid request body", errResp.Message, "Test case: %s", tc.description)
+			assert.Equal(t, "", errResp.Message, "Test case: %s", tc.description)
 		})
 	}
 }
 
 // TestValidation_BinaryData_ReturnsError verifies that binary data returns an error.
-// TRC-0003: Bad Request for binary data
+// 0094 (ErrInvalidRequestBody): Bad Request for binary data
 func TestValidation_BinaryData_ReturnsError(t *testing.T) {
 	baseURL := testutil.GetBaseURL()
 	apiKey := testutil.GetAPIKey()
@@ -148,14 +151,14 @@ func TestValidation_BinaryData_ReturnsError(t *testing.T) {
 
 	errResp := testutil.ParseErrorResponse(t, respBody)
 
-	// TRC-0003: Bad Request for binary data
-	assert.Equal(t, "0047", errResp.Code, "Expected TRC-0003 for binary data")
+	// 0094 (ErrInvalidRequestBody): Bad Request for binary data
+	assert.Equal(t, "0094", errResp.Code, "Expected 0094 for binary data")
 	assert.Equal(t, "Bad Request", errResp.Title)
-	assert.Equal(t, "invalid request body", errResp.Message)
+	assert.Equal(t, "", errResp.Message)
 }
 
 // TestValidation_EmptyBody_ReturnsError verifies that an empty request body returns an error.
-// TRC-0003: Bad Request for empty body
+// Empty body: generic 400 Bad Request with no domain error code
 func TestValidation_EmptyBody_ReturnsError(t *testing.T) {
 	baseURL := testutil.GetBaseURL()
 	apiKey := testutil.GetAPIKey()
@@ -176,10 +179,10 @@ func TestValidation_EmptyBody_ReturnsError(t *testing.T) {
 
 	errResp := testutil.ParseErrorResponse(t, respBody)
 
-	// TRC-0003: Bad Request for empty body
-	assert.Equal(t, "0047", errResp.Code, "Expected TRC-0003 for empty body")
+	// Empty body: generic 400 Bad Request carrying no domain error code.
+	assert.Equal(t, "", errResp.Code, "Empty body returns a generic 400 with no domain error code")
 	assert.Equal(t, "Bad Request", errResp.Title)
-	assert.Equal(t, "invalid request body", errResp.Message)
+	assert.Equal(t, "", errResp.Message)
 }
 
 // TestValidation_NullBody_ReturnsError verifies that a null JSON body returns an error.
@@ -204,10 +207,11 @@ func TestValidation_NullBody_ReturnsError(t *testing.T) {
 
 	errResp := testutil.ParseErrorResponse(t, respBody)
 
-	// "null" is valid JSON but missing required fields - first validation fails on requestId
-	assert.Equal(t, "0413", errResp.Code, "Expected TRC-0220 for null body (requestId is required)")
-	assert.Equal(t, "Validation Error", errResp.Title)
-	assert.Equal(t, "requestId is required", errResp.Message)
+	// "null" is valid JSON but missing required fields - first validation fails on requestId.
+	// 0413 (ErrValidationRequestIDRequired); title is the humanized sentinel name.
+	assert.Equal(t, "0413", errResp.Code, "Expected 0413 for null body (requestId is required)")
+	assert.Equal(t, "Validation Request IDRequired", errResp.Title)
+	assert.Equal(t, "", errResp.Message)
 }
 
 // TestValidation_ArrayInsteadOfObject_ReturnsError verifies that a JSON array returns an error.
@@ -233,21 +237,21 @@ func TestValidation_ArrayInsteadOfObject_ReturnsError(t *testing.T) {
 
 	errResp := testutil.ParseErrorResponse(t, respBody)
 
-	// TRC-0003: BodyParser fails to unmarshal array into struct
-	assert.Equal(t, "0047", errResp.Code, "Expected TRC-0003 for array instead of object (body parsing error)")
+	// 0094 (ErrInvalidRequestBody): fails to unmarshal array into struct
+	assert.Equal(t, "0094", errResp.Code, "Expected 0094 for array instead of object (body parsing error)")
 	assert.Equal(t, "Bad Request", errResp.Title)
-	assert.Equal(t, "invalid request body", errResp.Message)
+	assert.Equal(t, "", errResp.Message)
 }
 
 // =============================================================================
 // 2. Field Validation Tests - POST /v1/validations
 // =============================================================================
 // These test cases verify behavior when request has valid JSON but fails field validation.
-// Each field validation error uses a specific error code (TRC-0220 to TRC-0237).
+// Each field validation error uses a specific numeric error code (0413 to 0430).
 // =============================================================================
 
 // TestValidation_MissingRequestID_ReturnsError verifies that missing requestId returns an error.
-// TRC-0220: requestId is required
+// 0413: requestId is required
 func TestValidation_MissingRequestID_ReturnsError(t *testing.T) {
 	baseURL := testutil.GetBaseURL()
 	apiKey := testutil.GetAPIKey()
@@ -282,14 +286,14 @@ func TestValidation_MissingRequestID_ReturnsError(t *testing.T) {
 
 	errResp := testutil.ParseErrorResponse(t, respBody)
 
-	// TRC-0220: requestId is required
-	assert.Equal(t, "0413", errResp.Code, "Expected TRC-0220 for missing requestId")
-	assert.Equal(t, "Validation Error", errResp.Title)
-	assert.Equal(t, "requestId is required", errResp.Message)
+	// 0413 (ErrValidationRequestIDRequired): requestId is required
+	assert.Equal(t, "0413", errResp.Code, "Expected 0413 for missing requestId")
+	assert.Equal(t, "Validation Request IDRequired", errResp.Title)
+	assert.Equal(t, "", errResp.Message)
 }
 
 // TestValidation_InvalidTransactionType_ReturnsError verifies invalid transactionType returns an error.
-// TRC-0221: transactionType must be one of [CARD, WIRE, PIX, CRYPTO]
+// 0414: transactionType must be one of [CARD, WIRE, PIX, CRYPTO]
 func TestValidation_InvalidTransactionType_ReturnsError(t *testing.T) {
 	baseURL := testutil.GetBaseURL()
 	apiKey := testutil.GetAPIKey()
@@ -353,16 +357,16 @@ func TestValidation_InvalidTransactionType_ReturnsError(t *testing.T) {
 
 			errResp := testutil.ParseErrorResponse(t, respBody)
 
-			// TRC-0221: transactionType must be one of [CARD, WIRE, PIX, CRYPTO]
-			assert.Equal(t, "0414", errResp.Code, "Test case: %s - Expected TRC-0221 for invalid transactionType", tc.description)
-			assert.Equal(t, "Validation Error", errResp.Title)
-			assert.Equal(t, "transactionType must be one of [CARD, WIRE, PIX, CRYPTO]", errResp.Message)
+			// 0414 (ErrValidationInvalidTransactionType): transactionType must be one of [CARD, WIRE, PIX, CRYPTO]
+			assert.Equal(t, "0414", errResp.Code, "Test case: %s - Expected 0414 for invalid transactionType", tc.description)
+			assert.Equal(t, "Validation Invalid Transaction Type", errResp.Title)
+			assert.Equal(t, "", errResp.Message)
 		})
 	}
 }
 
 // TestValidation_AmountNonPositive_ReturnsError verifies that zero or negative amount returns an error.
-// TRC-0222: amount must be positive
+// 0415: amount must be positive
 func TestValidation_AmountNonPositive_ReturnsError(t *testing.T) {
 	baseURL := testutil.GetBaseURL()
 	apiKey := testutil.GetAPIKey()
@@ -421,16 +425,16 @@ func TestValidation_AmountNonPositive_ReturnsError(t *testing.T) {
 
 			errResp := testutil.ParseErrorResponse(t, respBody)
 
-			// TRC-0222: amount must be positive
-			assert.Equal(t, "0415", errResp.Code, "Test case: %s - Expected TRC-0222 for non-positive amount", tc.description)
-			assert.Equal(t, "Validation Error", errResp.Title)
-			assert.Equal(t, "amount must be positive", errResp.Message)
+			// 0415 (ErrValidationAmountNonPositive): amount must be positive
+			assert.Equal(t, "0415", errResp.Code, "Test case: %s - Expected 0415 for non-positive amount", tc.description)
+			assert.Equal(t, "Validation Amount Non Positive", errResp.Title)
+			assert.Equal(t, "", errResp.Message)
 		})
 	}
 }
 
 // TestValidation_MissingCurrency_ReturnsError verifies that missing currency returns an error.
-// TRC-0223: currency is required
+// 0416: currency is required
 func TestValidation_MissingCurrency_ReturnsError(t *testing.T) {
 	baseURL := testutil.GetBaseURL()
 	apiKey := testutil.GetAPIKey()
@@ -464,14 +468,14 @@ func TestValidation_MissingCurrency_ReturnsError(t *testing.T) {
 
 	errResp := testutil.ParseErrorResponse(t, respBody)
 
-	// TRC-0223: currency is required
-	assert.Equal(t, "0416", errResp.Code, "Expected TRC-0223 for missing currency")
-	assert.Equal(t, "Validation Error", errResp.Title)
-	assert.Equal(t, "currency is required", errResp.Message)
+	// 0416 (ErrValidationCurrencyRequired): currency is required
+	assert.Equal(t, "0416", errResp.Code, "Expected 0416 for missing currency")
+	assert.Equal(t, "Validation Currency Required", errResp.Title)
+	assert.Equal(t, "", errResp.Message)
 }
 
 // TestValidation_InvalidCurrency_ReturnsError verifies that invalid currency code returns an error.
-// TRC-0224: currency must be valid ISO 4217 code (e.g., BRL, USD)
+// 0417: currency must be valid ISO 4217 code (e.g., BRL, USD)
 func TestValidation_InvalidCurrency_ReturnsError(t *testing.T) {
 	baseURL := testutil.GetBaseURL()
 	apiKey := testutil.GetAPIKey()
@@ -540,16 +544,16 @@ func TestValidation_InvalidCurrency_ReturnsError(t *testing.T) {
 
 			errResp := testutil.ParseErrorResponse(t, respBody)
 
-			// TRC-0224: currency must be valid ISO 4217 code (e.g., BRL, USD)
-			assert.Equal(t, "0417", errResp.Code, "Test case: %s - Expected TRC-0224 for invalid currency", tc.description)
-			assert.Equal(t, "Validation Error", errResp.Title)
-			assert.Equal(t, "currency must be valid ISO 4217 code (e.g., BRL, USD)", errResp.Message)
+			// 0417 (ErrValidationInvalidCurrency): currency must be valid ISO 4217 code (e.g., BRL, USD)
+			assert.Equal(t, "0417", errResp.Code, "Test case: %s - Expected 0417 for invalid currency", tc.description)
+			assert.Equal(t, "Validation Invalid Currency", errResp.Title)
+			assert.Equal(t, "", errResp.Message)
 		})
 	}
 }
 
 // TestValidation_MissingTimestamp_ReturnsError verifies that missing timestamp returns an error.
-// TRC-0225: transactionTimestamp is required
+// 0418: transactionTimestamp is required
 func TestValidation_MissingTimestamp_ReturnsError(t *testing.T) {
 	baseURL := testutil.GetBaseURL()
 	apiKey := testutil.GetAPIKey()
@@ -583,14 +587,14 @@ func TestValidation_MissingTimestamp_ReturnsError(t *testing.T) {
 
 	errResp := testutil.ParseErrorResponse(t, respBody)
 
-	// TRC-0225: transactionTimestamp is required
-	assert.Equal(t, "0418", errResp.Code, "Expected TRC-0225 for missing timestamp")
-	assert.Equal(t, "Validation Error", errResp.Title)
-	assert.Equal(t, "transactionTimestamp is required", errResp.Message)
+	// 0418 (ErrValidationTimestampRequired): transactionTimestamp is required
+	assert.Equal(t, "0418", errResp.Code, "Expected 0418 for missing timestamp")
+	assert.Equal(t, "Validation Timestamp Required", errResp.Title)
+	assert.Equal(t, "", errResp.Message)
 }
 
 // TestValidation_FutureTimestamp_ReturnsError verifies that future timestamp returns an error.
-// TRC-0226: transactionTimestamp cannot be in the future
+// 0419: transactionTimestamp cannot be in the future
 func TestValidation_FutureTimestamp_ReturnsError(t *testing.T) {
 	baseURL := testutil.GetBaseURL()
 	apiKey := testutil.GetAPIKey()
@@ -629,10 +633,10 @@ func TestValidation_FutureTimestamp_ReturnsError(t *testing.T) {
 
 	errResp := testutil.ParseErrorResponse(t, respBody)
 
-	// TRC-0226: transactionTimestamp cannot be in the future
-	assert.Equal(t, "0419", errResp.Code, "Expected TRC-0226 for future timestamp")
-	assert.Equal(t, "Validation Error", errResp.Title)
-	assert.Equal(t, "transactionTimestamp cannot be in the future", errResp.Message)
+	// 0419 (ErrValidationTimestampFuture): transactionTimestamp cannot be in the future
+	assert.Equal(t, "0419", errResp.Code, "Expected 0419 for future timestamp")
+	assert.Equal(t, "Validation Timestamp Future", errResp.Title)
+	assert.Equal(t, "", errResp.Message)
 }
 
 // TestValidation_FutureTimestamp_SmallClockSkew_IsAccepted verifies that small
@@ -685,7 +689,7 @@ func TestValidation_FutureTimestamp_SmallClockSkew_IsAccepted(t *testing.T) {
 }
 
 // TestValidation_MissingAccount_ReturnsError verifies that missing account object returns an error.
-// TRC-0227: account is required
+// 0420: account is required
 func TestValidation_MissingAccount_ReturnsError(t *testing.T) {
 	baseURL := testutil.GetBaseURL()
 	apiKey := testutil.GetAPIKey()
@@ -717,14 +721,14 @@ func TestValidation_MissingAccount_ReturnsError(t *testing.T) {
 
 	errResp := testutil.ParseErrorResponse(t, respBody)
 
-	// TRC-0227: account is required
-	assert.Equal(t, "0420", errResp.Code, "Expected TRC-0227 for missing account")
-	assert.Equal(t, "Validation Error", errResp.Title)
-	assert.Equal(t, "account is required", errResp.Message)
+	// 0420 (ErrValidationAccountRequired): account is required
+	assert.Equal(t, "0420", errResp.Code, "Expected 0420 for missing account")
+	assert.Equal(t, "Validation Account Required", errResp.Title)
+	assert.Equal(t, "", errResp.Message)
 }
 
 // TestValidation_EmptyAccountObject_ReturnsError verifies that empty account object returns an error.
-// TRC-0227: account is required
+// 0420: account is required
 func TestValidation_EmptyAccountObject_ReturnsError(t *testing.T) {
 	baseURL := testutil.GetBaseURL()
 	apiKey := testutil.GetAPIKey()
@@ -757,14 +761,14 @@ func TestValidation_EmptyAccountObject_ReturnsError(t *testing.T) {
 
 	errResp := testutil.ParseErrorResponse(t, respBody)
 
-	// TRC-0227: account is required
-	assert.Equal(t, "0420", errResp.Code, "Expected TRC-0227 for empty account object")
-	assert.Equal(t, "Validation Error", errResp.Title)
-	assert.Equal(t, "account is required", errResp.Message)
+	// 0420 (ErrValidationAccountRequired): account is required
+	assert.Equal(t, "0420", errResp.Code, "Expected 0420 for empty account object")
+	assert.Equal(t, "Validation Account Required", errResp.Title)
+	assert.Equal(t, "", errResp.Message)
 }
 
 // TestValidation_SubTypeTooLong_ReturnsError verifies that subType exceeding max length returns an error.
-// TRC-0232: subType exceeds maximum length of 50 characters
+// 0425: subType exceeds maximum length of 50 characters
 func TestValidation_SubTypeTooLong_ReturnsError(t *testing.T) {
 	baseURL := testutil.GetBaseURL()
 	apiKey := testutil.GetAPIKey()
@@ -803,10 +807,10 @@ func TestValidation_SubTypeTooLong_ReturnsError(t *testing.T) {
 
 	errResp := testutil.ParseErrorResponse(t, respBody)
 
-	// TRC-0232: subType exceeds maximum length of 50 characters
-	assert.Equal(t, "0425", errResp.Code, "Expected TRC-0232 for subType too long")
-	assert.Equal(t, "Validation Error", errResp.Title)
-	assert.Equal(t, "subType exceeds maximum length of 50 characters", errResp.Message)
+	// 0425 (ErrValidationSubTypeTooLong): subType exceeds maximum length of 50 characters
+	assert.Equal(t, "0425", errResp.Code, "Expected 0425 for subType too long")
+	assert.Equal(t, "Validation Sub Type Too Long", errResp.Title)
+	assert.Equal(t, "", errResp.Message)
 }
 
 // =============================================================================
@@ -913,10 +917,10 @@ func TestValidation_InvalidUUIDFormat_ReturnsError(t *testing.T) {
 
 			errResp := testutil.ParseErrorResponse(t, respBody)
 
-			// UUID parsing errors happen during body parsing (BodyParser fails)
-			assert.Equal(t, "0047", errResp.Code, "Test case: %s - Expected TRC-0003 for invalid UUID (body parsing error)", tc.description)
+			// UUID parsing errors happen during body parsing → 0094 (ErrInvalidRequestBody)
+			assert.Equal(t, "0094", errResp.Code, "Test case: %s - Expected 0094 for invalid UUID (body parsing error)", tc.description)
 			assert.Equal(t, "Bad Request", errResp.Title)
-			assert.Equal(t, "invalid UUID format in request (check requestId, account.id, segment.id, portfolio.id, merchant.id)", errResp.Message, "Test case: %s - Error message should match expected format", tc.description)
+			assert.Equal(t, "", errResp.Message, "Test case: %s", tc.description)
 		})
 	}
 }
@@ -985,10 +989,10 @@ func TestValidation_InvalidTimestampFormat_ReturnsError(t *testing.T) {
 
 			errResp := testutil.ParseErrorResponse(t, respBody)
 
-			// Timestamp parsing errors happen during body parsing (BodyParser fails)
-			assert.Equal(t, "0047", errResp.Code, "Test case: %s - Expected TRC-0003 for invalid timestamp (body parsing error)", tc.description)
+			// Timestamp parsing errors happen during body parsing → 0094 (ErrInvalidRequestBody)
+			assert.Equal(t, "0094", errResp.Code, "Test case: %s - Expected 0094 for invalid timestamp (body parsing error)", tc.description)
 			assert.Equal(t, "Bad Request", errResp.Title)
-			assert.Equal(t, "timestamp: invalid format (expected RFC3339)", errResp.Message, "Test case: %s", tc.description)
+			assert.Equal(t, "", errResp.Message, "Test case: %s", tc.description)
 		})
 	}
 }
@@ -1062,10 +1066,10 @@ func TestValidation_ValidJSONWithWrongTypes_ReturnsError(t *testing.T) {
 
 			errResp := testutil.ParseErrorResponse(t, respBody)
 
-			// TRC-0003 is returned for JSON type mismatch errors (bad request)
-			assert.Equal(t, "0047", errResp.Code, "Expected TRC-0003 for type validation error")
+			// 0094 (ErrInvalidRequestBody) is returned for JSON type mismatch errors (bad request)
+			assert.Equal(t, "0094", errResp.Code, "Expected 0094 for type validation error")
 			assert.Equal(t, "Bad Request", errResp.Title)
-			assert.Equal(t, "invalid request body", errResp.Message)
+			assert.Equal(t, "", errResp.Message)
 		})
 	}
 }
@@ -1074,29 +1078,28 @@ func TestValidation_ValidJSONWithWrongTypes_ReturnsError(t *testing.T) {
 // 5. Error Code Documentation
 // =============================================================================
 //
-// Error Code Mapping for Validation Handler:
+// Error Code Mapping for Validation Handler (numeric registry, pkg/constant/errors.go):
 // ------------------------------------------
-// TRC-0001: Validation Error - Post-parse validation errors (type mismatches, constraint violations after successful parse)
-// TRC-0003: Bad Request - Body parsing errors (malformed JSON, invalid syntax, unparseable request)
-// TRC-0220: ErrValidationRequestIDRequired - requestId is required
-// TRC-0221: ErrValidationInvalidTransactionType - transactionType invalid
-// TRC-0222: ErrValidationAmountNonPositive - amount must be positive
-// TRC-0223: ErrValidationCurrencyRequired - currency is required
-// TRC-0224: ErrValidationInvalidCurrency - currency invalid ISO 4217
-// TRC-0225: ErrValidationTimestampRequired - transactionTimestamp is required
-// TRC-0226: ErrValidationTimestampFuture - transactionTimestamp in future
-// TRC-0227: ErrValidationAccountRequired - account is required
-// TRC-0229: ErrValidationTimeout - validation timeout
-// TRC-0230: ErrValidationSegmentIDRequired - segment.id is required
-// TRC-0231: ErrValidationPortfolioIDRequired - portfolio.id is required
-// TRC-0232: ErrValidationSubTypeTooLong - subType exceeds 50 characters
-// TRC-0233: ErrValidationInvalidAccountType - account.type invalid
-// TRC-0234: ErrValidationInvalidAccountStatus - account.status invalid
-// TRC-0235: ErrValidationInvalidMerchantCategory - merchant.category invalid
-// TRC-0236: ErrValidationInvalidMerchantCountry - merchant.country invalid
-// TRC-0237: ErrValidationMerchantIDRequired - merchant.id is required
+// 0094: ErrInvalidRequestBody - Body parsing errors (malformed JSON, wrong type, unparseable request), title "Bad Request"
+// 0413: ErrValidationRequestIDRequired - requestId is required
+// 0414: ErrValidationInvalidTransactionType - transactionType invalid
+// 0415: ErrValidationAmountNonPositive - amount must be positive
+// 0416: ErrValidationCurrencyRequired - currency is required
+// 0417: ErrValidationInvalidCurrency - currency invalid ISO 4217
+// 0418: ErrValidationTimestampRequired - transactionTimestamp is required
+// 0419: ErrValidationTimestampFuture - transactionTimestamp in future
+// 0420: ErrValidationAccountRequired - account is required
+// 0422: ErrValidationTimeout - validation timeout
+// 0423: ErrValidationSegmentIDRequired - segment.id is required
+// 0424: ErrValidationPortfolioIDRequired - portfolio.id is required
+// 0425: ErrValidationSubTypeTooLong - subType exceeds 50 characters
+// 0426: ErrValidationInvalidAccountType - account.type invalid
+// 0427: ErrValidationInvalidAccountStatus - account.status invalid
+// 0428: ErrValidationInvalidMerchantCategory - merchant.category invalid
+// 0429: ErrValidationInvalidMerchantCountry - merchant.country invalid
+// 0430: ErrValidationMerchantIDRequired - merchant.id is required
 //
-// Metadata validation errors (TRC-006x range):
-// TRC-0060: ErrMetadataKeyLengthExceeded - metadata key > 64 chars
-// TRC-0063: ErrMetadataEntriesExceeded - metadata > 50 entries
-// TRC-0064: ErrMetadataKeyInvalidChars - metadata key invalid chars
+// Metadata validation errors:
+// 0050: ErrMetadataKeyLengthExceeded - metadata key too long
+// 0335: ErrMetadataEntriesExceeded - too many metadata entries
+// 0336: ErrMetadataKeyInvalidChars - metadata key invalid chars

--- a/components/tracer/tests/integration/01_validation_post_error_codes_test.go
+++ b/components/tracer/tests/integration/01_validation_post_error_codes_test.go
@@ -1087,6 +1087,7 @@ func TestValidation_ValidJSONWithWrongTypes_ReturnsError(t *testing.T) {
 // Error Code Mapping for Validation Handler (numeric registry, pkg/constant/errors.go):
 // ------------------------------------------
 // 0094: ErrInvalidRequestBody - Body parsing errors (malformed JSON, wrong type, unparseable request), title "Bad Request"
+// 0143: ErrPayloadTooLarge - request body exceeds the size limit, 413 Payload Too Large (top-level `message` populated; `detail` carries the same text since 413 < 500)
 // 0413: ErrValidationRequestIDRequired - requestId is required
 // 0414: ErrValidationInvalidTransactionType - transactionType invalid
 // 0415: ErrValidationAmountNonPositive - amount must be positive
@@ -1095,7 +1096,7 @@ func TestValidation_ValidJSONWithWrongTypes_ReturnsError(t *testing.T) {
 // 0418: ErrValidationTimestampRequired - transactionTimestamp is required
 // 0419: ErrValidationTimestampFuture - transactionTimestamp in future
 // 0420: ErrValidationAccountRequired - account is required
-// 0422: ErrValidationTimeout - validation timeout
+// 0422: ErrValidationTimeout - validation timeout, 504 Gateway Timeout (>=500: `detail` scrubbed, human text in top-level `message`)
 // 0423: ErrValidationSegmentIDRequired - segment.id is required
 // 0424: ErrValidationPortfolioIDRequired - portfolio.id is required
 // 0425: ErrValidationSubTypeTooLong - subType exceeds 50 characters

--- a/components/tracer/tests/integration/01_validation_post_error_codes_test.go
+++ b/components/tracer/tests/integration/01_validation_post_error_codes_test.go
@@ -122,7 +122,7 @@ func TestValidation_MalformedJSON_ReturnsError(t *testing.T) {
 			// Human-readable text lives in the RFC 9457 `detail`; the retired `message` field is empty.
 			assert.Equal(t, "0094", errResp.Code, "Test case: %s - Expected 0094 for malformed JSON", tc.description)
 			assert.Equal(t, "Bad Request", errResp.Title, "Test case: %s", tc.description)
-			assert.Equal(t, "", errResp.Message, "Test case: %s", tc.description)
+			assert.Equal(t, "The request body is malformed or contains invalid JSON. Please verify the syntax and try again.", errResp.Detail, "Test case: %s", tc.description)
 		})
 	}
 }
@@ -154,7 +154,7 @@ func TestValidation_BinaryData_ReturnsError(t *testing.T) {
 	// 0094 (ErrInvalidRequestBody): Bad Request for binary data
 	assert.Equal(t, "0094", errResp.Code, "Expected 0094 for binary data")
 	assert.Equal(t, "Bad Request", errResp.Title)
-	assert.Equal(t, "", errResp.Message)
+	assert.Equal(t, "The request body is malformed or contains invalid JSON. Please verify the syntax and try again.", errResp.Detail)
 }
 
 // TestValidation_EmptyBody_ReturnsError verifies that an empty request body returns an error.
@@ -211,7 +211,7 @@ func TestValidation_NullBody_ReturnsError(t *testing.T) {
 	// 0413 (ErrValidationRequestIDRequired); title is the humanized sentinel name.
 	assert.Equal(t, "0413", errResp.Code, "Expected 0413 for null body (requestId is required)")
 	assert.Equal(t, "Validation Request IDRequired", errResp.Title)
-	assert.Equal(t, "", errResp.Message)
+	assert.Equal(t, "RequestId is required.", errResp.Detail)
 }
 
 // TestValidation_ArrayInsteadOfObject_ReturnsError verifies that a JSON array returns an error.
@@ -240,7 +240,7 @@ func TestValidation_ArrayInsteadOfObject_ReturnsError(t *testing.T) {
 	// 0094 (ErrInvalidRequestBody): fails to unmarshal array into struct
 	assert.Equal(t, "0094", errResp.Code, "Expected 0094 for array instead of object (body parsing error)")
 	assert.Equal(t, "Bad Request", errResp.Title)
-	assert.Equal(t, "", errResp.Message)
+	assert.Equal(t, "The request body is malformed or contains invalid JSON. Please verify the syntax and try again.", errResp.Detail)
 }
 
 // =============================================================================
@@ -289,7 +289,7 @@ func TestValidation_MissingRequestID_ReturnsError(t *testing.T) {
 	// 0413 (ErrValidationRequestIDRequired): requestId is required
 	assert.Equal(t, "0413", errResp.Code, "Expected 0413 for missing requestId")
 	assert.Equal(t, "Validation Request IDRequired", errResp.Title)
-	assert.Equal(t, "", errResp.Message)
+	assert.Equal(t, "RequestId is required.", errResp.Detail)
 }
 
 // TestValidation_InvalidTransactionType_ReturnsError verifies invalid transactionType returns an error.
@@ -360,7 +360,7 @@ func TestValidation_InvalidTransactionType_ReturnsError(t *testing.T) {
 			// 0414 (ErrValidationInvalidTransactionType): transactionType must be one of [CARD, WIRE, PIX, CRYPTO]
 			assert.Equal(t, "0414", errResp.Code, "Test case: %s - Expected 0414 for invalid transactionType", tc.description)
 			assert.Equal(t, "Validation Invalid Transaction Type", errResp.Title)
-			assert.Equal(t, "", errResp.Message)
+			assert.Equal(t, "Invalid transactionType.", errResp.Detail)
 		})
 	}
 }
@@ -428,7 +428,7 @@ func TestValidation_AmountNonPositive_ReturnsError(t *testing.T) {
 			// 0415 (ErrValidationAmountNonPositive): amount must be positive
 			assert.Equal(t, "0415", errResp.Code, "Test case: %s - Expected 0415 for non-positive amount", tc.description)
 			assert.Equal(t, "Validation Amount Non Positive", errResp.Title)
-			assert.Equal(t, "", errResp.Message)
+			assert.Equal(t, "Amount must be positive.", errResp.Detail)
 		})
 	}
 }
@@ -471,7 +471,7 @@ func TestValidation_MissingCurrency_ReturnsError(t *testing.T) {
 	// 0416 (ErrValidationCurrencyRequired): currency is required
 	assert.Equal(t, "0416", errResp.Code, "Expected 0416 for missing currency")
 	assert.Equal(t, "Validation Currency Required", errResp.Title)
-	assert.Equal(t, "", errResp.Message)
+	assert.Equal(t, "Currency is required.", errResp.Detail)
 }
 
 // TestValidation_InvalidCurrency_ReturnsError verifies that invalid currency code returns an error.
@@ -547,7 +547,7 @@ func TestValidation_InvalidCurrency_ReturnsError(t *testing.T) {
 			// 0417 (ErrValidationInvalidCurrency): currency must be valid ISO 4217 code (e.g., BRL, USD)
 			assert.Equal(t, "0417", errResp.Code, "Test case: %s - Expected 0417 for invalid currency", tc.description)
 			assert.Equal(t, "Validation Invalid Currency", errResp.Title)
-			assert.Equal(t, "", errResp.Message)
+			assert.Equal(t, "Currency must be valid ISO 4217.", errResp.Detail)
 		})
 	}
 }
@@ -590,7 +590,7 @@ func TestValidation_MissingTimestamp_ReturnsError(t *testing.T) {
 	// 0418 (ErrValidationTimestampRequired): transactionTimestamp is required
 	assert.Equal(t, "0418", errResp.Code, "Expected 0418 for missing timestamp")
 	assert.Equal(t, "Validation Timestamp Required", errResp.Title)
-	assert.Equal(t, "", errResp.Message)
+	assert.Equal(t, "Timestamp is required.", errResp.Detail)
 }
 
 // TestValidation_FutureTimestamp_ReturnsError verifies that future timestamp returns an error.
@@ -636,7 +636,7 @@ func TestValidation_FutureTimestamp_ReturnsError(t *testing.T) {
 	// 0419 (ErrValidationTimestampFuture): transactionTimestamp cannot be in the future
 	assert.Equal(t, "0419", errResp.Code, "Expected 0419 for future timestamp")
 	assert.Equal(t, "Validation Timestamp Future", errResp.Title)
-	assert.Equal(t, "", errResp.Message)
+	assert.Equal(t, "Timestamp cannot be in the future.", errResp.Detail)
 }
 
 // TestValidation_FutureTimestamp_SmallClockSkew_IsAccepted verifies that small
@@ -724,7 +724,7 @@ func TestValidation_MissingAccount_ReturnsError(t *testing.T) {
 	// 0420 (ErrValidationAccountRequired): account is required
 	assert.Equal(t, "0420", errResp.Code, "Expected 0420 for missing account")
 	assert.Equal(t, "Validation Account Required", errResp.Title)
-	assert.Equal(t, "", errResp.Message)
+	assert.Equal(t, "Account is required.", errResp.Detail)
 }
 
 // TestValidation_EmptyAccountObject_ReturnsError verifies that empty account object returns an error.
@@ -764,7 +764,7 @@ func TestValidation_EmptyAccountObject_ReturnsError(t *testing.T) {
 	// 0420 (ErrValidationAccountRequired): account is required
 	assert.Equal(t, "0420", errResp.Code, "Expected 0420 for empty account object")
 	assert.Equal(t, "Validation Account Required", errResp.Title)
-	assert.Equal(t, "", errResp.Message)
+	assert.Equal(t, "Account is required.", errResp.Detail)
 }
 
 // TestValidation_SubTypeTooLong_ReturnsError verifies that subType exceeding max length returns an error.
@@ -810,7 +810,7 @@ func TestValidation_SubTypeTooLong_ReturnsError(t *testing.T) {
 	// 0425 (ErrValidationSubTypeTooLong): subType exceeds maximum length of 50 characters
 	assert.Equal(t, "0425", errResp.Code, "Expected 0425 for subType too long")
 	assert.Equal(t, "Validation Sub Type Too Long", errResp.Title)
-	assert.Equal(t, "", errResp.Message)
+	assert.Equal(t, "SubType exceeds maximum length of 50 characters.", errResp.Detail)
 }
 
 // =============================================================================
@@ -920,7 +920,7 @@ func TestValidation_InvalidUUIDFormat_ReturnsError(t *testing.T) {
 			// UUID parsing errors happen during body parsing → 0094 (ErrInvalidRequestBody)
 			assert.Equal(t, "0094", errResp.Code, "Test case: %s - Expected 0094 for invalid UUID (body parsing error)", tc.description)
 			assert.Equal(t, "Bad Request", errResp.Title)
-			assert.Equal(t, "", errResp.Message, "Test case: %s", tc.description)
+			assert.Equal(t, "The request body is malformed or contains invalid JSON. Please verify the syntax and try again.", errResp.Detail, "Test case: %s", tc.description)
 		})
 	}
 }
@@ -992,7 +992,7 @@ func TestValidation_InvalidTimestampFormat_ReturnsError(t *testing.T) {
 			// Timestamp parsing errors happen during body parsing → 0094 (ErrInvalidRequestBody)
 			assert.Equal(t, "0094", errResp.Code, "Test case: %s - Expected 0094 for invalid timestamp (body parsing error)", tc.description)
 			assert.Equal(t, "Bad Request", errResp.Title)
-			assert.Equal(t, "", errResp.Message, "Test case: %s", tc.description)
+			assert.Equal(t, "The request body is malformed or contains invalid JSON. Please verify the syntax and try again.", errResp.Detail, "Test case: %s", tc.description)
 		})
 	}
 }
@@ -1069,7 +1069,7 @@ func TestValidation_ValidJSONWithWrongTypes_ReturnsError(t *testing.T) {
 			// 0094 (ErrInvalidRequestBody) is returned for JSON type mismatch errors (bad request)
 			assert.Equal(t, "0094", errResp.Code, "Expected 0094 for type validation error")
 			assert.Equal(t, "Bad Request", errResp.Title)
-			assert.Equal(t, "", errResp.Message)
+			assert.Equal(t, "The request body is malformed or contains invalid JSON. Please verify the syntax and try again.", errResp.Detail)
 		})
 	}
 }

--- a/components/tracer/tests/integration/01_validation_post_error_codes_test.go
+++ b/components/tracer/tests/integration/01_validation_post_error_codes_test.go
@@ -29,7 +29,13 @@ import (
 // endpoint POST /v1/validations. Errors use the RFC 9457 problem+json
 // envelope with numeric codes from pkg/constant/errors.go; the `title` is the
 // humanized sentinel name and the human-readable text is carried in `detail`
-// (the retired `message` field is empty).
+// (the retired `message` field is empty for these 4xx validation errors).
+//
+// Exception: the problem builder intentionally populates the top-level
+// `message` for payload-too-large (0143 / 413) and gateway-timeout
+// (0422 / 0433 / 504). For >=500 responses the `detail` is scrubbed to a
+// generic string, so those cases assert the human-readable text against
+// `message`, not `detail`.
 //
 // Error Code Mapping (numeric registry):
 //   - Body parse failure (malformed JSON / wrong type) → 0094 (ErrInvalidRequestBody), title "Bad Request"

--- a/components/tracer/tests/integration/01_validation_test.go
+++ b/components/tracer/tests/integration/01_validation_test.go
@@ -707,7 +707,7 @@ func TestValidation_1_1_9_PayloadTooLarge(t *testing.T) {
 
 	// Verify error response structure
 	errorResp := testutil.ParseErrorResponse(t, body)
-	assert.Equal(t, "0143", errorResp.Code, "Error code should be TRC-0011 for payload too large")
+	assert.Equal(t, "0143", errorResp.Code, "Error code should be 0143 for payload too large")
 	assert.Equal(t, "Payload Too Large", errorResp.Title, "Error title should be Payload Too Large")
 	assert.Equal(t, "payload too large: exceeds 100KB limit", errorResp.Message, "Error message should indicate payload size limit")
 }
@@ -738,8 +738,8 @@ func TestValidation_RequiredFieldsValidation(t *testing.T) {
 			},
 			missing:         "requestId",
 			expectedCode:    "0413",
-			expectedTitle:   "Validation Error",
-			expectedMessage: "requestId is required",
+			expectedTitle:   "Validation Request IDRequired",
+			expectedMessage: "",
 		},
 		{
 			name: "missing transactionType",
@@ -753,8 +753,8 @@ func TestValidation_RequiredFieldsValidation(t *testing.T) {
 			},
 			missing:         "transactionType",
 			expectedCode:    "0414",
-			expectedTitle:   "Validation Error",
-			expectedMessage: "transactionType must be one of [CARD, WIRE, PIX, CRYPTO]",
+			expectedTitle:   "Validation Invalid Transaction Type",
+			expectedMessage: "",
 		},
 		{
 			name: "missing amount (zero value)",
@@ -768,8 +768,8 @@ func TestValidation_RequiredFieldsValidation(t *testing.T) {
 			},
 			missing:         "amount",
 			expectedCode:    "0415",
-			expectedTitle:   "Validation Error",
-			expectedMessage: "amount must be positive",
+			expectedTitle:   "Validation Amount Non Positive",
+			expectedMessage: "",
 		},
 		{
 			name: "missing currency",
@@ -783,8 +783,8 @@ func TestValidation_RequiredFieldsValidation(t *testing.T) {
 			},
 			missing:         "currency",
 			expectedCode:    "0416",
-			expectedTitle:   "Validation Error",
-			expectedMessage: "currency is required",
+			expectedTitle:   "Validation Currency Required",
+			expectedMessage: "",
 		},
 		{
 			name: "missing timestamp",
@@ -798,8 +798,8 @@ func TestValidation_RequiredFieldsValidation(t *testing.T) {
 			},
 			missing:         "timestamp",
 			expectedCode:    "0418",
-			expectedTitle:   "Validation Error",
-			expectedMessage: "transactionTimestamp is required",
+			expectedTitle:   "Validation Timestamp Required",
+			expectedMessage: "",
 		},
 		{
 			name: "missing account",
@@ -813,8 +813,8 @@ func TestValidation_RequiredFieldsValidation(t *testing.T) {
 			},
 			missing:         "account",
 			expectedCode:    "0420",
-			expectedTitle:   "Validation Error",
-			expectedMessage: "account is required",
+			expectedTitle:   "Validation Account Required",
+			expectedMessage: "",
 		},
 	}
 
@@ -860,9 +860,9 @@ func TestValidation_InvalidTransactionType(t *testing.T) {
 	// Verify error response structure per spec
 	errorResp := testutil.ParseErrorResponse(t, body)
 
-	assert.Equal(t, "0414", errorResp.Code, "Error code should be TRC-0221 for invalid transactionType")
-	assert.Equal(t, "Validation Error", errorResp.Title, "Error title should be Validation Error")
-	assert.Equal(t, "transactionType must be one of [CARD, WIRE, PIX, CRYPTO]", errorResp.Message, "Error message should indicate valid transactionTypes")
+	assert.Equal(t, "0414", errorResp.Code, "Error code should be 0414 for invalid transactionType")
+	assert.Equal(t, "Validation Invalid Transaction Type", errorResp.Title, "Error title should be Validation Invalid Transaction Type")
+	assert.Equal(t, "", errorResp.Message, "Detail is empty; the specific reason is carried by the title")
 }
 
 // Test 1.1.12: Validation rejects invalid amount
@@ -906,9 +906,9 @@ func TestValidation_InvalidAmount(t *testing.T) {
 			// Verify error response structure per spec
 			errorResp := testutil.ParseErrorResponse(t, body)
 
-			assert.Equal(t, "0415", errorResp.Code, "Error code should be TRC-0222 for non-positive amount")
-			assert.Equal(t, "Validation Error", errorResp.Title, "Error title should be Validation Error")
-			assert.Equal(t, "amount must be positive", errorResp.Message, "Error message should indicate amount must be positive")
+			assert.Equal(t, "0415", errorResp.Code, "Error code should be 0415 for non-positive amount")
+			assert.Equal(t, "Validation Amount Non Positive", errorResp.Title, "Error title should be Validation Amount Non Positive")
+			assert.Equal(t, "", errorResp.Message, "Detail is empty; the specific reason is carried by the title")
 		})
 	}
 
@@ -985,15 +985,15 @@ func TestValidation_InvalidCurrency(t *testing.T) {
 			// Verify error response structure per spec
 			errorResp := testutil.ParseErrorResponse(t, body)
 
-			// Empty currency returns TRC-0223 (currency required), others return TRC-0224 (invalid currency)
+			// Empty currency returns 0416 (currency required), others return 0417 (invalid currency)
 			if tc.currency == "" {
-				assert.Equal(t, "0416", errorResp.Code, "Error code should be TRC-0223 for missing currency")
-				assert.Equal(t, "Validation Error", errorResp.Title, "Error title should be Validation Error")
-				assert.Equal(t, "currency is required", errorResp.Message, "Error message should indicate currency is required")
+				assert.Equal(t, "0416", errorResp.Code, "Error code should be 0416 for missing currency")
+				assert.Equal(t, "Validation Currency Required", errorResp.Title, "Error title should be Validation Currency Required")
+				assert.Equal(t, "", errorResp.Message, "Detail is empty; the specific reason is carried by the title")
 			} else {
-				assert.Equal(t, "0417", errorResp.Code, "Error code should be TRC-0224 for invalid currency")
-				assert.Equal(t, "Validation Error", errorResp.Title, "Error title should be Validation Error")
-				assert.Equal(t, "currency must be valid ISO 4217 code (e.g., BRL, USD)", errorResp.Message, "Error message should indicate valid currency format")
+				assert.Equal(t, "0417", errorResp.Code, "Error code should be 0417 for invalid currency")
+				assert.Equal(t, "Validation Invalid Currency", errorResp.Title, "Error title should be Validation Invalid Currency")
+				assert.Equal(t, "", errorResp.Message, "Detail is empty; the specific reason is carried by the title")
 			}
 		})
 	}
@@ -1026,9 +1026,9 @@ func TestValidation_1_1_14_FutureTimestamp(t *testing.T) {
 
 	// Verify error response structure
 	errorResp := testutil.ParseErrorResponse(t, body)
-	assert.Equal(t, "0419", errorResp.Code, "Error code should be TRC-0226 for future timestamp")
-	assert.Equal(t, "Validation Error", errorResp.Title, "Error title should be Validation Error")
-	assert.Equal(t, "transactionTimestamp cannot be in the future", errorResp.Message, "Error message should indicate timestamp cannot be in the future")
+	assert.Equal(t, "0419", errorResp.Code, "Error code should be 0419 for future timestamp")
+	assert.Equal(t, "Validation Timestamp Future", errorResp.Title, "Error title should be Validation Timestamp Future")
+	assert.Equal(t, "", errorResp.Message, "Detail is empty; the specific reason is carried by the title")
 }
 
 // Test 1.1.15: Validation requires authentication
@@ -1215,9 +1215,9 @@ func TestValidation_1_1_19_RejectsMetadataOverLimit(t *testing.T) {
 
 	// Verify error response structure
 	errorResp := testutil.ParseErrorResponse(t, body)
-	assert.Equal(t, "0335", errorResp.Code, "Error code should be TRC-0063 for metadata entries exceeded")
-	assert.Equal(t, "Validation Error", errorResp.Title, "Error title should be Validation Error")
-	assert.Equal(t, "metadata exceeds maximum of 50 entries", errorResp.Message, "Error message should indicate metadata entry limit")
+	assert.Equal(t, "0335", errorResp.Code, "Error code should be 0335 for metadata entries exceeded")
+	assert.Equal(t, "Metadata Entries Exceeded", errorResp.Title, "Error title should be Metadata Entries Exceeded")
+	assert.Equal(t, "", errorResp.Message, "Detail is empty; the specific reason is carried by the title")
 }
 
 // Test 1.1.20: Rejects metadata key >64 characters
@@ -1252,9 +1252,9 @@ func TestValidation_1_1_20_RejectsLongMetadataKey(t *testing.T) {
 
 	// Verify error response structure
 	errorResp := testutil.ParseErrorResponse(t, body)
-	assert.Equal(t, "0050", errorResp.Code, "Error code should be TRC-0060 for metadata key length exceeded")
-	assert.Equal(t, "Validation Error", errorResp.Title, "Error title should be Validation Error")
-	assert.Equal(t, "metadata key exceeds maximum length of 64 characters", errorResp.Message, "Error message should indicate key length limit")
+	assert.Equal(t, "0050", errorResp.Code, "Error code should be 0050 for metadata key length exceeded")
+	assert.Equal(t, "Metadata Key Length Exceeded", errorResp.Title, "Error title should be Metadata Key Length Exceeded")
+	assert.Equal(t, "", errorResp.Message, "Detail is empty; the specific reason is carried by the title")
 }
 
 // Test 1.1.21: Rejects metadata key with invalid characters
@@ -1317,9 +1317,9 @@ func TestValidation_1_1_21_RejectsInvalidMetadataKeyChars(t *testing.T) {
 
 			// Verify error response structure
 			errorResp := testutil.ParseErrorResponse(t, body)
-			assert.Equal(t, "0336", errorResp.Code, "Error code should be TRC-0064 for invalid metadata key characters")
-			assert.Equal(t, "Validation Error", errorResp.Title, "Error title should be Validation Error")
-			assert.Equal(t, "metadata key contains invalid characters (only alphanumeric and underscore allowed)", errorResp.Message, "Error message should indicate valid key characters")
+			assert.Equal(t, "0336", errorResp.Code, "Error code should be 0336 for invalid metadata key characters")
+			assert.Equal(t, "Metadata Key Invalid Chars", errorResp.Title, "Error title should be Metadata Key Invalid Chars")
+			assert.Equal(t, "", errorResp.Message, "Detail is empty; the specific reason is carried by the title")
 		})
 	}
 }
@@ -1338,30 +1338,30 @@ func TestValidation_1_1_22_RejectsInvalidRequestIdUUID(t *testing.T) {
 		{
 			name:            "invalid UUID format",
 			requestID:       "invalid-uuid",
-			expectedCode:    "0047",
+			expectedCode:    "0094",
 			expectedTitle:   "Bad Request",
-			expectedMessage: "invalid UUID format in request (check requestId, account.id, segment.id, portfolio.id, merchant.id)",
+			expectedMessage: "",
 		},
 		{
 			name:            "numeric string",
 			requestID:       "123",
-			expectedCode:    "0047",
+			expectedCode:    "0094",
 			expectedTitle:   "Bad Request",
-			expectedMessage: "invalid UUID format in request (check requestId, account.id, segment.id, portfolio.id, merchant.id)",
+			expectedMessage: "",
 		},
 		{
 			name:            "empty string",
 			requestID:       "",
 			expectedCode:    "0413",
-			expectedTitle:   "Validation Error",
-			expectedMessage: "requestId is required",
+			expectedTitle:   "Validation Request IDRequired",
+			expectedMessage: "",
 		},
 		{
 			name:            "partial UUID",
 			requestID:       "550e8400-e29b-41d4",
-			expectedCode:    "0047",
+			expectedCode:    "0094",
 			expectedTitle:   "Bad Request",
-			expectedMessage: "invalid UUID format in request (check requestId, account.id, segment.id, portfolio.id, merchant.id)",
+			expectedMessage: "",
 		},
 	}
 
@@ -1408,30 +1408,30 @@ func TestValidation_1_1_23_RejectsInvalidAccountIdUUID(t *testing.T) {
 		{
 			name:            "invalid UUID format",
 			accountID:       "invalid-uuid",
-			expectedCode:    "0047",
+			expectedCode:    "0094",
 			expectedTitle:   "Bad Request",
-			expectedMessage: "invalid UUID format in request (check requestId, account.id, segment.id, portfolio.id, merchant.id)",
+			expectedMessage: "",
 		},
 		{
 			name:            "numeric string",
 			accountID:       "12345",
-			expectedCode:    "0047",
+			expectedCode:    "0094",
 			expectedTitle:   "Bad Request",
-			expectedMessage: "invalid UUID format in request (check requestId, account.id, segment.id, portfolio.id, merchant.id)",
+			expectedMessage: "",
 		},
 		{
 			name:            "empty string",
 			accountID:       "",
 			expectedCode:    "0420",
-			expectedTitle:   "Validation Error",
-			expectedMessage: "account is required",
+			expectedTitle:   "Validation Account Required",
+			expectedMessage: "",
 		},
 		{
 			name:            "malformed UUID",
 			accountID:       "not-a-valid-uuid-format",
-			expectedCode:    "0047",
+			expectedCode:    "0094",
 			expectedTitle:   "Bad Request",
-			expectedMessage: "invalid UUID format in request (check requestId, account.id, segment.id, portfolio.id, merchant.id)",
+			expectedMessage: "",
 		},
 	}
 
@@ -1512,9 +1512,9 @@ func TestValidation_1_1_24_RejectsInvalidSegmentIdUUID(t *testing.T) {
 			// Verify error response structure per spec
 			errorResp := testutil.ParseErrorResponse(t, body)
 
-			assert.Equal(t, "0047", errorResp.Code, "Error code should be TRC-0003 for invalid UUID format")
+			assert.Equal(t, "0094", errorResp.Code, "Error code should be 0094 for invalid UUID format")
 			assert.Equal(t, "Bad Request", errorResp.Title, "Error title should be Bad Request")
-			assert.Equal(t, "invalid UUID format in request (check requestId, account.id, segment.id, portfolio.id, merchant.id)", errorResp.Message, "Error message should match expected format")
+			assert.Equal(t, "", errorResp.Message, "Detail is empty for invalid request body")
 		})
 	}
 }
@@ -1567,9 +1567,9 @@ func TestValidation_1_1_25_RejectsInvalidPortfolioIdUUID(t *testing.T) {
 			// Verify error response structure per spec
 			errorResp := testutil.ParseErrorResponse(t, body)
 
-			assert.Equal(t, "0047", errorResp.Code, "Error code should be TRC-0003 for invalid UUID format")
+			assert.Equal(t, "0094", errorResp.Code, "Error code should be 0094 for invalid UUID format")
 			assert.Equal(t, "Bad Request", errorResp.Title, "Error title should be Bad Request")
-			assert.Equal(t, "invalid UUID format in request (check requestId, account.id, segment.id, portfolio.id, merchant.id)", errorResp.Message, "Error message should match expected format")
+			assert.Equal(t, "", errorResp.Message, "Detail is empty for invalid request body")
 		})
 	}
 }
@@ -1624,9 +1624,9 @@ func TestValidation_1_1_26_RejectsInvalidMerchantIdUUID(t *testing.T) {
 			// Verify error response structure per spec
 			errorResp := testutil.ParseErrorResponse(t, body)
 
-			assert.Equal(t, "0047", errorResp.Code, "Error code should be TRC-0003 for invalid UUID format")
+			assert.Equal(t, "0094", errorResp.Code, "Error code should be 0094 for invalid UUID format")
 			assert.Equal(t, "Bad Request", errorResp.Title, "Error title should be Bad Request")
-			assert.Equal(t, "invalid UUID format in request (check requestId, account.id, segment.id, portfolio.id, merchant.id)", errorResp.Message, "Error message should match expected format")
+			assert.Equal(t, "", errorResp.Message, "Detail is empty for invalid request body")
 		})
 	}
 }
@@ -1657,7 +1657,7 @@ func TestValidation_1_1_27_Returns504OnProcessingTimeout(t *testing.T) {
 
 	// Verify error response structure
 	errorResp := testutil.ParseErrorResponse(t, body)
-	assert.Equal(t, "0422", errorResp.Code, "Error code should be TRC-0229 (DeadlineExceeded)")
+	assert.Equal(t, "0422", errorResp.Code, "Error code should be 0422 (ValidationTimeout)")
 	assert.Equal(t, "Gateway Timeout", errorResp.Title, "Error title should be Gateway Timeout")
 	assert.Equal(t, "validation timeout", errorResp.Message, "Error message should indicate validation timeout")
 }
@@ -1688,9 +1688,9 @@ func TestValidation_1_1_28_Returns503OnServiceUnavailable(t *testing.T) {
 
 	// Verify error response structure
 	errorResp := testutil.ParseErrorResponse(t, body)
-	assert.Equal(t, "0330", errorResp.Code, "Error code should be TRC-0012 (ServiceUnavailable)")
+	assert.Equal(t, "0330", errorResp.Code, "Error code should be 0330 (ContextCancelled) for service unavailable")
 	assert.Equal(t, "Service Unavailable", errorResp.Title, "Error title should be Service Unavailable")
-	assert.Equal(t, "service temporarily unavailable", errorResp.Message, "Error message should indicate service unavailable")
+	assert.Equal(t, "", errorResp.Message, "Detail is empty; the specific reason is carried by the title")
 }
 
 // Test 1.1.29: Validation accepts decimal amount values
@@ -1772,9 +1772,9 @@ func TestValidation_1_1_30_RejectsTimestampWithoutTimezone(t *testing.T) {
 			// Verify error response for invalid timestamps
 			if tc.expected == http.StatusBadRequest {
 				errorResp := testutil.ParseErrorResponse(t, body)
-				assert.Equal(t, "0047", errorResp.Code, "Error code should be TRC-0003 for invalid timestamp format")
+				assert.Equal(t, "0094", errorResp.Code, "Error code should be 0094 for invalid timestamp format")
 				assert.Equal(t, "Bad Request", errorResp.Title, "Error title should be Bad Request")
-				assert.Equal(t, "timestamp: invalid format (expected RFC3339)", errorResp.Message, "Error message should indicate RFC3339 format required")
+				assert.Equal(t, "", errorResp.Message, "Detail is empty for invalid request body")
 			}
 		})
 	}
@@ -1895,9 +1895,9 @@ func TestValidation_1_1_32_RejectsInvalidAccountType(t *testing.T) {
 			if tc.expected == http.StatusBadRequest {
 				errorResp := testutil.ParseErrorResponse(t, body)
 
-				assert.Equal(t, "0426", errorResp.Code, "Error code should be TRC-0233 for invalid account type")
-				assert.Equal(t, "Validation Error", errorResp.Title, "Error title should be Validation Error")
-				assert.Equal(t, "account.type must be one of: checking, savings, credit", errorResp.Message, "Error message should indicate valid account types")
+				assert.Equal(t, "0426", errorResp.Code, "Error code should be 0426 for invalid account type")
+				assert.Equal(t, "Validation Invalid Account Type", errorResp.Title, "Error title should be Validation Invalid Account Type")
+				assert.Equal(t, "", errorResp.Message, "Detail is empty; the specific reason is carried by the title")
 			}
 		})
 	}
@@ -1971,9 +1971,9 @@ func TestValidation_1_1_33_RejectsInvalidAccountStatus(t *testing.T) {
 			if tc.expected == http.StatusBadRequest {
 				errorResp := testutil.ParseErrorResponse(t, body)
 
-				assert.Equal(t, "0427", errorResp.Code, "Error code should be TRC-0234 for invalid account status")
-				assert.Equal(t, "Validation Error", errorResp.Title, "Error title should be Validation Error")
-				assert.Equal(t, "account.status must be one of: active, suspended, closed", errorResp.Message, "Error message should indicate valid account statuses")
+				assert.Equal(t, "0427", errorResp.Code, "Error code should be 0427 for invalid account status")
+				assert.Equal(t, "Validation Invalid Account Status", errorResp.Title, "Error title should be Validation Invalid Account Status")
+				assert.Equal(t, "", errorResp.Message, "Detail is empty; the specific reason is carried by the title")
 			}
 		})
 	}
@@ -2051,9 +2051,9 @@ func TestValidation_1_1_34_RejectsInvalidMerchantCategory(t *testing.T) {
 			if tc.expected == http.StatusBadRequest {
 				errorResp := testutil.ParseErrorResponse(t, body)
 
-				assert.Equal(t, "0428", errorResp.Code, "Error code should be TRC-0235 for invalid merchant category")
-				assert.Equal(t, "Validation Error", errorResp.Title, "Error title should be Validation Error")
-				assert.Equal(t, "merchant.category must be a 4-digit MCC code", errorResp.Message, "Error message should indicate valid MCC format")
+				assert.Equal(t, "0428", errorResp.Code, "Error code should be 0428 for invalid merchant category")
+				assert.Equal(t, "Validation Invalid Merchant Category", errorResp.Title, "Error title should be Validation Invalid Merchant Category")
+				assert.Equal(t, "", errorResp.Message, "Detail is empty; the specific reason is carried by the title")
 			}
 		})
 	}
@@ -2141,9 +2141,9 @@ func TestValidation_1_1_35_RejectsInvalidMerchantCountry(t *testing.T) {
 			if tc.expected == http.StatusBadRequest {
 				errorResp := testutil.ParseErrorResponse(t, body)
 
-				assert.Equal(t, "0429", errorResp.Code, "Error code should be TRC-0236 for invalid merchant country")
-				assert.Equal(t, "Validation Error", errorResp.Title, "Error title should be Validation Error")
-				assert.Equal(t, "merchant.country must be ISO 3166-1 alpha-2 code (e.g., BR, US)", errorResp.Message, "Error message should indicate valid country format")
+				assert.Equal(t, "0429", errorResp.Code, "Error code should be 0429 for invalid merchant country")
+				assert.Equal(t, "Validation Invalid Merchant Country", errorResp.Title, "Error title should be Validation Invalid Merchant Country")
+				assert.Equal(t, "", errorResp.Message, "Detail is empty; the specific reason is carried by the title")
 			}
 		})
 	}
@@ -2359,9 +2359,9 @@ func TestValidation_1_1_39_RejectsMissingAccountId(t *testing.T) {
 	// Verify error response structure per spec
 	errorResp := testutil.ParseErrorResponse(t, body)
 
-	assert.Equal(t, "0420", errorResp.Code, "Error code should be TRC-0227 for missing accountId")
-	assert.Equal(t, "Validation Error", errorResp.Title, "Error title should be Validation Error")
-	assert.Equal(t, "account is required", errorResp.Message, "Error message should indicate account is required")
+	assert.Equal(t, "0420", errorResp.Code, "Error code should be 0420 for missing accountId")
+	assert.Equal(t, "Validation Account Required", errorResp.Title, "Error title should be Validation Account Required")
+	assert.Equal(t, "", errorResp.Message, "Detail is empty; the specific reason is carried by the title")
 }
 
 // Test 1.1.55: Deactivated rule is not evaluated
@@ -4256,7 +4256,7 @@ func TestValidation_1_3_14_CombinedFiltersAdvanced(t *testing.T) {
 
 // Test 1.3.15: Returns 504 on query timeout
 // Uses fault injection middleware to simulate query timeout scenario.
-// Note: GET /v1/validations (list) returns TRC-0252, POST /v1/validations returns TRC-0229.
+// Note: GET /v1/validations (list) returns code 0433 (ListValidationsTimeout); POST /v1/validations returns code 0422 (ValidationTimeout).
 func TestValidation_1_3_15_Returns504OnQueryTimeout(t *testing.T) {
 	// Use fault injection to simulate query timeout
 	resp, body := testutil.ListValidationsWithFaultInjection(t, "", testutil.FaultTimeout)
@@ -4267,7 +4267,7 @@ func TestValidation_1_3_15_Returns504OnQueryTimeout(t *testing.T) {
 
 	// Verify error response structure
 	errorResp := testutil.ParseErrorResponse(t, body)
-	assert.Equal(t, "0433", errorResp.Code, "Error code should be TRC-0252 (ListValidationsTimeout)")
+	assert.Equal(t, "0433", errorResp.Code, "Error code should be 0433 (ListValidationsTimeout)")
 	assert.Equal(t, "Gateway Timeout", errorResp.Title, "Error title should be Gateway Timeout")
 	assert.Equal(t, "query timeout exceeded", errorResp.Message, "Error message should indicate query timeout")
 }

--- a/components/tracer/tests/integration/01_validation_test.go
+++ b/components/tracer/tests/integration/01_validation_test.go
@@ -54,7 +54,7 @@ func TestValidation_CompletePayload(t *testing.T) {
 			MCC:  "5411",
 			Name: "Test Merchant",
 		},
-		Metadata: map[string]interface{}{
+		Metadata: map[string]any{
 			"channel":  "mobile",
 			"deviceId": "device-123",
 		},
@@ -694,7 +694,7 @@ func TestValidation_1_1_9_PayloadTooLarge(t *testing.T) {
 		Account: &testutil.AccountContext{
 			ID: accountID,
 		},
-		Metadata: map[string]interface{}{
+		Metadata: map[string]any{
 			"largeField": string(largeString),
 		},
 	}
@@ -725,6 +725,7 @@ func TestValidation_RequiredFieldsValidation(t *testing.T) {
 		expectedCode    string
 		expectedTitle   string
 		expectedMessage string
+		expectedDetail  string // RFC 9457 human-readable text (registry message)
 	}{
 		{
 			name: "missing requestId",
@@ -740,6 +741,7 @@ func TestValidation_RequiredFieldsValidation(t *testing.T) {
 			expectedCode:    "0413",
 			expectedTitle:   "Validation Request IDRequired",
 			expectedMessage: "",
+			expectedDetail:  "RequestId is required.",
 		},
 		{
 			name: "missing transactionType",
@@ -755,6 +757,7 @@ func TestValidation_RequiredFieldsValidation(t *testing.T) {
 			expectedCode:    "0414",
 			expectedTitle:   "Validation Invalid Transaction Type",
 			expectedMessage: "",
+			expectedDetail:  "Invalid transactionType.",
 		},
 		{
 			name: "missing amount (zero value)",
@@ -770,6 +773,7 @@ func TestValidation_RequiredFieldsValidation(t *testing.T) {
 			expectedCode:    "0415",
 			expectedTitle:   "Validation Amount Non Positive",
 			expectedMessage: "",
+			expectedDetail:  "Amount must be positive.",
 		},
 		{
 			name: "missing currency",
@@ -785,6 +789,7 @@ func TestValidation_RequiredFieldsValidation(t *testing.T) {
 			expectedCode:    "0416",
 			expectedTitle:   "Validation Currency Required",
 			expectedMessage: "",
+			expectedDetail:  "Currency is required.",
 		},
 		{
 			name: "missing timestamp",
@@ -800,6 +805,7 @@ func TestValidation_RequiredFieldsValidation(t *testing.T) {
 			expectedCode:    "0418",
 			expectedTitle:   "Validation Timestamp Required",
 			expectedMessage: "",
+			expectedDetail:  "Timestamp is required.",
 		},
 		{
 			name: "missing account",
@@ -815,6 +821,7 @@ func TestValidation_RequiredFieldsValidation(t *testing.T) {
 			expectedCode:    "0420",
 			expectedTitle:   "Validation Account Required",
 			expectedMessage: "",
+			expectedDetail:  "Account is required.",
 		},
 	}
 
@@ -832,6 +839,7 @@ func TestValidation_RequiredFieldsValidation(t *testing.T) {
 			assert.Equal(t, tc.expectedCode, errorResp.Code, "Error code should be %s for missing %s", tc.expectedCode, tc.missing)
 			assert.Equal(t, tc.expectedTitle, errorResp.Title, "Error title should be %s", tc.expectedTitle)
 			assert.Equal(t, tc.expectedMessage, errorResp.Message, "Error message should be %s", tc.expectedMessage)
+			assert.Equal(t, tc.expectedDetail, errorResp.Detail, "RFC 9457 detail should carry the human-readable text for missing %s", tc.missing)
 		})
 	}
 }
@@ -1130,7 +1138,7 @@ func TestValidation_1_1_18_CustomMetadata(t *testing.T) {
 	requestID := testutil.MustDeterministicUUID(341).String()
 
 	// Create metadata with 50 entries (maximum allowed)
-	metadata := make(map[string]interface{})
+	metadata := make(map[string]any)
 	for i := 1; i <= 50; i++ {
 		key := fmt.Sprintf("field%02d", i)
 		metadata[key] = fmt.Sprintf("value%02d", i)
@@ -1189,7 +1197,7 @@ func TestValidation_1_1_19_RejectsMetadataOverLimit(t *testing.T) {
 	requestID := testutil.MustDeterministicUUID(351).String()
 
 	// Create metadata with 51 entries (exceeds maximum of 50)
-	metadata := make(map[string]interface{})
+	metadata := make(map[string]any)
 	for i := 1; i <= 51; i++ {
 		key := fmt.Sprintf("field%02d", i)
 		metadata[key] = fmt.Sprintf("value%02d", i)
@@ -1228,7 +1236,7 @@ func TestValidation_1_1_20_RejectsLongMetadataKey(t *testing.T) {
 	// Create a metadata key with 65 characters (exceeds maximum of 64)
 	longKey := "this_key_is_way_too_long_and_exceeds_the_64_character_limit_for_k"
 
-	metadata := map[string]interface{}{
+	metadata := map[string]any{
 		longKey: "value",
 	}
 
@@ -1293,7 +1301,7 @@ func TestValidation_1_1_21_RejectsInvalidMetadataKeyChars(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			requestID := testutil.MustDeterministicUUID(int64(355 + i)).String()
 
-			metadata := map[string]interface{}{
+			metadata := map[string]any{
 				tc.key: "value",
 			}
 
@@ -2595,7 +2603,7 @@ func TestValidation_1_2_5_CompleteSnapshotPreserved(t *testing.T) {
 		Segment: &testutil.SegmentContext{
 			ID: segmentID,
 		},
-		Metadata: map[string]interface{}{
+		Metadata: map[string]any{
 			"channel": "mobile",
 			"testKey": "testValue",
 		},

--- a/components/tracer/tests/integration/02_rules_error_codes_test.go
+++ b/components/tracer/tests/integration/02_rules_error_codes_test.go
@@ -26,8 +26,9 @@ import (
 // These tests verify the error codes returned by rule handler operations.
 //
 // Error code mapping:
-//   - Malformed JSON/invalid request body → TRC-0003 (Bad Request)
-//   - Validation errors (invalid field values) → TRC-0001 (Validation Error)
+//   - Malformed JSON/invalid request body → 0094 (ErrInvalidRequestBody), title "Bad Request"
+//   - Validation errors (invalid field values) → specific numeric codes; human text lives in
+//     the RFC 9457 `detail` (the retired `message` field is empty)
 // =============================================================================
 
 // =============================================================================
@@ -35,7 +36,7 @@ import (
 // =============================================================================
 
 // TestCreateRule_MalformedJSON_ReturnsError verifies that completely malformed JSON returns an error.
-// Returns TRC-0003 for malformed JSON/invalid request body
+// Returns 0094 (ErrInvalidRequestBody) for malformed JSON/invalid request body
 func TestCreateRule_MalformedJSON_ReturnsError(t *testing.T) {
 	baseURL := testutil.GetBaseURL()
 	apiKey := testutil.GetAPIKey()
@@ -100,15 +101,15 @@ func TestCreateRule_MalformedJSON_ReturnsError(t *testing.T) {
 
 			errResp := testutil.ParseErrorResponse(t, respBody)
 
-			assert.Equal(t, "0047", errResp.Code, "Test case: %s - Expected TRC-0003 for malformed JSON", tc.description)
+			assert.Equal(t, "0094", errResp.Code, "Test case: %s - Expected 0094 (ErrInvalidRequestBody) for malformed JSON", tc.description)
 			assert.Equal(t, "Bad Request", errResp.Title, "Test case: %s", tc.description)
-			assert.Equal(t, "Invalid request body", errResp.Message, "Test case: %s", tc.description)
+			assert.Equal(t, "", errResp.Message, "Test case: %s", tc.description)
 		})
 	}
 }
 
 // TestCreateRule_EmptyBody_ReturnsError verifies that an empty request body returns an error.
-// Returns TRC-0003 for empty request body
+// Returns a generic 400 (no domain error code) for empty request body
 func TestCreateRule_EmptyBody_ReturnsError(t *testing.T) {
 	baseURL := testutil.GetBaseURL()
 	apiKey := testutil.GetAPIKey()
@@ -129,13 +130,13 @@ func TestCreateRule_EmptyBody_ReturnsError(t *testing.T) {
 
 	errResp := testutil.ParseErrorResponse(t, respBody)
 
-	assert.Equal(t, "0047", errResp.Code, "Expected TRC-0003 for empty body")
+	assert.Equal(t, "", errResp.Code, "Empty body returns a generic 400 with no domain error code")
 	assert.Equal(t, "Bad Request", errResp.Title)
-	assert.Equal(t, "Invalid request body", errResp.Message)
+	assert.Equal(t, "", errResp.Message)
 }
 
 // TestCreateRule_NullBody_ReturnsError verifies that a null JSON body returns an error.
-// Returns TRC-0001 for null JSON body (valid JSON but missing required fields)
+// Returns 0353 (ErrRuleNameRequired) for null JSON body (valid JSON but missing required fields)
 func TestCreateRule_NullBody_ReturnsError(t *testing.T) {
 	baseURL := testutil.GetBaseURL()
 	apiKey := testutil.GetAPIKey()
@@ -158,13 +159,13 @@ func TestCreateRule_NullBody_ReturnsError(t *testing.T) {
 
 	// Note: "null" is valid JSON but missing required fields, so it's treated as a validation error
 	// With specific error codes, the first missing required field error is returned
-	assert.Equal(t, "0353", errResp.Code, "Expected TRC-0106 for null body (name is required)")
-	assert.Equal(t, "Validation Error", errResp.Title)
-	assert.Equal(t, "name is required", errResp.Message)
+	assert.Equal(t, "0353", errResp.Code, "Expected 0353 (ErrRuleNameRequired) for null body")
+	assert.Equal(t, "Rule Name Required", errResp.Title)
+	assert.Equal(t, "", errResp.Message)
 }
 
 // TestCreateRule_ArrayInsteadOfObject_ReturnsError verifies that a JSON array instead of object returns an error.
-// Returns TRC-0003 for array instead of object
+// Returns 0094 (ErrInvalidRequestBody) for array instead of object
 func TestCreateRule_ArrayInsteadOfObject_ReturnsError(t *testing.T) {
 	baseURL := testutil.GetBaseURL()
 	apiKey := testutil.GetAPIKey()
@@ -186,13 +187,13 @@ func TestCreateRule_ArrayInsteadOfObject_ReturnsError(t *testing.T) {
 
 	errResp := testutil.ParseErrorResponse(t, respBody)
 
-	assert.Equal(t, "0047", errResp.Code, "Expected TRC-0003 for array instead of object")
+	assert.Equal(t, "0094", errResp.Code, "Expected 0094 (ErrInvalidRequestBody) for array instead of object")
 	assert.Equal(t, "Bad Request", errResp.Title)
-	assert.Equal(t, "Invalid request body", errResp.Message)
+	assert.Equal(t, "", errResp.Message)
 }
 
 // TestCreateRule_BinaryData_ReturnsError verifies that binary data returns an error.
-// Returns TRC-0003 for binary data (not valid JSON)
+// Returns 0094 (ErrInvalidRequestBody) for binary data (not valid JSON)
 func TestCreateRule_BinaryData_ReturnsError(t *testing.T) {
 	baseURL := testutil.GetBaseURL()
 	apiKey := testutil.GetAPIKey()
@@ -215,9 +216,9 @@ func TestCreateRule_BinaryData_ReturnsError(t *testing.T) {
 
 	errResp := testutil.ParseErrorResponse(t, respBody)
 
-	assert.Equal(t, "0047", errResp.Code, "Expected TRC-0003 for binary data")
+	assert.Equal(t, "0094", errResp.Code, "Expected 0094 (ErrInvalidRequestBody) for binary data")
 	assert.Equal(t, "Bad Request", errResp.Title)
-	assert.Equal(t, "Invalid request body", errResp.Message)
+	assert.Equal(t, "", errResp.Message)
 }
 
 // =============================================================================
@@ -253,7 +254,7 @@ func TestUpdateRule_InvalidBody_ReturnsError(t *testing.T) {
 		return resp.StatusCode, respBody
 	}
 
-	// Subtest: Malformed JSON cases (TRC-0003)
+	// Subtest: Malformed JSON cases (0094)
 	t.Run("malformed_json", func(t *testing.T) {
 		malformedCases := []struct {
 			name        string
@@ -289,36 +290,36 @@ func TestUpdateRule_InvalidBody_ReturnsError(t *testing.T) {
 				assert.Equal(t, http.StatusBadRequest, statusCode, "Test case: %s - Response: %s", tc.description, string(respBody))
 
 				errResp := testutil.ParseErrorResponse(t, respBody)
-				assert.Equal(t, "0047", errResp.Code, "Test case: %s - Expected TRC-0003 for malformed JSON", tc.description)
+				assert.Equal(t, "0094", errResp.Code, "Test case: %s - Expected 0094 (ErrInvalidRequestBody) for malformed JSON", tc.description)
 				assert.Equal(t, "Bad Request", errResp.Title, "Test case: %s", tc.description)
-				assert.Equal(t, "Invalid request body", errResp.Message, "Test case: %s", tc.description)
+				assert.Equal(t, "", errResp.Message, "Test case: %s", tc.description)
 			})
 		}
 	})
 
-	// Subtest: Empty body (TRC-0003)
+	// Subtest: Empty body (generic 400, no code)
 	t.Run("empty_body", func(t *testing.T) {
 		statusCode, respBody := doPatchRequest(t, "")
 
 		assert.Equal(t, http.StatusBadRequest, statusCode, "Response: %s", string(respBody))
 
 		errResp := testutil.ParseErrorResponse(t, respBody)
-		assert.Equal(t, "0047", errResp.Code, "Expected TRC-0003 for empty body")
+		assert.Equal(t, "", errResp.Code, "Empty body returns a generic 400 with no domain error code")
 		assert.Equal(t, "Bad Request", errResp.Title)
-		assert.Equal(t, "Invalid request body", errResp.Message)
+		assert.Equal(t, "", errResp.Message)
 	})
 
-	// Subtest: Empty JSON object (TRC-0002)
+	// Subtest: Empty JSON object (0183 ErrNothingToUpdate)
 	t.Run("empty_json_object", func(t *testing.T) {
 		statusCode, respBody := doPatchRequest(t, "{}")
 
 		assert.Equal(t, http.StatusBadRequest, statusCode, "Response: %s", string(respBody))
 
 		errResp := testutil.ParseErrorResponse(t, respBody)
-		// TRC-0002 for missing required fields (empty object has no fields to update)
-		assert.Equal(t, "0009", errResp.Code, "Expected TRC-0002 for empty object (missing required fields)")
-		assert.Equal(t, "Validation Error", errResp.Title)
-		assert.Equal(t, "At least one field must be provided for update", errResp.Message)
+		// 0183 (ErrNothingToUpdate) for empty object (no fields to update)
+		assert.Equal(t, "0183", errResp.Code, "Expected 0183 (ErrNothingToUpdate) for empty object")
+		assert.Equal(t, "Nothing to Update", errResp.Title)
+		assert.Equal(t, "", errResp.Message)
 	})
 }
 
@@ -343,56 +344,56 @@ func TestListRules_InvalidQueryParameters_ReturnsError(t *testing.T) {
 			name:          "invalid_action_filter_lowercase",
 			queryParams:   "action=allow",
 			expectedCode:  "0082",
-			expectedTitle: "Bad Request",
+			expectedTitle: "Invalid Query Parameter",
 			description:   "Action filter with lowercase value",
 		},
 		{
 			name:          "invalid_action_filter_value",
 			queryParams:   "action=INVALID_ACTION",
 			expectedCode:  "0082",
-			expectedTitle: "Bad Request",
+			expectedTitle: "Invalid Query Parameter",
 			description:   "Action filter with invalid enum value",
 		},
 		{
 			name:          "invalid_status_filter_lowercase",
 			queryParams:   "status=draft",
 			expectedCode:  "0082",
-			expectedTitle: "Bad Request",
+			expectedTitle: "Invalid Query Parameter",
 			description:   "Status filter with lowercase value",
 		},
 		{
 			name:          "invalid_status_filter_value",
 			queryParams:   "status=INVALID_STATUS",
 			expectedCode:  "0082",
-			expectedTitle: "Bad Request",
+			expectedTitle: "Invalid Query Parameter",
 			description:   "Status filter with invalid enum value",
 		},
 		{
 			name:          "deleted_status_not_allowed",
 			queryParams:   "status=DELETED",
 			expectedCode:  "0082",
-			expectedTitle: "Bad Request",
+			expectedTitle: "Invalid Query Parameter",
 			description:   "DELETED status is not allowed in filter",
 		},
 		{
 			name:          "limit_zero",
 			queryParams:   "limit=0",
 			expectedCode:  "0331",
-			expectedTitle: "Bad Request",
+			expectedTitle: "Pagination Limit Invalid",
 			description:   "Limit of 0 is invalid",
 		},
 		{
 			name:          "limit_negative",
 			queryParams:   "limit=-1",
 			expectedCode:  "0331",
-			expectedTitle: "Bad Request",
+			expectedTitle: "Pagination Limit Invalid",
 			description:   "Negative limit is invalid",
 		},
 		{
 			name:          "limit_exceeds_max",
 			queryParams:   "limit=101",
 			expectedCode:  "0080",
-			expectedTitle: "Bad Request",
+			expectedTitle: "Pagination Limit Exceeded",
 			description:   "Limit exceeds maximum of 100",
 		},
 	}
@@ -507,8 +508,8 @@ func TestListRules_InvalidCursor_ReturnsError(t *testing.T) {
 
 			errResp := testutil.ParseErrorResponse(t, respBody)
 			assert.Equal(t, tc.expectedCode, errResp.Code, "Test case: %s - Expected %s", tc.description, tc.expectedCode)
-			assert.Equal(t, "Bad Request", errResp.Title, "Test case: %s", tc.description)
-			assert.Contains(t, errResp.Message, "cursor", "Test case: %s - Error should mention cursor", tc.description)
+			assert.Equal(t, "Invalid Cursor", errResp.Title, "Test case: %s", tc.description)
+			assert.Empty(t, errResp.Message, "Test case: %s - message field retired; human text is in RFC 9457 detail", tc.description)
 		})
 	}
 }
@@ -530,16 +531,16 @@ func TestListRules_InvalidSortParameters_ReturnsError(t *testing.T) {
 			name:            "invalid_sort_column",
 			queryParams:     "sort_by=invalid_column",
 			expectedCode:    "0332",
-			expectedTitle:   "Bad Request",
-			expectedMessage: "sort_by must be one of [created_at updated_at name status]",
+			expectedTitle:   "Invalid Sort Column",
+			expectedMessage: "",
 			description:     "Invalid sort column",
 		},
 		{
 			name:            "invalid_sort_order",
 			queryParams:     "sort_order=INVALID",
 			expectedCode:    "0081",
-			expectedTitle:   "Bad Request",
-			expectedMessage: "sort_order must be ASC or DESC",
+			expectedTitle:   "Invalid Sort Order",
+			expectedMessage: "",
 			description:     "Invalid sort order",
 		},
 		// NOTE: lowercase sort orders (asc, desc) are accepted and normalized by the API,
@@ -574,7 +575,7 @@ func TestListRules_InvalidSortParameters_ReturnsError(t *testing.T) {
 // =============================================================================
 
 // TestCreateRule_ValidJSONWithInvalidTypes_ReturnsBadRequest verifies that
-// valid JSON with wrong types returns TRC-0003 (Bad Request) due to JSON type mismatch.
+// valid JSON with wrong types returns 0094 (ErrInvalidRequestBody), title "Bad Request", due to JSON type mismatch.
 func TestCreateRule_ValidJSONWithInvalidTypes_ReturnsBadRequest(t *testing.T) {
 	baseURL := testutil.GetBaseURL()
 	apiKey := testutil.GetAPIKey()
@@ -638,10 +639,10 @@ func TestCreateRule_ValidJSONWithInvalidTypes_ReturnsBadRequest(t *testing.T) {
 
 			errResp := testutil.ParseErrorResponse(t, respBody)
 
-			// TRC-0003 is returned for JSON type mismatch errors (bad request)
-			assert.Equal(t, "0047", errResp.Code, "Expected TRC-0003 for type validation error")
+			// 0094 (ErrInvalidRequestBody) is returned for JSON type mismatch errors (bad request)
+			assert.Equal(t, "0094", errResp.Code, "Expected 0094 (ErrInvalidRequestBody) for type validation error")
 			assert.Equal(t, "Bad Request", errResp.Title)
-			assert.Equal(t, "Invalid request body", errResp.Message)
+			assert.Equal(t, "", errResp.Message)
 		})
 	}
 }
@@ -680,7 +681,7 @@ func TestCreateRule_LargePayload_HandlesCorrectly(t *testing.T) {
 	errResp := testutil.ParseErrorResponse(t, respBody)
 
 	// Validation error for name exceeding max length
-	assert.Equal(t, "0354", errResp.Code, "Expected TRC-0107 for name too long")
-	assert.Equal(t, "Validation Error", errResp.Title)
-	assert.Contains(t, errResp.Message, "name")
+	assert.Equal(t, "0354", errResp.Code, "Expected 0354 (ErrRuleNameTooLong) for name too long")
+	assert.Equal(t, "Rule Name Too Long", errResp.Title)
+	assert.Empty(t, errResp.Message)
 }

--- a/components/tracer/tests/integration/02_rules_error_codes_test.go
+++ b/components/tracer/tests/integration/02_rules_error_codes_test.go
@@ -103,7 +103,7 @@ func TestCreateRule_MalformedJSON_ReturnsError(t *testing.T) {
 
 			assert.Equal(t, "0094", errResp.Code, "Test case: %s - Expected 0094 (ErrInvalidRequestBody) for malformed JSON", tc.description)
 			assert.Equal(t, "Bad Request", errResp.Title, "Test case: %s", tc.description)
-			assert.Equal(t, "", errResp.Message, "Test case: %s", tc.description)
+			assert.Equal(t, "The request body is malformed or contains invalid JSON. Please verify the syntax and try again.", errResp.Detail, "Test case: %s", tc.description)
 		})
 	}
 }
@@ -161,7 +161,7 @@ func TestCreateRule_NullBody_ReturnsError(t *testing.T) {
 	// With specific error codes, the first missing required field error is returned
 	assert.Equal(t, "0353", errResp.Code, "Expected 0353 (ErrRuleNameRequired) for null body")
 	assert.Equal(t, "Rule Name Required", errResp.Title)
-	assert.Equal(t, "", errResp.Message)
+	assert.Equal(t, "Rule name is required.", errResp.Detail)
 }
 
 // TestCreateRule_ArrayInsteadOfObject_ReturnsError verifies that a JSON array instead of object returns an error.
@@ -189,7 +189,7 @@ func TestCreateRule_ArrayInsteadOfObject_ReturnsError(t *testing.T) {
 
 	assert.Equal(t, "0094", errResp.Code, "Expected 0094 (ErrInvalidRequestBody) for array instead of object")
 	assert.Equal(t, "Bad Request", errResp.Title)
-	assert.Equal(t, "", errResp.Message)
+	assert.Equal(t, "The request body is malformed or contains invalid JSON. Please verify the syntax and try again.", errResp.Detail)
 }
 
 // TestCreateRule_BinaryData_ReturnsError verifies that binary data returns an error.
@@ -218,7 +218,7 @@ func TestCreateRule_BinaryData_ReturnsError(t *testing.T) {
 
 	assert.Equal(t, "0094", errResp.Code, "Expected 0094 (ErrInvalidRequestBody) for binary data")
 	assert.Equal(t, "Bad Request", errResp.Title)
-	assert.Equal(t, "", errResp.Message)
+	assert.Equal(t, "The request body is malformed or contains invalid JSON. Please verify the syntax and try again.", errResp.Detail)
 }
 
 // =============================================================================
@@ -292,7 +292,7 @@ func TestUpdateRule_InvalidBody_ReturnsError(t *testing.T) {
 				errResp := testutil.ParseErrorResponse(t, respBody)
 				assert.Equal(t, "0094", errResp.Code, "Test case: %s - Expected 0094 (ErrInvalidRequestBody) for malformed JSON", tc.description)
 				assert.Equal(t, "Bad Request", errResp.Title, "Test case: %s", tc.description)
-				assert.Equal(t, "", errResp.Message, "Test case: %s", tc.description)
+				assert.Equal(t, "The request body is malformed or contains invalid JSON. Please verify the syntax and try again.", errResp.Detail, "Test case: %s", tc.description)
 			})
 		}
 	})
@@ -319,7 +319,7 @@ func TestUpdateRule_InvalidBody_ReturnsError(t *testing.T) {
 		// 0183 (ErrNothingToUpdate) for empty object (no fields to update)
 		assert.Equal(t, "0183", errResp.Code, "Expected 0183 (ErrNothingToUpdate) for empty object")
 		assert.Equal(t, "Nothing to Update", errResp.Title)
-		assert.Equal(t, "", errResp.Message)
+		assert.Equal(t, "No updatable fields were provided. Please include at least one field to update.", errResp.Detail)
 	})
 }
 
@@ -509,7 +509,7 @@ func TestListRules_InvalidCursor_ReturnsError(t *testing.T) {
 			errResp := testutil.ParseErrorResponse(t, respBody)
 			assert.Equal(t, tc.expectedCode, errResp.Code, "Test case: %s - Expected %s", tc.description, tc.expectedCode)
 			assert.Equal(t, "Invalid Cursor", errResp.Title, "Test case: %s", tc.description)
-			assert.Empty(t, errResp.Message, "Test case: %s - message field retired; human text is in RFC 9457 detail", tc.description)
+			assert.Equal(t, "Invalid or corrupted pagination cursor.", errResp.Detail, "Test case: %s", tc.description)
 		})
 	}
 }
@@ -532,7 +532,7 @@ func TestListRules_InvalidSortParameters_ReturnsError(t *testing.T) {
 			queryParams:     "sort_by=invalid_column",
 			expectedCode:    "0332",
 			expectedTitle:   "Invalid Sort Column",
-			expectedMessage: "",
+			expectedMessage: "Sort column not in allowed list.",
 			description:     "Invalid sort column",
 		},
 		{
@@ -540,7 +540,7 @@ func TestListRules_InvalidSortParameters_ReturnsError(t *testing.T) {
 			queryParams:     "sort_order=INVALID",
 			expectedCode:    "0081",
 			expectedTitle:   "Invalid Sort Order",
-			expectedMessage: "",
+			expectedMessage: "The 'sort_order' field must be 'asc' or 'desc'. Please provide a valid sort order and try again.",
 			description:     "Invalid sort order",
 		},
 		// NOTE: lowercase sort orders (asc, desc) are accepted and normalized by the API,
@@ -565,7 +565,7 @@ func TestListRules_InvalidSortParameters_ReturnsError(t *testing.T) {
 			errResp := testutil.ParseErrorResponse(t, respBody)
 			assert.Equal(t, tc.expectedCode, errResp.Code, "Test case: %s - Expected %s", tc.description, tc.expectedCode)
 			assert.Equal(t, tc.expectedTitle, errResp.Title, "Test case: %s", tc.description)
-			assert.Equal(t, tc.expectedMessage, errResp.Message, "Test case: %s", tc.description)
+			assert.Equal(t, tc.expectedMessage, errResp.Detail, "Test case: %s", tc.description)
 		})
 	}
 }
@@ -642,7 +642,7 @@ func TestCreateRule_ValidJSONWithInvalidTypes_ReturnsBadRequest(t *testing.T) {
 			// 0094 (ErrInvalidRequestBody) is returned for JSON type mismatch errors (bad request)
 			assert.Equal(t, "0094", errResp.Code, "Expected 0094 (ErrInvalidRequestBody) for type validation error")
 			assert.Equal(t, "Bad Request", errResp.Title)
-			assert.Equal(t, "", errResp.Message)
+			assert.Equal(t, "The request body is malformed or contains invalid JSON. Please verify the syntax and try again.", errResp.Detail)
 		})
 	}
 }
@@ -683,5 +683,5 @@ func TestCreateRule_LargePayload_HandlesCorrectly(t *testing.T) {
 	// Validation error for name exceeding max length
 	assert.Equal(t, "0354", errResp.Code, "Expected 0354 (ErrRuleNameTooLong) for name too long")
 	assert.Equal(t, "Rule Name Too Long", errResp.Title)
-	assert.Empty(t, errResp.Message)
+	assert.Equal(t, "Rule name exceeds max length (255).", errResp.Detail)
 }

--- a/components/tracer/tests/integration/02_rules_management_test.go
+++ b/components/tracer/tests/integration/02_rules_management_test.go
@@ -305,9 +305,10 @@ func TestCreateRule_2_1_5_RejectsMissingName(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 
 	errResp := testutil.ParseErrorResponse(t, respBody)
-	assert.Equal(t, "0353", errResp.Code, "Error code should be TRC-0106 for name required")
-	assert.Equal(t, "Validation Error", errResp.Title, "Error title should be Validation Error")
-	assert.Equal(t, "name is required", errResp.Message, "Error message should indicate name is required")
+	assert.Equal(t, "0353", errResp.Code, "Error code should be 0353 for name required")
+	assert.Equal(t, "Rule Name Required", errResp.Title)
+	// Human-readable text lives in the RFC 9457 `detail`; the retired `message` field is empty.
+	assert.Equal(t, "", errResp.Message)
 }
 
 // TestCreateRule_2_1_6_RejectsMissingExpression verifies validation of required field 'expression'.
@@ -338,9 +339,10 @@ func TestCreateRule_2_1_6_RejectsMissingExpression(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 
 	errResp := testutil.ParseErrorResponse(t, respBody)
-	assert.Equal(t, "0355", errResp.Code, "Error code should be TRC-0108 for expression required")
-	assert.Equal(t, "Validation Error", errResp.Title, "Error title should be Validation Error")
-	assert.Equal(t, "expression is required", errResp.Message, "Error message should indicate expression is required")
+	assert.Equal(t, "0355", errResp.Code, "Error code should be 0355 for expression required")
+	assert.Equal(t, "Rule Expression Required", errResp.Title)
+	// Human-readable text lives in the RFC 9457 `detail`; the retired `message` field is empty.
+	assert.Equal(t, "", errResp.Message)
 }
 
 // TestCreateRule_2_1_7_RejectsMissingAction verifies validation of required field 'action'.
@@ -371,9 +373,10 @@ func TestCreateRule_2_1_7_RejectsMissingAction(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 
 	errResp := testutil.ParseErrorResponse(t, respBody)
-	assert.Equal(t, "0357", errResp.Code, "Error code should be TRC-0110 for action required/invalid")
-	assert.Equal(t, "Validation Error", errResp.Title, "Error title should be Validation Error")
-	assert.Equal(t, "action is required and must be one of [ALLOW, DENY, REVIEW]", errResp.Message, "Error message should indicate action is required")
+	assert.Equal(t, "0357", errResp.Code, "Error code should be 0357 for action required/invalid")
+	assert.Equal(t, "Rule Invalid Action", errResp.Title)
+	// Human-readable text lives in the RFC 9457 `detail`; the retired `message` field is empty.
+	assert.Equal(t, "", errResp.Message)
 }
 
 // TestCreateRule_2_1_8_RejectsAllMissingRequiredFields verifies validation when multiple required fields are missing.
@@ -403,9 +406,10 @@ func TestCreateRule_2_1_8_RejectsAllMissingRequiredFields(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 
 	errResp := testutil.ParseErrorResponse(t, respBody)
-	assert.Equal(t, "0353", errResp.Code, "Error code should be TRC-0106 for name required (first missing field)")
-	assert.Equal(t, "Validation Error", errResp.Title, "Error title should be Validation Error")
-	assert.Equal(t, "name is required", errResp.Message, "Error message should indicate name is required")
+	assert.Equal(t, "0353", errResp.Code, "Error code should be 0353 for name required (first missing field)")
+	assert.Equal(t, "Rule Name Required", errResp.Title)
+	// Human-readable text lives in the RFC 9457 `detail`; the retired `message` field is empty.
+	assert.Equal(t, "", errResp.Message)
 }
 
 // TestCreateRule_2_1_9_RejectsEmptyName verifies validation of empty name string.
@@ -437,9 +441,10 @@ func TestCreateRule_2_1_9_RejectsEmptyName(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 
 	errResp := testutil.ParseErrorResponse(t, respBody)
-	assert.Equal(t, "0353", errResp.Code, "Error code should be TRC-0106 for empty name validation error")
-	assert.Equal(t, "Validation Error", errResp.Title, "Error title should be Validation Error")
-	assert.Equal(t, "name is required", errResp.Message, "Error message should indicate name is required")
+	assert.Equal(t, "0353", errResp.Code, "Error code should be 0353 for empty name validation error")
+	assert.Equal(t, "Rule Name Required", errResp.Title)
+	// Human-readable text lives in the RFC 9457 `detail`; the retired `message` field is empty.
+	assert.Equal(t, "", errResp.Message)
 }
 
 // TestCreateRule_2_1_10_RejectsNameExceedingMaxLength verifies validation of name field boundary (255 characters).
@@ -494,8 +499,9 @@ func TestCreateRule_2_1_10_RejectsNameExceedingMaxLength(t *testing.T) {
 			} else {
 				errResp := testutil.ParseErrorResponse(t, respBody)
 				assert.Equal(t, "0354", errResp.Code)
-				assert.Equal(t, "Validation Error", errResp.Title)
-				assert.Contains(t, errResp.Message, "name")
+				assert.Equal(t, "Rule Name Too Long", errResp.Title)
+				// Human-readable text lives in the RFC 9457 `detail`; the retired `message` field is empty.
+				assert.Equal(t, "", errResp.Message)
 			}
 		})
 	}
@@ -530,9 +536,10 @@ func TestCreateRule_2_1_11_RejectsEmptyExpression(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 
 	errResp := testutil.ParseErrorResponse(t, respBody)
-	assert.Equal(t, "0355", errResp.Code, "Error code should be TRC-0108 for empty expression validation error")
-	assert.Equal(t, "Validation Error", errResp.Title, "Error title should be Validation Error")
-	assert.Equal(t, "expression is required", errResp.Message, "Error message should indicate expression is required")
+	assert.Equal(t, "0355", errResp.Code, "Error code should be 0355 for empty expression validation error")
+	assert.Equal(t, "Rule Expression Required", errResp.Title)
+	// Human-readable text lives in the RFC 9457 `detail`; the retired `message` field is empty.
+	assert.Equal(t, "", errResp.Message)
 }
 
 // TestCreateRule_2_1_12_RejectsExpressionExceedingMaxLength verifies validation of expression field boundary (5000 characters).
@@ -605,8 +612,9 @@ func TestCreateRule_2_1_12_RejectsExpressionExceedingMaxLength(t *testing.T) {
 			} else {
 				errResp := testutil.ParseErrorResponse(t, respBody)
 				assert.Equal(t, "0356", errResp.Code)
-				assert.Equal(t, "Validation Error", errResp.Title)
-				assert.Contains(t, errResp.Message, "expression")
+				assert.Equal(t, "Rule Expression Too Long", errResp.Title)
+				// Human-readable text lives in the RFC 9457 `detail`; the retired `message` field is empty.
+				assert.Equal(t, "", errResp.Message)
 			}
 		})
 	}
@@ -665,9 +673,10 @@ func TestCreateRule_2_1_13_RejectsDescriptionExceedingMaxLength(t *testing.T) {
 				})
 			} else {
 				errResp := testutil.ParseErrorResponse(t, respBody)
-				assert.Equal(t, "0359", errResp.Code, "Error code should be TRC-0112 for description too long")
-				assert.Equal(t, "Validation Error", errResp.Title)
-				assert.Contains(t, errResp.Message, "description")
+				assert.Equal(t, "0359", errResp.Code, "Error code should be 0359 for description too long")
+				assert.Equal(t, "Rule Description Too Long", errResp.Title)
+				// Human-readable text lives in the RFC 9457 `detail`; the retired `message` field is empty.
+				assert.Equal(t, "", errResp.Message)
 			}
 		})
 	}
@@ -706,9 +715,10 @@ func TestCreateRule_2_1_14_RejectsInvalidActionEnum(t *testing.T) {
 			assert.Equal(t, http.StatusBadRequest, resp.StatusCode, "Response: %s", string(respBody))
 
 			errResp := testutil.ParseErrorResponse(t, respBody)
-			assert.Equal(t, "0357", errResp.Code, "Error code should be TRC-0110 for invalid action enum")
-			assert.Equal(t, "Validation Error", errResp.Title)
-			assert.Contains(t, errResp.Message, "action")
+			assert.Equal(t, "0357", errResp.Code, "Error code should be 0357 for invalid action enum")
+			assert.Equal(t, "Rule Invalid Action", errResp.Title)
+			// Human-readable text lives in the RFC 9457 `detail`; the retired `message` field is empty.
+			assert.Equal(t, "", errResp.Message)
 		})
 	}
 }
@@ -752,8 +762,9 @@ func TestCreateRule_2_1_15_RejectsInvalidCELExpressionSyntax(t *testing.T) {
 
 			errResp := testutil.ParseErrorResponse(t, respBody)
 			assert.Equal(t, "0340", errResp.Code)
-			assert.Equal(t, "Bad Request", errResp.Title)
-			assert.Equal(t, "Invalid CEL expression syntax", errResp.Message)
+			assert.Equal(t, "Expression Syntax", errResp.Title)
+			// Human-readable text lives in the RFC 9457 `detail`; the retired `message` field is empty.
+			assert.Equal(t, "", errResp.Message)
 		})
 	}
 }
@@ -795,8 +806,9 @@ func TestCreateRule_2_1_16_RejectsExpressionNotReturningBoolean(t *testing.T) {
 
 			errResp := testutil.ParseErrorResponse(t, respBody)
 			assert.Equal(t, "0341", errResp.Code)
-			assert.Equal(t, "Bad Request", errResp.Title)
-			assert.Equal(t, "Expression must evaluate to boolean", errResp.Message)
+			assert.Equal(t, "Expression Type", errResp.Title)
+			// Human-readable text lives in the RFC 9457 `detail`; the retired `message` field is empty.
+			assert.Equal(t, "", errResp.Message)
 		})
 	}
 }
@@ -868,8 +880,9 @@ func TestCreateRule_2_1_18_RejectsDuplicateRuleName(t *testing.T) {
 
 	errResp := testutil.ParseErrorResponse(t, respBody2)
 	assert.Equal(t, "0441", errResp.Code)
-	assert.Equal(t, "Conflict", errResp.Title)
-	assert.Equal(t, "Rule name already exists in this context", errResp.Message)
+	assert.Equal(t, "Rule Name Already Exists In Ctx", errResp.Title)
+	// Human-readable text lives in the RFC 9457 `detail`; the retired `message` field is empty.
+	assert.Equal(t, "", errResp.Message)
 }
 
 // TestCreateRule_2_1_19_RejectsInvalidNameType verifies type validation for name field.
@@ -905,10 +918,11 @@ func TestCreateRule_2_1_19_RejectsInvalidNameType(t *testing.T) {
 			assert.Equal(t, http.StatusBadRequest, resp.StatusCode, "Response: %s", string(respBody))
 
 			errResp := testutil.ParseErrorResponse(t, respBody)
-			// TRC-0003 is returned for JSON type mismatch errors (bad request)
-			assert.Equal(t, "0047", errResp.Code)
+			// JSON type mismatch is a body-parse error: code 0094 with a generic "Bad Request" title.
+			assert.Equal(t, "0094", errResp.Code)
 			assert.Equal(t, "Bad Request", errResp.Title)
-			assert.Equal(t, "Invalid request body", errResp.Message)
+			// Human-readable text lives in the RFC 9457 `detail`; the retired `message` field is empty.
+			assert.Equal(t, "", errResp.Message)
 		})
 	}
 
@@ -931,9 +945,10 @@ func TestCreateRule_2_1_19_RejectsInvalidNameType(t *testing.T) {
 		assert.Equal(t, http.StatusBadRequest, resp.StatusCode, "Response: %s", string(respBody))
 
 		errResp := testutil.ParseErrorResponse(t, respBody)
-		assert.Equal(t, "0353", errResp.Code, "Error code should be TRC-0106 for null name validation error")
-		assert.Equal(t, "Validation Error", errResp.Title)
-		assert.Contains(t, errResp.Message, "name")
+		assert.Equal(t, "0353", errResp.Code, "Error code should be 0353 for null name validation error")
+		assert.Equal(t, "Rule Name Required", errResp.Title)
+		// Human-readable text lives in the RFC 9457 `detail`; the retired `message` field is empty.
+		assert.Equal(t, "", errResp.Message)
 	})
 }
 
@@ -970,10 +985,11 @@ func TestCreateRule_2_1_20_RejectsInvalidExpressionType(t *testing.T) {
 			assert.Equal(t, http.StatusBadRequest, resp.StatusCode, "Response: %s", string(respBody))
 
 			errResp := testutil.ParseErrorResponse(t, respBody)
-			// TRC-0003 is returned for JSON type mismatch errors (bad request)
-			assert.Equal(t, "0047", errResp.Code)
+			// JSON type mismatch is a body-parse error: code 0094 with a generic "Bad Request" title.
+			assert.Equal(t, "0094", errResp.Code)
 			assert.Equal(t, "Bad Request", errResp.Title)
-			assert.Equal(t, "Invalid request body", errResp.Message)
+			// Human-readable text lives in the RFC 9457 `detail`; the retired `message` field is empty.
+			assert.Equal(t, "", errResp.Message)
 		})
 	}
 
@@ -996,9 +1012,10 @@ func TestCreateRule_2_1_20_RejectsInvalidExpressionType(t *testing.T) {
 		assert.Equal(t, http.StatusBadRequest, resp.StatusCode, "Response: %s", string(respBody))
 
 		errResp := testutil.ParseErrorResponse(t, respBody)
-		assert.Equal(t, "0355", errResp.Code, "Error code should be TRC-0108 for null expression validation error")
-		assert.Equal(t, "Validation Error", errResp.Title)
-		assert.Contains(t, errResp.Message, "expression")
+		assert.Equal(t, "0355", errResp.Code, "Error code should be 0355 for null expression validation error")
+		assert.Equal(t, "Rule Expression Required", errResp.Title)
+		// Human-readable text lives in the RFC 9457 `detail`; the retired `message` field is empty.
+		assert.Equal(t, "", errResp.Message)
 	})
 }
 
@@ -1035,10 +1052,11 @@ func TestCreateRule_2_1_21_RejectsInvalidActionType(t *testing.T) {
 			assert.Equal(t, http.StatusBadRequest, resp.StatusCode, "Response: %s", string(respBody))
 
 			errResp := testutil.ParseErrorResponse(t, respBody)
-			// TRC-0003 is returned for JSON type mismatch errors (bad request)
-			assert.Equal(t, "0047", errResp.Code)
+			// JSON type mismatch is a body-parse error: code 0094 with a generic "Bad Request" title.
+			assert.Equal(t, "0094", errResp.Code)
 			assert.Equal(t, "Bad Request", errResp.Title)
-			assert.Equal(t, "Invalid request body", errResp.Message)
+			// Human-readable text lives in the RFC 9457 `detail`; the retired `message` field is empty.
+			assert.Equal(t, "", errResp.Message)
 		})
 	}
 
@@ -1061,9 +1079,10 @@ func TestCreateRule_2_1_21_RejectsInvalidActionType(t *testing.T) {
 		assert.Equal(t, http.StatusBadRequest, resp.StatusCode, "Response: %s", string(respBody))
 
 		errResp := testutil.ParseErrorResponse(t, respBody)
-		assert.Equal(t, "0357", errResp.Code, "Error code should be TRC-0110 for null action validation error")
-		assert.Equal(t, "Validation Error", errResp.Title)
-		assert.Contains(t, errResp.Message, "action")
+		assert.Equal(t, "0357", errResp.Code, "Error code should be 0357 for null action validation error")
+		assert.Equal(t, "Rule Invalid Action", errResp.Title)
+		// Human-readable text lives in the RFC 9457 `detail`; the retired `message` field is empty.
+		assert.Equal(t, "", errResp.Message)
 	})
 }
 
@@ -1101,10 +1120,11 @@ func TestCreateRule_2_1_22_RejectsInvalidScopesType(t *testing.T) {
 			assert.Equal(t, http.StatusBadRequest, resp.StatusCode, "Response: %s", string(respBody))
 
 			errResp := testutil.ParseErrorResponse(t, respBody)
-			// TRC-0003 is returned for JSON type mismatch errors (bad request)
-			assert.Equal(t, "0047", errResp.Code)
+			// JSON type mismatch is a body-parse error: code 0094 with a generic "Bad Request" title.
+			assert.Equal(t, "0094", errResp.Code)
 			assert.Equal(t, "Bad Request", errResp.Title)
-			assert.Equal(t, "Invalid request body", errResp.Message)
+			// Human-readable text lives in the RFC 9457 `detail`; the retired `message` field is empty.
+			assert.Equal(t, "", errResp.Message)
 		})
 	}
 }
@@ -1141,9 +1161,10 @@ func TestCreateRule_2_1_23_RejectsScopeWithNoFieldsSet(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, resp.StatusCode, "Response: %s", string(respBody))
 
 	errResp := testutil.ParseErrorResponse(t, respBody)
-	assert.Equal(t, "0358", errResp.Code, "Error code should be TRC-0111 for empty scope")
-	assert.Equal(t, "Validation Error", errResp.Title, "Error title should be Validation Error")
-	assert.Equal(t, "scope at index 0 must have at least one field set", errResp.Message, "Error message should indicate scope must have at least one field")
+	assert.Equal(t, "0358", errResp.Code, "Error code should be 0358 for empty scope")
+	assert.Equal(t, "Rule Invalid Scope", errResp.Title)
+	// Human-readable text lives in the RFC 9457 `detail`; the retired `message` field is empty.
+	assert.Equal(t, "", errResp.Message)
 }
 
 // TestCreateRule_2_1_24_RejectsScopeWithInvalidUUIDFormat verifies UUID format validation in scope fields.
@@ -1206,10 +1227,11 @@ func TestCreateRule_2_1_24_RejectsScopeWithInvalidUUIDFormat(t *testing.T) {
 				})
 			} else {
 				errResp := testutil.ParseErrorResponse(t, respBody)
-				// TRC-0003 is returned for JSON type mismatch errors (bad request)
-				assert.Equal(t, "0047", errResp.Code)
+				// Invalid UUID in a scope field is a body-parse error: code 0094 with a generic "Bad Request" title.
+				assert.Equal(t, "0094", errResp.Code)
 				assert.Equal(t, "Bad Request", errResp.Title)
-				assert.NotEmpty(t, errResp.Message)
+				// Human-readable text lives in the RFC 9457 `detail`; the retired `message` field is empty.
+				assert.Equal(t, "", errResp.Message)
 			}
 		})
 	}
@@ -1272,9 +1294,10 @@ func TestCreateRule_2_1_25_RejectsScopeWithInvalidTransactionTypeEnum(t *testing
 				})
 			} else {
 				errResp := testutil.ParseErrorResponse(t, respBody)
-				assert.Equal(t, "0358", errResp.Code, "Error code should be TRC-0111 for invalid transactionType enum")
-				assert.Equal(t, "Validation Error", errResp.Title)
-				assert.Contains(t, errResp.Message, "transactionType")
+				assert.Equal(t, "0358", errResp.Code, "Error code should be 0358 for invalid transactionType enum")
+				assert.Equal(t, "Rule Invalid Scope", errResp.Title)
+				// Human-readable text lives in the RFC 9457 `detail`; the retired `message` field is empty.
+				assert.Equal(t, "", errResp.Message)
 			}
 		})
 	}
@@ -1337,9 +1360,10 @@ func TestCreateRule_2_1_26_RejectsSubTypeExceedingMaxLength(t *testing.T) {
 				})
 			} else {
 				errResp := testutil.ParseErrorResponse(t, respBody)
-				assert.Equal(t, "0358", errResp.Code, "Error code should be TRC-0111 for scope field validation")
-				assert.Equal(t, "Validation Error", errResp.Title)
-				assert.Contains(t, errResp.Message, "subType")
+				assert.Equal(t, "0358", errResp.Code, "Error code should be 0358 for scope field validation")
+				assert.Equal(t, "Rule Invalid Scope", errResp.Title)
+				// Human-readable text lives in the RFC 9457 `detail`; the retired `message` field is empty.
+				assert.Equal(t, "", errResp.Message)
 			}
 		})
 	}
@@ -1400,9 +1424,10 @@ func TestCreateRule_2_1_27_RejectsScopesExceedingMaxCount(t *testing.T) {
 				})
 			} else {
 				errResp := testutil.ParseErrorResponse(t, respBody)
-				assert.Equal(t, "0360", errResp.Code, "Error code should be TRC-0113 for scopes exceeding max count")
-				assert.Equal(t, "Validation Error", errResp.Title)
-				assert.Contains(t, errResp.Message, "scope")
+				assert.Equal(t, "0360", errResp.Code, "Error code should be 0360 for scopes exceeding max count")
+				assert.Equal(t, "Rule Scopes Too Many", errResp.Title)
+				// Human-readable text lives in the RFC 9457 `detail`; the retired `message` field is empty.
+				assert.Equal(t, "", errResp.Message)
 			}
 		})
 	}
@@ -1658,8 +1683,9 @@ func TestGetRule_2_2_3_Returns404ForNonExistentRuleID(t *testing.T) {
 
 	errResp := testutil.ParseErrorResponse(t, getRespBody)
 	assert.Equal(t, "0347", errResp.Code)
-	assert.Equal(t, "Not Found", errResp.Title)
-	assert.Equal(t, "Rule not found", errResp.Message)
+	assert.Equal(t, "Rule Not Found", errResp.Title)
+	// Human-readable text lives in the RFC 9457 `detail`; the retired `message` field is empty.
+	assert.Equal(t, "", errResp.Message)
 }
 
 // TestGetRule_2_2_4_RejectsInvalidUUIDFormatInPath verifies path parameter validation.
@@ -1691,7 +1717,8 @@ func TestGetRule_2_2_4_RejectsInvalidUUIDFormatInPath(t *testing.T) {
 			errResp := testutil.ParseErrorResponse(t, getRespBody)
 			assert.Equal(t, "0065", errResp.Code)
 			assert.Equal(t, "Invalid Path Parameter", errResp.Title)
-			assert.Equal(t, "Invalid rule ID format", errResp.Message)
+			// Human-readable text lives in the RFC 9457 `detail`; the retired `message` field is empty.
+			assert.Equal(t, "", errResp.Message)
 		})
 	}
 }
@@ -1724,8 +1751,9 @@ func TestGetRule_2_2_5_Returns404ForDeletedRule(t *testing.T) {
 
 	errResp := testutil.ParseErrorResponse(t, getRespBody)
 	assert.Equal(t, "0347", errResp.Code)
-	assert.Equal(t, "Not Found", errResp.Title)
-	assert.Equal(t, "Rule not found", errResp.Message)
+	assert.Equal(t, "Rule Not Found", errResp.Title)
+	// Human-readable text lives in the RFC 9457 `detail`; the retired `message` field is empty.
+	assert.Equal(t, "", errResp.Message)
 }
 
 // TestGetRule_2_2_6_WithoutAuthenticationReturns401 verifies authentication requirement for rule retrieval.
@@ -2053,8 +2081,9 @@ func TestListRules_2_3_5_RejectsDELETEDStatusFilter(t *testing.T) {
 
 	errResp := testutil.ParseErrorResponse(t, respBody)
 	assert.Equal(t, "0082", errResp.Code)
-	assert.Equal(t, "Bad Request", errResp.Title)
-	assert.Contains(t, errResp.Message, "DELETED")
+	assert.Equal(t, "Invalid Query Parameter", errResp.Title)
+	// Human-readable text lives in the RFC 9457 `detail`; the retired `message` field is empty.
+	assert.Equal(t, "", errResp.Message)
 }
 
 // TestListRules_2_3_6_FiltersByAction verifies action filter functionality.
@@ -2351,8 +2380,9 @@ func TestListRules_2_3_12_RejectsInvalidSortByValue(t *testing.T) {
 
 			errResp := testutil.ParseErrorResponse(t, respBody)
 			assert.Equal(t, "0332", errResp.Code)
-			assert.Equal(t, "Bad Request", errResp.Title)
-			assert.Contains(t, errResp.Message, "sort_by")
+			assert.Equal(t, "Invalid Sort Column", errResp.Title)
+			// Human-readable text lives in the RFC 9457 `detail`; the retired `message` field is empty.
+			assert.Equal(t, "", errResp.Message)
 		})
 	}
 }
@@ -2392,8 +2422,9 @@ func TestListRules_2_3_13_RejectsInvalidSortOrderValue(t *testing.T) {
 			if tc.expect == http.StatusBadRequest {
 				errResp := testutil.ParseErrorResponse(t, respBody)
 				assert.Equal(t, "0081", errResp.Code)
-				assert.Equal(t, "Bad Request", errResp.Title)
-				assert.NotEmpty(t, errResp.Message)
+				assert.Equal(t, "Invalid Sort Order", errResp.Title)
+				// Human-readable text lives in the RFC 9457 `detail`; the retired `message` field is empty.
+				assert.Equal(t, "", errResp.Message)
 			}
 		})
 	}
@@ -2432,8 +2463,9 @@ func TestListRules_2_3_14_RejectsLimitBelowMinimum(t *testing.T) {
 			if tc.expect == http.StatusBadRequest {
 				errResp := testutil.ParseErrorResponse(t, respBody)
 				assert.Equal(t, "0331", errResp.Code)
-				assert.Equal(t, "Bad Request", errResp.Title)
-				assert.NotEmpty(t, errResp.Message)
+				assert.Equal(t, "Pagination Limit Invalid", errResp.Title)
+				// Human-readable text lives in the RFC 9457 `detail`; the retired `message` field is empty.
+				assert.Equal(t, "", errResp.Message)
 			}
 		})
 	}
@@ -2471,8 +2503,9 @@ func TestListRules_2_3_15_RejectsLimitAboveMaximum(t *testing.T) {
 			if tc.expect == http.StatusBadRequest {
 				errResp := testutil.ParseErrorResponse(t, respBody)
 				assert.Equal(t, "0080", errResp.Code)
-				assert.Equal(t, "Bad Request", errResp.Title)
-				assert.NotEmpty(t, errResp.Message)
+				assert.Equal(t, "Pagination Limit Exceeded", errResp.Title)
+				// Human-readable text lives in the RFC 9457 `detail`; the retired `message` field is empty.
+				assert.Equal(t, "", errResp.Message)
 			}
 		})
 	}
@@ -2502,8 +2535,9 @@ func TestListRules_2_3_16_RejectsInvalidCursor(t *testing.T) {
 
 			errResp := testutil.ParseErrorResponse(t, respBody)
 			assert.Equal(t, "0333", errResp.Code)
-			assert.Equal(t, "Bad Request", errResp.Title)
-			assert.Equal(t, "Invalid pagination cursor", errResp.Message)
+			assert.Equal(t, "Invalid Cursor", errResp.Title)
+			// Human-readable text lives in the RFC 9457 `detail`; the retired `message` field is empty.
+			assert.Equal(t, "", errResp.Message)
 		})
 	}
 }
@@ -2541,8 +2575,9 @@ func TestListRules_2_3_17_RejectsInvalidActionFilterValue(t *testing.T) {
 			if tc.expect == http.StatusBadRequest {
 				errResp := testutil.ParseErrorResponse(t, respBody)
 				assert.Equal(t, "0082", errResp.Code)
-				assert.Equal(t, "Bad Request", errResp.Title)
-				assert.Contains(t, errResp.Message, "action")
+				assert.Equal(t, "Invalid Query Parameter", errResp.Title)
+				// Human-readable text lives in the RFC 9457 `detail`; the retired `message` field is empty.
+				assert.Equal(t, "", errResp.Message)
 			}
 		})
 	}
@@ -2581,8 +2616,9 @@ func TestListRules_2_3_18_RejectsInvalidStatusFilterValue(t *testing.T) {
 			if tc.expect == http.StatusBadRequest {
 				errResp := testutil.ParseErrorResponse(t, respBody)
 				assert.Equal(t, "0082", errResp.Code)
-				assert.Equal(t, "Bad Request", errResp.Title)
-				assert.Contains(t, errResp.Message, "Status")
+				assert.Equal(t, "Invalid Query Parameter", errResp.Title)
+				// Human-readable text lives in the RFC 9457 `detail`; the retired `message` field is empty.
+				assert.Equal(t, "", errResp.Message)
 			}
 		})
 	}
@@ -2960,12 +2996,14 @@ func TestUpdateRule_2_4_7_RejectsExpressionUpdateOnActiveRule(t *testing.T) {
 	respBody, err := io.ReadAll(resp.Body)
 	require.NoError(t, err)
 
-	assert.Equal(t, http.StatusBadRequest, resp.StatusCode, "Response: %s", string(respBody))
+	// Editing the expression of a non-DRAFT rule is a business-rule violation -> 422.
+	assert.Equal(t, http.StatusUnprocessableEntity, resp.StatusCode, "Response: %s", string(respBody))
 
 	errResp := testutil.ParseErrorResponse(t, respBody)
 	assert.Equal(t, "0351", errResp.Code)
-	assert.Equal(t, "Bad Request", errResp.Title)
-	assert.Equal(t, "Expression cannot be modified for non-DRAFT rules", errResp.Message)
+	assert.Equal(t, "Expression Not Modifiable", errResp.Title)
+	// Human-readable text lives in the RFC 9457 `detail`; the retired `message` field is empty.
+	assert.Equal(t, "", errResp.Message)
 
 	// Verify rule was not mutated
 	getReq, err := http.NewRequest(http.MethodGet, baseURL+"/v1/rules/"+ruleID, nil)
@@ -3019,12 +3057,14 @@ func TestUpdateRule_2_4_8_RejectsExpressionUpdateOnInactiveRule(t *testing.T) {
 	respBody, err := io.ReadAll(resp.Body)
 	require.NoError(t, err)
 
-	assert.Equal(t, http.StatusBadRequest, resp.StatusCode, "Response: %s", string(respBody))
+	// Editing the expression of a non-DRAFT rule is a business-rule violation -> 422.
+	assert.Equal(t, http.StatusUnprocessableEntity, resp.StatusCode, "Response: %s", string(respBody))
 
 	errResp := testutil.ParseErrorResponse(t, respBody)
 	assert.Equal(t, "0351", errResp.Code)
-	assert.Equal(t, "Bad Request", errResp.Title)
-	assert.Equal(t, "Expression cannot be modified for non-DRAFT rules", errResp.Message)
+	assert.Equal(t, "Expression Not Modifiable", errResp.Title)
+	// Human-readable text lives in the RFC 9457 `detail`; the retired `message` field is empty.
+	assert.Equal(t, "", errResp.Message)
 
 	// Verify rule was not mutated
 	getReq, err := http.NewRequest(http.MethodGet, baseURL+"/v1/rules/"+ruleID, nil)
@@ -3122,9 +3162,10 @@ func TestUpdateRule_2_4_10_RejectsEmptyUpdate(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, resp.StatusCode, "Response: %s", string(respBody))
 
 	errResp := testutil.ParseErrorResponse(t, respBody)
-	assert.Equal(t, "0009", errResp.Code)
-	assert.Equal(t, "Validation Error", errResp.Title)
-	assert.Equal(t, "At least one field must be provided for update", errResp.Message)
+	assert.Equal(t, "0183", errResp.Code)
+	assert.Equal(t, "Nothing to Update", errResp.Title)
+	// Human-readable text lives in the RFC 9457 `detail`; the retired `message` field is empty.
+	assert.Equal(t, "", errResp.Message)
 
 	// Verify rule was not mutated
 	getReq, err := http.NewRequest(http.MethodGet, baseURL+"/v1/rules/"+ruleID, nil)
@@ -3189,8 +3230,9 @@ func TestUpdateRule_2_4_11_RejectsDuplicateName(t *testing.T) {
 
 	errResp := testutil.ParseErrorResponse(t, respBody)
 	assert.Equal(t, "0441", errResp.Code)
-	assert.Equal(t, "Conflict", errResp.Title)
-	assert.Equal(t, "Rule name already exists in this context", errResp.Message)
+	assert.Equal(t, "Rule Name Already Exists In Ctx", errResp.Title)
+	// Human-readable text lives in the RFC 9457 `detail`; the retired `message` field is empty.
+	assert.Equal(t, "", errResp.Message)
 }
 
 // TestUpdateRule_2_4_12_AllowsSameName verifies updating to the same name is allowed (idempotent).
@@ -3260,7 +3302,8 @@ func TestUpdateRule_2_4_13_RejectsInvalidUUIDInPath(t *testing.T) {
 	errResp := testutil.ParseErrorResponse(t, respBody)
 	assert.Equal(t, "0065", errResp.Code) // Invalid path parameter (UUID format)
 	assert.Equal(t, "Invalid Path Parameter", errResp.Title)
-	assert.Equal(t, "Invalid rule ID format", errResp.Message)
+	// Human-readable text lives in the RFC 9457 `detail`; the retired `message` field is empty.
+	assert.Equal(t, "", errResp.Message)
 }
 
 // TestUpdateRule_2_4_14_Returns404ForNonExistentRuleID verifies error handling for missing resource.
@@ -3290,9 +3333,10 @@ func TestUpdateRule_2_4_14_Returns404ForNonExistentRuleID(t *testing.T) {
 	assert.Equal(t, http.StatusNotFound, resp.StatusCode, "Response: %s", string(respBody))
 
 	errResp := testutil.ParseErrorResponse(t, respBody)
-	assert.Equal(t, "0347", errResp.Code) // Rule not found
-	assert.Equal(t, "Not Found", errResp.Title)
-	assert.Equal(t, "Rule not found", errResp.Message)
+	assert.Equal(t, "0347", errResp.Code)
+	assert.Equal(t, "Rule Not Found", errResp.Title)
+	// Human-readable text lives in the RFC 9457 `detail`; the retired `message` field is empty.
+	assert.Equal(t, "", errResp.Message)
 }
 
 // TestUpdateRule_2_4_15_RejectsNameExceedingMaxLength verifies validation of name field boundary on update.
@@ -3340,8 +3384,9 @@ func TestUpdateRule_2_4_15_RejectsNameExceedingMaxLength(t *testing.T) {
 			if tc.expect == http.StatusBadRequest {
 				errResp := testutil.ParseErrorResponse(t, respBody)
 				assert.Equal(t, "0354", errResp.Code)
-				assert.Equal(t, "Validation Error", errResp.Title)
-				assert.Contains(t, errResp.Message, "name")
+				assert.Equal(t, "Rule Name Too Long", errResp.Title)
+				// Human-readable text lives in the RFC 9457 `detail`; the retired `message` field is empty.
+				assert.Equal(t, "", errResp.Message)
 			} else if tc.expect == http.StatusOK {
 				var result map[string]any
 				err = json.Unmarshal(respBody, &result)
@@ -3387,8 +3432,9 @@ func TestUpdateRule_2_4_16_RejectsInvalidExpressionSyntaxOnUpdate(t *testing.T) 
 
 	errResp := testutil.ParseErrorResponse(t, respBody)
 	assert.Equal(t, "0340", errResp.Code)
-	assert.Equal(t, "Bad Request", errResp.Title)
-	assert.Equal(t, "Invalid CEL expression syntax", errResp.Message)
+	assert.Equal(t, "Expression Syntax", errResp.Title)
+	// Human-readable text lives in the RFC 9457 `detail`; the retired `message` field is empty.
+	assert.Equal(t, "", errResp.Message)
 }
 
 // TestUpdateRule_2_4_17_RejectsExpressionNotReturningBooleanOnUpdate verifies expression type validation on update.
@@ -3424,8 +3470,9 @@ func TestUpdateRule_2_4_17_RejectsExpressionNotReturningBooleanOnUpdate(t *testi
 
 	errResp := testutil.ParseErrorResponse(t, respBody)
 	assert.Equal(t, "0341", errResp.Code)
-	assert.Equal(t, "Bad Request", errResp.Title)
-	assert.Equal(t, "Expression must evaluate to boolean", errResp.Message)
+	assert.Equal(t, "Expression Type", errResp.Title)
+	// Human-readable text lives in the RFC 9457 `detail`; the retired `message` field is empty.
+	assert.Equal(t, "", errResp.Message)
 }
 
 // TestUpdateRule_2_4_18_RejectsInvalidActionEnumOnUpdate verifies action validation on update.
@@ -3465,8 +3512,9 @@ func TestUpdateRule_2_4_18_RejectsInvalidActionEnumOnUpdate(t *testing.T) {
 
 			errResp := testutil.ParseErrorResponse(t, respBody)
 			assert.Equal(t, "0357", errResp.Code)
-			assert.Equal(t, "Validation Error", errResp.Title)
-			assert.Contains(t, errResp.Message, "action")
+			assert.Equal(t, "Rule Invalid Action", errResp.Title)
+			// Human-readable text lives in the RFC 9457 `detail`; the retired `message` field is empty.
+			assert.Equal(t, "", errResp.Message)
 		})
 	}
 }
@@ -3506,8 +3554,9 @@ func TestUpdateRule_2_4_19_RejectsInvalidScopeFormatOnUpdate(t *testing.T) {
 
 	errResp := testutil.ParseErrorResponse(t, respBody)
 	assert.Equal(t, "0358", errResp.Code)
-	assert.Equal(t, "Validation Error", errResp.Title)
-	assert.Contains(t, strings.ToLower(errResp.Message), "scope")
+	assert.Equal(t, "Rule Invalid Scope", errResp.Title)
+	// Human-readable text lives in the RFC 9457 `detail`; the retired `message` field is empty.
+	assert.Equal(t, "", errResp.Message)
 }
 
 // TestUpdateRule_2_4_20_WithoutAuthenticationReturns401 verifies authentication requirement for update.
@@ -3728,10 +3777,14 @@ func TestActivateRule_2_5_4_RevalidatesExpressionOnActivation(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, resp.StatusCode, "Response: %s", string(respBody))
 
 	errResp := testutil.ParseErrorResponse(t, respBody)
+	// Re-validating a corrupted expression on activation is a 400 with 0340 (syntax) or 0341 (type).
+	// NOTE: the endpoint currently returns 500 for this path — see suspected bug in the task report.
 	assert.True(t, errResp.Code == "0340" || errResp.Code == "0341",
-		"Expected TRC-0083 or TRC-0084, got %s", errResp.Code)
-	assert.Equal(t, "Bad Request", errResp.Title)
-	assert.NotEmpty(t, errResp.Message)
+		"Expected 0340 or 0341 (expression syntax/type), got %s", errResp.Code)
+	assert.True(t, errResp.Title == "Expression Syntax" || errResp.Title == "Expression Type",
+		"Expected Expression Syntax/Type title, got %s", errResp.Title)
+	// Human-readable text lives in the RFC 9457 `detail`; the retired `message` field is empty.
+	assert.Equal(t, "", errResp.Message)
 }
 
 // TestActivateRule_2_5_5_RejectsActivationOfDeletedRule verifies DELETED rules cannot be activated.
@@ -3758,8 +3811,9 @@ func TestActivateRule_2_5_5_RejectsActivationOfDeletedRule(t *testing.T) {
 
 	errResp := testutil.ParseErrorResponse(t, respBody)
 	assert.Equal(t, "0347", errResp.Code)
-	assert.Equal(t, "Not Found", errResp.Title)
-	assert.Equal(t, "Rule not found", errResp.Message)
+	assert.Equal(t, "Rule Not Found", errResp.Title)
+	// Human-readable text lives in the RFC 9457 `detail`; the retired `message` field is empty.
+	assert.Equal(t, "", errResp.Message)
 }
 
 // TestActivateRule_2_5_6_RejectsInvalidUUIDInPath verifies path parameter validation.
@@ -3783,7 +3837,8 @@ func TestActivateRule_2_5_6_RejectsInvalidUUIDInPath(t *testing.T) {
 	errResp := testutil.ParseErrorResponse(t, respBody)
 	assert.Equal(t, "0065", errResp.Code) // Invalid path parameter (UUID format)
 	assert.Equal(t, "Invalid Path Parameter", errResp.Title)
-	assert.Equal(t, "Invalid rule ID format", errResp.Message)
+	// Human-readable text lives in the RFC 9457 `detail`; the retired `message` field is empty.
+	assert.Equal(t, "", errResp.Message)
 }
 
 // TestActivateRule_2_5_7_Returns404ForNonExistentRuleID verifies error handling for missing resource.
@@ -3806,8 +3861,9 @@ func TestActivateRule_2_5_7_Returns404ForNonExistentRuleID(t *testing.T) {
 
 	errResp := testutil.ParseErrorResponse(t, respBody)
 	assert.Equal(t, "0347", errResp.Code) // Rule not found
-	assert.Equal(t, "Not Found", errResp.Title)
-	assert.Equal(t, "Rule not found", errResp.Message)
+	assert.Equal(t, "Rule Not Found", errResp.Title)
+	// Human-readable text lives in the RFC 9457 `detail`; the retired `message` field is empty.
+	assert.Equal(t, "", errResp.Message)
 }
 
 // TestActivateRule_2_5_8_WithoutAuthenticationReturns401 verifies authentication requirement for activation.
@@ -3911,9 +3967,9 @@ func TestDeactivateRule_2_6_2_RejectsDeactivationOfDraftRule(t *testing.T) {
 	require.NoError(t, err)
 	defer resp.Body.Close()
 
-	// DRAFT → INACTIVE is not a valid transition
-	assert.Equal(t, http.StatusBadRequest, resp.StatusCode,
-		"Deactivate from DRAFT should return 400 - invalid transition")
+	// DRAFT -> INACTIVE is not a valid transition; a business-rule violation maps to 422.
+	assert.Equal(t, http.StatusUnprocessableEntity, resp.StatusCode,
+		"Deactivate from DRAFT should return 422 - invalid transition")
 }
 
 // TestDeactivateRule_2_6_3_IdempotentDeactivationOfInactiveRule verifies deactivating an INACTIVE rule succeeds (no-op).
@@ -3992,8 +4048,9 @@ func TestDeactivateRule_2_6_4_RejectsDeactivationOfDeletedRule(t *testing.T) {
 
 	errResp := testutil.ParseErrorResponse(t, respBody)
 	assert.Equal(t, "0347", errResp.Code)
-	assert.Equal(t, "Not Found", errResp.Title)
-	assert.Equal(t, "Rule not found", errResp.Message)
+	assert.Equal(t, "Rule Not Found", errResp.Title)
+	// Human-readable text lives in the RFC 9457 `detail`; the retired `message` field is empty.
+	assert.Equal(t, "", errResp.Message)
 }
 
 // TestDeactivateRule_2_6_5_RejectsInvalidUUIDInPath verifies path parameter validation.
@@ -4017,7 +4074,8 @@ func TestDeactivateRule_2_6_5_RejectsInvalidUUIDInPath(t *testing.T) {
 	errResp := testutil.ParseErrorResponse(t, respBody)
 	assert.Equal(t, "0065", errResp.Code) // Invalid path parameter (UUID format)
 	assert.Equal(t, "Invalid Path Parameter", errResp.Title)
-	assert.Equal(t, "Invalid rule ID format", errResp.Message)
+	// Human-readable text lives in the RFC 9457 `detail`; the retired `message` field is empty.
+	assert.Equal(t, "", errResp.Message)
 }
 
 // TestDeactivateRule_2_6_6_Returns404ForNonExistentRuleID verifies error handling for missing resource.
@@ -4040,8 +4098,9 @@ func TestDeactivateRule_2_6_6_Returns404ForNonExistentRuleID(t *testing.T) {
 
 	errResp := testutil.ParseErrorResponse(t, respBody)
 	assert.Equal(t, "0347", errResp.Code) // Rule not found
-	assert.Equal(t, "Not Found", errResp.Title)
-	assert.Equal(t, "Rule not found", errResp.Message)
+	assert.Equal(t, "Rule Not Found", errResp.Title)
+	// Human-readable text lives in the RFC 9457 `detail`; the retired `message` field is empty.
+	assert.Equal(t, "", errResp.Message)
 }
 
 // TestDeactivateRule_2_6_7_WithoutAuthenticationReturns401 verifies authentication requirement for deactivation.
@@ -4150,12 +4209,14 @@ func TestDeleteRule_2_7_3_RejectsDeletionOfActiveRule(t *testing.T) {
 	respBody, err := io.ReadAll(resp.Body)
 	require.NoError(t, err)
 
-	assert.Equal(t, http.StatusBadRequest, resp.StatusCode, "Response: %s", string(respBody))
+	// Deleting an ACTIVE rule is an invalid status transition; a business-rule violation maps to 422.
+	assert.Equal(t, http.StatusUnprocessableEntity, resp.StatusCode, "Response: %s", string(respBody))
 
 	errResp := testutil.ParseErrorResponse(t, respBody)
-	assert.Equal(t, "0349", errResp.Code) // Invalid rule status transition
-	assert.Equal(t, "Invalid State Transition", errResp.Title)
-	assert.Equal(t, "invalid status transition from ACTIVE to DELETED", errResp.Message)
+	assert.Equal(t, "0349", errResp.Code)
+	assert.Equal(t, "Rule Invalid Status", errResp.Title)
+	// Human-readable text lives in the RFC 9457 `detail`; the retired `message` field is empty.
+	assert.Equal(t, "", errResp.Message)
 }
 
 // TestDeleteRule_2_7_4_RejectsDeletionOfAlreadyDeletedRule verifies already-deleted rules return 404.
@@ -4183,8 +4244,9 @@ func TestDeleteRule_2_7_4_RejectsDeletionOfAlreadyDeletedRule(t *testing.T) {
 
 	errResp := testutil.ParseErrorResponse(t, respBody)
 	assert.Equal(t, "0347", errResp.Code) // Rule not found
-	assert.Equal(t, "Not Found", errResp.Title)
-	assert.Equal(t, "Rule not found", errResp.Message)
+	assert.Equal(t, "Rule Not Found", errResp.Title)
+	// Human-readable text lives in the RFC 9457 `detail`; the retired `message` field is empty.
+	assert.Equal(t, "", errResp.Message)
 }
 
 // TestDeleteRule_2_7_5_RejectsInvalidUUIDInPath verifies path parameter validation.
@@ -4208,7 +4270,8 @@ func TestDeleteRule_2_7_5_RejectsInvalidUUIDInPath(t *testing.T) {
 	errResp := testutil.ParseErrorResponse(t, respBody)
 	assert.Equal(t, "0065", errResp.Code) // Invalid path parameter (UUID format)
 	assert.Equal(t, "Invalid Path Parameter", errResp.Title)
-	assert.Equal(t, "Invalid rule ID format", errResp.Message)
+	// Human-readable text lives in the RFC 9457 `detail`; the retired `message` field is empty.
+	assert.Equal(t, "", errResp.Message)
 }
 
 // TestDeleteRule_2_7_6_Returns404ForNonExistentRuleID verifies error handling for missing resource.
@@ -4231,8 +4294,9 @@ func TestDeleteRule_2_7_6_Returns404ForNonExistentRuleID(t *testing.T) {
 
 	errResp := testutil.ParseErrorResponse(t, respBody)
 	assert.Equal(t, "0347", errResp.Code) // Rule not found
-	assert.Equal(t, "Not Found", errResp.Title)
-	assert.Equal(t, "Rule not found", errResp.Message)
+	assert.Equal(t, "Rule Not Found", errResp.Title)
+	// Human-readable text lives in the RFC 9457 `detail`; the retired `message` field is empty.
+	assert.Equal(t, "", errResp.Message)
 }
 
 // TestDeleteRule_2_7_7_WithoutAuthenticationReturns401 verifies authentication requirement for deletion.
@@ -4340,9 +4404,9 @@ func TestDraftRule_2_8_2_RejectsDraftOfActiveRule(t *testing.T) {
 	require.NoError(t, err)
 	defer resp.Body.Close()
 
-	// ACTIVE → DRAFT is not a valid transition
-	assert.Equal(t, http.StatusBadRequest, resp.StatusCode,
-		"Draft from ACTIVE should return 400 - invalid transition")
+	// ACTIVE -> DRAFT is not a valid transition; a business-rule violation maps to 422.
+	assert.Equal(t, http.StatusUnprocessableEntity, resp.StatusCode,
+		"Draft from ACTIVE should return 422 - invalid transition")
 
 	// Verify state was NOT mutated
 	getReq, err := http.NewRequest(http.MethodGet, baseURL+"/v1/rules/"+ruleID, nil)
@@ -4417,7 +4481,8 @@ func TestDraftRule_2_8_4_RejectsInvalidUUIDInPath(t *testing.T) {
 	errResp := testutil.ParseErrorResponse(t, respBody)
 	assert.Equal(t, "0065", errResp.Code) // Invalid path parameter (UUID format)
 	assert.Equal(t, "Invalid Path Parameter", errResp.Title)
-	assert.Equal(t, "Invalid rule ID format", errResp.Message)
+	// Human-readable text lives in the RFC 9457 `detail`; the retired `message` field is empty.
+	assert.Equal(t, "", errResp.Message)
 }
 
 // TestDraftRule_2_8_5_Returns404ForNonExistentRuleID verifies error handling for missing resource.
@@ -4440,8 +4505,9 @@ func TestDraftRule_2_8_5_Returns404ForNonExistentRuleID(t *testing.T) {
 
 	errResp := testutil.ParseErrorResponse(t, respBody)
 	assert.Equal(t, "0347", errResp.Code) // Rule not found
-	assert.Equal(t, "Not Found", errResp.Title)
-	assert.Equal(t, "Rule not found", errResp.Message)
+	assert.Equal(t, "Rule Not Found", errResp.Title)
+	// Human-readable text lives in the RFC 9457 `detail`; the retired `message` field is empty.
+	assert.Equal(t, "", errResp.Message)
 }
 
 // TestDraftRule_2_8_6_WithoutAuthenticationReturns401 verifies authentication requirement for draft.
@@ -4499,6 +4565,7 @@ func TestDraftRule_2_8_7_RejectsDraftOfDeletedRule(t *testing.T) {
 
 	errResp := testutil.ParseErrorResponse(t, respBody)
 	assert.Equal(t, "0347", errResp.Code) // Rule not found
-	assert.Equal(t, "Not Found", errResp.Title)
-	assert.Equal(t, "Rule not found", errResp.Message)
+	assert.Equal(t, "Rule Not Found", errResp.Title)
+	// Human-readable text lives in the RFC 9457 `detail`; the retired `message` field is empty.
+	assert.Equal(t, "", errResp.Message)
 }

--- a/components/tracer/tests/integration/02_rules_management_test.go
+++ b/components/tracer/tests/integration/02_rules_management_test.go
@@ -307,8 +307,8 @@ func TestCreateRule_2_1_5_RejectsMissingName(t *testing.T) {
 	errResp := testutil.ParseErrorResponse(t, respBody)
 	assert.Equal(t, "0353", errResp.Code, "Error code should be 0353 for name required")
 	assert.Equal(t, "Rule Name Required", errResp.Title)
-	// Human-readable text lives in the RFC 9457 `detail`; the retired `message` field is empty.
-	assert.Equal(t, "", errResp.Message)
+	// Human-readable text lives in the RFC 9457 `detail`.
+	assert.Equal(t, "Rule name is required.", errResp.Detail)
 }
 
 // TestCreateRule_2_1_6_RejectsMissingExpression verifies validation of required field 'expression'.
@@ -341,8 +341,8 @@ func TestCreateRule_2_1_6_RejectsMissingExpression(t *testing.T) {
 	errResp := testutil.ParseErrorResponse(t, respBody)
 	assert.Equal(t, "0355", errResp.Code, "Error code should be 0355 for expression required")
 	assert.Equal(t, "Rule Expression Required", errResp.Title)
-	// Human-readable text lives in the RFC 9457 `detail`; the retired `message` field is empty.
-	assert.Equal(t, "", errResp.Message)
+	// Human-readable text lives in the RFC 9457 `detail`.
+	assert.Equal(t, "Rule expression is required.", errResp.Detail)
 }
 
 // TestCreateRule_2_1_7_RejectsMissingAction verifies validation of required field 'action'.
@@ -375,8 +375,8 @@ func TestCreateRule_2_1_7_RejectsMissingAction(t *testing.T) {
 	errResp := testutil.ParseErrorResponse(t, respBody)
 	assert.Equal(t, "0357", errResp.Code, "Error code should be 0357 for action required/invalid")
 	assert.Equal(t, "Rule Invalid Action", errResp.Title)
-	// Human-readable text lives in the RFC 9457 `detail`; the retired `message` field is empty.
-	assert.Equal(t, "", errResp.Message)
+	// Human-readable text lives in the RFC 9457 `detail`.
+	assert.Equal(t, "Action must be one of [ALLOW, DENY, REVIEW].", errResp.Detail)
 }
 
 // TestCreateRule_2_1_8_RejectsAllMissingRequiredFields verifies validation when multiple required fields are missing.
@@ -408,8 +408,8 @@ func TestCreateRule_2_1_8_RejectsAllMissingRequiredFields(t *testing.T) {
 	errResp := testutil.ParseErrorResponse(t, respBody)
 	assert.Equal(t, "0353", errResp.Code, "Error code should be 0353 for name required (first missing field)")
 	assert.Equal(t, "Rule Name Required", errResp.Title)
-	// Human-readable text lives in the RFC 9457 `detail`; the retired `message` field is empty.
-	assert.Equal(t, "", errResp.Message)
+	// Human-readable text lives in the RFC 9457 `detail`.
+	assert.Equal(t, "Rule name is required.", errResp.Detail)
 }
 
 // TestCreateRule_2_1_9_RejectsEmptyName verifies validation of empty name string.
@@ -443,8 +443,8 @@ func TestCreateRule_2_1_9_RejectsEmptyName(t *testing.T) {
 	errResp := testutil.ParseErrorResponse(t, respBody)
 	assert.Equal(t, "0353", errResp.Code, "Error code should be 0353 for empty name validation error")
 	assert.Equal(t, "Rule Name Required", errResp.Title)
-	// Human-readable text lives in the RFC 9457 `detail`; the retired `message` field is empty.
-	assert.Equal(t, "", errResp.Message)
+	// Human-readable text lives in the RFC 9457 `detail`.
+	assert.Equal(t, "Rule name is required.", errResp.Detail)
 }
 
 // TestCreateRule_2_1_10_RejectsNameExceedingMaxLength verifies validation of name field boundary (255 characters).
@@ -500,8 +500,8 @@ func TestCreateRule_2_1_10_RejectsNameExceedingMaxLength(t *testing.T) {
 				errResp := testutil.ParseErrorResponse(t, respBody)
 				assert.Equal(t, "0354", errResp.Code)
 				assert.Equal(t, "Rule Name Too Long", errResp.Title)
-				// Human-readable text lives in the RFC 9457 `detail`; the retired `message` field is empty.
-				assert.Equal(t, "", errResp.Message)
+				// Human-readable text lives in the RFC 9457 `detail`.
+				assert.Equal(t, "Rule name exceeds max length (255).", errResp.Detail)
 			}
 		})
 	}
@@ -538,8 +538,8 @@ func TestCreateRule_2_1_11_RejectsEmptyExpression(t *testing.T) {
 	errResp := testutil.ParseErrorResponse(t, respBody)
 	assert.Equal(t, "0355", errResp.Code, "Error code should be 0355 for empty expression validation error")
 	assert.Equal(t, "Rule Expression Required", errResp.Title)
-	// Human-readable text lives in the RFC 9457 `detail`; the retired `message` field is empty.
-	assert.Equal(t, "", errResp.Message)
+	// Human-readable text lives in the RFC 9457 `detail`.
+	assert.Equal(t, "Rule expression is required.", errResp.Detail)
 }
 
 // TestCreateRule_2_1_12_RejectsExpressionExceedingMaxLength verifies validation of expression field boundary (5000 characters).
@@ -613,8 +613,8 @@ func TestCreateRule_2_1_12_RejectsExpressionExceedingMaxLength(t *testing.T) {
 				errResp := testutil.ParseErrorResponse(t, respBody)
 				assert.Equal(t, "0356", errResp.Code)
 				assert.Equal(t, "Rule Expression Too Long", errResp.Title)
-				// Human-readable text lives in the RFC 9457 `detail`; the retired `message` field is empty.
-				assert.Equal(t, "", errResp.Message)
+				// Human-readable text lives in the RFC 9457 `detail`.
+				assert.Equal(t, "Rule expression exceeds max length (5000).", errResp.Detail)
 			}
 		})
 	}
@@ -675,8 +675,8 @@ func TestCreateRule_2_1_13_RejectsDescriptionExceedingMaxLength(t *testing.T) {
 				errResp := testutil.ParseErrorResponse(t, respBody)
 				assert.Equal(t, "0359", errResp.Code, "Error code should be 0359 for description too long")
 				assert.Equal(t, "Rule Description Too Long", errResp.Title)
-				// Human-readable text lives in the RFC 9457 `detail`; the retired `message` field is empty.
-				assert.Equal(t, "", errResp.Message)
+				// Human-readable text lives in the RFC 9457 `detail`.
+				assert.Equal(t, "Rule description exceeds max length (1000).", errResp.Detail)
 			}
 		})
 	}
@@ -717,8 +717,8 @@ func TestCreateRule_2_1_14_RejectsInvalidActionEnum(t *testing.T) {
 			errResp := testutil.ParseErrorResponse(t, respBody)
 			assert.Equal(t, "0357", errResp.Code, "Error code should be 0357 for invalid action enum")
 			assert.Equal(t, "Rule Invalid Action", errResp.Title)
-			// Human-readable text lives in the RFC 9457 `detail`; the retired `message` field is empty.
-			assert.Equal(t, "", errResp.Message)
+			// Human-readable text lives in the RFC 9457 `detail`.
+			assert.Equal(t, "Action must be one of [ALLOW, DENY, REVIEW].", errResp.Detail)
 		})
 	}
 }
@@ -763,8 +763,8 @@ func TestCreateRule_2_1_15_RejectsInvalidCELExpressionSyntax(t *testing.T) {
 			errResp := testutil.ParseErrorResponse(t, respBody)
 			assert.Equal(t, "0340", errResp.Code)
 			assert.Equal(t, "Expression Syntax", errResp.Title)
-			// Human-readable text lives in the RFC 9457 `detail`; the retired `message` field is empty.
-			assert.Equal(t, "", errResp.Message)
+			// Human-readable text lives in the RFC 9457 `detail`.
+			assert.Equal(t, "Invalid CEL syntax.", errResp.Detail)
 		})
 	}
 }
@@ -807,8 +807,8 @@ func TestCreateRule_2_1_16_RejectsExpressionNotReturningBoolean(t *testing.T) {
 			errResp := testutil.ParseErrorResponse(t, respBody)
 			assert.Equal(t, "0341", errResp.Code)
 			assert.Equal(t, "Expression Type", errResp.Title)
-			// Human-readable text lives in the RFC 9457 `detail`; the retired `message` field is empty.
-			assert.Equal(t, "", errResp.Message)
+			// Human-readable text lives in the RFC 9457 `detail`.
+			assert.Equal(t, "Expression must return boolean.", errResp.Detail)
 		})
 	}
 }
@@ -881,8 +881,8 @@ func TestCreateRule_2_1_18_RejectsDuplicateRuleName(t *testing.T) {
 	errResp := testutil.ParseErrorResponse(t, respBody2)
 	assert.Equal(t, "0441", errResp.Code)
 	assert.Equal(t, "Rule Name Already Exists In Ctx", errResp.Title)
-	// Human-readable text lives in the RFC 9457 `detail`; the retired `message` field is empty.
-	assert.Equal(t, "", errResp.Message)
+	// Human-readable text lives in the RFC 9457 `detail`.
+	assert.Equal(t, "Rule name already exists in this context.", errResp.Detail)
 }
 
 // TestCreateRule_2_1_19_RejectsInvalidNameType verifies type validation for name field.
@@ -921,8 +921,8 @@ func TestCreateRule_2_1_19_RejectsInvalidNameType(t *testing.T) {
 			// JSON type mismatch is a body-parse error: code 0094 with a generic "Bad Request" title.
 			assert.Equal(t, "0094", errResp.Code)
 			assert.Equal(t, "Bad Request", errResp.Title)
-			// Human-readable text lives in the RFC 9457 `detail`; the retired `message` field is empty.
-			assert.Equal(t, "", errResp.Message)
+			// Human-readable text lives in the RFC 9457 `detail`.
+			assert.Equal(t, "The request body is malformed or contains invalid JSON. Please verify the syntax and try again.", errResp.Detail)
 		})
 	}
 
@@ -947,8 +947,8 @@ func TestCreateRule_2_1_19_RejectsInvalidNameType(t *testing.T) {
 		errResp := testutil.ParseErrorResponse(t, respBody)
 		assert.Equal(t, "0353", errResp.Code, "Error code should be 0353 for null name validation error")
 		assert.Equal(t, "Rule Name Required", errResp.Title)
-		// Human-readable text lives in the RFC 9457 `detail`; the retired `message` field is empty.
-		assert.Equal(t, "", errResp.Message)
+		// Human-readable text lives in the RFC 9457 `detail`.
+		assert.Equal(t, "Rule name is required.", errResp.Detail)
 	})
 }
 
@@ -988,8 +988,8 @@ func TestCreateRule_2_1_20_RejectsInvalidExpressionType(t *testing.T) {
 			// JSON type mismatch is a body-parse error: code 0094 with a generic "Bad Request" title.
 			assert.Equal(t, "0094", errResp.Code)
 			assert.Equal(t, "Bad Request", errResp.Title)
-			// Human-readable text lives in the RFC 9457 `detail`; the retired `message` field is empty.
-			assert.Equal(t, "", errResp.Message)
+			// Human-readable text lives in the RFC 9457 `detail`.
+			assert.Equal(t, "The request body is malformed or contains invalid JSON. Please verify the syntax and try again.", errResp.Detail)
 		})
 	}
 
@@ -1014,8 +1014,8 @@ func TestCreateRule_2_1_20_RejectsInvalidExpressionType(t *testing.T) {
 		errResp := testutil.ParseErrorResponse(t, respBody)
 		assert.Equal(t, "0355", errResp.Code, "Error code should be 0355 for null expression validation error")
 		assert.Equal(t, "Rule Expression Required", errResp.Title)
-		// Human-readable text lives in the RFC 9457 `detail`; the retired `message` field is empty.
-		assert.Equal(t, "", errResp.Message)
+		// Human-readable text lives in the RFC 9457 `detail`.
+		assert.Equal(t, "Rule expression is required.", errResp.Detail)
 	})
 }
 
@@ -1055,8 +1055,8 @@ func TestCreateRule_2_1_21_RejectsInvalidActionType(t *testing.T) {
 			// JSON type mismatch is a body-parse error: code 0094 with a generic "Bad Request" title.
 			assert.Equal(t, "0094", errResp.Code)
 			assert.Equal(t, "Bad Request", errResp.Title)
-			// Human-readable text lives in the RFC 9457 `detail`; the retired `message` field is empty.
-			assert.Equal(t, "", errResp.Message)
+			// Human-readable text lives in the RFC 9457 `detail`.
+			assert.Equal(t, "The request body is malformed or contains invalid JSON. Please verify the syntax and try again.", errResp.Detail)
 		})
 	}
 
@@ -1081,8 +1081,8 @@ func TestCreateRule_2_1_21_RejectsInvalidActionType(t *testing.T) {
 		errResp := testutil.ParseErrorResponse(t, respBody)
 		assert.Equal(t, "0357", errResp.Code, "Error code should be 0357 for null action validation error")
 		assert.Equal(t, "Rule Invalid Action", errResp.Title)
-		// Human-readable text lives in the RFC 9457 `detail`; the retired `message` field is empty.
-		assert.Equal(t, "", errResp.Message)
+		// Human-readable text lives in the RFC 9457 `detail`.
+		assert.Equal(t, "Action must be one of [ALLOW, DENY, REVIEW].", errResp.Detail)
 	})
 }
 
@@ -1123,8 +1123,8 @@ func TestCreateRule_2_1_22_RejectsInvalidScopesType(t *testing.T) {
 			// JSON type mismatch is a body-parse error: code 0094 with a generic "Bad Request" title.
 			assert.Equal(t, "0094", errResp.Code)
 			assert.Equal(t, "Bad Request", errResp.Title)
-			// Human-readable text lives in the RFC 9457 `detail`; the retired `message` field is empty.
-			assert.Equal(t, "", errResp.Message)
+			// Human-readable text lives in the RFC 9457 `detail`.
+			assert.Equal(t, "The request body is malformed or contains invalid JSON. Please verify the syntax and try again.", errResp.Detail)
 		})
 	}
 }
@@ -1163,8 +1163,8 @@ func TestCreateRule_2_1_23_RejectsScopeWithNoFieldsSet(t *testing.T) {
 	errResp := testutil.ParseErrorResponse(t, respBody)
 	assert.Equal(t, "0358", errResp.Code, "Error code should be 0358 for empty scope")
 	assert.Equal(t, "Rule Invalid Scope", errResp.Title)
-	// Human-readable text lives in the RFC 9457 `detail`; the retired `message` field is empty.
-	assert.Equal(t, "", errResp.Message)
+	// Human-readable text lives in the RFC 9457 `detail`.
+	assert.Equal(t, "Scope must have at least one field set.", errResp.Detail)
 }
 
 // TestCreateRule_2_1_24_RejectsScopeWithInvalidUUIDFormat verifies UUID format validation in scope fields.
@@ -1230,8 +1230,8 @@ func TestCreateRule_2_1_24_RejectsScopeWithInvalidUUIDFormat(t *testing.T) {
 				// Invalid UUID in a scope field is a body-parse error: code 0094 with a generic "Bad Request" title.
 				assert.Equal(t, "0094", errResp.Code)
 				assert.Equal(t, "Bad Request", errResp.Title)
-				// Human-readable text lives in the RFC 9457 `detail`; the retired `message` field is empty.
-				assert.Equal(t, "", errResp.Message)
+				// Human-readable text lives in the RFC 9457 `detail`.
+				assert.Equal(t, "The request body is malformed or contains invalid JSON. Please verify the syntax and try again.", errResp.Detail)
 			}
 		})
 	}
@@ -1296,8 +1296,8 @@ func TestCreateRule_2_1_25_RejectsScopeWithInvalidTransactionTypeEnum(t *testing
 				errResp := testutil.ParseErrorResponse(t, respBody)
 				assert.Equal(t, "0358", errResp.Code, "Error code should be 0358 for invalid transactionType enum")
 				assert.Equal(t, "Rule Invalid Scope", errResp.Title)
-				// Human-readable text lives in the RFC 9457 `detail`; the retired `message` field is empty.
-				assert.Equal(t, "", errResp.Message)
+				// Human-readable text lives in the RFC 9457 `detail`.
+				assert.Equal(t, "Scope must have at least one field set.", errResp.Detail)
 			}
 		})
 	}
@@ -1362,8 +1362,8 @@ func TestCreateRule_2_1_26_RejectsSubTypeExceedingMaxLength(t *testing.T) {
 				errResp := testutil.ParseErrorResponse(t, respBody)
 				assert.Equal(t, "0358", errResp.Code, "Error code should be 0358 for scope field validation")
 				assert.Equal(t, "Rule Invalid Scope", errResp.Title)
-				// Human-readable text lives in the RFC 9457 `detail`; the retired `message` field is empty.
-				assert.Equal(t, "", errResp.Message)
+				// Human-readable text lives in the RFC 9457 `detail`.
+				assert.Equal(t, "Scope must have at least one field set.", errResp.Detail)
 			}
 		})
 	}
@@ -1426,8 +1426,8 @@ func TestCreateRule_2_1_27_RejectsScopesExceedingMaxCount(t *testing.T) {
 				errResp := testutil.ParseErrorResponse(t, respBody)
 				assert.Equal(t, "0360", errResp.Code, "Error code should be 0360 for scopes exceeding max count")
 				assert.Equal(t, "Rule Scopes Too Many", errResp.Title)
-				// Human-readable text lives in the RFC 9457 `detail`; the retired `message` field is empty.
-				assert.Equal(t, "", errResp.Message)
+				// Human-readable text lives in the RFC 9457 `detail`.
+				assert.Equal(t, "Rule scopes exceed maximum (100).", errResp.Detail)
 			}
 		})
 	}
@@ -1684,8 +1684,8 @@ func TestGetRule_2_2_3_Returns404ForNonExistentRuleID(t *testing.T) {
 	errResp := testutil.ParseErrorResponse(t, getRespBody)
 	assert.Equal(t, "0347", errResp.Code)
 	assert.Equal(t, "Rule Not Found", errResp.Title)
-	// Human-readable text lives in the RFC 9457 `detail`; the retired `message` field is empty.
-	assert.Equal(t, "", errResp.Message)
+	// Human-readable text lives in the RFC 9457 `detail`.
+	assert.Equal(t, "Rule not found by ID.", errResp.Detail)
 }
 
 // TestGetRule_2_2_4_RejectsInvalidUUIDFormatInPath verifies path parameter validation.
@@ -1717,8 +1717,8 @@ func TestGetRule_2_2_4_RejectsInvalidUUIDFormatInPath(t *testing.T) {
 			errResp := testutil.ParseErrorResponse(t, getRespBody)
 			assert.Equal(t, "0065", errResp.Code)
 			assert.Equal(t, "Invalid Path Parameter", errResp.Title)
-			// Human-readable text lives in the RFC 9457 `detail`; the retired `message` field is empty.
-			assert.Equal(t, "", errResp.Message)
+			// Human-readable text lives in the RFC 9457 `detail`.
+			assert.Contains(t, errResp.Detail, "path parameters are in an incorrect format")
 		})
 	}
 }
@@ -1752,8 +1752,8 @@ func TestGetRule_2_2_5_Returns404ForDeletedRule(t *testing.T) {
 	errResp := testutil.ParseErrorResponse(t, getRespBody)
 	assert.Equal(t, "0347", errResp.Code)
 	assert.Equal(t, "Rule Not Found", errResp.Title)
-	// Human-readable text lives in the RFC 9457 `detail`; the retired `message` field is empty.
-	assert.Equal(t, "", errResp.Message)
+	// Human-readable text lives in the RFC 9457 `detail`.
+	assert.Equal(t, "Rule not found by ID.", errResp.Detail)
 }
 
 // TestGetRule_2_2_6_WithoutAuthenticationReturns401 verifies authentication requirement for rule retrieval.
@@ -2082,8 +2082,8 @@ func TestListRules_2_3_5_RejectsDELETEDStatusFilter(t *testing.T) {
 	errResp := testutil.ParseErrorResponse(t, respBody)
 	assert.Equal(t, "0082", errResp.Code)
 	assert.Equal(t, "Invalid Query Parameter", errResp.Title)
-	// Human-readable text lives in the RFC 9457 `detail`; the retired `message` field is empty.
-	assert.Equal(t, "", errResp.Message)
+	// Human-readable text lives in the RFC 9457 `detail`.
+	assert.Contains(t, errResp.Detail, "query parameters are in an incorrect format")
 }
 
 // TestListRules_2_3_6_FiltersByAction verifies action filter functionality.
@@ -2381,8 +2381,8 @@ func TestListRules_2_3_12_RejectsInvalidSortByValue(t *testing.T) {
 			errResp := testutil.ParseErrorResponse(t, respBody)
 			assert.Equal(t, "0332", errResp.Code)
 			assert.Equal(t, "Invalid Sort Column", errResp.Title)
-			// Human-readable text lives in the RFC 9457 `detail`; the retired `message` field is empty.
-			assert.Equal(t, "", errResp.Message)
+			// Human-readable text lives in the RFC 9457 `detail`.
+			assert.Equal(t, "Sort column not in allowed list.", errResp.Detail)
 		})
 	}
 }
@@ -2423,8 +2423,8 @@ func TestListRules_2_3_13_RejectsInvalidSortOrderValue(t *testing.T) {
 				errResp := testutil.ParseErrorResponse(t, respBody)
 				assert.Equal(t, "0081", errResp.Code)
 				assert.Equal(t, "Invalid Sort Order", errResp.Title)
-				// Human-readable text lives in the RFC 9457 `detail`; the retired `message` field is empty.
-				assert.Equal(t, "", errResp.Message)
+				// Human-readable text lives in the RFC 9457 `detail`.
+				assert.Equal(t, "The 'sort_order' field must be 'asc' or 'desc'. Please provide a valid sort order and try again.", errResp.Detail)
 			}
 		})
 	}
@@ -2464,8 +2464,8 @@ func TestListRules_2_3_14_RejectsLimitBelowMinimum(t *testing.T) {
 				errResp := testutil.ParseErrorResponse(t, respBody)
 				assert.Equal(t, "0331", errResp.Code)
 				assert.Equal(t, "Pagination Limit Invalid", errResp.Title)
-				// Human-readable text lives in the RFC 9457 `detail`; the retired `message` field is empty.
-				assert.Equal(t, "", errResp.Message)
+				// Human-readable text lives in the RFC 9457 `detail`.
+				assert.Equal(t, "Pagination limit must be positive.", errResp.Detail)
 			}
 		})
 	}
@@ -2504,8 +2504,8 @@ func TestListRules_2_3_15_RejectsLimitAboveMaximum(t *testing.T) {
 				errResp := testutil.ParseErrorResponse(t, respBody)
 				assert.Equal(t, "0080", errResp.Code)
 				assert.Equal(t, "Pagination Limit Exceeded", errResp.Title)
-				// Human-readable text lives in the RFC 9457 `detail`; the retired `message` field is empty.
-				assert.Equal(t, "", errResp.Message)
+				// Human-readable text lives in the RFC 9457 `detail`.
+				assert.Contains(t, errResp.Detail, "maximum allowed of")
 			}
 		})
 	}
@@ -2536,8 +2536,8 @@ func TestListRules_2_3_16_RejectsInvalidCursor(t *testing.T) {
 			errResp := testutil.ParseErrorResponse(t, respBody)
 			assert.Equal(t, "0333", errResp.Code)
 			assert.Equal(t, "Invalid Cursor", errResp.Title)
-			// Human-readable text lives in the RFC 9457 `detail`; the retired `message` field is empty.
-			assert.Equal(t, "", errResp.Message)
+			// Human-readable text lives in the RFC 9457 `detail`.
+			assert.Equal(t, "Invalid or corrupted pagination cursor.", errResp.Detail)
 		})
 	}
 }
@@ -2576,8 +2576,8 @@ func TestListRules_2_3_17_RejectsInvalidActionFilterValue(t *testing.T) {
 				errResp := testutil.ParseErrorResponse(t, respBody)
 				assert.Equal(t, "0082", errResp.Code)
 				assert.Equal(t, "Invalid Query Parameter", errResp.Title)
-				// Human-readable text lives in the RFC 9457 `detail`; the retired `message` field is empty.
-				assert.Equal(t, "", errResp.Message)
+				// Human-readable text lives in the RFC 9457 `detail`.
+				assert.Contains(t, errResp.Detail, "query parameters are in an incorrect format")
 			}
 		})
 	}
@@ -2617,8 +2617,8 @@ func TestListRules_2_3_18_RejectsInvalidStatusFilterValue(t *testing.T) {
 				errResp := testutil.ParseErrorResponse(t, respBody)
 				assert.Equal(t, "0082", errResp.Code)
 				assert.Equal(t, "Invalid Query Parameter", errResp.Title)
-				// Human-readable text lives in the RFC 9457 `detail`; the retired `message` field is empty.
-				assert.Equal(t, "", errResp.Message)
+				// Human-readable text lives in the RFC 9457 `detail`.
+				assert.Contains(t, errResp.Detail, "query parameters are in an incorrect format")
 			}
 		})
 	}
@@ -3002,8 +3002,8 @@ func TestUpdateRule_2_4_7_RejectsExpressionUpdateOnActiveRule(t *testing.T) {
 	errResp := testutil.ParseErrorResponse(t, respBody)
 	assert.Equal(t, "0351", errResp.Code)
 	assert.Equal(t, "Expression Not Modifiable", errResp.Title)
-	// Human-readable text lives in the RFC 9457 `detail`; the retired `message` field is empty.
-	assert.Equal(t, "", errResp.Message)
+	// Human-readable text lives in the RFC 9457 `detail`.
+	assert.Equal(t, "Expression cannot be modified for non-DRAFT rules.", errResp.Detail)
 
 	// Verify rule was not mutated
 	getReq, err := http.NewRequest(http.MethodGet, baseURL+"/v1/rules/"+ruleID, nil)
@@ -3063,8 +3063,8 @@ func TestUpdateRule_2_4_8_RejectsExpressionUpdateOnInactiveRule(t *testing.T) {
 	errResp := testutil.ParseErrorResponse(t, respBody)
 	assert.Equal(t, "0351", errResp.Code)
 	assert.Equal(t, "Expression Not Modifiable", errResp.Title)
-	// Human-readable text lives in the RFC 9457 `detail`; the retired `message` field is empty.
-	assert.Equal(t, "", errResp.Message)
+	// Human-readable text lives in the RFC 9457 `detail`.
+	assert.Equal(t, "Expression cannot be modified for non-DRAFT rules.", errResp.Detail)
 
 	// Verify rule was not mutated
 	getReq, err := http.NewRequest(http.MethodGet, baseURL+"/v1/rules/"+ruleID, nil)
@@ -3164,8 +3164,8 @@ func TestUpdateRule_2_4_10_RejectsEmptyUpdate(t *testing.T) {
 	errResp := testutil.ParseErrorResponse(t, respBody)
 	assert.Equal(t, "0183", errResp.Code)
 	assert.Equal(t, "Nothing to Update", errResp.Title)
-	// Human-readable text lives in the RFC 9457 `detail`; the retired `message` field is empty.
-	assert.Equal(t, "", errResp.Message)
+	// Human-readable text lives in the RFC 9457 `detail`.
+	assert.Equal(t, "No updatable fields were provided. Please include at least one field to update.", errResp.Detail)
 
 	// Verify rule was not mutated
 	getReq, err := http.NewRequest(http.MethodGet, baseURL+"/v1/rules/"+ruleID, nil)
@@ -3231,8 +3231,8 @@ func TestUpdateRule_2_4_11_RejectsDuplicateName(t *testing.T) {
 	errResp := testutil.ParseErrorResponse(t, respBody)
 	assert.Equal(t, "0441", errResp.Code)
 	assert.Equal(t, "Rule Name Already Exists In Ctx", errResp.Title)
-	// Human-readable text lives in the RFC 9457 `detail`; the retired `message` field is empty.
-	assert.Equal(t, "", errResp.Message)
+	// Human-readable text lives in the RFC 9457 `detail`.
+	assert.Equal(t, "Rule name already exists in this context.", errResp.Detail)
 }
 
 // TestUpdateRule_2_4_12_AllowsSameName verifies updating to the same name is allowed (idempotent).
@@ -3302,8 +3302,8 @@ func TestUpdateRule_2_4_13_RejectsInvalidUUIDInPath(t *testing.T) {
 	errResp := testutil.ParseErrorResponse(t, respBody)
 	assert.Equal(t, "0065", errResp.Code) // Invalid path parameter (UUID format)
 	assert.Equal(t, "Invalid Path Parameter", errResp.Title)
-	// Human-readable text lives in the RFC 9457 `detail`; the retired `message` field is empty.
-	assert.Equal(t, "", errResp.Message)
+	// Human-readable text lives in the RFC 9457 `detail`.
+	assert.Contains(t, errResp.Detail, "path parameters are in an incorrect format")
 }
 
 // TestUpdateRule_2_4_14_Returns404ForNonExistentRuleID verifies error handling for missing resource.
@@ -3335,8 +3335,8 @@ func TestUpdateRule_2_4_14_Returns404ForNonExistentRuleID(t *testing.T) {
 	errResp := testutil.ParseErrorResponse(t, respBody)
 	assert.Equal(t, "0347", errResp.Code)
 	assert.Equal(t, "Rule Not Found", errResp.Title)
-	// Human-readable text lives in the RFC 9457 `detail`; the retired `message` field is empty.
-	assert.Equal(t, "", errResp.Message)
+	// Human-readable text lives in the RFC 9457 `detail`.
+	assert.Equal(t, "Rule not found by ID.", errResp.Detail)
 }
 
 // TestUpdateRule_2_4_15_RejectsNameExceedingMaxLength verifies validation of name field boundary on update.
@@ -3385,8 +3385,8 @@ func TestUpdateRule_2_4_15_RejectsNameExceedingMaxLength(t *testing.T) {
 				errResp := testutil.ParseErrorResponse(t, respBody)
 				assert.Equal(t, "0354", errResp.Code)
 				assert.Equal(t, "Rule Name Too Long", errResp.Title)
-				// Human-readable text lives in the RFC 9457 `detail`; the retired `message` field is empty.
-				assert.Equal(t, "", errResp.Message)
+				// Human-readable text lives in the RFC 9457 `detail`.
+				assert.Equal(t, "Rule name exceeds max length (255).", errResp.Detail)
 			} else if tc.expect == http.StatusOK {
 				var result map[string]any
 				err = json.Unmarshal(respBody, &result)
@@ -3433,8 +3433,8 @@ func TestUpdateRule_2_4_16_RejectsInvalidExpressionSyntaxOnUpdate(t *testing.T) 
 	errResp := testutil.ParseErrorResponse(t, respBody)
 	assert.Equal(t, "0340", errResp.Code)
 	assert.Equal(t, "Expression Syntax", errResp.Title)
-	// Human-readable text lives in the RFC 9457 `detail`; the retired `message` field is empty.
-	assert.Equal(t, "", errResp.Message)
+	// Human-readable text lives in the RFC 9457 `detail`.
+	assert.Equal(t, "Invalid CEL syntax.", errResp.Detail)
 }
 
 // TestUpdateRule_2_4_17_RejectsExpressionNotReturningBooleanOnUpdate verifies expression type validation on update.
@@ -3471,8 +3471,8 @@ func TestUpdateRule_2_4_17_RejectsExpressionNotReturningBooleanOnUpdate(t *testi
 	errResp := testutil.ParseErrorResponse(t, respBody)
 	assert.Equal(t, "0341", errResp.Code)
 	assert.Equal(t, "Expression Type", errResp.Title)
-	// Human-readable text lives in the RFC 9457 `detail`; the retired `message` field is empty.
-	assert.Equal(t, "", errResp.Message)
+	// Human-readable text lives in the RFC 9457 `detail`.
+	assert.Equal(t, "Expression must return boolean.", errResp.Detail)
 }
 
 // TestUpdateRule_2_4_18_RejectsInvalidActionEnumOnUpdate verifies action validation on update.
@@ -3513,8 +3513,8 @@ func TestUpdateRule_2_4_18_RejectsInvalidActionEnumOnUpdate(t *testing.T) {
 			errResp := testutil.ParseErrorResponse(t, respBody)
 			assert.Equal(t, "0357", errResp.Code)
 			assert.Equal(t, "Rule Invalid Action", errResp.Title)
-			// Human-readable text lives in the RFC 9457 `detail`; the retired `message` field is empty.
-			assert.Equal(t, "", errResp.Message)
+			// Human-readable text lives in the RFC 9457 `detail`.
+			assert.Equal(t, "Action must be one of [ALLOW, DENY, REVIEW].", errResp.Detail)
 		})
 	}
 }
@@ -3555,8 +3555,8 @@ func TestUpdateRule_2_4_19_RejectsInvalidScopeFormatOnUpdate(t *testing.T) {
 	errResp := testutil.ParseErrorResponse(t, respBody)
 	assert.Equal(t, "0358", errResp.Code)
 	assert.Equal(t, "Rule Invalid Scope", errResp.Title)
-	// Human-readable text lives in the RFC 9457 `detail`; the retired `message` field is empty.
-	assert.Equal(t, "", errResp.Message)
+	// Human-readable text lives in the RFC 9457 `detail`.
+	assert.Equal(t, "Scope must have at least one field set.", errResp.Detail)
 }
 
 // TestUpdateRule_2_4_20_WithoutAuthenticationReturns401 verifies authentication requirement for update.
@@ -3783,8 +3783,9 @@ func TestActivateRule_2_5_4_RevalidatesExpressionOnActivation(t *testing.T) {
 		"Expected 0340 or 0341 (expression syntax/type), got %s", errResp.Code)
 	assert.True(t, errResp.Title == "Expression Syntax" || errResp.Title == "Expression Type",
 		"Expected Expression Syntax/Type title, got %s", errResp.Title)
-	// Human-readable text lives in the RFC 9457 `detail`; the retired `message` field is empty.
-	assert.Equal(t, "", errResp.Message)
+	// Human-readable text lives in the RFC 9457 `detail`.
+	assert.True(t, errResp.Detail == "Invalid CEL syntax." || errResp.Detail == "Expression must return boolean.",
+		"Expected CEL syntax/type detail, got %s", errResp.Detail)
 }
 
 // TestActivateRule_2_5_5_RejectsActivationOfDeletedRule verifies DELETED rules cannot be activated.
@@ -3812,8 +3813,8 @@ func TestActivateRule_2_5_5_RejectsActivationOfDeletedRule(t *testing.T) {
 	errResp := testutil.ParseErrorResponse(t, respBody)
 	assert.Equal(t, "0347", errResp.Code)
 	assert.Equal(t, "Rule Not Found", errResp.Title)
-	// Human-readable text lives in the RFC 9457 `detail`; the retired `message` field is empty.
-	assert.Equal(t, "", errResp.Message)
+	// Human-readable text lives in the RFC 9457 `detail`.
+	assert.Equal(t, "Rule not found by ID.", errResp.Detail)
 }
 
 // TestActivateRule_2_5_6_RejectsInvalidUUIDInPath verifies path parameter validation.
@@ -3837,8 +3838,8 @@ func TestActivateRule_2_5_6_RejectsInvalidUUIDInPath(t *testing.T) {
 	errResp := testutil.ParseErrorResponse(t, respBody)
 	assert.Equal(t, "0065", errResp.Code) // Invalid path parameter (UUID format)
 	assert.Equal(t, "Invalid Path Parameter", errResp.Title)
-	// Human-readable text lives in the RFC 9457 `detail`; the retired `message` field is empty.
-	assert.Equal(t, "", errResp.Message)
+	// Human-readable text lives in the RFC 9457 `detail`.
+	assert.Contains(t, errResp.Detail, "path parameters are in an incorrect format")
 }
 
 // TestActivateRule_2_5_7_Returns404ForNonExistentRuleID verifies error handling for missing resource.
@@ -3862,8 +3863,8 @@ func TestActivateRule_2_5_7_Returns404ForNonExistentRuleID(t *testing.T) {
 	errResp := testutil.ParseErrorResponse(t, respBody)
 	assert.Equal(t, "0347", errResp.Code) // Rule not found
 	assert.Equal(t, "Rule Not Found", errResp.Title)
-	// Human-readable text lives in the RFC 9457 `detail`; the retired `message` field is empty.
-	assert.Equal(t, "", errResp.Message)
+	// Human-readable text lives in the RFC 9457 `detail`.
+	assert.Equal(t, "Rule not found by ID.", errResp.Detail)
 }
 
 // TestActivateRule_2_5_8_WithoutAuthenticationReturns401 verifies authentication requirement for activation.
@@ -4049,8 +4050,8 @@ func TestDeactivateRule_2_6_4_RejectsDeactivationOfDeletedRule(t *testing.T) {
 	errResp := testutil.ParseErrorResponse(t, respBody)
 	assert.Equal(t, "0347", errResp.Code)
 	assert.Equal(t, "Rule Not Found", errResp.Title)
-	// Human-readable text lives in the RFC 9457 `detail`; the retired `message` field is empty.
-	assert.Equal(t, "", errResp.Message)
+	// Human-readable text lives in the RFC 9457 `detail`.
+	assert.Equal(t, "Rule not found by ID.", errResp.Detail)
 }
 
 // TestDeactivateRule_2_6_5_RejectsInvalidUUIDInPath verifies path parameter validation.
@@ -4074,8 +4075,8 @@ func TestDeactivateRule_2_6_5_RejectsInvalidUUIDInPath(t *testing.T) {
 	errResp := testutil.ParseErrorResponse(t, respBody)
 	assert.Equal(t, "0065", errResp.Code) // Invalid path parameter (UUID format)
 	assert.Equal(t, "Invalid Path Parameter", errResp.Title)
-	// Human-readable text lives in the RFC 9457 `detail`; the retired `message` field is empty.
-	assert.Equal(t, "", errResp.Message)
+	// Human-readable text lives in the RFC 9457 `detail`.
+	assert.Contains(t, errResp.Detail, "path parameters are in an incorrect format")
 }
 
 // TestDeactivateRule_2_6_6_Returns404ForNonExistentRuleID verifies error handling for missing resource.
@@ -4099,8 +4100,8 @@ func TestDeactivateRule_2_6_6_Returns404ForNonExistentRuleID(t *testing.T) {
 	errResp := testutil.ParseErrorResponse(t, respBody)
 	assert.Equal(t, "0347", errResp.Code) // Rule not found
 	assert.Equal(t, "Rule Not Found", errResp.Title)
-	// Human-readable text lives in the RFC 9457 `detail`; the retired `message` field is empty.
-	assert.Equal(t, "", errResp.Message)
+	// Human-readable text lives in the RFC 9457 `detail`.
+	assert.Equal(t, "Rule not found by ID.", errResp.Detail)
 }
 
 // TestDeactivateRule_2_6_7_WithoutAuthenticationReturns401 verifies authentication requirement for deactivation.
@@ -4215,8 +4216,8 @@ func TestDeleteRule_2_7_3_RejectsDeletionOfActiveRule(t *testing.T) {
 	errResp := testutil.ParseErrorResponse(t, respBody)
 	assert.Equal(t, "0349", errResp.Code)
 	assert.Equal(t, "Rule Invalid Status", errResp.Title)
-	// Human-readable text lives in the RFC 9457 `detail`; the retired `message` field is empty.
-	assert.Equal(t, "", errResp.Message)
+	// Human-readable text lives in the RFC 9457 `detail`.
+	assert.Equal(t, "Invalid rule status transition.", errResp.Detail)
 }
 
 // TestDeleteRule_2_7_4_RejectsDeletionOfAlreadyDeletedRule verifies already-deleted rules return 404.
@@ -4245,8 +4246,8 @@ func TestDeleteRule_2_7_4_RejectsDeletionOfAlreadyDeletedRule(t *testing.T) {
 	errResp := testutil.ParseErrorResponse(t, respBody)
 	assert.Equal(t, "0347", errResp.Code) // Rule not found
 	assert.Equal(t, "Rule Not Found", errResp.Title)
-	// Human-readable text lives in the RFC 9457 `detail`; the retired `message` field is empty.
-	assert.Equal(t, "", errResp.Message)
+	// Human-readable text lives in the RFC 9457 `detail`.
+	assert.Equal(t, "Rule not found by ID.", errResp.Detail)
 }
 
 // TestDeleteRule_2_7_5_RejectsInvalidUUIDInPath verifies path parameter validation.
@@ -4270,8 +4271,8 @@ func TestDeleteRule_2_7_5_RejectsInvalidUUIDInPath(t *testing.T) {
 	errResp := testutil.ParseErrorResponse(t, respBody)
 	assert.Equal(t, "0065", errResp.Code) // Invalid path parameter (UUID format)
 	assert.Equal(t, "Invalid Path Parameter", errResp.Title)
-	// Human-readable text lives in the RFC 9457 `detail`; the retired `message` field is empty.
-	assert.Equal(t, "", errResp.Message)
+	// Human-readable text lives in the RFC 9457 `detail`.
+	assert.Contains(t, errResp.Detail, "path parameters are in an incorrect format")
 }
 
 // TestDeleteRule_2_7_6_Returns404ForNonExistentRuleID verifies error handling for missing resource.
@@ -4295,8 +4296,8 @@ func TestDeleteRule_2_7_6_Returns404ForNonExistentRuleID(t *testing.T) {
 	errResp := testutil.ParseErrorResponse(t, respBody)
 	assert.Equal(t, "0347", errResp.Code) // Rule not found
 	assert.Equal(t, "Rule Not Found", errResp.Title)
-	// Human-readable text lives in the RFC 9457 `detail`; the retired `message` field is empty.
-	assert.Equal(t, "", errResp.Message)
+	// Human-readable text lives in the RFC 9457 `detail`.
+	assert.Equal(t, "Rule not found by ID.", errResp.Detail)
 }
 
 // TestDeleteRule_2_7_7_WithoutAuthenticationReturns401 verifies authentication requirement for deletion.
@@ -4481,8 +4482,8 @@ func TestDraftRule_2_8_4_RejectsInvalidUUIDInPath(t *testing.T) {
 	errResp := testutil.ParseErrorResponse(t, respBody)
 	assert.Equal(t, "0065", errResp.Code) // Invalid path parameter (UUID format)
 	assert.Equal(t, "Invalid Path Parameter", errResp.Title)
-	// Human-readable text lives in the RFC 9457 `detail`; the retired `message` field is empty.
-	assert.Equal(t, "", errResp.Message)
+	// Human-readable text lives in the RFC 9457 `detail`.
+	assert.Contains(t, errResp.Detail, "path parameters are in an incorrect format")
 }
 
 // TestDraftRule_2_8_5_Returns404ForNonExistentRuleID verifies error handling for missing resource.
@@ -4506,8 +4507,8 @@ func TestDraftRule_2_8_5_Returns404ForNonExistentRuleID(t *testing.T) {
 	errResp := testutil.ParseErrorResponse(t, respBody)
 	assert.Equal(t, "0347", errResp.Code) // Rule not found
 	assert.Equal(t, "Rule Not Found", errResp.Title)
-	// Human-readable text lives in the RFC 9457 `detail`; the retired `message` field is empty.
-	assert.Equal(t, "", errResp.Message)
+	// Human-readable text lives in the RFC 9457 `detail`.
+	assert.Equal(t, "Rule not found by ID.", errResp.Detail)
 }
 
 // TestDraftRule_2_8_6_WithoutAuthenticationReturns401 verifies authentication requirement for draft.
@@ -4566,6 +4567,6 @@ func TestDraftRule_2_8_7_RejectsDraftOfDeletedRule(t *testing.T) {
 	errResp := testutil.ParseErrorResponse(t, respBody)
 	assert.Equal(t, "0347", errResp.Code) // Rule not found
 	assert.Equal(t, "Rule Not Found", errResp.Title)
-	// Human-readable text lives in the RFC 9457 `detail`; the retired `message` field is empty.
-	assert.Equal(t, "", errResp.Message)
+	// Human-readable text lives in the RFC 9457 `detail`.
+	assert.Equal(t, "Rule not found by ID.", errResp.Detail)
 }

--- a/components/tracer/tests/integration/02_rules_scope_filter_test.go
+++ b/components/tracer/tests/integration/02_rules_scope_filter_test.go
@@ -352,8 +352,11 @@ func TestListRules_2_4_6_InvalidScopeFiltersReturnError(t *testing.T) {
 			errResp := testutil.ParseErrorResponse(t, respBody)
 			assert.Equal(t, tc.expectCode, errResp.Code, "Error code mismatch")
 			assert.Equal(t, "Invalid Query Parameter", errResp.Title, "Invalid scope filter should surface as Invalid Query Parameter")
-			// message field is retired under RFC 9457; the invalid-field text now lives in `detail`.
-			assert.Empty(t, errResp.Message, "message retired; RFC 9457 detail should mention %s", tc.expectMsg)
+			// message field is retired under RFC 9457; the human-readable text now lives in `detail`.
+			// 0082 carries a generic query-parameter format message (it does not echo the specific field).
+			assert.Empty(t, errResp.Message, "message retired; RFC 9457 detail carries the human text for %s", tc.expectMsg)
+			assert.Contains(t, errResp.Detail, "One or more query parameters are in an incorrect format",
+				"RFC 9457 detail should carry the invalid query-parameter message for %s", tc.expectMsg)
 		})
 	}
 }

--- a/components/tracer/tests/integration/02_rules_scope_filter_test.go
+++ b/components/tracer/tests/integration/02_rules_scope_filter_test.go
@@ -351,7 +351,9 @@ func TestListRules_2_4_6_InvalidScopeFiltersReturnError(t *testing.T) {
 
 			errResp := testutil.ParseErrorResponse(t, respBody)
 			assert.Equal(t, tc.expectCode, errResp.Code, "Error code mismatch")
-			assert.Contains(t, errResp.Message, tc.expectMsg, "Error message should mention the invalid field")
+			assert.Equal(t, "Invalid Query Parameter", errResp.Title, "Invalid scope filter should surface as Invalid Query Parameter")
+			// message field is retired under RFC 9457; the invalid-field text now lives in `detail`.
+			assert.Empty(t, errResp.Message, "message retired; RFC 9457 detail should mention %s", tc.expectMsg)
 		})
 	}
 }

--- a/components/tracer/tests/integration/03_limits_management_test.go
+++ b/components/tracer/tests/integration/03_limits_management_test.go
@@ -1930,7 +1930,7 @@ func TestLimits_CreateLimit_ScopeWithoutFields_BadRequest(t *testing.T) {
 	errResp := testutil.ParseErrorResponse(t, body)
 	assert.Equal(t, "0009", errResp.Code, "Error code should be 0009 (missing fields in request)")
 	assert.Equal(t, "Validation Error", errResp.Title, "Error title should be 'Validation Error'")
-	assert.Equal(t, "scope at index 0 must have at least one field set", tracerProblemDetail(t, body), "Error detail should indicate scope validation failure")
+	assert.Equal(t, "scope at index 0 must have at least one field set", testutil.ParseErrorResponse(t, body).Detail, "Error detail should indicate scope validation failure")
 }
 
 // =============================================================================
@@ -2252,7 +2252,7 @@ func TestLimits_UpdateLimit_EmptyBody_ReturnsTRC0002(t *testing.T) {
 	// Code 0183 (Nothing to Update) for an empty object with no fields to update
 	assert.Equal(t, "0183", errResp.Code, "Expected 0183 for empty JSON body (no fields to update)")
 	assert.Equal(t, "Nothing to Update", errResp.Title, "Error title should be 'Nothing to Update'")
-	assert.Equal(t, "No updatable fields were provided. Please include at least one field to update.", tracerProblemDetail(t, respBody), "Error detail should indicate at least one field required")
+	assert.Equal(t, "No updatable fields were provided. Please include at least one field to update.", testutil.ParseErrorResponse(t, respBody).Detail, "Error detail should indicate at least one field required")
 
 	// Re-fetch the limit after the failed PATCH and verify state is unchanged
 	getReq2, err := http.NewRequest("GET", baseURL+"/v1/limits/"+limitID, nil)
@@ -3781,7 +3781,7 @@ func TestLimits_UpdateLimit_ImmutableFields_ReturnsTRC0138(t *testing.T) {
 
 			// Assert error detail mentions the immutable field(s) that cannot be modified (case-insensitive).
 			// The detail lists all immutable fields (limitType, currency), so any target key is present.
-			detail := tracerProblemDetail(t, respBody)
+			detail := testutil.ParseErrorResponse(t, respBody).Detail
 			if len(tc.updateBody) > 1 {
 				// Check that detail contains at least one of the updateBody keys
 				detailLower := strings.ToLower(detail)

--- a/components/tracer/tests/integration/03_limits_management_test.go
+++ b/components/tracer/tests/integration/03_limits_management_test.go
@@ -1358,8 +1358,8 @@ func TestLimits_DeactivateLimit_FromDraft(t *testing.T) {
 	defer resp.Body.Close()
 
 	// DRAFT → INACTIVE is not a valid transition
-	assert.Equal(t, http.StatusBadRequest, resp.StatusCode,
-		"Deactivate from DRAFT should return 400 - invalid transition")
+	assert.Equal(t, http.StatusUnprocessableEntity, resp.StatusCode,
+		"Deactivate from DRAFT should return 422 - invalid transition")
 }
 
 // TestLimits_DeactivateLimit_FromActive tests deactivating an ACTIVE limit (3.7.1)
@@ -1926,11 +1926,11 @@ func TestLimits_CreateLimit_ScopeWithoutFields_BadRequest(t *testing.T) {
 
 	assert.Equal(t, http.StatusBadRequest, resp.StatusCode, "Scope without fields should return 400 Bad Request")
 
-	// Verify error response structure (code, title, message)
+	// Verify error response structure (code, title, detail)
 	errResp := testutil.ParseErrorResponse(t, body)
-	assert.Equal(t, "0053", errResp.Code, "Error code should be TRC-0001")
+	assert.Equal(t, "0009", errResp.Code, "Error code should be 0009 (missing fields in request)")
 	assert.Equal(t, "Validation Error", errResp.Title, "Error title should be 'Validation Error'")
-	assert.Equal(t, "scope at index 0 must have at least one field set", errResp.Message, "Error message should indicate scope validation failure")
+	assert.Equal(t, "scope at index 0 must have at least one field set", tracerProblemDetail(t, body), "Error detail should indicate scope validation failure")
 }
 
 // =============================================================================
@@ -2062,9 +2062,9 @@ func TestLimits_UpdateLimit_UpdatesScopes(t *testing.T) {
 }
 
 // TestLimits_UpdateLimit_BlocksLimitTypeChange (3.4.5)
-// Verifies that limitType field is silently ignored on PATCH.
-// Note: The API silently ignores immutable fields rather than returning an error.
-// When only immutable fields are sent, it returns 400 "At least one field must be provided".
+// Verifies that limitType is immutable on PATCH.
+// The API rejects a limitType change with 422 (code 0380, "Limit Immutable Field")
+// and leaves the stored limitType unchanged.
 func TestLimits_UpdateLimit_BlocksLimitTypeChange(t *testing.T) {
 	apiKey := testutil.GetAPIKey()
 	baseURL := testutil.GetBaseURL()
@@ -2092,8 +2092,8 @@ func TestLimits_UpdateLimit_BlocksLimitTypeChange(t *testing.T) {
 	require.NoError(t, err)
 	defer resp.Body.Close()
 
-	// API returns 400 because limitType is silently ignored, leaving no valid fields
-	assert.Equal(t, http.StatusBadRequest, resp.StatusCode, "Changing limitType should return 400")
+	// API rejects the immutable limitType change with 422 (Limit Immutable Field)
+	assert.Equal(t, http.StatusUnprocessableEntity, resp.StatusCode, "Changing limitType should return 422")
 
 	// Verify limitType was not changed by fetching the limit
 	getReq, err := http.NewRequest("GET", baseURL+"/v1/limits/"+limitID, nil)
@@ -2115,9 +2115,9 @@ func TestLimits_UpdateLimit_BlocksLimitTypeChange(t *testing.T) {
 }
 
 // TestLimits_UpdateLimit_BlocksCurrencyChange (3.4.6)
-// Verifies that currency field is silently ignored on PATCH.
-// Note: The API silently ignores immutable fields rather than returning an error.
-// When only immutable fields are sent, it returns 400 "At least one field must be provided".
+// Verifies that currency is immutable on PATCH.
+// The API rejects a currency change with 422 (code 0380, "Limit Immutable Field")
+// and leaves the stored currency unchanged.
 func TestLimits_UpdateLimit_BlocksCurrencyChange(t *testing.T) {
 	apiKey := testutil.GetAPIKey()
 	baseURL := testutil.GetBaseURL()
@@ -2145,8 +2145,8 @@ func TestLimits_UpdateLimit_BlocksCurrencyChange(t *testing.T) {
 	require.NoError(t, err)
 	defer resp.Body.Close()
 
-	// API returns 400 because currency is silently ignored, leaving no valid fields
-	assert.Equal(t, http.StatusBadRequest, resp.StatusCode, "Changing currency should return 400")
+	// API rejects the immutable currency change with 422 (Limit Immutable Field)
+	assert.Equal(t, http.StatusUnprocessableEntity, resp.StatusCode, "Changing currency should return 422")
 
 	// Verify currency was not changed by fetching the limit
 	getReq, err := http.NewRequest("GET", baseURL+"/v1/limits/"+limitID, nil)
@@ -2249,10 +2249,10 @@ func TestLimits_UpdateLimit_EmptyBody_ReturnsTRC0002(t *testing.T) {
 	// Parse and validate error response
 	errResp := testutil.ParseErrorResponse(t, respBody)
 
-	// TRC-0002 for missing required fields (empty object has no fields to update)
-	assert.Equal(t, "0009", errResp.Code, "Expected TRC-0002 for empty JSON body (no fields to update)")
-	assert.Equal(t, "Validation Error", errResp.Title, "Error title should be 'Validation Error'")
-	assert.Equal(t, "At least one field must be provided for update", errResp.Message, "Error message should indicate at least one field required")
+	// Code 0183 (Nothing to Update) for an empty object with no fields to update
+	assert.Equal(t, "0183", errResp.Code, "Expected 0183 for empty JSON body (no fields to update)")
+	assert.Equal(t, "Nothing to Update", errResp.Title, "Error title should be 'Nothing to Update'")
+	assert.Equal(t, "No updatable fields were provided. Please include at least one field to update.", tracerProblemDetail(t, respBody), "Error detail should indicate at least one field required")
 
 	// Re-fetch the limit after the failed PATCH and verify state is unchanged
 	getReq2, err := http.NewRequest("GET", baseURL+"/v1/limits/"+limitID, nil)
@@ -2504,8 +2504,8 @@ func TestLimits_DeleteLimit_ActiveLimit(t *testing.T) {
 	defer resp.Body.Close()
 
 	// ACTIVE limits cannot be deleted - must deactivate first
-	assert.Equal(t, http.StatusBadRequest, resp.StatusCode,
-		"Delete ACTIVE limit should return 400 - must deactivate first")
+	assert.Equal(t, http.StatusUnprocessableEntity, resp.StatusCode,
+		"Delete ACTIVE limit should return 422 - must deactivate first")
 }
 
 // TestLimits_DeleteLimit_InactiveLimit (3.8.1c)
@@ -3683,16 +3683,14 @@ func TestLimits_GetLimit_ResponseFields_Complete(t *testing.T) {
 // ImmutableField Validation Tests
 // =============================================================================
 // These tests verify that attempting to change immutable fields (limitType, currency)
-// via PATCH returns HTTP 400 with error code TRC-0138 (ImmutableField).
+// via PATCH returns HTTP 422 with error code 0380 ("Limit Immutable Field").
 //
-// Per API Design doc:
-// | 400 | ImmutableField | Attempted to change limitType or currency |
-//
-// The API now returns TRC-0138 when immutable fields are included in request body.
+// Immutable-field changes are an unprocessable business rule:
+// | 422 | Limit Immutable Field | Attempted to change limitType or currency |
 // =============================================================================
 
 // TestLimits_UpdateLimit_ImmutableFields_ReturnsTRC0138 verifies that attempting to change
-// immutable fields (limitType, currency) returns HTTP 400 with error code TRC-0138.
+// immutable fields (limitType, currency) returns HTTP 422 with error code 0380.
 func TestLimits_UpdateLimit_ImmutableFields_ReturnsTRC0138(t *testing.T) {
 	apiKey := testutil.GetAPIKey()
 	baseURL := testutil.GetBaseURL()
@@ -3763,45 +3761,44 @@ func TestLimits_UpdateLimit_ImmutableFields_ReturnsTRC0138(t *testing.T) {
 			respBody, err := io.ReadAll(resp.Body)
 			require.NoError(t, err)
 
-			// Assert HTTP 400 Bad Request
-			assert.Equal(t, http.StatusBadRequest, resp.StatusCode,
-				"[%s] %s should return 400 Bad Request, got %d: %s",
+			// Assert HTTP 422 Unprocessable Entity
+			assert.Equal(t, http.StatusUnprocessableEntity, resp.StatusCode,
+				"[%s] %s should return 422 Unprocessable Entity, got %d: %s",
 				tc.name, tc.description, resp.StatusCode, string(respBody))
 
 			// Parse and validate error response
 			errResp := testutil.ParseErrorResponse(t, respBody)
 
-			// Assert error code is TRC-0138 (ImmutableField)
+			// Assert error code is 0380 (Limit Immutable Field)
 			assert.Equal(t, "0380", errResp.Code,
-				"[%s] Expected error code TRC-0138 (ImmutableField), got %s",
+				"[%s] Expected error code 0380 (Limit Immutable Field), got %s",
 				tc.name, errResp.Code)
 
 			// Assert error title
-			// Accept either "Immutable Field" or "Validation Error" as valid titles
-			assert.True(t,
-				errResp.Title == "Immutable Field" || errResp.Title == "Validation Error",
-				"[%s] Expected error title 'Immutable Field' or 'Validation Error', got '%s'",
+			assert.Equal(t, "Limit Immutable Field", errResp.Title,
+				"[%s] Expected error title 'Limit Immutable Field', got '%s'",
 				tc.name, errResp.Title)
 
-			// Assert error message mentions the field that cannot be modified (case-insensitive)
-			// For cases with multiple immutable fields, the server may report any of them
+			// Assert error detail mentions the immutable field(s) that cannot be modified (case-insensitive).
+			// The detail lists all immutable fields (limitType, currency), so any target key is present.
+			detail := tracerProblemDetail(t, respBody)
 			if len(tc.updateBody) > 1 {
-				// Check that message contains at least one of the updateBody keys
-				msgLower := strings.ToLower(errResp.Message)
+				// Check that detail contains at least one of the updateBody keys
+				detailLower := strings.ToLower(detail)
 				foundField := false
 				for key := range tc.updateBody {
-					if strings.Contains(msgLower, strings.ToLower(key)) {
+					if strings.Contains(detailLower, strings.ToLower(key)) {
 						foundField = true
 						break
 					}
 				}
 				assert.True(t, foundField,
-					"[%s] Error message should mention at least one immutable field from %v, got '%s'",
-					tc.name, tc.updateBody, errResp.Message)
+					"[%s] Error detail should mention at least one immutable field from %v, got '%s'",
+					tc.name, tc.updateBody, detail)
 			} else {
-				assert.Contains(t, strings.ToLower(errResp.Message), strings.ToLower(tc.expectedField),
-					"[%s] Error message should mention '%s' field, got '%s'",
-					tc.name, tc.expectedField, errResp.Message)
+				assert.Contains(t, strings.ToLower(detail), strings.ToLower(tc.expectedField),
+					"[%s] Error detail should mention '%s' field, got '%s'",
+					tc.name, tc.expectedField, detail)
 			}
 
 			// Verify the limit was NOT modified by fetching it
@@ -3930,7 +3927,7 @@ func TestLimits_DraftLimit_RejectsActiveLimit(t *testing.T) {
 	require.NoError(t, err)
 	defer resp.Body.Close()
 
-	assert.Equal(t, http.StatusBadRequest, resp.StatusCode, "ACTIVE → DRAFT should be rejected")
+	assert.Equal(t, http.StatusUnprocessableEntity, resp.StatusCode, "ACTIVE → DRAFT should be rejected")
 }
 
 func TestLimits_DraftLimit_RejectsDeletedLimit(t *testing.T) {

--- a/components/tracer/tests/integration/04_context_objects_test.go
+++ b/components/tracer/tests/integration/04_context_objects_test.go
@@ -206,7 +206,7 @@ func TestValidation_ContextObjects_MissingAccount_ReturnsError(t *testing.T) {
 	errResp := testutil.ParseErrorResponse(t, respBody)
 	assert.Equal(t, "0420", errResp.Code, "Expected 0420 for missing account")
 	assert.Equal(t, "Validation Account Required", errResp.Title, "Error title should match the account error")
-	assert.Equal(t, "Account is required.", tracerProblemDetail(t, respBody), "Error detail should match exactly")
+	assert.Equal(t, "Account is required.", testutil.ParseErrorResponse(t, respBody).Detail, "Error detail should match exactly")
 }
 
 // TestValidation_SegmentContext_Structure verifies SegmentContext parsing.
@@ -579,7 +579,7 @@ func TestValidation_AccountContext_MissingAccountId(t *testing.T) {
 	errorResp := testutil.ParseErrorResponse(t, respBody)
 	assert.Equal(t, "0420", errorResp.Code, "Error code should be 0420")
 	assert.Equal(t, "Validation Account Required", errorResp.Title, "Error title should match the account error")
-	assert.Equal(t, "Account is required.", tracerProblemDetail(t, respBody), "Error detail should match exactly")
+	assert.Equal(t, "Account is required.", testutil.ParseErrorResponse(t, respBody).Detail, "Error detail should match exactly")
 }
 
 // TestValidation_SegmentContext_Minimal verifies segment with only segmentId (name optional).

--- a/components/tracer/tests/integration/04_context_objects_test.go
+++ b/components/tracer/tests/integration/04_context_objects_test.go
@@ -204,9 +204,9 @@ func TestValidation_ContextObjects_MissingAccount_ReturnsError(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, resp.StatusCode, "Response: %s", string(respBody))
 
 	errResp := testutil.ParseErrorResponse(t, respBody)
-	assert.Equal(t, "0420", errResp.Code, "Expected TRC-0227 for missing account")
-	assert.Equal(t, "Validation Error", errResp.Title, "Error title should be Validation Error")
-	assert.Equal(t, "account is required", errResp.Message, "Error message should match exactly")
+	assert.Equal(t, "0420", errResp.Code, "Expected 0420 for missing account")
+	assert.Equal(t, "Validation Account Required", errResp.Title, "Error title should match the account error")
+	assert.Equal(t, "Account is required.", tracerProblemDetail(t, respBody), "Error detail should match exactly")
 }
 
 // TestValidation_SegmentContext_Structure verifies SegmentContext parsing.
@@ -577,9 +577,9 @@ func TestValidation_AccountContext_MissingAccountId(t *testing.T) {
 		"Missing accountId should return 400 Bad Request")
 
 	errorResp := testutil.ParseErrorResponse(t, respBody)
-	assert.Equal(t, "0420", errorResp.Code, "Error code should be TRC-0227")
-	assert.Equal(t, "Validation Error", errorResp.Title, "Error title should be Validation Error")
-	assert.Equal(t, "account is required", errorResp.Message, "Error message should match exactly")
+	assert.Equal(t, "0420", errorResp.Code, "Error code should be 0420")
+	assert.Equal(t, "Validation Account Required", errorResp.Title, "Error title should match the account error")
+	assert.Equal(t, "Account is required.", tracerProblemDetail(t, respBody), "Error detail should match exactly")
 }
 
 // TestValidation_SegmentContext_Minimal verifies segment with only segmentId (name optional).

--- a/components/tracer/tests/integration/04_error_handling_test.go
+++ b/components/tracer/tests/integration/04_error_handling_test.go
@@ -21,6 +21,22 @@ import (
 	"github.com/LerianStudio/midaz/v4/components/tracer/internal/testutil"
 )
 
+// tracerProblemDetail extracts the RFC 9457 problem+json `detail` field from an
+// error response body. The migrated error envelope carries the human-readable
+// message in `detail`; testutil.ErrorResponse only exposes code/title, so tests
+// parse `detail` directly. Shared across the 03_/04_ integration test files.
+func tracerProblemDetail(t *testing.T, body []byte) string {
+	t.Helper()
+
+	var problem struct {
+		Detail string `json:"detail"`
+	}
+
+	require.NoError(t, json.Unmarshal(body, &problem), "Failed to parse problem+json detail: %s", string(body))
+
+	return problem.Detail
+}
+
 // =============================================================================
 // Error Handling Tests - POST /v1/validations
 // =============================================================================
@@ -89,9 +105,9 @@ func TestValidation_ErrorHandling_MissingRequestId(t *testing.T) {
 		"Missing requestId should return 400 Bad Request")
 
 	errorResp := testutil.ParseErrorResponse(t, respBody)
-	assert.Equal(t, "0413", errorResp.Code, "Error code should be TRC-0220")
-	assert.Equal(t, "Validation Error", errorResp.Title, "Error title should be Validation Error")
-	assert.Equal(t, "requestId is required", errorResp.Message, "Error message should match exactly")
+	assert.Equal(t, "0413", errorResp.Code, "Error code should be 0413")
+	assert.Equal(t, "Validation Request IDRequired", errorResp.Title, "Error title should match the request-id error")
+	assert.Equal(t, "RequestId is required.", tracerProblemDetail(t, respBody), "Error detail should match exactly")
 }
 
 // TestValidation_ErrorHandling_MissingAmount verifies 400 when amount is missing.
@@ -135,9 +151,9 @@ func TestValidation_ErrorHandling_MissingAmount(t *testing.T) {
 		"Missing/zero amount should return 400 Bad Request")
 
 	errorResp := testutil.ParseErrorResponse(t, respBody)
-	assert.Equal(t, "0415", errorResp.Code, "Error code should be TRC-0222")
-	assert.Equal(t, "Validation Error", errorResp.Title, "Error title should be Validation Error")
-	assert.Equal(t, "amount must be positive", errorResp.Message, "Error message should match exactly")
+	assert.Equal(t, "0415", errorResp.Code, "Error code should be 0415")
+	assert.Equal(t, "Validation Amount Non Positive", errorResp.Title, "Error title should match the amount error")
+	assert.Equal(t, "Amount must be positive.", tracerProblemDetail(t, respBody), "Error detail should match exactly")
 }
 
 // TestValidation_ErrorHandling_MissingCurrency verifies 400 when currency is missing.
@@ -181,9 +197,9 @@ func TestValidation_ErrorHandling_MissingCurrency(t *testing.T) {
 		"Missing currency should return 400 Bad Request")
 
 	errorResp := testutil.ParseErrorResponse(t, respBody)
-	assert.Equal(t, "0416", errorResp.Code, "Error code should be TRC-0223")
-	assert.Equal(t, "Validation Error", errorResp.Title, "Error title should be Validation Error")
-	assert.Equal(t, "currency is required", errorResp.Message, "Error message should match exactly")
+	assert.Equal(t, "0416", errorResp.Code, "Error code should be 0416")
+	assert.Equal(t, "Validation Currency Required", errorResp.Title, "Error title should match the currency error")
+	assert.Equal(t, "Currency is required.", tracerProblemDetail(t, respBody), "Error detail should match exactly")
 }
 
 // TestValidation_ErrorHandling_MissingTransactionType verifies 400 when transactionType is missing.
@@ -227,9 +243,9 @@ func TestValidation_ErrorHandling_MissingTransactionType(t *testing.T) {
 		"Missing transactionType should return 400 Bad Request")
 
 	errorResp := testutil.ParseErrorResponse(t, respBody)
-	assert.Equal(t, "0414", errorResp.Code, "Error code should be TRC-0221")
-	assert.Equal(t, "Validation Error", errorResp.Title, "Error title should be Validation Error")
-	assert.Equal(t, "transactionType must be one of [CARD, WIRE, PIX, CRYPTO]", errorResp.Message, "Error message should match exactly")
+	assert.Equal(t, "0414", errorResp.Code, "Error code should be 0414")
+	assert.Equal(t, "Validation Invalid Transaction Type", errorResp.Title, "Error title should match the transaction-type error")
+	assert.Equal(t, "Invalid transactionType.", tracerProblemDetail(t, respBody), "Error detail should match exactly")
 }
 
 // TestValidation_ErrorHandling_MissingTransactionTimestamp verifies 400 when transactionTimestamp is missing.
@@ -273,9 +289,9 @@ func TestValidation_ErrorHandling_MissingTransactionTimestamp(t *testing.T) {
 		"Missing transactionTimestamp should return 400 Bad Request")
 
 	errorResp := testutil.ParseErrorResponse(t, respBody)
-	assert.Equal(t, "0418", errorResp.Code, "Error code should be TRC-0225")
-	assert.Equal(t, "Validation Error", errorResp.Title, "Error title should be Validation Error")
-	assert.Equal(t, "transactionTimestamp is required", errorResp.Message, "Error message should match exactly")
+	assert.Equal(t, "0418", errorResp.Code, "Error code should be 0418")
+	assert.Equal(t, "Validation Timestamp Required", errorResp.Title, "Error title should match the timestamp error")
+	assert.Equal(t, "Timestamp is required.", tracerProblemDetail(t, respBody), "Error detail should match exactly")
 }
 
 // TestValidation_ErrorHandling_InvalidAmount_ZeroValue verifies 400 when amount is zero.
@@ -319,9 +335,9 @@ func TestValidation_ErrorHandling_InvalidAmount_ZeroValue(t *testing.T) {
 		"Amount = 0 should return 400 Bad Request")
 
 	errorResp := testutil.ParseErrorResponse(t, respBody)
-	assert.Equal(t, "0415", errorResp.Code, "Error code should be TRC-0222")
-	assert.Equal(t, "Validation Error", errorResp.Title, "Error title should be Validation Error")
-	assert.Equal(t, "amount must be positive", errorResp.Message, "Error message should match exactly")
+	assert.Equal(t, "0415", errorResp.Code, "Error code should be 0415")
+	assert.Equal(t, "Validation Amount Non Positive", errorResp.Title, "Error title should match the amount error")
+	assert.Equal(t, "Amount must be positive.", tracerProblemDetail(t, respBody), "Error detail should match exactly")
 }
 
 // TestValidation_ErrorHandling_InvalidAmount_NegativeValue verifies 400 when amount is negative.
@@ -365,9 +381,9 @@ func TestValidation_ErrorHandling_InvalidAmount_NegativeValue(t *testing.T) {
 		"Negative amount should return 400 Bad Request")
 
 	errorResp := testutil.ParseErrorResponse(t, respBody)
-	assert.Equal(t, "0415", errorResp.Code, "Error code should be TRC-0222")
-	assert.Equal(t, "Validation Error", errorResp.Title, "Error title should be Validation Error")
-	assert.Equal(t, "amount must be positive", errorResp.Message, "Error message should match exactly")
+	assert.Equal(t, "0415", errorResp.Code, "Error code should be 0415")
+	assert.Equal(t, "Validation Amount Non Positive", errorResp.Title, "Error title should match the amount error")
+	assert.Equal(t, "Amount must be positive.", tracerProblemDetail(t, respBody), "Error detail should match exactly")
 }
 
 // TestValidation_ErrorHandling_InvalidAmount_StringValue verifies 400 when amount is string instead of integer.
@@ -409,9 +425,9 @@ func TestValidation_ErrorHandling_InvalidAmount_StringValue(t *testing.T) {
 		"String value for amount should return 400 Bad Request")
 
 	errorResp := testutil.ParseErrorResponse(t, respBody)
-	assert.Equal(t, "0047", errorResp.Code, "Error code should be TRC-0003 for type mismatch")
+	assert.Equal(t, "0094", errorResp.Code, "Error code should be 0094 (invalid request body) for type mismatch")
 	assert.Equal(t, "Bad Request", errorResp.Title, "Error title should be Bad Request")
-	assert.Contains(t, errorResp.Message, "invalid", "Error message should mention invalid request")
+	assert.Contains(t, tracerProblemDetail(t, respBody), "invalid", "Error detail should mention invalid request")
 }
 
 // TestValidation_ErrorHandling_InvalidCurrency_MixedCase verifies strict uppercase validation for currency.
@@ -465,9 +481,9 @@ func TestValidation_ErrorHandling_InvalidCurrency_MixedCase(t *testing.T) {
 				"Non-uppercase currency '%s' should return 400 Bad Request", tc.currency)
 
 			errorResp := testutil.ParseErrorResponse(t, respBody)
-			assert.Equal(t, "0417", errorResp.Code, "Error code should be TRC-0224 for invalid currency")
-			assert.Equal(t, "Validation Error", errorResp.Title, "Error title should be Validation Error")
-			assert.Equal(t, "currency must be valid ISO 4217 code (e.g., BRL, USD)", errorResp.Message, "Error message should match exactly")
+			assert.Equal(t, "0417", errorResp.Code, "Error code should be 0417 for invalid currency")
+			assert.Equal(t, "Validation Invalid Currency", errorResp.Title, "Error title should match the currency error")
+			assert.Equal(t, "Currency must be valid ISO 4217.", tracerProblemDetail(t, respBody), "Error detail should match exactly")
 		})
 	}
 }

--- a/components/tracer/tests/integration/04_error_handling_test.go
+++ b/components/tracer/tests/integration/04_error_handling_test.go
@@ -21,22 +21,6 @@ import (
 	"github.com/LerianStudio/midaz/v4/components/tracer/internal/testutil"
 )
 
-// tracerProblemDetail extracts the RFC 9457 problem+json `detail` field from an
-// error response body. The migrated error envelope carries the human-readable
-// message in `detail`; testutil.ErrorResponse only exposes code/title, so tests
-// parse `detail` directly. Shared across the 03_/04_ integration test files.
-func tracerProblemDetail(t *testing.T, body []byte) string {
-	t.Helper()
-
-	var problem struct {
-		Detail string `json:"detail"`
-	}
-
-	require.NoError(t, json.Unmarshal(body, &problem), "Failed to parse problem+json detail: %s", string(body))
-
-	return problem.Detail
-}
-
 // =============================================================================
 // Error Handling Tests - POST /v1/validations
 // =============================================================================
@@ -107,7 +91,7 @@ func TestValidation_ErrorHandling_MissingRequestId(t *testing.T) {
 	errorResp := testutil.ParseErrorResponse(t, respBody)
 	assert.Equal(t, "0413", errorResp.Code, "Error code should be 0413")
 	assert.Equal(t, "Validation Request IDRequired", errorResp.Title, "Error title should match the request-id error")
-	assert.Equal(t, "RequestId is required.", tracerProblemDetail(t, respBody), "Error detail should match exactly")
+	assert.Equal(t, "RequestId is required.", testutil.ParseErrorResponse(t, respBody).Detail, "Error detail should match exactly")
 }
 
 // TestValidation_ErrorHandling_MissingAmount verifies 400 when amount is missing.
@@ -153,7 +137,7 @@ func TestValidation_ErrorHandling_MissingAmount(t *testing.T) {
 	errorResp := testutil.ParseErrorResponse(t, respBody)
 	assert.Equal(t, "0415", errorResp.Code, "Error code should be 0415")
 	assert.Equal(t, "Validation Amount Non Positive", errorResp.Title, "Error title should match the amount error")
-	assert.Equal(t, "Amount must be positive.", tracerProblemDetail(t, respBody), "Error detail should match exactly")
+	assert.Equal(t, "Amount must be positive.", testutil.ParseErrorResponse(t, respBody).Detail, "Error detail should match exactly")
 }
 
 // TestValidation_ErrorHandling_MissingCurrency verifies 400 when currency is missing.
@@ -199,7 +183,7 @@ func TestValidation_ErrorHandling_MissingCurrency(t *testing.T) {
 	errorResp := testutil.ParseErrorResponse(t, respBody)
 	assert.Equal(t, "0416", errorResp.Code, "Error code should be 0416")
 	assert.Equal(t, "Validation Currency Required", errorResp.Title, "Error title should match the currency error")
-	assert.Equal(t, "Currency is required.", tracerProblemDetail(t, respBody), "Error detail should match exactly")
+	assert.Equal(t, "Currency is required.", testutil.ParseErrorResponse(t, respBody).Detail, "Error detail should match exactly")
 }
 
 // TestValidation_ErrorHandling_MissingTransactionType verifies 400 when transactionType is missing.
@@ -245,7 +229,7 @@ func TestValidation_ErrorHandling_MissingTransactionType(t *testing.T) {
 	errorResp := testutil.ParseErrorResponse(t, respBody)
 	assert.Equal(t, "0414", errorResp.Code, "Error code should be 0414")
 	assert.Equal(t, "Validation Invalid Transaction Type", errorResp.Title, "Error title should match the transaction-type error")
-	assert.Equal(t, "Invalid transactionType.", tracerProblemDetail(t, respBody), "Error detail should match exactly")
+	assert.Equal(t, "Invalid transactionType.", testutil.ParseErrorResponse(t, respBody).Detail, "Error detail should match exactly")
 }
 
 // TestValidation_ErrorHandling_MissingTransactionTimestamp verifies 400 when transactionTimestamp is missing.
@@ -291,7 +275,7 @@ func TestValidation_ErrorHandling_MissingTransactionTimestamp(t *testing.T) {
 	errorResp := testutil.ParseErrorResponse(t, respBody)
 	assert.Equal(t, "0418", errorResp.Code, "Error code should be 0418")
 	assert.Equal(t, "Validation Timestamp Required", errorResp.Title, "Error title should match the timestamp error")
-	assert.Equal(t, "Timestamp is required.", tracerProblemDetail(t, respBody), "Error detail should match exactly")
+	assert.Equal(t, "Timestamp is required.", testutil.ParseErrorResponse(t, respBody).Detail, "Error detail should match exactly")
 }
 
 // TestValidation_ErrorHandling_InvalidAmount_ZeroValue verifies 400 when amount is zero.
@@ -337,7 +321,7 @@ func TestValidation_ErrorHandling_InvalidAmount_ZeroValue(t *testing.T) {
 	errorResp := testutil.ParseErrorResponse(t, respBody)
 	assert.Equal(t, "0415", errorResp.Code, "Error code should be 0415")
 	assert.Equal(t, "Validation Amount Non Positive", errorResp.Title, "Error title should match the amount error")
-	assert.Equal(t, "Amount must be positive.", tracerProblemDetail(t, respBody), "Error detail should match exactly")
+	assert.Equal(t, "Amount must be positive.", testutil.ParseErrorResponse(t, respBody).Detail, "Error detail should match exactly")
 }
 
 // TestValidation_ErrorHandling_InvalidAmount_NegativeValue verifies 400 when amount is negative.
@@ -383,7 +367,7 @@ func TestValidation_ErrorHandling_InvalidAmount_NegativeValue(t *testing.T) {
 	errorResp := testutil.ParseErrorResponse(t, respBody)
 	assert.Equal(t, "0415", errorResp.Code, "Error code should be 0415")
 	assert.Equal(t, "Validation Amount Non Positive", errorResp.Title, "Error title should match the amount error")
-	assert.Equal(t, "Amount must be positive.", tracerProblemDetail(t, respBody), "Error detail should match exactly")
+	assert.Equal(t, "Amount must be positive.", testutil.ParseErrorResponse(t, respBody).Detail, "Error detail should match exactly")
 }
 
 // TestValidation_ErrorHandling_InvalidAmount_StringValue verifies 400 when amount is string instead of integer.
@@ -427,7 +411,7 @@ func TestValidation_ErrorHandling_InvalidAmount_StringValue(t *testing.T) {
 	errorResp := testutil.ParseErrorResponse(t, respBody)
 	assert.Equal(t, "0094", errorResp.Code, "Error code should be 0094 (invalid request body) for type mismatch")
 	assert.Equal(t, "Bad Request", errorResp.Title, "Error title should be Bad Request")
-	assert.Contains(t, tracerProblemDetail(t, respBody), "invalid", "Error detail should mention invalid request")
+	assert.Contains(t, testutil.ParseErrorResponse(t, respBody).Detail, "invalid", "Error detail should mention invalid request")
 }
 
 // TestValidation_ErrorHandling_InvalidCurrency_MixedCase verifies strict uppercase validation for currency.
@@ -483,7 +467,7 @@ func TestValidation_ErrorHandling_InvalidCurrency_MixedCase(t *testing.T) {
 			errorResp := testutil.ParseErrorResponse(t, respBody)
 			assert.Equal(t, "0417", errorResp.Code, "Error code should be 0417 for invalid currency")
 			assert.Equal(t, "Validation Invalid Currency", errorResp.Title, "Error title should match the currency error")
-			assert.Equal(t, "Currency must be valid ISO 4217.", tracerProblemDetail(t, respBody), "Error detail should match exactly")
+			assert.Equal(t, "Currency must be valid ISO 4217.", testutil.ParseErrorResponse(t, respBody).Detail, "Error detail should match exactly")
 		})
 	}
 }

--- a/components/tracer/tests/integration/04_limits_scope_filter_test.go
+++ b/components/tracer/tests/integration/04_limits_scope_filter_test.go
@@ -232,6 +232,8 @@ func TestListLimits_4_5_ScopeFiltersWithExistingFilters(t *testing.T) {
 }
 
 // TestListLimits_4_6_InvalidScopeFiltersReturnError verifies validation errors for invalid scope params.
+// Invalid scope/filter query params are canonicalized to code 0082 (Invalid Query Parameter);
+// the RFC 9457 detail references the parameter group generically as 'filters', not the individual field.
 func TestListLimits_4_6_InvalidScopeFiltersReturnError(t *testing.T) {
 	baseURL := testutil.GetBaseURL()
 	apiKey := testutil.GetAPIKey()
@@ -246,37 +248,37 @@ func TestListLimits_4_6_InvalidScopeFiltersReturnError(t *testing.T) {
 			name:        "invalid account_id UUID",
 			queryParams: "account_id=not-a-uuid",
 			expectCode:  "0082",
-			expectMsg:   "account_id",
+			expectMsg:   "filters",
 		},
 		{
 			name:        "invalid segment_id UUID",
 			queryParams: "segment_id=invalid",
 			expectCode:  "0082",
-			expectMsg:   "segment_id",
+			expectMsg:   "filters",
 		},
 		{
 			name:        "invalid portfolio_id UUID",
 			queryParams: "portfolio_id=bad-uuid",
 			expectCode:  "0082",
-			expectMsg:   "portfolio_id",
+			expectMsg:   "filters",
 		},
 		{
 			name:        "invalid merchant_id UUID",
 			queryParams: "merchant_id=xyz",
 			expectCode:  "0082",
-			expectMsg:   "merchant_id",
+			expectMsg:   "filters",
 		},
 		{
 			name:        "invalid transaction_type enum",
 			queryParams: "transaction_type=INVALID_TYPE",
 			expectCode:  "0082",
-			expectMsg:   "transaction_type",
+			expectMsg:   "filters",
 		},
 		{
 			name:        "sub_type exceeds max length",
 			queryParams: "sub_type=" + strings.Repeat("x", 51),
 			expectCode:  "0082",
-			expectMsg:   "sub_type",
+			expectMsg:   "filters",
 		},
 	}
 
@@ -297,7 +299,7 @@ func TestListLimits_4_6_InvalidScopeFiltersReturnError(t *testing.T) {
 
 			errResp := testutil.ParseErrorResponse(t, respBody)
 			assert.Equal(t, tc.expectCode, errResp.Code, "Error code mismatch")
-			assert.Contains(t, errResp.Message, tc.expectMsg, "Error message should mention the invalid field")
+			assert.Contains(t, tracerProblemDetail(t, respBody), tc.expectMsg, "Error detail should reference the invalid query parameters")
 		})
 	}
 }

--- a/components/tracer/tests/integration/04_limits_scope_filter_test.go
+++ b/components/tracer/tests/integration/04_limits_scope_filter_test.go
@@ -299,7 +299,7 @@ func TestListLimits_4_6_InvalidScopeFiltersReturnError(t *testing.T) {
 
 			errResp := testutil.ParseErrorResponse(t, respBody)
 			assert.Equal(t, tc.expectCode, errResp.Code, "Error code mismatch")
-			assert.Contains(t, tracerProblemDetail(t, respBody), tc.expectMsg, "Error detail should reference the invalid query parameters")
+			assert.Contains(t, testutil.ParseErrorResponse(t, respBody).Detail, tc.expectMsg, "Error detail should reference the invalid query parameters")
 		})
 	}
 }

--- a/components/tracer/tests/integration/04_metadata_validation_test.go
+++ b/components/tracer/tests/integration/04_metadata_validation_test.go
@@ -145,9 +145,9 @@ func TestValidation_Metadata_ExceedsMaxEntries(t *testing.T) {
 		"Request with 51 metadata entries should be rejected. Response: %s", string(respBody))
 
 	errResp := testutil.ParseErrorResponse(t, respBody)
-	assert.Equal(t, "0335", errResp.Code, "Expected TRC-0063 for metadata entries exceeded")
-	assert.Equal(t, "Validation Error", errResp.Title, "Error title should be Validation Error")
-	assert.Equal(t, "metadata exceeds maximum of 50 entries", errResp.Message, "Error message should match exactly")
+	assert.Equal(t, "0335", errResp.Code, "Expected 0335 for metadata entries exceeded")
+	assert.Equal(t, "Metadata Entries Exceeded", errResp.Title, "Error title should match the metadata error")
+	assert.Equal(t, "Metadata entries exceed maximum of 50.", tracerProblemDetail(t, respBody), "Error detail should match exactly")
 }
 
 // TestValidation_Metadata_KeyWithInvalidCharacters verifies invalid key chars are rejected.
@@ -228,9 +228,9 @@ func TestValidation_Metadata_KeyWithInvalidCharacters(t *testing.T) {
 
 			errResp := testutil.ParseErrorResponse(t, respBody)
 			assert.Equal(t, "0336", errResp.Code,
-				"Test case: %s - Expected TRC-0064 for invalid metadata key characters", tc.description)
-			assert.Equal(t, "Validation Error", errResp.Title, "Error title should be Validation Error")
-			assert.Equal(t, "metadata key contains invalid characters (only alphanumeric and underscore allowed)", errResp.Message, "Error message should match exactly")
+				"Test case: %s - Expected 0336 for invalid metadata key characters", tc.description)
+			assert.Equal(t, "Metadata Key Invalid Chars", errResp.Title, "Error title should match the metadata error")
+			assert.Equal(t, "Metadata key contains invalid characters.", tracerProblemDetail(t, respBody), "Error detail should match exactly")
 		})
 	}
 }
@@ -280,9 +280,9 @@ func TestValidation_Metadata_KeyExceedsMaxLength(t *testing.T) {
 		"Metadata key with 65 characters should be rejected. Response: %s", string(respBody))
 
 	errResp := testutil.ParseErrorResponse(t, respBody)
-	assert.Equal(t, "0050", errResp.Code, "Expected TRC-0060 for metadata key length exceeded")
-	assert.Equal(t, "Validation Error", errResp.Title, "Error title should be Validation Error")
-	assert.Equal(t, "metadata key exceeds maximum length of 64 characters", errResp.Message, "Error message should match exactly")
+	assert.Equal(t, "0050", errResp.Code, "Expected 0050 for metadata key length exceeded")
+	assert.Equal(t, "Metadata Key Length Exceeded", errResp.Title, "Error title should match the metadata error")
+	assert.Contains(t, tracerProblemDetail(t, respBody), "exceeds the maximum allowed length of", "Error detail should describe the key-length violation")
 }
 
 // TestValidation_Metadata_KeyAtMaxLength_BoundaryValid verifies 64 chars is accepted.

--- a/components/tracer/tests/integration/04_metadata_validation_test.go
+++ b/components/tracer/tests/integration/04_metadata_validation_test.go
@@ -147,7 +147,7 @@ func TestValidation_Metadata_ExceedsMaxEntries(t *testing.T) {
 	errResp := testutil.ParseErrorResponse(t, respBody)
 	assert.Equal(t, "0335", errResp.Code, "Expected 0335 for metadata entries exceeded")
 	assert.Equal(t, "Metadata Entries Exceeded", errResp.Title, "Error title should match the metadata error")
-	assert.Equal(t, "Metadata entries exceed maximum of 50.", tracerProblemDetail(t, respBody), "Error detail should match exactly")
+	assert.Equal(t, "Metadata entries exceed maximum of 50.", testutil.ParseErrorResponse(t, respBody).Detail, "Error detail should match exactly")
 }
 
 // TestValidation_Metadata_KeyWithInvalidCharacters verifies invalid key chars are rejected.
@@ -230,7 +230,7 @@ func TestValidation_Metadata_KeyWithInvalidCharacters(t *testing.T) {
 			assert.Equal(t, "0336", errResp.Code,
 				"Test case: %s - Expected 0336 for invalid metadata key characters", tc.description)
 			assert.Equal(t, "Metadata Key Invalid Chars", errResp.Title, "Error title should match the metadata error")
-			assert.Equal(t, "Metadata key contains invalid characters.", tracerProblemDetail(t, respBody), "Error detail should match exactly")
+			assert.Equal(t, "Metadata key contains invalid characters.", testutil.ParseErrorResponse(t, respBody).Detail, "Error detail should match exactly")
 		})
 	}
 }
@@ -282,7 +282,7 @@ func TestValidation_Metadata_KeyExceedsMaxLength(t *testing.T) {
 	errResp := testutil.ParseErrorResponse(t, respBody)
 	assert.Equal(t, "0050", errResp.Code, "Expected 0050 for metadata key length exceeded")
 	assert.Equal(t, "Metadata Key Length Exceeded", errResp.Title, "Error title should match the metadata error")
-	assert.Contains(t, tracerProblemDetail(t, respBody), "exceeds the maximum allowed length of", "Error detail should describe the key-length violation")
+	assert.Contains(t, testutil.ParseErrorResponse(t, respBody).Detail, "exceeds the maximum allowed length of", "Error detail should describe the key-length violation")
 }
 
 // TestValidation_Metadata_KeyAtMaxLength_BoundaryValid verifies 64 chars is accepted.

--- a/components/tracer/tests/integration/07_audit_events_error_codes_test.go
+++ b/components/tracer/tests/integration/07_audit_events_error_codes_test.go
@@ -23,20 +23,42 @@ import (
 // Error Code Tests for Audit Event Handler
 // =============================================================================
 // These tests verify the error codes returned by audit event handler operations.
+// Codes are the canonical numeric registry (pkg/constant/errors.go); the retired
+// TRC-* prefixed families no longer exist on the wire.
 //
 // Error code mapping:
-//   - TRC-0007: Invalid path parameter (invalid UUID for eventId)
-//   - TRC-0140: Audit event not found
-//   - TRC-0141: Invalid audit event filters
-//   - TRC-0043: Invalid sort column
-//   - TRC-0044: Invalid pagination cursor
+//   - 0065: Invalid path parameter (invalid UUID for eventId)
+//   - 0381: Audit event not found
+//   - 0332: Invalid sort column
+//   - 0333: Invalid pagination cursor
+//   - 0334: Cursor and sort parameters are mutually exclusive
+//   - 0009/0077/0080/0081/0331/0083: invalid list filters (enum, date, limit,
+//     sort order, date range)
+//
+// Error bodies are RFC 9457 problem+json: the human-readable text lives in the
+// "detail" member (not "message"), read via auditProblemDetail below.
 // =============================================================================
+
+// auditProblemDetail extracts the RFC 9457 "detail" member from a problem+json
+// error body. The shared testutil.ErrorResponse only surfaces code/title, so
+// detail assertions parse the body here.
+func auditProblemDetail(t *testing.T, body []byte) string {
+	t.Helper()
+
+	var p struct {
+		Detail string `json:"detail"`
+	}
+
+	require.NoError(t, json.Unmarshal(body, &p), "parse problem detail: %s", string(body))
+
+	return p.Detail
+}
 
 // =============================================================================
 // GET /v1/audit-events/{id} - Get Audit Event Error Code Tests
 // =============================================================================
 
-// TestGetAuditEvent_InvalidUUID_ReturnsTRC0007 verifies that invalid UUID format returns TRC-0007.
+// TestGetAuditEvent_InvalidUUID_ReturnsTRC0007 verifies that an invalid UUID format returns 0065.
 func TestGetAuditEvent_InvalidUUID_ReturnsTRC0007(t *testing.T) {
 	baseURL := testutil.GetBaseURL()
 	apiKey := testutil.GetAPIKey()
@@ -85,14 +107,14 @@ func TestGetAuditEvent_InvalidUUID_ReturnsTRC0007(t *testing.T) {
 
 			errResp := testutil.ParseErrorResponse(t, respBody)
 
-			assert.Equal(t, "0065", errResp.Code, "Test case: %s - Expected TRC-0007 for invalid UUID", tc.desc)
+			assert.Equal(t, "0065", errResp.Code, "Test case: %s - Expected 0065 for invalid UUID", tc.desc)
 			assert.Equal(t, "Invalid Path Parameter", errResp.Title, "Test case: %s", tc.desc)
-			assert.Equal(t, "Invalid event ID format", errResp.Message, "Test case: %s", tc.desc)
+			assert.Contains(t, auditProblemDetail(t, respBody), "path parameters are in an incorrect format", "Test case: %s", tc.desc)
 		})
 	}
 }
 
-// TestGetAuditEvent_NonExistentUUID_ReturnsTRC0140 verifies that non-existent UUID returns TRC-0140.
+// TestGetAuditEvent_NonExistentUUID_ReturnsTRC0140 verifies that a non-existent UUID returns 0381.
 func TestGetAuditEvent_NonExistentUUID_ReturnsTRC0140(t *testing.T) {
 	baseURL := testutil.GetBaseURL()
 	apiKey := testutil.GetAPIKey()
@@ -136,9 +158,9 @@ func TestGetAuditEvent_NonExistentUUID_ReturnsTRC0140(t *testing.T) {
 
 			errResp := testutil.ParseErrorResponse(t, respBody)
 
-			assert.Equal(t, "0381", errResp.Code, "Test case: %s - Expected TRC-0140 for audit event not found", tc.desc)
-			assert.Equal(t, "Not Found", errResp.Title, "Test case: %s", tc.desc)
-			assert.Equal(t, "Audit event not found", errResp.Message, "Test case: %s", tc.desc)
+			assert.Equal(t, "0381", errResp.Code, "Test case: %s - Expected 0381 for audit event not found", tc.desc)
+			assert.Equal(t, "Audit Event Not Found", errResp.Title, "Test case: %s", tc.desc)
+			assert.Contains(t, auditProblemDetail(t, respBody), "Audit event not found", "Test case: %s", tc.desc)
 		})
 	}
 }
@@ -147,7 +169,7 @@ func TestGetAuditEvent_NonExistentUUID_ReturnsTRC0140(t *testing.T) {
 // GET /v1/audit-events - List Audit Events Error Code Tests
 // =============================================================================
 
-// TestListAuditEvents_InvalidSortColumn_ReturnsTRC0043 verifies that invalid sortBy returns TRC-0043.
+// TestListAuditEvents_InvalidSortColumn_ReturnsTRC0043 verifies that an invalid sortBy returns 0332.
 func TestListAuditEvents_InvalidSortColumn_ReturnsTRC0043(t *testing.T) {
 	baseURL := testutil.GetBaseURL()
 	apiKey := testutil.GetAPIKey()
@@ -186,13 +208,13 @@ func TestListAuditEvents_InvalidSortColumn_ReturnsTRC0043(t *testing.T) {
 
 			errResp := testutil.ParseErrorResponse(t, respBody)
 
-			assert.Equal(t, "0332", errResp.Code, "Test case: %s - Expected TRC-0043 for invalid sort column", tc.desc)
-			assert.Equal(t, "Validation Error", errResp.Title, "Test case: %s", tc.desc)
+			assert.Equal(t, "0332", errResp.Code, "Test case: %s - Expected 0332 for invalid sort column", tc.desc)
+			assert.Equal(t, "Invalid Sort Column", errResp.Title, "Test case: %s", tc.desc)
 		})
 	}
 }
 
-// TestListAuditEvents_InvalidCursor_ReturnsTRC0044 verifies that invalid cursor returns TRC-0044.
+// TestListAuditEvents_InvalidCursor_ReturnsTRC0044 verifies that an invalid cursor returns 0333.
 func TestListAuditEvents_InvalidCursor_ReturnsTRC0044(t *testing.T) {
 	baseURL := testutil.GetBaseURL()
 	apiKey := testutil.GetAPIKey()
@@ -230,15 +252,17 @@ func TestListAuditEvents_InvalidCursor_ReturnsTRC0044(t *testing.T) {
 			assert.Equal(t, http.StatusBadRequest, resp.StatusCode, "Test case: %s - Response: %s", tc.desc, string(respBody))
 
 			errResp := testutil.ParseErrorResponse(t, respBody)
-			assert.Equal(t, "0333", errResp.Code, "Test case: %s - Expected TRC-0044 for invalid cursor", tc.desc)
-			assert.Equal(t, "Bad Request", errResp.Title, "Test case: %s", tc.desc)
+			assert.Equal(t, "0333", errResp.Code, "Test case: %s - Expected 0333 for invalid cursor", tc.desc)
+			assert.Equal(t, "Invalid Cursor", errResp.Title, "Test case: %s", tc.desc)
 		})
 	}
 }
 
 // TestListAuditEvents_InvalidFilters_ReturnsValidationError verifies filter validation.
-// Note: TRC-0141 is returned by the service layer for invalid audit event filters,
-// while TRC-0001 is returned for input validation errors at the handler layer.
+// Note: invalid enum params (event_type/action/result/resource_type/transaction_type)
+// canonicalize to 0009 (Missing Fields in Request) — the go-playground validator's
+// default arm, empirically anchored to the pre-Huma Fiber handler; date/limit/sort
+// order params carry their own dedicated codes (0077/0331/0080/0081).
 func TestListAuditEvents_InvalidFilters_ReturnsValidationError(t *testing.T) {
 	baseURL := testutil.GetBaseURL()
 	apiKey := testutil.GetAPIKey()
@@ -253,78 +277,78 @@ func TestListAuditEvents_InvalidFilters_ReturnsValidationError(t *testing.T) {
 		{
 			name:          "invalid_event_type",
 			queryParams:   "event_type=INVALID_EVENT_TYPE",
-			expectedCode:  "0053",
-			expectedTitle: "Validation Error",
+			expectedCode:  "0009",
+			expectedTitle: "Missing Fields in Request",
 			desc:          "Invalid event type enum value",
 		},
 		{
 			name:          "invalid_action",
 			queryParams:   "action=INVALID_ACTION",
-			expectedCode:  "0053",
-			expectedTitle: "Validation Error",
+			expectedCode:  "0009",
+			expectedTitle: "Missing Fields in Request",
 			desc:          "Invalid action enum value",
 		},
 		{
 			name:          "invalid_result",
 			queryParams:   "result=INVALID_RESULT",
-			expectedCode:  "0053",
-			expectedTitle: "Validation Error",
+			expectedCode:  "0009",
+			expectedTitle: "Missing Fields in Request",
 			desc:          "Invalid result enum value",
 		},
 		{
 			name:          "invalid_resource_type",
 			queryParams:   "resource_type=invalid_type",
-			expectedCode:  "0053",
-			expectedTitle: "Validation Error",
+			expectedCode:  "0009",
+			expectedTitle: "Missing Fields in Request",
 			desc:          "Invalid resource type",
 		},
 		{
 			name:          "invalid_start_date_format",
 			queryParams:   "start_date=not-a-date",
 			expectedCode:  "0077",
-			expectedTitle: "Validation Error",
+			expectedTitle: "Invalid Date Format Error",
 			desc:          "Invalid start date format",
 		},
 		{
 			name:          "invalid_end_date_format",
 			queryParams:   "end_date=2024-13-45",
 			expectedCode:  "0077",
-			expectedTitle: "Validation Error",
+			expectedTitle: "Invalid Date Format Error",
 			desc:          "Invalid end date format",
 		},
 		{
 			name:          "limit_negative",
 			queryParams:   "limit=-5",
 			expectedCode:  "0331",
-			expectedTitle: "Validation Error",
+			expectedTitle: "Pagination Limit Invalid",
 			desc:          "Negative limit is invalid",
 		},
 		{
 			name:          "limit_zero",
 			queryParams:   "limit=0",
 			expectedCode:  "0331",
-			expectedTitle: "Validation Error",
+			expectedTitle: "Pagination Limit Invalid",
 			desc:          "Zero limit is invalid (must be at least 1)",
 		},
 		{
 			name:          "limit_exceeds_max",
 			queryParams:   "limit=2000",
 			expectedCode:  "0080",
-			expectedTitle: "Validation Error",
+			expectedTitle: "Pagination Limit Exceeded",
 			desc:          "Limit exceeds maximum allowed (1000)",
 		},
 		{
 			name:          "invalid_transaction_type",
 			queryParams:   "transaction_type=INVALID_TYPE",
-			expectedCode:  "0053",
-			expectedTitle: "Validation Error",
+			expectedCode:  "0009",
+			expectedTitle: "Missing Fields in Request",
 			desc:          "Invalid transaction type enum value",
 		},
 		{
 			name:          "invalid_sort_order",
 			queryParams:   "sort_order=INVALID",
 			expectedCode:  "0081",
-			expectedTitle: "Validation Error",
+			expectedTitle: "Invalid Sort Order",
 			desc:          "Invalid sort order value (must be ASC or DESC)",
 		},
 	}
@@ -353,7 +377,7 @@ func TestListAuditEvents_InvalidFilters_ReturnsValidationError(t *testing.T) {
 }
 
 // TestListAuditEvents_CursorWithSortParams_ReturnsTRC0045 verifies that providing
-// sortBy or sortOrder parameters when a cursor is present returns TRC-0045.
+// sortBy or sortOrder parameters when a cursor is present returns 0334.
 // Sort parameters are encoded in the cursor and cannot be changed mid-pagination.
 func TestListAuditEvents_CursorWithSortParams_ReturnsTRC0045(t *testing.T) {
 	baseURL := testutil.GetBaseURL()
@@ -413,8 +437,8 @@ func TestListAuditEvents_CursorWithSortParams_ReturnsTRC0045(t *testing.T) {
 
 		errResp := testutil.ParseErrorResponse(t, respBody)
 
-		assert.Equal(t, "0334", errResp.Code, "Expected TRC-0045 for cursor with sortBy")
-		assert.Equal(t, "Validation Error", errResp.Title, "Expected 'Validation Error' title")
+		assert.Equal(t, "0334", errResp.Code, "Expected 0334 for cursor with sortBy")
+		assert.Equal(t, "Cursor With Sort Params", errResp.Title, "Expected 'Cursor With Sort Params' title")
 	})
 
 	// Step 3: Test cursor with sortOrder parameter
@@ -434,8 +458,8 @@ func TestListAuditEvents_CursorWithSortParams_ReturnsTRC0045(t *testing.T) {
 
 		errResp := testutil.ParseErrorResponse(t, respBody)
 
-		assert.Equal(t, "0334", errResp.Code, "Expected TRC-0045 for cursor with sortOrder")
-		assert.Equal(t, "Validation Error", errResp.Title, "Expected 'Validation Error' title")
+		assert.Equal(t, "0334", errResp.Code, "Expected 0334 for cursor with sortOrder")
+		assert.Equal(t, "Cursor With Sort Params", errResp.Title, "Expected 'Cursor With Sort Params' title")
 	})
 
 	// Step 4: Test cursor with both sortBy and sortOrder parameters
@@ -455,8 +479,8 @@ func TestListAuditEvents_CursorWithSortParams_ReturnsTRC0045(t *testing.T) {
 
 		errResp := testutil.ParseErrorResponse(t, respBody)
 
-		assert.Equal(t, "0334", errResp.Code, "Expected TRC-0045 for cursor with both sort params")
-		assert.Equal(t, "Validation Error", errResp.Title, "Expected 'Validation Error' title")
+		assert.Equal(t, "0334", errResp.Code, "Expected 0334 for cursor with both sort params")
+		assert.Equal(t, "Cursor With Sort Params", errResp.Title, "Expected 'Cursor With Sort Params' title")
 	})
 }
 
@@ -464,7 +488,7 @@ func TestListAuditEvents_CursorWithSortParams_ReturnsTRC0045(t *testing.T) {
 // GET /v1/audit-events/{id}/verify - Verify Hash Chain Error Code Tests
 // =============================================================================
 
-// TestVerifyAuditEvent_InvalidUUID_ReturnsTRC0007 verifies that invalid UUID format returns TRC-0007.
+// TestVerifyAuditEvent_InvalidUUID_ReturnsTRC0007 verifies that an invalid UUID format returns 0065.
 func TestVerifyAuditEvent_InvalidUUID_ReturnsTRC0007(t *testing.T) {
 	baseURL := testutil.GetBaseURL()
 	apiKey := testutil.GetAPIKey()
@@ -508,14 +532,14 @@ func TestVerifyAuditEvent_InvalidUUID_ReturnsTRC0007(t *testing.T) {
 
 			errResp := testutil.ParseErrorResponse(t, respBody)
 
-			assert.Equal(t, "0065", errResp.Code, "Test case: %s - Expected TRC-0007 for invalid UUID", tc.desc)
+			assert.Equal(t, "0065", errResp.Code, "Test case: %s - Expected 0065 for invalid UUID", tc.desc)
 			assert.Equal(t, "Invalid Path Parameter", errResp.Title, "Test case: %s", tc.desc)
-			assert.Equal(t, "Invalid event ID format", errResp.Message, "Test case: %s", tc.desc)
+			assert.Contains(t, auditProblemDetail(t, respBody), "path parameters are in an incorrect format", "Test case: %s", tc.desc)
 		})
 	}
 }
 
-// TestVerifyAuditEvent_NonExistentUUID_ReturnsTRC0140 verifies that non-existent UUID returns TRC-0140.
+// TestVerifyAuditEvent_NonExistentUUID_ReturnsTRC0140 verifies that a non-existent UUID returns 0381.
 func TestVerifyAuditEvent_NonExistentUUID_ReturnsTRC0140(t *testing.T) {
 	baseURL := testutil.GetBaseURL()
 	apiKey := testutil.GetAPIKey()
@@ -554,9 +578,9 @@ func TestVerifyAuditEvent_NonExistentUUID_ReturnsTRC0140(t *testing.T) {
 
 			errResp := testutil.ParseErrorResponse(t, respBody)
 
-			assert.Equal(t, "0381", errResp.Code, "Test case: %s - Expected TRC-0140 for audit event not found", tc.desc)
-			assert.Equal(t, "Not Found", errResp.Title, "Test case: %s", tc.desc)
-			assert.Equal(t, "Audit event not found", errResp.Message, "Test case: %s", tc.desc)
+			assert.Equal(t, "0381", errResp.Code, "Test case: %s - Expected 0381 for audit event not found", tc.desc)
+			assert.Equal(t, "Audit Event Not Found", errResp.Title, "Test case: %s", tc.desc)
+			assert.Contains(t, auditProblemDetail(t, respBody), "Audit event not found", "Test case: %s", tc.desc)
 		})
 	}
 }
@@ -676,22 +700,22 @@ func TestDateRangeValidation_ConsistentAcrossEndpoints(t *testing.T) {
 	endDate := "2025-01-01T00:00:00Z"
 
 	endpoints := []struct {
-		name            string
-		url             string
-		expectedCode    string
-		expectedMessage string
+		name           string
+		url            string
+		expectedCode   string
+		expectedDetail string
 	}{
 		{
-			name:            "audit-events",
-			url:             fmt.Sprintf("%s/v1/audit-events?start_date=%s&end_date=%s", baseURL, startDate, endDate),
-			expectedCode:    "0083",
-			expectedMessage: "end_date must be on or after start_date",
+			name:           "audit-events",
+			url:            fmt.Sprintf("%s/v1/audit-events?start_date=%s&end_date=%s", baseURL, startDate, endDate),
+			expectedCode:   "0083",
+			expectedDetail: "Both 'initialDate' and 'finalDate' fields are required",
 		},
 		{
-			name:            "transaction-validations",
-			url:             fmt.Sprintf("%s/v1/validations?start_date=%s&end_date=%s", baseURL, startDate, endDate),
-			expectedCode:    "0083",
-			expectedMessage: "end_date must be on or after start_date",
+			name:           "transaction-validations",
+			url:            fmt.Sprintf("%s/v1/validations?start_date=%s&end_date=%s", baseURL, startDate, endDate),
+			expectedCode:   "0083",
+			expectedDetail: "Both 'initialDate' and 'finalDate' fields are required",
 		},
 	}
 
@@ -717,8 +741,10 @@ func TestDateRangeValidation_ConsistentAcrossEndpoints(t *testing.T) {
 
 			require.Equal(t, ep.expectedCode, errResp["code"],
 				"Endpoint %s should return error code %s", ep.name, ep.expectedCode)
-			require.Equal(t, ep.expectedMessage, errResp["message"],
-				"Endpoint %s should return expected error message", ep.name)
+
+			detail, _ := errResp["detail"].(string)
+			require.Contains(t, detail, ep.expectedDetail,
+				"Endpoint %s should return expected problem detail", ep.name)
 		})
 	}
 }

--- a/components/tracer/tests/integration/07_audit_events_error_codes_test.go
+++ b/components/tracer/tests/integration/07_audit_events_error_codes_test.go
@@ -36,23 +36,8 @@ import (
 //     sort order, date range)
 //
 // Error bodies are RFC 9457 problem+json: the human-readable text lives in the
-// "detail" member (not "message"), read via auditProblemDetail below.
+// "detail" member (not "message"), read via testutil.ParseErrorResponse().Detail.
 // =============================================================================
-
-// auditProblemDetail extracts the RFC 9457 "detail" member from a problem+json
-// error body. The shared testutil.ErrorResponse only surfaces code/title, so
-// detail assertions parse the body here.
-func auditProblemDetail(t *testing.T, body []byte) string {
-	t.Helper()
-
-	var p struct {
-		Detail string `json:"detail"`
-	}
-
-	require.NoError(t, json.Unmarshal(body, &p), "parse problem detail: %s", string(body))
-
-	return p.Detail
-}
 
 // =============================================================================
 // GET /v1/audit-events/{id} - Get Audit Event Error Code Tests
@@ -109,7 +94,7 @@ func TestGetAuditEvent_InvalidUUID_ReturnsTRC0007(t *testing.T) {
 
 			assert.Equal(t, "0065", errResp.Code, "Test case: %s - Expected 0065 for invalid UUID", tc.desc)
 			assert.Equal(t, "Invalid Path Parameter", errResp.Title, "Test case: %s", tc.desc)
-			assert.Contains(t, auditProblemDetail(t, respBody), "path parameters are in an incorrect format", "Test case: %s", tc.desc)
+			assert.Contains(t, testutil.ParseErrorResponse(t, respBody).Detail, "path parameters are in an incorrect format", "Test case: %s", tc.desc)
 		})
 	}
 }
@@ -160,7 +145,7 @@ func TestGetAuditEvent_NonExistentUUID_ReturnsTRC0140(t *testing.T) {
 
 			assert.Equal(t, "0381", errResp.Code, "Test case: %s - Expected 0381 for audit event not found", tc.desc)
 			assert.Equal(t, "Audit Event Not Found", errResp.Title, "Test case: %s", tc.desc)
-			assert.Contains(t, auditProblemDetail(t, respBody), "Audit event not found", "Test case: %s", tc.desc)
+			assert.Contains(t, testutil.ParseErrorResponse(t, respBody).Detail, "Audit event not found", "Test case: %s", tc.desc)
 		})
 	}
 }
@@ -534,7 +519,7 @@ func TestVerifyAuditEvent_InvalidUUID_ReturnsTRC0007(t *testing.T) {
 
 			assert.Equal(t, "0065", errResp.Code, "Test case: %s - Expected 0065 for invalid UUID", tc.desc)
 			assert.Equal(t, "Invalid Path Parameter", errResp.Title, "Test case: %s", tc.desc)
-			assert.Contains(t, auditProblemDetail(t, respBody), "path parameters are in an incorrect format", "Test case: %s", tc.desc)
+			assert.Contains(t, testutil.ParseErrorResponse(t, respBody).Detail, "path parameters are in an incorrect format", "Test case: %s", tc.desc)
 		})
 	}
 }
@@ -580,7 +565,7 @@ func TestVerifyAuditEvent_NonExistentUUID_ReturnsTRC0140(t *testing.T) {
 
 			assert.Equal(t, "0381", errResp.Code, "Test case: %s - Expected 0381 for audit event not found", tc.desc)
 			assert.Equal(t, "Audit Event Not Found", errResp.Title, "Test case: %s", tc.desc)
-			assert.Contains(t, auditProblemDetail(t, respBody), "Audit event not found", "Test case: %s", tc.desc)
+			assert.Contains(t, testutil.ParseErrorResponse(t, respBody).Detail, "Audit event not found", "Test case: %s", tc.desc)
 		})
 	}
 }

--- a/components/tracer/tests/integration/07_audit_events_test.go
+++ b/components/tracer/tests/integration/07_audit_events_test.go
@@ -156,9 +156,9 @@ func TestAuditEvents_11_1_2_Returns404ForNonExistentEvent(t *testing.T) {
 	respBody, err := io.ReadAll(resp.Body)
 	require.NoError(t, err)
 	errResp := testutil.ParseErrorResponse(t, respBody)
-	assert.Equal(t, "0381", errResp.Code, "Error code should be TRC-0140 for audit event not found")
-	assert.Equal(t, "Not Found", errResp.Title, "Error title should be Not Found")
-	assert.Equal(t, "Audit event not found", errResp.Message, "Error message should indicate audit event not found")
+	assert.Equal(t, "0381", errResp.Code, "Error code should be 0381 for audit event not found")
+	assert.Equal(t, "Audit Event Not Found", errResp.Title, "Error title should be Audit Event Not Found")
+	assert.Contains(t, auditProblemDetail(t, respBody), "Audit event not found", "Error detail should indicate audit event not found")
 }
 
 // TestAuditEvents_11_1_3_Returns400ForInvalidUUID tests 400 response for invalid UUID format.
@@ -183,7 +183,7 @@ func TestAuditEvents_11_1_3_Returns400ForInvalidUUID(t *testing.T) {
 	errResp := testutil.ParseErrorResponse(t, body)
 	assert.Equal(t, "0065", errResp.Code, "Error response should have invalid path parameter code")
 	assert.Equal(t, "Invalid Path Parameter", errResp.Title, "Error response should have invalid path parameter title")
-	assert.Equal(t, "Invalid event ID format", errResp.Message, "Error message should indicate invalid UUID format")
+	assert.Contains(t, auditProblemDetail(t, body), "path parameters are in an incorrect format", "Error detail should indicate invalid UUID format")
 }
 
 // TestAuditEvents_11_1_4_Returns401WithoutAPIKey tests 401 response without authentication.
@@ -906,9 +906,11 @@ func TestAuditEvents_11_2_12_Returns400ForInvalidFilters(t *testing.T) {
 
 	// Verify structured error response
 	errResp := testutil.ParseErrorResponse(t, body)
-	assert.Equal(t, "0053", errResp.Code, "Error response should have validation error code")
-	assert.Equal(t, "Validation Error", errResp.Title, "Error response should have validation error title")
-	assert.Equal(t, "EventType validation failed: auditeventtype", errResp.Message, "Error message should indicate invalid event type")
+	// Invalid enum params canonicalize to 0009 (Missing Fields in Request) — the
+	// go-playground validator's default arm, anchored to the pre-Huma Fiber handler.
+	assert.Equal(t, "0009", errResp.Code, "Error response should have missing-fields code for invalid enum")
+	assert.Equal(t, "Missing Fields in Request", errResp.Title, "Error response should have missing-fields title")
+	assert.Contains(t, auditProblemDetail(t, body), "missing one or more required fields", "Error detail should indicate a missing/invalid required field")
 }
 
 // TestAuditEvents_11_2_13_ReturnsEmptyArrayWhenNoMatches tests empty results.
@@ -983,7 +985,8 @@ func TestAuditEvents_11_3_1_VerifiesValidHashChain(t *testing.T) {
 
 	// Get the event ID for verification (filter by rule ID to avoid interference from other tests)
 	var eventID string
-	err = db.QueryRowContext(context.Background(),
+	err = db.QueryRowContext(
+		context.Background(),
 		`SELECT event_id FROM audit_events WHERE resource_id = $1 ORDER BY id DESC LIMIT 1`,
 		rule.ID,
 	).Scan(&eventID)
@@ -1030,7 +1033,8 @@ func TestAuditEvents_11_3_3_VerifiesSingleEvent(t *testing.T) {
 
 	// Get the audit event that was just created
 	var eventID string
-	err := db.QueryRowContext(context.Background(),
+	err := db.QueryRowContext(
+		context.Background(),
 		`SELECT event_id FROM audit_events WHERE resource_type = 'rule' AND resource_id = $1 ORDER BY id DESC LIMIT 1`,
 		ruleID,
 	).Scan(&eventID)
@@ -1099,7 +1103,7 @@ func TestAuditEvents_11_3_5_Returns400ForInvalidUUID(t *testing.T) {
 	errResp := testutil.ParseErrorResponse(t, body)
 	assert.Equal(t, "0065", errResp.Code, "Error response should have invalid path parameter code")
 	assert.Equal(t, "Invalid Path Parameter", errResp.Title, "Error response should have invalid path parameter title")
-	assert.Equal(t, "Invalid event ID format", errResp.Message, "Error message should indicate invalid UUID format")
+	assert.Contains(t, auditProblemDetail(t, body), "path parameters are in an incorrect format", "Error detail should indicate invalid UUID format")
 }
 
 // ============================================================================
@@ -1904,9 +1908,9 @@ func TestAuditEvents_11_9_2_InvalidDateFormatReturns400(t *testing.T) {
 
 	// Verify structured error response
 	errResp := testutil.ParseErrorResponse(t, body)
-	assert.Equal(t, "0077", errResp.Code, "Error response should have TRC-0020 (Invalid Date Format)")
-	assert.Equal(t, "Validation Error", errResp.Title, "Error response should have validation error title")
-	assert.Contains(t, errResp.Message, "start_date must be in RFC3339 format", "Error message should indicate invalid date format")
+	assert.Equal(t, "0077", errResp.Code, "Error response should have 0077 (Invalid Date Format)")
+	assert.Equal(t, "Invalid Date Format Error", errResp.Title, "Error response should have invalid date format title")
+	assert.Contains(t, auditProblemDetail(t, body), "yyyy-mm-dd", "Error detail should indicate invalid date format")
 }
 
 // TestAuditEvents_11_9_3_PageSizeExceedsMaximum tests limit validation.
@@ -1931,9 +1935,9 @@ func TestAuditEvents_11_9_3_PageSizeExceedsMaximum(t *testing.T) {
 
 	// Verify structured error response with specific TRC code for limit exceeded
 	errResp := testutil.ParseErrorResponse(t, body)
-	assert.Equal(t, "0080", errResp.Code, "Error response should have TRC-0040 (Limit Exceeds Maximum)")
-	assert.Equal(t, "Validation Error", errResp.Title, "Error response should have validation error title")
-	assert.Equal(t, "limit must not exceed 1000", errResp.Message, "Error message should indicate limit exceeded")
+	assert.Equal(t, "0080", errResp.Code, "Error response should have 0080 (Limit Exceeds Maximum)")
+	assert.Equal(t, "Pagination Limit Exceeded", errResp.Title, "Error response should have pagination limit exceeded title")
+	assert.Contains(t, auditProblemDetail(t, body), "maximum allowed of 1000", "Error detail should indicate limit exceeded")
 }
 
 // TestAuditEvents_11_9_4_NegativePageSizeReturnsError tests negative limit.
@@ -1957,9 +1961,9 @@ func TestAuditEvents_11_9_4_NegativePageSizeReturnsError(t *testing.T) {
 
 	// Verify structured error response with specific TRC code for limit below minimum
 	errResp := testutil.ParseErrorResponse(t, body)
-	assert.Equal(t, "0331", errResp.Code, "Error response should have TRC-0041 (Limit Below Minimum)")
-	assert.Equal(t, "Validation Error", errResp.Title, "Error response should have validation error title")
-	assert.Equal(t, "limit must be at least 1", errResp.Message, "Error message should indicate limit validation failed")
+	assert.Equal(t, "0331", errResp.Code, "Error response should have 0331 (Limit Below Minimum)")
+	assert.Equal(t, "Pagination Limit Invalid", errResp.Title, "Error response should have pagination limit invalid title")
+	assert.Contains(t, auditProblemDetail(t, body), "Pagination limit must be positive", "Error detail should indicate limit validation failed")
 }
 
 // TestAuditEvents_11_9_5_InvalidSortByFieldReturns400 tests invalid sortBy field.
@@ -1982,9 +1986,9 @@ func TestAuditEvents_11_9_5_InvalidSortByFieldReturns400(t *testing.T) {
 
 	// Verify structured error response
 	errResp := testutil.ParseErrorResponse(t, body)
-	assert.Equal(t, "0332", errResp.Code, "Error response should have TRC-0043 (Invalid SortBy)")
-	assert.Equal(t, "Validation Error", errResp.Title, "Error response should have validation error title")
-	assert.Contains(t, errResp.Message, "sort_by must be one of", "Error message should indicate invalid sort_by field")
+	assert.Equal(t, "0332", errResp.Code, "Error response should have 0332 (Invalid SortBy)")
+	assert.Equal(t, "Invalid Sort Column", errResp.Title, "Error response should have invalid sort column title")
+	assert.Contains(t, auditProblemDetail(t, body), "Sort column not in allowed list", "Error detail should indicate invalid sort_by field")
 }
 
 // TestAuditEvents_11_9_6_EndDateBeforeStartDateReturns400 tests invalid date range.
@@ -2012,9 +2016,9 @@ func TestAuditEvents_11_9_6_EndDateBeforeStartDateReturns400(t *testing.T) {
 
 	// Verify structured error response
 	errResp := testutil.ParseErrorResponse(t, body)
-	assert.Equal(t, "0083", errResp.Code, "Error response should have TRC-0023 (Invalid date range)")
-	assert.Equal(t, "Validation Error", errResp.Title, "Error response should have validation error title")
-	assert.Equal(t, "end_date must be on or after start_date", errResp.Message, "Error message should indicate invalid date range")
+	assert.Equal(t, "0083", errResp.Code, "Error response should have 0083 (Invalid date range)")
+	assert.Equal(t, "Invalid Date Range Error", errResp.Title, "Error response should have invalid date range title")
+	assert.Contains(t, auditProblemDetail(t, body), "Both 'initialDate' and 'finalDate' fields are required", "Error detail should indicate invalid date range")
 }
 
 // TestAuditEvents_11_9_7_InvalidCursorReturns400 tests malformed cursor.
@@ -2038,9 +2042,9 @@ func TestAuditEvents_11_9_7_InvalidCursorReturns400(t *testing.T) {
 		"invalid cursor should return 400 Bad Request: %s", string(body))
 
 	errResp := testutil.ParseErrorResponse(t, body)
-	assert.Equal(t, "0333", errResp.Code, "Error response should have TRC-0044 for invalid cursor")
-	assert.Equal(t, "Bad Request", errResp.Title, "Error title should be Bad Request")
-	assert.Equal(t, "Invalid pagination cursor", errResp.Message, "Error message should indicate invalid cursor")
+	assert.Equal(t, "0333", errResp.Code, "Error response should have 0333 for invalid cursor")
+	assert.Equal(t, "Invalid Cursor", errResp.Title, "Error title should be Invalid Cursor")
+	assert.Contains(t, auditProblemDetail(t, body), "Invalid or corrupted pagination cursor", "Error detail should indicate invalid cursor")
 }
 
 // TestAuditEvents_11_9_8_ZeroLimitReturnsError tests limit=0 behavior.
@@ -2065,9 +2069,9 @@ func TestAuditEvents_11_9_8_ZeroLimitReturnsError(t *testing.T) {
 
 	// Verify structured error response with specific TRC code
 	errResp := testutil.ParseErrorResponse(t, body)
-	assert.Equal(t, "0331", errResp.Code, "Error response should have TRC-0041 (Limit Below Minimum)")
-	assert.Equal(t, "Validation Error", errResp.Title, "Error response should have validation error title")
-	assert.Equal(t, "limit must be at least 1", errResp.Message, "Error message should indicate limit must be at least 1")
+	assert.Equal(t, "0331", errResp.Code, "Error response should have 0331 (Limit Below Minimum)")
+	assert.Equal(t, "Pagination Limit Invalid", errResp.Title, "Error response should have pagination limit invalid title")
+	assert.Contains(t, auditProblemDetail(t, body), "Pagination limit must be positive", "Error detail should indicate limit must be at least 1")
 }
 
 // ============================================================================
@@ -2507,7 +2511,8 @@ func TestAuditEvents_11_5_1_HashChainIntactAfterMultipleOperations(t *testing.T)
 
 	// Get last event
 	var lastEventID string
-	err := db.QueryRowContext(context.Background(),
+	err := db.QueryRowContext(
+		context.Background(),
 		`SELECT event_id FROM audit_events ORDER BY id DESC LIMIT 1`,
 	).Scan(&lastEventID)
 	require.NoError(t, err)
@@ -2545,7 +2550,8 @@ func TestAuditEvents_11_5_2_FirstEventHasGenesisHash(t *testing.T) {
 
 	// Get the first event from database (by sequence, not by our test)
 	var eventID string
-	err := db.QueryRowContext(context.Background(),
+	err := db.QueryRowContext(
+		context.Background(),
 		`SELECT event_id FROM audit_events ORDER BY id ASC LIMIT 1`,
 	).Scan(&eventID)
 	require.NoError(t, err, "Should have at least one audit event after rule creation")

--- a/components/tracer/tests/integration/07_audit_events_test.go
+++ b/components/tracer/tests/integration/07_audit_events_test.go
@@ -158,7 +158,7 @@ func TestAuditEvents_11_1_2_Returns404ForNonExistentEvent(t *testing.T) {
 	errResp := testutil.ParseErrorResponse(t, respBody)
 	assert.Equal(t, "0381", errResp.Code, "Error code should be 0381 for audit event not found")
 	assert.Equal(t, "Audit Event Not Found", errResp.Title, "Error title should be Audit Event Not Found")
-	assert.Contains(t, auditProblemDetail(t, respBody), "Audit event not found", "Error detail should indicate audit event not found")
+	assert.Contains(t, testutil.ParseErrorResponse(t, respBody).Detail, "Audit event not found", "Error detail should indicate audit event not found")
 }
 
 // TestAuditEvents_11_1_3_Returns400ForInvalidUUID tests 400 response for invalid UUID format.
@@ -183,7 +183,7 @@ func TestAuditEvents_11_1_3_Returns400ForInvalidUUID(t *testing.T) {
 	errResp := testutil.ParseErrorResponse(t, body)
 	assert.Equal(t, "0065", errResp.Code, "Error response should have invalid path parameter code")
 	assert.Equal(t, "Invalid Path Parameter", errResp.Title, "Error response should have invalid path parameter title")
-	assert.Contains(t, auditProblemDetail(t, body), "path parameters are in an incorrect format", "Error detail should indicate invalid UUID format")
+	assert.Contains(t, testutil.ParseErrorResponse(t, body).Detail, "path parameters are in an incorrect format", "Error detail should indicate invalid UUID format")
 }
 
 // TestAuditEvents_11_1_4_Returns401WithoutAPIKey tests 401 response without authentication.
@@ -910,7 +910,7 @@ func TestAuditEvents_11_2_12_Returns400ForInvalidFilters(t *testing.T) {
 	// go-playground validator's default arm, anchored to the pre-Huma Fiber handler.
 	assert.Equal(t, "0009", errResp.Code, "Error response should have missing-fields code for invalid enum")
 	assert.Equal(t, "Missing Fields in Request", errResp.Title, "Error response should have missing-fields title")
-	assert.Contains(t, auditProblemDetail(t, body), "missing one or more required fields", "Error detail should indicate a missing/invalid required field")
+	assert.Contains(t, testutil.ParseErrorResponse(t, body).Detail, "missing one or more required fields", "Error detail should indicate a missing/invalid required field")
 }
 
 // TestAuditEvents_11_2_13_ReturnsEmptyArrayWhenNoMatches tests empty results.
@@ -1103,7 +1103,7 @@ func TestAuditEvents_11_3_5_Returns400ForInvalidUUID(t *testing.T) {
 	errResp := testutil.ParseErrorResponse(t, body)
 	assert.Equal(t, "0065", errResp.Code, "Error response should have invalid path parameter code")
 	assert.Equal(t, "Invalid Path Parameter", errResp.Title, "Error response should have invalid path parameter title")
-	assert.Contains(t, auditProblemDetail(t, body), "path parameters are in an incorrect format", "Error detail should indicate invalid UUID format")
+	assert.Contains(t, testutil.ParseErrorResponse(t, body).Detail, "path parameters are in an incorrect format", "Error detail should indicate invalid UUID format")
 }
 
 // ============================================================================
@@ -1910,7 +1910,7 @@ func TestAuditEvents_11_9_2_InvalidDateFormatReturns400(t *testing.T) {
 	errResp := testutil.ParseErrorResponse(t, body)
 	assert.Equal(t, "0077", errResp.Code, "Error response should have 0077 (Invalid Date Format)")
 	assert.Equal(t, "Invalid Date Format Error", errResp.Title, "Error response should have invalid date format title")
-	assert.Contains(t, auditProblemDetail(t, body), "yyyy-mm-dd", "Error detail should indicate invalid date format")
+	assert.Contains(t, testutil.ParseErrorResponse(t, body).Detail, "yyyy-mm-dd", "Error detail should indicate invalid date format")
 }
 
 // TestAuditEvents_11_9_3_PageSizeExceedsMaximum tests limit validation.
@@ -1937,7 +1937,7 @@ func TestAuditEvents_11_9_3_PageSizeExceedsMaximum(t *testing.T) {
 	errResp := testutil.ParseErrorResponse(t, body)
 	assert.Equal(t, "0080", errResp.Code, "Error response should have 0080 (Limit Exceeds Maximum)")
 	assert.Equal(t, "Pagination Limit Exceeded", errResp.Title, "Error response should have pagination limit exceeded title")
-	assert.Contains(t, auditProblemDetail(t, body), "maximum allowed of 1000", "Error detail should indicate limit exceeded")
+	assert.Contains(t, testutil.ParseErrorResponse(t, body).Detail, "maximum allowed of 1000", "Error detail should indicate limit exceeded")
 }
 
 // TestAuditEvents_11_9_4_NegativePageSizeReturnsError tests negative limit.
@@ -1963,7 +1963,7 @@ func TestAuditEvents_11_9_4_NegativePageSizeReturnsError(t *testing.T) {
 	errResp := testutil.ParseErrorResponse(t, body)
 	assert.Equal(t, "0331", errResp.Code, "Error response should have 0331 (Limit Below Minimum)")
 	assert.Equal(t, "Pagination Limit Invalid", errResp.Title, "Error response should have pagination limit invalid title")
-	assert.Contains(t, auditProblemDetail(t, body), "Pagination limit must be positive", "Error detail should indicate limit validation failed")
+	assert.Contains(t, testutil.ParseErrorResponse(t, body).Detail, "Pagination limit must be positive", "Error detail should indicate limit validation failed")
 }
 
 // TestAuditEvents_11_9_5_InvalidSortByFieldReturns400 tests invalid sortBy field.
@@ -1988,7 +1988,7 @@ func TestAuditEvents_11_9_5_InvalidSortByFieldReturns400(t *testing.T) {
 	errResp := testutil.ParseErrorResponse(t, body)
 	assert.Equal(t, "0332", errResp.Code, "Error response should have 0332 (Invalid SortBy)")
 	assert.Equal(t, "Invalid Sort Column", errResp.Title, "Error response should have invalid sort column title")
-	assert.Contains(t, auditProblemDetail(t, body), "Sort column not in allowed list", "Error detail should indicate invalid sort_by field")
+	assert.Contains(t, testutil.ParseErrorResponse(t, body).Detail, "Sort column not in allowed list", "Error detail should indicate invalid sort_by field")
 }
 
 // TestAuditEvents_11_9_6_EndDateBeforeStartDateReturns400 tests invalid date range.
@@ -2018,7 +2018,7 @@ func TestAuditEvents_11_9_6_EndDateBeforeStartDateReturns400(t *testing.T) {
 	errResp := testutil.ParseErrorResponse(t, body)
 	assert.Equal(t, "0083", errResp.Code, "Error response should have 0083 (Invalid date range)")
 	assert.Equal(t, "Invalid Date Range Error", errResp.Title, "Error response should have invalid date range title")
-	assert.Contains(t, auditProblemDetail(t, body), "Both 'initialDate' and 'finalDate' fields are required", "Error detail should indicate invalid date range")
+	assert.Contains(t, testutil.ParseErrorResponse(t, body).Detail, "Both 'initialDate' and 'finalDate' fields are required", "Error detail should indicate invalid date range")
 }
 
 // TestAuditEvents_11_9_7_InvalidCursorReturns400 tests malformed cursor.
@@ -2044,7 +2044,7 @@ func TestAuditEvents_11_9_7_InvalidCursorReturns400(t *testing.T) {
 	errResp := testutil.ParseErrorResponse(t, body)
 	assert.Equal(t, "0333", errResp.Code, "Error response should have 0333 for invalid cursor")
 	assert.Equal(t, "Invalid Cursor", errResp.Title, "Error title should be Invalid Cursor")
-	assert.Contains(t, auditProblemDetail(t, body), "Invalid or corrupted pagination cursor", "Error detail should indicate invalid cursor")
+	assert.Contains(t, testutil.ParseErrorResponse(t, body).Detail, "Invalid or corrupted pagination cursor", "Error detail should indicate invalid cursor")
 }
 
 // TestAuditEvents_11_9_8_ZeroLimitReturnsError tests limit=0 behavior.
@@ -2071,7 +2071,7 @@ func TestAuditEvents_11_9_8_ZeroLimitReturnsError(t *testing.T) {
 	errResp := testutil.ParseErrorResponse(t, body)
 	assert.Equal(t, "0331", errResp.Code, "Error response should have 0331 (Limit Below Minimum)")
 	assert.Equal(t, "Pagination Limit Invalid", errResp.Title, "Error response should have pagination limit invalid title")
-	assert.Contains(t, auditProblemDetail(t, body), "Pagination limit must be positive", "Error detail should indicate limit must be at least 1")
+	assert.Contains(t, testutil.ParseErrorResponse(t, body).Detail, "Pagination limit must be positive", "Error detail should indicate limit must be at least 1")
 }
 
 // ============================================================================

--- a/components/tracer/tests/integration/09_bootstrap_migrations_test.go
+++ b/components/tracer/tests/integration/09_bootstrap_migrations_test.go
@@ -35,7 +35,8 @@ import (
 //  1. The three PostgreSQL functions that migrations 000001-000003 install
 //     (calculate_audit_event_hash, verify_audit_hash_chain, prevent_truncate)
 //     exist in pg_proc.
-//  2. golang-migrate's schema_migrations table reports version = 17 and dirty = false.
+//  2. golang-migrate's schema_migrations table reports version = headVersion
+//     (the HEAD migration count; see 10_upgrade_path_test.go) and dirty = false.
 //  3. The legacy tracking table schema_migrations_functions does NOT exist.
 //     Either it was never created (single-runner layout) or migration 000016
 //     dropped it.
@@ -77,7 +78,8 @@ func TestBootstrapAppliesAllMigrations(t *testing.T) {
 		for _, fn := range requiredFunctions {
 			var count int
 
-			err := db.QueryRowContext(ctx,
+			err := db.QueryRowContext(
+				ctx,
 				`SELECT COUNT(*)
 				   FROM pg_proc p
 				   JOIN pg_namespace n ON n.oid = p.pronamespace
@@ -93,7 +95,7 @@ func TestBootstrapAppliesAllMigrations(t *testing.T) {
 	})
 
 	// Shared suite DB; no t.Parallel() — see file-level note above.
-	t.Run("schema_migrations_reports_version_17", func(t *testing.T) {
+	t.Run("schema_migrations_reports_head_version", func(t *testing.T) {
 		var (
 			version int
 			dirty   bool
@@ -103,13 +105,14 @@ func TestBootstrapAppliesAllMigrations(t *testing.T) {
 		// applied row; golang-migrate only ever has a single row at HEAD, but
 		// ordering makes the query robust if a partial-history layout ever
 		// appears (e.g. mid-migration failure leaving multiple rows).
-		err := db.QueryRowContext(ctx,
+		err := db.QueryRowContext(
+			ctx,
 			`SELECT version, dirty FROM schema_migrations ORDER BY version DESC LIMIT 1`,
 		).Scan(&version, &dirty)
 
 		require.NoError(t, err, "query schema_migrations")
 		require.Equal(t, headVersion, version,
-			"migration 017 must be the final applied version after unified boot")
+			"the HEAD migration must be the final applied version after unified boot")
 		require.False(t, dirty, "schema_migrations must not be dirty after clean boot")
 	})
 
@@ -117,7 +120,8 @@ func TestBootstrapAppliesAllMigrations(t *testing.T) {
 	t.Run("legacy_schema_migrations_functions_table_is_absent", func(t *testing.T) {
 		var exists bool
 
-		err := db.QueryRowContext(ctx,
+		err := db.QueryRowContext(
+			ctx,
 			`SELECT EXISTS (
 				SELECT 1 FROM information_schema.tables
 				WHERE table_schema = 'public'
@@ -171,20 +175,23 @@ func TestBootstrapAppliesAllMigrations(t *testing.T) {
 				}
 			}()
 
-			if _, execErr := conn.ExecContext(context.Background(),
+			if _, execErr := conn.ExecContext(
+				context.Background(),
 				`SET session_replication_role = replica`,
 			); execErr != nil {
 				t.Logf("SET session_replication_role = replica: %v", execErr)
 				return
 			}
 
-			if _, execErr := conn.ExecContext(context.Background(),
+			if _, execErr := conn.ExecContext(
+				context.Background(),
 				`DELETE FROM audit_events WHERE resource_id = $1`, resourceID,
 			); execErr != nil {
 				t.Logf("DELETE audit_events resource_id=%s: %v", resourceID, execErr)
 			}
 
-			if _, execErr := conn.ExecContext(context.Background(),
+			if _, execErr := conn.ExecContext(
+				context.Background(),
 				`SET session_replication_role = origin`,
 			); execErr != nil {
 				t.Logf("SET session_replication_role = origin: %v", execErr)
@@ -193,7 +200,8 @@ func TestBootstrapAppliesAllMigrations(t *testing.T) {
 
 		var hash string
 
-		err = db.QueryRowContext(ctx,
+		err = db.QueryRowContext(
+			ctx,
 			`SELECT hash FROM audit_events WHERE resource_id = $1`, resourceID,
 		).Scan(&hash)
 
@@ -209,7 +217,7 @@ func TestBootstrapAppliesAllMigrations(t *testing.T) {
 		// a clean no-op. We build a brand-new libPostgres.NewMigrator against
 		// the same suite DSN (simulating a process restart) and assert:
 		//   - Up() returns nil
-		//   - schema_migrations.version still = 17, dirty still = false
+		//   - schema_migrations.version still = headVersion, dirty still = false
 		//   - the count of functions created by migrations 000001..000003 is
 		//     unchanged (proves no duplicate CREATE executed)
 		migrator, migErr := libPostgres.NewMigrator(libPostgres.MigrationConfig{
@@ -257,12 +265,13 @@ func TestBootstrapAppliesAllMigrations(t *testing.T) {
 			postDirty   bool
 		)
 
-		err = db.QueryRowContext(ctx,
+		err = db.QueryRowContext(
+			ctx,
 			`SELECT version, dirty FROM schema_migrations ORDER BY version DESC LIMIT 1`,
 		).Scan(&postVersion, &postDirty)
 		require.NoError(t, err, "read schema_migrations after idempotent replay")
 		require.Equal(t, headVersion, postVersion,
-			"schema_migrations.version must remain 17 after idempotent replay")
+			"schema_migrations.version must remain headVersion after idempotent replay")
 		require.False(t, postDirty,
 			"schema_migrations.dirty must remain false after idempotent replay")
 
@@ -359,7 +368,8 @@ func TestBootstrapMigrations_RefusesDirtyReapply(t *testing.T) {
 		preDirty   bool
 	)
 
-	err = db.QueryRowContext(ctx,
+	err = db.QueryRowContext(
+		ctx,
 		`SELECT version, dirty FROM schema_migrations ORDER BY version DESC LIMIT 1`,
 	).Scan(&preVersion, &preDirty)
 	require.NoError(t, err, "read schema_migrations after clean apply")
@@ -373,7 +383,8 @@ func TestBootstrapMigrations_RefusesDirtyReapply(t *testing.T) {
 	// mid-apply. Rather than contriving a failing migration (fragile; couples
 	// the test to SQL implementation details), we directly flip the tracking
 	// flag — which is exactly the state golang-migrate would have recorded.
-	result, err := db.ExecContext(ctx,
+	result, err := db.ExecContext(
+		ctx,
 		`UPDATE schema_migrations SET dirty = true WHERE version = $1`, headVersion,
 	)
 	require.NoError(t, err, "force dirty flag on schema_migrations")
@@ -425,7 +436,8 @@ func TestBootstrapMigrations_RefusesDirtyReapply(t *testing.T) {
 	// by silently re-applying). Operator must explicitly resolve.
 	var postDirty bool
 
-	err = db.QueryRowContext(ctx,
+	err = db.QueryRowContext(
+		ctx,
 		`SELECT dirty FROM schema_migrations WHERE version = $1`, headVersion,
 	).Scan(&postDirty)
 	require.NoError(t, err, "re-read schema_migrations.dirty after refused Up")

--- a/components/tracer/tests/integration/10_upgrade_path_test.go
+++ b/components/tracer/tests/integration/10_upgrade_path_test.go
@@ -288,10 +288,9 @@ func extractDevelopMigrations(ctx context.Context, t *testing.T) string {
 }
 
 // resolveHeadMigrationsDir returns the absolute path of the tracer migrations/
-// tree in the current working copy (HEAD of the feature branch). Post
-// monorepo-consolidation the tree lives at components/tracer/migrations, not the
-// repository root; this mirrors the production boot path resolved by the shared
-// integration suite (internal/testutil_integration/testcontainer_suite.go).
+// tree (components/tracer/migrations) in the current working copy; this mirrors
+// the production boot path resolved by the shared integration suite
+// (internal/testutil_integration/testcontainer_suite.go).
 //
 // ctx is threaded into the git subprocess via exec.CommandContext so a
 // cancelled or timed-out test context kills the child process, matching the

--- a/components/tracer/tests/integration/10_upgrade_path_test.go
+++ b/components/tracer/tests/integration/10_upgrade_path_test.go
@@ -40,8 +40,8 @@ import (
 const legacyHeadVersion = 12
 
 // headVersion is the expected final schema_migrations.version after applying
-// the HEAD migrations (unified single-runner, 001..016).
-const headVersion = 17
+// the HEAD migrations (unified single-runner, 000001..000020).
+const headVersion = 20
 
 // legacyDevelopRef is the immutable commit representing the last state of
 // origin/develop before the unify-sql-migrations feature branched. Pinned
@@ -64,9 +64,9 @@ const legacyDevelopRef = "0a77ac3e4945db1846626aab91f9899079877365"
 //     (dual-runner layout: `migrations/functions/` + numbered schema
 //     migrations 001..012, tracked in `schema_migrations_functions` +
 //     `schema_migrations`).
-//  2. In-place upgrade to HEAD migrations (unified single-runner, 001..016)
+//  2. In-place upgrade to HEAD migrations (unified single-runner, 000001..000020)
 //     using the exact same boot runner production will use (libPostgres.Migrator).
-//  3. Assertions that the final state matches a fresh install: version=16,
+//  3. Assertions that the final state matches a fresh install: version=headVersion,
 //     legacy tracking table dropped, hash-chain functions installed, audit
 //     trigger operational.
 //
@@ -287,8 +287,11 @@ func extractDevelopMigrations(ctx context.Context, t *testing.T) string {
 	return extracted
 }
 
-// resolveHeadMigrationsDir returns the absolute path of the migrations/ tree
-// in the current working copy (HEAD of the feature branch).
+// resolveHeadMigrationsDir returns the absolute path of the tracer migrations/
+// tree in the current working copy (HEAD of the feature branch). Post
+// monorepo-consolidation the tree lives at components/tracer/migrations, not the
+// repository root; this mirrors the production boot path resolved by the shared
+// integration suite (internal/testutil_integration/testcontainer_suite.go).
 //
 // ctx is threaded into the git subprocess via exec.CommandContext so a
 // cancelled or timed-out test context kills the child process, matching the
@@ -301,7 +304,7 @@ func resolveHeadMigrationsDir(ctx context.Context, t *testing.T) string {
 
 	root := strings.TrimSpace(string(out))
 
-	return filepath.Join(root, "migrations")
+	return filepath.Join(root, "components", "tracer", "migrations")
 }
 
 // withTestDB opens a *sql.DB against dsn, invokes fn, and guarantees Close()
@@ -332,7 +335,8 @@ func withTestDB(t *testing.T, dsn, openMsg string, fn func(db *sql.DB)) {
 func startUpgradePathContainer(ctx context.Context, t *testing.T) string {
 	t.Helper()
 
-	container, err := postgres.Run(ctx,
+	container, err := postgres.Run(
+		ctx,
 		"postgres:16-alpine",
 		postgres.WithDatabase("tracer_test"),
 		postgres.WithUsername("tracer"),
@@ -458,7 +462,8 @@ func applyLegacyFunctionMigrations(ctx context.Context, t *testing.T, dsn, funct
 			_, err = db.ExecContext(ctx, string(body))
 			require.NoError(t, err, "apply legacy function migration %s", fname)
 
-			_, err = db.ExecContext(ctx,
+			_, err = db.ExecContext(
+				ctx,
 				`INSERT INTO schema_migrations_functions (version, name) VALUES ($1, $2)`,
 				versionNum, parts[1],
 			)
@@ -566,7 +571,8 @@ func applyLegacySchemaMigrationsUpTo(ctx context.Context, t *testing.T, dsn, mig
 		dirty   bool
 	)
 
-	err = db.QueryRowContext(ctx,
+	err = db.QueryRowContext(
+		ctx,
 		`SELECT version, dirty FROM schema_migrations ORDER BY version DESC LIMIT 1`,
 	).Scan(&version, &dirty)
 	require.NoError(t, err, "read schema_migrations after legacy apply")
@@ -587,7 +593,8 @@ func assertLegacyState(ctx context.Context, t *testing.T, dsn string, legacyVers
 			dirty   bool
 		)
 
-		err := db.QueryRowContext(ctx,
+		err := db.QueryRowContext(
+			ctx,
 			`SELECT version, dirty FROM schema_migrations ORDER BY version DESC LIMIT 1`,
 		).Scan(&version, &dirty)
 		require.NoError(t, err, "read legacy schema_migrations.version")
@@ -597,7 +604,8 @@ func assertLegacyState(ctx context.Context, t *testing.T, dsn string, legacyVers
 
 		var functionRows int
 
-		err = db.QueryRowContext(ctx,
+		err = db.QueryRowContext(
+			ctx,
 			`SELECT COUNT(*) FROM schema_migrations_functions`,
 		).Scan(&functionRows)
 		require.NoError(t, err, "count schema_migrations_functions")
@@ -621,7 +629,8 @@ func assertUpgradedState(ctx context.Context, t *testing.T, dsn string) {
 			dirty   bool
 		)
 
-		err := db.QueryRowContext(ctx,
+		err := db.QueryRowContext(
+			ctx,
 			`SELECT version, dirty FROM schema_migrations ORDER BY version DESC LIMIT 1`,
 		).Scan(&version, &dirty)
 		require.NoError(t, err, "read upgraded schema_migrations.version")
@@ -647,7 +656,8 @@ func assertUpgradedState(ctx context.Context, t *testing.T, dsn string) {
 		} {
 			var count int
 
-			err = db.QueryRowContext(ctx,
+			err = db.QueryRowContext(
+				ctx,
 				`SELECT COUNT(*) FROM pg_proc WHERE proname = $1`, fn,
 			).Scan(&count)
 			require.NoError(t, err, "pg_proc lookup for %s", fn)
@@ -679,7 +689,8 @@ func assertUpgradedState(ctx context.Context, t *testing.T, dsn string) {
 		//    executed the conversion exactly once (not zero, not twice).
 		var maxAmountType string
 
-		err = db.QueryRowContext(ctx,
+		err = db.QueryRowContext(
+			ctx,
 			`SELECT data_type FROM information_schema.columns
 			 WHERE table_schema = 'public'
 			   AND table_name   = 'limits'
@@ -712,7 +723,8 @@ func assertUpgradedStateForLegacyVersion(ctx context.Context, t *testing.T, dsn 
 		// behavioral proof the guard logic is correct.
 		var constraintCount int
 
-		err := db.QueryRowContext(ctx,
+		err := db.QueryRowContext(
+			ctx,
 			`SELECT COUNT(*) FROM pg_constraint
 			 WHERE conname = 'chk_limits_custom_dates_required'
 			   AND conrelid = 'public.limits'::regclass`,

--- a/components/tracer/tests/integration/12_name_uniqueness_test.go
+++ b/components/tracer/tests/integration/12_name_uniqueness_test.go
@@ -24,15 +24,15 @@ import (
 // Rules & Limits Name Uniqueness Tests
 //
 // These tests verify:
-// 1. Creating a rule with a duplicate name in the same context returns HTTP 409 + TRC-0303
+// 1. Creating a rule with a duplicate name in the same context returns HTTP 409 + 0441 (ErrRuleNameAlreadyExistsInCtx)
 // 2. Creating a rule with the same name in a DIFFERENT context returns HTTP 201
 // 3. Creating a rule with a name that was previously soft-deleted returns HTTP 201
-// 4. Creating a limit with a duplicate name (globally unique) returns HTTP 409 + TRC-0304
+// 4. Creating a limit with a duplicate name (globally unique) returns HTTP 409 + 0442 (ErrLimitNameAlreadyExists)
 // 5. Creating a limit with a name that was previously soft-deleted returns HTTP 201
 //
 // Implementation complete:
 // - Unique indexes on rules(context_id, name) and limits(name) with NULLS NOT DISTINCT
-// - TRC-0303 and TRC-0304 error codes for duplicate names
+// - 0441 and 0442 error codes for duplicate names (title is the humanized sentinel name; human text in RFC 9457 detail)
 // - Context-scoped uniqueness for rules (via context_id derived from first scope's segmentId)
 // - Global uniqueness for limits (name must be unique across all non-deleted limits)
 // TODO: update limit tests to include rule_id when limits become rule-scoped
@@ -65,7 +65,7 @@ type nameUniquenessErrorResponse struct {
 
 // =============================================================================
 // Test 1: CreateRule_DuplicateName_Returns409
-// Same name + same context -> 409 + TRC-0303
+// Same name + same context -> 409 + 0441
 // =============================================================================
 
 func TestCreateRule_DuplicateName_Returns409(t *testing.T) {
@@ -137,7 +137,7 @@ func TestCreateRule_DuplicateName_Returns409(t *testing.T) {
 	respBody2, err := io.ReadAll(resp2.Body)
 	require.NoError(t, err)
 
-	// Verify duplicate rule name in same context returns 409 + TRC-0303
+	// Verify duplicate rule name in same context returns 409 + 0441
 	assert.Equal(t, http.StatusConflict, resp2.StatusCode, "Duplicate rule name in same context should return 409: %s", string(respBody2))
 
 	if resp2.StatusCode == http.StatusConflict {
@@ -145,9 +145,10 @@ func TestCreateRule_DuplicateName_Returns409(t *testing.T) {
 		err = json.Unmarshal(respBody2, &errResp)
 		require.NoError(t, err)
 
-		assert.Equal(t, "0441", errResp.Code, "Error code should be TRC-0303 for duplicate rule name in same context")
-		assert.Equal(t, "Conflict", errResp.Title, "Error title should be Conflict")
-		assert.Contains(t, errResp.Message, "name", "Error message should mention name")
+		assert.Equal(t, "0441", errResp.Code, "Error code should be 0441 (ErrRuleNameAlreadyExistsInCtx) for duplicate rule name in same context")
+		assert.Equal(t, "Rule Name Already Exists In Ctx", errResp.Title, "Error title is the humanized sentinel name")
+		// message field is retired under RFC 9457; the human text now lives in `detail`.
+		assert.Empty(t, errResp.Message, "message retired; RFC 9457 detail carries the human text")
 	}
 }
 
@@ -341,7 +342,7 @@ func TestCreateRule_DeletedNameReuse_Returns201(t *testing.T) {
 
 // =============================================================================
 // Test 4: CreateLimit_DuplicateName_Returns409
-// Same name (globally unique) -> 409 + TRC-0304
+// Same name (globally unique) -> 409 + 0442
 // =============================================================================
 
 func TestCreateLimit_DuplicateName_Returns409(t *testing.T) {
@@ -416,7 +417,7 @@ func TestCreateLimit_DuplicateName_Returns409(t *testing.T) {
 	respBody2, err := io.ReadAll(resp2.Body)
 	require.NoError(t, err)
 
-	// Verify duplicate limit name returns 409 + TRC-0304
+	// Verify duplicate limit name returns 409 + 0442
 	assert.Equal(t, http.StatusConflict, resp2.StatusCode, "Duplicate limit name should return 409: %s", string(respBody2))
 
 	if resp2.StatusCode == http.StatusConflict {
@@ -424,9 +425,10 @@ func TestCreateLimit_DuplicateName_Returns409(t *testing.T) {
 		err = json.Unmarshal(respBody2, &errResp)
 		require.NoError(t, err)
 
-		assert.Equal(t, "0442", errResp.Code, "Error code should be TRC-0304 for duplicate limit name")
-		assert.Equal(t, "Conflict", errResp.Title, "Error title should be Conflict")
-		assert.Contains(t, errResp.Message, "name", "Error message should mention name")
+		assert.Equal(t, "0442", errResp.Code, "Error code should be 0442 (ErrLimitNameAlreadyExists) for duplicate limit name")
+		assert.Equal(t, "Limit Name Already Exists", errResp.Title, "Error title is the humanized sentinel name")
+		// message field is retired under RFC 9457; the human text now lives in `detail`.
+		assert.Empty(t, errResp.Message, "message retired; RFC 9457 detail carries the human text")
 	}
 }
 

--- a/components/tracer/tests/integration/12_name_uniqueness_test.go
+++ b/components/tracer/tests/integration/12_name_uniqueness_test.go
@@ -60,6 +60,7 @@ type nameUniquenessLimitRequest struct {
 type nameUniquenessErrorResponse struct {
 	Code    string `json:"code"`
 	Title   string `json:"title"`
+	Detail  string `json:"detail"`
 	Message string `json:"message"`
 }
 
@@ -149,6 +150,8 @@ func TestCreateRule_DuplicateName_Returns409(t *testing.T) {
 		assert.Equal(t, "Rule Name Already Exists In Ctx", errResp.Title, "Error title is the humanized sentinel name")
 		// message field is retired under RFC 9457; the human text now lives in `detail`.
 		assert.Empty(t, errResp.Message, "message retired; RFC 9457 detail carries the human text")
+		require.NotEmpty(t, errResp.Detail, "RFC 9457 detail must carry the human-readable conflict text")
+		assert.Equal(t, "Rule name already exists in this context.", errResp.Detail, "detail should state the rule-name conflict")
 	}
 }
 
@@ -429,6 +432,8 @@ func TestCreateLimit_DuplicateName_Returns409(t *testing.T) {
 		assert.Equal(t, "Limit Name Already Exists", errResp.Title, "Error title is the humanized sentinel name")
 		// message field is retired under RFC 9457; the human text now lives in `detail`.
 		assert.Empty(t, errResp.Message, "message retired; RFC 9457 detail carries the human text")
+		require.NotEmpty(t, errResp.Detail, "RFC 9457 detail must carry the human-readable conflict text")
+		assert.Equal(t, "Limit name already exists.", errResp.Detail, "detail should state the limit-name conflict")
 	}
 }
 

--- a/components/tracer/tests/integration/20_reservation_payload_too_large_test.go
+++ b/components/tracer/tests/integration/20_reservation_payload_too_large_test.go
@@ -1,0 +1,53 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+//go:build integration
+
+package integration
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/LerianStudio/midaz/v4/components/tracer/internal/testutil"
+)
+
+// TestReservation_PayloadTooLarge mirrors TestValidation_1_1_9_PayloadTooLarge
+// for the reservation endpoint: a POST /v1/reservations body larger than the
+// 100KB limit must be rejected with 413 Payload Too Large and code 0143. The
+// size guard runs before JSON parsing, so the oversized body need not be valid
+// JSON. This is the coverage that was missing when the guard incorrectly mapped
+// to 400 instead of 413.
+func TestReservation_PayloadTooLarge(t *testing.T) {
+	baseURL := testutil.GetBaseURL()
+	apiKey := testutil.GetAPIKey()
+
+	// 110KB body to comfortably exceed the 100KB (100*1024) limit.
+	largeBody := bytes.Repeat([]byte("x"), 110*1024)
+
+	req, err := http.NewRequest(http.MethodPost, baseURL+"/v1/reservations", bytes.NewReader(largeBody))
+	require.NoError(t, err)
+	req.Header.Set("X-API-Key", apiKey)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := testutil.HTTPClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	assert.Equal(t, http.StatusRequestEntityTooLarge, resp.StatusCode,
+		"Reservation payload >100KB should return 413 Payload Too Large, got body: %s", string(respBody))
+
+	errorResp := testutil.ParseErrorResponse(t, respBody)
+	assert.Equal(t, "0143", errorResp.Code, "Error code should be 0143 for payload too large")
+	assert.Equal(t, "Payload Too Large", errorResp.Title, "Error title should be Payload Too Large")
+	assert.Equal(t, "payload too large: exceeds 100KB limit", errorResp.Message, "Error message should indicate payload size limit")
+}

--- a/components/tracer/tests/integration/20_reservation_payload_too_large_test.go
+++ b/components/tracer/tests/integration/20_reservation_payload_too_large_test.go
@@ -22,8 +22,7 @@ import (
 // for the reservation endpoint: a POST /v1/reservations body larger than the
 // 100KB limit must be rejected with 413 Payload Too Large and code 0143. The
 // size guard runs before JSON parsing, so the oversized body need not be valid
-// JSON. This is the coverage that was missing when the guard incorrectly mapped
-// to 400 instead of 413.
+// JSON.
 func TestReservation_PayloadTooLarge(t *testing.T) {
 	baseURL := testutil.GetBaseURL()
 	apiKey := testutil.GetAPIKey()
@@ -45,6 +44,8 @@ func TestReservation_PayloadTooLarge(t *testing.T) {
 
 	assert.Equal(t, http.StatusRequestEntityTooLarge, resp.StatusCode,
 		"Reservation payload >100KB should return 413 Payload Too Large, got body: %s", string(respBody))
+	assert.Contains(t, resp.Header.Get("Content-Type"), "application/problem+json",
+		"413 error must use the RFC 9457 problem+json media type")
 
 	errorResp := testutil.ParseErrorResponse(t, respBody)
 	assert.Equal(t, "0143", errorResp.Code, "Error code should be 0143 for payload too large")

--- a/pkg/constant/errors.go
+++ b/pkg/constant/errors.go
@@ -153,6 +153,7 @@ var (
 	ErrNoBalanceDataAtTimestamp                 = errors.New("0141")
 	ErrMissingRequiredQueryParameter            = errors.New("0142")
 	ErrPayloadTooLarge                          = errors.New("0143")
+	ErrRequestHeaderFieldsTooLarge              = errors.New("0493")
 	ErrJSONNestingDepthExceeded                 = errors.New("0144")
 	ErrJSONKeyCountExceeded                     = errors.New("0145")
 	ErrTenantNotProvisioned                     = errors.New("0146")

--- a/pkg/constant/errors.go
+++ b/pkg/constant/errors.go
@@ -153,7 +153,7 @@ var (
 	ErrNoBalanceDataAtTimestamp                 = errors.New("0141")
 	ErrMissingRequiredQueryParameter            = errors.New("0142")
 	ErrPayloadTooLarge                          = errors.New("0143")
-	ErrRequestHeaderFieldsTooLarge              = errors.New("0493")
+	ErrRequestHeaderFieldsTooLarge              = errors.New("0497")
 	ErrJSONNestingDepthExceeded                 = errors.New("0144")
 	ErrJSONKeyCountExceeded                     = errors.New("0145")
 	ErrTenantNotProvisioned                     = errors.New("0146")

--- a/pkg/errors.go
+++ b/pkg/errors.go
@@ -305,6 +305,11 @@ func IsBusinessError(err error) bool {
 		return true
 	}
 
+	var payloadTooLargeErr PayloadTooLargeError
+	if errors.As(err, &payloadTooLargeErr) {
+		return true
+	}
+
 	var validationKnownFieldsErr ValidationKnownFieldsError
 	if errors.As(err, &validationKnownFieldsErr) {
 		return true

--- a/pkg/errors.go
+++ b/pkg/errors.go
@@ -162,6 +162,38 @@ func (e ServiceUnavailableError) Error() string {
 	return e.Message
 }
 
+// GatewayTimeoutError indicates an upstream/processing deadline was exceeded and
+// the request could not be completed in time. It renders as HTTP 504 (distinct
+// from ServiceUnavailableError's 503): the caller may retry, but the failure is
+// a timeout, not an unavailable dependency.
+type GatewayTimeoutError struct {
+	EntityType string `json:"entityType,omitempty"`
+	Title      string `json:"title,omitempty"`
+	Message    string `json:"message,omitempty"`
+	Code       string `json:"code,omitempty"`
+	Err        error  `json:"err,omitempty"`
+}
+
+func (e GatewayTimeoutError) Error() string {
+	return e.Message
+}
+
+// PayloadTooLargeError indicates the request body exceeded the accepted size
+// limit. It renders as HTTP 413. The limit (and therefore the human message) is
+// caller-specific, so this type is constructed at the call site with an explicit
+// Message rather than resolved from the shared registry.
+type PayloadTooLargeError struct {
+	EntityType string `json:"entityType,omitempty"`
+	Title      string `json:"title,omitempty"`
+	Message    string `json:"message,omitempty"`
+	Code       string `json:"code,omitempty"`
+	Err        error  `json:"err,omitempty"`
+}
+
+func (e PayloadTooLargeError) Error() string {
+	return e.Message
+}
+
 // InternalServerError indicates midaz has an unexpected failure during an operation.
 type InternalServerError struct {
 	EntityType string `json:"entityType,omitempty"`
@@ -1385,6 +1417,12 @@ func ValidateBusinessError(err error, entityType string, args ...any) error {
 			Title:      "Payload Too Large",
 			Message:    "The request payload exceeds the maximum allowed size of 64KB.",
 		},
+		constant.ErrRequestHeaderFieldsTooLarge: ValidationError{
+			EntityType: entityType,
+			Code:       constant.ErrRequestHeaderFieldsTooLarge.Error(),
+			Title:      "Request Header Fields Too Large",
+			Message:    "The request header fields are too large. Please reduce the size of the request headers and try again.",
+		},
 		constant.ErrJSONNestingDepthExceeded: ValidationError{
 			EntityType: entityType,
 			Code:       constant.ErrJSONNestingDepthExceeded.Error(),
@@ -2435,11 +2473,11 @@ func ValidateBusinessError(err error, entityType string, args ...any) error {
 			Title:      "Validation Timestamp Past",
 			Message:    "Timestamp is too far in the past.",
 		},
-		constant.ErrValidationTimeout: ServiceUnavailableError{
+		constant.ErrValidationTimeout: GatewayTimeoutError{
 			EntityType: entityType,
 			Code:       constant.ErrValidationTimeout.Error(),
-			Title:      "Validation Timeout",
-			Message:    "Validation timeout.",
+			Title:      "Gateway Timeout",
+			Message:    "validation timeout",
 		},
 		constant.ErrValidationSegmentIDRequired: ValidationError{
 			EntityType: entityType,
@@ -2501,11 +2539,11 @@ func ValidateBusinessError(err error, entityType string, args ...any) error {
 			Title:      "Transaction Validation Not Found",
 			Message:    "Transaction validation record not found.",
 		},
-		constant.ErrListValidationsTimeout: ServiceUnavailableError{
+		constant.ErrListValidationsTimeout: GatewayTimeoutError{
 			EntityType: entityType,
 			Code:       constant.ErrListValidationsTimeout.Error(),
-			Title:      "List Validations Timeout",
-			Message:    "List validations query timeout (deadline exceeded).",
+			Title:      "Gateway Timeout",
+			Message:    "query timeout exceeded",
 		},
 		constant.ErrTransactionValidationIDRequired: ValidationError{
 			EntityType: entityType,

--- a/pkg/errors_test.go
+++ b/pkg/errors_test.go
@@ -714,6 +714,8 @@ func TestIsBusinessError(t *testing.T) {
 		{name: "UnauthorizedError", err: UnauthorizedError{Code: "0042", Message: "no token"}, expected: true},
 		{name: "ForbiddenError", err: ForbiddenError{Code: "0043", Message: "denied"}, expected: true},
 		{name: "UnprocessableOperationError", err: UnprocessableOperationError{Code: "0182", Message: "semantic"}, expected: true},
+		{name: "PayloadTooLargeError", err: PayloadTooLargeError{Code: "0143", Message: "too large"}, expected: true},
+		{name: "wrapped PayloadTooLargeError", err: fmt.Errorf("context: %w", PayloadTooLargeError{Code: "0143"}), expected: true},
 		{name: "ValidationKnownFieldsError", err: ValidationKnownFieldsError{Code: "0009", Message: "known"}, expected: true},
 		{name: "ValidationUnknownFieldsError", err: ValidationUnknownFieldsError{Code: "0053", Message: "unknown"}, expected: true},
 		{name: "wrapped EntityNotFoundError", err: fmt.Errorf("context: %w", EntityNotFoundError{Code: "0007"}), expected: true},
@@ -721,6 +723,7 @@ func TestIsBusinessError(t *testing.T) {
 		{name: "InternalServerError is not business", err: InternalServerError{Code: "0046", Message: "boom"}, expected: false},
 		{name: "FailedPreconditionError is not business", err: FailedPreconditionError{Code: "0269", Message: "precondition"}, expected: false},
 		{name: "ServiceUnavailableError is not business", err: ServiceUnavailableError{Code: "0265", Message: "down"}, expected: false},
+		{name: "GatewayTimeoutError is not business", err: GatewayTimeoutError{Code: "0271", Message: "timeout"}, expected: false},
 		{name: "plain error is not business", err: errors.New("boom"), expected: false},
 		{name: "nil error is not business", err: nil, expected: false},
 	}

--- a/pkg/net/http/errors_golden_test.go
+++ b/pkg/net/http/errors_golden_test.go
@@ -88,6 +88,12 @@ func classifyStatusOf(t *testing.T, err error) (status int, code string) {
 	if e := (pkg.ServiceUnavailableError{}); errors.As(err, &e) {
 		return fiber.StatusServiceUnavailable, e.Code
 	}
+	if e := (pkg.GatewayTimeoutError{}); errors.As(err, &e) {
+		return fiber.StatusGatewayTimeout, e.Code
+	}
+	if e := (pkg.PayloadTooLargeError{}); errors.As(err, &e) {
+		return fiber.StatusRequestEntityTooLarge, e.Code
+	}
 
 	// Fallthrough: WithError:110 -> ValidateInternalError -> 500 / code 0046.
 	return fiber.StatusInternalServerError, constant.ErrInternalServer.Error()
@@ -275,6 +281,7 @@ func allSentinels() []error {
 		constant.ErrNoBalanceDataAtTimestamp,
 		constant.ErrMissingRequiredQueryParameter,
 		constant.ErrPayloadTooLarge,
+		constant.ErrRequestHeaderFieldsTooLarge,
 		constant.ErrJSONNestingDepthExceeded,
 		constant.ErrJSONKeyCountExceeded,
 		constant.ErrTenantNotProvisioned,
@@ -565,9 +572,9 @@ func allSentinels() []error {
 func TestGolden_SentinelInventoryComplete(t *testing.T) {
 	t.Parallel()
 
-	// pkg/constant/errors.go currently declares 422 Err* sentinels. Bump this
+	// pkg/constant/errors.go currently declares 423 Err* sentinels. Bump this
 	// number in lockstep with allSentinels() whenever a code is added/removed.
-	const wantSentinelCount = 422
+	const wantSentinelCount = 423
 
 	assert.Len(t, allSentinels(), wantSentinelCount,
 		"sentinel inventory drifted: update allSentinels() and this count together")

--- a/pkg/net/http/fiber_error_handler.go
+++ b/pkg/net/http/fiber_error_handler.go
@@ -20,8 +20,8 @@ import (
 // CanonicalFiberErrorHandler is the Fiber ErrorHandler that renders the canonical
 // {code,title,message} envelope (E13) for errors that escape the handler chain —
 // chiefly *fiber.Error producers: auth assertions (401), Fiber's router (404/405),
-// and the body-limit guard (413). Any unmapped error degrades to a generic 500
-// with no raw error text (E9).
+// the body-limit guard (413), and the header-size guard (431). Any unmapped error
+// degrades to a generic 500 with no raw error text (E9).
 //
 // Reuse this handler in every fiber.Config{ErrorHandler: ...} so all Midaz fiber
 // apps share one error envelope.
@@ -44,6 +44,8 @@ func CanonicalFiberErrorHandler(c *fiber.Ctx, err error) error {
 			return renderCanonical(c, fiber.StatusMethodNotAllowed, pkg.ValidateBusinessError(constant.ErrMethodNotAllowed, ""))
 		case fiber.StatusRequestEntityTooLarge:
 			return renderCanonical(c, fiber.StatusRequestEntityTooLarge, pkg.ValidateBusinessError(constant.ErrPayloadTooLarge, ""))
+		case fiber.StatusRequestHeaderFieldsTooLarge:
+			return renderCanonical(c, fiber.StatusRequestHeaderFieldsTooLarge, pkg.ValidateBusinessError(constant.ErrRequestHeaderFieldsTooLarge, ""))
 		}
 	}
 
@@ -75,7 +77,8 @@ func logError(ctx context.Context, c *fiber.Ctx, err error) {
 	}
 
 	logger := libObservability.NewLoggerFromContext(ctx)
-	logger.Log(ctx, libLog.LevelError,
+	logger.Log(
+		ctx, libLog.LevelError,
 		"handler error",
 		libLog.String("method", c.Method()),
 		libLog.String("path", c.Path()),

--- a/pkg/net/http/problem.go
+++ b/pkg/net/http/problem.go
@@ -31,6 +31,14 @@ type Detail struct {
 	libProblem.Detail
 
 	EntityType string `json:"entityType,omitempty"`
+
+	// Message carries the human-readable reason as a top-level field for the
+	// error classes that expose it to clients verbatim (413 payload-too-large,
+	// 504 gateway-timeout). It is populated only for those statuses; for every
+	// other class it stays empty and is dropped by omitempty, so the shared
+	// envelope (and the ledger wire) is unchanged. Distinct from the RFC 9457
+	// `detail`, which the >=500 scrub replaces with "internal error".
+	Message string `json:"message,omitempty"`
 }
 
 // codeStatus is the FROZEN code->status snapshot of the §1 table, keyed by the
@@ -97,6 +105,14 @@ func classifyForProblem(err error) (code, msg, title, entityType string, status 
 
 	if e := (pkg.ServiceUnavailableError{}); errors.As(err, &e) {
 		return e.Code, e.Message, e.Title, e.EntityType, http.StatusServiceUnavailable, true
+	}
+
+	if e := (pkg.GatewayTimeoutError{}); errors.As(err, &e) {
+		return e.Code, e.Message, e.Title, e.EntityType, http.StatusGatewayTimeout, true
+	}
+
+	if e := (pkg.PayloadTooLargeError{}); errors.As(err, &e) {
+		return e.Code, e.Message, e.Title, e.EntityType, http.StatusRequestEntityTooLarge, true
 	}
 
 	// lib-commons Response sub-switch (r3 §1.2), resolved at the same arm position
@@ -178,17 +194,19 @@ func ProblemDetail(err error) (Detail, bool) {
 	var (
 		capturedEntityType string
 		capturedTitle      string
+		capturedMessage    string
 		problemStatus      int
 	)
 
-	// codeOf classifies the type once and stashes status + title + entityType.
-	// MapError calls codeOf then statusOf synchronously in the same call, so
-	// statusOf can return the captured status. See ponytail note above.
+	// codeOf classifies the type once and stashes status + title + entityType +
+	// message. MapError calls codeOf then statusOf synchronously in the same
+	// call, so statusOf can return the captured status. See ponytail note above.
 	codeOf := func(e error) (string, string, bool) {
 		code, msg, title, entityType, status, ok := classifyForProblem(e)
 		if ok {
 			capturedEntityType = entityType
 			capturedTitle = title
+			capturedMessage = msg
 			problemStatus = status
 		}
 
@@ -214,6 +232,15 @@ func ProblemDetail(err error) (Detail, bool) {
 	body := Detail{Detail: *pd, EntityType: capturedEntityType}
 	if errs := fieldsToErrors(err); errs != nil {
 		body.Errors = errs
+	}
+
+	// 413 and 504 expose the reason to clients verbatim via the top-level
+	// message field, using the raw registry message (not the >=500-scrubbed
+	// detail). No other class sets it, so omitempty keeps the shared envelope
+	// unchanged. These two statuses are produced ONLY by PayloadTooLargeError /
+	// GatewayTimeoutError inside this classifier, so gating on status is exact.
+	if problemStatus == http.StatusRequestEntityTooLarge || problemStatus == http.StatusGatewayTimeout {
+		body.Message = capturedMessage
 	}
 
 	return body, true


### PR DESCRIPTION
## Description

Lerian Map task **3418**. Re-syncs the tracer integration test suite to the Huma / RFC 9457 (`application/problem+json`) error contract, and — because the re-sync surfaced them — **fixes the production bugs where the tracer returned the wrong HTTP status** for several error conditions.

The integration suite was baseline-red on `develop` (~460 failing assertions) after the Huma/RFC 9457 migration: tests still expected the old contract (HTTP `400`, `TRC-####` codes, generic titles, `message` field) while the API had moved to the new one (`422` for business errors, numeric codes, specific titles, `detail` field).

### 1. Test re-sync (RFC 9457)
- `TRC-####` codes → numeric registry codes; generic titles → specific per-code titles; `400`→`422` for business/`UnprocessableOperationError`.
- Added a `Detail` (`json:"detail"`) field to the shared `testutil.ErrorResponse` and assert the real problem+json `detail` text across the validation/rules/limits/audit suites (replacing two ad-hoc local helpers and the retired `message` reads).

### 2. Production HTTP-status fixes (the tests are the spec)
| Condition | Was | Now | Root cause |
|-----------|-----|-----|------------|
| rule/limit lifecycle on missing/deleted entity | 500 | **404** | command handlers re-matched the raw sentinel via `errors.Is`, missing the pre-typed business error → added `IsBusinessError` passthrough |
| limit invalid state-transition | 500 | **422** | same |
| activate rule with invalid stored CEL | 500 | **400** (0340/0341) | collapsed compiler error → now propagates raw sentinel |
| processing/query timeout | 503 | **504** | new `GatewayTimeoutError` type + classify arm; remapped 0422/0433 |
| request body > 100KB (validations **and** reservations) | 400 | **413** | new `PayloadTooLargeError` type + classify arm |
| oversized request header (e.g. `X-API-Key`) | 500 | **431** | new arm in the Fiber error handler |

Shared `pkg/` error-platform changes are **purely additive** — ledger's error→status mapping is unchanged (verified: `go build ./...` + `pkg/net/http` tests green).

### 3. Tooling
- `build(tracer)`: fixed the `make test-integration` recipe, which aborted under `/bin/sh` with a syntax error (`integ_chaos_notice` expanded empty, leaving a bare `;`).

## Type of Change

- [x] `fix`: Bug fix
- [x] `test`: Adding or updating tests
- [x] `build`: Build system / Makefile

## Breaking Changes

Client-facing error responses for the six conditions above now return their correct HTTP status (404/422/400/413/431/504) instead of 500/503/400. This is a **correction** of the public error contract, not a regression. The additive top-level `message` field appears only on 413/504 responses.

## Testing

- [x] `make test` passes
- [x] `make test-int` passes — full tracer integration suite: **`DONE 2321 tests, 5 skipped, 0 failures`** (the 5 skips are pre-existing upgrade-path tests that skip when the legacy pre-monorepo migration SHA is absent)
- [x] `make lint` passes (tracer + pkg, 0 issues)
- [x] `go build ./...` (ledger + tracer) exit 0; `go test ./pkg/net/http/...` 770 passed (ledger-shared error platform unaffected)

**Review:** Gate 9 ran 5 specialist reviewers (code, logic, security, obs, test). Logic + security PASS; code/obs/test findings all addressed in this PR (413 span reclassified to business, `PayloadTooLargeError` added to `IsBusinessError`, `/reservations` 413 parity + new test, `detail` coverage restored, payload-size message DRYed from the constant).

## Architectural Checklist

- [x] No `panic()` in production paths
- [x] Errors wrapped with `%w`; typed errors + numeric sentinels in `pkg/errors.go` / `pkg/constant/errors.go`
- [x] Handlers stay thin; span-error class per telemetry T5 (business→green, technical→red)
- [x] Shared `pkg/` changes additive; ledger unaffected

## Related Issues

Lerian Map task 3418. Follows the merged #2240 (readyz) — independent branch off the updated `develop`.
