### PR TITLE
feat(tracer): adopt service discovery parity

### DIFF
--- a/components/tracer/.env.example
+++ b/components/tracer/.env.example
@@ -349,6 +349,60 @@ TRACER_TLS_KEY_FILE=
 # RequireAndVerifyClientCert.
 TRACER_TLS_CLIENT_CA_FILE=
 
+# =============================================================================
+# SERVICE DISCOVERY (opt-in; no-op when SD_ENABLED=false)
+# =============================================================================
+# Registers this instance in Consul and resolves downstream hosts (e.g.
+# plugin-auth) via Consul instead of static addresses. Default is OFF: when
+# SD_ENABLED=false a no-op Manager is wired, no Consul connection is attempted,
+# and Resolve returns the static fallback host unchanged.
+#
+# When SD_ENABLED=true, SD_EXTERNAL_ADDRESS (or SD_INTERNAL_ADDRESS) is REQUIRED.
+# Enabling discovery with no advertise endpoint aborts boot (ErrNoEndpoint).
+# Canonical SD_* names below are read by libsd.ConfigFromEnv(). Legacy names
+# SD_ADVERTISE_* / SERVICE_ADVERTISE_* remain honored, so existing deployments
+# keep working without any change.
+SD_ENABLED=false
+# Consul HTTPS API (host:port); central agents typically listen on :8501.
+SD_ADDRESS=localhost:8500
+# REQUIRED when SD_ENABLED=true (unless SD_INTERNAL_ADDRESS is set) — hostname
+# ("tracer.dev.example.net") or full URL ("https://tracer.dev.example.net").
+SD_EXTERNAL_ADDRESS=
+# External port override; 0 = use the port from Register (SERVER_ADDRESS).
+SD_EXTERNAL_PORT=
+# Workload scope for tag-based isolation per environment (empty = no filtering).
+SD_WORKLOAD=
+# "true" for HTTPS to the discovery server.
+SD_TLS=false
+# "true" to skip discovery-server cert verification (dev/self-signed only).
+SD_TLS_SKIP_VERIFY=false
+# ACL token sent to the discovery server.
+SD_TOKEN=
+# --- Optional v1.0.0 tuning (safe blank defaults; unset = library default) ---
+# In-cluster Kubernetes service DNS endpoint; satisfies the advertise requirement
+# on its own when SD_EXTERNAL_ADDRESS is empty.
+SD_INTERNAL_ADDRESS=
+# Internal port override; 0 = use the port from Register (SERVER_ADDRESS).
+SD_INTERNAL_PORT=
+# Internal endpoint scheme (e.g. "http"); empty uses the caller convention.
+SD_INTERNAL_SCHEME=
+# Preferred endpoint view for resolves: internal|external (default external).
+# Also governs the plugin-auth resolve (honored via ResolvePreferredURL).
+SD_PREFER_VIEW=
+# Allow stale Consul reads for lower-latency resolves (default true).
+SD_ALLOW_STALE=
+# Discovery HTTP transport dial timeout (Go duration, e.g. "5s").
+SD_DIAL_TIMEOUT=
+# Discovery HTTP transport TLS handshake timeout (Go duration).
+SD_TLS_HANDSHAKE_TIMEOUT=
+# Discovery HTTP transport response-header timeout (Go duration).
+SD_RESPONSE_HEADER_TIMEOUT=
+# First-resolve seed timeout before the watch takes over (Go duration).
+SD_SEED_TIMEOUT=
+# Bounds each Consul blocking-query long-poll (Go duration, default 30s).
+# Keep below the ingress read timeout in front of Consul to mitigate 504s.
+SD_WATCH_WAIT_TIME=
+
 # ============================================================================
 # Streaming (lib-streaming producer)
 # ============================================================================

--- a/components/tracer/internal/bootstrap/config.go
+++ b/components/tracer/internal/bootstrap/config.go
@@ -22,6 +22,7 @@ import (
 	libRuntime "github.com/LerianStudio/lib-observability/runtime"
 	libOtel "github.com/LerianStudio/lib-observability/tracing"
 	libZap "github.com/LerianStudio/lib-observability/zap"
+	libsd "github.com/LerianStudio/lib-service-discovery"
 	libStreaming "github.com/LerianStudio/lib-streaming"
 	"google.golang.org/grpc"
 
@@ -43,6 +44,7 @@ import (
 	trcConstant "github.com/LerianStudio/midaz/v4/components/tracer/pkg/constant"
 	"github.com/LerianStudio/midaz/v4/components/tracer/pkg/model"
 	"github.com/LerianStudio/midaz/v4/components/tracer/pkg/resilience"
+	pkgsd "github.com/LerianStudio/midaz/v4/pkg/servicediscovery"
 )
 
 // Config is the top level configuration struct for the entire application.
@@ -1127,6 +1129,7 @@ func initHTTPServer(
 	mtComponents *componentsMT,
 	mtMetrics metrics.MultiTenantMetrics,
 	txBeginner pgdb.TxBeginner,
+	authHost string,
 ) (*HTTPServer, *services.ReservationService, error) {
 	_ = ctx // reserved for future ctx-aware initialization (e.g., when NewValidationService takes ctx)
 	// Init Transaction Validation repository and queries
@@ -1206,8 +1209,10 @@ func initHTTPServer(
 		SwaggerEnabled:       cfg.SwaggerEnabled,
 	}
 
-	// Create auth guard with all authentication configuration.
-	authClient := authMiddleware.NewAuthClient(cfg.PluginAuthAddress, cfg.PluginAuthEnabled, &logger)
+	// Create auth guard with all authentication configuration. authHost is the
+	// plugin-auth host resolved via service discovery (or the static
+	// PLUGIN_AUTH_ADDRESS when discovery is disabled or resolution fails).
+	authClient := authMiddleware.NewAuthClient(authHost, cfg.PluginAuthEnabled, &logger)
 	// Note: NewAuthGuard builds APIKeyAuth which is a Fiber
 	// handler closure; ctx propagation would require refactoring the Fiber
 	// middleware API surface to take ctx, which it deliberately doesn't (Fiber
@@ -1941,10 +1946,30 @@ func InitServers(ctx context.Context) (*Service, error) {
 		healthChecker.SetTenantManagerProber(newTenantManagerHealthProber(mtComponents.tmClient, cfg.ApplicationName))
 	}
 
+	// Service discovery: build the Manager (no-op when disabled), parse the
+	// advertised port + descriptor (gated on enabled), and resolve plugin-auth
+	// through discovery — mirroring the ledger's wireServiceDiscovery. The
+	// recorder is a no-op unless discovery is enabled, so SD off emits zero SD
+	// metrics. The factory is read nil-safely (telemetry is nil when
+	// ENABLE_TELEMETRY=false).
+	sd, err := wireServiceDiscovery(cfg, logger, metricsFactoryFromTelemetry(telemetry))
+	if err != nil {
+		return nil, err
+	}
+
+	// Close the boot-time-Resolve watcher goroutine if boot fails after SD
+	// wiring. When SD is enabled, ResolveAuthHost lazy-spawns a background
+	// watcher via the Manager; on a partial-boot failure below the Service is
+	// never built and the launcher's Runnable never runs, so that watcher would
+	// leak. On success the closer is disarmed and the Runnable owns the graceful
+	// close.
+	sdBootCloser := pkgsd.NewBootCloser(logger, sd.manager)
+	defer sdBootCloser.CloseOnBootFailure()
+
 	// Init HTTP server with all services. mtComponents is nil in single-tenant
 	// mode; the HTTP server builder threads pgManager + supervisor through to
 	// the TenantMiddleware when non-nil.
-	serverAPI, reservationService, err := initHTTPServer(ctx, cfg, pgConn, limitDeps, evaluateRulesQuery, auditWriter, auditEventRepo, ruleService, healthChecker, logger, telemetry, clk, mtComponents, mtMetrics, txBeginner)
+	serverAPI, reservationService, err := initHTTPServer(ctx, cfg, pgConn, limitDeps, evaluateRulesQuery, auditWriter, auditEventRepo, ruleService, healthChecker, logger, telemetry, clk, mtComponents, mtMetrics, txBeginner, sd.authHost)
 	if err != nil {
 		return nil, err
 	}
@@ -1958,10 +1983,100 @@ func InitServers(ctx context.Context) (*Service, error) {
 		return nil, err
 	}
 
+	// Hand the service-discovery outputs to the Service so Run() can register the
+	// discovery Launcher app (only when enabled) and drive graceful deregister.
+	svc.ServiceDiscovery = sd.manager
+	svc.ServiceDiscoveryEnabled = sd.enabled
+	svc.ServiceDescriptor = sd.descriptor
+	svc.ServiceDiscoveryMetrics = sd.recorder
+
+	// The launcher Runnable now owns the manager's graceful close; disarm the
+	// boot-failure closer so it does not double-close on the success path.
+	sdBootCloser.Disarm()
+
 	// Mark initialization as successful; defer cleanup will not close the connection.
 	initSuccess = true
 
 	return svc, nil
+}
+
+// metricsFactoryFromTelemetry reads the MetricsFactory off the telemetry handle
+// nil-safely: telemetry is nil when ENABLE_TELEMETRY=false, in which case the
+// downstream recorder degrades to a no-op.
+func metricsFactoryFromTelemetry(telemetry *libOtel.Telemetry) *libMetrics.MetricsFactory {
+	if telemetry == nil {
+		return nil
+	}
+
+	return telemetry.MetricsFactory
+}
+
+// serviceDiscoveryWiring holds the service-discovery outputs consumed by the
+// composition root: the Manager, whether discovery is enabled, the descriptor to
+// register, the plugin-auth host resolved (or degraded) via discovery, and the
+// metrics recorder threaded through the SD call paths. The recorder is a no-op
+// unless discovery is enabled, upholding the invariant that SD off emits zero
+// SD metrics.
+type serviceDiscoveryWiring struct {
+	manager    *libsd.Manager
+	enabled    bool
+	descriptor libsd.Service
+	authHost   string
+	recorder   pkgsd.MetricsRecorder
+}
+
+// wireServiceDiscovery builds the discovery Manager (fail-fast on
+// misconfiguration) and resolves the plugin-auth host — degrading to the static
+// PLUGIN_AUTH_ADDRESS when auth is disabled or resolution fails so a discovery
+// outage never fails boot.
+//
+// The advertised port is parsed and the descriptor built ONLY when discovery is
+// enabled: the descriptor is consumed solely by the discovery runnable (wired
+// only when enabled), so a malformed SERVER_ADDRESS must not abort boot with
+// discovery off. The resolve timeout is created only when auth is enabled, since
+// ResolveAuthHost returns the static host without touching the context otherwise.
+//
+// The metrics recorder is built AFTER BuildManager reports enabled so it is a
+// NopMetricsRecorder whenever discovery is disabled: with SD off, resolve (and
+// every downstream SD metric) emits nothing, even though metricsFactory is
+// non-nil. When enabled it is the OTel-backed recorder.
+func wireServiceDiscovery(cfg *Config, logger libLog.Logger, metricsFactory *libMetrics.MetricsFactory) (serviceDiscoveryWiring, error) {
+	manager, enabled, err := pkgsd.BuildManager(logger)
+	if err != nil {
+		return serviceDiscoveryWiring{}, err
+	}
+
+	recorder := pkgsd.MetricsRecorder(pkgsd.NopMetricsRecorder{})
+	if enabled {
+		recorder = pkgsd.NewMetricsFactoryRecorder(metricsFactory, logger)
+	}
+
+	var descriptor libsd.Service
+
+	if enabled {
+		serverPort, portErr := pkgsd.ParseServerPort(cfg.ServerAddress)
+		if portErr != nil {
+			return serviceDiscoveryWiring{}, portErr
+		}
+
+		descriptor = pkgsd.BuildServiceDescriptor("midaz-tracer", serverPort)
+	}
+
+	authHost := cfg.PluginAuthAddress
+	if cfg.PluginAuthEnabled {
+		resolveCtx, cancel := context.WithTimeout(context.Background(), pkgsd.ResolveTimeout)
+		authHost = pkgsd.ResolveAuthHost(resolveCtx, manager, cfg.PluginAuthEnabled, cfg.PluginAuthAddress, recorder)
+
+		cancel()
+	}
+
+	return serviceDiscoveryWiring{
+		manager:    manager,
+		enabled:    enabled,
+		descriptor: descriptor,
+		authHost:   authHost,
+		recorder:   recorder,
+	}, nil
 }
 
 // initRuleCacheStack builds the clock, rule cache, rule-sync repository, and

--- a/components/tracer/internal/bootstrap/service.go
+++ b/components/tracer/internal/bootstrap/service.go
@@ -19,10 +19,12 @@ import (
 	libObservability "github.com/LerianStudio/lib-observability"
 	libLog "github.com/LerianStudio/lib-observability/log"
 	libRuntime "github.com/LerianStudio/lib-observability/runtime"
+	libsd "github.com/LerianStudio/lib-service-discovery"
 	libStreaming "github.com/LerianStudio/lib-streaming"
 
 	"github.com/LerianStudio/midaz/v4/components/tracer/internal/adapters/http/in"
 	"github.com/LerianStudio/midaz/v4/components/tracer/internal/services/workers"
+	pkgsd "github.com/LerianStudio/midaz/v4/pkg/servicediscovery"
 )
 
 // Service is the application glue where we put all top level components to be used.
@@ -76,6 +78,23 @@ type Service struct {
 	// StreamingEnabled mirrors cfg.StreamingEnabled so Run() can decide
 	// whether to register the producer-drain Launcher app.
 	StreamingEnabled bool
+
+	// ServiceDiscovery is the lib-service-discovery Manager. It is always
+	// non-nil (a working no-op when discovery is disabled), so callers can
+	// invoke Register/Deregister/Resolve unconditionally.
+	ServiceDiscovery *libsd.Manager
+	// ServiceDiscoveryEnabled mirrors SD_ENABLED so Run() can decide whether
+	// to register the discovery register/deregister Launcher app.
+	ServiceDiscoveryEnabled bool
+	// ServiceDescriptor is the descriptor advertised to the registry. It is
+	// built at wiring time only when discovery is enabled (so a malformed
+	// SERVER_ADDRESS never aborts boot with discovery off) and reused by the
+	// service-discovery runnable. It is zero-value when discovery is disabled.
+	ServiceDescriptor libsd.Service
+	// ServiceDiscoveryMetrics records SD register/deregister metrics through the
+	// discovery runnable. It is a NopMetricsRecorder when discovery is disabled,
+	// so no SD metrics are emitted with SD off.
+	ServiceDiscoveryMetrics pkgsd.MetricsRecorder
 }
 
 // Run starts the application.
@@ -109,6 +128,15 @@ func (app *Service) Run() {
 	opts := []libCommons.LauncherOption{
 		libCommons.WithLogger(app.Logger),
 		libCommons.RunApp("HTTP Service", app.HTTPServer),
+	}
+
+	// Service discovery: register only when discovery is enabled so boot parity
+	// is preserved (no extra Launcher entry / goroutine otherwise). The 30s TTL
+	// on the descriptor is the backstop that drops a stale instance from the
+	// registry if a deregister is missed.
+	if shouldRegisterServiceDiscovery(app.ServiceDiscoveryEnabled, app.ServiceDiscovery) {
+		opts = append(opts, libCommons.RunApp("Service Discovery",
+			pkgsd.NewRunnable(app.ServiceDiscovery, app.ServiceDescriptor, app.Logger, app.ServiceDiscoveryMetrics)))
 	}
 
 	// gRPC reservation seam (opt-in via TRACER_GRPC_PORT). Registered as its own
@@ -229,6 +257,15 @@ func (app *Service) installDrainHandler() func() {
 // is present. The disabled path (NoopEmitter) registers nothing.
 func shouldRegisterStreamingProducer(enabled bool, closeHook func() error) bool {
 	return enabled && closeHook != nil
+}
+
+// shouldRegisterServiceDiscovery reports whether the service-discovery
+// register/deregister runnable should be registered with the Launcher. It is a
+// pure predicate: registration happens only when discovery is enabled AND a
+// Manager is present. The disabled path registers nothing so the Launcher app
+// list stays lean and boot parity is preserved.
+func shouldRegisterServiceDiscovery(enabled bool, mgr *libsd.Manager) bool {
+	return enabled && mgr != nil
 }
 
 // streamingProducerRunnable adapts the lib-streaming producer's Close hook to

--- a/components/tracer/internal/bootstrap/service_discovery_test.go
+++ b/components/tracer/internal/bootstrap/service_discovery_test.go
@@ -1,0 +1,205 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package bootstrap
+
+import (
+	"errors"
+	"testing"
+
+	libLog "github.com/LerianStudio/lib-observability/log"
+	"github.com/LerianStudio/lib-observability/metrics"
+	libOtel "github.com/LerianStudio/lib-observability/tracing"
+	libsd "github.com/LerianStudio/lib-service-discovery"
+	pkgsd "github.com/LerianStudio/midaz/v4/pkg/servicediscovery"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// clearServiceDiscoveryEnv wipes the discovery-toggle and advertise env vars so a
+// test starts from a known-disabled, no-endpoint baseline regardless of the host
+// environment. t.Setenv restores the originals at test end.
+func clearServiceDiscoveryEnv(t *testing.T) {
+	t.Helper()
+
+	t.Setenv("SD_ENABLED", "")
+	t.Setenv("SERVICE_DISCOVERY_ENABLED", "")
+	t.Setenv("SD_EXTERNAL_ADDRESS", "")
+	t.Setenv("SD_INTERNAL_ADDRESS", "")
+	t.Setenv("SD_ADVERTISE_ADDRESS", "")
+}
+
+// TestWireServiceDiscovery_DisabledIgnoresMalformedServerAddress locks the boot
+// parity invariant: with discovery disabled the advertised port is never parsed,
+// so a malformed SERVER_ADDRESS must NOT abort boot. The descriptor stays
+// zero-value.
+func TestWireServiceDiscovery_DisabledIgnoresMalformedServerAddress(t *testing.T) {
+	clearServiceDiscoveryEnv(t)
+
+	cfg := &Config{ServerAddress: "not-a-valid-address", PluginAuthEnabled: false, PluginAuthAddress: "http://plugin-auth:4000"}
+
+	sd, err := wireServiceDiscovery(cfg, libLog.NewNop(), metrics.NewNopFactory())
+
+	require.NoError(t, err, "malformed SERVER_ADDRESS must not fail boot when discovery is disabled")
+	require.False(t, sd.enabled)
+	require.NotNil(t, sd.manager)
+	assert.Empty(t, sd.descriptor.ID, "descriptor must stay zero-value when discovery is disabled")
+	assert.Equal(t, "http://plugin-auth:4000", sd.authHost,
+		"auth disabled returns the static host without resolving")
+}
+
+// TestWireServiceDiscovery_AuthEnabledDiscoveryDisabledFallsBackToStaticHost
+// covers the realistic production state: auth on, discovery not yet rolled out.
+// With SD disabled the no-op Manager's Resolve returns the fallback immediately,
+// so authHost degrades to the static PluginAuthAddress without hanging.
+func TestWireServiceDiscovery_AuthEnabledDiscoveryDisabledFallsBackToStaticHost(t *testing.T) {
+	clearServiceDiscoveryEnv(t)
+
+	cfg := &Config{ServerAddress: ":4020", PluginAuthEnabled: true, PluginAuthAddress: "http://plugin-auth:4000"}
+
+	sd, err := wireServiceDiscovery(cfg, libLog.NewNop(), metrics.NewNopFactory())
+
+	require.NoError(t, err)
+	require.False(t, sd.enabled, "discovery must stay disabled when SD_ENABLED is unset")
+	require.NotNil(t, sd.manager)
+	assert.Equal(t, "http://plugin-auth:4000", sd.authHost,
+		"auth enabled + discovery disabled must fall back to the static host")
+}
+
+// TestWireServiceDiscovery_DisabledUsesNopRecorder locks the SD metrics
+// INVARIANT: when discovery is disabled, wireServiceDiscovery must forward a
+// NopMetricsRecorder — even though a real MetricsFactory is available — so the
+// resolve path (and every downstream SD metric) emits nothing with SD off.
+func TestWireServiceDiscovery_DisabledUsesNopRecorder(t *testing.T) {
+	clearServiceDiscoveryEnv(t)
+
+	cfg := &Config{ServerAddress: ":4020", PluginAuthEnabled: true, PluginAuthAddress: "http://plugin-auth:4000"}
+
+	sd, err := wireServiceDiscovery(cfg, libLog.NewNop(), metrics.NewNopFactory())
+
+	require.NoError(t, err)
+	require.False(t, sd.enabled)
+
+	_, isNop := sd.recorder.(pkgsd.NopMetricsRecorder)
+	assert.True(t, isNop,
+		"SD disabled must yield a NopMetricsRecorder so zero SD metrics are emitted")
+}
+
+// TestWireServiceDiscovery_EnabledUsesRealRecorder asserts that when discovery is
+// enabled with a real MetricsFactory the wiring carries the OTel-backed recorder
+// (not the no-op), so register/deregister/resolve metrics actually flow.
+// PluginAuthEnabled=false so ResolveAuthHost is skipped and the test never dials
+// a registry; the recorder posture is what is under test.
+func TestWireServiceDiscovery_EnabledUsesRealRecorder(t *testing.T) {
+	clearServiceDiscoveryEnv(t)
+	t.Setenv("SD_ENABLED", "true")
+	t.Setenv("SD_EXTERNAL_ADDRESS", "midaz-tracer")
+
+	cfg := &Config{ServerAddress: ":4020", PluginAuthEnabled: false, PluginAuthAddress: "http://plugin-auth:4000"}
+
+	sd, err := wireServiceDiscovery(cfg, libLog.NewNop(), metrics.NewNopFactory())
+
+	require.NoError(t, err)
+	require.True(t, sd.enabled)
+	require.NotNil(t, sd.recorder)
+	assert.Equal(t, "midaz-tracer", sd.descriptor.Name,
+		"enabled discovery must advertise under the midaz-tracer registry name")
+
+	_, isNop := sd.recorder.(pkgsd.NopMetricsRecorder)
+	assert.False(t, isNop,
+		"SD enabled with a real factory must yield the OTel-backed recorder")
+}
+
+// TestWireServiceDiscovery_EnabledNilFactoryDegradesToNop asserts that when SD is
+// enabled but telemetry is off (nil factory), the recorder degrades to a no-op via
+// NewMetricsFactoryRecorder — safe, and never a nil deref at the call sites.
+func TestWireServiceDiscovery_EnabledNilFactoryDegradesToNop(t *testing.T) {
+	clearServiceDiscoveryEnv(t)
+	t.Setenv("SD_ENABLED", "true")
+	t.Setenv("SD_EXTERNAL_ADDRESS", "midaz-tracer")
+
+	cfg := &Config{ServerAddress: ":4020", PluginAuthEnabled: false, PluginAuthAddress: "http://plugin-auth:4000"}
+
+	sd, err := wireServiceDiscovery(cfg, libLog.NewNop(), nil)
+
+	require.NoError(t, err)
+	require.True(t, sd.enabled)
+	require.NotNil(t, sd.recorder)
+
+	_, isNop := sd.recorder.(pkgsd.NopMetricsRecorder)
+	assert.True(t, isNop, "nil factory must degrade to a NopMetricsRecorder")
+}
+
+// TestWireServiceDiscovery_EnabledNoEndpointFailsFast locks the wrapper's
+// fail-fast contract: enabling discovery with no advertise endpoint must abort
+// boot with an error wrapping libsd.ErrNoEndpoint.
+func TestWireServiceDiscovery_EnabledNoEndpointFailsFast(t *testing.T) {
+	clearServiceDiscoveryEnv(t)
+	t.Setenv("SD_ENABLED", "true")
+
+	cfg := &Config{ServerAddress: ":4020", PluginAuthEnabled: false, PluginAuthAddress: "http://plugin-auth:4000"}
+
+	_, err := wireServiceDiscovery(cfg, libLog.NewNop(), metrics.NewNopFactory())
+
+	require.Error(t, err, "enabling discovery with no advertise endpoint must fail boot")
+	assert.True(t, errors.Is(err, libsd.ErrNoEndpoint),
+		"the error must wrap libsd.ErrNoEndpoint")
+}
+
+// TestWireServiceDiscovery_EnabledMalformedServerAddressFailsFast is the mirror
+// of the disabled-parity test: with discovery ENABLED the advertised port IS
+// parsed, so a malformed SERVER_ADDRESS must abort boot. SD_EXTERNAL_ADDRESS is
+// set so BuildManager does not fail-fast on a missing endpoint first — the
+// ParseServerPort error branch is the one under test. The wiring returns the
+// zero value on failure.
+func TestWireServiceDiscovery_EnabledMalformedServerAddressFailsFast(t *testing.T) {
+	clearServiceDiscoveryEnv(t)
+	t.Setenv("SD_ENABLED", "true")
+	t.Setenv("SD_EXTERNAL_ADDRESS", "midaz-tracer")
+
+	cfg := &Config{ServerAddress: "not-a-valid-address", PluginAuthEnabled: false, PluginAuthAddress: "http://plugin-auth:4000"}
+
+	sd, err := wireServiceDiscovery(cfg, libLog.NewNop(), metrics.NewNopFactory())
+
+	require.Error(t, err, "malformed SERVER_ADDRESS must abort boot when discovery is enabled")
+	require.False(t, sd.enabled, "failed wiring must return the zero value")
+	require.Nil(t, sd.manager, "failed wiring must return the zero value")
+	assert.Empty(t, sd.descriptor.ID, "failed wiring must return the zero-value descriptor")
+}
+
+// TestMetricsFactoryFromTelemetry locks the nil-safe telemetry read: a nil
+// handle (ENABLE_TELEMETRY=false) yields a nil factory so the downstream
+// recorder degrades to a no-op, and a non-nil handle returns its MetricsFactory
+// unchanged. NewNopFactory gives a cheap real *MetricsFactory to prove the
+// non-nil branch without booting real telemetry.
+func TestMetricsFactoryFromTelemetry(t *testing.T) {
+	t.Parallel()
+
+	assert.Nil(t, metricsFactoryFromTelemetry(nil),
+		"nil telemetry must yield a nil factory so the recorder degrades to a no-op")
+
+	factory := metrics.NewNopFactory()
+	telemetry := &libOtel.Telemetry{MetricsFactory: factory}
+
+	assert.Same(t, factory, metricsFactoryFromTelemetry(telemetry),
+		"non-nil telemetry must return its MetricsFactory handle unchanged")
+}
+
+// TestShouldRegisterServiceDiscovery asserts the pure launcher predicate: the
+// Service Discovery Launcher app registers IFF discovery is enabled AND a Manager
+// is present.
+func TestShouldRegisterServiceDiscovery(t *testing.T) {
+	t.Parallel()
+
+	mgr := &libsd.Manager{}
+
+	assert.True(t, shouldRegisterServiceDiscovery(true, mgr),
+		"enabled + non-nil manager must register")
+	assert.False(t, shouldRegisterServiceDiscovery(false, mgr),
+		"disabled must not register even with a manager")
+	assert.False(t, shouldRegisterServiceDiscovery(true, nil),
+		"enabled + nil manager must not register")
+	assert.False(t, shouldRegisterServiceDiscovery(false, nil),
+		"disabled + nil manager must not register")
+}


### PR DESCRIPTION
## Description

Aligns the `tracer` component with the `ledger`'s Service Discovery (SD) posture (task 3390). Post monorepo-unification, the tracer resolved `plugin-auth` via a static `PLUGIN_AUTH_ADDRESS` while the ledger resolves the **same** dependency via SD (`pkgsd.ResolveAuthHost`) — the one place the tracer diverged from the ledger's SD posture.

When `SD_ENABLED=true`, the tracer now builds the SD Manager, registers itself as `midaz-tracer`, and resolves `plugin-auth` via SD (fail-open to the static host). It reuses the shared `pkg/servicediscovery` wrapper **unchanged**. Opt-in via `SD_ENABLED`; when disabled (default) behavior is byte-for-byte identical to before (no-op Manager, static auth host, no launcher app, zero SD metrics).

Advertises the HTTP port (`:4020` / `SERVER_ADDRESS`), not `TRACER_GRPC_PORT` (opt-in/empty). The absence of SD in the ledger→tracer reservation seam is intentional and unchanged (the tracer is the gRPC/mTLS **server** there; nothing to discover).

## Type of Change

- [x] `feat`: New feature (additive, opt-in)

## Breaking Changes

None. `SD_ENABLED` defaults to `false`; existing tracer deployments are unaffected.

## Testing

- [x] `make test` passes (tracer unit: 4768 tests / 39 packages; new wiring funcs 100% cover)
- [ ] `make test-int` — not run (opt-in/no-op composition-root wiring; no integration surface exercised)
- [x] `make lint` — no NEW issues (2 pre-existing develop-baseline issues: `InitServers` gocyclo >18 and an unused `//nolint:dogsled` in `Shutdown` — confirmed pre-existing via baseline stash; CI uses only-new-issues)
- [x] `make sec` / `make vulncheck` — `govulncheck` clean (no called vulnerabilities; `go.mod` unchanged)

**Test evidence / Actions run:** TDD RED→GREEN; 6 dev-cycle reviewers PASS (code, logic, nil, obs, commons, test).

## Architectural Checklist

- [x] No `panic()` in production paths
- [x] Timestamps use `time.Now().UTC()` (N/A — no timestamps added)
- [x] Errors wrapped with `%w`
- [x] Handlers stay thin (N/A — `internal/bootstrap` wiring only)
- [x] Infrastructure concerns kept in `internal/bootstrap`

## Related Issues

Lerian Map task 3390.
