### PR TITLE
ci(fork-pr-promote): use conventional-commit title for promotion PR

### DIFF
--- a/.github/workflows/fork-pr-promote.yml
+++ b/.github/workflows/fork-pr-promote.yml
@@ -55,6 +55,6 @@ jobs:
             gh pr create \
               --base develop \
               --head fork \
-              --title "Promote fork -> develop" \
+              --title "chore(release): promote fork -> develop" \
               --body "Opened automatically after #${{ github.event.pull_request.number }} merged into \`fork\`. Same-repo branch — runs full CI with secrets."
           fi


### PR DESCRIPTION
## Summary
The automatically-opened \`fork -> develop\` promotion PR now always uses the title \`chore(release): promote fork -> develop\`, matching this repo's Conventional Commits convention instead of a plain, type-less title.

## Test plan
- [ ] Merge a fork PR into \`fork\` and confirm the auto-opened promotion PR has this exact title.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the promotion pull request title to follow the project’s release naming convention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->