### PR TITLE
feat(ledger): emit active_account billing event on posted transactions

### DIFF
--- a/components/ledger/internal/services/command/billing_active_account.go
+++ b/components/ledger/internal/services/command/billing_active_account.go
@@ -1,0 +1,59 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package command
+
+import (
+	"strings"
+
+	"github.com/LerianStudio/lib-streaming/v2/billing"
+	"github.com/LerianStudio/midaz/v4/components/ledger/internal/adapters/postgres/transaction"
+	"github.com/LerianStudio/midaz/v4/pkg/constant"
+)
+
+// activeAccountMetric is the Lago billable metric code emitted once per unique
+// internal account that participated in an approved transaction.
+const activeAccountMetric = "active_account"
+
+// buildActiveAccountBillingPayloads derives the active-account billable payloads
+// for a committed transaction. It returns one payload per unique internal
+// account referenced by the transaction's operations, preserving first-seen
+// order. External accounts (alias prefixed with constant.DefaultExternalAccountAliasPrefix)
+// are excluded, and a transaction that is nil or not APPROVED yields nothing.
+func buildActiveAccountBillingPayloads(tran *transaction.Transaction) []billing.BillablePayload {
+	if tran == nil || tran.Status.Code != constant.APPROVED {
+		return nil
+	}
+
+	var payloads []billing.BillablePayload
+
+	seen := make(map[string]struct{})
+
+	for _, op := range tran.Operations {
+		if op == nil {
+			continue
+		}
+
+		if strings.HasPrefix(op.AccountAlias, constant.DefaultExternalAccountAliasPrefix) {
+			continue
+		}
+
+		if _, ok := seen[op.AccountID]; ok {
+			continue
+		}
+
+		seen[op.AccountID] = struct{}{}
+
+		payloads = append(payloads, billing.BillablePayload{
+			Metric:         activeAccountMetric,
+			SubscriptionId: op.AccountID,
+			Properties: map[string]*billing.PropertyValue{
+				"account_id":     billing.StringProperty(op.AccountID),
+				"transaction_id": billing.StringProperty(tran.ID),
+			},
+		})
+	}
+
+	return payloads
+}

--- a/components/ledger/internal/services/command/billing_active_account.go
+++ b/components/ledger/internal/services/command/billing_active_account.go
@@ -7,12 +7,14 @@ package command
 import (
 	"context"
 	"strings"
+	"time"
 
 	libObservability "github.com/LerianStudio/lib-observability/v2"
 	libLog "github.com/LerianStudio/lib-observability/v2/log"
 	libOpentelemetry "github.com/LerianStudio/lib-observability/v2/tracing"
 	libStreaming "github.com/LerianStudio/lib-streaming/v2"
 	"github.com/LerianStudio/lib-streaming/v2/billing"
+	"go.opentelemetry.io/otel/trace"
 
 	"github.com/LerianStudio/midaz/v4/components/ledger/internal/adapters/postgres/transaction"
 	"github.com/LerianStudio/midaz/v4/pkg/constant"
@@ -50,6 +52,10 @@ func (uc *UseCase) SendActiveAccountBillingEvents(ctx context.Context, tran *tra
 		return
 	}
 
+	if ctx.Err() != nil {
+		return
+	}
+
 	ctxSend, span := tracer.Start(ctx, "command.send_active_account_billing_events_async")
 	defer span.End()
 
@@ -58,40 +64,50 @@ func (uc *UseCase) SendActiveAccountBillingEvents(ctx context.Context, tran *tra
 	payloads := buildActiveAccountBillingPayloads(tran)
 
 	for i := range payloads {
+		if ctxSend.Err() != nil {
+			return
+		}
+
 		// &payloads[i] rather than a copy: BillablePayload is a protobuf message
 		// embedding a sync.Mutex, so copying it by value trips govet copylocks.
-		p := &payloads[i]
+		uc.emitActiveAccountBillingEvent(ctxSend, span, logger, tenantID, &payloads[i], tran.CreatedAt)
+	}
+}
 
-		raw, err := uc.BillingSerializer.Serialize(p)
-		if err != nil {
-			libOpentelemetry.HandleSpanError(span, "billing serialize failed; skipping emit", err)
+// emitActiveAccountBillingEvent serializes one billable payload through the
+// billing serializer and emits it via the streaming seam. Serialize and emit
+// failures are span-recorded, warn-logged and swallowed — billing is
+// best-effort and MUST NOT fail the parent transaction.
+func (uc *UseCase) emitActiveAccountBillingEvent(ctx context.Context, span trace.Span, logger libLog.Logger, tenantID string, p *billing.BillablePayload, ts time.Time) {
+	raw, err := uc.BillingSerializer.Serialize(p)
+	if err != nil {
+		libOpentelemetry.HandleSpanError(span, "billing serialize failed; skipping emit", err)
 
-			logger.Log(ctxSend, libLog.LevelWarn, "billing serialize failed; skipping emit",
-				libLog.String("metric", p.GetMetric()),
-				libLog.String("subscription_id", p.GetSubscriptionId()),
-				libLog.String("tenant_id", tenantID),
-				libLog.Err(err))
+		logger.Log(ctx, libLog.LevelWarn, "billing serialize failed; skipping emit",
+			libLog.String("metric", p.GetMetric()),
+			libLog.String("subscription_id", p.GetSubscriptionId()),
+			libLog.String("tenant_id", tenantID),
+			libLog.Err(err))
 
-			continue
-		}
+		return
+	}
 
-		if err := uc.Streaming.Emit(ctxSend, libStreaming.EmitRequest{
-			DefinitionKey: billing.Definition().Key,
-			TenantID:      tenantID,
-			Subject:       p.GetSubscriptionId(),
-			Timestamp:     tran.CreatedAt,
-			Payload:       raw,
-		}); err != nil {
-			libOpentelemetry.HandleSpanError(span, "billing emit failed", err)
+	if err := uc.Streaming.Emit(ctx, libStreaming.EmitRequest{
+		DefinitionKey: billing.Definition().Key,
+		TenantID:      tenantID,
+		Subject:       p.GetSubscriptionId(),
+		Timestamp:     ts,
+		Payload:       raw,
+	}); err != nil {
+		libOpentelemetry.HandleSpanError(span, "billing emit failed", err)
 
-			logger.Log(ctxSend, libLog.LevelWarn, "billing emit failed",
-				libLog.String("metric", p.GetMetric()),
-				libLog.String("subscription_id", p.GetSubscriptionId()),
-				libLog.String("tenant_id", tenantID),
-				libLog.Err(err))
+		logger.Log(ctx, libLog.LevelWarn, "billing emit failed",
+			libLog.String("metric", p.GetMetric()),
+			libLog.String("subscription_id", p.GetSubscriptionId()),
+			libLog.String("tenant_id", tenantID),
+			libLog.Err(err))
 
-			continue
-		}
+		return
 	}
 }
 

--- a/components/ledger/internal/services/command/billing_active_account.go
+++ b/components/ledger/internal/services/command/billing_active_account.go
@@ -8,8 +8,9 @@ import (
 	"context"
 	"strings"
 
-	libObs "github.com/LerianStudio/lib-observability/v2"
+	libObservability "github.com/LerianStudio/lib-observability/v2"
 	libLog "github.com/LerianStudio/lib-observability/v2/log"
+	libOpentelemetry "github.com/LerianStudio/lib-observability/v2/tracing"
 	libStreaming "github.com/LerianStudio/lib-streaming/v2"
 	"github.com/LerianStudio/lib-streaming/v2/billing"
 
@@ -26,19 +27,33 @@ const activeAccountMetric = "active_account"
 // internal account that participated in an approved transaction, encoding each
 // payload through the billing serializer's Confluent-Protobuf wire format.
 //
+// phase is the lifecycle phase resolved by CreateOrUpdateTransaction. A
+// TransactionLifecyclePhaseNoop phase means the caller observed no state change
+// (e.g. a unique-violation redelivery with no eligible status transition), so
+// billing early-returns without emitting — this keeps billing at idempotency
+// parity with SendTransactionEvents, which skips the same phase, preventing a
+// double-emit on reprocessing.
+//
 // Fire-and-forget: a nil emitter or nil serializer means billing is disabled and
-// the call is a clean no-op, and serialize/emit failures are warn-logged and
-// swallowed — this MUST NOT fail the parent transaction. Billing does not use
-// pkgStreaming.EmitImportant/ToEmitRequest (the JSON path); it emits the raw
-// Protobuf bytes directly through the Emitter seam.
-func (uc *UseCase) SendActiveAccountBillingEvents(ctx context.Context, tran *transaction.Transaction) {
-	logger, _, _, _ := libObs.NewTrackingFromContext(ctx)
+// the call is a clean no-op, and serialize/emit failures are span-recorded,
+// warn-logged and swallowed — this MUST NOT fail the parent transaction. Billing
+// does not use pkgStreaming.EmitImportant/ToEmitRequest (the JSON path); it emits
+// the raw Protobuf bytes directly through the Emitter seam.
+func (uc *UseCase) SendActiveAccountBillingEvents(ctx context.Context, tran *transaction.Transaction, phase string) {
+	logger, tracer, _, _ := libObservability.NewTrackingFromContext(ctx)
+
+	if phase == TransactionLifecyclePhaseNoop {
+		return
+	}
 
 	if uc.Streaming == nil || uc.BillingSerializer == nil {
 		return
 	}
 
-	tenantID := pkgStreaming.ResolveTenantID(ctx)
+	ctxSend, span := tracer.Start(ctx, "command.send_active_account_billing_events_async")
+	defer span.End()
+
+	tenantID := pkgStreaming.ResolveTenantID(ctxSend)
 
 	payloads := buildActiveAccountBillingPayloads(tran)
 
@@ -49,7 +64,9 @@ func (uc *UseCase) SendActiveAccountBillingEvents(ctx context.Context, tran *tra
 
 		raw, err := uc.BillingSerializer.Serialize(p)
 		if err != nil {
-			logger.Log(ctx, libLog.LevelWarn, "billing serialize failed; skipping emit",
+			libOpentelemetry.HandleSpanError(span, "billing serialize failed; skipping emit", err)
+
+			logger.Log(ctxSend, libLog.LevelWarn, "billing serialize failed; skipping emit",
 				libLog.String("metric", p.GetMetric()),
 				libLog.String("subscription_id", p.GetSubscriptionId()),
 				libLog.String("tenant_id", tenantID),
@@ -58,13 +75,16 @@ func (uc *UseCase) SendActiveAccountBillingEvents(ctx context.Context, tran *tra
 			continue
 		}
 
-		if err := uc.Streaming.Emit(ctx, libStreaming.EmitRequest{
+		if err := uc.Streaming.Emit(ctxSend, libStreaming.EmitRequest{
 			DefinitionKey: billing.Definition().Key,
 			TenantID:      tenantID,
 			Subject:       p.GetSubscriptionId(),
+			Timestamp:     tran.CreatedAt,
 			Payload:       raw,
 		}); err != nil {
-			logger.Log(ctx, libLog.LevelWarn, "billing emit failed",
+			libOpentelemetry.HandleSpanError(span, "billing emit failed", err)
+
+			logger.Log(ctxSend, libLog.LevelWarn, "billing emit failed",
 				libLog.String("metric", p.GetMetric()),
 				libLog.String("subscription_id", p.GetSubscriptionId()),
 				libLog.String("tenant_id", tenantID),
@@ -91,6 +111,10 @@ func buildActiveAccountBillingPayloads(tran *transaction.Transaction) []billing.
 
 	for _, op := range tran.Operations {
 		if op == nil {
+			continue
+		}
+
+		if op.AccountID == "" {
 			continue
 		}
 

--- a/components/ledger/internal/services/command/billing_active_account.go
+++ b/components/ledger/internal/services/command/billing_active_account.go
@@ -5,16 +5,75 @@
 package command
 
 import (
+	"context"
 	"strings"
 
+	libObs "github.com/LerianStudio/lib-observability/v2"
+	libLog "github.com/LerianStudio/lib-observability/v2/log"
+	libStreaming "github.com/LerianStudio/lib-streaming/v2"
 	"github.com/LerianStudio/lib-streaming/v2/billing"
+
 	"github.com/LerianStudio/midaz/v4/components/ledger/internal/adapters/postgres/transaction"
 	"github.com/LerianStudio/midaz/v4/pkg/constant"
+	pkgStreaming "github.com/LerianStudio/midaz/v4/pkg/streaming"
 )
 
 // activeAccountMetric is the Lago billable metric code emitted once per unique
 // internal account that participated in an approved transaction.
 const activeAccountMetric = "active_account"
+
+// SendActiveAccountBillingEvents emits one billing_recorded event per unique
+// internal account that participated in an approved transaction, encoding each
+// payload through the billing serializer's Confluent-Protobuf wire format.
+//
+// Fire-and-forget: a nil emitter or nil serializer means billing is disabled and
+// the call is a clean no-op, and serialize/emit failures are warn-logged and
+// swallowed — this MUST NOT fail the parent transaction. Billing does not use
+// pkgStreaming.EmitImportant/ToEmitRequest (the JSON path); it emits the raw
+// Protobuf bytes directly through the Emitter seam.
+func (uc *UseCase) SendActiveAccountBillingEvents(ctx context.Context, tran *transaction.Transaction) {
+	logger, _, _, _ := libObs.NewTrackingFromContext(ctx)
+
+	if uc.Streaming == nil || uc.BillingSerializer == nil {
+		return
+	}
+
+	tenantID := pkgStreaming.ResolveTenantID(ctx)
+
+	payloads := buildActiveAccountBillingPayloads(tran)
+
+	for i := range payloads {
+		// &payloads[i] rather than a copy: BillablePayload is a protobuf message
+		// embedding a sync.Mutex, so copying it by value trips govet copylocks.
+		p := &payloads[i]
+
+		raw, err := uc.BillingSerializer.Serialize(p)
+		if err != nil {
+			logger.Log(ctx, libLog.LevelWarn, "billing serialize failed; skipping emit",
+				libLog.String("metric", p.GetMetric()),
+				libLog.String("subscription_id", p.GetSubscriptionId()),
+				libLog.String("tenant_id", tenantID),
+				libLog.Err(err))
+
+			continue
+		}
+
+		if err := uc.Streaming.Emit(ctx, libStreaming.EmitRequest{
+			DefinitionKey: billing.Definition().Key,
+			TenantID:      tenantID,
+			Subject:       p.GetSubscriptionId(),
+			Payload:       raw,
+		}); err != nil {
+			logger.Log(ctx, libLog.LevelWarn, "billing emit failed",
+				libLog.String("metric", p.GetMetric()),
+				libLog.String("subscription_id", p.GetSubscriptionId()),
+				libLog.String("tenant_id", tenantID),
+				libLog.Err(err))
+
+			continue
+		}
+	}
+}
 
 // buildActiveAccountBillingPayloads derives the active-account billable payloads
 // for a committed transaction. It returns one payload per unique internal

--- a/components/ledger/internal/services/command/billing_active_account_test.go
+++ b/components/ledger/internal/services/command/billing_active_account_test.go
@@ -1,0 +1,117 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package command
+
+import (
+	"testing"
+
+	"github.com/LerianStudio/lib-streaming/v2/billing"
+	"github.com/LerianStudio/midaz/v4/components/ledger/internal/adapters/postgres/operation"
+	"github.com/LerianStudio/midaz/v4/components/ledger/internal/adapters/postgres/transaction"
+	"github.com/LerianStudio/midaz/v4/pkg/constant"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newBillingTransaction(id, status string, ops ...*operation.Operation) *transaction.Transaction {
+	return &transaction.Transaction{
+		ID:         id,
+		Status:     transaction.Status{Code: status},
+		Operations: ops,
+	}
+}
+
+func TestBuildActiveAccountBillingPayloads(t *testing.T) {
+	t.Parallel()
+
+	const (
+		txID  = "11111111-1111-1111-1111-111111111111"
+		accA  = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+		accB  = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+		accC  = "cccccccc-cccc-cccc-cccc-cccccccccccc"
+		extID = "eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee"
+	)
+
+	tests := []struct {
+		name           string
+		tran           *transaction.Transaction
+		wantAccountIDs []string
+	}{
+		{
+			name: "mixed internal and external ops drops external",
+			tran: newBillingTransaction(txID, constant.APPROVED,
+				&operation.Operation{AccountID: accA, AccountAlias: "@person1"},
+				&operation.Operation{AccountID: extID, AccountAlias: constant.DefaultExternalAccountAliasPrefix + "USD"},
+			),
+			wantAccountIDs: []string{accA},
+		},
+		{
+			name: "same internal account across two ops yields one payload",
+			tran: newBillingTransaction(txID, constant.APPROVED,
+				&operation.Operation{AccountID: accA, AccountAlias: "@person1"},
+				&operation.Operation{AccountID: accA, AccountAlias: "@person1"},
+			),
+			wantAccountIDs: []string{accA},
+		},
+		{
+			name: "all external yields nothing",
+			tran: newBillingTransaction(txID, constant.APPROVED,
+				&operation.Operation{AccountID: extID, AccountAlias: constant.DefaultExternalAccountAliasPrefix + "USD"},
+				&operation.Operation{AccountID: extID, AccountAlias: constant.DefaultExternalAccountAliasPrefix + "BRL"},
+			),
+			wantAccountIDs: nil,
+		},
+		{
+			name: "non-approved transaction yields nothing",
+			tran: newBillingTransaction(txID, constant.PENDING,
+				&operation.Operation{AccountID: accA, AccountAlias: "@person1"},
+			),
+			wantAccountIDs: nil,
+		},
+		{
+			name:           "nil transaction yields nothing",
+			tran:           nil,
+			wantAccountIDs: nil,
+		},
+		{
+			name: "three distinct internal accounts yield three payloads preserving order",
+			tran: newBillingTransaction(txID, constant.APPROVED,
+				&operation.Operation{AccountID: accA, AccountAlias: "@person1"},
+				&operation.Operation{AccountID: accB, AccountAlias: "@person2"},
+				&operation.Operation{AccountID: accC, AccountAlias: "@person3"},
+			),
+			wantAccountIDs: []string{accA, accB, accC},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := buildActiveAccountBillingPayloads(tt.tran)
+
+			require.Len(t, got, len(tt.wantAccountIDs))
+
+			for i, wantID := range tt.wantAccountIDs {
+				payload := got[i]
+				require.NotNil(t, payload)
+
+				assert.Equal(t, activeAccountMetric, payload.GetMetric())
+				assert.Equal(t, "active_account", payload.GetMetric())
+				assert.Equal(t, wantID, payload.GetSubscriptionId())
+
+				props := payload.GetProperties()
+				require.Contains(t, props, "account_id")
+				require.Contains(t, props, "transaction_id")
+				assert.Equal(t, wantID, props["account_id"].GetStringValue())
+				assert.Equal(t, txID, props["transaction_id"].GetStringValue())
+			}
+		})
+	}
+}
+
+// ensure the billing import is exercised even if the table changes.
+var _ = billing.BillablePayload{}

--- a/components/ledger/internal/services/command/billing_active_account_test.go
+++ b/components/ledger/internal/services/command/billing_active_account_test.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/LerianStudio/lib-streaming/v2/billing"
 	"github.com/LerianStudio/midaz/v4/components/ledger/internal/adapters/postgres/operation"
@@ -23,6 +24,10 @@ import (
 // exporting it, and the codebase already hand-rolls its streaming double
 // (pkgStreaming.MockEmitter) for the same reason, so this mirrors that
 // convention: canned, deterministic bytes or a configured error.
+// fixedBillingTime is a deterministic timestamp for the emit-path fixture so the
+// EmitRequest.Timestamp assertion is stable and never reads time.Now().
+var fixedBillingTime = time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+
 type fakeSerializer struct {
 	raw []byte
 	err error
@@ -163,6 +168,7 @@ func TestSendActiveAccountBillingEvents(t *testing.T) {
 		&operation.Operation{AccountID: accA, AccountAlias: "@person1"},
 		&operation.Operation{AccountID: accB, AccountAlias: "@person2"},
 	)
+	approvedTwo.CreatedAt = fixedBillingTime
 
 	tests := []struct {
 		name           string
@@ -277,6 +283,7 @@ func TestSendActiveAccountBillingEvents(t *testing.T) {
 				assert.Equal(t, wantSubject, events[i].Subject)
 				assert.Equal(t, pkgStreaming.DefaultTenantID, events[i].TenantID)
 				assert.Equal(t, fakeBytes, []byte(events[i].Payload))
+				assert.Equal(t, fixedBillingTime, events[i].Timestamp)
 			}
 		})
 	}

--- a/components/ledger/internal/services/command/billing_active_account_test.go
+++ b/components/ledger/internal/services/command/billing_active_account_test.go
@@ -5,15 +5,36 @@
 package command
 
 import (
+	"context"
+	"errors"
 	"testing"
 
 	"github.com/LerianStudio/lib-streaming/v2/billing"
 	"github.com/LerianStudio/midaz/v4/components/ledger/internal/adapters/postgres/operation"
 	"github.com/LerianStudio/midaz/v4/components/ledger/internal/adapters/postgres/transaction"
 	"github.com/LerianStudio/midaz/v4/pkg/constant"
+	pkgStreaming "github.com/LerianStudio/midaz/v4/pkg/streaming"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// fakeSerializer is a hand-rolled double for the unexported billingSerializer
+// seam. GoMock cannot generate a mock for a package-private interface without
+// exporting it, and the codebase already hand-rolls its streaming double
+// (pkgStreaming.MockEmitter) for the same reason, so this mirrors that
+// convention: canned, deterministic bytes or a configured error.
+type fakeSerializer struct {
+	raw []byte
+	err error
+}
+
+func (f fakeSerializer) Serialize(*billing.BillablePayload) ([]byte, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+
+	return f.raw, nil
+}
 
 func newBillingTransaction(id, status string, ops ...*operation.Operation) *transaction.Transaction {
 	return &transaction.Transaction{
@@ -108,6 +129,125 @@ func TestBuildActiveAccountBillingPayloads(t *testing.T) {
 				require.Contains(t, props, "transaction_id")
 				assert.Equal(t, wantID, props["account_id"].GetStringValue())
 				assert.Equal(t, txID, props["transaction_id"].GetStringValue())
+			}
+		})
+	}
+}
+
+func TestSendActiveAccountBillingEvents(t *testing.T) {
+	t.Parallel()
+
+	const (
+		txID = "11111111-1111-1111-1111-111111111111"
+		accA = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+		accB = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+	)
+
+	fakeBytes := []byte{0x00, 0x00, 0x00, 0x00, 0x01}
+
+	approvedTwo := newBillingTransaction(txID, constant.APPROVED,
+		&operation.Operation{AccountID: accA, AccountAlias: "@person1"},
+		&operation.Operation{AccountID: accB, AccountAlias: "@person2"},
+	)
+
+	tests := []struct {
+		name           string
+		tran           *transaction.Transaction
+		withStreaming  bool
+		withSerializer bool
+		emitErr        error
+		serializeErr   error
+		wantSubjects   []string
+	}{
+		{
+			name:           "two unique internal accounts emit two events",
+			tran:           approvedTwo,
+			withStreaming:  true,
+			withSerializer: true,
+			wantSubjects:   []string{accA, accB},
+		},
+		{
+			name:           "emitter error is swallowed and nothing captured",
+			tran:           approvedTwo,
+			withStreaming:  true,
+			withSerializer: true,
+			emitErr:        errors.New("broker down"),
+			wantSubjects:   nil,
+		},
+		{
+			name:           "serializer error skips emit",
+			tran:           approvedTwo,
+			withStreaming:  true,
+			withSerializer: true,
+			serializeErr:   errors.New("registry down"),
+			wantSubjects:   nil,
+		},
+		{
+			name:           "nil serializer is a clean no-op",
+			tran:           approvedTwo,
+			withStreaming:  true,
+			withSerializer: false,
+			wantSubjects:   nil,
+		},
+		{
+			name:           "nil streaming is a clean no-op",
+			tran:           approvedTwo,
+			withStreaming:  false,
+			withSerializer: true,
+			wantSubjects:   nil,
+		},
+		{
+			name:           "non-approved transaction emits nothing",
+			tran:           newBillingTransaction(txID, constant.PENDING, &operation.Operation{AccountID: accA, AccountAlias: "@person1"}),
+			withStreaming:  true,
+			withSerializer: true,
+			wantSubjects:   nil,
+		},
+		{
+			name:           "nil transaction is a clean no-op",
+			tran:           nil,
+			withStreaming:  true,
+			withSerializer: true,
+			wantSubjects:   nil,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var mockEmitter *pkgStreaming.MockEmitter
+
+			uc := &UseCase{}
+
+			if tt.withStreaming {
+				mockEmitter = pkgStreaming.NewMockEmitter()
+				mockEmitter.SetError(tt.emitErr)
+				uc.Streaming = mockEmitter
+			}
+
+			if tt.withSerializer {
+				uc.BillingSerializer = fakeSerializer{raw: fakeBytes, err: tt.serializeErr}
+			}
+
+			require.NotPanics(t, func() {
+				uc.SendActiveAccountBillingEvents(context.Background(), tt.tran)
+			})
+
+			if mockEmitter == nil {
+				return
+			}
+
+			events := mockEmitter.Events()
+			require.Len(t, events, len(tt.wantSubjects))
+
+			for i, wantSubject := range tt.wantSubjects {
+				assert.Equal(t, billing.Definition().Key, events[i].DefinitionKey)
+				assert.Equal(t, "billing_recorded", events[i].DefinitionKey)
+				assert.Equal(t, wantSubject, events[i].Subject)
+				assert.Equal(t, pkgStreaming.DefaultTenantID, events[i].TenantID)
+				assert.Equal(t, fakeBytes, []byte(events[i].Payload))
 			}
 		})
 	}

--- a/components/ledger/internal/services/command/billing_active_account_test.go
+++ b/components/ledger/internal/services/command/billing_active_account_test.go
@@ -105,6 +105,22 @@ func TestBuildActiveAccountBillingPayloads(t *testing.T) {
 			),
 			wantAccountIDs: []string{accA, accB, accC},
 		},
+		{
+			name: "operation with empty account id is skipped",
+			tran: newBillingTransaction(txID, constant.APPROVED,
+				&operation.Operation{AccountID: "", AccountAlias: "@person1"},
+				&operation.Operation{AccountID: accA, AccountAlias: "@person1"},
+			),
+			wantAccountIDs: []string{accA},
+		},
+		{
+			name: "nil operation entry is skipped",
+			tran: newBillingTransaction(txID, constant.APPROVED,
+				nil,
+				&operation.Operation{AccountID: accA, AccountAlias: "@person1"},
+			),
+			wantAccountIDs: []string{accA},
+		},
 	}
 
 	for _, tt := range tests {
@@ -117,10 +133,8 @@ func TestBuildActiveAccountBillingPayloads(t *testing.T) {
 			require.Len(t, got, len(tt.wantAccountIDs))
 
 			for i, wantID := range tt.wantAccountIDs {
-				payload := got[i]
-				require.NotNil(t, payload)
+				payload := &got[i]
 
-				assert.Equal(t, activeAccountMetric, payload.GetMetric())
 				assert.Equal(t, "active_account", payload.GetMetric())
 				assert.Equal(t, wantID, payload.GetSubscriptionId())
 
@@ -153,6 +167,7 @@ func TestSendActiveAccountBillingEvents(t *testing.T) {
 	tests := []struct {
 		name           string
 		tran           *transaction.Transaction
+		phase          string
 		withStreaming  bool
 		withSerializer bool
 		emitErr        error
@@ -162,13 +177,23 @@ func TestSendActiveAccountBillingEvents(t *testing.T) {
 		{
 			name:           "two unique internal accounts emit two events",
 			tran:           approvedTwo,
+			phase:          TransactionLifecyclePhaseCreated,
 			withStreaming:  true,
 			withSerializer: true,
 			wantSubjects:   []string{accA, accB},
 		},
 		{
+			name:           "noop phase emits nothing even when approved",
+			tran:           approvedTwo,
+			phase:          TransactionLifecyclePhaseNoop,
+			withStreaming:  true,
+			withSerializer: true,
+			wantSubjects:   nil,
+		},
+		{
 			name:           "emitter error is swallowed and nothing captured",
 			tran:           approvedTwo,
+			phase:          TransactionLifecyclePhaseCreated,
 			withStreaming:  true,
 			withSerializer: true,
 			emitErr:        errors.New("broker down"),
@@ -177,6 +202,7 @@ func TestSendActiveAccountBillingEvents(t *testing.T) {
 		{
 			name:           "serializer error skips emit",
 			tran:           approvedTwo,
+			phase:          TransactionLifecyclePhaseCreated,
 			withStreaming:  true,
 			withSerializer: true,
 			serializeErr:   errors.New("registry down"),
@@ -185,6 +211,7 @@ func TestSendActiveAccountBillingEvents(t *testing.T) {
 		{
 			name:           "nil serializer is a clean no-op",
 			tran:           approvedTwo,
+			phase:          TransactionLifecyclePhaseCreated,
 			withStreaming:  true,
 			withSerializer: false,
 			wantSubjects:   nil,
@@ -192,6 +219,7 @@ func TestSendActiveAccountBillingEvents(t *testing.T) {
 		{
 			name:           "nil streaming is a clean no-op",
 			tran:           approvedTwo,
+			phase:          TransactionLifecyclePhaseCreated,
 			withStreaming:  false,
 			withSerializer: true,
 			wantSubjects:   nil,
@@ -199,6 +227,7 @@ func TestSendActiveAccountBillingEvents(t *testing.T) {
 		{
 			name:           "non-approved transaction emits nothing",
 			tran:           newBillingTransaction(txID, constant.PENDING, &operation.Operation{AccountID: accA, AccountAlias: "@person1"}),
+			phase:          TransactionLifecyclePhaseCreated,
 			withStreaming:  true,
 			withSerializer: true,
 			wantSubjects:   nil,
@@ -206,6 +235,7 @@ func TestSendActiveAccountBillingEvents(t *testing.T) {
 		{
 			name:           "nil transaction is a clean no-op",
 			tran:           nil,
+			phase:          TransactionLifecyclePhaseCreated,
 			withStreaming:  true,
 			withSerializer: true,
 			wantSubjects:   nil,
@@ -232,7 +262,7 @@ func TestSendActiveAccountBillingEvents(t *testing.T) {
 			}
 
 			require.NotPanics(t, func() {
-				uc.SendActiveAccountBillingEvents(context.Background(), tt.tran)
+				uc.SendActiveAccountBillingEvents(context.Background(), tt.tran, tt.phase)
 			})
 
 			if mockEmitter == nil {
@@ -243,7 +273,6 @@ func TestSendActiveAccountBillingEvents(t *testing.T) {
 			require.Len(t, events, len(tt.wantSubjects))
 
 			for i, wantSubject := range tt.wantSubjects {
-				assert.Equal(t, billing.Definition().Key, events[i].DefinitionKey)
 				assert.Equal(t, "billing_recorded", events[i].DefinitionKey)
 				assert.Equal(t, wantSubject, events[i].Subject)
 				assert.Equal(t, pkgStreaming.DefaultTenantID, events[i].TenantID)
@@ -252,6 +281,3 @@ func TestSendActiveAccountBillingEvents(t *testing.T) {
 		})
 	}
 }
-
-// ensure the billing import is exercised even if the table changes.
-var _ = billing.BillablePayload{}

--- a/components/ledger/internal/services/command/create_balance_transaction_operations_async.go
+++ b/components/ledger/internal/services/command/create_balance_transaction_operations_async.go
@@ -158,7 +158,7 @@ func (uc *UseCase) CreateBalanceTransactionOperationsAsync(ctx context.Context, 
 
 		var wg sync.WaitGroup
 
-		wg.Add(3)
+		wg.Add(4)
 
 		go func() {
 			defer wg.Done()
@@ -170,6 +170,11 @@ func (uc *UseCase) CreateBalanceTransactionOperationsAsync(ctx context.Context, 
 			defer wg.Done()
 
 			runWithTimeout(func(c context.Context) { uc.SendBalanceChangedEvents(c, tran) })
+		}()
+		go func() {
+			defer wg.Done()
+
+			runWithTimeout(func(c context.Context) { uc.SendActiveAccountBillingEvents(c, tran) })
 		}()
 
 		wg.Wait()

--- a/components/ledger/internal/services/command/create_balance_transaction_operations_async.go
+++ b/components/ledger/internal/services/command/create_balance_transaction_operations_async.go
@@ -16,6 +16,7 @@ import (
 
 	libObservability "github.com/LerianStudio/lib-observability/v2"
 	libLog "github.com/LerianStudio/lib-observability/v2/log"
+	libRuntime "github.com/LerianStudio/lib-observability/v2/runtime"
 	libOpentelemetry "github.com/LerianStudio/lib-observability/v2/tracing"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgconn"
@@ -171,10 +172,14 @@ func (uc *UseCase) CreateBalanceTransactionOperationsAsync(ctx context.Context, 
 
 			runWithTimeout(func(c context.Context) { uc.SendBalanceChangedEvents(c, tran) })
 		}()
+		// Billing is the newest emitter and is wrapped in panic recovery here.
+		// The three sibling goroutines above lack recovery as a pre-existing,
+		// separately tracked follow-up — do not wrap them in this change.
 		go func() {
 			defer wg.Done()
+			defer libRuntime.RecoverWithPolicyAndContext(base, logger, "transaction", "send-active-account-billing", libRuntime.KeepRunning)
 
-			runWithTimeout(func(c context.Context) { uc.SendActiveAccountBillingEvents(c, tran) })
+			runWithTimeout(func(c context.Context) { uc.SendActiveAccountBillingEvents(c, tran, phase) })
 		}()
 
 		wg.Wait()

--- a/components/ledger/internal/services/command/create_bulk_transaction_operations_async.go
+++ b/components/ledger/internal/services/command/create_bulk_transaction_operations_async.go
@@ -16,6 +16,7 @@ import (
 
 	libObservability "github.com/LerianStudio/lib-observability/v2"
 	libLog "github.com/LerianStudio/lib-observability/v2/log"
+	libRuntime "github.com/LerianStudio/lib-observability/v2/runtime"
 	libOpentelemetry "github.com/LerianStudio/lib-observability/v2/tracing"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgconn"
@@ -587,7 +588,7 @@ func (uc *UseCase) processMetadataAndEvents(
 
 			var wg sync.WaitGroup
 
-			wg.Add(3)
+			wg.Add(4)
 
 			go func() {
 				defer wg.Done()
@@ -599,6 +600,17 @@ func (uc *UseCase) processMetadataAndEvents(
 				defer wg.Done()
 
 				runWithTimeout(func(c context.Context) { uc.SendBalanceChangedEvents(c, tx) })
+			}()
+			// Billing shares the same phase gate as SendTransactionEvents above, so
+			// it inherits the same once-per-posted-tx idempotency. It is the newest
+			// emitter and is wrapped in panic recovery here; the three sibling
+			// goroutines above lack recovery as a pre-existing, separately tracked
+			// follow-up — do not wrap them in this change.
+			go func() {
+				defer wg.Done()
+				defer libRuntime.RecoverWithPolicyAndContext(base, logger, "transaction", "send-active-account-billing", libRuntime.KeepRunning)
+
+				runWithTimeout(func(c context.Context) { uc.SendActiveAccountBillingEvents(c, tx, phase) })
 			}()
 
 			wg.Wait()


### PR DESCRIPTION
<table border="0" cellspacing="0" cellpadding="0">
  <tr>
    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
    <td><h1>Midaz</h1></td>
  </tr>
</table>

---

## Description

Emits the `active_account` Lago-metering billing event on posted transactions, building on
the billing wiring foundation (catalog + route + graceful serializer) already merged into this
branch. When a transaction is posted, one `billing_recorded` event is emitted per **unique
internal account** it touches.

- **Payload builder** — a pure function maps a posted (APPROVED) transaction to one
  `billing.BillablePayload` per unique internal account: `@external/*` legs are excluded,
  accounts are de-duplicated, and each payload carries `Metric="active_account"`,
  `SubscriptionId=account_id`, and `Properties{account_id, transaction_id}` (built via
  `billing.StringProperty`).
- **Emit helper** — `SendActiveAccountBillingEvents` serializes each payload through the
  billing `Serializer` seam and publishes it via the streaming `Emitter`. It is best-effort:
  a nil emitter/serializer (billing disabled) is a clean no-op, and serialize/emit failures
  are span-recorded, warn-logged, and swallowed — **never failing the transaction**.
- **Wiring** — the emit runs in the transaction post-commit fan-out, once per posted
  transaction across the single-transaction and bulk paths, independent of
  `RABBITMQ_TRANSACTION_EVENTS_ENABLED`. It is **idempotent**: gated on the lifecycle phase so
  message redelivery / reprocessing does not double-emit.

No billable event is emitted unless a Schema Registry is configured and reachable; otherwise
billing stays gracefully disabled (from the foundation change).

## Type of Change

- [x] `feat`: New feature or capability
- [x] `fix`: Bug fix (idempotency + bulk-path coverage from review)

## Breaking Changes

None. Additive: the emit only fires when billing is enabled (Schema Registry reachable), and
never alters or blocks the transaction outcome. Existing streaming and transaction behavior is
unchanged.

## Testing

- [x] `make test` passes
- [x] `make lint` passes (golangci-lint v2, 0 issues; `go vet` copylocks clean)
- [x] `make sec` and `make vulncheck` pass (govulncheck: 0 affecting)

**Test evidence:** Code review by 8 reviewers (code, logic, streaming, observability, nil-safety,
security, tenancy, test) over two iterations — the pool surfaced and the change fixes two
revenue-correctness gaps (double-emit on reprocessing; the bulk transaction path was unbilled).
Unit tests cover the builder (dedup, external exclusion, APPROVED/Noop gating, empty/nil edges)
and the emit helper (success, emit-failure-swallowed, serialize-failure-skipped, nil no-op).
Manual end-to-end test on a local Docker + Redpanda stack with a reachable Schema Registry: one
posted transaction (`@external` → two internal accounts) produced exactly two `billing_recorded`
messages — `ce-type: studio.lerian.billing.recorded`, `ce-subject` = each account id,
Confluent-Protobuf payload decoding to `Metric=active_account` with `account_id`/`transaction_id`
properties; the external leg produced no event.

## Architectural Checklist

- [x] No `panic()` in production paths; new goroutines carry runtime panic recovery
- [x] Timestamps use existing transaction timestamp for deterministic billing-period attribution
- [x] Errors wrapped with `%w`; technical failures recorded on the span
- [x] Handlers stay thin — emission lives in the command use case, not the HTTP layer
- [x] Infrastructure concerns kept in `internal/bootstrap`

## Related Issues

None.
