### PR TITLE
feat(ledger): declare streaming-manifest permission in RI manifests

### DIFF
--- a/components/ledger/permissions.yaml
+++ b/components/ledger/permissions.yaml
@@ -119,6 +119,9 @@ permissions:
   - { resource: settings, action: get,    effect: allow, roles: [editor, viewer] }
   - { resource: settings, action: delete, effect: allow, roles: [editor] }
 
+  # streaming-manifest — event catalog (streaming_manifest_route.go:35)
+  - { resource: streaming-manifest, action: get, effect: allow, roles: [editor, viewer] }
+
   # transaction-routes (routes.go:357)
   - { resource: transaction-routes, action: post,   effect: allow, roles: [editor] }
   - { resource: transaction-routes, action: patch,  effect: allow, roles: [editor] }

--- a/components/tracer/permissions.yaml
+++ b/components/tracer/permissions.yaml
@@ -46,6 +46,9 @@ permissions:
   # audit-events — hash-chained audit read (routes.go:574)
   - { resource: audit-events, action: get, effect: allow, roles: [editor, viewer] }
 
+  # streaming-manifest — event catalog (streaming_manifest_route.go:48)
+  - { resource: streaming-manifest, action: get, effect: allow, roles: [editor, viewer] }
+
 roles:
   # ### TEAM: please confirm ### — role -> group bindings are INFERRED.
   - name: editor


### PR DESCRIPTION
<table border="0" cellspacing="0" cellpadding="0">
  <tr>
    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
    <td><h1>Midaz</h1></td>
  </tr>
</table>

---

## Description

The `GET /v1/streaming/manifest` route is registered on both binaries and
enforces `auth.Authorize(<service>, "streaming-manifest", "get")` — `midaz`
on the ledger (`streaming_manifest_route.go:35`) and `tracer` on the tracer
service (`streaming_manifest_route.go:48`). The Access-Manager RI permission
manifests added in #2329 never declared this resource, so the access-manager
grants no policy for it and the endpoint returns `403 Forbidden`.

This declares `streaming-manifest: get` for the `editor` and `viewer` roles
in both manifests, matching the existing read-verb convention (read verbs go
to editor + viewer). Every other entry in these manifests already traces to a
real route guard; this closes the one gap.

- `components/ledger/permissions.yaml` (service `midaz`)
- `components/tracer/permissions.yaml` (service `tracer`)

No Go code changes: the RI manifests are published by the shared CI workflow
(`permission-manifest-publish`), already pinned on `develop` since #2329.

## Type of Change

- [x] `feat`: New feature or capability

## Breaking Changes

None. Additive grant only — no existing permission, role, or binding is
changed. The reconciler is namespace-scoped and does not touch legacy grants.

## Testing

- [ ] `make test` passes
- [ ] `make test-int` passes if integration paths are exercised
- [ ] `make lint` passes
- [ ] `make sec` and `make vulncheck` pass

**Test evidence / Actions run:** manifest-only change (no Go paths exercised).
Both files validated: parse clean and the `streaming-manifest` entry resolves
to `{service, action: get, effect: allow, roles: [editor, viewer]}` under
services `midaz` and `tracer`.

## Architectural Checklist

Not applicable — declarative YAML manifest change, no Go/production code.

## Related Issues

None.
