### PR TITLE
fix(ci): set GH_REPO for fork workflows' gh commands

### DIFF
--- a/.github/workflows/fork-pr-notice.yml
+++ b/.github/workflows/fork-pr-notice.yml
@@ -20,6 +20,7 @@ jobs:
       - name: Comment with the promotion flow explanation
         env:
           GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           BASE_REF: ${{ github.event.pull_request.base.ref }}
         run: |

--- a/.github/workflows/fork-pr-promote.yml
+++ b/.github/workflows/fork-pr-promote.yml
@@ -38,6 +38,7 @@ jobs:
       - name: Open or confirm the fork -> develop promotion PR
         env:
           GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
           existing=$(gh pr list --head fork --base develop --json number --jq '.[0].number // empty')


### PR DESCRIPTION
## Summary
Fixes a real bug caught while live-testing the trusted-promotion flow from #2365 with an actual fork PR (#2381, opened from `bedatty-bot/midaz`).

`fork-pr-notice.yml` failed on `gh pr comment` with `fatal: not a git repository (or any of the parent directories): .git`. Both `fork-pr-notice.yml` and `fork-pr-promote.yml` are intentionally metadata-only (no `actions/checkout`), so `gh` has no local git repo to infer the target repository from, and neither passed `--repo` either. Setting `GH_REPO: ${{ github.repository }}` fixes both.

## Test plan
- [ ] Confirm `fork-pr-notice.yml` successfully comments on PR #2381 after this merges (re-run the workflow, or open a new test PR).
- [ ] Confirm `fork-pr-promote.yml` successfully opens the promotion PR once #2381 is merged into `fork`.