### PR TITLE
ci(fork-pr-notice): edit existing comment instead of creating new ones

### DIFF
--- a/.github/workflows/fork-pr-notice.yml
+++ b/.github/workflows/fork-pr-notice.yml
@@ -113,4 +113,8 @@ jobs:
           EOF
           fi
 
-          gh pr comment "$PR_NUMBER" --body-file /tmp/notice-body.md
+          # --edit-last updates this workflow's own previous comment on the
+          # PR (e.g. the initial wrong-branch warning) instead of piling up
+          # a new one on every retarget/edit; --create-if-none covers the
+          # first run, when there's nothing yet to edit.
+          gh pr comment "$PR_NUMBER" --edit-last --create-if-none --body-file /tmp/notice-body.md


### PR DESCRIPTION
## Summary
Opening a fork PR against the wrong base, then retargeting to \`fork\`, posted two separate bot comments on the same PR (visible on #2391) instead of updating one in place.

\`gh pr comment --edit-last\` edits this workflow's own previous comment on the PR; \`--create-if-none\` covers the first run when there's nothing yet to edit. Both comments come from the same GITHUB_TOKEN bot identity across runs on a given fork PR, and no other workflow comments on the fork PR itself (fork-pr-promote.yml comments on the separate \`fork -> develop\` promotion PR instead), so \`--edit-last\` can't accidentally target an unrelated comment here.

## Test plan
- [ ] Open a fork PR against \`develop\`, confirm the warning comment.
- [ ] Retarget to \`fork\`, confirm the SAME comment updates in place (no second comment).
- [ ] Push an unsigned commit, confirm the caution block still appears/updates correctly on that one comment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated pull request notifications to edit the latest existing notice when possible.
  * Prevented duplicate notifications by creating a new notice only when no existing one is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->