### PR TITLE
feat(ledger): route commit/cancel reads to primary

### DIFF
--- a/components/ledger/docs/read-routing/transactional-reads-catalog.md
+++ b/components/ledger/docs/read-routing/transactional-reads-catalog.md
@@ -1,0 +1,97 @@
+# Catálogo de Leituras Transacionais (Read-Routing)
+
+Catálogo normativo "uma verdade por leitura" para o roteamento de leituras
+no caminho de comando do ledger (create / commit / cancel / revert) e nas leituras de
+validação puras que participam desse caminho.
+
+O objetivo é registrar, para cada leitura, se ela **semeia estado** que será escrito
+logo em seguida (e portanto **precisa ler do primário** para não observar réplica
+defasada antes do commit) ou se é apenas **validação / cache-fronted / fora do caminho
+de comando** (e pode continuar servida pela réplica ou pelo cache).
+
+Cada linha aponta o `file.go:line` real do call site. Os âmbitos amplos
+(`organization_id`, `ledger_id`) não são repetidos aqui: as leituras vivem sob o mesmo
+contexto de tenant/ledger do comando que as originou.
+
+## Classificação (rótulos)
+
+- **`read-before-write-que-semeia-estado`** → leitura cujo resultado alimenta o cálculo
+  de balances/operações que serão persistidos no mesmo comando. Classificação: **primário**.
+- **`validation-only`** → leitura que apenas valida regra/rota/estado e **não** semeia o
+  balance a ser escrito. Pode ficar na **réplica**.
+- **`cache-fronted`** → leitura servida por Redis (cache-aside) com fallback ao banco; o
+  fallback herda a classificação do caminho. Prioridade baixa para roteamento explícito.
+- **`not-on-command-path`** → leitura que não pertence ao caminho de mutação de balance
+  (ex.: claim de idempotência em Redis). Sem roteamento de réplica/primário aplicável.
+
+## Tabela do Catálogo
+
+| Leitura (método + call site) | Fluxo | Origem atual | Classificação | Rótulo | Justificativa |
+|---|---|---|---|---|---|
+| `Query.GetBalances` → `BalanceRepo.ListByAliasesWithKeys` — `transaction_create.go:1291` (impl em `get_balances.go:36`) | create | Redis-cache + réplica (fallback) | **primário** | `read-before-write-que-semeia-estado` | Semeia os balances usados para montar/validar operações antes do commit. Roteada ao primário via `readrouting.WithPrimaryRead(ctx)` em `transaction_create.go:1289`. |
+| `Query.GetBalances` (enriquecimento de overdraft) — `transaction_create.go:1333-1334` | create | Redis-cache + réplica (fallback) | **primário** | `read-before-write-que-semeia-estado` | Lê o balance do companion `#overdraft` para calcular o déficit que vira operação persistida. Herda o `ctx` já marcado em `:1289` (não requer marcação própria). |
+| `Query.GetBalances` — `transaction_state_handlers.go:433` | commit / cancel | Redis-cache + réplica (fallback) | **primário** | `read-before-write-que-semeia-estado` | Semeia os balances da transição de estado antes do write. Roteada ao primário via `ctx = readrouting.WithPrimaryRead(ctx)` marcado em `commitOrCancelTransaction` (`transaction_state_handlers.go:431`), imediatamente antes de `GetBalances` (`:433`). |
+| `Query.GetBalances` (enriquecimento de overdraft no cancel) — `transaction_state_handlers.go:448-449` | cancel | Redis-cache + réplica (fallback) | **primário** | `read-before-write-que-semeia-estado` | Recalcula o leg de overdraft no cancelamento; semeia operação persistida. Roteada ao primário: herda o `ctx` marcado em `:431` (não requer marcação própria). |
+| `TransactionRouteRepo.FindByID` (fallback da route-cache) — `get_or_create_transaction_route_cache.go:70`, via `ValidateAccountingRules` | create | Redis puro + banco (fallback, negative caching) | réplica | `validation-only` `cache-fronted` | Valida a existência/config da rota; não semeia balance. Fallback ao banco só em cache miss. Permanece na réplica — no-op deliberado: leitura de validação pura, permanece na réplica. |
+| `Query.GetParsedLedgerSettings` → `GetLedgerSettings` — `get_ledger_settings_parsed.go:22` (cache-aside em `get_ledger_settings.go:32`, TTL 5min) | create / commit / cancel | Redis-cache + banco (fallback) | réplica | `validation-only` `cache-fronted` | Lê flags de validação (`validateAccountType`, `validateRoutes`); não semeia balance. Cache-aside best-effort. |
+| `Command.CreateOrCheckTransactionIdempotency` — `create_transaction_idempotency.go:45` (`TransactionRedisRepo.SetNX`/`Get`) | create | Redis puro | — | `not-on-command-path` | Claim de idempotência em Redis (não Postgres); é um lock, não uma leitura que semeia balance. Fora do eixo réplica/primário. |
+| `Query.GetWriteBehindTransaction` — `transaction_state_handlers.go:75` | commit / cancel | réplica | réplica | `validation-only` | Recupera a transação write-behind para validar o estado atual; não lê nem semeia balance. |
+| `Query.GetParentByTransactionID` — `transaction_state_handlers.go:159` | revert | réplica | réplica | `validation-only` | Verifica existência do pai antes do revert; não semeia balance. |
+| `Query.GetTransactionWithOperationsByID` — `transaction_state_handlers.go:174` | revert | réplica | réplica | `validation-only` | Lê a transação-alvo + operações para montar o reverso; a semente de balance do reverso vem do `GetBalances` do novo create, não daqui. |
+| `Query.GetOperationRouteByID` — `transaction_state_handlers.go:222` | revert | réplica | réplica | `validation-only` | Resolve a operation route por id para validar o reverso; não semeia balance. |
+| `Query.GetTransactionByID` — `get_id_transaction.go:23` | consulta pura | réplica | réplica | `validation-only` | Consulta de leitura por id fora da mutação de balance (também reutilizada por validações); não semeia estado a ser escrito. |
+
+## Contagem / tally
+
+- Total de linhas: **12**.
+- **primário / semeia estado** (`read-before-write-que-semeia-estado`): **4** — todas roteadas ao primário (2 no create, 2 no commit/cancel); nenhuma pendente.
+- **validation-only** (inclui as duas também rotuladas `cache-fronted`): **7**.
+- **not-on-command-path**: **1** (idempotência Redis).
+
+## Exceção de camada (marcação no handler)
+
+O roteamento de leitura é intent-based: o *handler* marca a intenção no `ctx` e o
+use case a herda transparentemente. A intenção é marcada **no handler**, não no use
+case:
+
+- create → `executeCreateTransaction` marca `ctx = readrouting.WithPrimaryRead(ctx)`
+  em `transaction_create.go:1289`, imediatamente antes de `GetBalances` (`:1291`).
+- commit / cancel → `commitOrCancelTransaction` (`transaction_state_handlers.go:313`)
+  marca `ctx = readrouting.WithPrimaryRead(ctx)` em `:431`, imediatamente antes de
+  `GetBalances` (`:433`) — mesmo wrap de uma linha do create.
+
+Isso é uma exceção deliberada à regra "sem lógica de infraestrutura no handler",
+sustentada por dois mitigadores:
+
+1. **Ponto único de convergência** — todas as leituras transacionais do fluxo passam
+   por `GetBalances`, então a marcação vive em um único lugar por fluxo (create; commit/
+   cancel), não espalhada pelos use cases.
+2. **Wrap de uma linha, sem lógica de negócio** — a marcação é apenas
+   `ctx = readrouting.WithPrimaryRead(ctx)` (ver `pkg/readrouting/intent.go`), transporte
+   puro de intenção via `context.Context`; nenhuma decisão de negócio vaza para o handler.
+
+## Consistência com o offload analítico
+
+A regra **"uma verdade por leitura"** vale em conjunto com o offload analítico:
+
+- Leituras **transacionais** que semeiam estado no caminho de comando → **primário**
+  (nunca réplica, nunca offload analítico). São a fonte de verdade para o write.
+- Leituras **analíticas / de consulta pura** (busca, listagem, relatórios) → réplica ou
+  o offload de busca (Elasticsearch), jamais o primário.
+
+Nenhuma leitura deve ter classificação ambígua: cada linha desta tabela tem exatamente
+um rótulo primário de origem. Se uma consulta passar a semear estado, ela migra para
+**primário** e entra nesta tabela; se deixar de semear, sai do caminho de comando.
+
+## Locking reads
+
+O único `SELECT ... FOR UPDATE` do componente é:
+
+- `LedgerPostgreSQLRepository.UpdateSettingsAtomic` — `ledger.postgresql.go:955`
+  (`SELECT settings FROM ledger ... FOR UPDATE`), dentro da própria transação de
+  escrita (read-modify-write atômico das settings do ledger).
+
+Esse lock **não** está no caminho transacional de balances (create/commit/cancel/
+revert) — pertence à mutação atômica de settings do ledger e roda em sua própria tx.
+Portanto **não requer roteamento**: já lê e escreve consistentemente na mesma conexão
+de escrita. Registrado aqui por completude.

--- a/components/ledger/docs/read-routing/transactional-reads-catalog.md
+++ b/components/ledger/docs/read-routing/transactional-reads-catalog.md
@@ -2,7 +2,7 @@
 
 Catálogo normativo "uma verdade por leitura" para o roteamento de leituras
 no caminho de comando do ledger (create / commit / cancel / revert) e nas leituras de
-validação puras que participam desse caminho.
+validação pura que participam desse caminho.
 
 O objetivo é registrar, para cada leitura, se ela **semeia estado** que será escrito
 logo em seguida (e portanto **precisa ler do primário** para não observar réplica
@@ -30,9 +30,9 @@ contexto de tenant/ledger do comando que as originou.
 |---|---|---|---|---|---|
 | `Query.GetBalances` → `BalanceRepo.ListByAliasesWithKeys` — `transaction_create.go:1291` (impl em `get_balances.go:36`) | create | Redis-cache + réplica (fallback) | **primário** | `read-before-write-que-semeia-estado` | Semeia os balances usados para montar/validar operações antes do commit. Roteada ao primário via `readrouting.WithPrimaryRead(ctx)` em `transaction_create.go:1289`. |
 | `Query.GetBalances` (enriquecimento de overdraft) — `transaction_create.go:1333-1334` | create | Redis-cache + réplica (fallback) | **primário** | `read-before-write-que-semeia-estado` | Lê o balance do companion `#overdraft` para calcular o déficit que vira operação persistida. Herda o `ctx` já marcado em `:1289` (não requer marcação própria). |
-| `Query.GetBalances` — `transaction_state_handlers.go:433` | commit / cancel | Redis-cache + réplica (fallback) | **primário** | `read-before-write-que-semeia-estado` | Semeia os balances da transição de estado antes do write. Roteada ao primário via `ctx = readrouting.WithPrimaryRead(ctx)` marcado em `commitOrCancelTransaction` (`transaction_state_handlers.go:431`), imediatamente antes de `GetBalances` (`:433`). |
-| `Query.GetBalances` (enriquecimento de overdraft no cancel) — `transaction_state_handlers.go:448-449` | cancel | Redis-cache + réplica (fallback) | **primário** | `read-before-write-que-semeia-estado` | Recalcula o leg de overdraft no cancelamento; semeia operação persistida. Roteada ao primário: herda o `ctx` marcado em `:431` (não requer marcação própria). |
-| `TransactionRouteRepo.FindByID` (fallback da route-cache) — `get_or_create_transaction_route_cache.go:70`, via `ValidateAccountingRules` | create | Redis puro + banco (fallback, negative caching) | réplica | `validation-only` `cache-fronted` | Valida a existência/config da rota; não semeia balance. Fallback ao banco só em cache miss. Permanece na réplica — no-op deliberado: leitura de validação pura, permanece na réplica. |
+| `Query.GetBalances` — `transaction_state_handlers.go:435` | commit / cancel | Redis-cache + réplica (fallback) | **primário** | `read-before-write-que-semeia-estado` | Semeia os balances da transição de estado antes do write. Roteada ao primário via `readCtx := readrouting.WithPrimaryRead(ctx)` marcado em `commitOrCancelTransaction` (`transaction_state_handlers.go:433`), imediatamente antes de `GetBalances` (`:435`), que recebe o `readCtx` dedicado. |
+| `Query.GetBalances` (enriquecimento de overdraft no cancel) — `transaction_state_handlers.go:450-451` | cancel | Redis-cache + réplica (fallback) | **primário** | `read-before-write-que-semeia-estado` | Recalcula o leg de overdraft no cancelamento; semeia operação persistida. Roteada ao primário: recebe o mesmo `readCtx` dedicado marcado em `:433` (não requer marcação própria). |
+| `TransactionRouteRepo.FindByID` (fallback da route-cache) — `get_or_create_transaction_route_cache.go:70`, via `ValidateAccountingRules` (`transaction_create.go` no create; `transaction_state_handlers.go:462` no commit/cancel) | create / commit / cancel | Redis puro + banco (fallback, negative caching) | réplica | `validation-only` `cache-fronted` | Valida a existência/config da rota; não semeia balance. Fallback ao banco só em cache miss. Permanece na réplica — no-op deliberado: leitura de validação pura. No commit/cancel roda sob o `ctx` não marcado (nunca sob o `readCtx` dedicado), ou seja, deliberadamente não roteada ao primário. |
 | `Query.GetParsedLedgerSettings` → `GetLedgerSettings` — `get_ledger_settings_parsed.go:22` (cache-aside em `get_ledger_settings.go:32`, TTL 5min) | create / commit / cancel | Redis-cache + banco (fallback) | réplica | `validation-only` `cache-fronted` | Lê flags de validação (`validateAccountType`, `validateRoutes`); não semeia balance. Cache-aside best-effort. |
 | `Command.CreateOrCheckTransactionIdempotency` — `create_transaction_idempotency.go:45` (`TransactionRedisRepo.SetNX`/`Get`) | create | Redis puro | — | `not-on-command-path` | Claim de idempotência em Redis (não Postgres); é um lock, não uma leitura que semeia balance. Fora do eixo réplica/primário. |
 | `Query.GetWriteBehindTransaction` — `transaction_state_handlers.go:75` | commit / cancel | réplica | réplica | `validation-only` | Recupera a transação write-behind para validar o estado atual; não lê nem semeia balance. |
@@ -57,8 +57,10 @@ case:
 - create → `executeCreateTransaction` marca `ctx = readrouting.WithPrimaryRead(ctx)`
   em `transaction_create.go:1289`, imediatamente antes de `GetBalances` (`:1291`).
 - commit / cancel → `commitOrCancelTransaction` (`transaction_state_handlers.go:313`)
-  marca `ctx = readrouting.WithPrimaryRead(ctx)` em `:431`, imediatamente antes de
-  `GetBalances` (`:433`) — mesmo wrap de uma linha do create.
+  marca `readCtx := readrouting.WithPrimaryRead(ctx)` em `:433`, imediatamente antes de
+  `GetBalances` (`:435`). Diferente do create, aqui a marcação usa um `ctx` dedicado
+  (`readCtx`), escopado apenas às leituras de balance anteriores ao write; o `ctx` não
+  marcado segue para as demais operações (validação, seed no Redis, escrita).
 
 Isso é uma exceção deliberada à regra "sem lógica de infraestrutura no handler",
 sustentada por dois mitigadores:
@@ -67,7 +69,7 @@ sustentada por dois mitigadores:
    por `GetBalances`, então a marcação vive em um único lugar por fluxo (create; commit/
    cancel), não espalhada pelos use cases.
 2. **Wrap de uma linha, sem lógica de negócio** — a marcação é apenas
-   `ctx = readrouting.WithPrimaryRead(ctx)` (ver `pkg/readrouting/intent.go`), transporte
+   `readrouting.WithPrimaryRead(ctx)` (ver `pkg/readrouting/intent.go`), transporte
    puro de intenção via `context.Context`; nenhuma decisão de negócio vaza para o handler.
 
 ## Consistência com o offload analítico

--- a/components/ledger/internal/adapters/http/in/transaction_primary_read_intent_test.go
+++ b/components/ledger/internal/adapters/http/in/transaction_primary_read_intent_test.go
@@ -9,6 +9,7 @@ import (
 	"go/ast"
 	"go/parser"
 	"go/token"
+	"os"
 	"strings"
 	"testing"
 
@@ -29,10 +30,10 @@ import (
 	"github.com/LerianStudio/midaz/v4/pkg/utils"
 )
 
-// TestCreateTransaction_MarksPrimaryReadIntent locks the ADR-001 decision that
-// the transaction-create flow marks its pre-write balance reads with the
-// primary-read intent so the read-routing seam can steer the DB miss to the
-// primary. It asserts on the two facets that make the mechanism real:
+// TestCreateTransaction_MarksPrimaryReadIntent verifies the create flow marks
+// the primary-read intent before its pre-write balance reads so the read-routing
+// seam can steer the DB miss to the primary. It asserts on the two facets that
+// make the mechanism real:
 //
 //  1. Mechanism: the intent marker survives the exact call sequence the handler
 //     uses. GetBalances (the direct pre-write read) and enrichOverdraftOperations
@@ -255,4 +256,201 @@ func stmtCallsSelector(stmt ast.Stmt, pkg, fn string) bool {
 	})
 
 	return found
+}
+
+// TestCommitCancel_MarksPrimaryReadIntent locks the decision that the
+// commit/cancel state-transition flow marks its pre-write balance read with the
+// primary-read intent. The read at the GetBalances call site feeds
+// buildBalanceOperations and (on cancel) enrichOverdraftOperations, whose result
+// seeds the authoritative balance via the NX-seed — the stale-read money-
+// corruption scenario the seam guards against. It asserts:
+//
+//  1. Mechanism: the intent marker survives the exact call sequence the handler
+//     uses — GetBalances and the cancel overdraft-enrichment read (which reuses
+//     the SAME ctx) both forward a marked ctx down to the balance DB seam target.
+//     A negative baseline proves an unmarked ctx stays unmarked.
+//  2. Placement: a structural guard over the live source of
+//     commitOrCancelTransaction proves the `readrouting.WithPrimaryRead(ctx)`
+//     wrap exists AND sits AFTER the validation-only reads (GetParsedLedgerSettings)
+//     and BEFORE the GetBalances read, so validation-only reads are not marked
+//     while both pre-write balance reads are.
+func TestCommitCancel_MarksPrimaryReadIntent(t *testing.T) {
+	t.Run("direct_balance_read_forwards_marked_ctx_to_db_seam", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		captured, uc := newPrimaryReadCapturingUseCase(ctrl)
+
+		organizationID := uuid.New()
+		ledgerID := uuid.New()
+		aliases := []string{"@alice#default"}
+
+		ctx := readrouting.WithPrimaryRead(context.Background())
+
+		_, err := uc.GetBalances(ctx, organizationID, ledgerID, aliases)
+		require.NoError(t, err)
+
+		require.True(t, captured.seen, "balance DB repository was never reached; the cache-miss path must fall through to the seam target")
+		assert.True(t, captured.primaryRead, "the ctx reaching the balance DB seam must carry the primary-read intent")
+	})
+
+	t.Run("cancel_overdraft_enrichment_read_forwards_marked_ctx_to_db_seam", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		captured, uc := newPrimaryReadCapturingUseCase(ctrl)
+
+		handler := &TransactionHandler{Query: uc}
+
+		orgID := uuid.New()
+		ledgerID := uuid.New()
+
+		source := overdraftEnabledBalance(t, "@alice", decimal.NewFromInt(50), "100")
+
+		primary := mmodel.BalanceOperation{
+			Balance: source,
+			Alias:   "0#@alice#default",
+			Amount: mtransaction.Amount{
+				Asset:           "BRL",
+				Value:           decimal.NewFromInt(100),
+				Operation:       libConstants.DEBIT,
+				TransactionType: libConstants.CREATED,
+				Direction:       constant.DirectionCredit,
+			},
+			InternalKey: utils.BalanceInternalKey(orgID, ledgerID, "@alice#default"),
+		}
+
+		validate := &mtransaction.Responses{
+			From:    map[string]mtransaction.Amount{"0#@alice#default": primary.Amount},
+			Sources: []string{"@alice#default"},
+			Aliases: []string{"@alice#default"},
+		}
+
+		// The single ctx reassignment at the GetBalances call site also covers the
+		// cancel overdraft-enrichment read, which inherits the same ctx and uses
+		// handler.Query.GetBalances as its loader exactly as at the handler site.
+		ctx := readrouting.WithPrimaryRead(context.Background())
+
+		_, _, err := enrichOverdraftOperations(ctx, orgID, ledgerID,
+			[]mmodel.BalanceOperation{primary}, validate, handler.Query.GetBalances)
+		require.NoError(t, err)
+
+		require.True(t, captured.seen, "cancel overdraft companion read never reached the balance DB seam")
+		assert.True(t, captured.primaryRead, "the ctx reaching the balance DB seam via the cancel overdraft read must carry the primary-read intent")
+	})
+
+	t.Run("unmarked_baseline_ctx_is_not_marked", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		captured, uc := newPrimaryReadCapturingUseCase(ctrl)
+
+		_, err := uc.GetBalances(context.Background(), uuid.New(), uuid.New(), []string{"@alice#default"})
+		require.NoError(t, err)
+
+		require.True(t, captured.seen)
+		assert.False(t, captured.primaryRead, "a flow not going through commit/cancel must NOT carry the primary-read intent")
+	})
+
+	t.Run("wrap_exists_and_is_positioned_between_validation_reads_and_get_balances", func(t *testing.T) {
+		src := readStateHandlerSource(t)
+
+		positions := analyzeCommitCancelWrap(t, src, "commitOrCancelTransaction")
+
+		if positions.wrap == -1 {
+			t.Fatal("no `readrouting.WithPrimaryRead(ctx)` wrap found in commitOrCancelTransaction; the commit/cancel flow does not mark the primary-read intent")
+		}
+
+		if positions.getBalances == -1 {
+			t.Fatal("no GetBalances call found in commitOrCancelTransaction; the read call site moved")
+		}
+
+		if positions.getLedgerSettings == -1 {
+			t.Fatal("no GetParsedLedgerSettings call found in commitOrCancelTransaction; the validation-only read moved")
+		}
+
+		if positions.wrap >= positions.getBalances {
+			t.Errorf("the WithPrimaryRead wrap (stmt %d) must precede the GetBalances read (stmt %d) so both pre-write balance reads observe the mark", positions.wrap, positions.getBalances)
+		}
+
+		if positions.wrap <= positions.getLedgerSettings {
+			t.Errorf("the WithPrimaryRead wrap (stmt %d) must FOLLOW the validation-only GetParsedLedgerSettings read (stmt %d) so validation-only reads are NOT marked", positions.wrap, positions.getLedgerSettings)
+		}
+	})
+}
+
+// commitCancelWrapPositions holds the top-level statement indices of the marker
+// wrap and the reads it must sit between within commitOrCancelTransaction.
+type commitCancelWrapPositions struct {
+	wrap              int
+	getBalances       int
+	getLedgerSettings int
+}
+
+// analyzeCommitCancelWrap returns the top-level statement indices, within the
+// named function body, of the `readrouting.WithPrimaryRead(...)` wrap, the first
+// GetBalances call, and the validation-only GetParsedLedgerSettings call. Each is
+// -1 when absent. Statement indices are sufficient because all three live at the
+// top level of the sequential commit/cancel flow.
+func analyzeCommitCancelWrap(t *testing.T, src, funcName string) commitCancelWrapPositions {
+	t.Helper()
+
+	fset := token.NewFileSet()
+
+	file, err := parser.ParseFile(fset, "src.go", src, 0)
+	if err != nil {
+		t.Fatalf("parse source: %v", err)
+	}
+
+	var fn *ast.FuncDecl
+
+	for _, decl := range file.Decls {
+		if d, ok := decl.(*ast.FuncDecl); ok && d.Name.Name == funcName {
+			fn = d
+			break
+		}
+	}
+
+	if fn == nil || fn.Body == nil {
+		t.Fatalf("function %q not found or has no body", funcName)
+	}
+
+	positions := commitCancelWrapPositions{wrap: -1, getBalances: -1, getLedgerSettings: -1}
+
+	for i, stmt := range fn.Body.List {
+		if positions.wrap == -1 && stmtCallsSelector(stmt, "readrouting", "WithPrimaryRead") {
+			positions.wrap = i
+		}
+
+		if positions.getBalances == -1 && stmtCallsMethod(stmt, "GetBalances") {
+			positions.getBalances = i
+		}
+
+		if positions.getLedgerSettings == -1 && stmtCallsMethod(stmt, "GetParsedLedgerSettings") {
+			positions.getLedgerSettings = i
+		}
+	}
+
+	return positions
+}
+
+// readStateHandlerSource reads transaction_state_handlers.go from disk so the
+// placement guard runs against the live source, not a snapshot, and fails the
+// moment the commit/cancel seam is edited.
+func readStateHandlerSource(t *testing.T) string {
+	t.Helper()
+
+	const path = "transaction_state_handlers.go"
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+
+	src := string(data)
+	if !strings.Contains(src, "func (handler *TransactionHandler) commitOrCancelTransaction") {
+		t.Fatalf("%s does not contain commitOrCancelTransaction — the gate is pointed at the wrong file", path)
+	}
+
+	return src
 }

--- a/components/ledger/internal/adapters/http/in/transaction_primary_read_intent_test.go
+++ b/components/ledger/internal/adapters/http/in/transaction_primary_read_intent_test.go
@@ -270,10 +270,12 @@ func stmtCallsSelector(stmt ast.Stmt, pkg, fn string) bool {
 //     the SAME ctx) both forward a marked ctx down to the balance DB seam target.
 //     A negative baseline proves an unmarked ctx stays unmarked.
 //  2. Placement: a structural guard over the live source of
-//     commitOrCancelTransaction proves the `readrouting.WithPrimaryRead(ctx)`
-//     wrap exists AND sits AFTER the validation-only reads (GetParsedLedgerSettings)
-//     and BEFORE the GetBalances read, so validation-only reads are not marked
-//     while both pre-write balance reads are.
+//     commitOrCancelTransaction proves the dedicated-var wrap
+//     `readCtx := readrouting.WithPrimaryRead(ctx)` exists AND sits AFTER the
+//     validation-only reads (GetParsedLedgerSettings) and BEFORE the GetBalances
+//     read; that GetBalances and the cancel overdraft read receive readCtx while
+//     ValidateAccountingRules keeps the unmarked ctx, so only the pre-write
+//     balance reads are routed to primary.
 func TestCommitCancel_MarksPrimaryReadIntent(t *testing.T) {
 	t.Run("direct_balance_read_forwards_marked_ctx_to_db_seam", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
@@ -326,8 +328,8 @@ func TestCommitCancel_MarksPrimaryReadIntent(t *testing.T) {
 			Aliases: []string{"@alice#default"},
 		}
 
-		// The single ctx reassignment at the GetBalances call site also covers the
-		// cancel overdraft-enrichment read, which inherits the same ctx and uses
+		// The dedicated readCtx at the GetBalances call site also covers the cancel
+		// overdraft-enrichment read, which receives the same readCtx and uses
 		// handler.Query.GetBalances as its loader exactly as at the handler site.
 		ctx := readrouting.WithPrimaryRead(context.Background())
 
@@ -352,13 +354,13 @@ func TestCommitCancel_MarksPrimaryReadIntent(t *testing.T) {
 		assert.False(t, captured.primaryRead, "a flow not going through commit/cancel must NOT carry the primary-read intent")
 	})
 
-	t.Run("wrap_exists_and_is_positioned_between_validation_reads_and_get_balances", func(t *testing.T) {
+	t.Run("dedicated_readctx_wrap_is_scoped_to_the_pre_write_balance_reads", func(t *testing.T) {
 		src := readStateHandlerSource(t)
 
 		positions := analyzeCommitCancelWrap(t, src, "commitOrCancelTransaction")
 
 		if positions.wrap == -1 {
-			t.Fatal("no `readrouting.WithPrimaryRead(ctx)` wrap found in commitOrCancelTransaction; the commit/cancel flow does not mark the primary-read intent")
+			t.Fatal("no dedicated `readCtx := readrouting.WithPrimaryRead(ctx)` wrap found in commitOrCancelTransaction; the commit/cancel flow must mark the primary-read intent on a dedicated ctx var, not reassign ctx")
 		}
 
 		if positions.getBalances == -1 {
@@ -370,28 +372,48 @@ func TestCommitCancel_MarksPrimaryReadIntent(t *testing.T) {
 		}
 
 		if positions.wrap >= positions.getBalances {
-			t.Errorf("the WithPrimaryRead wrap (stmt %d) must precede the GetBalances read (stmt %d) so both pre-write balance reads observe the mark", positions.wrap, positions.getBalances)
+			t.Errorf("the readCtx wrap (stmt %d) must precede the GetBalances read (stmt %d) so both pre-write balance reads observe the mark", positions.wrap, positions.getBalances)
 		}
 
 		if positions.wrap <= positions.getLedgerSettings {
-			t.Errorf("the WithPrimaryRead wrap (stmt %d) must FOLLOW the validation-only GetParsedLedgerSettings read (stmt %d) so validation-only reads are NOT marked", positions.wrap, positions.getLedgerSettings)
+			t.Errorf("the readCtx wrap (stmt %d) must FOLLOW the validation-only GetParsedLedgerSettings read (stmt %d) so validation-only reads are NOT marked", positions.wrap, positions.getLedgerSettings)
+		}
+
+		// Arg identity: the marker must be scoped to the pre-write balance reads.
+		if !positions.getBalancesTakesReadCtx {
+			t.Error("the GetBalances read must receive the dedicated readCtx (the primary-read marker); passing the unmarked ctx would stop routing the balance seed to primary")
+		}
+
+		if !positions.enrichTakesReadCtx {
+			t.Error("the cancel enrichOverdraftOperations read must receive the dedicated readCtx so its internal GetBalances is routed to primary")
+		}
+
+		if positions.validateTakesReadCtx {
+			t.Error("ValidateAccountingRules must NOT receive the dedicated readCtx: it is validation-only (route-cache) and deliberately keeps the unmarked ctx")
 		}
 	})
 }
 
 // commitCancelWrapPositions holds the top-level statement indices of the marker
-// wrap and the reads it must sit between within commitOrCancelTransaction.
+// wrap and the reads it must sit between within commitOrCancelTransaction, plus
+// the arg-identity checks that scope the marker to the pre-write balance reads.
 type commitCancelWrapPositions struct {
 	wrap              int
 	getBalances       int
 	getLedgerSettings int
+
+	getBalancesTakesReadCtx bool
+	enrichTakesReadCtx      bool
+	validateTakesReadCtx    bool
 }
 
-// analyzeCommitCancelWrap returns the top-level statement indices, within the
-// named function body, of the `readrouting.WithPrimaryRead(...)` wrap, the first
-// GetBalances call, and the validation-only GetParsedLedgerSettings call. Each is
-// -1 when absent. Statement indices are sufficient because all three live at the
-// top level of the sequential commit/cancel flow.
+// analyzeCommitCancelWrap returns, within the named function body, the top-level
+// statement indices of the dedicated `readCtx := readrouting.WithPrimaryRead(...)`
+// wrap, the first GetBalances call, and the validation-only GetParsedLedgerSettings
+// call (each -1 when absent), and whether GetBalances, enrichOverdraftOperations,
+// and ValidateAccountingRules receive `readCtx` as their context argument.
+// Statement indices are sufficient because the reads live at the top level of the
+// sequential commit/cancel flow.
 func analyzeCommitCancelWrap(t *testing.T, src, funcName string) commitCancelWrapPositions {
 	t.Helper()
 
@@ -418,7 +440,7 @@ func analyzeCommitCancelWrap(t *testing.T, src, funcName string) commitCancelWra
 	positions := commitCancelWrapPositions{wrap: -1, getBalances: -1, getLedgerSettings: -1}
 
 	for i, stmt := range fn.Body.List {
-		if positions.wrap == -1 && stmtCallsSelector(stmt, "readrouting", "WithPrimaryRead") {
+		if positions.wrap == -1 && stmtDefinesReadCtxFromPrimaryRead(stmt) {
 			positions.wrap = i
 		}
 
@@ -429,9 +451,90 @@ func analyzeCommitCancelWrap(t *testing.T, src, funcName string) commitCancelWra
 		if positions.getLedgerSettings == -1 && stmtCallsMethod(stmt, "GetParsedLedgerSettings") {
 			positions.getLedgerSettings = i
 		}
+
+		if callFirstArgIsIdent(stmt, "GetBalances", "readCtx") {
+			positions.getBalancesTakesReadCtx = true
+		}
+
+		if callFirstArgIsIdent(stmt, "enrichOverdraftOperations", "readCtx") {
+			positions.enrichTakesReadCtx = true
+		}
+
+		if callFirstArgIsIdent(stmt, "ValidateAccountingRules", "readCtx") {
+			positions.validateTakesReadCtx = true
+		}
 	}
 
 	return positions
+}
+
+// stmtDefinesReadCtxFromPrimaryRead reports whether stmt is a short-var
+// definition `readCtx := readrouting.WithPrimaryRead(...)` — the dedicated-var
+// form that scopes the primary-read marker without reassigning ctx.
+func stmtDefinesReadCtxFromPrimaryRead(stmt ast.Stmt) bool {
+	assign, ok := stmt.(*ast.AssignStmt)
+	if !ok || assign.Tok != token.DEFINE || len(assign.Lhs) != 1 || len(assign.Rhs) != 1 {
+		return false
+	}
+
+	lhs, ok := assign.Lhs[0].(*ast.Ident)
+	if !ok || lhs.Name != "readCtx" {
+		return false
+	}
+
+	call, ok := assign.Rhs[0].(*ast.CallExpr)
+	if !ok {
+		return false
+	}
+
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok || sel.Sel.Name != "WithPrimaryRead" {
+		return false
+	}
+
+	pkg, ok := sel.X.(*ast.Ident)
+
+	return ok && pkg.Name == "readrouting"
+}
+
+// callFirstArgIsIdent reports whether stmt contains a call to callee whose first
+// argument is exactly the identifier argName. callee matches either a method call
+// (`x.callee(...)`) or a plain function call (`callee(...)`), so both
+// `handler.Query.GetBalances(readCtx, ...)` and `enrichOverdraftOperations(readCtx, ...)`
+// are recognized — used to assert which reads receive the dedicated readCtx versus
+// the unmarked ctx.
+func callFirstArgIsIdent(stmt ast.Stmt, callee, argName string) bool {
+	found := false
+
+	ast.Inspect(stmt, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok || len(call.Args) == 0 {
+			return true
+		}
+
+		var name string
+
+		switch fun := call.Fun.(type) {
+		case *ast.SelectorExpr:
+			name = fun.Sel.Name
+		case *ast.Ident:
+			name = fun.Name
+		default:
+			return true
+		}
+
+		if name != callee {
+			return true
+		}
+
+		if id, ok := call.Args[0].(*ast.Ident); ok && id.Name == argName {
+			found = true
+		}
+
+		return true
+	})
+
+	return found
 }
 
 // readStateHandlerSource reads transaction_state_handlers.go from disk so the

--- a/components/ledger/internal/adapters/http/in/transaction_state_handlers.go
+++ b/components/ledger/internal/adapters/http/in/transaction_state_handlers.go
@@ -423,14 +423,16 @@ func (handler *TransactionHandler) commitOrCancelTransaction(ctx context.Context
 		action = constant.ActionCancel
 	}
 
-	// Route this pre-write balance read (and the cancel overdraft-enrichment read
-	// that inherits this ctx) to the primary: its result seeds the authoritative
-	// balance via the NX-seed, so a stale replica read here corrupts money. The
-	// flag governs the effect; the mark is unconditional. Validation-only reads
-	// above (ledger settings, route cache) are intentionally left unmarked.
-	ctx = readrouting.WithPrimaryRead(ctx)
+	// Route ONLY the pre-write balance reads to the primary via a dedicated ctx:
+	// their result seeds the authoritative balance via the NX-seed, so a stale
+	// replica read here corrupts money. The mark lives on readCtx, scoped to the
+	// direct balance read and the cancel overdraft-enrichment read; the unmarked
+	// ctx flows to everything else (validation, Redis seed, balance processing,
+	// write) so those keep their default routing. The flag governs the effect; the
+	// mark is unconditional.
+	readCtx := readrouting.WithPrimaryRead(ctx)
 
-	balances, err := handler.Query.GetBalances(ctx, organizationID, ledgerID, validate.Aliases)
+	balances, err := handler.Query.GetBalances(readCtx, organizationID, ledgerID, validate.Aliases)
 	if err != nil {
 		libOpentelemetry.HandleSpanError(span, "Failed to get balances", err)
 		logger.Log(ctx, libLog.LevelError, "Failed to get balances", libLog.Err(err))
@@ -445,7 +447,7 @@ func (handler *TransactionHandler) commitOrCancelTransaction(ctx context.Context
 
 	var companionFromTos []mtransaction.FromTo
 	if transactionStatus == constant.CANCELED {
-		balanceOps, companionFromTos, err = enrichOverdraftOperations(ctx, organizationID, ledgerID, balanceOps,
+		balanceOps, companionFromTos, err = enrichOverdraftOperations(readCtx, organizationID, ledgerID, balanceOps,
 			validate, handler.Query.GetBalances)
 		if err != nil {
 			libOpentelemetry.HandleSpanError(span, "Failed to enrich canceled overdraft operations", err)

--- a/components/ledger/internal/adapters/http/in/transaction_state_handlers.go
+++ b/components/ledger/internal/adapters/http/in/transaction_state_handlers.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/LerianStudio/midaz/v4/components/ledger/internal/adapters/postgres/transaction"
 	"github.com/LerianStudio/midaz/v4/components/ledger/internal/services/command"
+	"github.com/LerianStudio/midaz/v4/components/ledger/pkg/readrouting"
 	"github.com/LerianStudio/midaz/v4/pkg"
 	"github.com/LerianStudio/midaz/v4/pkg/constant"
 	"github.com/LerianStudio/midaz/v4/pkg/mtransaction"
@@ -421,6 +422,13 @@ func (handler *TransactionHandler) commitOrCancelTransaction(ctx context.Context
 	if transactionStatus == constant.CANCELED {
 		action = constant.ActionCancel
 	}
+
+	// Route this pre-write balance read (and the cancel overdraft-enrichment read
+	// that inherits this ctx) to the primary: its result seeds the authoritative
+	// balance via the NX-seed, so a stale replica read here corrupts money. The
+	// flag governs the effect; the mark is unconditional. Validation-only reads
+	// above (ledger settings, route cache) are intentionally left unmarked.
+	ctx = readrouting.WithPrimaryRead(ctx)
 
 	balances, err := handler.Query.GetBalances(ctx, organizationID, ledgerID, validate.Aliases)
 	if err != nil {

--- a/components/ledger/internal/adapters/postgres/balance/balance_read_routing_mt_integration_test.go
+++ b/components/ledger/internal/adapters/postgres/balance/balance_read_routing_mt_integration_test.go
@@ -1,0 +1,155 @@
+//go:build integration
+
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package balance
+
+import (
+	"context"
+	"testing"
+
+	libCommons "github.com/LerianStudio/lib-commons/v6/commons"
+	libPostgres "github.com/LerianStudio/lib-commons/v6/commons/postgres"
+	tmcore "github.com/LerianStudio/lib-commons/v6/commons/tenant-manager/core"
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/LerianStudio/midaz/v4/components/ledger/pkg/readrouting"
+	"github.com/LerianStudio/midaz/v4/pkg/constant"
+	"github.com/LerianStudio/midaz/v4/pkg/utils"
+	pgtestutil "github.com/LerianStudio/midaz/v4/tests/utils/postgres"
+	redistestutil "github.com/LerianStudio/midaz/v4/tests/utils/redis"
+)
+
+// TestTransactionalRead_MultiTenant is the multi-tenant (MT) non-regression proof for
+// the read-routing seam. It mirrors TestTransactionalRead_UnderDivergence but forces
+// resolution through the TENANT context handle instead of the static r.connection,
+// proving that a marked transactional read lands on the TENANT's primary and a pure
+// query stays on the TENANT's replica.
+//
+// MT wiring: the repo is constructed with requireTenant=true so the static-connection
+// fallback in getDB is OFF (r.connection is nil). The A(primary)/B(replica) dbresolver
+// handle is injected into context via tmcore.ContextWithPG(..., constant.ModuleTransaction),
+// which is exactly the key getDB prioritizes (GetPGContext(ctx, ModuleTransaction)). A
+// tenant id is set via tmcore.ContextWithTenantID to represent a resolved tenant. This
+// makes the seam operate on the tenant's handle without ever touching r.connection.
+//
+// The deterministic divergence is identical to the single-tenant divergence test: two INDEPENDENT Postgres
+// containers wired PrimaryDSN=A / ReplicaDSN=B behind one *libPostgres.Client. They do
+// NOT replicate; A holds the seeded balance row, B does not (infinite lag). Redis is
+// provisioned and the balance key is verified ABSENT to document the NX-seed (cache
+// miss -> Postgres) precondition. Helpers migrateSchema / requireRowCount /
+// requireRedisKeyAbsent are reused from the sibling divergence file in this package.
+func TestTransactionalRead_MultiTenant(t *testing.T) {
+	// --- Two independent Postgres containers: A = tenant primary, B = tenant replica ---
+	primary := pgtestutil.SetupContainer(t) // A
+	replica := pgtestutil.SetupContainer(t) // B
+
+	migrationsPath := pgtestutil.FindMigrationsPath(t, "transaction")
+
+	primaryDSN := pgtestutil.BuildConnectionString(primary.Host, primary.Port, primary.Config)
+	replicaDSN := pgtestutil.BuildConnectionString(replica.Host, replica.Port, replica.Config)
+
+	migrateSchema(t, primaryDSN, primary.Config.DBName, migrationsPath)
+	migrateSchema(t, replicaDSN, replica.Config.DBName, migrationsPath)
+
+	// Single lib-commons client wiring PrimaryDSN -> A and ReplicaDSN -> B, mirroring the
+	// transactional client bootstrap builds. This is the TENANT handle: it is injected
+	// into context, NOT set on the repo's static connection.
+	conn, err := libPostgres.New(libPostgres.Config{
+		PrimaryDSN: primaryDSN,
+		ReplicaDSN: replicaDSN,
+	})
+	require.NoError(t, err, "failed to build postgres client over A(primary)/B(replica)")
+	require.NoError(t, conn.Connect(context.Background()), "failed to connect postgres client")
+
+	t.Cleanup(func() {
+		if closeErr := conn.Close(); closeErr != nil {
+			t.Logf("failed to close postgres client: %v", closeErr)
+		}
+	})
+
+	// Resolve the dbresolver.DB (A/B-wired) that middleware would inject per tenant.
+	tenantResolver, err := conn.Resolver(context.Background())
+	require.NoError(t, err, "failed to resolve tenant dbresolver handle")
+
+	// --- Redis container for the cache overlay (NX-seed precondition) ---
+	redisResult := redistestutil.SetupContainer(t)
+
+	// --- Divergence: seed the balance ONLY in A (tenant primary) with a KNOWN fresh value ---
+	orgID := uuid.Must(libCommons.GenerateUUIDv7())
+	ledgerID := uuid.Must(libCommons.GenerateUUIDv7())
+	accountID := uuid.Must(libCommons.GenerateUUIDv7())
+	tenantID := uuid.Must(libCommons.GenerateUUIDv7()).String()
+
+	const (
+		alias        = "@mt-divergence"
+		balanceKey   = "default"
+		aliasWithKey = alias + "#" + balanceKey
+	)
+
+	primaryFresh := decimal.NewFromInt(999)
+
+	params := pgtestutil.DefaultBalanceParams()
+	params.Alias = alias
+	params.Key = balanceKey
+	params.Available = primaryFresh
+	pgtestutil.CreateTestBalance(t, primary.DB, orgID, ledgerID, accountID, params)
+
+	// Guard the divergence deterministically: A HAS the row, B does NOT.
+	requireRowCount(t, primary.DB, orgID, ledgerID, alias, 1, "tenant primary (A) must contain the seeded row")
+	requireRowCount(t, replica.DB, orgID, ledgerID, alias, 0, "tenant replica (B) must NOT contain the seeded row")
+
+	// --- NX-seed precondition: force the Redis balance key ABSENT ---
+	internalKey := utils.BalanceInternalKey(orgID, ledgerID, aliasWithKey)
+	requireRedisKeyAbsent(t, redisResult.Client, internalKey)
+
+	// Build the tenant-carrying context: the module-specific PG handle + tenant id, as
+	// the tenant middleware (lib-commons tenant managers) would inject in MT mode.
+	tenantCtx := tmcore.ContextWithPG(context.Background(), tenantResolver, constant.ModuleTransaction)
+	tenantCtx = tmcore.ContextWithTenantID(tenantCtx, tenantID)
+
+	// Repo built with requireTenant=true so the static r.connection path is OFF: the ONLY
+	// resolvable handle is the one carried in context. r.connection is deliberately nil.
+	repo := NewBalancePostgreSQLRepository(nil, true, true)
+
+	// Subtest 1: flag ON + intent MARKED + tenant handle -> reads the TENANT PRIMARY (A).
+	t.Run("mt_flag_on_intent_marked_reads_tenant_primary_NX_seed", func(t *testing.T) {
+		repo.routeTxReadsToPrimary = true
+
+		markedCtx := readrouting.WithPrimaryRead(tenantCtx)
+
+		// Defensive: the tenant PG handle MUST be present on the context, else resolution
+		// silently fell to the static path and this test degenerates to single-tenant.
+		require.NotNil(t, tmcore.GetPGContext(markedCtx, constant.ModuleTransaction),
+			"tenant PG handle missing from context: resolution would fall to the static path (test degraded to ST)")
+
+		balances, err := repo.ListByAliasesWithKeys(markedCtx, orgID, ledgerID, []string{aliasWithKey})
+		require.NoError(t, err, "marked read routed to tenant primary should succeed")
+		require.Len(t, balances, 1, "tenant primary (A) holds the fresh row, so exactly one balance is returned")
+
+		assert.Equal(t, alias, balances[0].Alias, "alias should match the tenant primary row")
+		assert.True(t, balances[0].Available.Equal(primaryFresh),
+			"marked read on the tenant handle must return A's fresh value (%s), got %s", primaryFresh, balances[0].Available)
+	})
+
+	// Subtest 2: flag ON + intent ABSENT + tenant handle -> stays on the TENANT REPLICA (B).
+	t.Run("mt_pure_query_unmarked_ctx_stays_on_tenant_replica", func(t *testing.T) {
+		repo.routeTxReadsToPrimary = true
+
+		// Defensive: the tenant PG handle MUST be present on the (unmarked) context too.
+		require.NotNil(t, tmcore.GetPGContext(tenantCtx, constant.ModuleTransaction),
+			"tenant PG handle missing from context: resolution would fall to the static path (test degraded to ST)")
+
+		// No WithPrimaryRead: a pure MT query must be unaffected by the rollout and read
+		// the tenant replica (B), which lacks the diverged row.
+		balances, err := repo.ListByAliasesWithKeys(tenantCtx, orgID, ledgerID, []string{aliasWithKey})
+		require.NoError(t, err, "pure query on tenant replica should succeed even when the row is absent")
+		assert.Empty(t, balances,
+			"unmarked ctx with flag ON must read the tenant replica (B) -> empty result, proving pure MT queries are unaffected")
+	})
+}

--- a/components/ledger/internal/adapters/postgres/balance/balance_require_tenant_test.go
+++ b/components/ledger/internal/adapters/postgres/balance/balance_require_tenant_test.go
@@ -1,0 +1,76 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package balance
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/LerianStudio/midaz/v4/components/ledger/pkg/readrouting"
+)
+
+// TestAcquireRead_RequireTenantFailsClosed locks the read-seam invariant: with
+// requireTenant=true and routeTxReadsToPrimary=true, a routed read (primary-read
+// intent marked in ctx) that carries NO tenant postgres handle MUST fail closed
+// with the explicit tenant-missing error BEFORE any static-fallback / routing
+// decision. The repository is built with a nil static connection so ANY static
+// fallback would surface a distinct failure ("postgres connection not available"
+// or a nil-conn panic) rather than the tenant-missing sentinel — proving getDB's
+// tenant guard fires FIRST (check order), and acquireRead never reaches the
+// routing/tx path on a wrong handle.
+func TestAcquireRead_RequireTenantFailsClosed(t *testing.T) {
+	const wantErr = "tenant postgres connection missing from context"
+
+	// A single non-empty entry so the read method does not short-circuit on the
+	// empty-input fast path and actually reaches acquireRead -> getDB.
+	aliasesWithKeys := []string{"alias1#default"}
+	orgID := uuid.New()
+	ledgerID := uuid.New()
+
+	tests := []struct {
+		name string
+		call func(r *BalancePostgreSQLRepository, ctx context.Context) error
+	}{
+		{
+			name: "ListByAliasesWithKeys",
+			call: func(r *BalancePostgreSQLRepository, ctx context.Context) error {
+				_, err := r.ListByAliasesWithKeys(ctx, orgID, ledgerID, aliasesWithKeys)
+				return err
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// connection=nil => any static fallback would fail distinctly.
+			// routeTxReadsToPrimary=true, requireTenant=true.
+			repo := NewBalancePostgreSQLRepository(nil, true, true)
+
+			// MARKED primary-read intent, but NO tenant handle injected into ctx.
+			ctx := readrouting.WithPrimaryRead(context.Background())
+
+			// Guard: the intent is actually marked, so this exercises the routed
+			// path, not a plain read.
+			if !readrouting.IsPrimaryRead(ctx) {
+				t.Fatalf("test setup: expected primary-read intent to be marked in ctx")
+			}
+
+			err := tt.call(repo, ctx)
+
+			if err == nil {
+				t.Fatalf("expected tenant-missing error, got nil (read must fail closed, not fall back to static connection)")
+			}
+
+			// Assert on the SPECIFIC tenant-missing message, not a generic non-nil
+			// error. A different message (e.g. "postgres connection not available")
+			// would mean a static-fallback attempt slipped past the tenant guard.
+			if got := err.Error(); got != wantErr {
+				t.Fatalf("expected tenant-missing error %q, got %q — the tenant guard must fire before any static fallback or routing decision", wantErr, got)
+			}
+		})
+	}
+}

--- a/components/ledger/internal/adapters/postgres/readseam/readseam.go
+++ b/components/ledger/internal/adapters/postgres/readseam/readseam.go
@@ -110,7 +110,7 @@ func AcquireReadFrom(ctx context.Context, conn ReadConn, routeToPrimary bool) (r
 	return tx, release, ReadSourcePrimary, nil
 }
 
-// recordReadSource emits the RF-06 read-source signal for a served read: the
+// recordReadSource emits the read-source signal for a served read: the
 // db.read_source attribute on the caller's existing span and the
 // db_read_source_total counter. It is best-effort — an unavailable metrics
 // factory is swallowed at Debug and never fails the read; it never panics and

--- a/components/ledger/internal/adapters/postgres/readseam/readseam_test.go
+++ b/components/ledger/internal/adapters/postgres/readseam/readseam_test.go
@@ -269,7 +269,7 @@ func attributeValue(span sdktrace.ReadOnlySpan, key string) (string, bool) {
 	return "", false
 }
 
-// TestReadSourceObservability locks the RF-06 read-source signal: AcquireReadFrom
+// TestReadSourceObservability locks the read-source signal: AcquireReadFrom
 // returns ReadSourcePrimary only when routeToPrimary AND the primary-read intent
 // is present, else ReadSourceReplica; and it records db.read_source on the
 // caller's span matching the returned source in BOTH success branches.
@@ -383,7 +383,7 @@ func collectReadSourceCounters(t *testing.T, reader *sdkmetric.ManualReader) map
 	return totals
 }
 
-// TestReadSource_EmitsCounter locks the metric half of the RF-06 signal: when a
+// TestReadSource_EmitsCounter locks the metric half of the read-source signal: when a
 // real MetricsFactory is present on the context, AcquireReadFrom emits
 // db_read_source_total once per call with the correct source label, for BOTH the
 // primary branch (flag on + intent) and the replica branch (flag off). The read

--- a/pkg/utils/metrics.go
+++ b/pkg/utils/metrics.go
@@ -144,7 +144,7 @@ var (
 	}
 
 	// DBReadSourceTotal counts read-routing decisions by the source that served
-	// the read (RF-06). Counter. Single bounded label: source (primary|replica).
+	// the read. Counter. Single bounded label: source (primary|replica).
 	// Per-operation granularity is the span (db.read_source attribute), not a label.
 	DBReadSourceTotal = metrics.Metric{
 		Name:        "db_read_source_total",


### PR DESCRIPTION
<!--
PR metadata (for reference — not part of the PR body):
  Head: feature/ledger-transactional-queries-catalog-mt
  Base: feature/ledger-transactional-queries
  Title: feat(ledger): route commit/cancel reads to primary
  Scope: ledger (from .github/workflows/pr-validation.yml allowlist)
This file is untracked scratch — do NOT commit it.
-->

<table border="0" cellspacing="0" cellpadding="0">
  <tr>
    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
    <td><h1>Midaz</h1></td>
  </tr>
</table>

## Description

Extends transactional read-to-primary routing to the commit/cancel flow and adds the normative read-routing catalog + multi-tenant coverage. The commit/cancel pre-write balance read (and the cancel overdraft-enrichment read that inherits the context) is now marked for primary routing, mirroring the create flow. Fully gated behind `DB_TRANSACTION_ROUTE_TX_READS_TO_PRIMARY` (default `false`) — no behavior change until enabled.

- Mark intent in `commitOrCancelTransaction` before the balance read (handler-level one-line context wrap).
- Versioned transactional-reads catalog classifying every command-path read (primary vs replica) with justification, the handler-marking exception, and the locking-reads note.
- Multi-tenant tests: a marked read hits the tenant primary; a pure query stays on the tenant replica. Plus a `requireTenant` fail-closed unit test.
- Comment cleanup: internal planning identifiers removed from read-routing comments.

## Type of Change

- [x] `feat`: New feature or capability

## Breaking Changes

None. Additive and backwards-compatible; the rollout flag ships `false`, so behavior is unchanged until it is turned on.

## Testing

- [x] `make test` passes (unit green on changed packages)
- [x] `make test-int` passes if integration paths are exercised — multi-tenant + divergence tests pass (scoped to the balance package)
- [x] `make lint` passes — golangci-lint v2 clean on changed files
- [ ] `make sec` and `make vulncheck` pass — `govulncheck` reports 0; `make sec` (gosec) not run locally, deferred to CI

**Test evidence / Actions run:** Reviewed via ring:reviewing-code — 6/6 reviewers PASS, 0 blocking findings. Full-suite `make test-int` discovery is blocked by a pre-existing, unrelated CRM test compile error; balance-package tests were run scoped.

## Architectural Checklist

- [x] No `panic()` in production paths
- [x] Timestamps use `time.Now().UTC()` — N/A (no new timestamps introduced)
- [x] Errors wrapped with `%w`
- [x] Handlers stay thin (parse, validate, call service) — one-line context tag, not domain logic (documented exception)
- [x] Infrastructure concerns kept in `internal/bootstrap`

## Related Issues

N/A
