### PR TITLE
fix(fees): rename fees tenant-manager module to fees-api

### DIFF
--- a/components/ledger/internal/bootstrap/config.fees_test.go
+++ b/components/ledger/internal/bootstrap/config.fees_test.go
@@ -148,13 +148,13 @@ func TestFeesDefaultCurrencyDefault(t *testing.T) {
 		"an explicit DEFAULT_CURRENCY must not be overridden")
 }
 
-// TestModuleFeesProvisioningName locks the tenant-manager / auth namespace value.
-// The standalone fees service registered under "plugin-fees" (auth namespace +
-// single-module tenant service name). Renaming this breaks RBAC and tenant DB
-// resolution for already-provisioned tenants (the CRM crm->crm-api footgun).
+// TestModuleFeesProvisioningName locks the tenant-manager module name. The value
+// MUST match what tenant-manager provisions for the fee module, or per-tenant fee
+// DB resolution silently misses. The auth/RBAC namespace is a separate literal
+// (feeshared constant.ApplicationName) and is NOT covered by this test.
 func TestModuleFeesProvisioningName(t *testing.T) {
 	t.Parallel()
 
-	assert.Equal(t, "plugin-fees", constant.ModuleFees,
-		"ModuleFees MUST equal 'plugin-fees' to match tenant-manager provisioning + RBAC (R9, P4-T22)")
+	assert.Equal(t, "fees-api", constant.ModuleFees,
+		"ModuleFees MUST equal 'fees-api' to match tenant-manager provisioning")
 }

--- a/components/ledger/internal/bootstrap/config.go
+++ b/components/ledger/internal/bootstrap/config.go
@@ -1563,7 +1563,7 @@ func buildUnifiedRouteSetup(
 	// the fee pack/billing_package repos read tmcore.GetMBContext(ctx) on the
 	// GENERIC key (the standalone fees service ran single-module — it registered
 	// its manager under the SERVICE name with no WithModule). A module-keyed
-	// WithMB would write the plugin-fees key while the repos read the generic
+	// WithMB would write the fee module key while the repos read the generic
 	// key, so MT fee requests would fail DB resolution. Route scoping keeps the
 	// generic-key write from colliding with the module-keyed onboarding/
 	// transaction injection on ledger routes. (The manager itself still carries

--- a/components/ledger/internal/bootstrap/config.mongo.fees.go
+++ b/components/ledger/internal/bootstrap/config.mongo.fees.go
@@ -82,7 +82,7 @@ func initFeesMongo(opts *Options, cfg *Config, logger libLog.Logger) (*feesMongo
 }
 
 // buildFeesMongoManager builds the fee tenant-manager Mongo manager. It reuses
-// ledger's tenant client and is keyed on constant.ModuleFees ("plugin-fees") so
+// ledger's tenant client and is keyed on constant.ModuleFees so
 // tenant-manager resolves the fee module DB for the merged binary. The per-tenant
 // DB lands on the request context (tmcore) via the CRM-style route-scoped
 // middleware in buildUnifiedRouteSetup.

--- a/docs/auth/RBAC-NAMESPACES.md
+++ b/docs/auth/RBAC-NAMESPACES.md
@@ -37,7 +37,7 @@ namespace literals:
 | Namespace | Owner / code | Resources | Source |
 |-----------|--------------|-----------|--------|
 | `midaz` | ledger — `midazName` const; CRM (collapsed package) — `ApplicationName` const | `organizations`, `ledgers`, `assets`, `asset-rates`, `portfolios`, `segments`, `accounts`, `balances`, `transactions`, `operations`, `settings`, `account-types`, `operation-routes`, `transaction-routes`, `holders`, `instruments` | `components/ledger/internal/adapters/http/in/routes.go` (`midazName = "midaz"`, helper `protectedMidaz`); `components/ledger/internal/adapters/http/in/crm_routes.go` (`const ApplicationName = "midaz"`) for the `holders`/`instruments` resources |
-| `plugin-fees` | fees (embedded in ledger) | `packages`, `estimates`, `billing-packages`, `billing-calculate` | `components/ledger/internal/adapters/http/in/fees_routes.go` (`feesApplicationName = "plugin-fees"`, helper `protectedFees`); also `pkg/constant.ModuleFees = "plugin-fees"` and `components/ledger/pkg/feeshared/constant/app.go`. The ledger-scoped `/v2` twins in `fees_v2_register.go` (`RegisterFeesV2RoutesToApp`) attach the same `feeGuardRoutes` table through the same helper — same namespace, same tuples |
+| `plugin-fees` | fees (embedded in ledger) | `packages`, `estimates`, `billing-packages`, `billing-calculate` | `components/ledger/internal/adapters/http/in/fees_routes.go` (`feesApplicationName = "plugin-fees"`, helper `protectedFees`) and `components/ledger/pkg/feeshared/constant/app.go` (`ApplicationName = "plugin-fees"`). The tenant-manager module name is a SEPARATE literal (`pkg/constant.ModuleFees = "fees-api"`) and carries no authz meaning. The ledger-scoped `/v2` twins in `fees_v2_register.go` (`RegisterFeesV2RoutesToApp`) attach the same `feeGuardRoutes` table through the same helper — same namespace, same tuples |
 
 The `account-types`, `operation-routes`, and `transaction-routes` resources authorize under the
 `midaz` namespace (helper `protectedMidaz`), parity with `main` — there is no separate `routing`
@@ -67,8 +67,11 @@ Consequences:
   is X1 (below) — the in-code flip is intentional and lands at v4; the policy migration is gated
   to release, not to merge.
 - The fee/billing namespace literal is intentionally identical (`plugin-fees`) across the
-  ledger route registrar, `pkg/constant.ModuleFees`, and `components/ledger/pkg/feeshared` so the
-  embedded fee code, its Mongo tenant client, and its authz all key on the same string.
+  ledger route registrar and `components/ledger/pkg/feeshared`, so the embedded fee code and its
+  authz key on the same string. Its Mongo tenant client keys on a different string:
+  `pkg/constant.ModuleFees` (`fees-api`) is the tenant-manager MODULE name, matching what
+  tenant-manager provisions for fees. Authz namespace and tenant module are independent — renaming
+  one does not move the other.
 
 ## X1 — policy migration (`plugin-crm` → `midaz`)
 

--- a/docs/runbooks/v4-x1-rbac-migration-and-rollback.md
+++ b/docs/runbooks/v4-x1-rbac-migration-and-rollback.md
@@ -57,7 +57,7 @@ Namespace layout in v4 (for context — the CRM and routing rows flipped to `mid
 | `midaz` | organizations, ledgers, assets, asset-rates, portfolios, segments, accounts, balances, transactions, operations, settings | `routes.go` (`midazName`, `protectedMidaz`) |
 | `midaz` (flipped in v4) | **holders, instruments, related-parties** | `crm_routes.go:20`, `crm_routes.go:62-79` |
 | `midaz` (flipped in v4) | account-types, operation-routes, transaction-routes | `routes.go` (`midazName`, `protectedMidaz`) |
-| `plugin-fees` (**UNCHANGED**) | packages, estimates, billing-packages, billing-calculate | `fees_routes.go:18` (`feesApplicationName`), `pkg/constant/module.go:24` |
+| `plugin-fees` (**UNCHANGED**) | packages, estimates, billing-packages, billing-calculate | `fees_routes.go:18` (`feesApplicationName`), `components/ledger/pkg/feeshared/constant/app.go` |
 
 > **Fees do NOT migrate.** `plugin-fees:*` is intentionally preserved with no migration
 > (`RBAC-NAMESPACES.md:7-8, 15, 84-86`). Do not touch fees grants during X1.

--- a/pkg/constant/module.go
+++ b/pkg/constant/module.go
@@ -13,13 +13,6 @@ const (
 	// schemas. The value MUST be "crm-api" to match tenant-manager provisioning.
 	ModuleCRM = "crm-api"
 	// ModuleFees is the tenant-manager module name for fee/billing-package database
-	// schemas. The value MUST be "plugin-fees" to match tenant-manager provisioning:
-	// the standalone fees service registered its per-tenant Mongo manager under
-	// constant.ApplicationName ("plugin-fees") as the tenant-manager SERVICE name
-	// with NO WithModule (single-module mode), and its auth/RBAC policies key on
-	// the same "plugin-fees" namespace (R9, P4-T22). Renaming this breaks tenant DB
-	// resolution and RBAC for tenants already provisioned under "plugin-fees".
-	// (Mirrors the CRM crm->crm-api footgun: the embedded name MUST match prod
-	// provisioning. See P4-T22 for cross-team confirmation of the provisioning name.)
-	ModuleFees = "plugin-fees"
+	// schemas.
+	ModuleFees = "fees-api"
 )

--- a/pkg/constant/module.go
+++ b/pkg/constant/module.go
@@ -13,6 +13,7 @@ const (
 	// schemas. The value MUST be "crm-api" to match tenant-manager provisioning.
 	ModuleCRM = "crm-api"
 	// ModuleFees is the tenant-manager module name for fee/billing-package database
-	// schemas.
+	// schemas. The value MUST be "fees-api" to match tenant-manager provisioning.
+	// The fee auth/RBAC namespace is a separate literal (feeshared ApplicationName).
 	ModuleFees = "fees-api"
 )


### PR DESCRIPTION
<table border="0" cellspacing="0" cellpadding="0">
  <tr>
    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
    <td><h1>Midaz</h1></td>
  </tr>
</table>

---

## Description

Renames the tenant-manager module name for fees from `plugin-fees` to `fees-api`,
aligning the code with what tenant-manager actually provisions for the fee module.

`pkg/constant.ModuleFees` feeds `tmmongo.WithModule(...)` in
`components/ledger/internal/bootstrap/config.mongo.fees.go`, which is how
tenant-manager resolves the per-tenant fee Mongo DB. The constant had drifted from
the provisioned name; this restores the match.

**The fee authz/RBAC namespace is unaffected.** It is a separate literal —
`components/ledger/pkg/feeshared/constant/app.go` (`ApplicationName = "plugin-fees"`)
and `fees_routes.go` (`feesApplicationName`) — and stays `plugin-fees`. No policy
migration and no grant changes are implied by this PR. The old comment on
`ModuleFees` conflated the two; that conflation is corrected here.

Follow-up work in this PR, all consequences of the rename:

- `config.fees_test.go` — `TestModuleFeesProvisioningName` still asserted the old
  value and failed the unit lane. Retargeted to `fees-api`, and its comment no
  longer claims the constant governs RBAC.
- `config.mongo.fees.go`, `config.go` — comments that inlined the old literal.
- `docs/auth/RBAC-NAMESPACES.md`, `docs/runbooks/v4-x1-rbac-migration-and-rollback.md`
  — both listed `pkg/constant.ModuleFees` as a source of the `plugin-fees` authz
  namespace and asserted the literal was "intentionally identical" across the route
  registrar, `ModuleFees`, and `feeshared`. That invariant no longer holds; the docs
  now state that authz namespace and tenant module are independent.

## Type of Change

- [ ] `feat`: New feature or capability
- [x] `fix`: Bug fix
- [ ] `perf`: Performance improvement
- [ ] `refactor`: Internal restructuring with no behavior change
- [ ] `docs`: Documentation only
- [ ] `style`: Formatting, whitespace, naming (no logic change)
- [ ] `test`: Adding or updating tests
- [ ] `ci`: CI pipeline or workflow changes
- [ ] `build`: Build system, Dockerfile, Go module dependencies
- [ ] `chore`: Maintenance, config, tooling
- [ ] `revert`: Reverts a previous commit
- [ ] `BREAKING CHANGE`: Consumers must update their integration

## Breaking Changes

None.

`ModuleFees` is an internal tenant-manager module key, not a public API, CLI flag,
config key, event schema, or storage format. It is not exported to clients and has
no wire representation.

The rename does change which module name tenant-manager is asked to resolve for the
fee Mongo DB. This is an alignment fix: tenant-manager already provisions fees under
`fees-api`, so the previous `plugin-fees` value was the divergent one.

The fee authz namespace (`plugin-fees`) is untouched, so no RBAC grants are orphaned
and the X1 policy migration scope is unchanged.

## Testing

- [x] `make test` passes
- [ ] `make test-int` passes if integration paths are exercised
- [x] `make lint` passes
- [ ] `make sec` and `make vulncheck` pass

**Test evidence / Actions run:**

```
$ go build ./...
(clean)

$ go test ./components/ledger/internal/bootstrap/ ./pkg/constant/...
ok  github.com/LerianStudio/midaz/v4/components/ledger/internal/bootstrap  1.588s
ok  github.com/LerianStudio/midaz/v4/pkg/constant                          0.007s

$ golangci-lint run --new-from-rev=origin/develop \
    ./pkg/constant/... ./components/ledger/internal/bootstrap/...
0 issues.
```

`TestModuleFeesProvisioningName` failed on the first commit of this branch and passes
after the second. Integration lanes and `make sec` / `make vulncheck` were not run
locally; CI covers them.

## Architectural Checklist

- [x] No `panic()` in production paths
- [x] Timestamps use `time.Now().UTC()`
- [x] Errors wrapped with `%w`
- [x] Handlers stay thin (parse, validate, call service)
- [x] Infrastructure concerns kept in `internal/bootstrap`

## Related Issues

