### PR TITLE
ci: allow release as a valid PR title scope

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -40,6 +40,7 @@ jobs:
         ci
         docs
         tests
+        release
       go_version: "1.26.6"
       golangci_lint_version: "v2.12.2"
       app_name_prefix: "midaz"


### PR DESCRIPTION
## Summary
\`fork-pr-promote.yml\`'s auto-opened promotion PR titles itself \`chore(release): promote fork -> develop\` (#2396), but \`release\` wasn't in \`pr_title_scopes\`:

\`\`\`
Error: Unknown scope "release" found in pull request title "chore(release): promote fork -> develop". Scope must match one of: crm, ledger, tracer, fees, api, pkg, infra, migrations, scripts, deps, ci, docs, tests.
\`\`\`

Adds \`release\` to the allowed list.

## Test plan
- [ ] Merge a fork PR into \`fork\` and confirm the auto-opened promotion PR passes the title-scope check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Pull requests can now use `release` as a valid title scope during validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->