### PR TITLE
fix(ci): use full path in extra_builds app_name_overrides

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,14 +40,14 @@ jobs:
           {
             "filter_paths": "components/ledger/migrations-image",
             "path_level": 1,
-            "app_name_overrides": "migrations-image:midaz-ledger-migrations",
+            "app_name_overrides": "components/ledger/migrations-image:midaz-ledger-migrations",
             "force_full_matrix": true,
             "shared_paths": "components/ledger/migrations\ncomponents/ledger/migrations-image"
           },
           {
             "filter_paths": "components/tracer/migrations-image",
             "path_level": 1,
-            "app_name_overrides": "migrations-image:midaz-tracer-migrations",
+            "app_name_overrides": "components/tracer/migrations-image:midaz-tracer-migrations",
             "force_full_matrix": true,
             "shared_paths": "components/tracer/migrations\ncomponents/tracer/migrations-image"
           }


### PR DESCRIPTION
<table border="0" cellspacing="0" cellpadding="0">
  <tr>
    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
    <td><h1>Midaz</h1></td>
  </tr>
</table>

---

## Description

Corrects the `app_name_overrides` keys in the `extra_builds` block of
`.github/workflows/release.yml`. The key before the colon must be the **full
build path** (matching each entry's `filter_paths`), not the basename.

- `migrations-image:midaz-ledger-migrations` -> `components/ledger/migrations-image:midaz-ledger-migrations`
- `migrations-image:midaz-tracer-migrations` -> `components/tracer/migrations-image:midaz-tracer-migrations`

Without the full path the shared release workflow cannot map the build path to
the overridden image name, so the `midaz-ledger-migrations` /
`midaz-tracer-migrations` images would not build/publish under the intended names.

## Type of Change

- [ ] `feat`: New feature or capability
- [x] `fix`: Bug fix
- [ ] `perf`: Performance improvement
- [ ] `refactor`: Internal restructuring with no behavior change
- [ ] `docs`: Documentation only
- [ ] `style`: Formatting, whitespace, naming (no logic change)
- [ ] `test`: Adding or updating tests
- [x] `ci`: CI pipeline or workflow changes
- [ ] `build`: Build system, Dockerfile, Go module dependencies
- [ ] `chore`: Maintenance, config, tooling
- [ ] `revert`: Reverts a previous commit
- [ ] `BREAKING CHANGE`: Consumers must update their integration

## Breaking Changes

None.

## Testing

- [ ] `make test` passes
- [ ] `make test-int` passes if integration paths are exercised
- [ ] `make lint` passes
- [ ] `make sec` and `make vulncheck` pass

**Test evidence / Actions run:** workflow-only change. `release.yml` re-validated locally — YAML parses and both `extra_builds` JSON entries are well-formed. Actual image build/publish is verified on the next release run.

## Architectural Checklist

- [ ] No `panic()` in production paths
- [ ] Timestamps use `time.Now().UTC()`
- [ ] Errors wrapped with `%w`
- [ ] Handlers stay thin (parse, validate, call service)
- [ ] Infrastructure concerns kept in `internal/bootstrap`

## Related Issues

Closes #
