### PR TITLE
ci: .coderabbit.yaml docs-only + warn on unsigned fork-PR commits

### DIFF
--- a/.github/workflows/fork-pr-notice.yml
+++ b/.github/workflows/fork-pr-notice.yml
@@ -63,16 +63,25 @@ jobs:
           fi
 
           # Both `fork` and `develop` enforce required_signatures (an org
-          # ruleset) — an unsigned commit merges nowhere here, but the
+          # ruleset) — an unverified commit merges nowhere here, but the
           # merge button just goes red with no context unless someone
           # notices. Flag it up front instead of letting it surface later.
-          unsigned_count=$(gh api "repos/$GH_REPO/pulls/$PR_NUMBER/commits" --jq '[.[] | select(.commit.verification.verified == false)] | length')
-          total_count=$(gh api "repos/$GH_REPO/pulls/$PR_NUMBER/commits" --jq 'length')
-          if [[ "$unsigned_count" -gt 0 ]]; then
+          # --paginate --slurp: the default single-page fetch would silently
+          # under-count commits/PRs with more than 30 commits (this
+          # endpoint's own hard cap is 250 — unrealistic for this flow's
+          # PRs, so no separate fallback for that).
+          # verified == false, not reason == "unsigned": that also catches
+          # commits that ARE signed but fail verification for another
+          # reason (unknown_key, bad_email, expired_key, ...) — those are
+          # just as blocked by required_signatures as a truly unsigned one.
+          commits_json=$(gh api --paginate --slurp "repos/$GH_REPO/pulls/$PR_NUMBER/commits" --jq '[.[][]]')
+          unverified_count=$(jq '[.[] | select(.commit.verification.verified == false)] | length' <<<"$commits_json")
+          total_count=$(jq 'length' <<<"$commits_json")
+          if [[ "$unverified_count" -gt 0 ]]; then
             cat >> /tmp/notice-body.md <<EOF
 
           > [!CAUTION]
-          > ✍️ **$unsigned_count of $total_count commit(s) in this PR aren't signed.** Both \`fork\` and \`develop\` require signed commits to merge — GitHub will block the merge button until this is fixed.
+          > ✍️ **$unverified_count of $total_count commit(s) in this PR could not be verified.** Both \`fork\` and \`develop\` require signed, verified commits to merge — GitHub will block the merge button until this is fixed.
 
           Sign your commits (e.g. \`git commit -S\`, or configure SSH commit signing) and force-push this branch. See [GitHub's guide to signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and the [commit signing section of CONTRIBUTING.md](https://github.com/LerianStudio/midaz/blob/develop/CONTRIBUTING.md#commit-signing-requirement).
           EOF

--- a/.github/workflows/fork-pr-notice.yml
+++ b/.github/workflows/fork-pr-notice.yml
@@ -61,4 +61,21 @@ jobs:
           🤖 *This message was generated automatically.*
           EOF
           fi
+
+          # Both `fork` and `develop` enforce required_signatures (an org
+          # ruleset) — an unsigned commit merges nowhere here, but the
+          # merge button just goes red with no context unless someone
+          # notices. Flag it up front instead of letting it surface later.
+          unsigned_count=$(gh api "repos/$GH_REPO/pulls/$PR_NUMBER/commits" --jq '[.[] | select(.commit.verification.verified == false)] | length')
+          total_count=$(gh api "repos/$GH_REPO/pulls/$PR_NUMBER/commits" --jq 'length')
+          if [[ "$unsigned_count" -gt 0 ]]; then
+            cat >> /tmp/notice-body.md <<EOF
+
+          > [!CAUTION]
+          > ✍️ **$unsigned_count of $total_count commit(s) in this PR aren't signed.** Both \`fork\` and \`develop\` require signed commits to merge — GitHub will block the merge button until this is fixed.
+
+          Sign your commits (e.g. \`git commit -S\`, or configure SSH commit signing) and force-push this branch. See [GitHub's guide to signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and the [commit signing section of CONTRIBUTING.md](https://github.com/LerianStudio/midaz/blob/develop/CONTRIBUTING.md#commit-signing-requirement).
+          EOF
+          fi
+
           gh pr comment "$PR_NUMBER" --body-file /tmp/notice-body.md

--- a/.github/workflows/fork-pr-notice.yml
+++ b/.github/workflows/fork-pr-notice.yml
@@ -74,9 +74,12 @@ jobs:
           # commits that ARE signed but fail verification for another
           # reason (unknown_key, bad_email, expired_key, ...) — those are
           # just as blocked by required_signatures as a truly unsigned one.
-          commits_json=$(gh api --paginate --slurp "repos/$GH_REPO/pulls/$PR_NUMBER/commits" --jq '[.[][]]')
-          unverified_count=$(jq '[.[] | select(.commit.verification.verified == false)] | length' <<<"$commits_json")
-          total_count=$(jq 'length' <<<"$commits_json")
+          # --slurp isn't accepted together with --jq (gh api rejects the
+          # combination outright), so the flattening has to happen in a
+          # separate, standalone jq call instead of inline on the gh api call.
+          commits_json=$(gh api --paginate --slurp "repos/$GH_REPO/pulls/$PR_NUMBER/commits")
+          unverified_count=$(jq '[.[][] | select(.commit.verification.verified == false)] | length' <<<"$commits_json")
+          total_count=$(jq '[.[][]] | length' <<<"$commits_json")
           if [[ "$unverified_count" -gt 0 ]]; then
             cat >> /tmp/notice-body.md <<EOF
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,10 @@ jobs:
       enable_changelog: ${{ github.ref == 'refs/heads/main' }}
       release_single_app: true
       app_name_prefix: "midaz"
+      # Default plus .coderabbit.yaml: it's a CodeRabbit-only config file,
+      # not something that should trigger a release or contact Ungoliant.
+      ignore_globs: "*.md docs/* .github/* LICENSE* .gitignore .coderabbit.yaml"
+      ungoliant_skip_globs: ".releaserc.yml .github/* .coderabbit.yaml"
       # Image/release filter: the two app image-bearing components. CRM rolls up under
       # components/ledger (a ledger package tree, not a standalone image); reporter
       # was extracted out of this repo entirely. The dedicated migration-runner images


### PR DESCRIPTION
## Summary

**release.yml:** follow-up to #2388, which added the same override to \`pr-validation.yml\`. \`go-release.yml\` has the same \`ignore_globs\` mechanism (default \`*.md docs/* .github/* LICENSE* .gitignore\`, "when only these change on a branch push, the release is skipped") plus a separate \`ungoliant_skip_globs\` (default \`.releaserc.yml .github/*\`, "when every changed file matches one, Ungoliant is never contacted"). Neither default covers root-level \`.coderabbit.yaml\`, so editing just the CodeRabbit config would still trigger a release and contact Ungoliant. Overriding both with their defaults plus \`.coderabbit.yaml\`.

**fork-pr-notice.yml:** both \`fork\` and \`develop\` enforce \`required_signatures\` via an org ruleset (verified via \`gh api repos/LerianStudio/midaz/rules/branches/{fork,develop}\`) — an unsigned commit can't merge here, but the merge button just goes red with no context unless someone happens to notice. The notice comment now checks commit verification status via the \`pulls/{n}/commits\` API and appends a \`[!CAUTION]\` block (with links to GitHub's signing docs and CONTRIBUTING.md's commit-signing section) whenever any commit in the PR is unverified.

## Test plan
- [ ] Push a commit touching only \`.coderabbit.yaml\` to \`develop\`/\`release-candidate\`/\`main\` and confirm the release pipeline skips (no version bump, no Ungoliant contact).
- [ ] Open a fork PR with an unsigned commit and confirm the notice comment includes the signing warning.
- [ ] Open a fork PR with all commits signed and confirm no signing warning appears.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Release automation now ignores documentation, Markdown, repository metadata, license, and configuration-only changes.
  * These non-product updates no longer trigger release processing.

* **Bug Fixes**
  * Pull request notices now correctly process commit results across paginated responses.
  * Commit verification and total commit counts are now calculated accurately for pull requests with many commits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->