### PR TITLE
feat(tracer): rename limit streaming wire field currency to asset

### DIFF
--- a/components/tracer/internal/services/command/limit_streaming_test.go
+++ b/components/tracer/internal/services/command/limit_streaming_test.go
@@ -100,7 +100,7 @@ func TestCreateLimit_EmitsLimitCreated(t *testing.T) {
 	assert.Equal(t, result.ID.String(), payload.ID)
 	assert.Equal(t, "DRAFT", payload.Status)
 	assert.Equal(t, "DAILY", payload.LimitType)
-	assert.Equal(t, "USD", payload.Currency)
+	assert.Equal(t, "USD", payload.Asset)
 	require.Len(t, payload.Scopes, 1)
 
 	assertLimitFenceClean(t, emitted[0].Payload)

--- a/docs/streaming/tracer-events.md
+++ b/docs/streaming/tracer-events.md
@@ -265,7 +265,7 @@ Source: `pkg/streaming/events/limit_created.go`, `limit_updated.go`.
   "id":              "uuid",
   "status":          "DRAFT | ACTIVE | INACTIVE | DELETED",
   "limitType":       "DAILY | WEEKLY | MONTHLY | CUSTOM | PER_TRANSACTION",
-  "currency":        "ISO-4217",
+  "asset":           "asset code",
   "scopes":          [ { /* RuleScopePayload — 6 keys */ } ],
   "activeTimeStart": "HH:MM | null",
   "activeTimeEnd":   "HH:MM | null",
@@ -282,7 +282,7 @@ Source: `pkg/streaming/events/limit_created.go`, `limit_updated.go`.
 | `id` | string | Limit ID. |
 | `status` | string | `DRAFT` / `ACTIVE` / `INACTIVE` / `DELETED`. |
 | `limitType` | string | `DAILY` / `WEEKLY` / `MONTHLY` / `CUSTOM` / `PER_TRANSACTION`. |
-| `currency` | string | ISO-4217 code. |
+| `asset` | string | Asset code. |
 | `scopes` | array | Shared `RuleScopePayload` elements (6 keys each); `[]` when empty. |
 | `activeTimeStart` | string \| null | Time-of-day window start (`HH:MM`), `null` when unset. |
 | `activeTimeEnd` | string \| null | Time-of-day window end (`HH:MM`), `null` when unset. |
@@ -311,7 +311,7 @@ Source: `pkg/streaming/events/limit_activated.go`, `limit_deactivated.go`,
 Unlike Rule, the Limit domain model has no `ActivatedAt` / `DeactivatedAt`
 fields, so all three status-transition events carry the same minimal shape.
 
-**Excluded:** `limitType`, `currency`, `scopes`, all time-window fields,
+**Excluded:** `limitType`, `asset`, `scopes`, all time-window fields,
 `name`, `description`, `maxAmount`.
 
 ### `limit.deleted` — 2 fields
@@ -325,7 +325,7 @@ Source: `pkg/streaming/events/limit_deleted.go`. `ce-subject` = limit ID.
 }
 ```
 
-**Excluded:** `status`, `limitType`, `currency`, `scopes`, all time-window
+**Excluded:** `status`, `limitType`, `asset`, `scopes`, all time-window
 fields, `name`, `description`, `maxAmount`.
 
 ## What is deliberately off the wire, and why

--- a/pkg/streaming/events/limit_activated_test.go
+++ b/pkg/streaming/events/limit_activated_test.go
@@ -79,7 +79,7 @@ func TestLimitActivatedPayload_JSONShape(t *testing.T) {
 	}
 
 	for _, forbidden := range []string{
-		"activatedAt", "deactivatedAt", "limitType", "currency", "scopes", "maxAmount", "name", "description",
+		"activatedAt", "deactivatedAt", "limitType", "asset", "scopes", "maxAmount", "name", "description",
 	} {
 		_, present := generic[forbidden]
 		assert.Falsef(t, present, "field %q must NOT appear", forbidden)

--- a/pkg/streaming/events/limit_created.go
+++ b/pkg/streaming/events/limit_created.go
@@ -44,13 +44,10 @@ var LimitCreatedDefinition = Definition{
 // reuse RuleScopePayload since model.Limit.Scopes is the same []model.Scope
 // type as model.Rule.Scopes.
 type LimitCreatedPayload struct {
-	ID        string `json:"id"`
-	Status    string `json:"status"`
-	LimitType string `json:"limitType"`
-	// Currency deliberately carries the renamed domain field model.Limit.Asset.
-	// The wire name/json tag stay "currency" for consumer compatibility; do not
-	// rename without a SchemaVersion bump and coordinated consumer rollout.
-	Currency        string             `json:"currency"`
+	ID              string             `json:"id"`
+	Status          string             `json:"status"`
+	LimitType       string             `json:"limitType"`
+	Asset           string             `json:"asset"`
 	Scopes          []RuleScopePayload `json:"scopes"`
 	ActiveTimeStart *string            `json:"activeTimeStart"`
 	ActiveTimeEnd   *string            `json:"activeTimeEnd"`
@@ -71,7 +68,7 @@ func NewLimitCreated(limit *model.Limit) LimitCreatedPayload {
 		ID:              limit.ID.String(),
 		Status:          string(limit.Status),
 		LimitType:       string(limit.LimitType),
-		Currency:        limit.Asset,
+		Asset:           limit.Asset,
 		Scopes:          newRuleScopePayloads(limit.Scopes),
 		ActiveTimeStart: formatOptionalTimeOfDay(limit.ActiveTimeStart),
 		ActiveTimeEnd:   formatOptionalTimeOfDay(limit.ActiveTimeEnd),

--- a/pkg/streaming/events/limit_created_test.go
+++ b/pkg/streaming/events/limit_created_test.go
@@ -100,7 +100,7 @@ func TestNewLimitCreated_MapsMinimalLimit(t *testing.T) {
 	assert.Equal(t, fixedLimitUUID.String(), payload.ID)
 	assert.Equal(t, "DRAFT", payload.Status)
 	assert.Equal(t, "DAILY", payload.LimitType)
-	assert.Equal(t, "USD", payload.Currency)
+	assert.Equal(t, "USD", payload.Asset)
 	require.NotNil(t, payload.Scopes)
 	assert.Len(t, payload.Scopes, 0)
 	assert.Nil(t, payload.ActiveTimeStart)
@@ -166,7 +166,7 @@ func TestLimitCreatedPayload_JSONShape(t *testing.T) {
 		"id":              {},
 		"status":          {},
 		"limitType":       {},
-		"currency":        {},
+		"asset":           {},
 		"scopes":          {},
 		"activeTimeStart": {},
 		"activeTimeEnd":   {},

--- a/pkg/streaming/events/limit_deactivated_test.go
+++ b/pkg/streaming/events/limit_deactivated_test.go
@@ -79,7 +79,7 @@ func TestLimitDeactivatedPayload_JSONShape(t *testing.T) {
 	}
 
 	for _, forbidden := range []string{
-		"activatedAt", "deactivatedAt", "limitType", "currency", "scopes", "maxAmount", "name", "description",
+		"activatedAt", "deactivatedAt", "limitType", "asset", "scopes", "maxAmount", "name", "description",
 	} {
 		_, present := generic[forbidden]
 		assert.Falsef(t, present, "field %q must NOT appear", forbidden)

--- a/pkg/streaming/events/limit_deleted_test.go
+++ b/pkg/streaming/events/limit_deleted_test.go
@@ -91,7 +91,7 @@ func TestLimitDeletedPayload_JSONShape(t *testing.T) {
 	}
 
 	for _, forbidden := range []string{
-		"status", "name", "description", "maxAmount", "limitType", "currency", "scopes",
+		"status", "name", "description", "maxAmount", "limitType", "asset", "scopes",
 	} {
 		_, present := generic[forbidden]
 		assert.Falsef(t, present, "field %q must NOT appear", forbidden)

--- a/pkg/streaming/events/limit_drafted_test.go
+++ b/pkg/streaming/events/limit_drafted_test.go
@@ -75,7 +75,7 @@ func TestLimitDraftedPayload_JSONShape(t *testing.T) {
 	}
 
 	for _, forbidden := range []string{
-		"activatedAt", "deactivatedAt", "limitType", "currency", "scopes", "maxAmount", "name", "description",
+		"activatedAt", "deactivatedAt", "limitType", "asset", "scopes", "maxAmount", "name", "description",
 	} {
 		_, present := generic[forbidden]
 		assert.Falsef(t, present, "field %q must NOT appear", forbidden)

--- a/pkg/streaming/events/limit_updated.go
+++ b/pkg/streaming/events/limit_updated.go
@@ -26,13 +26,10 @@ var LimitUpdatedDefinition = Definition{
 // same twelve-field shape as LimitCreatedPayload; the fence EXCLUDES name,
 // description, and maxAmount.
 type LimitUpdatedPayload struct {
-	ID        string `json:"id"`
-	Status    string `json:"status"`
-	LimitType string `json:"limitType"`
-	// Currency deliberately carries the renamed domain field model.Limit.Asset.
-	// The wire name/json tag stay "currency" for consumer compatibility; do not
-	// rename without a SchemaVersion bump and coordinated consumer rollout.
-	Currency        string             `json:"currency"`
+	ID              string             `json:"id"`
+	Status          string             `json:"status"`
+	LimitType       string             `json:"limitType"`
+	Asset           string             `json:"asset"`
 	Scopes          []RuleScopePayload `json:"scopes"`
 	ActiveTimeStart *string            `json:"activeTimeStart"`
 	ActiveTimeEnd   *string            `json:"activeTimeEnd"`
@@ -50,7 +47,7 @@ func NewLimitUpdated(limit *model.Limit) LimitUpdatedPayload {
 		ID:              limit.ID.String(),
 		Status:          string(limit.Status),
 		LimitType:       string(limit.LimitType),
-		Currency:        limit.Asset,
+		Asset:           limit.Asset,
 		Scopes:          newRuleScopePayloads(limit.Scopes),
 		ActiveTimeStart: formatOptionalTimeOfDay(limit.ActiveTimeStart),
 		ActiveTimeEnd:   formatOptionalTimeOfDay(limit.ActiveTimeEnd),

--- a/pkg/streaming/events/limit_updated_test.go
+++ b/pkg/streaming/events/limit_updated_test.go
@@ -27,7 +27,7 @@ func TestNewLimitUpdated_MapsMinimalLimit(t *testing.T) {
 	assert.Equal(t, fixedLimitUUID.String(), payload.ID)
 	assert.Equal(t, "DRAFT", payload.Status)
 	assert.Equal(t, "DAILY", payload.LimitType)
-	assert.Equal(t, "USD", payload.Currency)
+	assert.Equal(t, "USD", payload.Asset)
 	require.NotNil(t, payload.Scopes)
 	assert.Len(t, payload.Scopes, 0)
 	assert.Nil(t, payload.ActiveTimeStart)
@@ -74,7 +74,7 @@ func TestLimitUpdatedPayload_JSONShape(t *testing.T) {
 		"id":              {},
 		"status":          {},
 		"limitType":       {},
-		"currency":        {},
+		"asset":           {},
 		"scopes":          {},
 		"activeTimeStart": {},
 		"activeTimeEnd":   {},


### PR DESCRIPTION
## What

The `limit.created` and `limit.updated` streaming events now emit the wire key `asset` instead of `currency`. The field already carried `model.Limit.Asset`; the domain model and the HTTP API already use `asset`, so this aligns the streaming wire with the rest of the surface — the streaming payload was the last place still on the legacy `currency` name.

- `pkg/streaming/events/limit_created.go` and `limit_updated.go`: payload field `Currency` → `Asset`, json tag `currency` → `asset`, constructor mapping unchanged (`Asset: limit.Asset`). The obsolete "keep the wire name as currency" comments are removed.
- `SchemaVersion` stays `1.0.0`: these events have not shipped to production, so no version guard is needed and no consumer is versioned against the old key.
- The four snapshot events (`activated` / `deactivated` / `deleted` / `drafted`) do not carry this field; their JSONShape tests continue to assert the renamed key does not leak onto them.

## Tests & docs

- The two JSONShape/Definition tests and the four snapshot forbidden-key tests are updated to `asset`; field counts (12/12) and Definition keys (`limit.created` / `limit.updated`) are unchanged. The tracer command-layer consumer test reads the renamed field.
- `docs/streaming/tracer-events.md` updated (payload example, field table, snapshot exclusion lists) to `asset`.
- Repo-wide unit suite green; full lint (0 issues); no dependency, proto, or OpenAPI change.

## Notes

- The emitted **value** is unchanged — only the wire **key** name changed.
- No external API contract file changed; the RFC/OpenAPI surfaces are untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Limit-created and limit-updated streaming events now use the `asset` field instead of `currency`.
  * Updated event documentation and payload validation to reflect the new field name.
  * Other limit event payloads now consistently exclude `asset` where applicable.
  * Updated streaming event tests to verify the revised JSON payload structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->