### PR TITLE
feat(ledger): add active-account billing wiring foundation

### DIFF
--- a/components/ledger/.env.example
+++ b/components/ledger/.env.example
@@ -462,6 +462,14 @@ STREAMING_ENABLED=false
 # STREAMING_TLS_ENABLED=false
 # STREAMING_TLS_CA_CERT=
 
+# --- Schema Registry (billing emits) ---
+# Read by lib-streaming LoadConfig; midaz does not parse these. Empty URL is the
+# safe default: it disables billing emits and NEVER crashes the app. Username and
+# password are optional basic-auth (both-or-neither) and are never logged.
+STREAMING_SCHEMA_REGISTRY_URL=
+# STREAMING_SCHEMA_REGISTRY_USERNAME=
+# STREAMING_SCHEMA_REGISTRY_PASSWORD=
+
 # --- Ledger->Tracer reservation seam (see docs/architecture/ledger-tracer-topology.md) ---
 # This block is the CLIENT side of the reservation seam: the ledger calls the
 # tracer to reserve/confirm/release transaction capacity from the transaction

--- a/components/ledger/internal/bootstrap/billing_serializer_test.go
+++ b/components/ledger/internal/bootstrap/billing_serializer_test.go
@@ -22,15 +22,20 @@ type captureLogger struct {
 }
 
 type captureEntry struct {
-	level libLog.Level
-	msg   string
+	level  libLog.Level
+	msg    string
+	fields []libLog.Field
 }
 
-func (c *captureLogger) Log(_ context.Context, level libLog.Level, msg string, _ ...libLog.Field) {
+func (c *captureLogger) Log(_ context.Context, level libLog.Level, msg string, fields ...libLog.Field) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	c.entries = append(c.entries, captureEntry{level: level, msg: msg})
+	c.entries = append(c.entries, captureEntry{
+		level:  level,
+		msg:    msg,
+		fields: append([]libLog.Field(nil), fields...),
+	})
 }
 
 func (c *captureLogger) With(_ ...libLog.Field) libLog.Logger { return c }
@@ -57,6 +62,35 @@ func (c *captureLogger) warnMessages() []string {
 	return msgs
 }
 
+// warnErrMessages returns the `.Error()` string of every WARN entry's "error"
+// field, in order. It lets a test assert WHICH error drove a graceful-
+// degradation WARN — e.g. the guard's raw ctx error ("context canceled")
+// versus the wrapped registry error the without-guard path would produce.
+func (c *captureLogger) warnErrMessages() []string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	var msgs []string
+
+	for _, e := range c.entries {
+		if e.level != libLog.LevelWarn {
+			continue
+		}
+
+		for _, f := range e.fields {
+			if f.Key != "error" {
+				continue
+			}
+
+			if err, ok := f.Value.(error); ok && err != nil {
+				msgs = append(msgs, err.Error())
+			}
+		}
+	}
+
+	return msgs
+}
+
 // TestBuildBillingSerializer exercises the network-free decision core across its
 // graceful-degradation branches: every branch yields a nil serializer, never a
 // propagated error or a panic. The disabled case additionally proves the builder
@@ -66,12 +100,17 @@ func (c *captureLogger) warnMessages() []string {
 func TestBuildBillingSerializer(t *testing.T) {
 	t.Parallel()
 
+	canceledCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+
 	tests := []struct {
 		name          string
+		ctx           context.Context
 		cfg           libStreaming.Config
 		logger        libLog.Logger
 		wantWarnCount int
 		wantWarnMsg   string
+		wantWarnErr   string
 	}{
 		{
 			name:          "disabled short-circuits to nil without registry contact",
@@ -91,6 +130,20 @@ func TestBuildBillingSerializer(t *testing.T) {
 			cfg:    libStreaming.Config{Enabled: true, SchemaRegistryURL: ""},
 			logger: nil,
 		},
+		{
+			name:          "canceled context short-circuits before registry contact",
+			ctx:           canceledCtx,
+			cfg:           libStreaming.Config{Enabled: true, SchemaRegistryURL: "http://schema-registry.invalid:8081"},
+			logger:        &captureLogger{},
+			wantWarnCount: 1,
+			wantWarnMsg:   "Billing serializer disabled",
+			// The guard warns with the raw ctx.Err() ("context canceled"),
+			// proving it short-circuited BEFORE any registry contact. Without
+			// the guard the same inputs still degrade to nil+1 WARN, but the
+			// error is the wrapped registry round-trip failure — so this exact
+			// message is what distinguishes the guarded path.
+			wantWarnErr: context.Canceled.Error(),
+		},
 	}
 
 	for _, tt := range tests {
@@ -98,7 +151,12 @@ func TestBuildBillingSerializer(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			got := buildBillingSerializer(context.Background(), tt.cfg, tt.logger)
+			ctx := tt.ctx
+			if ctx == nil {
+				ctx = context.Background()
+			}
+
+			got := buildBillingSerializer(ctx, tt.cfg, tt.logger)
 			if got != nil {
 				t.Fatalf("expected nil serializer, got %v", got)
 			}
@@ -118,6 +176,14 @@ func TestBuildBillingSerializer(t *testing.T) {
 				msgs := cl.warnMessages()
 				if len(msgs) != 1 || msgs[0] != tt.wantWarnMsg {
 					t.Fatalf("expected single WARN %q, got %v", tt.wantWarnMsg, msgs)
+				}
+			}
+
+			if tt.wantWarnErr != "" {
+				errMsgs := cl.warnErrMessages()
+				if len(errMsgs) != 1 || errMsgs[0] != tt.wantWarnErr {
+					t.Fatalf("expected single WARN error %q (guard short-circuit), got %v",
+						tt.wantWarnErr, errMsgs)
 				}
 			}
 		})

--- a/components/ledger/internal/bootstrap/billing_serializer_test.go
+++ b/components/ledger/internal/bootstrap/billing_serializer_test.go
@@ -39,51 +39,88 @@ func (c *captureLogger) Enabled(_ libLog.Level) bool          { return true }
 func (c *captureLogger) Sync(_ context.Context) error         { return nil }
 
 func (c *captureLogger) warnCount() int {
+	return len(c.warnMessages())
+}
+
+func (c *captureLogger) warnMessages() []string {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	n := 0
+	var msgs []string
+
 	for _, e := range c.entries {
 		if e.level == libLog.LevelWarn {
-			n++
+			msgs = append(msgs, e.msg)
 		}
 	}
 
-	return n
+	return msgs
 }
 
-// TestBuildBillingSerializer_DisabledShortCircuitsToNil asserts that when the
-// streaming master switch is off the builder returns a nil serializer without
-// contacting the registry, propagating no error and never panicking.
-func TestBuildBillingSerializer_DisabledShortCircuitsToNil(t *testing.T) {
+// TestBuildBillingSerializer exercises the network-free decision core across its
+// graceful-degradation branches: every branch yields a nil serializer, never a
+// propagated error or a panic. The disabled case additionally proves the builder
+// neither warns nor contacts the registry (wantWarnCount 0); the empty-URL case
+// proves the fail-closed registry-client error is swallowed into a single, named
+// WARN; the nil-logger case proves the graceful branch tolerates a nil logger.
+func TestBuildBillingSerializer(t *testing.T) {
 	t.Parallel()
 
-	got := buildBillingSerializer(context.Background(), libStreaming.Config{Enabled: false}, nil)
-	if got != nil {
-		t.Fatalf("expected nil serializer when streaming disabled, got %v", got)
+	tests := []struct {
+		name          string
+		cfg           libStreaming.Config
+		logger        libLog.Logger
+		wantWarnCount int
+		wantWarnMsg   string
+	}{
+		{
+			name:          "disabled short-circuits to nil without registry contact",
+			cfg:           libStreaming.Config{Enabled: false},
+			logger:        &captureLogger{},
+			wantWarnCount: 0,
+		},
+		{
+			name:          "empty registry url degrades to nil with one warn",
+			cfg:           libStreaming.Config{Enabled: true, SchemaRegistryURL: ""},
+			logger:        &captureLogger{},
+			wantWarnCount: 1,
+			wantWarnMsg:   "Billing serializer disabled",
+		},
+		{
+			name:   "nil logger does not panic on graceful branch",
+			cfg:    libStreaming.Config{Enabled: true, SchemaRegistryURL: ""},
+			logger: nil,
+		},
 	}
-}
 
-// TestBuildBillingSerializer_EmptyRegistryURLGracefullyNil asserts that an
-// enabled config with no Schema Registry URL degrades gracefully: the fail-closed
-// registry-client constructor error is swallowed into a nil serializer plus a
-// single WARN, never a propagated error or a panic.
-func TestBuildBillingSerializer_EmptyRegistryURLGracefullyNil(t *testing.T) {
-	t.Parallel()
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
-	logger := &captureLogger{}
+			got := buildBillingSerializer(context.Background(), tt.cfg, tt.logger)
+			if got != nil {
+				t.Fatalf("expected nil serializer, got %v", got)
+			}
 
-	got := buildBillingSerializer(
-		context.Background(),
-		libStreaming.Config{Enabled: true, SchemaRegistryURL: ""},
-		logger,
-	)
-	if got != nil {
-		t.Fatalf("expected nil serializer when registry URL empty, got %v", got)
-	}
+			cl, ok := tt.logger.(*captureLogger)
+			if !ok {
+				// nil-logger case: the nil-serializer assertion above already
+				// proves no panic on the graceful branch.
+				return
+			}
 
-	if logger.warnCount() != 1 {
-		t.Fatalf("expected exactly one WARN on the graceful branch, got %d", logger.warnCount())
+			if cl.warnCount() != tt.wantWarnCount {
+				t.Fatalf("expected %d WARN(s), got %d", tt.wantWarnCount, cl.warnCount())
+			}
+
+			if tt.wantWarnMsg != "" {
+				msgs := cl.warnMessages()
+				if len(msgs) != 1 || msgs[0] != tt.wantWarnMsg {
+					t.Fatalf("expected single WARN %q, got %v", tt.wantWarnMsg, msgs)
+				}
+			}
+		})
 	}
 }
 
@@ -97,20 +134,5 @@ func TestBuildBillingSerializerFromEnv_DisabledReturnsNil(t *testing.T) {
 	got := buildBillingSerializerFromEnv(context.Background(), nil)
 	if got != nil {
 		t.Fatalf("expected nil serializer when streaming disabled via env, got %v", got)
-	}
-}
-
-// TestBuildBillingSerializer_NilLoggerNoPanic asserts the builder tolerates a
-// nil logger on its graceful branches without dereferencing it.
-func TestBuildBillingSerializer_NilLoggerNoPanic(t *testing.T) {
-	t.Parallel()
-
-	got := buildBillingSerializer(
-		context.Background(),
-		libStreaming.Config{Enabled: true, SchemaRegistryURL: ""},
-		nil,
-	)
-	if got != nil {
-		t.Fatalf("expected nil serializer, got %v", got)
 	}
 }

--- a/components/ledger/internal/bootstrap/billing_serializer_test.go
+++ b/components/ledger/internal/bootstrap/billing_serializer_test.go
@@ -1,0 +1,116 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package bootstrap
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	libLog "github.com/LerianStudio/lib-observability/v2/log"
+	libStreaming "github.com/LerianStudio/lib-streaming/v2"
+)
+
+// captureLogger is a minimal libLog.Logger that records every Log call so a
+// test can assert that a graceful-degradation WARN was emitted. It is safe for
+// concurrent use so t.Parallel tests can share the type.
+type captureLogger struct {
+	mu      sync.Mutex
+	entries []captureEntry
+}
+
+type captureEntry struct {
+	level libLog.Level
+	msg   string
+}
+
+func (c *captureLogger) Log(_ context.Context, level libLog.Level, msg string, _ ...libLog.Field) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.entries = append(c.entries, captureEntry{level: level, msg: msg})
+}
+
+func (c *captureLogger) With(_ ...libLog.Field) libLog.Logger { return c }
+func (c *captureLogger) WithGroup(_ string) libLog.Logger     { return c }
+func (c *captureLogger) Enabled(_ libLog.Level) bool          { return true }
+func (c *captureLogger) Sync(_ context.Context) error         { return nil }
+
+func (c *captureLogger) warnCount() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	n := 0
+	for _, e := range c.entries {
+		if e.level == libLog.LevelWarn {
+			n++
+		}
+	}
+
+	return n
+}
+
+// TestBuildBillingSerializer_DisabledShortCircuitsToNil asserts that when the
+// streaming master switch is off the builder returns a nil serializer without
+// contacting the registry, propagating no error and never panicking.
+func TestBuildBillingSerializer_DisabledShortCircuitsToNil(t *testing.T) {
+	t.Parallel()
+
+	got := buildBillingSerializer(context.Background(), libStreaming.Config{Enabled: false}, nil)
+	if got != nil {
+		t.Fatalf("expected nil serializer when streaming disabled, got %v", got)
+	}
+}
+
+// TestBuildBillingSerializer_EmptyRegistryURLGracefullyNil asserts that an
+// enabled config with no Schema Registry URL degrades gracefully: the fail-closed
+// registry-client constructor error is swallowed into a nil serializer plus a
+// single WARN, never a propagated error or a panic.
+func TestBuildBillingSerializer_EmptyRegistryURLGracefullyNil(t *testing.T) {
+	t.Parallel()
+
+	logger := &captureLogger{}
+
+	got := buildBillingSerializer(
+		context.Background(),
+		libStreaming.Config{Enabled: true, SchemaRegistryURL: ""},
+		logger,
+	)
+	if got != nil {
+		t.Fatalf("expected nil serializer when registry URL empty, got %v", got)
+	}
+
+	if logger.warnCount() != 1 {
+		t.Fatalf("expected exactly one WARN on the graceful branch, got %d", logger.warnCount())
+	}
+}
+
+// TestBuildBillingSerializerFromEnv_DisabledReturnsNil covers the env-reading
+// wrapper: with the streaming master switch off it loads the config, sees
+// Enabled=false, and degrades to a nil serializer without touching a registry.
+// Not parallel: it sets an environment variable via t.Setenv.
+func TestBuildBillingSerializerFromEnv_DisabledReturnsNil(t *testing.T) {
+	t.Setenv("STREAMING_ENABLED", "false")
+
+	got := buildBillingSerializerFromEnv(context.Background(), nil)
+	if got != nil {
+		t.Fatalf("expected nil serializer when streaming disabled via env, got %v", got)
+	}
+}
+
+// TestBuildBillingSerializer_NilLoggerNoPanic asserts the builder tolerates a
+// nil logger on its graceful branches without dereferencing it.
+func TestBuildBillingSerializer_NilLoggerNoPanic(t *testing.T) {
+	t.Parallel()
+
+	got := buildBillingSerializer(
+		context.Background(),
+		libStreaming.Config{Enabled: true, SchemaRegistryURL: ""},
+		nil,
+	)
+	if got != nil {
+		t.Fatalf("expected nil serializer, got %v", got)
+	}
+}

--- a/components/ledger/internal/bootstrap/config.go
+++ b/components/ledger/internal/bootstrap/config.go
@@ -809,6 +809,12 @@ func InitServersWithOptions(opts *Options) (*Service, error) {
 		addCleanup(func() { _ = streamingClose() })
 	}
 
+	// === Billing serializer (metering) ===
+	// Built once here (one Schema Registry round-trip at construction), never on
+	// the request path. Graceful degradation: a nil value means billing is
+	// disabled (registry absent/unreachable at boot) and never fails startup.
+	billingSerializer := buildBillingSerializerFromEnv(context.Background(), logger)
+
 	// === Use cases ===
 
 	// Arm lib-observability's panic-observability trident so every
@@ -847,6 +853,15 @@ func InitServersWithOptions(opts *Options) (*Service, error) {
 		Streaming: streamingEmitter,
 		// Observability (D6)
 		MetricsFactory: metricsFactory,
+	}
+
+	// Nil-guard the billing serializer assignment: buildBillingSerializerFromEnv
+	// returns a concrete *billing.Serializer, and a nil one assigned directly to
+	// the interface field would become a non-nil typed-nil interface. Assigning
+	// only when non-nil keeps commandUseCase.BillingSerializer == nil (the
+	// "billing disabled" signal) intact.
+	if billingSerializer != nil {
+		commandUseCase.BillingSerializer = billingSerializer
 	}
 
 	queryUseCase := &query.UseCase{

--- a/components/ledger/internal/bootstrap/config.go
+++ b/components/ledger/internal/bootstrap/config.go
@@ -855,14 +855,12 @@ func InitServersWithOptions(opts *Options) (*Service, error) {
 		MetricsFactory: metricsFactory,
 	}
 
-	// Nil-guard the billing serializer assignment: buildBillingSerializerFromEnv
-	// returns a concrete *billing.Serializer, and a nil one assigned directly to
-	// the interface field would become a non-nil typed-nil interface. Assigning
-	// only when non-nil keeps commandUseCase.BillingSerializer == nil (the
-	// "billing disabled" signal) intact.
-	if billingSerializer != nil {
-		commandUseCase.BillingSerializer = billingSerializer
-	}
+	// Nil-guard the billing serializer assignment via the tested UseCase setter:
+	// buildBillingSerializerFromEnv returns a concrete *billing.Serializer, and a
+	// nil one assigned directly to the interface field would become a non-nil
+	// typed-nil interface. SetBillingSerializer keeps that guard in one place, so
+	// commandUseCase.BillingSerializer stays nil (the "billing disabled" signal).
+	commandUseCase.SetBillingSerializer(billingSerializer)
 
 	queryUseCase := &query.UseCase{
 		// Onboarding domain

--- a/components/ledger/internal/bootstrap/streaming.go
+++ b/components/ledger/internal/bootstrap/streaming.go
@@ -205,12 +205,19 @@ func buildBillingSerializerFromEnv(ctx context.Context, logger libLog.Logger) *b
 //
 // Branches:
 //   - streaming disabled (Enabled=false): return nil, no registry contact.
+//   - context canceled/expired: WARN + nil, before any registry contact.
 //   - NewSchemaRegistryClient fails (empty URL or partial credentials, both
 //     fail-closed): WARN + nil.
 //   - billing.NewSerializer fails (registry round-trip): WARN + nil.
 //   - success: the constructed serializer.
 func buildBillingSerializer(ctx context.Context, cfg libStreaming.Config, logger libLog.Logger) *billing.Serializer {
 	if !cfg.Enabled {
+		return nil
+	}
+
+	if err := ctx.Err(); err != nil {
+		warnBillingDisabled(ctx, logger, err)
+
 		return nil
 	}
 

--- a/components/ledger/internal/bootstrap/streaming.go
+++ b/components/ledger/internal/bootstrap/streaming.go
@@ -12,6 +12,7 @@ import (
 	libLog "github.com/LerianStudio/lib-observability/v2/log"
 	libOpentelemetry "github.com/LerianStudio/lib-observability/v2/tracing"
 	libStreaming "github.com/LerianStudio/lib-streaming/v2"
+	billing "github.com/LerianStudio/lib-streaming/v2/billing"
 
 	pkgStreaming "github.com/LerianStudio/midaz/v4/pkg/streaming"
 	"github.com/LerianStudio/midaz/v4/pkg/streaming/events"
@@ -126,6 +127,12 @@ func BuildStreamingEmitter(
 		Source(streamingCfg.CloudEventsSource).
 		Catalog(catalog).
 		Routes(routes...).
+		// The shared billing_recorded route targets a FIXED literal topic owned
+		// by the billing package (not a per-product topic from pkgStreaming.TopicName),
+		// so it is wired explicitly here rather than through buildRoutes. Merge is
+		// replace-by-DefinitionKey: billing_recorded matches no domain route, so it
+		// is appended and every domain route stays intact.
+		RouteOverrides(billing.Route()).
 		Target(libStreaming.TargetConfig{
 			Name:    streamingPrimaryTargetName,
 			Kind:    libStreaming.TransportKafkaLike,
@@ -166,6 +173,74 @@ func BuildStreamingEmitter(
 	}
 
 	return emitter, emitter.Close, nil
+}
+
+// buildBillingSerializerFromEnv loads the streaming config from the environment
+// and delegates to buildBillingSerializer. It is the composition-root entry
+// point (config.go) uses; the env read is separated from the network-free
+// decision core so the latter stays unit-testable with a hand-built config.
+//
+// A LoadConfig failure degrades gracefully to a nil serializer (billing
+// disabled) rather than failing boot — mirroring the builder's posture.
+func buildBillingSerializerFromEnv(ctx context.Context, logger libLog.Logger) *billing.Serializer {
+	cfg, _, err := libStreaming.LoadConfig()
+	if err != nil {
+		warnBillingDisabled(ctx, logger, err)
+
+		return nil
+	}
+
+	return buildBillingSerializer(ctx, cfg, logger)
+}
+
+// buildBillingSerializer builds the billing Serializer with graceful
+// degradation: any wiring failure yields a nil serializer (billing disabled)
+// and a single WARN, never a boot failure. This preserves backward-compatible
+// startup for deployments without a Schema Registry.
+//
+// It returns the concrete *billing.Serializer (not the command seam) so the
+// caller can nil-guard the interface assignment at the injection site and avoid
+// the typed-nil-interface trap: a nil *billing.Serializer assigned straight to
+// an interface compares NON-nil, so the caller assigns only when non-nil.
+//
+// Branches:
+//   - streaming disabled (Enabled=false): return nil, no registry contact.
+//   - NewSchemaRegistryClient fails (empty URL or partial credentials, both
+//     fail-closed): WARN + nil.
+//   - billing.NewSerializer fails (registry round-trip): WARN + nil.
+//   - success: the constructed serializer.
+func buildBillingSerializer(ctx context.Context, cfg libStreaming.Config, logger libLog.Logger) *billing.Serializer {
+	if !cfg.Enabled {
+		return nil
+	}
+
+	client, err := libStreaming.NewSchemaRegistryClient(cfg)
+	if err != nil {
+		warnBillingDisabled(ctx, logger, err)
+
+		return nil
+	}
+
+	serializer, err := billing.NewSerializer(ctx, client)
+	if err != nil {
+		warnBillingDisabled(ctx, logger, err)
+
+		return nil
+	}
+
+	return serializer
+}
+
+// warnBillingDisabled logs the single, uniform graceful-degradation WARN shared
+// by every billing-serializer failure branch. The err is attached; no secret is
+// ever included (NewSchemaRegistryClient's error never carries the password).
+func warnBillingDisabled(ctx context.Context, logger libLog.Logger, err error) {
+	if logger == nil {
+		return
+	}
+
+	logger.Log(ctx, libLog.LevelWarn, "Billing serializer disabled",
+		libLog.Bool("billing_enabled", false), libLog.Err(err))
 }
 
 // midazEventDefinitions returns the canonical, ordered list of midaz event
@@ -247,6 +322,11 @@ func buildCatalog() (libStreaming.Catalog, error) {
 			SchemaVersion: rd.def.SchemaVersion,
 		})
 	}
+
+	// The shared billing_recorded event is owned by lib-streaming's billing
+	// package: its Definition is a ready EventDefinition (Confluent-framed
+	// protobuf content type), added as-is rather than via the midaz registry.
+	entries = append(entries, billing.Definition())
 
 	return libStreaming.NewCatalog(entries...)
 }

--- a/components/ledger/internal/bootstrap/streaming_billing_test.go
+++ b/components/ledger/internal/bootstrap/streaming_billing_test.go
@@ -1,0 +1,60 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package bootstrap
+
+import (
+	"testing"
+
+	libStreaming "github.com/LerianStudio/lib-streaming/v2"
+	billing "github.com/LerianStudio/lib-streaming/v2/billing"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBillingEventWiredIntoCatalog locks Task 1.2.2: the shared billing_recorded
+// definition owned by lib-streaming's billing package is registered in the midaz
+// streaming catalog, and its route resolves to the FIXED shared billing topic
+// (owned by the billing package, NOT rendered via pkgStreaming.TopicName) without
+// colliding with any midaz domain route.
+func TestBillingEventWiredIntoCatalog(t *testing.T) {
+	t.Parallel()
+
+	catalog, err := buildCatalog()
+	require.NoError(t, err)
+
+	// (1) The catalog must contain the shared billing definition key. This is the
+	// production wiring under test: buildCatalog appends billing.Definition().
+	catalogKeys := make(map[string]struct{}, catalog.Len())
+	for _, d := range catalog.Definitions() {
+		catalogKeys[d.Key] = struct{}{}
+	}
+
+	_, ok := catalogKeys[billing.Definition().Key]
+	assert.Truef(t, ok, "billing definition %q must be registered in the streaming catalog", billing.Definition().Key)
+
+	// Contract lock: the shared billing key must not drift.
+	assert.Equal(t, "billing_recorded", billing.Definition().Key,
+		"billing definition key drifted from the shared contract")
+
+	// (2) The billing route is wired via Builder.RouteOverrides on top of the
+	// domain routes. RouteOverrides merges replace-by-DefinitionKey; billing_recorded
+	// matches NO domain route, so it is appended and every domain route survives.
+	// Assert the no-collision invariant that wiring relies on.
+	domainRoutes := buildRoutes(streamingPrimaryTargetName)
+	for _, r := range domainRoutes {
+		assert.NotEqualf(t, billing.Definition().Key, r.DefinitionKey,
+			"billing_recorded must not collide with domain route %q", r.DefinitionKey)
+	}
+
+	// The billing route resolves to the fixed shared literal topic (not a
+	// per-product topic rendered from pkgStreaming.TopicName).
+	billingRoute := billing.Route()
+	assert.Equal(t, billing.Definition().Key, billingRoute.DefinitionKey,
+		"billing route DefinitionKey must equal the billing definition key")
+	assert.Equal(t, libStreaming.KafkaTopic(billing.Topic), billingRoute.Destination,
+		"billing route must target the fixed shared billing topic")
+	assert.Equal(t, "lerian.streaming.billing.recorded", billing.Topic,
+		"billing topic literal drifted from the shared contract")
+}

--- a/components/ledger/internal/bootstrap/streaming_catalog_test.go
+++ b/components/ledger/internal/bootstrap/streaming_catalog_test.go
@@ -30,8 +30,11 @@ func TestMidazCatalogRoutesAssembly(t *testing.T) {
 
 	routes := buildRoutes(streamingPrimaryTargetName)
 
-	// One catalog entry and one route per definition.
-	assert.Equal(t, len(defs), catalog.Len(), "catalog entry count must equal definition count")
+	// One catalog entry per domain definition, plus the single shared
+	// billing_recorded entry appended by buildCatalog (owned by lib-streaming's
+	// billing package, not part of midazEventDefinitions). Routes from buildRoutes
+	// remain domain-only; the billing route is wired via Builder.RouteOverrides.
+	assert.Equal(t, len(defs)+1, catalog.Len(), "catalog = one entry per domain definition plus the shared billing entry")
 	assert.Len(t, routes, len(defs), "route count must equal definition count")
 
 	// The set of definition keys is the source of truth for the bijection, and

--- a/components/ledger/internal/services/command/billing_serializer_seam_test.go
+++ b/components/ledger/internal/services/command/billing_serializer_seam_test.go
@@ -1,0 +1,48 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package command
+
+import (
+	"testing"
+
+	billing "github.com/LerianStudio/lib-streaming/v2/billing"
+)
+
+// TestBillingSerializerSeam_ConcreteSatisfies locks that the concrete
+// *billing.Serializer satisfies the unexported billingSerializer seam the
+// UseCase field is typed on, so bootstrap can inject it and Phase 2 can fake it.
+func TestBillingSerializerSeam_ConcreteSatisfies(t *testing.T) {
+	t.Parallel()
+
+	var _ billingSerializer = (*billing.Serializer)(nil)
+}
+
+// TestBillingSerializer_NilGuardKeepsFieldNil is the typed-nil trap guard. A
+// disabled build yields a nil *billing.Serializer; the nil-guarded injection
+// (mirroring bootstrap config.go) must leave UseCase.BillingSerializer == nil,
+// and the test also documents the trap the guard exists to prevent.
+func TestBillingSerializer_NilGuardKeepsFieldNil(t *testing.T) {
+	t.Parallel()
+
+	var disabled *billing.Serializer // nil, as returned on the disabled branch
+
+	uc := &UseCase{}
+
+	// Correct guarded injection: only assign when non-nil.
+	if disabled != nil {
+		uc.BillingSerializer = disabled
+	}
+
+	if uc.BillingSerializer != nil {
+		t.Fatalf("expected BillingSerializer == nil when disabled, got a non-nil typed-nil interface")
+	}
+
+	// Document the trap the guard protects against: a typed-nil pointer assigned
+	// straight to the interface compares NON-nil.
+	var trap billingSerializer = disabled
+	if trap == nil {
+		t.Fatalf("expected typed-nil *billing.Serializer assigned to interface to be non-nil")
+	}
+}

--- a/components/ledger/internal/services/command/billing_serializer_seam_test.go
+++ b/components/ledger/internal/services/command/billing_serializer_seam_test.go
@@ -19,30 +19,50 @@ func TestBillingSerializerSeam_ConcreteSatisfies(t *testing.T) {
 	var _ billingSerializer = (*billing.Serializer)(nil)
 }
 
-// TestBillingSerializer_NilGuardKeepsFieldNil is the typed-nil trap guard. A
-// disabled build yields a nil *billing.Serializer; the nil-guarded injection
-// (mirroring bootstrap config.go) must leave UseCase.BillingSerializer == nil,
-// and the test also documents the trap the guard exists to prevent.
-func TestBillingSerializer_NilGuardKeepsFieldNil(t *testing.T) {
+// TestUseCase_SetBillingSerializer exercises the REAL production guard
+// (UseCase.SetBillingSerializer), the single place the typed-nil-interface trap
+// is defended. A nil *billing.Serializer must leave BillingSerializer == nil
+// (dropping the guard would assign a typed-nil pointer that compares NON-nil, so
+// this case FAILS on a regression); a non-nil pointer must be assigned.
+func TestUseCase_SetBillingSerializer(t *testing.T) {
 	t.Parallel()
 
-	var disabled *billing.Serializer // nil, as returned on the disabled branch
-
-	uc := &UseCase{}
-
-	// Correct guarded injection: only assign when non-nil.
-	if disabled != nil {
-		uc.BillingSerializer = disabled
+	tests := []struct {
+		name       string
+		serializer *billing.Serializer
+		wantNil    bool
+	}{
+		{
+			name:       "typed-nil pointer leaves field nil",
+			serializer: (*billing.Serializer)(nil),
+			wantNil:    true,
+		},
+		{
+			name:       "non-nil pointer is assigned",
+			serializer: &billing.Serializer{},
+			wantNil:    false,
+		},
 	}
 
-	if uc.BillingSerializer != nil {
-		t.Fatalf("expected BillingSerializer == nil when disabled, got a non-nil typed-nil interface")
-	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
-	// Document the trap the guard protects against: a typed-nil pointer assigned
-	// straight to the interface compares NON-nil.
-	var trap billingSerializer = disabled
-	if trap == nil {
-		t.Fatalf("expected typed-nil *billing.Serializer assigned to interface to be non-nil")
+			uc := &UseCase{}
+			uc.SetBillingSerializer(tt.serializer)
+
+			if tt.wantNil {
+				if uc.BillingSerializer != nil {
+					t.Fatalf("expected BillingSerializer == nil, got a non-nil typed-nil interface")
+				}
+
+				return
+			}
+
+			if uc.BillingSerializer == nil {
+				t.Fatalf("expected BillingSerializer to be assigned, got nil")
+			}
+		})
 	}
 }

--- a/components/ledger/internal/services/command/command.go
+++ b/components/ledger/internal/services/command/command.go
@@ -7,6 +7,7 @@ package command
 import (
 	"github.com/LerianStudio/lib-observability/v2/metrics"
 	libStreaming "github.com/LerianStudio/lib-streaming/v2"
+	billing "github.com/LerianStudio/lib-streaming/v2/billing"
 
 	onbMongo "github.com/LerianStudio/midaz/v4/components/ledger/internal/adapters/mongodb/onboarding"
 	txMongo "github.com/LerianStudio/midaz/v4/components/ledger/internal/adapters/mongodb/transaction"
@@ -27,6 +28,17 @@ import (
 	onbRedis "github.com/LerianStudio/midaz/v4/components/ledger/internal/adapters/redis/onboarding"
 	txRedis "github.com/LerianStudio/midaz/v4/components/ledger/internal/adapters/redis/transaction"
 )
+
+// billingSerializer is the narrow seam over lib-streaming's *billing.Serializer.
+// It exists so the billable-event emit path (Phase 2) can be unit-tested with a
+// fake and so a nil value cleanly means "billing disabled". The concrete
+// *billing.Serializer satisfies it; the assertion below locks that at compile
+// time.
+type billingSerializer interface {
+	Serialize(*billing.BillablePayload) ([]byte, error)
+}
+
+var _ billingSerializer = (*billing.Serializer)(nil)
 
 // UseCase is a struct that aggregates all repositories for both onboarding and transaction
 // domains, providing simplified access in use case implementations.
@@ -106,6 +118,17 @@ type UseCase struct {
 	// disabled" by every call site — never required for the request to
 	// succeed.
 	Streaming libStreaming.Emitter
+
+	// BillingSerializer encodes billable events into the Confluent-Protobuf
+	// wire format for the metering topic. It is built once at bootstrap (one
+	// Schema Registry round-trip at construction), never on the request path.
+	// A nil value means billing is disabled — the registry was absent or
+	// unreachable at boot — and is never required for a request to succeed.
+	// The field is the billingSerializer seam, so it MUST be assigned only a
+	// non-nil concrete serializer; a nil *billing.Serializer assigned directly
+	// would become a non-nil typed-nil interface (see the bootstrap injection
+	// nil-guard).
+	BillingSerializer billingSerializer
 
 	// --- Holder ownership (CRM seam, wired at bootstrap) ---
 

--- a/components/ledger/internal/services/command/command.go
+++ b/components/ledger/internal/services/command/command.go
@@ -40,6 +40,17 @@ type billingSerializer interface {
 
 var _ billingSerializer = (*billing.Serializer)(nil)
 
+// SetBillingSerializer assigns the billing serializer through the typed-nil
+// guard. It exists so the nil-interface trap — a nil *billing.Serializer
+// assigned straight to the billingSerializer interface field compares NON-nil —
+// is defended in ONE tested place shared by bootstrap and any future caller.
+// A nil pointer leaves BillingSerializer as a nil interface ("billing disabled").
+func (uc *UseCase) SetBillingSerializer(s *billing.Serializer) {
+	if s != nil {
+		uc.BillingSerializer = s
+	}
+}
+
 // UseCase is a struct that aggregates all repositories for both onboarding and transaction
 // domains, providing simplified access in use case implementations.
 type UseCase struct {

--- a/go.mod
+++ b/go.mod
@@ -87,7 +87,7 @@ require (
 	github.com/LerianStudio/lib-commons/v6 v6.5.1
 	github.com/LerianStudio/lib-observability/v2 v2.1.1
 	github.com/LerianStudio/lib-service-discovery v1.1.0
-	github.com/LerianStudio/lib-streaming/v2 v2.0.0
+	github.com/LerianStudio/lib-streaming/v2 v2.1.0
 	github.com/Shopify/toxiproxy/v2 v2.12.0
 	github.com/alicebob/miniredis/v2 v2.38.0
 	github.com/cucumber/godog v0.15.1
@@ -186,6 +186,7 @@ require (
 	github.com/sirupsen/logrus v1.9.4 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/tinylib/msgp v1.6.4 // indirect
+	github.com/twmb/franz-go/pkg/sr v1.8.0 // indirect
 	github.com/xdg-go/pbkdf2 v1.0.0 // indirect
 	github.com/xdg-go/scram v1.2.0 // indirect
 	github.com/xdg-go/stringprep v1.0.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -27,8 +27,8 @@ github.com/LerianStudio/lib-observability/v2 v2.1.1 h1:YpzgylqUqPg5g1FGpcf561SRb
 github.com/LerianStudio/lib-observability/v2 v2.1.1/go.mod h1:iXspGM6PRTf6BDtkTc0Z69R2HEv1GtjBsI/YSvewDgA=
 github.com/LerianStudio/lib-service-discovery v1.1.0 h1:rREGTNnlwoHdfsqDbDoOXAQkqQazVYT/b0yTypSWrk8=
 github.com/LerianStudio/lib-service-discovery v1.1.0/go.mod h1:d6pW/QMo1hYzLgzcxiTg3updjSs6m5sZkuOG3L4gwxo=
-github.com/LerianStudio/lib-streaming/v2 v2.0.0 h1:E5TokAl9vuMGKrfOc9Up2jazxjoxt1Dh6PwyNf0ZFKo=
-github.com/LerianStudio/lib-streaming/v2 v2.0.0/go.mod h1:LNPnBAgyCx1wZ4a+9XvxQieRc/Dl8AZ9A2sFrFmrz88=
+github.com/LerianStudio/lib-streaming/v2 v2.1.0 h1:3UjLKGww2o3DXiTEJak2z42oE/rkc34gLrBf91rT3n4=
+github.com/LerianStudio/lib-streaming/v2 v2.1.0/go.mod h1:LvPEIyvJ2hzoljLWhpKs6eRMQ3WytvET4P3lSC63mw8=
 github.com/Masterminds/squirrel v1.5.4 h1:uUcX/aBc8O7Fg9kaISIUsHXdKuqehiXAMQTYX8afzqM=
 github.com/Masterminds/squirrel v1.5.4/go.mod h1:NNaOrjSoIDfDA40n7sr2tPNZRfjzjA400rg+riTZj10=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
@@ -514,6 +514,8 @@ github.com/twmb/franz-go/pkg/kfake v0.0.0-20260606182254-a0f8f332c495 h1:Yls60qh
 github.com/twmb/franz-go/pkg/kfake v0.0.0-20260606182254-a0f8f332c495/go.mod h1:9j4VxU2ng6tHgD4lIkNJ5OJ3D6vgPhhIp3tBa7dJgLA=
 github.com/twmb/franz-go/pkg/kmsg v1.13.1 h1:fG5kItwysTk5UXqVwb64EpQEy3TydF3vYYK21nUQ+bI=
 github.com/twmb/franz-go/pkg/kmsg v1.13.1/go.mod h1:+DPt4NC8RmI6hqb8G09+3giKObE6uD2Eya6CfqBpeJY=
+github.com/twmb/franz-go/pkg/sr v1.8.0 h1:50iiB5/p9fEntgzd5S/FCd6v3Kkt0D26OtjBxNKjZcs=
+github.com/twmb/franz-go/pkg/sr v1.8.0/go.mod h1:64CsHlsQnyFRq1sYPcCmlRrEG3PlLPb6cDddx2wGr28=
 github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/valyala/fasthttp v1.72.0 h1:R7kYdoWhn1ye1fVpP+cDHDJwYm3NkwLliwgzJ/Abg7M=


### PR DESCRIPTION
<table border="0" cellspacing="0" cellpadding="0">
  <tr>
    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
    <td><h1>Midaz</h1></td>
  </tr>
</table>

---

## Description

Wiring foundation for the active-account billing event. This makes the ledger streaming
producer aware of the shared Lago-metering billing event and sets up a graceful,
Schema-Registry-backed serializer. No billing event is emitted yet — emission lands in a
follow-up change; this change only makes the producer capable of it without disturbing
existing streaming.

- **Dependency:** bump `lib-streaming/v2` v2.0.0 → v2.1.0 (the minimum version shipping the
  `billing` Confluent-Protobuf serializer + Schema Registry client; pulls `franz-go/pkg/sr`
  as an indirect dependency). No core streaming API change.
- **Catalog + route:** register `billing.Definition()` (`billing_recorded`) in the streaming
  catalog and `billing.Route()` via `Builder.RouteOverrides()` (append-only merge — every
  existing domain route stays intact).
- **Graceful serializer seam:** bootstrap a `billing.Serializer` over a Schema Registry client
  and inject it into `command.UseCase` behind a narrow `billingSerializer` interface. If the
  registry is unreachable or unset at bootstrap, log one WARN (`billing_enabled=false`) and
  inject a nil serializer — the service still boots with billing disabled (graceful
  degradation).
- **Config:** surface `STREAMING_SCHEMA_REGISTRY_URL` / `_USERNAME` / `_PASSWORD` in
  `.env.example` with safe empty defaults (empty URL = billing disabled, never a crash).

## Type of Change

- [x] `feat`: New feature or capability
- [x] `refactor`: Internal restructuring with no behavior change
- [x] `build`: Build system, Dockerfile, Go module dependencies

## Breaking Changes

None. Additive only: the new env vars are safe-by-default (empty ⇒ billing disabled), the
lib-streaming bump is a minor version with no core-API change, and existing CloudEvents/JSON
domain events are unaffected — the catalog grows by exactly one key and all domain routes are
preserved.

## Testing

- [x] `make test` passes
- [x] `make lint` passes (golangci-lint v2.11.3, 0 issues)
- [x] `make sec` and `make vulncheck` pass (govulncheck: 0 affecting)

**Test evidence:** Code review by 7 reviewers (code, logic, streaming, observability, nil-safety,
security, test), all PASS. Manual test in a local Docker + Redpanda stack:

- Graceful-disabled boot: `catalog_size` grows 49 → 50 and a single
  `WARN Billing serializer disabled billing_enabled=false` is logged; the service comes up
  healthy.
- Existing streaming intact: an `organization.created` event still flows to Redpanda with its
  full CloudEvent envelope and payload.
- Registry-present path: with a reachable Schema Registry, billing enables and self-registers
  the `lerian.streaming.billing.recorded-value` schema subject at bootstrap.

## Architectural Checklist

- [x] No `panic()` in production paths (graceful degradation returns nil + WARN)
- [x] Errors wrapped with `%w`
- [x] Handlers stay thin (parse, validate, call service)
- [x] Infrastructure concerns kept in `internal/bootstrap`

## Related Issues

None.
