### PR TITLE
fix(ci): don't promote same-repo merges + friendlier fork notice

### DIFF
--- a/.github/workflows/fork-pr-notice.yml
+++ b/.github/workflows/fork-pr-notice.yml
@@ -26,8 +26,39 @@ jobs:
         run: |
           set -euo pipefail
           if [[ "$BASE_REF" == "fork" ]]; then
-            body='Thanks for the contribution! Since this targets `fork`, a maintainer will review the diff and merge it normally when ready. That merge automatically opens a follow-up PR into `develop` with full CI (this repo does not grant secrets to PRs opened directly from a fork — a GitHub security restriction, not something disabled here). No action needed from you.'
+            cat > /tmp/notice-body.md <<'EOF'
+          > [!NOTE]
+          > ✅ **This PR is correctly targeting `fork`.**
+
+          🎉 **Thank you for contributing to Midaz — we really appreciate it, and contributions like yours are very welcome!**
+
+          A maintainer will review the diff and merge it into `fork` when ready — that's the ordinary GitHub merge button, nothing else needed from you. That merge automatically opens a follow-up PR into `develop` with full CI (this repo does not grant secrets to PRs opened directly from a fork — a GitHub security restriction, not something disabled here).
+
+          ### 📚 Related docs
+          - [CONTRIBUTING.md](https://github.com/LerianStudio/midaz/blob/develop/CONTRIBUTING.md#how-to-submit-a-pull-request) — full contribution flow
+          - [Securely using `pull_request_target`](https://docs.github.com/en/actions/reference/security/securely-using-pull_request_target) — why fork PRs don't get secrets by default
+
+          ---
+          🤖 *This message was generated automatically.*
+          EOF
           else
-            body="Thanks for the contribution! This PR targets \`$BASE_REF\`, but PRs from forks need to target \`fork\` instead — CI for forked PRs against other branches runs without secrets and some checks will fail. Please retarget this PR's base branch to \`fork\` (Edit button, top of the PR) and a maintainer will pick it up from there."
+            cat > /tmp/notice-body.md <<EOF
+          > [!WARNING]
+          > 🔀 **This PR needs to be retargeted — it's pointing at \`$BASE_REF\` instead of \`fork\`.**
+
+          🎉 **Thank you for contributing to Midaz — we really appreciate it, and contributions like yours are very welcome!** Just one small adjustment needed before CI can run fully: PRs opened from a fork against any branch other than \`fork\` run without secrets, so some CI checks will fail as a result — that's expected, not a bug on your end.
+
+          ### 🔧 What to do
+          1. Click **Edit** at the top of this PR.
+          2. Change the base branch from \`$BASE_REF\` to \`fork\`.
+          3. A maintainer will pick it up from there — no need to close and reopen this PR.
+
+          ### 📚 Related docs
+          - [CONTRIBUTING.md](https://github.com/LerianStudio/midaz/blob/develop/CONTRIBUTING.md#how-to-submit-a-pull-request) — full contribution flow, including a direct compare-link tip for targeting \`fork\`
+          - [Securely using \`pull_request_target\`](https://docs.github.com/en/actions/reference/security/securely-using-pull_request_target) — why fork PRs don't get secrets by default
+
+          ---
+          🤖 *This message was generated automatically.*
+          EOF
           fi
-          gh pr comment "$PR_NUMBER" --body "$body"
+          gh pr comment "$PR_NUMBER" --body-file /tmp/notice-body.md

--- a/.github/workflows/fork-pr-promote.yml
+++ b/.github/workflows/fork-pr-promote.yml
@@ -32,7 +32,14 @@ permissions:
 
 jobs:
   open-promotion-pr:
-    if: github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'fork'
+    # Excludes same-repo merges into `fork` — e.g. the develop -> fork
+    # backmerge sync (routine.yml) merges its own PR into fork too, and that
+    # isn't an external contribution to promote; it would just open a
+    # redundant fork -> develop PR for content develop already has.
+    if: >
+      github.event.pull_request.merged == true &&
+      github.event.pull_request.base.ref == 'fork' &&
+      github.event.pull_request.head.repo.full_name != github.repository
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - name: Open or confirm the fork -> develop promotion PR


### PR DESCRIPTION
## Summary
Caught live testing: PR #2380 (routine.yml's automated `develop -> fork` backmerge sync) merged into `fork`, and since fork-pr-promote.yml only checked `base.ref == 'fork'`, it triggered anyway — opening #2383, a redundant `fork -> develop` PR for content `develop` already had.

Adds a check that the merged PR's head repo differs from this repo (i.e. it's a genuine external contribution), so internal same-repo merges into `fork` (backmerge sync, or any other same-repo PR someone opens against `fork`) don't trigger promotion.

Also reformats fork-pr-notice.yml's comments: GitHub colored alert callouts (`> [!NOTE]` / `> [!WARNING]`), links to CONTRIBUTING.md and the pull_request_target security doc, a numbered "what to do" for the wrong-base-branch case, and an explicit thank-you up front — the message shouldn't read as a rejection.

## Test plan
- [ ] Close #2383 (superseded by this fix — it was a symptom of the bug this PR fixes).
- [ ] Confirm a future backmerge sync merge into `fork` does not open a new promotion PR.
- [ ] Confirm a genuine fork PR merge into `fork` still opens the promotion PR correctly.
- [ ] Confirm the reformatted notice comment renders correctly (colored callout, links, thank-you) on a real fork PR.