### PR TITLE
chore(infra): provision local billing topic and streaming runbook

### DIFF
--- a/components/infra/docker-compose.yml
+++ b/components/infra/docker-compose.yml
@@ -229,6 +229,7 @@ services:
       - --advertise-kafka-addr=internal://midaz-redpanda:9092,external://localhost:19092
     ports:
       - "19092:19092"
+      - "8081:8081"
     healthcheck:
       test: ["CMD-SHELL", "rpk cluster health | grep -q 'Healthy:.*true'"]
       interval: 10s
@@ -247,7 +248,10 @@ services:
   # registration functions — DO NOT hand-edit stale entries; keep in sync with:
   #   - midazEventDefinitions()  (components/ledger/internal/bootstrap/streaming.go) — 49 ledger/fee/crm topics
   #   - tracerEventDefinitions() (components/tracer/internal/bootstrap/streaming.go) — 12 tracer_rule.*/tracer_limit.* topics
-  # Total: 61 topics. Topic name = "lerian.streaming.<service>_<resource>.<event>".
+  # Total: 62 topics. Topic name = "lerian.streaming.<service>_<resource>.<event>".
+  # Note: lerian.streaming.billing.recorded is registered separately via
+  # billing.Definition() (not midazEventDefinitions()), so it is an explicit
+  # addition below rather than a member of the two catalog functions above.
   midaz-redpanda-init:
     container_name: midaz-redpanda-init
     image: redpandadata/redpanda:v24.2.7
@@ -324,6 +328,7 @@ services:
         rpk topic create lerian.streaming.tracer_rule.deleted -r 1 -p 1 --brokers midaz-redpanda:9092 || true
         rpk topic create lerian.streaming.tracer_rule.drafted -r 1 -p 1 --brokers midaz-redpanda:9092 || true
         rpk topic create lerian.streaming.tracer_rule.updated -r 1 -p 1 --brokers midaz-redpanda:9092 || true
+        rpk topic create lerian.streaming.billing.recorded -r 1 -p 1 --brokers midaz-redpanda:9092 || true
     networks:
       - infra-network
 

--- a/components/ledger/.env.example
+++ b/components/ledger/.env.example
@@ -466,6 +466,7 @@ STREAMING_ENABLED=false
 # Read by lib-streaming LoadConfig; midaz does not parse these. Empty URL is the
 # safe default: it disables billing emits and NEVER crashes the app. Username and
 # password are optional basic-auth (both-or-neither) and are never logged.
+# local (compose): STREAMING_SCHEMA_REGISTRY_URL=http://midaz-redpanda:8081
 STREAMING_SCHEMA_REGISTRY_URL=
 # STREAMING_SCHEMA_REGISTRY_USERNAME=
 # STREAMING_SCHEMA_REGISTRY_PASSWORD=

--- a/docs/architecture/billing-active-account-streaming.md
+++ b/docs/architecture/billing-active-account-streaming.md
@@ -1,0 +1,222 @@
+# Active-account billing over streaming
+
+> **Status: operations runbook.** This document is the single source of truth for how the ledger
+> emits the `active_account` billable event, how you enable it per environment, how you verify a pod
+> can bill, and what its durability limits are. Everything below is a **fact grounded in code** in
+> *this* repo, cited inline.
+>
+> **Scope.** Billing emission runs in-process inside the ledger binary on `:3002`. It piggybacks on
+> the same lib-streaming producer that carries every other ledger event; there is no separate service,
+> image, or port. A Schema Registry and a Kafka/Redpanda broker are **external** dependencies you
+> supply per environment.
+>
+> **Citation convention.** Unprefixed anchors name a symbol you can grep. Line ranges rot, so the
+> durable anchors are the cited **function, const, and file** names — grep those, not line numbers.
+
+---
+
+## 1. Overview — what fires, and when
+
+The ledger emits a Lago-metering billable event named `active_account`. It fires **once per unique
+internal account** touched by a **posted (APPROVED)** transaction.
+
+The derivation lives in `buildActiveAccountBillingPayloads`
+(`components/ledger/internal/services/command/billing_active_account.go`):
+
+- A transaction that is `nil` or whose status is not `APPROVED` yields **nothing**.
+- Each operation contributes its account, **de-duplicated** by account ID in first-seen order.
+- External-account legs are **excluded** — any operation whose alias starts with the external-account
+  prefix (`constant.DefaultExternalAccountAliasPrefix`, i.e. `@external/*`) is skipped.
+
+Emission is driven by `SendActiveAccountBillingEvents`, which early-returns on the no-op lifecycle
+phase (`TransactionLifecyclePhaseNoop`) so a redelivery with no eligible status transition never
+double-emits. This keeps billing at idempotency parity with `SendTransactionEvents`.
+
+### Payload and wire format
+
+Each payload is a `billing.BillablePayload` with these fields:
+
+| Field | Value |
+|---|---|
+| `Metric` | `active_account` (const `activeAccountMetric`) |
+| `SubscriptionId` | the internal account ID |
+| `Properties.account_id` | the internal account ID |
+| `Properties.transaction_id` | the transaction ID |
+
+The payload is **not JSON**. The billing serializer encodes it as **Confluent-framed Protobuf** — a
+leading `0x00` magic byte plus the schema ID, then the Protobuf body. Billing does **not** use the
+`ToEmitRequest` / `EmitImportant` JSON path that the domain events use; it emits raw Protobuf bytes
+directly through the `Emitter` seam.
+
+### Topic and CloudEvents envelope
+
+All active-account events land on a single shared topic:
+
+```
+lerian.streaming.billing.recorded
+```
+
+This is a fixed literal topic owned by lib-streaming's `billing` package, wired explicitly via
+`RouteOverrides(billing.Route())` in `BuildStreamingEmitter`
+(`components/ledger/internal/bootstrap/streaming.go`) — **not** a per-product topic derived from
+`pkgStreaming.TopicName`.
+
+| CloudEvents attribute | Value |
+|---|---|
+| `ce-type` | `studio.lerian.billing.recorded` |
+| `ce-source` | `lerian.midaz.ledger` |
+| `ce-subject` | the account ID |
+| `ce-datacontenttype` | `application/vnd.confluent.protobuf` |
+| `ce-tenantid` | resolved from the request context |
+
+---
+
+## 2. Enabling billing in an environment
+
+Billing emits **only** when both of these hold:
+
+1. `STREAMING_ENABLED=true` — the master streaming flag. When false, a `NoopEmitter` is injected and
+   no broker connection is attempted, so billing is off.
+2. A Schema Registry is **configured and reachable at bootstrap**. Without one, the billing serializer
+   is nil and billing is off (see §3).
+
+### The three Schema Registry env vars
+
+These are read by **lib-streaming's `LoadConfig`**, not by midaz directly. They are declared in
+`components/ledger/.env.example` under `--- Schema Registry (billing emits) ---`:
+
+| Variable | Purpose | Default |
+|---|---|---|
+| `STREAMING_SCHEMA_REGISTRY_URL` | Schema Registry endpoint. Empty ⇒ billing disabled. | empty |
+| `STREAMING_SCHEMA_REGISTRY_USERNAME` | Optional basic-auth username. | empty |
+| `STREAMING_SCHEMA_REGISTRY_PASSWORD` | Optional basic-auth password. | empty |
+
+**Safe by default.** All three ship empty. An empty URL disables billing and **never crashes the
+app** — the service boots and serves normally with billing off.
+
+**Both-or-neither credentials.** `USERNAME` and `PASSWORD` are a pair. A partial pair (one set, one
+empty) is rejected fail-closed by `NewSchemaRegistryClient`, which disables billing rather than
+connecting half-authenticated. The password is **never logged**.
+
+### Local vs deployed
+
+- **Local (compose):** point the URL at Redpanda's built-in Schema Registry, which listens on `:8081`:
+  ```
+  STREAMING_SCHEMA_REGISTRY_URL=http://midaz-redpanda:8081
+  ```
+  In-network containers reach it at `http://midaz-redpanda:8081`.
+- **Deployed:** the URL, username, and password are supplied per environment through the external
+  deploy repos (see §6). Absent ⇒ billing off (safe).
+
+---
+
+## 3. Verifying a pod can bill
+
+Billing readiness is decided **once at bootstrap** and surfaced in the boot log.
+`buildBillingSerializer` (`streaming.go`) resolves — and on first run self-registers — the schema
+subject `lerian.streaming.billing.recorded-value`, then injects the serializer. Every failure branch
+(streaming disabled, context canceled, empty URL or partial credentials, registry round-trip failure)
+degrades to a **nil serializer** and emits exactly one WARN through `warnBillingDisabled`:
+
+```
+WARN  Billing serializer disabled  billing_enabled=false  error=<cause>
+```
+
+**The check.** Grep the boot log for `billing_enabled`:
+
+- The `Billing serializer disabled` WARN with `billing_enabled=false` is present ⇒ **billing is off**.
+  Read the attached `error` and re-check the registry URL and its reachability.
+- A clean boot with billing **on** has **no** `Billing serializer disabled` line at all.
+
+**Asymmetric dependency.** The Schema Registry is needed **at boot only**. Once the serializer
+resolves the schema, `Serialize` and `Emit` do **no** registry I/O on the request path — a registry
+outage after boot does not affect in-flight transactions, and a registry outage at boot only disables
+billing (it never blocks startup).
+
+---
+
+## 4. Durability and limitations
+
+Billing is **best-effort, fire-and-forget**. It is wired to **never** fail the parent transaction.
+
+- **`RouteRequired` is not delivery durability.** `billing.Route()` is `RouteRequired`, which enforces
+  route-table completeness at **Build** time — the Builder refuses to construct if the route is
+  missing. It says nothing about whether any individual event is delivered.
+- **No outbox.** No outbox is wired for billing (a ratified deferral). There is no transactional
+  guarantee that an emitted event reaches the broker.
+- **Drop on failure.** A broker outage, an absent `lerian.streaming.billing.recorded` topic, or a
+  serialize/emit failure is span-recorded, warn-logged, and **dropped**. `SendActiveAccountBillingEvents`
+  and `emitActiveAccountBillingEvent` swallow the error and return; the transaction still succeeds.
+- **A lost billing event is a lost revenue signal** until an outbox lands. Adding one is a future
+  decision.
+
+Operationally: a healthy transaction path can still silently under-bill if the broker or topic is
+unavailable. Monitor the `billing serialize failed` and `billing emit failed` WARN lines and the
+recorded spans to catch drops.
+
+---
+
+## 5. Per-environment provisioning
+
+Two things must exist per environment before billing works:
+
+1. **A reachable Schema Registry** — its URL configured via `STREAMING_SCHEMA_REGISTRY_URL` (§2). The
+   serializer self-registers the `lerian.streaming.billing.recorded-value` subject on first run, so the
+   registry must be reachable at ledger boot.
+2. **The `lerian.streaming.billing.recorded` topic pre-created.** lib-streaming has **no** client-side
+   auto-create — an absent topic means dropped events, not an auto-provisioned one.
+
+### Local
+
+The `midaz-redpanda-init` compose service (`components/infra/docker-compose.yml`) pre-creates the topic
+alongside the domain topics:
+
+```
+rpk topic create lerian.streaming.billing.recorded -r 1 -p 1 --brokers midaz-redpanda:9092
+```
+
+Redpanda's built-in Schema Registry serves the local registry on `:8081`.
+
+### Deployed
+
+Topic creation is the platform's topic-provisioning responsibility for the target environment. Create
+`lerian.streaming.billing.recorded` through the same mechanism you use for the domain topics, and point
+`STREAMING_SCHEMA_REGISTRY_URL` at the environment's Schema Registry.
+
+---
+
+## 6. Deployment and external coordination
+
+### Deploy repos (external)
+
+This repo has **no** in-tree Helm chart or Terraform. The ledger deployment surfaces the three Schema
+Registry keys per environment from the external **LerianStudio deploy repos**:
+
+| Key | How it is surfaced |
+|---|---|
+| `STREAMING_SCHEMA_REGISTRY_URL` | values / ConfigMap (plain value per environment) |
+| `STREAMING_SCHEMA_REGISTRY_USERNAME` | Kubernetes Secret — **never** a plaintext value |
+| `STREAMING_SCHEMA_REGISTRY_PASSWORD` | Kubernetes Secret — **never** a plaintext value |
+
+If these keys are absent, billing is off and the service still runs (safe default). Add them per
+environment to turn billing on.
+
+### Lago prerequisite (external — owner: finance / billing-api)
+
+Before the emitted events produce revenue, a metric must exist in the billing tenant:
+
+- A Lago billable metric with code **`active_account`** must exist in the billing tenant.
+- Its aggregation type is chosen by finance — for example `unique_count` over the `account_id`
+  property, or `count`.
+
+`billing-api` decodes the Confluent-Protobuf payload **best-effort** and forwards it to Lago with **no
+re-validation**, dead-lettering on Lago rejection. A missing or misconfigured `active_account` metric
+in Lago therefore surfaces as DLQ entries in billing-api, not as ledger errors.
+
+---
+
+## Related documents
+
+- [CRM Field Encryption & KMS Key Management](crm-field-encryption.md) — the sibling deep doc whose
+  structure this runbook mirrors.
+- `components/ledger/.env.example` — the canonical env-var reference for the `STREAMING_*` knobs.


### PR DESCRIPTION
<table border="0" cellspacing="0" cellpadding="0">
  <tr>
    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
    <td><h1>Midaz</h1></td>
  </tr>
</table>

---

## Description

Provisions the local infrastructure and operations documentation for the active-account billing
event, whose producer and emit path are already merged into this branch. Infra + docs only — no
Go code, and no change to a running service's behavior (billing stays opt-in / safe-off by
default).

- **Local billing topic** — `redpanda-init` now pre-creates
  `lerian.streaming.billing.recorded` (lib-streaming has no client-side topic auto-create, so the
  topic must exist or a billing emit against a healthy broker is silently dropped).
- **Schema Registry reachable from the host** — publish Redpanda's built-in Schema Registry port
  `8081` so `rpk registry` / `curl` work from the host for debugging.
- **Documented local value** — a commented `STREAMING_SCHEMA_REGISTRY_URL=http://midaz-redpanda:8081`
  hint in `.env.example`, mirroring the existing commented `STREAMING_BROKERS` local value. The
  shipped defaults (`STREAMING_ENABLED=false`, empty registry URL) are unchanged.
- **Operations runbook** — `docs/architecture/billing-active-account-streaming.md`: how to enable
  billing per environment, the three `STREAMING_SCHEMA_REGISTRY_*` env vars and the
  graceful-degradation contract, the `billing_enabled` boot-log check for "is this pod able to
  bill?", the `RouteRequired` ≠ delivery-durability caveat (no outbox — a broker outage or absent
  topic drops the event), per-environment provisioning, the deployment env keys (external deploy
  repos), and the Lago `active_account` metric prerequisite (owned by finance / billing-api).

## Type of Change

- [x] `chore`: Maintenance, config, tooling (infra provisioning)
- [x] `docs`: Documentation only

## Breaking Changes

None. The topic pre-creation and the published debug port do not affect a running service; billing
only turns on when an operator sets a reachable registry URL. Shipped defaults are unchanged.

## Testing

- [x] `docker compose -f components/infra/docker-compose.yml config` is valid
- [x] Topic auto-create verified live — deleted `lerian.streaming.billing.recorded`, re-ran
      `midaz-redpanda-init`, and confirmed the topic was recreated by the init service
- [x] Runbook facts cross-checked against the code (`.env.example`, `billing.Topic`,
      `warnBillingDisabled`, `billing_active_account.go`)

**Test evidence:** The end-to-end billing path was already validated on a local Docker + Redpanda
stack (one posted transaction → two `billing_recorded` messages, one per unique internal account,
Confluent-Protobuf payload with `Metric=active_account` and `account_id`/`transaction_id`); this
change codifies the setup (topic + registry) that made it reproducible from the local stack.

## Architectural Checklist

- [x] No `panic()` in production paths (no code changed)
- [x] Infrastructure concerns kept in `components/infra`
- [x] Env-var defaults remain safe-by-default (billing opt-in)

## Related Issues

None.
