### PR TITLE
chore(deps): bump lib-auth to v3.4.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.26.4
 toolchain go1.26.6
 
 require (
-	github.com/LerianStudio/lib-auth/v3 v3.3.0
+	github.com/LerianStudio/lib-auth/v3 v3.4.0
 	github.com/Masterminds/squirrel v1.5.4
 	github.com/antlr4-go/antlr/v4 v4.13.1 // indirect
 	github.com/go-playground/locales v0.14.1

--- a/go.sum
+++ b/go.sum
@@ -17,8 +17,8 @@ github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c/go.mod h1:xomTg6
 github.com/DATA-DOG/go-sqlmock v1.5.2 h1:OcvFkGmslmlZibjAjaHm3L//6LiuBgolP7OputlJIzU=
 github.com/DATA-DOG/go-sqlmock v1.5.2/go.mod h1:88MAG/4G7SMwSE3CeA0ZKzrT5CiOU3OJ+JlNzwDqpNU=
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
-github.com/LerianStudio/lib-auth/v3 v3.3.0 h1:aDpJnAeER6CjBipggA7mVK951anOQzvkzqa8YzZgb0Q=
-github.com/LerianStudio/lib-auth/v3 v3.3.0/go.mod h1:mKU9zG1AeHE7Ux3iu1n+hZlzLA9KHDa5s+vC+XtbOM4=
+github.com/LerianStudio/lib-auth/v3 v3.4.0 h1:QmKh/ipCovA4PQO5k8sPDVtrZpahL5MXD+F6ikq2jAM=
+github.com/LerianStudio/lib-auth/v3 v3.4.0/go.mod h1:mKU9zG1AeHE7Ux3iu1n+hZlzLA9KHDa5s+vC+XtbOM4=
 github.com/LerianStudio/lib-commons/v6 v6.8.1 h1:qhKV/y4+3GmwX7wn6DBhtTkSW08MD71X+Wv57m8FjGQ=
 github.com/LerianStudio/lib-commons/v6 v6.8.1/go.mod h1:xnLzD7tvsyemX9ELIOCCBp1biIfml29ScjjPSt9ANbM=
 github.com/LerianStudio/lib-observability v1.1.0 h1:e/OrIoTKo8gI1RKXgKDyDDKcrddR4beh53al5ZmB6vQ=


### PR DESCRIPTION
## What this is

One line in `go.mod`: `lib-auth` `v3.3.0` → `v3.4.0`. No code changes.

## Why it matters here

`v3.4.0` derives the caller address inside the library — it reads the forwarded chain off the request, walks it right-to-left against `TRUSTED_PROXIES`, and forwards the first hop outside those ranges.

Until now the address forwarded on the authorize call came from Fiber's `c.IP()`. That resolves correctly only when the service sets the trusted-proxy chain on the `fiber.App` it builds — configuration this service does not set. Measured on `develop` before this change: `TrustProxy`, `TrustProxyConfig`, `ProxyHeader` and `EnableIPValidation` appear **zero** times.

Doing the derivation in the library is what makes this a bump rather than a change here. Nothing in this repository needs to learn about proxy chains.

`TRUSTED_PROXIES` is already provisioned for this service across its environments, so the derivation has what it needs on the first deploy — no accompanying GitOps change.

## Not touched

`TRUSTED_PROXY_CIDRS` is a different variable serving the tracer's audit trail. It is unrelated and stays as it is.

## Verification

Baseline captured **before** the bump on the same worktree, then re-run after:

| | before | after |
|---|---|---|
| `go build ./...` | clean | clean |
| `go vet ./...` | — | clean |
| packages ok | 96 | **96** |
| no test files | 30 | **30** |
| failures | 0 | **0** |

Identical. Only `go.mod` and `go.sum` changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
