### PR TITLE
fix(ledger): guard funds and cache on account/balance delete

### DIFF
--- a/components/ledger/internal/adapters/http/in/balance_delete_cache_eviction_integration_test.go
+++ b/components/ledger/internal/adapters/http/in/balance_delete_cache_eviction_integration_test.go
@@ -35,7 +35,7 @@ import (
 // survived the delete, so a later transaction kept operating on the removed
 // balance ("phantom" activity on a deleted account).
 //
-// With the fix, a delete plants a short-lived "<balanceKey>:deleted" tombstone,
+// With the fix, a delete plants a short-lived "<balanceKey>:deleted" delete marker,
 // soft-deletes the PostgreSQL row, then evicts (Del) the balance cache key. A
 // later transaction can no longer find the balance (cache evicted + row
 // soft-deleted, which the PG query filters out), so it is rejected with
@@ -116,15 +116,15 @@ func wireEmptyLedgerSettings(t *testing.T, infra *testInfra) {
 	infra.handler.Query.LedgerRepo = mockLedgerRepo
 }
 
-// tombstoneCacheKey returns the tombstone key Redis holds for a balance while a
+// deleteMarkerCacheKey returns the delete marker key Redis holds for a balance while a
 // delete is armed: the balance's internal cache key plus the ":deleted" suffix.
-func tombstoneCacheKey(orgID, ledgerID uuid.UUID, alias, key string) string {
+func deleteMarkerCacheKey(orgID, ledgerID uuid.UUID, alias, key string) string {
 	return utils.BalanceInternalKey(orgID, ledgerID, alias+"#"+key) + ":deleted"
 }
 
 // TestIntegration_BalanceDeleteCacheEviction_AccountCascade drives the account
 // cascade delete path (DeleteAllBalancesByAccountID): after a drained balance's
-// account is deleted, its cache key is evicted, a delete tombstone is armed, and
+// account is deleted, its cache key is evicted, a delete marker is armed, and
 // a subsequent crediting transaction is rejected with 0019 instead of mutating
 // the removed balance.
 func TestIntegration_BalanceDeleteCacheEviction_AccountCascade(t *testing.T) {
@@ -187,10 +187,10 @@ func TestIntegration_BalanceDeleteCacheEviction_AccountCascade(t *testing.T) {
 	evicted := getBalanceFromRedis(t, ctx, infra.redisRepo, infra.orgID, infra.ledgerID, deletedAlias, "default")
 	assert.Nil(t, evicted, "balance cache key must be evicted after delete")
 
-	// (ii) The honored-lock tombstone is armed on the separate ":deleted" key.
-	tombstone, err := infra.redisRepo.Get(ctx, tombstoneCacheKey(infra.orgID, infra.ledgerID, deletedAlias, "default"))
+	// (ii) The honored-lock delete marker is armed on the separate ":deleted" key.
+	deleteMarker, err := infra.redisRepo.Get(ctx, deleteMarkerCacheKey(infra.orgID, infra.ledgerID, deletedAlias, "default"))
 	require.NoError(t, err)
-	assert.Equal(t, "1", tombstone, "delete tombstone must be present after delete")
+	assert.Equal(t, "1", deleteMarker, "delete marker must be present after delete")
 
 	// (iii) A crediting transaction to the deleted balance is rejected with 0019.
 	// Pre-fix this would have succeeded on the lingering cache entry.
@@ -208,7 +208,7 @@ func TestIntegration_BalanceDeleteCacheEviction_AccountCascade(t *testing.T) {
 
 // TestIntegration_BalanceDeleteCacheEviction_SingleBalance drives the
 // single-balance delete path (DeleteBalance): after a drained balance is deleted
-// by id, its cache key is evicted, a delete tombstone is armed, and a subsequent
+// by id, its cache key is evicted, a delete marker is armed, and a subsequent
 // crediting transaction is rejected with 0019 instead of mutating the removed
 // balance.
 func TestIntegration_BalanceDeleteCacheEviction_SingleBalance(t *testing.T) {
@@ -267,10 +267,10 @@ func TestIntegration_BalanceDeleteCacheEviction_SingleBalance(t *testing.T) {
 	evicted := getBalanceFromRedis(t, ctx, infra.redisRepo, infra.orgID, infra.ledgerID, deletedAlias, "default")
 	assert.Nil(t, evicted, "balance cache key must be evicted after delete")
 
-	// (ii) The honored-lock tombstone is armed.
-	tombstone, err := infra.redisRepo.Get(ctx, tombstoneCacheKey(infra.orgID, infra.ledgerID, deletedAlias, "default"))
+	// (ii) The honored-lock delete marker is armed.
+	deleteMarker, err := infra.redisRepo.Get(ctx, deleteMarkerCacheKey(infra.orgID, infra.ledgerID, deletedAlias, "default"))
 	require.NoError(t, err)
-	assert.Equal(t, "1", tombstone, "delete tombstone must be present after delete")
+	assert.Equal(t, "1", deleteMarker, "delete marker must be present after delete")
 
 	// (iii) A crediting transaction to the deleted balance is rejected with 0019.
 	status, respBody = postTransactionJSON(t, infra, counterpartyAlias, deletedAlias, balanceCacheDeleteAsset, "100")

--- a/components/ledger/internal/adapters/http/in/balance_delete_cache_eviction_integration_test.go
+++ b/components/ledger/internal/adapters/http/in/balance_delete_cache_eviction_integration_test.go
@@ -1,0 +1,285 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+//go:build integration
+
+package in
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	libCommons "github.com/LerianStudio/lib-commons/v5/commons"
+	"github.com/LerianStudio/midaz/v3/components/ledger/internal/adapters/postgres/ledger"
+	cn "github.com/LerianStudio/midaz/v3/pkg/constant"
+	"github.com/LerianStudio/midaz/v3/pkg/utils"
+	postgrestestutil "github.com/LerianStudio/midaz/v3/tests/utils/postgres"
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+// =============================================================================
+// BALANCE DELETE CACHE-COHERENCE INTEGRATION TESTS (honored-lock)
+// =============================================================================
+// These tests lock the fixed behavior of both balance delete paths against the
+// cache-coherence regression where a deleted balance's Redis cache entry
+// survived the delete, so a later transaction kept operating on the removed
+// balance ("phantom" activity on a deleted account).
+//
+// With the fix, a delete plants a short-lived "<balanceKey>:deleted" tombstone,
+// soft-deletes the PostgreSQL row, then evicts (Del) the balance cache key. A
+// later transaction can no longer find the balance (cache evicted + row
+// soft-deleted, which the PG query filters out), so it is rejected with
+// ErrAccountIneligibility (0019 / HTTP 422) instead of succeeding.
+//
+// Pre-fix, the crediting transaction in each case would have SUCCEEDED (HTTP
+// 201) and mutated the deleted balance, because its cache entry lingered with
+// AllowReceiving=1. That success-vs-rejection flip is the regression these
+// tests guard.
+//
+// Delete is exercised at the use-case level (no HTTP delete route is wired into
+// this harness); the transaction flow runs through the real Fiber HTTP handler.
+// Both sides run against real Postgres + Redis + the Lua atomic script.
+
+// balanceCacheDeleteAsset is the shared asset code for these scenarios. It must
+// match on both sides of every transaction so asset validation passes.
+const balanceCacheDeleteAsset = "BRL"
+
+// postTransactionJSON posts a single JSON transfer of value from sourceAlias to
+// destAlias through the real HTTP handler and returns the HTTP status code and
+// the raw response body.
+func postTransactionJSON(t *testing.T, infra *testInfra, sourceAlias, destAlias, asset, value string) (int, string) {
+	t.Helper()
+
+	body := fmt.Sprintf(`{
+		"description": "cache-coherence integration transfer",
+		"pending": false,
+		"send": {
+			"asset": %[1]q,
+			"value": %[2]q,
+			"source": {
+				"from": [
+					{
+						"accountAlias": %[3]q,
+						"amount": { "asset": %[1]q, "value": %[2]q }
+					}
+				]
+			},
+			"distribute": {
+				"to": [
+					{
+						"accountAlias": %[4]q,
+						"amount": { "asset": %[1]q, "value": %[2]q }
+					}
+				]
+			}
+		}
+	}`, asset, value, sourceAlias, destAlias)
+
+	req := httptest.NewRequest("POST",
+		"/v1/organizations/"+infra.orgID.String()+"/ledgers/"+infra.ledgerID.String()+"/transactions/json",
+		bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := infra.app.Test(req, -1)
+	require.NoError(t, err, "HTTP request should not fail")
+
+	raw, err := io.ReadAll(resp.Body)
+	require.NoError(t, err, "should read response body")
+
+	return resp.StatusCode, string(raw)
+}
+
+// wireEmptyLedgerSettings satisfies the transaction-create flow's ledger
+// settings lookup, which this harness otherwise leaves unwired. Empty settings
+// mean route and account-type validation default off, so a plain transfer flows
+// through the balance path being exercised here.
+func wireEmptyLedgerSettings(t *testing.T, infra *testInfra) {
+	t.Helper()
+
+	ctrl := gomock.NewController(t)
+	mockLedgerRepo := ledger.NewMockRepository(ctrl)
+	mockLedgerRepo.EXPECT().
+		GetSettings(gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(map[string]any{}, nil).
+		AnyTimes()
+
+	infra.handler.Query.LedgerRepo = mockLedgerRepo
+}
+
+// tombstoneCacheKey returns the tombstone key Redis holds for a balance while a
+// delete is armed: the balance's internal cache key plus the ":deleted" suffix.
+func tombstoneCacheKey(orgID, ledgerID uuid.UUID, alias, key string) string {
+	return utils.BalanceInternalKey(orgID, ledgerID, alias+"#"+key) + ":deleted"
+}
+
+// TestIntegration_BalanceDeleteCacheEviction_AccountCascade drives the account
+// cascade delete path (DeleteAllBalancesByAccountID): after a drained balance's
+// account is deleted, its cache key is evicted, a delete tombstone is armed, and
+// a subsequent crediting transaction is rejected with 0019 instead of mutating
+// the removed balance.
+func TestIntegration_BalanceDeleteCacheEviction_AccountCascade(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	infra := setupTestInfra(t)
+	t.Setenv("RABBITMQ_TRANSACTION_ASYNC", "false")
+	wireEmptyLedgerSettings(t, infra)
+
+	ctx := context.Background()
+
+	deletedAccountID := uuid.Must(libCommons.GenerateUUIDv7())
+	counterpartyAccountID := uuid.Must(libCommons.GenerateUUIDv7())
+
+	const deletedAlias = "@cascade-deleted"
+	const counterpartyAlias = "@cascade-funder"
+
+	// The to-be-deleted balance is created already at zero available so it is
+	// eligible for deletion (a funded balance cannot be deleted). The
+	// counterparty carries the working funds for the round-trip below.
+	deletedParams := postgrestestutil.DefaultBalanceParams()
+	deletedParams.Alias = deletedAlias
+	deletedParams.AssetCode = balanceCacheDeleteAsset
+	deletedParams.Available = decimal.Zero
+	deletedParams.OnHold = decimal.Zero
+	postgrestestutil.CreateTestBalance(t, infra.pgContainer.DB,
+		infra.orgID, infra.ledgerID, deletedAccountID, deletedParams)
+
+	counterpartyParams := postgrestestutil.DefaultBalanceParams()
+	counterpartyParams.Alias = counterpartyAlias
+	counterpartyParams.AssetCode = balanceCacheDeleteAsset
+	counterpartyParams.Available = decimal.NewFromInt(100)
+	counterpartyParams.OnHold = decimal.Zero
+	postgrestestutil.CreateTestBalance(t, infra.pgContainer.DB,
+		infra.orgID, infra.ledgerID, counterpartyAccountID, counterpartyParams)
+
+	// Round-trip: fund the balance from the counterparty, then send it all back.
+	// This populates both Redis cache entries via the Lua atomic script and
+	// leaves the to-be-deleted balance back at zero available (still deletable).
+	status, respBody := postTransactionJSON(t, infra, counterpartyAlias, deletedAlias, balanceCacheDeleteAsset, "50")
+	require.Equal(t, 201, status, "funding transaction should succeed: %s", respBody)
+
+	status, respBody = postTransactionJSON(t, infra, deletedAlias, counterpartyAlias, balanceCacheDeleteAsset, "50")
+	require.Equal(t, 201, status, "return transaction should succeed: %s", respBody)
+
+	// The zeroed balance must be present in the cache before delete.
+	cached := getBalanceFromRedis(t, ctx, infra.redisRepo, infra.orgID, infra.ledgerID, deletedAlias, "default")
+	require.NotNil(t, cached, "balance cache key must exist before delete")
+	require.True(t, cached.Available.Equal(decimal.Zero),
+		"drained balance available should be zero, got %s", cached.Available.String())
+
+	// Delete the whole account (cascade over all its balances).
+	err := infra.handler.Command.DeleteAllBalancesByAccountID(ctx,
+		infra.orgID, infra.ledgerID, deletedAccountID, "integration-cascade-delete-request")
+	require.NoError(t, err, "account cascade delete should succeed")
+
+	// (i) The balance cache key is evicted.
+	evicted := getBalanceFromRedis(t, ctx, infra.redisRepo, infra.orgID, infra.ledgerID, deletedAlias, "default")
+	assert.Nil(t, evicted, "balance cache key must be evicted after delete")
+
+	// (ii) The honored-lock tombstone is armed on the separate ":deleted" key.
+	tombstone, err := infra.redisRepo.Get(ctx, tombstoneCacheKey(infra.orgID, infra.ledgerID, deletedAlias, "default"))
+	require.NoError(t, err)
+	assert.Equal(t, "1", tombstone, "delete tombstone must be present after delete")
+
+	// (iii) A crediting transaction to the deleted balance is rejected with 0019.
+	// Pre-fix this would have succeeded on the lingering cache entry.
+	status, respBody = postTransactionJSON(t, infra, counterpartyAlias, deletedAlias, balanceCacheDeleteAsset, "100")
+	assert.Equal(t, 422, status, "transaction on a deleted balance must be rejected, got %d: %s", status, respBody)
+	assert.True(t, strings.Contains(respBody, cn.ErrAccountIneligibility.Error()),
+		"rejection should carry 0019, got: %s", respBody)
+
+	// The counterparty balance must not have been mutated by the rejected transaction.
+	counterparty := getBalanceFromRedis(t, ctx, infra.redisRepo, infra.orgID, infra.ledgerID, counterpartyAlias, "default")
+	require.NotNil(t, counterparty, "counterparty balance should still exist")
+	assert.True(t, counterparty.Available.Equal(decimal.NewFromInt(100)),
+		"counterparty available must be unchanged (100) after the rejected transaction, got %s", counterparty.Available.String())
+}
+
+// TestIntegration_BalanceDeleteCacheEviction_SingleBalance drives the
+// single-balance delete path (DeleteBalance): after a drained balance is deleted
+// by id, its cache key is evicted, a delete tombstone is armed, and a subsequent
+// crediting transaction is rejected with 0019 instead of mutating the removed
+// balance.
+func TestIntegration_BalanceDeleteCacheEviction_SingleBalance(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	infra := setupTestInfra(t)
+	t.Setenv("RABBITMQ_TRANSACTION_ASYNC", "false")
+	wireEmptyLedgerSettings(t, infra)
+
+	ctx := context.Background()
+
+	deletedAccountID := uuid.Must(libCommons.GenerateUUIDv7())
+	counterpartyAccountID := uuid.Must(libCommons.GenerateUUIDv7())
+
+	const deletedAlias = "@single-deleted"
+	const counterpartyAlias = "@single-funder"
+
+	// The to-be-deleted balance starts at zero available so it is eligible for
+	// deletion; the counterparty carries the working funds for the round-trip.
+	deletedParams := postgrestestutil.DefaultBalanceParams()
+	deletedParams.Alias = deletedAlias
+	deletedParams.AssetCode = balanceCacheDeleteAsset
+	deletedParams.Available = decimal.Zero
+	deletedParams.OnHold = decimal.Zero
+	deletedBalanceID := postgrestestutil.CreateTestBalance(t, infra.pgContainer.DB,
+		infra.orgID, infra.ledgerID, deletedAccountID, deletedParams)
+
+	counterpartyParams := postgrestestutil.DefaultBalanceParams()
+	counterpartyParams.Alias = counterpartyAlias
+	counterpartyParams.AssetCode = balanceCacheDeleteAsset
+	counterpartyParams.Available = decimal.NewFromInt(100)
+	counterpartyParams.OnHold = decimal.Zero
+	postgrestestutil.CreateTestBalance(t, infra.pgContainer.DB,
+		infra.orgID, infra.ledgerID, counterpartyAccountID, counterpartyParams)
+
+	// Round-trip to populate both cache entries and leave the to-be-deleted
+	// balance back at zero available.
+	status, respBody := postTransactionJSON(t, infra, counterpartyAlias, deletedAlias, balanceCacheDeleteAsset, "50")
+	require.Equal(t, 201, status, "funding transaction should succeed: %s", respBody)
+
+	status, respBody = postTransactionJSON(t, infra, deletedAlias, counterpartyAlias, balanceCacheDeleteAsset, "50")
+	require.Equal(t, 201, status, "return transaction should succeed: %s", respBody)
+
+	cached := getBalanceFromRedis(t, ctx, infra.redisRepo, infra.orgID, infra.ledgerID, deletedAlias, "default")
+	require.NotNil(t, cached, "balance cache key must exist before delete")
+	require.True(t, cached.Available.Equal(decimal.Zero),
+		"drained balance available should be zero, got %s", cached.Available.String())
+
+	// Delete the single balance by id.
+	err := infra.handler.Command.DeleteBalance(ctx, infra.orgID, infra.ledgerID, deletedBalanceID)
+	require.NoError(t, err, "single-balance delete should succeed")
+
+	// (i) The balance cache key is evicted.
+	evicted := getBalanceFromRedis(t, ctx, infra.redisRepo, infra.orgID, infra.ledgerID, deletedAlias, "default")
+	assert.Nil(t, evicted, "balance cache key must be evicted after delete")
+
+	// (ii) The honored-lock tombstone is armed.
+	tombstone, err := infra.redisRepo.Get(ctx, tombstoneCacheKey(infra.orgID, infra.ledgerID, deletedAlias, "default"))
+	require.NoError(t, err)
+	assert.Equal(t, "1", tombstone, "delete tombstone must be present after delete")
+
+	// (iii) A crediting transaction to the deleted balance is rejected with 0019.
+	status, respBody = postTransactionJSON(t, infra, counterpartyAlias, deletedAlias, balanceCacheDeleteAsset, "100")
+	assert.Equal(t, 422, status, "transaction on a deleted balance must be rejected, got %d: %s", status, respBody)
+	assert.True(t, strings.Contains(respBody, cn.ErrAccountIneligibility.Error()),
+		"rejection should carry 0019, got: %s", respBody)
+
+	counterparty := getBalanceFromRedis(t, ctx, infra.redisRepo, infra.orgID, infra.ledgerID, counterpartyAlias, "default")
+	require.NotNil(t, counterparty, "counterparty balance should still exist")
+	assert.True(t, counterparty.Available.Equal(decimal.NewFromInt(100)),
+		"counterparty available must be unchanged (100) after the rejected transaction, got %s", counterparty.Available.String())
+}

--- a/components/ledger/internal/adapters/http/in/balance_delete_cache_eviction_integration_test.go
+++ b/components/ledger/internal/adapters/http/in/balance_delete_cache_eviction_integration_test.go
@@ -11,6 +11,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
@@ -85,7 +86,7 @@ func postTransactionJSON(t *testing.T, infra *testInfra, sourceAlias, destAlias,
 		}
 	}`, asset, value, sourceAlias, destAlias)
 
-	req := httptest.NewRequest("POST",
+	req := httptest.NewRequest(http.MethodPost,
 		"/v1/organizations/"+infra.orgID.String()+"/ledgers/"+infra.ledgerID.String()+"/transactions/json",
 		bytes.NewBufferString(body))
 	req.Header.Set("Content-Type", "application/json")

--- a/components/ledger/internal/adapters/http/in/balance_test.go
+++ b/components/ledger/internal/adapters/http/in/balance_test.go
@@ -748,10 +748,22 @@ func TestBalanceHandler_DeleteBalanceByID(t *testing.T) {
 			balanceID := uuid.New()
 
 			mockBalanceRepo := balance.NewMockRepository(ctrl)
+			mockRedisRepo := redis.NewMockRedisRepository(ctrl)
+			// The delete path plants and releases/evicts balance tombstones via the
+			// honored-lock guard. Lenient expectations keep this a handler test.
+			mockRedisRepo.EXPECT().
+				SetNX(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(true, nil).
+				AnyTimes()
+			mockRedisRepo.EXPECT().
+				Del(gomock.Any(), gomock.Any()).
+				Return(nil).
+				AnyTimes()
 			tt.setupMocks(mockBalanceRepo, orgID, ledgerID, balanceID)
 
 			uc := &command.UseCase{
-				BalanceRepo: mockBalanceRepo,
+				BalanceRepo:          mockBalanceRepo,
+				TransactionRedisRepo: mockRedisRepo,
 			}
 			handler := &BalanceHandler{Command: uc}
 

--- a/components/ledger/internal/adapters/http/in/balance_test.go
+++ b/components/ledger/internal/adapters/http/in/balance_test.go
@@ -749,7 +749,7 @@ func TestBalanceHandler_DeleteBalanceByID(t *testing.T) {
 
 			mockBalanceRepo := balance.NewMockRepository(ctrl)
 			mockRedisRepo := redis.NewMockRedisRepository(ctrl)
-			// The delete path plants and releases/evicts balance tombstones via the
+			// The delete path plants and releases/evicts balance delete markers via the
 			// honored-lock guard. Lenient expectations keep this a handler test.
 			mockRedisRepo.EXPECT().
 				SetNX(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).

--- a/components/ledger/internal/adapters/redis/transaction/consumer.redis.go
+++ b/components/ledger/internal/adapters/redis/transaction/consumer.redis.go
@@ -750,6 +750,7 @@ func (rr *RedisConsumerRepository) buildBalanceAtomicOperationPlan(ctx context.C
 //
 // Lua error codes emitted by balance_atomic_operation.lua:
 //   - "0018" → ErrInsufficientFunds (negative available on non-external credit-direction balance without overdraft fall-through)
+//   - "0019" → ErrAccountIneligibility (balance carries a live deletion tombstone; rejected before any mutation)
 //   - "0098" → ErrOnHoldExternalAccount (external account used in pending source)
 //   - "0139" → ErrTransactionBackupCacheRetrievalFailed (balance key vanished mid-script)
 //   - "0167" → ErrOverdraftLimitExceeded (transaction would push usage past the configured limit)
@@ -776,6 +777,13 @@ func mapBalanceAtomicScriptError(span trace.Span, err error) error {
 	if strings.Contains(err.Error(), constant.ErrInsufficientFunds.Error()) {
 		mappedErr := pkg.ValidateBusinessError(constant.ErrInsufficientFunds, "validateBalance")
 		libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Failed run lua script on redis", mappedErr)
+
+		return mappedErr
+	}
+
+	if strings.Contains(err.Error(), constant.ErrAccountIneligibility.Error()) {
+		mappedErr := pkg.ValidateBusinessError(constant.ErrAccountIneligibility, "validateBalance")
+		libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Account ineligible: balance carries a deletion tombstone", mappedErr)
 
 		return mappedErr
 	}

--- a/components/ledger/internal/adapters/redis/transaction/consumer.redis.go
+++ b/components/ledger/internal/adapters/redis/transaction/consumer.redis.go
@@ -750,7 +750,7 @@ func (rr *RedisConsumerRepository) buildBalanceAtomicOperationPlan(ctx context.C
 //
 // Lua error codes emitted by balance_atomic_operation.lua:
 //   - "0018" → ErrInsufficientFunds (negative available on non-external credit-direction balance without overdraft fall-through)
-//   - "0019" → ErrAccountIneligibility (balance carries a live deletion tombstone; rejected before any mutation)
+//   - "0019" → ErrAccountIneligibility (balance carries a live deletion marker; rejected before any mutation)
 //   - "0098" → ErrOnHoldExternalAccount (external account used in pending source)
 //   - "0139" → ErrTransactionBackupCacheRetrievalFailed (balance key vanished mid-script)
 //   - "0167" → ErrOverdraftLimitExceeded (transaction would push usage past the configured limit)
@@ -783,7 +783,7 @@ func mapBalanceAtomicScriptError(span trace.Span, err error) error {
 
 	if strings.Contains(err.Error(), constant.ErrAccountIneligibility.Error()) {
 		mappedErr := pkg.ValidateBusinessError(constant.ErrAccountIneligibility, "validateBalance")
-		libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Account ineligible: balance carries a deletion tombstone", mappedErr)
+		libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Account ineligible: balance carries a deletion marker", mappedErr)
 
 		return mappedErr
 	}

--- a/components/ledger/internal/adapters/redis/transaction/consumer_delete_marker_integration_test.go
+++ b/components/ledger/internal/adapters/redis/transaction/consumer_delete_marker_integration_test.go
@@ -22,11 +22,11 @@ import (
 )
 
 // =============================================================================
-// DELETE TOMBSTONE GUARD INTEGRATION TESTS (honored-lock)
+// DELETE MARKER GUARD INTEGRATION TESTS (honored-lock)
 // =============================================================================
 // These tests cover the Lua pre-pass in balance_atomic_operation.lua that
 // rejects a batch with ErrAccountIneligibility (0019) when any balance in it
-// carries a live "<balanceKey>:deleted" tombstone, before any mutation runs.
+// carries a live "<balanceKey>:deleted" delete marker, before any mutation runs.
 
 // readCachedBalance fetches and decodes the balance cache entry written by the
 // Lua script for the given key. It fails the test if the key is missing.
@@ -42,10 +42,10 @@ func readCachedBalance(t *testing.T, infra *integrationTestInfra, key string) ca
 	return cb
 }
 
-// TestIntegration_DeleteTombstone_RejectsAndDoesNotMutate exercises case (a):
-// a live tombstone on the single balance in the batch makes the atomic op
+// TestIntegration_DeleteMarker_RejectsAndDoesNotMutate exercises case (a):
+// a live delete marker on the single balance in the batch makes the atomic op
 // return 0019 and leaves the balance cache value/version untouched.
-func TestIntegration_DeleteTombstone_RejectsAndDoesNotMutate(t *testing.T) {
+func TestIntegration_DeleteMarker_RejectsAndDoesNotMutate(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode")
 	}
@@ -66,11 +66,11 @@ func TestIntegration_DeleteTombstone_RejectsAndDoesNotMutate(t *testing.T) {
 
 	before := readCachedBalance(t, infra, primeOp.InternalKey)
 
-	// Lay down the tombstone on the SEPARATE key; the balance key is untouched.
-	tombstoneKey := primeOp.InternalKey + ":deleted"
-	require.NoError(t, infra.redisContainer.Client.Set(ctx, tombstoneKey, "1", 0).Err())
+	// Lay down the delete marker on the SEPARATE key; the balance key is untouched.
+	deleteMarkerKey := primeOp.InternalKey + ":deleted"
+	require.NoError(t, infra.redisContainer.Client.Set(ctx, deleteMarkerKey, "1", 0).Err())
 
-	// A subsequent op on the tombstoned balance must be rejected with 0019.
+	// A subsequent op on the balance carrying a delete marker must be rejected with 0019.
 	rejectOp := overdraftOp(orgID, ledgerID, "@ts-single", "deposit", "credit",
 		decimal.NewFromInt(300), decimal.Zero, before.Version, nil,
 		constant.DEBIT, decimal.NewFromInt(100))
@@ -78,11 +78,11 @@ func TestIntegration_DeleteTombstone_RejectsAndDoesNotMutate(t *testing.T) {
 	_, err = infra.repo.ProcessBalanceAtomicOperation(ctx, orgID, ledgerID,
 		uuid.New(), constant.APPROVED, false, []mmodel.BalanceOperation{rejectOp})
 
-	require.Error(t, err, "tombstoned balance must be rejected")
+	require.Error(t, err, "balance carrying a delete marker must be rejected")
 	assert.True(t, strings.Contains(err.Error(), constant.ErrAccountIneligibility.Error()),
 		"error should contain 0019, got: %v", err)
 
-	// No mutation: value and version are exactly the pre-tombstone snapshot.
+	// No mutation: value and version are exactly the pre-delete-marker snapshot.
 	after := readCachedBalance(t, infra, primeOp.InternalKey)
 	assert.Equal(t, before.Available, after.Available,
 		"Available must be unchanged when the batch is rejected")
@@ -90,10 +90,10 @@ func TestIntegration_DeleteTombstone_RejectsAndDoesNotMutate(t *testing.T) {
 		"Version must not increment when the batch is rejected")
 }
 
-// TestIntegration_DeleteTombstone_NoTombstone_ProceedsNormally exercises case
-// (b): with no tombstone present, the atomic op mutates the balance as before.
+// TestIntegration_DeleteMarker_NoMarker_ProceedsNormally exercises case
+// (b): with no delete marker present, the atomic op mutates the balance as before.
 // This guards against the pre-pass rejecting healthy batches.
-func TestIntegration_DeleteTombstone_NoTombstone_ProceedsNormally(t *testing.T) {
+func TestIntegration_DeleteMarker_NoMarker_ProceedsNormally(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode")
 	}
@@ -110,17 +110,17 @@ func TestIntegration_DeleteTombstone_NoTombstone_ProceedsNormally(t *testing.T) 
 	result, err := infra.repo.ProcessBalanceAtomicOperation(ctx, orgID, ledgerID,
 		uuid.New(), constant.APPROVED, false, []mmodel.BalanceOperation{op})
 
-	require.NoError(t, err, "no tombstone -> op must proceed")
+	require.NoError(t, err, "no delete marker -> op must proceed")
 	require.Len(t, result.After, 1)
 	assert.True(t, result.After[0].Available.Equal(decimal.NewFromInt(300)),
 		"Available should decrement normally, got %s", result.After[0].Available)
 }
 
-// TestIntegration_DeleteTombstone_BatchAtomicity exercises case (c): a
-// two-balance batch where only one balance is tombstoned. The whole batch is
-// rejected with 0019 and the NON-tombstoned balance is left unmutated, proving
+// TestIntegration_DeleteMarker_BatchAtomicity exercises case (c): a
+// two-balance batch where only one balance carries a delete marker. The whole batch is
+// rejected with 0019 and the balance without a delete marker is left unmutated, proving
 // the pre-pass runs before any mutation in the batch.
-func TestIntegration_DeleteTombstone_BatchAtomicity(t *testing.T) {
+func TestIntegration_DeleteMarker_BatchAtomicity(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode")
 	}
@@ -144,10 +144,10 @@ func TestIntegration_DeleteTombstone_BatchAtomicity(t *testing.T) {
 
 	beforeA := readCachedBalance(t, infra, opA.InternalKey)
 
-	// Tombstone ONLY balance B.
+	// Delete marker ONLY balance B.
 	require.NoError(t, infra.redisContainer.Client.Set(ctx, opB.InternalKey+":deleted", "1", 0).Err())
 
-	// Re-run the batch (A first, then the tombstoned B). The pre-pass must
+	// Re-run the batch (A first, then B carrying a delete marker). The pre-pass must
 	// reject the whole batch before A is mutated.
 	nextA := overdraftOp(orgID, ledgerID, "@ts-batch-a", "deposit", "credit",
 		beforeA.availableDecimal(t), decimal.Zero, beforeA.Version, nil,
@@ -159,16 +159,16 @@ func TestIntegration_DeleteTombstone_BatchAtomicity(t *testing.T) {
 	_, err = infra.repo.ProcessBalanceAtomicOperation(ctx, orgID, ledgerID,
 		uuid.New(), constant.APPROVED, false, []mmodel.BalanceOperation{nextA, nextB})
 
-	require.Error(t, err, "batch with a tombstoned balance must be rejected")
+	require.Error(t, err, "batch with a balance carrying a delete marker must be rejected")
 	assert.True(t, strings.Contains(err.Error(), constant.ErrAccountIneligibility.Error()),
 		"error should contain 0019, got: %v", err)
 
-	// The non-tombstoned balance A must be untouched (pre-pass atomicity).
+	// The balance without a delete marker A must be untouched (pre-pass atomicity).
 	afterA := readCachedBalance(t, infra, opA.InternalKey)
 	assert.Equal(t, beforeA.Available, afterA.Available,
-		"non-tombstoned balance Available must be unchanged")
+		"balance without a delete marker Available must be unchanged")
 	assert.Equal(t, beforeA.Version, afterA.Version,
-		"non-tombstoned balance Version must not increment")
+		"balance without a delete marker Version must not increment")
 }
 
 // availableDecimal parses the cached Available string into a decimal for reuse

--- a/components/ledger/internal/adapters/redis/transaction/consumer_delete_tombstone_integration_test.go
+++ b/components/ledger/internal/adapters/redis/transaction/consumer_delete_tombstone_integration_test.go
@@ -1,0 +1,183 @@
+//go:build integration
+
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package redis
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/LerianStudio/midaz/v3/pkg/constant"
+	"github.com/LerianStudio/midaz/v3/pkg/mmodel"
+
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// =============================================================================
+// DELETE TOMBSTONE GUARD INTEGRATION TESTS (honored-lock)
+// =============================================================================
+// These tests cover the Lua pre-pass in balance_atomic_operation.lua that
+// rejects a batch with ErrAccountIneligibility (0019) when any balance in it
+// carries a live "<balanceKey>:deleted" tombstone, before any mutation runs.
+
+// readCachedBalance fetches and decodes the balance cache entry written by the
+// Lua script for the given key. It fails the test if the key is missing.
+func readCachedBalance(t *testing.T, infra *integrationTestInfra, key string) cachedBalance {
+	t.Helper()
+
+	raw, err := infra.redisContainer.Client.Get(context.Background(), key).Result()
+	require.NoError(t, err, "balance cache key %q must exist", key)
+
+	var cb cachedBalance
+	require.NoError(t, json.Unmarshal([]byte(raw), &cb))
+
+	return cb
+}
+
+// TestIntegration_DeleteTombstone_RejectsAndDoesNotMutate exercises case (a):
+// a live tombstone on the single balance in the batch makes the atomic op
+// return 0019 and leaves the balance cache value/version untouched.
+func TestIntegration_DeleteTombstone_RejectsAndDoesNotMutate(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	infra := setupRedisIntegrationInfra(t)
+	ctx := context.Background()
+	orgID := uuid.New()
+	ledgerID := uuid.New()
+
+	// Prime the balance cache with a successful op (version 1 -> 2, 500 -> 300).
+	primeOp := overdraftOp(orgID, ledgerID, "@ts-single", "deposit", "credit",
+		decimal.NewFromInt(500), decimal.Zero, 1, nil,
+		constant.DEBIT, decimal.NewFromInt(200))
+
+	_, err := infra.repo.ProcessBalanceAtomicOperation(ctx, orgID, ledgerID,
+		uuid.New(), constant.APPROVED, false, []mmodel.BalanceOperation{primeOp})
+	require.NoError(t, err)
+
+	before := readCachedBalance(t, infra, primeOp.InternalKey)
+
+	// Lay down the tombstone on the SEPARATE key; the balance key is untouched.
+	tombstoneKey := primeOp.InternalKey + ":deleted"
+	require.NoError(t, infra.redisContainer.Client.Set(ctx, tombstoneKey, "1", 0).Err())
+
+	// A subsequent op on the tombstoned balance must be rejected with 0019.
+	rejectOp := overdraftOp(orgID, ledgerID, "@ts-single", "deposit", "credit",
+		decimal.NewFromInt(300), decimal.Zero, before.Version, nil,
+		constant.DEBIT, decimal.NewFromInt(100))
+
+	_, err = infra.repo.ProcessBalanceAtomicOperation(ctx, orgID, ledgerID,
+		uuid.New(), constant.APPROVED, false, []mmodel.BalanceOperation{rejectOp})
+
+	require.Error(t, err, "tombstoned balance must be rejected")
+	assert.True(t, strings.Contains(err.Error(), constant.ErrAccountIneligibility.Error()),
+		"error should contain 0019, got: %v", err)
+
+	// No mutation: value and version are exactly the pre-tombstone snapshot.
+	after := readCachedBalance(t, infra, primeOp.InternalKey)
+	assert.Equal(t, before.Available, after.Available,
+		"Available must be unchanged when the batch is rejected")
+	assert.Equal(t, before.Version, after.Version,
+		"Version must not increment when the batch is rejected")
+}
+
+// TestIntegration_DeleteTombstone_NoTombstone_ProceedsNormally exercises case
+// (b): with no tombstone present, the atomic op mutates the balance as before.
+// This guards against the pre-pass rejecting healthy batches.
+func TestIntegration_DeleteTombstone_NoTombstone_ProceedsNormally(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	infra := setupRedisIntegrationInfra(t)
+	ctx := context.Background()
+	orgID := uuid.New()
+	ledgerID := uuid.New()
+
+	op := overdraftOp(orgID, ledgerID, "@ts-none", "deposit", "credit",
+		decimal.NewFromInt(500), decimal.Zero, 1, nil,
+		constant.DEBIT, decimal.NewFromInt(200))
+
+	result, err := infra.repo.ProcessBalanceAtomicOperation(ctx, orgID, ledgerID,
+		uuid.New(), constant.APPROVED, false, []mmodel.BalanceOperation{op})
+
+	require.NoError(t, err, "no tombstone -> op must proceed")
+	require.Len(t, result.After, 1)
+	assert.True(t, result.After[0].Available.Equal(decimal.NewFromInt(300)),
+		"Available should decrement normally, got %s", result.After[0].Available)
+}
+
+// TestIntegration_DeleteTombstone_BatchAtomicity exercises case (c): a
+// two-balance batch where only one balance is tombstoned. The whole batch is
+// rejected with 0019 and the NON-tombstoned balance is left unmutated, proving
+// the pre-pass runs before any mutation in the batch.
+func TestIntegration_DeleteTombstone_BatchAtomicity(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	infra := setupRedisIntegrationInfra(t)
+	ctx := context.Background()
+	orgID := uuid.New()
+	ledgerID := uuid.New()
+
+	opA := overdraftOp(orgID, ledgerID, "@ts-batch-a", "deposit", "credit",
+		decimal.NewFromInt(500), decimal.Zero, 1, nil,
+		constant.DEBIT, decimal.NewFromInt(100))
+	opB := overdraftOp(orgID, ledgerID, "@ts-batch-b", "deposit", "credit",
+		decimal.NewFromInt(500), decimal.Zero, 1, nil,
+		constant.DEBIT, decimal.NewFromInt(100))
+
+	// Prime both balances in the cache with a healthy batch.
+	_, err := infra.repo.ProcessBalanceAtomicOperation(ctx, orgID, ledgerID,
+		uuid.New(), constant.APPROVED, false, []mmodel.BalanceOperation{opA, opB})
+	require.NoError(t, err)
+
+	beforeA := readCachedBalance(t, infra, opA.InternalKey)
+
+	// Tombstone ONLY balance B.
+	require.NoError(t, infra.redisContainer.Client.Set(ctx, opB.InternalKey+":deleted", "1", 0).Err())
+
+	// Re-run the batch (A first, then the tombstoned B). The pre-pass must
+	// reject the whole batch before A is mutated.
+	nextA := overdraftOp(orgID, ledgerID, "@ts-batch-a", "deposit", "credit",
+		beforeA.availableDecimal(t), decimal.Zero, beforeA.Version, nil,
+		constant.DEBIT, decimal.NewFromInt(50))
+	nextB := overdraftOp(orgID, ledgerID, "@ts-batch-b", "deposit", "credit",
+		decimal.NewFromInt(400), decimal.Zero, 2, nil,
+		constant.DEBIT, decimal.NewFromInt(50))
+
+	_, err = infra.repo.ProcessBalanceAtomicOperation(ctx, orgID, ledgerID,
+		uuid.New(), constant.APPROVED, false, []mmodel.BalanceOperation{nextA, nextB})
+
+	require.Error(t, err, "batch with a tombstoned balance must be rejected")
+	assert.True(t, strings.Contains(err.Error(), constant.ErrAccountIneligibility.Error()),
+		"error should contain 0019, got: %v", err)
+
+	// The non-tombstoned balance A must be untouched (pre-pass atomicity).
+	afterA := readCachedBalance(t, infra, opA.InternalKey)
+	assert.Equal(t, beforeA.Available, afterA.Available,
+		"non-tombstoned balance Available must be unchanged")
+	assert.Equal(t, beforeA.Version, afterA.Version,
+		"non-tombstoned balance Version must not increment")
+}
+
+// availableDecimal parses the cached Available string into a decimal for reuse
+// as the next op's read version input.
+func (cb cachedBalance) availableDecimal(t *testing.T) decimal.Decimal {
+	t.Helper()
+
+	d, err := decimal.NewFromString(cb.Available)
+	require.NoError(t, err)
+
+	return d
+}

--- a/components/ledger/internal/adapters/redis/transaction/consumer_overdraft_error_mapper_test.go
+++ b/components/ledger/internal/adapters/redis/transaction/consumer_overdraft_error_mapper_test.go
@@ -99,6 +99,44 @@ func TestMapError_ExistingCodes_StillWork(t *testing.T) {
 	}
 }
 
+func TestMapError_AccountIneligibility(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name    string
+		luaErr  string
+		wantErr error
+	}{
+		{
+			name:    "bare code",
+			luaErr:  "0019",
+			wantErr: constant.ErrAccountIneligibility,
+		},
+		{
+			name:    "prefixed message",
+			luaErr:  "ERR 0019 account ineligible: balance carries a deletion tombstone",
+			wantErr: constant.ErrAccountIneligibility,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			tracer := noop.NewTracerProvider().Tracer("test")
+			_, span := tracer.Start(t.Context(), "test")
+			defer span.End()
+
+			rawErr := errors.New(tc.luaErr)
+			mapped := mapBalanceAtomicScriptError(span, rawErr)
+
+			expectedMsg := pkg.ValidateBusinessError(tc.wantErr, "validateBalance").Error()
+			assert.Equal(t, expectedMsg, mapped.Error(),
+				"Lua error %q must map to ErrAccountIneligibility", tc.luaErr)
+		})
+	}
+}
+
 func TestMapError_StaleBalance(t *testing.T) {
 	t.Parallel()
 

--- a/components/ledger/internal/adapters/redis/transaction/consumer_overdraft_error_mapper_test.go
+++ b/components/ledger/internal/adapters/redis/transaction/consumer_overdraft_error_mapper_test.go
@@ -114,7 +114,7 @@ func TestMapError_AccountIneligibility(t *testing.T) {
 		},
 		{
 			name:    "prefixed message",
-			luaErr:  "ERR 0019 account ineligible: balance carries a deletion tombstone",
+			luaErr:  "ERR 0019 account ineligible: balance carries a deletion marker",
 			wantErr: constant.ErrAccountIneligibility,
 		},
 	}

--- a/components/ledger/internal/adapters/redis/transaction/scripts/balance_atomic_operation.lua
+++ b/components/ledger/internal/adapters/redis/transaction/scripts/balance_atomic_operation.lua
@@ -268,15 +268,13 @@ local function main()
     -- shares the balance key's {transactions} hash slot. Running this pre-pass
     -- ahead of the first SET below means a rejection here leaves zero side
     -- effects across the batch, so no rollback is required. The stride mirrors
-    -- the main loop below (groupSize=24; ARGV[i] is the balance key). A single
-    -- variadic EXISTS returns the count of delete markers present; >0 means at least
-    -- one balance carries a delete marker, so the whole batch is rejected.
-    local deleteMarkerKeys = {}
+    -- the main loop below (groupSize=24; ARGV[i] is the balance key). A bounded
+    -- per-key EXISTS check early-returns on the first delete marker found, so the
+    -- whole batch is rejected without unpacking a client-influenced number of keys.
     for i = 1, #ARGV, groupSize do
-        deleteMarkerKeys[#deleteMarkerKeys + 1] = ARGV[i] .. ":deleted"
-    end
-    if #deleteMarkerKeys > 0 and redis.call("EXISTS", unpack(deleteMarkerKeys)) > 0 then
-        return redis.error_reply("0019")
+        if redis.call("EXISTS", ARGV[i] .. ":deleted") == 1 then
+            return redis.error_reply("0019")
+        end
     end
 
     for i = 1, #ARGV, groupSize do

--- a/components/ledger/internal/adapters/redis/transaction/scripts/balance_atomic_operation.lua
+++ b/components/ledger/internal/adapters/redis/transaction/scripts/balance_atomic_operation.lua
@@ -268,12 +268,15 @@ local function main()
     -- shares the balance key's {transactions} hash slot. Running this pre-pass
     -- ahead of the first SET below means a rejection here leaves zero side
     -- effects across the batch, so no rollback is required. The stride mirrors
-    -- the main loop below (groupSize=24; ARGV[i] is the balance key).
+    -- the main loop below (groupSize=24; ARGV[i] is the balance key). A single
+    -- variadic EXISTS returns the count of tombstones present; >0 means at least
+    -- one balance is tombstoned, so the whole batch is rejected.
+    local tombstoneKeys = {}
     for i = 1, #ARGV, groupSize do
-        local tombstoneKey = ARGV[i] .. ":deleted"
-        if redis.call("EXISTS", tombstoneKey) == 1 then
-            return redis.error_reply("0019")
-        end
+        tombstoneKeys[#tombstoneKeys + 1] = ARGV[i] .. ":deleted"
+    end
+    if #tombstoneKeys > 0 and redis.call("EXISTS", unpack(tombstoneKeys)) > 0 then
+        return redis.error_reply("0019")
     end
 
     for i = 1, #ARGV, groupSize do

--- a/components/ledger/internal/adapters/redis/transaction/scripts/balance_atomic_operation.lua
+++ b/components/ledger/internal/adapters/redis/transaction/scripts/balance_atomic_operation.lua
@@ -262,6 +262,20 @@ local function main()
     local timeNow = redis.call("TIME")
     local dueAt = tonumber(timeNow[1]) + tonumber(timeNow[2]) / 1000000
 
+    -- Tombstone guard: reject the whole batch before any mutation if any balance
+    -- in it carries a live deletion tombstone. The tombstone is a SEPARATE key
+    -- "<balanceKey>:deleted" that never overwrites the balance itself, and it
+    -- shares the balance key's {transactions} hash slot. Running this pre-pass
+    -- ahead of the first SET below means a rejection here leaves zero side
+    -- effects across the batch, so no rollback is required. The stride mirrors
+    -- the main loop below (groupSize=24; ARGV[i] is the balance key).
+    for i = 1, #ARGV, groupSize do
+        local tombstoneKey = ARGV[i] .. ":deleted"
+        if redis.call("EXISTS", tombstoneKey) == 1 then
+            return redis.error_reply("0019")
+        end
+    end
+
     for i = 1, #ARGV, groupSize do
         local redisBalanceKey = ARGV[i]
         local isPending = tonumber(ARGV[i + 1])

--- a/components/ledger/internal/adapters/redis/transaction/scripts/balance_atomic_operation.lua
+++ b/components/ledger/internal/adapters/redis/transaction/scripts/balance_atomic_operation.lua
@@ -262,20 +262,20 @@ local function main()
     local timeNow = redis.call("TIME")
     local dueAt = tonumber(timeNow[1]) + tonumber(timeNow[2]) / 1000000
 
-    -- Tombstone guard: reject the whole batch before any mutation if any balance
-    -- in it carries a live deletion tombstone. The tombstone is a SEPARATE key
+    -- Delete marker guard: reject the whole batch before any mutation if any balance
+    -- in it carries a live deletion marker. The delete marker is a SEPARATE key
     -- "<balanceKey>:deleted" that never overwrites the balance itself, and it
     -- shares the balance key's {transactions} hash slot. Running this pre-pass
     -- ahead of the first SET below means a rejection here leaves zero side
     -- effects across the batch, so no rollback is required. The stride mirrors
     -- the main loop below (groupSize=24; ARGV[i] is the balance key). A single
-    -- variadic EXISTS returns the count of tombstones present; >0 means at least
-    -- one balance is tombstoned, so the whole batch is rejected.
-    local tombstoneKeys = {}
+    -- variadic EXISTS returns the count of delete markers present; >0 means at least
+    -- one balance carries a delete marker, so the whole batch is rejected.
+    local deleteMarkerKeys = {}
     for i = 1, #ARGV, groupSize do
-        tombstoneKeys[#tombstoneKeys + 1] = ARGV[i] .. ":deleted"
+        deleteMarkerKeys[#deleteMarkerKeys + 1] = ARGV[i] .. ":deleted"
     end
-    if #tombstoneKeys > 0 and redis.call("EXISTS", unpack(tombstoneKeys)) > 0 then
+    if #deleteMarkerKeys > 0 and redis.call("EXISTS", unpack(deleteMarkerKeys)) > 0 then
         return redis.error_reply("0019")
     end
 

--- a/components/ledger/internal/services/command/balance_cache_delete_guard.go
+++ b/components/ledger/internal/services/command/balance_cache_delete_guard.go
@@ -24,30 +24,26 @@ const (
 	// instead of leaving a permanently poisoned balance key. It is intentionally NOT the
 	// 3600s balance cache TTL. SetNX multiplies its ttl argument by time.Second, so it is
 	// passed as a whole-second count via time.Duration(balanceDeleteTombstoneTTLSeconds).
-	balanceDeleteTombstoneTTLSeconds = 30 //nolint:unused // referenced once the delete flows are wired
+	balanceDeleteTombstoneTTLSeconds = 30
 
 	// tombstoneKeySuffix is appended to a balance's internal cache key to form its tombstone
 	// key. It MUST match the suffix the Redis Lua pre-pass derives (ARGV[i] .. ":deleted").
-	tombstoneKeySuffix = ":deleted" //nolint:unused // referenced once the delete flows are wired
+	tombstoneKeySuffix = ":deleted"
 
 	// tombstoneMarkerValue is the placeholder stored under a tombstone key. The value is
 	// never read: only the key's existence is meaningful to the honored-lock pre-pass.
-	tombstoneMarkerValue = "1" //nolint:unused // referenced once the delete flows are wired
+	tombstoneMarkerValue = "1"
 )
 
 // balanceCacheKeyFor returns the un-prefixed internal cache key for a balance. The
 // TransactionRedisRepo wrappers apply tenant namespacing to the whole key, so callers pass
 // this output directly.
-//
-//nolint:unused // referenced once the delete flows are wired
 func balanceCacheKeyFor(organizationID, ledgerID uuid.UUID, balance *mmodel.Balance) string {
 	return utils.BalanceInternalKey(organizationID, ledgerID, balance.Alias+"#"+balance.Key)
 }
 
 // tombstoneKeyFor returns the tombstone key for a balance: its internal cache key plus the
 // ":deleted" suffix. The tombstone is a SEPARATE key from the balance cache key.
-//
-//nolint:unused // referenced once the delete flows are wired
 func tombstoneKeyFor(organizationID, ledgerID uuid.UUID, balance *mmodel.Balance) string {
 	return balanceCacheKeyFor(organizationID, ledgerID, balance) + tombstoneKeySuffix
 }
@@ -57,8 +53,6 @@ func tombstoneKeyFor(organizationID, ledgerID uuid.UUID, balance *mmodel.Balance
 // A failed SetNX is logged and skipped (it weakens the guard but must not crash the delete).
 // The returned release closure Dels exactly the tombstone keys that were planted, for
 // defer-on-error rollback by the caller.
-//
-//nolint:unused // referenced once the delete flows are wired
 func (uc *UseCase) plantBalanceTombstones(ctx context.Context, organizationID, ledgerID uuid.UUID, balances []*mmodel.Balance) func() {
 	logger, tracer, _, _ := libObs.NewTrackingFromContext(ctx)
 
@@ -88,8 +82,6 @@ func (uc *UseCase) plantBalanceTombstones(ctx context.Context, organizationID, l
 
 // releaseBalanceTombstones Dels each previously planted tombstone key, logging a Warn on
 // error and continuing. A no-op Del on a missing key is safe.
-//
-//nolint:unused // referenced once the delete flows are wired
 func (uc *UseCase) releaseBalanceTombstones(ctx context.Context, tombstoneKeys []string) {
 	logger, tracer, _, _ := libObs.NewTrackingFromContext(ctx)
 
@@ -108,8 +100,6 @@ func (uc *UseCase) releaseBalanceTombstones(ctx context.Context, tombstoneKeys [
 // evictBalanceCaches Dels each balance's internal cache key after a committed delete. A
 // lingering cache key after a persisted delete is the bug this guards against, so a failed
 // Del is Warn-worthy but must not fail the already-committed delete.
-//
-//nolint:unused // referenced once the delete flows are wired
 func (uc *UseCase) evictBalanceCaches(ctx context.Context, organizationID, ledgerID uuid.UUID, balances []*mmodel.Balance) {
 	logger, tracer, _, _ := libObs.NewTrackingFromContext(ctx)
 

--- a/components/ledger/internal/services/command/balance_cache_delete_guard.go
+++ b/components/ledger/internal/services/command/balance_cache_delete_guard.go
@@ -1,0 +1,128 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package command
+
+import (
+	"context"
+	"time"
+
+	libObs "github.com/LerianStudio/lib-observability"
+	libLog "github.com/LerianStudio/lib-observability/log"
+	libOpentelemetry "github.com/LerianStudio/lib-observability/tracing"
+	"github.com/LerianStudio/midaz/v3/pkg/mmodel"
+	"github.com/LerianStudio/midaz/v3/pkg/utils"
+	"github.com/google/uuid"
+)
+
+const (
+	// balanceDeleteTombstoneTTLSeconds is the lifetime, in whole seconds, of a balance
+	// delete tombstone key. It is deliberately short: it must outlive the worst-case
+	// duration of a delete so the honored-lock pre-pass keeps rejecting mutations for the
+	// whole operation, yet expire quickly so a process that crashes mid-delete self-heals
+	// instead of leaving a permanently poisoned balance key. It is intentionally NOT the
+	// 3600s balance cache TTL. SetNX multiplies its ttl argument by time.Second, so it is
+	// passed as a whole-second count via time.Duration(balanceDeleteTombstoneTTLSeconds).
+	balanceDeleteTombstoneTTLSeconds = 30 //nolint:unused // referenced once the delete flows are wired
+
+	// tombstoneKeySuffix is appended to a balance's internal cache key to form its tombstone
+	// key. It MUST match the suffix the Redis Lua pre-pass derives (ARGV[i] .. ":deleted").
+	tombstoneKeySuffix = ":deleted" //nolint:unused // referenced once the delete flows are wired
+
+	// tombstoneMarkerValue is the placeholder stored under a tombstone key. The value is
+	// never read: only the key's existence is meaningful to the honored-lock pre-pass.
+	tombstoneMarkerValue = "1" //nolint:unused // referenced once the delete flows are wired
+)
+
+// balanceCacheKeyFor returns the un-prefixed internal cache key for a balance. The
+// TransactionRedisRepo wrappers apply tenant namespacing to the whole key, so callers pass
+// this output directly.
+//
+//nolint:unused // referenced once the delete flows are wired
+func balanceCacheKeyFor(organizationID, ledgerID uuid.UUID, balance *mmodel.Balance) string {
+	return utils.BalanceInternalKey(organizationID, ledgerID, balance.Alias+"#"+balance.Key)
+}
+
+// tombstoneKeyFor returns the tombstone key for a balance: its internal cache key plus the
+// ":deleted" suffix. The tombstone is a SEPARATE key from the balance cache key.
+//
+//nolint:unused // referenced once the delete flows are wired
+func tombstoneKeyFor(organizationID, ledgerID uuid.UUID, balance *mmodel.Balance) string {
+	return balanceCacheKeyFor(organizationID, ledgerID, balance) + tombstoneKeySuffix
+}
+
+// plantBalanceTombstones best-effort writes a short-lived tombstone key for each balance so
+// the Redis honored-lock pre-pass rejects concurrent mutations while a delete is in flight.
+// A failed SetNX is logged and skipped (it weakens the guard but must not crash the delete).
+// The returned release closure Dels exactly the tombstone keys that were planted, for
+// defer-on-error rollback by the caller.
+//
+//nolint:unused // referenced once the delete flows are wired
+func (uc *UseCase) plantBalanceTombstones(ctx context.Context, organizationID, ledgerID uuid.UUID, balances []*mmodel.Balance) func() {
+	logger, tracer, _, _ := libObs.NewTrackingFromContext(ctx)
+
+	spanCtx, span := tracer.Start(ctx, "exec.plant_balance_tombstones")
+	defer span.End()
+
+	planted := make([]string, 0, len(balances))
+
+	for _, balance := range balances {
+		tombstoneKey := tombstoneKeyFor(organizationID, ledgerID, balance)
+
+		if _, err := uc.TransactionRedisRepo.SetNX(spanCtx, tombstoneKey, tombstoneMarkerValue, time.Duration(balanceDeleteTombstoneTTLSeconds)); err != nil {
+			libOpentelemetry.HandleSpanError(span, "Failed to plant balance delete tombstone", err)
+
+			logger.Log(spanCtx, libLog.LevelWarn, "Failed to plant balance delete tombstone", libLog.Err(err))
+
+			continue
+		}
+
+		planted = append(planted, tombstoneKey)
+	}
+
+	return func() {
+		uc.releaseBalanceTombstones(ctx, planted)
+	}
+}
+
+// releaseBalanceTombstones Dels each previously planted tombstone key, logging a Warn on
+// error and continuing. A no-op Del on a missing key is safe.
+//
+//nolint:unused // referenced once the delete flows are wired
+func (uc *UseCase) releaseBalanceTombstones(ctx context.Context, tombstoneKeys []string) {
+	logger, tracer, _, _ := libObs.NewTrackingFromContext(ctx)
+
+	ctx, span := tracer.Start(ctx, "exec.release_balance_tombstones")
+	defer span.End()
+
+	for _, tombstoneKey := range tombstoneKeys {
+		if err := uc.TransactionRedisRepo.Del(ctx, tombstoneKey); err != nil {
+			libOpentelemetry.HandleSpanError(span, "Failed to release balance delete tombstone", err)
+
+			logger.Log(ctx, libLog.LevelWarn, "Failed to release balance delete tombstone", libLog.Err(err))
+		}
+	}
+}
+
+// evictBalanceCaches Dels each balance's internal cache key after a committed delete. A
+// lingering cache key after a persisted delete is the bug this guards against, so a failed
+// Del is Warn-worthy but must not fail the already-committed delete.
+//
+//nolint:unused // referenced once the delete flows are wired
+func (uc *UseCase) evictBalanceCaches(ctx context.Context, organizationID, ledgerID uuid.UUID, balances []*mmodel.Balance) {
+	logger, tracer, _, _ := libObs.NewTrackingFromContext(ctx)
+
+	ctx, span := tracer.Start(ctx, "exec.evict_balance_caches")
+	defer span.End()
+
+	for _, balance := range balances {
+		cacheKey := balanceCacheKeyFor(organizationID, ledgerID, balance)
+
+		if err := uc.TransactionRedisRepo.Del(ctx, cacheKey); err != nil {
+			libOpentelemetry.HandleSpanError(span, "Failed to evict balance cache key", err)
+
+			logger.Log(ctx, libLog.LevelWarn, "Failed to evict balance cache key", libLog.Err(err))
+		}
+	}
+}

--- a/components/ledger/internal/services/command/balance_cache_delete_guard.go
+++ b/components/ledger/internal/services/command/balance_cache_delete_guard.go
@@ -17,22 +17,22 @@ import (
 )
 
 const (
-	// balanceDeleteTombstoneTTLSeconds is the lifetime, in whole seconds, of a balance
-	// delete tombstone key. It is deliberately short: it must outlive the worst-case
+	// balanceDeleteMarkerTTLSeconds is the lifetime, in whole seconds, of a balance
+	// delete marker key. It is deliberately short: it must outlive the worst-case
 	// duration of a delete so the honored-lock pre-pass keeps rejecting mutations for the
 	// whole operation, yet expire quickly so a process that crashes mid-delete self-heals
 	// instead of leaving a permanently poisoned balance key. It is intentionally NOT the
 	// 3600s balance cache TTL. SetNX multiplies its ttl argument by time.Second, so it is
-	// passed as a whole-second count via time.Duration(balanceDeleteTombstoneTTLSeconds).
-	balanceDeleteTombstoneTTLSeconds = 30
+	// passed as a whole-second count via time.Duration(balanceDeleteMarkerTTLSeconds).
+	balanceDeleteMarkerTTLSeconds = 30
 
-	// tombstoneKeySuffix is appended to a balance's internal cache key to form its tombstone
+	// deleteMarkerKeySuffix is appended to a balance's internal cache key to form its delete marker
 	// key. It MUST match the suffix the Redis Lua pre-pass derives (ARGV[i] .. ":deleted").
-	tombstoneKeySuffix = ":deleted"
+	deleteMarkerKeySuffix = ":deleted"
 
-	// tombstoneMarkerValue is the placeholder stored under a tombstone key. The value is
+	// deleteMarkerValue is the placeholder stored under a delete marker key. The value is
 	// never read: only the key's existence is meaningful to the honored-lock pre-pass.
-	tombstoneMarkerValue = "1"
+	deleteMarkerValue = "1"
 )
 
 // balanceCacheKeyFor returns the un-prefixed internal cache key for a balance. The
@@ -42,64 +42,64 @@ func balanceCacheKeyFor(organizationID, ledgerID uuid.UUID, balance *mmodel.Bala
 	return utils.BalanceInternalKey(organizationID, ledgerID, balance.Alias+"#"+balance.Key)
 }
 
-// tombstoneKeyFor returns the tombstone key for a balance: its internal cache key plus the
-// ":deleted" suffix. The tombstone is a SEPARATE key from the balance cache key.
-func tombstoneKeyFor(organizationID, ledgerID uuid.UUID, balance *mmodel.Balance) string {
-	return balanceCacheKeyFor(organizationID, ledgerID, balance) + tombstoneKeySuffix
+// deleteMarkerKeyFor returns the delete marker key for a balance: its internal cache key plus the
+// ":deleted" suffix. The delete marker is a SEPARATE key from the balance cache key.
+func deleteMarkerKeyFor(organizationID, ledgerID uuid.UUID, balance *mmodel.Balance) string {
+	return balanceCacheKeyFor(organizationID, ledgerID, balance) + deleteMarkerKeySuffix
 }
 
-// plantBalanceTombstones best-effort writes a short-lived tombstone key for each balance so
+// plantBalanceDeleteMarkers best-effort writes a short-lived delete marker key for each balance so
 // the Redis honored-lock pre-pass rejects concurrent mutations while a delete is in flight.
 // A failed SetNX is logged and skipped (it weakens the guard but must not crash the delete).
-// The returned release closure Dels exactly the tombstone keys that were planted, for
+// The returned release closure Dels exactly the delete marker keys that were planted, for
 // defer-on-error rollback by the caller.
-func (uc *UseCase) plantBalanceTombstones(ctx context.Context, organizationID, ledgerID uuid.UUID, balances []*mmodel.Balance) func() {
+func (uc *UseCase) plantBalanceDeleteMarkers(ctx context.Context, organizationID, ledgerID uuid.UUID, balances []*mmodel.Balance) func() {
 	logger, tracer, _, _ := libObs.NewTrackingFromContext(ctx)
 
-	spanCtx, span := tracer.Start(ctx, "exec.plant_balance_tombstones")
+	spanCtx, span := tracer.Start(ctx, "exec.plant_balance_delete_markers")
 	defer span.End()
 
 	planted := make([]string, 0, len(balances))
 
 	for _, balance := range balances {
-		tombstoneKey := tombstoneKeyFor(organizationID, ledgerID, balance)
+		deleteMarkerKey := deleteMarkerKeyFor(organizationID, ledgerID, balance)
 
-		set, err := uc.TransactionRedisRepo.SetNX(spanCtx, tombstoneKey, tombstoneMarkerValue, time.Duration(balanceDeleteTombstoneTTLSeconds))
+		set, err := uc.TransactionRedisRepo.SetNX(spanCtx, deleteMarkerKey, deleteMarkerValue, time.Duration(balanceDeleteMarkerTTLSeconds))
 		if err != nil {
-			libOpentelemetry.HandleSpanError(span, "Failed to plant balance delete tombstone", err)
+			libOpentelemetry.HandleSpanError(span, "Failed to plant balance delete marker", err)
 
-			logger.Log(spanCtx, libLog.LevelWarn, "Failed to plant balance delete tombstone", libLog.Err(err))
+			logger.Log(spanCtx, libLog.LevelWarn, "Failed to plant balance delete marker", libLog.Err(err))
 
 			continue
 		}
 
-		// Track only a tombstone THIS operation acquired (SetNX true). A (false, nil)
+		// Track only a delete marker THIS operation acquired (SetNX true). A (false, nil)
 		// means a concurrent delete already owns the key: the guard is armed either
 		// way, so the delete proceeds, but releasing here would Del a sibling's
-		// tombstone and reopen the honored-lock hole. Only acquired keys are releasable.
+		// delete marker and reopen the honored-lock hole. Only acquired keys are releasable.
 		if set {
-			planted = append(planted, tombstoneKey)
+			planted = append(planted, deleteMarkerKey)
 		}
 	}
 
 	return func() {
-		uc.releaseBalanceTombstones(ctx, planted)
+		uc.releaseBalanceDeleteMarkers(ctx, planted)
 	}
 }
 
-// releaseBalanceTombstones Dels each previously planted tombstone key, logging a Warn on
+// releaseBalanceDeleteMarkers Dels each previously planted delete marker key, logging a Warn on
 // error and continuing. A no-op Del on a missing key is safe.
-func (uc *UseCase) releaseBalanceTombstones(ctx context.Context, tombstoneKeys []string) {
+func (uc *UseCase) releaseBalanceDeleteMarkers(ctx context.Context, deleteMarkerKeys []string) {
 	logger, tracer, _, _ := libObs.NewTrackingFromContext(ctx)
 
-	ctx, span := tracer.Start(ctx, "exec.release_balance_tombstones")
+	ctx, span := tracer.Start(ctx, "exec.release_balance_delete_markers")
 	defer span.End()
 
-	for _, tombstoneKey := range tombstoneKeys {
-		if err := uc.TransactionRedisRepo.Del(ctx, tombstoneKey); err != nil {
-			libOpentelemetry.HandleSpanError(span, "Failed to release balance delete tombstone", err)
+	for _, deleteMarkerKey := range deleteMarkerKeys {
+		if err := uc.TransactionRedisRepo.Del(ctx, deleteMarkerKey); err != nil {
+			libOpentelemetry.HandleSpanError(span, "Failed to release balance delete marker", err)
 
-			logger.Log(ctx, libLog.LevelWarn, "Failed to release balance delete tombstone", libLog.Err(err))
+			logger.Log(ctx, libLog.LevelWarn, "Failed to release balance delete marker", libLog.Err(err))
 		}
 	}
 }

--- a/components/ledger/internal/services/command/balance_cache_delete_guard.go
+++ b/components/ledger/internal/services/command/balance_cache_delete_guard.go
@@ -64,7 +64,8 @@ func (uc *UseCase) plantBalanceTombstones(ctx context.Context, organizationID, l
 	for _, balance := range balances {
 		tombstoneKey := tombstoneKeyFor(organizationID, ledgerID, balance)
 
-		if _, err := uc.TransactionRedisRepo.SetNX(spanCtx, tombstoneKey, tombstoneMarkerValue, time.Duration(balanceDeleteTombstoneTTLSeconds)); err != nil {
+		set, err := uc.TransactionRedisRepo.SetNX(spanCtx, tombstoneKey, tombstoneMarkerValue, time.Duration(balanceDeleteTombstoneTTLSeconds))
+		if err != nil {
 			libOpentelemetry.HandleSpanError(span, "Failed to plant balance delete tombstone", err)
 
 			logger.Log(spanCtx, libLog.LevelWarn, "Failed to plant balance delete tombstone", libLog.Err(err))
@@ -72,7 +73,13 @@ func (uc *UseCase) plantBalanceTombstones(ctx context.Context, organizationID, l
 			continue
 		}
 
-		planted = append(planted, tombstoneKey)
+		// Track only a tombstone THIS operation acquired (SetNX true). A (false, nil)
+		// means a concurrent delete already owns the key: the guard is armed either
+		// way, so the delete proceeds, but releasing here would Del a sibling's
+		// tombstone and reopen the honored-lock hole. Only acquired keys are releasable.
+		if set {
+			planted = append(planted, tombstoneKey)
+		}
 	}
 
 	return func() {

--- a/components/ledger/internal/services/command/balance_cache_delete_guard_test.go
+++ b/components/ledger/internal/services/command/balance_cache_delete_guard_test.go
@@ -1,0 +1,192 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package command
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/LerianStudio/midaz/v3/pkg/mmodel"
+	"github.com/LerianStudio/midaz/v3/pkg/utils"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+)
+
+func tombstoneTestBalance(alias, key string) *mmodel.Balance {
+	return &mmodel.Balance{Alias: alias, Key: key}
+}
+
+func TestTombstoneKeyFor(t *testing.T) {
+	t.Parallel()
+
+	organizationID := uuid.New()
+	ledgerID := uuid.New()
+
+	tests := []struct {
+		name  string
+		alias string
+		key   string
+	}{
+		{name: "simple alias and key", alias: "alias", key: "key"},
+		{name: "distinct alias and key", alias: "@person1", key: "usd"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			balance := tombstoneTestBalance(tt.alias, tt.key)
+
+			got := tombstoneKeyFor(organizationID, ledgerID, balance)
+
+			want := utils.BalanceInternalKey(organizationID, ledgerID, tt.alias+"#"+tt.key) + ":deleted"
+
+			assert.Equal(t, want, got)
+			// Tombstone MUST be a separate key from the balance cache key.
+			assert.NotEqual(t, utils.BalanceInternalKey(organizationID, ledgerID, tt.alias+"#"+tt.key), got)
+			assert.Contains(t, got, "balance:{transactions}:")
+			assert.Contains(t, got, tt.alias+"#"+tt.key+":deleted")
+		})
+	}
+}
+
+func TestPlantBalanceTombstones(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	organizationID := uuid.New()
+	ledgerID := uuid.New()
+
+	uc, _, mockRedisRepo := setupDeleteAllBalancesUseCase(t)
+
+	first := tombstoneTestBalance("@alice", "usd")
+	second := tombstoneTestBalance("@bob", "brl")
+	balances := []*mmodel.Balance{first, second}
+
+	firstTomb := utils.BalanceInternalKey(organizationID, ledgerID, "@alice#usd") + ":deleted"
+	secondTomb := utils.BalanceInternalKey(organizationID, ledgerID, "@bob#brl") + ":deleted"
+
+	// SetNX is called once per balance, with the correct tombstone key, a marker value,
+	// and the whole-second TTL constant (SetNX multiplies it by time.Second internally).
+	mockRedisRepo.EXPECT().
+		SetNX(gomock.Any(), firstTomb, "1", time.Duration(balanceDeleteTombstoneTTLSeconds)).
+		Return(true, nil)
+	mockRedisRepo.EXPECT().
+		SetNX(gomock.Any(), secondTomb, "1", time.Duration(balanceDeleteTombstoneTTLSeconds)).
+		Return(true, nil)
+
+	release := uc.plantBalanceTombstones(ctx, organizationID, ledgerID, balances)
+	assert.NotNil(t, release)
+
+	// The release closure must Del exactly the planted tombstone keys.
+	mockRedisRepo.EXPECT().Del(gomock.Any(), firstTomb).Return(nil)
+	mockRedisRepo.EXPECT().Del(gomock.Any(), secondTomb).Return(nil)
+
+	release()
+}
+
+func TestPlantBalanceTombstonesReleaseDelErrorSwallowed(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	organizationID := uuid.New()
+	ledgerID := uuid.New()
+
+	uc, _, mockRedisRepo := setupDeleteAllBalancesUseCase(t)
+
+	balance := tombstoneTestBalance("@alice", "usd")
+	tomb := utils.BalanceInternalKey(organizationID, ledgerID, "@alice#usd") + ":deleted"
+
+	mockRedisRepo.EXPECT().
+		SetNX(gomock.Any(), tomb, "1", time.Duration(balanceDeleteTombstoneTTLSeconds)).
+		Return(true, nil)
+
+	release := uc.plantBalanceTombstones(ctx, organizationID, ledgerID, []*mmodel.Balance{balance})
+
+	// A failed Del during release is logged and swallowed; it must not panic or propagate.
+	mockRedisRepo.EXPECT().Del(gomock.Any(), tomb).Return(errors.New("redis down"))
+
+	assert.NotPanics(t, func() { release() })
+}
+
+func TestPlantBalanceTombstonesSetNXErrorContinues(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	organizationID := uuid.New()
+	ledgerID := uuid.New()
+
+	uc, _, mockRedisRepo := setupDeleteAllBalancesUseCase(t)
+
+	first := tombstoneTestBalance("@alice", "usd")
+	second := tombstoneTestBalance("@bob", "brl")
+	balances := []*mmodel.Balance{first, second}
+
+	firstTomb := utils.BalanceInternalKey(organizationID, ledgerID, "@alice#usd") + ":deleted"
+	secondTomb := utils.BalanceInternalKey(organizationID, ledgerID, "@bob#brl") + ":deleted"
+
+	// First SetNX fails: it is logged and skipped, not planted. Second succeeds.
+	mockRedisRepo.EXPECT().
+		SetNX(gomock.Any(), firstTomb, "1", time.Duration(balanceDeleteTombstoneTTLSeconds)).
+		Return(false, errors.New("redis unavailable"))
+	mockRedisRepo.EXPECT().
+		SetNX(gomock.Any(), secondTomb, "1", time.Duration(balanceDeleteTombstoneTTLSeconds)).
+		Return(true, nil)
+
+	release := uc.plantBalanceTombstones(ctx, organizationID, ledgerID, balances)
+
+	// Release must Del ONLY the successfully planted key; the failed one is never Del'd.
+	mockRedisRepo.EXPECT().Del(gomock.Any(), firstTomb).Times(0)
+	mockRedisRepo.EXPECT().Del(gomock.Any(), secondTomb).Return(nil)
+
+	assert.NotPanics(t, func() { release() })
+}
+
+func TestEvictBalanceCaches(t *testing.T) {
+	t.Parallel()
+
+	organizationID := uuid.New()
+	ledgerID := uuid.New()
+
+	t.Run("dels each balance cache key", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := context.Background()
+		uc, _, mockRedisRepo := setupDeleteAllBalancesUseCase(t)
+
+		first := tombstoneTestBalance("@alice", "usd")
+		second := tombstoneTestBalance("@bob", "brl")
+
+		firstKey := utils.BalanceInternalKey(organizationID, ledgerID, "@alice#usd")
+		secondKey := utils.BalanceInternalKey(organizationID, ledgerID, "@bob#brl")
+
+		mockRedisRepo.EXPECT().Del(gomock.Any(), firstKey).Return(nil)
+		mockRedisRepo.EXPECT().Del(gomock.Any(), secondKey).Return(nil)
+
+		assert.NotPanics(t, func() {
+			uc.evictBalanceCaches(ctx, organizationID, ledgerID, []*mmodel.Balance{first, second})
+		})
+	})
+
+	t.Run("swallows and logs a del error", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := context.Background()
+		uc, _, mockRedisRepo := setupDeleteAllBalancesUseCase(t)
+
+		balance := tombstoneTestBalance("@alice", "usd")
+		key := utils.BalanceInternalKey(organizationID, ledgerID, "@alice#usd")
+
+		mockRedisRepo.EXPECT().Del(gomock.Any(), key).Return(errors.New("redis down"))
+
+		// A failed Del after a committed PG delete must not panic or propagate.
+		assert.NotPanics(t, func() {
+			uc.evictBalanceCaches(ctx, organizationID, ledgerID, []*mmodel.Balance{balance})
+		})
+	})
+}

--- a/components/ledger/internal/services/command/balance_cache_delete_guard_test.go
+++ b/components/ledger/internal/services/command/balance_cache_delete_guard_test.go
@@ -17,11 +17,11 @@ import (
 	"go.uber.org/mock/gomock"
 )
 
-func tombstoneTestBalance(alias, key string) *mmodel.Balance {
+func deleteMarkerTestBalance(alias, key string) *mmodel.Balance {
 	return &mmodel.Balance{Alias: alias, Key: key}
 }
 
-func TestTombstoneKeyFor(t *testing.T) {
+func TestDeleteMarkerKeyFor(t *testing.T) {
 	t.Parallel()
 
 	organizationID := uuid.New()
@@ -40,22 +40,22 @@ func TestTombstoneKeyFor(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			balance := tombstoneTestBalance(tt.alias, tt.key)
+			balance := deleteMarkerTestBalance(tt.alias, tt.key)
 
-			got := tombstoneKeyFor(organizationID, ledgerID, balance)
+			got := deleteMarkerKeyFor(organizationID, ledgerID, balance)
 
-			want := utils.BalanceInternalKey(organizationID, ledgerID, tt.alias+"#"+tt.key) + tombstoneKeySuffix
+			want := utils.BalanceInternalKey(organizationID, ledgerID, tt.alias+"#"+tt.key) + deleteMarkerKeySuffix
 
 			assert.Equal(t, want, got)
-			// Tombstone MUST be a separate key from the balance cache key.
+			// Delete marker MUST be a separate key from the balance cache key.
 			assert.NotEqual(t, utils.BalanceInternalKey(organizationID, ledgerID, tt.alias+"#"+tt.key), got)
 			assert.Contains(t, got, "balance:{transactions}:")
-			assert.Contains(t, got, tt.alias+"#"+tt.key+tombstoneKeySuffix)
+			assert.Contains(t, got, tt.alias+"#"+tt.key+deleteMarkerKeySuffix)
 		})
 	}
 }
 
-func TestPlantBalanceTombstones(t *testing.T) {
+func TestPlantBalanceDeleteMarkers(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
@@ -64,33 +64,33 @@ func TestPlantBalanceTombstones(t *testing.T) {
 
 	uc, _, mockRedisRepo := setupDeleteAllBalancesUseCase(t)
 
-	first := tombstoneTestBalance("@alice", "usd")
-	second := tombstoneTestBalance("@bob", "brl")
+	first := deleteMarkerTestBalance("@alice", "usd")
+	second := deleteMarkerTestBalance("@bob", "brl")
 	balances := []*mmodel.Balance{first, second}
 
-	firstTomb := utils.BalanceInternalKey(organizationID, ledgerID, "@alice#usd") + tombstoneKeySuffix
-	secondTomb := utils.BalanceInternalKey(organizationID, ledgerID, "@bob#brl") + tombstoneKeySuffix
+	firstTomb := utils.BalanceInternalKey(organizationID, ledgerID, "@alice#usd") + deleteMarkerKeySuffix
+	secondTomb := utils.BalanceInternalKey(organizationID, ledgerID, "@bob#brl") + deleteMarkerKeySuffix
 
-	// SetNX is called once per balance, with the correct tombstone key, a marker value,
+	// SetNX is called once per balance, with the correct delete marker key, a marker value,
 	// and the whole-second TTL constant (SetNX multiplies it by time.Second internally).
 	mockRedisRepo.EXPECT().
-		SetNX(gomock.Any(), firstTomb, "1", time.Duration(balanceDeleteTombstoneTTLSeconds)).
+		SetNX(gomock.Any(), firstTomb, "1", time.Duration(balanceDeleteMarkerTTLSeconds)).
 		Return(true, nil)
 	mockRedisRepo.EXPECT().
-		SetNX(gomock.Any(), secondTomb, "1", time.Duration(balanceDeleteTombstoneTTLSeconds)).
+		SetNX(gomock.Any(), secondTomb, "1", time.Duration(balanceDeleteMarkerTTLSeconds)).
 		Return(true, nil)
 
-	release := uc.plantBalanceTombstones(ctx, organizationID, ledgerID, balances)
+	release := uc.plantBalanceDeleteMarkers(ctx, organizationID, ledgerID, balances)
 	assert.NotNil(t, release)
 
-	// The release closure must Del exactly the planted tombstone keys.
+	// The release closure must Del exactly the planted delete marker keys.
 	mockRedisRepo.EXPECT().Del(gomock.Any(), firstTomb).Return(nil)
 	mockRedisRepo.EXPECT().Del(gomock.Any(), secondTomb).Return(nil)
 
 	release()
 }
 
-func TestPlantBalanceTombstonesReleaseDelErrorSwallowed(t *testing.T) {
+func TestPlantBalanceDeleteMarkersReleaseDelErrorSwallowed(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
@@ -99,14 +99,14 @@ func TestPlantBalanceTombstonesReleaseDelErrorSwallowed(t *testing.T) {
 
 	uc, _, mockRedisRepo := setupDeleteAllBalancesUseCase(t)
 
-	balance := tombstoneTestBalance("@alice", "usd")
-	tomb := utils.BalanceInternalKey(organizationID, ledgerID, "@alice#usd") + tombstoneKeySuffix
+	balance := deleteMarkerTestBalance("@alice", "usd")
+	tomb := utils.BalanceInternalKey(organizationID, ledgerID, "@alice#usd") + deleteMarkerKeySuffix
 
 	mockRedisRepo.EXPECT().
-		SetNX(gomock.Any(), tomb, "1", time.Duration(balanceDeleteTombstoneTTLSeconds)).
+		SetNX(gomock.Any(), tomb, "1", time.Duration(balanceDeleteMarkerTTLSeconds)).
 		Return(true, nil)
 
-	release := uc.plantBalanceTombstones(ctx, organizationID, ledgerID, []*mmodel.Balance{balance})
+	release := uc.plantBalanceDeleteMarkers(ctx, organizationID, ledgerID, []*mmodel.Balance{balance})
 
 	// A failed Del during release is logged and swallowed; it must not panic or propagate.
 	mockRedisRepo.EXPECT().Del(gomock.Any(), tomb).Return(errors.New("redis down"))
@@ -114,7 +114,7 @@ func TestPlantBalanceTombstonesReleaseDelErrorSwallowed(t *testing.T) {
 	assert.NotPanics(t, func() { release() })
 }
 
-func TestPlantBalanceTombstonesSetNXErrorContinues(t *testing.T) {
+func TestPlantBalanceDeleteMarkersSetNXErrorContinues(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
@@ -123,22 +123,22 @@ func TestPlantBalanceTombstonesSetNXErrorContinues(t *testing.T) {
 
 	uc, _, mockRedisRepo := setupDeleteAllBalancesUseCase(t)
 
-	first := tombstoneTestBalance("@alice", "usd")
-	second := tombstoneTestBalance("@bob", "brl")
+	first := deleteMarkerTestBalance("@alice", "usd")
+	second := deleteMarkerTestBalance("@bob", "brl")
 	balances := []*mmodel.Balance{first, second}
 
-	firstTomb := utils.BalanceInternalKey(organizationID, ledgerID, "@alice#usd") + tombstoneKeySuffix
-	secondTomb := utils.BalanceInternalKey(organizationID, ledgerID, "@bob#brl") + tombstoneKeySuffix
+	firstTomb := utils.BalanceInternalKey(organizationID, ledgerID, "@alice#usd") + deleteMarkerKeySuffix
+	secondTomb := utils.BalanceInternalKey(organizationID, ledgerID, "@bob#brl") + deleteMarkerKeySuffix
 
 	// First SetNX fails: it is logged and skipped, not planted. Second succeeds.
 	mockRedisRepo.EXPECT().
-		SetNX(gomock.Any(), firstTomb, "1", time.Duration(balanceDeleteTombstoneTTLSeconds)).
+		SetNX(gomock.Any(), firstTomb, "1", time.Duration(balanceDeleteMarkerTTLSeconds)).
 		Return(false, errors.New("redis unavailable"))
 	mockRedisRepo.EXPECT().
-		SetNX(gomock.Any(), secondTomb, "1", time.Duration(balanceDeleteTombstoneTTLSeconds)).
+		SetNX(gomock.Any(), secondTomb, "1", time.Duration(balanceDeleteMarkerTTLSeconds)).
 		Return(true, nil)
 
-	release := uc.plantBalanceTombstones(ctx, organizationID, ledgerID, balances)
+	release := uc.plantBalanceDeleteMarkers(ctx, organizationID, ledgerID, balances)
 
 	// Release must Del ONLY the successfully planted key; the failed one is never Del'd.
 	mockRedisRepo.EXPECT().Del(gomock.Any(), firstTomb).Times(0)
@@ -147,7 +147,7 @@ func TestPlantBalanceTombstonesSetNXErrorContinues(t *testing.T) {
 	assert.NotPanics(t, func() { release() })
 }
 
-func TestPlantBalanceTombstonesTracksOnlyAcquiredKeys(t *testing.T) {
+func TestPlantBalanceDeleteMarkersTracksOnlyAcquiredKeys(t *testing.T) {
 	t.Parallel()
 
 	organizationID := uuid.New()
@@ -159,17 +159,17 @@ func TestPlantBalanceTombstonesTracksOnlyAcquiredKeys(t *testing.T) {
 		released    bool
 	}{
 		{
-			// (true, nil): this operation acquired the tombstone, so it owns and
+			// (true, nil): this operation acquired the delete marker, so it owns and
 			// releases the key on rollback.
-			name:        "acquired tombstone is released",
+			name:        "acquired delete marker is released",
 			setNXResult: true,
 			released:    true,
 		},
 		{
-			// (false, nil): a concurrent delete already owns the tombstone. The
+			// (false, nil): a concurrent delete already owns the delete marker. The
 			// guard is armed either way, so this operation proceeds, but it must
 			// NOT release a sibling's key.
-			name:        "already-owned tombstone is not released",
+			name:        "already-owned delete marker is not released",
 			setNXResult: false,
 			released:    false,
 		},
@@ -182,14 +182,14 @@ func TestPlantBalanceTombstonesTracksOnlyAcquiredKeys(t *testing.T) {
 			ctx := context.Background()
 			uc, _, mockRedisRepo := setupDeleteAllBalancesUseCase(t)
 
-			balance := tombstoneTestBalance("@alice", "usd")
-			tomb := utils.BalanceInternalKey(organizationID, ledgerID, "@alice#usd") + tombstoneKeySuffix
+			balance := deleteMarkerTestBalance("@alice", "usd")
+			tomb := utils.BalanceInternalKey(organizationID, ledgerID, "@alice#usd") + deleteMarkerKeySuffix
 
 			mockRedisRepo.EXPECT().
-				SetNX(gomock.Any(), tomb, tombstoneMarkerValue, time.Duration(balanceDeleteTombstoneTTLSeconds)).
+				SetNX(gomock.Any(), tomb, deleteMarkerValue, time.Duration(balanceDeleteMarkerTTLSeconds)).
 				Return(tt.setNXResult, nil)
 
-			release := uc.plantBalanceTombstones(ctx, organizationID, ledgerID, []*mmodel.Balance{balance})
+			release := uc.plantBalanceDeleteMarkers(ctx, organizationID, ledgerID, []*mmodel.Balance{balance})
 			assert.NotNil(t, release)
 
 			if tt.released {
@@ -215,8 +215,8 @@ func TestEvictBalanceCaches(t *testing.T) {
 		ctx := context.Background()
 		uc, _, mockRedisRepo := setupDeleteAllBalancesUseCase(t)
 
-		first := tombstoneTestBalance("@alice", "usd")
-		second := tombstoneTestBalance("@bob", "brl")
+		first := deleteMarkerTestBalance("@alice", "usd")
+		second := deleteMarkerTestBalance("@bob", "brl")
 
 		firstKey := utils.BalanceInternalKey(organizationID, ledgerID, "@alice#usd")
 		secondKey := utils.BalanceInternalKey(organizationID, ledgerID, "@bob#brl")
@@ -235,7 +235,7 @@ func TestEvictBalanceCaches(t *testing.T) {
 		ctx := context.Background()
 		uc, _, mockRedisRepo := setupDeleteAllBalancesUseCase(t)
 
-		balance := tombstoneTestBalance("@alice", "usd")
+		balance := deleteMarkerTestBalance("@alice", "usd")
 		key := utils.BalanceInternalKey(organizationID, ledgerID, "@alice#usd")
 
 		mockRedisRepo.EXPECT().Del(gomock.Any(), key).Return(errors.New("redis down"))

--- a/components/ledger/internal/services/command/balance_cache_delete_guard_test.go
+++ b/components/ledger/internal/services/command/balance_cache_delete_guard_test.go
@@ -44,13 +44,13 @@ func TestTombstoneKeyFor(t *testing.T) {
 
 			got := tombstoneKeyFor(organizationID, ledgerID, balance)
 
-			want := utils.BalanceInternalKey(organizationID, ledgerID, tt.alias+"#"+tt.key) + ":deleted"
+			want := utils.BalanceInternalKey(organizationID, ledgerID, tt.alias+"#"+tt.key) + tombstoneKeySuffix
 
 			assert.Equal(t, want, got)
 			// Tombstone MUST be a separate key from the balance cache key.
 			assert.NotEqual(t, utils.BalanceInternalKey(organizationID, ledgerID, tt.alias+"#"+tt.key), got)
 			assert.Contains(t, got, "balance:{transactions}:")
-			assert.Contains(t, got, tt.alias+"#"+tt.key+":deleted")
+			assert.Contains(t, got, tt.alias+"#"+tt.key+tombstoneKeySuffix)
 		})
 	}
 }
@@ -68,8 +68,8 @@ func TestPlantBalanceTombstones(t *testing.T) {
 	second := tombstoneTestBalance("@bob", "brl")
 	balances := []*mmodel.Balance{first, second}
 
-	firstTomb := utils.BalanceInternalKey(organizationID, ledgerID, "@alice#usd") + ":deleted"
-	secondTomb := utils.BalanceInternalKey(organizationID, ledgerID, "@bob#brl") + ":deleted"
+	firstTomb := utils.BalanceInternalKey(organizationID, ledgerID, "@alice#usd") + tombstoneKeySuffix
+	secondTomb := utils.BalanceInternalKey(organizationID, ledgerID, "@bob#brl") + tombstoneKeySuffix
 
 	// SetNX is called once per balance, with the correct tombstone key, a marker value,
 	// and the whole-second TTL constant (SetNX multiplies it by time.Second internally).
@@ -100,7 +100,7 @@ func TestPlantBalanceTombstonesReleaseDelErrorSwallowed(t *testing.T) {
 	uc, _, mockRedisRepo := setupDeleteAllBalancesUseCase(t)
 
 	balance := tombstoneTestBalance("@alice", "usd")
-	tomb := utils.BalanceInternalKey(organizationID, ledgerID, "@alice#usd") + ":deleted"
+	tomb := utils.BalanceInternalKey(organizationID, ledgerID, "@alice#usd") + tombstoneKeySuffix
 
 	mockRedisRepo.EXPECT().
 		SetNX(gomock.Any(), tomb, "1", time.Duration(balanceDeleteTombstoneTTLSeconds)).
@@ -127,8 +127,8 @@ func TestPlantBalanceTombstonesSetNXErrorContinues(t *testing.T) {
 	second := tombstoneTestBalance("@bob", "brl")
 	balances := []*mmodel.Balance{first, second}
 
-	firstTomb := utils.BalanceInternalKey(organizationID, ledgerID, "@alice#usd") + ":deleted"
-	secondTomb := utils.BalanceInternalKey(organizationID, ledgerID, "@bob#brl") + ":deleted"
+	firstTomb := utils.BalanceInternalKey(organizationID, ledgerID, "@alice#usd") + tombstoneKeySuffix
+	secondTomb := utils.BalanceInternalKey(organizationID, ledgerID, "@bob#brl") + tombstoneKeySuffix
 
 	// First SetNX fails: it is logged and skipped, not planted. Second succeeds.
 	mockRedisRepo.EXPECT().
@@ -145,6 +145,62 @@ func TestPlantBalanceTombstonesSetNXErrorContinues(t *testing.T) {
 	mockRedisRepo.EXPECT().Del(gomock.Any(), secondTomb).Return(nil)
 
 	assert.NotPanics(t, func() { release() })
+}
+
+func TestPlantBalanceTombstonesTracksOnlyAcquiredKeys(t *testing.T) {
+	t.Parallel()
+
+	organizationID := uuid.New()
+	ledgerID := uuid.New()
+
+	tests := []struct {
+		name        string
+		setNXResult bool
+		released    bool
+	}{
+		{
+			// (true, nil): this operation acquired the tombstone, so it owns and
+			// releases the key on rollback.
+			name:        "acquired tombstone is released",
+			setNXResult: true,
+			released:    true,
+		},
+		{
+			// (false, nil): a concurrent delete already owns the tombstone. The
+			// guard is armed either way, so this operation proceeds, but it must
+			// NOT release a sibling's key.
+			name:        "already-owned tombstone is not released",
+			setNXResult: false,
+			released:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := context.Background()
+			uc, _, mockRedisRepo := setupDeleteAllBalancesUseCase(t)
+
+			balance := tombstoneTestBalance("@alice", "usd")
+			tomb := utils.BalanceInternalKey(organizationID, ledgerID, "@alice#usd") + tombstoneKeySuffix
+
+			mockRedisRepo.EXPECT().
+				SetNX(gomock.Any(), tomb, tombstoneMarkerValue, time.Duration(balanceDeleteTombstoneTTLSeconds)).
+				Return(tt.setNXResult, nil)
+
+			release := uc.plantBalanceTombstones(ctx, organizationID, ledgerID, []*mmodel.Balance{balance})
+			assert.NotNil(t, release)
+
+			if tt.released {
+				mockRedisRepo.EXPECT().Del(gomock.Any(), tomb).Return(nil)
+			} else {
+				mockRedisRepo.EXPECT().Del(gomock.Any(), tomb).Times(0)
+			}
+
+			assert.NotPanics(t, func() { release() })
+		})
+	}
 }
 
 func TestEvictBalanceCaches(t *testing.T) {

--- a/components/ledger/internal/services/command/delete_all_balances_by_account_id.go
+++ b/components/ledger/internal/services/command/delete_all_balances_by_account_id.go
@@ -59,13 +59,15 @@ func (uc *UseCase) DeleteAllBalancesByAccountID(ctx context.Context, organizatio
 		}
 
 		if cacheBalance != nil {
-			err = pkg.ValidateBusinessError(constant.ErrBalancesCantBeDeleted, "ListBalanceByAccountIDAndKey")
+			if !cacheBalance.Available.IsZero() || !cacheBalance.OnHold.IsZero() {
+				err = pkg.ValidateBusinessError(constant.ErrBalancesCantBeDeleted, "ListBalanceByAccountIDAndKey")
 
-			libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Balance cannot be deleted because there is transactions happening.", err)
+				libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Balance cannot be deleted because it still has funds in it.", err)
 
-			logger.Log(ctx, libLog.LevelWarn, fmt.Sprintf("Balance cannot be deleted because there is transactions happening: %v", err))
+				logger.Log(ctx, libLog.LevelWarn, "Balance cannot be deleted because it still has funds in it", libLog.Err(err))
 
-			return err
+				return err
+			}
 		}
 
 		if !balance.Available.IsZero() || !balance.OnHold.IsZero() {

--- a/components/ledger/internal/services/command/delete_all_balances_by_account_id.go
+++ b/components/ledger/internal/services/command/delete_all_balances_by_account_id.go
@@ -61,13 +61,13 @@ func (uc *UseCase) DeleteAllBalancesByAccountID(ctx context.Context, organizatio
 	}()
 
 	for _, balance := range balances {
-		cacheBalance, err := uc.TransactionRedisRepo.ListBalanceByKey(ctx, organizationID, ledgerID, fmt.Sprintf("%s#%s", balance.Alias, balance.Key))
-		if err != nil && !errors.Is(err, redis.Nil) {
-			libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Failed to get balance by key on redis", err)
+		cacheBalance, cacheErr := uc.TransactionRedisRepo.ListBalanceByKey(ctx, organizationID, ledgerID, fmt.Sprintf("%s#%s", balance.Alias, balance.Key))
+		if cacheErr != nil && !errors.Is(cacheErr, redis.Nil) {
+			libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Failed to get balance by key on redis", cacheErr)
 
-			logger.Log(ctx, libLog.LevelError, fmt.Sprintf("Error getting balance by key on redis: %v", err))
+			logger.Log(ctx, libLog.LevelError, fmt.Sprintf("Error getting balance by key on redis: %v", cacheErr))
 
-			return err
+			return cacheErr
 		}
 
 		if cacheBalance != nil {

--- a/components/ledger/internal/services/command/delete_all_balances_by_account_id.go
+++ b/components/ledger/internal/services/command/delete_all_balances_by_account_id.go
@@ -48,11 +48,11 @@ func (uc *UseCase) DeleteAllBalancesByAccountID(ctx context.Context, organizatio
 		return nil
 	}
 
-	// Plant tombstones so the honored-lock pre-pass rejects concurrent mutations for the
+	// Plant delete markers so the honored-lock pre-pass rejects concurrent mutations for the
 	// whole delete. Release them only when the delete fails, so a rejected guard, permission
-	// flip, or soft-delete leaves the account usable; a successful delete lets the tombstone
+	// flip, or soft-delete leaves the account usable; a successful delete lets the delete marker
 	// expire by its own TTL.
-	release := uc.plantBalanceTombstones(ctx, organizationID, ledgerID, balances)
+	release := uc.plantBalanceDeleteMarkers(ctx, organizationID, ledgerID, balances)
 
 	defer func() {
 		if err != nil {

--- a/components/ledger/internal/services/command/delete_all_balances_by_account_id.go
+++ b/components/ledger/internal/services/command/delete_all_balances_by_account_id.go
@@ -23,7 +23,7 @@ import (
 )
 
 // DeleteAllBalancesByAccountID delete all balances by account id in the repository.
-func (uc *UseCase) DeleteAllBalancesByAccountID(ctx context.Context, organizationID, ledgerID, accountID uuid.UUID, requestID string) error {
+func (uc *UseCase) DeleteAllBalancesByAccountID(ctx context.Context, organizationID, ledgerID, accountID uuid.UUID, requestID string) (err error) {
 	logger, tracer, _, _ := libObs.NewTrackingFromContext(ctx)
 
 	ctx, span := tracer.Start(ctx, "exec.delete_all_balances_by_account_id")
@@ -47,6 +47,18 @@ func (uc *UseCase) DeleteAllBalancesByAccountID(ctx context.Context, organizatio
 	if len(balances) == 0 {
 		return nil
 	}
+
+	// Plant tombstones so the honored-lock pre-pass rejects concurrent mutations for the
+	// whole delete. Release them only when the delete fails, so a rejected guard, permission
+	// flip, or soft-delete leaves the account usable; a successful delete lets the tombstone
+	// expire by its own TTL.
+	release := uc.plantBalanceTombstones(ctx, organizationID, ledgerID, balances)
+
+	defer func() {
+		if err != nil {
+			release()
+		}
+	}()
 
 	for _, balance := range balances {
 		cacheBalance, err := uc.TransactionRedisRepo.ListBalanceByKey(ctx, organizationID, ledgerID, fmt.Sprintf("%s#%s", balance.Alias, balance.Key))
@@ -107,6 +119,10 @@ func (uc *UseCase) DeleteAllBalancesByAccountID(ctx context.Context, organizatio
 
 		return err
 	}
+
+	// Drop the stale cache entries now that the rows are soft-deleted. Non-fatal: a failed
+	// eviction is logged and never fails the already-committed delete.
+	uc.evictBalanceCaches(ctx, organizationID, ledgerID, balances)
 
 	return nil
 }

--- a/components/ledger/internal/services/command/delete_all_balances_by_account_id.go
+++ b/components/ledger/internal/services/command/delete_all_balances_by_account_id.go
@@ -50,16 +50,12 @@ func (uc *UseCase) DeleteAllBalancesByAccountID(ctx context.Context, organizatio
 
 	for _, balance := range balances {
 		cacheBalance, err := uc.TransactionRedisRepo.ListBalanceByKey(ctx, organizationID, ledgerID, fmt.Sprintf("%s#%s", balance.Alias, balance.Key))
-		if err != nil {
-			if errors.Is(err, redis.Nil) {
-				continue
-			} else {
-				libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Failed to get balance by key on redis", err)
+		if err != nil && !errors.Is(err, redis.Nil) {
+			libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Failed to get balance by key on redis", err)
 
-				logger.Log(ctx, libLog.LevelError, fmt.Sprintf("Error getting balance by key on redis: %v", err))
+			logger.Log(ctx, libLog.LevelError, fmt.Sprintf("Error getting balance by key on redis: %v", err))
 
-				return err
-			}
+			return err
 		}
 
 		if cacheBalance != nil {

--- a/components/ledger/internal/services/command/delete_all_balances_by_account_id_test.go
+++ b/components/ledger/internal/services/command/delete_all_balances_by_account_id_test.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"testing"
+	"time"
 
 	libCommons "github.com/LerianStudio/lib-commons/v5/commons"
 	"github.com/LerianStudio/midaz/v3/components/ledger/internal/adapters/postgres/balance"
@@ -22,6 +23,27 @@ import (
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 )
+
+// expectTombstonePlant expects the tombstone SetNX write that precedes the funds guard.
+func expectTombstonePlant(m *redis.MockRedisRepository, org, ledger uuid.UUID, b *mmodel.Balance) *gomock.Call {
+	return m.EXPECT().
+		SetNX(gomock.Any(), tombstoneKeyFor(org, ledger, b), tombstoneMarkerValue, time.Duration(balanceDeleteTombstoneTTLSeconds)).
+		Return(true, nil)
+}
+
+// expectCacheEvict expects the cache-key Del that follows a committed soft-delete.
+func expectCacheEvict(m *redis.MockRedisRepository, org, ledger uuid.UUID, b *mmodel.Balance) *gomock.Call {
+	return m.EXPECT().
+		Del(gomock.Any(), balanceCacheKeyFor(org, ledger, b)).
+		Return(nil)
+}
+
+// expectTombstoneRelease expects the tombstone-key Del that runs only when the delete fails.
+func expectTombstoneRelease(m *redis.MockRedisRepository, org, ledger uuid.UUID, b *mmodel.Balance) *gomock.Call {
+	return m.EXPECT().
+		Del(gomock.Any(), tombstoneKeyFor(org, ledger, b)).
+		Return(nil)
+}
 
 func TestDeleteAllBalancesByAccountID(t *testing.T) {
 	ctx := context.Background()
@@ -61,9 +83,11 @@ func TestDeleteAllBalancesByAccountID(t *testing.T) {
 		mockBalanceRepo.EXPECT().
 			ListByAccountID(gomock.Any(), organizationID, ledgerID, accountID).
 			Return([]*mmodel.Balance{balanceItem}, nil)
+		expectTombstonePlant(mockRedisRepo, organizationID, ledgerID, balanceItem)
 		mockRedisRepo.EXPECT().
 			ListBalanceByKey(gomock.Any(), organizationID, ledgerID, balanceRedisKey(balanceItem)).
 			Return(nil, expectedErr)
+		expectTombstoneRelease(mockRedisRepo, organizationID, ledgerID, balanceItem)
 
 		err := uc.DeleteAllBalancesByAccountID(ctx, organizationID, ledgerID, accountID, requestID.String())
 		assert.ErrorIs(t, err, expectedErr)
@@ -76,6 +100,7 @@ func TestDeleteAllBalancesByAccountID(t *testing.T) {
 		mockBalanceRepo.EXPECT().
 			ListByAccountID(gomock.Any(), organizationID, ledgerID, accountID).
 			Return([]*mmodel.Balance{balanceItem}, nil)
+		expectTombstonePlant(mockRedisRepo, organizationID, ledgerID, balanceItem)
 		mockRedisRepo.EXPECT().
 			ListBalanceByKey(gomock.Any(), organizationID, ledgerID, balanceRedisKey(balanceItem)).
 			Return(&mmodel.Balance{}, nil)
@@ -85,6 +110,7 @@ func TestDeleteAllBalancesByAccountID(t *testing.T) {
 		mockBalanceRepo.EXPECT().
 			DeleteAllByIDs(gomock.Any(), organizationID, ledgerID, gomock.Any()).
 			Return(nil)
+		expectCacheEvict(mockRedisRepo, organizationID, ledgerID, balanceItem)
 
 		err := uc.DeleteAllBalancesByAccountID(ctx, organizationID, ledgerID, accountID, requestID.String())
 		assert.NoError(t, err)
@@ -97,9 +123,11 @@ func TestDeleteAllBalancesByAccountID(t *testing.T) {
 		mockBalanceRepo.EXPECT().
 			ListByAccountID(gomock.Any(), organizationID, ledgerID, accountID).
 			Return([]*mmodel.Balance{balanceItem}, nil)
+		expectTombstonePlant(mockRedisRepo, organizationID, ledgerID, balanceItem)
 		mockRedisRepo.EXPECT().
 			ListBalanceByKey(gomock.Any(), organizationID, ledgerID, balanceRedisKey(balanceItem)).
 			Return(nil, nil)
+		expectTombstoneRelease(mockRedisRepo, organizationID, ledgerID, balanceItem)
 
 		err := uc.DeleteAllBalancesByAccountID(ctx, organizationID, ledgerID, accountID, requestID.String())
 
@@ -117,6 +145,7 @@ func TestDeleteAllBalancesByAccountID(t *testing.T) {
 		mockBalanceRepo.EXPECT().
 			ListByAccountID(gomock.Any(), organizationID, ledgerID, accountID).
 			Return([]*mmodel.Balance{balanceItem}, nil)
+		expectTombstonePlant(mockRedisRepo, organizationID, ledgerID, balanceItem)
 		mockRedisRepo.EXPECT().
 			ListBalanceByKey(gomock.Any(), organizationID, ledgerID, balanceRedisKey(balanceItem)).
 			Return(nil, nil)
@@ -140,6 +169,7 @@ func TestDeleteAllBalancesByAccountID(t *testing.T) {
 				return nil
 			})
 		gomock.InOrder(firstCall, secondCall)
+		expectTombstoneRelease(mockRedisRepo, organizationID, ledgerID, balanceItem)
 
 		err := uc.DeleteAllBalancesByAccountID(ctx, organizationID, ledgerID, accountID, requestID.String())
 		assert.ErrorIs(t, err, expectedErr)
@@ -153,6 +183,7 @@ func TestDeleteAllBalancesByAccountID(t *testing.T) {
 		mockBalanceRepo.EXPECT().
 			ListByAccountID(gomock.Any(), organizationID, ledgerID, accountID).
 			Return([]*mmodel.Balance{balanceItem}, nil)
+		expectTombstonePlant(mockRedisRepo, organizationID, ledgerID, balanceItem)
 		mockRedisRepo.EXPECT().
 			ListBalanceByKey(gomock.Any(), organizationID, ledgerID, balanceRedisKey(balanceItem)).
 			Return(nil, nil)
@@ -174,6 +205,7 @@ func TestDeleteAllBalancesByAccountID(t *testing.T) {
 				assert.True(t, *update.AllowSending)
 				return nil
 			})
+		expectTombstoneRelease(mockRedisRepo, organizationID, ledgerID, balanceItem)
 
 		err := uc.DeleteAllBalancesByAccountID(ctx, organizationID, ledgerID, accountID, requestID.String())
 		assert.ErrorIs(t, err, expectedErr)
@@ -187,6 +219,7 @@ func TestDeleteAllBalancesByAccountID(t *testing.T) {
 		mockBalanceRepo.EXPECT().
 			ListByAccountID(gomock.Any(), organizationID, ledgerID, accountID).
 			Return([]*mmodel.Balance{balanceItem}, nil)
+		expectTombstonePlant(mockRedisRepo, organizationID, ledgerID, balanceItem)
 		mockRedisRepo.EXPECT().
 			ListBalanceByKey(gomock.Any(), organizationID, ledgerID, balanceRedisKey(balanceItem)).
 			Return(nil, nil)
@@ -204,6 +237,113 @@ func TestDeleteAllBalancesByAccountID(t *testing.T) {
 				assert.Equal(t, expectedID, ids[0])
 				return nil
 			})
+		expectCacheEvict(mockRedisRepo, organizationID, ledgerID, balanceItem)
+
+		err := uc.DeleteAllBalancesByAccountID(ctx, organizationID, ledgerID, accountID, requestID.String())
+		assert.NoError(t, err)
+	})
+}
+
+// TestDeleteAllBalancesByAccountIDBlockThenEvict locks the block-then-evict ordering: the
+// tombstone is planted BEFORE the funds guard reads, the cache is evicted AFTER the soft
+// delete commits, the tombstone is released ONLY when the delete fails, and a failed eviction
+// never fails an already-committed delete.
+func TestDeleteAllBalancesByAccountIDBlockThenEvict(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	organizationID := uuid.New()
+	ledgerID := uuid.New()
+	accountID := uuid.New()
+	requestID := uuid.Must(libCommons.GenerateUUIDv7())
+
+	t.Run("plants tombstone before guard and evicts after delete", func(t *testing.T) {
+		t.Parallel()
+
+		uc, mockBalanceRepo, mockRedisRepo := setupDeleteAllBalancesUseCase(t)
+		balanceItem := newTestBalance(decimal.Zero, decimal.Zero)
+
+		mockBalanceRepo.EXPECT().
+			ListByAccountID(gomock.Any(), organizationID, ledgerID, accountID).
+			Return([]*mmodel.Balance{balanceItem}, nil)
+
+		plant := mockRedisRepo.EXPECT().
+			SetNX(gomock.Any(), tombstoneKeyFor(organizationID, ledgerID, balanceItem), tombstoneMarkerValue, time.Duration(balanceDeleteTombstoneTTLSeconds)).
+			Return(true, nil)
+		guard := mockRedisRepo.EXPECT().
+			ListBalanceByKey(gomock.Any(), organizationID, ledgerID, balanceRedisKey(balanceItem)).
+			Return(&mmodel.Balance{}, nil)
+		mockBalanceRepo.EXPECT().
+			UpdateAllByAccountID(gomock.Any(), organizationID, ledgerID, accountID, gomock.Any()).
+			Return(nil)
+		del := mockBalanceRepo.EXPECT().
+			DeleteAllByIDs(gomock.Any(), organizationID, ledgerID, gomock.Any()).
+			Return(nil)
+		evict := mockRedisRepo.EXPECT().
+			Del(gomock.Any(), balanceCacheKeyFor(organizationID, ledgerID, balanceItem)).
+			Return(nil)
+
+		// tombstone-before-guard and evict-after-soft-delete.
+		gomock.InOrder(plant, guard)
+		gomock.InOrder(del, evict)
+
+		err := uc.DeleteAllBalancesByAccountID(ctx, organizationID, ledgerID, accountID, requestID.String())
+		assert.NoError(t, err)
+		// On success the tombstone release must NOT run: no Del of the tombstone key is set up,
+		// so the strict controller would fail if the release closure fired.
+	})
+
+	t.Run("delete error releases tombstone and skips evict", func(t *testing.T) {
+		t.Parallel()
+
+		uc, mockBalanceRepo, mockRedisRepo := setupDeleteAllBalancesUseCase(t)
+		balanceItem := newTestBalance(decimal.Zero, decimal.Zero)
+		expectedErr := errors.New("delete balances error")
+
+		mockBalanceRepo.EXPECT().
+			ListByAccountID(gomock.Any(), organizationID, ledgerID, accountID).
+			Return([]*mmodel.Balance{balanceItem}, nil)
+		expectTombstonePlant(mockRedisRepo, organizationID, ledgerID, balanceItem)
+		mockRedisRepo.EXPECT().
+			ListBalanceByKey(gomock.Any(), organizationID, ledgerID, balanceRedisKey(balanceItem)).
+			Return(&mmodel.Balance{}, nil)
+		// Flip to false before delete, then rollback to true after delete fails.
+		mockBalanceRepo.EXPECT().
+			UpdateAllByAccountID(gomock.Any(), organizationID, ledgerID, accountID, gomock.Any()).
+			Return(nil).
+			Times(2)
+		mockBalanceRepo.EXPECT().
+			DeleteAllByIDs(gomock.Any(), organizationID, ledgerID, gomock.Any()).
+			Return(expectedErr)
+		// Release Dels the tombstone key; the cache key is never evicted on the error path.
+		expectTombstoneRelease(mockRedisRepo, organizationID, ledgerID, balanceItem)
+
+		err := uc.DeleteAllBalancesByAccountID(ctx, organizationID, ledgerID, accountID, requestID.String())
+		assert.ErrorIs(t, err, expectedErr)
+	})
+
+	t.Run("evict del failure on success is non-fatal", func(t *testing.T) {
+		t.Parallel()
+
+		uc, mockBalanceRepo, mockRedisRepo := setupDeleteAllBalancesUseCase(t)
+		balanceItem := newTestBalance(decimal.Zero, decimal.Zero)
+
+		mockBalanceRepo.EXPECT().
+			ListByAccountID(gomock.Any(), organizationID, ledgerID, accountID).
+			Return([]*mmodel.Balance{balanceItem}, nil)
+		expectTombstonePlant(mockRedisRepo, organizationID, ledgerID, balanceItem)
+		mockRedisRepo.EXPECT().
+			ListBalanceByKey(gomock.Any(), organizationID, ledgerID, balanceRedisKey(balanceItem)).
+			Return(&mmodel.Balance{}, nil)
+		mockBalanceRepo.EXPECT().
+			UpdateAllByAccountID(gomock.Any(), organizationID, ledgerID, accountID, gomock.Any()).
+			Return(nil)
+		mockBalanceRepo.EXPECT().
+			DeleteAllByIDs(gomock.Any(), organizationID, ledgerID, gomock.Any()).
+			Return(nil)
+		mockRedisRepo.EXPECT().
+			Del(gomock.Any(), balanceCacheKeyFor(organizationID, ledgerID, balanceItem)).
+			Return(errors.New("evict failed"))
 
 		err := uc.DeleteAllBalancesByAccountID(ctx, organizationID, ledgerID, accountID, requestID.String())
 		assert.NoError(t, err)
@@ -290,6 +430,7 @@ func TestDeleteAllBalancesByAccountIDCacheMissFundsGuard(t *testing.T) {
 			mockBalanceRepo.EXPECT().
 				ListByAccountID(gomock.Any(), organizationID, ledgerID, accountID).
 				Return([]*mmodel.Balance{tt.balance}, nil)
+			expectTombstonePlant(mockRedisRepo, organizationID, ledgerID, tt.balance)
 			mockRedisRepo.EXPECT().
 				ListBalanceByKey(gomock.Any(), organizationID, ledgerID, balanceRedisKey(tt.balance)).
 				Return(tt.cacheBalance, tt.cacheErr)
@@ -301,10 +442,12 @@ func TestDeleteAllBalancesByAccountIDCacheMissFundsGuard(t *testing.T) {
 				mockBalanceRepo.EXPECT().
 					DeleteAllByIDs(gomock.Any(), organizationID, ledgerID, gomock.Any()).
 					Return(nil)
+				expectCacheEvict(mockRedisRepo, organizationID, ledgerID, tt.balance)
 			} else {
 				mockBalanceRepo.EXPECT().
 					DeleteAllByIDs(gomock.Any(), organizationID, ledgerID, gomock.Any()).
 					Times(0)
+				expectTombstoneRelease(mockRedisRepo, organizationID, ledgerID, tt.balance)
 			}
 
 			err := uc.DeleteAllBalancesByAccountID(ctx, organizationID, ledgerID, accountID, requestID.String())
@@ -336,6 +479,10 @@ func TestDeleteAllBalancesByAccountIDCacheMissFundsGuard(t *testing.T) {
 			ListByAccountID(gomock.Any(), organizationID, ledgerID, accountID).
 			Return([]*mmodel.Balance{zeroFundsBalance, onHoldFundsBalance}, nil)
 
+		// Both tombstones are planted up front, before the guard loop runs.
+		expectTombstonePlant(mockRedisRepo, organizationID, ledgerID, zeroFundsBalance)
+		expectTombstonePlant(mockRedisRepo, organizationID, ledgerID, onHoldFundsBalance)
+
 		firstLookup := mockRedisRepo.EXPECT().
 			ListBalanceByKey(gomock.Any(), organizationID, ledgerID, balanceRedisKey(zeroFundsBalance)).
 			Return(nil, goredis.Nil)
@@ -347,6 +494,10 @@ func TestDeleteAllBalancesByAccountIDCacheMissFundsGuard(t *testing.T) {
 		mockBalanceRepo.EXPECT().
 			DeleteAllByIDs(gomock.Any(), organizationID, ledgerID, gomock.Any()).
 			Times(0)
+
+		// On rejection both planted tombstones are released.
+		expectTombstoneRelease(mockRedisRepo, organizationID, ledgerID, zeroFundsBalance)
+		expectTombstoneRelease(mockRedisRepo, organizationID, ledgerID, onHoldFundsBalance)
 
 		err := uc.DeleteAllBalancesByAccountID(ctx, organizationID, ledgerID, accountID, requestID.String())
 

--- a/components/ledger/internal/services/command/delete_all_balances_by_account_id_test.go
+++ b/components/ledger/internal/services/command/delete_all_balances_by_account_id_test.go
@@ -212,6 +212,8 @@ func TestDeleteAllBalancesByAccountID(t *testing.T) {
 // cache miss: a balance absent from Redis (TTL expired) must still be checked against the
 // authoritative Postgres row so accounts holding funds are never soft-deleted.
 func TestDeleteAllBalancesByAccountIDCacheMissFundsGuard(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 	organizationID := uuid.New()
 	ledgerID := uuid.New()
@@ -257,6 +259,8 @@ func TestDeleteAllBalancesByAccountIDCacheMissFundsGuard(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			uc, mockBalanceRepo, mockRedisRepo := setupDeleteAllBalancesUseCase(t)
 
 			mockBalanceRepo.EXPECT().
@@ -292,6 +296,41 @@ func TestDeleteAllBalancesByAccountIDCacheMissFundsGuard(t *testing.T) {
 			assert.Equal(t, constant.ErrBalancesCantBeDeleted.Error(), validationErr.Code)
 		})
 	}
+
+	// Guards the loop across MULTIPLE balances: the first balance has zero funds on a cache
+	// miss (loop proceeds), the second holds on_hold funds on a cache miss (loop rejects).
+	// Deletion must be refused and DeleteAllByIDs must never run.
+	t.Run("multiple balances reject when a later balance still holds funds", func(t *testing.T) {
+		t.Parallel()
+
+		uc, mockBalanceRepo, mockRedisRepo := setupDeleteAllBalancesUseCase(t)
+
+		zeroFundsBalance := newTestBalance(decimal.Zero, decimal.Zero)
+		onHoldFundsBalance := newTestBalance(decimal.Zero, decimal.NewFromInt(5))
+
+		mockBalanceRepo.EXPECT().
+			ListByAccountID(gomock.Any(), organizationID, ledgerID, accountID).
+			Return([]*mmodel.Balance{zeroFundsBalance, onHoldFundsBalance}, nil)
+
+		firstLookup := mockRedisRepo.EXPECT().
+			ListBalanceByKey(gomock.Any(), organizationID, ledgerID, balanceRedisKey(zeroFundsBalance)).
+			Return(nil, goredis.Nil)
+		secondLookup := mockRedisRepo.EXPECT().
+			ListBalanceByKey(gomock.Any(), organizationID, ledgerID, balanceRedisKey(onHoldFundsBalance)).
+			Return(nil, goredis.Nil)
+		gomock.InOrder(firstLookup, secondLookup)
+
+		mockBalanceRepo.EXPECT().
+			DeleteAllByIDs(gomock.Any(), organizationID, ledgerID, gomock.Any()).
+			Times(0)
+
+		err := uc.DeleteAllBalancesByAccountID(ctx, organizationID, ledgerID, accountID, requestID.String())
+
+		var validationErr midazpkg.ValidationError
+		assert.Error(t, err)
+		assert.True(t, errors.As(err, &validationErr))
+		assert.Equal(t, constant.ErrBalancesCantBeDeleted.Error(), validationErr.Code)
+	})
 }
 
 func setupDeleteAllBalancesUseCase(t *testing.T) (*UseCase, *balance.MockRepository, *redis.MockRedisRepository) {

--- a/components/ledger/internal/services/command/delete_all_balances_by_account_id_test.go
+++ b/components/ledger/internal/services/command/delete_all_balances_by_account_id_test.go
@@ -24,10 +24,10 @@ import (
 	"go.uber.org/mock/gomock"
 )
 
-// expectTombstonePlant expects the tombstone SetNX write that precedes the funds guard.
-func expectTombstonePlant(m *redis.MockRedisRepository, org, ledger uuid.UUID, b *mmodel.Balance) *gomock.Call {
+// expectDeleteMarkerPlant expects the delete marker SetNX write that precedes the funds guard.
+func expectDeleteMarkerPlant(m *redis.MockRedisRepository, org, ledger uuid.UUID, b *mmodel.Balance) *gomock.Call {
 	return m.EXPECT().
-		SetNX(gomock.Any(), tombstoneKeyFor(org, ledger, b), tombstoneMarkerValue, time.Duration(balanceDeleteTombstoneTTLSeconds)).
+		SetNX(gomock.Any(), deleteMarkerKeyFor(org, ledger, b), deleteMarkerValue, time.Duration(balanceDeleteMarkerTTLSeconds)).
 		Return(true, nil)
 }
 
@@ -38,10 +38,10 @@ func expectCacheEvict(m *redis.MockRedisRepository, org, ledger uuid.UUID, b *mm
 		Return(nil)
 }
 
-// expectTombstoneRelease expects the tombstone-key Del that runs only when the delete fails.
-func expectTombstoneRelease(m *redis.MockRedisRepository, org, ledger uuid.UUID, b *mmodel.Balance) *gomock.Call {
+// expectDeleteMarkerRelease expects the delete marker-key Del that runs only when the delete fails.
+func expectDeleteMarkerRelease(m *redis.MockRedisRepository, org, ledger uuid.UUID, b *mmodel.Balance) *gomock.Call {
 	return m.EXPECT().
-		Del(gomock.Any(), tombstoneKeyFor(org, ledger, b)).
+		Del(gomock.Any(), deleteMarkerKeyFor(org, ledger, b)).
 		Return(nil)
 }
 
@@ -83,11 +83,11 @@ func TestDeleteAllBalancesByAccountID(t *testing.T) {
 		mockBalanceRepo.EXPECT().
 			ListByAccountID(gomock.Any(), organizationID, ledgerID, accountID).
 			Return([]*mmodel.Balance{balanceItem}, nil)
-		expectTombstonePlant(mockRedisRepo, organizationID, ledgerID, balanceItem)
+		expectDeleteMarkerPlant(mockRedisRepo, organizationID, ledgerID, balanceItem)
 		mockRedisRepo.EXPECT().
 			ListBalanceByKey(gomock.Any(), organizationID, ledgerID, balanceRedisKey(balanceItem)).
 			Return(nil, expectedErr)
-		expectTombstoneRelease(mockRedisRepo, organizationID, ledgerID, balanceItem)
+		expectDeleteMarkerRelease(mockRedisRepo, organizationID, ledgerID, balanceItem)
 
 		err := uc.DeleteAllBalancesByAccountID(ctx, organizationID, ledgerID, accountID, requestID.String())
 		assert.ErrorIs(t, err, expectedErr)
@@ -100,7 +100,7 @@ func TestDeleteAllBalancesByAccountID(t *testing.T) {
 		mockBalanceRepo.EXPECT().
 			ListByAccountID(gomock.Any(), organizationID, ledgerID, accountID).
 			Return([]*mmodel.Balance{balanceItem}, nil)
-		expectTombstonePlant(mockRedisRepo, organizationID, ledgerID, balanceItem)
+		expectDeleteMarkerPlant(mockRedisRepo, organizationID, ledgerID, balanceItem)
 		mockRedisRepo.EXPECT().
 			ListBalanceByKey(gomock.Any(), organizationID, ledgerID, balanceRedisKey(balanceItem)).
 			Return(&mmodel.Balance{}, nil)
@@ -123,11 +123,11 @@ func TestDeleteAllBalancesByAccountID(t *testing.T) {
 		mockBalanceRepo.EXPECT().
 			ListByAccountID(gomock.Any(), organizationID, ledgerID, accountID).
 			Return([]*mmodel.Balance{balanceItem}, nil)
-		expectTombstonePlant(mockRedisRepo, organizationID, ledgerID, balanceItem)
+		expectDeleteMarkerPlant(mockRedisRepo, organizationID, ledgerID, balanceItem)
 		mockRedisRepo.EXPECT().
 			ListBalanceByKey(gomock.Any(), organizationID, ledgerID, balanceRedisKey(balanceItem)).
 			Return(nil, nil)
-		expectTombstoneRelease(mockRedisRepo, organizationID, ledgerID, balanceItem)
+		expectDeleteMarkerRelease(mockRedisRepo, organizationID, ledgerID, balanceItem)
 
 		err := uc.DeleteAllBalancesByAccountID(ctx, organizationID, ledgerID, accountID, requestID.String())
 
@@ -145,7 +145,7 @@ func TestDeleteAllBalancesByAccountID(t *testing.T) {
 		mockBalanceRepo.EXPECT().
 			ListByAccountID(gomock.Any(), organizationID, ledgerID, accountID).
 			Return([]*mmodel.Balance{balanceItem}, nil)
-		expectTombstonePlant(mockRedisRepo, organizationID, ledgerID, balanceItem)
+		expectDeleteMarkerPlant(mockRedisRepo, organizationID, ledgerID, balanceItem)
 		mockRedisRepo.EXPECT().
 			ListBalanceByKey(gomock.Any(), organizationID, ledgerID, balanceRedisKey(balanceItem)).
 			Return(nil, nil)
@@ -169,7 +169,7 @@ func TestDeleteAllBalancesByAccountID(t *testing.T) {
 				return nil
 			})
 		gomock.InOrder(firstCall, secondCall)
-		expectTombstoneRelease(mockRedisRepo, organizationID, ledgerID, balanceItem)
+		expectDeleteMarkerRelease(mockRedisRepo, organizationID, ledgerID, balanceItem)
 
 		err := uc.DeleteAllBalancesByAccountID(ctx, organizationID, ledgerID, accountID, requestID.String())
 		assert.ErrorIs(t, err, expectedErr)
@@ -183,7 +183,7 @@ func TestDeleteAllBalancesByAccountID(t *testing.T) {
 		mockBalanceRepo.EXPECT().
 			ListByAccountID(gomock.Any(), organizationID, ledgerID, accountID).
 			Return([]*mmodel.Balance{balanceItem}, nil)
-		expectTombstonePlant(mockRedisRepo, organizationID, ledgerID, balanceItem)
+		expectDeleteMarkerPlant(mockRedisRepo, organizationID, ledgerID, balanceItem)
 		mockRedisRepo.EXPECT().
 			ListBalanceByKey(gomock.Any(), organizationID, ledgerID, balanceRedisKey(balanceItem)).
 			Return(nil, nil)
@@ -205,7 +205,7 @@ func TestDeleteAllBalancesByAccountID(t *testing.T) {
 				assert.True(t, *update.AllowSending)
 				return nil
 			})
-		expectTombstoneRelease(mockRedisRepo, organizationID, ledgerID, balanceItem)
+		expectDeleteMarkerRelease(mockRedisRepo, organizationID, ledgerID, balanceItem)
 
 		err := uc.DeleteAllBalancesByAccountID(ctx, organizationID, ledgerID, accountID, requestID.String())
 		assert.ErrorIs(t, err, expectedErr)
@@ -219,7 +219,7 @@ func TestDeleteAllBalancesByAccountID(t *testing.T) {
 		mockBalanceRepo.EXPECT().
 			ListByAccountID(gomock.Any(), organizationID, ledgerID, accountID).
 			Return([]*mmodel.Balance{balanceItem}, nil)
-		expectTombstonePlant(mockRedisRepo, organizationID, ledgerID, balanceItem)
+		expectDeleteMarkerPlant(mockRedisRepo, organizationID, ledgerID, balanceItem)
 		mockRedisRepo.EXPECT().
 			ListBalanceByKey(gomock.Any(), organizationID, ledgerID, balanceRedisKey(balanceItem)).
 			Return(nil, nil)
@@ -245,8 +245,8 @@ func TestDeleteAllBalancesByAccountID(t *testing.T) {
 }
 
 // TestDeleteAllBalancesByAccountIDBlockThenEvict locks the block-then-evict ordering: the
-// tombstone is planted BEFORE the funds guard reads, the cache is evicted AFTER the soft
-// delete commits, the tombstone is released ONLY when the delete fails, and a failed eviction
+// delete marker is planted BEFORE the funds guard reads, the cache is evicted AFTER the soft
+// delete commits, the delete marker is released ONLY when the delete fails, and a failed eviction
 // never fails an already-committed delete.
 func TestDeleteAllBalancesByAccountIDBlockThenEvict(t *testing.T) {
 	t.Parallel()
@@ -257,7 +257,7 @@ func TestDeleteAllBalancesByAccountIDBlockThenEvict(t *testing.T) {
 	accountID := uuid.New()
 	requestID := uuid.Must(libCommons.GenerateUUIDv7())
 
-	t.Run("plants tombstone before guard and evicts after delete", func(t *testing.T) {
+	t.Run("plants delete marker before guard and evicts after delete", func(t *testing.T) {
 		t.Parallel()
 
 		uc, mockBalanceRepo, mockRedisRepo := setupDeleteAllBalancesUseCase(t)
@@ -268,7 +268,7 @@ func TestDeleteAllBalancesByAccountIDBlockThenEvict(t *testing.T) {
 			Return([]*mmodel.Balance{balanceItem}, nil)
 
 		plant := mockRedisRepo.EXPECT().
-			SetNX(gomock.Any(), tombstoneKeyFor(organizationID, ledgerID, balanceItem), tombstoneMarkerValue, time.Duration(balanceDeleteTombstoneTTLSeconds)).
+			SetNX(gomock.Any(), deleteMarkerKeyFor(organizationID, ledgerID, balanceItem), deleteMarkerValue, time.Duration(balanceDeleteMarkerTTLSeconds)).
 			Return(true, nil)
 		guard := mockRedisRepo.EXPECT().
 			ListBalanceByKey(gomock.Any(), organizationID, ledgerID, balanceRedisKey(balanceItem)).
@@ -283,17 +283,17 @@ func TestDeleteAllBalancesByAccountIDBlockThenEvict(t *testing.T) {
 			Del(gomock.Any(), balanceCacheKeyFor(organizationID, ledgerID, balanceItem)).
 			Return(nil)
 
-		// tombstone-before-guard and evict-after-soft-delete.
+		// delete marker-before-guard and evict-after-soft-delete.
 		gomock.InOrder(plant, guard)
 		gomock.InOrder(del, evict)
 
 		err := uc.DeleteAllBalancesByAccountID(ctx, organizationID, ledgerID, accountID, requestID.String())
 		assert.NoError(t, err)
-		// On success the tombstone release must NOT run: no Del of the tombstone key is set up,
+		// On success the delete marker release must NOT run: no Del of the delete marker key is set up,
 		// so the strict controller would fail if the release closure fired.
 	})
 
-	t.Run("delete error releases tombstone and skips evict", func(t *testing.T) {
+	t.Run("delete error releases delete marker and skips evict", func(t *testing.T) {
 		t.Parallel()
 
 		uc, mockBalanceRepo, mockRedisRepo := setupDeleteAllBalancesUseCase(t)
@@ -303,7 +303,7 @@ func TestDeleteAllBalancesByAccountIDBlockThenEvict(t *testing.T) {
 		mockBalanceRepo.EXPECT().
 			ListByAccountID(gomock.Any(), organizationID, ledgerID, accountID).
 			Return([]*mmodel.Balance{balanceItem}, nil)
-		expectTombstonePlant(mockRedisRepo, organizationID, ledgerID, balanceItem)
+		expectDeleteMarkerPlant(mockRedisRepo, organizationID, ledgerID, balanceItem)
 		mockRedisRepo.EXPECT().
 			ListBalanceByKey(gomock.Any(), organizationID, ledgerID, balanceRedisKey(balanceItem)).
 			Return(&mmodel.Balance{}, nil)
@@ -315,8 +315,8 @@ func TestDeleteAllBalancesByAccountIDBlockThenEvict(t *testing.T) {
 		mockBalanceRepo.EXPECT().
 			DeleteAllByIDs(gomock.Any(), organizationID, ledgerID, gomock.Any()).
 			Return(expectedErr)
-		// Release Dels the tombstone key; the cache key is never evicted on the error path.
-		expectTombstoneRelease(mockRedisRepo, organizationID, ledgerID, balanceItem)
+		// Release Dels the delete marker key; the cache key is never evicted on the error path.
+		expectDeleteMarkerRelease(mockRedisRepo, organizationID, ledgerID, balanceItem)
 
 		err := uc.DeleteAllBalancesByAccountID(ctx, organizationID, ledgerID, accountID, requestID.String())
 		assert.ErrorIs(t, err, expectedErr)
@@ -331,7 +331,7 @@ func TestDeleteAllBalancesByAccountIDBlockThenEvict(t *testing.T) {
 		mockBalanceRepo.EXPECT().
 			ListByAccountID(gomock.Any(), organizationID, ledgerID, accountID).
 			Return([]*mmodel.Balance{balanceItem}, nil)
-		expectTombstonePlant(mockRedisRepo, organizationID, ledgerID, balanceItem)
+		expectDeleteMarkerPlant(mockRedisRepo, organizationID, ledgerID, balanceItem)
 		mockRedisRepo.EXPECT().
 			ListBalanceByKey(gomock.Any(), organizationID, ledgerID, balanceRedisKey(balanceItem)).
 			Return(&mmodel.Balance{}, nil)
@@ -430,7 +430,7 @@ func TestDeleteAllBalancesByAccountIDCacheMissFundsGuard(t *testing.T) {
 			mockBalanceRepo.EXPECT().
 				ListByAccountID(gomock.Any(), organizationID, ledgerID, accountID).
 				Return([]*mmodel.Balance{tt.balance}, nil)
-			expectTombstonePlant(mockRedisRepo, organizationID, ledgerID, tt.balance)
+			expectDeleteMarkerPlant(mockRedisRepo, organizationID, ledgerID, tt.balance)
 			mockRedisRepo.EXPECT().
 				ListBalanceByKey(gomock.Any(), organizationID, ledgerID, balanceRedisKey(tt.balance)).
 				Return(tt.cacheBalance, tt.cacheErr)
@@ -447,7 +447,7 @@ func TestDeleteAllBalancesByAccountIDCacheMissFundsGuard(t *testing.T) {
 				mockBalanceRepo.EXPECT().
 					DeleteAllByIDs(gomock.Any(), organizationID, ledgerID, gomock.Any()).
 					Times(0)
-				expectTombstoneRelease(mockRedisRepo, organizationID, ledgerID, tt.balance)
+				expectDeleteMarkerRelease(mockRedisRepo, organizationID, ledgerID, tt.balance)
 			}
 
 			err := uc.DeleteAllBalancesByAccountID(ctx, organizationID, ledgerID, accountID, requestID.String())
@@ -479,9 +479,9 @@ func TestDeleteAllBalancesByAccountIDCacheMissFundsGuard(t *testing.T) {
 			ListByAccountID(gomock.Any(), organizationID, ledgerID, accountID).
 			Return([]*mmodel.Balance{zeroFundsBalance, onHoldFundsBalance}, nil)
 
-		// Both tombstones are planted up front, before the guard loop runs.
-		expectTombstonePlant(mockRedisRepo, organizationID, ledgerID, zeroFundsBalance)
-		expectTombstonePlant(mockRedisRepo, organizationID, ledgerID, onHoldFundsBalance)
+		// Both delete markers are planted up front, before the guard loop runs.
+		expectDeleteMarkerPlant(mockRedisRepo, organizationID, ledgerID, zeroFundsBalance)
+		expectDeleteMarkerPlant(mockRedisRepo, organizationID, ledgerID, onHoldFundsBalance)
 
 		firstLookup := mockRedisRepo.EXPECT().
 			ListBalanceByKey(gomock.Any(), organizationID, ledgerID, balanceRedisKey(zeroFundsBalance)).
@@ -495,9 +495,9 @@ func TestDeleteAllBalancesByAccountIDCacheMissFundsGuard(t *testing.T) {
 			DeleteAllByIDs(gomock.Any(), organizationID, ledgerID, gomock.Any()).
 			Times(0)
 
-		// On rejection both planted tombstones are released.
-		expectTombstoneRelease(mockRedisRepo, organizationID, ledgerID, zeroFundsBalance)
-		expectTombstoneRelease(mockRedisRepo, organizationID, ledgerID, onHoldFundsBalance)
+		// On rejection both planted delete markers are released.
+		expectDeleteMarkerRelease(mockRedisRepo, organizationID, ledgerID, zeroFundsBalance)
+		expectDeleteMarkerRelease(mockRedisRepo, organizationID, ledgerID, onHoldFundsBalance)
 
 		err := uc.DeleteAllBalancesByAccountID(ctx, organizationID, ledgerID, accountID, requestID.String())
 

--- a/components/ledger/internal/services/command/delete_all_balances_by_account_id_test.go
+++ b/components/ledger/internal/services/command/delete_all_balances_by_account_id_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/LerianStudio/midaz/v3/pkg/constant"
 	"github.com/LerianStudio/midaz/v3/pkg/mmodel"
 	"github.com/google/uuid"
+	goredis "github.com/redis/go-redis/v9"
 	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
@@ -205,6 +206,92 @@ func TestDeleteAllBalancesByAccountID(t *testing.T) {
 		err := uc.DeleteAllBalancesByAccountID(ctx, organizationID, ledgerID, accountID, requestID.String())
 		assert.NoError(t, err)
 	})
+}
+
+// TestDeleteAllBalancesByAccountIDCacheMissFundsGuard covers the funds guard on a Redis
+// cache miss: a balance absent from Redis (TTL expired) must still be checked against the
+// authoritative Postgres row so accounts holding funds are never soft-deleted.
+func TestDeleteAllBalancesByAccountIDCacheMissFundsGuard(t *testing.T) {
+	ctx := context.Background()
+	organizationID := uuid.New()
+	ledgerID := uuid.New()
+	accountID := uuid.New()
+	requestID := uuid.Must(libCommons.GenerateUUIDv7())
+
+	tests := []struct {
+		name          string
+		balance       *mmodel.Balance
+		cacheBalance  *mmodel.Balance
+		cacheErr      error
+		expectProceed bool
+	}{
+		{
+			name:          "on_hold funds with cache miss prevents deletion",
+			balance:       newTestBalance(decimal.Zero, decimal.NewFromInt(5)),
+			cacheBalance:  nil,
+			cacheErr:      goredis.Nil,
+			expectProceed: false,
+		},
+		{
+			name:          "available funds with cache miss prevents deletion",
+			balance:       newTestBalance(decimal.NewFromInt(7), decimal.Zero),
+			cacheBalance:  nil,
+			cacheErr:      goredis.Nil,
+			expectProceed: false,
+		},
+		{
+			name:          "cached balance still prevents deletion",
+			balance:       newTestBalance(decimal.Zero, decimal.Zero),
+			cacheBalance:  &mmodel.Balance{},
+			cacheErr:      nil,
+			expectProceed: false,
+		},
+		{
+			name:          "zero funds with cache miss proceeds to deletion",
+			balance:       newTestBalance(decimal.Zero, decimal.Zero),
+			cacheBalance:  nil,
+			cacheErr:      goredis.Nil,
+			expectProceed: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			uc, mockBalanceRepo, mockRedisRepo := setupDeleteAllBalancesUseCase(t)
+
+			mockBalanceRepo.EXPECT().
+				ListByAccountID(gomock.Any(), organizationID, ledgerID, accountID).
+				Return([]*mmodel.Balance{tt.balance}, nil)
+			mockRedisRepo.EXPECT().
+				ListBalanceByKey(gomock.Any(), organizationID, ledgerID, balanceRedisKey(tt.balance)).
+				Return(tt.cacheBalance, tt.cacheErr)
+
+			if tt.expectProceed {
+				mockBalanceRepo.EXPECT().
+					UpdateAllByAccountID(gomock.Any(), organizationID, ledgerID, accountID, gomock.Any()).
+					Return(nil)
+				mockBalanceRepo.EXPECT().
+					DeleteAllByIDs(gomock.Any(), organizationID, ledgerID, gomock.Any()).
+					Return(nil)
+			} else {
+				mockBalanceRepo.EXPECT().
+					DeleteAllByIDs(gomock.Any(), organizationID, ledgerID, gomock.Any()).
+					Times(0)
+			}
+
+			err := uc.DeleteAllBalancesByAccountID(ctx, organizationID, ledgerID, accountID, requestID.String())
+
+			if tt.expectProceed {
+				assert.NoError(t, err)
+				return
+			}
+
+			var validationErr midazpkg.ValidationError
+			assert.Error(t, err)
+			assert.True(t, errors.As(err, &validationErr))
+			assert.Equal(t, constant.ErrBalancesCantBeDeleted.Error(), validationErr.Code)
+		})
+	}
 }
 
 func setupDeleteAllBalancesUseCase(t *testing.T) (*UseCase, *balance.MockRepository, *redis.MockRedisRepository) {

--- a/components/ledger/internal/services/command/delete_all_balances_by_account_id_test.go
+++ b/components/ledger/internal/services/command/delete_all_balances_by_account_id_test.go
@@ -69,9 +69,9 @@ func TestDeleteAllBalancesByAccountID(t *testing.T) {
 		assert.ErrorIs(t, err, expectedErr)
 	})
 
-	t.Run("redis balance present prevents deletion", func(t *testing.T) {
+	t.Run("redis zero-funds balance present proceeds to deletion", func(t *testing.T) {
 		uc, mockBalanceRepo, mockRedisRepo := setupDeleteAllBalancesUseCase(t)
-		balanceItem := newTestBalance(decimal.NewFromInt(1), decimal.Zero)
+		balanceItem := newTestBalance(decimal.Zero, decimal.Zero)
 
 		mockBalanceRepo.EXPECT().
 			ListByAccountID(gomock.Any(), organizationID, ledgerID, accountID).
@@ -79,13 +79,15 @@ func TestDeleteAllBalancesByAccountID(t *testing.T) {
 		mockRedisRepo.EXPECT().
 			ListBalanceByKey(gomock.Any(), organizationID, ledgerID, balanceRedisKey(balanceItem)).
 			Return(&mmodel.Balance{}, nil)
+		mockBalanceRepo.EXPECT().
+			UpdateAllByAccountID(gomock.Any(), organizationID, ledgerID, accountID, gomock.Any()).
+			Return(nil)
+		mockBalanceRepo.EXPECT().
+			DeleteAllByIDs(gomock.Any(), organizationID, ledgerID, gomock.Any()).
+			Return(nil)
 
 		err := uc.DeleteAllBalancesByAccountID(ctx, organizationID, ledgerID, accountID, requestID.String())
-
-		var validationErr midazpkg.ValidationError
-		assert.Error(t, err)
-		assert.True(t, errors.As(err, &validationErr))
-		assert.Equal(t, constant.ErrBalancesCantBeDeleted.Error(), validationErr.Code)
+		assert.NoError(t, err)
 	})
 
 	t.Run("balances with funds remaining prevent deletion", func(t *testing.T) {
@@ -208,9 +210,10 @@ func TestDeleteAllBalancesByAccountID(t *testing.T) {
 	})
 }
 
-// TestDeleteAllBalancesByAccountIDCacheMissFundsGuard covers the funds guard on a Redis
-// cache miss: a balance absent from Redis (TTL expired) must still be checked against the
-// authoritative Postgres row so accounts holding funds are never soft-deleted.
+// TestDeleteAllBalancesByAccountIDCacheMissFundsGuard covers the funds guard for both a
+// Redis cache hit and a cache miss: a cached balance blocks deletion only when it still
+// holds funds, and a balance absent from Redis (TTL expired) must still be checked against
+// the authoritative Postgres row so accounts holding funds are never soft-deleted.
 func TestDeleteAllBalancesByAccountIDCacheMissFundsGuard(t *testing.T) {
 	t.Parallel()
 
@@ -242,11 +245,11 @@ func TestDeleteAllBalancesByAccountIDCacheMissFundsGuard(t *testing.T) {
 			expectProceed: false,
 		},
 		{
-			name:          "cached balance still prevents deletion",
+			name:          "cached zero-funds balance proceeds to deletion",
 			balance:       newTestBalance(decimal.Zero, decimal.Zero),
 			cacheBalance:  &mmodel.Balance{},
 			cacheErr:      nil,
-			expectProceed: false,
+			expectProceed: true,
 		},
 		{
 			name:          "zero funds with cache miss proceeds to deletion",
@@ -254,6 +257,27 @@ func TestDeleteAllBalancesByAccountIDCacheMissFundsGuard(t *testing.T) {
 			cacheBalance:  nil,
 			cacheErr:      goredis.Nil,
 			expectProceed: true,
+		},
+		{
+			name:          "cached available funds prevents deletion",
+			balance:       newTestBalance(decimal.Zero, decimal.Zero),
+			cacheBalance:  newTestBalance(decimal.NewFromInt(7), decimal.Zero),
+			cacheErr:      nil,
+			expectProceed: false,
+		},
+		{
+			name:          "cached on_hold funds prevents deletion",
+			balance:       newTestBalance(decimal.Zero, decimal.Zero),
+			cacheBalance:  newTestBalance(decimal.Zero, decimal.NewFromInt(9)),
+			cacheErr:      nil,
+			expectProceed: false,
+		},
+		{
+			name:          "cached zero-funds but postgres funds prevents deletion",
+			balance:       newTestBalance(decimal.NewFromInt(3), decimal.Zero),
+			cacheBalance:  &mmodel.Balance{},
+			cacheErr:      nil,
+			expectProceed: false,
 		},
 	}
 

--- a/components/ledger/internal/services/command/delete_balance.go
+++ b/components/ledger/internal/services/command/delete_balance.go
@@ -48,12 +48,12 @@ func (uc *UseCase) DeleteBalance(ctx context.Context, organizationID, ledgerID, 
 		return err
 	}
 
-	// Plant a tombstone so the honored-lock pre-pass rejects concurrent mutations while the
+	// Plant a delete marker so the honored-lock pre-pass rejects concurrent mutations while the
 	// delete is in flight. Release it only when the delete fails, so a rejected guard or a
-	// failed soft-delete leaves the balance usable; a successful delete lets the tombstone
+	// failed soft-delete leaves the balance usable; a successful delete lets the delete marker
 	// expire by its own TTL.
 	if balance != nil {
-		release := uc.plantBalanceTombstones(ctx, organizationID, ledgerID, []*mmodel.Balance{balance})
+		release := uc.plantBalanceDeleteMarkers(ctx, organizationID, ledgerID, []*mmodel.Balance{balance})
 
 		defer func() {
 			if err != nil {

--- a/components/ledger/internal/services/command/delete_balance.go
+++ b/components/ledger/internal/services/command/delete_balance.go
@@ -22,7 +22,7 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
-func (uc *UseCase) DeleteBalance(ctx context.Context, organizationID, ledgerID, balanceID uuid.UUID) error {
+func (uc *UseCase) DeleteBalance(ctx context.Context, organizationID, ledgerID, balanceID uuid.UUID) (err error) {
 	logger, tracer, _, _ := libObs.NewTrackingFromContext(ctx)
 
 	ctx, span := tracer.Start(ctx, "exec.delete_balance")
@@ -48,6 +48,20 @@ func (uc *UseCase) DeleteBalance(ctx context.Context, organizationID, ledgerID, 
 		return err
 	}
 
+	// Plant a tombstone so the honored-lock pre-pass rejects concurrent mutations while the
+	// delete is in flight. Release it only when the delete fails, so a rejected guard or a
+	// failed soft-delete leaves the balance usable; a successful delete lets the tombstone
+	// expire by its own TTL.
+	if balance != nil {
+		release := uc.plantBalanceTombstones(ctx, organizationID, ledgerID, []*mmodel.Balance{balance})
+
+		defer func() {
+			if err != nil {
+				release()
+			}
+		}()
+	}
+
 	if balance != nil && (!balance.Available.IsZero() || !balance.OnHold.IsZero()) {
 		err = pkg.ValidateBusinessError(constant.ErrBalancesCantBeDeleted, constant.EntityBalance)
 		libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Balance cannot be deleted because it still has funds in it.", err)
@@ -62,6 +76,12 @@ func (uc *UseCase) DeleteBalance(ctx context.Context, organizationID, ledgerID, 
 		logger.Log(ctx, libLog.LevelError, "Error delete balance", libLog.Err(err))
 
 		return err
+	}
+
+	// Drop the stale cache entry now that the row is soft-deleted. Non-fatal: a failed eviction
+	// is logged and never fails the already-committed delete.
+	if balance != nil {
+		uc.evictBalanceCaches(ctx, organizationID, ledgerID, []*mmodel.Balance{balance})
 	}
 
 	uc.emitBalanceDeletedEvent(ctx, span, logger, balance, time.Now())

--- a/components/ledger/internal/services/command/delete_balance_streaming_test.go
+++ b/components/ledger/internal/services/command/delete_balance_streaming_test.go
@@ -12,6 +12,7 @@ import (
 
 	libStreaming "github.com/LerianStudio/lib-streaming"
 	"github.com/LerianStudio/midaz/v3/components/ledger/internal/adapters/postgres/balance"
+	redis "github.com/LerianStudio/midaz/v3/components/ledger/internal/adapters/redis/transaction"
 	"github.com/LerianStudio/midaz/v3/pkg/constant"
 	"github.com/LerianStudio/midaz/v3/pkg/mmodel"
 	pkgStreaming "github.com/LerianStudio/midaz/v3/pkg/streaming"
@@ -50,9 +51,20 @@ func newDeleteBalanceStreamingTestUseCase(t *testing.T, ctrl *gomock.Controller,
 		Return(nil).
 		AnyTimes()
 
+	mockRedisRepo := redis.NewMockRedisRepository(ctrl)
+	mockRedisRepo.EXPECT().
+		SetNX(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(true, nil).
+		AnyTimes()
+	mockRedisRepo.EXPECT().
+		Del(gomock.Any(), gomock.Any()).
+		Return(nil).
+		AnyTimes()
+
 	return &UseCase{
-		BalanceRepo: mockBalanceRepo,
-		Streaming:   emitter,
+		BalanceRepo:          mockBalanceRepo,
+		TransactionRedisRepo: mockRedisRepo,
+		Streaming:            emitter,
 	}
 }
 

--- a/components/ledger/internal/services/command/delete_balance_test.go
+++ b/components/ledger/internal/services/command/delete_balance_test.go
@@ -64,9 +64,9 @@ func TestDeleteBalance(t *testing.T) {
 				mockBalanceRepo.EXPECT().
 					Find(gomock.Any(), organizationID, ledgerID, balanceID).
 					Return(bal, nil)
-				// Tombstone is planted before the funds guard; a rejected delete releases it.
-				expectTombstonePlant(mockRedisRepo, organizationID, ledgerID, bal)
-				expectTombstoneRelease(mockRedisRepo, organizationID, ledgerID, bal)
+				// Delete marker is planted before the funds guard; a rejected delete releases it.
+				expectDeleteMarkerPlant(mockRedisRepo, organizationID, ledgerID, bal)
+				expectDeleteMarkerRelease(mockRedisRepo, organizationID, ledgerID, bal)
 
 				err := uc.DeleteBalance(ctx, organizationID, ledgerID, balanceID)
 
@@ -91,12 +91,12 @@ func TestDeleteBalance(t *testing.T) {
 		mockBalanceRepo.EXPECT().
 			Find(gomock.Any(), organizationID, ledgerID, balanceID).
 			Return(zeroBalance, nil)
-		expectTombstonePlant(mockRedisRepo, organizationID, ledgerID, zeroBalance)
+		expectDeleteMarkerPlant(mockRedisRepo, organizationID, ledgerID, zeroBalance)
 		mockBalanceRepo.EXPECT().
 			Delete(gomock.Any(), organizationID, ledgerID, balanceID).
 			Return(expectedErr)
-		// A failed delete releases the tombstone and never evicts the cache key.
-		expectTombstoneRelease(mockRedisRepo, organizationID, ledgerID, zeroBalance)
+		// A failed delete releases the delete marker and never evicts the cache key.
+		expectDeleteMarkerRelease(mockRedisRepo, organizationID, ledgerID, zeroBalance)
 
 		err := uc.DeleteBalance(ctx, organizationID, ledgerID, balanceID)
 
@@ -132,7 +132,7 @@ func TestDeleteBalance(t *testing.T) {
 		mockBalanceRepo.EXPECT().
 			Find(gomock.Any(), organizationID, ledgerID, balanceID).
 			Return(zeroBalance, nil)
-		expectTombstonePlant(mockRedisRepo, organizationID, ledgerID, zeroBalance)
+		expectDeleteMarkerPlant(mockRedisRepo, organizationID, ledgerID, zeroBalance)
 		mockBalanceRepo.EXPECT().
 			Delete(gomock.Any(), organizationID, ledgerID, balanceID).
 			Return(nil)
@@ -145,8 +145,8 @@ func TestDeleteBalance(t *testing.T) {
 }
 
 // TestDeleteBalanceBlockThenEvict locks the block-then-evict ordering for the single-balance
-// delete: the tombstone is planted BEFORE the funds guard (so it fires even when the guard
-// rejects), the cache is evicted AFTER the soft delete commits, the tombstone is released
+// delete: the delete marker is planted BEFORE the funds guard (so it fires even when the guard
+// rejects), the cache is evicted AFTER the soft delete commits, the delete marker is released
 // ONLY when the delete fails, and a failed eviction never fails an already-committed delete.
 func TestDeleteBalanceBlockThenEvict(t *testing.T) {
 	t.Parallel()
@@ -166,7 +166,7 @@ func TestDeleteBalanceBlockThenEvict(t *testing.T) {
 		}
 	}
 
-	t.Run("plants tombstone before delete and evicts after delete", func(t *testing.T) {
+	t.Run("plants delete marker before delete and evicts after delete", func(t *testing.T) {
 		t.Parallel()
 
 		uc, mockBalanceRepo, mockRedisRepo := setupDeleteBalanceUseCase(t)
@@ -175,7 +175,7 @@ func TestDeleteBalanceBlockThenEvict(t *testing.T) {
 		mockBalanceRepo.EXPECT().
 			Find(gomock.Any(), organizationID, ledgerID, balanceID).
 			Return(bal, nil)
-		plant := expectTombstonePlant(mockRedisRepo, organizationID, ledgerID, bal)
+		plant := expectDeleteMarkerPlant(mockRedisRepo, organizationID, ledgerID, bal)
 		del := mockBalanceRepo.EXPECT().
 			Delete(gomock.Any(), organizationID, ledgerID, balanceID).
 			Return(nil)
@@ -186,11 +186,11 @@ func TestDeleteBalanceBlockThenEvict(t *testing.T) {
 
 		err := uc.DeleteBalance(ctx, organizationID, ledgerID, balanceID)
 		assert.NoError(t, err)
-		// On success the tombstone release must NOT run: no Del of the tombstone key is set up,
+		// On success the delete marker release must NOT run: no Del of the delete marker key is set up,
 		// so the strict controller fails if the release closure fires.
 	})
 
-	t.Run("funds guard rejection releases tombstone and skips evict", func(t *testing.T) {
+	t.Run("funds guard rejection releases delete marker and skips evict", func(t *testing.T) {
 		t.Parallel()
 
 		uc, mockBalanceRepo, mockRedisRepo := setupDeleteBalanceUseCase(t)
@@ -205,12 +205,12 @@ func TestDeleteBalanceBlockThenEvict(t *testing.T) {
 		mockBalanceRepo.EXPECT().
 			Find(gomock.Any(), organizationID, ledgerID, balanceID).
 			Return(bal, nil)
-		// SetNX firing on the reject path proves the tombstone is planted BEFORE the funds guard.
-		expectTombstonePlant(mockRedisRepo, organizationID, ledgerID, bal)
+		// SetNX firing on the reject path proves the delete marker is planted BEFORE the funds guard.
+		expectDeleteMarkerPlant(mockRedisRepo, organizationID, ledgerID, bal)
 		mockBalanceRepo.EXPECT().
 			Delete(gomock.Any(), organizationID, ledgerID, balanceID).
 			Times(0)
-		expectTombstoneRelease(mockRedisRepo, organizationID, ledgerID, bal)
+		expectDeleteMarkerRelease(mockRedisRepo, organizationID, ledgerID, bal)
 
 		err := uc.DeleteBalance(ctx, organizationID, ledgerID, balanceID)
 
@@ -220,7 +220,7 @@ func TestDeleteBalanceBlockThenEvict(t *testing.T) {
 		assert.Equal(t, constant.ErrBalancesCantBeDeleted.Error(), validationErr.Code)
 	})
 
-	t.Run("delete error releases tombstone and skips evict", func(t *testing.T) {
+	t.Run("delete error releases delete marker and skips evict", func(t *testing.T) {
 		t.Parallel()
 
 		uc, mockBalanceRepo, mockRedisRepo := setupDeleteBalanceUseCase(t)
@@ -230,12 +230,12 @@ func TestDeleteBalanceBlockThenEvict(t *testing.T) {
 		mockBalanceRepo.EXPECT().
 			Find(gomock.Any(), organizationID, ledgerID, balanceID).
 			Return(bal, nil)
-		expectTombstonePlant(mockRedisRepo, organizationID, ledgerID, bal)
+		expectDeleteMarkerPlant(mockRedisRepo, organizationID, ledgerID, bal)
 		mockBalanceRepo.EXPECT().
 			Delete(gomock.Any(), organizationID, ledgerID, balanceID).
 			Return(expectedErr)
-		// Release Dels the tombstone key; the cache key is never evicted on the error path.
-		expectTombstoneRelease(mockRedisRepo, organizationID, ledgerID, bal)
+		// Release Dels the delete marker key; the cache key is never evicted on the error path.
+		expectDeleteMarkerRelease(mockRedisRepo, organizationID, ledgerID, bal)
 
 		err := uc.DeleteBalance(ctx, organizationID, ledgerID, balanceID)
 		assert.ErrorIs(t, err, expectedErr)
@@ -250,7 +250,7 @@ func TestDeleteBalanceBlockThenEvict(t *testing.T) {
 		mockBalanceRepo.EXPECT().
 			Find(gomock.Any(), organizationID, ledgerID, balanceID).
 			Return(bal, nil)
-		expectTombstonePlant(mockRedisRepo, organizationID, ledgerID, bal)
+		expectDeleteMarkerPlant(mockRedisRepo, organizationID, ledgerID, bal)
 		mockBalanceRepo.EXPECT().
 			Delete(gomock.Any(), organizationID, ledgerID, balanceID).
 			Return(nil)

--- a/components/ledger/internal/services/command/delete_balance_test.go
+++ b/components/ledger/internal/services/command/delete_balance_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/LerianStudio/midaz/v3/components/ledger/internal/adapters/postgres/balance"
+	redis "github.com/LerianStudio/midaz/v3/components/ledger/internal/adapters/redis/transaction"
 	midazpkg "github.com/LerianStudio/midaz/v3/pkg"
 	"github.com/LerianStudio/midaz/v3/pkg/constant"
 	"github.com/LerianStudio/midaz/v3/pkg/mmodel"
@@ -26,7 +27,7 @@ func TestDeleteBalance(t *testing.T) {
 	balanceID := uuid.New()
 
 	t.Run("find balance error", func(t *testing.T) {
-		uc, mockBalanceRepo := setupDeleteBalanceUseCase(t)
+		uc, mockBalanceRepo, _ := setupDeleteBalanceUseCase(t)
 		expectedErr := errors.New("database connection error")
 
 		mockBalanceRepo.EXPECT().
@@ -51,9 +52,11 @@ func TestDeleteBalance(t *testing.T) {
 
 		for _, tc := range cases {
 			t.Run(tc.name, func(t *testing.T) {
-				uc, mockBalanceRepo := setupDeleteBalanceUseCase(t)
+				uc, mockBalanceRepo, mockRedisRepo := setupDeleteBalanceUseCase(t)
 				bal := &mmodel.Balance{
 					ID:        balanceID.String(),
+					Alias:     "alias",
+					Key:       "key",
 					Available: tc.available,
 					OnHold:    tc.onHold,
 				}
@@ -61,6 +64,9 @@ func TestDeleteBalance(t *testing.T) {
 				mockBalanceRepo.EXPECT().
 					Find(gomock.Any(), organizationID, ledgerID, balanceID).
 					Return(bal, nil)
+				// Tombstone is planted before the funds guard; a rejected delete releases it.
+				expectTombstonePlant(mockRedisRepo, organizationID, ledgerID, bal)
+				expectTombstoneRelease(mockRedisRepo, organizationID, ledgerID, bal)
 
 				err := uc.DeleteBalance(ctx, organizationID, ledgerID, balanceID)
 
@@ -72,9 +78,11 @@ func TestDeleteBalance(t *testing.T) {
 	})
 
 	t.Run("delete error", func(t *testing.T) {
-		uc, mockBalanceRepo := setupDeleteBalanceUseCase(t)
+		uc, mockBalanceRepo, mockRedisRepo := setupDeleteBalanceUseCase(t)
 		zeroBalance := &mmodel.Balance{
 			ID:        balanceID.String(),
+			Alias:     "alias",
+			Key:       "key",
 			Available: decimal.Zero,
 			OnHold:    decimal.Zero,
 		}
@@ -83,9 +91,12 @@ func TestDeleteBalance(t *testing.T) {
 		mockBalanceRepo.EXPECT().
 			Find(gomock.Any(), organizationID, ledgerID, balanceID).
 			Return(zeroBalance, nil)
+		expectTombstonePlant(mockRedisRepo, organizationID, ledgerID, zeroBalance)
 		mockBalanceRepo.EXPECT().
 			Delete(gomock.Any(), organizationID, ledgerID, balanceID).
 			Return(expectedErr)
+		// A failed delete releases the tombstone and never evicts the cache key.
+		expectTombstoneRelease(mockRedisRepo, organizationID, ledgerID, zeroBalance)
 
 		err := uc.DeleteBalance(ctx, organizationID, ledgerID, balanceID)
 
@@ -94,7 +105,7 @@ func TestDeleteBalance(t *testing.T) {
 	})
 
 	t.Run("nil balance proceeds to delete", func(t *testing.T) {
-		uc, mockBalanceRepo := setupDeleteBalanceUseCase(t)
+		uc, mockBalanceRepo, _ := setupDeleteBalanceUseCase(t)
 
 		mockBalanceRepo.EXPECT().
 			Find(gomock.Any(), organizationID, ledgerID, balanceID).
@@ -109,9 +120,11 @@ func TestDeleteBalance(t *testing.T) {
 	})
 
 	t.Run("deletes balance with zero funds", func(t *testing.T) {
-		uc, mockBalanceRepo := setupDeleteBalanceUseCase(t)
+		uc, mockBalanceRepo, mockRedisRepo := setupDeleteBalanceUseCase(t)
 		zeroBalance := &mmodel.Balance{
 			ID:        balanceID.String(),
+			Alias:     "alias",
+			Key:       "key",
 			Available: decimal.Zero,
 			OnHold:    decimal.Zero,
 		}
@@ -119,9 +132,11 @@ func TestDeleteBalance(t *testing.T) {
 		mockBalanceRepo.EXPECT().
 			Find(gomock.Any(), organizationID, ledgerID, balanceID).
 			Return(zeroBalance, nil)
+		expectTombstonePlant(mockRedisRepo, organizationID, ledgerID, zeroBalance)
 		mockBalanceRepo.EXPECT().
 			Delete(gomock.Any(), organizationID, ledgerID, balanceID).
 			Return(nil)
+		expectCacheEvict(mockRedisRepo, organizationID, ledgerID, zeroBalance)
 
 		err := uc.DeleteBalance(ctx, organizationID, ledgerID, balanceID)
 
@@ -129,15 +144,136 @@ func TestDeleteBalance(t *testing.T) {
 	})
 }
 
-func setupDeleteBalanceUseCase(t *testing.T) (*UseCase, *balance.MockRepository) {
+// TestDeleteBalanceBlockThenEvict locks the block-then-evict ordering for the single-balance
+// delete: the tombstone is planted BEFORE the funds guard (so it fires even when the guard
+// rejects), the cache is evicted AFTER the soft delete commits, the tombstone is released
+// ONLY when the delete fails, and a failed eviction never fails an already-committed delete.
+func TestDeleteBalanceBlockThenEvict(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	organizationID := uuid.New()
+	ledgerID := uuid.New()
+	balanceID := uuid.New()
+
+	newZeroBalance := func() *mmodel.Balance {
+		return &mmodel.Balance{
+			ID:        balanceID.String(),
+			Alias:     "alias",
+			Key:       "key",
+			Available: decimal.Zero,
+			OnHold:    decimal.Zero,
+		}
+	}
+
+	t.Run("plants tombstone before delete and evicts after delete", func(t *testing.T) {
+		t.Parallel()
+
+		uc, mockBalanceRepo, mockRedisRepo := setupDeleteBalanceUseCase(t)
+		bal := newZeroBalance()
+
+		mockBalanceRepo.EXPECT().
+			Find(gomock.Any(), organizationID, ledgerID, balanceID).
+			Return(bal, nil)
+		plant := expectTombstonePlant(mockRedisRepo, organizationID, ledgerID, bal)
+		del := mockBalanceRepo.EXPECT().
+			Delete(gomock.Any(), organizationID, ledgerID, balanceID).
+			Return(nil)
+		evict := expectCacheEvict(mockRedisRepo, organizationID, ledgerID, bal)
+
+		// plant-before-delete and evict-after-soft-delete.
+		gomock.InOrder(plant, del, evict)
+
+		err := uc.DeleteBalance(ctx, organizationID, ledgerID, balanceID)
+		assert.NoError(t, err)
+		// On success the tombstone release must NOT run: no Del of the tombstone key is set up,
+		// so the strict controller fails if the release closure fires.
+	})
+
+	t.Run("funds guard rejection releases tombstone and skips evict", func(t *testing.T) {
+		t.Parallel()
+
+		uc, mockBalanceRepo, mockRedisRepo := setupDeleteBalanceUseCase(t)
+		bal := &mmodel.Balance{
+			ID:        balanceID.String(),
+			Alias:     "alias",
+			Key:       "key",
+			Available: decimal.Zero,
+			OnHold:    decimal.NewFromInt(5),
+		}
+
+		mockBalanceRepo.EXPECT().
+			Find(gomock.Any(), organizationID, ledgerID, balanceID).
+			Return(bal, nil)
+		// SetNX firing on the reject path proves the tombstone is planted BEFORE the funds guard.
+		expectTombstonePlant(mockRedisRepo, organizationID, ledgerID, bal)
+		mockBalanceRepo.EXPECT().
+			Delete(gomock.Any(), organizationID, ledgerID, balanceID).
+			Times(0)
+		expectTombstoneRelease(mockRedisRepo, organizationID, ledgerID, bal)
+
+		err := uc.DeleteBalance(ctx, organizationID, ledgerID, balanceID)
+
+		var validationErr midazpkg.ValidationError
+		assert.Error(t, err)
+		assert.True(t, errors.As(err, &validationErr))
+		assert.Equal(t, constant.ErrBalancesCantBeDeleted.Error(), validationErr.Code)
+	})
+
+	t.Run("delete error releases tombstone and skips evict", func(t *testing.T) {
+		t.Parallel()
+
+		uc, mockBalanceRepo, mockRedisRepo := setupDeleteBalanceUseCase(t)
+		bal := newZeroBalance()
+		expectedErr := errors.New("delete failed")
+
+		mockBalanceRepo.EXPECT().
+			Find(gomock.Any(), organizationID, ledgerID, balanceID).
+			Return(bal, nil)
+		expectTombstonePlant(mockRedisRepo, organizationID, ledgerID, bal)
+		mockBalanceRepo.EXPECT().
+			Delete(gomock.Any(), organizationID, ledgerID, balanceID).
+			Return(expectedErr)
+		// Release Dels the tombstone key; the cache key is never evicted on the error path.
+		expectTombstoneRelease(mockRedisRepo, organizationID, ledgerID, bal)
+
+		err := uc.DeleteBalance(ctx, organizationID, ledgerID, balanceID)
+		assert.ErrorIs(t, err, expectedErr)
+	})
+
+	t.Run("evict del failure on success is non-fatal", func(t *testing.T) {
+		t.Parallel()
+
+		uc, mockBalanceRepo, mockRedisRepo := setupDeleteBalanceUseCase(t)
+		bal := newZeroBalance()
+
+		mockBalanceRepo.EXPECT().
+			Find(gomock.Any(), organizationID, ledgerID, balanceID).
+			Return(bal, nil)
+		expectTombstonePlant(mockRedisRepo, organizationID, ledgerID, bal)
+		mockBalanceRepo.EXPECT().
+			Delete(gomock.Any(), organizationID, ledgerID, balanceID).
+			Return(nil)
+		mockRedisRepo.EXPECT().
+			Del(gomock.Any(), balanceCacheKeyFor(organizationID, ledgerID, bal)).
+			Return(errors.New("evict failed"))
+
+		err := uc.DeleteBalance(ctx, organizationID, ledgerID, balanceID)
+		assert.NoError(t, err)
+	})
+}
+
+func setupDeleteBalanceUseCase(t *testing.T) (*UseCase, *balance.MockRepository, *redis.MockRedisRepository) {
 	t.Helper()
 
 	ctrl := gomock.NewController(t)
 	t.Cleanup(ctrl.Finish)
 
 	mockBalanceRepo := balance.NewMockRepository(ctrl)
+	mockRedisRepo := redis.NewMockRedisRepository(ctrl)
 
 	return &UseCase{
-		BalanceRepo: mockBalanceRepo,
-	}, mockBalanceRepo
+		BalanceRepo:          mockBalanceRepo,
+		TransactionRedisRepo: mockRedisRepo,
+	}, mockBalanceRepo, mockRedisRepo
 }

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	go.opentelemetry.io/otel/trace v1.44.0
 	go.uber.org/mock v0.6.0
 	go.uber.org/zap v1.28.0 // indirect
-	google.golang.org/grpc v1.81.1 // indirect
+	google.golang.org/grpc v1.82.1 // indirect
 	google.golang.org/protobuf v1.36.11
 )
 

--- a/go.sum
+++ b/go.sum
@@ -706,8 +706,8 @@ google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa h1:
 google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa/go.mod h1:q4lMZS6kskjT5HvCPrnnypcDPVJqT/f4nfxmkE7gryY=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa h1:mZHHdPZl0dbGHCflZgAq/Q468DWVFcU2whhB2KAo8fk=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
-google.golang.org/grpc v1.81.1 h1:VnnIIZ88UzOOKLukQi+ImGz8O1Wdp8nAGGnvOfEIWQQ=
-google.golang.org/grpc v1.81.1/go.mod h1:xGH9GfzOyMTGIOXBJmXt+BX/V0kcdQbdcuwQ/zNw42I=
+google.golang.org/grpc v1.82.1 h1:NnAxzGRA0677vCa4BUkOAnO5+FfQqVl9iUXeD0IqcGE=
+google.golang.org/grpc v1.82.1/go.mod h1:yzTZ1TB1Z3SG+LIYaI+WiE8D5+PZ3ArnrSp8zF3+/ZA=
 google.golang.org/protobuf v1.36.11 h1:fV6ZwhNocDyBLK0dj+fg8ektcVegBBuEolpbTQyBNVE=
 google.golang.org/protobuf v1.36.11/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=

--- a/tests/utils/stubs/balance.go
+++ b/tests/utils/stubs/balance.go
@@ -1,0 +1,133 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+// Package stubs provides test doubles for tests.
+//
+// This file contains BalanceRepoStub, a no-op implementation of the ledger
+// balance repository contract. Like logger.go it carries no build tag so it is
+// available in both unit and integration test contexts.
+package stubs
+
+import (
+	"context"
+	"time"
+
+	libHTTP "github.com/LerianStudio/lib-commons/v5/commons/net/http"
+	"github.com/LerianStudio/midaz/v3/pkg/mmodel"
+	netHTTP "github.com/LerianStudio/midaz/v3/pkg/net/http"
+	"github.com/google/uuid"
+)
+
+// BalanceRepoStub is a no-op test double for the ledger balance repository.
+//
+// The concrete balance repository interface lives under the ledger internal
+// tree, which the shared test-utils module may not import; conformance is
+// verified structurally at the assignment site inside the ledger package.
+//
+// Use it when a UseCase under integration test needs a BalanceRepo dependency
+// but the scenario does not exercise real balance persistence (e.g. asset and
+// account handler tests that only assert on the onboarding side effects).
+//
+// Reads return empty results and writes succeed silently, so account creation
+// paths that auto-create a default balance complete without a live balance
+// store. Create echoes the supplied balance back so callers that use the
+// returned value keep working.
+type BalanceRepoStub struct{}
+
+// NewBalanceRepoStub returns a BalanceRepoStub ready for use as a
+// balance.Repository test double.
+func NewBalanceRepoStub() *BalanceRepoStub {
+	return &BalanceRepoStub{}
+}
+
+// Create echoes the supplied balance back with no error.
+func (s *BalanceRepoStub) Create(_ context.Context, b *mmodel.Balance) (*mmodel.Balance, error) {
+	return b, nil
+}
+
+// Find returns no balance and no error.
+func (s *BalanceRepoStub) Find(_ context.Context, _, _, _ uuid.UUID) (*mmodel.Balance, error) {
+	return nil, nil
+}
+
+// FindByAccountIDAndKey returns no balance and no error.
+func (s *BalanceRepoStub) FindByAccountIDAndKey(_ context.Context, _, _, _ uuid.UUID, _ string) (*mmodel.Balance, error) {
+	return nil, nil
+}
+
+// ExistsByAccountIDAndKey reports that no balance exists, so default-balance
+// creation paths proceed to Create.
+func (s *BalanceRepoStub) ExistsByAccountIDAndKey(_ context.Context, _, _, _ uuid.UUID, _ string) (bool, error) {
+	return false, nil
+}
+
+// ListAll returns an empty page.
+func (s *BalanceRepoStub) ListAll(_ context.Context, _, _ uuid.UUID, _ netHTTP.Pagination) ([]*mmodel.Balance, libHTTP.CursorPagination, error) {
+	return nil, libHTTP.CursorPagination{}, nil
+}
+
+// ListAllByAccountID returns an empty page.
+func (s *BalanceRepoStub) ListAllByAccountID(_ context.Context, _, _, _ uuid.UUID, _ netHTTP.Pagination) ([]*mmodel.Balance, libHTTP.CursorPagination, error) {
+	return nil, libHTTP.CursorPagination{}, nil
+}
+
+// ListByAccountIDs returns no balances and no error.
+func (s *BalanceRepoStub) ListByAccountIDs(_ context.Context, _, _ uuid.UUID, _ []uuid.UUID) ([]*mmodel.Balance, error) {
+	return nil, nil
+}
+
+// ListByIDs returns no balances and no error.
+func (s *BalanceRepoStub) ListByIDs(_ context.Context, _, _ uuid.UUID, _ []uuid.UUID) ([]*mmodel.Balance, error) {
+	return nil, nil
+}
+
+// ListByAliases returns no balances and no error.
+func (s *BalanceRepoStub) ListByAliases(_ context.Context, _, _ uuid.UUID, _ []string) ([]*mmodel.Balance, error) {
+	return nil, nil
+}
+
+// ListByAliasesWithKeys returns no balances and no error.
+func (s *BalanceRepoStub) ListByAliasesWithKeys(_ context.Context, _, _ uuid.UUID, _ []string) ([]*mmodel.Balance, error) {
+	return nil, nil
+}
+
+// BalancesUpdate succeeds silently.
+func (s *BalanceRepoStub) BalancesUpdate(_ context.Context, _, _ uuid.UUID, _ []*mmodel.Balance) error {
+	return nil
+}
+
+// Update returns no balance and no error.
+func (s *BalanceRepoStub) Update(_ context.Context, _, _, _ uuid.UUID, _ mmodel.UpdateBalance) (*mmodel.Balance, error) {
+	return nil, nil
+}
+
+// Delete succeeds silently.
+func (s *BalanceRepoStub) Delete(_ context.Context, _, _, _ uuid.UUID) error {
+	return nil
+}
+
+// DeleteAllByIDs succeeds silently.
+func (s *BalanceRepoStub) DeleteAllByIDs(_ context.Context, _, _ uuid.UUID, _ []uuid.UUID) error {
+	return nil
+}
+
+// UpdateMany reports zero rows updated and no error.
+func (s *BalanceRepoStub) UpdateMany(_ context.Context, _, _ uuid.UUID, _ []mmodel.BalanceRedis) (int64, error) {
+	return 0, nil
+}
+
+// UpdateAllByAccountID succeeds silently.
+func (s *BalanceRepoStub) UpdateAllByAccountID(_ context.Context, _, _, _ uuid.UUID, _ mmodel.UpdateBalance) error {
+	return nil
+}
+
+// ListByAccountID returns no balances and no error.
+func (s *BalanceRepoStub) ListByAccountID(_ context.Context, _, _, _ uuid.UUID) ([]*mmodel.Balance, error) {
+	return nil, nil
+}
+
+// ListByAccountIDAtTimestamp returns no balances and no error.
+func (s *BalanceRepoStub) ListByAccountIDAtTimestamp(_ context.Context, _, _, _ uuid.UUID, _ time.Time) ([]*mmodel.Balance, error) {
+	return nil, nil
+}


### PR DESCRIPTION
<table border="0" cellspacing="0" cellpadding="0">
  <tr><td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td><td><h1>Midaz</h1></td></tr>
</table>

---

## Description

Hardens account and balance deletion against three money-integrity defects, plus a transitive security bump:

- **Delete with `on_hold` funds on a cache miss.** The delete cascade skipped the authoritative Postgres funds guard via `continue` on `redis.Nil`, so an account still holding `on_hold`/`available` funds could be soft-deleted when its balance was absent from the Redis cache. A cache miss now falls through, so non-zero `available`/`on_hold` blocks deletion against the Postgres row.
- **Delete blocked merely because the balance was cached.** The `cacheBalance != nil` branch now funds-checks the cached balance instead of blocking unconditionally: a cached zero-funds balance is deletable, a funded one still blocks. The authoritative Postgres guard is kept as belt-and-suspenders.
- **Transactions could still operate on a deleted account/balance** — the Redis balance key survived deletion, so post-delete transactions kept mutating phantom balance state that lived only in cache and was invisible to the API. "Honored-lock": both delete paths plant a short-TTL delete marker `<balanceKey>:deleted` before the funds guard; the Lua atomic op rejects any transaction whose balance carries the marker (reusing `ErrAccountIneligibility` / `0019`); the balance cache key is evicted after the Postgres soft-delete. Covers the account-cascade and single-balance delete paths.
- **deps** — bump `google.golang.org/grpc` v1.81.1 → v1.82.1 to resolve `GO-2026-6061`.

## Type of Change

- [x] `fix`: Bug fix
- [x] `style`: Formatting, whitespace, naming (no logic change)
- [x] `test`: Adding or updating tests
- [x] `build`: Build system, Dockerfile, Go module dependencies

## Breaking Changes

None. No public API/contract change; reuses the existing `0019` error (no new sentinel); no new Lua ARGV field; no config/env changes.

## Testing

- [x] `make test` passes (unit, `-race`)
- [x] `make test-int` passes (new testcontainer integration tests, both delete paths)
- [x] `make lint` passes
- [x] `make sec` and `make vulncheck` pass (govulncheck: 0 affecting)

**Test evidence:** money-path code review across the whole diff; live rebuilt-ledger verification of all three fixes on both delete paths; local e2e run showed no regression on the changed surface (transaction / balance / account-delete all green).

## Architectural Checklist

- [x] No `panic()` in production paths
- [ ] Timestamps use `time.Now().UTC()` — n/a (no new timestamps introduced)
- [x] Errors wrapped with `%w` (business errors returned directly per convention)
- [x] Handlers stay thin (parse, validate, call service)
- [x] Infrastructure concerns kept in `internal/bootstrap`

## Related Issues

None.
