### PR TITLE
chore(ci): bump shared pipe to v1.47.4 (helm dispatch to main)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   pipeline:
-    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/go-release.yml@v1.46.5
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/go-release.yml@v1.47.4
     with:
       enable_changelog: ${{ github.ref == 'refs/heads/main' }}
       release_single_app: true


### PR DESCRIPTION
Bumps the shared release workflow to **`@v1.47.4`**.

**Why:** the helm chart-update dispatch (`helm_target_ref`) defaults to the retired `develop` branch on the current pipe version. `v1.47.4` defaults it to `main`, so releases dispatch chart updates to `LerianStudio/helm` `main` — aligning with the trunk-based migration (develop is being retired in the helm repo).

Single-line change to `.github/workflows/release.yml`.