### PR TITLE
feat(ledger): resolve migrations from absolute /migrations path

### DIFF
--- a/components/ledger/Dockerfile
+++ b/components/ledger/Dockerfile
@@ -29,18 +29,11 @@ LABEL org.opencontainers.image.licenses="Elastic-2.0"
 LABEL org.opencontainers.image.version="${VERSION}"
 LABEL org.opencontainers.image.created="${BUILD_DATE}"
 
-# The migrator resolves its source via filepath.Abs(os.Getwd()) applied to the
-# CWD-relative "components/ledger/migrations/...". The :nonroot base runs with
-# CWD /home/nonroot, so stage the migrations there and pin WORKDIR to match.
-WORKDIR /home/nonroot
-
 COPY --from=builder /app /app
-COPY --chown=nonroot:nonroot --from=builder \
-  /ledger-app/components/ledger/migrations/onboarding \
-  /home/nonroot/components/ledger/migrations/onboarding
-COPY --chown=nonroot:nonroot --from=builder \
-  /ledger-app/components/ledger/migrations/transaction \
-  /home/nonroot/components/ledger/migrations/transaction
+# Stage migrations at an absolute, world-readable path outside /home/nonroot so
+# the migrator resolves them regardless of CWD or the runtime user.
+COPY --from=builder /ledger-app/components/ledger/migrations/onboarding /migrations/onboarding
+COPY --from=builder /ledger-app/components/ledger/migrations/transaction /migrations/transaction
 
 EXPOSE 3002
 

--- a/components/ledger/internal/bootstrap/config.postgres.onboarding.go
+++ b/components/ledger/internal/bootstrap/config.postgres.onboarding.go
@@ -172,7 +172,7 @@ func defaultOnboardingPostgresMigrator(cfg *Config, logger libLog.Logger) error 
 		PrimaryDSN:     primaryDSN,
 		DatabaseName:   cfg.OnbPrefixedPrimaryDBName,
 		Component:      "ledger",
-		MigrationsPath: "components/ledger/migrations/onboarding",
+		MigrationsPath: "/migrations/onboarding",
 		Logger:         logger,
 	})
 	if err != nil {

--- a/components/ledger/internal/bootstrap/config.postgres.transaction.go
+++ b/components/ledger/internal/bootstrap/config.postgres.transaction.go
@@ -172,7 +172,7 @@ func defaultTransactionPostgresMigrator(cfg *Config, logger libLog.Logger) error
 		PrimaryDSN:     primaryDSN,
 		DatabaseName:   cfg.TxnPrefixedPrimaryDBName,
 		Component:      "ledger",
-		MigrationsPath: "components/ledger/migrations/transaction",
+		MigrationsPath: "/migrations/transaction",
 		Logger:         logger,
 	})
 	if err != nil {


### PR DESCRIPTION
<table border="0" cellspacing="0" cellpadding="0">
  <tr>
    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
    <td><h1>Midaz</h1></td>
  </tr>
</table>

---

## Description

The ledger crash-loops on startup with
`failed to open source, "file:///home/nonroot/components/ledger/migrations/onboarding": open .: permission denied`.

The in-process migrator (lib-commons v5.10.0) resolves its source via
`filepath.Abs(os.Getwd())` on a CWD-relative path. Under the
`distroless/static-debian12:nonroot` base the process runs with CWD
`/home/nonroot` — which the base ships as `0700`, owned by UID 65532 — while the
deployment runs the container as **UID 1000**. UID 1000 cannot traverse the
`0700` home dir, so any migration path under it is unreadable and `migrate` fails
with `open .: permission denied`. The 3.8.x images ran fine as UID 1000 because
their migrations sat at a world-accessible path outside the home dir.

This stages the migrations at the absolute, world-readable
`/migrations/{onboarding,transaction}` (`root:root`, dir `0755`, files `0644`)
and points the migrator config there. `filepath.Abs` of an already-absolute path
is a no-op, so resolution is now independent of CWD, image `WORKDIR`, k8s
`workingDir`, and the runtime UID.

Supersedes #2239 (`WORKDIR /`) and #2245 (staging under `/home/nonroot`) — both
addressed the wrong layer; the running process CWD and the home-dir permissions
defeated them.

## Type of Change

- [x] `feat`: New feature or capability
- [x] `fix`: Bug fix
- [ ] `perf`: Performance improvement
- [ ] `refactor`: Internal restructuring with no behavior change
- [ ] `docs`: Documentation only
- [ ] `style`: Formatting, whitespace, naming (no logic change)
- [ ] `test`: Adding or updating tests
- [ ] `ci`: CI pipeline or workflow changes
- [x] `build`: Build system, Dockerfile, Go module dependencies
- [ ] `chore`: Maintenance, config, tooling
- [ ] `revert`: Reverts a previous commit
- [ ] `BREAKING CHANGE`: Consumers must update their integration

## Breaking Changes

None. Migration staging moves to `/migrations/...`; no runtime API/config surface
changes. Note: native `make run` (host) does not migrate against `/migrations`,
but in-process host migration was already non-functional from the component-dir
CWD (the relative path doubled); `make up` (container) is unaffected.

## Testing

- [ ] `make test` passes
- [ ] `make test-int` passes if integration paths are exercised
- [x] `make lint` passes
- [ ] `make sec` and `make vulncheck` pass

**Test evidence / Actions run:** Reproduced the exact pod condition locally.
`docker compose build`; image inspect confirms migrations at
`/migrations/{onboarding,transaction}`, `root:root`, world-readable. Ran the
image as **UID 1000** (the pod's user) against a fresh Postgres: both PG init
steps passed with zero `permission denied`, onboarding migrations applied
(`schema_migrations` v19, `dirty=f`, 8 tables) and transaction (v35, `dirty=f`,
9 tables). `golangci-lint v2` on the two changed Go files: 0 issues.

## Architectural Checklist

- [x] No `panic()` in production paths
- [x] Timestamps use `time.Now().UTC()`
- [x] Errors wrapped with `%w`
- [x] Handlers stay thin (parse, validate, call service)
- [x] Infrastructure concerns kept in `internal/bootstrap`

## Related Issues

Closes #
