### PR TITLE
fix(ledger): stop DELETE asset 500ing on external accounts

### DIFF
--- a/components/ledger/internal/adapters/postgres/account/account.postgresql.go
+++ b/components/ledger/internal/adapters/postgres/account/account.postgresql.go
@@ -1261,6 +1261,7 @@ func (r *AccountPostgreSQLRepository) ListExternalAccountsByAssetCode(ctx contex
 			&acc.Name,
 			&acc.ParentAccountID,
 			&acc.EntityID,
+			&acc.HolderID,
 			&acc.AssetCode,
 			&acc.OrganizationID,
 			&acc.LedgerID,
@@ -1274,6 +1275,7 @@ func (r *AccountPostgreSQLRepository) ListExternalAccountsByAssetCode(ctx contex
 			&acc.UpdatedAt,
 			&acc.DeletedAt,
 			&acc.Blocked,
+			&acc.HolderCheckSkipped,
 		); err != nil {
 			libOpentelemetry.HandleSpanError(span, "Failed to scan row", err)
 


### PR DESCRIPTION
## Description

`ListExternalAccountsByAssetCode` (added by PR #2200 to cascade-soft-delete
external accounts on asset delete) selects all 19 columns of the shared
`accountColumnList`, but its `rows.Scan(...)` only listed 17 destinations —
missing `HolderID` and `HolderCheckSkipped`, two columns a later commit added
to the shared column list without touching this method's `Scan` call.

`rows.Scan` only fails once a row exists to scan, and every asset
auto-creates its canonical `@external/{code}` account on creation, so
**every** asset delete with a live external account — i.e. effectively every
asset delete — hit `sql: expected 17 destination arguments in Scan, got 19`.
The raw scan error propagated unwrapped through `delete_asset.go` straight to
a `500`/`0046` instead of the expected `204`.

Fix: scan `HolderID` and `HolderCheckSkipped` in the same positions `FindAll`
and every other `Find`/`List` method in this file already use, matching
`accountColumnList`'s column order.

Internal tracking: Map card #3656.

## Type of Change

- [x] `fix`: Bug fix
- [ ] `feat`: New feature or capability
- [ ] `perf`: Performance improvement
- [ ] `refactor`: Internal restructuring with no behavior change
- [ ] `docs`: Documentation only
- [ ] `style`: Formatting, whitespace, naming (no logic change)
- [ ] `test`: Adding or updating tests
- [ ] `ci`: CI pipeline or workflow changes
- [ ] `build`: Build system, Dockerfile, Go module dependencies
- [ ] `chore`: Maintenance, config, tooling
- [ ] `revert`: Reverts a previous commit
- [ ] `BREAKING CHANGE`: Consumers must update their integration

## Breaking Changes

None.

## Testing

- [x] `make test` passes
- [x] `make test-int` passes if integration paths are exercised
- [x] `make lint` passes
- [ ] `make sec` and `make vulncheck` pass

**Test evidence:** Ran the existing integration tests covering this method
directly (`go test ./components/ledger/internal/adapters/postgres/account/...
-run TestIntegration_AccountRepository_ListExternalAccountsByAssetCode
-tags=integration`) — both `ReturnsOnlyLiveExternals` (previously failing
with the scan arg-count mismatch) and `ReturnsEmptyWhenNone` now pass. Full
`account` package suite (81 integration tests) and the `account` +
`command` unit test packages (783 tests) pass with no regressions.

## Architectural Checklist

- [x] No `panic()` in production paths
- [x] Timestamps use `time.Now().UTC()`
- [x] Errors wrapped with `%w`
- [x] Handlers stay thin (parse, validate, call service)
- [x] Infrastructure concerns kept in `internal/bootstrap`

## Related Issues

Closes #