### PR TITLE
fix(ledger): two-phase overdraft cancel balance and pending destination reads

### DIFF
--- a/components/ledger/internal/adapters/http/in/transaction_state_fallback_operations_test.go
+++ b/components/ledger/internal/adapters/http/in/transaction_state_fallback_operations_test.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"net/http"
 	"net/http/httptest"
 	"testing"
 
@@ -149,7 +150,7 @@ func TestCancelTransaction_WriteBehindMiss_FallbackLoadsOperations(t *testing.T)
 		handler.CancelTransaction,
 	)
 
-	req := httptest.NewRequest("POST",
+	req := httptest.NewRequest(http.MethodPost,
 		"/test/"+orgID.String()+"/"+ledgerID.String()+"/transactions/"+transactionID.String()+"/cancel",
 		nil)
 	resp, err := app.Test(req)
@@ -235,7 +236,7 @@ func TestCancelTransaction_WriteBehindMiss_NonexistentTransaction_Returns404(t *
 		handler.CancelTransaction,
 	)
 
-	req := httptest.NewRequest("POST",
+	req := httptest.NewRequest(http.MethodPost,
 		"/test/"+orgID.String()+"/"+ledgerID.String()+"/transactions/"+transactionID.String()+"/cancel",
 		nil)
 	resp, err := app.Test(req)
@@ -249,4 +250,112 @@ func TestCancelTransaction_WriteBehindMiss_NonexistentTransaction_Returns404(t *
 	var errResp map[string]any
 	require.NoError(t, json.Unmarshal(body, &errResp), "error response should be valid JSON")
 	assert.Equal(t, cn.ErrEntityNotFound.Error(), errResp["code"], "expected entity-not-found code")
+}
+
+// TestCancelTransaction_WriteBehindMiss_RowOnlyFallbackReturnsRealTransaction pins the
+// OTHER branch of the empty-value guard: FindWithOperations returns an empty transaction
+// (its INNER JOIN matched no operation rows), but the transaction itself exists and simply
+// has no operations. The guard must fall back to the row-only read, which returns the REAL
+// row — not a not-found. Here that row is APPROVED, so the state machine short-circuits at
+// its not-pending guard and answers 409, proving the fallback carried a live transaction
+// (not a nil/empty value) into commitOrCancelTransaction.
+func TestCancelTransaction_WriteBehindMiss_RowOnlyFallbackReturnsRealTransaction(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
+	orgID := uuid.New()
+	ledgerID := uuid.New()
+	transactionID := uuid.New()
+
+	mockTransactionRepo := transaction.NewMockRepository(ctrl)
+	mockMetadataRepo := mongodb.NewMockRepository(ctrl)
+	mockRedisRepo := redis.NewMockRedisRepository(ctrl)
+
+	amount := decimal.NewFromInt(100)
+
+	// A REAL, operation-less transaction: valid ids and APPROVED status so
+	// commitOrCancelTransaction parses the ids and returns at the not-pending guard.
+	tranRowOnly := &transaction.Transaction{
+		ID:             transactionID.String(),
+		OrganizationID: orgID.String(),
+		LedgerID:       ledgerID.String(),
+		AssetCode:      "BRL",
+		Amount:         &amount,
+		Status:         transaction.Status{Code: cn.APPROVED},
+	}
+
+	// Write-behind cache miss forces the database fallback.
+	mockRedisRepo.EXPECT().
+		GetBytes(gomock.Any(), gomock.Any()).
+		Return(nil, errors.New("cache miss")).
+		AnyTimes()
+
+	// INNER JOIN matched no operation rows: empty transaction, no error — triggers the guard.
+	mockTransactionRepo.EXPECT().
+		FindWithOperations(gomock.Any(), orgID, ledgerID, transactionID).
+		Return(&transaction.Transaction{}, nil).
+		Times(1)
+
+	// The guard falls back to the row-only read, which returns the REAL operation-less row.
+	mockTransactionRepo.EXPECT().
+		Find(gomock.Any(), orgID, ledgerID, transactionID).
+		Return(tranRowOnly, nil).
+		Times(1)
+
+	// Metadata lookup runs on both reads (with-operations empty result + row-only result).
+	mockMetadataRepo.EXPECT().
+		FindByEntity(gomock.Any(), "Transaction", transactionID.String()).
+		Return(nil, nil).
+		Times(2)
+
+	// Lock acquired, then released on the not-pending guard error path.
+	mockRedisRepo.EXPECT().
+		SetNX(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(true, nil).
+		Times(1)
+	mockRedisRepo.EXPECT().
+		Del(gomock.Any(), gomock.Any()).
+		Return(nil).
+		Times(1)
+
+	queryUC := &query.UseCase{
+		TransactionRepo:         mockTransactionRepo,
+		TransactionMetadataRepo: mockMetadataRepo,
+		TransactionRedisRepo:    mockRedisRepo,
+	}
+	commandUC := &command.UseCase{
+		TransactionRedisRepo: mockRedisRepo,
+	}
+	handler := &TransactionHandler{Query: queryUC, Command: commandUC}
+
+	app := fiber.New()
+	app.Post(
+		"/test/:organization_id/:ledger_id/transactions/:transaction_id/cancel",
+		func(c fiber.Ctx) error {
+			c.Locals("organization_id", orgID)
+			c.Locals("ledger_id", ledgerID)
+			c.Locals("transaction_id", transactionID)
+			return c.Next()
+		},
+		handler.CancelTransaction,
+	)
+
+	req := httptest.NewRequest(http.MethodPost,
+		"/test/"+orgID.String()+"/"+ledgerID.String()+"/transactions/"+transactionID.String()+"/cancel",
+		nil)
+	resp, err := app.Test(req)
+
+	require.NoError(t, err)
+	assert.Equal(t, 409, resp.StatusCode,
+		"a real operation-less transaction from the row-only fallback must reach the not-pending guard")
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	var errResp map[string]any
+	require.NoError(t, json.Unmarshal(body, &errResp), "error response should be valid JSON")
+	assert.Equal(t, cn.ErrCommitTransactionNotPending.Error(), errResp["code"],
+		"expected error code 0099 (ErrCommitTransactionNotPending)")
 }

--- a/components/ledger/internal/adapters/http/in/transaction_state_fallback_operations_test.go
+++ b/components/ledger/internal/adapters/http/in/transaction_state_fallback_operations_test.go
@@ -1,0 +1,252 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package in
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gofiber/fiber/v3"
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	libConstants "github.com/LerianStudio/lib-commons/v6/commons/constants"
+
+	mongodb "github.com/LerianStudio/midaz/v4/components/ledger/internal/adapters/mongodb/transaction"
+	"github.com/LerianStudio/midaz/v4/components/ledger/internal/adapters/postgres/operation"
+	"github.com/LerianStudio/midaz/v4/components/ledger/internal/adapters/postgres/transaction"
+	redis "github.com/LerianStudio/midaz/v4/components/ledger/internal/adapters/redis/transaction"
+	"github.com/LerianStudio/midaz/v4/components/ledger/internal/services/command"
+	"github.com/LerianStudio/midaz/v4/components/ledger/internal/services/query"
+	"github.com/LerianStudio/midaz/v4/pkg"
+	cn "github.com/LerianStudio/midaz/v4/pkg/constant"
+	"github.com/LerianStudio/midaz/v4/pkg/mtransaction"
+)
+
+// TestCancelTransaction_WriteBehindMiss_FallbackLoadsOperations pins the money-path
+// fix for the two-phase overdraft cancel. The write-behind cache is cleared once the
+// create persists, so a later /cancel misses it and falls through to the database.
+// That fallback MUST read the transaction WITH its operations
+// (GetTransactionWithOperationsByID / FindWithOperations): commitOrCancelTransaction's
+// annotateCanceledOverdraftAmounts step reads tran.Operations to size the overdraft
+// deficit, and a row-only read (GetTransactionByID / Find) leaves Operations empty so
+// the cancel restores the whole hold to available instead of only the non-overdraft
+// portion.
+//
+// The transaction is APPROVED here so the commit/cancel state machine short-circuits
+// at its not-pending guard right after the fetch — that keeps the assertion on the
+// fetch selection alone. Find is deliberately NOT stubbed, so the gomock controller
+// fails the test if the fallback still calls the row-only read. The downstream
+// consumption (operations -> OverdraftAmount -> Lua -> Available) is covered by
+// TestAnnotateCanceledOverdraftAmounts_UsesPendingCompanionAmount and the redis Lua
+// integration tests (TestIntegration_Overdraft_PendingLegacyCancelRestoresCompanion).
+func TestCancelTransaction_WriteBehindMiss_FallbackLoadsOperations(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
+	orgID := uuid.New()
+	ledgerID := uuid.New()
+	transactionID := uuid.New()
+
+	mockTransactionRepo := transaction.NewMockRepository(ctrl)
+	mockMetadataRepo := mongodb.NewMockRepository(ctrl)
+	mockRedisRepo := redis.NewMockRedisRepository(ctrl)
+
+	amount := decimal.NewFromInt(100)
+	txBody := mtransaction.Transaction{
+		Send: mtransaction.Send{
+			Asset: "BRL",
+			Value: amount,
+			Source: mtransaction.Source{
+				From: []mtransaction.FromTo{{AccountAlias: "@source"}},
+			},
+			Distribute: mtransaction.Distribute{
+				To: []mtransaction.FromTo{{AccountAlias: "@dest"}},
+			},
+		},
+	}
+
+	// A transaction that overflowed a 50-available balance into a 50 overdraft hold:
+	// the ONHOLD companion leg on the overdraft balance is the deficit annotate reads.
+	deficit := decimal.NewFromInt(50)
+	tranWithOps := &transaction.Transaction{
+		ID:             transactionID.String(),
+		OrganizationID: orgID.String(),
+		LedgerID:       ledgerID.String(),
+		AssetCode:      "BRL",
+		Amount:         &amount,
+		// APPROVED (not PENDING) so the state machine returns at the not-pending guard.
+		Status: transaction.Status{Code: cn.APPROVED},
+		Body:   txBody,
+		Operations: []*operation.Operation{
+			{
+				Type:         libConstants.DEBIT,
+				BalanceKey:   cn.OverdraftBalanceKey,
+				AccountAlias: "@source",
+				Amount:       operation.Amount{Value: &deficit},
+			},
+		},
+	}
+
+	// Write-behind cache miss forces the database fallback.
+	mockRedisRepo.EXPECT().
+		GetBytes(gomock.Any(), gomock.Any()).
+		Return(nil, errors.New("cache miss")).
+		AnyTimes()
+
+	// The fallback MUST use the with-operations read.
+	mockTransactionRepo.EXPECT().
+		FindWithOperations(gomock.Any(), orgID, ledgerID, transactionID).
+		Return(tranWithOps, nil).
+		Times(1)
+
+	// Find (row-only read) MUST NOT be reached: any call fails the test.
+
+	mockMetadataRepo.EXPECT().
+		FindByEntity(gomock.Any(), "Transaction", transactionID.String()).
+		Return(nil, nil).
+		Times(1)
+
+	// Lock acquired, then released on the not-pending guard error path.
+	mockRedisRepo.EXPECT().
+		SetNX(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(true, nil).
+		Times(1)
+	mockRedisRepo.EXPECT().
+		Del(gomock.Any(), gomock.Any()).
+		Return(nil).
+		Times(1)
+
+	queryUC := &query.UseCase{
+		TransactionRepo:         mockTransactionRepo,
+		TransactionMetadataRepo: mockMetadataRepo,
+		TransactionRedisRepo:    mockRedisRepo,
+	}
+	commandUC := &command.UseCase{
+		TransactionRedisRepo: mockRedisRepo,
+	}
+	handler := &TransactionHandler{Query: queryUC, Command: commandUC}
+
+	app := fiber.New()
+	app.Post(
+		"/test/:organization_id/:ledger_id/transactions/:transaction_id/cancel",
+		func(c fiber.Ctx) error {
+			c.Locals("organization_id", orgID)
+			c.Locals("ledger_id", ledgerID)
+			c.Locals("transaction_id", transactionID)
+			return c.Next()
+		},
+		handler.CancelTransaction,
+	)
+
+	req := httptest.NewRequest("POST",
+		"/test/"+orgID.String()+"/"+ledgerID.String()+"/transactions/"+transactionID.String()+"/cancel",
+		nil)
+	resp, err := app.Test(req)
+
+	require.NoError(t, err)
+	assert.Equal(t, 409, resp.StatusCode, "expected HTTP 409 for non-PENDING status after the with-operations fallback")
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	var errResp map[string]any
+	require.NoError(t, json.Unmarshal(body, &errResp), "error response should be valid JSON")
+	assert.Equal(t, cn.ErrCommitTransactionNotPending.Error(), errResp["code"],
+		"expected error code 0099 (ErrCommitTransactionNotPending)")
+}
+
+// TestCancelTransaction_WriteBehindMiss_NonexistentTransaction_Returns404 guards the
+// with-operations fallback against its INNER JOIN semantics: FindWithOperations returns
+// an empty transaction (no error) when it matches no operation rows — a nonexistent
+// transaction, or one with no operations. Without the empty-value guard,
+// commitOrCancelTransaction would parse an empty organization id and panic. The guard
+// falls back to the row-only read, which reports not-found, so the response stays a
+// clean 404.
+func TestCancelTransaction_WriteBehindMiss_NonexistentTransaction_Returns404(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
+	orgID := uuid.New()
+	ledgerID := uuid.New()
+	transactionID := uuid.New()
+
+	mockTransactionRepo := transaction.NewMockRepository(ctrl)
+	mockMetadataRepo := mongodb.NewMockRepository(ctrl)
+	mockRedisRepo := redis.NewMockRedisRepository(ctrl)
+
+	// Write-behind cache miss forces the database fallback.
+	mockRedisRepo.EXPECT().
+		GetBytes(gomock.Any(), gomock.Any()).
+		Return(nil, errors.New("cache miss")).
+		AnyTimes()
+
+	// INNER JOIN matched nothing: empty transaction, no error.
+	mockTransactionRepo.EXPECT().
+		FindWithOperations(gomock.Any(), orgID, ledgerID, transactionID).
+		Return(&transaction.Transaction{}, nil).
+		Times(1)
+
+	// Metadata lookup runs against the empty (non-nil) transaction.
+	mockMetadataRepo.EXPECT().
+		FindByEntity(gomock.Any(), "Transaction", transactionID.String()).
+		Return(nil, nil).
+		Times(1)
+
+	// The guard falls back to the row-only read, which surfaces the not-found error.
+	mockTransactionRepo.EXPECT().
+		Find(gomock.Any(), orgID, ledgerID, transactionID).
+		Return(nil, pkg.EntityNotFoundError{
+			EntityType: "Transaction",
+			Code:       cn.ErrEntityNotFound.Error(),
+			Title:      "Entity Not Found",
+			Message:    "Transaction not found",
+		}).
+		Times(1)
+
+	queryUC := &query.UseCase{
+		TransactionRepo:         mockTransactionRepo,
+		TransactionMetadataRepo: mockMetadataRepo,
+		TransactionRedisRepo:    mockRedisRepo,
+	}
+	handler := &TransactionHandler{Query: queryUC}
+
+	app := fiber.New()
+	app.Post(
+		"/test/:organization_id/:ledger_id/transactions/:transaction_id/cancel",
+		func(c fiber.Ctx) error {
+			c.Locals("organization_id", orgID)
+			c.Locals("ledger_id", ledgerID)
+			c.Locals("transaction_id", transactionID)
+			return c.Next()
+		},
+		handler.CancelTransaction,
+	)
+
+	req := httptest.NewRequest("POST",
+		"/test/"+orgID.String()+"/"+ledgerID.String()+"/transactions/"+transactionID.String()+"/cancel",
+		nil)
+	resp, err := app.Test(req)
+
+	require.NoError(t, err)
+	assert.Equal(t, 404, resp.StatusCode, "an empty with-operations result must degrade to a not-found, never a panic")
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	var errResp map[string]any
+	require.NoError(t, json.Unmarshal(body, &errResp), "error response should be valid JSON")
+	assert.Equal(t, cn.ErrEntityNotFound.Error(), errResp["code"], "expected entity-not-found code")
+}

--- a/components/ledger/internal/adapters/http/in/transaction_state_handlers.go
+++ b/components/ledger/internal/adapters/http/in/transaction_state_handlers.go
@@ -83,11 +83,32 @@ func (handler *TransactionHandler) commitTransaction(ctx context.Context, organi
 
 	tran, err := handler.Query.GetWriteBehindTransaction(ctx, organizationID, ledgerID, transactionID)
 	if err != nil {
-		tran, err = handler.Query.GetTransactionByID(ctx, organizationID, ledgerID, transactionID)
+		// Load the operations with the transaction: cancel needs them to unwind an
+		// overdraft hold. The write-behind cache is cleared once the create persists,
+		// so this fallback carries the transaction into commitOrCancelTransaction and
+		// its annotateCanceledOverdraftAmounts step, which reads tran.Operations to
+		// size the overdraft deficit. A row-only read leaves Operations empty and the
+		// cancel restores the full hold to available instead of only the non-overdraft
+		// portion.
+		tran, err = handler.Query.GetTransactionWithOperationsByID(ctx, organizationID, ledgerID, transactionID)
 		if err != nil {
 			handleSpanByErrorClass(span, "Failed to retrieve transaction on query", err)
 
 			return nil, err
+		}
+
+		// FindWithOperations joins on operations, so a transaction with no rows comes
+		// back as an empty value with no error. Fall back to the row-only read, which
+		// reports not-found for a missing transaction and returns the real row for an
+		// operation-less one — either way commitOrCancelTransaction never parses an
+		// empty organization id.
+		if tran == nil || tran.ID == "" {
+			tran, err = handler.Query.GetTransactionByID(ctx, organizationID, ledgerID, transactionID)
+			if err != nil {
+				handleSpanByErrorClass(span, "Failed to retrieve transaction on query", err)
+
+				return nil, err
+			}
 		}
 	}
 

--- a/components/ledger/internal/adapters/http/in/transaction_test.go
+++ b/components/ledger/internal/adapters/http/in/transaction_test.go
@@ -368,9 +368,9 @@ func TestCommitTransaction_InvalidStatus_ReturnsError(t *testing.T) {
 				Body: txBody,
 			}
 
-			// Mock: Find transaction
+			// Mock: fetch transaction with its operations (commit/cancel fallback)
 			mockTransactionRepo.EXPECT().
-				Find(gomock.Any(), orgID, ledgerID, transactionID).
+				FindWithOperations(gomock.Any(), orgID, ledgerID, transactionID).
 				Return(tran, nil).
 				Times(1)
 
@@ -1425,7 +1425,7 @@ func TestCommitTransaction_GetTransactionError_ReturnsError(t *testing.T) {
 
 	// Mock: Transaction lookup returns error
 	mockTransactionRepo.EXPECT().
-		Find(gomock.Any(), orgID, ledgerID, transactionID).
+		FindWithOperations(gomock.Any(), orgID, ledgerID, transactionID).
 		Return(nil, pkg.EntityNotFoundError{
 			EntityType: "Transaction",
 			Code:       cn.ErrEntityNotFound.Error(),
@@ -1516,9 +1516,9 @@ func TestCommitTransaction_RedisLockError_ReturnsError(t *testing.T) {
 		Body: txBody,
 	}
 
-	// Mock: Transaction found successfully
+	// Mock: commit/cancel fallback fetch (with operations)
 	mockTransactionRepo.EXPECT().
-		Find(gomock.Any(), orgID, ledgerID, transactionID).
+		FindWithOperations(gomock.Any(), orgID, ledgerID, transactionID).
 		Return(tran, nil).
 		Times(1)
 
@@ -1630,9 +1630,9 @@ func TestCommitTransaction_LockNotAcquired_ReturnsError(t *testing.T) {
 		Body: txBody,
 	}
 
-	// Mock: Transaction found successfully
+	// Mock: commit/cancel fallback fetch (with operations)
 	mockTransactionRepo.EXPECT().
-		Find(gomock.Any(), orgID, ledgerID, transactionID).
+		FindWithOperations(gomock.Any(), orgID, ledgerID, transactionID).
 		Return(tran, nil).
 		Times(1)
 
@@ -2498,7 +2498,7 @@ func TestCancelTransaction(t *testing.T) {
 			name: "transaction not found returns 404",
 			setupMocks: func(transactionRepo *transaction.MockRepository, metadataRepo *mongodb.MockRepository, operationRepo *operation.MockRepository, redisRepo *redis.MockRedisRepository, orgID, ledgerID, transactionID uuid.UUID) {
 				transactionRepo.EXPECT().
-					Find(gomock.Any(), orgID, ledgerID, transactionID).
+					FindWithOperations(gomock.Any(), orgID, ledgerID, transactionID).
 					Return(nil, pkg.EntityNotFoundError{
 						EntityType: "Transaction",
 						Code:       cn.ErrEntityNotFound.Error(),
@@ -2548,9 +2548,9 @@ func TestCancelTransaction(t *testing.T) {
 					Body: txBody,
 				}
 
-				// Query.GetTransactionByID
+				// commit/cancel fallback fetch (with operations)
 				transactionRepo.EXPECT().
-					Find(gomock.Any(), orgID, ledgerID, transactionID).
+					FindWithOperations(gomock.Any(), orgID, ledgerID, transactionID).
 					Return(tran, nil).
 					Times(1)
 
@@ -2612,9 +2612,9 @@ func TestCancelTransaction(t *testing.T) {
 					Body: txBody,
 				}
 
-				// Query.GetTransactionByID
+				// commit/cancel fallback fetch (with operations)
 				transactionRepo.EXPECT().
-					Find(gomock.Any(), orgID, ledgerID, transactionID).
+					FindWithOperations(gomock.Any(), orgID, ledgerID, transactionID).
 					Return(tran, nil).
 					Times(1)
 
@@ -2673,9 +2673,9 @@ func TestCancelTransaction(t *testing.T) {
 					Body: txBody,
 				}
 
-				// Query.GetTransactionByID
+				// commit/cancel fallback fetch (with operations)
 				transactionRepo.EXPECT().
-					Find(gomock.Any(), orgID, ledgerID, transactionID).
+					FindWithOperations(gomock.Any(), orgID, ledgerID, transactionID).
 					Return(tran, nil).
 					Times(1)
 
@@ -2716,9 +2716,9 @@ func TestCancelTransaction(t *testing.T) {
 					},
 				}
 
-				// Query.GetTransactionByID - Find succeeds
+				// commit/cancel fallback fetch (with operations) succeeds
 				transactionRepo.EXPECT().
-					Find(gomock.Any(), orgID, ledgerID, transactionID).
+					FindWithOperations(gomock.Any(), orgID, ledgerID, transactionID).
 					Return(tran, nil).
 					Times(1)
 
@@ -2895,7 +2895,7 @@ func TestCancelTransaction_WriteBehindMiss_PostgresMiss(t *testing.T) {
 
 	// Postgres miss
 	mockTransactionRepo.EXPECT().
-		Find(gomock.Any(), orgID, ledgerID, tranID).
+		FindWithOperations(gomock.Any(), orgID, ledgerID, tranID).
 		Return(nil, errors.New("record not found")).
 		Times(1)
 
@@ -2946,7 +2946,7 @@ func TestCancelTransaction_WriteBehindMiss_PostgresHit(t *testing.T) {
 
 	// Postgres hit
 	mockTransactionRepo.EXPECT().
-		Find(gomock.Any(), orgID, ledgerID, tranID).
+		FindWithOperations(gomock.Any(), orgID, ledgerID, tranID).
 		Return(tran, nil).
 		Times(1)
 
@@ -3058,7 +3058,7 @@ func TestCommitTransaction_WriteBehindMiss_PostgresMiss(t *testing.T) {
 
 	// Postgres miss
 	mockTransactionRepo.EXPECT().
-		Find(gomock.Any(), orgID, ledgerID, tranID).
+		FindWithOperations(gomock.Any(), orgID, ledgerID, tranID).
 		Return(nil, errors.New("record not found")).
 		Times(1)
 
@@ -3109,7 +3109,7 @@ func TestCommitTransaction_WriteBehindMiss_PostgresHit(t *testing.T) {
 
 	// Postgres hit
 	mockTransactionRepo.EXPECT().
-		Find(gomock.Any(), orgID, ledgerID, tranID).
+		FindWithOperations(gomock.Any(), orgID, ledgerID, tranID).
 		Return(tran, nil).
 		Times(1)
 

--- a/components/ledger/internal/services/query/get_all_metadata_transactions.go
+++ b/components/ledger/internal/services/query/get_all_metadata_transactions.go
@@ -102,7 +102,7 @@ func (uc *UseCase) GetAllMetadataTransactions(ctx context.Context, organizationI
 		}
 
 		trans[i].Source = source
-		trans[i].Destination = destination
+		trans[i].Destination = resolveDestination(destination, trans[i].Body)
 
 		if data, ok := metadataMap[trans[i].ID]; ok {
 			trans[i].Metadata = data

--- a/components/ledger/internal/services/query/get_all_metadata_transactions_test.go
+++ b/components/ledger/internal/services/query/get_all_metadata_transactions_test.go
@@ -482,6 +482,91 @@ func TestGetAllMetadataTransactionsWithMixedOperations(t *testing.T) {
 	assert.NotContains(t, result[0].Source, "unblock-destination")
 }
 
+// TestGetAllMetadataTransactions_PendingOverdraftDerivesDestinationFromBody pins
+// the Body-derived destination fallback in the metadata read path so it agrees
+// with the listing and individual paths: a PENDING overdraft transaction carries
+// only source-side operations (DEBIT + ON_HOLD + OVERDRAFT) and no CREDIT leg, so
+// operation-based reconstruction yields an empty Destination and the read path
+// must fall back to the submitted destination persisted in the body, in the same
+// bare-alias form the write path caches. Reverting the resolveDestination call in
+// GetAllMetadataTransactions makes this test fail.
+func TestGetAllMetadataTransactions_PendingOverdraftDerivesDestinationFromBody(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockMetadataRepo := mongodb.NewMockRepository(ctrl)
+	mockTransactionRepo := transaction.NewMockRepository(ctrl)
+
+	orgID := uuid.New()
+	ledgerID := uuid.New()
+	txID := uuid.New()
+
+	filter := http.QueryHeader{
+		Metadata: &bson.M{"key": "value"},
+		Limit:    10,
+		Page:     1,
+	}
+
+	metadataList := []*mongodb.Metadata{
+		{
+			ID:       bson.NewObjectID(),
+			EntityID: txID.String(),
+			Data:     map[string]any{"key": "value"},
+		},
+	}
+
+	// Only source-side legs are persisted before commit: the real DEBIT plus the
+	// ON_HOLD and OVERDRAFT system legs. None classify onto Destination.
+	ops := []*operation.Operation{
+		{ID: uuid.New().String(), Type: constant.DEBIT, AccountAlias: "@alice"},
+		{ID: uuid.New().String(), Type: constant.ONHOLD, AccountAlias: "@alice"},
+		{ID: uuid.New().String(), Type: constant.OVERDRAFT, AccountAlias: "@alice"},
+	}
+
+	transactions := []*transaction.Transaction{
+		{
+			ID:         txID.String(),
+			Operations: ops,
+			Body:       overdraftPendingBody(),
+		},
+	}
+
+	mockMetadataRepo.EXPECT().
+		FindList(gomock.Any(), constant.EntityTransaction, gomock.Cond(func(qh http.QueryHeader) bool {
+			return isWindowed(qh.StartDate, qh.EndDate)
+		})).
+		Return(metadataList, nil)
+
+	mockTransactionRepo.EXPECT().
+		FindOrListAllWithOperations(gomock.Any(), orgID, ledgerID, []uuid.UUID{txID}, gomock.Cond(func(p http.Pagination) bool {
+			return isWindowed(p.StartDate, p.EndDate)
+		})).
+		Return(transactions, libHTTP.CursorPagination{}, nil)
+
+	mockMetadataRepo.EXPECT().
+		FindByEntityIDs(gomock.Any(), constant.EntityOperation, gomock.Any()).
+		Return([]*mongodb.Metadata{}, nil)
+
+	uc := &UseCase{
+		TransactionMetadataRepo: mockMetadataRepo,
+		TransactionRepo:         mockTransactionRepo,
+	}
+
+	result, _, err := uc.GetAllMetadataTransactions(context.Background(), orgID, ledgerID, filter)
+
+	assert.NoError(t, err)
+	assert.Len(t, result, 1)
+
+	// Source is reconstructed from the DEBIT leg exactly as before.
+	assert.Equal(t, []string{"@alice"}, result[0].Source)
+
+	// Destination is derived from the submitted body: the overdraft companion is
+	// filtered and the "#default" suffix stripped, matching the cache-hit format.
+	assert.Equal(t, []string{"@merchant", "@suffixed"}, result[0].Destination)
+	assert.NotContains(t, result[0].Destination, "@companion", "overdraft companion must be filtered")
+	assert.NotContains(t, result[0].Destination, "@suffixed#default", "alias key suffix must be stripped")
+}
+
 // TestGetAllMetadataTransactions_NoMetadata ensures that when metadata lookup
 // returns an empty (non-nil) slice, the use case returns no transactions and no error,
 // and does not call the transaction repository.

--- a/components/ledger/internal/services/query/get_all_transactions.go
+++ b/components/ledger/internal/services/query/get_all_transactions.go
@@ -7,6 +7,7 @@ package query
 import (
 	"context"
 	"errors"
+	"strings"
 	"time"
 
 	libHTTP "github.com/LerianStudio/lib-commons/v6/commons/net/http"
@@ -19,12 +20,65 @@ import (
 	"github.com/LerianStudio/midaz/v4/components/ledger/internal/services"
 	"github.com/LerianStudio/midaz/v4/pkg"
 	"github.com/LerianStudio/midaz/v4/pkg/constant"
+	"github.com/LerianStudio/midaz/v4/pkg/mtransaction"
 	"github.com/LerianStudio/midaz/v4/pkg/net/http"
 	"github.com/LerianStudio/midaz/v4/pkg/utils"
 
 	// GetAllTransactions fetch all Transactions from the repository
 	libLog "github.com/LerianStudio/lib-observability/v2/log"
 )
+
+// resolveDestination returns the operation-reconstructed destination when it is
+// non-empty; otherwise it falls back to the submitted destination derived from
+// the body. A reconstructed destination is never overwritten, and a transaction
+// with no submitted destination stays empty. Keeping this decision in one place
+// keeps GET-listing and GET-individual reads consistent.
+func resolveDestination(reconstructed []string, body mtransaction.Transaction) []string {
+	if len(reconstructed) > 0 {
+		return reconstructed
+	}
+
+	if derived := deriveDestinationFromBody(body); len(derived) > 0 {
+		return derived
+	}
+
+	return reconstructed
+}
+
+// deriveDestinationFromBody returns the submitted destination aliases from a
+// persisted transaction body, in the same bare-alias form the write path caches
+// via getAliasWithoutKey(filterCompanionAliases(...)): the system-managed
+// overdraft companion is skipped and any "#balanceKey" suffix is stripped.
+//
+// It is the canonical fallback when operation-based reconstruction yields no
+// destination — typically a pre-commit overdraft, whose persisted legs are all
+// source-side (DEBIT + ON_HOLD + OVERDRAFT) with no CREDIT leg, so the submitted
+// destination survives only in the body. Keeping the alias treatment identical
+// to the cache path avoids trading a cache-vs-DB emptiness gap for a cache-vs-DB
+// format gap.
+func deriveDestinationFromBody(body mtransaction.Transaction) []string {
+	to := body.Send.Distribute.To
+	if len(to) == 0 {
+		return nil
+	}
+
+	destination := make([]string, 0, len(to))
+
+	for _, entry := range to {
+		if entry.BalanceKey == constant.OverdraftBalanceKey {
+			continue
+		}
+
+		alias := entry.AccountAlias
+		if idx := strings.Index(alias, mtransaction.AliasSeparatorString); idx >= 0 {
+			alias = alias[:idx]
+		}
+
+		destination = append(destination, alias)
+	}
+
+	return destination
+}
 
 func (uc *UseCase) GetAllTransactions(ctx context.Context, organizationID, ledgerID uuid.UUID, filter http.QueryHeader) (_ []*transaction.Transaction, _ libHTTP.CursorPagination, err error) {
 	logger, tracer, _, _ := libObservability.NewTrackingFromContext(ctx)
@@ -112,7 +166,7 @@ func (uc *UseCase) GetAllTransactions(ctx context.Context, organizationID, ledge
 		}
 
 		trans[i].Source = source
-		trans[i].Destination = destination
+		trans[i].Destination = resolveDestination(destination, trans[i].Body)
 
 		if data, ok := metadataMap[trans[i].ID]; ok {
 			trans[i].Metadata = data
@@ -197,7 +251,7 @@ func (uc *UseCase) GetOperationsByTransaction(ctx context.Context, organizationI
 	}
 
 	tran.Source = source
-	tran.Destination = destination
+	tran.Destination = resolveDestination(destination, tran.Body)
 	tran.Operations = operations
 
 	return tran, nil

--- a/components/ledger/internal/services/query/get_all_transactions_test.go
+++ b/components/ledger/internal/services/query/get_all_transactions_test.go
@@ -21,8 +21,329 @@ import (
 	"github.com/LerianStudio/midaz/v4/components/ledger/internal/adapters/postgres/transaction"
 	"github.com/LerianStudio/midaz/v4/components/ledger/internal/services"
 	"github.com/LerianStudio/midaz/v4/pkg/constant"
+	"github.com/LerianStudio/midaz/v4/pkg/mtransaction"
 	"github.com/LerianStudio/midaz/v4/pkg/net/http"
 )
+
+// overdraftPendingBody builds a persisted transaction body whose submitted
+// destination is a single account, plus a system-managed overdraft companion
+// and an alias carrying a "#balanceKey" suffix. It exercises the alias-parity
+// contract of the Body-derived destination: the companion must be filtered
+// (mirrors filterCompanionAliases) and the "#key" suffix stripped (mirrors
+// getAliasWithoutKey), yielding exactly the bare submitted alias.
+func overdraftPendingBody() mtransaction.Transaction {
+	return mtransaction.Transaction{
+		Pending: true,
+		Send: mtransaction.Send{
+			Distribute: mtransaction.Distribute{
+				To: []mtransaction.FromTo{
+					{AccountAlias: "@merchant", BalanceKey: constant.DefaultBalanceKey},
+					{AccountAlias: "@companion", BalanceKey: constant.OverdraftBalanceKey},
+					{AccountAlias: "@suffixed#default", BalanceKey: constant.DefaultBalanceKey},
+				},
+			},
+		},
+	}
+}
+
+// TestGetOperationsByTransaction_PendingOverdraftDerivesDestinationFromBody pins
+// the fix for the cache-vs-DB divergence: a PENDING overdraft transaction has
+// only source-side operations (DEBIT + ON_HOLD + OVERDRAFT) and NO CREDIT leg,
+// so operation-based reconstruction yields an empty Destination. The read path
+// must fall back to the submitted destination persisted in the body, in the same
+// bare-alias form the write path caches.
+func TestGetOperationsByTransaction_PendingOverdraftDerivesDestinationFromBody(t *testing.T) {
+	t.Parallel()
+
+	organizationID := uuid.Must(libCommons.GenerateUUIDv7())
+	ledgerID := uuid.Must(libCommons.GenerateUUIDv7())
+	transactionID := uuid.New()
+	filter := http.QueryHeader{Limit: 10, Page: 1, SortOrder: "asc"}
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockOpRepo := operation.NewMockRepository(ctrl)
+	mockMetaRepo := mongodb.NewMockRepository(ctrl)
+
+	// Only source-side legs are persisted before commit: the real DEBIT plus the
+	// ON_HOLD and OVERDRAFT system legs. None classify onto Destination.
+	ops := []*operation.Operation{
+		{
+			ID:            uuid.New().String(),
+			TransactionID: transactionID.String(),
+			Type:          constant.DEBIT,
+			AccountAlias:  "@alice",
+		},
+		{
+			ID:            uuid.New().String(),
+			TransactionID: transactionID.String(),
+			Type:          constant.ONHOLD,
+			AccountAlias:  "@alice",
+		},
+		{
+			ID:            uuid.New().String(),
+			TransactionID: transactionID.String(),
+			Type:          constant.OVERDRAFT,
+			AccountAlias:  "@alice",
+		},
+	}
+
+	mockOpRepo.EXPECT().
+		FindAll(gomock.Any(), organizationID, ledgerID, transactionID, filter.ToCursorPagination()).
+		Return(ops, libHTTP.CursorPagination{}, nil).
+		Times(1)
+
+	mockMetaRepo.EXPECT().
+		FindByEntityIDs(gomock.Any(), "Operation", gomock.Any()).
+		Return(nil, nil).
+		Times(1)
+
+	uc := UseCase{
+		OperationRepo:           mockOpRepo,
+		TransactionMetadataRepo: mockMetaRepo,
+	}
+
+	tran := &transaction.Transaction{
+		ID:             transactionID.String(),
+		OrganizationID: organizationID.String(),
+		LedgerID:       ledgerID.String(),
+		Status:         transaction.Status{Code: constant.PENDING},
+		Body:           overdraftPendingBody(),
+	}
+
+	result, err := uc.GetOperationsByTransaction(context.Background(), organizationID, ledgerID, tran, filter)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, result)
+
+	// Source is reconstructed from the DEBIT leg exactly as before.
+	assert.Equal(t, []string{"@alice"}, result.Source)
+
+	// Destination is derived from the submitted body: the overdraft companion is
+	// filtered and the "#default" suffix stripped, matching the cache-hit format.
+	assert.Equal(t, []string{"@merchant", "@suffixed"}, result.Destination)
+	assert.NotContains(t, result.Destination, "@companion", "overdraft companion must be filtered")
+	assert.NotContains(t, result.Destination, "@suffixed#default", "alias key suffix must be stripped")
+}
+
+// TestGetOperationsByTransaction_PendingOverdraftNoSubmittedDestinationStaysEmpty
+// pins the empty branch of the Body-derived fallback: when the reconstructed
+// destination is empty AND the submitted body carries no usable destination
+// (either an empty To list or only the system-managed overdraft companion), the
+// read path must NOT fabricate a destination — Destination stays empty.
+func TestGetOperationsByTransaction_PendingOverdraftNoSubmittedDestinationStaysEmpty(t *testing.T) {
+	t.Parallel()
+
+	organizationID := uuid.Must(libCommons.GenerateUUIDv7())
+	ledgerID := uuid.Must(libCommons.GenerateUUIDv7())
+	filter := http.QueryHeader{Limit: 10, Page: 1, SortOrder: "asc"}
+
+	tests := []struct {
+		name string
+		body mtransaction.Transaction
+	}{
+		{
+			name: "empty submitted destination",
+			body: mtransaction.Transaction{
+				Pending: true,
+				Send: mtransaction.Send{
+					Distribute: mtransaction.Distribute{To: []mtransaction.FromTo{}},
+				},
+			},
+		},
+		{
+			name: "only overdraft companion submitted",
+			body: mtransaction.Transaction{
+				Pending: true,
+				Send: mtransaction.Send{
+					Distribute: mtransaction.Distribute{
+						To: []mtransaction.FromTo{
+							{AccountAlias: "@companion", BalanceKey: constant.OverdraftBalanceKey},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			transactionID := uuid.New()
+
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockOpRepo := operation.NewMockRepository(ctrl)
+			mockMetaRepo := mongodb.NewMockRepository(ctrl)
+
+			// Source-only legs: reconstruction produces no destination, so the
+			// Body-derived fallback is exercised on an input that yields nothing.
+			ops := []*operation.Operation{
+				{ID: uuid.New().String(), TransactionID: transactionID.String(), Type: constant.DEBIT, AccountAlias: "@alice"},
+				{ID: uuid.New().String(), TransactionID: transactionID.String(), Type: constant.ONHOLD, AccountAlias: "@alice"},
+				{ID: uuid.New().String(), TransactionID: transactionID.String(), Type: constant.OVERDRAFT, AccountAlias: "@alice"},
+			}
+
+			mockOpRepo.EXPECT().
+				FindAll(gomock.Any(), organizationID, ledgerID, transactionID, filter.ToCursorPagination()).
+				Return(ops, libHTTP.CursorPagination{}, nil).
+				Times(1)
+
+			mockMetaRepo.EXPECT().
+				FindByEntityIDs(gomock.Any(), "Operation", gomock.Any()).
+				Return(nil, nil).
+				Times(1)
+
+			uc := UseCase{
+				OperationRepo:           mockOpRepo,
+				TransactionMetadataRepo: mockMetaRepo,
+			}
+
+			tran := &transaction.Transaction{
+				ID:             transactionID.String(),
+				OrganizationID: organizationID.String(),
+				LedgerID:       ledgerID.String(),
+				Status:         transaction.Status{Code: constant.PENDING},
+				Body:           tt.body,
+			}
+
+			result, err := uc.GetOperationsByTransaction(context.Background(), organizationID, ledgerID, tran, filter)
+
+			assert.NoError(t, err)
+			assert.NotNil(t, result)
+			assert.Equal(t, []string{"@alice"}, result.Source)
+			assert.Empty(t, result.Destination, "no usable submitted destination must not fabricate a destination")
+		})
+	}
+}
+
+// TestGetAllTransactions_PendingOverdraftDerivesDestinationFromBody is the listing
+// counterpart: GET-listing and GET-individual must agree, so the same Body-derived
+// fallback applies when a listed PENDING overdraft transaction has no CREDIT leg.
+func TestGetAllTransactions_PendingOverdraftDerivesDestinationFromBody(t *testing.T) {
+	t.Parallel()
+
+	organizationID := uuid.Must(libCommons.GenerateUUIDv7())
+	ledgerID := uuid.Must(libCommons.GenerateUUIDv7())
+	transactionID := uuid.New()
+	filter := http.QueryHeader{Limit: 10, Page: 1, SortOrder: "asc"}
+	mockCur := libHTTP.CursorPagination{Next: "next", Prev: "prev"}
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockTransactionRepo := transaction.NewMockRepository(ctrl)
+	mockMetadataRepo := mongodb.NewMockRepository(ctrl)
+
+	ops := []*operation.Operation{
+		{ID: uuid.New().String(), TransactionID: transactionID.String(), Type: constant.DEBIT, AccountAlias: "@alice"},
+		{ID: uuid.New().String(), TransactionID: transactionID.String(), Type: constant.ONHOLD, AccountAlias: "@alice"},
+		{ID: uuid.New().String(), TransactionID: transactionID.String(), Type: constant.OVERDRAFT, AccountAlias: "@alice"},
+	}
+
+	trans := []*transaction.Transaction{
+		{
+			ID:             transactionID.String(),
+			OrganizationID: organizationID.String(),
+			LedgerID:       ledgerID.String(),
+			Status:         transaction.Status{Code: constant.PENDING},
+			Operations:     ops,
+			Body:           overdraftPendingBody(),
+		},
+	}
+
+	mockTransactionRepo.EXPECT().
+		FindOrListAllWithOperations(gomock.Any(), organizationID, ledgerID, []uuid.UUID{}, gomock.Any()).
+		Return(trans, mockCur, nil).
+		Times(1)
+
+	mockMetadataRepo.EXPECT().
+		FindByEntityIDs(gomock.Any(), "Transaction", []string{transactionID.String()}).
+		Return([]*mongodb.Metadata{}, nil).
+		Times(1)
+
+	mockMetadataRepo.EXPECT().
+		FindByEntityIDs(gomock.Any(), "Operation", gomock.Any()).
+		Return([]*mongodb.Metadata{}, nil).
+		Times(1)
+
+	uc := UseCase{
+		TransactionRepo:         mockTransactionRepo,
+		TransactionMetadataRepo: mockMetadataRepo,
+	}
+
+	result, _, err := uc.GetAllTransactions(context.TODO(), organizationID, ledgerID, filter)
+
+	assert.NoError(t, err)
+	assert.Len(t, result, 1)
+	assert.Equal(t, []string{"@alice"}, result[0].Source)
+	assert.Equal(t, []string{"@merchant", "@suffixed"}, result[0].Destination)
+}
+
+// TestGetOperationsByTransaction_CreditDestinationNotOverwrittenByBody is the
+// non-regression guard: an APPROVED transaction carries a real CREDIT leg, so the
+// Destination must be reconstructed from that operation and NEVER overwritten or
+// duplicated by the submitted body — even when the body is present.
+func TestGetOperationsByTransaction_CreditDestinationNotOverwrittenByBody(t *testing.T) {
+	t.Parallel()
+
+	organizationID := uuid.Must(libCommons.GenerateUUIDv7())
+	ledgerID := uuid.Must(libCommons.GenerateUUIDv7())
+	transactionID := uuid.New()
+	filter := http.QueryHeader{Limit: 10, Page: 1, SortOrder: "asc"}
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockOpRepo := operation.NewMockRepository(ctrl)
+	mockMetaRepo := mongodb.NewMockRepository(ctrl)
+
+	ops := []*operation.Operation{
+		{ID: uuid.New().String(), TransactionID: transactionID.String(), Type: constant.DEBIT, AccountAlias: "@alice"},
+		{ID: uuid.New().String(), TransactionID: transactionID.String(), Type: constant.CREDIT, AccountAlias: "@merchant"},
+	}
+
+	mockOpRepo.EXPECT().
+		FindAll(gomock.Any(), organizationID, ledgerID, transactionID, filter.ToCursorPagination()).
+		Return(ops, libHTTP.CursorPagination{}, nil).
+		Times(1)
+
+	mockMetaRepo.EXPECT().
+		FindByEntityIDs(gomock.Any(), "Operation", gomock.Any()).
+		Return(nil, nil).
+		Times(1)
+
+	uc := UseCase{
+		OperationRepo:           mockOpRepo,
+		TransactionMetadataRepo: mockMetaRepo,
+	}
+
+	tran := &transaction.Transaction{
+		ID:             transactionID.String(),
+		OrganizationID: organizationID.String(),
+		LedgerID:       ledgerID.String(),
+		Status:         transaction.Status{Code: constant.APPROVED},
+		// A stale/foreign body must not leak onto a committed destination.
+		Body: mtransaction.Transaction{
+			Send: mtransaction.Send{
+				Distribute: mtransaction.Distribute{
+					To: []mtransaction.FromTo{{AccountAlias: "@ghost", BalanceKey: constant.DefaultBalanceKey}},
+				},
+			},
+		},
+	}
+
+	result, err := uc.GetOperationsByTransaction(context.Background(), organizationID, ledgerID, tran, filter)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, result)
+	assert.Equal(t, []string{"@merchant"}, result.Destination, "credit-derived destination must win over the body")
+	assert.NotContains(t, result.Destination, "@ghost", "body must not overwrite a reconstructed destination")
+}
 
 func TestGetAllTransactions(t *testing.T) {
 	organizationID := uuid.Must(libCommons.GenerateUUIDv7())


### PR DESCRIPTION
## Summary

Two independent, pre-existing defects in the two-phase (pending → commit/cancel)
transaction flow when the source uses overdraft. Both are shared by the v1 and v2
transaction endpoints (same handler and query core) and are not regressions of
recent work.

## Bug 1 — cancel of a pending overdraft transaction restored the source balance incorrectly (money-path)

When a pending transaction that drew on overdraft is canceled, the source balance
was restored to an inconsistent state: the full hold was returned to `available`
while the overdraft usage was left outstanding. That yields a balance with
`available > 0` and `overdraftUsed > 0` at the same time — a state no legitimate
operation can reach — and breaks double-entry conservation.

Root cause: the commit/cancel core fetches the transaction from the write-behind
cache first and falls back to a database read on a miss. The write-behind entry is
cleared once the transaction persists, so a cancel deterministically hits the
fallback, which used a row-only read carrying no operations. Without operations the
overdraft-reversal step is a no-op, and the atomic balance update never unwinds the
overdraft portion of the hold.

Fix: load the fallback read with operations so the cancel can size and reverse the
overdraft usage. A guard degrades to the row-only read when the operation-joined
read returns an empty value (no operation rows), preserving not-found behavior.

## Bug 2 — a pending transaction returned an empty `destination` when read from the database

A GET of a pending transaction returned the submitted `destination` on a cache hit
but an empty list when served from the database — the same resource answered
differently depending on cache state.

Root cause: database reads rebuild `source`/`destination` from settled operations
(DEBIT → source, CREDIT → destination). A pre-commit overdraft transaction has only
source-side legs (DEBIT, ON_HOLD, OVERDRAFT) and no CREDIT, so `destination` rebuilt
as empty, while the submitted destination remained available on the persisted
transaction body.

Fix: when operation-based reconstruction yields no destination, derive it from the
submitted destination on the transaction body, in the same bare-alias form the cache
stores. Applied to all three read paths (individual, listing, metadata listing) so
the endpoints stay consistent.

## Validation

- Unit and integration tests added/updated for both fixes.
- End-to-end two-phase overdraft suite passes on both v1 and v2 (previously 2 of 5
  subtests passing; now 5 of 5).
