### PR TITLE
feat(ledger): transaction API v2 foundation (phase 1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -191,7 +191,7 @@ Producer is `github.com/LerianStudio/lib-streaming`. Wire format: CloudEvents 1.
 - IMPORTANT-posture direct emits MUST go through `pkgStreaming.EmitImportant`. Build/emit failures MUST NOT fail the request: log Warn, span-record, return success. `EmitImportant` bounds direct emit latency with `STREAMING_IMPORTANT_EMIT_TIMEOUT_MS` (default 5s) so broker issues cannot hold HTTP responses until client timeout. Durability is the outbox's job. CRITICAL events use outbox-only (atomic with DB), no direct emit.
 - Emit POST-COMMIT and PRE-METADATA-WRITE — never at HTTP handlers. `ce-subject` is the aggregate ID, passed as `libStreaming.EmitRequest.Subject`.
 - Register the producer's `Close()` as `libCommons.RunApp("Streaming Producer", ...)` so it drains on SIGTERM (mirror `eventListenerRunnable`).
-- lib-streaming is pinned at v2.0.0-beta.1, which exports Catalog/policy constants (e.g. `BuildManifest`, `DefaultDeliveryPolicy`, `ResolveDeliveryPolicy`). The producer is assembled with `libStreaming.NewBuilder()` (`.Source()/.Catalog()/.Routes()/.Target()`); wire `WithOutboxRepository(repo)` when outbox lands.
+- lib-streaming is pinned at v2.0.0, which exports Catalog/policy constants (e.g. `BuildManifest`, `DefaultDeliveryPolicy`, `ResolveDeliveryPolicy`). The producer is assembled with `libStreaming.NewBuilder()` (`.Source()/.Catalog()/.Routes()/.Target()`); wire `WithOutboxRepository(repo)` when outbox lands.
 
 ### Event modeling (`pkg/streaming/events`)
 

--- a/components/ledger/README.md
+++ b/components/ledger/README.md
@@ -146,7 +146,7 @@ Shared code lives at the repo root: `pkg/mmodel` (domain models), `pkg/mtransact
 | **Cache / balance-sync** | Valkey/Redis 8 |
 | **Messaging** | RabbitMQ 4.1.x |
 | **Decimals** | `shopspring/decimal` (never float64) |
-| **Auth** | lib-auth v3.0.0 (Access Manager plugin) |
+| **Auth** | lib-auth v3.2.0 (Access Manager plugin) |
 | **Shared platform** | lib-commons v6.0.0, lib-observability v2.1.0, lib-streaming v2.0.0 |
 | **Observability** | OpenTelemetry via lib-observability; otel-lgtm / Grafana stack from `components/infra` |
 

--- a/components/ledger/README.md
+++ b/components/ledger/README.md
@@ -147,7 +147,7 @@ Shared code lives at the repo root: `pkg/mmodel` (domain models), `pkg/mtransact
 | **Messaging** | RabbitMQ 4.1.x |
 | **Decimals** | `shopspring/decimal` (never float64) |
 | **Auth** | lib-auth v3.0.0 (Access Manager plugin) |
-| **Shared platform** | lib-commons v6.0.0, lib-observability v2.1.0, lib-streaming v2.0.0-beta.1 |
+| **Shared platform** | lib-commons v6.0.0, lib-observability v2.1.0, lib-streaming v2.0.0 |
 | **Observability** | OpenTelemetry via lib-observability; otel-lgtm / Grafana stack from `components/infra` |
 
 ---

--- a/components/ledger/internal/adapters/http/in/transaction_create.go
+++ b/components/ledger/internal/adapters/http/in/transaction_create.go
@@ -991,8 +991,22 @@ func (handler *TransactionHandler) buildStandardOp(
 // `replayed` flag so each transport can set X-Idempotency-Replayed itself. The ~480-line
 // orchestration in executeCreateTransaction is untouched: this is the thin transport
 // boundary only.
-func (handler *TransactionHandler) createTransaction(ctx context.Context, params *transactionPathParams, transactionInput mtransaction.Transaction, transactionStatus, idempotencyKey string, idempotencyTTL time.Duration) (*transaction.Transaction, bool, error) {
-	return handler.executeCreateTransaction(ctx, params, transactionInput, transactionStatus, false, idempotencyKey, idempotencyTTL)
+func (handler *TransactionHandler) createTransaction(ctx context.Context, params *transactionPathParams, transactionInput mtransaction.Transaction, transactionStatus, idempotencyKey string, idempotencyTTL time.Duration, idempotencyHashSource ...string) (*transaction.Transaction, bool, error) {
+	return handler.executeCreateTransaction(ctx, params, transactionInput, transactionStatus, false, idempotencyKey, idempotencyTTL, idempotencyHashSource...)
+}
+
+// resolveIdempotencyHashSource returns the string the idempotency hash is computed over.
+// With no override (all v1 callers) it serializes the canonical built transaction, so the
+// hash is byte-identical to the pre-v2 behavior. When the v2 surface supplies a non-empty
+// override (the raw v2 request body as submitted), that override is the source instead —
+// keying v2 idempotency by the pre-translation body per ADR-004. Only the source bytes
+// change; the HashSHA256 mechanism at the call site is shared.
+func resolveIdempotencyHashSource(transactionInput mtransaction.Transaction, override ...string) (string, error) {
+	if len(override) > 0 && override[0] != "" {
+		return override[0], nil
+	}
+
+	return libCommons.StructToJSONString(transactionInput)
 }
 
 // createRevertTransaction creates a reversal transaction. The action is forced
@@ -1052,7 +1066,7 @@ func resolveTransactionSkips(input mtransaction.Transaction, settings mmodel.Led
 }
 
 //nolint:gocyclo // Orchestration step with conditional branches per transaction type; refactor candidate.
-func (handler *TransactionHandler) executeCreateTransaction(ctx context.Context, params *transactionPathParams, transactionInput mtransaction.Transaction, transactionStatus string, isRevert bool, idempotencyKey string, idempotencyTTL time.Duration) (*transaction.Transaction, bool, error) {
+func (handler *TransactionHandler) executeCreateTransaction(ctx context.Context, params *transactionPathParams, transactionInput mtransaction.Transaction, transactionStatus string, isRevert bool, idempotencyKey string, idempotencyTTL time.Duration, idempotencyHashSource ...string) (*transaction.Transaction, bool, error) {
 	logger, tracer, _, _ := libObservability.NewTrackingFromContext(ctx)
 
 	_, span := tracer.Start(ctx, "handler.create_transaction.orchestrate")
@@ -1104,10 +1118,14 @@ func (handler *TransactionHandler) executeCreateTransaction(ctx context.Context,
 	//
 	// idempotencyKey/idempotencyTTL are resolved by the transport (the Fiber
 	// GetIdempotencyKeyAndTTL or the Huma header read) and passed in; the hash is
-	// still computed here over the SAME built transactionInput so it is byte-
-	// identical across both transports. The X-Idempotency-Replayed header is set by
-	// the transport off the returned replayed flag, not here.
-	ts, err := libCommons.StructToJSONString(transactionInput)
+	// computed here over the idempotency hash SOURCE. v1 callers pass no override, so
+	// the source is the built transactionInput and the hash stays byte-identical across
+	// both v1 transports. The v2 surface passes the raw pre-translation body as the
+	// override (ADR-004), so v2 dedups by the body as submitted; the HashSHA256
+	// mechanism is unchanged, only the source bytes differ, so v1 and v2 keys never
+	// collide by construction. The X-Idempotency-Replayed header is set by the transport
+	// off the returned replayed flag, not here.
+	hashSource, err := resolveIdempotencyHashSource(transactionInput, idempotencyHashSource...)
 	if err != nil {
 		libOpentelemetry.HandleSpanError(span, "Failed to serialize transaction for idempotency hash", err)
 		logger.Log(ctx, libLog.LevelError, "Failed to serialize transaction for idempotency hash", libLog.Err(err))
@@ -1115,7 +1133,7 @@ func (handler *TransactionHandler) executeCreateTransaction(ctx context.Context,
 		return nil, false, err
 	}
 
-	idempotencyHash := libCommons.HashSHA256(ts)
+	idempotencyHash := libCommons.HashSHA256(hashSource)
 
 	idempotencyResult, err := handler.Command.CreateOrCheckTransactionIdempotency(ctx, params.OrganizationID, params.LedgerID, idempotencyKey, idempotencyHash, idempotencyTTL)
 	if err != nil {

--- a/components/ledger/internal/adapters/http/in/transaction_create.go
+++ b/components/ledger/internal/adapters/http/in/transaction_create.go
@@ -995,12 +995,9 @@ func (handler *TransactionHandler) createTransaction(ctx context.Context, params
 	return handler.executeCreateTransaction(ctx, params, transactionInput, transactionStatus, false, idempotencyKey, idempotencyTTL, idempotencyHashSource...)
 }
 
-// resolveIdempotencyHashSource returns the string the idempotency hash is computed over.
-// With no override (all v1 callers) it serializes the canonical built transaction, so the
-// hash is byte-identical to the pre-v2 behavior. When the v2 surface supplies a non-empty
-// override (the raw v2 request body as submitted), that override is the source instead —
-// keying v2 idempotency by the pre-translation body per ADR-004. Only the source bytes
-// change; the HashSHA256 mechanism at the call site is shared.
+// resolveIdempotencyHashSource returns the string the idempotency hash is computed over:
+// the non-empty override when supplied, else the canonical serialized transaction. Keying
+// off a raw pre-translation body via the override is the ADR-004 contract.
 func resolveIdempotencyHashSource(transactionInput mtransaction.Transaction, override ...string) (string, error) {
 	if len(override) > 0 && override[0] != "" {
 		return override[0], nil
@@ -1116,15 +1113,11 @@ func (handler *TransactionHandler) executeCreateTransaction(ctx context.Context,
 	// hash keys on the raw body, not the package version. Package version is
 	// deliberately NOT part of the key.
 	//
-	// idempotencyKey/idempotencyTTL are resolved by the transport (the Fiber
-	// GetIdempotencyKeyAndTTL or the Huma header read) and passed in; the hash is
-	// computed here over the idempotency hash SOURCE. v1 callers pass no override, so
-	// the source is the built transactionInput and the hash stays byte-identical across
-	// both v1 transports. The v2 surface passes the raw pre-translation body as the
-	// override (ADR-004), so v2 dedups by the body as submitted; the HashSHA256
-	// mechanism is unchanged, only the source bytes differ, so v1 and v2 keys never
-	// collide by construction. The X-Idempotency-Replayed header is set by the transport
-	// off the returned replayed flag, not here.
+	// idempotencyKey/idempotencyTTL are resolved by the transport and passed in; the hash
+	// is computed here over the idempotency hash SOURCE resolved by
+	// resolveIdempotencyHashSource. An optional override keys the hash off the raw body as
+	// submitted (ADR-004); with no override the source is the canonical transactionInput.
+	// The HashSHA256 mechanism is the same regardless of which source is used.
 	hashSource, err := resolveIdempotencyHashSource(transactionInput, idempotencyHashSource...)
 	if err != nil {
 		libOpentelemetry.HandleSpanError(span, "Failed to serialize transaction for idempotency hash", err)

--- a/components/ledger/internal/adapters/http/in/transaction_create.go
+++ b/components/ledger/internal/adapters/http/in/transaction_create.go
@@ -307,7 +307,7 @@ func resolveRouteCodesFromCache(operations []*operation.Operation, cache *mmodel
 		// semantic OperationTypeOverride (BLOCK/UNBLOCK). When the route
 		// configures a dedicated Block/Unblock AccountingEntry, route the
 		// rubric lookup to it; otherwise leave resolvedAction unchanged so
-		// block/unblock keep resolving via the Direct rubric (Phase 1 parity).
+		// block/unblock keep resolving via the Direct rubric.
 		switch operationTypeOverride {
 		case constant.BLOCK:
 			if blockEntryConfigured(cache, action, *op.RouteID, func(ae *mmodel.AccountingEntries) bool {
@@ -997,7 +997,7 @@ func (handler *TransactionHandler) createTransaction(ctx context.Context, params
 
 // resolveIdempotencyHashSource returns the string the idempotency hash is computed over:
 // the non-empty override when supplied, else the canonical serialized transaction. Keying
-// off a raw pre-translation body via the override is the ADR-004 contract.
+// off a raw pre-translation body via the override is the v2 idempotency contract.
 func resolveIdempotencyHashSource(transactionInput mtransaction.Transaction, override ...string) (string, error) {
 	if len(override) > 0 && override[0] != "" {
 		return override[0], nil
@@ -1116,7 +1116,7 @@ func (handler *TransactionHandler) executeCreateTransaction(ctx context.Context,
 	// idempotencyKey/idempotencyTTL are resolved by the transport and passed in; the hash
 	// is computed here over the idempotency hash SOURCE resolved by
 	// resolveIdempotencyHashSource. An optional override keys the hash off the raw body as
-	// submitted (ADR-004); with no override the source is the canonical transactionInput.
+	// submitted; with no override the source is the canonical transactionInput.
 	// The HashSHA256 mechanism is the same regardless of which source is used.
 	hashSource, err := resolveIdempotencyHashSource(transactionInput, idempotencyHashSource...)
 	if err != nil {

--- a/components/ledger/internal/adapters/http/in/transaction_handler_huma.go
+++ b/components/ledger/internal/adapters/http/in/transaction_handler_huma.go
@@ -73,7 +73,7 @@ var secTransactionBearer = []map[string][]string{
 // to the SAME transport-neutral createTransaction core the Fiber wrapper calls, and
 // projects the built transaction + the replayed flag onto the typed Out. The parent
 // transaction id is uuid.Nil on the create routes (no :transaction_id segment).
-func (handler *TransactionHandler) createTransactionShell(ctx context.Context, orgStr, ledgerStr string, transactionInput mtransaction.Transaction, transactionStatus, idempotencyKey, idempotencyTTL string) (*CreateTransactionOutputHuma, error) {
+func (handler *TransactionHandler) createTransactionShell(ctx context.Context, orgStr, ledgerStr string, transactionInput mtransaction.Transaction, transactionStatus, idempotencyKey, idempotencyTTL string, idempotencyHashSource ...string) (*CreateTransactionOutputHuma, error) {
 	orgID, ledgerID, err := parseOrgLedger(orgStr, ledgerStr)
 	if err != nil {
 		return nil, pkgHTTP.HumaProblem(err)
@@ -82,7 +82,7 @@ func (handler *TransactionHandler) createTransactionShell(ctx context.Context, o
 	params := &transactionPathParams{OrganizationID: orgID, LedgerID: ledgerID, TransactionID: uuid.Nil}
 	ttl := pkgHTTP.ParseIdempotencyTTL(idempotencyTTL)
 
-	tran, replayed, err := handler.createTransaction(ctx, params, transactionInput, transactionStatus, idempotencyKey, ttl)
+	tran, replayed, err := handler.createTransaction(ctx, params, transactionInput, transactionStatus, idempotencyKey, ttl, idempotencyHashSource...)
 	if err != nil {
 		return nil, pkgHTTP.HumaProblem(err)
 	}

--- a/components/ledger/internal/adapters/http/in/transaction_v2_handler.go
+++ b/components/ledger/internal/adapters/http/in/transaction_v2_handler.go
@@ -11,11 +11,11 @@ import (
 	pkgHTTP "github.com/LerianStudio/midaz/v4/pkg/net/http"
 )
 
-// This file is the v2 transaction terminal (ADR-006 filename-suffix versioning).
+// This file is the v2 transaction terminal.
 // Transport-only: decode the flat single-leg v2 body, translate it to the canonical
 // Transaction, and delegate to the shared createTransactionShell funnel. The direct-vs-
 // hold action is carried by Translate's pending flag, and idempotency keys off the raw
-// v2 body as submitted, pre-translation (ADR-004), passed to the funnel as the hash-
+// v2 body as submitted, pre-translation, passed to the funnel as the hash-
 // source override. Conventions mirror the v1 Huma create shells (see
 // transaction_handler_huma.go's header): path params are plain strings validated by the
 // ParseUUIDPathParameters Fiber middleware, the body carries RawBody so
@@ -58,7 +58,7 @@ func (handler *TransactionHandler) CreateTransactionDirectV2Huma(ctx context.Con
 		return nil, pkgHTTP.HumaProblem(err)
 	}
 
-	// ADR-004: key v2 idempotency off the v2 body AS SUBMITTED (pre-translation). The raw
+	// Key v2 idempotency off the v2 body AS SUBMITTED (pre-translation). The raw
 	// request bytes are passed as the hash-source override so the funnel hashes them
 	// instead of the canonical translated transaction; v1 callers pass no override and
 	// stay byte-identical.

--- a/components/ledger/internal/adapters/http/in/transaction_v2_handler.go
+++ b/components/ledger/internal/adapters/http/in/transaction_v2_handler.go
@@ -44,6 +44,10 @@ type CreateTransactionDirectV2InputHuma struct {
 // Replayed). Translate business errors and the input's route-UUID validation surface as
 // RFC 9457 4xx via pkgHTTP.HumaProblem.
 func (handler *TransactionHandler) CreateTransactionDirectV2Huma(ctx context.Context, in *CreateTransactionDirectV2InputHuma) (*CreateTransactionOutputHuma, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, pkgHTTP.HumaProblem(err)
+	}
+
 	payload := new(mtransaction.CreateTransactionV2Input)
 	if _, err := pkgHTTP.DecodeAndValidate(in.RawBody, payload); err != nil {
 		return nil, pkgHTTP.HumaProblem(err)

--- a/components/ledger/internal/adapters/http/in/transaction_v2_handler.go
+++ b/components/ledger/internal/adapters/http/in/transaction_v2_handler.go
@@ -11,21 +11,18 @@ import (
 	pkgHTTP "github.com/LerianStudio/midaz/v4/pkg/net/http"
 )
 
-// This file is the v2 transaction terminal (ADR-006 filename-suffix versioning). It
-// is transport-only: the handler decodes the flat single-leg v2 body, translates it to
-// the canonical Transaction, and delegates to the SAME createTransaction funnel the v1
-// create ops use (via createTransactionShell). The ~480-line create orchestration and
-// its fee/reserve seams are NOT touched — the only new code is the thin decode →
-// translate boundary, the direct-vs-hold action encoded by Translate's pending flag,
-// and the raw-body idempotency hash source the funnel accepts via an additive parameter
-// (ADR-004: v2 keys idempotency off the body as submitted, pre-translation; v1 is
-// byte-identical). Conventions mirror the v1 Huma create shells (see
+// This file is the v2 transaction terminal (ADR-006 filename-suffix versioning).
+// Transport-only: decode the flat single-leg v2 body, translate it to the canonical
+// Transaction, and delegate to the shared createTransactionShell funnel. The direct-vs-
+// hold action is carried by Translate's pending flag, and idempotency keys off the raw
+// v2 body as submitted, pre-translation (ADR-004), passed to the funnel as the hash-
+// source override. Conventions mirror the v1 Huma create shells (see
 // transaction_handler_huma.go's header): path params are plain strings validated by the
-// ParseUUIDPathParameters Fiber middleware, the body carries RawBody + SkipValidateBody
-// so http.DecodeAndValidate is the sole body validator, and errors flow through the
-// shared pkgHTTP.HumaProblem RFC 9457 envelope (business errors from Translate map to a
-// 4xx with a green span; a malformed route UUID is caught by the input's uuid validate
-// tag as a clean 400).
+// ParseUUIDPathParameters Fiber middleware, the body carries RawBody so
+// http.DecodeAndValidate is the sole body validator, and errors flow through the shared
+// pkgHTTP.HumaProblem RFC 9457 envelope (business errors from Translate map to a 4xx with
+// a green span; a malformed route UUID is caught by the input's uuid validate tag as a
+// clean 400).
 
 // CreateTransactionDirectV2InputHuma is the v2 direct-create request envelope. The
 // org/ledger path params are plain strings (validated by the ParseUUIDPathParameters

--- a/components/ledger/internal/adapters/http/in/transaction_v2_handler.go
+++ b/components/ledger/internal/adapters/http/in/transaction_v2_handler.go
@@ -1,0 +1,59 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package in
+
+import (
+	"context"
+
+	"github.com/LerianStudio/midaz/v4/pkg/mtransaction"
+	pkgHTTP "github.com/LerianStudio/midaz/v4/pkg/net/http"
+)
+
+// This file is the v2 transaction terminal (ADR-006 filename-suffix versioning). It
+// is transport-only: the handler decodes the flat single-leg v2 body, translates it to
+// the canonical Transaction, and delegates to the SAME createTransaction funnel the v1
+// create ops use (via createTransactionShell). The ~480-line create orchestration and
+// its idempotency/fee/reserve seams are NOT touched — the only new code is the thin
+// decode → translate boundary and the direct-vs-hold action encoded by Translate's
+// pending flag. Conventions mirror the v1 Huma create shells (see
+// transaction_handler_huma.go's header): path params are plain strings validated by the
+// ParseUUIDPathParameters Fiber middleware, the body carries RawBody + SkipValidateBody
+// so http.DecodeAndValidate is the sole body validator, and errors flow through the
+// shared pkgHTTP.HumaProblem RFC 9457 envelope (business errors from Translate map to a
+// 4xx with a green span; a malformed route UUID is caught by the input's uuid validate
+// tag as a clean 400).
+
+// CreateTransactionDirectV2InputHuma is the v2 direct-create request envelope. The
+// org/ledger path params are plain strings (validated by the ParseUUIDPathParameters
+// Fiber middleware attached before this terminal). RawBody keeps the body out of Huma's
+// validator so the flat v2 model is decoded imperatively via http.DecodeAndValidate.
+type CreateTransactionDirectV2InputHuma struct {
+	OrganizationID string `path:"organization_id" doc:"Organization ID (UUID)"`
+	LedgerID       string `path:"ledger_id" doc:"Ledger ID (UUID)"`
+	IdempotencyKey string `header:"X-Idempotency" doc:"Idempotency key to safely retry the create; an identical retry returns the original transaction"`
+	IdempotencyTTL string `header:"X-TTL" doc:"Idempotency slot TTL in seconds (default 300)"`
+	RawBody        []byte `contentType:"application/json"`
+}
+
+// CreateTransactionDirectV2Huma decodes+validates the flat v2 body imperatively (the
+// SAME http.DecodeAndValidate the v1 create ops run over their input types), translates
+// it to the canonical single-leg Transaction with the direct (non-pending) action, and
+// delegates to the shared createTransactionShell — reusing the v1 createTransaction
+// funnel and its CreateTransactionOutputHuma success envelope (201 + X-Idempotency-
+// Replayed). Translate business errors and the input's route-UUID validation surface as
+// RFC 9457 4xx via pkgHTTP.HumaProblem.
+func (handler *TransactionHandler) CreateTransactionDirectV2Huma(ctx context.Context, in *CreateTransactionDirectV2InputHuma) (*CreateTransactionOutputHuma, error) {
+	payload := new(mtransaction.CreateTransactionV2Input)
+	if _, err := pkgHTTP.DecodeAndValidate(in.RawBody, payload); err != nil {
+		return nil, pkgHTTP.HumaProblem(err)
+	}
+
+	transactionInput, err := payload.Translate(false)
+	if err != nil {
+		return nil, pkgHTTP.HumaProblem(err)
+	}
+
+	return handler.createTransactionShell(ctx, in.OrganizationID, in.LedgerID, transactionInput, transactionInput.InitialStatus(), in.IdempotencyKey, in.IdempotencyTTL)
+}

--- a/components/ledger/internal/adapters/http/in/transaction_v2_handler.go
+++ b/components/ledger/internal/adapters/http/in/transaction_v2_handler.go
@@ -15,9 +15,11 @@ import (
 // is transport-only: the handler decodes the flat single-leg v2 body, translates it to
 // the canonical Transaction, and delegates to the SAME createTransaction funnel the v1
 // create ops use (via createTransactionShell). The ~480-line create orchestration and
-// its idempotency/fee/reserve seams are NOT touched — the only new code is the thin
-// decode → translate boundary and the direct-vs-hold action encoded by Translate's
-// pending flag. Conventions mirror the v1 Huma create shells (see
+// its fee/reserve seams are NOT touched — the only new code is the thin decode →
+// translate boundary, the direct-vs-hold action encoded by Translate's pending flag,
+// and the raw-body idempotency hash source the funnel accepts via an additive parameter
+// (ADR-004: v2 keys idempotency off the body as submitted, pre-translation; v1 is
+// byte-identical). Conventions mirror the v1 Huma create shells (see
 // transaction_handler_huma.go's header): path params are plain strings validated by the
 // ParseUUIDPathParameters Fiber middleware, the body carries RawBody + SkipValidateBody
 // so http.DecodeAndValidate is the sole body validator, and errors flow through the
@@ -55,5 +57,9 @@ func (handler *TransactionHandler) CreateTransactionDirectV2Huma(ctx context.Con
 		return nil, pkgHTTP.HumaProblem(err)
 	}
 
-	return handler.createTransactionShell(ctx, in.OrganizationID, in.LedgerID, transactionInput, transactionInput.InitialStatus(), in.IdempotencyKey, in.IdempotencyTTL)
+	// ADR-004: key v2 idempotency off the v2 body AS SUBMITTED (pre-translation). The raw
+	// request bytes are passed as the hash-source override so the funnel hashes them
+	// instead of the canonical translated transaction; v1 callers pass no override and
+	// stay byte-identical.
+	return handler.createTransactionShell(ctx, in.OrganizationID, in.LedgerID, transactionInput, transactionInput.InitialStatus(), in.IdempotencyKey, in.IdempotencyTTL, string(in.RawBody))
 }

--- a/components/ledger/internal/adapters/http/in/transaction_v2_handler_integration_test.go
+++ b/components/ledger/internal/adapters/http/in/transaction_v2_handler_integration_test.go
@@ -1,0 +1,554 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+//go:build integration
+
+package in
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"io"
+	nethttp "net/http"
+	"net/http/httptest"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	libCommons "github.com/LerianStudio/lib-commons/v6/commons"
+	"github.com/gofiber/fiber/v3"
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	redisadapter "github.com/LerianStudio/midaz/v4/components/ledger/internal/adapters/redis/transaction"
+	cn "github.com/LerianStudio/midaz/v4/pkg/constant"
+	"github.com/LerianStudio/midaz/v4/pkg/utils"
+	postgrestestutil "github.com/LerianStudio/midaz/v4/tests/utils/postgres"
+)
+
+// This file is the Task 1.3.3 gate: the integration + v1↔v2 parity proof for the v2
+// `direct` transaction endpoint (POST /v2/.../transactions/direct). It mounts BOTH the
+// v2 `direct` op and the v1 `/json` op through the SAME production Huma seams
+// (buildHumaV2DirectApp -> RegisterTransactionV2RoutesToApp and buildHumaTransactionApp
+// -> RegisterTransactionRoutes, both defined in the sibling unit-test files) against the
+// SAME real-repo handler backed by testcontainers (PostgreSQL + MongoDB + Redis), so
+// every assertion exercises the committed money path — not a stub.
+//
+// NOT PARALLEL: buildHumaTransactionApp / buildHumaV2DirectApp call libProblem.Install()
+// (process-global huma.NewError hook) and Huma validation uses process-global sync.Pools;
+// concurrent builds cross-contaminate. Every test here stays sequential.
+//
+// No time.Now() is used for any business value: the v2 Translate sets no transaction date
+// (the funnel defaults it), parity ignores IDs/timestamps, and the only wall-clock use is
+// the async-idempotency-store poll, which is bounded by a fixed retry count, not a clock.
+
+// --- request helpers ----------------------------------------------------------
+
+// v2DirectURL builds the concrete v2 direct path for the given org/ledger.
+func v2DirectURL(orgID, ledgerID uuid.UUID) string {
+	return "/v2/organizations/" + orgID.String() + "/ledgers/" + ledgerID.String() + "/transactions/direct"
+}
+
+// v1JSONURL builds the concrete v1 /json path for the given org/ledger.
+func v1JSONURL(orgID, ledgerID uuid.UUID) string {
+	return "/v1/organizations/" + orgID.String() + "/ledgers/" + ledgerID.String() + "/transactions/json"
+}
+
+// postTransaction issues a POST to the given app/url with the JSON body and an optional
+// X-Idempotency header (sent only when idempotencyKey is non-empty).
+func postTransaction(t *testing.T, app *fiber.App, url, body, idempotencyKey string) *nethttp.Response {
+	t.Helper()
+
+	req := httptest.NewRequest(nethttp.MethodPost, url, strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	if idempotencyKey != "" {
+		req.Header.Set("X-Idempotency", idempotencyKey)
+	}
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: 0})
+	require.NoError(t, err, "HTTP request should not fail at the transport layer")
+
+	return resp
+}
+
+// decodeTxResponse reads and unmarshals a transaction response body into a generic map,
+// asserting the expected status code (dumping the body on mismatch).
+func decodeTxResponse(t *testing.T, resp *nethttp.Response, wantStatus int) map[string]any {
+	t.Helper()
+
+	body := drainBody(t, resp)
+
+	require.Equal(t, wantStatus, resp.StatusCode,
+		"unexpected HTTP status; body: %s", string(body))
+
+	var result map[string]any
+	require.NoError(t, json.Unmarshal(body, &result), "response should be valid JSON; body: %s", string(body))
+
+	return result
+}
+
+// drainBody reads and closes the response body.
+func drainBody(t *testing.T, resp *nethttp.Response) []byte {
+	t.Helper()
+
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err, "should read response body")
+
+	return body
+}
+
+// --- assertion helpers ---------------------------------------------------------
+
+// countTransactionsInLedger counts persisted transactions scoped to a ledger.
+func countTransactionsInLedger(t *testing.T, db *sql.DB, ledgerID uuid.UUID) int {
+	t.Helper()
+
+	var n int
+
+	err := db.QueryRow(`SELECT COUNT(*) FROM transaction WHERE ledger_id = $1`, ledgerID).Scan(&n)
+	require.NoError(t, err, "failed to count transactions in ledger")
+
+	return n
+}
+
+// operationEconomicRow is the economically-meaningful projection of an operation row,
+// stripped of IDs/timestamps so two operations from different ledgers can be compared for
+// v1↔v2 parity.
+type operationEconomicRow struct {
+	Type           string
+	AssetCode      string
+	AccountAlias   string
+	Amount         decimal.Decimal
+	AvailableAfter decimal.Decimal
+	OnHoldAfter    decimal.Decimal
+}
+
+// fetchOperationRows returns the economic projection of every operation for a transaction,
+// ordered by type (CREDIT before DEBIT) for stable cross-ledger comparison.
+func fetchOperationRows(t *testing.T, db *sql.DB, txID uuid.UUID) []operationEconomicRow {
+	t.Helper()
+
+	rows, err := db.Query(`
+		SELECT type, asset_code, account_alias, amount, available_balance_after, on_hold_balance_after
+		FROM operation
+		WHERE transaction_id = $1
+		ORDER BY type
+	`, txID)
+	require.NoError(t, err, "failed to query operations")
+
+	defer func() { _ = rows.Close() }()
+
+	var out []operationEconomicRow
+
+	for rows.Next() {
+		var r operationEconomicRow
+
+		require.NoError(t, rows.Scan(
+			&r.Type, &r.AssetCode, &r.AccountAlias, &r.Amount, &r.AvailableAfter, &r.OnHoldAfter,
+		), "failed to scan operation row")
+
+		out = append(out, r)
+	}
+
+	require.NoError(t, rows.Err(), "operation row iteration error")
+
+	return out
+}
+
+// requireDecimalEqual asserts two decimals are numerically equal (no float comparison).
+func requireDecimalEqual(t *testing.T, want, got decimal.Decimal, msgAndArgs ...any) {
+	t.Helper()
+
+	require.Truef(t, want.Equal(got), "expected decimal %s, got %s (%v)", want.String(), got.String(), msgAndArgs)
+}
+
+// volatileResponseKeys are the identity/timestamp fields deleted (recursively) before a
+// v1↔v2 response deep-equal, so two economically-identical transactions in two ledgers
+// compare equal on everything that carries economic meaning.
+var volatileResponseKeys = map[string]struct{}{
+	"id":                  {},
+	"transactionId":       {},
+	"parentTransactionId": {},
+	"ledgerId":            {},
+	"organizationId":      {},
+	"accountId":           {},
+	"balanceId":           {},
+	"createdAt":           {},
+	"updatedAt":           {},
+	"deletedAt":           {},
+	"route":               {},
+	"routeId":             {},
+}
+
+// stripVolatile recursively removes identity/timestamp keys so the remaining tree is the
+// economic content of the transaction response.
+func stripVolatile(v any) any {
+	switch node := v.(type) {
+	case map[string]any:
+		for k := range node {
+			if _, drop := volatileResponseKeys[k]; drop {
+				delete(node, k)
+				continue
+			}
+
+			node[k] = stripVolatile(node[k])
+		}
+
+		return node
+	case []any:
+		for i := range node {
+			node[i] = stripVolatile(node[i])
+		}
+
+		return node
+	default:
+		return v
+	}
+}
+
+// waitForIdempotencyStored polls Redis until the async goroutine
+// (SetTransactionIdempotencyValue, fired post-write in executeCreateTransaction) has stored
+// the serialized transaction under the idempotency slot. SetNX seeds the slot with an EMPTY
+// value first; the cached response lands only when the goroutine runs, so a replay call
+// issued too early would race into the "key in use" 409 instead of the cached replay. The
+// bound is a fixed retry count (no wall clock).
+func waitForIdempotencyStored(t *testing.T, ctx context.Context, redisRepo redisadapter.RedisRepository, orgID, ledgerID uuid.UUID, key string) {
+	t.Helper()
+
+	internalKey := utils.IdempotencyInternalKey(orgID, ledgerID, key)
+
+	for i := 0; i < 400; i++ {
+		value, err := redisRepo.Get(ctx, internalKey)
+		if err == nil && strings.HasPrefix(strings.TrimSpace(value), "{") {
+			return
+		}
+
+		time.Sleep(25 * time.Millisecond)
+	}
+
+	t.Fatalf("idempotency cached response was not stored in redis for key %q within the retry budget", key)
+}
+
+// seedTransfer seeds a source/destination balance pair for a transfer test and returns
+// their balance IDs. Source starts with `available` and zero on-hold; destination starts
+// empty. Aliases are fixed so identical aliases can be reused across ledgers for parity.
+func seedTransfer(t *testing.T, db *sql.DB, orgID, ledgerID uuid.UUID, sourceAlias, destAlias string, available int64) (sourceBalanceID, destBalanceID uuid.UUID) {
+	t.Helper()
+
+	sourceAccountID := uuid.Must(libCommons.GenerateUUIDv7())
+	destAccountID := uuid.Must(libCommons.GenerateUUIDv7())
+
+	srcParams := postgrestestutil.DefaultBalanceParams()
+	srcParams.Alias = sourceAlias
+	srcParams.AssetCode = "USD"
+	srcParams.Available = decimal.NewFromInt(available)
+	srcParams.OnHold = decimal.Zero
+	sourceBalanceID = postgrestestutil.CreateTestBalance(t, db, orgID, ledgerID, sourceAccountID, srcParams)
+
+	dstParams := postgrestestutil.DefaultBalanceParams()
+	dstParams.Alias = destAlias
+	dstParams.AssetCode = "USD"
+	dstParams.Available = decimal.Zero
+	dstParams.OnHold = decimal.Zero
+	destBalanceID = postgrestestutil.CreateTestBalance(t, db, orgID, ledgerID, destAccountID, dstParams)
+
+	return sourceBalanceID, destBalanceID
+}
+
+// equivalentV2Body / equivalentV1Body are the economically-identical 100 USD transfer
+// bodies for the two surfaces, using the same aliases so the resulting transactions differ
+// only by IDs/timestamps.
+const (
+	equivalentV2Body = `{"description":"v1 v2 parity transfer","asset":"USD","amount":"100","from":"@src","to":"@dst"}`
+
+	equivalentV1Body = `{
+		"description":"v1 v2 parity transfer",
+		"send":{
+			"asset":"USD",
+			"value":"100",
+			"source":{"from":[{"accountAlias":"@src","amount":{"asset":"USD","value":"100"}}]},
+			"distribute":{"to":[{"accountAlias":"@dst","amount":{"asset":"USD","value":"100"}}]}
+		}
+	}`
+)
+
+// =============================================================================
+// 1. PARITY (core): v2 `direct` is indistinguishable from v1 `/json` for the same
+//    economic intent — same asset, amount, legs, source/destination effects, and final
+//    Available/OnHold on both accounts, comparing transactions/operations ignoring
+//    IDs and timestamps.
+// =============================================================================
+
+func TestIntegration_TransactionV2Direct_ParityWithV1JSON(t *testing.T) {
+	// NOT parallel: process-global huma state (see file header).
+	// The postgres client constructor enforces TLS by the ENV_NAME security tier and
+	// refuses plaintext unless ALLOW_INSECURE_TLS=true. `make test-integration` exports it;
+	// set it here too so the test is runnable directly (mirrors
+	// composition_mt_isolation_integration_test.go).
+	t.Setenv("ALLOW_INSECURE_TLS", "true")
+
+	infra := setupTestInfra(t)
+	t.Setenv("RABBITMQ_TRANSACTION_ASYNC", "false")
+
+	ctx := context.Background()
+
+	// Two ledgers under the SAME org so both transfers can use IDENTICAL aliases and
+	// starting balances; the only legitimate difference in the two responses is then the
+	// ledger id (stripped) plus per-row IDs/timestamps.
+	ledgerV1 := infra.ledgerID
+	ledgerV2 := uuid.Must(libCommons.GenerateUUIDv7())
+	seedLedgerSettings(t, infra.pgContainer.DB, infra.orgID, ledgerV2)
+
+	v1Src, v1Dst := seedTransfer(t, infra.pgContainer.DB, infra.orgID, ledgerV1, "@src", "@dst", 1000)
+	v2Src, v2Dst := seedTransfer(t, infra.pgContainer.DB, infra.orgID, ledgerV2, "@src", "@dst", 1000)
+
+	v1App := buildHumaTransactionApp(t, infra.handler, true)
+	v2App := buildHumaV2DirectApp(t, infra.handler)
+
+	// Act: economically-equivalent transfers on each surface. Each surface is fully
+	// processed (create -> drain -> assert balances) BEFORE the next is created, because
+	// the balance-sync schedule (schedule:balance-sync ZSET) is GLOBAL, not per-ledger:
+	// draining ledgerV1 while ledgerV2's keys are still pending would claim them under the
+	// wrong ledger and leave ledgerV2's cold balances stale.
+	v1Resp := decodeTxResponse(t, postTransaction(t, v1App, v1JSONURL(infra.orgID, ledgerV1), equivalentV1Body, ""), nethttp.StatusCreated)
+	v1TxID := uuid.MustParse(v1Resp["id"].(string))
+	assert.Equal(t, cn.APPROVED, postgrestestutil.GetTransactionStatus(t, infra.pgContainer.DB, v1TxID), "v1 transaction should be APPROVED in DB")
+	drainBalanceSync(t, ctx, infra.handler.Command, infra.redisRepo, infra.orgID, ledgerV1)
+
+	v2Resp := decodeTxResponse(t, postTransaction(t, v2App, v2DirectURL(infra.orgID, ledgerV2), equivalentV2Body, ""), nethttp.StatusCreated)
+	v2TxID := uuid.MustParse(v2Resp["id"].(string))
+	assert.Equal(t, cn.APPROVED, postgrestestutil.GetTransactionStatus(t, infra.pgContainer.DB, v2TxID), "v2 transaction should be APPROVED in DB")
+	drainBalanceSync(t, ctx, infra.handler.Command, infra.redisRepo, infra.orgID, ledgerV2)
+
+	// Balances: source 1000 -> 900, destination 0 -> 100, on-hold 0, on BOTH surfaces.
+	requireDecimalEqual(t, decimal.NewFromInt(900), postgrestestutil.GetBalanceAvailable(t, infra.pgContainer.DB, v1Src), "v1 source available")
+	requireDecimalEqual(t, decimal.NewFromInt(900), postgrestestutil.GetBalanceAvailable(t, infra.pgContainer.DB, v2Src), "v2 source available")
+	requireDecimalEqual(t, decimal.NewFromInt(100), postgrestestutil.GetBalanceAvailable(t, infra.pgContainer.DB, v1Dst), "v1 dest available")
+	requireDecimalEqual(t, decimal.NewFromInt(100), postgrestestutil.GetBalanceAvailable(t, infra.pgContainer.DB, v2Dst), "v2 dest available")
+	requireDecimalEqual(t, decimal.Zero, postgrestestutil.GetBalanceOnHold(t, infra.pgContainer.DB, v1Src), "v1 source on-hold")
+	requireDecimalEqual(t, decimal.Zero, postgrestestutil.GetBalanceOnHold(t, infra.pgContainer.DB, v2Src), "v2 source on-hold")
+
+	// Operations: exactly 1 DEBIT + 1 CREDIT on each, and the economic projection is
+	// IDENTICAL between the two surfaces (type, asset, alias, amount, balance-after).
+	v1Ops := fetchOperationRows(t, infra.pgContainer.DB, v1TxID)
+	v2Ops := fetchOperationRows(t, infra.pgContainer.DB, v2TxID)
+
+	require.Len(t, v1Ops, 2, "v1 transaction should have exactly 2 operations")
+	require.Len(t, v2Ops, 2, "v2 transaction should have exactly 2 operations")
+	assertOperationSetsEqual(t, v1Ops, v2Ops)
+
+	// Response deep-equal, ignoring IDs/timestamps: the v2 direct response is
+	// indistinguishable from the v1 /json response for the same economic intent.
+	assert.Equal(t, "USD", v1Resp["assetCode"])
+	assert.Equal(t, "USD", v2Resp["assetCode"])
+
+	require.Equal(t, stripVolatile(v1Resp), stripVolatile(v2Resp),
+		"v2 direct transaction must be indistinguishable from the v1 /json equivalent (ignoring IDs/timestamps)")
+}
+
+// assertOperationSetsEqual asserts two 2-element operation sets carry identical economic
+// content leg-for-leg (matched by type, since ORDER BY type makes both deterministic).
+func assertOperationSetsEqual(t *testing.T, a, b []operationEconomicRow) {
+	t.Helper()
+
+	sort.Slice(a, func(i, j int) bool { return a[i].Type < a[j].Type })
+	sort.Slice(b, func(i, j int) bool { return b[i].Type < b[j].Type })
+
+	require.Equal(t, len(a), len(b), "operation set sizes differ")
+
+	for i := range a {
+		assert.Equal(t, a[i].Type, b[i].Type, "operation[%d] type", i)
+		assert.Equal(t, a[i].AssetCode, b[i].AssetCode, "operation[%d] asset", i)
+		assert.Equal(t, a[i].AccountAlias, b[i].AccountAlias, "operation[%d] alias", i)
+		requireDecimalEqual(t, a[i].Amount, b[i].Amount, "operation[%d] amount", i)
+		requireDecimalEqual(t, a[i].AvailableAfter, b[i].AvailableAfter, "operation[%d] available-after", i)
+		requireDecimalEqual(t, a[i].OnHoldAfter, b[i].OnHoldAfter, "operation[%d] on-hold-after", i)
+	}
+}
+
+// =============================================================================
+// 2. VALIDATION BEFORE ANY LEDGER EFFECT: a v2 `direct` missing a required field (or with
+//    a malformed body) is rejected at the decode boundary (4xx) with NO transaction /
+//    operation / balance mutation.
+// =============================================================================
+
+func TestIntegration_TransactionV2Direct_ValidationBeforeLedgerEffect(t *testing.T) {
+	// NOT parallel: process-global huma state (see file header).
+	// The postgres client constructor enforces TLS by the ENV_NAME security tier and
+	// refuses plaintext unless ALLOW_INSECURE_TLS=true. `make test-integration` exports it;
+	// set it here too so the test is runnable directly (mirrors
+	// composition_mt_isolation_integration_test.go).
+	t.Setenv("ALLOW_INSECURE_TLS", "true")
+
+	infra := setupTestInfra(t)
+	t.Setenv("RABBITMQ_TRANSACTION_ASYNC", "false")
+
+	srcID, dstID := seedTransfer(t, infra.pgContainer.DB, infra.orgID, infra.ledgerID, "@src", "@dst", 1000)
+
+	v2App := buildHumaV2DirectApp(t, infra.handler)
+	url := v2DirectURL(infra.orgID, infra.ledgerID)
+
+	cases := []struct {
+		name       string
+		body       string
+		wantStatus int
+	}{
+		{
+			// `from` is validate:"required" on CreateTransactionV2Input; the imperative
+			// DecodeAndValidate surfaces a ValidationError -> canonical 400 before the funnel.
+			name:       "missing required from field",
+			body:       `{"asset":"USD","amount":"100","to":"@dst"}`,
+			wantStatus: nethttp.StatusBadRequest,
+		},
+		{
+			name:       "missing required asset field",
+			body:       `{"amount":"100","from":"@src","to":"@dst"}`,
+			wantStatus: nethttp.StatusBadRequest,
+		},
+		{
+			name:       "malformed json body",
+			body:       `{not-json`,
+			wantStatus: nethttp.StatusBadRequest,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			resp := postTransaction(t, v2App, url, tc.body, "")
+			_ = drainBody(t, resp)
+			assert.Equal(t, tc.wantStatus, resp.StatusCode, "%s should be rejected at the decode boundary", tc.name)
+		})
+	}
+
+	// No ledger effect: no transaction, and balances untouched.
+	assert.Equal(t, 0, countTransactionsInLedger(t, infra.pgContainer.DB, infra.ledgerID), "no transaction should be persisted for rejected requests")
+	requireDecimalEqual(t, decimal.NewFromInt(1000), postgrestestutil.GetBalanceAvailable(t, infra.pgContainer.DB, srcID), "source balance must be untouched")
+	requireDecimalEqual(t, decimal.Zero, postgrestestutil.GetBalanceAvailable(t, infra.pgContainer.DB, dstID), "destination balance must be untouched")
+}
+
+// =============================================================================
+// 3. BUSINESS RULE: `from == to` is a Translate business error -> 422, with NO ledger
+//    effect (the error fires before the create funnel touches any balance).
+// =============================================================================
+
+func TestIntegration_TransactionV2Direct_FromEqualsTo_BusinessError(t *testing.T) {
+	// NOT parallel: process-global huma state (see file header).
+	// The postgres client constructor enforces TLS by the ENV_NAME security tier and
+	// refuses plaintext unless ALLOW_INSECURE_TLS=true. `make test-integration` exports it;
+	// set it here too so the test is runnable directly (mirrors
+	// composition_mt_isolation_integration_test.go).
+	t.Setenv("ALLOW_INSECURE_TLS", "true")
+
+	infra := setupTestInfra(t)
+	t.Setenv("RABBITMQ_TRANSACTION_ASYNC", "false")
+
+	srcID, _ := seedTransfer(t, infra.pgContainer.DB, infra.orgID, infra.ledgerID, "@same", "@dst", 1000)
+
+	v2App := buildHumaV2DirectApp(t, infra.handler)
+
+	resp := postTransaction(t, v2App, v2DirectURL(infra.orgID, infra.ledgerID), `{"asset":"USD","amount":"100","from":"@same","to":"@same"}`, "")
+	body := drainBody(t, resp)
+
+	assert.Equal(t, nethttp.StatusUnprocessableEntity, resp.StatusCode,
+		"from == to is a business error (ErrTransactionAmbiguous / 0090) -> 422; body: %s", string(body))
+	assert.Contains(t, string(body), "0090", "response should carry the ambiguous-transaction business error code")
+
+	// No ledger effect.
+	assert.Equal(t, 0, countTransactionsInLedger(t, infra.pgContainer.DB, infra.ledgerID), "ambiguous transaction must not persist")
+	requireDecimalEqual(t, decimal.NewFromInt(1000), postgrestestutil.GetBalanceAvailable(t, infra.pgContainer.DB, srcID), "balance must be untouched on business error")
+}
+
+// =============================================================================
+// 4. IDEMPOTENCY (Task 1.3.2 / ADR-004):
+//    (a) two identical v2 `direct` calls (same X-Idempotency key + body) -> the second
+//        REPLAYS the first (X-Idempotency-Replayed: true, same tx id) and creates NO
+//        second transaction.
+//    (b) a v1 `/json` call keyed off the SAME economic intent does NOT cross-dedup with
+//        the v2 one: v2 keys idempotency off the RAW v2 body, v1 off the CANONICAL built
+//        transaction, so the hashes differ by construction and each surface creates its
+//        own distinct transaction.
+// =============================================================================
+
+func TestIntegration_TransactionV2Direct_Idempotency(t *testing.T) {
+	// NOT parallel: process-global huma state (see file header).
+	// The postgres client constructor enforces TLS by the ENV_NAME security tier and
+	// refuses plaintext unless ALLOW_INSECURE_TLS=true. `make test-integration` exports it;
+	// set it here too so the test is runnable directly (mirrors
+	// composition_mt_isolation_integration_test.go).
+	t.Setenv("ALLOW_INSECURE_TLS", "true")
+
+	infra := setupTestInfra(t)
+	t.Setenv("RABBITMQ_TRANSACTION_ASYNC", "false")
+
+	ctx := context.Background()
+
+	v1App := buildHumaTransactionApp(t, infra.handler, true)
+	v2App := buildHumaV2DirectApp(t, infra.handler)
+
+	// --- (a) v2 replay on an explicit idempotency key -----------------------------
+	seedTransfer(t, infra.pgContainer.DB, infra.orgID, infra.ledgerID, "@src", "@dst", 1000)
+
+	idempotencyKey := uuid.NewString()
+	url := v2DirectURL(infra.orgID, infra.ledgerID)
+
+	first := postTransaction(t, v2App, url, equivalentV2Body, idempotencyKey)
+	firstResult := decodeTxResponse(t, first, nethttp.StatusCreated)
+	assert.Equal(t, "false", first.Header.Get("X-Idempotency-Replayed"), "first call must not be a replay")
+
+	firstTxID := firstResult["id"].(string)
+
+	// Wait for the async idempotency-value store before replaying (see helper doc).
+	waitForIdempotencyStored(t, ctx, infra.redisRepo, infra.orgID, infra.ledgerID, idempotencyKey)
+
+	second := postTransaction(t, v2App, url, equivalentV2Body, idempotencyKey)
+	secondResult := decodeTxResponse(t, second, nethttp.StatusCreated)
+
+	assert.Equal(t, "true", second.Header.Get("X-Idempotency-Replayed"), "second identical call must be a replay")
+	assert.Equal(t, firstTxID, secondResult["id"].(string), "replay must return the FIRST transaction's id")
+	assert.Equal(t, 1, countTransactionsInLedger(t, infra.pgContainer.DB, infra.ledgerID),
+		"an idempotent replay must NOT create a second transaction")
+
+	// --- (b) v1 does NOT cross-dedup with v2 (ADR-004: different key source) -------
+	// Both calls below omit X-Idempotency, so each surface derives its key from the body
+	// hash: v2 from the raw flat body, v1 from the canonical built transaction. The hashes
+	// differ by construction, so neither replays the other. Distinct account aliases keep
+	// the balance effects independent; the idempotency internal key is (org, ledger, hash)
+	// and does not include the accounts, so the non-collision is proven purely by the hash
+	// source difference within the SAME ledger.
+	seedTransfer(t, infra.pgContainer.DB, infra.orgID, infra.ledgerID, "@xsrc", "@xdst", 1000)
+	seedTransfer(t, infra.pgContainer.DB, infra.orgID, infra.ledgerID, "@ysrc", "@ydst", 1000)
+
+	v2CrossBody := `{"description":"cross dedup","asset":"USD","amount":"100","from":"@xsrc","to":"@xdst"}`
+	v1CrossBody := `{
+		"description":"cross dedup",
+		"send":{
+			"asset":"USD",
+			"value":"100",
+			"source":{"from":[{"accountAlias":"@ysrc","amount":{"asset":"USD","value":"100"}}]},
+			"distribute":{"to":[{"accountAlias":"@ydst","amount":{"asset":"USD","value":"100"}}]}
+		}
+	}`
+
+	countBefore := countTransactionsInLedger(t, infra.pgContainer.DB, infra.ledgerID)
+
+	v2Cross := postTransaction(t, v2App, url, v2CrossBody, "")
+	v2CrossResult := decodeTxResponse(t, v2Cross, nethttp.StatusCreated)
+
+	v1Cross := postTransaction(t, v1App, v1JSONURL(infra.orgID, infra.ledgerID), v1CrossBody, "")
+	v1CrossResult := decodeTxResponse(t, v1Cross, nethttp.StatusCreated)
+
+	assert.Equal(t, "false", v1Cross.Header.Get("X-Idempotency-Replayed"),
+		"the v1 call must NOT replay the v2 transaction (different idempotency key source per ADR-004)")
+	assert.NotEqual(t, v2CrossResult["id"].(string), v1CrossResult["id"].(string),
+		"v1 and v2 body-hash keys must not collide: each surface creates its own transaction")
+	assert.Equal(t, countBefore+2, countTransactionsInLedger(t, infra.pgContainer.DB, infra.ledgerID),
+		"v2 and v1 must each create a distinct transaction (no cross-dedup)")
+}

--- a/components/ledger/internal/adapters/http/in/transaction_v2_handler_integration_test.go
+++ b/components/ledger/internal/adapters/http/in/transaction_v2_handler_integration_test.go
@@ -30,7 +30,7 @@ import (
 	postgrestestutil "github.com/LerianStudio/midaz/v4/tests/utils/postgres"
 )
 
-// This file is the Task 1.3.3 gate: the integration + v1↔v2 parity proof for the v2
+// This file is the integration + v1↔v2 parity proof for the v2
 // `direct` transaction endpoint (POST /v2/.../transactions/direct). It mounts BOTH the
 // v2 `direct` op and the v1 `/json` op through the SAME production Huma seams
 // (buildHumaV2DirectApp -> RegisterTransactionV2RoutesToApp and buildHumaTransactionApp
@@ -466,7 +466,7 @@ func TestIntegration_TransactionV2Direct_FromEqualsTo_BusinessError(t *testing.T
 }
 
 // =============================================================================
-// 4. IDEMPOTENCY (Task 1.3.2 / ADR-004):
+// 4. IDEMPOTENCY:
 //    (a) two identical v2 `direct` calls (same X-Idempotency key + body) -> the second
 //        REPLAYS the first (X-Idempotency-Replayed: true, same tx id) and creates NO
 //        second transaction.
@@ -515,7 +515,7 @@ func TestIntegration_TransactionV2Direct_Idempotency(t *testing.T) {
 	assert.Equal(t, 1, countTransactionsInLedger(t, infra.pgContainer.DB, infra.ledgerID),
 		"an idempotent replay must NOT create a second transaction")
 
-	// --- (b) v1 does NOT cross-dedup with v2 (ADR-004: different key source) -------
+	// --- (b) v1 does NOT cross-dedup with v2 (different key source) -------
 	// Both calls below omit X-Idempotency, so each surface derives its key from the body
 	// hash: v2 from the raw flat body, v1 from the canonical built transaction. The hashes
 	// differ by construction, so neither replays the other. Distinct account aliases keep
@@ -545,7 +545,7 @@ func TestIntegration_TransactionV2Direct_Idempotency(t *testing.T) {
 	v1CrossResult := decodeTxResponse(t, v1Cross, nethttp.StatusCreated)
 
 	assert.Equal(t, "false", v1Cross.Header.Get("X-Idempotency-Replayed"),
-		"the v1 call must NOT replay the v2 transaction (different idempotency key source per ADR-004)")
+		"the v1 call must NOT replay the v2 transaction (different idempotency key source)")
 	assert.NotEqual(t, v2CrossResult["id"].(string), v1CrossResult["id"].(string),
 		"v1 and v2 body-hash keys must not collide: each surface creates its own transaction")
 	assert.Equal(t, countBefore+2, countTransactionsInLedger(t, infra.pgContainer.DB, infra.ledgerID),

--- a/components/ledger/internal/adapters/http/in/transaction_v2_handler_integration_test.go
+++ b/components/ledger/internal/adapters/http/in/transaction_v2_handler_integration_test.go
@@ -13,7 +13,6 @@ import (
 	"io"
 	nethttp "net/http"
 	"net/http/httptest"
-	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -335,6 +334,8 @@ func TestIntegration_TransactionV2Direct_ParityWithV1JSON(t *testing.T) {
 	requireDecimalEqual(t, decimal.NewFromInt(100), postgrestestutil.GetBalanceAvailable(t, infra.pgContainer.DB, v2Dst), "v2 dest available")
 	requireDecimalEqual(t, decimal.Zero, postgrestestutil.GetBalanceOnHold(t, infra.pgContainer.DB, v1Src), "v1 source on-hold")
 	requireDecimalEqual(t, decimal.Zero, postgrestestutil.GetBalanceOnHold(t, infra.pgContainer.DB, v2Src), "v2 source on-hold")
+	requireDecimalEqual(t, decimal.Zero, postgrestestutil.GetBalanceOnHold(t, infra.pgContainer.DB, v1Dst), "v1 dest on-hold")
+	requireDecimalEqual(t, decimal.Zero, postgrestestutil.GetBalanceOnHold(t, infra.pgContainer.DB, v2Dst), "v2 dest on-hold")
 
 	// Operations: exactly 1 DEBIT + 1 CREDIT on each, and the economic projection is
 	// IDENTICAL between the two surfaces (type, asset, alias, amount, balance-after).
@@ -355,12 +356,10 @@ func TestIntegration_TransactionV2Direct_ParityWithV1JSON(t *testing.T) {
 }
 
 // assertOperationSetsEqual asserts two 2-element operation sets carry identical economic
-// content leg-for-leg (matched by type, since ORDER BY type makes both deterministic).
+// content leg-for-leg. Both inputs come from fetchOperationRows, whose `ORDER BY type` is
+// the single source of ordering, so the rows line up index-for-index without re-sorting.
 func assertOperationSetsEqual(t *testing.T, a, b []operationEconomicRow) {
 	t.Helper()
-
-	sort.Slice(a, func(i, j int) bool { return a[i].Type < a[j].Type })
-	sort.Slice(b, func(i, j int) bool { return b[i].Type < b[j].Type })
 
 	require.Equal(t, len(a), len(b), "operation set sizes differ")
 
@@ -551,4 +550,46 @@ func TestIntegration_TransactionV2Direct_Idempotency(t *testing.T) {
 		"v1 and v2 body-hash keys must not collide: each surface creates its own transaction")
 	assert.Equal(t, countBefore+2, countTransactionsInLedger(t, infra.pgContainer.DB, infra.ledgerID),
 		"v2 and v1 must each create a distinct transaction (no cross-dedup)")
+}
+
+// =============================================================================
+// 5. INSUFFICIENT FUNDS (money-path defense-in-depth): a v2 `direct` transfer for MORE
+//    than the source's available balance is rejected by the atomic balance commit as a
+//    business error (ErrInsufficientFunds / 0018 -> 422), with NO transaction persisted
+//    and BOTH balances left exactly as seeded (the Lua commit is atomic, so a rejected
+//    transfer moves nothing).
+// =============================================================================
+
+func TestIntegration_TransactionV2Direct_InsufficientFunds(t *testing.T) {
+	// NOT parallel: process-global huma state (see file header).
+	// The postgres client constructor enforces TLS by the ENV_NAME security tier and
+	// refuses plaintext unless ALLOW_INSECURE_TLS=true. `make test-integration` exports it;
+	// set it here too so the test is runnable directly (mirrors
+	// composition_mt_isolation_integration_test.go).
+	t.Setenv("ALLOW_INSECURE_TLS", "true")
+
+	infra := setupTestInfra(t)
+	t.Setenv("RABBITMQ_TRANSACTION_ASYNC", "false")
+
+	// Source seeded with 1000 available; the transfer below asks for 5000.
+	srcID, dstID := seedTransfer(t, infra.pgContainer.DB, infra.orgID, infra.ledgerID, "@src", "@dst", 1000)
+
+	v2App := buildHumaV2DirectApp(t, infra.handler)
+
+	resp := postTransaction(t, v2App, v2DirectURL(infra.orgID, infra.ledgerID),
+		`{"description":"v2 insufficient funds","asset":"USD","amount":"5000","from":"@src","to":"@dst"}`, "")
+	body := drainBody(t, resp)
+
+	assert.Equal(t, nethttp.StatusUnprocessableEntity, resp.StatusCode,
+		"a transfer exceeding available funds is a business error (ErrInsufficientFunds / 0018) -> 422; body: %s", string(body))
+	assert.Contains(t, string(body), "0018", "response should carry the insufficient-funds business error code")
+
+	// No ledger effect: no transaction persisted, and both balances untouched (available
+	// and on-hold), because the atomic commit rejected before moving anything.
+	assert.Equal(t, 0, countTransactionsInLedger(t, infra.pgContainer.DB, infra.ledgerID),
+		"an insufficient-funds transfer must not persist a transaction")
+	requireDecimalEqual(t, decimal.NewFromInt(1000), postgrestestutil.GetBalanceAvailable(t, infra.pgContainer.DB, srcID), "source available must be untouched")
+	requireDecimalEqual(t, decimal.Zero, postgrestestutil.GetBalanceOnHold(t, infra.pgContainer.DB, srcID), "source on-hold must be untouched")
+	requireDecimalEqual(t, decimal.Zero, postgrestestutil.GetBalanceAvailable(t, infra.pgContainer.DB, dstID), "destination available must be untouched")
+	requireDecimalEqual(t, decimal.Zero, postgrestestutil.GetBalanceOnHold(t, infra.pgContainer.DB, dstID), "destination on-hold must be untouched")
 }

--- a/components/ledger/internal/adapters/http/in/transaction_v2_handler_test.go
+++ b/components/ledger/internal/adapters/http/in/transaction_v2_handler_test.go
@@ -1,0 +1,165 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package in
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/LerianStudio/lib-auth/v3/auth/middleware"
+	openapi "github.com/LerianStudio/lib-commons/v6/commons/net/http/openapi"
+	libProblem "github.com/LerianStudio/lib-commons/v6/commons/net/http/problem"
+	libLog "github.com/LerianStudio/lib-observability/v2/log"
+	"github.com/gofiber/fiber/v3"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pkgHTTP "github.com/LerianStudio/midaz/v4/pkg/net/http"
+)
+
+// buildHumaV2DirectApp mounts the v2 `direct` transaction op through the SAME
+// production seam (RegisterTransactionV2RoutesToApp) the unified server uses, on a
+// fresh Fiber app + its own /v2 Huma contract. It mirrors buildHumaTransactionApp:
+// problem.Install() before any huma.Register, WithRecover as the first middleware so
+// a nil-repo panic in the unwired funnel unwinds to a 500 (not a dropped connection),
+// the ledger schema namer installed after openapi.New and before registration (the v2
+// output embeds transaction.Transaction, which nests operation.{Status,Balance,Amount}
+// and clashes on the bare names without it), and auth disabled so requests reach the
+// terminal. A bare handler is enough: these tests prove the transport boundary (decode,
+// translate, route-UUID hygiene, error class) and funnel entry — the committed money
+// path is the Task 1.3.3 integration+parity test.
+//
+// MUST-NOT-PARALLELIZE (same rationale as buildHumaTransactionApp): libProblem.Install()
+// swaps the process-global huma.NewError hook and Huma validation uses process-global
+// sync.Pools — concurrent builds/requests cross-contaminate.
+func buildHumaV2DirectApp(t *testing.T, handler *TransactionHandler) *fiber.App {
+	t.Helper()
+
+	app := fiber.New(fiber.Config{
+		ErrorHandler: pkgHTTP.CanonicalFiberErrorHandler,
+	})
+
+	app.Use(pkgHTTP.WithRecover(pkgHTTP.WithRecoverLogger(&libLog.GoLogger{})))
+
+	libProblem.Install()
+
+	apiV2 := app.Group("/v2")
+
+	humaAPI := openapi.New(app, apiV2, openapi.Config{Title: "ledger-test-v2", Version: "test", Servers: []string{"/v2"}})
+	pkgHTTP.InstallLedgerSchemaNamer(humaAPI)
+
+	RegisterTransactionV2RoutesToApp(apiV2, humaAPI, &middleware.AuthClient{Enabled: false}, handler, nil)
+
+	return app
+}
+
+// directV2ConcretePath builds the concrete /v2 direct path for a random org+ledger so
+// ParseUUIDPathParameters passes and dispatch reaches the terminal.
+func directV2ConcretePath() string {
+	return "/v2/organizations/" + uuid.New().String() + "/ledgers/" + uuid.New().String() + "/transactions/direct"
+}
+
+// postDirectV2 issues an authenticated POST to the v2 direct route with the given JSON body.
+func postDirectV2(t *testing.T, app *fiber.App, body string) *http.Response {
+	t.Helper()
+
+	req := httptest.NewRequest(http.MethodPost, directV2ConcretePath(), strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: 0})
+	require.NoError(t, err)
+
+	return resp
+}
+
+// TestCreateTransactionDirectV2Huma_MalformedBody_400 proves the real handler decodes
+// the flat v2 body through http.DecodeAndValidate (the SAME validator the v1 create
+// ops run): malformed JSON is the canonical 400 RFC 9457 problem — never a native Huma
+// 422 and never the 501 stub.
+func TestCreateTransactionDirectV2Huma_MalformedBody_400(t *testing.T) {
+	// NOT parallel: process-global huma state.
+	app := buildHumaV2DirectApp(t, &TransactionHandler{})
+
+	resp := postDirectV2(t, app, `{not-json`)
+	defer func() { _ = resp.Body.Close() }()
+
+	body, _ := io.ReadAll(resp.Body)
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode, "malformed v2 body stays canonical 400 — no native Huma 422, no 501 stub")
+	assert.Contains(t, string(body), "status", "error body must be the RFC 9457 problem envelope")
+}
+
+// TestCreateTransactionDirectV2Huma_MalformedRouteUUID_400 pins the route-UUID hygiene
+// contract: routeId is an optional *string on the flat v2 input, so a malformed route
+// UUID MUST surface as a clean 400 at the decode boundary — never fall through to a deep
+// 500 in the funnel.
+func TestCreateTransactionDirectV2Huma_MalformedRouteUUID_400(t *testing.T) {
+	// NOT parallel: process-global huma state.
+	app := buildHumaV2DirectApp(t, &TransactionHandler{})
+
+	resp := postDirectV2(t, app, `{"asset":"BRL","amount":"100","from":"@src","to":"@dst","routeId":"not-a-uuid"}`)
+	defer func() { _ = resp.Body.Close() }()
+
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode, "malformed routeId must be a clean 400, not a deep 500")
+}
+
+// TestCreateTransactionDirectV2Huma_MalformedOperationRouteUUID_400 mirrors the routeId
+// hygiene for the per-leg operationRouteId.
+func TestCreateTransactionDirectV2Huma_MalformedOperationRouteUUID_400(t *testing.T) {
+	// NOT parallel: process-global huma state.
+	app := buildHumaV2DirectApp(t, &TransactionHandler{})
+
+	resp := postDirectV2(t, app, `{"asset":"BRL","amount":"100","from":"@src","to":"@dst","operationRouteId":"not-a-uuid"}`)
+	defer func() { _ = resp.Body.Close() }()
+
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode, "malformed operationRouteId must be a clean 400, not a deep 500")
+}
+
+// TestCreateTransactionDirectV2Huma_Ambiguous_422 proves a Translate business error
+// (from == to) maps to the canonical 422 RFC 9457 problem (span stays green) — the
+// handler decodes, translates, and surfaces the business error without reaching the
+// funnel.
+func TestCreateTransactionDirectV2Huma_Ambiguous_422(t *testing.T) {
+	// NOT parallel: process-global huma state.
+	app := buildHumaV2DirectApp(t, &TransactionHandler{})
+
+	resp := postDirectV2(t, app, `{"asset":"BRL","amount":"100","from":"@same","to":"@same"}`)
+	defer func() { _ = resp.Body.Close() }()
+
+	assert.Equal(t, http.StatusUnprocessableEntity, resp.StatusCode, "source == destination is a Translate business error → 422")
+}
+
+// TestCreateTransactionDirectV2Huma_NonPositiveAmount_422 proves the second Translate
+// business branch (non-positive amount) also maps to a canonical 422.
+func TestCreateTransactionDirectV2Huma_NonPositiveAmount_422(t *testing.T) {
+	// NOT parallel: process-global huma state.
+	app := buildHumaV2DirectApp(t, &TransactionHandler{})
+
+	resp := postDirectV2(t, app, `{"asset":"BRL","amount":"0","from":"@src","to":"@dst"}`)
+	defer func() { _ = resp.Body.Close() }()
+
+	assert.Equal(t, http.StatusUnprocessableEntity, resp.StatusCode, "non-positive amount is a Translate business error → 422")
+}
+
+// TestCreateTransactionDirectV2Huma_ValidBodyEntersFunnel proves the happy-path wiring
+// up to the funnel: a fully valid flat body passes decode + Translate(false) and is
+// handed to the SAME createTransaction funnel the v1 create ops use. With a bare handler
+// the funnel's first repository call has no wired dependency, so WithRecover maps the
+// resulting panic to a 500 — proving the request progressed PAST the transport/translate
+// boundary into the funnel (never the 501 stub, never a decode/translate 4xx). The
+// committed transaction result is asserted by the Task 1.3.3 integration+parity test.
+func TestCreateTransactionDirectV2Huma_ValidBodyEntersFunnel(t *testing.T) {
+	// NOT parallel: process-global huma state.
+	app := buildHumaV2DirectApp(t, &TransactionHandler{})
+
+	resp := postDirectV2(t, app, `{"description":"v2 direct","asset":"BRL","amount":"100","from":"@src","to":"@dst"}`)
+	defer func() { _ = resp.Body.Close() }()
+
+	assert.Equal(t, http.StatusInternalServerError, resp.StatusCode,
+		"valid body must clear the transport/translate boundary and enter the funnel (unwired repos → recovered 500; committed path is Task 1.3.3)")
+}

--- a/components/ledger/internal/adapters/http/in/transaction_v2_handler_test.go
+++ b/components/ledger/internal/adapters/http/in/transaction_v2_handler_test.go
@@ -33,7 +33,7 @@ import (
 // and clashes on the bare names without it), and auth disabled so requests reach the
 // terminal. A bare handler is enough: these tests prove the transport boundary (decode,
 // translate, route-UUID hygiene, error class) and funnel entry — the committed money
-// path is the Task 1.3.3 integration+parity test.
+// path is the integration+parity test.
 //
 // MUST-NOT-PARALLELIZE (same rationale as buildHumaTransactionApp): libProblem.Install()
 // swaps the process-global huma.NewError hook and Huma validation uses process-global
@@ -152,7 +152,7 @@ func TestCreateTransactionDirectV2Huma_NonPositiveAmount_422(t *testing.T) {
 // the funnel's first repository call has no wired dependency, so WithRecover maps the
 // resulting panic to a 500 — proving the request progressed PAST the transport/translate
 // boundary into the funnel (never the 501 stub, never a decode/translate 4xx). The
-// committed transaction result is asserted by the Task 1.3.3 integration+parity test.
+// committed transaction result is asserted by the integration+parity test.
 func TestCreateTransactionDirectV2Huma_ValidBodyEntersFunnel(t *testing.T) {
 	// NOT parallel: process-global huma state.
 	app := buildHumaV2DirectApp(t, &TransactionHandler{})
@@ -161,5 +161,5 @@ func TestCreateTransactionDirectV2Huma_ValidBodyEntersFunnel(t *testing.T) {
 	defer func() { _ = resp.Body.Close() }()
 
 	assert.Equal(t, http.StatusInternalServerError, resp.StatusCode,
-		"valid body must clear the transport/translate boundary and enter the funnel (unwired repos → recovered 500; committed path is Task 1.3.3)")
+		"valid body must clear the transport/translate boundary and enter the funnel (unwired repos → recovered 500; committed path is the integration+parity test)")
 }

--- a/components/ledger/internal/adapters/http/in/transaction_v2_idempotency_huma_test.go
+++ b/components/ledger/internal/adapters/http/in/transaction_v2_idempotency_huma_test.go
@@ -1,0 +1,228 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package in
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	libCommons "github.com/LerianStudio/lib-commons/v6/commons"
+	libConstants "github.com/LerianStudio/lib-commons/v6/commons/constants"
+	"github.com/gofiber/fiber/v3"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	txRedis "github.com/LerianStudio/midaz/v4/components/ledger/internal/adapters/redis/transaction"
+	"github.com/LerianStudio/midaz/v4/components/ledger/internal/services/command"
+	"github.com/LerianStudio/midaz/v4/pkg/mtransaction"
+	pkgHTTP "github.com/LerianStudio/midaz/v4/pkg/net/http"
+)
+
+// Task 1.3.2 — v2 idempotency is keyed by the v2 body AS SUBMITTED (pre-translation),
+// per ADR-004. The v1 create funnel hashes the CANONICAL built transaction
+// (StructToJSONString(transactionInput)); the v2 surface must instead hash the raw
+// flat v2 request bytes so two identical v2 `direct` submissions dedup by the body the
+// client actually sent — while the funnel still persists the canonical transaction.
+//
+// These tests probe the SAME first-repo touch the v1 wiring suite uses
+// (TransactionRedisRepo.SetNX, whose internalKey is
+// utils.IdempotencyInternalKey(org, ledger, <key>) and — with no caller X-Idempotency —
+// <key> falls back to the computed hash). So the SetNX internalKey embeds the hash
+// SOURCE by construction, observed without Redis.
+//
+// Not parallel: buildHumaV2DirectApp / buildHumaTransactionApp mutate process-global
+// huma state (see their headers).
+
+const (
+	// v2DirectBody is a minimal valid flat v2 `direct` body: amount 100 > 0 clears the
+	// funnel's non-positive guard and reaches the idempotency claim; from != to clears
+	// the Translate ambiguity guard.
+	v2DirectBody = `{"description":"v2 direct","asset":"BRL","amount":"100","from":"@src","to":"@dst"}`
+
+	// v1JSONBody is the v1 /json analogue whose CANONICAL built form differs from its raw
+	// bytes — so a hash over the canonical transaction can never collide with a hash over
+	// these raw bytes.
+	v1JSONBody = `{"send":{"asset":"BRL","value":"100","source":{"from":[{"accountAlias":"@src","amount":{"asset":"BRL","value":"100"}}]},"distribute":{"to":[{"accountAlias":"@dst","amount":{"asset":"BRL","value":"100"}}]}}}`
+)
+
+// captureSetNXKey wires a TransactionHandler whose Command is a real use case backed by a
+// mocked Redis repo. SetNX captures the internalKey the funnel computed (a losing claim,
+// so Get drives the replay short-circuit to 201 before the nil Query is touched). getValue
+// is the JSON the losing-claim Get returns (the cached canonical replay).
+func captureSetNXKey(t *testing.T, ctrl *gomock.Controller, gotKey *string, getValue string) *TransactionHandler {
+	t.Helper()
+
+	redisMock := txRedis.NewMockRedisRepository(ctrl)
+
+	redisMock.EXPECT().
+		SetNX(gomock.Any(), gomock.Any(), "", gomock.Any()).
+		DoAndReturn(func(_ context.Context, key, _ string, _ time.Duration) (bool, error) {
+			*gotKey = key
+
+			return false, nil // losing claim -> Get() -> replay branch
+		}).Times(1)
+
+	redisMock.EXPECT().
+		Get(gomock.Any(), gomock.Any()).
+		Return(getValue, nil).
+		Times(1)
+
+	return &TransactionHandler{Command: &command.UseCase{TransactionRedisRepo: redisMock}}
+}
+
+// canonicalV1IdempotencyHash reproduces the funnel's v1 hash source EXACTLY: decode the
+// raw body into CreateTransactionInput (the same DecodeAndValidate the handler runs),
+// BuildTransaction(), apply the default balance keys to both legs (the two
+// ApplyDefaultBalanceKeys calls that precede the hash in executeCreateTransaction), then
+// StructToJSONString + HashSHA256. If the v1 hash SOURCE ever drifts, this lock breaks.
+func canonicalV1IdempotencyHash(t *testing.T, rawBody string) string {
+	t.Helper()
+
+	payload := new(mtransaction.CreateTransactionInput)
+	_, err := pkgHTTP.DecodeAndValidate([]byte(rawBody), payload)
+	require.NoError(t, err, "v1 body must decode for the canonical-hash reconstruction")
+
+	tx := payload.BuildTransaction()
+	mtransaction.ApplyDefaultBalanceKeys(tx.Send.Source.From)
+	mtransaction.ApplyDefaultBalanceKeys(tx.Send.Distribute.To)
+
+	ts, err := libCommons.StructToJSONString(*tx)
+	require.NoError(t, err)
+
+	return libCommons.HashSHA256(ts)
+}
+
+// TestHuma_CreateTransactionDirectV2_IdempotencyKeyedByRawV2Body proves the v2 direct
+// surface keys idempotency off the RAW v2 body as submitted (ADR-004), not off the
+// canonical translated transaction. THE TOOTH: on the header-only v2 path the funnel
+// hashes StructToJSONString(canonicalTransaction), so the captured internalKey embeds
+// that canonical hash — the raw-body-hash assertion fails until the v2 seam supplies the
+// raw bytes as the hash source.
+func TestHuma_CreateTransactionDirectV2_IdempotencyKeyedByRawV2Body(t *testing.T) {
+	// NOT parallel: process-global huma state.
+	orgID := uuid.New()
+	ledgerID := uuid.New()
+
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
+	var gotKey string
+
+	handler := captureSetNXKey(t, ctrl, &gotKey, "{}")
+	app := buildHumaV2DirectApp(t, handler)
+
+	url := "/v2/organizations/" + orgID.String() + "/ledgers/" + ledgerID.String() + "/transactions/direct"
+	req := httptest.NewRequest(http.MethodPost, url, strings.NewReader(v2DirectBody))
+	req.Header.Set("Content-Type", "application/json")
+	// No X-Idempotency header on purpose: the key falls back to the computed hash, so the
+	// SetNX internalKey embeds the hash SOURCE.
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: 0})
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	rawBodyHash := libCommons.HashSHA256(v2DirectBody)
+
+	assert.Contains(t, gotKey, rawBodyHash,
+		"v2 idempotency must be keyed by the raw v2 body as submitted (ADR-004); got internalKey=%q (a different hash here means v2 still hashes the canonical translated transaction)", gotKey)
+
+	// And it must NOT be the canonical translated-transaction hash the v1 funnel uses.
+	// (The v2 flat body translates to a full canonical Transaction whose serialized form
+	// differs from the raw bytes, so the two hashes are distinct by construction.)
+	payload := new(mtransaction.CreateTransactionV2Input)
+	_, derr := pkgHTTP.DecodeAndValidate([]byte(v2DirectBody), payload)
+	require.NoError(t, derr)
+
+	canonical, terr := payload.Translate(false)
+	require.NoError(t, terr)
+
+	mtransaction.ApplyDefaultBalanceKeys(canonical.Send.Source.From)
+	mtransaction.ApplyDefaultBalanceKeys(canonical.Send.Distribute.To)
+
+	ts, serr := libCommons.StructToJSONString(canonical)
+	require.NoError(t, serr)
+
+	assert.NotContains(t, gotKey, libCommons.HashSHA256(ts),
+		"v2 must NOT key idempotency off the canonical translated transaction")
+}
+
+// TestHuma_CreateTransactionDirectV2_ReplayReturnsCanonicalResult proves the critical
+// edge case: the idempotency record stores the CANONICAL persisted transaction, keyed by
+// the v2-body hash. A losing claim whose cached value is a canonical transaction replays
+// that canonical result (201 + X-Idempotency-Replayed:true) without creating a new one.
+func TestHuma_CreateTransactionDirectV2_ReplayReturnsCanonicalResult(t *testing.T) {
+	// NOT parallel: process-global huma state.
+	orgID := uuid.New()
+	ledgerID := uuid.New()
+
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
+	var gotKey string
+
+	// The cached value is the CANONICAL transaction (a full transaction.Transaction),
+	// NOT the raw v2 body — proving hashed-source (v2 body) and persisted-result
+	// (canonical) are decoupled.
+	canonicalID := uuid.New().String()
+	handler := captureSetNXKey(t, ctrl, &gotKey, `{"id":"`+canonicalID+`"}`)
+	app := buildHumaV2DirectApp(t, handler)
+
+	url := "/v2/organizations/" + orgID.String() + "/ledgers/" + ledgerID.String() + "/transactions/direct"
+	req := httptest.NewRequest(http.MethodPost, url, strings.NewReader(v2DirectBody))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: 0})
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	body, _ := io.ReadAll(resp.Body)
+
+	assert.Contains(t, gotKey, libCommons.HashSHA256(v2DirectBody),
+		"replay claim must be keyed by the raw v2 body")
+	assert.Equal(t, http.StatusCreated, resp.StatusCode, "v2 replay returns 201, body: %s", string(body))
+	assert.Equal(t, "true", resp.Header.Get(libConstants.IdempotencyReplayed),
+		"a losing v2 claim with a cached canonical value replays -> X-Idempotency-Replayed:true")
+	assert.Contains(t, string(body), canonicalID,
+		"the replay returns the CANONICAL persisted transaction (keyed by the v2-body hash), not the raw v2 body")
+}
+
+// TestHuma_CreateTransactionV1JSON_IdempotencyStillKeyedByCanonicalBody is the v1
+// regression lock: the v1 /json funnel must remain byte-identical — hashing the canonical
+// built transaction, NEVER the raw request bytes. Guards against the additive v2 seam
+// leaking onto the v1 hash source.
+func TestHuma_CreateTransactionV1JSON_IdempotencyStillKeyedByCanonicalBody(t *testing.T) {
+	// NOT parallel: process-global huma state.
+	orgID := uuid.New()
+	ledgerID := uuid.New()
+
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
+	var gotKey string
+
+	handler := captureSetNXKey(t, ctrl, &gotKey, "{}")
+	app := buildHumaTransactionApp(t, handler, true)
+
+	url := "/v1/organizations/" + orgID.String() + "/ledgers/" + ledgerID.String() + "/transactions/json"
+	req := httptest.NewRequest(http.MethodPost, url, strings.NewReader(v1JSONBody))
+	req.Header.Set("Content-Type", "application/json")
+	// No X-Idempotency header: v1 key falls back to the canonical-transaction hash.
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: 0})
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	assert.Contains(t, gotKey, canonicalV1IdempotencyHash(t, v1JSONBody),
+		"v1 idempotency must stay keyed by the canonical built transaction (byte-identical)")
+	assert.NotContains(t, gotKey, libCommons.HashSHA256(v1JSONBody),
+		"v1 must NOT key idempotency off the raw request bytes; the additive v2 seam must not leak onto v1")
+}

--- a/components/ledger/internal/adapters/http/in/transaction_v2_idempotency_huma_test.go
+++ b/components/ledger/internal/adapters/http/in/transaction_v2_idempotency_huma_test.go
@@ -27,8 +27,8 @@ import (
 	pkgHTTP "github.com/LerianStudio/midaz/v4/pkg/net/http"
 )
 
-// Task 1.3.2 — v2 idempotency is keyed by the v2 body AS SUBMITTED (pre-translation),
-// per ADR-004. The v1 create funnel hashes the CANONICAL built transaction
+// v2 idempotency is keyed by the v2 body AS SUBMITTED (pre-translation). The v1 create
+// funnel hashes the CANONICAL built transaction
 // (StructToJSONString(transactionInput)); the v2 surface must instead hash the raw
 // flat v2 request bytes so two identical v2 `direct` submissions dedup by the body the
 // client actually sent — while the funnel still persists the canonical transaction.
@@ -102,7 +102,7 @@ func canonicalV1IdempotencyHash(t *testing.T, rawBody string) string {
 }
 
 // TestHuma_CreateTransactionDirectV2_IdempotencyKeyedByRawV2Body proves the v2 direct
-// surface keys idempotency off the RAW v2 body as submitted (ADR-004), not off the
+// surface keys idempotency off the RAW v2 body as submitted, not off the
 // canonical translated transaction. THE TOOTH: on the header-only v2 path the funnel
 // hashes StructToJSONString(canonicalTransaction), so the captured internalKey embeds
 // that canonical hash — the raw-body-hash assertion fails until the v2 seam supplies the
@@ -133,7 +133,7 @@ func TestHuma_CreateTransactionDirectV2_IdempotencyKeyedByRawV2Body(t *testing.T
 	rawBodyHash := libCommons.HashSHA256(v2DirectBody)
 
 	assert.Contains(t, gotKey, rawBodyHash,
-		"v2 idempotency must be keyed by the raw v2 body as submitted (ADR-004); got internalKey=%q (a different hash here means v2 still hashes the canonical translated transaction)", gotKey)
+		"v2 idempotency must be keyed by the raw v2 body as submitted; got internalKey=%q (a different hash here means v2 still hashes the canonical translated transaction)", gotKey)
 
 	// And it must NOT be the canonical translated-transaction hash the v1 funnel uses.
 	// (The v2 flat body translates to a full canonical Transaction whose serialized form

--- a/components/ledger/internal/adapters/http/in/transaction_v2_register.go
+++ b/components/ledger/internal/adapters/http/in/transaction_v2_register.go
@@ -1,0 +1,93 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package in
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/LerianStudio/lib-auth/v3/auth/middleware"
+	"github.com/danielgtaylor/huma/v2"
+	"github.com/gofiber/fiber/v3"
+
+	pkgHTTP "github.com/LerianStudio/midaz/v4/pkg/net/http"
+)
+
+// This file is the v2 transaction contract seam (ADR-006: filename-suffix
+// versioning — v1 files are left untouched). It registers the v2 `direct`
+// transaction op onto the SECOND, independent Huma contract instance and attaches
+// the SAME Fiber auth chain the v1 transaction ops carry (protectedMidaz,
+// authz namespace "midaz", (resource, verb) = ("transactions","post")). No new
+// policy is introduced: authorization is per-tenant, identical to v1.
+//
+// The handler is a STUB for Task 1.1.2: it returns a clean RFC 9457 501
+// Not Implemented (never a panic). Task 1.3.1 replaces the body with the real
+// translate + funnel logic that reuses the v1 createTransaction core. Path params
+// follow the asset/CRM Huma convention — plain strings with only `doc:` (no
+// format:uuid tag) so ParseUUIDPathParameters stays the sole UUID validator on the
+// Fiber chain, not a native Huma 422.
+
+// CreateTransactionDirectV2InputHuma is the v2 direct-create request envelope. The
+// org/ledger path params are plain strings (validated by the ParseUUIDPathParameters
+// Fiber middleware attached before this terminal). RawBody keeps the body out of
+// Huma's validator so Task 1.3.1 can decode the v2 direct model imperatively.
+type CreateTransactionDirectV2InputHuma struct {
+	OrganizationID string `path:"organization_id" doc:"Organization ID (UUID)"`
+	LedgerID       string `path:"ledger_id" doc:"Ledger ID (UUID)"`
+	IdempotencyKey string `header:"X-Idempotency" doc:"Idempotency key to safely retry the create; an identical retry returns the original transaction"`
+	IdempotencyTTL string `header:"X-TTL" doc:"Idempotency slot TTL in seconds (default 300)"`
+	RawBody        []byte `contentType:"application/json"`
+}
+
+// CreateTransactionDirectV2OutputHuma pins the 201 create status (parity with the
+// v1 create ops). The response body lands in Task 1.3.1 once the translator exists.
+type CreateTransactionDirectV2OutputHuma struct {
+	Status int
+}
+
+// CreateTransactionDirectV2Huma is the STUB terminal for the v2 `direct` op. It
+// returns a clean RFC 9457 501 Not Implemented so the route is real and protected
+// while the translate + funnel logic is pending (Task 1.3.1). It never panics.
+func (handler *TransactionHandler) CreateTransactionDirectV2Huma(_ context.Context, _ *CreateTransactionDirectV2InputHuma) (*CreateTransactionDirectV2OutputHuma, error) {
+	return nil, huma.Error501NotImplemented("v2 direct transaction create is not implemented yet")
+}
+
+// RegisterTransactionV2Routes registers the v2 transaction ops on the INDEPENDENT
+// v2 Huma API. Task 1.1.2 registers ONLY `direct`; hold/block/commit/cancel/revert
+// arrive in later phases. Auth is the Fiber guard chain attached in
+// RegisterTransactionV2RoutesToApp BEFORE this terminal, not here — the per-op
+// Security metadata is SPEC-ONLY. Paths are GROUP-RELATIVE (the /v2 prefix rides
+// the OpenAPI servers entry).
+func RegisterTransactionV2Routes(api huma.API, h *TransactionHandler) {
+	const listPath = "/organizations/{organization_id}/ledgers/{ledger_id}/transactions"
+
+	huma.Register(api, huma.Operation{
+		OperationID:      "createTransactionDirectV2",
+		Method:           http.MethodPost,
+		Path:             listPath + "/direct",
+		Summary:          "Create a Transaction using the v2 direct model",
+		Tags:             []string{"Transactions"},
+		Security:         secTransactionBearer,
+		SkipValidateBody: true, // body decoded imperatively (Task 1.3.1), mirroring the v1 create ops.
+		DefaultStatus:    http.StatusCreated,
+	}, h.CreateTransactionDirectV2Huma)
+}
+
+// RegisterTransactionV2RoutesToApp wires the v2 `direct` op end-to-end: it attaches
+// the Fiber auth chain — auth.Authorize("midaz","transactions","post") + the tenant
+// PostAuthMiddlewares + ParseUUIDPathParameters("transaction") — as MIDDLEWARE ONLY
+// (group-relative path, no terminal) on the /v2 GROUP, then registers the Huma
+// terminal via RegisterTransactionV2Routes on the SAME group's Huma API. This is the
+// SAME (namespace, resource, verb) tuple and the SAME tenant chain the v1 transaction
+// CREATE ops carry — no new policy, authorization is per-tenant.
+func RegisterTransactionV2RoutesToApp(group fiber.Router, api huma.API, auth *middleware.AuthClient, th *TransactionHandler, routeOptions *pkgHTTP.ProtectedRouteOptions) {
+	const directPath = "/organizations/:organization_id/ledgers/:ledger_id/transactions/direct"
+
+	parse := pkgHTTP.ParseUUIDPathParameters("transaction")
+
+	routePost(group, directPath, protectedMidaz(auth, "transactions", "post", routeOptions, parse))
+
+	RegisterTransactionV2Routes(api, th)
+}

--- a/components/ledger/internal/adapters/http/in/transaction_v2_register.go
+++ b/components/ledger/internal/adapters/http/in/transaction_v2_register.go
@@ -61,12 +61,12 @@ func (handler *TransactionHandler) CreateTransactionDirectV2Huma(_ context.Conte
 // Security metadata is SPEC-ONLY. Paths are GROUP-RELATIVE (the /v2 prefix rides
 // the OpenAPI servers entry).
 func RegisterTransactionV2Routes(api huma.API, h *TransactionHandler) {
-	const listPath = "/organizations/{organization_id}/ledgers/{ledger_id}/transactions"
+	const transactionsBasePath = "/organizations/{organization_id}/ledgers/{ledger_id}/transactions"
 
 	huma.Register(api, huma.Operation{
 		OperationID:      "createTransactionDirectV2",
 		Method:           http.MethodPost,
-		Path:             listPath + "/direct",
+		Path:             transactionsBasePath + "/direct",
 		Summary:          "Create a Transaction using the v2 direct model",
 		Tags:             []string{"Transactions"},
 		Security:         secTransactionBearer,

--- a/components/ledger/internal/adapters/http/in/transaction_v2_register.go
+++ b/components/ledger/internal/adapters/http/in/transaction_v2_register.go
@@ -14,7 +14,7 @@ import (
 	pkgHTTP "github.com/LerianStudio/midaz/v4/pkg/net/http"
 )
 
-// This file is the v2 transaction contract seam (ADR-006: filename-suffix
+// This file is the v2 transaction contract seam (filename-suffix
 // versioning — v1 files are left untouched). It registers the v2 `direct`
 // transaction op onto the SECOND, independent Huma contract instance and attaches
 // the SAME Fiber auth chain the v1 transaction ops carry (protectedMidaz,
@@ -28,7 +28,7 @@ import (
 // the sole path-UUID validator on the Fiber chain, not a native Huma 422.
 
 // RegisterTransactionV2Routes registers the v2 transaction ops on the INDEPENDENT
-// v2 Huma API. Task 1.1.2 registers ONLY `direct`; hold/block/commit/cancel/revert
+// v2 Huma API. It registers ONLY `direct`; hold/block/commit/cancel/revert
 // arrive in later phases. Auth is the Fiber guard chain attached in
 // RegisterTransactionV2RoutesToApp BEFORE this terminal, not here — the per-op
 // Security metadata is SPEC-ONLY. Paths are GROUP-RELATIVE (the /v2 prefix rides

--- a/components/ledger/internal/adapters/http/in/transaction_v2_register.go
+++ b/components/ledger/internal/adapters/http/in/transaction_v2_register.go
@@ -5,7 +5,6 @@
 package in
 
 import (
-	"context"
 	"net/http"
 
 	"github.com/LerianStudio/lib-auth/v3/auth/middleware"
@@ -22,37 +21,11 @@ import (
 // authz namespace "midaz", (resource, verb) = ("transactions","post")). No new
 // policy is introduced: authorization is per-tenant, identical to v1.
 //
-// The handler is a STUB for Task 1.1.2: it returns a clean RFC 9457 501
-// Not Implemented (never a panic). Task 1.3.1 replaces the body with the real
-// translate + funnel logic that reuses the v1 createTransaction core. Path params
-// follow the asset/CRM Huma convention — plain strings with only `doc:` (no
-// format:uuid tag) so ParseUUIDPathParameters stays the sole UUID validator on the
-// Fiber chain, not a native Huma 422.
-
-// CreateTransactionDirectV2InputHuma is the v2 direct-create request envelope. The
-// org/ledger path params are plain strings (validated by the ParseUUIDPathParameters
-// Fiber middleware attached before this terminal). RawBody keeps the body out of
-// Huma's validator so Task 1.3.1 can decode the v2 direct model imperatively.
-type CreateTransactionDirectV2InputHuma struct {
-	OrganizationID string `path:"organization_id" doc:"Organization ID (UUID)"`
-	LedgerID       string `path:"ledger_id" doc:"Ledger ID (UUID)"`
-	IdempotencyKey string `header:"X-Idempotency" doc:"Idempotency key to safely retry the create; an identical retry returns the original transaction"`
-	IdempotencyTTL string `header:"X-TTL" doc:"Idempotency slot TTL in seconds (default 300)"`
-	RawBody        []byte `contentType:"application/json"`
-}
-
-// CreateTransactionDirectV2OutputHuma pins the 201 create status (parity with the
-// v1 create ops). The response body lands in Task 1.3.1 once the translator exists.
-type CreateTransactionDirectV2OutputHuma struct {
-	Status int
-}
-
-// CreateTransactionDirectV2Huma is the STUB terminal for the v2 `direct` op. It
-// returns a clean RFC 9457 501 Not Implemented so the route is real and protected
-// while the translate + funnel logic is pending (Task 1.3.1). It never panics.
-func (handler *TransactionHandler) CreateTransactionDirectV2Huma(_ context.Context, _ *CreateTransactionDirectV2InputHuma) (*CreateTransactionDirectV2OutputHuma, error) {
-	return nil, huma.Error501NotImplemented("v2 direct transaction create is not implemented yet")
-}
+// The `direct` terminal (CreateTransactionDirectV2Huma) lives in
+// transaction_v2_handler.go: it decodes the flat v2 body, translates it, and enters
+// the v1 createTransaction funnel. Path params follow the asset/CRM Huma convention —
+// plain strings with only `doc:` (no format:uuid tag) so ParseUUIDPathParameters stays
+// the sole path-UUID validator on the Fiber chain, not a native Huma 422.
 
 // RegisterTransactionV2Routes registers the v2 transaction ops on the INDEPENDENT
 // v2 Huma API. Task 1.1.2 registers ONLY `direct`; hold/block/commit/cancel/revert
@@ -70,7 +43,7 @@ func RegisterTransactionV2Routes(api huma.API, h *TransactionHandler) {
 		Summary:          "Create a Transaction using the v2 direct model",
 		Tags:             []string{"Transactions"},
 		Security:         secTransactionBearer,
-		SkipValidateBody: true, // body decoded imperatively (Task 1.3.1), mirroring the v1 create ops.
+		SkipValidateBody: true, // body decoded imperatively (http.DecodeAndValidate), mirroring the v1 create ops.
 		DefaultStatus:    http.StatusCreated,
 	}, h.CreateTransactionDirectV2Huma)
 }

--- a/components/ledger/internal/adapters/http/in/transaction_v2_register_test.go
+++ b/components/ledger/internal/adapters/http/in/transaction_v2_register_test.go
@@ -1,0 +1,125 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package in
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/LerianStudio/lib-auth/v3/auth/middleware"
+	openapi "github.com/LerianStudio/lib-commons/v6/commons/net/http/openapi"
+	"github.com/danielgtaylor/huma/v2"
+	"github.com/gofiber/fiber/v3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const directV2RoutePath = "/v2/organizations/:organization_id/ledgers/:ledger_id/transactions/direct"
+
+// registerV2DirectRoutesForTest wires the v2 `direct` op onto a fresh Fiber app +
+// its own /v2 Huma contract, exactly as the production humaMountV2 seam does. A
+// zero-value TransactionHandler is safe because registration never invokes the
+// handler.
+func registerV2DirectRoutesForTest(auth *middleware.AuthClient) *fiber.App {
+	app := fiber.New()
+
+	apiV2 := app.Group("/v2")
+	humaAPI := openapi.New(app, apiV2, openapi.Config{Title: "Midaz Ledger API v2", Version: "4.0.0", Servers: []string{"/v2"}})
+
+	RegisterTransactionV2RoutesToApp(apiV2, humaAPI, auth, &TransactionHandler{}, nil)
+
+	return app
+}
+
+// TestRegisterTransactionV2RoutesToApp_MountsDirectRoute asserts the v2 `direct`
+// POST route is mounted on the /v2 group (Fiber chain) and registered on the v2
+// Huma contract with OperationID createTransactionDirectV2.
+func TestRegisterTransactionV2RoutesToApp_MountsDirectRoute(t *testing.T) {
+	t.Parallel()
+
+	auth := &middleware.AuthClient{Enabled: false}
+	app := registerV2DirectRoutesForTest(auth)
+
+	routeSet := make(map[string]bool)
+	for _, r := range app.GetRoutes() {
+		routeSet[r.Method+":"+r.Path] = true
+	}
+
+	assert.True(t, routeSet[fiber.MethodPost+":"+directV2RoutePath],
+		"should register POST /v2 transactions/direct")
+}
+
+// TestRegisterTransactionV2Routes_RegistersHumaOperation asserts the direct op is
+// present on the v2 Huma document with the canonical OperationID at the
+// group-relative path.
+func TestRegisterTransactionV2Routes_RegistersHumaOperation(t *testing.T) {
+	t.Parallel()
+
+	app := fiber.New()
+	apiV2 := app.Group("/v2")
+	humaAPI := openapi.New(app, apiV2, openapi.Config{Title: "Midaz Ledger API v2", Version: "4.0.0", Servers: []string{"/v2"}})
+
+	RegisterTransactionV2Routes(humaAPI, &TransactionHandler{})
+
+	const opPath = "/organizations/{organization_id}/ledgers/{ledger_id}/transactions/direct"
+
+	pathItem, ok := humaAPI.OpenAPI().Paths[opPath]
+	require.Truef(t, ok, "v2 contract should carry the direct op path %q", opPath)
+	require.NotNil(t, pathItem.Post, "direct op path should carry a POST operation")
+
+	assert.Equal(t, "createTransactionDirectV2", pathItem.Post.OperationID,
+		"direct op should advertise OperationID createTransactionDirectV2")
+	assert.Equal(t, http.StatusCreated, pathItem.Post.DefaultStatus,
+		"direct op should default to 201 Created (create parity)")
+}
+
+// TestV2DirectRoute_RequiresAuth proves the v2 direct route shares the v1 protected
+// chain: with auth enabled and no bearer token the request is rejected before
+// reaching the stub handler.
+func TestV2DirectRoute_RequiresAuth(t *testing.T) {
+	t.Parallel()
+
+	// Address must be non-empty so Authorize enforces the token check (it is never
+	// dialed: a missing token short-circuits with 401 first).
+	auth := &middleware.AuthClient{Enabled: true, Address: "http://auth.invalid"}
+	app := registerV2DirectRoutesForTest(auth)
+
+	const concretePath = "/v2/organizations/00000000-0000-0000-0000-000000000001/ledgers/00000000-0000-0000-0000-000000000002/transactions/direct"
+
+	req := httptest.NewRequest(fiber.MethodPost, concretePath, nil)
+
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+
+	defer func() { _ = resp.Body.Close() }()
+
+	assert.Equal(t, fiber.StatusUnauthorized, resp.StatusCode,
+		"tokenless v2 direct request must be rejected by the transactions:post auth chain")
+}
+
+// TestCreateTransactionDirectV2Huma_ReturnsNotImplemented pins the Task 1.1.2 stub
+// contract: the handler returns a clean RFC 9457 501 (never a panic). Task 1.3.1
+// replaces this body with the real translate + funnel logic.
+func TestCreateTransactionDirectV2Huma_ReturnsNotImplemented(t *testing.T) {
+	t.Parallel()
+
+	handler := &TransactionHandler{}
+
+	out, err := handler.CreateTransactionDirectV2Huma(context.Background(), &CreateTransactionDirectV2InputHuma{
+		OrganizationID: "00000000-0000-0000-0000-000000000001",
+		LedgerID:       "00000000-0000-0000-0000-000000000002",
+	})
+
+	assert.Nil(t, out, "stub returns no body")
+	require.Error(t, err, "stub must return an error")
+
+	var statusErr huma.StatusError
+	require.True(t, errors.As(err, &statusErr), "stub error should expose an HTTP status")
+	assert.Equal(t, http.StatusNotImplemented, statusErr.GetStatus(),
+		"stub should map to 501 Not Implemented")
+}

--- a/components/ledger/internal/adapters/http/in/transaction_v2_register_test.go
+++ b/components/ledger/internal/adapters/http/in/transaction_v2_register_test.go
@@ -50,7 +50,7 @@ func TestRegisterTransactionV2RoutesToApp_MountsDirectRoute(t *testing.T) {
 		routeSet[r.Method+":"+r.Path] = true
 	}
 
-	assert.True(t, routeSet[fiber.MethodPost+":"+directV2RoutePath],
+	assert.True(t, routeSet[http.MethodPost+":"+directV2RoutePath],
 		"should register POST /v2 transactions/direct")
 }
 
@@ -92,7 +92,7 @@ func TestV2DirectRoute_RequiresAuth(t *testing.T) {
 
 	const concretePath = "/v2/organizations/00000000-0000-0000-0000-000000000001/ledgers/00000000-0000-0000-0000-000000000002/transactions/direct"
 
-	req := httptest.NewRequest(fiber.MethodPost, concretePath, nil)
+	req := httptest.NewRequest(http.MethodPost, concretePath, nil)
 
 	resp, err := app.Test(req)
 	require.NoError(t, err)

--- a/components/ledger/internal/adapters/http/in/transaction_v2_register_test.go
+++ b/components/ledger/internal/adapters/http/in/transaction_v2_register_test.go
@@ -5,18 +5,17 @@
 package in
 
 import (
-	"context"
-	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
 	"github.com/LerianStudio/lib-auth/v3/auth/middleware"
 	openapi "github.com/LerianStudio/lib-commons/v6/commons/net/http/openapi"
-	"github.com/danielgtaylor/huma/v2"
 	"github.com/gofiber/fiber/v3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	pkgHTTP "github.com/LerianStudio/midaz/v4/pkg/net/http"
 )
 
 const directV2RoutePath = "/v2/organizations/:organization_id/ledgers/:ledger_id/transactions/direct"
@@ -30,6 +29,7 @@ func registerV2DirectRoutesForTest(auth *middleware.AuthClient) *fiber.App {
 
 	apiV2 := app.Group("/v2")
 	humaAPI := openapi.New(app, apiV2, openapi.Config{Title: "Midaz Ledger API v2", Version: "4.0.0", Servers: []string{"/v2"}})
+	pkgHTTP.InstallLedgerSchemaNamer(humaAPI)
 
 	RegisterTransactionV2RoutesToApp(apiV2, humaAPI, auth, &TransactionHandler{}, nil)
 
@@ -63,6 +63,7 @@ func TestRegisterTransactionV2Routes_RegistersHumaOperation(t *testing.T) {
 	app := fiber.New()
 	apiV2 := app.Group("/v2")
 	humaAPI := openapi.New(app, apiV2, openapi.Config{Title: "Midaz Ledger API v2", Version: "4.0.0", Servers: []string{"/v2"}})
+	pkgHTTP.InstallLedgerSchemaNamer(humaAPI)
 
 	RegisterTransactionV2Routes(humaAPI, &TransactionHandler{})
 
@@ -100,26 +101,4 @@ func TestV2DirectRoute_RequiresAuth(t *testing.T) {
 
 	assert.Equal(t, fiber.StatusUnauthorized, resp.StatusCode,
 		"tokenless v2 direct request must be rejected by the transactions:post auth chain")
-}
-
-// TestCreateTransactionDirectV2Huma_ReturnsNotImplemented pins the Task 1.1.2 stub
-// contract: the handler returns a clean RFC 9457 501 (never a panic). Task 1.3.1
-// replaces this body with the real translate + funnel logic.
-func TestCreateTransactionDirectV2Huma_ReturnsNotImplemented(t *testing.T) {
-	t.Parallel()
-
-	handler := &TransactionHandler{}
-
-	out, err := handler.CreateTransactionDirectV2Huma(context.Background(), &CreateTransactionDirectV2InputHuma{
-		OrganizationID: "00000000-0000-0000-0000-000000000001",
-		LedgerID:       "00000000-0000-0000-0000-000000000002",
-	})
-
-	assert.Nil(t, out, "stub returns no body")
-	require.Error(t, err, "stub must return an error")
-
-	var statusErr huma.StatusError
-	require.True(t, errors.As(err, &statusErr), "stub error should expose an HTTP status")
-	assert.Equal(t, http.StatusNotImplemented, statusErr.GetStatus(),
-		"stub should map to 501 Not Implemented")
 }

--- a/components/ledger/internal/bootstrap/config.go
+++ b/components/ledger/internal/bootstrap/config.go
@@ -1125,9 +1125,13 @@ func InitServersWithOptions(opts *Options) (*Service, error) {
 	// humaMountV2 wires the /v2 Huma terminals + Fiber auth/tenant chain on the
 	// SECOND, independent contract instance (ADR-003: one OpenAPI document per API
 	// version, each with its OWN Huma component registry so v1 and v2 schema names
-	// never collide). Task 1.1.2 registers the `direct` transaction route here; the
-	// v2 contract mounts no ops yet, so its OpenAPI document is intentionally empty.
-	humaMountV2 := func(_ fiber.Router, _ huma.API) {
+	// never collide). Task 1.1.2 registers the `direct` transaction op: it carries
+	// transactionRouteOptions ([authAssertion, WithTenantDB]) and authorizes against
+	// the "midaz" appName (protectedMidaz, transactions:post) — the SAME auth + tenant
+	// chain the v1 transaction CREATE ops use, no new policy. Later phases add
+	// hold/block/commit/cancel/revert here.
+	humaMountV2 := func(group fiber.Router, api huma.API) {
+		httpin.RegisterTransactionV2RoutesToApp(group, api, auth, transactionHandler, routeSetup.transactionRouteOptions)
 	}
 
 	transactionRouteRegistrar := func(router fiber.Router) {

--- a/components/ledger/internal/bootstrap/config.go
+++ b/components/ledger/internal/bootstrap/config.go
@@ -1122,6 +1122,14 @@ func InitServersWithOptions(opts *Options) (*Service, error) {
 		httpin.RegisterCompositionRoutesToApp(group, api, auth, compositionHandler, routeSetup.compositionRouteOptions)
 	}
 
+	// humaMountV2 wires the /v2 Huma terminals + Fiber auth/tenant chain on the
+	// SECOND, independent contract instance (ADR-003: one OpenAPI document per API
+	// version, each with its OWN Huma component registry so v1 and v2 schema names
+	// never collide). Task 1.1.2 registers the `direct` transaction route here; the
+	// v2 contract mounts no ops yet, so its OpenAPI document is intentionally empty.
+	humaMountV2 := func(_ fiber.Router, _ huma.API) {
+	}
+
 	transactionRouteRegistrar := func(router fiber.Router) {
 		httpin.RegisterTransactionRoutesToApp(router, auth, transactionHandler, operationHandler, assetRateHandler, balanceHandler, operationRouteHandler, transactionRouteHandler, routeSetup.transactionRouteOptions)
 	}
@@ -1149,6 +1157,7 @@ func InitServersWithOptions(opts *Options) (*Service, error) {
 		telemetry,
 		readyzHandler,
 		humaMount,
+		humaMountV2,
 		onboardingRouteRegistrar,
 		transactionRouteRegistrar,
 		ledgerRouteRegistrar,

--- a/components/ledger/internal/bootstrap/config.go
+++ b/components/ledger/internal/bootstrap/config.go
@@ -1123,9 +1123,9 @@ func InitServersWithOptions(opts *Options) (*Service, error) {
 	}
 
 	// humaMountV2 wires the /v2 Huma terminals + Fiber auth/tenant chain on the
-	// SECOND, independent contract instance (ADR-003: one OpenAPI document per API
+	// SECOND, independent contract instance (one OpenAPI document per API
 	// version, each with its OWN Huma component registry so v1 and v2 schema names
-	// never collide). Task 1.1.2 registers the `direct` transaction op: it carries
+	// never collide). It registers the `direct` transaction op: it carries
 	// transactionRouteOptions ([authAssertion, WithTenantDB]) and authorizes against
 	// the "midaz" appName (protectedMidaz, transactions:post) — the SAME auth + tenant
 	// chain the v1 transaction CREATE ops use, no new policy. Later phases add

--- a/components/ledger/internal/bootstrap/service_test.go
+++ b/components/ledger/internal/bootstrap/service_test.go
@@ -243,7 +243,7 @@ func TestNewUnifiedServer_CreatesServer(t *testing.T) {
 	t.Run("creates_server_without_route_registrars", func(t *testing.T) {
 		t.Parallel()
 
-		server := NewUnifiedServer(":0", "", logger, telemetry, nil, nil)
+		server := NewUnifiedServer(":0", "", logger, telemetry, nil, nil, nil)
 
 		require.NotNil(t, server, "NewUnifiedServer should return non-nil server")
 		assert.Equal(t, ":0", server.ServerAddress())
@@ -258,7 +258,7 @@ func TestNewUnifiedServer_CreatesServer(t *testing.T) {
 			})
 		}
 
-		server := NewUnifiedServer(":0", "", logger, telemetry, nil, nil, registrar)
+		server := NewUnifiedServer(":0", "", logger, telemetry, nil, nil, nil, registrar)
 
 		require.NotNil(t, server, "NewUnifiedServer should return non-nil server when a registrar is provided")
 		assert.Equal(t, ":0", server.ServerAddress())

--- a/components/ledger/internal/bootstrap/unified-server.go
+++ b/components/ledger/internal/bootstrap/unified-server.go
@@ -60,6 +60,7 @@ func NewUnifiedServer(
 	telemetry *libOpentelemetry.Telemetry,
 	readyzHandler *ReadyzHandler,
 	humaMount HumaRouteRegistrar,
+	humaMountV2 HumaRouteRegistrar,
 	routeRegistrars ...RouteRegistrar,
 ) *UnifiedServer {
 	app := fiber.New(fiber.Config{
@@ -157,6 +158,50 @@ func NewUnifiedServer(
 		// Mounted AFTER humaMount so the snapshotted spec is complete.
 		if swaggerEnabled() {
 			openapi.ServeSpec(app, humaAPI, logger, "/v1", "Midaz Ledger API")
+		}
+	}
+
+	// Second, INDEPENDENT contract instance (ADR-003). The /v2 API binds to its
+	// own Fiber group and its own Huma document with a SEPARATE component registry,
+	// so v1 and v2 schema names never collide and no schema namer is needed here.
+	// problem.Install() is idempotent (sync.Once), so calling it again keeps this
+	// block self-sufficient when only humaMountV2 is supplied. The v1 mount above
+	// is left byte-identical.
+	if humaMountV2 != nil {
+		problem.Install()
+
+		apiV2 := app.Group("/v2")
+
+		humaAPIV2 := openapi.New(app, apiV2, openapi.Config{
+			Title:       "Midaz Ledger API v2",
+			Version:     version,
+			Description: "Midaz Ledger v2 API contract.",
+			Servers:     []string{"/v2"},
+		})
+
+		// Declare the same security schemes the v1 document carries so per-op
+		// Security metadata registered by humaMountV2 resolves in the generated
+		// spec. SPEC metadata only — runtime auth stays the Fiber guard chain.
+		openapi.DeclareBearerAuth(humaAPIV2)
+
+		componentsV2 := humaAPIV2.OpenAPI().Components
+		if componentsV2.SecuritySchemes == nil {
+			componentsV2.SecuritySchemes = map[string]*huma.SecurityScheme{}
+		}
+
+		componentsV2.SecuritySchemes["ApiKeyAuth"] = &huma.SecurityScheme{
+			Type:        "apiKey",
+			In:          "header",
+			Name:        "X-API-Key",
+			Description: "Static API key presented in the X-API-Key header.",
+		}
+
+		humaMountV2(apiV2, humaAPIV2)
+
+		// Native Huma OpenAPI 3.1 spec + Scalar docs for v2, gated on swaggerEnabled().
+		// Mounted AFTER humaMountV2 so the snapshotted spec is complete.
+		if swaggerEnabled() {
+			openapi.ServeSpec(app, humaAPIV2, logger, "/v2", "Midaz Ledger API v2")
 		}
 	}
 

--- a/components/ledger/internal/bootstrap/unified-server.go
+++ b/components/ledger/internal/bootstrap/unified-server.go
@@ -110,99 +110,23 @@ func NewUnifiedServer(
 		}
 	}
 
-	// Huma bootstrap (asset migration DE-RISK). problem.Install() overrides the
-	// process-global huma.NewError to the org-wide RFC 9457 model; it MUST run
-	// before any huma.Register and is idempotent (sync.Once). The Huma API binds to
-	// a /v1 Fiber GROUP with Servers ["/v1"] and GROUP-RELATIVE op paths, so the
-	// humafiber v2 adapter registers on that group (Fiber prepends /v1) and the
-	// adapter's ctx (built from c.Context()) reaches the migrated handlers with
-	// the per-route tenant/DB intact — the auth+tenant middleware chain is attached
-	// on the SAME group inside humaMount, before each Huma terminal.
+	// Huma bootstrap (asset migration DE-RISK). Each contract instance binds to its
+	// own Fiber GROUP with a GROUP-RELATIVE op path set and its own Huma document;
+	// the auth+tenant middleware chain is attached on the SAME group inside the mount
+	// closure, before each Huma terminal. Both the /v1 and the /v2 mounts route
+	// through mountHumaContract, which owns the invariant scaffolding.
 	if humaMount != nil {
-		problem.Install()
-
-		apiV1 := app.Group("/v1")
-
-		humaAPI := openapi.New(app, apiV1, openapi.Config{
-			Title:   "Midaz Ledger API",
-			Version: version,
-			Servers: []string{"/v1"},
-		})
-
-		// Disambiguate the one cross-package schema-name clash (mmodel.Balance vs
-		// operation.Balance) before any huma.Register on the shared API; the registry
-		// namer is captured on first registration. See InstallLedgerSchemaNamer.
-		midazhttp.InstallLedgerSchemaNamer(humaAPI)
-
-		// Declare the security schemes referenced by per-op Security metadata so the
-		// generated spec resolves them. SPEC metadata only — runtime auth stays the
-		// Fiber guard chain. BearerAuth via the shared lib-commons helper; ApiKeyAuth
-		// declared locally (no helper), mirroring the helper's nil-guard.
-		openapi.DeclareBearerAuth(humaAPI)
-
-		components := humaAPI.OpenAPI().Components
-		if components.SecuritySchemes == nil {
-			components.SecuritySchemes = map[string]*huma.SecurityScheme{}
-		}
-
-		components.SecuritySchemes["ApiKeyAuth"] = &huma.SecurityScheme{
-			Type:        "apiKey",
-			In:          "header",
-			Name:        "X-API-Key",
-			Description: "Static API key presented in the X-API-Key header.",
-		}
-
-		humaMount(apiV1, humaAPI)
-
-		// Native Huma OpenAPI 3.1 spec + Scalar docs, gated on swaggerEnabled().
-		// Mounted AFTER humaMount so the snapshotted spec is complete.
-		if swaggerEnabled() {
-			openapi.ServeSpec(app, humaAPI, logger, "/v1", "Midaz Ledger API")
-		}
+		// v1: title "Midaz Ledger API", no Description, WITH the ledger schema namer
+		// to disambiguate the one cross-package schema-name clash (mmodel.Balance vs
+		// operation.Balance) before any huma.Register on the shared registry.
+		mountHumaContract(app, logger, "/v1", "Midaz Ledger API", "", version, true, humaMount)
 	}
 
-	// Second, INDEPENDENT contract instance (ADR-003). The /v2 API binds to its
-	// own Fiber group and its own Huma document with a SEPARATE component registry,
-	// so v1 and v2 schema names never collide and no schema namer is needed here.
-	// problem.Install() is idempotent (sync.Once), so calling it again keeps this
-	// block self-sufficient when only humaMountV2 is supplied. The v1 mount above
-	// is left byte-identical.
+	// Second, INDEPENDENT contract instance (ADR-003). The /v2 API owns a SEPARATE
+	// component registry, so v1 and v2 schema names never collide and no schema namer
+	// is needed here. The v1 mount above is left byte-identical.
 	if humaMountV2 != nil {
-		problem.Install()
-
-		apiV2 := app.Group("/v2")
-
-		humaAPIV2 := openapi.New(app, apiV2, openapi.Config{
-			Title:       "Midaz Ledger API v2",
-			Version:     version,
-			Description: "Midaz Ledger v2 API contract.",
-			Servers:     []string{"/v2"},
-		})
-
-		// Declare the same security schemes the v1 document carries so per-op
-		// Security metadata registered by humaMountV2 resolves in the generated
-		// spec. SPEC metadata only — runtime auth stays the Fiber guard chain.
-		openapi.DeclareBearerAuth(humaAPIV2)
-
-		componentsV2 := humaAPIV2.OpenAPI().Components
-		if componentsV2.SecuritySchemes == nil {
-			componentsV2.SecuritySchemes = map[string]*huma.SecurityScheme{}
-		}
-
-		componentsV2.SecuritySchemes["ApiKeyAuth"] = &huma.SecurityScheme{
-			Type:        "apiKey",
-			In:          "header",
-			Name:        "X-API-Key",
-			Description: "Static API key presented in the X-API-Key header.",
-		}
-
-		humaMountV2(apiV2, humaAPIV2)
-
-		// Native Huma OpenAPI 3.1 spec + Scalar docs for v2, gated on swaggerEnabled().
-		// Mounted AFTER humaMountV2 so the snapshotted spec is complete.
-		if swaggerEnabled() {
-			openapi.ServeSpec(app, humaAPIV2, logger, "/v2", "Midaz Ledger API v2")
-		}
+		mountHumaContract(app, logger, "/v2", "Midaz Ledger API v2", "Midaz Ledger v2 API contract.", version, false, humaMountV2)
 	}
 
 	// End tracing spans middleware (must be last)
@@ -246,6 +170,66 @@ func NewUnifiedServer(
 		logger:        logger,
 		telemetry:     telemetry,
 		readyzHandler: readyzHandler,
+	}
+}
+
+// mountHumaContract mounts one independent Huma contract instance under prefix and
+// encapsulates the INVARIANT scaffolding shared by every version: problem.Install()
+// (idempotent RFC 9457 model override, MUST precede any huma.Register), the Fiber
+// group + Huma document creation, the BearerAuth + ApiKeyAuth SPEC-ONLY security
+// scheme declarations, the mount closure invocation, and the swaggerEnabled()-gated
+// native OpenAPI 3.1 spec + Scalar docs surface.
+//
+// The DIVERGENT bits are parameters: prefix (Fiber group + Servers entry + ServeSpec
+// prefix), title/description/version (Info metadata), installSchemaNamer (v1 needs
+// the ledger schema namer to break one cross-package name clash; v2 owns a separate
+// registry and opts out), and the mount closure (per-version op registration + the
+// per-group Fiber auth/tenant chain). ServeSpec runs AFTER mount so the snapshotted
+// spec is complete. Security schemes are SPEC metadata only — runtime auth stays the
+// Fiber guard chain the mount closure attaches.
+func mountHumaContract(
+	app *fiber.App,
+	logger libLog.Logger,
+	prefix string,
+	title string,
+	description string,
+	version string,
+	installSchemaNamer bool,
+	mount HumaRouteRegistrar,
+) {
+	problem.Install()
+
+	group := app.Group(prefix)
+
+	api := openapi.New(app, group, openapi.Config{
+		Title:       title,
+		Version:     version,
+		Description: description,
+		Servers:     []string{prefix},
+	})
+
+	if installSchemaNamer {
+		midazhttp.InstallLedgerSchemaNamer(api)
+	}
+
+	openapi.DeclareBearerAuth(api)
+
+	components := api.OpenAPI().Components
+	if components.SecuritySchemes == nil {
+		components.SecuritySchemes = map[string]*huma.SecurityScheme{}
+	}
+
+	components.SecuritySchemes["ApiKeyAuth"] = &huma.SecurityScheme{
+		Type:        "apiKey",
+		In:          "header",
+		Name:        "X-API-Key",
+		Description: "Static API key presented in the X-API-Key header.",
+	}
+
+	mount(group, api)
+
+	if swaggerEnabled() {
+		openapi.ServeSpec(app, api, logger, prefix, title)
 	}
 }
 

--- a/components/ledger/internal/bootstrap/unified-server.go
+++ b/components/ledger/internal/bootstrap/unified-server.go
@@ -123,10 +123,13 @@ func NewUnifiedServer(
 	}
 
 	// Second, INDEPENDENT contract instance (ADR-003). The /v2 API owns a SEPARATE
-	// component registry, so v1 and v2 schema names never collide and no schema namer
-	// is needed here. The v1 mount above is left byte-identical.
+	// component registry, so v1 and v2 schema names never collide across contracts.
+	// The ledger schema namer is still installed WITHIN the v2 registry because the
+	// v2 create output embeds transaction.Transaction, which nests operation.Operation
+	// → operation.{Status,Balance,Amount} and clashes with transaction.Status on the
+	// bare schema names (the SAME disambiguation the v1 mount applies).
 	if humaMountV2 != nil {
-		mountHumaContract(app, logger, "/v2", "Midaz Ledger API v2", "Midaz Ledger v2 API contract.", version, false, humaMountV2)
+		mountHumaContract(app, logger, "/v2", "Midaz Ledger API v2", "Midaz Ledger v2 API contract.", version, true, humaMountV2)
 	}
 
 	// End tracing spans middleware (must be last)

--- a/components/ledger/internal/bootstrap/unified-server.go
+++ b/components/ledger/internal/bootstrap/unified-server.go
@@ -120,7 +120,7 @@ func NewUnifiedServer(
 		mountHumaContract(app, logger, "/v1", "Midaz Ledger API", "", version, humaMount)
 	}
 
-	// Second, INDEPENDENT contract instance (ADR-003). The /v2 API owns a SEPARATE
+	// Second, INDEPENDENT contract instance. The /v2 API owns a SEPARATE
 	// component registry, so v1 and v2 schema names never collide across contracts.
 	if humaMountV2 != nil {
 		mountHumaContract(app, logger, "/v2", "Midaz Ledger API v2", "Midaz Ledger v2 API contract.", version, humaMountV2)

--- a/components/ledger/internal/bootstrap/unified-server.go
+++ b/components/ledger/internal/bootstrap/unified-server.go
@@ -116,20 +116,14 @@ func NewUnifiedServer(
 	// closure, before each Huma terminal. Both the /v1 and the /v2 mounts route
 	// through mountHumaContract, which owns the invariant scaffolding.
 	if humaMount != nil {
-		// v1: title "Midaz Ledger API", no Description, WITH the ledger schema namer
-		// to disambiguate the one cross-package schema-name clash (mmodel.Balance vs
-		// operation.Balance) before any huma.Register on the shared registry.
-		mountHumaContract(app, logger, "/v1", "Midaz Ledger API", "", version, true, humaMount)
+		// v1: title "Midaz Ledger API", no Description.
+		mountHumaContract(app, logger, "/v1", "Midaz Ledger API", "", version, humaMount)
 	}
 
 	// Second, INDEPENDENT contract instance (ADR-003). The /v2 API owns a SEPARATE
 	// component registry, so v1 and v2 schema names never collide across contracts.
-	// The ledger schema namer is still installed WITHIN the v2 registry because the
-	// v2 create output embeds transaction.Transaction, which nests operation.Operation
-	// → operation.{Status,Balance,Amount} and clashes with transaction.Status on the
-	// bare schema names (the SAME disambiguation the v1 mount applies).
 	if humaMountV2 != nil {
-		mountHumaContract(app, logger, "/v2", "Midaz Ledger API v2", "Midaz Ledger v2 API contract.", version, true, humaMountV2)
+		mountHumaContract(app, logger, "/v2", "Midaz Ledger API v2", "Midaz Ledger v2 API contract.", version, humaMountV2)
 	}
 
 	// End tracing spans middleware (must be last)
@@ -179,17 +173,21 @@ func NewUnifiedServer(
 // mountHumaContract mounts one independent Huma contract instance under prefix and
 // encapsulates the INVARIANT scaffolding shared by every version: problem.Install()
 // (idempotent RFC 9457 model override, MUST precede any huma.Register), the Fiber
-// group + Huma document creation, the BearerAuth + ApiKeyAuth SPEC-ONLY security
-// scheme declarations, the mount closure invocation, and the swaggerEnabled()-gated
-// native OpenAPI 3.1 spec + Scalar docs surface.
+// group + Huma document creation, the ledger schema namer, the BearerAuth + ApiKeyAuth
+// SPEC-ONLY security scheme declarations, the mount closure invocation, and the
+// swaggerEnabled()-gated native OpenAPI 3.1 spec + Scalar docs surface.
+//
+// Every contract installs the ledger schema namer within its own registry to
+// disambiguate the nested operation.* schemas (operation.{Status,Balance,Amount})
+// against the top-level transaction.* schemas (transaction.Status): the v2 create
+// output embeds transaction.Transaction, which nests operation.Operation, and the v1
+// contract carries the same cross-package clash — so the namer applies uniformly.
 //
 // The DIVERGENT bits are parameters: prefix (Fiber group + Servers entry + ServeSpec
-// prefix), title/description/version (Info metadata), installSchemaNamer (v1 needs
-// the ledger schema namer to break one cross-package name clash; v2 owns a separate
-// registry and opts out), and the mount closure (per-version op registration + the
-// per-group Fiber auth/tenant chain). ServeSpec runs AFTER mount so the snapshotted
-// spec is complete. Security schemes are SPEC metadata only — runtime auth stays the
-// Fiber guard chain the mount closure attaches.
+// prefix), title/description/version (Info metadata), and the mount closure (per-version
+// op registration + the per-group Fiber auth/tenant chain). ServeSpec runs AFTER mount
+// so the snapshotted spec is complete. Security schemes are SPEC metadata only — runtime
+// auth stays the Fiber guard chain the mount closure attaches.
 func mountHumaContract(
 	app *fiber.App,
 	logger libLog.Logger,
@@ -197,7 +195,6 @@ func mountHumaContract(
 	title string,
 	description string,
 	version string,
-	installSchemaNamer bool,
 	mount HumaRouteRegistrar,
 ) {
 	problem.Install()
@@ -211,9 +208,7 @@ func mountHumaContract(
 		Servers:     []string{prefix},
 	})
 
-	if installSchemaNamer {
-		midazhttp.InstallLedgerSchemaNamer(api)
-	}
+	midazhttp.InstallLedgerSchemaNamer(api)
 
 	openapi.DeclareBearerAuth(api)
 

--- a/components/ledger/internal/bootstrap/unified-server_v2_direct_test.go
+++ b/components/ledger/internal/bootstrap/unified-server_v2_direct_test.go
@@ -47,7 +47,7 @@ func newV2DirectServer(t *testing.T, auth *middleware.AuthClient) *UnifiedServer
 	return server
 }
 
-// TestNewUnifiedServer_V2DirectRouteInContract asserts Task 1.1.2 (a): the `direct`
+// TestNewUnifiedServer_V2DirectRouteInContract asserts the `direct`
 // operation is registered on the INDEPENDENT v2 contract and surfaces in
 // /v2/openapi.json with OperationID createTransactionDirectV2, method POST, at the
 // group-relative direct path.
@@ -73,7 +73,7 @@ func TestNewUnifiedServer_V2DirectRouteInContract(t *testing.T) {
 		"direct op should advertise OperationID createTransactionDirectV2")
 }
 
-// TestNewUnifiedServer_V2DirectRouteRequiresAuth asserts Task 1.1.2 (b): the v2
+// TestNewUnifiedServer_V2DirectRouteRequiresAuth asserts the v2
 // direct route is guarded by the SAME protected chain as v1 (protectedMidaz,
 // transactions:post). With auth enabled and no bearer token, the request is
 // rejected before reaching the handler — never public.
@@ -104,7 +104,7 @@ func TestNewUnifiedServer_V2DirectRouteRequiresAuth(t *testing.T) {
 // fields, so http.DecodeAndValidate rejects it with the canonical 400 RFC 9457
 // problem+json (never a panic, never the removed 501 stub). This exercises the seam the
 // in-memory handler unit test cannot: the Fiber chain and the Huma terminal are wired to
-// the SAME path and hand off correctly. The committed money path is the Task 1.3.3
+// the SAME path and hand off correctly. The committed money path is the
 // integration+parity test.
 func TestNewUnifiedServer_V2DirectRouteReachesRealHandler(t *testing.T) {
 	t.Parallel()

--- a/components/ledger/internal/bootstrap/unified-server_v2_direct_test.go
+++ b/components/ledger/internal/bootstrap/unified-server_v2_direct_test.go
@@ -96,22 +96,26 @@ func TestNewUnifiedServer_V2DirectRouteRequiresAuth(t *testing.T) {
 		"tokenless v2 direct request must be blocked by the transactions:post auth chain")
 }
 
-// TestNewUnifiedServer_V2DirectRouteReachesStub proves the mounted route→terminal
+// TestNewUnifiedServer_V2DirectRouteReachesRealHandler proves the mounted route→terminal
 // composition end-to-end: an AUTHENTICATED (auth disabled) POST to the CONCRETE /v2
 // direct path traverses the full Fiber middleware chain (auth passthrough + tenant
-// post-auth + ParseUUIDPathParameters) and dispatches to the Huma 501 stub, returning
-// a clean RFC 9457 problem+json envelope (never a panic). This exercises the seam the
-// in-memory handler unit test cannot: the Fiber chain and the Huma terminal are wired
-// to the SAME path and hand off correctly.
-func TestNewUnifiedServer_V2DirectRouteReachesStub(t *testing.T) {
+// post-auth + ParseUUIDPathParameters) and dispatches to the REAL handler, which decodes
+// the flat v2 body. An empty `{}` body is missing the required asset/amount/from/to
+// fields, so http.DecodeAndValidate rejects it with the canonical 400 RFC 9457
+// problem+json (never a panic, never the removed 501 stub). This exercises the seam the
+// in-memory handler unit test cannot: the Fiber chain and the Huma terminal are wired to
+// the SAME path and hand off correctly. The committed money path is the Task 1.3.3
+// integration+parity test.
+func TestNewUnifiedServer_V2DirectRouteReachesRealHandler(t *testing.T) {
 	t.Parallel()
 
 	server := newV2DirectServer(t, &middleware.AuthClient{Enabled: false})
 
 	const concretePath = "/v2/organizations/00000000-0000-0000-0000-000000000001/ledgers/00000000-0000-0000-0000-000000000002/transactions/direct"
 
-	// A well-formed body + Content-Type is required so Huma's request parse succeeds
-	// and dispatch reaches the terminal; the stub ignores the body and returns 501.
+	// Empty body + Content-Type: Huma's request parse succeeds (RawBody), dispatch
+	// reaches the real handler, and DecodeAndValidate rejects the missing required
+	// fields with the canonical 400.
 	req, err := http.NewRequest(http.MethodPost, concretePath, bytes.NewReader([]byte("{}")))
 	require.NoError(t, err)
 
@@ -122,18 +126,18 @@ func TestNewUnifiedServer_V2DirectRouteReachesStub(t *testing.T) {
 
 	defer func() { _ = resp.Body.Close() }()
 
-	require.Equal(t, http.StatusNotImplemented, resp.StatusCode,
-		"authenticated v2 direct request must reach the 501 stub through the mounted chain")
+	require.Equal(t, http.StatusBadRequest, resp.StatusCode,
+		"authenticated v2 direct request must reach the real handler and 400 on the empty body through the mounted chain")
 	assert.Contains(t, resp.Header.Get("Content-Type"), "application/problem+json",
-		"501 stub must serialize the RFC 9457 problem+json envelope")
+		"the handler must serialize the RFC 9457 problem+json envelope")
 
 	body, err := io.ReadAll(resp.Body)
 	require.NoError(t, err)
 
 	var problem map[string]any
 	require.NoError(t, json.Unmarshal(body, &problem), "body should decode as RFC 9457 JSON")
-	assert.Equal(t, float64(http.StatusNotImplemented), problem["status"],
-		"RFC 9457 envelope should carry status:501")
+	assert.Equal(t, float64(http.StatusBadRequest), problem["status"],
+		"RFC 9457 envelope should carry status:400")
 }
 
 // TestNewUnifiedServer_V2SpecNotServedWhenDocsDisabled asserts the swaggerEnabled

--- a/components/ledger/internal/bootstrap/unified-server_v2_direct_test.go
+++ b/components/ledger/internal/bootstrap/unified-server_v2_direct_test.go
@@ -1,0 +1,104 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package bootstrap
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/LerianStudio/lib-auth/v3/auth/middleware"
+	libOpentelemetry "github.com/LerianStudio/lib-observability/v2/tracing"
+	"github.com/danielgtaylor/huma/v2"
+	"github.com/gofiber/fiber/v3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	httpin "github.com/LerianStudio/midaz/v4/components/ledger/internal/adapters/http/in"
+)
+
+// directOpV2Path is the GROUP-RELATIVE op path the v2 `direct` operation registers
+// under (the /v2 prefix rides the OpenAPI servers entry, so it is absent here).
+const directOpV2Path = "/organizations/{organization_id}/ledgers/{ledger_id}/transactions/direct"
+
+// newV2DirectServer builds a unified server whose /v2 contract mounts ONLY the
+// `direct` transaction op via the production seam httpin.RegisterTransactionV2RoutesToApp,
+// using the supplied auth client. The /v1 contract is left unmounted (nil humaMount):
+// this test isolates the v2 direct route + its Fiber auth chain. A zero-value
+// TransactionHandler is safe because registration never invokes the handler.
+func newV2DirectServer(t *testing.T, auth *middleware.AuthClient) *UnifiedServer {
+	t.Helper()
+
+	logger := newTestLogger()
+	telemetry := &libOpentelemetry.Telemetry{}
+
+	humaMountV2 := func(group fiber.Router, api huma.API) {
+		httpin.RegisterTransactionV2RoutesToApp(group, api, auth, &httpin.TransactionHandler{}, nil)
+	}
+
+	server := NewUnifiedServer(":0", "test-version", logger, telemetry, nil, nil, humaMountV2)
+	require.NotNil(t, server, "NewUnifiedServer should return a non-nil server")
+	require.NotNil(t, server.app, "server should hold a Fiber app")
+
+	return server
+}
+
+// TestNewUnifiedServer_V2DirectRouteInContract asserts Task 1.1.2 (a): the `direct`
+// operation is registered on the INDEPENDENT v2 contract and surfaces in
+// /v2/openapi.json with OperationID createTransactionDirectV2, method POST, at the
+// group-relative direct path.
+func TestNewUnifiedServer_V2DirectRouteInContract(t *testing.T) {
+	// ServeSpec is gated on LEDGER_HUMA_DOCS_ENABLED; enable it so /v2/openapi.json
+	// is mounted. t.Setenv precludes t.Parallel here.
+	t.Setenv("LEDGER_HUMA_DOCS_ENABLED", "true")
+
+	server := newV2DirectServer(t, &middleware.AuthClient{Enabled: false})
+
+	v2doc := fetchOpenAPISpec(t, server.app, "/v2/openapi.json")
+
+	paths, ok := v2doc["paths"].(map[string]any)
+	require.True(t, ok, "v2 spec should carry a paths object")
+
+	pathItem, ok := paths[directOpV2Path].(map[string]any)
+	require.Truef(t, ok, "v2 spec should register the direct op path %q; paths=%v", directOpV2Path, keysOf(paths))
+
+	post, ok := pathItem["post"].(map[string]any)
+	require.True(t, ok, "direct op path should carry a POST operation")
+
+	assert.Equal(t, "createTransactionDirectV2", post["operationId"],
+		"direct op should advertise OperationID createTransactionDirectV2")
+}
+
+// TestNewUnifiedServer_V2DirectRouteRequiresAuth asserts Task 1.1.2 (b): the v2
+// direct route is guarded by the SAME protected chain as v1 (protectedMidaz,
+// transactions:post). With auth enabled and no bearer token, the request is
+// rejected before reaching the handler — never public.
+func TestNewUnifiedServer_V2DirectRouteRequiresAuth(t *testing.T) {
+	// Address must be non-empty so Authorize enforces the token check (it is never
+	// dialed: a missing token short-circuits with 401 first).
+	server := newV2DirectServer(t, &middleware.AuthClient{Enabled: true, Address: "http://auth.invalid"})
+
+	const concretePath = "/v2/organizations/00000000-0000-0000-0000-000000000001/ledgers/00000000-0000-0000-0000-000000000002/transactions/direct"
+
+	req, err := http.NewRequest(http.MethodPost, concretePath, nil)
+	require.NoError(t, err)
+
+	resp, err := server.app.Test(req)
+	require.NoError(t, err)
+
+	defer func() { _ = resp.Body.Close() }()
+
+	assert.Contains(t, []int{http.StatusUnauthorized, http.StatusForbidden}, resp.StatusCode,
+		"tokenless v2 direct request must be blocked by the transactions:post auth chain")
+}
+
+// keysOf returns the keys of a decoded JSON object for diagnostic messages.
+func keysOf(m map[string]any) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+
+	return keys
+}

--- a/components/ledger/internal/bootstrap/unified-server_v2_direct_test.go
+++ b/components/ledger/internal/bootstrap/unified-server_v2_direct_test.go
@@ -5,6 +5,9 @@
 package bootstrap
 
 import (
+	"bytes"
+	"encoding/json"
+	"io"
 	"net/http"
 	"testing"
 
@@ -89,8 +92,70 @@ func TestNewUnifiedServer_V2DirectRouteRequiresAuth(t *testing.T) {
 
 	defer func() { _ = resp.Body.Close() }()
 
-	assert.Contains(t, []int{http.StatusUnauthorized, http.StatusForbidden}, resp.StatusCode,
+	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode,
 		"tokenless v2 direct request must be blocked by the transactions:post auth chain")
+}
+
+// TestNewUnifiedServer_V2DirectRouteReachesStub proves the mounted route→terminal
+// composition end-to-end: an AUTHENTICATED (auth disabled) POST to the CONCRETE /v2
+// direct path traverses the full Fiber middleware chain (auth passthrough + tenant
+// post-auth + ParseUUIDPathParameters) and dispatches to the Huma 501 stub, returning
+// a clean RFC 9457 problem+json envelope (never a panic). This exercises the seam the
+// in-memory handler unit test cannot: the Fiber chain and the Huma terminal are wired
+// to the SAME path and hand off correctly.
+func TestNewUnifiedServer_V2DirectRouteReachesStub(t *testing.T) {
+	t.Parallel()
+
+	server := newV2DirectServer(t, &middleware.AuthClient{Enabled: false})
+
+	const concretePath = "/v2/organizations/00000000-0000-0000-0000-000000000001/ledgers/00000000-0000-0000-0000-000000000002/transactions/direct"
+
+	// A well-formed body + Content-Type is required so Huma's request parse succeeds
+	// and dispatch reaches the terminal; the stub ignores the body and returns 501.
+	req, err := http.NewRequest(http.MethodPost, concretePath, bytes.NewReader([]byte("{}")))
+	require.NoError(t, err)
+
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := server.app.Test(req)
+	require.NoError(t, err)
+
+	defer func() { _ = resp.Body.Close() }()
+
+	require.Equal(t, http.StatusNotImplemented, resp.StatusCode,
+		"authenticated v2 direct request must reach the 501 stub through the mounted chain")
+	assert.Contains(t, resp.Header.Get("Content-Type"), "application/problem+json",
+		"501 stub must serialize the RFC 9457 problem+json envelope")
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	var problem map[string]any
+	require.NoError(t, json.Unmarshal(body, &problem), "body should decode as RFC 9457 JSON")
+	assert.Equal(t, float64(http.StatusNotImplemented), problem["status"],
+		"RFC 9457 envelope should carry status:501")
+}
+
+// TestNewUnifiedServer_V2SpecNotServedWhenDocsDisabled asserts the swaggerEnabled
+// NEGATIVE gate for v2: with LEDGER_HUMA_DOCS_ENABLED off, GET /v2/openapi.json is
+// NOT served (404). Every other v2-spec test enables the flag; this covers the
+// gated-off branch.
+func TestNewUnifiedServer_V2SpecNotServedWhenDocsDisabled(t *testing.T) {
+	// Explicitly disable the docs gate. t.Setenv precludes t.Parallel here.
+	t.Setenv("LEDGER_HUMA_DOCS_ENABLED", "false")
+
+	server := newV2DirectServer(t, &middleware.AuthClient{Enabled: false})
+
+	req, err := http.NewRequest(http.MethodGet, "/v2/openapi.json", nil)
+	require.NoError(t, err)
+
+	resp, err := server.app.Test(req)
+	require.NoError(t, err)
+
+	defer func() { _ = resp.Body.Close() }()
+
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode,
+		"v2 openapi.json must not be served when LEDGER_HUMA_DOCS_ENABLED is off")
 }
 
 // keysOf returns the keys of a decoded JSON object for diagnostic messages.

--- a/components/ledger/internal/bootstrap/unified-server_v2_test.go
+++ b/components/ledger/internal/bootstrap/unified-server_v2_test.go
@@ -69,7 +69,7 @@ func serverURLs(t *testing.T, doc map[string]any) []string {
 	return urls
 }
 
-// TestNewUnifiedServer_V2ContractMountedIndependently asserts ADR-003: the
+// TestNewUnifiedServer_V2ContractMountedIndependently asserts that the
 // unified server exposes a SECOND, independent OpenAPI contract instance under
 // /v2 (OAS 3.1, servers ["/v2"]) alongside the untouched /v1 contract (servers
 // ["/v1"]). Each instance owns its Info metadata, proving two independent Huma
@@ -83,7 +83,7 @@ func TestNewUnifiedServer_V2ContractMountedIndependently(t *testing.T) {
 	telemetry := &libOpentelemetry.Telemetry{}
 
 	// Empty mounts: this task mounts the contract surfaces without registering
-	// ops (v2 ops arrive in Task 1.1.2). A non-nil mount is what triggers each
+	// ops (v2 ops arrive later). A non-nil mount is what triggers each
 	// version's Huma bootstrap block.
 	emptyMount := func(_ fiber.Router, _ huma.API) {}
 
@@ -112,7 +112,7 @@ func TestNewUnifiedServer_V2ContractMountedIndependently(t *testing.T) {
 	assert.Equal(t, "Midaz Ledger API v2", v2info["title"], "v2 carries its own title")
 }
 
-// TestNewUnifiedServer_V2DirectOpDoesNotLeakIntoV1 asserts ADR-003 PATH isolation:
+// TestNewUnifiedServer_V2DirectOpDoesNotLeakIntoV1 asserts PATH isolation:
 // the v2 `direct` op (createTransactionDirectV2) appears ONLY in the /v2 document's
 // path set and NEVER in the /v1 document's, proving the two Huma contracts own
 // SEPARATE registries rather than sharing one. Both contracts are mounted in ONE

--- a/components/ledger/internal/bootstrap/unified-server_v2_test.go
+++ b/components/ledger/internal/bootstrap/unified-server_v2_test.go
@@ -10,11 +10,14 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/LerianStudio/lib-auth/v3/auth/middleware"
 	libOpentelemetry "github.com/LerianStudio/lib-observability/v2/tracing"
 	"github.com/danielgtaylor/huma/v2"
 	"github.com/gofiber/fiber/v3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	httpin "github.com/LerianStudio/midaz/v4/components/ledger/internal/adapters/http/in"
 )
 
 // fetchOpenAPISpec drives the in-process Fiber app for the given spec path and
@@ -107,4 +110,45 @@ func TestNewUnifiedServer_V2ContractMountedIndependently(t *testing.T) {
 	require.NotNil(t, v2info, "v2 spec should carry an info object")
 	assert.Equal(t, "Midaz Ledger API", v1info["title"], "v1 title unchanged")
 	assert.Equal(t, "Midaz Ledger API v2", v2info["title"], "v2 carries its own title")
+}
+
+// TestNewUnifiedServer_V2DirectOpDoesNotLeakIntoV1 asserts ADR-003 PATH isolation:
+// the v2 `direct` op (createTransactionDirectV2) appears ONLY in the /v2 document's
+// path set and NEVER in the /v1 document's, proving the two Huma contracts own
+// SEPARATE registries rather than sharing one. Both contracts are mounted in ONE
+// server: v1 carries no ops (empty mount) while v2 mounts the production direct-op
+// seam. Path-set isolation is a stronger guarantee than the Info-title check above.
+func TestNewUnifiedServer_V2DirectOpDoesNotLeakIntoV1(t *testing.T) {
+	// ServeSpec is gated on LEDGER_HUMA_DOCS_ENABLED; enable it so both spec routes
+	// are mounted. t.Setenv precludes t.Parallel here.
+	t.Setenv("LEDGER_HUMA_DOCS_ENABLED", "true")
+
+	logger := newTestLogger()
+	telemetry := &libOpentelemetry.Telemetry{}
+
+	emptyMount := func(_ fiber.Router, _ huma.API) {}
+	directMountV2 := func(group fiber.Router, api huma.API) {
+		httpin.RegisterTransactionV2RoutesToApp(group, api, &middleware.AuthClient{Enabled: false}, &httpin.TransactionHandler{}, nil)
+	}
+
+	server := NewUnifiedServer(":0", "test-version", logger, telemetry, nil, emptyMount, directMountV2)
+	require.NotNil(t, server, "NewUnifiedServer should return a non-nil server")
+	require.NotNil(t, server.app, "server should hold a Fiber app")
+
+	const directOpPath = "/organizations/{organization_id}/ledgers/{ledger_id}/transactions/direct"
+
+	// v2 document MUST carry the direct op.
+	v2doc := fetchOpenAPISpec(t, server.app, "/v2/openapi.json")
+	v2paths, ok := v2doc["paths"].(map[string]any)
+	require.True(t, ok, "v2 spec should carry a paths object")
+	_, inV2 := v2paths[directOpPath]
+	assert.Truef(t, inV2, "v2 document MUST carry the direct op path %q; paths=%v", directOpPath, keysOf(v2paths))
+
+	// v1 document MUST NOT carry the direct op. A v1 document with no registered ops
+	// may omit the paths object entirely; if present, it must not leak the v2 op.
+	v1doc := fetchOpenAPISpec(t, server.app, "/v1/openapi.json")
+	if v1paths, ok := v1doc["paths"].(map[string]any); ok {
+		_, inV1 := v1paths[directOpPath]
+		assert.Falsef(t, inV1, "v2 direct op MUST NOT leak into the v1 document; v1 paths=%v", keysOf(v1paths))
+	}
 }

--- a/components/ledger/internal/bootstrap/unified-server_v2_test.go
+++ b/components/ledger/internal/bootstrap/unified-server_v2_test.go
@@ -1,0 +1,110 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package bootstrap
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+
+	libOpentelemetry "github.com/LerianStudio/lib-observability/v2/tracing"
+	"github.com/danielgtaylor/huma/v2"
+	"github.com/gofiber/fiber/v3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fetchOpenAPISpec drives the in-process Fiber app for the given spec path and
+// decodes the JSON body into a generic document. It fails the test if the route
+// is not served with 200 application/json.
+func fetchOpenAPISpec(t *testing.T, app *fiber.App, specPath string) map[string]any {
+	t.Helper()
+
+	req, err := http.NewRequest(http.MethodGet, specPath, nil)
+	require.NoError(t, err)
+
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+
+	require.Equal(t, http.StatusOK, resp.StatusCode, "spec %q should be served", specPath)
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	var doc map[string]any
+	require.NoError(t, json.Unmarshal(body, &doc), "spec %q should decode as JSON", specPath)
+
+	return doc
+}
+
+// serverURLs extracts the advertised server URLs from a decoded OpenAPI doc.
+func serverURLs(t *testing.T, doc map[string]any) []string {
+	t.Helper()
+
+	rawServers, ok := doc["servers"].([]any)
+	require.True(t, ok, "spec should carry a servers array")
+
+	urls := make([]string, 0, len(rawServers))
+
+	for _, raw := range rawServers {
+		server, ok := raw.(map[string]any)
+		require.True(t, ok, "each server entry should be an object")
+
+		url, ok := server["url"].(string)
+		require.True(t, ok, "each server entry should carry a url string")
+
+		urls = append(urls, url)
+	}
+
+	return urls
+}
+
+// TestNewUnifiedServer_V2ContractMountedIndependently asserts ADR-003: the
+// unified server exposes a SECOND, independent OpenAPI contract instance under
+// /v2 (OAS 3.1, servers ["/v2"]) alongside the untouched /v1 contract (servers
+// ["/v1"]). Each instance owns its Info metadata, proving two independent Huma
+// component registries rather than one shared document.
+func TestNewUnifiedServer_V2ContractMountedIndependently(t *testing.T) {
+	// ServeSpec is gated on LEDGER_HUMA_DOCS_ENABLED; enable it so both the /v1
+	// and /v2 spec routes are mounted. t.Setenv precludes t.Parallel here.
+	t.Setenv("LEDGER_HUMA_DOCS_ENABLED", "true")
+
+	logger := newTestLogger()
+	telemetry := &libOpentelemetry.Telemetry{}
+
+	// Empty mounts: this task mounts the contract surfaces without registering
+	// ops (v2 ops arrive in Task 1.1.2). A non-nil mount is what triggers each
+	// version's Huma bootstrap block.
+	emptyMount := func(_ fiber.Router, _ huma.API) {}
+
+	server := NewUnifiedServer(":0", "test-version", logger, telemetry, nil, emptyMount, emptyMount)
+	require.NotNil(t, server, "NewUnifiedServer should return a non-nil server")
+	require.NotNil(t, server.app, "server should hold a Fiber app")
+
+	// v2 contract: served, OAS 3.1, advertises /v2 only.
+	v2doc := fetchOpenAPISpec(t, server.app, "/v2/openapi.json")
+	assert.Equal(t, "3.1.0", v2doc["openapi"], "v2 spec should be OAS 3.1")
+	assert.Equal(t, []string{"/v2"}, serverURLs(t, v2doc), "v2 spec should advertise the /v2 server only")
+
+	// v1 contract: unchanged, OAS 3.1, advertises /v1 only. v2 mounting must not
+	// leak into the v1 document.
+	v1doc := fetchOpenAPISpec(t, server.app, "/v1/openapi.json")
+	assert.Equal(t, "3.1.0", v1doc["openapi"], "v1 spec should remain OAS 3.1")
+	assert.Equal(t, []string{"/v1"}, serverURLs(t, v1doc), "v1 spec should still advertise the /v1 server only")
+
+	// Independent Info objects prove two distinct contract instances (separate
+	// Huma component registries), not a single shared document.
+	v1info, _ := v1doc["info"].(map[string]any)
+	v2info, _ := v2doc["info"].(map[string]any)
+	require.NotNil(t, v1info, "v1 spec should carry an info object")
+	require.NotNil(t, v2info, "v2 spec should carry an info object")
+	assert.Equal(t, "Midaz Ledger API", v1info["title"], "v1 title unchanged")
+	assert.Equal(t, "Midaz Ledger API v2", v2info["title"], "v2 carries its own title")
+}

--- a/components/ledger/internal/bootstrap/unified-server_v2_test.go
+++ b/components/ledger/internal/bootstrap/unified-server_v2_test.go
@@ -135,20 +135,18 @@ func TestNewUnifiedServer_V2DirectOpDoesNotLeakIntoV1(t *testing.T) {
 	require.NotNil(t, server, "NewUnifiedServer should return a non-nil server")
 	require.NotNil(t, server.app, "server should hold a Fiber app")
 
-	const directOpPath = "/organizations/{organization_id}/ledgers/{ledger_id}/transactions/direct"
-
 	// v2 document MUST carry the direct op.
 	v2doc := fetchOpenAPISpec(t, server.app, "/v2/openapi.json")
 	v2paths, ok := v2doc["paths"].(map[string]any)
 	require.True(t, ok, "v2 spec should carry a paths object")
-	_, inV2 := v2paths[directOpPath]
-	assert.Truef(t, inV2, "v2 document MUST carry the direct op path %q; paths=%v", directOpPath, keysOf(v2paths))
+	_, inV2 := v2paths[directOpV2Path]
+	assert.Truef(t, inV2, "v2 document MUST carry the direct op path %q; paths=%v", directOpV2Path, keysOf(v2paths))
 
 	// v1 document MUST NOT carry the direct op. A v1 document with no registered ops
 	// may omit the paths object entirely; if present, it must not leak the v2 op.
 	v1doc := fetchOpenAPISpec(t, server.app, "/v1/openapi.json")
 	if v1paths, ok := v1doc["paths"].(map[string]any); ok {
-		_, inV1 := v1paths[directOpPath]
+		_, inV1 := v1paths[directOpV2Path]
 		assert.Falsef(t, inV1, "v2 direct op MUST NOT leak into the v1 document; v1 paths=%v", keysOf(v1paths))
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.26.4
 toolchain go1.26.5
 
 require (
-	github.com/LerianStudio/lib-auth/v3 v3.1.0
+	github.com/LerianStudio/lib-auth/v3 v3.2.0
 	github.com/Masterminds/squirrel v1.5.4
 	github.com/antlr4-go/antlr/v4 v4.13.1
 	github.com/go-playground/locales v0.14.1

--- a/go.mod
+++ b/go.mod
@@ -87,7 +87,7 @@ require (
 	github.com/LerianStudio/lib-commons/v6 v6.0.0
 	github.com/LerianStudio/lib-observability/v2 v2.1.0
 	github.com/LerianStudio/lib-service-discovery v1.1.0
-	github.com/LerianStudio/lib-streaming/v2 v2.0.0-beta.1
+	github.com/LerianStudio/lib-streaming/v2 v2.0.0
 	github.com/Shopify/toxiproxy/v2 v2.12.0
 	github.com/alicebob/miniredis/v2 v2.38.0
 	github.com/cucumber/godog v0.15.1

--- a/go.sum
+++ b/go.sum
@@ -17,8 +17,8 @@ github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c/go.mod h1:xomTg6
 github.com/DATA-DOG/go-sqlmock v1.5.2 h1:OcvFkGmslmlZibjAjaHm3L//6LiuBgolP7OputlJIzU=
 github.com/DATA-DOG/go-sqlmock v1.5.2/go.mod h1:88MAG/4G7SMwSE3CeA0ZKzrT5CiOU3OJ+JlNzwDqpNU=
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
-github.com/LerianStudio/lib-auth/v3 v3.1.0 h1:89Zrk4T8zJ4aYseEQAd48jBz020RFiJdSQuZSetShRw=
-github.com/LerianStudio/lib-auth/v3 v3.1.0/go.mod h1:NWCpNMetNbsvNkptG61o7BRfXcT9sHLIRShaQU76Gj4=
+github.com/LerianStudio/lib-auth/v3 v3.2.0 h1:TfZpd8ER82fWO0HwsjsiP6HJ5zsX6IHwLUevJdM/pbM=
+github.com/LerianStudio/lib-auth/v3 v3.2.0/go.mod h1:NWCpNMetNbsvNkptG61o7BRfXcT9sHLIRShaQU76Gj4=
 github.com/LerianStudio/lib-commons/v6 v6.0.0 h1:XDKyCKdb2h3l0MBwQQNBRuCsiSTjafJfgp/QLMAEzd0=
 github.com/LerianStudio/lib-commons/v6 v6.0.0/go.mod h1:bOPZG4oO2xoSE307JJyXKyhmBo7EyQ5g8DEw5fI/ZEg=
 github.com/LerianStudio/lib-observability v1.1.0 h1:e/OrIoTKo8gI1RKXgKDyDDKcrddR4beh53al5ZmB6vQ=

--- a/go.sum
+++ b/go.sum
@@ -27,8 +27,8 @@ github.com/LerianStudio/lib-observability/v2 v2.1.0 h1:/w5u44Zpe9R+R3d/Ti3//OdJR
 github.com/LerianStudio/lib-observability/v2 v2.1.0/go.mod h1:iXspGM6PRTf6BDtkTc0Z69R2HEv1GtjBsI/YSvewDgA=
 github.com/LerianStudio/lib-service-discovery v1.1.0 h1:rREGTNnlwoHdfsqDbDoOXAQkqQazVYT/b0yTypSWrk8=
 github.com/LerianStudio/lib-service-discovery v1.1.0/go.mod h1:d6pW/QMo1hYzLgzcxiTg3updjSs6m5sZkuOG3L4gwxo=
-github.com/LerianStudio/lib-streaming/v2 v2.0.0-beta.1 h1:QlfrBpwd2VraLmURfYPFBVdDejDDwDWgjNsXyefDYOQ=
-github.com/LerianStudio/lib-streaming/v2 v2.0.0-beta.1/go.mod h1:SHodsEhv1U1Wra+vbk3KoQ7glHrtKJpbCNog3cqnmM8=
+github.com/LerianStudio/lib-streaming/v2 v2.0.0 h1:E5TokAl9vuMGKrfOc9Up2jazxjoxt1Dh6PwyNf0ZFKo=
+github.com/LerianStudio/lib-streaming/v2 v2.0.0/go.mod h1:LNPnBAgyCx1wZ4a+9XvxQieRc/Dl8AZ9A2sFrFmrz88=
 github.com/Masterminds/squirrel v1.5.4 h1:uUcX/aBc8O7Fg9kaISIUsHXdKuqehiXAMQTYX8afzqM=
 github.com/Masterminds/squirrel v1.5.4/go.mod h1:NNaOrjSoIDfDA40n7sr2tPNZRfjzjA400rg+riTZj10=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -769,7 +769,7 @@ are set programmatically by `applyConfigDefaults()`.
 | BALANCE_SYNC_FLUSH_TIMEOUT_MS | 500 | Max ms before flush (TIMEOUT trigger) |
 | BALANCE_SYNC_POLL_INTERVAL_MS | 50 | ZSET polling interval (ms) when draining |
 
-#### Streaming (lib-streaming/v2 v2.0.0-beta.1 / Kafka)
+#### Streaming (lib-streaming/v2 v2.0.0 / Kafka)
 The master flag is `STREAMING_ENABLED`; when false, a no-op emitter is injected. The rest are
 loaded by `libStreaming.LoadConfig()` with franz-go defaults. Wire format: CloudEvents 1.0 binary
 mode on Kafka.
@@ -998,7 +998,7 @@ There is no standalone CRM image — CRM ships inside the ledger image.
 |------------|---------|---------|
 | github.com/LerianStudio/lib-commons/v6 | v6.0.0 | Shared library (tenant-manager, Redis, HTTP toolkit, lifecycle, outbox, Huma/OpenAPI + RFC 9457 problem wrappers) |
 | github.com/LerianStudio/lib-observability/v2 | v2.1.0 | Logging, metrics, tracing, assertions, panic recovery, redaction |
-| github.com/LerianStudio/lib-streaming/v2 | v2.0.0-beta.1 | CloudEvents/Kafka streaming producer (franz-go) |
+| github.com/LerianStudio/lib-streaming/v2 | v2.0.0 | CloudEvents/Kafka streaming producer (franz-go) |
 | github.com/LerianStudio/lib-auth/v3 | v3.0.0 | Authentication middleware |
 | github.com/danielgtaylor/huma/v2 | v2.38.0 | OpenAPI 3.1 contract + request/response validation over Fiber |
 | github.com/gofiber/fiber/v3 | v3.4.0 | HTTP framework (runtime router / middleware) |

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -999,7 +999,7 @@ There is no standalone CRM image — CRM ships inside the ledger image.
 | github.com/LerianStudio/lib-commons/v6 | v6.0.0 | Shared library (tenant-manager, Redis, HTTP toolkit, lifecycle, outbox, Huma/OpenAPI + RFC 9457 problem wrappers) |
 | github.com/LerianStudio/lib-observability/v2 | v2.1.0 | Logging, metrics, tracing, assertions, panic recovery, redaction |
 | github.com/LerianStudio/lib-streaming/v2 | v2.0.0 | CloudEvents/Kafka streaming producer (franz-go) |
-| github.com/LerianStudio/lib-auth/v3 | v3.0.0 | Authentication middleware |
+| github.com/LerianStudio/lib-auth/v3 | v3.2.0 | Authentication middleware |
 | github.com/danielgtaylor/huma/v2 | v2.38.0 | OpenAPI 3.1 contract + request/response validation over Fiber |
 | github.com/gofiber/fiber/v3 | v3.4.0 | HTTP framework (runtime router / middleware) |
 | github.com/hashicorp/vault/api | v1.23.0 | Vault Transit client — CRM envelope KEK (envelope mode) |

--- a/pkg/mtransaction/v2_input.go
+++ b/pkg/mtransaction/v2_input.go
@@ -36,11 +36,14 @@ type CreateTransactionV2Input struct {
 	// To is the destination account alias (single credit leg).
 	To string `json:"to" validate:"required"`
 
-	// RouteID is the optional TRANSACTION route UUID.
-	RouteID *string `json:"routeId,omitempty"`
+	// RouteID is the optional TRANSACTION route UUID. Validated as a UUID at
+	// decode (same tag as the v1 input) so a malformed value is a clean 400, not
+	// a deep funnel error.
+	RouteID *string `json:"routeId,omitempty" validate:"omitempty,uuid" example:"00000000-0000-0000-0000-000000000000" format:"uuid"`
 
-	// OperationRouteID is the optional per-leg OPERATION route UUID.
-	OperationRouteID *string `json:"operationRouteId,omitempty"`
+	// OperationRouteID is the optional per-leg OPERATION route UUID. Validated as
+	// a UUID at decode for the same reason as RouteID.
+	OperationRouteID *string `json:"operationRouteId,omitempty" validate:"omitempty,uuid" example:"00000000-0000-0000-0000-000000000000" format:"uuid"`
 
 	// Metadata holds flat custom key-value attributes. Values must be flat
 	// (string, number, boolean) — no nested objects.

--- a/pkg/mtransaction/v2_input.go
+++ b/pkg/mtransaction/v2_input.go
@@ -4,7 +4,12 @@
 
 package mtransaction
 
-import "fmt"
+import (
+	"github.com/shopspring/decimal"
+
+	"github.com/LerianStudio/midaz/v4/pkg"
+	"github.com/LerianStudio/midaz/v4/pkg/constant"
+)
 
 // CreateTransactionV2Input is the flat, single-leg request payload for the
 // Transaction API v2. It mirrors the canonical Transaction shape explicitly
@@ -42,16 +47,66 @@ type CreateTransactionV2Input struct {
 	Metadata map[string]any `json:"metadata,omitempty" validate:"dive,keys,keymax=100,endkeys,omitempty,nonested,valuemax=2000"`
 }
 
-// Translate converts the flat v2 input into the canonical Transaction. The
-// pending flag encodes the action intent (direct=false, hold=true) and is set
-// by the endpoint, not the request body.
+// Translate converts the flat v2 input into the canonical single-leg
+// Transaction. The pending flag encodes the action intent (direct=false,
+// hold=true) and is set by the endpoint, not the request body.
 //
-// The mapping is implemented in Task 1.2.2. Until then Translate returns a
-// not-implemented error so no caller can mistake a zero-value Transaction for a
-// successfully translated one.
+// Route identifiers map at two independent levels: RouteID is the TRANSACTION
+// route (Transaction.RouteID); OperationRouteID is the per-leg OPERATION route
+// (FromTo.RouteID) and is copied onto both the source and distribution legs.
+// Nil route pointers stay nil so downstream ledger settings resolve defaults.
+//
+// A malformed or non-positive amount and a source equal to the destination are
+// rejected as business errors (422), mirroring the v1 transaction-value and
+// ambiguity validations, so the HTTP layer maps them to 4xx.
 func (in CreateTransactionV2Input) Translate(pending bool) (Transaction, error) {
-	return Transaction{}, fmt.Errorf(
-		"mtransaction: CreateTransactionV2Input.Translate is not implemented (pending=%t): mapping lands in Task 1.2.2",
-		pending,
-	)
+	value, err := decimal.NewFromString(in.Amount)
+	if err != nil || value.LessThanOrEqual(decimal.Zero) {
+		return Transaction{}, pkg.ValidateBusinessError(constant.ErrInvalidTransactionNonPositiveValue, constant.EntityTransaction)
+	}
+
+	if in.From == in.To {
+		return Transaction{}, pkg.ValidateBusinessError(constant.ErrTransactionAmbiguous, constant.EntityTransaction)
+	}
+
+	send := Send{
+		Asset: in.Asset,
+		Value: value,
+		Source: Source{
+			From: []FromTo{{
+				AccountAlias: in.From,
+				Amount:       &Amount{Asset: in.Asset, Value: value},
+				RouteID:      cloneStringPtr(in.OperationRouteID),
+				IsFrom:       true,
+			}},
+		},
+		Distribute: Distribute{
+			To: []FromTo{{
+				AccountAlias: in.To,
+				Amount:       &Amount{Asset: in.Asset, Value: value},
+				RouteID:      cloneStringPtr(in.OperationRouteID),
+			}},
+		},
+	}
+
+	return Transaction{
+		Description: in.Description,
+		Code:        in.Code,
+		Pending:     pending,
+		Metadata:    in.Metadata,
+		RouteID:     cloneStringPtr(in.RouteID),
+		Send:        send,
+	}, nil
+}
+
+// cloneStringPtr returns an independent copy of p, or nil when p is nil, so
+// callers never alias the input's route pointers onto the produced legs.
+func cloneStringPtr(p *string) *string {
+	if p == nil {
+		return nil
+	}
+
+	v := *p
+
+	return &v
 }

--- a/pkg/mtransaction/v2_input.go
+++ b/pkg/mtransaction/v2_input.go
@@ -1,0 +1,57 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package mtransaction
+
+import "fmt"
+
+// CreateTransactionV2Input is the flat, single-leg request payload for the
+// Transaction API v2. It mirrors the canonical Transaction shape explicitly
+// rather than embedding mmodel/canonical types, so domain evolution never leaks
+// onto the wire contract. The richer discriminated (flat-OR-arrays) format is
+// reserved for a later phase; v2.1.1 keeps every leg field a simple scalar.
+type CreateTransactionV2Input struct {
+	// Human-readable description of the transaction.
+	Description string `json:"description,omitempty"`
+
+	// Transaction code for reference.
+	Code string `json:"code,omitempty"`
+
+	// Asset code shared by both legs. Same value semantics as v1.
+	Asset string `json:"asset" validate:"required"`
+
+	// Amount carried as a string to preserve JSON precision. Same value
+	// semantics as v1; Translate parses it into a decimal.
+	Amount string `json:"amount" validate:"required"`
+
+	// From is the source account alias (single debit leg).
+	From string `json:"from" validate:"required"`
+
+	// To is the destination account alias (single credit leg).
+	To string `json:"to" validate:"required"`
+
+	// RouteID is the optional TRANSACTION route UUID.
+	RouteID *string `json:"routeId,omitempty"`
+
+	// OperationRouteID is the optional per-leg OPERATION route UUID.
+	OperationRouteID *string `json:"operationRouteId,omitempty"`
+
+	// Metadata holds flat custom key-value attributes. Values must be flat
+	// (string, number, boolean) — no nested objects.
+	Metadata map[string]any `json:"metadata,omitempty" validate:"dive,keys,keymax=100,endkeys,omitempty,nonested,valuemax=2000"`
+}
+
+// Translate converts the flat v2 input into the canonical Transaction. The
+// pending flag encodes the action intent (direct=false, hold=true) and is set
+// by the endpoint, not the request body.
+//
+// The mapping is implemented in Task 1.2.2. Until then Translate returns a
+// not-implemented error so no caller can mistake a zero-value Transaction for a
+// successfully translated one.
+func (in CreateTransactionV2Input) Translate(pending bool) (Transaction, error) {
+	return Transaction{}, fmt.Errorf(
+		"mtransaction: CreateTransactionV2Input.Translate is not implemented (pending=%t): mapping lands in Task 1.2.2",
+		pending,
+	)
+}

--- a/pkg/mtransaction/v2_input_test.go
+++ b/pkg/mtransaction/v2_input_test.go
@@ -8,9 +8,12 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/LerianStudio/midaz/v4/pkg"
+	"github.com/LerianStudio/midaz/v4/pkg/constant"
 	"github.com/LerianStudio/midaz/v4/pkg/mtransaction"
 	nethttp "github.com/LerianStudio/midaz/v4/pkg/net/http"
 )
@@ -107,16 +110,205 @@ func TestCreateTransactionV2Input_Validation(t *testing.T) {
 	}
 }
 
-// TestCreateTransactionV2Input_Translate_Stub locks the stub contract for Task
-// 1.2.1: Translate compiles and returns a not-implemented error rather than a
-// silently valid transaction. The mapping logic itself is Task 1.2.2.
-func TestCreateTransactionV2Input_Translate_Stub(t *testing.T) {
+// TestCreateTransactionV2Input_Translate exercises the flat -> canonical
+// single-leg mapping produced by Task 1.2.2: happy-path field propagation,
+// two-level route mapping (transaction route vs per-leg operation route), the
+// pending flag, and the named business-error edge cases.
+func TestCreateTransactionV2Input_Translate(t *testing.T) {
 	t.Parallel()
 
-	for _, pending := range []bool{false, true} {
-		got, err := validV2Input().Translate(pending)
+	tests := []struct {
+		name     string
+		input    mtransaction.CreateTransactionV2Input
+		pending  bool
+		wantErr  bool
+		wantCode string
+		verify   func(t *testing.T, got mtransaction.Transaction)
+	}{
+		{
+			name:    "single from/to happy path maps every field",
+			input:   validV2Input(),
+			pending: false,
+			verify: func(t *testing.T, got mtransaction.Transaction) {
+				t.Helper()
 
-		require.Error(t, err)
-		assert.True(t, got.IsEmpty(), "stub must not produce a populated transaction")
+				assert.Equal(t, "New Transaction", got.Description)
+				assert.Equal(t, "TR12345", got.Code)
+				assert.False(t, got.Pending)
+				assert.Equal(t, map[string]any{"reference": "TRANSACTION-001"}, got.Metadata)
+
+				// Transaction route (level 1) maps from RouteID.
+				require.NotNil(t, got.RouteID)
+				assert.Equal(t, "00000000-0000-0000-0000-000000000000", *got.RouteID)
+
+				// Top-level asset/amount propagate to Send.
+				assert.Equal(t, "BRL", got.Send.Asset)
+				assert.True(t, decimal.RequireFromString("1000").Equal(got.Send.Value),
+					"send value = %s", got.Send.Value)
+
+				// Source (debit) leg.
+				require.Len(t, got.Send.Source.From, 1)
+				from := got.Send.Source.From[0]
+				assert.Equal(t, "@person1", from.AccountAlias)
+				assert.True(t, from.IsFrom, "source leg must carry IsFrom=true")
+				require.NotNil(t, from.Amount)
+				assert.Equal(t, "BRL", from.Amount.Asset)
+				assert.True(t, decimal.RequireFromString("1000").Equal(from.Amount.Value))
+				require.NotNil(t, from.RouteID, "source leg operation route")
+				assert.Equal(t, "11111111-1111-1111-1111-111111111111", *from.RouteID)
+
+				// Distribute (credit) leg.
+				require.Len(t, got.Send.Distribute.To, 1)
+				to := got.Send.Distribute.To[0]
+				assert.Equal(t, "@person2", to.AccountAlias)
+				assert.False(t, to.IsFrom, "distribute leg must not carry IsFrom")
+				require.NotNil(t, to.Amount)
+				assert.Equal(t, "BRL", to.Amount.Asset)
+				assert.True(t, decimal.RequireFromString("1000").Equal(to.Amount.Value))
+				require.NotNil(t, to.RouteID, "distribute leg operation route")
+				assert.Equal(t, "11111111-1111-1111-1111-111111111111", *to.RouteID)
+
+				// Per-leg operation-route pointers must be independent copies,
+				// not the same shared pointer aliased onto both legs.
+				assert.NotSame(t, from.RouteID, to.RouteID)
+			},
+		},
+		{
+			name: "distinct asset and amount propagate identically to both legs",
+			input: func() mtransaction.CreateTransactionV2Input {
+				in := validV2Input()
+				in.Asset = "USD"
+				in.Amount = "42.55"
+
+				return in
+			}(),
+			verify: func(t *testing.T, got mtransaction.Transaction) {
+				t.Helper()
+
+				want := decimal.RequireFromString("42.55")
+				assert.Equal(t, "USD", got.Send.Asset)
+				assert.True(t, want.Equal(got.Send.Value))
+
+				require.Len(t, got.Send.Source.From, 1)
+				require.NotNil(t, got.Send.Source.From[0].Amount)
+				assert.Equal(t, "USD", got.Send.Source.From[0].Amount.Asset)
+				assert.True(t, want.Equal(got.Send.Source.From[0].Amount.Value))
+
+				require.Len(t, got.Send.Distribute.To, 1)
+				require.NotNil(t, got.Send.Distribute.To[0].Amount)
+				assert.Equal(t, "USD", got.Send.Distribute.To[0].Amount.Asset)
+				assert.True(t, want.Equal(got.Send.Distribute.To[0].Amount.Value))
+			},
+		},
+		{
+			name:    "pending flag propagates to Transaction.Pending",
+			input:   validV2Input(),
+			pending: true,
+			verify: func(t *testing.T, got mtransaction.Transaction) {
+				t.Helper()
+
+				assert.True(t, got.Pending)
+				assert.Equal(t, constant.PENDING, got.InitialStatus())
+			},
+		},
+		{
+			name: "nil RouteID leaves transaction route unset",
+			input: func() mtransaction.CreateTransactionV2Input {
+				in := validV2Input()
+				in.RouteID = nil
+
+				return in
+			}(),
+			verify: func(t *testing.T, got mtransaction.Transaction) {
+				t.Helper()
+
+				assert.Nil(t, got.RouteID, "nil transaction route must stay nil")
+			},
+		},
+		{
+			name: "nil OperationRouteID leaves both legs without an operation route",
+			input: func() mtransaction.CreateTransactionV2Input {
+				in := validV2Input()
+				in.OperationRouteID = nil
+
+				return in
+			}(),
+			verify: func(t *testing.T, got mtransaction.Transaction) {
+				t.Helper()
+
+				require.Len(t, got.Send.Source.From, 1)
+				require.Len(t, got.Send.Distribute.To, 1)
+				assert.Nil(t, got.Send.Source.From[0].RouteID)
+				assert.Nil(t, got.Send.Distribute.To[0].RouteID)
+			},
+		},
+		{
+			name: "empty amount is a business error",
+			input: func() mtransaction.CreateTransactionV2Input {
+				in := validV2Input()
+				in.Amount = ""
+
+				return in
+			}(),
+			wantErr:  true,
+			wantCode: constant.ErrInvalidTransactionNonPositiveValue.Error(),
+		},
+		{
+			name: "non-numeric amount is a business error",
+			input: func() mtransaction.CreateTransactionV2Input {
+				in := validV2Input()
+				in.Amount = "abc"
+
+				return in
+			}(),
+			wantErr:  true,
+			wantCode: constant.ErrInvalidTransactionNonPositiveValue.Error(),
+		},
+		{
+			name: "zero amount is a non-positive business error",
+			input: func() mtransaction.CreateTransactionV2Input {
+				in := validV2Input()
+				in.Amount = "0"
+
+				return in
+			}(),
+			wantErr:  true,
+			wantCode: constant.ErrInvalidTransactionNonPositiveValue.Error(),
+		},
+		{
+			name: "from equal to to is an ambiguous business error",
+			input: func() mtransaction.CreateTransactionV2Input {
+				in := validV2Input()
+				in.From = "@same"
+				in.To = "@same"
+
+				return in
+			}(),
+			wantErr:  true,
+			wantCode: constant.ErrTransactionAmbiguous.Error(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := tt.input.Translate(tt.pending)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.True(t, got.IsEmpty(), "error path must not leak a populated transaction")
+
+				var uoErr pkg.UnprocessableOperationError
+				require.ErrorAs(t, err, &uoErr, "business errors must be UnprocessableOperationError (422)")
+				assert.Equal(t, tt.wantCode, uoErr.Code)
+
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, tt.verify)
+			tt.verify(t, got)
+		})
 	}
 }

--- a/pkg/mtransaction/v2_input_test.go
+++ b/pkg/mtransaction/v2_input_test.go
@@ -111,9 +111,9 @@ func TestCreateTransactionV2Input_Validation(t *testing.T) {
 }
 
 // TestCreateTransactionV2Input_Translate exercises the flat -> canonical
-// single-leg mapping produced by Task 1.2.2: happy-path field propagation,
-// two-level route mapping (transaction route vs per-leg operation route), the
-// pending flag, and the named business-error edge cases.
+// single-leg mapping: happy-path field propagation, two-level route mapping
+// (transaction route vs per-leg operation route), the pending flag, and the
+// named business-error edge cases.
 func TestCreateTransactionV2Input_Translate(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/mtransaction/v2_input_test.go
+++ b/pkg/mtransaction/v2_input_test.go
@@ -1,0 +1,122 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package mtransaction_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/LerianStudio/midaz/v4/pkg/mtransaction"
+	nethttp "github.com/LerianStudio/midaz/v4/pkg/net/http"
+)
+
+// validV2Input returns a fully populated, valid CreateTransactionV2Input.
+func validV2Input() mtransaction.CreateTransactionV2Input {
+	routeID := "00000000-0000-0000-0000-000000000000"
+	operationRouteID := "11111111-1111-1111-1111-111111111111"
+
+	return mtransaction.CreateTransactionV2Input{
+		Description:      "New Transaction",
+		Code:             "TR12345",
+		Asset:            "BRL",
+		Amount:           "1000",
+		From:             "@person1",
+		To:               "@person2",
+		RouteID:          &routeID,
+		OperationRouteID: &operationRouteID,
+		Metadata:         map[string]any{"reference": "TRANSACTION-001"},
+	}
+}
+
+func TestCreateTransactionV2Input_Validation(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		mutate  func(in *mtransaction.CreateTransactionV2Input)
+		wantErr bool
+	}{
+		{
+			name:    "fully populated valid input passes",
+			mutate:  func(_ *mtransaction.CreateTransactionV2Input) {},
+			wantErr: false,
+		},
+		{
+			name:    "missing asset fails",
+			mutate:  func(in *mtransaction.CreateTransactionV2Input) { in.Asset = "" },
+			wantErr: true,
+		},
+		{
+			name:    "missing amount fails",
+			mutate:  func(in *mtransaction.CreateTransactionV2Input) { in.Amount = "" },
+			wantErr: true,
+		},
+		{
+			name:    "missing from fails",
+			mutate:  func(in *mtransaction.CreateTransactionV2Input) { in.From = "" },
+			wantErr: true,
+		},
+		{
+			name:    "missing to fails",
+			mutate:  func(in *mtransaction.CreateTransactionV2Input) { in.To = "" },
+			wantErr: true,
+		},
+		{
+			name: "metadata key over 100 chars fails (keymax)",
+			mutate: func(in *mtransaction.CreateTransactionV2Input) {
+				in.Metadata = map[string]any{strings.Repeat("k", 101): "value"}
+			},
+			wantErr: true,
+		},
+		{
+			name: "metadata value over 2000 chars fails (valuemax)",
+			mutate: func(in *mtransaction.CreateTransactionV2Input) {
+				in.Metadata = map[string]any{"key": strings.Repeat("v", 2001)}
+			},
+			wantErr: true,
+		},
+		{
+			name: "nested metadata value fails (nonested)",
+			mutate: func(in *mtransaction.CreateTransactionV2Input) {
+				in.Metadata = map[string]any{"key": map[string]any{"nested": "value"}}
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			in := validV2Input()
+			tt.mutate(&in)
+
+			err := nethttp.ValidateStruct(in)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+		})
+	}
+}
+
+// TestCreateTransactionV2Input_Translate_Stub locks the stub contract for Task
+// 1.2.1: Translate compiles and returns a not-implemented error rather than a
+// silently valid transaction. The mapping logic itself is Task 1.2.2.
+func TestCreateTransactionV2Input_Translate_Stub(t *testing.T) {
+	t.Parallel()
+
+	for _, pending := range []bool{false, true} {
+		got, err := validV2Input().Translate(pending)
+
+		require.Error(t, err)
+		assert.True(t, got.IsEmpty(), "stub must not produce a populated transaction")
+	}
+}

--- a/pkg/mtransaction/v2_input_test.go
+++ b/pkg/mtransaction/v2_input_test.go
@@ -90,6 +90,30 @@ func TestCreateTransactionV2Input_Validation(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name: "non-UUID routeId fails (uuid tag)",
+			mutate: func(in *mtransaction.CreateTransactionV2Input) {
+				bad := "not-a-uuid"
+				in.RouteID = &bad
+			},
+			wantErr: true,
+		},
+		{
+			name: "non-UUID operationRouteId fails (uuid tag)",
+			mutate: func(in *mtransaction.CreateTransactionV2Input) {
+				bad := "not-a-uuid"
+				in.OperationRouteID = &bad
+			},
+			wantErr: true,
+		},
+		{
+			name: "nil route ids pass (omitempty)",
+			mutate: func(in *mtransaction.CreateTransactionV2Input) {
+				in.RouteID = nil
+				in.OperationRouteID = nil
+			},
+			wantErr: false,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Description

**Transaction API v2 foundation** (Phase 1 of the `refactor-transactional-v2` cycle). Adds a `/v2` transactional surface with an intent-oriented flat body and semantic action URLs that compiles to the canonical `mtransaction.Transaction` model and **re-enters the existing creation funnel** (`executeCreateTransaction`) — without changing the engine or the v1 surface.

Delivered in this phase (the 3 epics):

- **1.1 — Mount `/v2`:** a second Fiber `/v2` group + a second, independent OpenAPI contract instance (ADR-003), served on its own path. Extracted the shared `mountHumaContract` helper (v1 + v2 through the same seam; **v1 output is byte-identical**, verified by test).
- **1.2 — Translator:** `CreateTransactionV2Input` (flat, typed independently of `mmodel` — wire isolation) + `Translate(pending)` mapping to the canonical `Transaction`, with two-level route mapping (transaction vs operation route, FR-6) and named business edge cases (invalid/non-positive amount, `from == to`) surfaced as 422.
- **1.3 — `direct` end-to-end:** `POST /v2/organizations/{organization_id}/ledgers/{ledger_id}/transactions/direct` creates and commits through the existing funnel; idempotency is keyed off the **v2 body as submitted** (ADR-004) via an additive hash-source seam that keeps v1 hashing byte-identical. Authorization uses the same chain as v1 (namespace `midaz`, per-tenant).

Also included: dependency bumps — `lib-streaming` v2.0.0-beta.1 → **v2.0.0** and `lib-auth/v3` v3.1.0 → **v3.2.0** (both API-compatible: clean build, consumer tests green; version strings synced in the docs).

Tracked on the Lerian Map (initiative #382): cards #3553 (1.1), #3554 (1.2), #3555 (1.3). Phases 2–6 follow in subsequent PRs.

## Type of Change

- [x] `feat`: New feature or capability

## Breaking Changes

None. The v2 surface is **additive**; v1 remains byte-identical (v1 mount unchanged, v1 idempotency hashing unchanged — locked by regression and parity tests).

## Testing

- [x] `make test` passes — full repo unit suite: **14474 tests, 0 failures**.
- [x] `make test-int` passes if integration paths are exercised — v2 `direct` integration tests (v1↔v2 parity of transaction/operations/balances, validation with no ledger effect, `from == to`, idempotency + no cross-dedup, insufficient-funds) **green with real testcontainers**. The full integration suite has 1 pre-existing, unrelated failure (`TestIntegration_AssetHandler_AccountWithDeletedAsset`, confirmed identical on `develop`).
- [x] `make lint` passes — 0 issues in the phase directories.
- [x] `make sec` and `make vulncheck` pass — 0 vulnerabilities affecting the code; no new dependencies beyond the intentional lib-streaming/lib-auth bumps.

**Test evidence / Actions run:** Ring money-path review on each epic (2 floor reviewers + security/tenancy/nil/test/commons/obs specialists); integration executed locally (OrbStack/testcontainers).

## Architectural Checklist

- [x] No `panic()` in production paths
- [x] Timestamps use `time.Now().UTC()` (no new `time.Now()` in tests; fixed time values)
- [x] Errors wrapped with `%w` (business errors via `pkg.ValidateBusinessError`; technical via `HandleSpanError`)
- [x] Handlers stay thin (parse, validate, call service) — the v2 handler is decode → translate → delegate to the funnel
- [x] Infrastructure concerns kept in `internal/bootstrap` (`/v2` mount in the composition root)

## Related Issues

Lerian Map: initiative #382 (V2 Transactional Endpoints in the Ledger), Phase 1 — cards #3553 / #3554 / #3555.
