### PR TITLE
feat(ledger): add per-type default balance direction

### DIFF
--- a/components/ledger/api/openapi.huma.yaml
+++ b/components/ledger/api/openapi.huma.yaml
@@ -144,6 +144,10 @@ components:
             - "2021-01-01T00:00:00Z"
           format: date-time
           type: string
+        defaultDirection:
+          examples:
+            - credit
+          type: string
         deletedAt:
           examples:
             - "2021-01-01T00:00:00Z"

--- a/components/ledger/internal/adapters/postgres/accounttype/accounttype.go
+++ b/components/ledger/internal/adapters/postgres/accounttype/accounttype.go
@@ -15,28 +15,30 @@ import (
 
 // AccountTypePostgreSQLModel represents the database model for account types
 type AccountTypePostgreSQLModel struct {
-	ID             uuid.UUID    `db:"id"`
-	OrganizationID uuid.UUID    `db:"organization_id"`
-	LedgerID       uuid.UUID    `db:"ledger_id"`
-	Name           string       `db:"name"`
-	Description    string       `db:"description"`
-	KeyValue       string       `db:"key_value"`
-	CreatedAt      time.Time    `db:"created_at"`
-	UpdatedAt      time.Time    `db:"updated_at"`
-	DeletedAt      sql.NullTime `db:"deleted_at"`
+	ID               uuid.UUID    `db:"id"`
+	OrganizationID   uuid.UUID    `db:"organization_id"`
+	LedgerID         uuid.UUID    `db:"ledger_id"`
+	Name             string       `db:"name"`
+	Description      string       `db:"description"`
+	KeyValue         string       `db:"key_value"`
+	DefaultDirection string       `db:"default_direction"`
+	CreatedAt        time.Time    `db:"created_at"`
+	UpdatedAt        time.Time    `db:"updated_at"`
+	DeletedAt        sql.NullTime `db:"deleted_at"`
 }
 
 // ToEntity converts the database model to a domain model
 func (m *AccountTypePostgreSQLModel) ToEntity() *mmodel.AccountType {
 	e := &mmodel.AccountType{
-		ID:             m.ID,
-		OrganizationID: m.OrganizationID,
-		LedgerID:       m.LedgerID,
-		Name:           m.Name,
-		Description:    m.Description,
-		KeyValue:       m.KeyValue,
-		CreatedAt:      m.CreatedAt,
-		UpdatedAt:      m.UpdatedAt,
+		ID:               m.ID,
+		OrganizationID:   m.OrganizationID,
+		LedgerID:         m.LedgerID,
+		Name:             m.Name,
+		Description:      m.Description,
+		KeyValue:         m.KeyValue,
+		DefaultDirection: m.DefaultDirection,
+		CreatedAt:        m.CreatedAt,
+		UpdatedAt:        m.UpdatedAt,
 	}
 
 	if m.DeletedAt.Valid {
@@ -54,6 +56,7 @@ func (m *AccountTypePostgreSQLModel) FromEntity(accountType *mmodel.AccountType)
 	m.Name = accountType.Name
 	m.Description = accountType.Description
 	m.KeyValue = strings.ToLower(accountType.KeyValue)
+	m.DefaultDirection = accountType.DefaultDirection
 	m.CreatedAt = accountType.CreatedAt
 	m.UpdatedAt = accountType.UpdatedAt
 

--- a/components/ledger/internal/adapters/postgres/accounttype/accounttype.postgresql.go
+++ b/components/ledger/internal/adapters/postgres/accounttype/accounttype.postgresql.go
@@ -39,6 +39,7 @@ var accountTypeColumnList = []string{
 	"name",
 	"description",
 	"key_value",
+	"default_direction",
 	"created_at",
 	"updated_at",
 	"deleted_at",
@@ -121,6 +122,12 @@ func (r *AccountTypePostgreSQLRepository) Create(ctx context.Context, organizati
 	record := &AccountTypePostgreSQLModel{}
 	record.FromEntity(accountType)
 
+	// An empty direction maps to the column default so the positional INSERT never
+	// sends an empty string that would violate the default_direction CHECK.
+	if record.DefaultDirection == "" {
+		record.DefaultDirection = constant.DirectionCredit
+	}
+
 	query, args, err := squirrel.Insert(r.tableName).
 		Columns(accountTypeColumnList...).
 		Values(
@@ -130,6 +137,7 @@ func (r *AccountTypePostgreSQLRepository) Create(ctx context.Context, organizati
 			record.Name,
 			record.Description,
 			record.KeyValue,
+			record.DefaultDirection,
 			record.CreatedAt,
 			record.UpdatedAt,
 			record.DeletedAt,
@@ -157,6 +165,7 @@ func (r *AccountTypePostgreSQLRepository) Create(ctx context.Context, organizati
 		&inserted.Name,
 		&inserted.Description,
 		&inserted.KeyValue,
+		&inserted.DefaultDirection,
 		&inserted.CreatedAt,
 		&inserted.UpdatedAt,
 		&inserted.DeletedAt,
@@ -207,8 +216,9 @@ func (r *AccountTypePostgreSQLRepository) FindByID(ctx context.Context, organiza
 			ledger_id, 
 			name, 
 			description, 
-			key_value, 
-			created_at, 
+			key_value,
+			default_direction,
+			created_at,
 			updated_at, 
 			deleted_at 
 		FROM account_type 
@@ -225,6 +235,7 @@ func (r *AccountTypePostgreSQLRepository) FindByID(ctx context.Context, organiza
 		&record.Name,
 		&record.Description,
 		&record.KeyValue,
+		&record.DefaultDirection,
 		&record.CreatedAt,
 		&record.UpdatedAt,
 		&record.DeletedAt,
@@ -272,8 +283,9 @@ func (r *AccountTypePostgreSQLRepository) FindByKey(ctx context.Context, organiz
 			ledger_id, 
 			name, 
 			description, 
-			key_value, 
-			created_at, 
+			key_value,
+			default_direction,
+			created_at,
 			updated_at, 
 			deleted_at 
 		FROM account_type 
@@ -290,6 +302,7 @@ func (r *AccountTypePostgreSQLRepository) FindByKey(ctx context.Context, organiz
 		&record.Name,
 		&record.Description,
 		&record.KeyValue,
+		&record.DefaultDirection,
 		&record.CreatedAt,
 		&record.UpdatedAt,
 		&record.DeletedAt,
@@ -345,6 +358,10 @@ func (r *AccountTypePostgreSQLRepository) Update(ctx context.Context, organizati
 		update = update.Set("description", record.Description)
 	}
 
+	if accountType.DefaultDirection != "" {
+		update = update.Set("default_direction", record.DefaultDirection)
+	}
+
 	update = update.Suffix("RETURNING " + strings.Join(accountTypeColumnList, ", "))
 
 	query, args, err := update.ToSql()
@@ -368,6 +385,7 @@ func (r *AccountTypePostgreSQLRepository) Update(ctx context.Context, organizati
 		&updated.Name,
 		&updated.Description,
 		&updated.KeyValue,
+		&updated.DefaultDirection,
 		&updated.CreatedAt,
 		&updated.UpdatedAt,
 		&updated.DeletedAt,
@@ -494,6 +512,7 @@ func (r *AccountTypePostgreSQLRepository) FindAll(ctx context.Context, organizat
 			&record.Name,
 			&record.Description,
 			&record.KeyValue,
+			&record.DefaultDirection,
 			&record.CreatedAt,
 			&record.UpdatedAt,
 			&record.DeletedAt,
@@ -556,8 +575,9 @@ func (r *AccountTypePostgreSQLRepository) ListByIDs(ctx context.Context, organiz
 		ledger_id, 
 		name, 
 		description, 
-		key_value, 
-		created_at, 
+		key_value,
+		default_direction,
+		created_at,
 		updated_at, 
 		deleted_at 
 	FROM account_type 
@@ -588,6 +608,7 @@ func (r *AccountTypePostgreSQLRepository) ListByIDs(ctx context.Context, organiz
 			&record.Name,
 			&record.Description,
 			&record.KeyValue,
+			&record.DefaultDirection,
 			&record.CreatedAt,
 			&record.UpdatedAt,
 			&record.DeletedAt,

--- a/components/ledger/internal/adapters/postgres/accounttype/accounttype.postgresql_integration_test.go
+++ b/components/ledger/internal/adapters/postgres/accounttype/accounttype.postgresql_integration_test.go
@@ -8,11 +8,13 @@ package accounttype
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
 	libCommons "github.com/LerianStudio/lib-commons/v6/commons"
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -277,6 +279,117 @@ func TestIntegration_AccountTypeRepository_Create_DuplicateKeyValueFails(t *test
 	assert.Nil(t, created)
 }
 
+func TestIntegration_AccountTypeRepository_Create_RoundTripsDefaultDirection(t *testing.T) {
+	container := pgtestutil.SetupContainer(t)
+
+	repo := createRepository(t, container)
+
+	orgID := pgtestutil.CreateTestOrganization(t, container.DB)
+	ledgerID := pgtestutil.CreateTestLedger(t, container.DB, orgID)
+
+	now := time.Now().Truncate(time.Microsecond)
+
+	accountType := &mmodel.AccountType{
+		ID:               uuid.Must(libCommons.GenerateUUIDv7()),
+		OrganizationID:   orgID,
+		LedgerID:         ledgerID,
+		Name:             "Debit Direction Type",
+		Description:      "Persists default_direction=debit",
+		KeyValue:         "debit-direction-type",
+		DefaultDirection: "debit",
+		CreatedAt:        now,
+		UpdatedAt:        now,
+	}
+
+	ctx := context.Background()
+
+	created, err := repo.Create(ctx, orgID, ledgerID, accountType)
+
+	require.NoError(t, err, "Create should not return error")
+	require.NotNil(t, created)
+	assert.Equal(t, "debit", created.DefaultDirection, "created row should carry default_direction")
+
+	found, err := repo.FindByID(ctx, orgID, ledgerID, accountType.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "debit", found.DefaultDirection, "default_direction should round-trip through the read path")
+}
+
+func TestIntegration_AccountTypeRepository_Create_DefaultsDirectionToCredit(t *testing.T) {
+	container := pgtestutil.SetupContainer(t)
+
+	repo := createRepository(t, container)
+
+	orgID := pgtestutil.CreateTestOrganization(t, container.DB)
+	ledgerID := pgtestutil.CreateTestLedger(t, container.DB, orgID)
+
+	now := time.Now().Truncate(time.Microsecond)
+
+	// The command service is responsible for defaulting an absent direction to
+	// "credit"; simulate that contract at the adapter boundary.
+	accountType := &mmodel.AccountType{
+		ID:               uuid.Must(libCommons.GenerateUUIDv7()),
+		OrganizationID:   orgID,
+		LedgerID:         ledgerID,
+		Name:             "Credit Default Type",
+		Description:      "Persists default_direction=credit",
+		KeyValue:         "credit-default-type",
+		DefaultDirection: "credit",
+		CreatedAt:        now,
+		UpdatedAt:        now,
+	}
+
+	ctx := context.Background()
+
+	created, err := repo.Create(ctx, orgID, ledgerID, accountType)
+
+	require.NoError(t, err, "Create with credit direction must satisfy the CHECK constraint")
+	require.NotNil(t, created)
+
+	found, err := repo.FindByID(ctx, orgID, ledgerID, accountType.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "credit", found.DefaultDirection)
+}
+
+// TestIntegration_AccountTypeRepository_Create_RejectsOutOfDomainDirection proves that
+// migration 000020's CHECK constraint (default_direction IN ('credit','debit')) actually
+// rejects an out-of-domain value at the database boundary. It bypasses the service and
+// repository guards — which coerce or validate the direction upstream — by inserting an
+// invalid value with a raw SQL exec, then asserts the CHECK-violation SQLSTATE (23514).
+func TestIntegration_AccountTypeRepository_Create_RejectsOutOfDomainDirection(t *testing.T) {
+	container := pgtestutil.SetupContainer(t)
+
+	// createRepository runs the onboarding migrations, so the CHECK is in place.
+	createRepository(t, container)
+
+	orgID := pgtestutil.CreateTestOrganization(t, container.DB)
+	ledgerID := pgtestutil.CreateTestLedger(t, container.DB, orgID)
+
+	now := time.Now().Truncate(time.Microsecond)
+
+	// Insert directly on the DB handle so no upstream guard coerces the value.
+	_, err := container.DB.Exec(
+		`INSERT INTO account_type
+			(id, organization_id, ledger_id, name, description, key_value, default_direction, created_at, updated_at)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $8)`,
+		uuid.Must(libCommons.GenerateUUIDv7()),
+		orgID,
+		ledgerID,
+		"Sideways Type",
+		"Out-of-domain default_direction",
+		"sideways-type",
+		"sideways",
+		now,
+	)
+
+	require.Error(t, err, "the CHECK constraint must reject an out-of-domain default_direction")
+
+	var pgErr *pgconn.PgError
+
+	require.True(t, errors.As(err, &pgErr), "expected a *pgconn.PgError, got %T", err)
+	assert.Equal(t, "23514", pgErr.Code, "SQLSTATE should be a check_violation")
+	assert.Equal(t, "account_type_default_direction_check", pgErr.ConstraintName, "the default_direction CHECK should be the violated constraint")
+}
+
 // ============================================================================
 // Update Tests
 // ============================================================================
@@ -323,6 +436,46 @@ func TestIntegration_AccountTypeRepository_Update_ChangesNameAndDescription(t *t
 	assert.Equal(t, "Updated Description", found.Description, "description should be updated")
 	assert.Equal(t, "update-test", found.KeyValue, "key_value should remain unchanged")
 	assert.True(t, found.UpdatedAt.After(originalUpdatedAt), "updated_at should be changed after update")
+}
+
+func TestIntegration_AccountTypeRepository_Update_ChangesDefaultDirectionOnlyWhenSet(t *testing.T) {
+	container := pgtestutil.SetupContainer(t)
+
+	repo := createRepository(t, container)
+
+	orgID := pgtestutil.CreateTestOrganization(t, container.DB)
+	ledgerID := pgtestutil.CreateTestLedger(t, container.DB, orgID)
+
+	params := pgtestutil.AccountTypeParams{
+		Name:        "Direction Update Type",
+		Description: "Seeded with default credit direction",
+		KeyValue:    "direction-update",
+	}
+	accountTypeID := pgtestutil.CreateTestAccountType(t, container.DB, orgID, ledgerID, params)
+
+	ctx := context.Background()
+
+	// Seeded row uses the column default.
+	seeded, err := repo.FindByID(ctx, orgID, ledgerID, accountTypeID)
+	require.NoError(t, err)
+	assert.Equal(t, "credit", seeded.DefaultDirection, "seeded row should default to credit")
+
+	// A set direction is applied.
+	_, err = repo.Update(ctx, orgID, ledgerID, accountTypeID, &mmodel.AccountType{DefaultDirection: "debit"})
+	require.NoError(t, err)
+
+	afterSet, err := repo.FindByID(ctx, orgID, ledgerID, accountTypeID)
+	require.NoError(t, err)
+	assert.Equal(t, "debit", afterSet.DefaultDirection, "direction should be updated to debit")
+
+	// An unset (empty) direction leaves the column unchanged.
+	_, err = repo.Update(ctx, orgID, ledgerID, accountTypeID, &mmodel.AccountType{Name: "Renamed"})
+	require.NoError(t, err)
+
+	afterUnset, err := repo.FindByID(ctx, orgID, ledgerID, accountTypeID)
+	require.NoError(t, err)
+	assert.Equal(t, "debit", afterUnset.DefaultDirection, "direction should remain debit when the update omits it")
+	assert.Equal(t, "Renamed", afterUnset.Name, "name should still update independently")
 }
 
 func TestIntegration_AccountTypeRepository_Update_ReturnsErrNotFound(t *testing.T) {

--- a/components/ledger/internal/adapters/postgres/accounttype/accounttype.postgresql_integration_test.go
+++ b/components/ledger/internal/adapters/postgres/accounttype/accounttype.postgresql_integration_test.go
@@ -24,6 +24,12 @@ import (
 	pgtestutil "github.com/LerianStudio/midaz/v4/tests/utils/postgres"
 )
 
+// fixedIntegrationTime is a deterministic UTC instant used by the persistence
+// tests. It carries microsecond precision (654321 micros) because Postgres
+// round-trips timestamps at microsecond precision; a fixed value keeps the
+// round-trip assertions reproducible without relying on time.Now().
+var fixedIntegrationTime = time.Date(2026, 1, 2, 3, 4, 5, 654321*1000, time.UTC)
+
 // createRepository creates an AccountTypePostgreSQLRepository connected to the test database.
 func createRepository(t *testing.T, container *pgtestutil.ContainerResult) *AccountTypePostgreSQLRepository {
 	t.Helper()
@@ -103,7 +109,7 @@ func TestIntegration_AccountTypeRepository_FindByID_IgnoresDeletedAccountType(t 
 	ledgerID := pgtestutil.CreateTestLedger(t, container.DB, orgID)
 
 	// Insert deleted account type
-	deletedAt := time.Now().Add(-1 * time.Hour)
+	deletedAt := fixedIntegrationTime.Add(-1 * time.Hour)
 	params := pgtestutil.AccountTypeParams{
 		Name:        "Deleted Type",
 		Description: "This type was deleted",
@@ -210,7 +216,7 @@ func TestIntegration_AccountTypeRepository_Create(t *testing.T) {
 	orgID := pgtestutil.CreateTestOrganization(t, container.DB)
 	ledgerID := pgtestutil.CreateTestLedger(t, container.DB, orgID)
 
-	now := time.Now().Truncate(time.Microsecond)
+	now := fixedIntegrationTime
 
 	accountType := &mmodel.AccountType{
 		ID:             uuid.Must(libCommons.GenerateUUIDv7()),
@@ -255,7 +261,7 @@ func TestIntegration_AccountTypeRepository_Create_DuplicateKeyValueFails(t *test
 	}
 	pgtestutil.CreateTestAccountType(t, container.DB, orgID, ledgerID, params)
 
-	now := time.Now().Truncate(time.Microsecond)
+	now := fixedIntegrationTime
 
 	// Try to create second with same key_value
 	accountType := &mmodel.AccountType{
@@ -287,7 +293,7 @@ func TestIntegration_AccountTypeRepository_Create_RoundTripsDefaultDirection(t *
 	orgID := pgtestutil.CreateTestOrganization(t, container.DB)
 	ledgerID := pgtestutil.CreateTestLedger(t, container.DB, orgID)
 
-	now := time.Now().Truncate(time.Microsecond)
+	now := fixedIntegrationTime
 
 	accountType := &mmodel.AccountType{
 		ID:               uuid.Must(libCommons.GenerateUUIDv7()),
@@ -322,7 +328,7 @@ func TestIntegration_AccountTypeRepository_Create_DefaultsDirectionToCredit(t *t
 	orgID := pgtestutil.CreateTestOrganization(t, container.DB)
 	ledgerID := pgtestutil.CreateTestLedger(t, container.DB, orgID)
 
-	now := time.Now().Truncate(time.Microsecond)
+	now := fixedIntegrationTime
 
 	// The command service is responsible for defaulting an absent direction to
 	// "credit"; simulate that contract at the adapter boundary.
@@ -364,7 +370,7 @@ func TestIntegration_AccountTypeRepository_Create_RejectsOutOfDomainDirection(t 
 	orgID := pgtestutil.CreateTestOrganization(t, container.DB)
 	ledgerID := pgtestutil.CreateTestLedger(t, container.DB, orgID)
 
-	now := time.Now().Truncate(time.Microsecond)
+	now := fixedIntegrationTime
 
 	// Insert directly on the DB handle so no upstream guard coerces the value.
 	_, err := container.DB.Exec(
@@ -730,7 +736,7 @@ func TestIntegration_AccountTypeRepository_ListByIDs_IgnoresDeletedAccountTypes(
 	activeID := pgtestutil.CreateTestAccountType(t, container.DB, orgID, ledgerID, activeParams)
 
 	// Create deleted account type
-	deletedAt := time.Now().Add(-1 * time.Hour)
+	deletedAt := fixedIntegrationTime.Add(-1 * time.Hour)
 	deletedParams := pgtestutil.AccountTypeParams{
 		Name:        "Deleted Type",
 		Description: "Deleted",
@@ -830,7 +836,7 @@ func TestIntegration_AccountTypeRepository_Delete_AllowsReusingSameKeyValue(t *t
 	require.NoError(t, err)
 
 	// Create new account type with same key_value
-	now := time.Now().Truncate(time.Microsecond)
+	now := fixedIntegrationTime
 	newAccountType := &mmodel.AccountType{
 		ID:             uuid.Must(libCommons.GenerateUUIDv7()),
 		OrganizationID: orgID,

--- a/components/ledger/internal/adapters/postgres/accounttype/accounttype_test.go
+++ b/components/ledger/internal/adapters/postgres/accounttype/accounttype_test.go
@@ -15,6 +15,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// fixedTestTime is a deterministic UTC instant used by the mapping tests so the
+// timestamps stay reproducible instead of relying on time.Now().
+var fixedTestTime = time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+
 func TestAccountTypePostgreSQLModel_ToEntity(t *testing.T) {
 	t.Run("with_all_fields_populated", func(t *testing.T) {
 		deletedAt := time.Now().Add(-24 * time.Hour)
@@ -75,8 +79,8 @@ func TestAccountTypePostgreSQLModel_ToEntity(t *testing.T) {
 			Description:      "Testing default_direction mapping",
 			KeyValue:         "debit-type",
 			DefaultDirection: "debit",
-			CreatedAt:        time.Now(),
-			UpdatedAt:        time.Now(),
+			CreatedAt:        fixedTestTime,
+			UpdatedAt:        fixedTestTime,
 		}
 
 		entity := model.ToEntity()
@@ -146,8 +150,8 @@ func TestAccountTypePostgreSQLModel_FromEntity(t *testing.T) {
 			Description:      "Testing default_direction mapping",
 			KeyValue:         "debit-type",
 			DefaultDirection: "debit",
-			CreatedAt:        time.Now(),
-			UpdatedAt:        time.Now(),
+			CreatedAt:        fixedTestTime,
+			UpdatedAt:        fixedTestTime,
 		}
 
 		var model AccountTypePostgreSQLModel

--- a/components/ledger/internal/adapters/postgres/accounttype/accounttype_test.go
+++ b/components/ledger/internal/adapters/postgres/accounttype/accounttype_test.go
@@ -65,6 +65,25 @@ func TestAccountTypePostgreSQLModel_ToEntity(t *testing.T) {
 		require.NotNil(t, entity)
 		assert.Nil(t, entity.DeletedAt, "DeletedAt should be nil when Valid is false, even with non-zero Time")
 	})
+
+	t.Run("maps_default_direction", func(t *testing.T) {
+		model := &AccountTypePostgreSQLModel{
+			ID:               uuid.New(),
+			OrganizationID:   uuid.New(),
+			LedgerID:         uuid.New(),
+			Name:             "Debit Type",
+			Description:      "Testing default_direction mapping",
+			KeyValue:         "debit-type",
+			DefaultDirection: "debit",
+			CreatedAt:        time.Now(),
+			UpdatedAt:        time.Now(),
+		}
+
+		entity := model.ToEntity()
+
+		require.NotNil(t, entity)
+		assert.Equal(t, "debit", entity.DefaultDirection, "DefaultDirection should be copied to the entity")
+	})
 }
 
 func TestAccountTypePostgreSQLModel_FromEntity(t *testing.T) {
@@ -116,6 +135,25 @@ func TestAccountTypePostgreSQLModel_FromEntity(t *testing.T) {
 
 		assert.False(t, model.DeletedAt.Valid, "DeletedAt.Valid should be false when entity.DeletedAt is nil")
 		assert.True(t, model.DeletedAt.Time.IsZero(), "DeletedAt.Time should be zero when entity.DeletedAt is nil")
+	})
+
+	t.Run("maps_default_direction", func(t *testing.T) {
+		entity := &mmodel.AccountType{
+			ID:               uuid.New(),
+			OrganizationID:   uuid.New(),
+			LedgerID:         uuid.New(),
+			Name:             "Debit Type",
+			Description:      "Testing default_direction mapping",
+			KeyValue:         "debit-type",
+			DefaultDirection: "debit",
+			CreatedAt:        time.Now(),
+			UpdatedAt:        time.Now(),
+		}
+
+		var model AccountTypePostgreSQLModel
+		model.FromEntity(entity)
+
+		assert.Equal(t, "debit", model.DefaultDirection, "DefaultDirection should be copied from the entity")
 	})
 
 	t.Run("converts_keyvalue_to_lowercase", func(t *testing.T) {

--- a/components/ledger/internal/services/command/create_account.go
+++ b/components/ledger/internal/services/command/create_account.go
@@ -211,16 +211,17 @@ func (uc *UseCase) CreateAccount(ctx context.Context, organizationID, ledgerID u
 	}
 
 	balanceInput := mmodel.CreateBalanceInput{
-		RequestID:      requestID,
-		OrganizationID: organizationID,
-		LedgerID:       ledgerID,
-		AccountID:      accountID,
-		Alias:          *alias,
-		Key:            constant.DefaultBalanceKey,
-		AssetCode:      cai.AssetCode,
-		AccountType:    cai.Type,
-		AllowSending:   true,
-		AllowReceiving: true,
+		RequestID:        requestID,
+		OrganizationID:   organizationID,
+		LedgerID:         ledgerID,
+		AccountID:        accountID,
+		Alias:            *alias,
+		Key:              constant.DefaultBalanceKey,
+		AssetCode:        cai.AssetCode,
+		AccountType:      cai.Type,
+		DefaultDirection: uc.resolveDefaultBalanceDirectionForType(ctx, organizationID, ledgerID, cai.Type, isExternal),
+		AllowSending:     true,
+		AllowReceiving:   true,
 	}
 
 	_, err = uc.CreateDefaultBalance(ctx, balanceInput)

--- a/components/ledger/internal/services/command/create_account_streaming_test.go
+++ b/components/ledger/internal/services/command/create_account_streaming_test.go
@@ -57,6 +57,12 @@ func newStreamingTestUseCase(t *testing.T, ctrl *gomock.Controller, emitter libS
 		GetSettings(gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(nil, nil).AnyTimes()
 
+	// Best-effort account-type default-direction lookup (non-external path).
+	// A miss degrades gracefully to no type default -> credit fallback.
+	mockAccountTypeRepo.EXPECT().
+		FindByKey(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(nil, errors.New("not found")).AnyTimes()
+
 	mockAssetRepo.EXPECT().
 		FindByNameOrCode(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(true, nil).AnyTimes()

--- a/components/ledger/internal/services/command/create_account_test.go
+++ b/components/ledger/internal/services/command/create_account_test.go
@@ -77,6 +77,11 @@ func TestCreateAccountScenarios(t *testing.T) {
 					GetSettings(gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(nil, nil).AnyTimes()
 
+				// Best-effort default-direction resolution (non-external).
+				mockAccountTypeRepo.EXPECT().
+					FindByKey(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil, services.ErrDatabaseItemNotFound).AnyTimes()
+
 				mockAssetRepo.EXPECT().
 					FindByNameOrCode(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(true, nil).AnyTimes()
@@ -121,13 +126,15 @@ func TestCreateAccountScenarios(t *testing.T) {
 					GetSettings(gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(map[string]any{"accounting": map[string]any{"validateAccountType": true}}, nil).AnyTimes()
 
+				// Called by accounting validation AND by the best-effort
+				// default-direction resolution (both non-external).
 				mockAccountTypeRepo.EXPECT().
 					FindByKey(gomock.Any(), organizationID, ledgerID, "deposit").
 					Return(&mmodel.AccountType{
 						KeyValue: "deposit",
 						Name:     "Deposit Account",
 					}, nil).
-					Times(1)
+					MinTimes(1)
 
 				mockAssetRepo.EXPECT().
 					FindByNameOrCode(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
@@ -313,6 +320,11 @@ func TestCreateAccountScenarios(t *testing.T) {
 					GetSettings(gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(nil, nil).AnyTimes()
 
+				// Best-effort default-direction resolution (non-external).
+				mockAccountTypeRepo.EXPECT().
+					FindByKey(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil, services.ErrDatabaseItemNotFound).AnyTimes()
+
 				mockAssetRepo.EXPECT().
 					FindByNameOrCode(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(true, nil).AnyTimes()
@@ -357,6 +369,11 @@ func TestCreateAccountScenarios(t *testing.T) {
 				mockLedgerRepo.EXPECT().
 					GetSettings(gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(nil, nil).AnyTimes()
+
+				// Best-effort default-direction resolution (non-external).
+				mockAccountTypeRepo.EXPECT().
+					FindByKey(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil, services.ErrDatabaseItemNotFound).AnyTimes()
 
 				mockAssetRepo.EXPECT().
 					FindByNameOrCode(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
@@ -853,6 +870,12 @@ func TestCreateAccountEdgeCases(t *testing.T) {
 
 			tt.mockSetup(mockAssetRepo, mockPortfolioRepo, mockAccountRepo, mockMetadataRepo, mockAccountTypeRepo, mockBalance, mockLedgerRepo)
 
+			// Best-effort default-direction resolution looks up the (non-external)
+			// account type; a miss degrades gracefully to the credit fallback.
+			mockAccountTypeRepo.EXPECT().
+				FindByKey(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(nil, services.ErrDatabaseItemNotFound).AnyTimes()
+
 			account, err := uc.CreateAccount(ctx, organizationID, ledgerID, tt.input, token)
 
 			if tt.expectError {
@@ -917,10 +940,11 @@ func TestCreateAccountValidationEdgeCases(t *testing.T) {
 					GetSettings(gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(nil, nil).AnyTimes()
 
-				// Should not call AccountTypeRepo since validation is disabled
+				// Validation is disabled, but the best-effort default-direction
+				// resolution still looks up the (non-external) account type.
 				mockAccountTypeRepo.EXPECT().
 					FindByKey(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-					Times(0)
+					Return(nil, services.ErrDatabaseItemNotFound).AnyTimes()
 
 				mockAssetRepo.EXPECT().
 					FindByNameOrCode(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
@@ -966,14 +990,16 @@ func TestCreateAccountValidationEdgeCases(t *testing.T) {
 					GetSettings(gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(map[string]any{"accounting": map[string]any{"validateAccountType": true}}, nil).AnyTimes()
 
-				// Mock account type found - repository handles case insensitivity
+				// Mock account type found - repository handles case insensitivity.
+				// Called by accounting validation AND by the best-effort
+				// default-direction resolution (both non-external).
 				mockAccountTypeRepo.EXPECT().
 					FindByKey(gomock.Any(), organizationID, ledgerID, "DePoSiT").
 					Return(&mmodel.AccountType{
 						KeyValue: "deposit", // Lowercase in database
 						Name:     "Deposit Account",
 					}, nil).
-					Times(1)
+					MinTimes(1)
 
 				mockAssetRepo.EXPECT().
 					FindByNameOrCode(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
@@ -1220,11 +1246,17 @@ func TestCreateAccountExternalAlias(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 
-			uc, mockAssetRepo, _, mockAccountRepo, mockMetadataRepo, _, mockBalance, mockLedgerRepo := setupTest(ctrl)
+			uc, mockAssetRepo, _, mockAccountRepo, mockMetadataRepo, mockAccountTypeRepo, mockBalance, mockLedgerRepo := setupTest(ctrl)
 
 			mockLedgerRepo.EXPECT().
 				GetSettings(gomock.Any(), gomock.Any(), gomock.Any()).
 				Return(nil, nil).AnyTimes()
+
+			// Best-effort default-direction resolution looks up the (non-external)
+			// account type; external accounts bypass it. A miss degrades gracefully.
+			mockAccountTypeRepo.EXPECT().
+				FindByKey(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(nil, services.ErrDatabaseItemNotFound).AnyTimes()
 
 			mockAssetRepo.EXPECT().
 				FindByNameOrCode(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
@@ -1364,6 +1396,11 @@ func TestCreateAccountBlockedFlag(t *testing.T) {
 	mockLedgerRepo.EXPECT().
 		GetSettings(gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(nil, nil).AnyTimes()
+
+	// Best-effort account-type default-direction lookup (non-external path).
+	mockAccountTypeRepo.EXPECT().
+		FindByKey(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(nil, services.ErrDatabaseItemNotFound).AnyTimes()
 
 	mockAssetRepo.EXPECT().
 		FindByNameOrCode(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).

--- a/components/ledger/internal/services/command/create_account_type.go
+++ b/components/ledger/internal/services/command/create_account_type.go
@@ -39,15 +39,21 @@ func (uc *UseCase) CreateAccountType(ctx context.Context, organizationID, ledger
 
 	now := time.Now()
 
+	defaultDirection := constant.DirectionCredit
+	if payload.DefaultDirection != nil {
+		defaultDirection = *payload.DefaultDirection
+	}
+
 	accountType := &mmodel.AccountType{
-		ID:             uuid.Must(libCommons.GenerateUUIDv7()),
-		OrganizationID: organizationID,
-		LedgerID:       ledgerID,
-		Name:           payload.Name,
-		Description:    payload.Description,
-		KeyValue:       payload.KeyValue,
-		CreatedAt:      now,
-		UpdatedAt:      now,
+		ID:               uuid.Must(libCommons.GenerateUUIDv7()),
+		OrganizationID:   organizationID,
+		LedgerID:         ledgerID,
+		Name:             payload.Name,
+		Description:      payload.Description,
+		KeyValue:         payload.KeyValue,
+		DefaultDirection: defaultDirection,
+		CreatedAt:        now,
+		UpdatedAt:        now,
 	}
 
 	createdAccountType, err := uc.AccountTypeRepo.Create(ctx, organizationID, ledgerID, accountType)

--- a/components/ledger/internal/services/command/create_account_type_test.go
+++ b/components/ledger/internal/services/command/create_account_type_test.go
@@ -166,6 +166,59 @@ func TestCreateAccountTypeValidatesInput(t *testing.T) {
 	}
 }
 
+// TestCreateAccountTypeDefaultsDirectionToCredit tests that an absent DefaultDirection
+// on the input resolves to constant.DirectionCredit on the built AccountType, so the
+// positional INSERT never sends an empty string that would violate the CHECK constraint.
+func TestCreateAccountTypeDefaultsDirectionToCredit(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	organizationID := uuid.Must(libCommons.GenerateUUIDv7())
+	ledgerID := uuid.Must(libCommons.GenerateUUIDv7())
+
+	debit := constant.DirectionDebit
+
+	testCases := []struct {
+		name     string
+		input    *string
+		expected string
+	}{
+		{name: "absent defaults to credit", input: nil, expected: constant.DirectionCredit},
+		{name: "explicit debit is preserved", input: &debit, expected: constant.DirectionDebit},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			payload := &mmodel.CreateAccountTypeInput{
+				Name:             "Assets",
+				Description:      "Asset accounts",
+				KeyValue:         "assets",
+				DefaultDirection: tc.input,
+			}
+
+			mockAccountTypeRepo := accounttype.NewMockRepository(ctrl)
+
+			uc := UseCase{
+				AccountTypeRepo: mockAccountTypeRepo,
+			}
+
+			mockAccountTypeRepo.EXPECT().
+				Create(gomock.Any(), organizationID, ledgerID, gomock.Any()).
+				DoAndReturn(func(ctx context.Context, orgID, ledID any, accountType *mmodel.AccountType) (*mmodel.AccountType, error) {
+					assert.Equal(t, tc.expected, accountType.DefaultDirection)
+
+					return accountType, nil
+				}).
+				Times(1)
+
+			result, err := uc.CreateAccountType(context.Background(), organizationID, ledgerID, payload)
+
+			assert.NoError(t, err)
+			assert.NotNil(t, result)
+		})
+	}
+}
+
 // TestCreateAccountTypeDuplicateKeyValue tests creating account type with a duplicate key value
 func TestCreateAccountTypeDuplicateKeyValue(t *testing.T) {
 	ctrl := gomock.NewController(t)

--- a/components/ledger/internal/services/command/create_balance.go
+++ b/components/ledger/internal/services/command/create_balance.go
@@ -22,9 +22,11 @@ import (
 
 // CreateDefaultBalance creates the default balance for a newly-created
 // account or asset. The balance key is hardcoded to
-// constant.DefaultBalanceKey and the direction is derived from the account
-// type: external accounts get constant.DirectionDebit, all others get
-// constant.DirectionCredit.
+// constant.DefaultBalanceKey and the direction is resolved by precedence:
+// the account type's default (input.DefaultDirection, when set) wins,
+// otherwise the account-type-implied default applies (external ->
+// constant.DirectionDebit, all others -> constant.DirectionCredit). The
+// default path has no explicit caller override.
 //
 // Additional (non-default) balances are created via CreateAdditionalBalance,
 // which is exposed through the POST /balances HTTP endpoint and applies
@@ -93,7 +95,7 @@ func (uc *UseCase) CreateDefaultBalance(ctx context.Context, input mmodel.Create
 		AccountType:    input.AccountType,
 		AllowSending:   input.AllowSending,
 		AllowReceiving: input.AllowReceiving,
-		Direction:      defaultBalanceDirection(input.AccountType),
+		Direction:      resolveBalanceDirection("", input.DefaultDirection, input.AccountType),
 		CreatedAt:      now,
 		UpdatedAt:      now,
 	}

--- a/components/ledger/internal/services/command/create_balance_additional.go
+++ b/components/ledger/internal/services/command/create_balance_additional.go
@@ -124,13 +124,25 @@ func (uc *UseCase) CreateAdditionalBalance(ctx context.Context, organizationID, 
 		return nil, pkg.ValidateBusinessError(constant.ErrAdditionalBalanceNotAllowed, constant.EntityBalance, defaultBalance.Alias)
 	}
 
-	// Direction defaults to "credit" when the caller omits it. Validation
-	// above guarantees that any provided value is one of the supported
-	// enum members.
-	direction := constant.DirectionCredit
+	// Direction is resolved by precedence: an explicit caller override wins
+	// (validated above), otherwise the account type's default is inherited,
+	// otherwise the account-type-implied default applies (non-external ->
+	// credit). The type-default lookup is best-effort and non-external here
+	// (external returns above); a miss/error degrades to no type default.
+	var explicitDirection string
 	if cbi.Direction != nil {
-		direction = *cbi.Direction
+		explicitDirection = *cbi.Direction
 	}
+
+	// The type-default lookup is only consulted when there is no explicit
+	// override; an explicit direction wins in resolveBalanceDirection anyway,
+	// so the DB read is pure waste when one is present.
+	var typeDefaultDirection string
+	if explicitDirection == "" {
+		typeDefaultDirection = uc.resolveTypeDefaultDirection(ctx, organizationID, ledgerID, defaultBalance.AccountType)
+	}
+
+	direction := resolveBalanceDirection(explicitDirection, typeDefaultDirection, defaultBalance.AccountType)
 
 	additionalBalance := &mmodel.Balance{
 		ID:             uuid.Must(libCommons.GenerateUUIDv7()).String(),

--- a/components/ledger/internal/services/command/create_balance_direction_acceptance_integration_test.go
+++ b/components/ledger/internal/services/command/create_balance_direction_acceptance_integration_test.go
@@ -143,12 +143,14 @@ func (h *acceptanceDirectionHarness) seedAccountType(t *testing.T, key string, d
 
 // readBackBalanceDirection reads the persisted direction for a balance by ID
 // directly from the balance database.
-func (h *acceptanceDirectionHarness) readBackBalanceDirection(t *testing.T, balanceID string) string {
+func (h *acceptanceDirectionHarness) readBackBalanceDirection(ctx context.Context, t *testing.T, balanceID string) string {
 	t.Helper()
+
+	require.NoError(t, ctx.Err())
 
 	var direction string
 
-	err := h.balanceDB.QueryRow(`SELECT direction FROM balance WHERE id = $1`, balanceID).Scan(&direction)
+	err := h.balanceDB.QueryRowContext(ctx, `SELECT direction FROM balance WHERE id = $1`, balanceID).Scan(&direction)
 	require.NoError(t, err, "failed to read back balance direction")
 
 	return direction
@@ -157,12 +159,14 @@ func (h *acceptanceDirectionHarness) readBackBalanceDirection(t *testing.T, bala
 // countBalancesForAccount returns the number of balance rows persisted for the
 // given account, used to assert that a rejected additional-balance request
 // wrote nothing.
-func (h *acceptanceDirectionHarness) countBalancesForAccount(t *testing.T, accountID uuid.UUID) int {
+func (h *acceptanceDirectionHarness) countBalancesForAccount(ctx context.Context, t *testing.T, accountID uuid.UUID) int {
 	t.Helper()
+
+	require.NoError(t, ctx.Err())
 
 	var count int
 
-	err := h.balanceDB.QueryRow(`SELECT COUNT(*) FROM balance WHERE account_id = $1`, accountID).Scan(&count)
+	err := h.balanceDB.QueryRowContext(ctx, `SELECT COUNT(*) FROM balance WHERE account_id = $1`, accountID).Scan(&count)
 	require.NoError(t, err, "failed to count balances for account")
 
 	return count
@@ -272,7 +276,7 @@ func TestIntegration_AcceptanceInitialBalanceDirection(t *testing.T) {
 
 			assert.Equal(t, tt.expectedDirection, bal.Direction, "returned balance direction")
 
-			persisted := h.readBackBalanceDirection(t, bal.ID)
+			persisted := h.readBackBalanceDirection(ctx, t, bal.ID)
 			assert.Equal(t, tt.expectedDirection, persisted, "persisted balance direction")
 		})
 	}
@@ -285,7 +289,7 @@ func TestIntegration_AcceptanceInitialBalanceDirection(t *testing.T) {
 // default balance to exist so CreateAdditionalBalance can read the account's
 // AccountType from it; A6 uses it to materialize B1/B2 at distinct type-default
 // snapshots.
-func (h *acceptanceDirectionHarness) createDefaultBalanceForAccount(t *testing.T, ctx context.Context, accountID uuid.UUID, typeKey string) *mmodel.Balance {
+func (h *acceptanceDirectionHarness) createDefaultBalanceForAccount(ctx context.Context, t *testing.T, accountID uuid.UUID, typeKey string) *mmodel.Balance {
 	t.Helper()
 
 	dir := h.uc.resolveDefaultBalanceDirectionForType(ctx, h.orgID, h.ledgerID, typeKey, false)
@@ -354,7 +358,7 @@ func TestIntegration_AcceptanceAdditionalBalanceOverride(t *testing.T) {
 
 			// The default balance must exist first: CreateAdditionalBalance reads
 			// the account's AccountType from it (and rejects external types).
-			h.createDefaultBalanceForAccount(t, ctx, accountID, typeKey)
+			h.createDefaultBalanceForAccount(ctx, t, accountID, typeKey)
 
 			additional, err := h.uc.CreateAdditionalBalance(ctx, h.orgID, h.ledgerID, accountID, &mmodel.CreateAdditionalBalance{
 				Key:       tt.key,
@@ -365,7 +369,7 @@ func TestIntegration_AcceptanceAdditionalBalanceOverride(t *testing.T) {
 
 			assert.Equal(t, tt.expectedDirection, additional.Direction, "returned additional balance direction")
 
-			persisted := h.readBackBalanceDirection(t, additional.ID)
+			persisted := h.readBackBalanceDirection(ctx, t, additional.ID)
 			assert.Equal(t, tt.expectedDirection, persisted, "persisted additional balance direction")
 		})
 	}
@@ -396,7 +400,7 @@ func TestIntegration_AcceptanceAdditionalBalanceExternalRejected(t *testing.T) {
 	externalDefaultParams.AccountType = constant.ExternalAccountType
 	pgtestutil.CreateTestBalance(t, h.balanceDB, h.orgID, h.ledgerID, accountID, externalDefaultParams)
 
-	require.Equal(t, 1, h.countBalancesForAccount(t, accountID), "only the seeded default balance must exist before the rejected request")
+	require.Equal(t, 1, h.countBalancesForAccount(ctx, t, accountID), "only the seeded default balance must exist before the rejected request")
 
 	additional, err := h.uc.CreateAdditionalBalance(ctx, h.orgID, h.ledgerID, accountID, &mmodel.CreateAdditionalBalance{
 		Key: "external-additional",
@@ -413,7 +417,7 @@ func TestIntegration_AcceptanceAdditionalBalanceExternalRejected(t *testing.T) {
 	assert.Equal(t, constant.ErrAdditionalBalanceNotAllowed.Error(), unprocessable.Code, "error code must be the additional-balance-not-allowed sentinel")
 
 	// No additional row was persisted: still only the seeded default balance.
-	assert.Equal(t, 1, h.countBalancesForAccount(t, accountID), "no additional balance row must be persisted after rejection")
+	assert.Equal(t, 1, h.countBalancesForAccount(ctx, t, accountID), "no additional balance row must be persisted after rejection")
 }
 
 // TestIntegration_AcceptanceEditDefaultAffectsFutureOnly proves that editing an
@@ -442,7 +446,7 @@ func TestIntegration_AcceptanceEditDefaultAffectsFutureOnly(t *testing.T) {
 
 	// B1: created while the type default is credit.
 	accountID1 := uuid.Must(libCommons.GenerateUUIDv7())
-	b1 := h.createDefaultBalanceForAccount(t, ctx, accountID1, typeKey)
+	b1 := h.createDefaultBalanceForAccount(ctx, t, accountID1, typeKey)
 	assert.Equal(t, constant.DirectionCredit, b1.Direction, "B1 must inherit the type default credit at creation")
 
 	// Flip the type default to debit.
@@ -453,10 +457,10 @@ func TestIntegration_AcceptanceEditDefaultAffectsFutureOnly(t *testing.T) {
 
 	// B2: same type key, created AFTER the edit -> inherits the new debit default.
 	accountID2 := uuid.Must(libCommons.GenerateUUIDv7())
-	b2 := h.createDefaultBalanceForAccount(t, ctx, accountID2, typeKey)
+	b2 := h.createDefaultBalanceForAccount(ctx, t, accountID2, typeKey)
 	assert.Equal(t, constant.DirectionDebit, b2.Direction, "B2 must inherit the updated type default debit at creation")
 
 	// B1 re-read: immutable — still credit despite the type edit.
-	b1Persisted := h.readBackBalanceDirection(t, b1.ID)
+	b1Persisted := h.readBackBalanceDirection(ctx, t, b1.ID)
 	assert.Equal(t, constant.DirectionCredit, b1Persisted, "B1 must remain credit after the type default is edited")
 }

--- a/components/ledger/internal/services/command/create_balance_direction_acceptance_integration_test.go
+++ b/components/ledger/internal/services/command/create_balance_direction_acceptance_integration_test.go
@@ -1,0 +1,462 @@
+//go:build integration
+
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package command
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+
+	libCommons "github.com/LerianStudio/lib-commons/v6/commons"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/LerianStudio/midaz/v4/components/ledger/internal/adapters/postgres/accounttype"
+	"github.com/LerianStudio/midaz/v4/components/ledger/internal/adapters/postgres/balance"
+	"github.com/LerianStudio/midaz/v4/pkg"
+	"github.com/LerianStudio/midaz/v4/pkg/constant"
+	"github.com/LerianStudio/midaz/v4/pkg/mmodel"
+	testutils "github.com/LerianStudio/midaz/v4/tests/utils"
+	pgtestutil "github.com/LerianStudio/midaz/v4/tests/utils/postgres"
+)
+
+// acceptanceDirectionHarness wires the real account-type and balance
+// repositories against real PostgreSQL for the default-balance-direction
+// acceptance tests. The account_type table lives in the onboarding migration
+// set and the balance table lives in the transaction migration set; those two
+// sets share a single golang-migrate schema_migrations bookkeeping table and
+// therefore cannot both be applied to one database. They are provisioned in two
+// containers here — the balance table carries no foreign key to account_type or
+// account, and the initial-balance seam only reads the type via AccountTypeRepo
+// and writes the balance via BalanceRepo, so splitting the schemas is faithful
+// to production behavior.
+//
+// Reusable by Tasks 2.2.3 (additional-balance) and 2.2.4 (edit-default): call
+// setupAcceptanceDirectionHarness once per test, seed types via seedAccountType,
+// and drive the same UseCase.
+type acceptanceDirectionHarness struct {
+	uc *UseCase
+
+	// onboardingDB is the raw handle to the database holding the account_type
+	// and account tables; seed types and accounts here.
+	onboardingDB *sql.DB
+
+	// balanceDB is the raw handle to the database holding the balance table;
+	// used for direct read-back assertions.
+	balanceDB *sql.DB
+
+	orgID    uuid.UUID
+	ledgerID uuid.UUID
+}
+
+// setupAcceptanceDirectionHarness spins two PostgreSQL containers (onboarding
+// for account_type/account, transaction for balance), constructs the real
+// AccountTypePostgreSQLRepository and BalancePostgreSQLRepository, wires them
+// into a single *UseCase, and seeds one organization + ledger on both databases
+// so the shared org/ledger IDs resolve on either side.
+func setupAcceptanceDirectionHarness(t *testing.T) *acceptanceDirectionHarness {
+	t.Helper()
+
+	onboardingContainer := pgtestutil.SetupContainer(t)
+	transactionContainer := pgtestutil.SetupContainer(t)
+
+	accountTypeRepo := newAccountTypeRepoForHarness(t, onboardingContainer)
+	balanceRepo := newBalanceRepoForHarness(t, transactionContainer)
+
+	orgID := uuid.Must(libCommons.GenerateUUIDv7())
+	ledgerID := uuid.Must(libCommons.GenerateUUIDv7())
+
+	// Seed org + ledger on the onboarding side only: the account_type table
+	// references them there. The balance table (transaction side) carries no
+	// foreign keys, so it needs no organization/ledger rows.
+	seedOrganizationAndLedger(t, onboardingContainer.DB, orgID, ledgerID)
+
+	uc := &UseCase{
+		AccountTypeRepo: accountTypeRepo,
+		BalanceRepo:     balanceRepo,
+	}
+
+	return &acceptanceDirectionHarness{
+		uc:           uc,
+		onboardingDB: onboardingContainer.DB,
+		balanceDB:    transactionContainer.DB,
+		orgID:        orgID,
+		ledgerID:     ledgerID,
+	}
+}
+
+// newAccountTypeRepoForHarness applies the onboarding migrations and returns a
+// real account-type repository bound to the container connection.
+func newAccountTypeRepoForHarness(t *testing.T, container *pgtestutil.ContainerResult) *accounttype.AccountTypePostgreSQLRepository {
+	t.Helper()
+
+	migrationsPath := pgtestutil.FindMigrationsPath(t, "onboarding")
+	connStr := pgtestutil.BuildConnectionString(container.Host, container.Port, container.Config)
+	conn := pgtestutil.CreatePostgresClient(t, connStr, connStr, container.Config.DBName, migrationsPath)
+
+	return accounttype.NewAccountTypePostgreSQLRepository(conn)
+}
+
+// newBalanceRepoForHarness applies the transaction migrations and returns a real
+// balance repository bound to the container connection.
+func newBalanceRepoForHarness(t *testing.T, container *pgtestutil.ContainerResult) *balance.BalancePostgreSQLRepository {
+	t.Helper()
+
+	migrationsPath := pgtestutil.FindMigrationsPath(t, "transaction")
+	connStr := pgtestutil.BuildConnectionString(container.Host, container.Port, container.Config)
+	conn := pgtestutil.CreatePostgresClient(t, connStr, connStr, container.Config.DBName, migrationsPath)
+
+	return balance.NewBalancePostgreSQLRepository(conn, false)
+}
+
+// seedOrganizationAndLedger inserts an organization and ledger with the given
+// IDs directly, so both container databases share the same scope identifiers.
+// The INSERTs are delegated to the shared fixtures
+// (pgtestutil.CreateTestOrganizationWithID / CreateTestLedgerWithID) to avoid
+// duplicating the org/ledger seed SQL and its "Test Org"/"Test Ledger" literals.
+func seedOrganizationAndLedger(t *testing.T, db *sql.DB, orgID, ledgerID uuid.UUID) {
+	t.Helper()
+
+	pgtestutil.CreateTestOrganizationWithID(t, db, orgID)
+	pgtestutil.CreateTestLedgerWithID(t, db, ledgerID, orgID)
+}
+
+// seedAccountType inserts an account type with the given key and optional
+// default direction on the onboarding database. Reusable by 2.2.3/2.2.4.
+func (h *acceptanceDirectionHarness) seedAccountType(t *testing.T, key string, defaultDirection *string) {
+	t.Helper()
+
+	params := pgtestutil.AccountTypeParams{
+		Name:             key + " type",
+		Description:      "acceptance seed",
+		KeyValue:         key,
+		DefaultDirection: defaultDirection,
+	}
+	pgtestutil.CreateTestAccountType(t, h.onboardingDB, h.orgID, h.ledgerID, params)
+}
+
+// readBackBalanceDirection reads the persisted direction for a balance by ID
+// directly from the balance database.
+func (h *acceptanceDirectionHarness) readBackBalanceDirection(t *testing.T, balanceID string) string {
+	t.Helper()
+
+	var direction string
+
+	err := h.balanceDB.QueryRow(`SELECT direction FROM balance WHERE id = $1`, balanceID).Scan(&direction)
+	require.NoError(t, err, "failed to read back balance direction")
+
+	return direction
+}
+
+// countBalancesForAccount returns the number of balance rows persisted for the
+// given account, used to assert that a rejected additional-balance request
+// wrote nothing.
+func (h *acceptanceDirectionHarness) countBalancesForAccount(t *testing.T, accountID uuid.UUID) int {
+	t.Helper()
+
+	var count int
+
+	err := h.balanceDB.QueryRow(`SELECT COUNT(*) FROM balance WHERE account_id = $1`, accountID).Scan(&count)
+	require.NoError(t, err, "failed to count balances for account")
+
+	return count
+}
+
+// TestIntegration_AcceptanceInitialBalanceDirection exercises the initial
+// balance direction resolution seam (CreateAccount ->
+// resolveDefaultBalanceDirectionForType -> CreateDefaultBalance) end-to-end
+// against real PostgreSQL, asserting both the returned balance's Direction and
+// the direction persisted in the balance row.
+//
+// Rows mirror the acceptance table:
+//   - A1: type default "debit" (non-external)        -> debit
+//   - A2: type default "credit" (non-external)       -> credit
+//   - A3: type with no configured default            -> credit (implied default)
+//   - A4: external bypass (type not seeded)          -> debit, no error
+//   - A7: unseeded type (FindByKey miss)             -> credit, no error
+//
+// A3 note: the resolver's terminal fallback (defaultBalanceDirection) supplies
+// "credit" when the type carries no configured default. CreateDefaultBalance
+// always persists the resolved value, so the balance direction is set by the
+// resolver, never by the balance column's own default.
+func TestIntegration_AcceptanceInitialBalanceDirection(t *testing.T) {
+	h := setupAcceptanceDirectionHarness(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+
+	tests := []struct {
+		name              string
+		typeKey           string
+		seedType          bool
+		seedDirection     *string
+		isExternal        bool
+		expectedDirection string
+	}{
+		{
+			name:              "A1 type default debit -> debit",
+			typeKey:           "loan",
+			seedType:          true,
+			seedDirection:     testutils.Ptr(constant.DirectionDebit),
+			isExternal:        false,
+			expectedDirection: constant.DirectionDebit,
+		},
+		{
+			name:              "A2 type default credit -> credit",
+			typeKey:           "deposit",
+			seedType:          true,
+			seedDirection:     testutils.Ptr(constant.DirectionCredit),
+			isExternal:        false,
+			expectedDirection: constant.DirectionCredit,
+		},
+		{
+			name:              "A3 type without configured default -> credit (implied default)",
+			typeKey:           "savings",
+			seedType:          true,
+			seedDirection:     nil,
+			isExternal:        false,
+			expectedDirection: constant.DirectionCredit,
+		},
+		{
+			name:              "A4 external bypass -> debit, no error",
+			typeKey:           constant.ExternalAccountType,
+			seedType:          false,
+			seedDirection:     nil,
+			isExternal:        true,
+			expectedDirection: constant.DirectionDebit,
+		},
+		{
+			name:              "A7 unseeded type FindByKey miss -> credit, no error",
+			typeKey:           "unregistered",
+			seedType:          false,
+			seedDirection:     nil,
+			isExternal:        false,
+			expectedDirection: constant.DirectionCredit,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.seedType {
+				h.seedAccountType(t, tt.typeKey, tt.seedDirection)
+			}
+
+			accountID := uuid.Must(libCommons.GenerateUUIDv7())
+
+			// Reproduce the create_account seam: resolve the type default, then
+			// create the default balance with the resolved direction.
+			dir := h.uc.resolveDefaultBalanceDirectionForType(ctx, h.orgID, h.ledgerID, tt.typeKey, tt.isExternal)
+
+			bal, err := h.uc.CreateDefaultBalance(ctx, mmodel.CreateBalanceInput{
+				OrganizationID:   h.orgID,
+				LedgerID:         h.ledgerID,
+				AccountID:        accountID,
+				Alias:            "@acceptance/" + tt.typeKey,
+				AssetCode:        "USD",
+				AccountType:      tt.typeKey,
+				DefaultDirection: dir,
+				AllowSending:     true,
+				AllowReceiving:   true,
+			})
+
+			// A4/A7 assert graceful degradation: no error on external bypass or
+			// on a type-lookup miss.
+			require.NoError(t, err, "CreateDefaultBalance must not fail")
+			require.NotNil(t, bal, "created balance must not be nil")
+
+			assert.Equal(t, tt.expectedDirection, bal.Direction, "returned balance direction")
+
+			persisted := h.readBackBalanceDirection(t, bal.ID)
+			assert.Equal(t, tt.expectedDirection, persisted, "persisted balance direction")
+		})
+	}
+}
+
+// createDefaultBalanceForAccount reproduces the create_account initial-balance
+// seam (resolveDefaultBalanceDirectionForType -> CreateDefaultBalance) for the
+// given account and type key, returning the created balance. Reused by the
+// additional-balance (A5) and edit-default (A6) acceptance tests: A5 needs a
+// default balance to exist so CreateAdditionalBalance can read the account's
+// AccountType from it; A6 uses it to materialize B1/B2 at distinct type-default
+// snapshots.
+func (h *acceptanceDirectionHarness) createDefaultBalanceForAccount(t *testing.T, ctx context.Context, accountID uuid.UUID, typeKey string) *mmodel.Balance {
+	t.Helper()
+
+	dir := h.uc.resolveDefaultBalanceDirectionForType(ctx, h.orgID, h.ledgerID, typeKey, false)
+
+	bal, err := h.uc.CreateDefaultBalance(ctx, mmodel.CreateBalanceInput{
+		OrganizationID:   h.orgID,
+		LedgerID:         h.ledgerID,
+		AccountID:        accountID,
+		Alias:            "@acceptance/" + accountID.String(),
+		AssetCode:        "USD",
+		AccountType:      typeKey,
+		DefaultDirection: dir,
+		AllowSending:     true,
+		AllowReceiving:   true,
+	})
+	require.NoError(t, err, "CreateDefaultBalance must not fail")
+	require.NotNil(t, bal, "created default balance must not be nil")
+
+	return bal
+}
+
+// TestIntegration_AcceptanceAdditionalBalanceOverride exercises the additional
+// -balance direction seam (CreateAdditionalBalance) against real PostgreSQL.
+// CreateAdditionalBalance loads the account's existing DEFAULT balance to read
+// its AccountType, so each subtest seeds a default balance first, then adds an
+// additional balance and asserts the resolved/persisted direction.
+//
+// Acceptance row A5:
+//   - override wins:            explicit Direction=debit beats type default credit -> debit
+//   - no override inherits type: Direction=nil inherits the type default          -> credit
+func TestIntegration_AcceptanceAdditionalBalanceOverride(t *testing.T) {
+	h := setupAcceptanceDirectionHarness(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+
+	const typeKey = "wallet"
+
+	// Type default is "credit"; the additional-balance override/inherit paths
+	// resolve against it.
+	h.seedAccountType(t, typeKey, testutils.Ptr(constant.DirectionCredit))
+
+	tests := []struct {
+		name              string
+		key               string
+		direction         *string
+		expectedDirection string
+	}{
+		{
+			name:              "override wins: explicit debit beats type default credit",
+			key:               "override-key",
+			direction:         testutils.Ptr(constant.DirectionDebit),
+			expectedDirection: constant.DirectionDebit,
+		},
+		{
+			name:              "no override inherits type default credit",
+			key:               "inherit-key",
+			direction:         nil,
+			expectedDirection: constant.DirectionCredit,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			accountID := uuid.Must(libCommons.GenerateUUIDv7())
+
+			// The default balance must exist first: CreateAdditionalBalance reads
+			// the account's AccountType from it (and rejects external types).
+			h.createDefaultBalanceForAccount(t, ctx, accountID, typeKey)
+
+			additional, err := h.uc.CreateAdditionalBalance(ctx, h.orgID, h.ledgerID, accountID, &mmodel.CreateAdditionalBalance{
+				Key:       tt.key,
+				Direction: tt.direction,
+			})
+			require.NoError(t, err, "CreateAdditionalBalance must not fail")
+			require.NotNil(t, additional, "created additional balance must not be nil")
+
+			assert.Equal(t, tt.expectedDirection, additional.Direction, "returned additional balance direction")
+
+			persisted := h.readBackBalanceDirection(t, additional.ID)
+			assert.Equal(t, tt.expectedDirection, persisted, "persisted additional balance direction")
+		})
+	}
+}
+
+// TestIntegration_AcceptanceAdditionalBalanceExternalRejected proves that
+// CreateAdditionalBalance rejects an external account BEFORE any direction
+// resolution: the guard (create_balance_additional.go) fires on the default
+// balance's AccountType == constant.ExternalAccountType and returns the
+// additional-balance-not-allowed business error, persisting no additional row.
+//
+// The external default balance is seeded directly (AccountType = external, Key =
+// default) because the harness's default-balance helper resolves direction and is
+// meant for non-external types; here the type never reaches the resolver.
+func TestIntegration_AcceptanceAdditionalBalanceExternalRejected(t *testing.T) {
+	h := setupAcceptanceDirectionHarness(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+
+	accountID := uuid.Must(libCommons.GenerateUUIDv7())
+
+	// Seed the account's DEFAULT balance with the external account type. This is
+	// the row CreateAdditionalBalance loads to read the AccountType from.
+	externalDefaultParams := pgtestutil.DefaultBalanceParams()
+	externalDefaultParams.Alias = "@acceptance/external/" + accountID.String()
+	externalDefaultParams.Key = constant.DefaultBalanceKey
+	externalDefaultParams.AccountType = constant.ExternalAccountType
+	pgtestutil.CreateTestBalance(t, h.balanceDB, h.orgID, h.ledgerID, accountID, externalDefaultParams)
+
+	require.Equal(t, 1, h.countBalancesForAccount(t, accountID), "only the seeded default balance must exist before the rejected request")
+
+	additional, err := h.uc.CreateAdditionalBalance(ctx, h.orgID, h.ledgerID, accountID, &mmodel.CreateAdditionalBalance{
+		Key: "external-additional",
+	})
+
+	require.Error(t, err, "CreateAdditionalBalance must reject an external account type")
+	require.Nil(t, additional, "no additional balance must be returned on rejection")
+
+	// Assert the error IS the additional-balance-not-allowed business error: it
+	// maps to constant.ErrAdditionalBalanceNotAllowed (code "0124") through
+	// pkg.ValidateBusinessError -> UnprocessableOperationError.
+	var unprocessable pkg.UnprocessableOperationError
+	require.ErrorAs(t, err, &unprocessable, "error must be an UnprocessableOperationError")
+	assert.Equal(t, constant.ErrAdditionalBalanceNotAllowed.Error(), unprocessable.Code, "error code must be the additional-balance-not-allowed sentinel")
+
+	// No additional row was persisted: still only the seeded default balance.
+	assert.Equal(t, 1, h.countBalancesForAccount(t, accountID), "no additional balance row must be persisted after rejection")
+}
+
+// TestIntegration_AcceptanceEditDefaultAffectsFutureOnly proves that editing an
+// account type's default direction affects only balances created AFTER the
+// edit: direction is resolved at balance-creation time and persisted on the
+// row, never re-derived from the type. Acceptance row A6.
+//
+// The account type is seeded via the fixture directly (not the harness helper)
+// because this test needs the returned account-type ID to call
+// AccountTypeRepo.Update.
+func TestIntegration_AcceptanceEditDefaultAffectsFutureOnly(t *testing.T) {
+	h := setupAcceptanceDirectionHarness(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+
+	const typeKey = "ledger-cash"
+
+	// Seed the type with default "credit"; capture the ID for the later Update.
+	accountTypeID := pgtestutil.CreateTestAccountType(t, h.onboardingDB, h.orgID, h.ledgerID, pgtestutil.AccountTypeParams{
+		Name:             typeKey + " type",
+		Description:      "acceptance seed",
+		KeyValue:         typeKey,
+		DefaultDirection: testutils.Ptr(constant.DirectionCredit),
+	})
+
+	// B1: created while the type default is credit.
+	accountID1 := uuid.Must(libCommons.GenerateUUIDv7())
+	b1 := h.createDefaultBalanceForAccount(t, ctx, accountID1, typeKey)
+	assert.Equal(t, constant.DirectionCredit, b1.Direction, "B1 must inherit the type default credit at creation")
+
+	// Flip the type default to debit.
+	_, err := h.uc.AccountTypeRepo.Update(ctx, h.orgID, h.ledgerID, accountTypeID, &mmodel.AccountType{
+		DefaultDirection: constant.DirectionDebit,
+	})
+	require.NoError(t, err, "AccountTypeRepo.Update must not fail")
+
+	// B2: same type key, created AFTER the edit -> inherits the new debit default.
+	accountID2 := uuid.Must(libCommons.GenerateUUIDv7())
+	b2 := h.createDefaultBalanceForAccount(t, ctx, accountID2, typeKey)
+	assert.Equal(t, constant.DirectionDebit, b2.Direction, "B2 must inherit the updated type default debit at creation")
+
+	// B1 re-read: immutable — still credit despite the type edit.
+	b1Persisted := h.readBackBalanceDirection(t, b1.ID)
+	assert.Equal(t, constant.DirectionCredit, b1Persisted, "B1 must remain credit after the type default is edited")
+}

--- a/components/ledger/internal/services/command/create_balance_direction_wiring_test.go
+++ b/components/ledger/internal/services/command/create_balance_direction_wiring_test.go
@@ -159,7 +159,6 @@ func TestCreateAccountBalanceDirectionWiring(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -317,7 +316,6 @@ func TestCreateAdditionalBalanceDirectionWiring(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/components/ledger/internal/services/command/create_balance_direction_wiring_test.go
+++ b/components/ledger/internal/services/command/create_balance_direction_wiring_test.go
@@ -1,0 +1,360 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package command
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	mongodb "github.com/LerianStudio/midaz/v4/components/ledger/internal/adapters/mongodb/onboarding"
+	"github.com/LerianStudio/midaz/v4/components/ledger/internal/adapters/postgres/account"
+	"github.com/LerianStudio/midaz/v4/components/ledger/internal/adapters/postgres/accounttype"
+	"github.com/LerianStudio/midaz/v4/components/ledger/internal/adapters/postgres/asset"
+	"github.com/LerianStudio/midaz/v4/components/ledger/internal/adapters/postgres/balance"
+	"github.com/LerianStudio/midaz/v4/components/ledger/internal/adapters/postgres/ledger"
+	"github.com/LerianStudio/midaz/v4/components/ledger/internal/adapters/postgres/portfolio"
+	"github.com/LerianStudio/midaz/v4/components/ledger/internal/services"
+	"github.com/LerianStudio/midaz/v4/pkg"
+	"github.com/LerianStudio/midaz/v4/pkg/constant"
+	"github.com/LerianStudio/midaz/v4/pkg/mmodel"
+	testutils "github.com/LerianStudio/midaz/v4/tests/utils"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+)
+
+// TestCreateAccountBalanceDirectionWiring covers Task 1.3.2 for the INITIAL
+// balance path (CreateAccount -> CreateDefaultBalance): the account type's
+// DefaultDirection is resolved once (best-effort) and flows through the
+// resolver into the default balance's Direction.
+func TestCreateAccountBalanceDirectionWiring(t *testing.T) {
+	t.Parallel()
+
+	setupTest := func(ctrl *gomock.Controller) (*UseCase, *asset.MockRepository, *account.MockRepository, *mongodb.MockRepository, *accounttype.MockRepository, *balance.MockRepository, *ledger.MockRepository) {
+		mockAssetRepo := asset.NewMockRepository(ctrl)
+		mockAccountRepo := account.NewMockRepository(ctrl)
+		mockMetadataRepo := mongodb.NewMockRepository(ctrl)
+		mockAccountTypeRepo := accounttype.NewMockRepository(ctrl)
+		mockBalanceRepo := balance.NewMockRepository(ctrl)
+		mockLedgerRepo := ledger.NewMockRepository(ctrl)
+		mockPortfolioRepo := portfolio.NewMockRepository(ctrl)
+
+		uc := &UseCase{
+			AssetRepo:              mockAssetRepo,
+			PortfolioRepo:          mockPortfolioRepo,
+			AccountRepo:            mockAccountRepo,
+			OnboardingMetadataRepo: mockMetadataRepo,
+			AccountTypeRepo:        mockAccountTypeRepo,
+			BalanceRepo:            mockBalanceRepo,
+			LedgerRepo:             mockLedgerRepo,
+		}
+
+		return uc, mockAssetRepo, mockAccountRepo, mockMetadataRepo, mockAccountTypeRepo, mockBalanceRepo, mockLedgerRepo
+	}
+
+	ctx := context.Background()
+	organizationID := uuid.New()
+	ledgerID := uuid.New()
+	externalAlias := "@external/USD"
+
+	tests := []struct {
+		name              string
+		input             *mmodel.CreateAccountInput
+		typeLookup        func(mockAccountTypeRepo *accounttype.MockRepository)
+		expectedDirection string
+	}{
+		{
+			name: "type default debit -> initial balance debit",
+			input: &mmodel.CreateAccountInput{
+				Name:      "Debit Account",
+				Type:      "loan",
+				AssetCode: "USD",
+			},
+			typeLookup: func(mockAccountTypeRepo *accounttype.MockRepository) {
+				mockAccountTypeRepo.EXPECT().
+					FindByKey(gomock.Any(), organizationID, ledgerID, "loan").
+					Return(&mmodel.AccountType{KeyValue: "loan", DefaultDirection: constant.DirectionDebit}, nil).
+					Times(1)
+			},
+			expectedDirection: constant.DirectionDebit,
+		},
+		{
+			name: "type default credit -> initial balance credit",
+			input: &mmodel.CreateAccountInput{
+				Name:      "Credit Account",
+				Type:      "deposit",
+				AssetCode: "USD",
+			},
+			typeLookup: func(mockAccountTypeRepo *accounttype.MockRepository) {
+				mockAccountTypeRepo.EXPECT().
+					FindByKey(gomock.Any(), organizationID, ledgerID, "deposit").
+					Return(&mmodel.AccountType{KeyValue: "deposit", DefaultDirection: constant.DirectionCredit}, nil).
+					Times(1)
+			},
+			expectedDirection: constant.DirectionCredit,
+		},
+		{
+			name: "type with no default -> non-external falls back to credit",
+			input: &mmodel.CreateAccountInput{
+				Name:      "No-Default Account",
+				Type:      "savings",
+				AssetCode: "USD",
+			},
+			typeLookup: func(mockAccountTypeRepo *accounttype.MockRepository) {
+				mockAccountTypeRepo.EXPECT().
+					FindByKey(gomock.Any(), organizationID, ledgerID, "savings").
+					Return(&mmodel.AccountType{KeyValue: "savings", DefaultDirection: ""}, nil).
+					Times(1)
+			},
+			expectedDirection: constant.DirectionCredit,
+		},
+		{
+			name: "type lookup not-found -> graceful fallback to credit, no failure",
+			input: &mmodel.CreateAccountInput{
+				Name:      "Missing-Type Account",
+				Type:      "unregistered",
+				AssetCode: "USD",
+			},
+			typeLookup: func(mockAccountTypeRepo *accounttype.MockRepository) {
+				mockAccountTypeRepo.EXPECT().
+					FindByKey(gomock.Any(), organizationID, ledgerID, "unregistered").
+					Return(nil, services.ErrDatabaseItemNotFound).
+					Times(1)
+			},
+			expectedDirection: constant.DirectionCredit,
+		},
+		{
+			name: "type lookup technical error -> graceful fallback to credit, no failure",
+			input: &mmodel.CreateAccountInput{
+				Name:      "Errored-Type Account",
+				Type:      "flaky",
+				AssetCode: "USD",
+			},
+			typeLookup: func(mockAccountTypeRepo *accounttype.MockRepository) {
+				mockAccountTypeRepo.EXPECT().
+					FindByKey(gomock.Any(), organizationID, ledgerID, "flaky").
+					Return(nil, errors.New("database connection error")).
+					Times(1)
+			},
+			expectedDirection: constant.DirectionCredit,
+		},
+		{
+			name: "external account -> no type lookup, debit via bypass",
+			input: &mmodel.CreateAccountInput{
+				Name:      "External Account",
+				Type:      "external",
+				AssetCode: "USD",
+				Alias:     &externalAlias,
+			},
+			typeLookup: func(mockAccountTypeRepo *accounttype.MockRepository) {
+				mockAccountTypeRepo.EXPECT().
+					FindByKey(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Times(0)
+			},
+			expectedDirection: constant.DirectionDebit,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			uc, mockAssetRepo, mockAccountRepo, mockMetadataRepo, mockAccountTypeRepo, mockBalanceRepo, mockLedgerRepo := setupTest(ctrl)
+
+			// Validation is OFF: the type default must still be resolved.
+			mockLedgerRepo.EXPECT().
+				GetSettings(gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(nil, nil).AnyTimes()
+
+			tt.typeLookup(mockAccountTypeRepo)
+
+			mockAssetRepo.EXPECT().
+				FindByNameOrCode(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(true, nil).AnyTimes()
+
+			mockAccountRepo.EXPECT().
+				FindByAlias(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(false, nil).AnyTimes()
+
+			mockAccountRepo.EXPECT().
+				Create(gomock.Any(), gomock.Any()).
+				DoAndReturn(func(_ context.Context, in *mmodel.Account) (*mmodel.Account, error) {
+					out := *in
+					return &out, nil
+				}).AnyTimes()
+
+			mockMetadataRepo.EXPECT().
+				Create(gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(nil).AnyTimes()
+
+			mockBalanceRepo.EXPECT().
+				ExistsByAccountIDAndKey(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(false, nil).AnyTimes()
+
+			mockBalanceRepo.EXPECT().
+				Create(gomock.Any(), gomock.Any()).
+				DoAndReturn(func(_ context.Context, b *mmodel.Balance) (*mmodel.Balance, error) {
+					assert.Equal(t, tt.expectedDirection, b.Direction, "default balance direction")
+					return b, nil
+				}).
+				Times(1)
+
+			acc, err := uc.CreateAccount(ctx, organizationID, ledgerID, tt.input, "Bearer test-token")
+
+			assert.NoError(t, err)
+			assert.NotNil(t, acc)
+		})
+	}
+}
+
+// TestCreateAdditionalBalanceDirectionWiring covers Task 1.3.2 for the
+// ADDITIONAL balance path: the caller override wins (RF-03); without an
+// override the account type's DefaultDirection is inherited (RF-02); a
+// non-external type with no default falls back to credit; a type-lookup
+// miss/error degrades gracefully to credit without failing the request.
+func TestCreateAdditionalBalanceDirectionWiring(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	organizationID := uuid.New()
+	ledgerID := uuid.New()
+	accountID := uuid.New()
+
+	setupTest := func(ctrl *gomock.Controller) (*UseCase, *balance.MockRepository, *accounttype.MockRepository) {
+		mockBalanceRepo := balance.NewMockRepository(ctrl)
+		mockAccountTypeRepo := accounttype.NewMockRepository(ctrl)
+
+		uc := &UseCase{
+			BalanceRepo:     mockBalanceRepo,
+			AccountTypeRepo: mockAccountTypeRepo,
+		}
+
+		return uc, mockBalanceRepo, mockAccountTypeRepo
+	}
+
+	defaultBalance := &mmodel.Balance{
+		ID:             uuid.New().String(),
+		Alias:          "test-alias",
+		Key:            constant.DefaultBalanceKey,
+		OrganizationID: organizationID.String(),
+		LedgerID:       ledgerID.String(),
+		AccountID:      accountID.String(),
+		AssetCode:      "USD",
+		AccountType:    "deposit",
+		AllowSending:   true,
+		AllowReceiving: true,
+	}
+
+	tests := []struct {
+		name              string
+		direction         *string
+		typeLookup        func(mockAccountTypeRepo *accounttype.MockRepository)
+		expectedDirection string
+	}{
+		{
+			name:      "explicit override wins over type default",
+			direction: testutils.Ptr(constant.DirectionDebit),
+			typeLookup: func(mockAccountTypeRepo *accounttype.MockRepository) {
+				// An explicit override wins without inheriting the type default,
+				// so the lookup must be skipped entirely.
+				mockAccountTypeRepo.EXPECT().
+					FindByKey(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Times(0)
+			},
+			expectedDirection: constant.DirectionDebit,
+		},
+		{
+			name:      "no override inherits type default debit",
+			direction: nil,
+			typeLookup: func(mockAccountTypeRepo *accounttype.MockRepository) {
+				mockAccountTypeRepo.EXPECT().
+					FindByKey(gomock.Any(), organizationID, ledgerID, "deposit").
+					Return(&mmodel.AccountType{KeyValue: "deposit", DefaultDirection: constant.DirectionDebit}, nil).
+					Times(1)
+			},
+			expectedDirection: constant.DirectionDebit,
+		},
+		{
+			name:      "no override, type has no default -> credit fallback",
+			direction: nil,
+			typeLookup: func(mockAccountTypeRepo *accounttype.MockRepository) {
+				mockAccountTypeRepo.EXPECT().
+					FindByKey(gomock.Any(), organizationID, ledgerID, "deposit").
+					Return(&mmodel.AccountType{KeyValue: "deposit", DefaultDirection: ""}, nil).
+					Times(1)
+			},
+			expectedDirection: constant.DirectionCredit,
+		},
+		{
+			name:      "no override, type lookup miss -> credit fallback, no failure",
+			direction: nil,
+			typeLookup: func(mockAccountTypeRepo *accounttype.MockRepository) {
+				mockAccountTypeRepo.EXPECT().
+					FindByKey(gomock.Any(), organizationID, ledgerID, "deposit").
+					Return(nil, services.ErrDatabaseItemNotFound).
+					Times(1)
+			},
+			expectedDirection: constant.DirectionCredit,
+		},
+		{
+			name:      "no override, type lookup technical error -> credit fallback, no failure",
+			direction: nil,
+			typeLookup: func(mockAccountTypeRepo *accounttype.MockRepository) {
+				mockAccountTypeRepo.EXPECT().
+					FindByKey(gomock.Any(), organizationID, ledgerID, "deposit").
+					Return(nil, errors.New("database connection error")).
+					Times(1)
+			},
+			expectedDirection: constant.DirectionCredit,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			uc, mockBalanceRepo, mockAccountTypeRepo := setupTest(ctrl)
+
+			cbi := &mmodel.CreateAdditionalBalance{
+				Key:       "asset-freeze",
+				Direction: tt.direction,
+			}
+
+			mockBalanceRepo.EXPECT().
+				FindByAccountIDAndKey(gomock.Any(), organizationID, ledgerID, accountID, "asset-freeze").
+				Return(nil, pkg.ValidateBusinessError(constant.ErrEntityNotFound, constant.EntityBalance)).
+				Times(1)
+
+			mockBalanceRepo.EXPECT().
+				FindByAccountIDAndKey(gomock.Any(), organizationID, ledgerID, accountID, constant.DefaultBalanceKey).
+				Return(defaultBalance, nil).
+				Times(1)
+
+			tt.typeLookup(mockAccountTypeRepo)
+
+			mockBalanceRepo.EXPECT().
+				Create(gomock.Any(), gomock.Any()).
+				DoAndReturn(func(_ context.Context, b *mmodel.Balance) (*mmodel.Balance, error) {
+					assert.Equal(t, tt.expectedDirection, b.Direction, "additional balance direction")
+					return b, nil
+				}).
+				Times(1)
+
+			result, err := uc.CreateAdditionalBalance(ctx, organizationID, ledgerID, accountID, cbi)
+
+			assert.NoError(t, err)
+			assert.NotNil(t, result)
+		})
+	}
+}

--- a/components/ledger/internal/services/command/resolve_balance_direction.go
+++ b/components/ledger/internal/services/command/resolve_balance_direction.go
@@ -1,0 +1,25 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package command
+
+import "github.com/LerianStudio/midaz/v4/pkg/constant"
+
+// resolveBalanceDirection decides a balance's direction by precedence:
+// an explicit caller override wins; failing that, the account type's default
+// wins; failing that, the direction implied by the account type is used
+// (external -> debit, others -> credit). explicit and typeDefault carry the
+// direction only when set to constant.DirectionCredit or constant.DirectionDebit;
+// any other value (including the empty string "not set") falls through.
+func resolveBalanceDirection(explicit, typeDefault, accountType string) string {
+	if explicit == constant.DirectionCredit || explicit == constant.DirectionDebit {
+		return explicit
+	}
+
+	if typeDefault == constant.DirectionCredit || typeDefault == constant.DirectionDebit {
+		return typeDefault
+	}
+
+	return defaultBalanceDirection(accountType)
+}

--- a/components/ledger/internal/services/command/resolve_balance_direction_test.go
+++ b/components/ledger/internal/services/command/resolve_balance_direction_test.go
@@ -101,7 +101,6 @@ func TestResolveBalanceDirection(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/components/ledger/internal/services/command/resolve_balance_direction_test.go
+++ b/components/ledger/internal/services/command/resolve_balance_direction_test.go
@@ -1,0 +1,113 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package command
+
+import (
+	"testing"
+
+	"github.com/LerianStudio/midaz/v4/pkg/constant"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestResolveBalanceDirection(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		explicit    string
+		typeDefault string
+		accountType string
+		want        string
+	}{
+		// RF-03: explicit caller override always wins, regardless of the type
+		// default or the account type.
+		{
+			name:        "explicit credit wins over debit type default",
+			explicit:    constant.DirectionCredit,
+			typeDefault: constant.DirectionDebit,
+			accountType: constant.ExternalAccountType,
+			want:        constant.DirectionCredit,
+		},
+		{
+			name:        "explicit debit wins over credit type default",
+			explicit:    constant.DirectionDebit,
+			typeDefault: constant.DirectionCredit,
+			accountType: "asset",
+			want:        constant.DirectionDebit,
+		},
+		{
+			name:        "explicit credit wins with no type default and external account",
+			explicit:    constant.DirectionCredit,
+			typeDefault: "",
+			accountType: constant.ExternalAccountType,
+			want:        constant.DirectionCredit,
+		},
+		{
+			name:        "explicit debit wins with no type default and non-external account",
+			explicit:    constant.DirectionDebit,
+			typeDefault: "",
+			accountType: "liability",
+			want:        constant.DirectionDebit,
+		},
+
+		// RF-02: no explicit, so the type default decides.
+		{
+			name:        "type default credit used when no explicit",
+			explicit:    "",
+			typeDefault: constant.DirectionCredit,
+			accountType: constant.ExternalAccountType,
+			want:        constant.DirectionCredit,
+		},
+		{
+			name:        "type default debit used when no explicit",
+			explicit:    "",
+			typeDefault: constant.DirectionDebit,
+			accountType: "asset",
+			want:        constant.DirectionDebit,
+		},
+
+		// RF-04: neither explicit nor type default set -> fall through to
+		// defaultBalanceDirection (external -> debit, others -> credit).
+		{
+			name:        "fallback to debit for external account",
+			explicit:    "",
+			typeDefault: "",
+			accountType: constant.ExternalAccountType,
+			want:        constant.DirectionDebit,
+		},
+		{
+			name:        "fallback to debit for external account case-insensitive",
+			explicit:    "",
+			typeDefault: "",
+			accountType: "EXTERNAL",
+			want:        constant.DirectionDebit,
+		},
+		{
+			name:        "fallback to credit for non-external account",
+			explicit:    "",
+			typeDefault: "",
+			accountType: "asset",
+			want:        constant.DirectionCredit,
+		},
+		{
+			name:        "fallback to credit for empty account type",
+			explicit:    "",
+			typeDefault: "",
+			accountType: "",
+			want:        constant.DirectionCredit,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := resolveBalanceDirection(tt.explicit, tt.typeDefault, tt.accountType)
+
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/components/ledger/internal/services/command/resolve_type_default_direction.go
+++ b/components/ledger/internal/services/command/resolve_type_default_direction.go
@@ -1,0 +1,55 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package command
+
+import (
+	"context"
+
+	libObservability "github.com/LerianStudio/lib-observability/v2"
+	libLog "github.com/LerianStudio/lib-observability/v2/log"
+	"github.com/google/uuid"
+)
+
+// resolveDefaultBalanceDirectionForType returns the account type's configured
+// default balance direction for the initial-balance path. External accounts
+// bypass the lookup entirely (their direction is fixed by the account-type-
+// implied default downstream), so the result is empty for them and the lookup
+// is skipped. For non-external types it delegates to resolveTypeDefaultDirection,
+// which is best-effort and never fails the caller.
+func (uc *UseCase) resolveDefaultBalanceDirectionForType(ctx context.Context, organizationID, ledgerID uuid.UUID, accountType string, isExternal bool) string {
+	if isExternal {
+		return ""
+	}
+
+	return uc.resolveTypeDefaultDirection(ctx, organizationID, ledgerID, accountType)
+}
+
+// resolveTypeDefaultDirection returns the account type's configured default
+// balance direction for the given key, best-effort. It is graceful by design:
+// an unwired repository, a not-found type, or any technical error resolves to
+// the empty string ("no type default") and never fails the caller, so the
+// direction falls back to the account-type-implied default downstream. The
+// caller MUST NOT invoke this for external account types.
+func (uc *UseCase) resolveTypeDefaultDirection(ctx context.Context, organizationID, ledgerID uuid.UUID, accountType string) string {
+	if uc.AccountTypeRepo == nil || accountType == "" {
+		return ""
+	}
+
+	logger, _, _, _ := libObservability.NewTrackingFromContext(ctx)
+
+	at, err := uc.AccountTypeRepo.FindByKey(ctx, organizationID, ledgerID, accountType)
+	if err != nil {
+		logger.Log(ctx, libLog.LevelDebug, "Account type default direction lookup miss; falling back to implied default",
+			libLog.String("account_type", accountType))
+
+		return ""
+	}
+
+	if at == nil {
+		return ""
+	}
+
+	return at.DefaultDirection
+}

--- a/components/ledger/internal/services/command/resolve_type_default_direction.go
+++ b/components/ledger/internal/services/command/resolve_type_default_direction.go
@@ -37,6 +37,10 @@ func (uc *UseCase) resolveTypeDefaultDirection(ctx context.Context, organization
 		return ""
 	}
 
+	if ctx.Err() != nil {
+		return ""
+	}
+
 	logger, _, _, _ := libObservability.NewTrackingFromContext(ctx)
 
 	at, err := uc.AccountTypeRepo.FindByKey(ctx, organizationID, ledgerID, accountType)

--- a/components/ledger/internal/services/command/update_account_type.go
+++ b/components/ledger/internal/services/command/update_account_type.go
@@ -43,6 +43,10 @@ func (uc *UseCase) UpdateAccountType(ctx context.Context, organizationID, ledger
 		Description: input.Description,
 	}
 
+	if input.DefaultDirection != nil {
+		accountType.DefaultDirection = *input.DefaultDirection
+	}
+
 	accountTypeUpdated, err := uc.AccountTypeRepo.Update(ctx, organizationID, ledgerID, id, accountType)
 	if err != nil {
 		if errors.Is(err, services.ErrDatabaseItemNotFound) {

--- a/components/ledger/internal/services/command/update_account_type_test.go
+++ b/components/ledger/internal/services/command/update_account_type_test.go
@@ -362,6 +362,73 @@ func TestUpdateAccountTypePartialUpdate(t *testing.T) {
 	}
 }
 
+// TestUpdateAccountTypeThreadsDefaultDirection tests that a non-nil DefaultDirection
+// pointer is propagated onto the AccountType passed to the repository, while a nil
+// pointer leaves it empty so the repository skips the column.
+func TestUpdateAccountTypeThreadsDefaultDirection(t *testing.T) {
+	debit := constant.DirectionDebit
+
+	tests := []struct {
+		name      string
+		direction *string
+		expected  string
+	}{
+		{name: "non-nil pointer propagates", direction: &debit, expected: constant.DirectionDebit},
+		{name: "nil pointer leaves direction empty", direction: nil, expected: ""},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			organizationID := uuid.Must(libCommons.GenerateUUIDv7())
+			ledgerID := uuid.Must(libCommons.GenerateUUIDv7())
+			accountTypeID := uuid.Must(libCommons.GenerateUUIDv7())
+
+			payload := &mmodel.UpdateAccountTypeInput{
+				Name:             "Updated Name",
+				DefaultDirection: tc.direction,
+			}
+
+			expectedAccountType := &mmodel.AccountType{
+				ID:             accountTypeID,
+				OrganizationID: organizationID,
+				LedgerID:       ledgerID,
+				Name:           payload.Name,
+				KeyValue:       "test_key",
+			}
+
+			mockAccountTypeRepo := accounttype.NewMockRepository(ctrl)
+			mockMetadataRepo := mongodb.NewMockRepository(ctrl)
+
+			uc := UseCase{
+				AccountTypeRepo:        mockAccountTypeRepo,
+				OnboardingMetadataRepo: mockMetadataRepo,
+			}
+
+			mockAccountTypeRepo.EXPECT().
+				Update(gomock.Any(), organizationID, ledgerID, accountTypeID, gomock.Any()).
+				DoAndReturn(func(ctx context.Context, orgID, ledID, id any, accountType *mmodel.AccountType) (*mmodel.AccountType, error) {
+					assert.Equal(t, tc.expected, accountType.DefaultDirection)
+
+					return expectedAccountType, nil
+				}).
+				Times(1)
+
+			mockMetadataRepo.EXPECT().
+				Update(gomock.Any(), constant.EntityAccountType, accountTypeID.String(), map[string]any{}).
+				Return(nil).
+				Times(1)
+
+			result, err := uc.UpdateAccountType(context.Background(), organizationID, ledgerID, accountTypeID, payload)
+
+			assert.NoError(t, err)
+			assert.NotNil(t, result)
+		})
+	}
+}
+
 // TestUpdateAccountTypeEmptyInput tests updating account type with empty input
 func TestUpdateAccountTypeEmptyInput(t *testing.T) {
 	ctrl := gomock.NewController(t)

--- a/components/ledger/migrations/onboarding/000020_add_default_direction_to_account_type.down.sql
+++ b/components/ledger/migrations/onboarding/000020_add_default_direction_to_account_type.down.sql
@@ -1,0 +1,7 @@
+-- Rollback: remove the default_direction column from the account_type table.
+--
+-- Uses IF EXISTS so the rollback is safe to run against databases that
+-- never received the up migration.
+
+ALTER TABLE account_type
+    DROP COLUMN IF EXISTS default_direction;

--- a/components/ledger/migrations/onboarding/000020_add_default_direction_to_account_type.up.sql
+++ b/components/ledger/migrations/onboarding/000020_add_default_direction_to_account_type.up.sql
@@ -1,0 +1,15 @@
+-- Add the default_direction column to the account_type table.
+--
+-- default_direction records the accounting direction ("credit"/"debit") an
+-- account of this type resolves to when the direction is not otherwise
+-- determined. Defaults to 'credit' so pre-existing rows and non-external
+-- accounts preserve the prior implicit behavior; external accounts never
+-- consult the type.
+--
+-- This is a metadata-only ALTER on PostgreSQL 11+ (non-volatile constant
+-- default). No table rewrite is triggered; pre-existing rows read 'credit'
+-- without physical update. IF NOT EXISTS keeps the ALTER idempotent.
+
+ALTER TABLE account_type
+    ADD COLUMN IF NOT EXISTS default_direction VARCHAR(16) NOT NULL DEFAULT 'credit'
+                             CHECK (default_direction IN ('credit', 'debit'));

--- a/components/ledger/migrations/onboarding/000020_add_default_direction_to_account_type_test.go
+++ b/components/ledger/migrations/onboarding/000020_add_default_direction_to_account_type_test.go
@@ -1,0 +1,124 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package migrations
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestMigration000020_FilesExist verifies that migration 000020 ships both
+// up and down SQL files and that neither is empty.
+func TestMigration000020_FilesExist(t *testing.T) {
+	t.Parallel()
+
+	dir := migrationsDir(t)
+
+	tests := []struct {
+		name     string
+		filename string
+	}{
+		{
+			name:     "up migration file exists",
+			filename: "000020_add_default_direction_to_account_type.up.sql",
+		},
+		{
+			name:     "down migration file exists",
+			filename: "000020_add_default_direction_to_account_type.down.sql",
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			path := filepath.Join(dir, tc.filename)
+			_, err := os.Stat(path)
+			require.NoError(t, err, "migration file %s must exist", tc.filename)
+
+			content, err := os.ReadFile(path)
+			require.NoError(t, err, "migration file %s must be readable", tc.filename)
+			assert.NotEmpty(t, string(content), "migration file %s must not be empty", tc.filename)
+		})
+	}
+}
+
+// TestMigration000020_UpSQL_AddsDefaultDirectionColumn verifies the up migration
+// adds the default_direction column to the account_type table with the correct
+// default and CHECK constraint.
+func TestMigration000020_UpSQL_AddsDefaultDirectionColumn(t *testing.T) {
+	t.Parallel()
+
+	dir := migrationsDir(t)
+	path := filepath.Join(dir, "000020_add_default_direction_to_account_type.up.sql")
+
+	content, err := os.ReadFile(path)
+	require.NoError(t, err, "up migration file must be readable")
+
+	sql := strings.ToLower(string(content))
+
+	tests := []struct {
+		name        string
+		substring   string
+		description string
+	}{
+		{name: "targets account_type table", substring: "alter table account_type", description: "must alter the account_type table"},
+		{name: "uses IF NOT EXISTS for idempotency", substring: "if not exists", description: "must use IF NOT EXISTS for idempotent re-runs"},
+		{name: "adds default_direction column", substring: "default_direction", description: "must add default_direction column"},
+		{name: "default_direction is VARCHAR(16)", substring: "varchar(16)", description: "default_direction column must be VARCHAR(16)"},
+		{name: "default_direction is NOT NULL", substring: "not null", description: "default_direction column must be NOT NULL"},
+		{name: "default_direction defaults to 'credit'", substring: "default 'credit'", description: "default_direction column must default to 'credit'"},
+		{name: "default_direction has CHECK constraint", substring: "check (default_direction in ('credit', 'debit'))", description: "default_direction column must have a CHECK constraint limiting values to credit/debit"},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Contains(t, sql, tc.substring, tc.description)
+		})
+	}
+}
+
+// TestMigration000020_DownSQL_DropsDefaultDirectionColumn verifies the down
+// migration removes the default_direction column added by the up migration.
+func TestMigration000020_DownSQL_DropsDefaultDirectionColumn(t *testing.T) {
+	t.Parallel()
+
+	dir := migrationsDir(t)
+	path := filepath.Join(dir, "000020_add_default_direction_to_account_type.down.sql")
+
+	content, err := os.ReadFile(path)
+	require.NoError(t, err, "down migration file must be readable")
+
+	sql := strings.ToLower(string(content))
+
+	tests := []struct {
+		name        string
+		substring   string
+		description string
+	}{
+		{name: "targets account_type table", substring: "alter table account_type", description: "must alter the account_type table"},
+		{name: "uses IF EXISTS for idempotency", substring: "if exists", description: "must use IF EXISTS for idempotent rollback"},
+		{name: "drops default_direction column", substring: "default_direction", description: "must drop default_direction column"},
+		{name: "uses DROP COLUMN statement", substring: "drop column", description: "must DROP COLUMN the default_direction field"},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Contains(t, sql, tc.substring, tc.description)
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -84,8 +84,8 @@ require (
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2
-	github.com/LerianStudio/lib-commons/v6 v6.2.0
-	github.com/LerianStudio/lib-observability/v2 v2.1.0
+	github.com/LerianStudio/lib-commons/v6 v6.3.0
+	github.com/LerianStudio/lib-observability/v2 v2.1.1
 	github.com/LerianStudio/lib-service-discovery v1.1.0
 	github.com/LerianStudio/lib-streaming/v2 v2.0.0
 	github.com/Shopify/toxiproxy/v2 v2.12.0

--- a/go.mod
+++ b/go.mod
@@ -84,7 +84,7 @@ require (
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2
-	github.com/LerianStudio/lib-commons/v6 v6.3.0
+	github.com/LerianStudio/lib-commons/v6 v6.4.0
 	github.com/LerianStudio/lib-observability/v2 v2.1.1
 	github.com/LerianStudio/lib-service-discovery v1.1.0
 	github.com/LerianStudio/lib-streaming/v2 v2.0.0

--- a/go.sum
+++ b/go.sum
@@ -19,12 +19,12 @@ github.com/DATA-DOG/go-sqlmock v1.5.2/go.mod h1:88MAG/4G7SMwSE3CeA0ZKzrT5CiOU3OJ
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/LerianStudio/lib-auth/v3 v3.3.0 h1:aDpJnAeER6CjBipggA7mVK951anOQzvkzqa8YzZgb0Q=
 github.com/LerianStudio/lib-auth/v3 v3.3.0/go.mod h1:mKU9zG1AeHE7Ux3iu1n+hZlzLA9KHDa5s+vC+XtbOM4=
-github.com/LerianStudio/lib-commons/v6 v6.2.0 h1:oeG2AkO3A1JXZhAywjaB44mHCS1wWBnsgXI1wZ3SfSY=
-github.com/LerianStudio/lib-commons/v6 v6.2.0/go.mod h1:yo2QHBbXXwKNw1Wygip+Z/AANpIunyuXnEAZZT8hGQg=
+github.com/LerianStudio/lib-commons/v6 v6.3.0 h1:oosLXSUBDi2rkw9B7AOSPohDZwOaYxAStCzmqNmxuKI=
+github.com/LerianStudio/lib-commons/v6 v6.3.0/go.mod h1:yo2QHBbXXwKNw1Wygip+Z/AANpIunyuXnEAZZT8hGQg=
 github.com/LerianStudio/lib-observability v1.1.0 h1:e/OrIoTKo8gI1RKXgKDyDDKcrddR4beh53al5ZmB6vQ=
 github.com/LerianStudio/lib-observability v1.1.0/go.mod h1:PBtmXygWXmcsTnyNLBetyYb/OtsWq6WT9fSJvoppeUQ=
-github.com/LerianStudio/lib-observability/v2 v2.1.0 h1:/w5u44Zpe9R+R3d/Ti3//OdJRUL0M17bWNDe74QjRH4=
-github.com/LerianStudio/lib-observability/v2 v2.1.0/go.mod h1:iXspGM6PRTf6BDtkTc0Z69R2HEv1GtjBsI/YSvewDgA=
+github.com/LerianStudio/lib-observability/v2 v2.1.1 h1:YpzgylqUqPg5g1FGpcf561SRbrgKT8wfUoD236CMGHo=
+github.com/LerianStudio/lib-observability/v2 v2.1.1/go.mod h1:iXspGM6PRTf6BDtkTc0Z69R2HEv1GtjBsI/YSvewDgA=
 github.com/LerianStudio/lib-service-discovery v1.1.0 h1:rREGTNnlwoHdfsqDbDoOXAQkqQazVYT/b0yTypSWrk8=
 github.com/LerianStudio/lib-service-discovery v1.1.0/go.mod h1:d6pW/QMo1hYzLgzcxiTg3updjSs6m5sZkuOG3L4gwxo=
 github.com/LerianStudio/lib-streaming/v2 v2.0.0 h1:E5TokAl9vuMGKrfOc9Up2jazxjoxt1Dh6PwyNf0ZFKo=

--- a/go.sum
+++ b/go.sum
@@ -19,8 +19,8 @@ github.com/DATA-DOG/go-sqlmock v1.5.2/go.mod h1:88MAG/4G7SMwSE3CeA0ZKzrT5CiOU3OJ
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/LerianStudio/lib-auth/v3 v3.3.0 h1:aDpJnAeER6CjBipggA7mVK951anOQzvkzqa8YzZgb0Q=
 github.com/LerianStudio/lib-auth/v3 v3.3.0/go.mod h1:mKU9zG1AeHE7Ux3iu1n+hZlzLA9KHDa5s+vC+XtbOM4=
-github.com/LerianStudio/lib-commons/v6 v6.3.0 h1:oosLXSUBDi2rkw9B7AOSPohDZwOaYxAStCzmqNmxuKI=
-github.com/LerianStudio/lib-commons/v6 v6.3.0/go.mod h1:yo2QHBbXXwKNw1Wygip+Z/AANpIunyuXnEAZZT8hGQg=
+github.com/LerianStudio/lib-commons/v6 v6.4.0 h1:0oLtobZ7XsBXx0QvHLGG6SByXn9YqMjkjYmSVrMuxoM=
+github.com/LerianStudio/lib-commons/v6 v6.4.0/go.mod h1:yo2QHBbXXwKNw1Wygip+Z/AANpIunyuXnEAZZT8hGQg=
 github.com/LerianStudio/lib-observability v1.1.0 h1:e/OrIoTKo8gI1RKXgKDyDDKcrddR4beh53al5ZmB6vQ=
 github.com/LerianStudio/lib-observability v1.1.0/go.mod h1:PBtmXygWXmcsTnyNLBetyYb/OtsWq6WT9fSJvoppeUQ=
 github.com/LerianStudio/lib-observability/v2 v2.1.1 h1:YpzgylqUqPg5g1FGpcf561SRbrgKT8wfUoD236CMGHo=

--- a/pkg/constant/errors.go
+++ b/pkg/constant/errors.go
@@ -475,6 +475,8 @@ var (
 	ErrReadyzRedisPingFailed                  = errors.New("0494")
 	ErrReadyzTenantManagerUnavailable         = errors.New("0495")
 	ErrReadyzStreamingUnhealthy               = errors.New("0496")
+	// 0499 is intentionally skipped: it is the last slot of the reserved Tracer platform block (0328-0499); 0500 starts fresh beyond all documented blocks.
+	ErrInvalidAccountTypeDirection = errors.New("0500")
 )
 
 // List of CRM domain errors.

--- a/pkg/errors.go
+++ b/pkg/errors.go
@@ -1158,6 +1158,12 @@ func ValidateBusinessError(err error, entityType string, args ...any) error {
 			Title:      "Invalid Characters",
 			Message:    "The field 'keyValue' contains invalid characters. Use only letters, numbers, underscores and hyphens.",
 		},
+		constant.ErrInvalidAccountTypeDirection: ValidationError{
+			EntityType: entityType,
+			Code:       constant.ErrInvalidAccountTypeDirection.Error(),
+			Title:      "Invalid Account Type Direction",
+			Message:    "The field 'defaultDirection' has an invalid value. Use one of the allowed values: credit or debit.",
+		},
 		constant.ErrDuplicateAccountTypeKeyValue: EntityConflictError{
 			EntityType: entityType,
 			Code:       constant.ErrDuplicateAccountTypeKeyValue.Error(),

--- a/pkg/mmodel/account-type.go
+++ b/pkg/mmodel/account-type.go
@@ -24,6 +24,8 @@ type AccountType struct {
 	Description string `json:"description,omitempty" example:"Assets that are expected to be converted to cash within one year"`
 	// A unique key value identifier for the account type.
 	KeyValue string `json:"keyValue,omitempty" example:"current_assets"`
+	// The default operation direction (credit or debit) for accounts of this type. Empty means no default.
+	DefaultDirection string `json:"defaultDirection,omitempty" example:"credit"`
 	// The timestamp when the account type was created.
 	CreatedAt time.Time `json:"createdAt" example:"2021-01-01T00:00:00Z" format:"date-time"`
 	// The timestamp when the account type was last updated.
@@ -43,6 +45,8 @@ type CreateAccountTypeInput struct {
 	Description string `json:"description,omitempty" validate:"max=500" example:"Assets that are expected to be converted to cash within one year"`
 	// A unique key value identifier for the account type.
 	KeyValue string `json:"keyValue" validate:"required,max=50,invalidaccounttype" example:"current_assets"`
+	// The default operation direction (credit or debit) for accounts of this type.
+	DefaultDirection *string `json:"defaultDirection,omitempty" validate:"omitempty,accounttypedirection" example:"credit"`
 	// Custom key-value pairs for extending the account type information
 	// required: false
 	// example: {"department": "Treasury", "purpose": "Operating Expenses", "region": "Global"}
@@ -55,6 +59,8 @@ type UpdateAccountTypeInput struct {
 	Name string `json:"name,omitempty" validate:"max=100" example:"Current Assets"`
 	// Detailed description of the account type.
 	Description string `json:"description,omitempty" validate:"max=500" example:"Assets that are expected to be converted to cash within one year"`
+	// The default operation direction (credit or debit) for accounts of this type.
+	DefaultDirection *string `json:"defaultDirection,omitempty" validate:"omitempty,accounttypedirection" example:"credit"`
 	// Custom key-value pairs for extending the account type information
 	// required: false
 	// example: {"department": "Treasury", "purpose": "Operating Expenses", "region": "Global"}

--- a/pkg/mmodel/account-type_test.go
+++ b/pkg/mmodel/account-type_test.go
@@ -1,0 +1,134 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package mmodel_test
+
+import (
+	"encoding/json"
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/LerianStudio/midaz/v4/pkg"
+	cn "github.com/LerianStudio/midaz/v4/pkg/constant"
+	"github.com/LerianStudio/midaz/v4/pkg/mmodel"
+	libHTTP "github.com/LerianStudio/midaz/v4/pkg/net/http"
+	testutils "github.com/LerianStudio/midaz/v4/tests/utils"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestAccountTypeDefaultDirection exercises the real production validation path
+// (http.ValidateStruct) over the create and update inputs for the account type
+// defaultDirection field. It asserts credit/debit are accepted, absent is
+// accepted, and an arbitrary value is rejected with ErrInvalidAccountTypeDirection.
+func TestAccountTypeDefaultDirection(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		direction *string
+		wantErr   bool
+	}{
+		{name: "accepts credit", direction: testutils.Ptr(cn.DirectionCredit), wantErr: false},
+		{name: "accepts debit", direction: testutils.Ptr(cn.DirectionDebit), wantErr: false},
+		{name: "accepts absent (nil pointer)", direction: nil, wantErr: false},
+		{name: "rejects arbitrary value", direction: testutils.Ptr("sideways"), wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run("create/"+tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			input := mmodel.CreateAccountTypeInput{
+				Name:             "Current Assets",
+				KeyValue:         "current_assets",
+				DefaultDirection: tt.direction,
+			}
+
+			err := libHTTP.ValidateStruct(&input)
+			assertDirectionErr(t, err, tt.wantErr)
+		})
+
+		t.Run("update/"+tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			input := mmodel.UpdateAccountTypeInput{
+				Name:             "Current Assets",
+				DefaultDirection: tt.direction,
+			}
+
+			err := libHTTP.ValidateStruct(&input)
+			assertDirectionErr(t, err, tt.wantErr)
+		})
+	}
+}
+
+// assertDirectionErr checks the validation outcome: on wantErr it requires a
+// ValidationError carrying the ErrInvalidAccountTypeDirection code; otherwise it
+// requires no error.
+func assertDirectionErr(t *testing.T, err error, wantErr bool) {
+	t.Helper()
+
+	if !wantErr {
+		require.NoError(t, err)
+		return
+	}
+
+	require.Error(t, err)
+
+	var vErr pkg.ValidationError
+
+	require.True(t, errors.As(err, &vErr), "expected pkg.ValidationError, got %T", err)
+	require.Equal(t, cn.ErrInvalidAccountTypeDirection.Error(), vErr.Code)
+	require.NotEmpty(t, vErr.Message, "ValidationError.Message must not be blank")
+	require.Contains(t, vErr.Message, cn.DirectionCredit, "message should mention the allowed direction values")
+}
+
+// TestAccountTypeDefaultDirectionJSONTag asserts the JSON tag on the
+// defaultDirection field is exactly "defaultDirection" (camelCase) across the
+// domain, create-input and update-input structs.
+func TestAccountTypeDefaultDirectionJSONTag(t *testing.T) {
+	t.Parallel()
+
+	const wantTag = "defaultDirection"
+
+	types := []struct {
+		name string
+		typ  reflect.Type
+	}{
+		{name: "AccountType", typ: reflect.TypeOf(mmodel.AccountType{})},
+		{name: "CreateAccountTypeInput", typ: reflect.TypeOf(mmodel.CreateAccountTypeInput{})},
+		{name: "UpdateAccountTypeInput", typ: reflect.TypeOf(mmodel.UpdateAccountTypeInput{})},
+	}
+
+	for _, tc := range types {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			field, ok := tc.typ.FieldByName("DefaultDirection")
+			require.True(t, ok, "%s must have a DefaultDirection field", tc.name)
+
+			jsonName := strings.SplitN(field.Tag.Get("json"), ",", 2)[0]
+			require.Equal(t, wantTag, jsonName, "%s.DefaultDirection json tag", tc.name)
+		})
+	}
+}
+
+// TestAccountTypeDefaultDirectionMarshal confirms the domain struct marshals the
+// field under the camelCase key when set.
+func TestAccountTypeDefaultDirectionMarshal(t *testing.T) {
+	t.Parallel()
+
+	at := mmodel.AccountType{DefaultDirection: cn.DirectionCredit}
+
+	b, err := json.Marshal(at)
+	require.NoError(t, err)
+
+	var round map[string]any
+
+	require.NoError(t, json.Unmarshal(b, &round))
+	require.Equal(t, cn.DirectionCredit, round["defaultDirection"])
+}

--- a/pkg/mmodel/balance.go
+++ b/pkg/mmodel/balance.go
@@ -388,6 +388,12 @@ type CreateBalanceInput struct {
 	// maxLength: 50
 	AccountType string
 
+	// DefaultDirection is the account type's configured default balance
+	// direction ("credit" or "debit"), resolved by the caller. Empty means
+	// the type has no configured default; the direction then falls back to
+	// the account-type-implied default (external -> debit, others -> credit).
+	DefaultDirection string
+
 	// Whether the account should be allowed to send funds from this balance
 	// example: true
 	AllowSending bool

--- a/pkg/net/http/errors_golden_test.go
+++ b/pkg/net/http/errors_golden_test.go
@@ -272,6 +272,7 @@ func allSentinels() map[string]error {
 		"ErrAccountingAliasValidationFailed":          constant.ErrAccountingAliasValidationFailed,
 		"ErrAccountingAccountTypeValidationFailed":    constant.ErrAccountingAccountTypeValidationFailed,
 		"ErrInvalidAccountTypeKeyValue":               constant.ErrInvalidAccountTypeKeyValue,
+		"ErrInvalidAccountTypeDirection":              constant.ErrInvalidAccountTypeDirection,
 		"ErrInvalidFutureTransactionDate":             constant.ErrInvalidFutureTransactionDate,
 		"ErrInvalidPendingFutureTransactionDate":      constant.ErrInvalidPendingFutureTransactionDate,
 		"ErrDuplicatedAliasKeyValue":                  constant.ErrDuplicatedAliasKeyValue,

--- a/pkg/net/http/withBody.go
+++ b/pkg/net/http/withBody.go
@@ -232,6 +232,8 @@ func ValidateStruct(s any) error {
 				return pkg.ValidateBusinessError(cn.ErrAccountAliasInvalid, "")
 			case "invalidaccounttype":
 				return pkg.ValidateBusinessError(cn.ErrInvalidAccountTypeKeyValue, "", fieldError.Translate(trans))
+			case "accounttypedirection":
+				return pkg.ValidateBusinessError(cn.ErrInvalidAccountTypeDirection, "", fieldError.Translate(trans))
 			}
 		}
 
@@ -303,6 +305,7 @@ func newValidator() (*validator.Validate, ut.Translator, error) {
 	_ = v.RegisterValidation("prohibitedexternalaccountprefix", validateProhibitedExternalAccountPrefix)
 	_ = v.RegisterValidation("invalidaliascharacters", validateInvalidAliasCharacters)
 	_ = v.RegisterValidation("invalidaccounttype", validateAccountType)
+	_ = v.RegisterValidation("accounttypedirection", validateAccountTypeDirection)
 	_ = v.RegisterValidation("nowhitespaces", validateNoWhitespaces)
 	_ = v.RegisterValidation("metadatakeyformat", validateMetadataKeyFormat)
 
@@ -383,6 +386,14 @@ func newValidator() (*validator.Validate, ut.Translator, error) {
 		return ut.Add("invalidaccounttype", "{0}", true)
 	}, func(ut ut.Translator, fe validator.FieldError) string {
 		t, _ := ut.T("invalidaccounttype", formatErrorFieldName(fe.Namespace()))
+
+		return t
+	})
+
+	_ = v.RegisterTranslation("accounttypedirection", trans, func(ut ut.Translator) error {
+		return ut.Add("accounttypedirection", "{0} must be one of the allowed values: credit or debit", true)
+	}, func(ut ut.Translator, fe validator.FieldError) string {
+		t, _ := ut.T("accounttypedirection", formatErrorFieldName(fe.Namespace()))
 
 		return t
 	})
@@ -507,6 +518,16 @@ func validateAccountType(fl validator.FieldLevel) bool {
 	match, _ := regexp.MatchString(`^[a-zA-Z0-9_-]+$`, f)
 
 	return match
+}
+
+// validateAccountTypeDirection checks the value is one of the allowed operation directions (credit or debit), matched case-sensitively.
+func validateAccountTypeDirection(fl validator.FieldLevel) bool {
+	f, ok := fl.Field().Interface().(string)
+	if !ok {
+		return false
+	}
+
+	return f == cn.DirectionCredit || f == cn.DirectionDebit
 }
 
 // validateNoWhitespaces ensures the provided string does not contain any whitespace characters. Return false if input is invalid.

--- a/postman/MIDAZ.postman_collection.json
+++ b/postman/MIDAZ.postman_collection.json
@@ -15138,7 +15138,7 @@
                 }
               ],
               "cookie": [],
-              "body": "{\n  \"createdAt\": \"2021-01-01T00:00:00Z\",\n  \"deletedAt\": \"2021-01-01T00:00:00Z\",\n  \"description\": \"Assets that are expected to be converted to cash within one year\",\n  \"id\": \"01965ed9-7fa4-75b2-8872-fc9e8509ab0a\",\n  \"keyValue\": \"current_assets\",\n  \"ledgerId\": \"01965ed9-7fa4-75b2-8872-fc9e8509ab0a\",\n  \"metadata\": {\n    \"key\": \"value\"\n  },\n  \"name\": \"Current Assets\",\n  \"organizationId\": \"01965ed9-7fa4-75b2-8872-fc9e8509ab0a\",\n  \"updatedAt\": \"2021-01-01T00:00:00Z\"\n}"
+              "body": "{\n  \"createdAt\": \"2021-01-01T00:00:00Z\",\n  \"defaultDirection\": \"credit\",\n  \"deletedAt\": \"2021-01-01T00:00:00Z\",\n  \"description\": \"Assets that are expected to be converted to cash within one year\",\n  \"id\": \"01965ed9-7fa4-75b2-8872-fc9e8509ab0a\",\n  \"keyValue\": \"current_assets\",\n  \"ledgerId\": \"01965ed9-7fa4-75b2-8872-fc9e8509ab0a\",\n  \"metadata\": {\n    \"key\": \"value\"\n  },\n  \"name\": \"Current Assets\",\n  \"organizationId\": \"01965ed9-7fa4-75b2-8872-fc9e8509ab0a\",\n  \"updatedAt\": \"2021-01-01T00:00:00Z\"\n}"
             }
           ],
           "event": [
@@ -15446,7 +15446,7 @@
                 }
               ],
               "cookie": [],
-              "body": "{\n  \"createdAt\": \"2021-01-01T00:00:00Z\",\n  \"deletedAt\": \"2021-01-01T00:00:00Z\",\n  \"description\": \"Assets that are expected to be converted to cash within one year\",\n  \"id\": \"01965ed9-7fa4-75b2-8872-fc9e8509ab0a\",\n  \"keyValue\": \"current_assets\",\n  \"ledgerId\": \"01965ed9-7fa4-75b2-8872-fc9e8509ab0a\",\n  \"metadata\": {\n    \"key\": \"value\"\n  },\n  \"name\": \"Current Assets\",\n  \"organizationId\": \"01965ed9-7fa4-75b2-8872-fc9e8509ab0a\",\n  \"updatedAt\": \"2021-01-01T00:00:00Z\"\n}"
+              "body": "{\n  \"createdAt\": \"2021-01-01T00:00:00Z\",\n  \"defaultDirection\": \"credit\",\n  \"deletedAt\": \"2021-01-01T00:00:00Z\",\n  \"description\": \"Assets that are expected to be converted to cash within one year\",\n  \"id\": \"01965ed9-7fa4-75b2-8872-fc9e8509ab0a\",\n  \"keyValue\": \"current_assets\",\n  \"ledgerId\": \"01965ed9-7fa4-75b2-8872-fc9e8509ab0a\",\n  \"metadata\": {\n    \"key\": \"value\"\n  },\n  \"name\": \"Current Assets\",\n  \"organizationId\": \"01965ed9-7fa4-75b2-8872-fc9e8509ab0a\",\n  \"updatedAt\": \"2021-01-01T00:00:00Z\"\n}"
             }
           ],
           "event": [
@@ -15650,7 +15650,7 @@
                 }
               ],
               "cookie": [],
-              "body": "{\n  \"createdAt\": \"2021-01-01T00:00:00Z\",\n  \"deletedAt\": \"2021-01-01T00:00:00Z\",\n  \"description\": \"Assets that are expected to be converted to cash within one year\",\n  \"id\": \"01965ed9-7fa4-75b2-8872-fc9e8509ab0a\",\n  \"keyValue\": \"current_assets\",\n  \"ledgerId\": \"01965ed9-7fa4-75b2-8872-fc9e8509ab0a\",\n  \"metadata\": {\n    \"key\": \"value\"\n  },\n  \"name\": \"Current Assets\",\n  \"organizationId\": \"01965ed9-7fa4-75b2-8872-fc9e8509ab0a\",\n  \"updatedAt\": \"2021-01-01T00:00:00Z\"\n}"
+              "body": "{\n  \"createdAt\": \"2021-01-01T00:00:00Z\",\n  \"defaultDirection\": \"credit\",\n  \"deletedAt\": \"2021-01-01T00:00:00Z\",\n  \"description\": \"Assets that are expected to be converted to cash within one year\",\n  \"id\": \"01965ed9-7fa4-75b2-8872-fc9e8509ab0a\",\n  \"keyValue\": \"current_assets\",\n  \"ledgerId\": \"01965ed9-7fa4-75b2-8872-fc9e8509ab0a\",\n  \"metadata\": {\n    \"key\": \"value\"\n  },\n  \"name\": \"Current Assets\",\n  \"organizationId\": \"01965ed9-7fa4-75b2-8872-fc9e8509ab0a\",\n  \"updatedAt\": \"2021-01-01T00:00:00Z\"\n}"
             }
           ],
           "event": [

--- a/postman/specs/ledger/openapi.huma.yaml
+++ b/postman/specs/ledger/openapi.huma.yaml
@@ -144,6 +144,10 @@ components:
             - "2021-01-01T00:00:00Z"
           format: date-time
           type: string
+        defaultDirection:
+          examples:
+            - credit
+          type: string
         deletedAt:
           examples:
             - "2021-01-01T00:00:00Z"

--- a/postman/specs/midaz.openapi.json
+++ b/postman/specs/midaz.openapi.json
@@ -14432,6 +14432,12 @@
             "format": "date-time",
             "type": "string"
           },
+          "defaultDirection": {
+            "examples": [
+              "credit"
+            ],
+            "type": "string"
+          },
           "deletedAt": {
             "examples": [
               "2021-01-01T00:00:00Z"

--- a/postman/specs/midaz.openapi.yaml
+++ b/postman/specs/midaz.openapi.yaml
@@ -9224,6 +9224,10 @@ components:
             - '2021-01-01T00:00:00Z'
           format: date-time
           type: string
+        defaultDirection:
+          examples:
+            - credit
+          type: string
         deletedAt:
           examples:
             - '2021-01-01T00:00:00Z'

--- a/tests/utils/postgres/fixtures.go
+++ b/tests/utils/postgres/fixtures.go
@@ -47,6 +47,23 @@ func CreateTestOrganizationWithParams(t *testing.T, db *sql.DB, params Organizat
 	t.Helper()
 
 	id := uuid.Must(libCommons.GenerateUUIDv7())
+
+	return createTestOrganizationRow(t, db, id, params)
+}
+
+// CreateTestOrganizationWithID inserts a test organization using a caller-supplied
+// ID (with default params), returning that same ID. Use it when two databases must
+// share the same pre-chosen organization identifier.
+func CreateTestOrganizationWithID(t *testing.T, db *sql.DB, id uuid.UUID) uuid.UUID {
+	t.Helper()
+
+	return createTestOrganizationRow(t, db, id, DefaultOrganizationParams())
+}
+
+// createTestOrganizationRow performs the organization INSERT for a fixed ID and params.
+func createTestOrganizationRow(t *testing.T, db *sql.DB, id uuid.UUID, params OrganizationParams) uuid.UUID {
+	t.Helper()
+
 	now := time.Now().Truncate(time.Microsecond)
 
 	_, err := db.Exec(`
@@ -84,6 +101,23 @@ func CreateTestLedgerWithParams(t *testing.T, db *sql.DB, orgID uuid.UUID, param
 	t.Helper()
 
 	id := uuid.Must(libCommons.GenerateUUIDv7())
+
+	return createTestLedgerRow(t, db, id, orgID, params)
+}
+
+// CreateTestLedgerWithID inserts a test ledger using a caller-supplied ID (with
+// default params) under the given organization, returning that same ID. Use it when
+// two databases must share the same pre-chosen ledger identifier.
+func CreateTestLedgerWithID(t *testing.T, db *sql.DB, id, orgID uuid.UUID) uuid.UUID {
+	t.Helper()
+
+	return createTestLedgerRow(t, db, id, orgID, DefaultLedgerParams())
+}
+
+// createTestLedgerRow performs the ledger INSERT for a fixed ID and params.
+func createTestLedgerRow(t *testing.T, db *sql.DB, id, orgID uuid.UUID, params LedgerParams) uuid.UUID {
+	t.Helper()
+
 	now := time.Now().Truncate(time.Microsecond)
 
 	_, err := db.Exec(`
@@ -594,10 +628,11 @@ func CreateTestSegmentWithParams(t *testing.T, db *sql.DB, orgID, ledgerID uuid.
 
 // AccountTypeParams holds parameters for creating a test account type.
 type AccountTypeParams struct {
-	Name        string
-	Description string
-	KeyValue    string
-	DeletedAt   *time.Time
+	Name             string
+	Description      string
+	KeyValue         string
+	DefaultDirection *string
+	DeletedAt        *time.Time
 }
 
 // DefaultAccountTypeParams returns default parameters for creating a test account type.
@@ -616,10 +651,19 @@ func CreateTestAccountType(t *testing.T, db *sql.DB, orgID, ledgerID uuid.UUID, 
 	id := uuid.Must(libCommons.GenerateUUIDv7())
 	now := time.Now().Truncate(time.Microsecond)
 
-	_, err := db.Exec(`
-		INSERT INTO account_type (id, organization_id, ledger_id, name, description, key_value, created_at, updated_at, deleted_at)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
-	`, id, orgID, ledgerID, params.Name, params.Description, params.KeyValue, now, now, params.DeletedAt)
+	var err error
+	if params.DefaultDirection != nil {
+		_, err = db.Exec(`
+			INSERT INTO account_type (id, organization_id, ledger_id, name, description, key_value, default_direction, created_at, updated_at, deleted_at)
+			VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+		`, id, orgID, ledgerID, params.Name, params.Description, params.KeyValue, *params.DefaultDirection, now, now, params.DeletedAt)
+	} else {
+		_, err = db.Exec(`
+			INSERT INTO account_type (id, organization_id, ledger_id, name, description, key_value, created_at, updated_at, deleted_at)
+			VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+		`, id, orgID, ledgerID, params.Name, params.Description, params.KeyValue, now, now, params.DeletedAt)
+	}
+
 	require.NoError(t, err, "failed to create test account type")
 
 	return id


### PR DESCRIPTION
<table border="0" cellspacing="0" cellpadding="0">
  <tr>
    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
    <td><h1>Midaz</h1></td>
  </tr>
</table>

---

## Description

Adds a per-account-type **`defaultDirection`** (`credit`/`debit`) and makes a balance's direction resolve from it. This is the integration branch for the complete backend feature; it consolidates two already-reviewed sub-PRs (#2273, #2276) for a single merge into `develop`.

A balance's direction is decided by a single precedence rule — **explicit caller override > account-type default > the existing `defaultBalanceDirection`** — applied to both the initial (account-creation) and additional balance paths through one shared `resolveBalanceDirection`.

What it contains:

- **Model + validation:** optional `defaultDirection` on the account type and its create/update inputs, validated by a dedicated `accounttypedirection` validator with sentinel `ErrInvalidAccountTypeDirection` (`0500`).
- **Persistence:** new `default_direction` column (migration `000020`, `NOT NULL DEFAULT 'credit'` with a `CHECK`) threaded through the Postgres adapter and command services. The account-type lookup on the balance paths is best-effort — a miss or technical error degrades to the implied default and never fails account/balance creation; it is skipped for external accounts and when an explicit override is present.
- **Contract:** OpenAPI (Huma) golden + published Postman specs regenerated (`defaultDirection` on the `AccountType` schema).
- **Acceptance:** integration test suite (testcontainers) proving the full matrix end-to-end.

Current behavior is preserved: `defaultBalanceDirection` is **unchanged** (terminal fallback), external accounts still resolve to `debit`, and account types with no configured default still resolve to `credit`.

## Type of Change

- [x] `feat`: New feature or capability
- [ ] `fix`: Bug fix
- [ ] `perf`: Performance improvement
- [ ] `refactor`: Internal restructuring with no behavior change
- [ ] `docs`: Documentation only
- [ ] `style`: Formatting, whitespace, naming (no logic change)
- [ ] `test`: Adding or updating tests
- [ ] `ci`: CI pipeline or workflow changes
- [ ] `build`: Build system, Dockerfile, Go module dependencies
- [ ] `chore`: Maintenance, config, tooling
- [ ] `revert`: Reverts a previous commit
- [ ] `BREAKING CHANGE`: Consumers must update their integration

## Breaking Changes

None. All changes are additive — a new optional field (`defaultDirection` on the account type model + its create/update inputs, plus `DefaultDirection` on `CreateBalanceInput`), a new error sentinel (`0500`), and a new migration column with a safe default. Existing consumers compile unchanged and behave identically when the field is absent. `go.mod`/`go.sum` are untouched.

## Testing

- [x] `make test` passes
- [x] `make test-int` passes if integration paths are exercised
- [x] `make lint` passes
- [ ] `make sec` and `make vulncheck` pass

**Test evidence / Actions run:**
- Unit + integration acceptance suite green (testcontainers, PostgreSQL 17): the precedence resolver (100% covered), persistence round-trip incl. a CHECK-rejection case, and the acceptance matrix (type default, implied default, external bypass, explicit override, external additional-balance rejection, edit-affects-only-future, lookup miss).
- **Manual E2E** against a freshly-rebuilt local stack (fresh DB, image from this branch): **14/14** real HTTP scenarios passed — happy, error (`0124`, `0066`, `0500`), and edge paths — plus telemetry confirmed in Grafana.
- `golangci-lint` clean; `go.mod`/`go.sum` unchanged, so the dependency/vulnerability surface is unchanged — CI runs `make sec`/`make vulncheck`.

## Architectural Checklist

- [x] No `panic()` in production paths
- [x] Timestamps use `time.Now().UTC()`
- [x] Errors wrapped with `%w`
- [x] Handlers stay thin (parse, validate, call service)
- [x] Infrastructure concerns kept in `internal/bootstrap`

## Related Issues

Closes #
