### PR TITLE
fix: point every permission manifest at the real Casdoor groups

### DIFF
--- a/components/ledger/internal/services/fees/permissions.yaml
+++ b/components/ledger/internal/services/fees/permissions.yaml
@@ -41,13 +41,19 @@ permissions:
   - { resource: billing-calculate, action: post, effect: allow, roles: [editor] }
 
 roles:
-  # ### TEAM: please confirm ### — role -> group bindings are INFERRED.
+  # Group bindings are CONFIRMED against the central Access Manager seed
+  # (plugin-access-manager, components/auth/init/casdoor/init_data.json): the real
+  # groups are plugin-fees-{editor,contributor,viewer}-group. The manifest only
+  # REFERENCES pre-existing groups, it never creates them — a name absent from the
+  # seed reconciles into a role with zero members. The seed also carries
+  # plugin-fees-contributor-group, but this manifest declares no `contributor`
+  # role, so that group stays unbound here.
   - name: editor
     granted_to:
-      - group: fees-admins   ### TEAM: please confirm ###
+      - group: plugin-fees-editor-group
   - name: viewer
     granted_to:
-      - group: fees-viewers  ### TEAM: please confirm ###
+      - group: plugin-fees-viewer-group
 
 m2m:
   # EXPORT: fees exposes its M2M editor surface. IMPORT: it calls midaz (the

--- a/components/ledger/permissions.yaml
+++ b/components/ledger/permissions.yaml
@@ -22,8 +22,8 @@
 # data (Authorize takes only subject/resource/action), so the editor/viewer split
 # below is an INFERRED convention, mirroring the plugin-fees manifest: read verbs
 # (get, head) are granted to editor + viewer; every mutating verb (post/put/patch/
-# delete) to editor only. The granted_to group bindings under `roles:` are likewise
-# inferred and each carries a confirm marker.
+# delete) to editor only. The granted_to group bindings under `roles:` are NOT
+# inferred — they are confirmed against the central Access Manager seed (see below).
 service: midaz
 version: 1
 permissions:
@@ -135,16 +135,19 @@ permissions:
   - { resource: transactions, action: head,  effect: allow, roles: [editor, viewer] }
 
 roles:
-  # ### TEAM: please confirm ### — role -> group bindings are INFERRED (no group
-  # data in code). The manifest only references pre-existing groups; it never
-  # creates them. Confirm the real group names, or drop granted_to to leave the
-  # roles unbound (still valid).
+  # Group bindings are CONFIRMED against the central Access Manager seed
+  # (plugin-access-manager, components/auth/init/casdoor/init_data.json): the real
+  # groups are midaz-{editor,contributor,viewer}-group. The manifest only
+  # REFERENCES pre-existing groups, it never creates them — a name absent from the
+  # seed reconciles into a role with zero members. The seed also carries
+  # midaz-contributor-group, but this manifest declares no `contributor` role, so
+  # that group stays unbound here.
   - name: editor
     granted_to:
-      - group: midaz-admins   ### TEAM: please confirm ###
+      - group: midaz-editor-group
   - name: viewer
     granted_to:
-      - group: midaz-viewers  ### TEAM: please confirm ###
+      - group: midaz-viewer-group
 
 m2m:
   # EXPORT: midaz is the target of plugin-fees' `needs: [midaz]` (fees calls the

--- a/components/tracer/permissions.yaml
+++ b/components/tracer/permissions.yaml
@@ -50,13 +50,19 @@ permissions:
   - { resource: streaming-manifest, action: get, effect: allow, roles: [editor, viewer] }
 
 roles:
-  # ### TEAM: please confirm ### — role -> group bindings are INFERRED.
+  # Group bindings are CONFIRMED against the central Access Manager seed
+  # (plugin-access-manager, components/auth/init/casdoor/init_data.json): the real
+  # groups are tracer-{editor,contributor,viewer}-group. The manifest only
+  # REFERENCES pre-existing groups, it never creates them — a name absent from the
+  # seed reconciles into a role with zero members. The seed also carries
+  # tracer-contributor-group, tracer-validator-group and tracer-audit-viewer-group;
+  # this manifest declares no matching role, so those groups stay unbound here.
   - name: editor
     granted_to:
-      - group: tracer-admins   ### TEAM: please confirm ###
+      - group: tracer-editor-group
   - name: viewer
     granted_to:
-      - group: tracer-viewers  ### TEAM: please confirm ###
+      - group: tracer-viewer-group
 
 m2m:
   # EXPORT: the ledger (midaz) calls tracer's reservation API via an M2M token, so


### PR DESCRIPTION
<table border="0" cellspacing="0" cellpadding="0">
  <tr>
    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
    <td><h1>Midaz</h1></td>
  </tr>
</table>

---

## Description

Every access-manager declaration manifest in this repo granted its roles to
**groups that do not exist**. The declared names follow a convention nothing
creates (plural, no `-group` suffix); the real groups live in the central Access
Manager seed, `plugin-access-manager/components/auth/init/casdoor/init_data.json`.

| Manifest | Role | Declared (does not exist) | Real seeded group |
|---|---|---|---|
| `components/ledger/internal/services/fees/permissions.yaml` (`plugin-fees`) | `editor` | `fees-admins` | `plugin-fees-editor-group` |
| `components/ledger/internal/services/fees/permissions.yaml` (`plugin-fees`) | `viewer` | `fees-viewers` | `plugin-fees-viewer-group` |
| `components/ledger/permissions.yaml` (`midaz`) | `editor` | `midaz-admins` | `midaz-editor-group` |
| `components/ledger/permissions.yaml` (`midaz`) | `viewer` | `midaz-viewers` | `midaz-viewer-group` |
| `components/tracer/permissions.yaml` (`tracer`) | `editor` | `tracer-admins` | `tracer-editor-group` |
| `components/tracer/permissions.yaml` (`tracer`) | `viewer` | `tracer-viewers` | `tracer-viewer-group` |

### Why this matters — the current failure mode is a silent false green

A manifest only **references** pre-existing groups; it never creates them, and
`lib-auth/v3 auth/declaration` validates structure only (service, version,
effect, role cross-references) — it has no way to know whether a group exists.
So today:

1. the plugin publishes its declaration with a group name nothing resolves;
2. the access-manager reconciler stores a **dangling group reference**;
3. the reconcile **reports success**;
4. the role ends up with **ZERO members** — nobody can actually reach the
   guarded routes through the role that was supposedly granted.

Nothing fails, nothing warns. The bad grant is only visible by diffing the
manifest against the seed by hand.

The in-flight access-manager change that rejects a grant to an unknown group
with **HTTP 422** (LerianStudio/plugin-access-manager#364) converts that silence
into a hard failure at publish time — and all three manifests here are among the
ones it would reject. This PR is what makes them publishable under that gate.

### Scope of the change

Only the `granted_to` group names, plus the now-answered `### TEAM: please
confirm ###` markers on those lines (the group bindings are no longer inferred:
they are confirmed against the seed, and the comment now cites it). Declared
permissions, role names and the `m2m` contracts are **untouched**.

Deliberately **not** done: the seed also carries `plugin-fees-contributor-group`,
`midaz-contributor-group`, `tracer-contributor-group`, `tracer-validator-group`
and `tracer-audit-viewer-group`. No manifest here declares a matching role, so
those groups stay unbound rather than inventing roles this repo does not enforce.

## Type of Change

- [x] `fix`: Bug fix

## Breaking Changes

None. No Go code, no route, no runtime behaviour changes — nothing in the repo
loads these YAML files today (no `embed`, no loader), so this is purely the
declaration data that the access-manager reconciler consumes.

For the deployed side this is a **correction toward** working RBAC: roles that
today reconcile with zero members will, after the next reconcile, actually bind
to the seeded groups. Members of `<slug>-editor-group` / `<slug>-viewer-group`
gain the access the manifest always intended to grant them.

## Testing

- [x] `go build ./...` — exit 0
- [x] `go test ./components/ledger/internal/services/fees/... -cover` — `ok` (87.3% / 73.5%)
- [x] `go test ./components/tracer/internal/adapters/http/in/... -count=1` — `ok`
- [x] `golangci-lint run ./components/ledger/internal/services/fees/...` — `0 issues.`
- [ ] `make test-int` — not run: no integration path touches these manifests
- [ ] `make sec` / `make vulncheck` — not run: no Go, dependency or config surface changed

**Test evidence:** a throwaway harness (not committed) parsed each manifest into
`lib-auth/v3 auth/declaration.DeclarationManifest`, ran `Validate()`, and
cross-checked every `granted_to` group against the 78 groups in the Access
Manager seed.

Before this change:

```
--- FAIL: TestManifestGroupsExistInSeed (0.00s)
    seed groups loaded: 78
    fees/permissions.yaml: service "plugin-fees" role "editor" grants to group "fees-admins" which does NOT exist in the seed
    fees/permissions.yaml: service "plugin-fees" role "viewer" grants to group "fees-viewers" which does NOT exist in the seed
    ledger/permissions.yaml: service "midaz" role "editor" grants to group "midaz-admins" which does NOT exist in the seed
    ledger/permissions.yaml: service "midaz" role "viewer" grants to group "midaz-viewers" which does NOT exist in the seed
    tracer/permissions.yaml: service "tracer" role "editor" grants to group "tracer-admins" which does NOT exist in the seed
    tracer/permissions.yaml: service "tracer" role "viewer" grants to group "tracer-viewers" which does NOT exist in the seed
FAIL
```

After:

```
=== RUN   TestManifestGroupsExistInSeed
    seed groups loaded: 78
    OK fees/permissions.yaml:   plugin-fees/editor -> plugin-fees-editor-group
    OK fees/permissions.yaml:   plugin-fees/viewer -> plugin-fees-viewer-group
    OK ledger/permissions.yaml: midaz/editor       -> midaz-editor-group
    OK ledger/permissions.yaml: midaz/viewer       -> midaz-viewer-group
    OK tracer/permissions.yaml: tracer/editor      -> tracer-editor-group
    OK tracer/permissions.yaml: tracer/viewer      -> tracer-viewer-group
--- PASS: TestManifestGroupsExistInSeed (0.00s)
PASS
```

That harness is intentionally not committed: it can only run where the
`plugin-access-manager` seed is checked out. Enforcing this parity for real
belongs on the access-manager side, which is exactly what the 422 gate does.

## Architectural Checklist

- [x] No `panic()` in production paths — no Go changed
- [x] Timestamps use `time.Now().UTC()` — no Go changed
- [x] Errors wrapped with `%w` — no Go changed
- [x] Handlers stay thin (parse, validate, call service) — no handler changed
- [x] Infrastructure concerns kept in `internal/bootstrap` — no bootstrap changed

## Related Issues

Context (not closed by this PR): LerianStudio/plugin-access-manager#364 — the
change that starts rejecting a grant to a non-existent group with 422.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
