### PR TITLE
feat(ledger): route transactional reads to primary db

### DIFF
--- a/components/ledger/.env.example
+++ b/components/ledger/.env.example
@@ -114,6 +114,10 @@ DB_TRANSACTION_REPLICA_SSLMODE=disable
 DB_TRANSACTION_MAX_OPEN_CONNS=3000
 DB_TRANSACTION_MAX_IDLE_CONNS=3000
 
+# Rollout flag: route transactional-flow reads to the PRIMARY (not the replica).
+# Default false (safe/backwards-compatible); an invalid value falls back to false.
+DB_TRANSACTION_ROUTE_TX_READS_TO_PRIMARY=false
+
 # MONGO DB - Transaction
 MONGO_TRANSACTION_HOST=midaz-mongodb
 MONGO_TRANSACTION_MAX_POOL_SIZE=1000

--- a/components/ledger/internal/adapters/http/in/transaction_block_unblock_integration_test.go
+++ b/components/ledger/internal/adapters/http/in/transaction_block_unblock_integration_test.go
@@ -84,7 +84,7 @@ func setupBlockUnblockInfra(t *testing.T) *blockUnblockInfra {
 
 	transactionRepo := transaction.NewTransactionPostgreSQLRepository(pgConn)
 	operationRepo := operation.NewOperationPostgreSQLRepository(pgConn)
-	balanceRepo := balance.NewBalancePostgreSQLRepository(pgConn)
+	balanceRepo := balance.NewBalancePostgreSQLRepository(pgConn, false)
 	metadataRepo := mongodb.NewMetadataMongoDBRepository(mongoConn)
 	redisRepo, err := redis.NewConsumerRedis(redisConn)
 	require.NoError(t, err, "failed to create Redis repository")

--- a/components/ledger/internal/adapters/http/in/transaction_create.go
+++ b/components/ledger/internal/adapters/http/in/transaction_create.go
@@ -24,6 +24,7 @@ import (
 	"github.com/LerianStudio/midaz/v4/components/ledger/internal/adapters/postgres/operation"
 	"github.com/LerianStudio/midaz/v4/components/ledger/internal/adapters/postgres/transaction"
 	"github.com/LerianStudio/midaz/v4/components/ledger/internal/services/command"
+	"github.com/LerianStudio/midaz/v4/components/ledger/pkg/readrouting"
 	"github.com/LerianStudio/midaz/v4/pkg"
 	"github.com/LerianStudio/midaz/v4/pkg/constant"
 	"github.com/LerianStudio/midaz/v4/pkg/mtransaction"
@@ -1282,6 +1283,10 @@ func (handler *TransactionHandler) executeCreateTransaction(ctx context.Context,
 
 		return nil, false, pkg.ValidateBusinessError(err, constant.EntityTransaction)
 	}
+
+	// Mark the transactional-flow balance reads below so they can be served from
+	// the primary, avoiding a stale replica read before the commit.
+	ctx = readrouting.WithPrimaryRead(ctx)
 
 	balances, err := handler.Query.GetBalances(ctx, params.OrganizationID, params.LedgerID, validate.Aliases)
 	if err != nil {

--- a/components/ledger/internal/adapters/http/in/transaction_fee_async_integration_test.go
+++ b/components/ledger/internal/adapters/http/in/transaction_fee_async_integration_test.go
@@ -102,7 +102,7 @@ func TestFeeProof_T25_AsyncFeeInclusive(t *testing.T) {
 
 	transactionRepo := transaction.NewTransactionPostgreSQLRepository(pgConn)
 	operationRepo := operation.NewOperationPostgreSQLRepository(pgConn)
-	balanceRepo := balance.NewBalancePostgreSQLRepository(pgConn)
+	balanceRepo := balance.NewBalancePostgreSQLRepository(pgConn, false)
 	metaRepo := mongotxn.NewMetadataMongoDBRepository(mongoConn)
 	onbMetaRepo := mongoonb.NewMetadataMongoDBRepository(mongoConn)
 	redisRepo, err := redis.NewConsumerRedis(redisConn)

--- a/components/ledger/internal/adapters/http/in/transaction_fee_harness_integration_test.go
+++ b/components/ledger/internal/adapters/http/in/transaction_fee_harness_integration_test.go
@@ -113,7 +113,7 @@ func setupFeeHarness(t *testing.T) *feeHarness {
 	// Transaction-domain repos.
 	transactionRepo := transaction.NewTransactionPostgreSQLRepository(h.pgConn)
 	operationRepo := operation.NewOperationPostgreSQLRepository(h.pgConn)
-	balanceRepo := balance.NewBalancePostgreSQLRepository(h.pgConn)
+	balanceRepo := balance.NewBalancePostgreSQLRepository(h.pgConn, false)
 	h.metaRepo = mongotxn.NewMetadataMongoDBRepository(mongoTxnConn)
 
 	redisRepo, err := redis.NewConsumerRedis(redisConn)

--- a/components/ledger/internal/adapters/http/in/transaction_integration_test.go
+++ b/components/ledger/internal/adapters/http/in/transaction_integration_test.go
@@ -101,7 +101,7 @@ func setupTestInfra(t *testing.T) *testInfra {
 	// Create repositories
 	transactionRepo := transaction.NewTransactionPostgreSQLRepository(infra.pgConn)
 	operationRepo := operation.NewOperationPostgreSQLRepository(infra.pgConn)
-	balanceRepo := balance.NewBalancePostgreSQLRepository(infra.pgConn)
+	balanceRepo := balance.NewBalancePostgreSQLRepository(infra.pgConn, false)
 	ledgerRepo := ledger.NewLedgerPostgreSQLRepository(infra.pgConn)
 	metadataRepo := mongodb.NewMetadataMongoDBRepository(mongoConn)
 	redisRepo, err := redis.NewConsumerRedis(redisConn)
@@ -666,7 +666,7 @@ func setupAsyncTestInfra(t *testing.T) *testAsyncInfra {
 	// Create repositories
 	transactionRepo := transaction.NewTransactionPostgreSQLRepository(infra.pgConn)
 	operationRepo := operation.NewOperationPostgreSQLRepository(infra.pgConn)
-	balanceRepo := balance.NewBalancePostgreSQLRepository(infra.pgConn)
+	balanceRepo := balance.NewBalancePostgreSQLRepository(infra.pgConn, false)
 	ledgerRepo := ledger.NewLedgerPostgreSQLRepository(infra.pgConn)
 	metadataRepo := mongodb.NewMetadataMongoDBRepository(mongoConn)
 	redisRepo, err := redis.NewConsumerRedis(redisConn)

--- a/components/ledger/internal/adapters/http/in/transaction_primary_read_intent_test.go
+++ b/components/ledger/internal/adapters/http/in/transaction_primary_read_intent_test.go
@@ -1,0 +1,258 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package in
+
+import (
+	"context"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"strings"
+	"testing"
+
+	libConstants "github.com/LerianStudio/lib-commons/v6/commons/constants"
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"github.com/LerianStudio/midaz/v4/components/ledger/internal/adapters/postgres/balance"
+	redis "github.com/LerianStudio/midaz/v4/components/ledger/internal/adapters/redis/transaction"
+	"github.com/LerianStudio/midaz/v4/components/ledger/internal/services/query"
+	"github.com/LerianStudio/midaz/v4/components/ledger/pkg/readrouting"
+	"github.com/LerianStudio/midaz/v4/pkg/constant"
+	"github.com/LerianStudio/midaz/v4/pkg/mmodel"
+	"github.com/LerianStudio/midaz/v4/pkg/mtransaction"
+	"github.com/LerianStudio/midaz/v4/pkg/utils"
+)
+
+// TestCreateTransaction_MarksPrimaryReadIntent locks the ADR-001 decision that
+// the transaction-create flow marks its pre-write balance reads with the
+// primary-read intent so the read-routing seam can steer the DB miss to the
+// primary. It asserts on the two facets that make the mechanism real:
+//
+//  1. Mechanism: the intent marker survives the exact call sequence the handler
+//     uses. GetBalances (the direct pre-write read) and enrichOverdraftOperations
+//     (the second, overdraft-enrichment read that reuses the SAME ctx) both
+//     forward a marked ctx down to the seam target — the balance DB repository,
+//     which is where the read-routing seam observes the intent. A negative
+//     baseline proves an unmarked ctx stays unmarked, so the assertion is not
+//     trivially true.
+//  2. Placement: a structural guard over the live source of executeCreateTransaction
+//     proves the `readrouting.WithPrimaryRead(ctx)` wrap actually exists in the
+//     handler and positionally precedes the GetBalances read (and therefore the
+//     overdraft read, which follows it). Runtime mocks cannot catch a future
+//     removal or reorder of the wrap; the AST guard can. This mirrors the
+//     existing fee-seam structural guards (transaction_fee_seam_structure_test.go).
+func TestCreateTransaction_MarksPrimaryReadIntent(t *testing.T) {
+	t.Run("direct_balance_read_forwards_marked_ctx_to_db_seam", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		captured, uc := newPrimaryReadCapturingUseCase(ctrl)
+
+		organizationID := uuid.New()
+		ledgerID := uuid.New()
+		aliases := []string{"@alice#default"}
+
+		// Reproduce the handler's exact call sequence: mark the ctx, then read.
+		ctx := readrouting.WithPrimaryRead(context.Background())
+
+		_, err := uc.GetBalances(ctx, organizationID, ledgerID, aliases)
+		require.NoError(t, err)
+
+		require.True(t, captured.seen, "balance DB repository was never reached; the cache-miss path must fall through to the seam target")
+		assert.True(t, captured.primaryRead, "the ctx reaching the balance DB seam must carry the primary-read intent")
+	})
+
+	t.Run("overdraft_enrichment_read_forwards_marked_ctx_to_db_seam", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		captured, uc := newPrimaryReadCapturingUseCase(ctrl)
+
+		handler := &TransactionHandler{Query: uc}
+
+		orgID := uuid.New()
+		ledgerID := uuid.New()
+
+		source := overdraftEnabledBalance(t, "@alice", decimal.NewFromInt(50), "100")
+
+		primary := mmodel.BalanceOperation{
+			Balance: source,
+			Alias:   "0#@alice#default",
+			Amount: mtransaction.Amount{
+				Asset:           "BRL",
+				Value:           decimal.NewFromInt(100),
+				Operation:       libConstants.DEBIT,
+				TransactionType: libConstants.CREATED,
+				Direction:       constant.DirectionCredit,
+			},
+			InternalKey: utils.BalanceInternalKey(orgID, ledgerID, "@alice#default"),
+		}
+
+		validate := &mtransaction.Responses{
+			From:    map[string]mtransaction.Amount{"0#@alice#default": primary.Amount},
+			Sources: []string{"@alice#default"},
+			Aliases: []string{"@alice#default"},
+		}
+
+		// enrichOverdraftOperations is invoked with the SAME wrapped ctx the
+		// handler holds, and the loader is handler.Query.GetBalances exactly as
+		// at the create call site. The overdraft read must therefore forward the
+		// mark down to the same DB seam target.
+		ctx := readrouting.WithPrimaryRead(context.Background())
+
+		_, _, err := enrichOverdraftOperations(ctx, orgID, ledgerID,
+			[]mmodel.BalanceOperation{primary}, validate, handler.Query.GetBalances)
+		require.NoError(t, err)
+
+		require.True(t, captured.seen, "overdraft companion read never reached the balance DB seam")
+		assert.True(t, captured.primaryRead, "the ctx reaching the balance DB seam via the overdraft read must carry the primary-read intent")
+	})
+
+	t.Run("unmarked_baseline_ctx_is_not_marked", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		captured, uc := newPrimaryReadCapturingUseCase(ctrl)
+
+		_, err := uc.GetBalances(context.Background(), uuid.New(), uuid.New(), []string{"@alice#default"})
+		require.NoError(t, err)
+
+		require.True(t, captured.seen)
+		assert.False(t, captured.primaryRead, "a pure/unmarked read must NOT carry the primary-read intent")
+	})
+
+	t.Run("wrap_exists_and_precedes_get_balances_in_source", func(t *testing.T) {
+		src := readSeamSource(t)
+
+		wrapPos, getBalancesPos := analyzePrimaryReadWrap(t, src, "executeCreateTransaction")
+
+		if wrapPos == -1 {
+			t.Fatal("no `readrouting.WithPrimaryRead(ctx)` wrap found in executeCreateTransaction; the create flow does not mark the primary-read intent")
+		}
+
+		if getBalancesPos == -1 {
+			t.Fatal("no GetBalances call found in executeCreateTransaction; the read call site moved")
+		}
+
+		if wrapPos >= getBalancesPos {
+			t.Errorf("the WithPrimaryRead wrap (stmt %d) must precede the GetBalances read (stmt %d) so both pre-write balance reads observe the mark", wrapPos, getBalancesPos)
+		}
+	})
+}
+
+// primaryReadCapture records what the balance DB seam observed.
+type primaryReadCapture struct {
+	seen        bool
+	primaryRead bool
+}
+
+// newPrimaryReadCapturingUseCase builds a real query.UseCase whose Redis cache
+// always misses (forcing GetBalances to fall through to the DB seam) and whose
+// balance DB repository records the primary-read intent of the ctx it receives.
+func newPrimaryReadCapturingUseCase(ctrl *gomock.Controller) (*primaryReadCapture, *query.UseCase) {
+	captured := &primaryReadCapture{}
+
+	mockRedis := redis.NewMockRedisRepository(ctrl)
+	mockBalance := balance.NewMockRepository(ctrl)
+
+	// Cache miss on every alias: empty value -> GetBalances falls through to DB.
+	mockRedis.EXPECT().
+		Get(gomock.Any(), gomock.Any()).
+		Return("", nil).
+		AnyTimes()
+
+	mockBalance.EXPECT().
+		ListByAliasesWithKeys(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, _, _ uuid.UUID, aliases []string) ([]*mmodel.Balance, error) {
+			captured.seen = true
+			captured.primaryRead = readrouting.IsPrimaryRead(ctx)
+
+			out := make([]*mmodel.Balance, 0, len(aliases))
+			for _, a := range aliases {
+				alias, _, _ := strings.Cut(a, "#")
+				out = append(out, companionOverdraftBalance(alias))
+			}
+
+			return out, nil
+		}).
+		AnyTimes()
+
+	uc := &query.UseCase{
+		BalanceRepo:          mockBalance,
+		TransactionRedisRepo: mockRedis,
+	}
+
+	return captured, uc
+}
+
+// analyzePrimaryReadWrap returns the top-level statement indices, within the
+// named function body, of the `readrouting.WithPrimaryRead(...)` wrap and the
+// first `GetBalances(...)` call. Either is -1 when absent. Statement indices are
+// sufficient because both live at the top level of the strictly-sequential
+// create flow.
+func analyzePrimaryReadWrap(t *testing.T, src, funcName string) (wrapPos, getBalancesPos int) {
+	t.Helper()
+
+	fset := token.NewFileSet()
+
+	file, err := parser.ParseFile(fset, "src.go", src, 0)
+	if err != nil {
+		t.Fatalf("parse source: %v", err)
+	}
+
+	var fn *ast.FuncDecl
+
+	for _, decl := range file.Decls {
+		if d, ok := decl.(*ast.FuncDecl); ok && d.Name.Name == funcName {
+			fn = d
+			break
+		}
+	}
+
+	if fn == nil || fn.Body == nil {
+		t.Fatalf("function %q not found or has no body", funcName)
+	}
+
+	wrapPos, getBalancesPos = -1, -1
+
+	for i, stmt := range fn.Body.List {
+		if wrapPos == -1 && stmtCallsSelector(stmt, "readrouting", "WithPrimaryRead") {
+			wrapPos = i
+		}
+
+		if getBalancesPos == -1 && stmtCallsMethod(stmt, "GetBalances") {
+			getBalancesPos = i
+		}
+	}
+
+	return wrapPos, getBalancesPos
+}
+
+// stmtCallsSelector reports whether the statement contains a call of the form
+// pkg.Fn(...), matching both the package identifier and the function name.
+func stmtCallsSelector(stmt ast.Stmt, pkg, fn string) bool {
+	found := false
+
+	ast.Inspect(stmt, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+
+		if sel, ok := call.Fun.(*ast.SelectorExpr); ok && sel.Sel.Name == fn {
+			if id, ok := sel.X.(*ast.Ident); ok && id.Name == pkg {
+				found = true
+			}
+		}
+
+		return true
+	})
+
+	return found
+}

--- a/components/ledger/internal/adapters/postgres/balance/balance.postgresql.go
+++ b/components/ledger/internal/adapters/postgres/balance/balance.postgresql.go
@@ -28,11 +28,14 @@ import (
 	"github.com/google/uuid"
 	"github.com/lib/pq"
 	"github.com/shopspring/decimal"
+	"go.opentelemetry.io/otel/trace"
 
+	"github.com/LerianStudio/midaz/v4/components/ledger/internal/adapters/postgres/readseam"
 	"github.com/LerianStudio/midaz/v4/pkg"
 	"github.com/LerianStudio/midaz/v4/pkg/constant"
 	"github.com/LerianStudio/midaz/v4/pkg/mmodel"
 	"github.com/LerianStudio/midaz/v4/pkg/net/http"
+	"github.com/LerianStudio/midaz/v4/pkg/repository"
 )
 
 var balanceColumnList = []string{
@@ -84,16 +87,20 @@ type Repository interface {
 
 // BalancePostgreSQLRepository is a Postgresql-specific implementation of the BalanceRepository.
 type BalancePostgreSQLRepository struct {
-	connection    *libPostgres.Client
-	tableName     string
-	requireTenant bool
+	connection            *libPostgres.Client
+	tableName             string
+	requireTenant         bool
+	routeTxReadsToPrimary bool
 }
 
 // NewBalancePostgreSQLRepository returns a new instance of BalancePostgreSQLRepository using the given Postgres connection.
-func NewBalancePostgreSQLRepository(pc *libPostgres.Client, requireTenant ...bool) *BalancePostgreSQLRepository {
+// routeTxReadsToPrimary enables routing transactional-flow reads to the primary
+// (via a read-only transaction) when the request carries the primary-read intent.
+func NewBalancePostgreSQLRepository(pc *libPostgres.Client, routeTxReadsToPrimary bool, requireTenant ...bool) *BalancePostgreSQLRepository {
 	c := &BalancePostgreSQLRepository{
-		connection: pc,
-		tableName:  "balance",
+		connection:            pc,
+		tableName:             "balance",
+		routeTxReadsToPrimary: routeTxReadsToPrimary,
 	}
 	if len(requireTenant) > 0 {
 		c.requireTenant = requireTenant[0]
@@ -125,6 +132,35 @@ func (r *BalancePostgreSQLRepository) getDB(ctx context.Context) (dbresolver.DB,
 	}
 
 	return r.connection.Resolver(ctx)
+}
+
+// acquireRead resolves the read handle for the current request and a release
+// func that MUST be deferred by the caller. The routing decision (direct replica
+// read vs. read-only transaction pinned to the primary) lives in the readseam
+// package; this method only supplies the resolved connection and the flag.
+func (r *BalancePostgreSQLRepository) acquireRead(ctx context.Context) (repository.DBReader, func() error, error) {
+	db, err := r.getDB(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// The read-source signal is emitted inside the seam; balance keeps its
+	// 3-return so the read call sites stay untouched.
+	reader, release, _, err := readseam.AcquireReadFrom(ctx, db, r.routeTxReadsToPrimary)
+
+	return reader, release, err
+}
+
+// releaseRead runs the acquire-seam release func and records any finalize error
+// on the span. Read methods defer this so a read-only tx is always finalized.
+func releaseRead(span trace.Span, release func() error) {
+	if release == nil {
+		return
+	}
+
+	if err := release(); err != nil {
+		libOpentelemetry.HandleSpanError(span, "Failed to release read", err)
+	}
 }
 
 func (r *BalancePostgreSQLRepository) Create(ctx context.Context, balance *mmodel.Balance) (*mmodel.Balance, error) {
@@ -246,12 +282,13 @@ func (r *BalancePostgreSQLRepository) ListByAccountIDs(ctx context.Context, orga
 	ctx, span := tracer.Start(ctx, "postgres.list_balances_by_ids")
 	defer span.End()
 
-	db, err := r.getDB(ctx)
+	db, release, err := r.acquireRead(ctx)
 	if err != nil {
 		libOpentelemetry.HandleSpanError(span, "Failed to get database connection", err)
 
 		return nil, err
 	}
+	defer releaseRead(span, release)
 
 	var balances []*mmodel.Balance
 
@@ -334,11 +371,12 @@ func (r *BalancePostgreSQLRepository) ListByIDs(ctx context.Context, organizatio
 		return []*mmodel.Balance{}, nil
 	}
 
-	db, err := r.getDB(ctx)
+	db, release, err := r.acquireRead(ctx)
 	if err != nil {
 		libOpentelemetry.HandleSpanError(span, "Failed to get database connection", err)
 		return nil, err
 	}
+	defer releaseRead(span, release)
 
 	var balances []*mmodel.Balance
 
@@ -416,12 +454,13 @@ func (r *BalancePostgreSQLRepository) ListAll(ctx context.Context, organizationI
 	ctx, span := tracer.Start(ctx, "postgres.list_all_balances")
 	defer span.End()
 
-	db, err := r.getDB(ctx)
+	db, release, err := r.acquireRead(ctx)
 	if err != nil {
 		libOpentelemetry.HandleSpanError(span, "Failed to get database connection", err)
 
 		return nil, libHTTP.CursorPagination{}, err
 	}
+	defer releaseRead(span, release)
 
 	balances := make([]*mmodel.Balance, 0)
 
@@ -538,12 +577,13 @@ func (r *BalancePostgreSQLRepository) ListAllByAccountID(ctx context.Context, or
 	ctx, span := tracer.Start(ctx, "postgres.list_all_balances_by_account_id")
 	defer span.End()
 
-	db, err := r.getDB(ctx)
+	db, release, err := r.acquireRead(ctx)
 	if err != nil {
 		libOpentelemetry.HandleSpanError(span, "Failed to get database connection", err)
 
 		return nil, libHTTP.CursorPagination{}, err
 	}
+	defer releaseRead(span, release)
 
 	balances := make([]*mmodel.Balance, 0)
 
@@ -661,12 +701,13 @@ func (r *BalancePostgreSQLRepository) ListByAliases(ctx context.Context, organiz
 	ctx, span := tracer.Start(ctx, "postgres.list_balances_by_aliases")
 	defer span.End()
 
-	db, err := r.getDB(ctx)
+	db, release, err := r.acquireRead(ctx)
 	if err != nil {
 		libOpentelemetry.HandleSpanError(span, "Failed to get database connection", err)
 
 		return nil, err
 	}
+	defer releaseRead(span, release)
 
 	var balances []*mmodel.Balance
 
@@ -749,11 +790,12 @@ func (r *BalancePostgreSQLRepository) ListByAliasesWithKeys(ctx context.Context,
 		return []*mmodel.Balance{}, nil
 	}
 
-	db, err := r.getDB(ctx)
+	db, release, err := r.acquireRead(ctx)
 	if err != nil {
 		libOpentelemetry.HandleSpanError(span, "Failed to get database connection", err)
 		return nil, err
 	}
+	defer releaseRead(span, release)
 
 	orConditions := make(squirrel.Or, 0, len(aliasesWithKeys))
 
@@ -946,12 +988,13 @@ func (r *BalancePostgreSQLRepository) Find(ctx context.Context, organizationID, 
 	ctx, span := tracer.Start(ctx, "postgres.find_balance")
 	defer span.End()
 
-	db, err := r.getDB(ctx)
+	db, release, err := r.acquireRead(ctx)
 	if err != nil {
 		libOpentelemetry.HandleSpanError(span, "Failed to get database connection", err)
 
 		return nil, err
 	}
+	defer releaseRead(span, release)
 
 	balance := &BalancePostgreSQLModel{}
 
@@ -1020,12 +1063,13 @@ func (r *BalancePostgreSQLRepository) FindByAccountIDAndKey(ctx context.Context,
 	ctx, span := tracer.Start(ctx, "postgres.find_balance_by_account_id_and_key")
 	defer span.End()
 
-	db, err := r.getDB(ctx)
+	db, release, err := r.acquireRead(ctx)
 	if err != nil {
 		libOpentelemetry.HandleSpanError(span, "Failed to get database connection", err)
 
 		return nil, err
 	}
+	defer releaseRead(span, release)
 
 	balance := &BalancePostgreSQLModel{}
 
@@ -1087,12 +1131,13 @@ func (r *BalancePostgreSQLRepository) ExistsByAccountIDAndKey(ctx context.Contex
 	ctx, span := tracer.Start(ctx, "postgres.exists_balance_by_account_id_and_key")
 	defer span.End()
 
-	db, err := r.getDB(ctx)
+	db, release, err := r.acquireRead(ctx)
 	if err != nil {
 		libOpentelemetry.HandleSpanError(span, "Failed to get database connection", err)
 
 		return false, err
 	}
+	defer releaseRead(span, release)
 
 	_, spanQuery := tracer.Start(ctx, "postgres.exists.query")
 
@@ -1571,11 +1616,12 @@ func (r *BalancePostgreSQLRepository) ListByAccountID(ctx context.Context, organ
 	ctx, span := tracer.Start(ctx, "postgres.list_balances_by_account_id")
 	defer span.End()
 
-	db, err := r.getDB(ctx)
+	db, release, err := r.acquireRead(ctx)
 	if err != nil {
 		libOpentelemetry.HandleSpanError(span, "Failed to get database connection", err)
 		return nil, err
 	}
+	defer releaseRead(span, release)
 
 	var balances []*mmodel.Balance
 
@@ -1652,11 +1698,12 @@ func (r *BalancePostgreSQLRepository) ListByAccountIDAtTimestamp(ctx context.Con
 	ctx, span := tracer.Start(ctx, "postgres.list_balances_by_account_id_at_timestamp")
 	defer span.End()
 
-	db, err := r.getDB(ctx)
+	db, release, err := r.acquireRead(ctx)
 	if err != nil {
 		libOpentelemetry.HandleSpanError(span, "Failed to get database connection", err)
 		return nil, err
 	}
+	defer releaseRead(span, release)
 
 	balances := make([]*mmodel.Balance, 0)
 

--- a/components/ledger/internal/adapters/postgres/balance/balance.postgresql_integration_test.go
+++ b/components/ledger/internal/adapters/postgres/balance/balance.postgresql_integration_test.go
@@ -35,7 +35,7 @@ func createRepository(t *testing.T, container *pgtestutil.ContainerResult) *Bala
 
 	conn := pgtestutil.CreatePostgresClient(t, connStr, connStr, container.Config.DBName, migrationsPath)
 
-	return NewBalancePostgreSQLRepository(conn)
+	return NewBalancePostgreSQLRepository(conn, false)
 }
 
 // createTestAccountForBalance inserts a minimal account directly for balance tests.

--- a/components/ledger/internal/adapters/postgres/balance/balance_read_routing_divergence_integration_test.go
+++ b/components/ledger/internal/adapters/postgres/balance/balance_read_routing_divergence_integration_test.go
@@ -1,0 +1,189 @@
+//go:build integration
+
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package balance
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	libCommons "github.com/LerianStudio/lib-commons/v6/commons"
+	libPostgres "github.com/LerianStudio/lib-commons/v6/commons/postgres"
+	"github.com/google/uuid"
+	"github.com/redis/go-redis/v9"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/LerianStudio/midaz/v4/components/ledger/pkg/readrouting"
+	"github.com/LerianStudio/midaz/v4/pkg/utils"
+	pgtestutil "github.com/LerianStudio/midaz/v4/tests/utils/postgres"
+	redistestutil "github.com/LerianStudio/midaz/v4/tests/utils/redis"
+)
+
+// TestTransactionalRead_UnderDivergence proves the read-routing feature end-to-end
+// under a PRIMARY/REPLICA divergence, on the NX-seed money path (balance absent in
+// Redis -> hydrated from Postgres).
+//
+// Real streaming replication is non-deterministic, so instead we provision TWO
+// INDEPENDENT Postgres containers wired as "primary" (A) and "replica" (B) behind a
+// single dbresolver-backed *libPostgres.Client. They do NOT replicate: their contents
+// are controlled independently. Writing a balance row ONLY to A and leaving B without
+// that row simulates INFINITE replication lag deterministically.
+//
+// dbresolver routes non-transactional reads (QueryContext) to the replica pool (B) and
+// pins read-only BeginTx to the primary pool (A). readseam.AcquireReadFrom opens a
+// read-only tx exactly when the rollout flag is on AND the context carries the
+// primary-read intent, which is what routes the read to A. This is the seam under test.
+//
+// Placement rationale: this file lives at the balance repository layer because the
+// most honest exercise of the NX-seed read is repo.ListByAliasesWithKeys -- the exact
+// method query.UseCase.GetBalances falls through to on a Redis cache miss. Asserting
+// here keeps the two-Postgres divergence the SOLE variable and avoids dragging the
+// tenant-namespaced Redis key path and full UseCase wiring into the routing signal.
+// A real Redis container is still provisioned and the balance key is verified ABSENT
+// so the NX-seed (cache miss -> Postgres) precondition is documented and enforced.
+func TestTransactionalRead_UnderDivergence(t *testing.T) {
+	// --- Two independent Postgres containers: A = primary, B = replica ---
+	primary := pgtestutil.SetupContainer(t) // A
+	replica := pgtestutil.SetupContainer(t) // B
+
+	migrationsPath := pgtestutil.FindMigrationsPath(t, "transaction")
+
+	primaryDSN := pgtestutil.BuildConnectionString(primary.Host, primary.Port, primary.Config)
+	replicaDSN := pgtestutil.BuildConnectionString(replica.Host, replica.Port, replica.Config)
+
+	// Migrate BOTH databases so the schema (balance table) exists in each. The
+	// divergence under test is ROW CONTENT, not schema: A has the row, B does not.
+	migrateSchema(t, primaryDSN, primary.Config.DBName, migrationsPath)
+	migrateSchema(t, replicaDSN, replica.Config.DBName, migrationsPath)
+
+	// Single lib-commons client wiring PrimaryDSN -> A and ReplicaDSN -> B, mirroring
+	// how bootstrap/config.postgres.transaction*.go builds the transactional client.
+	conn, err := libPostgres.New(libPostgres.Config{
+		PrimaryDSN: primaryDSN,
+		ReplicaDSN: replicaDSN,
+	})
+	require.NoError(t, err, "failed to build postgres client over A(primary)/B(replica)")
+	require.NoError(t, conn.Connect(context.Background()), "failed to connect postgres client")
+
+	t.Cleanup(func() {
+		if closeErr := conn.Close(); closeErr != nil {
+			t.Logf("failed to close postgres client: %v", closeErr)
+		}
+	})
+
+	// --- Redis container for the cache overlay (NX-seed precondition) ---
+	redisResult := redistestutil.SetupContainer(t)
+
+	// --- Divergence: seed the balance ONLY in A (primary) with a KNOWN fresh value ---
+	orgID := uuid.Must(libCommons.GenerateUUIDv7())
+	ledgerID := uuid.Must(libCommons.GenerateUUIDv7())
+	accountID := uuid.Must(libCommons.GenerateUUIDv7())
+
+	const (
+		alias        = "@divergence"
+		balanceKey   = "default"
+		aliasWithKey = alias + "#" + balanceKey
+	)
+
+	primaryFresh := decimal.NewFromInt(777)
+
+	params := pgtestutil.DefaultBalanceParams()
+	params.Alias = alias
+	params.Key = balanceKey
+	params.Available = primaryFresh
+	pgtestutil.CreateTestBalance(t, primary.DB, orgID, ledgerID, accountID, params)
+
+	// Guard the divergence deterministically: A HAS the row, B does NOT.
+	requireRowCount(t, primary.DB, orgID, ledgerID, alias, 1, "primary (A) must contain the seeded row")
+	requireRowCount(t, replica.DB, orgID, ledgerID, alias, 0, "replica (B) must NOT contain the seeded row")
+
+	// --- NX-seed precondition: force the Redis balance key ABSENT ---
+	internalKey := utils.BalanceInternalKey(orgID, ledgerID, aliasWithKey)
+	requireRedisKeyAbsent(t, redisResult.Client, internalKey)
+
+	ctx := context.Background()
+
+	// Subtest 1: flag ON + intent marked -> reads PRIMARY (A) fresh value.
+	t.Run("flag_on_intent_marked_reads_primary_NX_seed", func(t *testing.T) {
+		repo := NewBalancePostgreSQLRepository(conn, true)
+
+		markedCtx := readrouting.WithPrimaryRead(ctx)
+
+		balances, err := repo.ListByAliasesWithKeys(markedCtx, orgID, ledgerID, []string{aliasWithKey})
+		require.NoError(t, err, "read routed to primary should succeed")
+		require.Len(t, balances, 1, "primary (A) holds the fresh row, so exactly one balance is returned")
+
+		assert.Equal(t, alias, balances[0].Alias, "alias should match the primary row")
+		assert.True(t, balances[0].Available.Equal(primaryFresh),
+			"routed read must return A's fresh value (%s), got %s", primaryFresh, balances[0].Available)
+	})
+
+	// Subtest 2: flag OFF -> reads REPLICA (B), which lacks the row (documents current behavior).
+	t.Run("flag_off_reads_replica_missing_row", func(t *testing.T) {
+		repo := NewBalancePostgreSQLRepository(conn, false)
+
+		// Intent marker is irrelevant when the flag is off; mark it to prove the flag
+		// alone gates routing.
+		markedCtx := readrouting.WithPrimaryRead(ctx)
+
+		balances, err := repo.ListByAliasesWithKeys(markedCtx, orgID, ledgerID, []string{aliasWithKey})
+		require.NoError(t, err, "replica read should succeed even when the row is absent")
+		assert.Empty(t, balances,
+			"flag OFF reads replica (B), which does not have the diverged row -> empty result")
+	})
+
+	// Subtest 3: pure query (unmarked ctx) with flag ON -> stays on REPLICA (B).
+	t.Run("pure_query_unmarked_ctx_stays_on_replica", func(t *testing.T) {
+		repo := NewBalancePostgreSQLRepository(conn, true)
+
+		// No WithPrimaryRead: a pure/read-only query must be unaffected by the rollout.
+		balances, err := repo.ListByAliasesWithKeys(ctx, orgID, ledgerID, []string{aliasWithKey})
+		require.NoError(t, err, "pure query on replica should succeed")
+		assert.Empty(t, balances,
+			"unmarked ctx with flag ON must read replica (B) -> empty result, proving pure queries are unaffected")
+	})
+}
+
+// migrateSchema applies the transaction-component migrations to the target DSN.
+// Used to bring BOTH the primary (A) and replica (B) databases to the same schema so
+// the divergence under test is purely row content.
+func migrateSchema(t *testing.T, dsn, dbName, migrationsPath string) {
+	t.Helper()
+
+	migrator, err := libPostgres.NewMigrator(libPostgres.MigrationConfig{
+		PrimaryDSN:     dsn,
+		DatabaseName:   dbName,
+		MigrationsPath: migrationsPath,
+	})
+	require.NoError(t, err, "failed to create migrator for %s", dbName)
+	require.NoError(t, migrator.Up(context.Background()), "failed to run migrations for %s", dbName)
+}
+
+// requireRowCount asserts the number of non-deleted balance rows for an alias in a raw
+// database handle, making the primary/replica divergence explicit and deterministic.
+func requireRowCount(t *testing.T, db *sql.DB, orgID, ledgerID uuid.UUID, alias string, want int, msg string) {
+	t.Helper()
+
+	var got int
+	err := db.QueryRow(
+		`SELECT COUNT(*) FROM balance WHERE organization_id = $1 AND ledger_id = $2 AND alias = $3 AND deleted_at IS NULL`,
+		orgID, ledgerID, alias,
+	).Scan(&got)
+	require.NoError(t, err, "failed to count balance rows: %s", msg)
+	require.Equal(t, want, got, msg)
+}
+
+// requireRedisKeyAbsent asserts the given key is not present in Redis, enforcing the
+// NX-seed precondition (cache miss -> read falls through to Postgres).
+func requireRedisKeyAbsent(t *testing.T, client *redis.Client, key string) {
+	t.Helper()
+
+	_, err := client.Get(context.Background(), key).Result()
+	require.ErrorIs(t, err, redis.Nil, "Redis balance key must be ABSENT for the NX-seed path")
+}

--- a/components/ledger/internal/adapters/postgres/readseam/readseam.go
+++ b/components/ledger/internal/adapters/postgres/readseam/readseam.go
@@ -10,6 +10,7 @@ package readseam
 import (
 	"context"
 	"database/sql"
+	"fmt"
 
 	libObservability "github.com/LerianStudio/lib-observability/v2"
 	libLog "github.com/LerianStudio/lib-observability/v2/log"
@@ -81,18 +82,29 @@ func AcquireReadFrom(ctx context.Context, conn ReadConn, routeToPrimary bool) (r
 		return conn, func() error { return nil }, ReadSourceReplica, nil
 	}
 
+	// Fail fast on an already-cancelled context: a caller cancellation is not a
+	// technical failure, so it must not flip the span red (telemetry T5). Return
+	// the wrapped ctx error and no reader (fail-closed) before the BeginTx round-trip.
+	if err := ctx.Err(); err != nil {
+		return nil, nil, "", fmt.Errorf("primary read aborted before opening transaction: %w", err)
+	}
+
 	tx, err := conn.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
 	if err != nil {
 		libOpentelemetry.HandleSpanError(trace.SpanFromContext(ctx), "Failed to open read-only transaction for primary read", err)
 
-		return nil, nil, "", err
+		return nil, nil, "", fmt.Errorf("open read-only primary read transaction: %w", err)
 	}
 
 	recordReadSource(ctx, ReadSourcePrimary)
 
 	// A read-only tx performs no writes; committing just releases the connection.
 	release := func() error {
-		return tx.Commit()
+		if err := tx.Commit(); err != nil {
+			return fmt.Errorf("commit read-only primary read transaction: %w", err)
+		}
+
+		return nil
 	}
 
 	return tx, release, ReadSourcePrimary, nil

--- a/components/ledger/internal/adapters/postgres/readseam/readseam.go
+++ b/components/ledger/internal/adapters/postgres/readseam/readseam.go
@@ -1,0 +1,122 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+// Package readseam decides the read source for a request: a direct connection
+// (replica) or a read-only transaction pinned to the primary. It isolates the
+// dbresolver coupling so entity adapters depend only on repository.DBReader.
+package readseam
+
+import (
+	"context"
+	"database/sql"
+
+	libObservability "github.com/LerianStudio/lib-observability/v2"
+	libLog "github.com/LerianStudio/lib-observability/v2/log"
+	libOpentelemetry "github.com/LerianStudio/lib-observability/v2/tracing"
+	"github.com/bxcodec/dbresolver/v2"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/LerianStudio/midaz/v4/components/ledger/pkg/readrouting"
+	"github.com/LerianStudio/midaz/v4/pkg/repository"
+	"github.com/LerianStudio/midaz/v4/pkg/utils"
+)
+
+// ReadSource identifies which database served a read. It is used as both the
+// AcquireReadFrom return value and the span-attribute / metric-label string.
+type ReadSource string
+
+const (
+	// ReadSourcePrimary marks a read served by the primary (read-only tx).
+	ReadSourcePrimary ReadSource = "primary"
+	// ReadSourceReplica marks a read served directly by the resolved handle (replica).
+	ReadSourceReplica ReadSource = "replica"
+)
+
+// readSourceAttributeKey is the span attribute recording the served read source.
+const readSourceAttributeKey = "db.read_source"
+
+// readSourceLabels holds the precomputed counter label map per read source so the
+// hot read path reuses one map per branch instead of allocating a fresh map on
+// every read. Safe to share: the metrics builder's WithLabels only reads the map
+// (copies entries into its own attribute slice) and never retains or mutates it.
+var readSourceLabels = map[ReadSource]map[string]string{
+	ReadSourcePrimary: {"source": string(ReadSourcePrimary)},
+	ReadSourceReplica: {"source": string(ReadSourceReplica)},
+}
+
+// ReadConn is a connection handle that can serve reads and open a read-only tx.
+// dbresolver.DB satisfies it directly (no wrapper needed).
+type ReadConn interface {
+	repository.DBReader
+	BeginTx(ctx context.Context, opts *sql.TxOptions) (dbresolver.Tx, error)
+}
+
+// Compile-time guarantees that both dbresolver handles satisfy the read surface,
+// that dbresolver.Tx is a finalizable read tx, and that dbresolver.DB satisfies
+// the acquire seam's handle interface.
+var (
+	_ repository.DBReader = (dbresolver.DB)(nil)
+	_ repository.DBReader = (dbresolver.Tx)(nil)
+	_ repository.DBReadTx = (dbresolver.Tx)(nil)
+	_ ReadConn            = (dbresolver.DB)(nil)
+)
+
+// AcquireReadFrom decides the read source and returns a release func the caller
+// MUST defer.
+//
+// When routeToPrimary is enabled AND the context carries the primary-read intent,
+// the read is wrapped in a read-only transaction so dbresolver routes it to the
+// primary (BeginTx always targets the primary). Otherwise it returns the handle
+// directly and a no-op release, preserving replica read behavior byte-for-byte.
+//
+// Fail-closed: when the read-only transaction cannot be opened, the error is
+// returned and NO direct/replica reader is handed back. For a ledger, reading
+// wrong state is worse than failing.
+func AcquireReadFrom(ctx context.Context, conn ReadConn, routeToPrimary bool) (repository.DBReader, func() error, ReadSource, error) {
+	if !routeToPrimary || !readrouting.IsPrimaryRead(ctx) {
+		recordReadSource(ctx, ReadSourceReplica)
+
+		return conn, func() error { return nil }, ReadSourceReplica, nil
+	}
+
+	tx, err := conn.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
+	if err != nil {
+		libOpentelemetry.HandleSpanError(trace.SpanFromContext(ctx), "Failed to open read-only transaction for primary read", err)
+
+		return nil, nil, "", err
+	}
+
+	recordReadSource(ctx, ReadSourcePrimary)
+
+	// A read-only tx performs no writes; committing just releases the connection.
+	release := func() error {
+		return tx.Commit()
+	}
+
+	return tx, release, ReadSourcePrimary, nil
+}
+
+// recordReadSource emits the RF-06 read-source signal for a served read: the
+// db.read_source attribute on the caller's existing span and the
+// db_read_source_total counter. It is best-effort — an unavailable metrics
+// factory is swallowed at Debug and never fails the read; it never panics and
+// never opens a child span.
+func recordReadSource(ctx context.Context, source ReadSource) {
+	trace.SpanFromContext(ctx).SetAttributes(attribute.String(readSourceAttributeKey, string(source)))
+
+	logger, _, _, factory := libObservability.NewTrackingFromContext(ctx)
+	if factory == nil {
+		return
+	}
+
+	counter, err := factory.Counter(utils.DBReadSourceTotal)
+	if err == nil {
+		err = counter.WithLabels(readSourceLabels[source]).Add(ctx, 1)
+	}
+
+	if err != nil && logger != nil {
+		logger.Log(ctx, libLog.LevelDebug, "Failed to emit read-source counter", libLog.Err(err))
+	}
+}

--- a/components/ledger/internal/adapters/postgres/readseam/readseam_test.go
+++ b/components/ledger/internal/adapters/postgres/readseam/readseam_test.go
@@ -204,6 +204,28 @@ func TestAcquireReadFrom_FailClosedOnBeginTxError(t *testing.T) {
 		"fail-closed must NOT emit a db.read_source attribute")
 }
 
+// TestAcquireReadFrom_FailsFastOnCancelledContext proves the primary-read path
+// aborts before the BeginTx round-trip when the caller's context is already
+// cancelled: it returns a context.Canceled error, no reader, no release, the
+// zero ReadSource, and never touches the connection (BeginTx not called).
+func TestAcquireReadFrom_FailsFastOnCancelledContext(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(readrouting.WithPrimaryRead(context.Background()))
+	cancel()
+
+	conn := &fakeReadConn{tx: &fakeTx{}}
+
+	reader, release, source, err := AcquireReadFrom(ctx, conn, true)
+
+	require.Error(t, err, "must fail fast when the context is already cancelled")
+	assert.ErrorIs(t, err, context.Canceled, "must propagate the context cancellation")
+	assert.Nil(t, reader, "must NOT return a reader on cancelled-context fail-fast")
+	assert.Nil(t, release, "must NOT return a release func on cancelled-context fail-fast")
+	assert.Equal(t, ReadSource(""), source, "cancelled-context fail-fast must return the zero ReadSource")
+	assert.False(t, conn.beginCalled, "must NOT open a transaction when the context is already cancelled")
+}
+
 // recordingReadSeamContext starts a recording SDK span on the given context so
 // AcquireReadFrom can attach db.read_source to trace.SpanFromContext(ctx), and
 // returns the child context, the recorder, and the span's End func (which the

--- a/components/ledger/internal/adapters/postgres/readseam/readseam_test.go
+++ b/components/ledger/internal/adapters/postgres/readseam/readseam_test.go
@@ -1,0 +1,476 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package readseam
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+
+	libObservability "github.com/LerianStudio/lib-observability/v2"
+	"github.com/LerianStudio/lib-observability/v2/metrics"
+	"github.com/bxcodec/dbresolver/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/metric/noop"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+
+	"github.com/LerianStudio/midaz/v4/components/ledger/pkg/readrouting"
+	"github.com/LerianStudio/midaz/v4/pkg/utils"
+)
+
+// fakeTx is a minimal dbresolver.Tx double for the read-only transaction path.
+// It records the commit call so tests can assert the release lifecycle and can be
+// primed with commitErr to exercise release-error propagation. The read-only seam
+// finalizes via Commit and never rolls back, so Rollback carries no bookkeeping.
+type fakeTx struct {
+	committed bool
+	commitErr error
+}
+
+func (t *fakeTx) Commit() error {
+	t.committed = true
+
+	return t.commitErr
+}
+
+func (t *fakeTx) Rollback() error { return nil }
+
+func (t *fakeTx) Exec(_ string, _ ...any) (sql.Result, error) { return nil, nil }
+
+func (t *fakeTx) ExecContext(_ context.Context, _ string, _ ...any) (sql.Result, error) {
+	return nil, nil
+}
+
+func (t *fakeTx) Prepare(_ string) (dbresolver.Stmt, error) { return nil, nil }
+
+func (t *fakeTx) PrepareContext(_ context.Context, _ string) (dbresolver.Stmt, error) {
+	return nil, nil
+}
+
+func (t *fakeTx) Query(_ string, _ ...any) (*sql.Rows, error) { return nil, nil }
+
+func (t *fakeTx) QueryContext(_ context.Context, _ string, _ ...any) (*sql.Rows, error) {
+	return nil, nil
+}
+
+func (t *fakeTx) QueryRow(_ string, _ ...any) *sql.Row { return nil }
+
+func (t *fakeTx) QueryRowContext(_ context.Context, _ string, _ ...any) *sql.Row {
+	return nil
+}
+
+func (t *fakeTx) Stmt(_ dbresolver.Stmt) dbresolver.Stmt { return nil }
+
+func (t *fakeTx) StmtContext(_ context.Context, _ dbresolver.Stmt) dbresolver.Stmt { return nil }
+
+// Ensure the fake satisfies the concrete dbresolver.Tx interface used in the seam.
+var _ dbresolver.Tx = (*fakeTx)(nil)
+
+// fakeReadConn is a ReadConn double for exercising AcquireReadFrom without a real
+// dbresolver / database. It records whether BeginTx was invoked so tests can assert
+// which branch the seam took.
+type fakeReadConn struct {
+	beginCalled bool
+	beginOpts   *sql.TxOptions
+	tx          dbresolver.Tx
+	beginErr    error
+}
+
+func (c *fakeReadConn) QueryContext(_ context.Context, _ string, _ ...any) (*sql.Rows, error) {
+	return nil, nil
+}
+
+func (c *fakeReadConn) QueryRowContext(_ context.Context, _ string, _ ...any) *sql.Row {
+	return nil
+}
+
+func (c *fakeReadConn) BeginTx(_ context.Context, opts *sql.TxOptions) (dbresolver.Tx, error) {
+	c.beginCalled = true
+	c.beginOpts = opts
+
+	if c.beginErr != nil {
+		return nil, c.beginErr
+	}
+
+	return c.tx, nil
+}
+
+// Ensure the fake satisfies the seam's handle interface.
+var _ ReadConn = (*fakeReadConn)(nil)
+
+func TestAcquireReadFrom(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		routeToPrimary bool
+		primaryIntent  bool
+		wantBeginTx    bool
+	}{
+		{
+			name:           "flag off, intent absent -> direct read (no BeginTx)",
+			routeToPrimary: false,
+			primaryIntent:  false,
+			wantBeginTx:    false,
+		},
+		{
+			name:           "flag off, intent present -> direct read (no BeginTx)",
+			routeToPrimary: false,
+			primaryIntent:  true,
+			wantBeginTx:    false,
+		},
+		{
+			name:           "flag on, intent absent -> direct read (no BeginTx)",
+			routeToPrimary: true,
+			primaryIntent:  false,
+			wantBeginTx:    false,
+		},
+		{
+			name:           "flag on, intent present -> read-only tx opened (BeginTx)",
+			routeToPrimary: true,
+			primaryIntent:  true,
+			wantBeginTx:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := context.Background()
+			if tt.primaryIntent {
+				ctx = readrouting.WithPrimaryRead(ctx)
+			}
+
+			ftx := &fakeTx{}
+			conn := &fakeReadConn{tx: ftx}
+
+			reader, release, _, err := AcquireReadFrom(ctx, conn, tt.routeToPrimary)
+			require.NoError(t, err)
+			require.NotNil(t, reader)
+			require.NotNil(t, release)
+
+			assert.Equal(t, tt.wantBeginTx, conn.beginCalled, "BeginTx branch mismatch")
+
+			if tt.wantBeginTx {
+				// read-only tx opened with ReadOnly option, reader IS the tx
+				require.NotNil(t, conn.beginOpts)
+				assert.True(t, conn.beginOpts.ReadOnly, "tx must be read-only")
+				assert.Same(t, dbresolver.Tx(ftx), reader.(dbresolver.Tx),
+					"reader must be the read-only tx")
+
+				require.NoError(t, release())
+				assert.True(t, ftx.committed, "read-only tx must be finalized (committed) on release")
+			} else {
+				// direct path: reader is the connection, release is a no-op
+				assert.NoError(t, release())
+				assert.False(t, ftx.committed)
+			}
+		})
+	}
+}
+
+func TestAcquireReadFrom_FailClosedOnBeginTxError(t *testing.T) {
+	t.Parallel()
+
+	ctx := readrouting.WithPrimaryRead(context.Background())
+
+	beginErr := errors.New("primary unavailable")
+	conn := &fakeReadConn{beginErr: beginErr}
+
+	ctx, recorder, endSpan := recordingReadSeamContext(ctx)
+
+	reader, release, source, err := AcquireReadFrom(ctx, conn, true)
+	endSpan()
+
+	require.Error(t, err, "must fail closed when BeginTx fails")
+	assert.ErrorIs(t, err, beginErr, "must propagate the BeginTx error")
+	assert.Nil(t, reader, "must NOT return a replica/direct reader on fail-closed")
+	assert.Nil(t, release, "must NOT return a release func on fail-closed")
+	assert.Equal(t, ReadSource(""), source, "fail-closed must return the zero ReadSource")
+	assert.True(t, conn.beginCalled)
+
+	// The fail-closed path must NOT set a misleading db.read_source attribute.
+	span := endedReadSeamSpan(t, recorder)
+	assert.False(t, hasAttribute(span, "db.read_source"),
+		"fail-closed must NOT emit a db.read_source attribute")
+}
+
+// recordingReadSeamContext starts a recording SDK span on the given context so
+// AcquireReadFrom can attach db.read_source to trace.SpanFromContext(ctx), and
+// returns the child context, the recorder, and the span's End func (which the
+// test MUST call before inspecting recorded attributes).
+func recordingReadSeamContext(ctx context.Context) (context.Context, *tracetest.SpanRecorder, func()) {
+	recorder := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder))
+
+	ctx, span := tp.Tracer("readseam-test").Start(ctx, "readseam.acquire")
+
+	return ctx, recorder, func() { span.End() }
+}
+
+// endedReadSeamSpan returns the single recorded span, failing if none was captured.
+func endedReadSeamSpan(t *testing.T, recorder *tracetest.SpanRecorder) sdktrace.ReadOnlySpan {
+	t.Helper()
+
+	ended := recorder.Ended()
+	require.Len(t, ended, 1, "exactly one span must be recorded")
+
+	return ended[0]
+}
+
+func hasAttribute(span sdktrace.ReadOnlySpan, key string) bool {
+	for _, kv := range span.Attributes() {
+		if string(kv.Key) == key {
+			return true
+		}
+	}
+
+	return false
+}
+
+func attributeValue(span sdktrace.ReadOnlySpan, key string) (string, bool) {
+	for _, kv := range span.Attributes() {
+		if string(kv.Key) == key {
+			return kv.Value.AsString(), true
+		}
+	}
+
+	return "", false
+}
+
+// TestReadSourceObservability locks the RF-06 read-source signal: AcquireReadFrom
+// returns ReadSourcePrimary only when routeToPrimary AND the primary-read intent
+// is present, else ReadSourceReplica; and it records db.read_source on the
+// caller's span matching the returned source in BOTH success branches.
+func TestReadSourceObservability(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		routeToPrimary bool
+		primaryIntent  bool
+		wantSource     ReadSource
+	}{
+		{
+			name:           "flag off, intent absent -> replica",
+			routeToPrimary: false,
+			primaryIntent:  false,
+			wantSource:     ReadSourceReplica,
+		},
+		{
+			name:           "flag off, intent present -> replica (baseline)",
+			routeToPrimary: false,
+			primaryIntent:  true,
+			wantSource:     ReadSourceReplica,
+		},
+		{
+			name:           "flag on, intent absent -> replica",
+			routeToPrimary: true,
+			primaryIntent:  false,
+			wantSource:     ReadSourceReplica,
+		},
+		{
+			name:           "flag on, intent present -> primary",
+			routeToPrimary: true,
+			primaryIntent:  true,
+			wantSource:     ReadSourcePrimary,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := context.Background()
+			if tt.primaryIntent {
+				ctx = readrouting.WithPrimaryRead(ctx)
+			}
+
+			ctx, recorder, endSpan := recordingReadSeamContext(ctx)
+
+			conn := &fakeReadConn{tx: &fakeTx{}}
+
+			_, release, source, err := AcquireReadFrom(ctx, conn, tt.routeToPrimary)
+			require.NoError(t, err)
+			require.NotNil(t, release)
+			require.NoError(t, release())
+			endSpan()
+
+			assert.Equal(t, tt.wantSource, source, "returned ReadSource mismatch")
+
+			span := endedReadSeamSpan(t, recorder)
+			got, ok := attributeValue(span, "db.read_source")
+			require.True(t, ok, "db.read_source attribute must be set in both success branches")
+			assert.Equal(t, string(tt.wantSource), got, "db.read_source attribute must match returned source")
+		})
+	}
+}
+
+// newReaderFactory builds a real MetricsFactory backed by a manual reader so the
+// test can read back the db_read_source_total points emitted by recordReadSource.
+func newReaderFactory(t *testing.T) (*sdkmetric.ManualReader, *metrics.MetricsFactory) {
+	t.Helper()
+
+	reader := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+
+	t.Cleanup(func() { _ = mp.Shutdown(context.Background()) })
+
+	factory, err := metrics.NewMetricsFactory(mp.Meter("readseam-metrics-test"), nil)
+	require.NoError(t, err)
+
+	return reader, factory
+}
+
+// collectReadSourceCounters returns a map of source-label -> value for the
+// db_read_source_total counter.
+func collectReadSourceCounters(t *testing.T, reader *sdkmetric.ManualReader) map[string]int64 {
+	t.Helper()
+
+	var rm metricdata.ResourceMetrics
+
+	require.NoError(t, reader.Collect(context.Background(), &rm))
+
+	totals := make(map[string]int64)
+
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name != utils.DBReadSourceTotal.Name {
+				continue
+			}
+
+			sum, ok := m.Data.(metricdata.Sum[int64])
+			require.True(t, ok, "data type must be Sum[int64], got %T", m.Data)
+
+			for _, dp := range sum.DataPoints {
+				source, _ := dp.Attributes.Value("source")
+				totals[source.AsString()] = dp.Value
+			}
+		}
+	}
+
+	return totals
+}
+
+// TestReadSource_EmitsCounter locks the metric half of the RF-06 signal: when a
+// real MetricsFactory is present on the context, AcquireReadFrom emits
+// db_read_source_total once per call with the correct source label, for BOTH the
+// primary branch (flag on + intent) and the replica branch (flag off). The read
+// itself must never be failed by the metric path.
+func TestReadSource_EmitsCounter(t *testing.T) {
+	t.Parallel()
+
+	reader, factory := newReaderFactory(t)
+
+	ctx := libObservability.ContextWithMetricFactory(context.Background(), factory)
+
+	// Replica branch: flag off -> direct read, source=replica.
+	replicaConn := &fakeReadConn{tx: &fakeTx{}}
+
+	reader1, release1, source1, err := AcquireReadFrom(ctx, replicaConn, false)
+	require.NoError(t, err, "metric emission must never fail the read")
+	require.NotNil(t, reader1)
+	require.NoError(t, release1())
+	assert.Equal(t, ReadSourceReplica, source1)
+
+	// Primary branch: flag on + intent -> read-only tx, source=primary.
+	primaryCtx := readrouting.WithPrimaryRead(ctx)
+	primaryConn := &fakeReadConn{tx: &fakeTx{}}
+
+	reader2, release2, source2, err := AcquireReadFrom(primaryCtx, primaryConn, true)
+	require.NoError(t, err, "metric emission must never fail the read")
+	require.NotNil(t, reader2)
+	require.NoError(t, release2())
+	assert.Equal(t, ReadSourcePrimary, source2)
+	require.True(t, primaryConn.beginCalled, "guard: primary branch must open the read-only tx")
+
+	totals := collectReadSourceCounters(t, reader)
+
+	assert.Equal(t, int64(1), totals[string(ReadSourceReplica)],
+		"one replica read must be counted on db_read_source_total{source=replica}")
+	assert.Equal(t, int64(1), totals[string(ReadSourcePrimary)],
+		"one primary read must be counted on db_read_source_total{source=primary}")
+}
+
+// TestReadSource_NilFactory_SwallowsAndSucceeds exercises the factory==nil guard:
+// when the context carries an explicit nil MetricsFactory, recordReadSource returns
+// early without emitting, and the read still succeeds. This proves the metric path
+// never fails a read even when no factory is available.
+func TestReadSource_NilFactory_SwallowsAndSucceeds(t *testing.T) {
+	t.Parallel()
+
+	ctx := libObservability.ContextWithMetricFactory(context.Background(), nil)
+
+	conn := &fakeReadConn{tx: &fakeTx{}}
+
+	reader, release, source, err := AcquireReadFrom(ctx, conn, false)
+	require.NoError(t, err)
+	require.NotNil(t, reader)
+	require.NotNil(t, release)
+	require.NoError(t, release())
+	assert.Equal(t, ReadSourceReplica, source)
+}
+
+// failingCounterMeter embeds a noop meter and forces Int64Counter to error so a
+// factory built over it makes recordReadSource take its emit-error swallow branch.
+type failingCounterMeter struct {
+	metric.Meter
+}
+
+func (m failingCounterMeter) Int64Counter(string, ...metric.Int64CounterOption) (metric.Int64Counter, error) {
+	return nil, errors.New("counter unavailable")
+}
+
+// TestReadSource_EmitError_SwallowsAndSucceeds exercises the best-effort contract:
+// when the counter cannot be created, recordReadSource swallows the error (logs at
+// Debug) and AcquireReadFrom still returns a valid reader with no error.
+func TestReadSource_EmitError_SwallowsAndSucceeds(t *testing.T) {
+	t.Parallel()
+
+	factory, err := metrics.NewMetricsFactory(
+		failingCounterMeter{Meter: noop.NewMeterProvider().Meter("readseam-fail-test")}, nil)
+	require.NoError(t, err)
+
+	ctx := libObservability.ContextWithMetricFactory(context.Background(), factory)
+
+	conn := &fakeReadConn{tx: &fakeTx{}}
+
+	reader, release, source, err := AcquireReadFrom(ctx, conn, false)
+	require.NoError(t, err, "a metric-emission error must never fail the read")
+	require.NotNil(t, reader)
+	require.NotNil(t, release)
+	require.NoError(t, release())
+	assert.Equal(t, ReadSourceReplica, source)
+}
+
+// TestAcquireReadFrom_PropagatesCommitError verifies the primary path's release func
+// surfaces the read-only tx commit error to the caller.
+func TestAcquireReadFrom_PropagatesCommitError(t *testing.T) {
+	t.Parallel()
+
+	ctx := readrouting.WithPrimaryRead(context.Background())
+
+	commitErr := errors.New("commit failed")
+	ftx := &fakeTx{commitErr: commitErr}
+	conn := &fakeReadConn{tx: ftx}
+
+	reader, release, source, err := AcquireReadFrom(ctx, conn, true)
+	require.NoError(t, err)
+	require.NotNil(t, reader)
+	require.NotNil(t, release)
+	assert.Equal(t, ReadSourcePrimary, source)
+
+	relErr := release()
+	require.Error(t, relErr, "release must surface the commit error")
+	assert.ErrorIs(t, relErr, commitErr, "release must propagate the underlying commit error")
+	assert.True(t, ftx.committed, "release must attempt commit on the read-only tx")
+}

--- a/components/ledger/internal/bootstrap/config.go
+++ b/components/ledger/internal/bootstrap/config.go
@@ -152,6 +152,8 @@ type Config struct {
 	TxnPrefixedMaxOpenConnections int `env:"DB_TRANSACTION_MAX_OPEN_CONNS"`
 	TxnPrefixedMaxIdleConnections int `env:"DB_TRANSACTION_MAX_IDLE_CONNS"`
 
+	RouteTransactionalReadsToPrimary bool `env:"DB_TRANSACTION_ROUTE_TX_READS_TO_PRIMARY"`
+
 	// --- Onboarding MongoDB fields (MONGO_ONBOARDING_* env tags) ---
 	OnbPrefixedMongoURI          string `env:"MONGO_ONBOARDING_URI"`
 	OnbPrefixedMongoDBHost       string `env:"MONGO_ONBOARDING_HOST"`

--- a/components/ledger/internal/bootstrap/config.postgres.transaction.go
+++ b/components/ledger/internal/bootstrap/config.postgres.transaction.go
@@ -39,6 +39,12 @@ type transactionPostgresComponents struct {
 // initTransactionPostgres initializes PostgreSQL components for the transaction domain.
 // Dispatches to single-tenant or multi-tenant initialization based on Options.
 func initTransactionPostgres(opts *Options, cfg *Config, logger libLog.Logger) (*transactionPostgresComponents, error) {
+	// The transactional-read routing flag is resolved here, at the transaction
+	// repository construction site, and passed into the repositories that route
+	// primary-read intent through a read-only transaction.
+	logger.Log(context.Background(), libLog.LevelDebug, "transaction PG construction",
+		libLog.Bool("route_transactional_reads_to_primary", cfg.RouteTransactionalReadsToPrimary))
+
 	if opts != nil && opts.MultiTenantEnabled {
 		return initTransactionMultiTenantPostgres(opts, cfg, logger)
 	}
@@ -82,7 +88,7 @@ func initTransactionMultiTenantPostgres(opts *Options, cfg *Config, logger libLo
 		transactionRepo:      transaction.NewTransactionPostgreSQLRepository(conn, true),
 		operationRepo:        operation.NewOperationPostgreSQLRepository(conn, true),
 		assetRateRepo:        assetrate.NewAssetRatePostgreSQLRepository(conn, true),
-		balanceRepo:          balance.NewBalancePostgreSQLRepository(conn, true),
+		balanceRepo:          balance.NewBalancePostgreSQLRepository(conn, cfg.RouteTransactionalReadsToPrimary, true),
 		operationRouteRepo:   operationroute.NewOperationRoutePostgreSQLRepository(conn, true),
 		transactionRouteRepo: transactionroute.NewTransactionRoutePostgreSQLRepository(conn, true),
 		quarantineRepo:       transactionquarantine.NewQuarantinePostgreSQLRepository(conn, true),
@@ -101,7 +107,7 @@ func initTransactionSingleTenantPostgres(cfg *Config, logger libLog.Logger) (*tr
 		transactionRepo:      transaction.NewTransactionPostgreSQLRepository(conn),
 		operationRepo:        operation.NewOperationPostgreSQLRepository(conn),
 		assetRateRepo:        assetrate.NewAssetRatePostgreSQLRepository(conn),
-		balanceRepo:          balance.NewBalancePostgreSQLRepository(conn),
+		balanceRepo:          balance.NewBalancePostgreSQLRepository(conn, cfg.RouteTransactionalReadsToPrimary),
 		operationRouteRepo:   operationroute.NewOperationRoutePostgreSQLRepository(conn),
 		transactionRouteRepo: transactionroute.NewTransactionRoutePostgreSQLRepository(conn),
 		quarantineRepo:       transactionquarantine.NewQuarantinePostgreSQLRepository(conn),

--- a/components/ledger/internal/bootstrap/config.route_tx_reads_test.go
+++ b/components/ledger/internal/bootstrap/config.route_tx_reads_test.go
@@ -5,6 +5,7 @@
 package bootstrap
 
 import (
+	"os"
 	"reflect"
 	"testing"
 
@@ -53,6 +54,9 @@ func TestConfig_RouteTransactionalReadsToPrimary_EnvParsing(t *testing.T) {
 			// Note: t.Parallel() omitted because t.Setenv is incompatible with parallel sub-tests.
 			if tt.set {
 				t.Setenv("DB_TRANSACTION_ROUTE_TX_READS_TO_PRIMARY", tt.value)
+			} else if orig, had := os.LookupEnv("DB_TRANSACTION_ROUTE_TX_READS_TO_PRIMARY"); had {
+				os.Unsetenv("DB_TRANSACTION_ROUTE_TX_READS_TO_PRIMARY")
+				t.Cleanup(func() { os.Setenv("DB_TRANSACTION_ROUTE_TX_READS_TO_PRIMARY", orig) })
 			}
 
 			cfg := &Config{}

--- a/components/ledger/internal/bootstrap/config.route_tx_reads_test.go
+++ b/components/ledger/internal/bootstrap/config.route_tx_reads_test.go
@@ -1,0 +1,70 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package bootstrap
+
+import (
+	"reflect"
+	"testing"
+
+	libCommons "github.com/LerianStudio/lib-commons/v6/commons"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestConfig_RouteTransactionalReadsToPrimary_FieldTag locks the rollout-flag
+// field onto the exact env var name. The transactional-read routing rollout is
+// gated by this flag; renaming the field or the tag silently disables the gate.
+func TestConfig_RouteTransactionalReadsToPrimary_FieldTag(t *testing.T) {
+	t.Parallel()
+
+	field, found := reflect.TypeOf(Config{}).FieldByName("RouteTransactionalReadsToPrimary")
+	require.True(t, found, "Config must have field RouteTransactionalReadsToPrimary")
+	assert.Equal(t, "DB_TRANSACTION_ROUTE_TX_READS_TO_PRIMARY", field.Tag.Get("env"),
+		"RouteTransactionalReadsToPrimary must read from DB_TRANSACTION_ROUTE_TX_READS_TO_PRIMARY")
+	assert.Equal(t, reflect.Bool, field.Type.Kind(),
+		"RouteTransactionalReadsToPrimary must be a bool")
+}
+
+// TestConfig_RouteTransactionalReadsToPrimary_EnvParsing verifies safe-by-default,
+// tolerant parsing via the repo's SetConfigFromEnvVars mechanism:
+//   - unset          => false (backwards-compatible; app must not break)
+//   - "true"         => true  (explicit opt-in)
+//   - "false"        => false (explicit opt-out)
+//   - invalid value  => false (fallback; SetConfigFromEnvVars must not error/panic)
+func TestConfig_RouteTransactionalReadsToPrimary_EnvParsing(t *testing.T) {
+	// Note: t.Parallel() omitted because sub-tests use t.Setenv.
+
+	tests := []struct {
+		name  string
+		set   bool
+		value string
+		want  bool
+	}{
+		{name: "unset_defaults_false", set: false, want: false},
+		{name: "explicit_true", set: true, value: "true", want: true},
+		{name: "explicit_false", set: true, value: "false", want: false},
+		{name: "invalid_falls_back_false", set: true, value: "notabool", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Note: t.Parallel() omitted because t.Setenv is incompatible with parallel sub-tests.
+			if tt.set {
+				t.Setenv("DB_TRANSACTION_ROUTE_TX_READS_TO_PRIMARY", tt.value)
+			}
+
+			cfg := &Config{}
+			err := libCommons.SetConfigFromEnvVars(cfg)
+			require.NoError(t, err,
+				"SetConfigFromEnvVars must never fail on a missing or invalid rollout flag")
+
+			applyConfigDefaults(cfg)
+
+			assert.Equal(t, tt.want, cfg.RouteTransactionalReadsToPrimary,
+				"RouteTransactionalReadsToPrimary must resolve to %v for value %q (set=%v)",
+				tt.want, tt.value, tt.set)
+		})
+	}
+}

--- a/components/ledger/pkg/readrouting/intent.go
+++ b/components/ledger/pkg/readrouting/intent.go
@@ -1,0 +1,31 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+// Package readrouting transports read-routing intent through context.Context.
+// It carries only the intent marker; the routing decision (flag + adapter seam)
+// is made elsewhere.
+package readrouting
+
+import "context"
+
+// primaryReadKey is an unexported context key type to avoid collisions with
+// keys defined in other packages.
+type primaryReadKey struct{}
+
+// WithPrimaryRead returns a child context marked to route reads to the primary.
+func WithPrimaryRead(ctx context.Context) context.Context {
+	return context.WithValue(ctx, primaryReadKey{}, struct{}{})
+}
+
+// IsPrimaryRead reports whether ctx carries the primary-read intent marker.
+// It returns false for a nil or unmarked context.
+func IsPrimaryRead(ctx context.Context) bool {
+	if ctx == nil {
+		return false
+	}
+
+	_, ok := ctx.Value(primaryReadKey{}).(struct{})
+
+	return ok
+}

--- a/components/ledger/pkg/readrouting/intent_test.go
+++ b/components/ledger/pkg/readrouting/intent_test.go
@@ -1,0 +1,71 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package readrouting
+
+import (
+	"context"
+	"testing"
+)
+
+func TestPrimaryReadIntent(t *testing.T) {
+	tests := []struct {
+		name string
+		ctx  func() context.Context
+		want bool
+	}{
+		{
+			name: "marked context returns true",
+			ctx:  func() context.Context { return WithPrimaryRead(context.Background()) },
+			want: true,
+		},
+		{
+			name: "background context returns false",
+			ctx:  func() context.Context { return context.Background() },
+			want: false,
+		},
+		{
+			name: "todo context returns false",
+			ctx:  func() context.Context { return context.TODO() },
+			want: false,
+		},
+		{
+			name: "child of marked context stays true",
+			ctx: func() context.Context {
+				return context.WithValue(WithPrimaryRead(context.Background()), struct{}{}, "x")
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsPrimaryRead(tt.ctx()); got != tt.want {
+				t.Fatalf("IsPrimaryRead() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestPrimaryReadIntent_ChildDoesNotLeakToParent verifies that marking a child
+// context does not mutate the unmarked parent (isolation).
+func TestPrimaryReadIntent_ChildDoesNotLeakToParent(t *testing.T) {
+	parent := context.Background()
+	child := WithPrimaryRead(parent)
+
+	if !IsPrimaryRead(child) {
+		t.Fatal("expected child context to be marked")
+	}
+	if IsPrimaryRead(parent) {
+		t.Fatal("parent context must not inherit the child's mark")
+	}
+}
+
+//nolint:staticcheck // intentionally passing a nil context to assert no panic
+func TestPrimaryReadIntent_NilContextSafe(t *testing.T) {
+	var ctx context.Context
+	if IsPrimaryRead(ctx) {
+		t.Fatal("nil context must return false")
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -66,7 +66,7 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.44.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.44.0 // indirect
 	go.opentelemetry.io/otel/log v0.20.0 // indirect
-	go.opentelemetry.io/otel/metric v1.44.0 // indirect
+	go.opentelemetry.io/otel/metric v1.44.0
 	go.opentelemetry.io/otel/sdk v1.44.0
 	go.opentelemetry.io/otel/sdk/log v0.20.0 // indirect
 	go.opentelemetry.io/otel/sdk/metric v1.44.0

--- a/pkg/repository/read.go
+++ b/pkg/repository/read.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package repository
+
+import (
+	"context"
+	"database/sql"
+)
+
+// DBReader is a minimal read interface satisfied by both dbresolver.DB and dbresolver.Tx.
+// Read operations depend on this instead of a concrete handle so a caller can be served
+// by either a direct connection or a read-only transaction.
+type DBReader interface {
+	QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error)
+	QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row
+}
+
+// DBReadTx is a read surface that can be finalized (a read-only transaction).
+// It is satisfied by database transaction types (e.g., dbresolver.Tx) and lets the
+// acquirer release the underlying connection once the read completes.
+type DBReadTx interface {
+	DBReader
+	Commit() error
+	Rollback() error
+}

--- a/pkg/utils/metrics.go
+++ b/pkg/utils/metrics.go
@@ -143,6 +143,15 @@ var (
 		Description: "Total backup-replay records whose after-balances were recomputed rather than replayed from Lua, risking overdraft audit divergence.",
 	}
 
+	// DBReadSourceTotal counts read-routing decisions by the source that served
+	// the read (RF-06). Counter. Single bounded label: source (primary|replica).
+	// Per-operation granularity is the span (db.read_source attribute), not a label.
+	DBReadSourceTotal = metrics.Metric{
+		Name:        "db_read_source_total",
+		Unit:        "1",
+		Description: "Count of read-routing decisions by served source (primary|replica).",
+	}
+
 	// CircuitBreakerState indicates the current state of the RabbitMQ circuit breaker.
 	// Values: 0 = closed (healthy), 1 = open (unhealthy), 2 = half-open (recovering)
 	CircuitBreakerState = metrics.Metric{


### PR DESCRIPTION
<table border="0" cellspacing="0" cellpadding="0">
  <tr>
    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
    <td><h1>Midaz</h1></td>
  </tr>
</table>

---

## Description

Introduces the mechanism to serve **transactional-flow reads from the PostgreSQL primary** instead of the read replica, closing the replication-lag window on the money path. Fully gated behind `DB_TRANSACTION_ROUTE_TX_READS_TO_PRIMARY` (default `false`) — **no behavior change until enabled**.

How it works:
- A request-context intent marker (`readrouting.WithPrimaryRead`) tags a read as transactional.
- The balance adapter acquires reads through a shared seam (`readseam.AcquireReadFrom`) that, when the flag is on **and** the intent is present, wraps the read in a **read-only transaction** over `dbresolver.DB` — forcing the primary identically in single- and multi-tenant mode.
- **Fail-closed:** if the read-only tx cannot open, the read errors rather than silently falling back to the (possibly stale) replica.
- Read source is observable via a `db.read_source` span attribute and a `db_read_source_total{source}` counter (baseline measurable with the flag off).

The intent is marked at the transaction-create call site (`executeCreateTransaction`, before `GetBalances`) — an accepted, localized exception to "no domain logic in handlers" (the real read call site is the handler; `WriteTransaction` receives already-resolved balances). Shared read abstractions (`repository.DBReader` / `DBReadTx`) live in `pkg/repository`; the routing seam is a new `components/ledger/internal/adapters/postgres/readseam` package so the remaining transactional adapters can route through the same seam in follow-up work.

## Type of Change

- [x] `feat`: New feature or capability

## Breaking Changes

None. Additive and backwards-compatible: the new env var is safe-by-default (missing/invalid → `false`, never breaks startup); the one changed constructor signature (`NewBalancePostgreSQLRepository`) is in an `internal/` package with all in-tree callers updated. Rolling updates unaffected (flag ships off).

## Testing

- [x] `make test` passes — unit green on all changed packages (readrouting 100%, readseam 95.2%, bootstrap config flag, http/in intent test)
- [x] `make test-int` passes if integration paths are exercised — the two-container divergence test `TestTransactionalRead_UnderDivergence` passes (3/3 subtests)
- [x] `make lint` passes — golangci-lint v2 clean on changed files
- [ ] `make sec` and `make vulncheck` pass — `govulncheck` reports 0 vulnerabilities; `make sec` (gosec) not run locally, deferred to CI

**Test evidence / Actions run:** Reviewed via Ring dev-cycle — Epic 1.2 seam 8/8 reviewers PASS, Epic 1.3 pilot 6/6 PASS, Epic 1.1 deferred review PASS. Full-suite `make test-int` discovery is currently blocked by a **pre-existing, unrelated** compile error in `crm/.../instrument.mongodb_integration_test.go` (`mongotestutil.CreateTestAliasSimple` undefined); the divergence test was run scoped to its package.

## Architectural Checklist

- [x] No `panic()` in production paths
- [x] Timestamps use `time.Now().UTC()` — N/A (no new timestamps introduced)
- [x] Errors wrapped with `%w`
- [x] Handlers stay thin (parse, validate, call service) — the one handler change is a single context-value tag, not domain logic (documented exception)
- [x] Infrastructure concerns kept in `internal/bootstrap`

## Related Issues

