### PR TITLE
ci(fork-pr-notice): re-check commit signatures on every push

### DIFF
--- a/.github/workflows/fork-pr-notice.yml
+++ b/.github/workflows/fork-pr-notice.yml
@@ -3,13 +3,17 @@ name: Fork PR Notice
 # Comments when a PR is opened from a fork, explaining the trusted-promotion
 # flow (fork-pr-promote.yml) and redirecting PRs opened against the wrong
 # base branch. Also reacts when the base branch is later changed (edited),
-# so retargeting to `fork` gets its own confirmation instead of silence.
+# so retargeting to `fork` gets its own confirmation instead of silence, and
+# on every new push (synchronize), so the unverified-commits warning below
+# gets re-evaluated and dropped once a contributor pushes a signed fixup —
+# the comment is rebuilt from scratch and edited in place each run, so a
+# now-clean signature status just means the caution block isn't re-added.
 # Metadata-only: no checkout, no code execution, safe under
 # pull_request_target despite the elevated token it carries.
 
 on:
   pull_request_target:
-    types: [opened, edited]
+    types: [opened, edited, synchronize]
 
 permissions:
   pull-requests: write
@@ -20,7 +24,7 @@ jobs:
     # base branch itself changed, so we don't spam a comment on every edit.
     if: >
       github.event.pull_request.head.repo.full_name != github.repository &&
-      (github.event.action == 'opened' || github.event.changes.base != null)
+      (github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.changes.base != null)
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - name: Comment with the promotion flow explanation


### PR DESCRIPTION
## Summary
Per https://github.com/LerianStudio/midaz/pull/2391#issuecomment-5399869316 — the unverified-commits caution block never got re-evaluated once posted, because \`synchronize\` (new commits pushed to the PR) wasn't in the trigger types at all. A contributor could push a fully-signed fixup and the warning would just sit there forever.

Adds \`synchronize\` to the trigger and job condition. Since the notice comment is already rebuilt from scratch and edited in place (\`--edit-last\`, from #2392) on every run, this is enough by itself: a push where all commits now verify simply means the caution block isn't re-added when the comment is rebuilt.

## Test plan
- [ ] On a fork PR with an unverified-commit warning, push a signed fixup commit and confirm the same comment updates to drop the caution block.
- [ ] Push an additional commit that's still unsigned and confirm the caution block stays (with updated counts).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fork pull request notices and unverified-commit warnings are now refreshed after new commits are pushed.
  * Notifications continue to update when pull requests are opened or their base branch changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->