### PR TITLE
ci: add fork PR coverage-comment fallback

### DIFF
--- a/.github/workflows/pr-coverage-comment.yml
+++ b/.github/workflows/pr-coverage-comment.yml
@@ -22,7 +22,7 @@ jobs:
     if: >
       github.event.workflow_run.event == 'pull_request' &&
       github.event.workflow_run.head_repository.full_name != github.repository
-    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/go-pr-coverage-comment.yml@v1.57.0-beta.2
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/go-pr-coverage-comment.yml@develop
     with:
       source_run_id: ${{ github.event.workflow_run.id }}
       pr_number: ${{ github.event.workflow_run.pull_requests[0].number }}

--- a/.github/workflows/pr-coverage-comment.yml
+++ b/.github/workflows/pr-coverage-comment.yml
@@ -1,0 +1,30 @@
+name: PR Coverage Comment (fork fallback)
+
+# go-pr-analysis.yml's inline coverage-comment step can't post on fork PRs:
+# pull_request runs from forks always get a read-only GITHUB_TOKEN and no
+# custom secrets, no matter what permissions the call chain declares. This
+# stub runs under workflow_run instead (not fork-restricted, so its token is
+# write-scoped) and delegates to go-pr-coverage-comment.yml, which only reads
+# the coverage-report-* artifacts PR Validation already produced — it never
+# checks out the PR's code.
+
+on:
+  workflow_run:
+    workflows: ["PR Validation"]
+    types: [completed]
+
+permissions:
+  actions: read
+  pull-requests: write
+
+jobs:
+  comment:
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.head_repository.full_name != github.repository
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/go-pr-coverage-comment.yml@v1.57.0-beta.2
+    with:
+      source_run_id: ${{ github.event.workflow_run.id }}
+      pr_number: ${{ github.event.workflow_run.pull_requests[0].number }}
+      coverage_threshold: 80
+    secrets: inherit

--- a/.github/workflows/pr-coverage-comment.yml
+++ b/.github/workflows/pr-coverage-comment.yml
@@ -13,9 +13,16 @@ on:
     workflows: ["PR Validation"]
     types: [completed]
 
+# Keyed on PR number so an older PR Validation run finishing after a newer one
+# (e.g. its Coverage job took longer) can't post a stale coverage comment over
+# the current one — the older workflow_run job gets cancelled instead.
+concurrency:
+  group: pr-coverage-comment-${{ github.event.workflow_run.pull_requests[0].number || github.event.workflow_run.head_branch }}
+  cancel-in-progress: true
+
 permissions:
-  actions: read
-  pull-requests: write
+  actions: read       # download-artifact from the PR Validation run
+  pull-requests: write # create/update the sticky coverage comment
 
 jobs:
   comment:
@@ -27,4 +34,3 @@ jobs:
       source_run_id: ${{ github.event.workflow_run.id }}
       pr_number: ${{ github.event.workflow_run.pull_requests[0].number }}
       coverage_threshold: 80
-    secrets: inherit

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
   validate:
-    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/go-pr-validation.yml@v1.56.0-beta.1
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/go-pr-validation.yml@v1.57.0-beta.2
     with:
       enforce_source_branches: true
       allowed_source_branches: 'hotfix/*|release-candidate'

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
   validate:
-    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/go-pr-validation.yml@v1.57.0-beta.2
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/go-pr-validation.yml@develop
     with:
       enforce_source_branches: true
       allowed_source_branches: 'hotfix/*|release-candidate'


### PR DESCRIPTION
## Summary
- Bumps the `validate` job's `go-pr-validation.yml` reference to `v1.57.0-beta.2`, which scopes the Coverage job's `continue-on-error` to the expected 403 on fork PRs (`LerianStudio/github-actions-shared-workflows#679`).
- Adds `.github/workflows/pr-coverage-comment.yml`: a `workflow_run` stub that fires when `PR Validation` completes and, for PRs from forks only, calls the new reusable `go-pr-coverage-comment.yml`. That workflow downloads the `coverage-report-*` artifacts the analysis run already produced and posts/updates the sticky coverage comment — no checkout of the PR's code, so the write-scoped token never touches fork code.

## Context
Fixes the 403 seen in PR #2352 (opened from `mvanhorn/midaz`, a fork): https://github.com/LerianStudio/midaz/actions/runs/32344833689/job/96479202043?pr=2352

Related: LerianStudio/github-actions-shared-workflows#678, LerianStudio/github-actions-shared-workflows#679

## Test plan
- [ ] Push a commit to this PR (or open a throwaway fork PR) and confirm `PR Validation`'s Coverage job passes without the 403 failing it.
- [ ] Confirm the `PR Coverage Comment (fork fallback)` workflow triggers after `PR Validation` completes on a fork PR and posts the sticky coverage comment.
- [ ] Confirm a same-repo PR still gets the coverage comment immediately from the inline step (unchanged behavior).