### PR TITLE
fix(ledger): authorize routing under midaz appName

### DIFF
--- a/components/ledger/internal/adapters/http/in/accounttype_handler_huma.go
+++ b/components/ledger/internal/adapters/http/in/accounttype_handler_huma.go
@@ -25,10 +25,10 @@ import (
 // helpers (parseOrgLedger, parsePathUUID) and the shared error projection
 // (pkgHTTP.HumaProblem) are reused verbatim.
 //
-// AUTH NOTE: account-types runs under appName "routing" (protectedRouting), NOT
-// "midaz" — the per-op (routing, account-types, verb) authz tuples are preserved
-// BYTE-FOR-BYTE by the Fiber guard chain attached in RegisterAccountTypeRoutesToApp.
-// The Security metadata below is SPEC-ONLY (bearer OR api-key for the generated OAS).
+// AUTH NOTE: account-types authorizes under the "midaz" appName — the per-op
+// (midaz, account-types, verb) authz tuples are attached by the Fiber guard chain in
+// RegisterAccountTypeRoutesToApp. The Security metadata below is SPEC-ONLY (bearer OR
+// api-key for the generated OAS).
 
 // secAccountTypeBearerOrAPIKey advertises that each account-type op accepts EITHER a
 // JWT bearer token OR an X-API-Key (two entries = OR). SPEC metadata only; runtime
@@ -341,15 +341,13 @@ func RegisterAccountTypeV2RoutesToApp(group fiber.Router, api huma.API, auth *mi
 // registerAccountTypeRoutesToApp is the single description of the account-type route
 // surface, shared by every versioned contract that serves it, mirroring
 // RegisterAssetRoutesToApp. For each of the five ops it attaches the Fiber auth chain —
-// protectedRouting(auth,"account-types",verb) (= auth.Authorize("routing","account-types",
+// protectedMidaz(auth,"account-types",verb) (= auth.Authorize("midaz","account-types",
 // verb) + tenant PostAuthMiddlewares) + ParseUUIDPathParameters("account_type") — as
 // MIDDLEWARE ONLY (no terminal) on the VERSIONED GROUP with GROUP-RELATIVE paths, then
 // registers the Huma terminals via RegisterAccountTypeRoutes on the SAME group's Huma API.
-// Unlike the other Wave-1 resources, account-type authorizes against the "routing" appName
-// (protectedRouting, NOT protectedMidaz), exactly as the pre-migration routes.go did — this
-// preserves the ("routing","account-types",verb) authz tuples and tenant resolution
-// BYTE-FOR-BYTE on whichever version group it is mounted on; no account-type route becomes
-// public. The op order (post, patch, get-by-id, list, delete) matches routes.go.
+// The ("midaz","account-types",verb) authz tuples and tenant resolution hold on whichever
+// version group it is mounted on; no account-type route becomes public. The op order
+// (post, patch, get-by-id, list, delete) matches routes.go.
 //
 // opSuffix distinguishes the operation IDs one version group publishes from another's —
 // see routeOpSuffixV1. Nothing else varies between contracts, so a change to the surface
@@ -362,11 +360,11 @@ func registerAccountTypeRoutesToApp(group fiber.Router, api huma.API, auth *midd
 
 	parse := pkgHTTP.ParseUUIDPathParameters("account_type")
 
-	routePost(group, listPath, protectedRouting(auth, "account-types", "post", routeOptions, parse))
-	routePatch(group, idPath, protectedRouting(auth, "account-types", "patch", routeOptions, parse))
-	routeGet(group, idPath, protectedRouting(auth, "account-types", "get", routeOptions, parse))
-	routeGet(group, listPath, protectedRouting(auth, "account-types", "get", routeOptions, parse))
-	routeDelete(group, idPath, protectedRouting(auth, "account-types", "delete", routeOptions, parse))
+	routePost(group, listPath, protectedMidaz(auth, "account-types", "post", routeOptions, parse))
+	routePatch(group, idPath, protectedMidaz(auth, "account-types", "patch", routeOptions, parse))
+	routeGet(group, idPath, protectedMidaz(auth, "account-types", "get", routeOptions, parse))
+	routeGet(group, listPath, protectedMidaz(auth, "account-types", "get", routeOptions, parse))
+	routeDelete(group, idPath, protectedMidaz(auth, "account-types", "delete", routeOptions, parse))
 
 	RegisterAccountTypeRoutes(api, h, opSuffix)
 }

--- a/components/ledger/internal/adapters/http/in/accounttype_huma_test.go
+++ b/components/ledger/internal/adapters/http/in/accounttype_huma_test.go
@@ -45,7 +45,7 @@ import (
 // sub-second; keep them sequential.
 //
 // authOK=false makes the shim reject with the ledger's canonical 401 envelope
-// (mirroring the routing-appName auth.Authorize failure) so the auth-preserved
+// (mirroring the midaz-appName auth.Authorize failure) so the auth-preserved
 // contract is testable without a live lib-auth server.
 func buildHumaAccountTypeApp(t *testing.T, handler *AccountTypeHandler, authOK bool) *fiber.App {
 	t.Helper()
@@ -59,7 +59,7 @@ func buildHumaAccountTypeApp(t *testing.T, handler *AccountTypeHandler, authOK b
 
 	apiV1 := f.Group("/v1")
 
-	// Auth shim: stands in for protectedRouting -> auth.Authorize("routing",
+	// Auth shim: stands in for protectedMidaz -> auth.Authorize("midaz",
 	// "account-types", verb). A rejected request (authOK=false) must never reach
 	// Huma — it returns the ledger 401.
 	apiV1.Use(func(c fiber.Ctx) error {

--- a/components/ledger/internal/adapters/http/in/authz_appname_guard_test.go
+++ b/components/ledger/internal/adapters/http/in/authz_appname_guard_test.go
@@ -1,0 +1,166 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package in
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/LerianStudio/lib-auth/v3/auth/middleware"
+	openapi "github.com/LerianStudio/lib-commons/v6/commons/net/http/openapi"
+	libProblem "github.com/LerianStudio/lib-commons/v6/commons/net/http/problem"
+	"github.com/danielgtaylor/huma/v2"
+	"github.com/gofiber/fiber/v3"
+	jwt "github.com/golang-jwt/jwt/v5"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pkgHTTP "github.com/LerianStudio/midaz/v4/pkg/net/http"
+)
+
+// TestAuthz_RoutingResources_AuthorizeUnderMidazAppName locks the authorization
+// appName for the three route-management resources (operation-routes,
+// transaction-routes, account-types): every op must be guarded by
+// auth.Authorize(midazName, resource, verb). It drives the PRODUCTION registration
+// functions through a capturing authz server that records the forwarded product;
+// a future migration that repoints any of these ops to a different appName makes
+// the recorded product diverge and fails this guard.
+//
+// The capturing server always denies (authorized=false). The auth middleware
+// forwards the product to the authz service BEFORE reading the decision, so the
+// product is captured on every request while the 403 short-circuits the chain —
+// the business terminals never run, so zero-value handlers are sufficient.
+//
+// NOT parallel: libProblem.Install swaps a process-global huma.NewError hook and
+// Huma validation uses process-global sync.Pools; concurrent builds cross-
+// contaminate. These cases are sub-second; keep them sequential.
+func TestAuthz_RoutingResources_AuthorizeUnderMidazAppName(t *testing.T) {
+	orgID := uuid.NewString()
+	ledgerID := uuid.NewString()
+	resourceID := uuid.NewString()
+	base := "/v1/organizations/" + orgID + "/ledgers/" + ledgerID
+
+	cases := []struct {
+		name     string
+		register func(group fiber.Router, api huma.API, auth *middleware.AuthClient)
+		list     string
+		byID     string
+	}{
+		{
+			name: "operation-routes",
+			register: func(group fiber.Router, api huma.API, auth *middleware.AuthClient) {
+				registerOperationRouteRoutesToApp(group, api, auth, &OperationRouteHandler{}, nil, routeOpSuffixV1)
+			},
+			list: base + "/operation-routes",
+			byID: base + "/operation-routes/" + resourceID,
+		},
+		{
+			name: "transaction-routes",
+			register: func(group fiber.Router, api huma.API, auth *middleware.AuthClient) {
+				registerTransactionRouteRoutesToApp(group, api, auth, &TransactionRouteHandler{}, nil, routeOpSuffixV1)
+			},
+			list: base + "/transaction-routes",
+			byID: base + "/transaction-routes/" + resourceID,
+		},
+		{
+			name: "account-types",
+			register: func(group fiber.Router, api huma.API, auth *middleware.AuthClient) {
+				registerAccountTypeRoutesToApp(group, api, auth, &AccountTypeHandler{}, nil, routeOpSuffixV1)
+			},
+			list: base + "/account-types",
+			byID: base + "/account-types/" + resourceID,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var product string
+
+			srv := newAuthzProductCapture(t, &product)
+			defer srv.Close()
+
+			auth := &middleware.AuthClient{Address: srv.URL, Enabled: true}
+
+			f := fiber.New(fiber.Config{ErrorHandler: pkgHTTP.CanonicalFiberErrorHandler})
+			libProblem.Install()
+
+			group := f.Group("/v1")
+			api := openapi.New(f, group, openapi.Config{Title: "authz-guard", Version: "test", Servers: []string{"/v1"}})
+			tc.register(group, api, auth)
+
+			token := "Bearer " + guardBearerToken(t)
+
+			verbs := []struct {
+				method string
+				path   string
+			}{
+				{fiber.MethodPost, tc.list},
+				{fiber.MethodGet, tc.list},
+				{fiber.MethodGet, tc.byID},
+				{fiber.MethodPatch, tc.byID},
+				{fiber.MethodDelete, tc.byID},
+			}
+
+			for _, v := range verbs {
+				product = ""
+
+				req := httptest.NewRequest(v.method, v.path, nil)
+				req.Header.Set("Authorization", token)
+
+				resp, err := f.Test(req, fiber.TestConfig{Timeout: 0})
+				require.NoError(t, err)
+				require.Equalf(t, fiber.StatusForbidden, resp.StatusCode,
+					"%s %s must reach auth and be denied", v.method, v.path)
+				assert.Equalf(t, midazName, product,
+					"%s %s must authorize under the midaz appName, got %q", v.method, v.path, product)
+			}
+		})
+	}
+}
+
+// newAuthzProductCapture returns an httptest server standing in for the authz
+// service. It records the forwarded product into *product and always denies, so
+// the caller's route chain stops at the 403 without running business terminals.
+func newAuthzProductCapture(t *testing.T, product *string) *httptest.Server {
+	t.Helper()
+
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]string
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Errorf("authz capture: decode request body: %v", err)
+		}
+
+		*product = body["product"]
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		if _, err := w.Write([]byte(`{"authorized":false}`)); err != nil {
+			t.Errorf("authz capture: write response: %v", err)
+		}
+	}))
+}
+
+// guardBearerToken mints a normal-user token whose owner+sub claims let the auth
+// middleware derive a subject and forward the route product. The token is parsed
+// unverified by the middleware (no verification cert configured), so the signing
+// key is irrelevant.
+func guardBearerToken(t *testing.T) string {
+	t.Helper()
+
+	tok := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+		"type":  "normal-user",
+		"owner": "guard-org",
+		"sub":   "guard-user",
+	})
+
+	signed, err := tok.SignedString([]byte("guard-secret"))
+	require.NoError(t, err)
+
+	return signed
+}

--- a/components/ledger/internal/adapters/http/in/fees_routes.go
+++ b/components/ledger/internal/adapters/http/in/fees_routes.go
@@ -88,8 +88,8 @@ func attachFeeGuards(group fiber.Router, auth *middleware.AuthClient, routeOptio
 	}
 }
 
-// protectedFees is the plugin-fees analogue of protectedMidaz/protectedRouting: it
-// builds the auth-attaching Fiber chain under the "plugin-fees" authz appName.
+// protectedFees is the plugin-fees analogue of protectedMidaz: it builds the
+// auth-attaching Fiber chain under the "plugin-fees" authz appName.
 func protectedFees(auth *middleware.AuthClient, resource, action string, routeOptions *http.ProtectedRouteOptions, handlers ...fiber.Handler) []fiber.Handler {
 	return http.ProtectedRouteChain(auth.Authorize(feesApplicationName, resource, action), routeOptions, handlers...)
 }

--- a/components/ledger/internal/adapters/http/in/huma_contract_mount.go
+++ b/components/ledger/internal/adapters/http/in/huma_contract_mount.go
@@ -85,8 +85,8 @@ type HumaMountDeps struct {
 // authz tuple and the same route options the pre-Huma inline route used:
 //   - organization/ledger/portfolio/segment/account/asset use OnboardingOptions
 //     ([authAssertion, WithTenantDB]).
-//   - account-type uses OnboardingOptions too, but authorizes against the "routing"
-//     appName (protectedRouting).
+//   - account-type uses OnboardingOptions too, authorizing against the "midaz"
+//     appName (protectedMidaz).
 //   - asset-rate uses TransactionOptions ([authAssertion, WithTenantDB]) — it is
 //     MONEY-adjacent (exchange rates), so it shares the transaction tenant chain.
 //   - metadata-index uses LedgerOptions ([authAssertion] ONLY, no WithTenantDB).
@@ -120,9 +120,7 @@ func (d HumaMountDeps) registerWave1(group fiber.Router, api huma.API) {
 
 // registerWave2 mounts balance, operation-read, transaction-count, operation-route
 // and transaction-route. All carry TransactionOptions ([authAssertion,
-// WithTenantDB]). balance/operation/count authorize against the "midaz" appName
-// (protectedMidaz); operation-route/transaction-route authorize against the
-// "routing" appName (protectedRouting).
+// WithTenantDB]) and authorize against the "midaz" appName (protectedMidaz).
 func (d HumaMountDeps) registerWave2(group fiber.Router, api huma.API) {
 	RegisterBalanceRoutesToApp(group, api, d.Auth, d.Balance, d.TransactionOptions)
 	RegisterOperationRoutesToApp(group, api, d.Auth, d.Operation, d.TransactionOptions)
@@ -140,9 +138,8 @@ func (d HumaMountDeps) registerWave2(group fiber.Router, api huma.API) {
 // The seven onboarding families — organizations, ledgers, portfolios, segments,
 // accounts, account-types, assets — carry OnboardingOptions and reuse the same authz
 // tuples and tenant chain as their v1 twins; they are straight mirrors, additive over v1,
-// with no new policy surface. account-types is the one nuance: it authorizes against the
-// "routing" appName (protectedRouting), NOT "midaz", exactly as on v1 (see
-// registerWave1 / registerAccountTypeRoutesToApp).
+// with no new policy surface. account-types authorizes against the "midaz" appName
+// (protectedMidaz), exactly as on v1 (see registerWave1 / registerAccountTypeRoutesToApp).
 //
 // metadata-index is the LEDGER-AGNOSTIC settings resource: it carries LedgerOptions
 // ([authAssertion] ONLY, no WithTenantDB) and authorizes against the "midaz" appName under
@@ -177,10 +174,10 @@ func (d HumaMountDeps) registerWave2(group fiber.Router, api huma.API) {
 // resource; it is served ONLY on this /v2 contract (see RegisterCompositionV2RoutesToApp).
 //
 // operation-routes carry TransactionOptions ([authAssertion, WithTenantDB]) and authorize
-// against the "routing" appName (protectedRouting), NOT "midaz", exactly as on v1 (see
-// registerWave2 / RegisterOperationRouteRoutesToApp). transaction-routes likewise carry
-// TransactionOptions and authorize against the "routing" appName (protectedRouting), NOT
-// "midaz", exactly as on v1 (see registerWave2 / RegisterTransactionRouteRoutesToApp).
+// against the "midaz" appName (protectedMidaz), exactly as on v1 (see registerWave2 /
+// RegisterOperationRouteRoutesToApp). transaction-routes likewise carry TransactionOptions
+// and authorize against the "midaz" appName (protectedMidaz), exactly as on v1 (see
+// registerWave2 / RegisterTransactionRouteRoutesToApp).
 func (d HumaMountDeps) MountV2(group fiber.Router, api huma.API) {
 	RegisterOrganizationV2RoutesToApp(group, api, d.Auth, d.Organization, d.OnboardingOptions)
 	RegisterLedgerV2RoutesToApp(group, api, d.Auth, d.Ledger, d.OnboardingOptions)

--- a/components/ledger/internal/adapters/http/in/operation_route_handler_huma.go
+++ b/components/ledger/internal/adapters/http/in/operation_route_handler_huma.go
@@ -19,11 +19,10 @@ import (
 // money-read + routing). It mirrors the asset exemplar (asset_handler_huma.go); see
 // that file's header for the full conventions. Operation-route-specific notes:
 //
-//  1. AUTH is the "routing" appName, resource "operation-routes" (protectedRouting
-//     in routes.go), NOT "midaz". The Fiber guard chain is Bearer-only (no
-//     X-API-Key), so the per-op Security metadata here is
+//  1. AUTH is the "midaz" appName, resource "operation-routes". The Fiber guard
+//     chain is Bearer-only (no X-API-Key), so the per-op Security metadata here is
 //     Bearer-only too — this is SPEC metadata only; runtime auth stays the Fiber
-//     guard chain (auth.Authorize("routing","operation-routes",verb) + tenant +
+//     guard chain (auth.Authorize("midaz","operation-routes",verb) + tenant +
 //     ParseUUIDPathParameters("operation_route")) attached in the unified server
 //     BEFORE the Huma terminal.
 //  2. MERGE-PATCH landmine: the PATCH core (updateOperationRoute in
@@ -257,7 +256,7 @@ func (handler *OperationRouteHandler) DeleteOperationRouteByIDHuma(ctx context.C
 
 // RegisterOperationRouteRoutes registers the five migrated operation-route
 // operations on the shared Huma API. It is the per-file seam the unified server
-// calls; the auth ("routing","operation-routes",verb) + tenant +
+// calls; the auth ("midaz","operation-routes",verb) + tenant +
 // ParseUUIDPathParameters("operation_route") middleware chain is attached on the
 // version group (Fiber-level) BEFORE the Huma terminal, not here. Paths are
 // GROUP-RELATIVE (see asset_handler_huma.go's RegisterAssetRoutes header for the

--- a/components/ledger/internal/adapters/http/in/operation_route_huma_test.go
+++ b/components/ledger/internal/adapters/http/in/operation_route_huma_test.go
@@ -33,8 +33,8 @@ import (
 
 // buildHumaOperationRouteApp mounts the five operation-route Huma operations on a
 // /v1 group, faithfully mirroring the production wiring (see buildHumaAssetApp for
-// the full rationale). auth resource is "operation-routes" under the "routing"
-// appName; the auth shim stands in for auth.Authorize("routing","operation-routes",
+// the full rationale). auth resource is "operation-routes" under the "midaz"
+// appName; the auth shim stands in for auth.Authorize("midaz","operation-routes",
 // verb) + tenant PostAuthMiddlewares.
 //
 // MUST-NOT-PARALLELIZE: libProblem.Install() swaps the process-global huma.NewError

--- a/components/ledger/internal/adapters/http/in/routes.go
+++ b/components/ledger/internal/adapters/http/in/routes.go
@@ -12,10 +12,7 @@ import (
 	"github.com/LerianStudio/midaz/v4/pkg/net/http"
 )
 
-const (
-	midazName   = "midaz"
-	routingName = "routing"
-)
+const midazName = "midaz"
 
 // SettingsMaxPayloadSize defines the maximum payload size for settings endpoints (64KB).
 const SettingsMaxPayloadSize = 64 * 1024
@@ -297,13 +294,12 @@ func RegisterOperationRouteV2RoutesToApp(group fiber.Router, api huma.API, auth 
 }
 
 // registerOperationRouteRoutesToApp is the single description of the operation-route surface,
-// shared by every versioned contract that serves it. Auth is the "routing" appName:
-// auth.Authorize("routing","operation-routes",verb) + tenant +
+// shared by every versioned contract that serves it. Auth is the "midaz" appName:
+// auth.Authorize("midaz","operation-routes",verb) + tenant +
 // ParseUUIDPathParameters("operation_route"), attached as MIDDLEWARE ONLY (group-relative
 // paths, no terminal) on the versioned group, then it registers the Huma terminals via
-// RegisterOperationRouteRoutes on the SAME group's Huma API. This preserves the pre-Huma
-// ("routing","operation-routes",verb) authz tuples and tenant resolution BYTE-FOR-BYTE on
-// whichever version group it is mounted on.
+// RegisterOperationRouteRoutes on the SAME group's Huma API. The ("midaz","operation-routes",
+// verb) authz tuples and tenant resolution hold on whichever version group it is mounted on.
 //
 // opSuffix distinguishes the operation IDs one version group publishes from another's — see
 // routeOpSuffixV1. Nothing else varies between contracts, so a change to the surface reaches
@@ -316,11 +312,11 @@ func registerOperationRouteRoutesToApp(group fiber.Router, api huma.API, auth *m
 
 	parse := http.ParseUUIDPathParameters("operation_route")
 
-	routePost(group, listPath, protectedRouting(auth, "operation-routes", "post", routeOptions, parse))
-	routeGet(group, listPath, protectedRouting(auth, "operation-routes", "get", routeOptions, parse))
-	routeGet(group, idPath, protectedRouting(auth, "operation-routes", "get", routeOptions, parse))
-	routePatch(group, idPath, protectedRouting(auth, "operation-routes", "patch", routeOptions, parse))
-	routeDelete(group, idPath, protectedRouting(auth, "operation-routes", "delete", routeOptions, parse))
+	routePost(group, listPath, protectedMidaz(auth, "operation-routes", "post", routeOptions, parse))
+	routeGet(group, listPath, protectedMidaz(auth, "operation-routes", "get", routeOptions, parse))
+	routeGet(group, idPath, protectedMidaz(auth, "operation-routes", "get", routeOptions, parse))
+	routePatch(group, idPath, protectedMidaz(auth, "operation-routes", "patch", routeOptions, parse))
+	routeDelete(group, idPath, protectedMidaz(auth, "operation-routes", "delete", routeOptions, parse))
 
 	RegisterOperationRouteRoutes(api, orh, opSuffix)
 }
@@ -340,13 +336,12 @@ func RegisterTransactionRouteV2RoutesToApp(group fiber.Router, api huma.API, aut
 }
 
 // registerTransactionRouteRoutesToApp is the single description of the transaction-route surface,
-// shared by every versioned contract that serves it. Auth is the "routing" appName:
-// auth.Authorize("routing","transaction-routes",verb) + tenant +
+// shared by every versioned contract that serves it. Auth is the "midaz" appName:
+// auth.Authorize("midaz","transaction-routes",verb) + tenant +
 // ParseUUIDPathParameters("transaction_route"), attached as MIDDLEWARE ONLY (group-relative
 // paths, no terminal) on the versioned group, then it registers the Huma terminals via
-// RegisterTransactionRouteRoutes on the SAME group's Huma API. This preserves the pre-Huma
-// ("routing","transaction-routes",verb) authz tuples and tenant resolution BYTE-FOR-BYTE on
-// whichever version group it is mounted on.
+// RegisterTransactionRouteRoutes on the SAME group's Huma API. The ("midaz","transaction-routes",
+// verb) authz tuples and tenant resolution hold on whichever version group it is mounted on.
 //
 // opSuffix distinguishes the operation IDs one version group publishes from another's — see
 // routeOpSuffixV1. Nothing else varies between contracts, so a change to the surface reaches
@@ -359,21 +354,17 @@ func registerTransactionRouteRoutesToApp(group fiber.Router, api huma.API, auth 
 
 	parse := http.ParseUUIDPathParameters("transaction_route")
 
-	routePost(group, listPath, protectedRouting(auth, "transaction-routes", "post", routeOptions, parse))
-	routeGet(group, listPath, protectedRouting(auth, "transaction-routes", "get", routeOptions, parse))
-	routeGet(group, idPath, protectedRouting(auth, "transaction-routes", "get", routeOptions, parse))
-	routePatch(group, idPath, protectedRouting(auth, "transaction-routes", "patch", routeOptions, parse))
-	routeDelete(group, idPath, protectedRouting(auth, "transaction-routes", "delete", routeOptions, parse))
+	routePost(group, listPath, protectedMidaz(auth, "transaction-routes", "post", routeOptions, parse))
+	routeGet(group, listPath, protectedMidaz(auth, "transaction-routes", "get", routeOptions, parse))
+	routeGet(group, idPath, protectedMidaz(auth, "transaction-routes", "get", routeOptions, parse))
+	routePatch(group, idPath, protectedMidaz(auth, "transaction-routes", "patch", routeOptions, parse))
+	routeDelete(group, idPath, protectedMidaz(auth, "transaction-routes", "delete", routeOptions, parse))
 
 	RegisterTransactionRouteRoutes(api, trh, opSuffix)
 }
 
 func protectedMidaz(auth *middleware.AuthClient, resource, action string, routeOptions *http.ProtectedRouteOptions, handlers ...fiber.Handler) []fiber.Handler {
 	return http.ProtectedRouteChain(auth.Authorize(midazName, resource, action), routeOptions, handlers...)
-}
-
-func protectedRouting(auth *middleware.AuthClient, resource, action string, routeOptions *http.ProtectedRouteOptions, handlers ...fiber.Handler) []fiber.Handler {
-	return http.ProtectedRouteChain(auth.Authorize(routingName, resource, action), routeOptions, handlers...)
 }
 
 // registerRoute registers a protected handler chain on a Fiber v3 router. Fiber

--- a/components/ledger/internal/adapters/http/in/transaction_route_handler_huma.go
+++ b/components/ledger/internal/adapters/http/in/transaction_route_handler_huma.go
@@ -20,11 +20,10 @@ import (
 // (operation_route_handler_huma.go); see the asset exemplar's header for the full
 // conventions. Transaction-route-specific notes:
 //
-//  1. AUTH is the "routing" appName, resource "transaction-routes" (protectedRouting
-//     in routes.go), NOT "midaz". The Fiber guard chain is Bearer-only, so the
-//     per-op Security metadata here is Bearer-only too —
+//  1. AUTH is the "midaz" appName, resource "transaction-routes". The Fiber guard
+//     chain is Bearer-only, so the per-op Security metadata here is Bearer-only too —
 //     SPEC metadata only; runtime auth stays the Fiber guard chain
-//     (auth.Authorize("routing","transaction-routes",verb) + tenant +
+//     (auth.Authorize("midaz","transaction-routes",verb) + tenant +
 //     ParseUUIDPathParameters("transaction_route")) attached in the unified server
 //     BEFORE the Huma terminal.
 //  2. NO merge-patch landmine. Unlike operation-route, transaction-route uses a
@@ -253,7 +252,7 @@ func (handler *TransactionRouteHandler) DeleteTransactionRouteByIDHuma(ctx conte
 
 // RegisterTransactionRouteRoutes registers the five migrated transaction-route
 // operations on the shared Huma API. It is the per-file seam the unified server
-// calls; the auth ("routing","transaction-routes",verb) + tenant +
+// calls; the auth ("midaz","transaction-routes",verb) + tenant +
 // ParseUUIDPathParameters("transaction_route") middleware chain is attached on the
 // /v1 group (Fiber-level) BEFORE the Huma terminal, not here. Paths are
 // GROUP-RELATIVE (see asset_handler_huma.go's RegisterAssetRoutes header for the

--- a/components/ledger/internal/adapters/http/in/transaction_route_huma_test.go
+++ b/components/ledger/internal/adapters/http/in/transaction_route_huma_test.go
@@ -33,9 +33,9 @@ import (
 
 // buildHumaTransactionRouteApp mounts the five transaction-route Huma operations on
 // a /v1 group, faithfully mirroring the production wiring (see buildHumaAssetApp for
-// the full rationale). auth resource is "transaction-routes" under the "routing"
-// appName (protectedRouting in routes.go); the auth shim stands in for
-// auth.Authorize("routing","transaction-routes",verb) + tenant PostAuthMiddlewares.
+// the full rationale). auth resource is "transaction-routes" under the "midaz"
+// appName (protectedMidaz in routes.go); the auth shim stands in for
+// auth.Authorize("midaz","transaction-routes",verb) + tenant PostAuthMiddlewares.
 //
 // MUST-NOT-PARALLELIZE: libProblem.Install() swaps the process-global huma.NewError
 // hook and Huma validation uses process-global sync.Pools; concurrent builds/requests

--- a/docs/auth/RBAC-NAMESPACES.md
+++ b/docs/auth/RBAC-NAMESPACES.md
@@ -29,16 +29,20 @@ namespace string.
 > A grant that authorizes a `/v1` fee call authorizes its `/v2` twin, and vice versa. No second
 > policy surface exists to migrate.
 
-## The three namespaces
+## The two namespaces
 
-The merged binary calls `auth.Authorize(<namespace>, <resource>, <action>)` under three distinct
+The merged binary calls `auth.Authorize(<namespace>, <resource>, <action>)` under two distinct
 namespace literals:
 
 | Namespace | Owner / code | Resources | Source |
 |-----------|--------------|-----------|--------|
-| `midaz` | ledger — `midazName` const; CRM (collapsed package) — `ApplicationName` const | `organizations`, `ledgers`, `assets`, `asset-rates`, `portfolios`, `segments`, `accounts`, `balances`, `transactions`, `operations`, `settings`, `holders`, `instruments` | `components/ledger/internal/adapters/http/in/routes.go` (`midazName = "midaz"`, helper `protectedMidaz`); `components/ledger/internal/adapters/http/in/crm_routes.go` (`const ApplicationName = "midaz"`) for the `holders`/`instruments` resources |
-| `routing` | ledger — `routingName` const | `account-types`, `operation-routes`, `transaction-routes` | `components/ledger/internal/adapters/http/in/routes.go` (`routingName = "routing"`, helper `protectedRouting`) |
+| `midaz` | ledger — `midazName` const; CRM (collapsed package) — `ApplicationName` const | `organizations`, `ledgers`, `assets`, `asset-rates`, `portfolios`, `segments`, `accounts`, `balances`, `transactions`, `operations`, `settings`, `account-types`, `operation-routes`, `transaction-routes`, `holders`, `instruments` | `components/ledger/internal/adapters/http/in/routes.go` (`midazName = "midaz"`, helper `protectedMidaz`); `components/ledger/internal/adapters/http/in/crm_routes.go` (`const ApplicationName = "midaz"`) for the `holders`/`instruments` resources |
 | `plugin-fees` | fees (embedded in ledger) | `packages`, `estimates`, `billing-packages`, `billing-calculate` | `components/ledger/internal/adapters/http/in/fees_routes.go` (`feesApplicationName = "plugin-fees"`, helper `protectedFees`); also `pkg/constant.ModuleFees = "plugin-fees"` and `components/ledger/pkg/feeshared/constant/app.go`. The ledger-scoped `/v2` twins in `fees_v2_register.go` (`RegisterFeesV2RoutesToApp`) attach the same `feeGuardRoutes` table through the same helper — same namespace, same tuples |
+
+The `account-types`, `operation-routes`, and `transaction-routes` resources authorize under the
+`midaz` namespace (helper `protectedMidaz`), parity with `main` — there is no separate `routing`
+namespace in the ledger binary. The tenant-manager grant re-key for any environment that still holds
+`routing:*` grants remains gated to X1 (below).
 
 The `(<action>)` dimension is the HTTP verb mapped to `get` / `post` / `patch` / `delete`. The CRM
 `related-parties` DELETE authorizes under the `instruments` resource (sub-resource maintenance,
@@ -46,7 +50,7 @@ verb `delete`), not its own resource.
 
 ## Tenant-manager policy-key coupling
 
-The three namespace strings above are the **policy keys** that tenant-manager RBAC policies are
+The two namespace strings above are the **policy keys** that tenant-manager RBAC policies are
 written against. Authorization for a request resolves as:
 
 ```
@@ -88,7 +92,7 @@ not require the policies to be migrated first. Local/dev deployments with auth d
 unaffected. Until the migration runs, environments with auth enabled must have their
 tenant-manager policies updated in lockstep with the v4 release.
 
-The remaining namespaces (`midaz`, `routing`, `plugin-fees`) are the authoritative authorization
+The remaining namespaces (`midaz`, `plugin-fees`) are the authoritative authorization
 contract for the unified binary. Risk **R9** (the original namespace divergence) is closed for
 CRM by this flip; the fee namespace stays distinct by design.
 
@@ -97,48 +101,45 @@ CRM by this flip; the fee namespace stays distinct by design.
 # Cross-monorepo namespace strategy (Epic 3.3 — auth-stabilization)
 
 The section above scopes R9/X1 to the **ledger binary** and the CRM flip. This section widens the
-lens to the **whole monorepo**: after consolidation, four authz namespaces ship across the two Go
+lens to the **whole monorepo**: after consolidation, three authz namespaces ship across the two Go
 deploy units. This is a **decision document only** — it records options + a recommendation for the
 owner and **defers all execution to the X1 gate**. No namespace literal is changed by this doc.
 
-## 1. Current state — four namespaces across two deploy units
+## 1. Current state — three namespaces across two deploy units
 
 `auth.Authorize(<namespace>, <resource>, <action>)` (lib-auth v3.0.0, global RBAC check) is called
-under four distinct namespace literals across the monorepo:
+under three distinct namespace literals across the monorepo:
 
 Refs below are anchored on **symbol names**, not line numbers: line numbers rot silently on the
 next edit to the file, and four of the eight that used to sit in this table had already drifted.
 
 | Namespace | Deploy unit | Resources (verified) | Source (file + symbol) |
 |-----------|-------------|----------------------|------------------------|
-| `midaz` | ledger (`:3002`) | `organizations`, `ledgers`, `assets`, `asset-rates`, `portfolios`, `segments`, `accounts`, `balances`, `transactions`, `operations`, `settings`, `holders`, `instruments` | `components/ledger/internal/adapters/http/in/routes.go` (`midazName`, helper `protectedMidaz`); `crm_routes.go` (`ApplicationName`) for `holders`/`instruments` |
-| `routing` | ledger (`:3002`, same binary) | `account-types`, `operation-routes`, `transaction-routes` | `components/ledger/internal/adapters/http/in/routes.go` (`routingName`, helper `protectedRouting`) |
+| `midaz` | ledger (`:3002`) | `organizations`, `ledgers`, `assets`, `asset-rates`, `portfolios`, `segments`, `accounts`, `balances`, `transactions`, `operations`, `settings`, `account-types`, `operation-routes`, `transaction-routes`, `holders`, `instruments` | `components/ledger/internal/adapters/http/in/routes.go` (`midazName`, helper `protectedMidaz`); `crm_routes.go` (`ApplicationName`) for `holders`/`instruments` |
 | `plugin-fees` | ledger (`:3002`, same binary) | `packages`, `estimates`, `billing-packages`, `billing-calculate` | `components/ledger/internal/adapters/http/in/fees_routes.go` (`feesApplicationName`, table `feeGuardRoutes`, helpers `attachFeeGuards`/`protectedFees`); the ledger-scoped `/v2` twins in `fees_v2_register.go` (`RegisterFeesV2RoutesToApp`) attach the same table |
 | `tracer` | tracer (`:4020`) | `reservations`, `audit-events` | `components/tracer/pkg/constant/app.go` (`ApplicationName`); wired via `components/tracer/internal/bootstrap/config.go` (`AppName:`), consumed at `middleware/auth_guard.go` (`(*AuthGuard).Protect`) |
 
-> **Audit-ref check:** every symbol above resolves in the tree as written, and the namespace-to-
-> resource split is as listed — `routing` separating
-> `account-types`/`operation-routes`/`transaction-routes` from their `midaz` siblings inside the
-> **same ledger binary**. Three of the four namespaces (`midaz`/`routing`/`plugin-fees`) ship from
-> the one ledger binary; only `tracer` is a separate deploy unit. Serving fees at a second scope
-> (`/v2`) added no namespace: the count stays four.
+> **Audit-ref check:** every symbol above resolves in the tree as written. `account-types`,
+> `operation-routes`, and `transaction-routes` authorize under `midaz` (helper `protectedMidaz`),
+> parity with `main`; the ledger binary carries no separate `routing` namespace. Two of the three
+> namespaces (`midaz`/`plugin-fees`) ship from the one ledger binary; only `tracer` is a separate
+> deploy unit. Serving fees at a second scope (`/v2`) added no namespace: the count stays three.
 
 ## 2. Consequence — silent 403 across the platform
 
-The four literals are independent **policy keys** in tenant-manager. A grant under one key is
+The three literals are independent **policy keys** in tenant-manager. A grant under one key is
 invisible to the others. So a tenant provisioned with `midaz:*` (a natural "give me everything"
-grant) **silently 403s** every `routing`, `plugin-fees`, and `tracer` resource:
+grant) **silently 403s** every `plugin-fees` and `tracer` resource:
 
 ```
 midaz:transactions:post     → 200   (granted)
-routing:operation-routes:post → 403  (no routing grant — silent)
 plugin-fees:packages:post     → 403  (no plugin-fees grant — silent)
 tracer:audit-events:get       → 403  (no tracer grant — silent)
 ```
 
 Failure mode is the worst kind: **silent 403, no hint that the answer is "wrong namespace".** To
-authorize one logical platform, an integrator must provision grants in **four namespaces** and
-discover the boundaries by hitting 403s. Three of those boundaries (`midaz`/`routing`/`plugin-fees`)
+authorize one logical platform, an integrator must provision grants in **three namespaces** and
+discover the boundaries by hitting 403s. Two of those boundaries (`midaz`/`plugin-fees`)
 live in a single binary, which makes the split especially non-obvious.
 
 ## 3. Trust-model context (owner decision, 2026-06-06)
@@ -175,8 +176,11 @@ Three independent sub-decisions:
 
 **Recommendation (one call, owner-gated):**
 
-- **A1 — unify `routing` into `midaz`.** Same binary, same domain, smallest blast radius, kills the
-  least-defensible split. This is the single highest-value change.
+- **A1 — unify `routing` into `midaz`. Landed in code.** `account-types`, `operation-routes`, and
+  `transaction-routes` now register under `midaz` (helper `protectedMidaz`), parity with `main`;
+  the ledger binary no longer defines a `routing` namespace. Same binary, same domain, smallest
+  blast radius, kills the least-defensible split. The tenant-manager grant re-key for any
+  environment that still holds `routing:*` grants remains gated to X1 (§5).
 - **B1 — keep `plugin-fees` separate.** Honors the R9 closure; do not reopen a settled decision for
   marginal grant-count savings.
 - **C1 — keep `tracer` per-deploy-unit**, but ship a **documented grant bundle** (the
@@ -206,7 +210,7 @@ plugin-crm:holders:{get,post,patch,delete}  →  midaz:holders:{get,post,patch,d
 plugin-crm:aliases:{get,post,patch,delete}  →  midaz:instruments:{get,post,patch,delete}
    (related-parties DELETE)                  →  midaz:instruments:delete
 
-# Epic 3.3 — routing unification (proposed, A1, if accepted at the gate)
+# Epic 3.3 — routing unification (A1 landed in code; grant re-key at the gate)
 routing:account-types:{get,post,patch,delete}      →  midaz:account-types:{...}
 routing:operation-routes:{get,post,patch,delete}   →  midaz:operation-routes:{...}
 routing:transaction-routes:{get,post,patch,delete} →  midaz:transaction-routes:{...}
@@ -218,15 +222,18 @@ tracer:*        (C1 — stays distinct; documented grant bundle)
 
 Sequencing within the single X1 release:
 
-1. **Code:** flip `routingName`/`protectedRouting` to register under `midazName` (one-line per
-   helper at `routes.go:27,231`), landing in the same release as the CRM flip. Merge ≠ authz merge:
-   the code change can merge ahead; grants migrate at the release gate.
+1. **Code — landed.** `account-types`, `operation-routes`, and `transaction-routes` register under
+   `midazName` via `protectedMidaz`; the `routing` const and helper are removed from `routes.go`.
+   Merge ≠ authz merge: the code change merges ahead; grants migrate at the release gate.
 2. **Policy:** tenant-manager re-issues `plugin-crm:*` **and** `routing:*` grants under `midaz` in
    one migration window, executed with the plugin-auth team.
 3. **Docs:** publish the platform grant bundle (the §1 table, post-unification: `midaz` +
    `plugin-fees` + `tracer`) so integrators see the full three-namespace set up front.
 
 **This document decides nothing unilaterally.** It records the current state, the consequence, the
-trust model, and a recommended option set. Execution — including whether to accept A1 at all — is
-**deferred to the X1 gate**, owner-decided with the plugin-auth team, so that the only namespace
-break integrators ever absorb is the single coordinated X1 migration.
+trust model, and a recommended option set. The A1 **code** decision has landed — `account-types`,
+`operation-routes`, and `transaction-routes` are folded into `midaz` in the ledger binary (§4, §5).
+What remains **deferred to the X1 gate** is the **execution** of the tenant-manager policy migration
+and the re-key of any environment still holding `routing:*` grants — owner-decided with the
+plugin-auth team, so that the only namespace break integrators ever absorb is the single coordinated
+X1 migration.

--- a/docs/runbooks/v4-x1-rbac-migration-and-rollback.md
+++ b/docs/runbooks/v4-x1-rbac-migration-and-rollback.md
@@ -56,19 +56,19 @@ Namespace layout in v4 (for context — only the CRM rows are migrating):
 |-----------|-----------|--------|
 | `midaz` | organizations, ledgers, assets, asset-rates, portfolios, segments, accounts, balances, transactions, operations, settings | `routes.go:15` (`midazName`), `protectedMidaz` `routes.go:307-309` |
 | `midaz` (flipped in v4) | **holders, instruments, related-parties** | `crm_routes.go:20`, `crm_routes.go:62-79` |
-| `routing` | account-types, operation-routes, transaction-routes | `routes.go:16` (`routingName`), `protectedRouting` `routes.go:311-313` |
+| `midaz` (flipped in v4) | account-types, operation-routes, transaction-routes | `routes.go:15` (`midazName`), `protectedMidaz` `routes.go:307-309` |
 | `plugin-fees` (**UNCHANGED**) | packages, estimates, billing-packages, billing-calculate | `fees_routes.go:18` (`feesApplicationName`), `pkg/constant/module.go:24` |
 
 > **Fees do NOT migrate.** `plugin-fees:*` is intentionally preserved with no migration
 > (`RBAC-NAMESPACES.md:7-8, 15, 84-86`). Do not touch fees grants during X1.
 >
-> **Routing does NOT migrate either (this build).** `account-types`, `operation-routes`, and
-> `transaction-routes` stay under the `routing` namespace — `protectedRouting` still calls
-> `auth.Authorize(routingName, ...)` (`routes.go:312`; `routingName = "routing"` at `routes.go:16`).
-> X1 touches CRM holders/instruments only. `RBAC-NAMESPACES.md` Epic 3.3 *proposes* folding
-> `routing:* → midaz:*` into a later release; if a future build flips `protectedRouting` to `midazName`,
-> routing grants must migrate too and the matrix + smoke tests below must add the routing routes.
-> **Re-verify `routes.go:312` before each release** to confirm routing has not been folded into X1.
+> **Routing now authorizes under `midaz`.** `account-types`, `operation-routes`, and
+> `transaction-routes` are wired via `protectedMidaz` → `auth.Authorize(midazName, ...)`; the separate
+> `routing` namespace (the `routingName` const and `protectedRouting` helper) was removed. On the auth
+> side these are already granted under `midaz` on `develop` (plugin-access-manager migrations 30/31 +
+> `init_data` seeds + `midaz-m2m-permission` → `midaz-editor-role`). Re-keying any legacy
+> `routing:*`-only environment — and its forward/rollback/smoke-test sequencing — is owned by the X1
+> migration owner; see `docs/auth/RBAC-NAMESPACES.md`.
 
 ---
 
@@ -360,6 +360,6 @@ re-check the migration matrix. The series falling to zero confirms the window cl
 
 - `docs/auth/RBAC-NAMESPACES.md` — X1 gate definition, migration matrix, fail-closed model (authoritative).
 - `components/ledger/internal/adapters/http/in/crm_routes.go` (`:20`, `:62-79`) — the flip and authz calls.
-- `components/ledger/internal/adapters/http/in/routes.go` (`:15-16` names, `:307-313` `protectedMidaz`/`protectedRouting`) — namespace helpers.
+- `components/ledger/internal/adapters/http/in/routes.go` (`:15` `midazName`, `:307-309` `protectedMidaz`) — namespace helper.
 - `components/ledger/internal/adapters/http/in/fees_routes.go` (`:18`), `pkg/constant/module.go` (`:24`) — fees namespace (unchanged).
 - `docs/standards/telemetry.md`, `docs/standards/error-handling.md` — logging/error conventions for triage.

--- a/docs/runbooks/v4-x1-rbac-migration-and-rollback.md
+++ b/docs/runbooks/v4-x1-rbac-migration-and-rollback.md
@@ -50,13 +50,13 @@
   Each is wired via `protectedMidaz(auth, resource, action, ...)` → `auth.Authorize(ApplicationName, resource, action)` (`crm_routes.go:62-79`).
 - **Net effect:** the authz namespace for these routes moves from `plugin-crm` → `midaz`.
 
-Namespace layout in v4 (for context — only the CRM rows are migrating):
+Namespace layout in v4 (for context — the CRM and routing rows flipped to `midaz` in v4):
 
 | Namespace | Resources | Source |
 |-----------|-----------|--------|
-| `midaz` | organizations, ledgers, assets, asset-rates, portfolios, segments, accounts, balances, transactions, operations, settings | `routes.go:15` (`midazName`), `protectedMidaz` `routes.go:307-309` |
+| `midaz` | organizations, ledgers, assets, asset-rates, portfolios, segments, accounts, balances, transactions, operations, settings | `routes.go` (`midazName`, `protectedMidaz`) |
 | `midaz` (flipped in v4) | **holders, instruments, related-parties** | `crm_routes.go:20`, `crm_routes.go:62-79` |
-| `midaz` (flipped in v4) | account-types, operation-routes, transaction-routes | `routes.go:15` (`midazName`), `protectedMidaz` `routes.go:307-309` |
+| `midaz` (flipped in v4) | account-types, operation-routes, transaction-routes | `routes.go` (`midazName`, `protectedMidaz`) |
 | `plugin-fees` (**UNCHANGED**) | packages, estimates, billing-packages, billing-calculate | `fees_routes.go:18` (`feesApplicationName`), `pkg/constant/module.go:24` |
 
 > **Fees do NOT migrate.** `plugin-fees:*` is intentionally preserved with no migration
@@ -360,6 +360,6 @@ re-check the migration matrix. The series falling to zero confirms the window cl
 
 - `docs/auth/RBAC-NAMESPACES.md` — X1 gate definition, migration matrix, fail-closed model (authoritative).
 - `components/ledger/internal/adapters/http/in/crm_routes.go` (`:20`, `:62-79`) — the flip and authz calls.
-- `components/ledger/internal/adapters/http/in/routes.go` (`:15` `midazName`, `:307-309` `protectedMidaz`) — namespace helper.
+- `components/ledger/internal/adapters/http/in/routes.go` (`midazName`, `protectedMidaz`) — namespace helper.
 - `components/ledger/internal/adapters/http/in/fees_routes.go` (`:18`), `pkg/constant/module.go` (`:24`) — fees namespace (unchanged).
 - `docs/standards/telemetry.md`, `docs/standards/error-handling.md` — logging/error conventions for triage.


### PR DESCRIPTION
## Description

Realign the ledger routing resources — `operation-routes`, `transaction-routes`,
and `account-types` — so they authorize under the `midaz` appName instead of a
separate `routing` appName. This restores parity with the released contract, where
these resources already authorize under `midaz`.

The separate `routing` appName had been reintroduced into the ledger HTTP layer
during the Huma handler wiring, diverging from the released behavior. This PR
removes the `protectedRouting` helper and the `routingName` constant; every call
site now uses `protectedMidaz`. A guard test locks the `midaz` appName across the
three resources and all four verbs (post/get/patch/delete) so a future migration
cannot silently re-drift the namespace.

This is a ledger-only change. On the authorization service these three resources
are already granted under the `midaz` appName (editor/contributor/viewer roles and
the M2M permission), so no paired auth-side change is required. The RBAC reference
and the X1 migration runbook are reconciled in the same PR to match the code.

## Type of Change

- [x] `fix`: Bug fix
- [x] `docs`: Documentation only

## Breaking Changes

None for API consumers. The `(resource, verb)` authorization tuples are unchanged;
only the appName the ledger forwards moves from `routing` to `midaz`. Environments
that already carry `midaz` grants for these resources (the current state) are
unaffected; the RBAC docs describe the grant considerations for any environment
still holding only `routing` grants.

## Testing

- [ ] `make test` passes
- [ ] `make test-int` passes if integration paths are exercised
- [ ] `make lint` passes
- [ ] `make sec` and `make vulncheck` pass

**Test evidence:** `go build ./...` clean; `go test` on the affected package green
— the new appName guard test (3 resources x 5 verbs) plus the operation-route,
transaction-route and account-type Huma suites (285 tests in the package); `gofmt`
clean on touched files. Reviewed through the standard review gate (code + logic +
security + tenancy + nil + test + dead-code) with findings remediated. Full
`make lint` / `make sec` / `make test-int` run in CI.

## Architectural Checklist

- [x] No `panic()` in production paths
- [x] Handlers stay thin (parse, validate, call service)
- [x] Infrastructure concerns kept in `internal/bootstrap`

## Related Issues

None.
