### PR TITLE
fix(infra): provision tracer database via postgres-init sidecar

### DIFF
--- a/components/infra/docker-compose.yml
+++ b/components/infra/docker-compose.yml
@@ -142,6 +142,40 @@ services:
     networks:
       - infra-network
 
+  # One-shot database provisioner. postgres only auto-runs
+  # /docker-entrypoint-initdb.d/*.sql on a FRESH data volume, so an existing
+  # volume that predates a newly-added database (e.g. tracer) never receives it
+  # and that service crash-loops on `database "..." does not exist`. This sidecar
+  # re-applies the idempotent init.sql against the healthy primary on every
+  # `make up`, provisioning any missing role/slot/database without touching
+  # existing data. Runs once, then exits.
+  #
+  # App services (ledger/tracer) live in separate compose files, so they cannot
+  # depend on this sidecar's completion. On a stale volume they may briefly race
+  # it and hit 3D000 before it finishes; their own restart policy / readiness
+  # retry rides out that one-time window — strictly better than the DB never
+  # existing.
+  midaz-postgres-init:
+    container_name: midaz-postgres-init
+    image: postgres:17
+    depends_on:
+      midaz-postgres-primary:
+        condition: service_healthy
+    environment:
+      PGPASSWORD: ${DB_PASSWORD}
+    entrypoint: /bin/sh
+    command:
+      - -c
+      - |
+        psql -v ON_ERROR_STOP=1 \
+          -h midaz-postgres-primary -p ${DB_PORT} -U ${DB_USER} -d postgres \
+          -f /init.sql
+    volumes:
+      - ./postgres/init.sql:/init.sql:ro
+    restart: "no"
+    networks:
+      - infra-network
+
   midaz-otel-lgtm:
     container_name: midaz-otel-lgtm
     image: grafana/otel-lgtm:latest

--- a/components/infra/postgres/init.sql
+++ b/components/infra/postgres/init.sql
@@ -1,19 +1,36 @@
-CREATE USER replicator WITH REPLICATION LOGIN ENCRYPTED PASSWORD 'replicator_password';
+-- Postgres bootstrap for the Midaz infra stack.
+--
+-- This script is applied in TWO situations and must stay idempotent for both:
+--   1. Auto-run by postgres on a FRESH data volume (mounted at
+--      /docker-entrypoint-initdb.d/init.sql).
+--   2. Re-run on EVERY `make up` by the midaz-postgres-init sidecar against the
+--      already-healthy primary.
+-- postgres only auto-runs docker-entrypoint-initdb.d on a fresh volume, so an
+-- EXISTING volume that predates a newly-added database (e.g. tracer) would never
+-- get it and that service crash-loops on `database "..." does not exist`
+-- (SQLSTATE 3D000). The sidecar closes that gap; every statement below is
+-- guarded so re-applying against a populated cluster provisions only what is
+-- missing and never errors on what already exists.
 
-SELECT pg_create_physical_replication_slot('replication_slot');
-SELECT * FROM pg_create_logical_replication_slot('logical_slot', 'pgoutput');
+-- Replication role for the physical/logical replica. The password literal here
+-- must match REPLICATION_PASSWORD in .env (the replica authenticates with that
+-- env value) — keep the two in sync; the guard only checks role existence, so
+-- changing one without the other silently breaks replica auth.
+SELECT 'CREATE USER replicator WITH REPLICATION LOGIN ENCRYPTED PASSWORD ''replicator_password'''
+  WHERE NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'replicator')\gexec
 
-CREATE DATABASE onboarding;
-CREATE DATABASE transaction;
+-- Replication slots consumed by the replica and by logical decoding.
+SELECT pg_create_physical_replication_slot('replication_slot')
+  WHERE NOT EXISTS (SELECT FROM pg_replication_slots WHERE slot_name = 'replication_slot');
+SELECT pg_create_logical_replication_slot('logical_slot', 'pgoutput')
+  WHERE NOT EXISTS (SELECT FROM pg_replication_slots WHERE slot_name = 'logical_slot');
 
--- tracer (transaction validation / audit-hash-chain service).
--- Created idempotently so a manual re-run against an already-populated cluster
--- does not error. init.sql ONLY executes automatically on a FRESH (empty) data
--- volume. EXISTING-VOLUME RUNBOOK: a deployment whose postgres volume predates
--- this line will NOT get the `tracer` database from init.sql. On such a volume,
--- create it once out-of-band before starting tracer:
---   psql -h midaz-postgres-primary -p 5701 -U midaz -c "CREATE DATABASE tracer;"
--- (tracer's own bootstrap runs migrations against this DB but does NOT create
--- it — connecting to a missing `tracer` DB fails fast and leaves /readyz red.)
+-- Application databases.
+SELECT 'CREATE DATABASE onboarding'
+  WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = 'onboarding')\gexec
+SELECT 'CREATE DATABASE transaction'
+  WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = 'transaction')\gexec
+-- tracer: transaction validation / audit-hash-chain service. Its own bootstrap
+-- runs migrations against this DB but does NOT create it.
 SELECT 'CREATE DATABASE tracer'
   WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = 'tracer')\gexec

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	go.opentelemetry.io/otel/trace v1.44.0
 	go.uber.org/mock v0.6.0
 	go.uber.org/zap v1.28.0 // indirect
-	google.golang.org/grpc v1.81.1
+	google.golang.org/grpc v1.82.1
 	google.golang.org/protobuf v1.36.11
 )
 

--- a/go.sum
+++ b/go.sum
@@ -690,8 +690,8 @@ google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa h1:
 google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa/go.mod h1:q4lMZS6kskjT5HvCPrnnypcDPVJqT/f4nfxmkE7gryY=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa h1:mZHHdPZl0dbGHCflZgAq/Q468DWVFcU2whhB2KAo8fk=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
-google.golang.org/grpc v1.81.1 h1:VnnIIZ88UzOOKLukQi+ImGz8O1Wdp8nAGGnvOfEIWQQ=
-google.golang.org/grpc v1.81.1/go.mod h1:xGH9GfzOyMTGIOXBJmXt+BX/V0kcdQbdcuwQ/zNw42I=
+google.golang.org/grpc v1.82.1 h1:NnAxzGRA0677vCa4BUkOAnO5+FfQqVl9iUXeD0IqcGE=
+google.golang.org/grpc v1.82.1/go.mod h1:yzTZ1TB1Z3SG+LIYaI+WiE8D5+PZ3ArnrSp8zF3+/ZA=
 google.golang.org/protobuf v1.36.11 h1:fV6ZwhNocDyBLK0dj+fg8ektcVegBBuEolpbTQyBNVE=
 google.golang.org/protobuf v1.36.11/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=


### PR DESCRIPTION
## What

Provisions the `tracer` database in the local infra Postgres automatically, so `make up` + the tracer service work without any manual `CREATE DATABASE`.

## Why

`postgres` only auto-runs `docker-entrypoint-initdb.d/*.sql` on a **fresh** data volume. An existing/stale volume that predates a newly-added database (e.g. `tracer`, added during the phased tracer integration in `115cfd015`) never receives it, so the tracer service crash-loops on `database "tracer" does not exist` (SQLSTATE 3D000). The original commit knowingly documented this as a manual runbook step; this PR closes that punt (Lerian Map task 3419).

## How

- **`components/infra/postgres/init.sql`** — made fully idempotent: the `replicator` role, both replication slots, and all three `CREATE DATABASE` (`onboarding`/`transaction`/`tracer`) are now guarded (`WHERE NOT EXISTS ... \gexec` / guarded slot functions), so re-applying against a populated cluster provisions only what's missing and never errors.
- **`components/infra/docker-compose.yml`** — new one-shot `midaz-postgres-init` sidecar (mirrors the existing `midaz-mongodb-init` / `midaz-redpanda-init` / `midaz-hc-vault-init` pattern): waits for the primary `service_healthy`, then re-applies `init.sql` on every `make up`, self-healing stale volumes without touching existing data.

Because the sidecar re-runs `init.sql` on every `make up` (new behavior — the file previously ran exactly once on a fresh volume), full re-run safety of every statement is mandatory and verified.

## Verification

Reviewed by Ring code/logic/security reviewers (all PASS; findings applied). Validated end-to-end on a **from-scratch** stack (all docker torn down incl. volumes):

- Fresh volume → infra up, sidecar gated on primary healthy, **exit 0**; `onboarding`/`transaction`/`tracer` auto-provisioned; replica **healthy** (guarded role/slots didn't break replication).
- Stale-volume self-heal on the real primary: `DROP DATABASE tracer` → sidecar re-run recreates **only** `tracer`, exit 0, no errors.
- Full platform up together: ledger `/readyz` **200** (`postgres_onboarding`/`postgres_transaction` up) and tracer `/readyz` **200** (tracer PG up) — no manual DB creation.