### PR TITLE
feat(ledger): preserve v1 remaining legs and fee economics

### DIFF
--- a/components/ledger/internal/adapters/http/in/fees_huma_test.go
+++ b/components/ledger/internal/adapters/http/in/fees_huma_test.go
@@ -298,6 +298,59 @@ func TestHuma_UpdatePackage_Success(t *testing.T) {
 	assert.Equal(t, packID.String(), got["id"])
 }
 
+func TestHuma_UpdatePackage_OperationRoutePatchSemantics(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	packID := uuid.New()
+	fromID := uuid.NewString()
+	toID := uuid.NewString()
+	tests := []struct {
+		name   string
+		body   string
+		assert func(*testing.T, *model.UpdatePackageInput)
+	}{
+		{
+			name: "two partial fees carry only explicit route values",
+			body: `{"fees":{"firstFee":{"operationRouteFromId":"` + fromID + `"},"secondFee":{"operationRouteToId":"` + toID + `"}}}`,
+			assert: func(t *testing.T, input *model.UpdatePackageInput) {
+				require.Len(t, input.Fee, 2)
+				require.NotNil(t, input.Fee["firstFee"].OperationRouteFromID)
+				assert.Equal(t, fromID, *input.Fee["firstFee"].OperationRouteFromID)
+				require.NotNil(t, input.Fee["secondFee"].OperationRouteToID)
+				assert.Equal(t, toID, *input.Fee["secondFee"].OperationRouteToID)
+			},
+		},
+		{
+			name: "null remains an explicit field clear rather than fee removal",
+			body: `{"fees":{"serviceFee":{"operationRouteFromId":null}}}`,
+			assert: func(t *testing.T, input *model.UpdatePackageInput) {
+				fee := input.Fee["serviceFee"]
+				assert.Nil(t, fee.OperationRouteFromID)
+				assert.False(t, fee.ValidateIfFeeIsNil())
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stub := &stubPackageService{getByIDResult: &pack.Package{ID: packID}}
+			app := buildHumaPackageApp(t, &PackageHandler{Service: stub}, true)
+			req := httptest.NewRequest(http.MethodPatch, feePkgV2Base+orgID.String()+"/ledgers/"+validLedgerUUID()+"/packages/"+packID.String(), bytes.NewBufferString(tt.body))
+			req.Header.Set("Content-Type", "application/json")
+
+			resp, err := app.Test(req, fiber.TestConfig{Timeout: 0})
+			require.NoError(t, err)
+			defer func() { _ = resp.Body.Close() }()
+			respBody, _ := io.ReadAll(resp.Body)
+			require.Equal(t, http.StatusOK, resp.StatusCode, "body: %s", string(respBody))
+			require.True(t, stub.updateCalled)
+			require.NotNil(t, stub.gotUpdate)
+			tt.assert(t, stub.gotUpdate)
+		})
+	}
+}
+
 func TestHuma_DeletePackage_204Empty(t *testing.T) {
 	orgID := uuid.New()
 	packID := uuid.New()

--- a/components/ledger/internal/adapters/http/in/transaction_block_unblock_integration_test.go
+++ b/components/ledger/internal/adapters/http/in/transaction_block_unblock_integration_test.go
@@ -71,16 +71,15 @@ func setupBlockUnblockInfra(t *testing.T) *blockUnblockInfra {
 
 	infra := &blockUnblockInfra{}
 
-	infra.pgContainer = postgrestestutil.SetupContainer(t)
-	infra.mongoContainer = mongotestutil.SetupContainer(t)
-	infra.redisContainer = redistestutil.SetupContainer(t)
+	infra.pgContainer = postgrestestutil.SetupMigratedContainer(t, "transaction")
+	infra.mongoContainer = mongotestutil.SetupReusableContainer(t)
+	infra.redisContainer = redistestutil.SetupReusableContainer(t)
 
-	migrationsPath := postgrestestutil.FindMigrationsPath(t, "transaction")
 	connStr := postgrestestutil.BuildConnectionString(infra.pgContainer.Host, infra.pgContainer.Port, infra.pgContainer.Config)
-	pgConn := postgrestestutil.CreatePostgresClient(t, connStr, connStr, infra.pgContainer.Config.DBName, migrationsPath)
+	pgConn := postgrestestutil.ConnectPostgresClient(t, connStr, connStr)
 
-	mongoConn := mongotestutil.CreateConnection(t, infra.mongoContainer.URI, "test_db")
-	redisConn := redistestutil.CreateConnection(t, infra.redisContainer.Addr)
+	mongoConn := mongotestutil.CreateConnection(t, infra.mongoContainer.URI, infra.mongoContainer.DBName)
+	redisConn := redistestutil.CreateConnectionWithDB(t, infra.redisContainer.Addr, infra.redisContainer.DB)
 
 	transactionRepo := transaction.NewTransactionPostgreSQLRepository(pgConn)
 	operationRepo := operation.NewOperationPostgreSQLRepository(pgConn)

--- a/components/ledger/internal/adapters/http/in/transaction_fee_async_integration_test.go
+++ b/components/ledger/internal/adapters/http/in/transaction_fee_async_integration_test.go
@@ -80,10 +80,10 @@ func TestFeeProof_T25_AsyncFeeInclusive(t *testing.T) {
 	t.Setenv("RABBITMQ_TRANSACTION_BALANCE_OPERATION_KEY", "test.fee.key")
 	t.Setenv("RABBITMQ_TRANSACTION_BALANCE_OPERATION_QUEUE", "test.fee.queue")
 
-	pgContainer := postgrestestutil.SetupContainer(t)
-	mongoContainer := mongotestutil.SetupContainer(t)
-	redisContainer := redistestutil.SetupContainer(t)
-	rabbitContainer := rabbitmqtestutil.SetupContainer(t)
+	pgContainer := postgrestestutil.SetupLedgerContainer(t)
+	mongoContainer := mongotestutil.SetupReusableContainer(t)
+	redisContainer := redistestutil.SetupReusableContainer(t)
+	rabbitContainer := rabbitmqtestutil.SetupReusableContainer(t)
 
 	rabbitHealthURL := "http://" + rabbitContainer.Host + ":" + rabbitContainer.MgmtPort
 	t.Setenv("RABBITMQ_HEALTH_CHECK_URL", rabbitHealthURL)
@@ -91,13 +91,11 @@ func TestFeeProof_T25_AsyncFeeInclusive(t *testing.T) {
 	rabbitmqtestutil.SetupExchange(t, rabbitContainer.Channel, "test.fee.exchange", "direct")
 	rabbitmqtestutil.SetupQueue(t, rabbitContainer.Channel, "test.fee.queue", "test.fee.exchange", "test.fee.key")
 
-	migrationsPath := postgrestestutil.FindMigrationsPath(t, "transaction")
 	connStr := postgrestestutil.BuildConnectionString(pgContainer.Host, pgContainer.Port, pgContainer.Config)
-	pgConn := postgrestestutil.CreatePostgresClient(t, connStr, connStr, pgContainer.Config.DBName, migrationsPath)
-	postgrestestutil.ApplyOnboardingSchema(t, pgContainer.DB)
+	pgConn := postgrestestutil.ConnectPostgresClient(t, connStr, connStr)
 
-	mongoConn := mongotestutil.CreateConnection(t, mongoContainer.URI, "test_db")
-	redisConn := redistestutil.CreateConnection(t, redisContainer.Addr)
+	mongoConn := mongotestutil.CreateConnection(t, mongoContainer.URI, mongoContainer.DBName)
+	redisConn := redistestutil.CreateConnectionWithDB(t, redisContainer.Addr, redisContainer.DB)
 	logger := &libLog.GoLogger{Level: libLog.LevelInfo}
 
 	transactionRepo := transaction.NewTransactionPostgreSQLRepository(pgConn)
@@ -142,7 +140,7 @@ func TestFeeProof_T25_AsyncFeeInclusive(t *testing.T) {
 		TransactionMetadataRepo: metaRepo, TransactionRedisRepo: redisRepo, RabbitMQRepo: producerRepo,
 	}
 
-	feeConn := &feesmongo.MongoConnection{ConnectionStringSource: mongoContainer.URI, Database: "test_db", MaxPoolSize: 1, DB: mongoContainer.Client}
+	feeConn := &feesmongo.MongoConnection{ConnectionStringSource: mongoContainer.URI, Database: mongoContainer.DBName, MaxPoolSize: 1, DB: mongoContainer.Client}
 	packageRepo, err := pack.NewPackageMongoDBRepository(feeConn, logger)
 	require.NoError(t, err)
 	resolver, err := feesservices.NewQueryResolver(queryUC)
@@ -184,6 +182,7 @@ func TestFeeProof_T25_AsyncFeeInclusive(t *testing.T) {
 
 	routes, err := rabbitmq.NewConsumerRoutes(consumerConn, 1, 1, logger, telemetry)
 	require.NoError(t, err, "failed to create consumer routes")
+	t.Cleanup(routes.StopConsumers)
 	consumer := &asyncFeeConsumer{routes: routes, useCase: commandUC}
 	routes.Register(os.Getenv("RABBITMQ_TRANSACTION_BALANCE_OPERATION_QUEUE"), consumer.handle)
 

--- a/components/ledger/internal/adapters/http/in/transaction_fee_harness_integration_test.go
+++ b/components/ledger/internal/adapters/http/in/transaction_fee_harness_integration_test.go
@@ -30,10 +30,13 @@ import (
 	"github.com/LerianStudio/midaz/v4/components/ledger/internal/adapters/postgres/balance"
 	"github.com/LerianStudio/midaz/v4/components/ledger/internal/adapters/postgres/ledger"
 	"github.com/LerianStudio/midaz/v4/components/ledger/internal/adapters/postgres/operation"
+	"github.com/LerianStudio/midaz/v4/components/ledger/internal/adapters/postgres/operationroute"
 	"github.com/LerianStudio/midaz/v4/components/ledger/internal/adapters/postgres/organization"
 	"github.com/LerianStudio/midaz/v4/components/ledger/internal/adapters/postgres/portfolio"
+	"github.com/LerianStudio/midaz/v4/components/ledger/internal/adapters/postgres/revertclaim"
 	"github.com/LerianStudio/midaz/v4/components/ledger/internal/adapters/postgres/segment"
 	"github.com/LerianStudio/midaz/v4/components/ledger/internal/adapters/postgres/transaction"
+	"github.com/LerianStudio/midaz/v4/components/ledger/internal/adapters/postgres/transactionroute"
 	redis "github.com/LerianStudio/midaz/v4/components/ledger/internal/adapters/redis/transaction"
 	"github.com/LerianStudio/midaz/v4/components/ledger/internal/services/command"
 	"github.com/LerianStudio/midaz/v4/components/ledger/internal/services/query"
@@ -60,11 +63,13 @@ type feeHarness struct {
 	mongoContainer *mongotestutil.ContainerResult
 	redisContainer *redistestutil.ContainerResult
 
-	pgConn      *libPostgres.Client
-	db          *sql.DB
-	redisRepo   redis.RedisRepository
-	metaRepo    mongotxn.Repository
-	packageRepo pack.Repository
+	pgConn               *libPostgres.Client
+	db                   *sql.DB
+	redisRepo            redis.RedisRepository
+	metaRepo             mongotxn.Repository
+	packageRepo          pack.Repository
+	operationRouteRepo   *operationroute.OperationRoutePostgreSQLRepository
+	transactionRouteRepo *transactionroute.TransactionRoutePostgreSQLRepository
 
 	commandUC *command.UseCase
 	queryUC   *query.UseCase
@@ -94,27 +99,27 @@ func setupFeeHarness(t *testing.T) *feeHarness {
 
 	h := &feeHarness{}
 
-	h.pgContainer = postgrestestutil.SetupContainer(t)
-	h.mongoContainer = mongotestutil.SetupContainer(t)
-	h.redisContainer = redistestutil.SetupContainer(t)
+	h.pgContainer = postgrestestutil.SetupLedgerContainer(t)
+	h.mongoContainer = mongotestutil.SetupReusableContainer(t)
+	h.redisContainer = redistestutil.SetupReusableContainer(t)
 	h.db = h.pgContainer.DB
 
-	// Transaction schema via golang-migrate (owns schema_migrations).
-	migrationsPath := postgrestestutil.FindMigrationsPath(t, "transaction")
 	connStr := postgrestestutil.BuildConnectionString(h.pgContainer.Host, h.pgContainer.Port, h.pgContainer.Config)
-	h.pgConn = postgrestestutil.CreatePostgresClient(t, connStr, connStr, h.pgContainer.Config.DBName, migrationsPath)
+	h.pgConn = postgrestestutil.ConnectPostgresClient(t, connStr, connStr)
 
-	// Onboarding schema applied directly (disjoint tables; IF NOT EXISTS).
-	postgrestestutil.ApplyOnboardingSchema(t, h.db)
-
-	mongoTxnConn := mongotestutil.CreateConnection(t, h.mongoContainer.URI, "test_db")
-	redisConn := redistestutil.CreateConnection(t, h.redisContainer.Addr)
+	mongoTxnConn := mongotestutil.CreateConnection(t, h.mongoContainer.URI, h.mongoContainer.DBName)
+	redisConn := redistestutil.CreateConnectionWithDB(t, h.redisContainer.Addr, h.redisContainer.DB)
 
 	// Transaction-domain repos.
 	transactionRepo := transaction.NewTransactionPostgreSQLRepository(h.pgConn)
 	operationRepo := operation.NewOperationPostgreSQLRepository(h.pgConn)
+	revertClaimRepo := revertclaim.NewPostgreSQLRepository(h.pgConn)
+	operationRouteRepo := operationroute.NewOperationRoutePostgreSQLRepository(h.pgConn)
+	transactionRouteRepo := transactionroute.NewTransactionRoutePostgreSQLRepository(h.pgConn)
 	balanceRepo := balance.NewBalancePostgreSQLRepository(h.pgConn, false)
 	h.metaRepo = mongotxn.NewMetadataMongoDBRepository(mongoTxnConn)
+	h.operationRouteRepo = operationRouteRepo
+	h.transactionRouteRepo = transactionRouteRepo
 
 	redisRepo, err := redis.NewConsumerRedis(redisConn)
 	require.NoError(t, err, "redis repo")
@@ -140,6 +145,8 @@ func setupFeeHarness(t *testing.T) *feeHarness {
 		OnboardingMetadataRepo:  onbMetaRepo,
 		TransactionRepo:         transactionRepo,
 		OperationRepo:           operationRepo,
+		OperationRouteRepo:      operationRouteRepo,
+		TransactionRouteRepo:    transactionRouteRepo,
 		BalanceRepo:             balanceRepo,
 		TransactionMetadataRepo: h.metaRepo,
 		TransactionRedisRepo:    redisRepo,
@@ -154,6 +161,7 @@ func setupFeeHarness(t *testing.T) *feeHarness {
 		OnboardingMetadataRepo:  onbMetaRepo,
 		TransactionRepo:         transactionRepo,
 		OperationRepo:           operationRepo,
+		RevertClaimRepo:         revertClaimRepo,
 		BalanceRepo:             balanceRepo,
 		TransactionMetadataRepo: h.metaRepo,
 		TransactionRedisRepo:    redisRepo,
@@ -164,7 +172,7 @@ func setupFeeHarness(t *testing.T) *feeHarness {
 	logger := &libLog.GoLogger{}
 	feeConn := &feesmongo.MongoConnection{
 		ConnectionStringSource: h.mongoContainer.URI,
-		Database:               "test_db",
+		Database:               h.mongoContainer.DBName,
 		MaxPoolSize:            1,
 		DB:                     h.mongoContainer.Client,
 	}

--- a/components/ledger/internal/adapters/http/in/transaction_fee_helpers_integration_test.go
+++ b/components/ledger/internal/adapters/http/in/transaction_fee_helpers_integration_test.go
@@ -174,13 +174,17 @@ func (h *feeHarness) seedBalanceWithSegment(t *testing.T, alias, asset string, a
 
 // feeSpec describes one fee inside a seeded package.
 type feeSpec struct {
-	label         string
-	rule          string // "flatFee" | "percentual" | "maxBetweenTypes"
-	calcs         []feemodel.Calculation
-	deductible    bool
-	creditAccount string
-	priority      int
-	referenceAmt  string // defaults to originalAmount
+	label                string
+	rule                 string // "flatFee" | "percentual" | "maxBetweenTypes"
+	calcs                []feemodel.Calculation
+	deductible           bool
+	creditAccount        string
+	priority             int
+	referenceAmt         string // defaults to originalAmount
+	routeFrom            *string
+	routeTo              *string
+	operationRouteFromID *string
+	operationRouteToID   *string
 }
 
 // packageSpec describes a fee package to seed.
@@ -223,10 +227,14 @@ func (h *feeHarness) seedPackage(t *testing.T, spec packageSpec) uuid.UUID {
 				ApplicationRule: f.rule,
 				Calculations:    f.calcs,
 			},
-			ReferenceAmount:  ref,
-			Priority:         priority,
-			IsDeductibleFrom: &ded,
-			CreditAccount:    f.creditAccount,
+			ReferenceAmount:      ref,
+			Priority:             priority,
+			IsDeductibleFrom:     &ded,
+			CreditAccount:        f.creditAccount,
+			RouteFrom:            f.routeFrom,
+			RouteTo:              f.routeTo,
+			OperationRouteFromID: f.operationRouteFromID,
+			OperationRouteToID:   f.operationRouteToID,
 		}
 	}
 
@@ -290,25 +298,26 @@ func maxBetweenFee(label, creditAccount, flatVal, percentVal string, deductible 
 
 // persistedLeg is one row of the Postgres operation table for a transaction.
 type persistedLeg struct {
-	Type   string
-	Alias  string
-	Amount decimal.Decimal
-	Key    string
-	Route  *string
+	Type    string
+	Alias   string
+	Amount  decimal.Decimal
+	Key     string
+	Route   *string
+	RouteID *uuid.UUID
 }
 
 // loadLegs reads all operations persisted for a transaction.
 func loadLegs(t *testing.T, db *sql.DB, txID uuid.UUID) []persistedLeg {
 	t.Helper()
 
-	rows, err := db.Query(`SELECT type, account_alias, amount, balance_key, route FROM operation WHERE transaction_id = $1`, txID)
+	rows, err := db.Query(`SELECT type, account_alias, amount, balance_key, route, route_id FROM operation WHERE transaction_id = $1`, txID)
 	require.NoError(t, err, "query operations")
 	defer func() { _ = rows.Close() }()
 
 	var legs []persistedLeg
 	for rows.Next() {
 		var l persistedLeg
-		require.NoError(t, rows.Scan(&l.Type, &l.Alias, &l.Amount, &l.Key, &l.Route), "scan operation")
+		require.NoError(t, rows.Scan(&l.Type, &l.Alias, &l.Amount, &l.Key, &l.Route, &l.RouteID), "scan operation")
 		legs = append(legs, l)
 	}
 	require.NoError(t, rows.Err(), "operation rows iteration")

--- a/components/ledger/internal/adapters/http/in/transaction_fee_proof_integration_test.go
+++ b/components/ledger/internal/adapters/http/in/transaction_fee_proof_integration_test.go
@@ -411,7 +411,13 @@ func TestFeeProof_T16_C9_PerMode(t *testing.T) {
 		resp := h.post(t, app, h.txPath("annotation"), body, nil)
 		require.Equalf(t, 201, resp.status, "annotation create must succeed: %s", string(resp.rawBody))
 
-		legs := loadLegs(t, h.db, mustTxID(t, resp))
+		transactionID := mustTxID(t, resp)
+		assert.True(t, dbTxAmount(t, h.db, transactionID).Equal(decimal.NewFromInt(1000)),
+			"NOTED must preserve its nonzero informational transaction amount")
+		legs := loadLegs(t, h.db, transactionID)
+		for _, leg := range legs {
+			assert.True(t, leg.Amount.IsZero(), "NOTED operation rows must carry zero economic amount")
+		}
 		assert.Empty(t, feeCreditLegs(legs, "@fee_rev"),
 			"annotation (NOTED) must emit NO fee legs (one-sided, no balance movement)")
 	})

--- a/components/ledger/internal/adapters/http/in/transaction_fee_remaining_integration_test.go
+++ b/components/ledger/internal/adapters/http/in/transaction_fee_remaining_integration_test.go
@@ -1,0 +1,314 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+//go:build integration
+
+package in
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	cn "github.com/LerianStudio/midaz/v4/pkg/constant"
+	"github.com/LerianStudio/midaz/v4/pkg/mmodel"
+	postgrestestutil "github.com/LerianStudio/midaz/v4/tests/utils/postgres"
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFeeProof_V1RemainingDuplicateAliasPreservesBalanceIdentity(t *testing.T) {
+	h := setupFeeHarness(t)
+	app := h.newApp()
+
+	accountParams := postgrestestutil.DefaultAccountParams()
+	accountParams.Alias = "@payer"
+	accountParams.AssetCode = "USD"
+	accountParams.Type = "deposit"
+	payerAccountID := postgrestestutil.CreateTestAccountWithParams(t, h.db, h.orgID, h.ledgerID, accountParams)
+
+	seedPayerBalance := func(key string) uuid.UUID {
+		params := postgrestestutil.DefaultBalanceParams()
+		params.Alias = "@payer"
+		params.Key = key
+		params.AssetCode = "USD"
+		params.Available = decimal.NewFromInt(1000)
+		params.OnHold = decimal.Zero
+
+		return postgrestestutil.CreateTestBalance(t, h.db, h.orgID, h.ledgerID, payerAccountID, params)
+	}
+
+	reservedBalanceID := seedPayerBalance("reserved")
+	availableBalanceID := seedPayerBalance("available")
+	defaultBalanceID := seedPayerBalance("default")
+	receiverBalanceID := h.seedBalance(t, "@receiver", "USD", decimal.Zero, "deposit")
+	feeBalanceID := h.seedBalance(t, "@fee_rev", "USD", decimal.Zero, "deposit")
+
+	h.seedPackage(t, packageSpec{
+		label: "remaining_duplicate_alias",
+		fees:  []feeSpec{flatFee("remaining_fee", "@fee_rev", "10", false)},
+	})
+
+	body := `{
+		"description":"remaining duplicate alias with fee",
+		"pending":false,
+		"send":{
+			"asset":"USD","value":"100",
+			"source":{"from":[
+				{"accountAlias":"@payer","balanceKey":"reserved","amount":{"asset":"USD","value":"60"}},
+				{"accountAlias":"@payer","balanceKey":"available","remaining":"remaining"}
+			]},
+			"distribute":{"to":[{"accountAlias":"@receiver","amount":{"asset":"USD","value":"100"}}]}
+		}
+	}`
+
+	resp := h.createJSON(t, app, body, nil)
+	require.Equalf(t, 201, resp.status, "remaining+fee create must succeed: %s", string(resp.rawBody))
+
+	txID := mustTxID(t, resp)
+	require.Equal(t, cn.APPROVED, dbTxStatus(t, h.db, txID))
+	drainBalanceSync(t, h.ctx(), h.commandUC, h.redisRepo, h.orgID, h.ledgerID)
+
+	legs := loadLegs(t, h.db, txID)
+	require.Len(t, legs, 7, "two authored debits, two fee debits, one transfer credit, and two fee credits must persist")
+	requireBalanced(t, legs, "remaining duplicate alias fee transaction")
+
+	assertLegSet := func(alias, key, operationType string, wantAmounts ...decimal.Decimal) {
+		t.Helper()
+
+		got := make([]decimal.Decimal, 0, len(wantAmounts))
+		for _, leg := range legs {
+			if leg.Alias == alias && leg.Key == key && leg.Type == operationType {
+				got = append(got, leg.Amount)
+			}
+		}
+
+		require.Len(t, got, len(wantAmounts), "%s/%s/%s operation count", alias, key, operationType)
+		for _, want := range wantAmounts {
+			matched := false
+			for i, amount := range got {
+				if amount.Equal(want) {
+					got = append(got[:i], got[i+1:]...)
+					matched = true
+
+					break
+				}
+			}
+			require.Truef(t, matched, "%s/%s/%s must contain amount %s", alias, key, operationType, want)
+		}
+	}
+
+	assertLegSet("@payer", "reserved", cn.DEBIT, decimal.NewFromInt(60))
+	assertLegSet("@payer", "available", cn.DEBIT, decimal.NewFromInt(40))
+	assertLegSet("@payer", "default", cn.DEBIT, decimal.NewFromInt(6), decimal.NewFromInt(4))
+	assertLegSet("@receiver", "default", cn.CREDIT, decimal.NewFromInt(100))
+	assertLegSet("@fee_rev", "default", cn.CREDIT, decimal.NewFromInt(6), decimal.NewFromInt(4))
+
+	requireDecimalEqual(t, decimal.NewFromInt(940), postgrestestutil.GetBalanceAvailable(t, h.db, reservedBalanceID), "reserved balance after explicit leg")
+	requireDecimalEqual(t, decimal.NewFromInt(960), postgrestestutil.GetBalanceAvailable(t, h.db, availableBalanceID), "available balance after remaining leg")
+	requireDecimalEqual(t, decimal.NewFromInt(990), postgrestestutil.GetBalanceAvailable(t, h.db, defaultBalanceID), "default balance after proportional fee legs")
+	requireDecimalEqual(t, decimal.NewFromInt(100), postgrestestutil.GetBalanceAvailable(t, h.db, receiverBalanceID), "receiver balance")
+	requireDecimalEqual(t, decimal.NewFromInt(10), postgrestestutil.GetBalanceAvailable(t, h.db, feeBalanceID), "fee revenue balance")
+
+	debits := decimal.Zero
+	credits := decimal.Zero
+	for _, leg := range legs {
+		switch leg.Type {
+		case cn.DEBIT:
+			debits = debits.Add(leg.Amount)
+		case cn.CREDIT:
+			credits = credits.Add(leg.Amount)
+		}
+	}
+	requireDecimalEqual(t, decimal.NewFromInt(110), debits, "persisted debit total")
+	requireDecimalEqual(t, decimal.NewFromInt(110), credits, "persisted credit total")
+	assert.True(t, debits.Equal(credits), "persisted operations must remain exact double entry")
+}
+
+func TestFeeProof_V1RemainingFeeWithExplicitAccountingRoutes(t *testing.T) {
+	h := setupFeeHarness(t)
+	app := h.newApp()
+
+	_, err := h.db.Exec(`
+		UPDATE ledger
+		SET settings = '{"accounting":{"validateRoutes":true}}'::jsonb
+		WHERE id = $1 AND organization_id = $2`, h.ledgerID, h.orgID)
+	require.NoError(t, err, "enable accounting route validation")
+
+	fixedTime := time.Date(2026, 8, 17, 0, 0, 0, 0, time.UTC)
+	sourceRouteID := uuid.New()
+	destinationRouteID := uuid.New()
+	transactionRouteID := uuid.New()
+
+	_, err = h.operationRouteRepo.Create(h.ctx(), h.orgID, h.ledgerID, &mmodel.OperationRoute{
+		ID:             sourceRouteID,
+		OrganizationID: h.orgID,
+		LedgerID:       h.ledgerID,
+		Title:          "fee source route",
+		OperationType:  "source",
+		AccountingEntries: &mmodel.AccountingEntries{Direct: &mmodel.AccountingEntry{
+			Debit: &mmodel.AccountingRubric{Code: "1000", Description: "fee source debit"},
+		}},
+		CreatedAt: fixedTime,
+		UpdatedAt: fixedTime,
+	})
+	require.NoError(t, err, "create source operation route")
+
+	_, err = h.operationRouteRepo.Create(h.ctx(), h.orgID, h.ledgerID, &mmodel.OperationRoute{
+		ID:             destinationRouteID,
+		OrganizationID: h.orgID,
+		LedgerID:       h.ledgerID,
+		Title:          "fee destination route",
+		OperationType:  "destination",
+		AccountingEntries: &mmodel.AccountingEntries{Direct: &mmodel.AccountingEntry{
+			Credit: &mmodel.AccountingRubric{Code: "2000", Description: "fee destination credit"},
+		}},
+		CreatedAt: fixedTime,
+		UpdatedAt: fixedTime,
+	})
+	require.NoError(t, err, "create destination operation route")
+
+	_, err = h.transactionRouteRepo.Create(h.ctx(), h.orgID, h.ledgerID, &mmodel.TransactionRoute{
+		ID:             transactionRouteID,
+		OrganizationID: h.orgID,
+		LedgerID:       h.ledgerID,
+		Title:          "remaining fee route",
+		OperationRoutes: []mmodel.OperationRoute{
+			{ID: sourceRouteID},
+			{ID: destinationRouteID},
+		},
+		CreatedAt: fixedTime,
+		UpdatedAt: fixedTime,
+	})
+	require.NoError(t, err, "create transaction route")
+
+	accountParams := postgrestestutil.DefaultAccountParams()
+	accountParams.Alias = "@payer"
+	accountParams.AssetCode = "USD"
+	accountParams.Type = "deposit"
+	payerAccountID := postgrestestutil.CreateTestAccountWithParams(t, h.db, h.orgID, h.ledgerID, accountParams)
+	seedPayerBalance := func(key string) uuid.UUID {
+		params := postgrestestutil.DefaultBalanceParams()
+		params.Alias = "@payer"
+		params.Key = key
+		params.AssetCode = "USD"
+		params.Available = decimal.NewFromInt(1000)
+		params.OnHold = decimal.Zero
+
+		return postgrestestutil.CreateTestBalance(t, h.db, h.orgID, h.ledgerID, payerAccountID, params)
+	}
+	reservedBalanceID := seedPayerBalance("reserved")
+	availableBalanceID := seedPayerBalance("available")
+	defaultBalanceID := seedPayerBalance("default")
+	receiverBalanceID := h.seedBalance(t, "@receiver", "USD", decimal.Zero, "deposit")
+	feeBalanceID := h.seedBalance(t, "@fee_rev", "USD", decimal.Zero, "deposit")
+
+	legacyFrom := uuid.NewString()
+	legacyTo := uuid.NewString()
+	sourceRouteString := sourceRouteID.String()
+	destinationRouteString := destinationRouteID.String()
+	fee := flatFee("accounting_remaining_fee", "@fee_rev", "10", false)
+	fee.routeFrom = &legacyFrom
+	fee.routeTo = &legacyTo
+	fee.operationRouteFromID = &sourceRouteString
+	fee.operationRouteToID = &destinationRouteString
+	h.seedPackage(t, packageSpec{label: "accounting_remaining", fees: []feeSpec{fee}})
+
+	body := fmt.Sprintf(`{
+		"description":"remaining fee with accounting routes",
+		"pending":false,
+		"routeId":"%s",
+		"send":{
+			"asset":"USD","value":"100",
+			"source":{"from":[
+				{"accountAlias":"@payer","balanceKey":"reserved","routeId":"%s","amount":{"asset":"USD","value":"60"}},
+				{"accountAlias":"@payer","balanceKey":"available","routeId":"%s","remaining":"remaining"}
+			]},
+			"distribute":{"to":[{"accountAlias":"@receiver","routeId":"%s","amount":{"asset":"USD","value":"100"}}]}
+		}
+	}`, transactionRouteID, sourceRouteID, sourceRouteID, destinationRouteID)
+
+	resp := h.createJSON(t, app, body, nil)
+	require.Equalf(t, 201, resp.status, "remaining+fee accounting create must succeed: %s", string(resp.rawBody))
+
+	txID := mustTxID(t, resp)
+	require.Equal(t, cn.APPROVED, dbTxStatus(t, h.db, txID))
+	drainBalanceSync(t, h.ctx(), h.commandUC, h.redisRepo, h.orgID, h.ledgerID)
+
+	legs := loadLegs(t, h.db, txID)
+	require.Len(t, legs, 7)
+	requireBalanced(t, legs, "remaining fee with accounting routes")
+
+	for _, leg := range legs {
+		require.NotNil(t, leg.RouteID, "%s/%s operation route", leg.Alias, leg.Type)
+
+		switch leg.Type {
+		case cn.DEBIT:
+			assert.Equal(t, sourceRouteID, *leg.RouteID)
+		case cn.CREDIT:
+			assert.Equal(t, destinationRouteID, *leg.RouteID)
+		}
+
+		if leg.Alias == "@payer" && leg.Key == "default" {
+			require.NotNil(t, leg.Route)
+			assert.Equal(t, legacyFrom, *leg.Route, "UUID-looking debit label remains legacy Route")
+		}
+
+		if leg.Alias == "@fee_rev" {
+			require.NotNil(t, leg.Route)
+			assert.Equal(t, legacyTo, *leg.Route, "UUID-looking credit label remains legacy Route")
+		}
+	}
+
+	requireDecimalEqual(t, decimal.NewFromInt(940), postgrestestutil.GetBalanceAvailable(t, h.db, reservedBalanceID), "reserved balance")
+	requireDecimalEqual(t, decimal.NewFromInt(960), postgrestestutil.GetBalanceAvailable(t, h.db, availableBalanceID), "available balance")
+	requireDecimalEqual(t, decimal.NewFromInt(990), postgrestestutil.GetBalanceAvailable(t, h.db, defaultBalanceID), "default fee balance")
+	requireDecimalEqual(t, decimal.NewFromInt(100), postgrestestutil.GetBalanceAvailable(t, h.db, receiverBalanceID), "receiver balance")
+	requireDecimalEqual(t, decimal.NewFromInt(10), postgrestestutil.GetBalanceAvailable(t, h.db, feeBalanceID), "fee revenue balance")
+}
+
+func TestFeeProof_ZeroFeeIsNoOp(t *testing.T) {
+	tests := []struct {
+		name string
+		fee  feeSpec
+	}{
+		{name: "flat zero", fee: flatFee("flat_zero", "@fee_rev", "0", false)},
+		{name: "percentage zero", fee: percentualFee("percentage_zero", "@fee_rev", "0", false)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := setupFeeHarness(t)
+			app := h.newApp()
+			payerBalanceID := h.seedBalance(t, "@payer", "USD", decimal.NewFromInt(1000), "deposit")
+			receiverBalanceID := h.seedBalance(t, "@receiver", "USD", decimal.Zero, "deposit")
+			feeBalanceID := h.seedBalance(t, "@fee_rev", "USD", decimal.Zero, "deposit")
+			h.seedPackage(t, packageSpec{label: "zero_fee", fees: []feeSpec{tt.fee}})
+
+			body := `{
+				"description":"zero fee no-op",
+				"pending":false,
+				"send":{
+					"asset":"USD","value":"100",
+					"source":{"from":[{"accountAlias":"@payer","amount":{"asset":"USD","value":"100"}}]},
+					"distribute":{"to":[{"accountAlias":"@receiver","amount":{"asset":"USD","value":"100"}}]}
+				}
+			}`
+
+			resp := h.createJSON(t, app, body, nil)
+			require.Equalf(t, 201, resp.status, "zero fee create must succeed: %s", string(resp.rawBody))
+
+			txID := mustTxID(t, resp)
+			drainBalanceSync(t, h.ctx(), h.commandUC, h.redisRepo, h.orgID, h.ledgerID)
+			legs := loadLegs(t, h.db, txID)
+			require.Len(t, legs, 2, "a zero result must persist only the authored transfer legs")
+			requireBalanced(t, legs, "zero fee transaction")
+			requireDecimalEqual(t, decimal.NewFromInt(900), postgrestestutil.GetBalanceAvailable(t, h.db, payerBalanceID), "payer balance")
+			requireDecimalEqual(t, decimal.NewFromInt(100), postgrestestutil.GetBalanceAvailable(t, h.db, receiverBalanceID), "receiver balance")
+			requireDecimalEqual(t, decimal.Zero, postgrestestutil.GetBalanceAvailable(t, h.db, feeBalanceID), "fee revenue balance")
+		})
+	}
+}

--- a/components/ledger/internal/adapters/http/in/transaction_integration_test.go
+++ b/components/ledger/internal/adapters/http/in/transaction_integration_test.go
@@ -42,6 +42,7 @@ import (
 	"github.com/LerianStudio/midaz/v4/components/ledger/internal/adapters/postgres/ledger"
 	"github.com/LerianStudio/midaz/v4/components/ledger/internal/adapters/postgres/operation"
 	"github.com/LerianStudio/midaz/v4/components/ledger/internal/adapters/postgres/operationroute"
+	"github.com/LerianStudio/midaz/v4/components/ledger/internal/adapters/postgres/revertclaim"
 	"github.com/LerianStudio/midaz/v4/components/ledger/internal/adapters/postgres/transaction"
 	"github.com/LerianStudio/midaz/v4/components/ledger/internal/adapters/rabbitmq"
 	redis "github.com/LerianStudio/midaz/v4/components/ledger/internal/adapters/redis/transaction"
@@ -58,6 +59,9 @@ import (
 	redistestutil "github.com/LerianStudio/midaz/v4/tests/utils/redis"
 )
 
+const integrationRedisDatasetGeneration = "645439df-1837-421e-9607-f60b091542c9"
+const integrationRolloutInitializationID = "52c85247-b684-4ff7-a45e-41d8f437e4f1"
+
 // testInfra holds all test infrastructure components.
 type testInfra struct {
 	pgContainer    *postgrestestutil.ContainerResult
@@ -65,6 +69,7 @@ type testInfra struct {
 	redisContainer *redistestutil.ContainerResult
 	pgConn         *libPostgres.Client
 	redisRepo      redis.RedisRepository
+	revertFreeze   *redis.RevertUpdateFreezeGuard
 	metadataRepo   mongodb.Repository
 	handler        *TransactionHandler
 	app            *fiber.App
@@ -82,22 +87,23 @@ func setupTestInfra(t *testing.T) *testInfra {
 
 	infra := &testInfra{}
 
-	// Start containers
-	infra.pgContainer = postgrestestutil.SetupContainer(t)
-	infra.mongoContainer = mongotestutil.SetupContainer(t)
-	infra.redisContainer = redistestutil.SetupContainer(t)
+	// Start reusable datastore processes with test-isolated databases.
+	infra.pgContainer = postgrestestutil.SetupMigratedContainer(t, "transaction")
+	infra.mongoContainer = mongotestutil.SetupReusableContainer(t)
+	infra.redisContainer = redistestutil.SetupReusableContainerWithConfig(
+		t, redistestutil.FinancialContainerConfig(),
+	)
 
 	// Create PostgreSQL connection following lib-commons pattern
-	migrationsPath := postgrestestutil.FindMigrationsPath(t, "transaction")
 	connStr := postgrestestutil.BuildConnectionString(infra.pgContainer.Host, infra.pgContainer.Port, infra.pgContainer.Config)
 
-	infra.pgConn = postgrestestutil.CreatePostgresClient(t, connStr, connStr, infra.pgContainer.Config.DBName, migrationsPath)
+	infra.pgConn = postgrestestutil.ConnectPostgresClient(t, connStr, connStr)
 
 	// Create MongoDB connection
-	mongoConn := mongotestutil.CreateConnection(t, infra.mongoContainer.URI, "test_db")
+	mongoConn := mongotestutil.CreateConnection(t, infra.mongoContainer.URI, infra.mongoContainer.DBName)
 
 	// Create Redis connection
-	redisConn := redistestutil.CreateConnection(t, infra.redisContainer.Addr)
+	redisConn := redistestutil.CreateConnectionWithDB(t, infra.redisContainer.Addr, infra.redisContainer.DB)
 
 	// Create repositories
 	transactionRepo := transaction.NewTransactionPostgreSQLRepository(infra.pgConn)
@@ -108,12 +114,27 @@ func setupTestInfra(t *testing.T) *testInfra {
 	// bidirectional-route gate (which resolves an operation's route_id) can run against a real
 	// repository instead of nil-panicking into a generic 500.
 	operationRouteRepo := operationroute.NewOperationRoutePostgreSQLRepository(infra.pgConn)
+	revertClaimRepo := revertclaim.NewPostgreSQLRepository(infra.pgConn)
 	metadataRepo := mongodb.NewMetadataMongoDBRepository(mongoConn)
 	redisRepo, err := redis.NewConsumerRedis(redisConn)
 	require.NoError(t, err, "failed to create Redis repository")
+	initializer := redis.NewRevertUpdateFreezeGuard(redisConn, redis.RevertUpdateFreezeInitialize,
+		integrationRedisDatasetGeneration).WithRolloutInitializationWitness(revertClaimRepo,
+		integrationRolloutInitializationID)
+	require.Eventually(t, func() bool {
+		return initializer.FinancialDurability(context.Background()) == nil
+	}, 10*time.Second, 50*time.Millisecond, "financial Redis test fixture never became durable")
+	require.NoError(t, initializer.InitializeFinancialDatasetGeneration(context.Background()),
+		"failed to initialize financial Redis dataset generation")
+	revertFreeze := redis.NewRevertUpdateFreezeGuard(redisConn, redis.RevertUpdateFreezeFinalized,
+		integrationRedisDatasetGeneration).WithRolloutInitializationWitness(revertClaimRepo, "")
+	require.NoError(t, revertFreeze.Activate(context.Background()), "failed to initialize active revert rollout barrier")
+	require.NoError(t, revertFreeze.MarkPhaseZeroDrained(context.Background()), "failed to initialize drained revert rollout barrier")
+	require.NoError(t, revertFreeze.Finalize(context.Background()), "failed to initialize finalized revert rollout barrier")
 
 	// Store repositories for test assertions
 	infra.redisRepo = redisRepo
+	infra.revertFreeze = revertFreeze
 	infra.metadataRepo = metadataRepo
 
 	// Create use cases
@@ -128,16 +149,22 @@ func setupTestInfra(t *testing.T) *testInfra {
 	}
 	commandUC := &command.UseCase{
 		TransactionRepo:         transactionRepo,
+		RevertClaimRepo:         revertClaimRepo,
+		RevertRolloutLease:      revertFreeze,
 		OperationRepo:           operationRepo,
 		BalanceRepo:             balanceRepo,
 		TransactionMetadataRepo: metadataRepo,
 		TransactionRedisRepo:    redisRepo,
+		RevertIdempotencyMode:   revertIdempotencyModeFinal,
 	}
 
 	// Create handler
 	infra.handler = &TransactionHandler{
-		Query:   queryUC,
-		Command: commandUC,
+		Query:                    queryUC,
+		Command:                  commandUC,
+		RevertIdempotencyMode:    revertIdempotencyModeFinal,
+		RevertUpdateFreeze:       revertFreeze,
+		FinancialRedisDurability: redis.NewFinancialRedisDurabilityGuard(redisConn),
 	}
 
 	// Use fake UUIDs for org and ledger (they're in the onboarding component, not transaction)
@@ -613,10 +640,10 @@ func setupAsyncTestInfra(t *testing.T) *testAsyncInfra {
 	infra := &testAsyncInfra{}
 
 	// Start containers
-	infra.pgContainer = postgrestestutil.SetupContainer(t)
-	infra.mongoContainer = mongotestutil.SetupContainer(t)
-	infra.redisContainer = redistestutil.SetupContainer(t)
-	infra.rabbitmqContainer = rabbitmqtestutil.SetupContainer(t)
+	infra.pgContainer = postgrestestutil.SetupMigratedContainer(t, "transaction")
+	infra.mongoContainer = mongotestutil.SetupReusableContainer(t)
+	infra.redisContainer = redistestutil.SetupReusableContainer(t)
+	infra.rabbitmqContainer = rabbitmqtestutil.SetupReusableContainer(t)
 
 	// Register cleanup for consumer connection
 	// NOTE: Consumer connection must be closed BEFORE containers to avoid reconnection errors.
@@ -624,6 +651,10 @@ func setupAsyncTestInfra(t *testing.T) *testAsyncInfra {
 	// so some "connection reset" logs may still appear during cleanup - this is expected behavior.
 	// Container cleanup is handled automatically by SetupContainer via t.Cleanup().
 	t.Cleanup(func() {
+		if infra.consumerRoutes != nil {
+			infra.consumerRoutes.StopConsumers()
+		}
+
 		// Close the consumer's RabbitMQ channel and connection first to signal goroutines to stop.
 		// The consumer watches for channel closure via NotifyClose, then enters retry mode.
 		if infra.consumerRabbitMQConn != nil {
@@ -633,9 +664,6 @@ func setupAsyncTestInfra(t *testing.T) *testAsyncInfra {
 			if infra.consumerRabbitMQConn.Connection != nil {
 				_ = infra.consumerRabbitMQConn.Connection.Close()
 			}
-			// Wait for the consumer's first retry backoff (~200-400ms) to start,
-			// so container termination happens while consumer is sleeping, not connecting.
-			time.Sleep(500 * time.Millisecond)
 		}
 	})
 
@@ -657,16 +685,15 @@ func setupAsyncTestInfra(t *testing.T) *testAsyncInfra {
 	rabbitmqtestutil.SetupQueue(t, infra.rabbitmqContainer.Channel, "test.transaction.queue", "test.transaction.exchange", "test.transaction.key")
 
 	// Create PostgreSQL connection following lib-commons pattern
-	migrationsPath := postgrestestutil.FindMigrationsPath(t, "transaction")
 	connStr := postgrestestutil.BuildConnectionString(infra.pgContainer.Host, infra.pgContainer.Port, infra.pgContainer.Config)
 
-	infra.pgConn = postgrestestutil.CreatePostgresClient(t, connStr, connStr, infra.pgContainer.Config.DBName, migrationsPath)
+	infra.pgConn = postgrestestutil.ConnectPostgresClient(t, connStr, connStr)
 
 	// Create MongoDB connection
-	mongoConn := mongotestutil.CreateConnection(t, infra.mongoContainer.URI, "test_db")
+	mongoConn := mongotestutil.CreateConnection(t, infra.mongoContainer.URI, infra.mongoContainer.DBName)
 
 	// Create Redis connection
-	redisConn := redistestutil.CreateConnection(t, infra.redisContainer.Addr)
+	redisConn := redistestutil.CreateConnectionWithDB(t, infra.redisContainer.Addr, infra.redisContainer.DB)
 	logger := &libLog.GoLogger{Level: libLog.LevelInfo}
 
 	// Create repositories
@@ -675,6 +702,7 @@ func setupAsyncTestInfra(t *testing.T) *testAsyncInfra {
 	balanceRepo := balance.NewBalancePostgreSQLRepository(infra.pgConn, false)
 	ledgerRepo := ledger.NewLedgerPostgreSQLRepository(infra.pgConn)
 	metadataRepo := mongodb.NewMetadataMongoDBRepository(mongoConn)
+	revertClaimRepo := revertclaim.NewPostgreSQLRepository(infra.pgConn)
 	redisRepo, err := redis.NewConsumerRedis(redisConn)
 	require.NoError(t, err, "failed to create Redis repository")
 
@@ -705,17 +733,20 @@ func setupAsyncTestInfra(t *testing.T) *testAsyncInfra {
 	}
 	infra.commandUC = &command.UseCase{
 		TransactionRepo:         transactionRepo,
+		RevertClaimRepo:         revertClaimRepo,
 		OperationRepo:           operationRepo,
 		BalanceRepo:             balanceRepo,
 		TransactionMetadataRepo: metadataRepo,
 		TransactionRedisRepo:    redisRepo,
 		RabbitMQRepo:            producerRepo,
+		RevertIdempotencyMode:   revertIdempotencyModeFinal,
 	}
 
 	// Create handler
 	infra.handler = &TransactionHandler{
-		Query:   queryUC,
-		Command: infra.commandUC,
+		Query:                 queryUC,
+		Command:               infra.commandUC,
+		RevertIdempotencyMode: revertIdempotencyModeFinal,
 	}
 
 	// Use fake UUIDs for org and ledger (they're in the onboarding component, not transaction)
@@ -2268,20 +2299,15 @@ func TestIntegration_TransactionHandler_IdempotencyReplay(t *testing.T) {
 	t.Logf("Idempotency replay test passed: transaction %s, balance %s", txID.String(), sourceBalance.String())
 }
 
-// TestIntegration_TransactionHandler_IdempotencyConflict tests that using the same
-// idempotency key with a different payload returns HTTP 409 Conflict.
+// TestIntegration_TransactionHandler_IdempotencyReplay_IgnoresChangedAmount proves
+// that an idempotency key always replays its first outcome, even when a later body
+// asks for a different amount.
 //
 // Flow:
 // 1. First request with X-Idempotency header creates transaction
-// 2. Second request with same key but different payload returns 409
-//
-// SKIPPED: This test documents EXPECTED behavior, but conflict detection is NOT implemented.
-// Current behavior: same key + different payload returns 201 with cached response (replay).
-// The hash parameter in CreateOrCheckTransactionIdempotency is only used as fallback key when
-// X-Idempotency header is not provided - it is never stored or compared.
-func TestIntegration_TransactionHandler_IdempotencyConflict(t *testing.T) {
-	t.Skip("PENDING: Conflict detection not implemented - same key returns cached response regardless of payload")
-
+// 2. Second request with the same key but a different amount replays the first
+// 3. Only the first amount affects balances
+func TestIntegration_TransactionHandler_IdempotencyReplay_IgnoresChangedAmount(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode")
 	}
@@ -2378,15 +2404,15 @@ func TestIntegration_TransactionHandler_IdempotencyConflict(t *testing.T) {
 	body2, err := io.ReadAll(resp2.Body)
 	require.NoError(t, err, "should read second response body")
 
-	// Second request with different payload should return 409 Conflict
-	// Note: The implementation may return 409 immediately (key exists without value during processing)
-	// or may return 409 after detecting hash mismatch
-	assert.Equal(t, 409, resp2.StatusCode,
-		"second request with different payload should return 409, got %d: %s", resp2.StatusCode, string(body2))
+	require.Equal(t, 201, resp2.StatusCode,
+		"the changed body must replay the first outcome, got %d: %s", resp2.StatusCode, string(body2))
+	assert.Equal(t, "true", resp2.Header.Get("X-Idempotency-Replayed"))
 
-	// Verify only the first transaction exists
-	var result1 map[string]any
+	// Verify the replay returned the first transaction.
+	var result1, result2 map[string]any
 	require.NoError(t, json.Unmarshal(body1, &result1), "first response should be valid JSON")
+	require.NoError(t, json.Unmarshal(body2, &result2), "replayed response should be valid JSON")
+	assert.Equal(t, result1["id"], result2["id"], "replay must return the first transaction")
 
 	txID, err := uuid.Parse(result1["id"].(string))
 	require.NoError(t, err, "transaction ID should be valid UUID")
@@ -2394,13 +2420,16 @@ func TestIntegration_TransactionHandler_IdempotencyConflict(t *testing.T) {
 	dbStatus := postgrestestutil.GetTransactionStatus(t, infra.pgContainer.DB, txID)
 	assert.NotEmpty(t, dbStatus, "first transaction should exist in database")
 
+	// Flush the first request's hot balance before checking PostgreSQL.
+	drainBalanceSync(t, context.Background(), infra.handler.Command, infra.redisRepo, infra.orgID, infra.ledgerID)
+
 	// Verify balance was only affected by the first transaction (100, not 200)
 	sourceBalance := postgrestestutil.GetBalanceByAlias(t, infra.pgContainer.DB, infra.orgID, infra.ledgerID, sourceAlias)
 	expectedBalance := initialBalance.Sub(decimal.NewFromInt(100))
 	assert.True(t, sourceBalance.Equal(expectedBalance),
 		"source balance should be %s (only first transaction), got %s", expectedBalance.String(), sourceBalance.String())
 
-	t.Logf("Idempotency conflict test passed: only transaction %s created, balance %s", txID.String(), sourceBalance.String())
+	t.Logf("Idempotency replay preserved transaction %s and balance %s", txID.String(), sourceBalance.String())
 }
 
 // TestIntegration_TransactionHandler_IdempotencyReplay_IgnoresReplayerSkip is the

--- a/components/ledger/internal/adapters/http/in/transaction_v1_remaining_lifecycle_integration_test.go
+++ b/components/ledger/internal/adapters/http/in/transaction_v1_remaining_lifecycle_integration_test.go
@@ -1,0 +1,163 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+//go:build integration
+
+package in
+
+import (
+	"context"
+	nethttp "net/http"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	cn "github.com/LerianStudio/midaz/v4/pkg/constant"
+	postgrestestutil "github.com/LerianStudio/midaz/v4/tests/utils/postgres"
+)
+
+const remainingLegV1PendingBody = `{
+	"description":"remaining leg pending",
+	"pending":true,
+	"send":{
+		"asset":"USD","value":"100",
+		"source":{"from":[
+			{"accountAlias":"@srcA","amount":{"asset":"USD","value":"60"}},
+			{"accountAlias":"@srcB","remaining":"remaining"}
+		]},
+		"distribute":{"to":[{"accountAlias":"@dstA","amount":{"asset":"USD","value":"100"}}]}
+	}
+}`
+
+func TestIntegration_TransactionV1Remaining_PendingCommit(t *testing.T) {
+	t.Setenv("ALLOW_INSECURE_TLS", "true")
+	t.Setenv("RABBITMQ_TRANSACTION_ASYNC", "false")
+
+	infra := setupTestInfra(t)
+	ctx := context.Background()
+	balances := seedAdvancedLegBalances(t, infra.pgContainer.DB, infra.orgID, infra.ledgerID, 1000)
+
+	created := decodeTxResponse(t, postTransaction(t, infra.app, v1JSONURL(infra.orgID, infra.ledgerID), remainingLegV1PendingBody, ""), nethttp.StatusCreated)
+	txID := parseTransactionID(t, created)
+
+	assert.Equal(t, cn.PENDING, postgrestestutil.GetTransactionStatus(t, infra.pgContainer.DB, txID))
+	drainBalanceSync(t, ctx, infra.handler.Command, infra.redisRepo, infra.orgID, infra.ledgerID)
+
+	requireDecimalEqual(t, decimal.NewFromInt(940), postgrestestutil.GetBalanceAvailable(t, infra.pgContainer.DB, balances.srcA), "@srcA available after pending create")
+	requireDecimalEqual(t, decimal.NewFromInt(60), postgrestestutil.GetBalanceOnHold(t, infra.pgContainer.DB, balances.srcA), "@srcA on-hold after pending create")
+	requireDecimalEqual(t, decimal.NewFromInt(960), postgrestestutil.GetBalanceAvailable(t, infra.pgContainer.DB, balances.srcB), "@srcB available after pending create")
+	requireDecimalEqual(t, decimal.NewFromInt(40), postgrestestutil.GetBalanceOnHold(t, infra.pgContainer.DB, balances.srcB), "@srcB on-hold after pending create")
+	requireDecimalEqual(t, decimal.Zero, postgrestestutil.GetBalanceAvailable(t, infra.pgContainer.DB, balances.dstA), "@dstA untouched before commit")
+
+	decodeTxResponse(t, postTransaction(t, infra.app, v1CommitURL(infra.orgID, infra.ledgerID, txID), "", ""), nethttp.StatusCreated)
+	assert.Equal(t, cn.APPROVED, postgrestestutil.GetTransactionStatus(t, infra.pgContainer.DB, txID))
+	drainBalanceSync(t, ctx, infra.handler.Command, infra.redisRepo, infra.orgID, infra.ledgerID)
+
+	requireDecimalEqual(t, decimal.NewFromInt(940), postgrestestutil.GetBalanceAvailable(t, infra.pgContainer.DB, balances.srcA), "@srcA available after commit")
+	requireDecimalEqual(t, decimal.Zero, postgrestestutil.GetBalanceOnHold(t, infra.pgContainer.DB, balances.srcA), "@srcA on-hold after commit")
+	requireDecimalEqual(t, decimal.NewFromInt(960), postgrestestutil.GetBalanceAvailable(t, infra.pgContainer.DB, balances.srcB), "@srcB available after commit")
+	requireDecimalEqual(t, decimal.Zero, postgrestestutil.GetBalanceOnHold(t, infra.pgContainer.DB, balances.srcB), "@srcB on-hold after commit")
+	requireDecimalEqual(t, decimal.NewFromInt(100), postgrestestutil.GetBalanceAvailable(t, infra.pgContainer.DB, balances.dstA), "@dstA credited after commit")
+
+	ops := fetchOperationRows(t, infra.pgContainer.DB, txID)
+	types := make([]string, 0, len(ops))
+	for _, op := range ops {
+		types = append(types, op.Type)
+	}
+	assert.ElementsMatch(t, []string{cn.ONHOLD, cn.ONHOLD, cn.DEBIT, cn.DEBIT, cn.CREDIT}, types,
+		"commit must settle both resolved remaining/explicit source legs")
+}
+
+func TestIntegration_TransactionV1Remaining_PendingCancel(t *testing.T) {
+	t.Setenv("ALLOW_INSECURE_TLS", "true")
+	t.Setenv("RABBITMQ_TRANSACTION_ASYNC", "false")
+
+	infra := setupTestInfra(t)
+	ctx := context.Background()
+	balances := seedAdvancedLegBalances(t, infra.pgContainer.DB, infra.orgID, infra.ledgerID, 1000)
+
+	created := decodeTxResponse(t, postTransaction(t, infra.app, v1JSONURL(infra.orgID, infra.ledgerID), remainingLegV1PendingBody, ""), nethttp.StatusCreated)
+	txID := parseTransactionID(t, created)
+	assert.Equal(t, cn.PENDING, postgrestestutil.GetTransactionStatus(t, infra.pgContainer.DB, txID))
+	drainBalanceSync(t, ctx, infra.handler.Command, infra.redisRepo, infra.orgID, infra.ledgerID)
+
+	decodeTxResponse(t, postTransaction(t, infra.app, v1CancelURL(infra.orgID, infra.ledgerID, txID), "", ""), nethttp.StatusCreated)
+	assert.Equal(t, cn.CANCELED, postgrestestutil.GetTransactionStatus(t, infra.pgContainer.DB, txID))
+	drainBalanceSync(t, ctx, infra.handler.Command, infra.redisRepo, infra.orgID, infra.ledgerID)
+
+	requireDecimalEqual(t, decimal.NewFromInt(1000), postgrestestutil.GetBalanceAvailable(t, infra.pgContainer.DB, balances.srcA), "@srcA restored after cancel")
+	requireDecimalEqual(t, decimal.Zero, postgrestestutil.GetBalanceOnHold(t, infra.pgContainer.DB, balances.srcA), "@srcA hold released after cancel")
+	requireDecimalEqual(t, decimal.NewFromInt(1000), postgrestestutil.GetBalanceAvailable(t, infra.pgContainer.DB, balances.srcB), "@srcB restored after cancel")
+	requireDecimalEqual(t, decimal.Zero, postgrestestutil.GetBalanceOnHold(t, infra.pgContainer.DB, balances.srcB), "@srcB hold released after cancel")
+	requireDecimalEqual(t, decimal.Zero, postgrestestutil.GetBalanceAvailable(t, infra.pgContainer.DB, balances.dstA), "@dstA untouched after cancel")
+
+	ops := fetchOperationRows(t, infra.pgContainer.DB, txID)
+	require.Len(t, ops, 4, "cancel must retain both holds and release both resolved source legs")
+	wantAmounts := map[string]decimal.Decimal{
+		"@srcA": decimal.NewFromInt(60),
+		"@srcB": decimal.NewFromInt(40),
+	}
+	seen := make(map[string]map[string]bool, len(wantAmounts))
+	for _, op := range ops {
+		amount, ok := wantAmounts[op.AccountAlias]
+		require.Truef(t, ok, "unexpected cancel operation alias %s", op.AccountAlias)
+		require.Contains(t, []string{cn.ONHOLD, cn.RELEASE}, op.Type, "unexpected cancel operation type")
+		if seen[op.AccountAlias] == nil {
+			seen[op.AccountAlias] = make(map[string]bool, 2)
+		}
+		require.Falsef(t, seen[op.AccountAlias][op.Type], "duplicate %s operation for %s", op.Type, op.AccountAlias)
+		seen[op.AccountAlias][op.Type] = true
+		requireDecimalEqual(t, amount, op.Amount, "%s %s amount", op.AccountAlias, op.Type)
+	}
+
+	for alias := range wantAmounts {
+		assert.Truef(t, seen[alias][cn.ONHOLD], "%s hold operation must persist", alias)
+		assert.Truef(t, seen[alias][cn.RELEASE], "%s release operation must persist", alias)
+	}
+}
+
+func TestIntegration_TransactionV1Remaining_DirectRevert(t *testing.T) {
+	t.Setenv("ALLOW_INSECURE_TLS", "true")
+	t.Setenv("RABBITMQ_TRANSACTION_ASYNC", "false")
+
+	infra := setupTestInfra(t)
+	ctx := context.Background()
+	balances := seedAdvancedLegBalances(t, infra.pgContainer.DB, infra.orgID, infra.ledgerID, 1000)
+
+	created := decodeTxResponse(t, postTransaction(t, infra.app, v1JSONURL(infra.orgID, infra.ledgerID), remainingLegV1Body, ""), nethttp.StatusCreated)
+	originID := parseTransactionID(t, created)
+	assert.Equal(t, cn.APPROVED, postgrestestutil.GetTransactionStatus(t, infra.pgContainer.DB, originID))
+	drainBalanceSync(t, ctx, infra.handler.Command, infra.redisRepo, infra.orgID, infra.ledgerID)
+
+	reversed := decodeTxResponse(t, postTransaction(t, infra.app, v1RevertURL(infra.orgID, infra.ledgerID, originID), "", ""), nethttp.StatusCreated)
+	reverseID := parseTransactionID(t, reversed)
+	assert.Equal(t, cn.APPROVED, postgrestestutil.GetTransactionStatus(t, infra.pgContainer.DB, reverseID))
+	drainBalanceSync(t, ctx, infra.handler.Command, infra.redisRepo, infra.orgID, infra.ledgerID)
+
+	requireDecimalEqual(t, decimal.NewFromInt(1000), postgrestestutil.GetBalanceAvailable(t, infra.pgContainer.DB, balances.srcA), "@srcA restored by revert")
+	requireDecimalEqual(t, decimal.NewFromInt(1000), postgrestestutil.GetBalanceAvailable(t, infra.pgContainer.DB, balances.srcB), "@srcB restored by revert")
+	requireDecimalEqual(t, decimal.Zero, postgrestestutil.GetBalanceAvailable(t, infra.pgContainer.DB, balances.dstA), "@dstA reversed")
+
+	reverseOps := fetchOperationRows(t, infra.pgContainer.DB, reverseID)
+	assert.Len(t, reverseOps, 3, "revert must preserve all resolved legs")
+	totals := sumOperationAmountsByType(reverseOps)
+	requireDecimalEqual(t, decimal.NewFromInt(100), totals[cn.DEBIT], "revert debit total")
+	requireDecimalEqual(t, decimal.NewFromInt(100), totals[cn.CREDIT], "revert credit total")
+	assert.True(t, totals[cn.DEBIT].Equal(totals[cn.CREDIT]), "revert must remain double-entry balanced")
+}
+
+func parseTransactionID(t *testing.T, response map[string]any) uuid.UUID {
+	t.Helper()
+
+	id, ok := response["id"].(string)
+	require.True(t, ok, "transaction response must contain an id")
+
+	parsed, err := uuid.Parse(id)
+	require.NoError(t, err, "transaction response id must be a UUID")
+
+	return parsed
+}

--- a/components/ledger/internal/adapters/http/in/transaction_v2_lifecycle_integration_test.go
+++ b/components/ledger/internal/adapters/http/in/transaction_v2_lifecycle_integration_test.go
@@ -10,21 +10,36 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"io"
 	nethttp "net/http"
 	"net/http/httptest"
+	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	libCommons "github.com/LerianStudio/lib-commons/v6/commons"
 	"github.com/gofiber/fiber/v3"
 	"github.com/google/uuid"
+	redislib "github.com/redis/go-redis/v9"
 	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/LerianStudio/midaz/v4/components/ledger/internal/adapters/postgres/ledger"
+	"github.com/LerianStudio/midaz/v4/components/ledger/internal/adapters/postgres/revertclaim"
+	"github.com/LerianStudio/midaz/v4/components/ledger/internal/adapters/postgres/transaction"
+	transactionredis "github.com/LerianStudio/midaz/v4/components/ledger/internal/adapters/redis/transaction"
+	"github.com/LerianStudio/midaz/v4/components/ledger/pkg/readrouting"
+	"github.com/LerianStudio/midaz/v4/pkg"
 	cn "github.com/LerianStudio/midaz/v4/pkg/constant"
+	"github.com/LerianStudio/midaz/v4/pkg/mmodel"
+	"github.com/LerianStudio/midaz/v4/pkg/repository"
+	"github.com/LerianStudio/midaz/v4/pkg/utils"
 	postgrestestutil "github.com/LerianStudio/midaz/v4/tests/utils/postgres"
+	redistestutil "github.com/LerianStudio/midaz/v4/tests/utils/redis"
 )
 
 // This file is the v2 transaction LIFECYCLE integration + parity proof: it exercises the v2
@@ -69,6 +84,83 @@ func v2RevertURL(orgID, ledgerID, txID uuid.UUID) string {
 
 func v1RevertURL(orgID, ledgerID, txID uuid.UUID) string {
 	return "/v1/organizations/" + orgID.String() + "/ledgers/" + ledgerID.String() + "/transactions/" + txID.String() + "/revert"
+}
+
+type skippedFirstLegacyHoldCleanupRepository struct {
+	transactionredis.RedisRepository
+	skipped   atomic.Bool
+	attempted chan struct{}
+}
+
+func (r *skippedFirstLegacyHoldCleanupRepository) RemoveMessageFromQueueIfStatus(
+	ctx context.Context,
+	key, expectedStatus, expectedOwner, expectedOutcome string,
+	allowTerminalOutcome bool,
+) (bool, error) {
+	if expectedStatus == cn.PENDING && expectedOwner == "" && expectedOutcome == "" &&
+		!allowTerminalOutcome && r.skipped.CompareAndSwap(false, true) {
+		close(r.attempted)
+
+		return false, nil
+	}
+
+	return r.RedisRepository.RemoveMessageFromQueueIfStatus(
+		ctx, key, expectedStatus, expectedOwner, expectedOutcome, allowTerminalOutcome,
+	)
+}
+
+func patchV1Transaction(t *testing.T, app *fiber.App, orgID, ledgerID, txID uuid.UUID, body string) *nethttp.Response {
+	t.Helper()
+
+	url := "/v1/organizations/" + orgID.String() + "/ledgers/" + ledgerID.String() + "/transactions/" + txID.String()
+	req := httptest.NewRequest(nethttp.MethodPatch, url, strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/merge-patch+json")
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: 0})
+	require.NoError(t, err)
+
+	return resp
+}
+
+func prepareRevertUpdateFreeze(t *testing.T, infra *testInfra) {
+	t.Helper()
+	client := infra.redisContainer.Client
+	ctx := context.Background()
+	// setupTestInfra starts at the normal finalized serving target. Rollout
+	// compatibility cases need a separate first-install fixture, so reset the
+	// isolated test certificate together with its Redis witnesses. Production
+	// has no such transition: PREPARED and later are deliberately forward-only.
+	_, err := infra.pgContainer.DB.ExecContext(ctx, `DELETE FROM transaction_revert_rollout_initialization`)
+	require.NoError(t, err)
+	require.NoError(t, client.Del(ctx, transactionredis.RevertUpdateFreezeKey,
+		transactionredis.RevertRolloutGenerationKey, transactionredis.FinancialDatasetGenerationKey).Err())
+	connection := redistestutil.CreateConnectionWithDB(t, infra.redisContainer.Addr, infra.redisContainer.DB)
+	rolloutWitness := revertclaim.NewPostgreSQLRepository(infra.pgConn)
+	initializer := transactionredis.NewRevertUpdateFreezeGuard(connection,
+		transactionredis.RevertUpdateFreezeInitialize, integrationRedisDatasetGeneration).
+		WithRolloutInitializationWitness(rolloutWitness, integrationRolloutInitializationID)
+	require.NoError(t, initializer.InitializeFinancialDatasetGeneration(ctx))
+	prepared := transactionredis.NewRevertUpdateFreezeGuard(connection,
+		transactionredis.RevertUpdateFreezePrepared, integrationRedisDatasetGeneration).
+		WithRolloutInitializationWitness(rolloutWitness, "")
+	require.NoError(t, prepared.ValidatePrepared(ctx))
+	infra.revertFreeze = prepared
+	infra.handler.RevertUpdateFreeze = prepared
+	infra.handler.Command.RevertRolloutLease = prepared
+}
+
+func activateRevertUpdateFreeze(t *testing.T, infra *testInfra) {
+	t.Helper()
+	prepareRevertUpdateFreeze(t, infra)
+	ctx := context.Background()
+	connection := redistestutil.CreateConnectionWithDB(t, infra.redisContainer.Addr, infra.redisContainer.DB)
+	rolloutWitness := revertclaim.NewPostgreSQLRepository(infra.pgConn)
+	active := transactionredis.NewRevertUpdateFreezeGuard(connection,
+		transactionredis.RevertUpdateFreezeActive, integrationRedisDatasetGeneration).
+		WithRolloutInitializationWitness(rolloutWitness, "")
+	require.NoError(t, active.Activate(ctx))
+	infra.revertFreeze = active
+	infra.handler.RevertUpdateFreeze = active
+	infra.handler.Command.RevertRolloutLease = active
 }
 
 // =============================================================================
@@ -148,6 +240,46 @@ func TestIntegration_TransactionV2Hold_CommitViaV2_ParityWithV1(t *testing.T) {
 	// settled operations embedded) is indistinguishable from the v1 commit response.
 	require.Equal(t, stripVolatile(v1CommitResp), stripVolatile(renameV2LegKeys(v2CommitResp)),
 		"v2 commit response must be indistinguishable from the v1 commit equivalent (ignoring IDs/timestamps)")
+}
+
+func TestIntegration_TransactionPendingCommitClearsDurableLegacyHoldBackup(t *testing.T) {
+	t.Setenv("ALLOW_INSECURE_TLS", "true")
+	t.Setenv("RABBITMQ_TRANSACTION_ASYNC", "false")
+
+	infra := setupTestInfra(t)
+	ctx := context.Background()
+	_, _ = seedFundedTransfer(t, infra.pgContainer.DB, infra.orgID, infra.ledgerID,
+		"@src", "@dst", 1000, 1000)
+	faultRepo := &skippedFirstLegacyHoldCleanupRepository{
+		RedisRepository: infra.redisRepo,
+		attempted:       make(chan struct{}),
+	}
+	infra.handler.Command.TransactionRedisRepo = faultRepo
+	v2App := buildHumaV2DirectApp(t, infra.handler)
+
+	pending := decodeTxResponse(t, postV2Create(t, v2App, "hold", infra.orgID, infra.ledgerID,
+		holdParityV2Body, ""), nethttp.StatusCreated)
+	pendingID := uuid.MustParse(pending["id"].(string))
+	select {
+	case <-faultRepo.attempted:
+	case <-time.After(3 * time.Second):
+		require.FailNow(t, "legacy hold cleanup was not attempted")
+	}
+
+	backupKey := utils.TransactionInternalKey(infra.orgID, infra.ledgerID, pendingID.String())
+	rawBackup, err := infra.redisRepo.ReadMessageFromQueue(ctx, backupKey)
+	require.NoError(t, err)
+	queued := mmodel.TransactionRedisQueue{}
+	require.NoError(t, json.Unmarshal(rawBackup, &queued))
+	assert.Equal(t, cn.PENDING, queued.TransactionStatus)
+	assert.Equal(t, cn.ActionHold, queued.Action)
+	assert.Empty(t, queued.AttemptOwner)
+	assert.Empty(t, queued.ExpectedOutcome)
+
+	decodeTxResponse(t, postTransaction(t, v2App,
+		v2CommitURL(infra.orgID, infra.ledgerID, pendingID), "", ""), nethttp.StatusCreated)
+	assert.Equal(t, cn.APPROVED,
+		postgrestestutil.GetTransactionStatus(t, infra.pgContainer.DB, pendingID))
 }
 
 // =============================================================================
@@ -577,7 +709,7 @@ func assertProblemCode(t *testing.T, resp *nethttp.Response, wantStatus int, wan
 //     SAME ParseUUIDPathParameters Fiber guard. Each gate has its own sentinel and its own
 //     status CLASS:
 //       - origin that was ALREADY reverted (a child revert exists)
-//             -> 409 ErrTransactionIDHasAlreadyParentTransaction (0087, EntityConflictError)
+//             -> 201 with the exact durable reverse and X-Idempotency-Replayed=true
 //       - the reverse transaction itself (carries a ParentTransactionID)
 //             -> 409 ErrTransactionIDIsAlreadyARevert (0088, EntityConflictError)
 //       - a non-APPROVED transaction (PENDING or CANCELED)
@@ -612,7 +744,7 @@ func TestIntegration_TransactionV2Revert_IneligibilityAndIDErrors(t *testing.T) 
 	v2App := buildHumaV2DirectApp(t, infra.handler)
 
 	// Subject pair 1: an APPROVED direct transfer and its reverse. After this pair the origin
-	// HAS a child revert and the reverse IS one, so each is the subject of its own gate.
+	// MUST replay its durable reverse while the reverse itself remains ineligible.
 	originResp := decodeTxResponse(t, postV2Create(t, v2App, "direct", infra.orgID, infra.ledgerID, equivalentV2Body, ""), nethttp.StatusCreated)
 	originTxID := uuid.MustParse(originResp["id"].(string))
 	require.Equal(t, cn.APPROVED, postgrestestutil.GetTransactionStatus(t, infra.pgContainer.DB, originTxID), "the origin transfer should be APPROVED")
@@ -667,12 +799,6 @@ func TestIntegration_TransactionV2Revert_IneligibilityAndIDErrors(t *testing.T) 
 		wantStatus int
 		wantCode   string
 	}{
-		{
-			name:       "revert of an already reverted transaction conflicts on the existing child",
-			url:        v2RevertURL(infra.orgID, infra.ledgerID, originTxID),
-			wantStatus: nethttp.StatusConflict,
-			wantCode:   cn.ErrTransactionIDHasAlreadyParentTransaction.Error(),
-		},
 		{
 			name:       "revert of a reverse transaction conflicts because it is already a revert",
 			url:        v2RevertURL(infra.orgID, infra.ledgerID, revertTxID),
@@ -747,14 +873,22 @@ func TestIntegration_TransactionV2Revert_IneligibilityAndIDErrors(t *testing.T) 
 		})
 	}
 
+	v2ReplayResponse := postTransaction(t, v2App, v2RevertURL(infra.orgID, infra.ledgerID, originTxID), "", "")
+	assert.Equal(t, "true", v2ReplayResponse.Header.Get("X-Idempotency-Replayed"))
+	v2Replay := decodeTxResponse(t, v2ReplayResponse, nethttp.StatusCreated)
+	assert.Equal(t, revertTxID.String(), v2Replay["id"], "same-origin v2 retry must return the durable reverse")
+	v1ReplayResponse := postTransaction(t, v1App, v1RevertURL(infra.orgID, infra.ledgerID, originTxID), "", "")
+	assert.Equal(t, "true", v1ReplayResponse.Header.Get("X-Idempotency-Replayed"))
+	v1Replay := decodeTxResponse(t, v1ReplayResponse, nethttp.StatusCreated)
+	assert.Equal(t, revertTxID.String(), v1Replay["id"], "same-origin v1 retry must return the durable reverse")
+
 	// v1↔v2 ineligibility parity, sampled on the two gates whose contract is easiest to get
-	// wrong: the same subjects rejected through the EXISTING v1 revert endpoint return the
+	// wrong: the same unknown subject rejected through the EXISTING v1 revert endpoint returns the
 	// byte-identical problem envelope, so the v2 surface adds no divergent error behavior.
 	for _, tc := range []struct {
 		name string
 		txID uuid.UUID
 	}{
-		{"already reverted origin", originTxID},
 		{"unknown transaction id", unknownTxID},
 	} {
 		v1Resp := postTransaction(t, v1App, v1RevertURL(infra.orgID, infra.ledgerID, tc.txID), "", "")
@@ -767,8 +901,8 @@ func TestIntegration_TransactionV2Revert_IneligibilityAndIDErrors(t *testing.T) 
 		assert.JSONEq(t, string(v1Body), string(v2Body), "%s: v1 and v2 revert must reject with the same problem envelope", tc.name)
 	}
 
-	// Every rejected revert left its subject exactly as it was and persisted nothing: the five
-	// created transactions plus the seeded degenerate one, and no extra reverse.
+	// Every rejected or replayed revert left its subject exactly as it was and persisted nothing:
+	// the five created transactions plus the seeded degenerate one, and no extra reverse.
 	assert.Equal(t, cn.APPROVED, postgrestestutil.GetTransactionStatus(t, infra.pgContainer.DB, originTxID), "the origin must stay APPROVED after the rejected reverts")
 	assert.Equal(t, cn.APPROVED, postgrestestutil.GetTransactionStatus(t, infra.pgContainer.DB, revertTxID), "the reverse must stay APPROVED after the rejected reverts")
 	assert.Equal(t, cn.PENDING, postgrestestutil.GetTransactionStatus(t, infra.pgContainer.DB, pendingTxID), "the PENDING subject must stay PENDING")
@@ -779,40 +913,14 @@ func TestIntegration_TransactionV2Revert_IneligibilityAndIDErrors(t *testing.T) 
 }
 
 // =============================================================================
-// 18. KNOWN DEFECT — REVERT IDEMPOTENCY IS NOT SCOPED BY ORIGIN.
-//     SKIPPED: this is the reproduction of an OPEN defect, kept executable-but-skipped rather
-//     than deleted so the knowledge and the arrangement survive until the fix lands.
+// 18. REVERT IDEMPOTENCY IS SCOPED BY ORIGIN.
 //
-//     A revert sends no X-Idempotency header, so its slot is derived entirely inside the create
-//     core. The reversal payload is a pure function of the origin's economic content and carries
-//     NO reference to the origin, so keying the slot on that payload alone makes two
-//     economically-identical origins in the same ledger share ONE slot: the second revert loses
-//     the SetNX, replays the FIRST reverse (201 with parentTransactionId pointing at origin A),
-//     and origin B is silently never reverted.
-//
-//     The fix — an origin-scoped preimage — was pulled back out of this branch: v1 revert is
-//     released, and re-shaping a live Redis key on its own would open a rolling-deploy window
-//     where a retried revert lands on a different slot and can double-revert. It re-lands
-//     together with the idempotency keyspace separation, which re-shapes the key anyway, behind
-//     a dual-write/dual-read migration. UN-SKIP this test then.
-//
-//     The body below is the full reproduction and asserts BOTH halves of the intended contract:
-//       (a) two identical origins each get their OWN reverse, linked to their OWN origin —
-//           this is the half that FAILS today;
-//       (b) a repeat revert of the SAME origin still lands on ONE slot and persists nothing —
-//           that shared claim is what serializes the read-then-act race in the
-//           GetParentByTransactionID gate, so scoping the key by origin must not make every
-//           revert unique. This half holds today and stays covered by
-//           TestIntegration_TransactionV2Revert_ConcurrentSingleWinner, which is NOT skipped.
+//     Two economically identical origins receive distinct, correctly-parented
+//     reverses, while a retry of one origin returns its one durable reverse and
+//     never persists or moves funds again.
 // =============================================================================
 
-func TestIntegration_TransactionV2Revert_IdempotencyNotScopedByOrigin_KnownDefect(t *testing.T) {
-	t.Skip("known defect: revert idempotency is keyed on the origin-agnostic reversal payload, " +
-		"so two economically-identical origins in one ledger share a slot and the second revert " +
-		"replays the first without reverting its own origin. The fix was pulled from this branch " +
-		"to avoid a Redis key-shape change on a released path; it re-lands together with the " +
-		"idempotency keyspace separation, behind a dual-write/dual-read migration. Un-skip when " +
-		"that lands.")
+func TestIntegration_TransactionV2Revert_IdempotencyScopedByOrigin(t *testing.T) {
 
 	// NOT parallel: process-global huma state (see file header).
 	t.Setenv("ALLOW_INSECURE_TLS", "true")
@@ -881,31 +989,2160 @@ func TestIntegration_TransactionV2Revert_IdempotencyNotScopedByOrigin_KnownDefec
 	requireDecimalEqual(t, decimal.NewFromInt(1000), postgrestestutil.GetBalanceAvailable(t, infra.pgContainer.DB, srcID), "source available restored after both reverts")
 	requireDecimalEqual(t, decimal.Zero, postgrestestutil.GetBalanceAvailable(t, infra.pgContainer.DB, dstID), "destination drained back after both reverts")
 
-	// (b) The preserved invariant: a REPEAT revert of the SAME origin is rejected and persists
-	// nothing. Sequentially the already-has-a-child gate fires first (409/0087); the shared
-	// idempotency claim is what covers the concurrent case the gate cannot.
+	// (b) A repeat revert of the SAME origin replays the durable reverse and persists nothing.
+	// The replay is resolved from PostgreSQL primary and must echo the reserved reverse ID.
 	repeat := postTransaction(t, v2App, v2RevertURL(infra.orgID, infra.ledgerID, originAID), "", "")
-	assertProblemCode(t, repeat, nethttp.StatusConflict, cn.ErrTransactionIDHasAlreadyParentTransaction.Error())
+	assert.Equal(t, "true", repeat.Header.Get("X-Idempotency-Replayed"))
+	repeatBody := decodeTxResponse(t, repeat, nethttp.StatusCreated)
+	assert.Equal(t, revertAID.String(), repeatBody["id"])
 
 	assert.Equal(t, 4, countTransactionsInLedger(t, infra.pgContainer.DB, infra.ledgerID),
 		"a repeat revert of the SAME origin must not persist a third transaction")
 }
 
+func TestIntegration_TransactionV2Revert_RolloutOldBridgeFinalNeverReplaysAnotherOrigin(t *testing.T) {
+	t.Setenv("ALLOW_INSECURE_TLS", "true")
+	t.Setenv("RABBITMQ_TRANSACTION_ASYNC", "false")
+
+	infra := setupTestInfra(t)
+	ctx := context.Background()
+	srcID, dstID := seedTransfer(t, infra.pgContainer.DB, infra.orgID, infra.ledgerID, "@src", "@dst", 1000)
+	v2App := buildHumaV2DirectApp(t, infra.handler)
+
+	const identicalOriginBody = `{"description":"rollout collision","asset":"USD","amount":"100","debits":[{"alias":"@src",` + v2ScopeJSON + `,"amount":"100"}],"credits":[{"alias":"@dst",` + v2ScopeJSON + `,"amount":"100"}]}`
+	originA := decodeTxResponse(t, postV2Create(t, v2App, "direct", infra.orgID, infra.ledgerID, identicalOriginBody, "rollout-a"), nethttp.StatusCreated)
+	originAID := uuid.MustParse(originA["id"].(string))
+	drainBalanceSync(t, ctx, infra.handler.Command, infra.redisRepo, infra.orgID, infra.ledgerID)
+	originB := decodeTxResponse(t, postV2Create(t, v2App, "direct", infra.orgID, infra.ledgerID, identicalOriginBody, "rollout-b"), nethttp.StatusCreated)
+	originBID := uuid.MustParse(originB["id"].(string))
+	drainBalanceSync(t, ctx, infra.handler.Command, infra.redisRepo, infra.orgID, infra.ledgerID)
+
+	reverseA := decodeTxResponse(t, postTransaction(t, v2App, v2RevertURL(infra.orgID, infra.ledgerID, originAID), "", ""), nethttp.StatusCreated)
+	reverseAID := uuid.MustParse(reverseA["id"].(string))
+	drainBalanceSync(t, ctx, infra.handler.Command, infra.redisRepo, infra.orgID, infra.ledgerID)
+
+	originATransaction, err := infra.handler.Query.GetTransactionWithOperationsByID(ctx, infra.orgID, infra.ledgerID, originAID)
+	require.NoError(t, err)
+	legacyHash, err := legacyRevertIdempotencyHash(originATransaction.TransactionRevert())
+	require.NoError(t, err)
+	persistedReverseA, err := infra.handler.Query.GetTransactionByID(ctx, infra.orgID, infra.ledgerID, reverseAID)
+	require.NoError(t, err)
+	legacyValue, err := json.Marshal(persistedReverseA)
+	require.NoError(t, err)
+	require.NoError(t, infra.redisRepo.Set(ctx, utils.IdempotencyInternalKey(infra.orgID, infra.ledgerID, legacyHash), string(legacyValue), 300))
+
+	activateRevertUpdateFreeze(t, infra)
+	infra.handler.RevertIdempotencyMode = revertIdempotencyModeLegacy
+	phaseZeroResponse := postTransaction(t, v2App, v2RevertURL(infra.orgID, infra.ledgerID, originBID), "", "")
+	assertProblemCode(t, phaseZeroResponse, nethttp.StatusConflict, cn.ErrIdempotencyKey.Error())
+	assert.Equal(t, 3, countTransactionsInLedger(t, infra.pgContainer.DB, infra.ledgerID),
+		"phase zero must reject a colliding cached reverse instead of returning origin A for origin B")
+
+	infra.handler.RevertIdempotencyMode = revertIdempotencyModeBridge
+	bridgeResponse := postTransaction(t, v2App, v2RevertURL(infra.orgID, infra.ledgerID, originBID), "", "")
+	assertProblemCode(t, bridgeResponse, nethttp.StatusConflict, cn.ErrIdempotencyKey.Error())
+	assert.Equal(t, 3, countTransactionsInLedger(t, infra.pgContainer.DB, infra.ledgerID),
+		"bridge must fence the colliding legacy slot rather than return origin A's reverse for origin B")
+
+	require.NoError(t, infra.revertFreeze.MarkPhaseZeroDrained(ctx),
+		"final cannot coexist directly with phase zero; bridge must first prove the old generation drained")
+	infra.handler.RevertIdempotencyMode = revertIdempotencyModeFinal
+	reverseB := decodeTxResponse(t, postTransaction(t, v2App, v2RevertURL(infra.orgID, infra.ledgerID, originBID), "", ""), nethttp.StatusCreated)
+	assert.NotEqual(t, reverseAID.String(), reverseB["id"])
+	assert.Equal(t, originBID.String(), reverseB["parentTransactionId"])
+	drainBalanceSync(t, ctx, infra.handler.Command, infra.redisRepo, infra.orgID, infra.ledgerID)
+
+	requireDecimalEqual(t, decimal.NewFromInt(1000), postgrestestutil.GetBalanceAvailable(t, infra.pgContainer.DB, srcID), "source restored by final after bridge fence")
+	requireDecimalEqual(t, decimal.Zero, postgrestestutil.GetBalanceAvailable(t, infra.pgContainer.DB, dstID), "destination restored by final after bridge fence")
+}
+
+func TestIntegration_TransactionV2Revert_RolloutOldInFlightAndBridgeShareLegacyBarrier(t *testing.T) {
+	t.Setenv("ALLOW_INSECURE_TLS", "true")
+	t.Setenv("RABBITMQ_TRANSACTION_ASYNC", "false")
+
+	infra := setupTestInfra(t)
+	ctx := context.Background()
+	srcID, dstID := seedFundedTransfer(t, infra.pgContainer.DB, infra.orgID, infra.ledgerID, "@src", "@dst", 1000, 1000)
+	v1App := buildHumaTransactionApp(t, infra.handler, true)
+	v2App := buildHumaV2DirectApp(t, infra.handler)
+	origin := decodeTxResponse(t, postV2Create(t, v2App, "direct", infra.orgID, infra.ledgerID, equivalentV2Body, ""), nethttp.StatusCreated)
+	originID := uuid.MustParse(origin["id"].(string))
+	drainBalanceSync(t, ctx, infra.handler.Command, infra.redisRepo, infra.orgID, infra.ledgerID)
+
+	originTransaction, err := infra.handler.Query.GetTransactionWithOperationsByID(ctx, infra.orgID, infra.ledgerID, originID)
+	require.NoError(t, err)
+	legacyHash, err := legacyRevertIdempotencyHash(originTransaction.TransactionRevert())
+	require.NoError(t, err)
+	legacyKey := utils.IdempotencyInternalKey(infra.orgID, infra.ledgerID, legacyHash)
+
+	activateRevertUpdateFreeze(t, infra)
+	infra.handler.RevertIdempotencyMode = revertIdempotencyModeLegacy
+	blockedUpdate := patchV1Transaction(t, v1App, infra.orgID, infra.ledgerID, originID, `{"description":"must not change during rollout"}`)
+	assertProblemCode(t, blockedUpdate, nethttp.StatusUnprocessableEntity, cn.ErrActionNotPermitted.Error())
+	originAfterBlockedUpdate, err := infra.handler.Query.GetTransactionWithOperationsByID(ctx, infra.orgID, infra.ledgerID, originID)
+	require.NoError(t, err)
+	legacyHashAfterBlockedUpdate, err := legacyRevertIdempotencyHash(originAfterBlockedUpdate.TransactionRevert())
+	require.NoError(t, err)
+	assert.Equal(t, legacyHash, legacyHashAfterBlockedUpdate,
+		"the shared freeze must keep the old payload-scoped barrier stable throughout coexistence")
+
+	// An old pod starts first and owns the released payload-hash barrier. Its
+	// empty value means in-flight, before it has a reverse response to cache.
+	acquired, err := infra.redisRepo.SetNX(ctx, legacyKey, "", 300)
+	require.NoError(t, err)
+	require.True(t, acquired)
+
+	phaseZeroBlocked := postTransaction(t, v2App, v2RevertURL(infra.orgID, infra.ledgerID, originID), "", "")
+	assertProblemCode(t, phaseZeroBlocked, nethttp.StatusConflict, cn.ErrIdempotencyKey.Error())
+	assert.Equal(t, 1, countTransactionsInLedger(t, infra.pgContainer.DB, infra.ledgerID),
+		"phase zero must retain the old payload-scoped revert algorithm")
+
+	infra.handler.RevertIdempotencyMode = revertIdempotencyModeBridge
+	blocked := postTransaction(t, v2App, v2RevertURL(infra.orgID, infra.ledgerID, originID), "", "")
+	assertProblemCode(t, blocked, nethttp.StatusConflict, cn.ErrIdempotencyKey.Error())
+	assert.Equal(t, 1, countTransactionsInLedger(t, infra.pgContainer.DB, infra.ledgerID),
+		"bridge must not move funds while an old request owns the shared barrier")
+	requireDecimalEqual(t, decimal.NewFromInt(900), postgrestestutil.GetBalanceAvailable(t, infra.pgContainer.DB, srcID), "blocked bridge leaves source unchanged")
+	requireDecimalEqual(t, decimal.NewFromInt(1100), postgrestestutil.GetBalanceAvailable(t, infra.pgContainer.DB, dstID), "blocked bridge leaves destination unchanged")
+
+	// A proven pre-movement old abort releases its own fence. The bridge must
+	// also have released its fresh PostgreSQL claim, so the retry can perform
+	// exactly one reversal.
+	require.NoError(t, infra.redisRepo.Del(ctx, legacyKey))
+	reverse := decodeTxResponse(t, postTransaction(t, v2App,
+		v2RevertURL(infra.orgID, infra.ledgerID, originID), "", ""), nethttp.StatusCreated)
+	assert.Equal(t, originID.String(), reverse["parentTransactionId"])
+	drainBalanceSync(t, ctx, infra.handler.Command, infra.redisRepo, infra.orgID, infra.ledgerID)
+	assert.Equal(t, 2, countTransactionsInLedger(t, infra.pgContainer.DB, infra.ledgerID))
+	requireDecimalEqual(t, decimal.NewFromInt(1000), postgrestestutil.GetBalanceAvailable(t, infra.pgContainer.DB, srcID), "source restored exactly once")
+	requireDecimalEqual(t, decimal.NewFromInt(1000), postgrestestutil.GetBalanceAvailable(t, infra.pgContainer.DB, dstID), "destination restored exactly once")
+
+	infra.handler.RevertIdempotencyMode = revertIdempotencyModeFinal
+	require.NoError(t, infra.revertFreeze.MarkPhaseZeroDrained(ctx))
+	require.NoError(t, infra.revertFreeze.Finalize(ctx))
+	infra.handler.RevertIdempotencyMode = revertIdempotencyModeBridge
+	downgrade := postTransaction(t, v2App, v2RevertURL(infra.orgID, infra.ledgerID, originID), "", "")
+	assertProblemCode(t, downgrade, nethttp.StatusServiceUnavailable, cn.ErrRevertRolloutFreezeRequired.Error())
+	assert.Equal(t, 2, countTransactionsInLedger(t, infra.pgContainer.DB, infra.ledgerID),
+		"a bridge downgrade after finalization must fail closed without another reverse")
+
+	infra.handler.RevertIdempotencyMode = revertIdempotencyModeFinal
+	updated := decodeTxResponse(t, patchV1Transaction(t, v1App, infra.orgID, infra.ledgerID, originID,
+		`{"description":"updates restored after finalization"}`), nethttp.StatusOK)
+	assert.Equal(t, "updates restored after finalization", updated["description"],
+		"finalized rollout must restore the approved transaction update contract")
+}
+
+func TestIntegration_TransactionUpdateFreeze_ApprovedBlockedPendingAllowedAndFinalizedRestores(t *testing.T) {
+	t.Setenv("ALLOW_INSECURE_TLS", "true")
+	t.Setenv("RABBITMQ_TRANSACTION_ASYNC", "false")
+
+	infra := setupTestInfra(t)
+	ctx := context.Background()
+	_, _ = seedFundedTransfer(t, infra.pgContainer.DB, infra.orgID, infra.ledgerID, "@src", "@dst", 2000, 2000)
+	v1App := buildHumaTransactionApp(t, infra.handler, true)
+	v2App := buildHumaV2DirectApp(t, infra.handler)
+
+	approved := decodeTxResponse(t, postV2Create(t, v2App, "direct", infra.orgID, infra.ledgerID, equivalentV2Body,
+		"freeze-approved"), nethttp.StatusCreated)
+	approvedID := uuid.MustParse(approved["id"].(string))
+	drainBalanceSync(t, ctx, infra.handler.Command, infra.redisRepo, infra.orgID, infra.ledgerID)
+	pending := decodeTxResponse(t, postV2Create(t, v2App, "hold", infra.orgID, infra.ledgerID, holdParityV2Body,
+		"freeze-pending"), nethttp.StatusCreated)
+	pendingID := uuid.MustParse(pending["id"].(string))
+
+	activateRevertUpdateFreeze(t, infra)
+	blocked := patchV1Transaction(t, v1App, infra.orgID, infra.ledgerID, approvedID, `{"description":"blocked approved update"}`)
+	assertProblemCode(t, blocked, nethttp.StatusUnprocessableEntity, cn.ErrActionNotPermitted.Error())
+	pendingUpdate := decodeTxResponse(t, patchV1Transaction(t, v1App, infra.orgID, infra.ledgerID, pendingID,
+		`{"description":"pending update remains allowed"}`), nethttp.StatusOK)
+	assert.Equal(t, "pending update remains allowed", pendingUpdate["description"])
+
+	require.NoError(t, infra.revertFreeze.MarkPhaseZeroDrained(ctx))
+	require.NoError(t, infra.revertFreeze.Finalize(ctx))
+	approvedUpdate := decodeTxResponse(t, patchV1Transaction(t, v1App, infra.orgID, infra.ledgerID, approvedID,
+		`{"description":"approved update restored"}`), nethttp.StatusOK)
+	assert.Equal(t, "approved update restored", approvedUpdate["description"])
+}
+
+func TestIntegration_TransactionV2Revert_RolloutBridgeAndFinalSharePostgresClaim(t *testing.T) {
+	t.Setenv("ALLOW_INSECURE_TLS", "true")
+	t.Setenv("RABBITMQ_TRANSACTION_ASYNC", "false")
+
+	infra := setupTestInfra(t)
+	ctx := context.Background()
+	srcID, dstID := seedFundedTransfer(t, infra.pgContainer.DB, infra.orgID, infra.ledgerID, "@src", "@dst", 1000, 1000)
+	v2App := buildHumaV2DirectApp(t, infra.handler)
+	origin := decodeTxResponse(t, postV2Create(t, v2App, "direct", infra.orgID, infra.ledgerID, equivalentV2Body, ""), nethttp.StatusCreated)
+	originID := uuid.MustParse(origin["id"].(string))
+	drainBalanceSync(t, ctx, infra.handler.Command, infra.redisRepo, infra.orgID, infra.ledgerID)
+
+	activateRevertUpdateFreeze(t, infra)
+	bridge := &TransactionHandler{Query: infra.handler.Query, Command: infra.handler.Command, RevertIdempotencyMode: revertIdempotencyModeBridge, RevertUpdateFreeze: infra.revertFreeze}
+	final := &TransactionHandler{Query: infra.handler.Query, Command: infra.handler.Command, RevertIdempotencyMode: revertIdempotencyModeFinal, RevertUpdateFreeze: infra.revertFreeze}
+	type result struct {
+		tran *transaction.Transaction
+		err  error
+	}
+	results := make(chan result, 2)
+	start := make(chan struct{})
+
+	for _, handler := range []*TransactionHandler{bridge, final} {
+		go func(h *TransactionHandler) {
+			<-start
+			tran, _, err := h.revertTransaction(ctx, infra.orgID, infra.ledgerID, originID)
+			results <- result{tran: tran, err: err}
+		}(handler)
+	}
+	close(start)
+	first, second := <-results, <-results
+
+	reverseIDs := make(map[string]struct{})
+	for _, got := range []result{first, second} {
+		if got.err == nil && got.tran != nil {
+			reverseIDs[got.tran.ID] = struct{}{}
+		}
+	}
+	require.Len(t, reverseIDs, 1,
+		"bridge and final may both return the durable replay, but must expose exactly one reserved reverse")
+	drainBalanceSync(t, ctx, infra.handler.Command, infra.redisRepo, infra.orgID, infra.ledgerID)
+	assert.Equal(t, 2, countTransactionsInLedger(t, infra.pgContainer.DB, infra.ledgerID))
+	requireDecimalEqual(t, decimal.NewFromInt(1000), postgrestestutil.GetBalanceAvailable(t, infra.pgContainer.DB, srcID), "source restored exactly once")
+	requireDecimalEqual(t, decimal.NewFromInt(1000), postgrestestutil.GetBalanceAvailable(t, infra.pgContainer.DB, dstID), "destination restored exactly once")
+}
+
+type lostBalanceResponseRepository struct {
+	transactionredis.RedisRepository
+	balanceCalls atomic.Int32
+}
+
+type lostLifecycleOutcomeResponseRepository struct {
+	transactionredis.RedisRepository
+	movementCommitted atomic.Bool
+	hiddenOutcomeRead atomic.Bool
+}
+
+type lostBackupEnrichmentResponseRepository struct {
+	transactionredis.RedisRepository
+	lost atomic.Bool
+}
+
+type lostSeedResponseRepository struct {
+	transactionredis.RedisRepository
+	seedCalls atomic.Int32
+}
+
+type failFirstOriginCompletionRepository struct {
+	transactionredis.RedisRepository
+	completionCalls atomic.Int32
+}
+
+type failBeforeFirstCompleteRevertLease struct {
+	delegate interface {
+		CompleteRevert(context.Context, string, string) error
+	}
+	calls atomic.Int32
+}
+
+func (l *failBeforeFirstCompleteRevertLease) CompleteRevert(ctx context.Context, mode, token string) error {
+	if l.calls.Add(1) == 1 {
+		return errors.New("simulated rollout generation completion failure")
+	}
+
+	return l.delegate.CompleteRevert(ctx, mode, token)
+}
+
+type pausedTransactionUpdateRepository struct {
+	transaction.Repository
+	started chan struct{}
+	release chan struct{}
+}
+
+type pausedTransactionWriteRepository struct {
+	transaction.Repository
+	started chan struct{}
+	release chan struct{}
+}
+
+type pausedLegacyRevertBalanceRepository struct {
+	transactionredis.RedisRepository
+	started chan struct{}
+	release chan struct{}
+}
+
+type pausedLegacyReplayRepository struct {
+	transactionredis.RedisRepository
+	started chan struct{}
+	release chan struct{}
+}
+
+type observedBalanceRepository struct {
+	transactionredis.RedisRepository
+	started chan struct{}
+}
+
+func (r *lostLifecycleOutcomeResponseRepository) AcquireOwnedKey(
+	ctx context.Context,
+	key, owner string,
+	ttl time.Duration,
+) (bool, error) {
+	if strings.HasPrefix(key, "pending_transaction:") {
+		ttl = 1
+	}
+
+	return r.RedisRepository.AcquireOwnedKey(ctx, key, owner, ttl)
+}
+
+func (r *pausedLegacyReplayRepository) CompleteUnownedKey(
+	ctx context.Context,
+	key, value string,
+	ttl time.Duration,
+) (bool, error) {
+	if strings.HasPrefix(key, "idempotency:") && value != "" {
+		r.started <- struct{}{}
+		<-r.release
+	}
+
+	return r.RedisRepository.CompleteUnownedKey(ctx, key, value, ttl)
+}
+
+func (r *pausedLegacyReplayRepository) CompleteOwnedKey(
+	ctx context.Context,
+	key, owner, value string,
+	ttl time.Duration,
+) (bool, error) {
+	if strings.HasPrefix(key, "idempotency:") && value != "" {
+		r.started <- struct{}{}
+		<-r.release
+	}
+
+	return r.RedisRepository.CompleteOwnedKey(ctx, key, owner, value, ttl)
+}
+
+func (r *lostLifecycleOutcomeResponseRepository) ProcessOutcomeBalanceAtomicOperation(
+	ctx context.Context,
+	organizationID, ledgerID, transactionID uuid.UUID,
+	transactionStatus string,
+	pending bool,
+	balances []mmodel.BalanceOperation,
+	attempt mmodel.BalanceExecutionAttempt,
+) (*mmodel.BalanceAtomicResult, error) {
+	result, err := r.RedisRepository.ProcessOutcomeBalanceAtomicOperation(ctx, organizationID, ledgerID,
+		transactionID, transactionStatus, pending, balances, attempt)
+	if err != nil {
+		return result, err
+	}
+	r.movementCommitted.Store(true)
+
+	return nil, errors.New("simulated lost response after immutable economic outcome")
+}
+
+func (r *lostLifecycleOutcomeResponseRepository) Get(ctx context.Context, key string) (string, error) {
+	if strings.HasSuffix(key, ":balance-outcome") && r.movementCommitted.Load() &&
+		r.hiddenOutcomeRead.CompareAndSwap(false, true) {
+		return "", errors.New("simulated outcome read outage after lost Lua response")
+	}
+
+	return r.RedisRepository.Get(ctx, key)
+}
+
+func (r *lostBackupEnrichmentResponseRepository) AcquireOwnedKey(
+	ctx context.Context,
+	key, owner string,
+	ttl time.Duration,
+) (bool, error) {
+	if strings.HasPrefix(key, "pending_transaction:") {
+		ttl = 1
+	}
+
+	return r.RedisRepository.AcquireOwnedKey(ctx, key, owner, ttl)
+}
+
+func (r *lostBackupEnrichmentResponseRepository) EnrichTransactionBackup(
+	ctx context.Context,
+	organizationID, ledgerID, transactionID uuid.UUID,
+	operations []mmodel.OperationRedis,
+	action string,
+	attempt *mmodel.BalanceExecutionAttempt,
+) ([]mmodel.OperationRedis, []mmodel.BalanceRedis, bool, error) {
+	canonical, balancesAfter, terminal, err := r.RedisRepository.EnrichTransactionBackup(ctx, organizationID, ledgerID, transactionID,
+		operations, action, attempt)
+	if err != nil {
+		return nil, nil, false, err
+	}
+	if r.lost.CompareAndSwap(false, true) {
+		return nil, nil, false, errors.New("simulated lost response after authoritative backup enrichment")
+	}
+
+	return canonical, balancesAfter, terminal, nil
+}
+
+func (r *pausedLegacyRevertBalanceRepository) ProcessBalanceAtomicOperation(
+	ctx context.Context,
+	organizationID, ledgerID, transactionID uuid.UUID,
+	transactionStatus string,
+	pending bool,
+	balances []mmodel.BalanceOperation,
+) (*mmodel.BalanceAtomicResult, error) {
+	select {
+	case r.started <- struct{}{}:
+	default:
+	}
+	<-r.release
+
+	return r.RedisRepository.ProcessBalanceAtomicOperation(ctx, organizationID, ledgerID, transactionID,
+		transactionStatus, pending, balances)
+}
+
+func (r *pausedLegacyRevertBalanceRepository) ProcessOutcomeBalanceAtomicOperation(
+	ctx context.Context,
+	organizationID, ledgerID, transactionID uuid.UUID,
+	transactionStatus string,
+	pending bool,
+	balances []mmodel.BalanceOperation,
+	attempt mmodel.BalanceExecutionAttempt,
+) (*mmodel.BalanceAtomicResult, error) {
+	select {
+	case r.started <- struct{}{}:
+	default:
+	}
+	<-r.release
+
+	return r.RedisRepository.ProcessOutcomeBalanceAtomicOperation(ctx, organizationID, ledgerID, transactionID,
+		transactionStatus, pending, balances, attempt)
+}
+
+func (r *observedBalanceRepository) ProcessBalanceAtomicOperation(
+	ctx context.Context,
+	organizationID, ledgerID, transactionID uuid.UUID,
+	transactionStatus string,
+	pending bool,
+	balances []mmodel.BalanceOperation,
+) (*mmodel.BalanceAtomicResult, error) {
+	select {
+	case r.started <- struct{}{}:
+	default:
+	}
+
+	return r.RedisRepository.ProcessBalanceAtomicOperation(ctx, organizationID, ledgerID, transactionID,
+		transactionStatus, pending, balances)
+}
+
+func (r *observedBalanceRepository) ProcessOutcomeBalanceAtomicOperation(
+	ctx context.Context,
+	organizationID, ledgerID, transactionID uuid.UUID,
+	transactionStatus string,
+	pending bool,
+	balances []mmodel.BalanceOperation,
+	attempt mmodel.BalanceExecutionAttempt,
+) (*mmodel.BalanceAtomicResult, error) {
+	select {
+	case r.started <- struct{}{}:
+	default:
+	}
+
+	return r.RedisRepository.ProcessOutcomeBalanceAtomicOperation(ctx, organizationID, ledgerID, transactionID,
+		transactionStatus, pending, balances, attempt)
+}
+
+func (r *pausedTransactionUpdateRepository) FindForUpdate(
+	ctx context.Context,
+	tx repository.DBExecutor,
+	organizationID, ledgerID, transactionID uuid.UUID,
+) (*transaction.Transaction, error) {
+	tran, err := r.Repository.FindForUpdate(ctx, tx, organizationID, ledgerID, transactionID)
+	if err != nil {
+		return nil, err
+	}
+	select {
+	case r.started <- struct{}{}:
+	default:
+	}
+	<-r.release
+
+	return tran, nil
+}
+
+func (r *pausedTransactionWriteRepository) UpdateTx(
+	ctx context.Context,
+	tx repository.DBExecutor,
+	organizationID, ledgerID, transactionID uuid.UUID,
+	tran *transaction.Transaction,
+) (*transaction.Transaction, error) {
+	r.started <- struct{}{}
+	<-r.release
+
+	return r.Repository.UpdateTx(ctx, tx, organizationID, ledgerID, transactionID, tran)
+}
+
+func (r *failFirstOriginCompletionRepository) CompleteOwnedKey(
+	ctx context.Context,
+	key, owner, value string,
+	ttl time.Duration,
+) (bool, error) {
+	if r.completionCalls.Add(1) == 1 {
+		return false, errors.New("simulated crash before origin replay completion")
+	}
+
+	return r.RedisRepository.CompleteOwnedKey(ctx, key, owner, value, ttl)
+}
+
+func (r *lostSeedResponseRepository) SeedTransactionBackup(
+	ctx context.Context,
+	organizationID, ledgerID, transactionID uuid.UUID,
+	message []byte,
+	attempt mmodel.BalanceExecutionAttempt,
+) error {
+	call := r.seedCalls.Add(1)
+	if err := r.RedisRepository.SeedTransactionBackup(ctx, organizationID, ledgerID, transactionID, message, attempt); err != nil {
+		return err
+	}
+	if call == 1 {
+		return errors.New("simulated connection loss after revert seed was written")
+	}
+
+	return nil
+}
+
+func (r *lostBalanceResponseRepository) ProcessBalanceAtomicOperation(
+	ctx context.Context,
+	organizationID, ledgerID, transactionID uuid.UUID,
+	transactionStatus string,
+	pending bool,
+	balances []mmodel.BalanceOperation,
+) (*mmodel.BalanceAtomicResult, error) {
+	call := r.balanceCalls.Add(1)
+	result, err := r.RedisRepository.ProcessBalanceAtomicOperation(
+		ctx, organizationID, ledgerID, transactionID, transactionStatus, pending, balances,
+	)
+	if err != nil {
+		return result, err
+	}
+
+	if call == 1 {
+		return nil, errors.New("simulated connection loss after balance Lua committed")
+	}
+
+	return result, nil
+}
+
+func (r *lostBalanceResponseRepository) ProcessOutcomeBalanceAtomicOperation(
+	ctx context.Context,
+	organizationID, ledgerID, transactionID uuid.UUID,
+	transactionStatus string,
+	pending bool,
+	balances []mmodel.BalanceOperation,
+	attempt mmodel.BalanceExecutionAttempt,
+) (*mmodel.BalanceAtomicResult, error) {
+	call := r.balanceCalls.Add(1)
+	result, err := r.RedisRepository.ProcessOutcomeBalanceAtomicOperation(
+		ctx, organizationID, ledgerID, transactionID, transactionStatus, pending, balances, attempt,
+	)
+	if err != nil {
+		return result, err
+	}
+	if call == 1 {
+		return nil, errors.New("simulated connection loss after outcome balance Lua committed")
+	}
+
+	return result, nil
+}
+
+func TestIntegration_TransactionV2Revert_CrashAfterPostgresPersistenceCompletesReplayOnRetry(t *testing.T) {
+	t.Setenv("ALLOW_INSECURE_TLS", "true")
+	t.Setenv("RABBITMQ_TRANSACTION_ASYNC", "false")
+
+	infra := setupTestInfra(t)
+	ctx := context.Background()
+	srcID, dstID := seedFundedTransfer(t, infra.pgContainer.DB, infra.orgID, infra.ledgerID, "@src", "@dst", 1000, 1000)
+	v2App := buildHumaV2DirectApp(t, infra.handler)
+	origin := decodeTxResponse(t, postV2Create(t, v2App, "direct", infra.orgID, infra.ledgerID, equivalentV2Body, ""), nethttp.StatusCreated)
+	originID := uuid.MustParse(origin["id"].(string))
+	drainBalanceSync(t, ctx, infra.handler.Command, infra.redisRepo, infra.orgID, infra.ledgerID)
+
+	faultRepo := &failFirstOriginCompletionRepository{RedisRepository: infra.redisRepo}
+	infra.handler.Command.TransactionRedisRepo = faultRepo
+	infra.handler.RevertIdempotencyMode = revertIdempotencyModeFinal
+
+	first := postTransaction(t, v2App, v2RevertURL(infra.orgID, infra.ledgerID, originID), "", "")
+	assertProblemCode(t, first, nethttp.StatusServiceUnavailable, cn.ErrRevertReconciliationRequired.Error())
+
+	claim, err := infra.handler.Command.GetRevertClaim(ctx, infra.orgID, infra.ledgerID, originID)
+	require.NoError(t, err)
+	require.NotNil(t, claim)
+	assert.Equal(t, revertclaim.StateCompleted, claim.State,
+		"the backup consumer may complete the durable transaction before the HTTP replay fence is materialized")
+	assert.Nil(t, claim.FailureReason, "a replay-fence retry cannot downgrade a completed money-path claim")
+	assert.Equal(t, 2, countTransactionsInLedger(t, infra.pgContainer.DB, infra.ledgerID),
+		"the reserved reverse is already durable when replay completion crashes")
+
+	originKey := originRevertIdempotencyKey(claim)
+	originOwner, err := infra.redisRepo.Get(ctx, originKey+":owner")
+	require.NoError(t, err)
+	assert.Equal(t, claim.ReverseTransactionID.String(), originOwner,
+		"an ambiguous completion retains the exact reserved owner")
+
+	retry := decodeTxResponse(t, postTransaction(t, v2App,
+		v2RevertURL(infra.orgID, infra.ledgerID, originID), "", ""), nethttp.StatusCreated)
+	assert.Equal(t, claim.ReverseTransactionID.String(), retry["id"])
+	assert.Equal(t, originID.String(), retry["parentTransactionId"])
+	assert.Equal(t, int32(2), faultRepo.completionCalls.Load(),
+		"retry completes the persisted reverse instead of attempting another movement")
+	drainBalanceSync(t, ctx, infra.handler.Command, infra.redisRepo, infra.orgID, infra.ledgerID)
+
+	completed, err := infra.handler.Command.GetRevertClaim(ctx, infra.orgID, infra.ledgerID, originID)
+	require.NoError(t, err)
+	require.NotNil(t, completed)
+	assert.Equal(t, revertclaim.StateCompleted, completed.State)
+	originOwner, err = infra.redisRepo.Get(ctx, originKey+":owner")
+	require.NoError(t, err)
+	assert.Empty(t, originOwner, "completion removes the in-flight owner token")
+	assert.Equal(t, 2, countTransactionsInLedger(t, infra.pgContainer.DB, infra.ledgerID))
+	requireDecimalEqual(t, decimal.NewFromInt(1000), postgrestestutil.GetBalanceAvailable(t, infra.pgContainer.DB, srcID), "source restored once")
+	requireDecimalEqual(t, decimal.NewFromInt(1000), postgrestestutil.GetBalanceAvailable(t, infra.pgContainer.DB, dstID), "destination restored once")
+}
+
+func TestIntegration_TransactionV2Revert_BridgeRetryUsesClaimedLegacyFenceAfterPayloadChanges(t *testing.T) {
+	t.Setenv("ALLOW_INSECURE_TLS", "true")
+	t.Setenv("RABBITMQ_TRANSACTION_ASYNC", "false")
+
+	infra := setupTestInfra(t)
+	ctx := context.Background()
+	_, _ = seedFundedTransfer(t, infra.pgContainer.DB, infra.orgID, infra.ledgerID, "@src", "@dst", 1000, 1000)
+	v2App := buildHumaV2DirectApp(t, infra.handler)
+	origin := decodeTxResponse(t, postV2Create(t, v2App, "direct", infra.orgID, infra.ledgerID,
+		equivalentV2Body, ""), nethttp.StatusCreated)
+	originID := uuid.MustParse(origin["id"].(string))
+	drainBalanceSync(t, ctx, infra.handler.Command, infra.redisRepo, infra.orgID, infra.ledgerID)
+
+	originTransaction, err := infra.handler.Query.GetTransactionWithOperationsByID(
+		readrouting.WithPrimaryRead(ctx), infra.orgID, infra.ledgerID, originID)
+	require.NoError(t, err)
+	originalHash, err := legacyRevertIdempotencyHash(originTransaction.TransactionRevert())
+	require.NoError(t, err)
+	originalLegacyKey := utils.IdempotencyInternalKey(infra.orgID, infra.ledgerID, originalHash)
+
+	activateRevertUpdateFreeze(t, infra)
+	infra.handler.RevertIdempotencyMode = revertIdempotencyModeBridge
+	faultRepo := &failFirstOriginCompletionRepository{RedisRepository: infra.redisRepo}
+	infra.handler.Command.TransactionRedisRepo = faultRepo
+
+	first := postTransaction(t, v2App, v2RevertURL(infra.orgID, infra.ledgerID, originID), "", "")
+	assertProblemCode(t, first, nethttp.StatusServiceUnavailable, cn.ErrRevertReconciliationRequired.Error())
+	claim, err := infra.handler.Command.GetRevertClaim(ctx, infra.orgID, infra.ledgerID, originID)
+	require.NoError(t, err)
+	require.NotNil(t, claim)
+	require.NotNil(t, claim.LegacyFenceKey)
+	assert.Equal(t, originalLegacyKey, *claim.LegacyFenceKey)
+	assert.Equal(t, revertclaim.StateCompleted, claim.State)
+
+	_, err = infra.pgContainer.DB.ExecContext(ctx, `
+		UPDATE transaction SET description = $1
+		WHERE organization_id = $2 AND ledger_id = $3 AND id = $4`,
+		"payload changed after bridge claimed its fence", infra.orgID, infra.ledgerID, originID)
+	require.NoError(t, err)
+	mutatedOrigin, err := infra.handler.Query.GetTransactionWithOperationsByID(
+		readrouting.WithPrimaryRead(ctx), infra.orgID, infra.ledgerID, originID)
+	require.NoError(t, err)
+	mutatedHash, err := legacyRevertIdempotencyHash(mutatedOrigin.TransactionRevert())
+	require.NoError(t, err)
+	mutatedLegacyKey := utils.IdempotencyInternalKey(infra.orgID, infra.ledgerID, mutatedHash)
+	require.NotEqual(t, originalLegacyKey, mutatedLegacyKey)
+
+	retry := decodeTxResponse(t, postTransaction(t, v2App,
+		v2RevertURL(infra.orgID, infra.ledgerID, originID), "", ""), nethttp.StatusCreated)
+	assert.Equal(t, claim.ReverseTransactionID.String(), retry["id"])
+	assert.Equal(t, originID.String(), retry["parentTransactionId"])
+	originalReplay, err := infra.redisRepo.Get(ctx, originalLegacyKey)
+	require.NoError(t, err)
+	assert.NotEmpty(t, originalReplay, "retry must complete the exact fence persisted at claim acquisition")
+	mutatedFence, err := infra.redisRepo.MGet(ctx, []string{mutatedLegacyKey, mutatedLegacyKey + ":owner"})
+	require.NoError(t, err)
+	assert.Empty(t, mutatedFence, "retry must never create or complete a key recalculated from mutable payload")
+}
+
+func TestIntegration_TransactionV2Revert_FailedRolloutCompletionRetriesExactPersistedGeneration(t *testing.T) {
+	t.Setenv("ALLOW_INSECURE_TLS", "true")
+	t.Setenv("RABBITMQ_TRANSACTION_ASYNC", "false")
+
+	infra := setupTestInfra(t)
+	ctx := context.Background()
+	srcID, dstID := seedFundedTransfer(t, infra.pgContainer.DB, infra.orgID, infra.ledgerID,
+		"@src", "@dst", 1000, 1000)
+	v2App := buildHumaV2DirectApp(t, infra.handler)
+	origin := decodeTxResponse(t, postV2Create(t, v2App, "direct", infra.orgID, infra.ledgerID,
+		equivalentV2Body, ""), nethttp.StatusCreated)
+	originID := uuid.MustParse(origin["id"].(string))
+	drainBalanceSync(t, ctx, infra.handler.Command, infra.redisRepo, infra.orgID, infra.ledgerID)
+
+	activateRevertUpdateFreeze(t, infra)
+	infra.handler.RevertIdempotencyMode = revertIdempotencyModeBridge
+	failedCompletion := &failBeforeFirstCompleteRevertLease{delegate: infra.revertFreeze}
+	infra.handler.Command.RevertRolloutLease = failedCompletion
+
+	first := postTransaction(t, v2App, v2RevertURL(infra.orgID, infra.ledgerID, originID), "", "")
+	assertProblemCode(t, first, nethttp.StatusServiceUnavailable, cn.ErrRevertReconciliationRequired.Error())
+	claim, err := infra.handler.Command.GetRevertClaim(ctx, infra.orgID, infra.ledgerID, originID)
+	require.NoError(t, err)
+	require.NotNil(t, claim)
+	require.Equal(t, revertclaim.StateCompleted, claim.State)
+	require.NotNil(t, claim.RolloutMode)
+	require.NotNil(t, claim.RolloutToken)
+	assert.Equal(t, revertIdempotencyModeBridge, *claim.RolloutMode)
+	require.NotNil(t, claim.RedisGeneration)
+	evidence, generationMatches, err := infra.redisRepo.TransactionEconomicEvidenceExists(ctx, infra.orgID, infra.ledgerID,
+		claim.ReverseTransactionID, *claim.RedisGeneration)
+	require.NoError(t, err)
+	assert.False(t, evidence, "transaction and operations are durable before rollout completion is retried")
+	assert.True(t, generationMatches)
+	require.NoError(t, infra.revertFreeze.MarkPhaseZeroDrained(ctx))
+	require.Error(t, infra.revertFreeze.Finalize(ctx),
+		"the surviving exact bridge generation must prevent a false rollout drain")
+
+	retry := decodeTxResponse(t, postTransaction(t, v2App,
+		v2RevertURL(infra.orgID, infra.ledgerID, originID), "", ""), nethttp.StatusCreated)
+	assert.Equal(t, claim.ReverseTransactionID.String(), retry["id"])
+	require.NoError(t, infra.revertFreeze.Finalize(ctx),
+		"HTTP adoption must seal the exact generation persisted before movement")
+	drainBalanceSync(t, ctx, infra.handler.Command, infra.redisRepo, infra.orgID, infra.ledgerID)
+	assert.Equal(t, int32(1), failedCompletion.calls.Load(),
+		"retry uses the durable claim through the HTTP handoff, not a second consumer mutation")
+	assert.Equal(t, 2, countTransactionsInLedger(t, infra.pgContainer.DB, infra.ledgerID))
+	requireDecimalEqual(t, decimal.NewFromInt(1000), postgrestestutil.GetBalanceAvailable(t,
+		infra.pgContainer.DB, srcID), "failed rollout completion cannot restore source twice")
+	requireDecimalEqual(t, decimal.NewFromInt(1000), postgrestestutil.GetBalanceAvailable(t,
+		infra.pgContainer.DB, dstID), "failed rollout completion cannot debit destination twice")
+}
+
+func TestIntegration_TransactionApprovedUpdateLeaseBlocksFreezeActivationUntilWriteCompletes(t *testing.T) {
+	t.Setenv("ALLOW_INSECURE_TLS", "true")
+	t.Setenv("RABBITMQ_TRANSACTION_ASYNC", "false")
+
+	infra := setupTestInfra(t)
+	ctx := context.Background()
+	_, _ = seedFundedTransfer(t, infra.pgContainer.DB, infra.orgID, infra.ledgerID, "@src", "@dst", 1000, 1000)
+	v2App := buildHumaV2DirectApp(t, infra.handler)
+	origin := decodeTxResponse(t, postV2Create(t, v2App, "direct", infra.orgID, infra.ledgerID, equivalentV2Body, ""), nethttp.StatusCreated)
+	originID := uuid.MustParse(origin["id"].(string))
+	drainBalanceSync(t, ctx, infra.handler.Command, infra.redisRepo, infra.orgID, infra.ledgerID)
+
+	prepareRevertUpdateFreeze(t, infra)
+	infra.handler.RevertIdempotencyMode = revertIdempotencyModeLegacy
+	pausedRepo := &pausedTransactionWriteRepository{
+		Repository: infra.handler.Command.TransactionRepo,
+		started:    make(chan struct{}, 1),
+		release:    make(chan struct{}),
+	}
+	infra.handler.Command.TransactionRepo = pausedRepo
+
+	type updateResult struct {
+		transaction *transaction.Transaction
+		err         error
+	}
+	result := make(chan updateResult, 1)
+	go func() {
+		updated, err := infra.handler.updateTransaction(ctx, infra.orgID, infra.ledgerID, originID,
+			&transaction.UpdateTransactionInput{Description: "write admitted before activation"})
+		result <- updateResult{transaction: updated, err: err}
+	}()
+
+	<-pausedRepo.started
+	require.Error(t, infra.revertFreeze.Activate(ctx),
+		"activation must be serialized after the PostgreSQL write admitted under the absent marker")
+	close(pausedRepo.release)
+	updated := <-result
+	require.NoError(t, updated.err)
+	require.NotNil(t, updated.transaction)
+	assert.Equal(t, "write admitted before activation", updated.transaction.Description)
+
+	require.NoError(t, infra.revertFreeze.Activate(ctx))
+	_, err := infra.handler.updateTransaction(ctx, infra.orgID, infra.ledgerID, originID,
+		&transaction.UpdateTransactionInput{Description: "must remain blocked"})
+	var frozen pkg.UnprocessableOperationError
+	require.ErrorAs(t, err, &frozen)
+	assert.Equal(t, cn.ErrActionNotPermitted.Error(), frozen.Code)
+}
+
+func TestIntegration_TransactionPendingUpdateSerializesCommitAcrossFreezeActivation(t *testing.T) {
+	t.Setenv("ALLOW_INSECURE_TLS", "true")
+	t.Setenv("RABBITMQ_TRANSACTION_ASYNC", "false")
+
+	infra := setupTestInfra(t)
+	ctx := context.Background()
+	_, _ = seedFundedTransfer(t, infra.pgContainer.DB, infra.orgID, infra.ledgerID, "@src", "@dst", 1000, 1000)
+	v2App := buildHumaV2DirectApp(t, infra.handler)
+	pending := decodeTxResponse(t, postV2Create(t, v2App, "hold", infra.orgID, infra.ledgerID, holdParityV2Body, ""), nethttp.StatusCreated)
+	pendingID := uuid.MustParse(pending["id"].(string))
+	drainBalanceSync(t, ctx, infra.handler.Command, infra.redisRepo, infra.orgID, infra.ledgerID)
+
+	prepareRevertUpdateFreeze(t, infra)
+	infra.handler.RevertIdempotencyMode = revertIdempotencyModeLegacy
+	pausedRepo := &pausedTransactionUpdateRepository{
+		Repository: infra.handler.Command.TransactionRepo,
+		started:    make(chan struct{}, 2),
+		release:    make(chan struct{}),
+	}
+	infra.handler.Command.TransactionRepo = pausedRepo
+	observedBalance := &observedBalanceRepository{
+		RedisRepository: infra.handler.Command.TransactionRedisRepo,
+		started:         make(chan struct{}, 1),
+	}
+	infra.handler.Command.TransactionRedisRepo = observedBalance
+
+	type updateResult struct {
+		transaction *transaction.Transaction
+		err         error
+	}
+	result := make(chan updateResult, 1)
+	go func() {
+		updated, err := infra.handler.updateTransaction(ctx, infra.orgID, infra.ledgerID, pendingID,
+			&transaction.UpdateTransactionInput{Description: "pending write serialized before approval"})
+		result <- updateResult{transaction: updated, err: err}
+	}()
+
+	<-pausedRepo.started
+	commitResult := make(chan updateResult, 1)
+	go func() {
+		committed, err := infra.handler.commitTransaction(ctx, infra.orgID, infra.ledgerID, pendingID, cn.APPROVED)
+		commitResult <- updateResult{transaction: committed, err: err}
+	}()
+	balanceMovedBeforePATCH := false
+	select {
+	case <-observedBalance.started:
+		balanceMovedBeforePATCH = true
+	case <-time.After(200 * time.Millisecond):
+	}
+	select {
+	case early := <-commitResult:
+		close(pausedRepo.release)
+		require.Failf(t, "commit bypassed row lock", "result=%v err=%v", early.transaction, early.err)
+	default:
+	}
+	require.NoError(t, infra.revertFreeze.Activate(ctx),
+		"a PENDING update may finish while its row lock prevents partial promotion")
+
+	close(pausedRepo.release)
+	updated := <-result
+	require.NoError(t, updated.err)
+	require.NotNil(t, updated.transaction)
+	assert.Equal(t, "pending write serialized before approval", updated.transaction.Description)
+	committed := <-commitResult
+	require.NoError(t, committed.err)
+	require.NotNil(t, committed.transaction)
+	assert.Equal(t, cn.APPROVED, committed.transaction.Status.Code)
+	var persistedStatus, persistedDescription string
+	require.NoError(t, infra.pgContainer.DB.QueryRowContext(ctx,
+		`SELECT status, description FROM transaction WHERE organization_id = $1 AND ledger_id = $2 AND id = $3`,
+		infra.orgID, infra.ledgerID, pendingID).Scan(&persistedStatus, &persistedDescription))
+	require.Equal(t, cn.APPROVED, persistedStatus)
+	require.Equal(t, "pending write serialized before approval", persistedDescription)
+	require.False(t, balanceMovedBeforePATCH,
+		"commit must not seed or move balances while PATCH owns the transaction row")
+	phase, err := infra.revertFreeze.Phase(ctx)
+	require.NoError(t, err)
+	require.Equal(t, transactionredis.RevertUpdateFreezeActive, phase)
+
+	_, err = infra.handler.updateTransaction(ctx, infra.orgID, infra.ledgerID, pendingID,
+		&transaction.UpdateTransactionInput{Description: "must remain frozen"})
+	var frozen pkg.UnprocessableOperationError
+	require.ErrorAs(t, err, &frozen)
+	assert.Equal(t, cn.ErrActionNotPermitted.Error(), frozen.Code)
+
+	require.NoError(t, infra.revertFreeze.MarkPhaseZeroDrained(ctx))
+	infra.handler.RevertIdempotencyMode = revertIdempotencyModeFinal
+	require.NoError(t, infra.revertFreeze.Finalize(ctx))
+	finalConnection := redistestutil.CreateConnectionWithDB(t, infra.redisContainer.Addr, infra.redisContainer.DB)
+	finalGuard := transactionredis.NewRevertUpdateFreezeGuard(finalConnection,
+		transactionredis.RevertUpdateFreezeFinalized, integrationRedisDatasetGeneration).
+		WithRolloutInitializationWitness(revertclaim.NewPostgreSQLRepository(infra.pgConn), "")
+	infra.revertFreeze = finalGuard
+	infra.handler.RevertUpdateFreeze = finalGuard
+	infra.handler.Command.RevertRolloutLease = finalGuard
+	finalizedUpdate, err := infra.handler.updateTransaction(ctx, infra.orgID, infra.ledgerID, pendingID,
+		&transaction.UpdateTransactionInput{Description: "approved updates restored immediately"})
+	require.NoError(t, err)
+	require.NotNil(t, finalizedUpdate)
+	assert.Equal(t, "approved updates restored immediately", finalizedUpdate.Description,
+		"the successful commit's Redis processing lock must not block finalized PATCH")
+}
+
+func TestIntegration_TransactionPendingUpdateSerializesCancelMovement(t *testing.T) {
+	t.Setenv("ALLOW_INSECURE_TLS", "true")
+	t.Setenv("RABBITMQ_TRANSACTION_ASYNC", "false")
+
+	infra := setupTestInfra(t)
+	ctx := context.Background()
+	srcID, dstID := seedFundedTransfer(t, infra.pgContainer.DB, infra.orgID, infra.ledgerID, "@src", "@dst", 1000, 1000)
+	v2App := buildHumaV2DirectApp(t, infra.handler)
+	pending := decodeTxResponse(t, postV2Create(t, v2App, "hold", infra.orgID, infra.ledgerID, holdParityV2Body, ""), nethttp.StatusCreated)
+	pendingID := uuid.MustParse(pending["id"].(string))
+	drainBalanceSync(t, ctx, infra.handler.Command, infra.redisRepo, infra.orgID, infra.ledgerID)
+
+	pausedRepo := &pausedTransactionUpdateRepository{
+		Repository: infra.handler.Command.TransactionRepo,
+		started:    make(chan struct{}, 2),
+		release:    make(chan struct{}),
+	}
+	infra.handler.Command.TransactionRepo = pausedRepo
+	observedBalance := &observedBalanceRepository{
+		RedisRepository: infra.handler.Command.TransactionRedisRepo,
+		started:         make(chan struct{}, 1),
+	}
+	infra.handler.Command.TransactionRedisRepo = observedBalance
+
+	type updateResult struct {
+		transaction *transaction.Transaction
+		err         error
+	}
+	patchResult := make(chan updateResult, 1)
+	go func() {
+		updated, err := infra.handler.updateTransaction(ctx, infra.orgID, infra.ledgerID, pendingID,
+			&transaction.UpdateTransactionInput{Description: "pending write serialized before cancel"})
+		patchResult <- updateResult{transaction: updated, err: err}
+	}()
+	<-pausedRepo.started
+
+	cancelResult := make(chan updateResult, 1)
+	go func() {
+		canceled, err := infra.handler.commitTransaction(ctx, infra.orgID, infra.ledgerID, pendingID, cn.CANCELED)
+		cancelResult <- updateResult{transaction: canceled, err: err}
+	}()
+	select {
+	case <-observedBalance.started:
+		require.Fail(t, "cancel moved balances while PATCH owned the transaction row")
+	case <-time.After(200 * time.Millisecond):
+	}
+	select {
+	case early := <-cancelResult:
+		require.Failf(t, "cancel bypassed row lock", "result=%v err=%v", early.transaction, early.err)
+	default:
+	}
+
+	close(pausedRepo.release)
+	updated := <-patchResult
+	require.NoError(t, updated.err)
+	require.Equal(t, "pending write serialized before cancel", updated.transaction.Description)
+	canceled := <-cancelResult
+	require.NoError(t, canceled.err)
+	require.Equal(t, cn.CANCELED, canceled.transaction.Status.Code)
+
+	var status, description string
+	require.NoError(t, infra.pgContainer.DB.QueryRowContext(ctx,
+		`SELECT status, description FROM transaction WHERE organization_id = $1 AND ledger_id = $2 AND id = $3`,
+		infra.orgID, infra.ledgerID, pendingID).Scan(&status, &description))
+	assert.Equal(t, cn.CANCELED, status)
+	assert.Equal(t, "pending write serialized before cancel", description)
+	drainBalanceSync(t, ctx, infra.handler.Command, infra.redisRepo, infra.orgID, infra.ledgerID)
+	requireDecimalEqual(t, decimal.NewFromInt(1000), postgrestestutil.GetBalanceAvailable(t, infra.pgContainer.DB, srcID),
+		"cancel restores the held source exactly once")
+	requireDecimalEqual(t, decimal.Zero, postgrestestutil.GetBalanceOnHold(t, infra.pgContainer.DB, srcID),
+		"cancel releases the source hold exactly once")
+	requireDecimalEqual(t, decimal.NewFromInt(1000), postgrestestutil.GetBalanceAvailable(t, infra.pgContainer.DB, dstID),
+		"cancel never credits the destination")
+	mutationKey := utils.PendingTransactionLockKey(infra.orgID, infra.ledgerID, pendingID.String())
+	mutationValues, err := infra.redisRepo.MGet(ctx, []string{mutationKey, mutationKey + ":owner"})
+	require.NoError(t, err)
+	assert.Empty(t, mutationValues,
+		"a terminal status with a durable handoff must release the request serialization immediately")
+}
+
+func TestIntegration_TransactionLifecycleLostOutcomeRejectsOppositeAfterProcessingLeaseExpires(t *testing.T) {
+	for _, scenario := range []struct {
+		name            string
+		firstStatus     string
+		oppositeURL     func(uuid.UUID, uuid.UUID, uuid.UUID) string
+		persistedStatus string
+		sourceAvailable int64
+		destination     int64
+		outcome         string
+	}{
+		{
+			name:            "committed outcome rejects delayed cancel",
+			firstStatus:     cn.APPROVED,
+			oppositeURL:     v2CancelURL,
+			persistedStatus: cn.APPROVED,
+			sourceAvailable: 900,
+			destination:     1100,
+			outcome:         mmodel.TransactionOutcomeCommitted,
+		},
+		{
+			name:            "aborted outcome rejects delayed commit",
+			firstStatus:     cn.CANCELED,
+			oppositeURL:     v2CommitURL,
+			persistedStatus: cn.CANCELED,
+			sourceAvailable: 1000,
+			destination:     1000,
+			outcome:         mmodel.TransactionOutcomeAborted,
+		},
+	} {
+		t.Run(scenario.name, func(t *testing.T) {
+			t.Setenv("ALLOW_INSECURE_TLS", "true")
+			t.Setenv("RABBITMQ_TRANSACTION_ASYNC", "false")
+
+			infra := setupTestInfra(t)
+			ctx := context.Background()
+			srcID, dstID := seedFundedTransfer(t, infra.pgContainer.DB, infra.orgID, infra.ledgerID,
+				"@src", "@dst", 1000, 1000)
+			v2App := buildHumaV2DirectApp(t, infra.handler)
+			pending := decodeTxResponse(t, postV2Create(t, v2App, "hold", infra.orgID, infra.ledgerID,
+				holdParityV2Body, ""), nethttp.StatusCreated)
+			pendingID := uuid.MustParse(pending["id"].(string))
+			drainBalanceSync(t, ctx, infra.handler.Command, infra.redisRepo, infra.orgID, infra.ledgerID)
+
+			faultRepo := &lostLifecycleOutcomeResponseRepository{RedisRepository: infra.redisRepo}
+			infra.handler.Command.TransactionRedisRepo = faultRepo
+			_, err := infra.handler.commitTransaction(ctx, infra.orgID, infra.ledgerID, pendingID, scenario.firstStatus)
+			var unavailable pkg.ServiceUnavailableError
+			require.ErrorAs(t, err, &unavailable)
+			assert.Equal(t, cn.ErrTransactionOutcomeReconciliationRequired.Error(), unavailable.Code)
+			assert.Equal(t, cn.PENDING, postgrestestutil.GetTransactionStatus(t, infra.pgContainer.DB, pendingID),
+				"lost response keeps PostgreSQL pending until exact outcome recovery")
+
+			outcomeKey := utils.TransactionBalanceOutcomeKey(infra.orgID, infra.ledgerID, pendingID)
+			rawOutcome, err := infra.redisRepo.Get(ctx, outcomeKey)
+			require.NoError(t, err)
+			var outcome mmodel.BalanceExecutionOutcome
+			require.NoError(t, json.Unmarshal([]byte(rawOutcome), &outcome))
+			assert.Equal(t, scenario.outcome, outcome.Outcome)
+
+			processingOwnerKey := utils.PendingTransactionLockKey(infra.orgID, infra.ledgerID, pendingID.String()) + ":owner"
+			require.Eventually(t, func() bool {
+				owner, readErr := infra.redisRepo.Get(ctx, processingOwnerKey)
+				return readErr == nil && owner == ""
+			}, 3*time.Second, 25*time.Millisecond,
+				"the test-shortened processing lease must expire while the durable outcome survives")
+
+			opposite := postTransaction(t, v2App,
+				scenario.oppositeURL(infra.orgID, infra.ledgerID, pendingID), "", "")
+			assertProblemCode(t, opposite, nethttp.StatusConflict, cn.ErrCommitTransactionNotPending.Error())
+			assert.Equal(t, scenario.persistedStatus,
+				postgrestestutil.GetTransactionStatus(t, infra.pgContainer.DB, pendingID),
+				"opposite retry must first persist the immutable winning outcome")
+			processingKey := utils.PendingTransactionLockKey(infra.orgID, infra.ledgerID, pendingID.String())
+			processingValues, err := infra.redisRepo.MGet(ctx, []string{processingKey, processingKey + ":owner"})
+			require.NoError(t, err)
+			assert.Empty(t, processingValues,
+				"a resolved opposite outcome must not retain the request serialization lease")
+
+			drainBalanceSync(t, ctx, infra.handler.Command, infra.redisRepo, infra.orgID, infra.ledgerID)
+			requireDecimalEqual(t, decimal.NewFromInt(scenario.sourceAvailable),
+				postgrestestutil.GetBalanceAvailable(t, infra.pgContainer.DB, srcID),
+				"source reflects exactly one terminal movement")
+			requireDecimalEqual(t, decimal.Zero,
+				postgrestestutil.GetBalanceOnHold(t, infra.pgContainer.DB, srcID),
+				"source hold is released exactly once")
+			requireDecimalEqual(t, decimal.NewFromInt(scenario.destination),
+				postgrestestutil.GetBalanceAvailable(t, infra.pgContainer.DB, dstID),
+				"destination reflects exactly one terminal movement")
+			assert.Equal(t, 1, countTransactionsInLedger(t, infra.pgContainer.DB, infra.ledgerID))
+		})
+	}
+}
+
+func TestIntegration_TransactionLifecycleLostEnrichmentResponsePreservesPostLuaEnvelope(t *testing.T) {
+	t.Setenv("ALLOW_INSECURE_TLS", "true")
+	t.Setenv("RABBITMQ_TRANSACTION_ASYNC", "false")
+
+	infra := setupTestInfra(t)
+	ctx := context.Background()
+	srcID, dstID := seedFundedTransfer(t, infra.pgContainer.DB, infra.orgID, infra.ledgerID,
+		"@src", "@dst", 1000, 1000)
+	v2App := buildHumaV2DirectApp(t, infra.handler)
+	pending := decodeTxResponse(t, postV2Create(t, v2App, "hold", infra.orgID, infra.ledgerID,
+		holdParityV2Body, ""), nethttp.StatusCreated)
+	pendingID := uuid.MustParse(pending["id"].(string))
+	drainBalanceSync(t, ctx, infra.handler.Command, infra.redisRepo, infra.orgID, infra.ledgerID)
+
+	faultRepo := &lostBackupEnrichmentResponseRepository{RedisRepository: infra.redisRepo}
+	infra.handler.Command.TransactionRedisRepo = faultRepo
+	result, err := infra.handler.commitTransaction(ctx, infra.orgID, infra.ledgerID, pendingID, cn.APPROVED)
+	assert.Nil(t, result)
+	require.ErrorContains(t, err, "simulated lost response after authoritative backup enrichment")
+	assert.Equal(t, cn.APPROVED, postgrestestutil.GetTransactionStatus(t, infra.pgContainer.DB, pendingID),
+		"the terminal SQL CAS is durable before an enrichment response can be lost")
+
+	backupKey := utils.TransactionInternalKey(infra.orgID, infra.ledgerID, pendingID.String())
+	rawBackup, err := infra.redisRepo.ReadMessageFromQueue(ctx, backupKey)
+	require.NoError(t, err)
+	envelope := mmodel.TransactionRedisQueue{}
+	require.NoError(t, json.Unmarshal(rawBackup, &envelope))
+	assert.Equal(t, pendingID, envelope.TransactionID)
+	assert.NotEmpty(t, envelope.AttemptOwner)
+	assert.Equal(t, mmodel.TransactionOutcomeCommitted, envelope.ExpectedOutcome)
+	require.NotEmpty(t, envelope.BalancesAfter, "the lost response must not erase the Lua-authored after state")
+	require.NotEmpty(t, envelope.Operations, "the lost response must retain the exact materialized operation IDs")
+	outcomeValue, err := infra.redisRepo.Get(ctx,
+		utils.TransactionBalanceOutcomeKey(infra.orgID, infra.ledgerID, pendingID))
+	require.NoError(t, err)
+	require.NotEmpty(t, outcomeValue, "cleanup is forbidden until delayed persistence proves all operations durable")
+
+	processingOwnerKey := utils.PendingTransactionLockKey(infra.orgID, infra.ledgerID, pendingID.String()) + ":owner"
+	require.Eventually(t, func() bool {
+		owner, readErr := infra.redisRepo.Get(ctx, processingOwnerKey)
+		return readErr == nil && owner == ""
+	}, 3*time.Second, 25*time.Millisecond)
+	infra.handler.Command.TransactionRedisRepo = infra.redisRepo
+	opposite, oppositeErr := infra.handler.commitTransaction(ctx, infra.orgID, infra.ledgerID, pendingID, cn.CANCELED)
+	assert.Nil(t, opposite)
+	var terminalConflict pkg.EntityConflictError
+	require.ErrorAs(t, oppositeErr, &terminalConflict)
+	assert.Equal(t, cn.ErrCommitTransactionNotPending.Error(), terminalConflict.Code)
+
+	drainBalanceSync(t, ctx, infra.handler.Command, infra.redisRepo, infra.orgID, infra.ledgerID)
+	requireDecimalEqual(t, decimal.NewFromInt(900),
+		postgrestestutil.GetBalanceAvailable(t, infra.pgContainer.DB, srcID), "commit movement occurs exactly once")
+	requireDecimalEqual(t, decimal.NewFromInt(1100),
+		postgrestestutil.GetBalanceAvailable(t, infra.pgContainer.DB, dstID), "opposite retry never moves balances")
+}
+
+func TestIntegration_TransactionPendingUpdateSerializesBackupConsumerPromotion(t *testing.T) {
+	t.Setenv("ALLOW_INSECURE_TLS", "true")
+	t.Setenv("RABBITMQ_TRANSACTION_ASYNC", "false")
+
+	infra := setupTestInfra(t)
+	ctx := context.Background()
+	_, _ = seedFundedTransfer(t, infra.pgContainer.DB, infra.orgID, infra.ledgerID, "@src", "@dst", 1000, 1000)
+	v2App := buildHumaV2DirectApp(t, infra.handler)
+	pending := decodeTxResponse(t, postV2Create(t, v2App, "hold", infra.orgID, infra.ledgerID, holdParityV2Body, ""), nethttp.StatusCreated)
+	pendingID := uuid.MustParse(pending["id"].(string))
+	drainBalanceSync(t, ctx, infra.handler.Command, infra.redisRepo, infra.orgID, infra.ledgerID)
+
+	prepareRevertUpdateFreeze(t, infra)
+	infra.handler.RevertIdempotencyMode = revertIdempotencyModeLegacy
+	pausedRepo := &pausedTransactionUpdateRepository{
+		Repository: infra.handler.Command.TransactionRepo,
+		started:    make(chan struct{}, 1),
+		release:    make(chan struct{}),
+	}
+	infra.handler.Command.TransactionRepo = pausedRepo
+
+	updateDone := make(chan error, 1)
+	go func() {
+		_, err := infra.handler.updateTransaction(ctx, infra.orgID, infra.ledgerID, pendingID,
+			&transaction.UpdateTransactionInput{Description: "completed before consumer promotion"})
+		updateDone <- err
+	}()
+	<-pausedRepo.started
+
+	approved := cn.APPROVED
+	promotionDone := make(chan error, 1)
+	go func() {
+		_, err := infra.handler.Command.UpdateTransactionStatus(ctx, &transaction.Transaction{
+			ID:             pendingID.String(),
+			OrganizationID: infra.orgID.String(),
+			LedgerID:       infra.ledgerID.String(),
+			Status: transaction.Status{
+				Code:        approved,
+				Description: &approved,
+			},
+		})
+		promotionDone <- err
+	}()
+	select {
+	case err := <-promotionDone:
+		require.Failf(t, "consumer bypassed row lock", "err=%v", err)
+	case <-time.After(200 * time.Millisecond):
+	}
+
+	require.NoError(t, infra.revertFreeze.Activate(ctx))
+	close(pausedRepo.release)
+	require.NoError(t, <-updateDone)
+	require.NoError(t, <-promotionDone)
+
+	var persistedStatus, persistedDescription string
+	require.NoError(t, infra.pgContainer.DB.QueryRowContext(ctx,
+		`SELECT status, description FROM transaction WHERE organization_id = $1 AND ledger_id = $2 AND id = $3`,
+		infra.orgID, infra.ledgerID, pendingID).Scan(&persistedStatus, &persistedDescription))
+	assert.Equal(t, cn.APPROVED, persistedStatus)
+	assert.Equal(t, "completed before consumer promotion", persistedDescription)
+}
+
+func TestIntegration_TransactionPendingUpdateCrashReleasesPostgresRowLock(t *testing.T) {
+	t.Setenv("ALLOW_INSECURE_TLS", "true")
+	t.Setenv("RABBITMQ_TRANSACTION_ASYNC", "false")
+
+	infra := setupTestInfra(t)
+	ctx := context.Background()
+	_, _ = seedFundedTransfer(t, infra.pgContainer.DB, infra.orgID, infra.ledgerID, "@src", "@dst", 1000, 1000)
+	v2App := buildHumaV2DirectApp(t, infra.handler)
+	pending := decodeTxResponse(t, postV2Create(t, v2App, "hold", infra.orgID, infra.ledgerID, holdParityV2Body, ""), nethttp.StatusCreated)
+	pendingID := uuid.MustParse(pending["id"].(string))
+
+	dbTx, err := infra.handler.Command.TransactionRepo.BeginTx(ctx)
+	require.NoError(t, err)
+	_, err = infra.handler.Command.TransactionRepo.FindForUpdate(ctx, dbTx, infra.orgID, infra.ledgerID, pendingID)
+	require.NoError(t, err)
+
+	approved := cn.APPROVED
+	promotionDone := make(chan error, 1)
+	go func() {
+		_, updateErr := infra.handler.Command.UpdateTransactionStatus(ctx, &transaction.Transaction{
+			ID:             pendingID.String(),
+			OrganizationID: infra.orgID.String(),
+			LedgerID:       infra.ledgerID.String(),
+			Status: transaction.Status{
+				Code:        approved,
+				Description: &approved,
+			},
+		})
+		promotionDone <- updateErr
+	}()
+	select {
+	case updateErr := <-promotionDone:
+		require.Failf(t, "promotion bypassed crashed request row lock", "err=%v", updateErr)
+	case <-time.After(200 * time.Millisecond):
+	}
+
+	// PostgreSQL releases row locks when the crashed request's connection rolls
+	// back. No persistent Redis lease exists to strand the PENDING transaction.
+	require.NoError(t, dbTx.Rollback())
+	select {
+	case updateErr := <-promotionDone:
+		require.NoError(t, updateErr)
+	case <-time.After(5 * time.Second):
+		require.Fail(t, "promotion remained blocked after PostgreSQL rollback")
+	}
+	mutationKey := utils.PendingTransactionLockKey(infra.orgID, infra.ledgerID, pendingID.String())
+	values, err := infra.redisRepo.MGet(ctx, []string{mutationKey, mutationKey + ":owner"})
+	require.NoError(t, err)
+	assert.Empty(t, values)
+}
+
+func TestIntegration_TransactionPhaseZeroRevertLeaseBlocksDrainUntilRequestCompletes(t *testing.T) {
+	t.Setenv("ALLOW_INSECURE_TLS", "true")
+	t.Setenv("RABBITMQ_TRANSACTION_ASYNC", "false")
+
+	infra := setupTestInfra(t)
+	ctx := context.Background()
+	_, _ = seedFundedTransfer(t, infra.pgContainer.DB, infra.orgID, infra.ledgerID, "@src", "@dst", 1000, 1000)
+	v2App := buildHumaV2DirectApp(t, infra.handler)
+	origin := decodeTxResponse(t, postV2Create(t, v2App, "direct", infra.orgID, infra.ledgerID, equivalentV2Body, ""), nethttp.StatusCreated)
+	originID := uuid.MustParse(origin["id"].(string))
+	drainBalanceSync(t, ctx, infra.handler.Command, infra.redisRepo, infra.orgID, infra.ledgerID)
+
+	activateRevertUpdateFreeze(t, infra)
+	infra.handler.RevertIdempotencyMode = revertIdempotencyModeLegacy
+	pausedRepo := &pausedLegacyRevertBalanceRepository{
+		RedisRepository: infra.redisRepo,
+		started:         make(chan struct{}, 1),
+		release:         make(chan struct{}),
+	}
+	infra.handler.Command.TransactionRedisRepo = pausedRepo
+
+	type revertResult struct {
+		transaction *transaction.Transaction
+		err         error
+	}
+	result := make(chan revertResult, 1)
+	go func() {
+		reverse, _, err := infra.handler.revertTransaction(ctx, infra.orgID, infra.ledgerID, originID)
+		result <- revertResult{transaction: reverse, err: err}
+	}()
+
+	<-pausedRepo.started
+	require.Error(t, infra.revertFreeze.MarkPhaseZeroDrained(ctx),
+		"phase-zero drain must be serialized after every admitted legacy revert")
+	loser, _, loserErr := infra.handler.revertTransaction(ctx, infra.orgID, infra.ledgerID, originID)
+	require.Error(t, loserErr)
+	require.Nil(t, loser)
+	require.Error(t, infra.revertFreeze.MarkPhaseZeroDrained(ctx),
+		"a same-origin loser shares the durable origin admission and cannot release it underneath the paused winner")
+	close(pausedRepo.release)
+	reverse := <-result
+	require.NoError(t, reverse.err)
+	require.NotNil(t, reverse.transaction)
+	require.NoError(t, infra.revertFreeze.MarkPhaseZeroDrained(ctx))
+}
+
+func TestIntegration_TransactionPhaseZeroDrainWaitsForLegacyReplayPublication(t *testing.T) {
+	t.Setenv("ALLOW_INSECURE_TLS", "true")
+	t.Setenv("RABBITMQ_TRANSACTION_ASYNC", "false")
+
+	infra := setupTestInfra(t)
+	ctx := context.Background()
+	_, _ = seedFundedTransfer(t, infra.pgContainer.DB, infra.orgID, infra.ledgerID, "@src", "@dst", 1000, 1000)
+	v2App := buildHumaV2DirectApp(t, infra.handler)
+	origin := decodeTxResponse(t, postV2Create(t, v2App, "direct", infra.orgID, infra.ledgerID, equivalentV2Body, ""), nethttp.StatusCreated)
+	originID := uuid.MustParse(origin["id"].(string))
+	drainBalanceSync(t, ctx, infra.handler.Command, infra.redisRepo, infra.orgID, infra.ledgerID)
+
+	activateRevertUpdateFreeze(t, infra)
+	infra.handler.RevertIdempotencyMode = revertIdempotencyModeLegacy
+	pausedRepo := &pausedLegacyReplayRepository{
+		RedisRepository: infra.redisRepo,
+		started:         make(chan struct{}, 1),
+		release:         make(chan struct{}),
+	}
+	infra.handler.Command.TransactionRedisRepo = pausedRepo
+
+	type revertResult struct {
+		transaction *transaction.Transaction
+		err         error
+	}
+	result := make(chan revertResult, 1)
+	go func() {
+		reverse, _, err := infra.handler.revertTransaction(ctx, infra.orgID, infra.ledgerID, originID)
+		result <- revertResult{transaction: reverse, err: err}
+	}()
+
+	<-pausedRepo.started
+	originTransaction, err := infra.handler.Query.GetTransactionWithOperationsByID(ctx, infra.orgID, infra.ledgerID, originID)
+	require.NoError(t, err)
+	legacyHash, err := legacyRevertIdempotencyHash(originTransaction.TransactionRevert())
+	require.NoError(t, err)
+	legacyKey := utils.IdempotencyInternalKey(infra.orgID, infra.ledgerID, legacyHash)
+	fenceTTL, err := infra.redisContainer.Client.TTL(ctx, legacyKey).Result()
+	require.NoError(t, err)
+	require.Equal(t, time.Duration(-1), fenceTTL, "phase-zero request fence must not expire before replay publication")
+	require.Error(t, infra.revertFreeze.MarkPhaseZeroDrained(ctx),
+		"drain must remain blocked while the admitted request publishes its replay")
+	select {
+	case early := <-result:
+		require.Failf(t, "phase-zero request returned before replay publication", "result=%+v", early)
+	default:
+	}
+
+	close(pausedRepo.release)
+	reverse := <-result
+	require.NoError(t, reverse.err)
+	require.NotNil(t, reverse.transaction)
+	require.NoError(t, infra.revertFreeze.MarkPhaseZeroDrained(ctx))
+
+	encodedReplay, err := infra.redisRepo.Get(ctx, legacyKey)
+	require.NoError(t, err)
+	persistedReplay := &transaction.Transaction{}
+	require.NoError(t, json.Unmarshal([]byte(encodedReplay), persistedReplay))
+	require.Equal(t, reverse.transaction.ID, persistedReplay.ID)
+	require.NotNil(t, persistedReplay.ParentTransactionID)
+	require.Equal(t, originID.String(), *persistedReplay.ParentTransactionID)
+}
+
+func TestIntegration_TransactionBridgeRevertLeaseBlocksFinalizationUntilRequestCompletes(t *testing.T) {
+	t.Setenv("ALLOW_INSECURE_TLS", "true")
+	t.Setenv("RABBITMQ_TRANSACTION_ASYNC", "false")
+
+	infra := setupTestInfra(t)
+	ctx := context.Background()
+	_, _ = seedFundedTransfer(t, infra.pgContainer.DB, infra.orgID, infra.ledgerID, "@src", "@dst", 1000, 1000)
+	v2App := buildHumaV2DirectApp(t, infra.handler)
+	origin := decodeTxResponse(t, postV2Create(t, v2App, "direct", infra.orgID, infra.ledgerID, equivalentV2Body, ""), nethttp.StatusCreated)
+	originID := uuid.MustParse(origin["id"].(string))
+	drainBalanceSync(t, ctx, infra.handler.Command, infra.redisRepo, infra.orgID, infra.ledgerID)
+
+	activateRevertUpdateFreeze(t, infra)
+	infra.handler.RevertIdempotencyMode = revertIdempotencyModeBridge
+	pausedRepo := &pausedFencedBalanceRepository{
+		RedisRepository: infra.redisRepo,
+		firstStarted:    make(chan uuid.UUID, 1),
+		releaseFirst:    make(chan struct{}),
+	}
+	infra.handler.Command.TransactionRedisRepo = pausedRepo
+
+	type revertResult struct {
+		transaction *transaction.Transaction
+		err         error
+	}
+	result := make(chan revertResult, 1)
+	go func() {
+		reverse, _, err := infra.handler.revertTransaction(ctx, infra.orgID, infra.ledgerID, originID)
+		result <- revertResult{transaction: reverse, err: err}
+	}()
+
+	<-pausedRepo.firstStarted
+	require.NoError(t, infra.revertFreeze.MarkPhaseZeroDrained(ctx),
+		"a bridge request may safely continue after phase zero is drained")
+	require.Error(t, infra.revertFreeze.Finalize(ctx),
+		"finalization must be serialized after every admitted bridge revert")
+	close(pausedRepo.releaseFirst)
+	reverse := <-result
+	require.NoError(t, reverse.err)
+	require.NotNil(t, reverse.transaction)
+	require.NoError(t, infra.revertFreeze.Finalize(ctx))
+}
+
+func TestIntegration_TransactionV2Revert_LostSeedResponsePreservesRecoveryEvidence(t *testing.T) {
+	t.Setenv("ALLOW_INSECURE_TLS", "true")
+	t.Setenv("RABBITMQ_TRANSACTION_ASYNC", "false")
+
+	infra := setupTestInfra(t)
+	ctx := context.Background()
+	srcID, dstID := seedFundedTransfer(t, infra.pgContainer.DB, infra.orgID, infra.ledgerID, "@src", "@dst", 1000, 1000)
+	v2App := buildHumaV2DirectApp(t, infra.handler)
+	origin := decodeTxResponse(t, postV2Create(t, v2App, "direct", infra.orgID, infra.ledgerID, equivalentV2Body, ""), nethttp.StatusCreated)
+	originID := uuid.MustParse(origin["id"].(string))
+	drainBalanceSync(t, ctx, infra.handler.Command, infra.redisRepo, infra.orgID, infra.ledgerID)
+
+	faultRepo := &lostSeedResponseRepository{RedisRepository: infra.redisRepo}
+	infra.handler.Command.TransactionRedisRepo = faultRepo
+	activateRevertUpdateFreeze(t, infra)
+	infra.handler.RevertIdempotencyMode = revertIdempotencyModeBridge
+
+	first := postTransaction(t, v2App, v2RevertURL(infra.orgID, infra.ledgerID, originID), "", "")
+	assertProblemCode(t, first, nethttp.StatusServiceUnavailable, cn.ErrRevertReconciliationRequired.Error())
+
+	claim, err := infra.handler.Command.GetRevertClaim(ctx, infra.orgID, infra.ledgerID, originID)
+	require.NoError(t, err)
+	require.NotNil(t, claim)
+	assert.Equal(t, revertclaim.StateReconciliationRequired, claim.State)
+	require.NotNil(t, claim.FailureReason)
+	assert.Equal(t, "revert_seed_write_outcome_ambiguous", *claim.FailureReason)
+
+	backup, err := infra.redisRepo.ReadMessageFromQueue(ctx,
+		utils.TransactionInternalKey(infra.orgID, infra.ledgerID, claim.ReverseTransactionID.String()))
+	require.NoError(t, err)
+	queued := mmodel.TransactionRedisQueue{}
+	require.NoError(t, json.Unmarshal(backup, &queued))
+	assert.Empty(t, queued.BalancesAfter, "a lost seed response occurs before any balance mutation")
+	require.NotNil(t, queued.ParentTransactionID)
+	assert.Equal(t, originID, *queued.ParentTransactionID)
+
+	originKey := originRevertIdempotencyKey(claim)
+	originOwner, err := infra.redisRepo.Get(ctx, originKey+":owner")
+	require.NoError(t, err)
+	assert.Equal(t, claim.ReverseTransactionID.String(), originOwner)
+	requireDecimalEqual(t, decimal.NewFromInt(900), postgrestestutil.GetBalanceAvailable(t, infra.pgContainer.DB, srcID), "lost seed response does not restore source")
+	requireDecimalEqual(t, decimal.NewFromInt(1100), postgrestestutil.GetBalanceAvailable(t, infra.pgContainer.DB, dstID), "lost seed response does not debit destination")
+
+	retry := postTransaction(t, v2App, v2RevertURL(infra.orgID, infra.ledgerID, originID), "", "")
+	assertProblemCode(t, retry, nethttp.StatusServiceUnavailable, cn.ErrRevertReconciliationRequired.Error())
+	assert.Equal(t, int32(1), faultRepo.seedCalls.Load(), "reconciliation fencing must prevent a second seed or balance attempt")
+}
+
+func TestIntegration_TransactionV2Revert_LostBalanceResponseStaysFenced(t *testing.T) {
+	t.Setenv("ALLOW_INSECURE_TLS", "true")
+	t.Setenv("RABBITMQ_TRANSACTION_ASYNC", "false")
+
+	infra := setupTestInfra(t)
+	ctx := context.Background()
+	_, _ = seedFundedTransfer(t, infra.pgContainer.DB, infra.orgID, infra.ledgerID, "@src", "@dst", 1000, 1000)
+	v2App := buildHumaV2DirectApp(t, infra.handler)
+
+	origin := decodeTxResponse(t, postV2Create(t, v2App, "direct", infra.orgID, infra.ledgerID, equivalentV2Body, ""), nethttp.StatusCreated)
+	originID := uuid.MustParse(origin["id"].(string))
+	drainBalanceSync(t, ctx, infra.handler.Command, infra.redisRepo, infra.orgID, infra.ledgerID)
+
+	originTransaction, err := infra.handler.Query.GetTransactionWithOperationsByID(ctx, infra.orgID, infra.ledgerID, originID)
+	require.NoError(t, err)
+	legacyHash, err := legacyRevertIdempotencyHash(originTransaction.TransactionRevert())
+	require.NoError(t, err)
+	legacyKey := utils.IdempotencyInternalKey(infra.orgID, infra.ledgerID, legacyHash)
+	originKey := utils.IdempotencyInternalKey(infra.orgID, infra.ledgerID,
+		libCommons.HashSHA256(utils.RevertIdempotencyHashSource(originID)))
+
+	faultRepo := &lostBalanceResponseRepository{RedisRepository: infra.redisRepo}
+	infra.handler.Command.TransactionRedisRepo = faultRepo
+	activateRevertUpdateFreeze(t, infra)
+	infra.handler.RevertIdempotencyMode = revertIdempotencyModeBridge
+
+	first := postTransaction(t, v2App, v2RevertURL(infra.orgID, infra.ledgerID, originID), "", "")
+	assertProblemCode(t, first, nethttp.StatusServiceUnavailable, cn.ErrRevertReconciliationRequired.Error())
+
+	claim, err := infra.handler.Command.GetRevertClaim(ctx, infra.orgID, infra.ledgerID, originID)
+	require.NoError(t, err)
+	require.NotNil(t, claim)
+	assert.Equal(t, revertclaim.StateReconciliationRequired, claim.State)
+	require.NotNil(t, claim.FailureReason)
+	assert.Equal(t, "balance_commit_outcome_ambiguous", *claim.FailureReason)
+
+	legacyOwner, err := infra.redisRepo.Get(ctx, legacyKey+":owner")
+	require.NoError(t, err)
+	assert.Equal(t, claim.ReverseTransactionID.String(), legacyOwner)
+	legacyTTL, err := infra.redisContainer.Client.TTL(ctx, legacyKey).Result()
+	require.NoError(t, err)
+	assert.Equal(t, time.Duration(-1), legacyTTL, "an ambiguous bridge fence must not expire")
+	legacyOwnerTTL, err := infra.redisContainer.Client.TTL(ctx, legacyKey+":owner").Result()
+	require.NoError(t, err)
+	assert.Equal(t, time.Duration(-1), legacyOwnerTTL, "an ambiguous owner token must not expire")
+	legacyAvailable, err := infra.redisRepo.SetNX(ctx, legacyKey, "late-owner", 300)
+	require.NoError(t, err)
+	assert.False(t, legacyAvailable, "an ambiguous response must retain the legacy bridge fence")
+	originAvailable, err := infra.redisRepo.SetNX(ctx, originKey, "late-origin", 300)
+	require.NoError(t, err)
+	assert.False(t, originAvailable, "an ambiguous response must retain the origin fence")
+
+	backup, err := infra.redisRepo.ReadMessageFromQueue(ctx,
+		utils.TransactionInternalKey(infra.orgID, infra.ledgerID, claim.ReverseTransactionID.String()))
+	require.NoError(t, err)
+	require.NotEmpty(t, backup, "the committed Lua movement must leave the reserved reverse recoverable")
+	backupEnvelope := mmodel.TransactionRedisQueue{}
+	require.NoError(t, json.Unmarshal(backup, &backupEnvelope))
+	require.NotNil(t, backupEnvelope.ParentTransactionID)
+	assert.Equal(t, originID, *backupEnvelope.ParentTransactionID,
+		"recovery must carry the exact origin independently of the economic payload")
+
+	sourceAfterFirst := getBalanceFromRedis(t, ctx, infra.redisRepo, infra.orgID, infra.ledgerID, "@src", cn.DefaultBalanceKey)
+	destinationAfterFirst := getBalanceFromRedis(t, ctx, infra.redisRepo, infra.orgID, infra.ledgerID, "@dst", cn.DefaultBalanceKey)
+	require.NotNil(t, sourceAfterFirst)
+	require.NotNil(t, destinationAfterFirst)
+	requireDecimalEqual(t, decimal.NewFromInt(1000), sourceAfterFirst.Available, "lost response still committed one source restoration")
+	requireDecimalEqual(t, decimal.NewFromInt(1000), destinationAfterFirst.Available, "lost response still committed one destination restoration")
+
+	// Recreate the durable state a hard process crash leaves when Redis commits
+	// but the process dies before it can mark the claim MUTATED/reconciliation.
+	// ARMED was committed on PostgreSQL primary before Lua could run. The retry
+	// must infer the commit only from Lua's atomic BalancesAfter outcome, never
+	// from process memory.
+	_, err = infra.pgContainer.DB.ExecContext(ctx, `
+		UPDATE transaction_revert_claim
+		SET state = 'ARMED', failure_reason = NULL
+		WHERE organization_id = $1 AND ledger_id = $2 AND origin_transaction_id = $3`,
+		infra.orgID, infra.ledgerID, originID)
+	require.NoError(t, err)
+
+	retry := postTransaction(t, v2App, v2RevertURL(infra.orgID, infra.ledgerID, originID), "", "")
+	assertProblemCode(t, retry, nethttp.StatusServiceUnavailable, cn.ErrRevertReconciliationRequired.Error())
+	assert.Equal(t, int32(1), faultRepo.balanceCalls.Load(), "retry must not dispatch a second balance mutation")
+	hardCrashClaim, err := infra.handler.Command.GetRevertClaim(ctx, infra.orgID, infra.ledgerID, originID)
+	require.NoError(t, err)
+	require.NotNil(t, hardCrashClaim)
+	assert.Equal(t, revertclaim.StateArmed, hardCrashClaim.State,
+		"a retry must not overwrite the shared phase while the original owner may still be completing persistence")
+	assert.Nil(t, hardCrashClaim.FailureReason,
+		"the HTTP 0505 response exposes reconciliation while ARMED remains the durable no-retry fence")
+	assert.Equal(t, 1, countTransactionsInLedger(t, infra.pgContainer.DB, infra.ledgerID),
+		"ambiguous movement stays unpersisted and fenced until backup reconciliation")
+
+	sourceAfterRetry := getBalanceFromRedis(t, ctx, infra.redisRepo, infra.orgID, infra.ledgerID, "@src", cn.DefaultBalanceKey)
+	destinationAfterRetry := getBalanceFromRedis(t, ctx, infra.redisRepo, infra.orgID, infra.ledgerID, "@dst", cn.DefaultBalanceKey)
+	requireDecimalEqual(t, sourceAfterFirst.Available, sourceAfterRetry.Available, "retry cannot restore the source twice")
+	requireDecimalEqual(t, destinationAfterFirst.Available, destinationAfterRetry.Available, "retry cannot debit the destination twice")
+
+	// Selective loss of every per-transaction Redis record while the global
+	// financial generation survives is not proof that Lua never moved money.
+	// ARMED on PostgreSQL is the durable witness that makes this fail closed.
+	_, err = infra.pgContainer.DB.ExecContext(ctx, `
+		UPDATE transaction_revert_claim
+		SET state = 'ARMED', failure_reason = NULL
+		WHERE organization_id = $1 AND ledger_id = $2 AND origin_transaction_id = $3`,
+		infra.orgID, infra.ledgerID, originID)
+	require.NoError(t, err)
+	backupKey := utils.TransactionInternalKey(infra.orgID, infra.ledgerID, claim.ReverseTransactionID.String())
+	executionKey := utils.TransactionBalanceExecutionKey(infra.orgID, infra.ledgerID, claim.ReverseTransactionID)
+	outcomeKey := utils.TransactionBalanceOutcomeKey(infra.orgID, infra.ledgerID, claim.ReverseTransactionID)
+	require.NoError(t, infra.redisContainer.Client.HDel(ctx, transactionredis.TransactionBackupQueue, backupKey).Err())
+	require.NoError(t, infra.redisContainer.Client.Del(ctx, outcomeKey, executionKey, executionKey+":owner").Err())
+
+	lostEvidenceRetry := postTransaction(t, v2App, v2RevertURL(infra.orgID, infra.ledgerID, originID), "", "")
+	assertProblemCode(t, lostEvidenceRetry, nethttp.StatusServiceUnavailable, cn.ErrRevertReconciliationRequired.Error())
+	assert.Equal(t, int32(1), faultRepo.balanceCalls.Load(), "selective Redis loss cannot authorize a second balance command")
+	lostEvidenceClaim, err := infra.handler.Command.GetRevertClaim(ctx, infra.orgID, infra.ledgerID, originID)
+	require.NoError(t, err)
+	require.NotNil(t, lostEvidenceClaim)
+	assert.Equal(t, revertclaim.StateReconciliationRequired, lostEvidenceClaim.State)
+	require.NotNil(t, lostEvidenceClaim.FailureReason)
+	assert.Equal(t, "armed_revert_economic_evidence_missing", *lostEvidenceClaim.FailureReason)
+
+	sourceAfterLoss := getBalanceFromRedis(t, ctx, infra.redisRepo, infra.orgID, infra.ledgerID, "@src", cn.DefaultBalanceKey)
+	destinationAfterLoss := getBalanceFromRedis(t, ctx, infra.redisRepo, infra.orgID, infra.ledgerID, "@dst", cn.DefaultBalanceKey)
+	requireDecimalEqual(t, sourceAfterFirst.Available, sourceAfterLoss.Available, "selective loss cannot restore the source twice")
+	requireDecimalEqual(t, destinationAfterFirst.Available, destinationAfterLoss.Available, "selective loss cannot debit the destination twice")
+}
+
+func TestIntegration_TransactionV2Revert_FinalRecoversBridgeCrashBeforeLuaThenMovesOnce(t *testing.T) {
+	t.Setenv("ALLOW_INSECURE_TLS", "true")
+	t.Setenv("RABBITMQ_TRANSACTION_ASYNC", "false")
+
+	infra := setupTestInfra(t)
+	ctx := context.Background()
+	srcID, dstID := seedFundedTransfer(t, infra.pgContainer.DB, infra.orgID, infra.ledgerID, "@src", "@dst", 1000, 1000)
+	v2App := buildHumaV2DirectApp(t, infra.handler)
+	origin := decodeTxResponse(t, postV2Create(t, v2App, "direct", infra.orgID, infra.ledgerID, equivalentV2Body, ""), nethttp.StatusCreated)
+	originID := uuid.MustParse(origin["id"].(string))
+	drainBalanceSync(t, ctx, infra.handler.Command, infra.redisRepo, infra.orgID, infra.ledgerID)
+
+	originTransaction, err := infra.handler.Query.GetTransactionWithOperationsByID(ctx, infra.orgID, infra.ledgerID, originID)
+	require.NoError(t, err)
+	require.NotNil(t, originTransaction)
+	legacyHash, err := legacyRevertIdempotencyHash(originTransaction.TransactionRevert())
+	require.NoError(t, err)
+	legacyKey := utils.IdempotencyInternalKey(infra.orgID, infra.ledgerID, legacyHash)
+
+	staleReverseID := uuid.New()
+	legacyOwner := staleReverseID.String()
+	rolloutMode := "bridge"
+	rolloutToken := "bridge-crash-token"
+	redisGeneration, err := infra.revertFreeze.FinancialDatasetGeneration(ctx)
+	require.NoError(t, err)
+	claim, acquired, err := infra.handler.Command.ClaimRevert(ctx, infra.orgID, infra.ledgerID, originID,
+		staleReverseID, &legacyKey, &legacyOwner, &rolloutMode, &rolloutToken, &redisGeneration)
+	require.NoError(t, err)
+	require.True(t, acquired)
+	originKey := originRevertIdempotencyKey(claim)
+	originAcquired, err := infra.redisRepo.AcquireOwnedKey(ctx, originKey, staleReverseID.String(), 0)
+	require.NoError(t, err)
+	require.True(t, originAcquired)
+
+	legacyAcquired, err := infra.redisRepo.AcquireOwnedKey(ctx, legacyKey, staleReverseID.String(), 0)
+	require.NoError(t, err)
+	require.True(t, legacyAcquired)
+	seed, err := json.Marshal(mmodel.TransactionRedisQueue{
+		TransactionID:       staleReverseID,
+		ParentTransactionID: &originID,
+		OrganizationID:      infra.orgID,
+		LedgerID:            infra.ledgerID,
+		TransactionStatus:   cn.CREATED,
+		Action:              cn.ActionRevert,
+		AttemptOwner:        staleReverseID.String(),
+		ExpectedOutcome:     mmodel.TransactionOutcomeCommitted,
+		RedisGeneration:     redisGeneration,
+	})
+	require.NoError(t, err)
+	staleBackupKey := utils.TransactionInternalKey(infra.orgID, infra.ledgerID, staleReverseID.String())
+	require.NoError(t, infra.redisRepo.AddMessageToQueue(ctx, staleBackupKey, seed))
+
+	_, err = infra.pgContainer.DB.ExecContext(ctx, `
+		UPDATE transaction SET description = $1
+		WHERE organization_id = $2 AND ledger_id = $3 AND id = $4`,
+		"payload changed after bridge acquired its fence", infra.orgID, infra.ledgerID, originID)
+	require.NoError(t, err)
+	mutatedOrigin, err := infra.handler.Query.GetTransactionWithOperationsByID(readrouting.WithPrimaryRead(ctx),
+		infra.orgID, infra.ledgerID, originID)
+	require.NoError(t, err)
+	mutatedHash, err := legacyRevertIdempotencyHash(mutatedOrigin.TransactionRevert())
+	require.NoError(t, err)
+	mutatedLegacyKey := utils.IdempotencyInternalKey(infra.orgID, infra.ledgerID, mutatedHash)
+	require.NotEqual(t, legacyKey, mutatedLegacyKey,
+		"the test must prove final recovery cannot recalculate the bridge fence from mutable payload")
+
+	infra.handler.RevertIdempotencyMode = revertIdempotencyModeFinal
+	reverse := decodeTxResponse(t, postTransaction(t, v2App,
+		v2RevertURL(infra.orgID, infra.ledgerID, originID), "", ""), nethttp.StatusCreated)
+	reverseID := uuid.MustParse(reverse["id"].(string))
+	assert.NotEqual(t, staleReverseID, reverseID, "recovery releases the abandoned reservation before retrying")
+	drainBalanceSync(t, ctx, infra.handler.Command, infra.redisRepo, infra.orgID, infra.ledgerID)
+
+	claim, err = infra.handler.Command.GetRevertClaim(ctx, infra.orgID, infra.ledgerID, originID)
+	require.NoError(t, err)
+	require.NotNil(t, claim)
+	assert.Equal(t, reverseID, claim.ReverseTransactionID)
+	assert.Equal(t, revertclaim.StateCompleted, claim.State)
+	legacyValues, err := infra.redisRepo.MGet(ctx, []string{legacyKey, legacyKey + ":owner"})
+	require.NoError(t, err)
+	assert.Empty(t, legacyValues, "final recovery must clear the exact persistent fence left by bridge")
+	mutatedLegacyValues, err := infra.redisRepo.MGet(ctx, []string{mutatedLegacyKey, mutatedLegacyKey + ":owner"})
+	require.NoError(t, err)
+	assert.Empty(t, mutatedLegacyValues, "recovery must not create or clean a recalculated legacy fence")
+	_, err = infra.redisRepo.ReadMessageFromQueue(ctx, staleBackupKey)
+	assert.ErrorIs(t, err, redislib.Nil)
+	assert.Equal(t, 2, countTransactionsInLedger(t, infra.pgContainer.DB, infra.ledgerID))
+	requireDecimalEqual(t, decimal.NewFromInt(1000), postgrestestutil.GetBalanceAvailable(t, infra.pgContainer.DB, srcID), "pre-Lua recovery restores source once")
+	requireDecimalEqual(t, decimal.NewFromInt(1000), postgrestestutil.GetBalanceAvailable(t, infra.pgContainer.DB, dstID), "pre-Lua recovery restores destination once")
+}
+
+func TestIntegration_TransactionV2Revert_CrashBeforeSeedRecoversThenMovesOnce(t *testing.T) {
+	t.Setenv("ALLOW_INSECURE_TLS", "true")
+	t.Setenv("RABBITMQ_TRANSACTION_ASYNC", "false")
+
+	infra := setupTestInfra(t)
+	ctx := context.Background()
+	srcID, dstID := seedFundedTransfer(t, infra.pgContainer.DB, infra.orgID, infra.ledgerID, "@src", "@dst", 1000, 1000)
+	v2App := buildHumaV2DirectApp(t, infra.handler)
+	origin := decodeTxResponse(t, postV2Create(t, v2App, "direct", infra.orgID, infra.ledgerID, equivalentV2Body, ""), nethttp.StatusCreated)
+	originID := uuid.MustParse(origin["id"].(string))
+	drainBalanceSync(t, ctx, infra.handler.Command, infra.redisRepo, infra.orgID, infra.ledgerID)
+
+	staleReverseID := uuid.New()
+	redisGeneration, err := infra.revertFreeze.FinancialDatasetGeneration(ctx)
+	require.NoError(t, err)
+	claim, acquired, err := infra.handler.Command.ClaimRevert(ctx, infra.orgID, infra.ledgerID, originID,
+		staleReverseID, nil, nil, nil, nil, &redisGeneration)
+	require.NoError(t, err)
+	require.True(t, acquired)
+	originKey := originRevertIdempotencyKey(claim)
+	originAcquired, err := infra.redisRepo.SetNX(ctx, originKey, "", 300)
+	require.NoError(t, err)
+	require.True(t, originAcquired)
+	originOwnerAcquired, err := infra.redisRepo.SetNX(ctx, originKey+":owner", staleReverseID.String(), 0)
+	require.NoError(t, err)
+	require.True(t, originOwnerAcquired)
+
+	// No execution lease and no backup remain after the simulated crash. On
+	// Redis primary, that absence proves balance Lua was never dispatched.
+	reverse := decodeTxResponse(t, postTransaction(t, v2App,
+		v2RevertURL(infra.orgID, infra.ledgerID, originID), "", ""), nethttp.StatusCreated)
+	reverseID := uuid.MustParse(reverse["id"].(string))
+	assert.NotEqual(t, staleReverseID, reverseID)
+	drainBalanceSync(t, ctx, infra.handler.Command, infra.redisRepo, infra.orgID, infra.ledgerID)
+
+	completed, err := infra.handler.Command.GetRevertClaim(ctx, infra.orgID, infra.ledgerID, originID)
+	require.NoError(t, err)
+	require.NotNil(t, completed)
+	assert.Equal(t, reverseID, completed.ReverseTransactionID)
+	assert.Equal(t, revertclaim.StateCompleted, completed.State)
+	assert.Equal(t, 2, countTransactionsInLedger(t, infra.pgContainer.DB, infra.ledgerID))
+	requireDecimalEqual(t, decimal.NewFromInt(1000), postgrestestutil.GetBalanceAvailable(t, infra.pgContainer.DB, srcID), "source restored once after crash-before-seed recovery")
+	requireDecimalEqual(t, decimal.NewFromInt(1000), postgrestestutil.GetBalanceAvailable(t, infra.pgContainer.DB, dstID), "destination restored once after crash-before-seed recovery")
+}
+
+type panicOnceLedgerSettingsRepository struct {
+	ledger.Repository
+	panicNext atomic.Bool
+}
+
+func (r *panicOnceLedgerSettingsRepository) GetSettings(
+	ctx context.Context,
+	organizationID, ledgerID uuid.UUID,
+) (map[string]any, error) {
+	if r.panicNext.Swap(false) {
+		panic("simulated process crash after persistent H1 and before queue seed")
+	}
+
+	return r.Repository.GetSettings(ctx, organizationID, ledgerID)
+}
+
+func TestIntegration_TransactionPhaseZeroCrashBeforeSeedHasDurableRecoverableH1Owner(t *testing.T) {
+	t.Setenv("ALLOW_INSECURE_TLS", "true")
+	t.Setenv("RABBITMQ_TRANSACTION_ASYNC", "false")
+
+	infra := setupTestInfra(t)
+	ctx := context.Background()
+	srcID, dstID := seedFundedTransfer(t, infra.pgContainer.DB, infra.orgID, infra.ledgerID,
+		"@src", "@dst", 1000, 1000)
+	v2App := buildHumaV2DirectApp(t, infra.handler)
+	origin := decodeTxResponse(t, postV2Create(t, v2App, "direct", infra.orgID, infra.ledgerID,
+		equivalentV2Body, "phase-zero-crash-before-seed"), nethttp.StatusCreated)
+	originID := uuid.MustParse(origin["id"].(string))
+	drainBalanceSync(t, ctx, infra.handler.Command, infra.redisRepo, infra.orgID, infra.ledgerID)
+
+	prepareRevertUpdateFreeze(t, infra)
+	infra.handler.RevertIdempotencyMode = revertIdempotencyModeLegacy
+	originalLedgerRepo := infra.handler.Query.LedgerRepo
+	crashingLedgerRepo := &panicOnceLedgerSettingsRepository{Repository: originalLedgerRepo}
+	crashingLedgerRepo.panicNext.Store(true)
+	infra.handler.Query.LedgerRepo = crashingLedgerRepo
+	infra.handler.Query.OnboardingRedisRepo = nil
+
+	require.Panics(t, func() {
+		_, _, _ = infra.handler.revertTransaction(ctx, infra.orgID, infra.ledgerID, originID)
+	})
+	infra.handler.Query.LedgerRepo = originalLedgerRepo
+
+	claim, err := infra.handler.Command.GetRevertClaim(ctx, infra.orgID, infra.ledgerID, originID)
+	require.NoError(t, err)
+	require.NotNil(t, claim, "persistent phase-zero H1 must never exist without a durable origin claim")
+	require.NotNil(t, claim.LegacyFenceKey)
+	require.NotNil(t, claim.LegacyFenceOwner)
+	require.Equal(t, claim.ReverseTransactionID.String(), *claim.LegacyFenceOwner)
+
+	values, err := infra.redisRepo.MGet(ctx, []string{*claim.LegacyFenceKey, *claim.LegacyFenceKey + ":owner"})
+	require.NoError(t, err)
+	require.Contains(t, values, *claim.LegacyFenceKey, "old-compatible H1 main fence must exist")
+	require.Equal(t, claim.ReverseTransactionID.String(), values[*claim.LegacyFenceKey+":owner"])
+	backupKey := utils.TransactionInternalKey(infra.orgID, infra.ledgerID, claim.ReverseTransactionID.String())
+	_, err = infra.redisRepo.ReadMessageFromQueue(ctx, backupKey)
+	require.ErrorIs(t, err, redislib.Nil, "the crash point is proven before queue seed")
+	require.Error(t, infra.revertFreeze.Activate(ctx),
+		"a crash after claim and H1 must keep marker activation blocked until the same origin is recovered")
+
+	executionKey := utils.TransactionBalanceExecutionKey(infra.orgID, infra.ledgerID, claim.ReverseTransactionID)
+	require.NoError(t, infra.redisContainer.Client.Del(ctx, executionKey, executionKey+":owner").Err(),
+		"simulate the crashed process losing the owner checked execution lease")
+
+	reverse, replayed, err := infra.handler.revertTransaction(ctx, infra.orgID, infra.ledgerID, originID)
+	require.NoError(t, err)
+	require.NotNil(t, reverse)
+	require.False(t, replayed, "the recovered pre-seed attempt creates one fresh reverse")
+	require.Equal(t, originID.String(), *reverse.ParentTransactionID)
+	require.NotEqual(t, claim.ReverseTransactionID.String(), reverse.ID,
+		"pre-movement recovery releases the abandoned reserved ID before retry")
+	originRolloutToken := libCommons.HashSHA256(strings.Join([]string{
+		infra.orgID.String(), infra.ledgerID.String(), originID.String(),
+	}, ":"))
+	terminalAdmitted, terminalLease, _, terminalErr := infra.revertFreeze.AcquireRevert(ctx,
+		revertIdempotencyModeLegacy, originRolloutToken, "post-terminal-probe")
+	require.NoError(t, terminalErr)
+	require.True(t, terminalAdmitted)
+	require.False(t, terminalLease,
+		"terminal handoff must seal the origin before removing its rollout attempts")
+	require.NoError(t, infra.revertFreeze.Activate(ctx),
+		"the retry releases the deterministic origin admission only after its terminal handoff")
+	replayedReverse, replayed, err := infra.handler.revertTransaction(ctx, infra.orgID, infra.ledgerID, originID)
+	require.NoError(t, err)
+	require.True(t, replayed)
+	require.Equal(t, reverse.ID, replayedReverse.ID,
+		"a completed phase-zero claim must replay after its terminal backup has been cleaned")
+
+	drainBalanceSync(t, ctx, infra.handler.Command, infra.redisRepo, infra.orgID, infra.ledgerID)
+	require.Equal(t, 2, countTransactionsInLedger(t, infra.pgContainer.DB, infra.ledgerID))
+	requireDecimalEqual(t, decimal.NewFromInt(1000),
+		postgrestestutil.GetBalanceAvailable(t, infra.pgContainer.DB, srcID), "source restored once")
+	requireDecimalEqual(t, decimal.NewFromInt(1000),
+		postgrestestutil.GetBalanceAvailable(t, infra.pgContainer.DB, dstID), "destination restored once")
+}
+
+func TestIntegration_TransactionBridgeCrashPreservesExactGenerationDrainUntilRecovery(t *testing.T) {
+	t.Setenv("ALLOW_INSECURE_TLS", "true")
+	t.Setenv("RABBITMQ_TRANSACTION_ASYNC", "false")
+
+	infra := setupTestInfra(t)
+	ctx := context.Background()
+	srcID, dstID := seedFundedTransfer(t, infra.pgContainer.DB, infra.orgID, infra.ledgerID,
+		"@src", "@dst", 1000, 1000)
+	v2App := buildHumaV2DirectApp(t, infra.handler)
+	origin := decodeTxResponse(t, postV2Create(t, v2App, "direct", infra.orgID, infra.ledgerID,
+		equivalentV2Body, "bridge-crash-before-seed"), nethttp.StatusCreated)
+	originID := uuid.MustParse(origin["id"].(string))
+	drainBalanceSync(t, ctx, infra.handler.Command, infra.redisRepo, infra.orgID, infra.ledgerID)
+
+	activateRevertUpdateFreeze(t, infra)
+	infra.handler.RevertIdempotencyMode = revertIdempotencyModeBridge
+	originalLedgerRepo := infra.handler.Query.LedgerRepo
+	crashingLedgerRepo := &panicOnceLedgerSettingsRepository{Repository: originalLedgerRepo}
+	crashingLedgerRepo.panicNext.Store(true)
+	infra.handler.Query.LedgerRepo = crashingLedgerRepo
+	infra.handler.Query.OnboardingRedisRepo = nil
+
+	require.Panics(t, func() {
+		_, _, _ = infra.handler.revertTransaction(ctx, infra.orgID, infra.ledgerID, originID)
+	})
+	infra.handler.Query.LedgerRepo = originalLedgerRepo
+
+	claim, err := infra.handler.Command.GetRevertClaim(ctx, infra.orgID, infra.ledgerID, originID)
+	require.NoError(t, err)
+	require.NotNil(t, claim)
+	require.NoError(t, infra.revertFreeze.MarkPhaseZeroDrained(ctx),
+		"phase-zero drain is independent from an admitted bridge origin")
+	require.Error(t, infra.revertFreeze.Finalize(ctx),
+		"a bridge crash after its durable claim must keep the bridge generation fenced")
+
+	executionKey := utils.TransactionBalanceExecutionKey(infra.orgID, infra.ledgerID, claim.ReverseTransactionID)
+	require.NoError(t, infra.redisContainer.Client.Del(ctx, executionKey, executionKey+":owner").Err())
+	reverse, replayed, err := infra.handler.revertTransaction(ctx, infra.orgID, infra.ledgerID, originID)
+	require.NoError(t, err)
+	require.NotNil(t, reverse)
+	require.False(t, replayed)
+	require.Equal(t, originID.String(), *reverse.ParentTransactionID)
+	require.NoError(t, infra.revertFreeze.Finalize(ctx),
+		"terminal recovery must release the bridge set, not the phase-zero set")
+
+	drainBalanceSync(t, ctx, infra.handler.Command, infra.redisRepo, infra.orgID, infra.ledgerID)
+	require.Equal(t, 2, countTransactionsInLedger(t, infra.pgContainer.DB, infra.ledgerID))
+	requireDecimalEqual(t, decimal.NewFromInt(1000),
+		postgrestestutil.GetBalanceAvailable(t, infra.pgContainer.DB, srcID), "source restored once")
+	requireDecimalEqual(t, decimal.NewFromInt(1000),
+		postgrestestutil.GetBalanceAvailable(t, infra.pgContainer.DB, dstID), "destination restored once")
+}
+
+type pausedRevertClaimRepository struct {
+	revertclaim.Repository
+	claimed chan *revertclaim.Claim
+	release chan struct{}
+}
+
+func (r *pausedRevertClaimRepository) Claim(
+	ctx context.Context,
+	organizationID, ledgerID, originID, reverseID uuid.UUID,
+	legacyFenceKey, legacyFenceOwner, rolloutMode, rolloutToken, redisGeneration *string,
+) (*revertclaim.Claim, bool, error) {
+	claim, acquired, err := r.Repository.Claim(ctx, organizationID, ledgerID, originID, reverseID,
+		legacyFenceKey, legacyFenceOwner, rolloutMode, rolloutToken, redisGeneration)
+	if err == nil && acquired {
+		r.claimed <- claim
+		<-r.release
+	}
+
+	return claim, acquired, err
+}
+
+func TestIntegration_TransactionV2Revert_VisibleClaimAlreadyHasExecutionAttempt(t *testing.T) {
+	t.Setenv("ALLOW_INSECURE_TLS", "true")
+	t.Setenv("RABBITMQ_TRANSACTION_ASYNC", "false")
+
+	infra := setupTestInfra(t)
+	ctx := context.Background()
+	srcID, dstID := seedFundedTransfer(t, infra.pgContainer.DB, infra.orgID, infra.ledgerID,
+		"@src", "@dst", 1000, 1000)
+	v2App := buildHumaV2DirectApp(t, infra.handler)
+	origin := decodeTxResponse(t, postV2Create(t, v2App, "direct", infra.orgID, infra.ledgerID,
+		equivalentV2Body, ""), nethttp.StatusCreated)
+	originID := uuid.MustParse(origin["id"].(string))
+	drainBalanceSync(t, ctx, infra.handler.Command, infra.redisRepo, infra.orgID, infra.ledgerID)
+
+	pausedClaims := &pausedRevertClaimRepository{
+		Repository: infra.handler.Command.RevertClaimRepo,
+		claimed:    make(chan *revertclaim.Claim, 1),
+		release:    make(chan struct{}),
+	}
+	infra.handler.Command.RevertClaimRepo = pausedClaims
+
+	type revertResult struct {
+		transaction *transaction.Transaction
+		err         error
+	}
+	firstResult := make(chan revertResult, 1)
+	go func() {
+		reverse, _, err := infra.handler.revertTransaction(ctx, infra.orgID, infra.ledgerID, originID)
+		firstResult <- revertResult{transaction: reverse, err: err}
+	}()
+
+	claim := <-pausedClaims.claimed
+	executionOwner, err := infra.redisRepo.Get(ctx, revertExecutionFenceKey(claim)+":owner")
+	require.NoError(t, err)
+	assert.Equal(t, claim.ReverseTransactionID.String(), executionOwner,
+		"a durable claim must never become visible before its stale-winner execution fence")
+
+	retry, _, retryErr := infra.handler.revertTransaction(ctx, infra.orgID, infra.ledgerID, originID)
+	assert.Nil(t, retry)
+	require.Error(t, retryErr)
+	var activeConflict pkg.EntityConflictError
+	require.ErrorAs(t, retryErr, &activeConflict)
+	assert.Equal(t, cn.ErrIdempotencyKey.Error(), activeConflict.Code)
+	select {
+	case early := <-firstResult:
+		require.Failf(t, "visible claim was recovered while its owner was live",
+			"transaction=%v err=%v", early.transaction, early.err)
+	default:
+	}
+
+	close(pausedClaims.release)
+	winner := <-firstResult
+	require.NoError(t, winner.err)
+	require.NotNil(t, winner.transaction)
+	drainBalanceSync(t, ctx, infra.handler.Command, infra.redisRepo, infra.orgID, infra.ledgerID)
+
+	assert.Equal(t, 2, countTransactionsInLedger(t, infra.pgContainer.DB, infra.ledgerID))
+	requireDecimalEqual(t, decimal.NewFromInt(1000),
+		postgrestestutil.GetBalanceAvailable(t, infra.pgContainer.DB, srcID), "source restored once")
+	requireDecimalEqual(t, decimal.NewFromInt(1000),
+		postgrestestutil.GetBalanceAvailable(t, infra.pgContainer.DB, dstID), "destination restored once")
+}
+
+type pausedFencedBalanceRepository struct {
+	transactionredis.RedisRepository
+	firstStarted chan uuid.UUID
+	releaseFirst chan struct{}
+	calls        atomic.Int32
+	movements    atomic.Int32
+}
+
+type pausedSeedResponseRepository struct {
+	transactionredis.RedisRepository
+	firstStarted chan uuid.UUID
+	releaseFirst chan struct{}
+	seedCalls    atomic.Int32
+}
+
+func (r *pausedSeedResponseRepository) SeedTransactionBackup(
+	ctx context.Context,
+	organizationID, ledgerID, transactionID uuid.UUID,
+	message []byte,
+	attempt mmodel.BalanceExecutionAttempt,
+) error {
+	call := r.seedCalls.Add(1)
+	if err := r.RedisRepository.SeedTransactionBackup(ctx, organizationID, ledgerID, transactionID, message, attempt); err != nil {
+		return err
+	}
+	if call != 1 {
+		return nil
+	}
+
+	queued := mmodel.TransactionRedisQueue{}
+	if err := json.Unmarshal(message, &queued); err != nil {
+		return err
+	}
+	r.firstStarted <- transactionID
+	<-r.releaseFirst
+
+	return errors.New("simulated stale seed response after successor takeover")
+}
+
+func (r *pausedFencedBalanceRepository) ProcessOutcomeBalanceAtomicOperation(
+	ctx context.Context,
+	organizationID, ledgerID, transactionID uuid.UUID,
+	transactionStatus string,
+	pending bool,
+	balances []mmodel.BalanceOperation,
+	attempt mmodel.BalanceExecutionAttempt,
+) (*mmodel.BalanceAtomicResult, error) {
+	if r.calls.Add(1) == 1 {
+		r.firstStarted <- transactionID
+		<-r.releaseFirst
+	}
+
+	result, err := r.RedisRepository.ProcessOutcomeBalanceAtomicOperation(ctx, organizationID, ledgerID,
+		transactionID, transactionStatus, pending, balances, attempt)
+	if err == nil {
+		r.movements.Add(1)
+	}
+
+	return result, err
+}
+
+func TestIntegration_TransactionV2Revert_ExpiredExecutionLeaseFencesPausedWinner(t *testing.T) {
+	t.Setenv("ALLOW_INSECURE_TLS", "true")
+	t.Setenv("RABBITMQ_TRANSACTION_ASYNC", "false")
+
+	infra := setupTestInfra(t)
+	ctx := context.Background()
+	srcID, dstID := seedFundedTransfer(t, infra.pgContainer.DB, infra.orgID, infra.ledgerID, "@src", "@dst", 1000, 1000)
+	v2App := buildHumaV2DirectApp(t, infra.handler)
+	origin := decodeTxResponse(t, postV2Create(t, v2App, "direct", infra.orgID, infra.ledgerID, equivalentV2Body, ""), nethttp.StatusCreated)
+	originID := uuid.MustParse(origin["id"].(string))
+	drainBalanceSync(t, ctx, infra.handler.Command, infra.redisRepo, infra.orgID, infra.ledgerID)
+
+	pausedRepo := &pausedFencedBalanceRepository{
+		RedisRepository: infra.redisRepo,
+		firstStarted:    make(chan uuid.UUID, 1),
+		releaseFirst:    make(chan struct{}),
+	}
+	infra.handler.Command.TransactionRedisRepo = pausedRepo
+
+	type revertResult struct {
+		transaction *transaction.Transaction
+		err         error
+	}
+	firstResult := make(chan revertResult, 1)
+	go func() {
+		tran, _, err := infra.handler.revertTransaction(ctx, infra.orgID, infra.ledgerID, originID)
+		firstResult <- revertResult{transaction: tran, err: err}
+	}()
+
+	var pausedReverseID uuid.UUID
+	select {
+	case pausedReverseID = <-pausedRepo.firstStarted:
+	case early := <-firstResult:
+		require.NoError(t, early.err, "first revert returned before reaching the paused seed")
+		require.FailNow(t, "first revert returned before reaching the paused seed")
+	case <-time.After(10 * time.Second):
+		require.FailNow(t, "first revert did not reach the paused seed")
+	}
+	claim, err := infra.handler.Command.GetRevertClaim(ctx, infra.orgID, infra.ledgerID, originID)
+	require.NoError(t, err)
+	require.NotNil(t, claim)
+	assert.Equal(t, pausedReverseID, claim.ReverseTransactionID)
+	fenceKey := revertExecutionFenceKey(claim)
+	fenceValue, err := infra.redisRepo.Get(ctx, fenceKey+":owner")
+	require.NoError(t, err)
+	assert.Equal(t, pausedReverseID.String(), fenceValue)
+
+	activeRetry, _, activeRetryErr := infra.handler.revertTransaction(ctx, infra.orgID, infra.ledgerID, originID)
+	assert.Nil(t, activeRetry)
+	require.Error(t, activeRetryErr)
+	assert.Equal(t, int32(1), pausedRepo.calls.Load(), "an active execution lease must not be mistaken for a crashed winner")
+
+	// Expiration is simulated by releasing both same-slot lease records with
+	// the old reverse's owner token. Because PostgreSQL was already ARMED before
+	// ProcessBalanceOperations could be invoked, the missing lease is ambiguous:
+	// it may be a pre-Lua crash or selective Redis loss after movement. Recovery
+	// must preserve the claim and refuse a successor forever.
+	released, err := infra.redisRepo.ReleaseOwnedKey(ctx, fenceKey, pausedReverseID.String())
+	require.NoError(t, err)
+	require.True(t, released)
+	takeover, _, takeoverErr := infra.handler.revertTransaction(ctx, infra.orgID, infra.ledgerID, originID)
+	assert.Nil(t, takeover)
+	require.Error(t, takeoverErr)
+	var reconciliation pkg.ServiceUnavailableError
+	require.ErrorAs(t, takeoverErr, &reconciliation)
+	assert.Equal(t, cn.ErrRevertReconciliationRequired.Error(), reconciliation.Code)
+	claim, err = infra.handler.Command.GetRevertClaim(ctx, infra.orgID, infra.ledgerID, originID)
+	require.NoError(t, err)
+	require.NotNil(t, claim)
+	assert.Equal(t, revertclaim.StateReconciliationRequired, claim.State)
+	assert.Equal(t, pausedReverseID, claim.ReverseTransactionID)
+
+	close(pausedRepo.releaseFirst)
+	stale := <-firstResult
+	assert.Nil(t, stale.transaction)
+	require.Error(t, stale.err)
+	var staleConflict pkg.EntityConflictError
+	require.ErrorAs(t, stale.err, &staleConflict)
+	assert.Equal(t, cn.ErrIdempotencyKey.Error(), staleConflict.Code)
+	assert.Equal(t, int32(0), pausedRepo.movements.Load(), "neither the stale executor nor a successor may move balances")
+
+	drainBalanceSync(t, ctx, infra.handler.Command, infra.redisRepo, infra.orgID, infra.ledgerID)
+	assert.Equal(t, 1, countTransactionsInLedger(t, infra.pgContainer.DB, infra.ledgerID))
+	requireDecimalEqual(t, decimal.NewFromInt(900), postgrestestutil.GetBalanceAvailable(t, infra.pgContainer.DB, srcID), "source remains at the origin result")
+	requireDecimalEqual(t, decimal.NewFromInt(1100), postgrestestutil.GetBalanceAvailable(t, infra.pgContainer.DB, dstID), "destination remains at the origin result")
+}
+
+func TestIntegration_TransactionV2Revert_PausedSeedWriterCannotDeleteSuccessorReplay(t *testing.T) {
+	t.Setenv("ALLOW_INSECURE_TLS", "true")
+	t.Setenv("RABBITMQ_TRANSACTION_ASYNC", "false")
+
+	infra := setupTestInfra(t)
+	ctx := context.Background()
+	srcID, dstID := seedFundedTransfer(t, infra.pgContainer.DB, infra.orgID, infra.ledgerID, "@src", "@dst", 1000, 1000)
+	v2App := buildHumaV2DirectApp(t, infra.handler)
+	origin := decodeTxResponse(t, postV2Create(t, v2App, "direct", infra.orgID, infra.ledgerID, equivalentV2Body, ""), nethttp.StatusCreated)
+	originID := uuid.MustParse(origin["id"].(string))
+	drainBalanceSync(t, ctx, infra.handler.Command, infra.redisRepo, infra.orgID, infra.ledgerID)
+	activateRevertUpdateFreeze(t, infra)
+	infra.handler.RevertIdempotencyMode = revertIdempotencyModeBridge
+
+	pausedRepo := &pausedSeedResponseRepository{
+		RedisRepository: infra.redisRepo,
+		firstStarted:    make(chan uuid.UUID, 1),
+		releaseFirst:    make(chan struct{}),
+	}
+	infra.handler.Command.TransactionRedisRepo = pausedRepo
+
+	type revertResult struct {
+		transaction *transaction.Transaction
+		err         error
+	}
+	firstResult := make(chan revertResult, 1)
+	go func() {
+		tran, _, err := infra.handler.revertTransaction(ctx, infra.orgID, infra.ledgerID, originID)
+		firstResult <- revertResult{transaction: tran, err: err}
+	}()
+
+	var pausedReverseID uuid.UUID
+	select {
+	case pausedReverseID = <-pausedRepo.firstStarted:
+	case early := <-firstResult:
+		require.NoError(t, early.err, "first revert returned before reaching the paused seed")
+		require.FailNow(t, "first revert returned before reaching the paused seed")
+	case <-time.After(10 * time.Second):
+		require.FailNow(t, "first revert did not reach the paused seed")
+	}
+	oldClaim, err := infra.handler.Command.GetRevertClaim(ctx, infra.orgID, infra.ledgerID, originID)
+	require.NoError(t, err)
+	require.NotNil(t, oldClaim)
+	assert.Equal(t, pausedReverseID, oldClaim.ReverseTransactionID)
+
+	activeRetry, _, activeRetryErr := infra.handler.revertTransaction(ctx, infra.orgID, infra.ledgerID, originID)
+	assert.Nil(t, activeRetry)
+	require.Error(t, activeRetryErr)
+	assert.Equal(t, int32(1), pausedRepo.seedCalls.Load(), "the live execution lease must fence takeover")
+
+	released, err := infra.redisRepo.ReleaseOwnedKey(ctx, revertExecutionFenceKey(oldClaim), pausedReverseID.String())
+	require.NoError(t, err)
+	require.True(t, released)
+	takeover, _, takeoverErr := infra.handler.revertTransaction(ctx, infra.orgID, infra.ledgerID, originID)
+	require.NoError(t, takeoverErr)
+	require.NotNil(t, takeover)
+	assert.NotEqual(t, pausedReverseID.String(), takeover.ID)
+
+	close(pausedRepo.releaseFirst)
+	stale := <-firstResult
+	assert.Nil(t, stale.transaction)
+	require.Error(t, stale.err)
+
+	claim, err := infra.handler.Command.GetRevertClaim(ctx, infra.orgID, infra.ledgerID, originID)
+	require.NoError(t, err)
+	require.NotNil(t, claim)
+	assert.Equal(t, uuid.MustParse(takeover.ID), claim.ReverseTransactionID)
+	assert.Equal(t, revertclaim.StateCompleted, claim.State)
+
+	replayJSON, err := infra.redisRepo.Get(ctx, originRevertIdempotencyKey(claim))
+	require.NoError(t, err)
+	replay := transaction.Transaction{}
+	require.NoError(t, json.Unmarshal([]byte(replayJSON), &replay))
+	assert.Equal(t, takeover.ID, replay.ID, "the stale winner cannot delete or replace the successor replay")
+	require.NotNil(t, replay.ParentTransactionID)
+	assert.Equal(t, originID.String(), *replay.ParentTransactionID)
+
+	drainBalanceSync(t, ctx, infra.handler.Command, infra.redisRepo, infra.orgID, infra.ledgerID)
+	assert.Equal(t, 2, countTransactionsInLedger(t, infra.pgContainer.DB, infra.ledgerID))
+	requireDecimalEqual(t, decimal.NewFromInt(1000), postgrestestutil.GetBalanceAvailable(t, infra.pgContainer.DB, srcID), "source restored exactly once")
+	requireDecimalEqual(t, decimal.NewFromInt(1000), postgrestestutil.GetBalanceAvailable(t, infra.pgContainer.DB, dstID), "destination restored exactly once")
+}
+
 // =============================================================================
-// 19. CONCURRENT REVERT OF ONE ORIGIN — EXACTLY ONE WINNER (money path): concurrent reverts of
-//     ONE origin all derive the SAME preimage — reverting one origin twice yields byte-identical
-//     reversal payloads — so exactly one of them wins the Redis SetNX and the rest are rejected
-//     BEFORE any balance work. This half of the claim's job is unaffected by the origin-scoping
-//     defect in section 18: widening the key by origin would preserve it, and the current
-//     origin-agnostic key already provides it. Section 18(b) only covers the SEQUENTIAL repeat,
-//     where the already-has-a-child gate fires first — it never exercises the window the claim
-//     exists for, and it is skipped besides.
-//
-//     That window is real: the eligibility gate reads GetParentByTransactionID, which cannot
-//     see a concurrent revert's not-yet-committed child (and, in production, reads a Postgres
-//     REPLICA while the child is written to the PRIMARY, which is tracked externally).
-//     The gate therefore cannot be the serialization point; the shared claim has to be. If it
-//     is not, the failure mode is a DOUBLE money movement: one origin reversed twice.
+// 19. CONCURRENT REVERT OF ONE ORIGIN — EXACTLY ONE MUTATION (money path):
+//     concurrent requests share the PostgreSQL claim and origin Redis barrier.
+//     Callers racing after persistence may receive the same successful replay;
+//     only one reverse transaction and one balance mutation may exist.
 //
 //     N racers revert one APPROVED origin from a common start barrier. The invariant asserted
 //     is "exactly one 201, every other answer a 4xx" rather than one specific sentinel: the
@@ -1036,9 +3273,10 @@ func TestIntegration_TransactionV2Revert_ConcurrentSingleWinner(t *testing.T) {
 	//
 	//   winner  — 201 + X-Idempotency-Replayed: false. Created the one reverse, moved money.
 	//   replay  — 201 + X-Idempotency-Replayed: true. Lost the claim, then read the winner's
-	//             cached reverse back out of the slot and echoed it. Creates nothing, moves
+	//             persisted reverse from PostgreSQL primary and echoed it. Creates nothing, moves
 	//             nothing, and MUST NOT be counted against the exactly-one-create invariant.
-	//   loser   — 4xx. Lost the claim before the winner had written its value.
+	//   loser   — 4xx while the claim is active, or 503/0505 after Redis has
+	//             committed but before PostgreSQL persistence is visible.
 	//
 	// Which of the two losing shapes a racer gets is a pure timing coin-flip against the
 	// winner's async cache write, so folding replays into winners would make the
@@ -1057,6 +3295,7 @@ func TestIntegration_TransactionV2Revert_ConcurrentSingleWinner(t *testing.T) {
 	allowedLoserCodes := []string{
 		cn.ErrIdempotencyKey.Error(),
 		cn.ErrTransactionIDHasAlreadyParentTransaction.Error(),
+		cn.ErrRevertReconciliationRequired.Error(),
 	}
 
 	for i, res := range results {
@@ -1073,8 +3312,14 @@ func TestIntegration_TransactionV2Revert_ConcurrentSingleWinner(t *testing.T) {
 			continue
 		}
 
-		assert.GreaterOrEqualf(t, res.status, 400, "racer %d: a losing revert must be a client rejection, not a server error; body: %s", i, res.body)
-		assert.Lessf(t, res.status, 500, "racer %d: a losing revert must be a client rejection, not a server error; body: %s", i, res.body)
+		assert.GreaterOrEqualf(t, res.status, 400, "racer %d: a losing revert must be fenced; body: %s", i, res.body)
+		if res.problemCode == cn.ErrRevertReconciliationRequired.Error() {
+			assert.Equalf(t, nethttp.StatusServiceUnavailable, res.status,
+				"racer %d: post-movement reconciliation must surface as 503; body: %s", i, res.body)
+		} else {
+			assert.Lessf(t, res.status, 500,
+				"racer %d: an active pre-movement claim is a client conflict; body: %s", i, res.body)
+		}
 		assert.Containsf(t, allowedLoserCodes, res.problemCode,
 			"racer %d: a losing revert may only be rejected for losing the idempotency claim (%v); body: %s",
 			i, allowedLoserCodes, res.body)
@@ -1120,4 +3365,103 @@ func TestIntegration_TransactionV2Revert_ConcurrentSingleWinner(t *testing.T) {
 	requireDecimalEqual(t, decimal.NewFromInt(1000), postgrestestutil.GetBalanceAvailable(t, infra.pgContainer.DB, dstID), "destination drained back exactly once (a double revert would read 900)")
 	requireDecimalEqual(t, decimal.Zero, postgrestestutil.GetBalanceOnHold(t, infra.pgContainer.DB, srcID), "source on-hold after the raced revert")
 	requireDecimalEqual(t, decimal.Zero, postgrestestutil.GetBalanceOnHold(t, infra.pgContainer.DB, dstID), "destination on-hold after the raced revert")
+}
+
+func TestIntegration_TransactionV2Revert_ConcurrentSingleWinnerWithFundsForOnlyOne(t *testing.T) {
+	t.Setenv("ALLOW_INSECURE_TLS", "true")
+	t.Setenv("RABBITMQ_TRANSACTION_ASYNC", "false")
+
+	infra := setupTestInfra(t)
+	ctx := context.Background()
+	srcID, dstID := seedTransfer(t, infra.pgContainer.DB, infra.orgID, infra.ledgerID, "@src", "@dst", 1000)
+	v2App := buildHumaV2DirectApp(t, infra.handler)
+	origin := decodeTxResponse(t, postV2Create(t, v2App, "direct", infra.orgID, infra.ledgerID,
+		equivalentV2Body, ""), nethttp.StatusCreated)
+	originID := uuid.MustParse(origin["id"].(string))
+	drainBalanceSync(t, ctx, infra.handler.Command, infra.redisRepo, infra.orgID, infra.ledgerID)
+	requireDecimalEqual(t, decimal.NewFromInt(100),
+		postgrestestutil.GetBalanceAvailable(t, infra.pgContainer.DB, dstID),
+		"destination must have funds for exactly one reversal")
+
+	results := make([]revertRaceResult, 2)
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	for i := range results {
+		wg.Add(1)
+		go func(slot int) {
+			defer wg.Done()
+			<-start
+			results[slot] = fireRevert(v2App, v2RevertURL(infra.orgID, infra.ledgerID, originID))
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+
+	freshIDs := make(map[string]struct{})
+	for i, result := range results {
+		require.NoErrorf(t, result.transportErr, "racer %d transport", i)
+		assert.NotEqualf(t, cn.ErrInsufficientFunds.Error(), result.problemCode,
+			"racer %d reached the balance engine instead of losing the origin claim: %s", i, result.body)
+		if result.status == nethttp.StatusCreated && result.replayed != "true" {
+			freshIDs[result.txID] = struct{}{}
+		}
+	}
+	require.Len(t, freshIDs, 1, "exactly one concurrent request may create the reverse")
+
+	drainBalanceSync(t, ctx, infra.handler.Command, infra.redisRepo, infra.orgID, infra.ledgerID)
+	assert.Equal(t, 2, countTransactionsInLedger(t, infra.pgContainer.DB, infra.ledgerID))
+	requireDecimalEqual(t, decimal.NewFromInt(1000),
+		postgrestestutil.GetBalanceAvailable(t, infra.pgContainer.DB, srcID), "source restored once")
+	requireDecimalEqual(t, decimal.Zero,
+		postgrestestutil.GetBalanceAvailable(t, infra.pgContainer.DB, dstID), "destination debited once")
+}
+
+func TestIntegration_TransactionV2Revert_ConcurrentReplayRecoveryNeverDowngradesCompletedClaim(t *testing.T) {
+	t.Setenv("ALLOW_INSECURE_TLS", "true")
+	t.Setenv("RABBITMQ_TRANSACTION_ASYNC", "false")
+
+	infra := setupTestInfra(t)
+	ctx := context.Background()
+	_, _ = seedFundedTransfer(t, infra.pgContainer.DB, infra.orgID, infra.ledgerID, "@src", "@dst", 1000, 1000)
+	v2App := buildHumaV2DirectApp(t, infra.handler)
+	origin := decodeTxResponse(t, postV2Create(t, v2App, "direct", infra.orgID, infra.ledgerID, equivalentV2Body, ""), nethttp.StatusCreated)
+	originID := uuid.MustParse(origin["id"].(string))
+	drainBalanceSync(t, ctx, infra.handler.Command, infra.redisRepo, infra.orgID, infra.ledgerID)
+	reverse := decodeTxResponse(t, postTransaction(t, v2App,
+		v2RevertURL(infra.orgID, infra.ledgerID, originID), "", ""), nethttp.StatusCreated)
+	reverseID := reverse["id"].(string)
+	drainBalanceSync(t, ctx, infra.handler.Command, infra.redisRepo, infra.orgID, infra.ledgerID)
+
+	claim, err := infra.handler.Command.GetRevertClaim(ctx, infra.orgID, infra.ledgerID, originID)
+	require.NoError(t, err)
+	require.NotNil(t, claim)
+	assert.Equal(t, revertclaim.StateCompleted, claim.State)
+	require.NoError(t, infra.redisRepo.Del(ctx, originRevertIdempotencyKey(claim)))
+
+	results := make([]revertRaceResult, concurrentRevertRacers)
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	for i := range results {
+		wg.Add(1)
+		go func(slot int) {
+			defer wg.Done()
+			<-start
+			results[slot] = fireRevert(v2App, v2RevertURL(infra.orgID, infra.ledgerID, originID))
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+
+	for i, result := range results {
+		require.NoErrorf(t, result.transportErr, "replay racer %d failed at the transport layer", i)
+		assert.Equalf(t, nethttp.StatusCreated, result.status, "replay racer %d returned %s", i, result.body)
+		assert.Equal(t, "true", result.replayed)
+		assert.Equal(t, reverseID, result.txID)
+	}
+	completed, err := infra.handler.Command.GetRevertClaim(ctx, infra.orgID, infra.ledgerID, originID)
+	require.NoError(t, err)
+	require.NotNil(t, completed)
+	assert.Equal(t, revertclaim.StateCompleted, completed.State)
+	assert.Nil(t, completed.FailureReason)
+	assert.Equal(t, 2, countTransactionsInLedger(t, infra.pgContainer.DB, infra.ledgerID))
 }

--- a/components/ledger/internal/adapters/mongodb/fees/billing_package/billing_package.mongodb_integration_test.go
+++ b/components/ledger/internal/adapters/mongodb/fees/billing_package/billing_package.mongodb_integration_test.go
@@ -123,7 +123,7 @@ func newMaintenancePackage(orgID, ledgerID, route string) *model.BillingPackage 
 // ============================================================================
 
 func TestIntegration_BillingPackageRepo_Create_PersistsAllFields(t *testing.T) {
-	container := mongotestutil.SetupContainer(t)
+	container := mongotestutil.SetupReusableContainer(t)
 	repo := newRepository(t, container)
 	ctx := context.Background()
 
@@ -201,7 +201,7 @@ func elemKeys(t *testing.T, arr any, i int) []string {
 // change, not a compile error. Scoping the by-ID verbs to a ledger must not move
 // a single key.
 func TestIntegration_BillingPackageRepo_DocumentShape(t *testing.T) {
-	container := mongotestutil.SetupContainer(t)
+	container := mongotestutil.SetupReusableContainer(t)
 	repo := newRepository(t, container)
 	ctx := context.Background()
 
@@ -251,7 +251,7 @@ func TestIntegration_BillingPackageRepo_DocumentShape(t *testing.T) {
 }
 
 func TestIntegration_BillingPackageRepo_Create_Nil(t *testing.T) {
-	container := mongotestutil.SetupContainer(t)
+	container := mongotestutil.SetupReusableContainer(t)
 	repo := newRepository(t, container)
 
 	result, err := repo.Create(context.Background(), nil)
@@ -266,7 +266,7 @@ func TestIntegration_BillingPackageRepo_Create_Nil(t *testing.T) {
 // ============================================================================
 
 func TestIntegration_BillingPackageRepo_FindByID(t *testing.T) {
-	container := mongotestutil.SetupContainer(t)
+	container := mongotestutil.SetupReusableContainer(t)
 	repo := newRepository(t, container)
 	ctx := context.Background()
 
@@ -284,7 +284,7 @@ func TestIntegration_BillingPackageRepo_FindByID(t *testing.T) {
 }
 
 func TestIntegration_BillingPackageRepo_FindByID_NotFound(t *testing.T) {
-	container := mongotestutil.SetupContainer(t)
+	container := mongotestutil.SetupReusableContainer(t)
 	repo := newRepository(t, container)
 
 	result, err := repo.FindByID(context.Background(), uuid.New().String(), uuid.New().String(), billing_package.AnyLedger)
@@ -295,7 +295,7 @@ func TestIntegration_BillingPackageRepo_FindByID_NotFound(t *testing.T) {
 }
 
 func TestIntegration_BillingPackageRepo_FindByID_WrongOrgIsolation(t *testing.T) {
-	container := mongotestutil.SetupContainer(t)
+	container := mongotestutil.SetupReusableContainer(t)
 	repo := newRepository(t, container)
 	ctx := context.Background()
 
@@ -311,7 +311,7 @@ func TestIntegration_BillingPackageRepo_FindByID_WrongOrgIsolation(t *testing.T)
 }
 
 func TestIntegration_BillingPackageRepo_FindByID_ExcludesSoftDeleted(t *testing.T) {
-	container := mongotestutil.SetupContainer(t)
+	container := mongotestutil.SetupReusableContainer(t)
 	repo := newRepository(t, container)
 	ctx := context.Background()
 
@@ -338,7 +338,7 @@ func TestIntegration_BillingPackageRepo_FindByID_ExcludesSoftDeleted(t *testing.
 // ============================================================================
 
 func TestIntegration_BillingPackageRepo_FindByID_WrongLedgerIsolation(t *testing.T) {
-	container := mongotestutil.SetupContainer(t)
+	container := mongotestutil.SetupReusableContainer(t)
 	repo := newRepository(t, container)
 	ctx := context.Background()
 
@@ -370,7 +370,7 @@ func TestIntegration_BillingPackageRepo_FindByID_WrongLedgerIsolation(t *testing
 }
 
 func TestIntegration_BillingPackageRepo_Update_WrongLedgerIsolation(t *testing.T) {
-	container := mongotestutil.SetupContainer(t)
+	container := mongotestutil.SetupReusableContainer(t)
 	repo := newRepository(t, container)
 	ctx := context.Background()
 
@@ -405,7 +405,7 @@ func TestIntegration_BillingPackageRepo_Update_WrongLedgerIsolation(t *testing.T
 }
 
 func TestIntegration_BillingPackageRepo_SoftDelete_WrongLedgerIsolation(t *testing.T) {
-	container := mongotestutil.SetupContainer(t)
+	container := mongotestutil.SetupReusableContainer(t)
 	repo := newRepository(t, container)
 	ctx := context.Background()
 
@@ -441,7 +441,7 @@ func TestIntegration_BillingPackageRepo_SoftDelete_WrongLedgerIsolation(t *testi
 // ============================================================================
 
 func TestIntegration_BillingPackageRepo_FindAll_FiltersAndPaginates(t *testing.T) {
-	container := mongotestutil.SetupContainer(t)
+	container := mongotestutil.SetupReusableContainer(t)
 	repo := newRepository(t, container)
 	ctx := context.Background()
 
@@ -498,7 +498,7 @@ func TestIntegration_BillingPackageRepo_FindAll_FiltersAndPaginates(t *testing.T
 }
 
 func TestIntegration_BillingPackageRepo_FindAll_ExcludesSoftDeleted(t *testing.T) {
-	container := mongotestutil.SetupContainer(t)
+	container := mongotestutil.SetupReusableContainer(t)
 	repo := newRepository(t, container)
 	ctx := context.Background()
 
@@ -527,7 +527,7 @@ func TestIntegration_BillingPackageRepo_FindAll_ExcludesSoftDeleted(t *testing.T
 // spans ledgers, so a surface whose path names a ledger must never reach here with
 // it. The organization boundary still holds under the widening.
 func TestIntegration_BillingPackageRepo_FindAll_AnyLedgerListsEveryLedger(t *testing.T) {
-	container := mongotestutil.SetupContainer(t)
+	container := mongotestutil.SetupReusableContainer(t)
 	repo := newRepository(t, container)
 	ctx := context.Background()
 
@@ -566,7 +566,7 @@ func TestIntegration_BillingPackageRepo_FindAll_AnyLedgerListsEveryLedger(t *tes
 }
 
 func TestIntegration_BillingPackageRepo_FindAll_Empty(t *testing.T) {
-	container := mongotestutil.SetupContainer(t)
+	container := mongotestutil.SetupReusableContainer(t)
 	repo := newRepository(t, container)
 
 	all, total, err := repo.FindAll(context.Background(), uuid.New().String(), uuid.New().String(), "", 10, 1)
@@ -580,7 +580,7 @@ func TestIntegration_BillingPackageRepo_FindAll_Empty(t *testing.T) {
 // ============================================================================
 
 func TestIntegration_BillingPackageRepo_FindMatchingPackages(t *testing.T) {
-	container := mongotestutil.SetupContainer(t)
+	container := mongotestutil.SetupReusableContainer(t)
 	repo := newRepository(t, container)
 	ctx := context.Background()
 
@@ -611,7 +611,7 @@ func TestIntegration_BillingPackageRepo_FindMatchingPackages(t *testing.T) {
 }
 
 func TestIntegration_BillingPackageRepo_FindActiveByType(t *testing.T) {
-	container := mongotestutil.SetupContainer(t)
+	container := mongotestutil.SetupReusableContainer(t)
 	repo := newRepository(t, container)
 	ctx := context.Background()
 
@@ -650,7 +650,7 @@ func TestIntegration_BillingPackageRepo_FindActiveByType(t *testing.T) {
 // ============================================================================
 
 func TestIntegration_BillingPackageRepo_Update_PersistsChange(t *testing.T) {
-	container := mongotestutil.SetupContainer(t)
+	container := mongotestutil.SetupReusableContainer(t)
 	repo := newRepository(t, container)
 	ctx := context.Background()
 
@@ -675,7 +675,7 @@ func TestIntegration_BillingPackageRepo_Update_PersistsChange(t *testing.T) {
 }
 
 func TestIntegration_BillingPackageRepo_Update_NotFound(t *testing.T) {
-	container := mongotestutil.SetupContainer(t)
+	container := mongotestutil.SetupReusableContainer(t)
 	repo := newRepository(t, container)
 
 	update := &bson.M{"$set": bson.M{"label": "x"}}
@@ -693,7 +693,7 @@ func TestIntegration_BillingPackageRepo_Update_NotFound(t *testing.T) {
 // ============================================================================
 
 func TestIntegration_BillingPackageRepo_SoftDelete_SetsDeletedAt(t *testing.T) {
-	container := mongotestutil.SetupContainer(t)
+	container := mongotestutil.SetupReusableContainer(t)
 	repo := newRepository(t, container)
 	ctx := context.Background()
 
@@ -713,7 +713,7 @@ func TestIntegration_BillingPackageRepo_SoftDelete_SetsDeletedAt(t *testing.T) {
 }
 
 func TestIntegration_BillingPackageRepo_SoftDelete_NotFound(t *testing.T) {
-	container := mongotestutil.SetupContainer(t)
+	container := mongotestutil.SetupReusableContainer(t)
 	repo := newRepository(t, container)
 
 	err := repo.SoftDelete(context.Background(), uuid.New().String(), uuid.New().String(), billing_package.AnyLedger)
@@ -725,7 +725,7 @@ func TestIntegration_BillingPackageRepo_SoftDelete_NotFound(t *testing.T) {
 }
 
 func TestIntegration_BillingPackageRepo_SoftDelete_Idempotency(t *testing.T) {
-	container := mongotestutil.SetupContainer(t)
+	container := mongotestutil.SetupReusableContainer(t)
 	repo := newRepository(t, container)
 	ctx := context.Background()
 

--- a/components/ledger/internal/adapters/mongodb/fees/billing_package/scope_plan_integration_test.go
+++ b/components/ledger/internal/adapters/mongodb/fees/billing_package/scope_plan_integration_test.go
@@ -74,7 +74,7 @@ func explainScopeFilter(t *testing.T, ctx context.Context, coll *mongo.Collectio
 // scan for it to remove. If a future filter stops pinning _id, these counts
 // climb with the collection and this test fails.
 func TestIntegration_BillingPackageScopeFilter_ResolvesBySingleDocumentFetch(t *testing.T) {
-	container := mongotestutil.SetupContainer(t)
+	container := mongotestutil.SetupReusableContainer(t)
 	ctx := context.Background()
 
 	conn := &feesmongo.MongoConnection{

--- a/components/ledger/internal/adapters/mongodb/fees/indexes_integration_test.go
+++ b/components/ledger/internal/adapters/mongodb/fees/indexes_integration_test.go
@@ -89,7 +89,7 @@ func listIndexNames(t *testing.T, ctx context.Context, container *mongotestutil.
 // code-created mongo.IndexModel, not migration files, so this is the only place
 // their existence is verified end-to-end.
 func TestIntegration_FeesEnsureIndexes_PackAndBillingPackage(t *testing.T) {
-	container := mongotestutil.SetupContainer(t)
+	container := mongotestutil.SetupReusableContainer(t)
 	ctx := context.Background()
 
 	conn := newFeesConnection(t, container)
@@ -132,7 +132,7 @@ func TestIntegration_FeesEnsureIndexes_PackAndBillingPackage(t *testing.T) {
 // counterpart here. Catching it needs the keys pinned against a committed
 // expectation, not a self-comparison.
 func TestIntegration_FeesEnsureIndexes_Idempotent(t *testing.T) {
-	container := mongotestutil.SetupContainer(t)
+	container := mongotestutil.SetupReusableContainer(t)
 	ctx := context.Background()
 
 	conn := newFeesConnection(t, container)

--- a/components/ledger/internal/adapters/mongodb/fees/pack/fee_operation_route_ids_test.go
+++ b/components/ledger/internal/adapters/mongodb/fees/pack/fee_operation_route_ids_test.go
@@ -1,0 +1,54 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package pack
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/LerianStudio/midaz/v4/components/ledger/pkg/feeshared/model"
+)
+
+func TestFeeOperationRouteIDsRoundTripIndependentlyFromLegacyLabels(t *testing.T) {
+	t.Parallel()
+
+	legacyFrom := uuid.NewString()
+	legacyTo := uuid.NewString()
+	operationFrom := uuid.NewString()
+	operationTo := uuid.NewString()
+	deductible := false
+
+	databaseFees, err := FromEntityFeeMap(map[string]model.Fee{"routed": {
+		FeeLabel: "routed fee",
+		CalculationModel: &model.CalculationModel{
+			ApplicationRule: model.FlatFee,
+			Calculations:    []model.Calculation{{Type: model.Flat, Value: "1"}},
+		},
+		ReferenceAmount:      model.OriginalAmount,
+		Priority:             1,
+		IsDeductibleFrom:     &deductible,
+		CreditAccount:        "@fee-revenue",
+		RouteFrom:            &legacyFrom,
+		RouteTo:              &legacyTo,
+		OperationRouteFromID: &operationFrom,
+		OperationRouteToID:   &operationTo,
+	}})
+	require.NoError(t, err)
+
+	persisted := databaseFees["routed"]
+	assert.Equal(t, legacyFrom, *persisted.RouteFrom)
+	assert.Equal(t, legacyTo, *persisted.RouteTo)
+	assert.Equal(t, operationFrom, *persisted.OperationRouteFromID)
+	assert.Equal(t, operationTo, *persisted.OperationRouteToID)
+
+	roundTrip := ToEntityFeeMap(databaseFees)["routed"]
+	assert.Equal(t, legacyFrom, *roundTrip.RouteFrom)
+	assert.Equal(t, legacyTo, *roundTrip.RouteTo)
+	assert.Equal(t, operationFrom, *roundTrip.OperationRouteFromID)
+	assert.Equal(t, operationTo, *roundTrip.OperationRouteToID)
+}

--- a/components/ledger/internal/adapters/mongodb/fees/pack/package.go
+++ b/components/ledger/internal/adapters/mongodb/fees/pack/package.go
@@ -43,14 +43,16 @@ type CalculationModel struct {
 
 // Fee represents an individual fee in the fees array
 type Fee struct {
-	FeeLabel         string           `bson:"fee_label"`
-	CalculationModel CalculationModel `bson:"calculation_model"`
-	ReferenceAmount  string           `bson:"reference_amount"`
-	Priority         int              `bson:"priority"`
-	IsDeductibleFrom *bool            `bson:"is_deductible_from"`
-	CreditAccount    string           `bson:"credit_account"`
-	RouteFrom        *string          `bson:"route_from"`
-	RouteTo          *string          `bson:"route_to"`
+	FeeLabel             string           `bson:"fee_label"`
+	CalculationModel     CalculationModel `bson:"calculation_model"`
+	ReferenceAmount      string           `bson:"reference_amount"`
+	Priority             int              `bson:"priority"`
+	IsDeductibleFrom     *bool            `bson:"is_deductible_from"`
+	CreditAccount        string           `bson:"credit_account"`
+	RouteFrom            *string          `bson:"route_from"`
+	RouteTo              *string          `bson:"route_to"`
+	OperationRouteFromID *string          `bson:"operation_route_from_id,omitempty"`
+	OperationRouteToID   *string          `bson:"operation_route_to_id,omitempty"`
 }
 
 // PackageMongoDBModel represents the MongoDB model for a pack
@@ -243,14 +245,16 @@ func ToEntityFeeMap(fees map[string]Fee) map[string]model.Fee {
 		}
 
 		feesModel[key] = model.Fee{
-			FeeLabel:         fee.FeeLabel,
-			CalculationModel: calcModelDB,
-			ReferenceAmount:  fee.ReferenceAmount,
-			Priority:         fee.Priority,
-			IsDeductibleFrom: fee.IsDeductibleFrom,
-			CreditAccount:    fee.CreditAccount,
-			RouteTo:          fee.RouteTo,
-			RouteFrom:        fee.RouteFrom,
+			FeeLabel:             fee.FeeLabel,
+			CalculationModel:     calcModelDB,
+			ReferenceAmount:      fee.ReferenceAmount,
+			Priority:             fee.Priority,
+			IsDeductibleFrom:     fee.IsDeductibleFrom,
+			CreditAccount:        fee.CreditAccount,
+			RouteTo:              fee.RouteTo,
+			RouteFrom:            fee.RouteFrom,
+			OperationRouteFromID: fee.OperationRouteFromID,
+			OperationRouteToID:   fee.OperationRouteToID,
 		}
 	}
 
@@ -298,14 +302,16 @@ func FromEntityFeeMap(fees map[string]model.Fee) (map[string]Fee, error) {
 		}
 
 		feesDBModel[strcase.ToLowerCamel(key)] = Fee{
-			FeeLabel:         fee.FeeLabel,
-			CalculationModel: calcModelDB,
-			ReferenceAmount:  fee.ReferenceAmount,
-			Priority:         fee.Priority,
-			IsDeductibleFrom: fee.IsDeductibleFrom,
-			CreditAccount:    fee.CreditAccount,
-			RouteTo:          fee.RouteTo,
-			RouteFrom:        fee.RouteFrom,
+			FeeLabel:             fee.FeeLabel,
+			CalculationModel:     calcModelDB,
+			ReferenceAmount:      fee.ReferenceAmount,
+			Priority:             fee.Priority,
+			IsDeductibleFrom:     fee.IsDeductibleFrom,
+			CreditAccount:        fee.CreditAccount,
+			RouteTo:              fee.RouteTo,
+			RouteFrom:            fee.RouteFrom,
+			OperationRouteFromID: fee.OperationRouteFromID,
+			OperationRouteToID:   fee.OperationRouteToID,
 		}
 	}
 

--- a/components/ledger/internal/adapters/mongodb/fees/pack/package_repository_integration_test.go
+++ b/components/ledger/internal/adapters/mongodb/fees/pack/package_repository_integration_test.go
@@ -112,7 +112,7 @@ func newTestPackage(ledgerID uuid.UUID) *Package {
 // ============================================================================
 
 func TestIntegration_PackRepo_Create_PersistsAllFields(t *testing.T) {
-	container := mongotestutil.SetupContainer(t)
+	container := mongotestutil.SetupReusableContainer(t)
 	repo := newPackRepository(t, container)
 	ctx := context.Background()
 
@@ -142,12 +142,62 @@ func TestIntegration_PackRepo_Create_PersistsAllFields(t *testing.T) {
 	assert.Equal(t, int64(1), count, "Create must persist exactly one org-tagged document")
 }
 
+func TestIntegration_PackRepo_FeeOperationRouteIDsRoundTripAndClearIndependently(t *testing.T) {
+	container := mongotestutil.SetupReusableContainer(t)
+	repo := newPackRepository(t, container)
+	ctx := context.Background()
+
+	orgID := uuid.New()
+	pkgEntity := newTestPackage(uuid.New())
+	legacyFrom := uuid.NewString()
+	legacyTo := uuid.NewString()
+	operationFrom := uuid.NewString()
+	operationTo := uuid.NewString()
+	fee := pkgEntity.Fees["adminFee"]
+	fee.RouteFrom = &legacyFrom
+	fee.RouteTo = &legacyTo
+	fee.OperationRouteFromID = &operationFrom
+	fee.OperationRouteToID = &operationTo
+	pkgEntity.Fees["adminFee"] = fee
+
+	created, err := repo.Create(ctx, pkgEntity, orgID)
+	require.NoError(t, err)
+	require.NotNil(t, created)
+
+	found, err := repo.FindByID(ctx, pkgEntity.ID, orgID, uuid.Nil)
+	require.NoError(t, err)
+	roundTrip := found.Fees["adminFee"]
+	assert.Equal(t, legacyFrom, *roundTrip.RouteFrom)
+	assert.Equal(t, legacyTo, *roundTrip.RouteTo)
+	assert.Equal(t, operationFrom, *roundTrip.OperationRouteFromID)
+	assert.Equal(t, operationTo, *roundTrip.OperationRouteToID)
+
+	var stored struct {
+		Fees map[string]Fee `bson:"fees"`
+	}
+	require.NoError(t, packCollection(container).FindOne(ctx, bson.M{"_id": pkgEntity.ID}).Decode(&stored))
+	assert.Equal(t, operationFrom, *stored.Fees["adminFee"].OperationRouteFromID)
+	assert.Equal(t, operationTo, *stored.Fees["adminFee"].OperationRouteToID)
+
+	updated, err := repo.Update(ctx, pkgEntity.ID, orgID, uuid.Nil, &bson.M{
+		"$unset": bson.M{"fees.adminFee.operation_route_from_id": ""},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, updated)
+	require.Contains(t, updated.Fees, "adminFee", "clearing one route ID must not remove the fee")
+	assert.Nil(t, updated.Fees["adminFee"].OperationRouteFromID)
+	require.NotNil(t, updated.Fees["adminFee"].OperationRouteToID)
+	assert.Equal(t, operationTo, *updated.Fees["adminFee"].OperationRouteToID)
+	require.NotNil(t, updated.Fees["adminFee"].RouteFrom)
+	assert.Equal(t, legacyFrom, *updated.Fees["adminFee"].RouteFrom, "legacy label must remain untouched")
+}
+
 // ============================================================================
 // FindByID Tests
 // ============================================================================
 
 func TestIntegration_PackRepo_FindByID(t *testing.T) {
-	container := mongotestutil.SetupContainer(t)
+	container := mongotestutil.SetupReusableContainer(t)
 	repo := newPackRepository(t, container)
 	ctx := context.Background()
 
@@ -165,7 +215,7 @@ func TestIntegration_PackRepo_FindByID(t *testing.T) {
 }
 
 func TestIntegration_PackRepo_FindByID_NotFound(t *testing.T) {
-	container := mongotestutil.SetupContainer(t)
+	container := mongotestutil.SetupReusableContainer(t)
 	repo := newPackRepository(t, container)
 
 	result, err := repo.FindByID(context.Background(), uuid.New(), uuid.New(), uuid.Nil)
@@ -175,7 +225,7 @@ func TestIntegration_PackRepo_FindByID_NotFound(t *testing.T) {
 }
 
 func TestIntegration_PackRepo_FindByID_WrongOrgIsolation(t *testing.T) {
-	container := mongotestutil.SetupContainer(t)
+	container := mongotestutil.SetupReusableContainer(t)
 	repo := newPackRepository(t, container)
 	ctx := context.Background()
 
@@ -190,7 +240,7 @@ func TestIntegration_PackRepo_FindByID_WrongOrgIsolation(t *testing.T) {
 }
 
 func TestIntegration_PackRepo_FindByID_ExcludesSoftDeleted(t *testing.T) {
-	container := mongotestutil.SetupContainer(t)
+	container := mongotestutil.SetupReusableContainer(t)
 	repo := newPackRepository(t, container)
 	ctx := context.Background()
 
@@ -208,7 +258,7 @@ func TestIntegration_PackRepo_FindByID_ExcludesSoftDeleted(t *testing.T) {
 }
 
 func TestIntegration_PackRepo_FindByID_WrongLedgerIsolation(t *testing.T) {
-	container := mongotestutil.SetupContainer(t)
+	container := mongotestutil.SetupReusableContainer(t)
 	repo := newPackRepository(t, container)
 	ctx := context.Background()
 
@@ -240,7 +290,7 @@ func TestIntegration_PackRepo_FindByID_WrongLedgerIsolation(t *testing.T) {
 }
 
 func TestIntegration_PackRepo_Update_WrongLedgerIsolation(t *testing.T) {
-	container := mongotestutil.SetupContainer(t)
+	container := mongotestutil.SetupReusableContainer(t)
 	repo := newPackRepository(t, container)
 	ctx := context.Background()
 
@@ -275,7 +325,7 @@ func TestIntegration_PackRepo_Update_WrongLedgerIsolation(t *testing.T) {
 }
 
 func TestIntegration_PackRepo_SoftDelete_WrongLedgerIsolation(t *testing.T) {
-	container := mongotestutil.SetupContainer(t)
+	container := mongotestutil.SetupReusableContainer(t)
 	repo := newPackRepository(t, container)
 	ctx := context.Background()
 
@@ -311,7 +361,7 @@ func TestIntegration_PackRepo_SoftDelete_WrongLedgerIsolation(t *testing.T) {
 // ledger reaches a package regardless of which ledger owns it, on all three
 // by-ID operations, and still excludes soft-deleted documents.
 func TestIntegration_PackRepo_ByID_OrganizationScopeUnchanged(t *testing.T) {
-	container := mongotestutil.SetupContainer(t)
+	container := mongotestutil.SetupReusableContainer(t)
 	repo := newPackRepository(t, container)
 	ctx := context.Background()
 
@@ -345,7 +395,7 @@ func TestIntegration_PackRepo_ByID_OrganizationScopeUnchanged(t *testing.T) {
 // ============================================================================
 
 func TestIntegration_PackRepo_FindList_FiltersAndPaginates(t *testing.T) {
-	container := mongotestutil.SetupContainer(t)
+	container := mongotestutil.SetupReusableContainer(t)
 	repo := newPackRepository(t, container)
 	ctx := context.Background()
 
@@ -405,7 +455,7 @@ func TestIntegration_PackRepo_FindList_FiltersAndPaginates(t *testing.T) {
 // ledger-scoped path it hands back packages the named ledger does not own. The
 // identifier is fixed rather than generated so the case is exercised every run.
 func TestIntegration_PackRepo_FindList_LedgerFilterHoldsForLeadingZeroIdentifier(t *testing.T) {
-	container := mongotestutil.SetupContainer(t)
+	container := mongotestutil.SetupReusableContainer(t)
 	repo := newPackRepository(t, container)
 	ctx := context.Background()
 
@@ -440,7 +490,7 @@ func TestIntegration_PackRepo_FindList_LedgerFilterHoldsForLeadingZeroIdentifier
 // widens the listing to every segment of the ledger, and the package it then returns
 // is the one that prices a transaction.
 func TestIntegration_PackRepo_FindList_SegmentFilterHoldsForLeadingZeroIdentifier(t *testing.T) {
-	container := mongotestutil.SetupContainer(t)
+	container := mongotestutil.SetupReusableContainer(t)
 	repo := newPackRepository(t, container)
 	ctx := context.Background()
 
@@ -478,7 +528,7 @@ func TestIntegration_PackRepo_FindList_SegmentFilterHoldsForLeadingZeroIdentifie
 }
 
 func TestIntegration_PackRepo_FindList_FilterByEnable(t *testing.T) {
-	container := mongotestutil.SetupContainer(t)
+	container := mongotestutil.SetupReusableContainer(t)
 	repo := newPackRepository(t, container)
 	ctx := context.Background()
 
@@ -507,7 +557,7 @@ func TestIntegration_PackRepo_FindList_FilterByEnable(t *testing.T) {
 }
 
 func TestIntegration_PackRepo_FindList_ExcludesSoftDeleted(t *testing.T) {
-	container := mongotestutil.SetupContainer(t)
+	container := mongotestutil.SetupReusableContainer(t)
 	repo := newPackRepository(t, container)
 	ctx := context.Background()
 
@@ -536,7 +586,7 @@ func TestIntegration_PackRepo_FindList_ExcludesSoftDeleted(t *testing.T) {
 // ============================================================================
 
 func TestIntegration_PackRepo_FindByOrganizationIDAndLedgerID(t *testing.T) {
-	container := mongotestutil.SetupContainer(t)
+	container := mongotestutil.SetupReusableContainer(t)
 	repo := newPackRepository(t, container)
 	ctx := context.Background()
 
@@ -570,7 +620,7 @@ func TestIntegration_PackRepo_FindByOrganizationIDAndLedgerID(t *testing.T) {
 }
 
 func TestIntegration_PackRepo_FindFeesAndAmountDataByPackageID(t *testing.T) {
-	container := mongotestutil.SetupContainer(t)
+	container := mongotestutil.SetupReusableContainer(t)
 	repo := newPackRepository(t, container)
 	ctx := context.Background()
 
@@ -591,7 +641,7 @@ func TestIntegration_PackRepo_FindFeesAndAmountDataByPackageID(t *testing.T) {
 }
 
 func TestIntegration_PackRepo_FindFeesAndAmountDataByPackageID_NotFound(t *testing.T) {
-	container := mongotestutil.SetupContainer(t)
+	container := mongotestutil.SetupReusableContainer(t)
 	repo := newPackRepository(t, container)
 
 	data, err := repo.FindFeesAndAmountDataByPackageID(context.Background(), uuid.New(), uuid.New())
@@ -607,7 +657,7 @@ func TestIntegration_PackRepo_FindFeesAndAmountDataByPackageID_NotFound(t *testi
 // ============================================================================
 
 func TestIntegration_PackRepo_Update_PersistsChange(t *testing.T) {
-	container := mongotestutil.SetupContainer(t)
+	container := mongotestutil.SetupReusableContainer(t)
 	repo := newPackRepository(t, container)
 	ctx := context.Background()
 
@@ -628,7 +678,7 @@ func TestIntegration_PackRepo_Update_PersistsChange(t *testing.T) {
 }
 
 func TestIntegration_PackRepo_Update_DisablesWhenFeesEmptied(t *testing.T) {
-	container := mongotestutil.SetupContainer(t)
+	container := mongotestutil.SetupReusableContainer(t)
 	repo := newPackRepository(t, container)
 	ctx := context.Background()
 
@@ -652,7 +702,7 @@ func TestIntegration_PackRepo_Update_DisablesWhenFeesEmptied(t *testing.T) {
 }
 
 func TestIntegration_PackRepo_Update_NotFound(t *testing.T) {
-	container := mongotestutil.SetupContainer(t)
+	container := mongotestutil.SetupReusableContainer(t)
 	repo := newPackRepository(t, container)
 
 	update := &bson.M{"$set": bson.M{"fee_group_label": "x"}}
@@ -669,7 +719,7 @@ func TestIntegration_PackRepo_Update_NotFound(t *testing.T) {
 // ============================================================================
 
 func TestIntegration_PackRepo_SoftDelete_SetsDeletedAt(t *testing.T) {
-	container := mongotestutil.SetupContainer(t)
+	container := mongotestutil.SetupReusableContainer(t)
 	repo := newPackRepository(t, container)
 	ctx := context.Background()
 
@@ -687,7 +737,7 @@ func TestIntegration_PackRepo_SoftDelete_SetsDeletedAt(t *testing.T) {
 }
 
 func TestIntegration_PackRepo_SoftDelete_NotFound(t *testing.T) {
-	container := mongotestutil.SetupContainer(t)
+	container := mongotestutil.SetupReusableContainer(t)
 	repo := newPackRepository(t, container)
 
 	err := repo.SoftDelete(context.Background(), uuid.New(), uuid.New(), uuid.Nil)
@@ -698,7 +748,7 @@ func TestIntegration_PackRepo_SoftDelete_NotFound(t *testing.T) {
 }
 
 func TestIntegration_PackRepo_SoftDelete_Idempotency(t *testing.T) {
-	container := mongotestutil.SetupContainer(t)
+	container := mongotestutil.SetupReusableContainer(t)
 	repo := newPackRepository(t, container)
 	ctx := context.Background()
 

--- a/components/ledger/internal/adapters/mongodb/fees/pack/scope_plan_integration_test.go
+++ b/components/ledger/internal/adapters/mongodb/fees/pack/scope_plan_integration_test.go
@@ -72,7 +72,7 @@ func explainScopeFilter(t *testing.T, ctx context.Context, coll *mongo.Collectio
 // scan for it to remove. If a future filter stops pinning _id, these counts
 // climb with the collection and this test fails.
 func TestIntegration_PackageScopeFilter_ResolvesBySingleDocumentFetch(t *testing.T) {
-	container := mongotestutil.SetupContainer(t)
+	container := mongotestutil.SetupReusableContainer(t)
 	ctx := context.Background()
 
 	conn := newPackConnection(t, container)

--- a/components/ledger/internal/adapters/postgres/operation/operation.postgresql_integration_test.go
+++ b/components/ledger/internal/adapters/postgres/operation/operation.postgresql_integration_test.go
@@ -28,11 +28,9 @@ import (
 func createRepository(t *testing.T, container *pgtestutil.ContainerResult) *OperationPostgreSQLRepository {
 	t.Helper()
 
-	migrationsPath := pgtestutil.FindMigrationsPath(t, "transaction")
-
 	connStr := pgtestutil.BuildConnectionString(container.Host, container.Port, container.Config)
 
-	conn := pgtestutil.CreatePostgresClient(t, connStr, connStr, container.Config.DBName, migrationsPath)
+	conn := pgtestutil.ConnectPostgresClient(t, connStr, connStr)
 
 	return NewOperationPostgreSQLRepository(conn)
 }
@@ -81,7 +79,7 @@ func createTestDependencies(t *testing.T, container *pgtestutil.ContainerResult)
 // ============================================================================
 
 func TestIntegration_OperationRepository_Create_Success(t *testing.T) {
-	container := pgtestutil.SetupContainer(t)
+	container := pgtestutil.SetupMigratedContainer(t, "transaction")
 	repo := createRepository(t, container)
 	ids := createTestDependencies(t, container)
 
@@ -148,7 +146,7 @@ func TestIntegration_OperationRepository_Create_Success(t *testing.T) {
 }
 
 func TestIntegration_OperationRepository_Create_GeneratesIDWhenEmpty(t *testing.T) {
-	container := pgtestutil.SetupContainer(t)
+	container := pgtestutil.SetupMigratedContainer(t, "transaction")
 	repo := createRepository(t, container)
 	ids := createTestDependencies(t, container)
 
@@ -205,7 +203,7 @@ func TestIntegration_OperationRepository_Create_GeneratesIDWhenEmpty(t *testing.
 // ============================================================================
 
 func TestIntegration_OperationRepository_Find_ReturnsOperation(t *testing.T) {
-	container := pgtestutil.SetupContainer(t)
+	container := pgtestutil.SetupMigratedContainer(t, "transaction")
 	repo := createRepository(t, container)
 	ids := createTestDependencies(t, container)
 
@@ -252,7 +250,7 @@ func TestIntegration_OperationRepository_Find_ReturnsOperation(t *testing.T) {
 }
 
 func TestIntegration_OperationRepository_Find_ReturnsEntityNotFoundError(t *testing.T) {
-	container := pgtestutil.SetupContainer(t)
+	container := pgtestutil.SetupMigratedContainer(t, "transaction")
 	repo := createRepository(t, container)
 	ids := createTestDependencies(t, container)
 
@@ -274,7 +272,7 @@ func TestIntegration_OperationRepository_Find_ReturnsEntityNotFoundError(t *test
 }
 
 func TestIntegration_OperationRepository_Find_IgnoresDeletedOperation(t *testing.T) {
-	container := pgtestutil.SetupContainer(t)
+	container := pgtestutil.SetupMigratedContainer(t, "transaction")
 	repo := createRepository(t, container)
 	ids := createTestDependencies(t, container)
 
@@ -309,7 +307,7 @@ func TestIntegration_OperationRepository_Find_IgnoresDeletedOperation(t *testing
 // ============================================================================
 
 func TestIntegration_OperationRepository_FindByAccount_ReturnsOperation(t *testing.T) {
-	container := pgtestutil.SetupContainer(t)
+	container := pgtestutil.SetupMigratedContainer(t, "transaction")
 	repo := createRepository(t, container)
 	ids := createTestDependencies(t, container)
 
@@ -342,7 +340,7 @@ func TestIntegration_OperationRepository_FindByAccount_ReturnsOperation(t *testi
 }
 
 func TestIntegration_OperationRepository_FindByAccount_ReturnsEntityNotFoundError(t *testing.T) {
-	container := pgtestutil.SetupContainer(t)
+	container := pgtestutil.SetupMigratedContainer(t, "transaction")
 	repo := createRepository(t, container)
 	ids := createTestDependencies(t, container)
 
@@ -362,7 +360,7 @@ func TestIntegration_OperationRepository_FindByAccount_ReturnsEntityNotFoundErro
 }
 
 func TestIntegration_OperationRepository_FindByAccount_WrongAccountReturnsError(t *testing.T) {
-	container := pgtestutil.SetupContainer(t)
+	container := pgtestutil.SetupMigratedContainer(t, "transaction")
 	repo := createRepository(t, container)
 	ids := createTestDependencies(t, container)
 
@@ -398,7 +396,7 @@ func TestIntegration_OperationRepository_FindByAccount_WrongAccountReturnsError(
 // ============================================================================
 
 func TestIntegration_OperationRepository_FindAll_ReturnsOperations(t *testing.T) {
-	container := pgtestutil.SetupContainer(t)
+	container := pgtestutil.SetupMigratedContainer(t, "transaction")
 	repo := createRepository(t, container)
 	ids := createTestDependencies(t, container)
 
@@ -431,7 +429,7 @@ func TestIntegration_OperationRepository_FindAll_ReturnsOperations(t *testing.T)
 }
 
 func TestIntegration_OperationRepository_FindAll_EmptyForNonExistentTransaction(t *testing.T) {
-	container := pgtestutil.SetupContainer(t)
+	container := pgtestutil.SetupMigratedContainer(t, "transaction")
 	repo := createRepository(t, container)
 	ids := createTestDependencies(t, container)
 
@@ -448,7 +446,7 @@ func TestIntegration_OperationRepository_FindAll_EmptyForNonExistentTransaction(
 }
 
 func TestIntegration_OperationRepository_FindAll_Pagination(t *testing.T) {
-	container := pgtestutil.SetupContainer(t)
+	container := pgtestutil.SetupMigratedContainer(t, "transaction")
 	repo := createRepository(t, container)
 	ids := createTestDependencies(t, container)
 
@@ -515,7 +513,7 @@ func TestIntegration_OperationRepository_FindAll_Pagination(t *testing.T) {
 }
 
 func TestIntegration_OperationRepository_FindAll_FiltersByDateRange(t *testing.T) {
-	container := pgtestutil.SetupContainer(t)
+	container := pgtestutil.SetupMigratedContainer(t, "transaction")
 	repo := createRepository(t, container)
 	ids := createTestDependencies(t, container)
 
@@ -563,7 +561,7 @@ func TestIntegration_OperationRepository_FindAll_FiltersByDateRange(t *testing.T
 // ============================================================================
 
 func TestIntegration_OperationRepository_FindAllByAccount_ReturnsOperations(t *testing.T) {
-	container := pgtestutil.SetupContainer(t)
+	container := pgtestutil.SetupMigratedContainer(t, "transaction")
 	repo := createRepository(t, container)
 	ids := createTestDependencies(t, container)
 
@@ -598,7 +596,7 @@ func TestIntegration_OperationRepository_FindAllByAccount_ReturnsOperations(t *t
 }
 
 func TestIntegration_OperationRepository_FindAllByAccount_FiltersByOperationType(t *testing.T) {
-	container := pgtestutil.SetupContainer(t)
+	container := pgtestutil.SetupMigratedContainer(t, "transaction")
 	repo := createRepository(t, container)
 	ids := createTestDependencies(t, container)
 
@@ -660,7 +658,7 @@ func TestIntegration_OperationRepository_FindAllByAccount_FiltersByOperationType
 }
 
 func TestIntegration_OperationRepository_FindAllByAccount_EmptyForNonExistentAccount(t *testing.T) {
-	container := pgtestutil.SetupContainer(t)
+	container := pgtestutil.SetupMigratedContainer(t, "transaction")
 	repo := createRepository(t, container)
 	ids := createTestDependencies(t, container)
 
@@ -677,7 +675,7 @@ func TestIntegration_OperationRepository_FindAllByAccount_EmptyForNonExistentAcc
 }
 
 func TestIntegration_OperationRepository_FindAllByAccount_Pagination(t *testing.T) {
-	container := pgtestutil.SetupContainer(t)
+	container := pgtestutil.SetupMigratedContainer(t, "transaction")
 	repo := createRepository(t, container)
 	ids := createTestDependencies(t, container)
 
@@ -748,7 +746,7 @@ func TestIntegration_OperationRepository_FindAllByAccount_Pagination(t *testing.
 // ============================================================================
 
 func TestIntegration_OperationRepository_ListByIDs_ReturnsMatchingOperations(t *testing.T) {
-	container := pgtestutil.SetupContainer(t)
+	container := pgtestutil.SetupMigratedContainer(t, "transaction")
 	repo := createRepository(t, container)
 	ids := createTestDependencies(t, container)
 
@@ -793,7 +791,7 @@ func TestIntegration_OperationRepository_ListByIDs_ReturnsMatchingOperations(t *
 }
 
 func TestIntegration_OperationRepository_ListByIDs_EmptyForNonExistentIDs(t *testing.T) {
-	container := pgtestutil.SetupContainer(t)
+	container := pgtestutil.SetupMigratedContainer(t, "transaction")
 	repo := createRepository(t, container)
 	ids := createTestDependencies(t, container)
 
@@ -810,7 +808,7 @@ func TestIntegration_OperationRepository_ListByIDs_EmptyForNonExistentIDs(t *tes
 }
 
 func TestIntegration_OperationRepository_ListByIDs_IgnoresDeletedOperations(t *testing.T) {
-	container := pgtestutil.SetupContainer(t)
+	container := pgtestutil.SetupMigratedContainer(t, "transaction")
 	repo := createRepository(t, container)
 	ids := createTestDependencies(t, container)
 
@@ -865,7 +863,7 @@ func TestIntegration_OperationRepository_ListByIDs_IgnoresDeletedOperations(t *t
 // ============================================================================
 
 func TestIntegration_OperationRepository_Update_Success(t *testing.T) {
-	container := pgtestutil.SetupContainer(t)
+	container := pgtestutil.SetupMigratedContainer(t, "transaction")
 	repo := createRepository(t, container)
 	ids := createTestDependencies(t, container)
 
@@ -910,7 +908,7 @@ func TestIntegration_OperationRepository_Update_Success(t *testing.T) {
 }
 
 func TestIntegration_OperationRepository_Update_ReturnsEntityNotFoundError(t *testing.T) {
-	container := pgtestutil.SetupContainer(t)
+	container := pgtestutil.SetupMigratedContainer(t, "transaction")
 	repo := createRepository(t, container)
 	ids := createTestDependencies(t, container)
 
@@ -935,7 +933,7 @@ func TestIntegration_OperationRepository_Update_ReturnsEntityNotFoundError(t *te
 }
 
 func TestIntegration_OperationRepository_Update_IgnoresDeletedOperation(t *testing.T) {
-	container := pgtestutil.SetupContainer(t)
+	container := pgtestutil.SetupMigratedContainer(t, "transaction")
 	repo := createRepository(t, container)
 	ids := createTestDependencies(t, container)
 
@@ -973,7 +971,7 @@ func TestIntegration_OperationRepository_Update_IgnoresDeletedOperation(t *testi
 // ============================================================================
 
 func TestIntegration_OperationRepository_Delete_SoftDeletesOperation(t *testing.T) {
-	container := pgtestutil.SetupContainer(t)
+	container := pgtestutil.SetupMigratedContainer(t, "transaction")
 	repo := createRepository(t, container)
 	ids := createTestDependencies(t, container)
 
@@ -1012,7 +1010,7 @@ func TestIntegration_OperationRepository_Delete_SoftDeletesOperation(t *testing.
 }
 
 func TestIntegration_OperationRepository_Delete_ReturnsEntityNotFoundError(t *testing.T) {
-	container := pgtestutil.SetupContainer(t)
+	container := pgtestutil.SetupMigratedContainer(t, "transaction")
 	repo := createRepository(t, container)
 	ids := createTestDependencies(t, container)
 
@@ -1031,7 +1029,7 @@ func TestIntegration_OperationRepository_Delete_ReturnsEntityNotFoundError(t *te
 }
 
 func TestIntegration_OperationRepository_Delete_AlreadyDeletedReturnsError(t *testing.T) {
-	container := pgtestutil.SetupContainer(t)
+	container := pgtestutil.SetupMigratedContainer(t, "transaction")
 	repo := createRepository(t, container)
 	ids := createTestDependencies(t, container)
 
@@ -1064,7 +1062,7 @@ func TestIntegration_OperationRepository_Delete_AlreadyDeletedReturnsError(t *te
 // ============================================================================
 
 func TestIntegration_OperationRepository_SchemaDefaults(t *testing.T) {
-	container := pgtestutil.SetupContainer(t)
+	container := pgtestutil.SetupMigratedContainer(t, "transaction")
 	repo := createRepository(t, container)
 	ids := createTestDependencies(t, container)
 
@@ -1181,7 +1179,7 @@ func TestIntegration_OperationRepository_SchemaDefaults(t *testing.T) {
 // TestIntegration_OperationRepository_NewColumnMigration_BackwardsCompatible tests that
 // existing rows without new columns still work correctly after a migration adds new columns.
 func TestIntegration_OperationRepository_NewColumnMigration_BackwardsCompatible(t *testing.T) {
-	container := pgtestutil.SetupContainer(t)
+	container := pgtestutil.SetupMigratedContainer(t, "transaction")
 	repo := createRepository(t, container)
 	ids := createTestDependencies(t, container)
 
@@ -1236,7 +1234,7 @@ func TestIntegration_OperationRepository_NewColumnMigration_BackwardsCompatible(
 // TestIntegration_OperationRepository_DecimalPrecision_Preserved tests that
 // large decimal values are preserved through the repository layer.
 func TestIntegration_OperationRepository_DecimalPrecision_Preserved(t *testing.T) {
-	container := pgtestutil.SetupContainer(t)
+	container := pgtestutil.SetupMigratedContainer(t, "transaction")
 	repo := createRepository(t, container)
 	ids := createTestDependencies(t, container)
 

--- a/components/ledger/internal/adapters/postgres/operation/operation_createbulk_integration_test.go
+++ b/components/ledger/internal/adapters/postgres/operation/operation_createbulk_integration_test.go
@@ -38,7 +38,7 @@ type bulkTestInfra struct {
 func setupBulkTestInfra(t *testing.T) *bulkTestInfra {
 	t.Helper()
 
-	container := pgtestutil.SetupContainer(t)
+	container := pgtestutil.SetupMigratedContainer(t, "transaction")
 	repo := createRepository(t, container)
 	ids := createTestDependencies(t, container)
 

--- a/components/ledger/internal/adapters/postgres/operation/operation_legacy_direction_integration_test.go
+++ b/components/ledger/internal/adapters/postgres/operation/operation_legacy_direction_integration_test.go
@@ -74,7 +74,7 @@ func insertLegacyDirectionNullOperation(
 }
 
 func TestIntegration_OperationRepository_LegacyDirectionFallback(t *testing.T) {
-	container := pgtestutil.SetupContainer(t)
+	container := pgtestutil.SetupMigratedContainer(t, "transaction")
 	repo := createRepository(t, container)
 	ids := createTestDependencies(t, container)
 	ctx := legacyDirectionTestContext(t)
@@ -163,7 +163,7 @@ func assertOperationNotInList(t *testing.T, operations []*Operation, operationID
 }
 
 func TestIntegration_OperationRepository_DirectionPassthroughOnModernRow(t *testing.T) {
-	container := pgtestutil.SetupContainer(t)
+	container := pgtestutil.SetupMigratedContainer(t, "transaction")
 	repo := createRepository(t, container)
 	ids := createTestDependencies(t, container)
 	ctx := legacyDirectionTestContext(t)

--- a/components/ledger/internal/adapters/postgres/operation/operation_redis_snapshot_integration_test.go
+++ b/components/ledger/internal/adapters/postgres/operation/operation_redis_snapshot_integration_test.go
@@ -44,7 +44,7 @@ import (
 // typed decimal rehydration intact on both Balance.OverdraftUsed and
 // BalanceAfter.OverdraftUsed.
 func TestIntegration_OperationRedis_RoundTrip_NonZeroSnapshot(t *testing.T) {
-	redisContainer := redistestutil.SetupContainer(t)
+	redisContainer := redistestutil.SetupReusableContainer(t)
 
 	ctx := context.Background()
 
@@ -119,7 +119,7 @@ func TestIntegration_OperationRedis_RoundTrip_NonZeroSnapshot(t *testing.T) {
 // preserved. Both `snapshot` and the typed Balance.OverdraftUsed fields
 // surface uniformly regardless of overdraft participation.
 func TestIntegration_OperationRedis_RoundTrip_ZeroShape(t *testing.T) {
-	redisContainer := redistestutil.SetupContainer(t)
+	redisContainer := redistestutil.SetupReusableContainer(t)
 
 	ctx := context.Background()
 
@@ -203,7 +203,7 @@ func TestIntegration_OperationRedis_RoundTrip_ZeroShape(t *testing.T) {
 // We write the payload directly as raw JSON (not via op.ToRedis) to simulate
 // the bytes that actually sit in Redis from an older build.
 func TestIntegration_OperationRedis_LegacyEnvelope(t *testing.T) {
-	redisContainer := redistestutil.SetupContainer(t)
+	redisContainer := redistestutil.SetupReusableContainer(t)
 
 	ctx := context.Background()
 

--- a/components/ledger/internal/adapters/postgres/operation/operation_snapshot_integration_test.go
+++ b/components/ledger/internal/adapters/postgres/operation/operation_snapshot_integration_test.go
@@ -91,7 +91,7 @@ func snapshotFixtureOperation(ids testIDs, now time.Time, snapshot mmodel.Operat
 // populated to non-zero values survives a PG round-trip with byte-level
 // JSONB fidelity and typed decimal rehydration.
 func TestIntegration_OperationSnapshot_CreateAndRead_NonZero(t *testing.T) {
-	container := pgtestutil.SetupContainer(t)
+	container := pgtestutil.SetupMigratedContainer(t, "transaction")
 	repo := createRepository(t, container)
 	ids := createTestDependencies(t, container)
 
@@ -143,7 +143,7 @@ func TestIntegration_OperationSnapshot_CreateAndRead_NonZero(t *testing.T) {
 // typed Balance.OverdraftUsed / BalanceAfter.OverdraftUsed set to
 // decimal.Zero.
 func TestIntegration_OperationSnapshot_CreateAndRead_ZeroShape(t *testing.T) {
-	container := pgtestutil.SetupContainer(t)
+	container := pgtestutil.SetupMigratedContainer(t, "transaction")
 	repo := createRepository(t, container)
 	ids := createTestDependencies(t, container)
 
@@ -188,7 +188,7 @@ func TestIntegration_OperationSnapshot_CreateAndRead_ZeroShape(t *testing.T) {
 // snapshot independently. Catches scan-site drift that would be hidden when
 // every row happens to have the same snapshot.
 func TestIntegration_OperationSnapshot_FindAll_MixedSnapshots(t *testing.T) {
-	container := pgtestutil.SetupContainer(t)
+	container := pgtestutil.SetupMigratedContainer(t, "transaction")
 	repo := createRepository(t, container)
 	ids := createTestDependencies(t, container)
 
@@ -261,7 +261,7 @@ func TestIntegration_OperationSnapshot_FindAll_MixedSnapshots(t *testing.T) {
 // production rows from before the snapshot migration landed must produce
 // exactly the same wire shape as freshly written non-overdraft ops.
 func TestIntegration_OperationSnapshot_LegacyRow(t *testing.T) {
-	container := pgtestutil.SetupContainer(t)
+	container := pgtestutil.SetupMigratedContainer(t, "transaction")
 	repo := createRepository(t, container)
 	ids := createTestDependencies(t, container)
 
@@ -324,7 +324,7 @@ func TestIntegration_OperationSnapshot_LegacyRow(t *testing.T) {
 // reconstruction would surface typed OverdraftUsed as decimal.Zero, defeating
 // the audit-trail purpose of the snapshot column.
 func TestIntegration_OperationSnapshot_PointInTime(t *testing.T) {
-	container := pgtestutil.SetupContainer(t)
+	container := pgtestutil.SetupMigratedContainer(t, "transaction")
 	repo := createRepository(t, container)
 	ids := createTestDependencies(t, container)
 
@@ -373,7 +373,7 @@ func TestIntegration_OperationSnapshot_PointInTime(t *testing.T) {
 // operationPointInTimeColumns list. Legacy rows decode to the always-
 // populated zero shape on the PIT path too.
 func TestIntegration_OperationSnapshot_PointInTime_LegacyRow(t *testing.T) {
-	container := pgtestutil.SetupContainer(t)
+	container := pgtestutil.SetupMigratedContainer(t, "transaction")
 	repo := createRepository(t, container)
 	ids := createTestDependencies(t, container)
 

--- a/components/ledger/internal/services/command/create_balance_direction_acceptance_integration_test.go
+++ b/components/ledger/internal/services/command/create_balance_direction_acceptance_integration_test.go
@@ -63,8 +63,8 @@ type acceptanceDirectionHarness struct {
 func setupAcceptanceDirectionHarness(t *testing.T) *acceptanceDirectionHarness {
 	t.Helper()
 
-	onboardingContainer := pgtestutil.SetupContainer(t)
-	transactionContainer := pgtestutil.SetupContainer(t)
+	onboardingContainer := pgtestutil.SetupMigratedContainer(t, "onboarding")
+	transactionContainer := pgtestutil.SetupMigratedContainer(t, "transaction")
 
 	accountTypeRepo := newAccountTypeRepoForHarness(t, onboardingContainer)
 	balanceRepo := newBalanceRepoForHarness(t, transactionContainer)
@@ -96,9 +96,8 @@ func setupAcceptanceDirectionHarness(t *testing.T) *acceptanceDirectionHarness {
 func newAccountTypeRepoForHarness(t *testing.T, container *pgtestutil.ContainerResult) *accounttype.AccountTypePostgreSQLRepository {
 	t.Helper()
 
-	migrationsPath := pgtestutil.FindMigrationsPath(t, "onboarding")
 	connStr := pgtestutil.BuildConnectionString(container.Host, container.Port, container.Config)
-	conn := pgtestutil.CreatePostgresClient(t, connStr, connStr, container.Config.DBName, migrationsPath)
+	conn := pgtestutil.ConnectPostgresClient(t, connStr, connStr)
 
 	return accounttype.NewAccountTypePostgreSQLRepository(conn)
 }
@@ -108,9 +107,8 @@ func newAccountTypeRepoForHarness(t *testing.T, container *pgtestutil.ContainerR
 func newBalanceRepoForHarness(t *testing.T, container *pgtestutil.ContainerResult) *balance.BalancePostgreSQLRepository {
 	t.Helper()
 
-	migrationsPath := pgtestutil.FindMigrationsPath(t, "transaction")
 	connStr := pgtestutil.BuildConnectionString(container.Host, container.Port, container.Config)
-	conn := pgtestutil.CreatePostgresClient(t, connStr, connStr, container.Config.DBName, migrationsPath)
+	conn := pgtestutil.ConnectPostgresClient(t, connStr, connStr)
 
 	return balance.NewBalancePostgreSQLRepository(conn, false)
 }

--- a/components/ledger/internal/services/fees/calculate-fee.go
+++ b/components/ledger/internal/services/fees/calculate-fee.go
@@ -65,7 +65,9 @@ func (uc *UseCase) CalculateFee(ctx context.Context, cf *model.FeeCalculate, org
 		return nil
 	}
 
-	validationResult, errValidationSend := transaction.ValidateSendSourceAndDistribute(ctx, cf.Transaction, "")
+	validationTransaction := transactionForFeeCalculation(cf.Transaction)
+
+	validationResult, errValidationSend := transaction.ValidateSendSourceAndDistribute(ctx, validationTransaction, "")
 	if errValidationSend != nil {
 		bizErr := pkg.ValidateBusinessError(constant.ErrValidateDistributeTransactionValue, "")
 		libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Failed to validate send struct", bizErr)
@@ -89,6 +91,40 @@ func (uc *UseCase) CalculateFee(ctx context.Context, cf *model.FeeCalculate, org
 	}
 
 	return uc.calculateFeeForMultiplePackages(ctx, logger, cf, packages, sendModel, validationResult, validationResultFromSize, validationResultToSize, organizationID)
+}
+
+// transactionForFeeCalculation gives every original leg a stable internal identity while the
+// fee engine operates on maps. The public transaction remains untouched: after calculation the
+// fee package materializer restores the authored alias and attributes in their original order.
+func transactionForFeeCalculation(input transaction.Transaction) transaction.Transaction {
+	cloned := input
+	cloned.Send.Source.From = append([]transaction.FromTo(nil), input.Send.Source.From...)
+	cloned.Send.Distribute.To = append([]transaction.FromTo(nil), input.Send.Distribute.To...)
+
+	qualifyDuplicateFeeAliases(cloned.Send.Source.From)
+	qualifyDuplicateFeeAliases(cloned.Send.Distribute.To)
+
+	return cloned
+}
+
+func qualifyDuplicateFeeAliases(entries []transaction.FromTo) {
+	counts := make(map[string]int, len(entries))
+	for _, entry := range entries {
+		if entry.AccountAlias == "" {
+			continue
+		}
+
+		counts[entry.AccountAlias]++
+	}
+
+	for _, count := range counts {
+		if count > 1 {
+			transaction.ApplyDefaultBalanceKeys(entries)
+			transaction.MutateConcatAliases(entries)
+
+			return
+		}
+	}
 }
 
 // resolveSourceSegment resolves the segment shared by the transaction's real
@@ -195,7 +231,7 @@ func (uc *UseCase) calculateFeeForSinglePackage(
 		ResolverCache:  make(map[string]*feeshared.Account),
 	}
 
-	errCalculateFee := feeUtils.CalculateFee(logger, cf, packFilter, validationResult, uc.defaultCurrency, segCtx)
+	errCalculateFee := feeUtils.CalculateFeePreservingLegs(logger, cf, packFilter, validationResult, uc.defaultCurrency, segCtx)
 	if errCalculateFee != nil {
 		return errCalculateFee
 	}
@@ -236,7 +272,7 @@ func (uc *UseCase) calculateFeeForMultiplePackages(
 		ResolverCache:  make(map[string]*feeshared.Account),
 	}
 
-	errCalculateFee := feeUtils.CalculateFee(logger, cf, packFilter, validationResult, uc.defaultCurrency, segCtx)
+	errCalculateFee := feeUtils.CalculateFeePreservingLegs(logger, cf, packFilter, validationResult, uc.defaultCurrency, segCtx)
 	if errCalculateFee != nil {
 		return errCalculateFee
 	}

--- a/components/ledger/internal/services/fees/calculate-fee_test.go
+++ b/components/ledger/internal/services/fees/calculate-fee_test.go
@@ -405,6 +405,179 @@ func TestCalculateFee_SinglePackage_Success(t *testing.T) {
 	assert.Greater(t, feeInput.Transaction.Send.Value.IntPart(), int64(1000))
 }
 
+func TestCalculateFee_RemainingSourceIsResolvedBeforeFeeDistribution(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockPackRepo := pack.NewMockRepository(ctrl)
+	orgID := uuid.New()
+	ledgerID := uuid.New()
+	packID := uuid.New()
+	deductible := false
+
+	feeSvc := &UseCase{packageRepo: mockPackRepo}
+	routeID := uuid.New().String()
+	rateID := uuid.New().String()
+	explicitMetadata := map[string]any{"leg": "explicit"}
+	remainingMetadata := map[string]any{"leg": "remaining"}
+	destinationMetadata := map[string]any{"leg": "destination"}
+	feeDebitRoute := "fee-debit-route"
+	feeCreditRoute := "fee-credit-route"
+	feeInput := &model.FeeCalculate{
+		LedgerID: ledgerID,
+		Transaction: transaction.Transaction{
+			Send: transaction.Send{
+				Asset: "USD",
+				Value: decimal.NewFromInt(100),
+				Source: transaction.Source{From: []transaction.FromTo{
+					{
+						AccountAlias:    "@payer",
+						BalanceKey:      "reserved",
+						Amount:          &transaction.Amount{Asset: "USD", Value: decimal.NewFromInt(60)},
+						Rate:            &transaction.Rate{From: "USD", To: "USDe", Value: decimal.NewFromInt(1), ExternalID: rateID},
+						Description:     "explicit leg",
+						ChartOfAccounts: "asset.explicit",
+						Metadata:        explicitMetadata,
+						IsFrom:          true,
+						Route:           "legacy-explicit",
+						RouteID:         &routeID,
+					},
+					{
+						AccountAlias:    "@payer",
+						BalanceKey:      "available",
+						Remaining:       "remaining",
+						Description:     "remaining leg",
+						ChartOfAccounts: "asset.remaining",
+						Metadata:        remainingMetadata,
+						IsFrom:          true,
+						Route:           "legacy-remaining",
+					},
+				}},
+				Distribute: transaction.Distribute{To: []transaction.FromTo{{
+					AccountAlias:    "@destination",
+					BalanceKey:      "settlement",
+					Share:           &transaction.Share{Percentage: 100},
+					Description:     "destination leg",
+					ChartOfAccounts: "liability.destination",
+					Metadata:        destinationMetadata,
+					Route:           "legacy-destination",
+					RouteID:         &routeID,
+				}}},
+			},
+		},
+	}
+
+	feePackage := &pack.Package{
+		ID:            packID,
+		MinimumAmount: decimal.NewFromInt(1),
+		MaximumAmount: decimal.NewFromInt(1000),
+		Fees: map[string]model.Fee{
+			"flat": {
+				CalculationModel: &model.CalculationModel{
+					ApplicationRule: "flatFee",
+					Calculations:    []model.Calculation{{Type: "flat", Value: "10"}},
+				},
+				ReferenceAmount:  "originalAmount",
+				Priority:         1,
+				IsDeductibleFrom: &deductible,
+				CreditAccount:    "@fee_account",
+				RouteFrom:        &feeDebitRoute,
+				RouteTo:          &feeCreditRoute,
+			},
+		},
+		WaivedAccounts: &[]string{},
+	}
+
+	mockPackRepo.EXPECT().
+		FindByOrganizationIDAndLedgerID(gomock.Any(), orgID, ledgerID).
+		Return([]*pack.Package{feePackage}, nil)
+
+	err := feeSvc.CalculateFee(context.Background(), feeInput, orgID)
+	assert.NoError(t, err)
+	assert.Equal(t, decimal.NewFromInt(110), feeInput.Transaction.Send.Value)
+	assert.Len(t, feeInput.Transaction.Send.Source.From, 4, "both original legs and both proportional fee legs must survive")
+
+	explicit := feeInput.Transaction.Send.Source.From[0]
+	assert.Equal(t, "@payer", explicit.AccountAlias)
+	assert.Equal(t, "reserved", explicit.BalanceKey)
+	assert.Equal(t, "explicit leg", explicit.Description)
+	assert.Equal(t, "asset.explicit", explicit.ChartOfAccounts)
+	assert.Equal(t, explicitMetadata, explicit.Metadata)
+	assert.True(t, explicit.IsFrom)
+	assert.Equal(t, "legacy-explicit", explicit.Route)
+	assert.Equal(t, &routeID, explicit.RouteID)
+	assert.Equal(t, &transaction.Rate{From: "USD", To: "USDe", Value: decimal.NewFromInt(1), ExternalID: rateID}, explicit.Rate)
+	assert.Nil(t, explicit.Share)
+	assert.Empty(t, explicit.Remaining)
+	if assert.NotNil(t, explicit.Amount) {
+		assert.Equal(t, decimal.NewFromInt(60), explicit.Amount.Value)
+	}
+
+	remaining := feeInput.Transaction.Send.Source.From[1]
+	assert.Equal(t, "@payer", remaining.AccountAlias)
+	assert.Equal(t, "available", remaining.BalanceKey)
+	assert.Equal(t, "remaining leg", remaining.Description)
+	assert.Equal(t, "asset.remaining", remaining.ChartOfAccounts)
+	assert.Equal(t, remainingMetadata, remaining.Metadata)
+	assert.True(t, remaining.IsFrom)
+	assert.Equal(t, "legacy-remaining", remaining.Route)
+	assert.Nil(t, remaining.RouteID)
+	assert.Nil(t, remaining.Share)
+	assert.Empty(t, remaining.Remaining)
+	if assert.NotNil(t, remaining.Amount) {
+		assert.Equal(t, decimal.NewFromInt(40), remaining.Amount.Value)
+	}
+
+	assert.Len(t, feeInput.Transaction.Send.Distribute.To, 3, "the destination plus both proportional fee credits must survive")
+	destination := feeInput.Transaction.Send.Distribute.To[0]
+	assert.Equal(t, "@destination", destination.AccountAlias)
+	assert.Equal(t, "settlement", destination.BalanceKey)
+	assert.Equal(t, "destination leg", destination.Description)
+	assert.Equal(t, "liability.destination", destination.ChartOfAccounts)
+	assert.Equal(t, destinationMetadata, destination.Metadata)
+	assert.Equal(t, "legacy-destination", destination.Route)
+	assert.Equal(t, &routeID, destination.RouteID)
+	assert.Nil(t, destination.Share)
+	assert.Empty(t, destination.Remaining)
+	if assert.NotNil(t, destination.Amount) {
+		assert.True(t, decimal.NewFromInt(100).Equal(destination.Amount.Value))
+	}
+
+	for _, feeLeg := range feeInput.Transaction.Send.Source.From[2:] {
+		assert.Equal(t, "@payer", feeLeg.AccountAlias)
+		assert.Equal(t, feeDebitRoute, feeLeg.Route)
+		assert.Empty(t, feeLeg.BalanceKey, "new fee legs retain the default-balance semantics")
+	}
+
+	for _, feeLeg := range feeInput.Transaction.Send.Distribute.To[1:] {
+		assert.Equal(t, "@fee_account", feeLeg.AccountAlias)
+		assert.Equal(t, feeCreditRoute, feeLeg.Route)
+		assert.Equal(t, "@payer", feeLeg.Metadata["source"])
+	}
+
+	var sourceTotal, destinationTotal decimal.Decimal
+	for _, leg := range feeInput.Transaction.Send.Source.From {
+		assert.NotNil(t, leg.Amount, "fee normalization must preserve every resolved source leg")
+		if leg.Amount != nil {
+			assert.True(t, leg.Amount.Value.IsPositive(), "fee normalization must not emit a zero source leg")
+			sourceTotal = sourceTotal.Add(leg.Amount.Value)
+		}
+	}
+
+	for _, leg := range feeInput.Transaction.Send.Distribute.To {
+		assert.NotNil(t, leg.Amount, "fee normalization must preserve every resolved destination leg")
+		if leg.Amount != nil {
+			assert.True(t, leg.Amount.Value.IsPositive(), "fee normalization must not emit a zero destination leg")
+			destinationTotal = destinationTotal.Add(leg.Amount.Value)
+		}
+	}
+
+	assert.True(t, decimal.NewFromInt(110).Equal(sourceTotal), "source legs must sum to the fee-inclusive amount: %s", sourceTotal)
+	assert.True(t, decimal.NewFromInt(110).Equal(destinationTotal), "destination legs must sum to the fee-inclusive amount: %s", destinationTotal)
+}
+
 // TestCalculateFee_SinglePackage_CalculateFeeError tests error when calculating fee in single package
 func TestCalculateFee_SinglePackage_CalculateFeeError(t *testing.T) {
 	ctrl := gomock.NewController(t)

--- a/components/ledger/internal/services/fees/estimate-fee-calculation.go
+++ b/components/ledger/internal/services/fees/estimate-fee-calculation.go
@@ -80,7 +80,9 @@ func (uc *UseCase) EstimateFeeCalculation(ctx context.Context, cf *model.FeeEsti
 		Transaction: cf.Transaction,
 	}
 
-	validationResult, errValidationSend := transaction.ValidateSendSourceAndDistribute(ctx, feeModel.Transaction, "")
+	validationTransaction := transactionForFeeCalculation(feeModel.Transaction)
+
+	validationResult, errValidationSend := transaction.ValidateSendSourceAndDistribute(ctx, validationTransaction, "")
 	if errValidationSend != nil {
 		libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Failed to validate send struct", errValidationSend)
 
@@ -107,7 +109,7 @@ func (uc *UseCase) EstimateFeeCalculation(ctx context.Context, cf *model.FeeEsti
 		LedgerID:       cf.LedgerID,
 	}
 
-	errCalculateFee := feeUtils.CalculateFee(logger, feeModel, packModel, validationResult, uc.defaultCurrency, segCtx)
+	errCalculateFee := feeUtils.CalculateFeePreservingLegs(logger, feeModel, packModel, validationResult, uc.defaultCurrency, segCtx)
 	if errCalculateFee != nil {
 		libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Failed to calculate fee", errCalculateFee)
 

--- a/components/ledger/internal/services/fees/estimate-fee-calculation_test.go
+++ b/components/ledger/internal/services/fees/estimate-fee-calculation_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.mongodb.org/mongo-driver/v2/mongo"
 	"go.uber.org/mock/gomock"
 )
@@ -319,6 +320,99 @@ func TestCreateFeeEstimate(t *testing.T) {
 				assert.Contains(t, toValues, "1600", "To should contain non-deductible fee 1600, got %v", toValues)
 			}
 		})
+	}
+}
+
+func TestEstimateFeeCalculation_PreservesDuplicateRemainingLegs(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockPackRepo := pack.NewMockRepository(ctrl)
+	feeSvc := &UseCase{packageRepo: mockPackRepo, defaultCurrency: "USD"}
+	orgID := uuid.New()
+	ledgerID := uuid.New()
+	packID := uuid.New()
+	deductible := false
+	operationRouteFromID := uuid.NewString()
+	operationRouteToID := uuid.NewString()
+	legacyRouteFrom := "estimate-debit"
+	legacyRouteTo := "estimate-credit"
+
+	feePackage := &pack.Package{
+		ID:            packID,
+		MinimumAmount: decimal.NewFromInt(1),
+		MaximumAmount: decimal.NewFromInt(1000),
+		Fees: map[string]model.Fee{
+			"flat": {
+				CalculationModel: &model.CalculationModel{
+					ApplicationRule: "flatFee",
+					Calculations:    []model.Calculation{{Type: "flat", Value: "10"}},
+				},
+				ReferenceAmount:      "originalAmount",
+				Priority:             1,
+				IsDeductibleFrom:     &deductible,
+				CreditAccount:        "@fee_account",
+				RouteFrom:            &legacyRouteFrom,
+				RouteTo:              &legacyRouteTo,
+				OperationRouteFromID: &operationRouteFromID,
+				OperationRouteToID:   &operationRouteToID,
+			},
+		},
+		WaivedAccounts: &[]string{},
+	}
+
+	mockPackRepo.EXPECT().
+		FindByID(gomock.Any(), packID, orgID, uuid.Nil).
+		Return(feePackage, nil)
+
+	input := &model.FeeEstimate{
+		PackageID: packID,
+		LedgerID:  ledgerID,
+		Transaction: transaction.Transaction{Send: transaction.Send{
+			Asset: "USD",
+			Value: decimal.NewFromInt(100),
+			Source: transaction.Source{From: []transaction.FromTo{
+				{AccountAlias: "@payer", BalanceKey: "reserved", Amount: &transaction.Amount{Asset: "USD", Value: decimal.NewFromInt(60)}, IsFrom: true},
+				{AccountAlias: "@payer", BalanceKey: "available", Remaining: "remaining", IsFrom: true},
+			}},
+			Distribute: transaction.Distribute{To: []transaction.FromTo{{
+				AccountAlias: "@destination",
+				Amount:       &transaction.Amount{Asset: "USD", Value: decimal.NewFromInt(100)},
+			}}},
+		}},
+	}
+
+	result, err := feeSvc.EstimateFeeCalculation(context.Background(), input, orgID)
+	assert.NoError(t, err)
+	if !assert.NotNil(t, result) {
+		return
+	}
+
+	assert.True(t, decimal.NewFromInt(110).Equal(result.Transaction.Send.Value))
+	assert.Len(t, result.Transaction.Send.Source.From, 4)
+	assert.Equal(t, "@payer", result.Transaction.Send.Source.From[0].AccountAlias)
+	assert.Equal(t, "reserved", result.Transaction.Send.Source.From[0].BalanceKey)
+	assert.Empty(t, result.Transaction.Send.Source.From[0].Remaining)
+	if assert.NotNil(t, result.Transaction.Send.Source.From[0].Amount) {
+		assert.True(t, decimal.NewFromInt(60).Equal(result.Transaction.Send.Source.From[0].Amount.Value))
+	}
+	assert.Equal(t, "@payer", result.Transaction.Send.Source.From[1].AccountAlias)
+	assert.Equal(t, "available", result.Transaction.Send.Source.From[1].BalanceKey)
+	assert.Empty(t, result.Transaction.Send.Source.From[1].Remaining)
+	if assert.NotNil(t, result.Transaction.Send.Source.From[1].Amount) {
+		assert.True(t, decimal.NewFromInt(40).Equal(result.Transaction.Send.Source.From[1].Amount.Value))
+	}
+	for _, feeLeg := range result.Transaction.Send.Source.From[2:] {
+		assert.Equal(t, legacyRouteFrom, feeLeg.Route)
+		require.NotNil(t, feeLeg.RouteID)
+		assert.Equal(t, operationRouteFromID, *feeLeg.RouteID)
+	}
+	for _, feeLeg := range result.Transaction.Send.Distribute.To[1:] {
+		assert.Equal(t, legacyRouteTo, feeLeg.Route)
+		require.NotNil(t, feeLeg.RouteID)
+		assert.Equal(t, operationRouteToID, *feeLeg.RouteID)
 	}
 }
 

--- a/components/ledger/internal/services/fees/update-package-by-id.go
+++ b/components/ledger/internal/services/fees/update-package-by-id.go
@@ -177,14 +177,12 @@ func (uc *UseCase) buildUpdateFields(ctx context.Context, logger libLog.Logger, 
 
 // validationFeesSetUnset Validate the fee struct to update correctly
 func (uc *UseCase) validationFeesSetUnset(ctx context.Context, minAmount decimal.Decimal, organizationID, ledgerID uuid.UUID, existingFees map[string]model.Fee, updateFeesEntity map[string]model.Fee, setFields, unsetFields bson.M) error {
-	// First pass: process all fees and build final state
-	finalFees := make(map[string]model.Fee)
-	prioritySet := make(map[int]struct{})
-
-	// Start with existing fees
+	// A PATCH fee contains only changed fields. Track the effective priority
+	// independently so an omitted priority preserves the stored value instead of
+	// becoming zero during cross-fee validation.
+	effectivePriorities := make(map[string]int, len(existingFees))
 	for key, fee := range existingFees {
-		finalFees[key] = fee
-		prioritySet[fee.Priority] = struct{}{}
+		effectivePriorities[key] = fee.Priority
 	}
 
 	// Process update fees
@@ -212,11 +210,10 @@ func (uc *UseCase) validationFeesSetUnset(ctx context.Context, minAmount decimal
 
 			setFields["fees."+keyFormatted] = mongoFee
 
-			// Add to final state for priority validation
-			finalFees[keyFormatted] = fee
+			effectivePriorities[keyFormatted] = fee.Priority
 		} else {
 			// Existing fee - check if it's being updated or removed
-			hasFieldsToUpdate, errSetFieldsToUpdate := fee.SetAndValidateHasFieldsToUpdate(ctx, fee.IsDeductibleFrom, minAmount, existingFees, keyFormatted, organizationID, ledgerID, setFields, uc.resolver)
+			hasFieldsToUpdate, errSetFieldsToUpdate := fee.SetAndValidateHasFieldsToUpdate(ctx, fee.IsDeductibleFrom, minAmount, existingFees, keyFormatted, organizationID, ledgerID, setFields, unsetFields, uc.resolver)
 			if errSetFieldsToUpdate != nil {
 				return errSetFieldsToUpdate
 			}
@@ -225,22 +222,21 @@ func (uc *UseCase) validationFeesSetUnset(ctx context.Context, minAmount decimal
 				// Fee is being removed
 				unsetFields["fees."+keyFormatted] = ""
 
-				delete(finalFees, keyFormatted)
-			} else {
-				// Fee is being updated - update in final state
-				finalFees[keyFormatted] = fee
+				delete(effectivePriorities, keyFormatted)
+			} else if fee.Priority != 0 {
+				effectivePriorities[keyFormatted] = fee.Priority
 			}
 		}
 	}
 
 	// Second pass: validate priorities in final state
 	finalPrioritySet := make(map[int]struct{})
-	for _, fee := range finalFees {
-		if _, exists := finalPrioritySet[fee.Priority]; exists {
+	for _, priority := range effectivePriorities {
+		if _, exists := finalPrioritySet[priority]; exists {
 			return pkg.ValidateBusinessError(constant.ErrPriorityInvalid, "")
 		}
 
-		finalPrioritySet[fee.Priority] = struct{}{}
+		finalPrioritySet[priority] = struct{}{}
 	}
 
 	return nil
@@ -323,13 +319,15 @@ func (uc *UseCase) convertFeeToMongoFormat(fee model.Fee) (pack.Fee, error) {
 	}
 
 	return pack.Fee{
-		FeeLabel:         fee.FeeLabel,
-		CalculationModel: calcModel,
-		ReferenceAmount:  fee.ReferenceAmount,
-		Priority:         fee.Priority,
-		IsDeductibleFrom: fee.IsDeductibleFrom,
-		CreditAccount:    fee.CreditAccount,
-		RouteFrom:        fee.RouteFrom,
-		RouteTo:          fee.RouteTo,
+		FeeLabel:             fee.FeeLabel,
+		CalculationModel:     calcModel,
+		ReferenceAmount:      fee.ReferenceAmount,
+		Priority:             fee.Priority,
+		IsDeductibleFrom:     fee.IsDeductibleFrom,
+		CreditAccount:        fee.CreditAccount,
+		RouteFrom:            fee.RouteFrom,
+		RouteTo:              fee.RouteTo,
+		OperationRouteFromID: fee.OperationRouteFromID,
+		OperationRouteToID:   fee.OperationRouteToID,
 	}, nil
 }

--- a/components/ledger/internal/services/fees/update_package_operation_route_ids_test.go
+++ b/components/ledger/internal/services/fees/update_package_operation_route_ids_test.go
@@ -1,0 +1,193 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package services
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.uber.org/mock/gomock"
+
+	"github.com/LerianStudio/midaz/v4/components/ledger/internal/adapters/mongodb/fees/pack"
+	"github.com/LerianStudio/midaz/v4/components/ledger/pkg/feeshared/model"
+)
+
+func decodeOperationRoutePatch(t *testing.T, raw string) *model.UpdatePackageInput {
+	t.Helper()
+
+	var input model.UpdatePackageInput
+	require.NoError(t, json.Unmarshal([]byte(raw), &input))
+
+	return &input
+}
+
+func TestUpdatePackageByID_TwoOperationRouteOnlyFeesPreserveEffectivePrioritiesAndWriteAtomically(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	repo := pack.NewMockRepository(ctrl)
+	orgID := uuid.New()
+	ledgerID := uuid.New()
+	packageID := uuid.New()
+	firstRouteID := uuid.NewString()
+	secondRouteID := uuid.NewString()
+	existing := map[string]model.Fee{
+		"firstFee":  {Priority: 1},
+		"secondFee": {Priority: 2},
+	}
+	input := decodeOperationRoutePatch(t, `{"fees":{"firstFee":{"operationRouteFromId":"`+firstRouteID+`"},"secondFee":{"operationRouteToId":"`+secondRouteID+`"}}}`)
+	require.NoError(t, input.ValidateFees())
+
+	repo.EXPECT().
+		FindFeesAndAmountDataByPackageID(gomock.Any(), orgID, packageID).
+		Return(&model.AmountData{
+			MinAmount: decimal.NewFromInt(1),
+			MaxAmount: decimal.NewFromInt(100),
+			Fees:      existing,
+			LedgerID:  ledgerID,
+		}, nil)
+
+	var captured *bson.M
+	repo.EXPECT().
+		Update(gomock.Any(), packageID, orgID, uuid.Nil, gomock.Any()).
+		DoAndReturn(func(_ context.Context, _, _, _ uuid.UUID, update *bson.M) (*pack.Package, error) {
+			captured = update
+
+			return &pack.Package{ID: packageID, LedgerID: ledgerID}, nil
+		}).
+		Times(1)
+
+	svc := &UseCase{packageRepo: repo}
+	require.NoError(t, svc.UpdatePackageByID(context.Background(), packageID, orgID, uuid.Nil, input))
+	require.NotNil(t, captured)
+
+	setFields, ok := (*captured)["$set"].(bson.M)
+	require.True(t, ok)
+	assert.Equal(t, &firstRouteID, setFields["fees.firstFee.operation_route_from_id"])
+	assert.Equal(t, &secondRouteID, setFields["fees.secondFee.operation_route_to_id"])
+	assert.Contains(t, setFields, "updated_at")
+	assert.Len(t, setFields, 3, "partial PATCH must not replace either complete fee")
+	assert.NotContains(t, *captured, "$unset")
+}
+
+func TestUpdatePackageByID_NullClearsOneOperationRouteWithoutRemovingFee(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		jsonField string
+		mongoPath string
+	}{
+		{
+			name:      "clear source operation route",
+			jsonField: "operationRouteFromId",
+			mongoPath: "fees.serviceFee.operation_route_from_id",
+		},
+		{
+			name:      "clear destination operation route",
+			jsonField: "operationRouteToId",
+			mongoPath: "fees.serviceFee.operation_route_to_id",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctrl := gomock.NewController(t)
+			repo := pack.NewMockRepository(ctrl)
+			orgID := uuid.New()
+			ledgerID := uuid.New()
+			packageID := uuid.New()
+			fromID := uuid.NewString()
+			toID := uuid.NewString()
+			input := decodeOperationRoutePatch(t, `{"fees":{"serviceFee":{"`+tt.jsonField+`":null}}}`)
+			require.NoError(t, input.ValidateFees())
+
+			repo.EXPECT().
+				FindFeesAndAmountDataByPackageID(gomock.Any(), orgID, packageID).
+				Return(&model.AmountData{
+					MinAmount: decimal.NewFromInt(1),
+					MaxAmount: decimal.NewFromInt(100),
+					Fees: map[string]model.Fee{"serviceFee": {
+						Priority:             1,
+						OperationRouteFromID: &fromID,
+						OperationRouteToID:   &toID,
+					}},
+					LedgerID: ledgerID,
+				}, nil)
+
+			var captured *bson.M
+			repo.EXPECT().
+				Update(gomock.Any(), packageID, orgID, uuid.Nil, gomock.Any()).
+				DoAndReturn(func(_ context.Context, _, _, _ uuid.UUID, update *bson.M) (*pack.Package, error) {
+					captured = update
+
+					return &pack.Package{ID: packageID, LedgerID: ledgerID}, nil
+				}).
+				Times(1)
+
+			svc := &UseCase{packageRepo: repo}
+			require.NoError(t, svc.UpdatePackageByID(context.Background(), packageID, orgID, uuid.Nil, input))
+			require.NotNil(t, captured)
+
+			unsetFields, ok := (*captured)["$unset"].(bson.M)
+			require.True(t, ok)
+			assert.Equal(t, "", unsetFields[tt.mongoPath])
+			assert.NotContains(t, unsetFields, "fees.serviceFee", "null must clear the field, not remove the fee")
+			assert.Len(t, unsetFields, 1)
+
+			setFields, ok := (*captured)["$set"].(bson.M)
+			require.True(t, ok)
+			assert.Contains(t, setFields, "updated_at")
+			assert.Len(t, setFields, 1)
+		})
+	}
+}
+
+func TestUpdatePackageByID_EmptyFeeObjectStillRemovesTheFee(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	repo := pack.NewMockRepository(ctrl)
+	orgID := uuid.New()
+	ledgerID := uuid.New()
+	packageID := uuid.New()
+	input := decodeOperationRoutePatch(t, `{"fees":{"serviceFee":{}}}`)
+	require.NoError(t, input.ValidateFees())
+
+	repo.EXPECT().
+		FindFeesAndAmountDataByPackageID(gomock.Any(), orgID, packageID).
+		Return(&model.AmountData{
+			MinAmount: decimal.NewFromInt(1),
+			MaxAmount: decimal.NewFromInt(100),
+			Fees:      map[string]model.Fee{"serviceFee": {Priority: 1}},
+			LedgerID:  ledgerID,
+		}, nil)
+
+	var captured *bson.M
+	repo.EXPECT().
+		Update(gomock.Any(), packageID, orgID, uuid.Nil, gomock.Any()).
+		DoAndReturn(func(_ context.Context, _, _, _ uuid.UUID, update *bson.M) (*pack.Package, error) {
+			captured = update
+
+			return &pack.Package{ID: packageID, LedgerID: ledgerID}, nil
+		})
+
+	svc := &UseCase{packageRepo: repo}
+	require.NoError(t, svc.UpdatePackageByID(context.Background(), packageID, orgID, uuid.Nil, input))
+	require.NotNil(t, captured)
+
+	unsetFields, ok := (*captured)["$unset"].(bson.M)
+	require.True(t, ok)
+	assert.Equal(t, "", unsetFields["fees.serviceFee"])
+	assert.Len(t, unsetFields, 1)
+}

--- a/components/ledger/internal/services/fees/zero_fee_test.go
+++ b/components/ledger/internal/services/fees/zero_fee_test.go
@@ -1,0 +1,119 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package services
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"github.com/LerianStudio/midaz/v4/components/ledger/internal/adapters/mongodb/fees/pack"
+	feeconstant "github.com/LerianStudio/midaz/v4/components/ledger/pkg/feeshared/constant"
+	"github.com/LerianStudio/midaz/v4/components/ledger/pkg/feeshared/model"
+	transaction "github.com/LerianStudio/midaz/v4/pkg/mtransaction"
+)
+
+func TestZeroFeeIsNoOpForCreateAndEstimate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		applicationRule string
+		calculationType string
+	}{
+		{name: "flat zero", applicationRule: feeconstant.AppRuleFlatFee, calculationType: feeconstant.FeeTypeFlat},
+		{name: "percentage zero", applicationRule: feeconstant.AppRulePercentual, calculationType: feeconstant.FeeTypePercentage},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			organizationID := uuid.New()
+			ledgerID := uuid.New()
+			packageID := uuid.New()
+			deductible := false
+			feePackage := &pack.Package{
+				ID:             packageID,
+				MinimumAmount:  decimal.NewFromInt(1),
+				MaximumAmount:  decimal.NewFromInt(1000),
+				WaivedAccounts: &[]string{},
+				Fees: map[string]model.Fee{"zero": {
+					CalculationModel: &model.CalculationModel{
+						ApplicationRule: tt.applicationRule,
+						Calculations: []model.Calculation{{
+							Type:  tt.calculationType,
+							Value: "0",
+						}},
+					},
+					ReferenceAmount:  "originalAmount",
+					Priority:         1,
+					IsDeductibleFrom: &deductible,
+					CreditAccount:    "@fee-revenue",
+				}},
+			}
+
+			newTransaction := func() transaction.Transaction {
+				return transaction.Transaction{Send: transaction.Send{
+					Asset: "USD",
+					Value: decimal.NewFromInt(100),
+					Source: transaction.Source{From: []transaction.FromTo{{
+						AccountAlias: "@payer",
+						Amount:       &transaction.Amount{Asset: "USD", Value: decimal.NewFromInt(100)},
+						IsFrom:       true,
+					}}},
+					Distribute: transaction.Distribute{To: []transaction.FromTo{{
+						AccountAlias: "@receiver",
+						Amount:       &transaction.Amount{Asset: "USD", Value: decimal.NewFromInt(100)},
+					}}},
+				}}
+			}
+
+			t.Run("create", func(t *testing.T) {
+				ctrl := gomock.NewController(t)
+				repo := pack.NewMockRepository(ctrl)
+				repo.EXPECT().
+					FindByOrganizationIDAndLedgerID(gomock.Any(), organizationID, ledgerID).
+					Return([]*pack.Package{feePackage}, nil)
+
+				input := &model.FeeCalculate{LedgerID: ledgerID, Transaction: newTransaction()}
+				err := (&UseCase{packageRepo: repo, defaultCurrency: "USD"}).CalculateFee(context.Background(), input, organizationID)
+				require.NoError(t, err)
+				assertZeroFeeNoOp(t, input.Transaction.Send, input.Transaction.Metadata)
+			})
+
+			t.Run("estimate", func(t *testing.T) {
+				ctrl := gomock.NewController(t)
+				repo := pack.NewMockRepository(ctrl)
+				repo.EXPECT().
+					FindByID(gomock.Any(), packageID, organizationID, uuid.Nil).
+					Return(feePackage, nil)
+
+				input := &model.FeeEstimate{PackageID: packageID, LedgerID: ledgerID, Transaction: newTransaction()}
+				result, err := (&UseCase{packageRepo: repo, defaultCurrency: "USD"}).EstimateFeeCalculation(context.Background(), input, organizationID)
+				require.NoError(t, err)
+				require.NotNil(t, result)
+				assertZeroFeeNoOp(t, result.Transaction.Send, result.Transaction.Metadata)
+			})
+		})
+	}
+}
+
+func assertZeroFeeNoOp(t *testing.T, send transaction.Send, metadata map[string]any) {
+	t.Helper()
+
+	assert.True(t, decimal.NewFromInt(100).Equal(send.Value))
+	require.Len(t, send.Source.From, 1)
+	require.Len(t, send.Distribute.To, 1)
+	assert.Equal(t, "@payer", send.Source.From[0].AccountAlias)
+	assert.Equal(t, "@receiver", send.Distribute.To[0].AccountAlias)
+	assert.NotContains(t, metadata, "feeApplied")
+	assert.NotContains(t, metadata, "packageAppliedID")
+}

--- a/components/ledger/pkg/fee/calculate-fee.go
+++ b/components/ledger/pkg/fee/calculate-fee.go
@@ -130,6 +130,7 @@ func CalculateFee(logger libLog.Logger, f *model.FeeCalculate, p *pack.Package, 
 	}
 
 	directAliasesPtr := &directAliases
+	legRoutes := newFeeLegRoutes(resp)
 
 	for feeIndex, fee := range fees {
 		valueToCalculate := selectReferenceAmount(fee, f.Transaction.Send.Value, originalTransactionValue)
@@ -153,18 +154,49 @@ func CalculateFee(logger libLog.Logger, f *model.FeeCalculate, p *pack.Package, 
 			return err
 		}
 
+		if result.Value.IsZero() {
+			continue
+		}
+
 		// Fee total is emitted unrounded: the ledger is arbitrary-precision and
 		// every serialization seam round-trips full precision (P4-T23). The
 		// residual-to-max reconciliation in applyFeeCorrection holds sum(legs) ==
 		// fee total exactly without any asset-scale rounding.
 
-		if err := applyDeductibleAndReferenceAmountRules(logger, feeIndex, directAliasesPtr, segmentIDs, segCtx, fee, resp, result, f); err != nil {
+		if err := applyDeductibleAndReferenceAmountRules(logger, feeIndex, directAliasesPtr, segmentIDs, segCtx, fee, resp, result, f, legRoutes); err != nil {
 			return err
 		}
 	}
 
-	f.Transaction.Send.Source.From = updatedAmountsFromFee(resp.From)
-	f.Transaction.Send.Distribute.To = updatedAmountsFromFee(resp.To)
+	f.Transaction.Send.Source.From = updatedAmountsFromFee(resp.From, resp.OperationRoutesFrom)
+	f.Transaction.Send.Distribute.To = updatedAmountsFromFee(resp.To, resp.OperationRoutesTo)
+
+	return nil
+}
+
+// CalculateFeePreservingLegs applies the fee engine while retaining every authored transaction
+// leg. It is the strict ledger/estimate seam: unlike the lower-level CalculateFee helper, it
+// requires the resolved maps to contain every original leg and fails closed if identities drift.
+func CalculateFeePreservingLegs(logger libLog.Logger, f *model.FeeCalculate, p *pack.Package, resp *transaction.Responses, defaultCurrency string, segCtx *SegmentContext) error {
+	originalFrom := append([]transaction.FromTo(nil), f.Transaction.Send.Source.From...)
+	originalTo := append([]transaction.FromTo(nil), f.Transaction.Send.Distribute.To...)
+
+	if err := CalculateFee(logger, f, p, resp, defaultCurrency, segCtx); err != nil {
+		return err
+	}
+
+	materializedFrom, err := materializeAmountsAfterFee(originalFrom, resp.From, resp.OperationRoutesFrom)
+	if err != nil {
+		return err
+	}
+
+	materializedTo, err := materializeAmountsAfterFee(originalTo, resp.To, resp.OperationRoutesTo)
+	if err != nil {
+		return err
+	}
+
+	f.Transaction.Send.Source.From = materializedFrom
+	f.Transaction.Send.Distribute.To = materializedTo
 
 	return nil
 }

--- a/components/ledger/pkg/fee/calculate-fee_test.go
+++ b/components/ledger/pkg/fee/calculate-fee_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/assert"
 
+	"github.com/LerianStudio/midaz/v4/pkg"
 	"github.com/LerianStudio/midaz/v4/pkg/constant"
 	transaction "github.com/LerianStudio/midaz/v4/pkg/mtransaction"
 )
@@ -1546,6 +1547,11 @@ func TestIsAccountExemptOrSegment_DecoratedKeys(t *testing.T) {
 			expected: true,
 		},
 		{
+			name:     "position and balance qualified fee key is canonicalized",
+			account:  "0#@account1#reserved->fee0->routeX",
+			expected: true,
+		},
+		{
 			name:     "fee_source-decorated key is canonicalized",
 			account:  "@creditAccount->fee_source0->@account1->routeY",
 			expected: true,
@@ -1574,6 +1580,89 @@ func TestIsAccountExemptOrSegment_DecoratedKeys(t *testing.T) {
 			assert.Equal(t, tt.expected, result)
 		})
 	}
+}
+
+func TestCalculateFeePreservingLegs_DuplicateAliasWaiverUsesAuthoredAlias(t *testing.T) {
+	t.Parallel()
+
+	logger, _ := libZap.New(libZap.Config{Environment: libZap.EnvironmentLocal, OTelLibraryName: "test"})
+	deductible := false
+	feeCalc := &model.FeeCalculate{Transaction: transaction.Transaction{Send: transaction.Send{
+		Asset: "USD",
+		Value: decimal.NewFromInt(100),
+		Source: transaction.Source{From: []transaction.FromTo{
+			{AccountAlias: "@payer", BalanceKey: "reserved", Amount: &transaction.Amount{Asset: "USD", Value: decimal.NewFromInt(60)}},
+			{AccountAlias: "@payer", BalanceKey: "available", Remaining: "remaining"},
+		}},
+		Distribute: transaction.Distribute{To: []transaction.FromTo{{
+			AccountAlias: "@receiver",
+			Amount:       &transaction.Amount{Asset: "USD", Value: decimal.NewFromInt(100)},
+		}}},
+	}}}
+	feePackage := &pack.Package{
+		Fees: map[string]model.Fee{"flat": {
+			CalculationModel: &model.CalculationModel{
+				ApplicationRule: feeconstant.AppRuleFlatFee,
+				Calculations:    []model.Calculation{{Type: feeconstant.FeeTypeFlat, Value: "10"}},
+			},
+			ReferenceAmount:  "originalAmount",
+			Priority:         1,
+			IsDeductibleFrom: &deductible,
+			CreditAccount:    "@fee_account",
+		}},
+		WaivedAccounts: &[]string{"@payer"},
+	}
+	resp := &transaction.Responses{
+		From: map[string]transaction.Amount{
+			"0#@payer#reserved":  {Asset: "USD", Value: decimal.NewFromInt(60)},
+			"1#@payer#available": {Asset: "USD", Value: decimal.NewFromInt(40)},
+		},
+		To: map[string]transaction.Amount{
+			"@receiver": {Asset: "USD", Value: decimal.NewFromInt(100)},
+		},
+	}
+
+	err := CalculateFeePreservingLegs(logger, feeCalc, feePackage, resp, "USD", nil)
+	assert.NoError(t, err)
+	assert.True(t, decimal.NewFromInt(100).Equal(feeCalc.Transaction.Send.Value), "an authored-alias waiver must suppress the fee")
+	assert.Len(t, feeCalc.Transaction.Send.Source.From, 2)
+	assert.Len(t, feeCalc.Transaction.Send.Distribute.To, 1)
+	assert.Empty(t, feeCalc.Transaction.Send.Source.From[1].Remaining)
+	if assert.NotNil(t, feeCalc.Transaction.Send.Source.From[1].Amount) {
+		assert.True(t, decimal.NewFromInt(40).Equal(feeCalc.Transaction.Send.Source.From[1].Amount.Value))
+	}
+}
+
+func TestCalculateFeePreservingLegs_FailsClosedWhenDuplicateIdentityWasCollapsed(t *testing.T) {
+	t.Parallel()
+
+	logger, _ := libZap.New(libZap.Config{Environment: libZap.EnvironmentLocal, OTelLibraryName: "test"})
+	feeCalc := &model.FeeCalculate{Transaction: transaction.Transaction{Send: transaction.Send{
+		Asset: "USD",
+		Value: decimal.NewFromInt(100),
+		Source: transaction.Source{From: []transaction.FromTo{
+			{AccountAlias: "@payer", Amount: &transaction.Amount{Asset: "USD", Value: decimal.NewFromInt(60)}},
+			{AccountAlias: "@payer", Remaining: "remaining"},
+		}},
+		Distribute: transaction.Distribute{To: []transaction.FromTo{{
+			AccountAlias: "@receiver",
+			Amount:       &transaction.Amount{Asset: "USD", Value: decimal.NewFromInt(100)},
+		}}},
+	}}}
+	resp := &transaction.Responses{
+		From: map[string]transaction.Amount{
+			"@payer": {Asset: "USD", Value: decimal.NewFromInt(40)},
+		},
+		To: map[string]transaction.Amount{
+			"@receiver": {Asset: "USD", Value: decimal.NewFromInt(100)},
+		},
+	}
+
+	err := CalculateFeePreservingLegs(logger, feeCalc, &pack.Package{}, resp, "USD", nil)
+	assert.Error(t, err)
+	internalErr, ok := err.(pkg.InternalServerError)
+	assert.True(t, ok)
+	assert.Equal(t, constant.ErrCalculateFee.Error(), internalErr.Code)
 }
 
 func TestIsAccountExemptOrSegment_ErrorOnMissingSegmentContext(t *testing.T) {
@@ -1725,7 +1814,7 @@ func TestUpdatedAmountsFromFee(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := updatedAmountsFromFee(tt.amounts)
+			result := updatedAmountsFromFee(tt.amounts, nil)
 			assert.Len(t, result, tt.expected)
 
 			if tt.expected > 0 {

--- a/components/ledger/pkg/fee/distribute.go
+++ b/components/ledger/pkg/fee/distribute.go
@@ -5,6 +5,7 @@
 package fee
 
 import (
+	"sort"
 	"strconv"
 	"strings"
 
@@ -20,6 +21,34 @@ import (
 	transaction "github.com/LerianStudio/midaz/v4/pkg/mtransaction"
 )
 
+type feeLegRoutes struct {
+	from map[string]string
+	to   map[string]string
+}
+
+func newFeeLegRoutes(resp *transaction.Responses) *feeLegRoutes {
+	if resp.OperationRoutesFrom == nil {
+		resp.OperationRoutesFrom = make(map[string]string)
+	}
+
+	if resp.OperationRoutesTo == nil {
+		resp.OperationRoutesTo = make(map[string]string)
+	}
+
+	return &feeLegRoutes{
+		from: resp.OperationRoutesFrom,
+		to:   resp.OperationRoutesTo,
+	}
+}
+
+func registerFeeLegRoute(routes map[string]string, key string, routeID *string) {
+	if routeID == nil || *routeID == "" {
+		return
+	}
+
+	routes[key] = *routeID
+}
+
 // applyDeductibleAndReferenceAmountRules applies the deductible and reference amount rules for a fee.
 // When segmentIDs is non-empty and segCtx is non-nil, segment-based exemption is used instead of exact alias matching.
 //
@@ -28,7 +57,7 @@ import (
 // the deductible fee is skipped entirely — the transaction initiator's exemption status determines
 // whether the fee is triggered.
 func applyDeductibleAndReferenceAmountRules(_ libLog.Logger, feeIndex int, waivedAccounts *[]string, segmentIDs []uuid.UUID, segCtx *SegmentContext, feeModel model.Fee,
-	resp *transaction.Responses, result transaction.Amount, f *model.FeeCalculate,
+	resp *transaction.Responses, result transaction.Amount, f *model.FeeCalculate, routes *feeLegRoutes,
 ) error {
 	originalRespToSize := len(resp.To)
 
@@ -59,7 +88,7 @@ func applyDeductibleAndReferenceAmountRules(_ libLog.Logger, feeIndex int, waive
 
 		var errFee error
 
-		resp.From, resp.To, errFee = applyProportionalFee(feeModel, feeIndex, &resp.From, resp.To, result, waivedAccounts, segmentIDs, segCtx, false)
+		resp.From, resp.To, errFee = applyProportionalFee(feeModel, feeIndex, &resp.From, resp.To, result, waivedAccounts, segmentIDs, segCtx, false, routes)
 		if errFee != nil {
 			return errFee
 		}
@@ -94,7 +123,7 @@ func applyDeductibleAndReferenceAmountRules(_ libLog.Logger, feeIndex int, waive
 
 		var errFee error
 
-		resp.To, _, errFee = applyProportionalFee(feeModel, feeIndex, &resp.To, nil, result, waivedAccounts, segmentIDs, segCtx, true)
+		resp.To, _, errFee = applyProportionalFee(feeModel, feeIndex, &resp.To, nil, result, waivedAccounts, segmentIDs, segCtx, true, routes)
 		if errFee != nil {
 			return errFee
 		}
@@ -155,7 +184,7 @@ func setFeeExemptionMetadata(f *model.FeeCalculate, reason string) {
 }
 
 // updatedAmountsFromFee updates the amounts from the fee
-func updatedAmountsFromFee(amounts map[string]transaction.Amount) []transaction.FromTo {
+func updatedAmountsFromFee(amounts map[string]transaction.Amount, operationRoutes map[string]string) []transaction.FromTo {
 	newFromTo := make([]transaction.FromTo, 0, len(amounts))
 
 	for account, amount := range amounts {
@@ -176,6 +205,7 @@ func updatedAmountsFromFee(amounts map[string]transaction.Amount) []transaction.
 		fromTo := transaction.FromTo{
 			AccountAlias: cleanAccount,
 			Amount:       &transaction.Amount{Asset: amount.Asset, Value: amount.Value},
+			EconomicRole: "FEE",
 		}
 		if len(metadata) > 0 {
 			fromTo.Metadata = metadata
@@ -185,10 +215,141 @@ func updatedAmountsFromFee(amounts map[string]transaction.Amount) []transaction.
 			fromTo.Route = route //nolint:staticcheck // legacy field kept for backward compatibility; RouteID is canonical
 		}
 
+		if routeID, ok := operationRoutes[account]; ok && routeID != "" {
+			fromTo.RouteID = &routeID
+		}
+
 		newFromTo = append(newFromTo, fromTo)
 	}
 
 	return newFromTo
+}
+
+// materializeAmountsAfterFee keeps authored legs stable while replacing their value expression
+// with the resolved amount used by the fee engine. Map-only fee calculations need a synthetic,
+// position-qualified key to distinguish duplicate aliases; that key never escapes into the
+// transaction payload. Fee-created legs are appended afterwards using the existing conversion
+// rules, with any embedded synthetic payer identity restored to its authored alias.
+func materializeAmountsAfterFee(original []transaction.FromTo, amounts map[string]transaction.Amount, operationRoutes map[string]string) ([]transaction.FromTo, error) {
+	materialized := make([]transaction.FromTo, 0, len(amounts))
+	consumed := make(map[string]struct{}, len(original))
+
+	for i, leg := range original {
+		key := originalAmountKey(i, leg, amounts, consumed)
+
+		amount, ok := amounts[key]
+		if !ok {
+			return nil, pkg.ValidateBusinessError(constant.ErrCalculateFee, "")
+		}
+
+		resolved := leg
+		resolved.Amount = &transaction.Amount{Asset: amount.Asset, Value: amount.Value}
+		resolved.Share = nil
+		resolved.Remaining = ""
+
+		materialized = append(materialized, resolved)
+		consumed[key] = struct{}{}
+	}
+
+	feeKeys := make([]string, 0, len(amounts)-len(consumed))
+	for key := range amounts {
+		if _, isOriginal := consumed[key]; !isOriginal {
+			feeKeys = append(feeKeys, key)
+		}
+	}
+
+	sort.Slice(feeKeys, func(i, j int) bool {
+		leftIndex, leftOK := syntheticFeeIndex(feeKeys[i])
+		rightIndex, rightOK := syntheticFeeIndex(feeKeys[j])
+
+		if leftOK && rightOK && leftIndex != rightIndex {
+			return leftIndex < rightIndex
+		}
+
+		if leftOK != rightOK {
+			return leftOK
+		}
+
+		return feeKeys[i] < feeKeys[j]
+	})
+
+	for _, key := range feeKeys {
+		feeLegs := updatedAmountsFromFee(map[string]transaction.Amount{key: amounts[key]}, operationRoutes)
+		if len(feeLegs) != 1 {
+			continue
+		}
+
+		feeLeg := feeLegs[0]
+		feeLeg.AccountAlias = transaction.FromTo{AccountAlias: feeLeg.AccountAlias}.SplitAlias()
+
+		if source, ok := feeLeg.Metadata["source"].(string); ok {
+			feeLeg.Metadata["source"] = transaction.FromTo{AccountAlias: source}.SplitAlias()
+		}
+
+		materialized = append(materialized, feeLeg)
+	}
+
+	return materialized, nil
+}
+
+func syntheticFeeIndex(key string) (int, bool) {
+	parts := strings.Split(key, "->")
+	if len(parts) < 3 {
+		return 0, false
+	}
+
+	segment := parts[1]
+
+	var numericSuffix string
+
+	switch {
+	case strings.HasPrefix(segment, "fee_source"):
+		numericSuffix = strings.TrimPrefix(segment, "fee_source")
+	case strings.HasPrefix(segment, "fee"):
+		numericSuffix = strings.TrimPrefix(segment, "fee")
+	default:
+		return 0, false
+	}
+
+	if numericSuffix == "" {
+		return 0, false
+	}
+
+	for i := range numericSuffix {
+		if numericSuffix[i] < '0' || numericSuffix[i] > '9' {
+			return 0, false
+		}
+	}
+
+	index, err := strconv.Atoi(numericSuffix)
+
+	return index, err == nil
+}
+
+func originalAmountKey(index int, leg transaction.FromTo, amounts map[string]transaction.Amount, consumed map[string]struct{}) string {
+	if _, ok := amounts[leg.AccountAlias]; ok {
+		if _, alreadyConsumed := consumed[leg.AccountAlias]; !alreadyConsumed {
+			return leg.AccountAlias
+		}
+	}
+
+	internal := leg
+	if internal.BalanceKey == "" {
+		internal.BalanceKey = constant.DefaultBalanceKey
+	}
+
+	key := internal.ConcatAlias(index)
+	if _, ok := amounts[key]; ok {
+		if _, alreadyConsumed := consumed[key]; !alreadyConsumed {
+			return key
+		}
+	}
+
+	if leg.AccountAlias == "" {
+		return leg.AccountAlias
+	}
+
+	return key
 }
 
 // trimFeeSuffix trims the fee suffix
@@ -275,6 +436,7 @@ func calculateProportionalFees(
 	isToStruct bool,
 	maxAccount string,
 	target *feeCorrectionTarget,
+	routes *feeLegRoutes,
 ) (map[string]transaction.Amount, map[string]transaction.Amount, decimal.Decimal, error) {
 	updateAmount := make(map[string]transaction.Amount)
 	updateAmountToStruct := amountsToStruct
@@ -342,9 +504,9 @@ func calculateProportionalFees(
 						pkg.ValidateBusinessError(constant.ErrDeductibleFeeExceedsAmount, "")
 				}
 
-				amount = emitDeductibleLeg(feeModel, feeIndex, key, amount, resultAmount, exemptAccounts, updateAmount, maxAccount, target)
+				amount = emitDeductibleLeg(feeModel, feeIndex, key, amount, resultAmount, exemptAccounts, updateAmount, maxAccount, target, routes)
 			} else {
-				updateAmountToStruct = emitNonDeductibleLeg(feeModel, feeIndex, key, resultAmount, exemptAccounts, updateAmount, updateAmountToStruct, maxAccount, target)
+				updateAmountToStruct = emitNonDeductibleLeg(feeModel, feeIndex, key, resultAmount, exemptAccounts, updateAmount, updateAmountToStruct, maxAccount, target, routes)
 			}
 
 			newFeeTotalPaying = newFeeTotalPaying.Add(feeApplied)
@@ -369,9 +531,12 @@ func emitDeductibleLeg(
 	updateAmount map[string]transaction.Amount,
 	maxAccount string,
 	target *feeCorrectionTarget,
+	routes *feeLegRoutes,
 ) transaction.Amount {
 	legKey := feeModel.CreditAccount + "->fee_source" + strconv.Itoa(feeIndex) + "->" + key + "->" + feeModel.GetRouteTo()
 	updateAmount[legKey] = resultAmount
+	registerFeeLegRoute(routes.to, legKey, feeModel.OperationRouteToID)
+
 	amount.Value = amount.Value.Sub(resultAmount.Value)
 
 	*exemptAccounts = append(*exemptAccounts, legKey)
@@ -398,18 +563,21 @@ func emitNonDeductibleLeg(
 	updateAmount, updateAmountToStruct map[string]transaction.Amount,
 	maxAccount string,
 	target *feeCorrectionTarget,
+	routes *feeLegRoutes,
 ) map[string]transaction.Amount {
 	feeKey := key + "->fee" + strconv.Itoa(feeIndex)
 	debitLegKey := feeKey + "->" + feeModel.GetRouteFrom()
 	feeSourceKey := feeModel.CreditAccount + "->fee_source" + strconv.Itoa(feeIndex) + "->" + key + "->" + feeModel.GetRouteTo()
 
 	updateAmount[debitLegKey] = resultAmount
+	registerFeeLegRoute(routes.from, debitLegKey, feeModel.OperationRouteFromID)
 
 	if updateAmountToStruct == nil {
 		updateAmountToStruct = make(map[string]transaction.Amount)
 	}
 
 	updateAmountToStruct[feeSourceKey] = resultAmount
+	registerFeeLegRoute(routes.to, feeSourceKey, feeModel.OperationRouteToID)
 
 	*exemptAccounts = append(*exemptAccounts, feeSourceKey)
 	*exemptAccounts = append(*exemptAccounts, debitLegKey)
@@ -508,7 +676,7 @@ func applyFeeCorrection(
 // applyProportionalFee applies the proportional fee
 func applyProportionalFee(feeModel model.Fee, feeIndex int, amounts *map[string]transaction.Amount,
 	amountsToStruct map[string]transaction.Amount, feeValue transaction.Amount, exemptAccounts *[]string,
-	segmentIDs []uuid.UUID, segCtx *SegmentContext, isToStruct bool,
+	segmentIDs []uuid.UUID, segCtx *SegmentContext, isToStruct bool, routes *feeLegRoutes,
 ) (map[string]transaction.Amount, map[string]transaction.Amount, error) {
 	maxAccount, err := findMaxAccount(*amounts, exemptAccounts, segmentIDs, segCtx)
 	if err != nil {
@@ -518,7 +686,7 @@ func applyProportionalFee(feeModel model.Fee, feeIndex int, amounts *map[string]
 	var target feeCorrectionTarget
 
 	updateAmount, updateAmountToStruct, newFeeTotalPaying, err := calculateProportionalFees(
-		feeModel, feeIndex, amounts, amountsToStruct, feeValue, exemptAccounts, segmentIDs, segCtx, isToStruct, maxAccount, &target,
+		feeModel, feeIndex, amounts, amountsToStruct, feeValue, exemptAccounts, segmentIDs, segCtx, isToStruct, maxAccount, &target, routes,
 	)
 	if err != nil {
 		return *amounts, amountsToStruct, err
@@ -573,7 +741,7 @@ func isAccountExempt(account string, exemptAccounts *[]string) bool {
 // silently charging accounts that should be exempt via segment waivers.
 // When segmentIDs is empty, it falls back to exact alias matching only.
 func isAccountExemptOrSegment(account string, exemptAccounts *[]string, segmentIDs []uuid.UUID, segCtx *SegmentContext) (bool, error) {
-	account = trimFeeSuffix(account)
+	account = transaction.FromTo{AccountAlias: trimFeeSuffix(account)}.SplitAlias()
 
 	if len(segmentIDs) > 0 {
 		if segCtx == nil || segCtx.Resolver == nil {

--- a/components/ledger/pkg/fee/remaining_review_regressions_test.go
+++ b/components/ledger/pkg/fee/remaining_review_regressions_test.go
@@ -1,0 +1,260 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package fee
+
+import (
+	"context"
+	"testing"
+
+	constant "github.com/LerianStudio/lib-commons/v6/commons/constants"
+	libZap "github.com/LerianStudio/lib-observability/v2/zap"
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/LerianStudio/midaz/v4/components/ledger/internal/adapters/mongodb/fees/pack"
+	feeconstant "github.com/LerianStudio/midaz/v4/components/ledger/pkg/feeshared/constant"
+	"github.com/LerianStudio/midaz/v4/components/ledger/pkg/feeshared/model"
+	transaction "github.com/LerianStudio/midaz/v4/pkg/mtransaction"
+)
+
+func TestUpdatedAmountsFromFee_UUIDLookingLegacyRouteIsNeverPromoted(t *testing.T) {
+	t.Parallel()
+
+	uuidRoute := uuid.NewString()
+	tests := []struct {
+		name     string
+		key      string
+		expected string
+	}{
+		{
+			name:     "fee debit UUID-looking legacy route",
+			key:      "@payer->fee2->" + uuidRoute,
+			expected: uuidRoute,
+		},
+		{
+			name:     "fee credit UUID-looking legacy route",
+			key:      "@fee-revenue->fee_source2->@payer->" + uuidRoute,
+			expected: uuidRoute,
+		},
+		{
+			name:     "legacy non UUID route",
+			key:      "@payer->fee2->legacy-route",
+			expected: "legacy-route",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			legs := updatedAmountsFromFee(map[string]transaction.Amount{
+				tt.key: {Asset: "USD", Value: decimal.NewFromInt(1)},
+			}, nil)
+			require.Len(t, legs, 1)
+			assert.Equal(t, tt.expected, legs[0].Route)
+			assert.Nil(t, legs[0].RouteID)
+		})
+	}
+}
+
+func TestCalculateFeePreservingLegs_ExplicitOperationRoutesReachPostFeeValidation(t *testing.T) {
+	t.Parallel()
+
+	logger, _ := libZap.New(libZap.Config{Environment: libZap.EnvironmentLocal, OTelLibraryName: "test"})
+	legacyFrom := uuid.NewString()
+	legacyTo := uuid.NewString()
+	operationFrom := uuid.NewString()
+	operationTo := uuid.NewString()
+	deductible := false
+	feeCalc := &model.FeeCalculate{Transaction: transaction.Transaction{Send: transaction.Send{
+		Asset: "USD",
+		Value: decimal.NewFromInt(100),
+		Source: transaction.Source{From: []transaction.FromTo{{
+			AccountAlias: "@payer",
+			Amount:       &transaction.Amount{Asset: "USD", Value: decimal.NewFromInt(100)},
+			IsFrom:       true,
+		}}},
+		Distribute: transaction.Distribute{To: []transaction.FromTo{{
+			AccountAlias: "@receiver",
+			Amount:       &transaction.Amount{Asset: "USD", Value: decimal.NewFromInt(100)},
+		}}},
+	}}}
+	feePackage := &pack.Package{
+		Fees: map[string]model.Fee{"routed": {
+			CalculationModel: &model.CalculationModel{
+				ApplicationRule: feeconstant.AppRuleFlatFee,
+				Calculations:    []model.Calculation{{Type: feeconstant.FeeTypeFlat, Value: "1"}},
+			},
+			ReferenceAmount:      feeconstant.ReferenceAmountOriginalAmount,
+			Priority:             1,
+			IsDeductibleFrom:     &deductible,
+			CreditAccount:        "@fee-revenue",
+			RouteFrom:            &legacyFrom,
+			RouteTo:              &legacyTo,
+			OperationRouteFromID: &operationFrom,
+			OperationRouteToID:   &operationTo,
+		}},
+		WaivedAccounts: &[]string{},
+	}
+	response := &transaction.Responses{
+		From: map[string]transaction.Amount{"@payer": {Asset: "USD", Value: decimal.NewFromInt(100)}},
+		To:   map[string]transaction.Amount{"@receiver": {Asset: "USD", Value: decimal.NewFromInt(100)}},
+	}
+
+	err := CalculateFeePreservingLegs(logger, feeCalc, feePackage, response, "USD", nil)
+	require.NoError(t, err)
+	require.Len(t, feeCalc.Transaction.Send.Source.From, 2)
+	require.Len(t, feeCalc.Transaction.Send.Distribute.To, 2)
+	assert.Equal(t, legacyFrom, feeCalc.Transaction.Send.Source.From[1].Route)
+	require.NotNil(t, feeCalc.Transaction.Send.Source.From[1].RouteID)
+	assert.Equal(t, operationFrom, *feeCalc.Transaction.Send.Source.From[1].RouteID)
+	assert.Equal(t, legacyTo, feeCalc.Transaction.Send.Distribute.To[1].Route)
+	require.NotNil(t, feeCalc.Transaction.Send.Distribute.To[1].RouteID)
+	assert.Equal(t, operationTo, *feeCalc.Transaction.Send.Distribute.To[1].RouteID)
+
+	for i := range feeCalc.Transaction.Send.Source.From {
+		feeCalc.Transaction.Send.Source.From[i].IsFrom = true
+	}
+	transaction.ApplyDefaultBalanceKeys(feeCalc.Transaction.Send.Source.From)
+	transaction.ApplyDefaultBalanceKeys(feeCalc.Transaction.Send.Distribute.To)
+	transaction.MutateConcatAliases(feeCalc.Transaction.Send.Source.From)
+	transaction.MutateConcatAliases(feeCalc.Transaction.Send.Distribute.To)
+
+	validation, err := transaction.ValidateSendSourceAndDistribute(context.Background(), feeCalc.Transaction, constant.CREATED)
+	require.NoError(t, err)
+	assert.Equal(t, operationFrom, validation.OperationRoutesFrom[feeCalc.Transaction.Send.Source.From[1].AccountAlias])
+	assert.Equal(t, operationTo, validation.OperationRoutesTo[feeCalc.Transaction.Send.Distribute.To[1].AccountAlias])
+}
+
+func TestCalculateFeePreservingLegs_ExplicitOperationRoutesSurviveMultipleAndDeductibleFees(t *testing.T) {
+	t.Parallel()
+
+	logger, _ := libZap.New(libZap.Config{Environment: libZap.EnvironmentLocal, OTelLibraryName: "test"})
+	deductible := true
+	nonDeductible := false
+	deductibleTo := uuid.NewString()
+	nonDeductibleFrom := uuid.NewString()
+	nonDeductibleTo := uuid.NewString()
+	deductibleLabel := "deductible-credit"
+	nonDeductibleFromLabel := "non-deductible-debit"
+	nonDeductibleToLabel := "non-deductible-credit"
+
+	feeCalc := &model.FeeCalculate{Transaction: transaction.Transaction{Send: transaction.Send{
+		Asset: "USD",
+		Value: decimal.NewFromInt(100),
+		Source: transaction.Source{From: []transaction.FromTo{{
+			AccountAlias: "@payer",
+			Amount:       &transaction.Amount{Asset: "USD", Value: decimal.NewFromInt(100)},
+			IsFrom:       true,
+		}}},
+		Distribute: transaction.Distribute{To: []transaction.FromTo{{
+			AccountAlias: "@receiver",
+			Amount:       &transaction.Amount{Asset: "USD", Value: decimal.NewFromInt(100)},
+		}}},
+	}}}
+	feePackage := &pack.Package{
+		Fees: map[string]model.Fee{
+			"deductible": {
+				CalculationModel: &model.CalculationModel{
+					ApplicationRule: feeconstant.AppRuleFlatFee,
+					Calculations:    []model.Calculation{{Type: feeconstant.FeeTypeFlat, Value: "10"}},
+				},
+				ReferenceAmount:    feeconstant.ReferenceAmountOriginalAmount,
+				Priority:           1,
+				IsDeductibleFrom:   &deductible,
+				CreditAccount:      "@fee-deductible",
+				RouteTo:            &deductibleLabel,
+				OperationRouteToID: &deductibleTo,
+			},
+			"non-deductible": {
+				CalculationModel: &model.CalculationModel{
+					ApplicationRule: feeconstant.AppRuleFlatFee,
+					Calculations:    []model.Calculation{{Type: feeconstant.FeeTypeFlat, Value: "5"}},
+				},
+				ReferenceAmount:      feeconstant.ReferenceAmountOriginalAmount,
+				Priority:             2,
+				IsDeductibleFrom:     &nonDeductible,
+				CreditAccount:        "@fee-non-deductible",
+				RouteFrom:            &nonDeductibleFromLabel,
+				RouteTo:              &nonDeductibleToLabel,
+				OperationRouteFromID: &nonDeductibleFrom,
+				OperationRouteToID:   &nonDeductibleTo,
+			},
+		},
+		WaivedAccounts: &[]string{},
+	}
+	response := &transaction.Responses{
+		From: map[string]transaction.Amount{"@payer": {Asset: "USD", Value: decimal.NewFromInt(100)}},
+		To:   map[string]transaction.Amount{"@receiver": {Asset: "USD", Value: decimal.NewFromInt(100)}},
+	}
+
+	require.NoError(t, CalculateFeePreservingLegs(logger, feeCalc, feePackage, response, "USD", nil))
+	assert.True(t, decimal.NewFromInt(105).Equal(feeCalc.Transaction.Send.Value))
+	require.Len(t, feeCalc.Transaction.Send.Source.From, 2)
+	require.Len(t, feeCalc.Transaction.Send.Distribute.To, 3)
+
+	nonDeductibleDebit := feeCalc.Transaction.Send.Source.From[1]
+	assert.Equal(t, nonDeductibleFromLabel, nonDeductibleDebit.Route)
+	require.NotNil(t, nonDeductibleDebit.RouteID)
+	assert.Equal(t, nonDeductibleFrom, *nonDeductibleDebit.RouteID)
+
+	deductibleCredit := feeCalc.Transaction.Send.Distribute.To[1]
+	assert.Equal(t, "@fee-deductible", deductibleCredit.AccountAlias)
+	assert.Equal(t, deductibleLabel, deductibleCredit.Route)
+	require.NotNil(t, deductibleCredit.RouteID)
+	assert.Equal(t, deductibleTo, *deductibleCredit.RouteID)
+
+	nonDeductibleCredit := feeCalc.Transaction.Send.Distribute.To[2]
+	assert.Equal(t, "@fee-non-deductible", nonDeductibleCredit.AccountAlias)
+	assert.Equal(t, nonDeductibleToLabel, nonDeductibleCredit.Route)
+	require.NotNil(t, nonDeductibleCredit.RouteID)
+	assert.Equal(t, nonDeductibleTo, *nonDeductibleCredit.RouteID)
+}
+
+func TestMaterializeAmountsAfterFee_OrdersSyntheticLegsByNumericFeeIndex(t *testing.T) {
+	t.Parallel()
+
+	original := []transaction.FromTo{{
+		AccountAlias: "@payer",
+		Amount:       &transaction.Amount{Asset: "USD", Value: decimal.NewFromInt(100)},
+	}}
+	amounts := map[string]transaction.Amount{
+		"@payer":                       {Asset: "USD", Value: decimal.NewFromInt(100)},
+		"@payer->fee10->route-fee-ten": {Asset: "USD", Value: decimal.NewFromInt(10)},
+		"@payer->fee2->route-fee-two":  {Asset: "USD", Value: decimal.NewFromInt(2)},
+	}
+
+	legs, err := materializeAmountsAfterFee(original, amounts, nil)
+	require.NoError(t, err)
+	require.Len(t, legs, 3)
+	assert.Equal(t, "route-fee-two", legs[1].Route)
+	assert.Equal(t, decimal.NewFromInt(2), legs[1].Amount.Value)
+	assert.Equal(t, "route-fee-ten", legs[2].Route)
+	assert.Equal(t, decimal.NewFromInt(10), legs[2].Amount.Value)
+}
+
+func TestMaterializeAmountsAfterFee_RouteLabelCannotOverrideStructuralFeeIndex(t *testing.T) {
+	t.Parallel()
+
+	original := []transaction.FromTo{{
+		AccountAlias: "@payer",
+		Amount:       &transaction.Amount{Asset: "USD", Value: decimal.NewFromInt(100)},
+	}}
+	amounts := map[string]transaction.Amount{
+		"@payer":                        {Asset: "USD", Value: decimal.NewFromInt(100)},
+		"@payer->fee2->fee_source10":    {Asset: "USD", Value: decimal.NewFromInt(2)},
+		"@payer->fee3->route-fee-three": {Asset: "USD", Value: decimal.NewFromInt(3)},
+	}
+
+	legs, err := materializeAmountsAfterFee(original, amounts, nil)
+	require.NoError(t, err)
+	require.Len(t, legs, 3)
+	assert.Equal(t, "fee_source10", legs[1].Route)
+	assert.Equal(t, decimal.NewFromInt(2), legs[1].Amount.Value)
+	assert.Equal(t, "route-fee-three", legs[2].Route)
+	assert.Equal(t, decimal.NewFromInt(3), legs[2].Amount.Value)
+}

--- a/components/ledger/pkg/fee/segment-resolution_test.go
+++ b/components/ledger/pkg/fee/segment-resolution_test.go
@@ -591,6 +591,38 @@ func TestIsAccountExemptWithSegments_AccountHasNilSegmentID(t *testing.T) {
 	}
 }
 
+func TestIsAccountExemptOrSegment_CompositeKeyUsesAuthoredAlias(t *testing.T) {
+	t.Parallel()
+
+	waivedSegment := segmentUUID("550e8400-e29b-41d4-a716-446655440001")
+	resolver := &mockSegmentResolver{
+		getAccountFn: func(_ context.Context, _, _ uuid.UUID, alias string) (*feeshared.Account, error) {
+			assert.Equal(t, "@payer", alias)
+
+			return &feeshared.Account{Alias: alias, SegmentID: &waivedSegment}, nil
+		},
+	}
+	aliases := []string{}
+	segCtx := &SegmentContext{
+		Ctx:            context.Background(),
+		Resolver:       resolver,
+		OrganizationID: testOrgID,
+		LedgerID:       testLedgerID,
+		ResolverCache:  make(map[string]*feeshared.Account),
+	}
+
+	exempt, err := isAccountExemptOrSegment(
+		"0#@payer#reserved->fee0->routeX",
+		&aliases,
+		[]uuid.UUID{waivedSegment},
+		segCtx,
+	)
+
+	assert.NoError(t, err)
+	assert.True(t, exempt)
+	assert.Equal(t, 1, resolver.callCount)
+}
+
 func TestIsAccountExemptWithSegments_ExternalAccount(t *testing.T) {
 	t.Parallel()
 

--- a/components/ledger/pkg/feeshared/model/create_package_input.go
+++ b/components/ledger/pkg/feeshared/model/create_package_input.go
@@ -36,6 +36,10 @@ func (cp *CreatePackageInput) GetTransactionRoute() string {
 // ValidateFees Validating the Fee map values
 func (cp *CreatePackageInput) ValidateFees() error {
 	for key, fee := range cp.Fee {
+		if err := fee.validateOperationRouteIDs(key); err != nil {
+			return err
+		}
+
 		if fee.Priority == 1 && fee.ReferenceAmount != OriginalAmount {
 			return pkg.ValidateBusinessError(constant.ErrPriorityOne, "", key)
 		}

--- a/components/ledger/pkg/feeshared/model/fee_operation_route_ids_test.go
+++ b/components/ledger/pkg/feeshared/model/fee_operation_route_ids_test.go
@@ -1,0 +1,93 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package model
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mongodb.org/mongo-driver/v2/bson"
+)
+
+func TestFeeOperationRouteIDsUpdateAndJSONContract(t *testing.T) {
+	t.Parallel()
+
+	fromID := uuid.NewString()
+	toID := uuid.NewString()
+	fee := &Fee{
+		OperationRouteFromID: &fromID,
+		OperationRouteToID:   &toID,
+	}
+	fields := bson.M{}
+	unsetFields := bson.M{}
+
+	assert.True(t, fee.updateOperationRouteFromID("service", fields, unsetFields))
+	assert.True(t, fee.updateOperationRouteToID("service", fields, unsetFields))
+	assert.Equal(t, &fromID, fields["fees.service.operation_route_from_id"])
+	assert.Equal(t, &toID, fields["fees.service.operation_route_to_id"])
+	assert.Empty(t, unsetFields)
+	assert.False(t, fee.ValidateIfFeeIsNil(), "an operation-route-only patch must not be mistaken for fee removal")
+
+	raw, err := json.Marshal(fee)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"feeLabel":"","calculationModel":null,"referenceAmount":"","isDeductibleFrom":null,"creditAccount":"","operationRouteFromId":"`+fromID+`","operationRouteToId":"`+toID+`"}`, string(raw))
+}
+
+func TestFeeOperationRouteIDPatchDistinguishesOmittedNullAndValue(t *testing.T) {
+	t.Parallel()
+
+	validID := uuid.NewString()
+	tests := []struct {
+		name        string
+		raw         string
+		wantRemoval bool
+		wantRouteID *string
+		wantNull    bool
+	}{
+		{
+			name:        "omitted preserves the existing field and empty fee means removal",
+			raw:         `{}`,
+			wantRemoval: true,
+		},
+		{
+			name:        "null clears only the field",
+			raw:         `{"operationRouteFromId":null}`,
+			wantRemoval: false,
+			wantNull:    true,
+		},
+		{
+			name:        "string updates the field",
+			raw:         `{"operationRouteFromId":"` + validID + `"}`,
+			wantRemoval: false,
+			wantRouteID: &validID,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var fee Fee
+			require.NoError(t, json.Unmarshal([]byte(tt.raw), &fee))
+			assert.Equal(t, tt.wantRemoval, fee.ValidateIfFeeIsNil())
+			assert.Equal(t, tt.wantRouteID, fee.OperationRouteFromID)
+
+			marshaled, err := json.Marshal(fee)
+			require.NoError(t, err)
+			var fields map[string]any
+			require.NoError(t, json.Unmarshal(marshaled, &fields))
+			if tt.wantNull {
+				value, exists := fields["operationRouteFromId"]
+				assert.True(t, exists)
+				assert.Nil(t, value)
+			} else if tt.wantRouteID == nil {
+				assert.NotContains(t, fields, "operationRouteFromId")
+			}
+		})
+	}
+}

--- a/components/ledger/pkg/feeshared/model/package.go
+++ b/components/ledger/pkg/feeshared/model/package.go
@@ -5,12 +5,14 @@
 package model
 
 import (
+	"encoding/json"
 	"fmt"
 
 	feeconstant "github.com/LerianStudio/midaz/v4/components/ledger/pkg/feeshared/constant"
 	"github.com/LerianStudio/midaz/v4/pkg"
 	"github.com/LerianStudio/midaz/v4/pkg/constant"
 
+	"github.com/google/uuid"
 	"github.com/shopspring/decimal"
 )
 
@@ -52,14 +54,69 @@ const (
 
 // Fee is a struct designed to encapsulate request create payload data.
 type Fee struct {
-	FeeLabel         string            `json:"feeLabel" validate:"required" example:"Taxa Administrativa"`
-	CalculationModel *CalculationModel `json:"calculationModel" validate:"required"`
-	ReferenceAmount  string            `json:"referenceAmount" validate:"oneof=originalAmount afterFeesAmount" example:"originalAmount"`
-	Priority         int               `json:"priority,omitempty" validate:"gte=0" example:"1"`
-	IsDeductibleFrom *bool             `json:"isDeductibleFrom" validate:"required" example:"true"`
-	CreditAccount    string            `json:"creditAccount" validate:"required" example:"conta_receita_taxas_adm"`
-	RouteFrom        *string           `json:"routeFrom,omitempty" example:"taxa_débito"`
-	RouteTo          *string           `json:"routeTo,omitempty" example:"taxa_crédito"`
+	FeeLabel             string            `json:"feeLabel" validate:"required" example:"Taxa Administrativa"`
+	CalculationModel     *CalculationModel `json:"calculationModel" validate:"required"`
+	ReferenceAmount      string            `json:"referenceAmount" validate:"oneof=originalAmount afterFeesAmount" example:"originalAmount"`
+	Priority             int               `json:"priority,omitempty" validate:"gte=0" example:"1"`
+	IsDeductibleFrom     *bool             `json:"isDeductibleFrom" validate:"required" example:"true"`
+	CreditAccount        string            `json:"creditAccount" validate:"required" example:"conta_receita_taxas_adm"`
+	RouteFrom            *string           `json:"routeFrom,omitempty" example:"taxa_débito"`
+	RouteTo              *string           `json:"routeTo,omitempty" example:"taxa_crédito"`
+	OperationRouteFromID *string           `json:"operationRouteFromId,omitempty" validate:"omitempty,uuid" example:"00000000-0000-0000-0000-000000000000" format:"uuid" nullable:"true"`
+	OperationRouteToID   *string           `json:"operationRouteToId,omitempty" validate:"omitempty,uuid" example:"00000000-0000-0000-0000-000000000000" format:"uuid" nullable:"true"`
+
+	operationRouteFromIDSet bool
+	operationRouteToIDSet   bool
+}
+
+// UnmarshalJSON preserves the PATCH distinction between an omitted operation
+// route (leave the stored value unchanged) and an explicit null (clear it).
+// The exported pointers remain the persisted/read representation, so create,
+// read and fee calculation keep their existing contract.
+func (f *Fee) UnmarshalJSON(data []byte) error {
+	type wireFee Fee
+
+	var decoded wireFee
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		return err
+	}
+
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(data, &fields); err != nil {
+		return err
+	}
+
+	*f = Fee(decoded)
+	_, f.operationRouteFromIDSet = fields["operationRouteFromId"]
+	_, f.operationRouteToIDSet = fields["operationRouteToId"]
+
+	return nil
+}
+
+// MarshalJSON keeps an explicit PATCH null visible to the fee HTTP decoder's
+// unknown-field comparison. A genuinely omitted route remains omitted.
+func (f Fee) MarshalJSON() ([]byte, error) {
+	type wireFee Fee
+
+	data, err := json.Marshal(wireFee(f))
+	if err != nil || (!f.operationRouteFromIDSet && !f.operationRouteToIDSet) {
+		return data, err
+	}
+
+	var fields map[string]any
+	if err := json.Unmarshal(data, &fields); err != nil {
+		return nil, err
+	}
+
+	if f.operationRouteFromIDSet && f.OperationRouteFromID == nil {
+		fields["operationRouteFromId"] = nil
+	}
+
+	if f.operationRouteToIDSet && f.OperationRouteToID == nil {
+		fields["operationRouteToId"] = nil
+	}
+
+	return json.Marshal(fields)
 }
 
 func (f *Fee) GetIsDeductibleFrom() bool {
@@ -186,10 +243,42 @@ func (f *Fee) ValidateIfFeeIsNil() bool {
 		f.ReferenceAmount == "" &&
 		f.Priority == 0 &&
 		f.IsDeductibleFrom == nil &&
-		f.CreditAccount == ""
+		f.CreditAccount == "" &&
+		!f.operationRouteFromIDSet &&
+		!f.operationRouteToIDSet &&
+		f.OperationRouteFromID == nil &&
+		f.OperationRouteToID == nil
+}
+
+func (f *Fee) validateOperationRouteIDs(feeKey string) error {
+	ids := []struct {
+		field string
+		value *string
+	}{
+		{field: "operationRouteFromId", value: f.OperationRouteFromID},
+		{field: "operationRouteToId", value: f.OperationRouteToID},
+	}
+
+	for _, id := range ids {
+		if id.value == nil || *id.value == "" {
+			continue
+		}
+
+		if _, err := uuid.Parse(*id.value); err != nil {
+			return pkg.ValidateBadRequestFieldsError(nil, pkg.FieldValidations{
+				feeKey + "." + id.field: "must be a valid UUID",
+			}, "Fee", nil)
+		}
+	}
+
+	return nil
 }
 
 func (f *Fee) ValidateNewFee(feeKey string, minAmount decimal.Decimal) error {
+	if err := f.validateOperationRouteIDs(feeKey); err != nil {
+		return err
+	}
+
 	if err := f.validateRequiredFields(); err != nil {
 		return err
 	}

--- a/components/ledger/pkg/feeshared/model/package_test.go
+++ b/components/ledger/pkg/feeshared/model/package_test.go
@@ -2177,6 +2177,7 @@ func TestFee_SetAndValidateHasFieldsToUpdate(t *testing.T) {
 				orgID,
 				ledgerID,
 				upFields,
+				bson.M{},
 				mockMidaz,
 			)
 
@@ -2321,6 +2322,7 @@ func TestFee_SetAndValidateHasFieldsToUpdate_CalculationModelCases(t *testing.T)
 				orgID,
 				ledgerID,
 				upFields,
+				bson.M{},
 				mockMidaz,
 			)
 
@@ -2500,6 +2502,7 @@ func TestFee_SetAndValidateHasFieldsToUpdate_IsDeductibleFromCases(t *testing.T)
 				orgID,
 				ledgerID,
 				upFields,
+				bson.M{},
 				mockMidaz,
 			)
 

--- a/components/ledger/pkg/feeshared/model/update_package_input.go
+++ b/components/ledger/pkg/feeshared/model/update_package_input.go
@@ -48,9 +48,14 @@ func (up *UpdatePackageInput) GetMaximumAmount() string {
 	return *up.MaxAmount
 }
 
+//nolint:gocognit // Fee validation checks every rule and priority combination; refactor candidate.
 func (up *UpdatePackageInput) ValidateFees() error {
 	for key, fee := range up.Fee {
 		if !fee.ValidateIfFeeIsNil() {
+			if err := fee.validateOperationRouteIDs(key); err != nil {
+				return err
+			}
+
 			if fee.Priority != 0 && fee.ReferenceAmount != "" {
 				if fee.Priority == 1 && fee.ReferenceAmount != OriginalAmount {
 					return pkg.ValidateBusinessError(constant.ErrPriorityOne, "", key)
@@ -164,7 +169,7 @@ func (a *AmountData) GetTransactionRoute() string {
 	return *a.TransactionRoute
 }
 
-func (f *Fee) SetAndValidateHasFieldsToUpdate(ctx context.Context, updateDeductibleFrom *bool, minAmount decimal.Decimal, existingFees map[string]Fee, feeKey string, organizationID, ledgerID uuid.UUID, upFields bson.M, resolver feeshared.MidazResolver) (bool, error) {
+func (f *Fee) SetAndValidateHasFieldsToUpdate(ctx context.Context, updateDeductibleFrom *bool, minAmount decimal.Decimal, existingFees map[string]Fee, feeKey string, organizationID, ledgerID uuid.UUID, upFields, unsetFields bson.M, resolver feeshared.MidazResolver) (bool, error) {
 	hasValueToUpdate := false
 
 	if updated, err := f.updateCalculationModel(existingFees, updateDeductibleFrom, feeKey, minAmount, upFields); err != nil {
@@ -204,6 +209,14 @@ func (f *Fee) SetAndValidateHasFieldsToUpdate(ctx context.Context, updateDeducti
 	}
 
 	if updated := f.updateRouteTo(feeKey, upFields); updated {
+		hasValueToUpdate = true
+	}
+
+	if updated := f.updateOperationRouteFromID(feeKey, upFields, unsetFields); updated {
+		hasValueToUpdate = true
+	}
+
+	if updated := f.updateOperationRouteToID(feeKey, upFields, unsetFields); updated {
 		hasValueToUpdate = true
 	}
 
@@ -366,6 +379,38 @@ func (f *Fee) updateRouteFrom(feeKey string, upFields bson.M) bool {
 func (f *Fee) updateRouteTo(feeKey string, upFields bson.M) bool {
 	if !commons.IsNilOrEmpty(f.RouteTo) {
 		upFields["fees."+feeKey+".route_to"] = f.RouteTo
+		return true
+	}
+
+	return false
+}
+
+func (f *Fee) updateOperationRouteFromID(feeKey string, upFields, unsetFields bson.M) bool {
+	if !commons.IsNilOrEmpty(f.OperationRouteFromID) {
+		upFields["fees."+feeKey+".operation_route_from_id"] = f.OperationRouteFromID
+
+		return true
+	}
+
+	if f.operationRouteFromIDSet {
+		unsetFields["fees."+feeKey+".operation_route_from_id"] = ""
+
+		return true
+	}
+
+	return false
+}
+
+func (f *Fee) updateOperationRouteToID(feeKey string, upFields, unsetFields bson.M) bool {
+	if !commons.IsNilOrEmpty(f.OperationRouteToID) {
+		upFields["fees."+feeKey+".operation_route_to_id"] = f.OperationRouteToID
+
+		return true
+	}
+
+	if f.operationRouteToIDSet {
+		unsetFields["fees."+feeKey+".operation_route_to_id"] = ""
+
 		return true
 	}
 

--- a/components/ledger/pkg/feeshared/nethttp/fee_operation_route_ids_test.go
+++ b/components/ledger/pkg/feeshared/nethttp/fee_operation_route_ids_test.go
@@ -1,0 +1,67 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package http
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/LerianStudio/midaz/v4/components/ledger/pkg/feeshared/model"
+)
+
+func TestFeeOperationRouteIDsAreOptionalUUIDsOnCreateAndUpdate(t *testing.T) {
+	t.Parallel()
+
+	enabled := true
+	deductible := false
+	validFrom := uuid.NewString()
+	validTo := uuid.NewString()
+	invalid := "not-a-uuid"
+
+	createInput := func(fromID, toID *string) *model.CreatePackageInput {
+		return &model.CreatePackageInput{
+			FeeGroupLabel: "routed fees",
+			LedgerID:      uuid.NewString(),
+			MinAmount:     "1",
+			MaxAmount:     "1000",
+			Enable:        &enabled,
+			Fee: map[string]model.Fee{"service": {
+				FeeLabel: "service fee",
+				CalculationModel: &model.CalculationModel{
+					ApplicationRule: model.FlatFee,
+					Calculations:    []model.Calculation{{Type: model.Flat, Value: "1"}},
+				},
+				ReferenceAmount:      model.OriginalAmount,
+				Priority:             1,
+				IsDeductibleFrom:     &deductible,
+				CreditAccount:        "@fee-revenue",
+				OperationRouteFromID: fromID,
+				OperationRouteToID:   toID,
+			}},
+		}
+	}
+
+	require.NoError(t, ValidateStruct(createInput(&validFrom, &validTo)))
+	assert.Error(t, ValidateStruct(createInput(&invalid, &validTo)))
+	assert.Error(t, ValidateStruct(createInput(&validFrom, &invalid)))
+
+	require.NoError(t, createInput(&validFrom, &validTo).ValidateFees())
+	assert.Error(t, createInput(&invalid, &validTo).ValidateFees())
+	assert.Error(t, createInput(&validFrom, &invalid).ValidateFees())
+
+	validUpdate := &model.UpdatePackageInput{Fee: map[string]model.Fee{"service": {
+		OperationRouteFromID: &validFrom,
+		OperationRouteToID:   &validTo,
+	}}}
+	require.NoError(t, validUpdate.ValidateFees())
+
+	invalidUpdate := &model.UpdatePackageInput{Fee: map[string]model.Fee{"service": {
+		OperationRouteFromID: &invalid,
+	}}}
+	assert.Error(t, invalidUpdate.ValidateFees())
+}

--- a/tests/e2e/fees_lifecycle_test.go
+++ b/tests/e2e/fees_lifecycle_test.go
@@ -168,7 +168,7 @@ func feelifecycleTransfer(t *testing.T, f fixture, from, to, value, route string
 	}
 
 	body := map[string]any{
-		"description": "xfer " + uuid.NewString()[:8],
+		"description": "xfer " + uuid.NewString(),
 		"send":        send,
 	}
 	if route != "" {

--- a/tests/e2e/fees_matrix_test.go
+++ b/tests/e2e/fees_matrix_test.go
@@ -128,7 +128,7 @@ func feematrixTryCreatePackage(t *testing.T, f fixture, opts feematrixPackageOpt
 	}
 
 	body := map[string]any{
-		"feeGroupLabel": "E2E Matrix " + uuid.NewString()[:8], "ledgerId": f.ledgerID,
+		"feeGroupLabel": "E2E Matrix " + uuid.NewString(), "ledgerId": f.ledgerID,
 		"minimumAmount": minAmount, "maximumAmount": maxAmount, "enable": true,
 		"fees": fees,
 	}


### PR DESCRIPTION
## Scope

Third stack layer. It closes v1 remaining-leg propagation, explicit fee operation routes, partial fee route patches, zero-fee behavior, and fee economics regressions across the Ledger API and fee engine.

## Review boundary

- 43 changed files against `agent/pr2337-layer2-money` (under the 150-file CodeRabbit limit).
- Owns the fee and remaining-leg integration/regression coverage.
- Local gate: `go test ./... -run ^ -count=0` passed; focused fee unit tests passed.

Depends on PR #2342.