### PR TITLE
chore(deps): bump lib-auth to v3.4.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.26.4
 toolchain go1.26.6
 
 require (
-	github.com/LerianStudio/lib-auth/v3 v3.3.0
+	github.com/LerianStudio/lib-auth/v3 v3.4.0
 	github.com/Masterminds/squirrel v1.5.4
 	github.com/antlr4-go/antlr/v4 v4.13.1 // indirect
 	github.com/go-playground/locales v0.14.1

--- a/go.sum
+++ b/go.sum
@@ -17,8 +17,8 @@ github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c/go.mod h1:xomTg6
 github.com/DATA-DOG/go-sqlmock v1.5.2 h1:OcvFkGmslmlZibjAjaHm3L//6LiuBgolP7OputlJIzU=
 github.com/DATA-DOG/go-sqlmock v1.5.2/go.mod h1:88MAG/4G7SMwSE3CeA0ZKzrT5CiOU3OJ+JlNzwDqpNU=
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
-github.com/LerianStudio/lib-auth/v3 v3.3.0 h1:aDpJnAeER6CjBipggA7mVK951anOQzvkzqa8YzZgb0Q=
-github.com/LerianStudio/lib-auth/v3 v3.3.0/go.mod h1:mKU9zG1AeHE7Ux3iu1n+hZlzLA9KHDa5s+vC+XtbOM4=
+github.com/LerianStudio/lib-auth/v3 v3.4.0 h1:QmKh/ipCovA4PQO5k8sPDVtrZpahL5MXD+F6ikq2jAM=
+github.com/LerianStudio/lib-auth/v3 v3.4.0/go.mod h1:mKU9zG1AeHE7Ux3iu1n+hZlzLA9KHDa5s+vC+XtbOM4=
 github.com/LerianStudio/lib-commons/v6 v6.7.0 h1:qXqltprs5gX9RDTrCAa4DOsrNJ9zc5X60LtxYEjWcCA=
 github.com/LerianStudio/lib-commons/v6 v6.7.0/go.mod h1:yo2QHBbXXwKNw1Wygip+Z/AANpIunyuXnEAZZT8hGQg=
 github.com/LerianStudio/lib-observability v1.1.0 h1:e/OrIoTKo8gI1RKXgKDyDDKcrddR4beh53al5ZmB6vQ=


### PR DESCRIPTION
Twin of #2372 for the release-candidate line.

**Redone on this base, not cherry-picked.** `develop` is **196 commits** ahead here. A `go.sum` resolved against a different dependency set is the kind of thing that merges cleanly and fails at build time later, so the bump was re-run on this branch and the checksums match the tree they land in.

## What changes

One line in `go.mod`: `lib-auth` `v3.3.0` → `v3.4.0`. No code.

`v3.4.0` derives the caller address inside the library — it reads the forwarded chain off the request, walks it right-to-left against `TRUSTED_PROXIES`, and forwards the first hop outside those ranges.

Until now the address forwarded on the authorize call came from Fiber's `c.IP()`, which resolves correctly only when the service sets the trusted-proxy chain on the `fiber.App` it builds — configuration this service does not set. That is why the derivation moved into the library: nothing in this repository needs to learn about proxy chains.

`TRUSTED_PROXIES` is already provisioned for this service across its environments, so no accompanying GitOps change is needed.

`TRUSTED_PROXY_CIDRS` is a different variable serving the tracer's audit trail — unrelated, untouched.

## Verification

Baseline captured on **this** branch before the bump, then re-run after:

| | before | after |
|---|---|---|
| packages ok | 94 | **94** |
| no test files | 28 | **28** |
| failures | 0 | **0** |
| `go build` / `go vet` | clean | clean |

Only `go.mod` and `go.sum` changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)