### PR TITLE
fix(pkg): compare the raw ce-source against the roster name

### DIFF
--- a/components/ledger/internal/bootstrap/streaming.go
+++ b/components/ledger/internal/bootstrap/streaming.go
@@ -55,15 +55,21 @@ const streamingFactRouteKey = streamingServiceName + ".facts." + streamingPrimar
 // (.env.example recommends the roster name "ledger"). lib-streaming REJECTS a
 // source that is not a single dot-free lowercase segment rather than rewriting
 // it, so a malformed value fails startup instead of silently colonizing another
-// application's topic namespace. This helper only trims the configured value and
-// returns it verbatim; streamingServiceName ("ledger") is a defense-in-depth
-// fallback for a nil or whitespace-only config value that slips past
-// LoadConfig's empty-string check, NOT the unset-env default.
+// application's topic namespace.
+//
+// Whitespace is trimmed ONLY to recognize "unset". The value returned is the RAW
+// configured one, deliberately: it is what RequireRosterSource compares, and
+// lib-streaming's ValidateSource rejects " ledger " because a space is not in the
+// ce-source charset. A helper that returned the trimmed value would wave a padded
+// source through the gate with streaming OFF and then refuse boot the day the flag
+// flips — the exact deferred failure the gate exists to pull forward.
+//
+// streamingServiceName ("ledger") is a defense-in-depth fallback for a nil or
+// whitespace-only config value that slips past LoadConfig's empty-string check,
+// NOT the unset-env default.
 func resolveStreamingSource(cfg *Config) string {
-	if cfg != nil {
-		if source := strings.TrimSpace(cfg.StreamingCloudEventsSource); source != "" {
-			return source
-		}
+	if cfg != nil && strings.TrimSpace(cfg.StreamingCloudEventsSource) != "" {
+		return cfg.StreamingCloudEventsSource
 	}
 
 	return streamingServiceName

--- a/components/ledger/internal/bootstrap/streaming_test.go
+++ b/components/ledger/internal/bootstrap/streaming_test.go
@@ -97,9 +97,12 @@ func TestResolveStreamingSource(t *testing.T) {
 			expected: "midaz-ledger-staging",
 		},
 		{
-			name:     "configured value is trimmed",
+			// Padded comes back RAW, not trimmed: the raw value is what the roster
+			// gate compares and what lib-streaming's ValidateSource rejects, so a
+			// padded source must refuse boot NOW rather than the day the flag flips.
+			name:     "padded configured value is returned raw",
 			cfg:      &Config{StreamingCloudEventsSource: "  midaz-ledger-shadow  "},
-			expected: "midaz-ledger-shadow",
+			expected: "  midaz-ledger-shadow  ",
 		},
 	}
 
@@ -296,6 +299,7 @@ func TestBuildStreamingEmitter_RefusesNonRosterSource(t *testing.T) {
 		"ledgerx",               // a PREFIXED grant would have reached this; a literal one does not
 		"lerian.midaz.ledger",   // stale pre-v3 dotted shape
 		"//lerian.midaz/ledger", // stale pre-v3 URI shape
+		" ledger ",              // roster name with padding: ValidateSource rejects the space
 	}
 
 	for _, source := range sources {

--- a/components/tracer/internal/bootstrap/streaming.go
+++ b/components/tracer/internal/bootstrap/streaming.go
@@ -53,15 +53,21 @@ const streamingFactRouteKey = streamingServiceName + ".facts." + streamingPrimar
 // (.env.example recommends the roster name "tracer"). lib-streaming REJECTS a
 // source that is not a single dot-free lowercase segment rather than rewriting
 // it, so a malformed value fails startup instead of silently colonizing another
-// application's topic namespace. This helper only trims the configured value and
-// returns it verbatim; streamingServiceName ("tracer") is a defense-in-depth
-// fallback for a nil or whitespace-only config value that slips past
-// LoadConfig's empty-string check, NOT the unset-env default.
+// application's topic namespace.
+//
+// Whitespace is trimmed ONLY to recognize "unset". The value returned is the RAW
+// configured one, deliberately: it is what RequireRosterSource compares, and
+// lib-streaming's ValidateSource rejects " tracer " because a space is not in the
+// ce-source charset. A helper that returned the trimmed value would wave a padded
+// source through the gate with streaming OFF and then refuse boot the day the flag
+// flips — the exact deferred failure the gate exists to pull forward.
+//
+// streamingServiceName ("tracer") is a defense-in-depth fallback for a nil or
+// whitespace-only config value that slips past LoadConfig's empty-string check,
+// NOT the unset-env default.
 func resolveStreamingSource(cfg *Config) string {
-	if cfg != nil {
-		if source := strings.TrimSpace(cfg.StreamingCloudEventsSource); source != "" {
-			return source
-		}
+	if cfg != nil && strings.TrimSpace(cfg.StreamingCloudEventsSource) != "" {
+		return cfg.StreamingCloudEventsSource
 	}
 
 	return streamingServiceName

--- a/components/tracer/internal/bootstrap/streaming_test.go
+++ b/components/tracer/internal/bootstrap/streaming_test.go
@@ -426,9 +426,12 @@ func TestResolveStreamingSource(t *testing.T) {
 			expected: "midaz-tracer-staging",
 		},
 		{
-			name:     "configured value is trimmed",
+			// Padded comes back RAW, not trimmed: the raw value is what the roster
+			// gate compares and what lib-streaming's ValidateSource rejects, so a
+			// padded source must refuse boot NOW rather than the day the flag flips.
+			name:     "padded configured value is returned raw",
 			cfg:      &Config{StreamingCloudEventsSource: "  midaz-tracer-shadow  "},
-			expected: "midaz-tracer-shadow",
+			expected: "  midaz-tracer-shadow  ",
 		},
 	}
 
@@ -500,6 +503,7 @@ func TestBuildStreamingEmitter_RefusesNonRosterSource(t *testing.T) {
 		"tracerx",               // a PREFIXED grant would have reached this; a literal one does not
 		"lerian.midaz.tracer",   // stale pre-v3 dotted shape
 		"//lerian.midaz/tracer", // stale pre-v3 URI shape
+		" tracer ",              // roster name with padding: ValidateSource rejects the space
 	}
 
 	for _, source := range sources {


### PR DESCRIPTION
## What

Follow-up to #2345: the roster boot gate compared the TRIMMED source, so `STREAMING_CLOUDEVENTS_SOURCE=" ledger "` passed the gate with streaming off and refused boot the day the flag flips (the lib validates the raw value) — the exact deferred failure the gate exists to kill. The resolver now trims only to recognize an unset value and returns the raw one; padded roster names are refused at boot in both components, crossed with enabled=false/true in the refusal tables. Found by the audit-trail migration review; same fix already landed there.

Gates: build, vet (default+integration), unit -race on the 4 touched packages, lint identical to the develop baseline (zero findings in touched files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)