### PR TITLE
chore(deps): drop stale trivy CVE suppressions

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,11 +1,6 @@
-# CVE-2025-57319 (fast-redact, JS): disputed prototype-pollution advisory. Not a real
-# finding in this Go repo's scanned components. Pre-existing suppression, left as-is.
-CVE-2025-57319
-
-# CVE-2026-45045 (github.com/gofiber/fiber/v2): X-Real-IP spoofing via Header.Add() in the
-# proxy BalancerForward middleware. No upstream fix exists — v2.52.13 is the latest fiber/v2
-# (maintenance mode); the fix ships only in fiber/v3 (>= 3.3.0), which midaz depends on
-# indirectly and has bumped. midaz does not use fiber's proxy / BalancerForward middleware
-# (no middleware/proxy import), so the vulnerable reverse-proxy code path is unreachable.
-# Re-evaluate when a patched fiber/v2 ships or the HTTP runtime migrates to fiber/v3.
-CVE-2026-45045 exp:2027-01-05
+# Trivy CVE suppressions. Intentionally empty.
+#
+# Every entry must carry: why it is not exploitable here, and an exp: date so the
+# suppression expires instead of rotting. Re-check before adding one — the last two
+# entries (CVE-2025-57319 fast-redact, CVE-2026-45045 gofiber/fiber v2) both outlived
+# the finding they suppressed.


### PR DESCRIPTION
## What

Empties `.trivyignore`. Both suppressions it carried are stale — neither matches a live finding any more.

## Why

**CVE-2026-45045 — `github.com/gofiber/fiber/v2`** — fixed upstream.
- Fixed in `fiber/v2` **v2.52.14**. `go.mod:145` pins **v2.52.15**.
- Verified in the module cache: `middleware/proxy/proxy.go` `BalancerForward` now calls `Header.Set("X-Real-IP", c.IP())`, not `Header.Add`.
- The suppression comment claimed v2.52.13 was the latest v2 release and that no upstream fix existed. Both were true when written and are not now.

**CVE-2025-57319 — `fast-redact` (JS)** — dependency is gone.
- It reached the scan through `components/console/package-lock.json` (3 hits at `2af78e027`, the commit that added the suppression). That lockfile left the repo when console was extracted.
- The only lockfile left, `postman/generator/package-lock.json`, contains neither `fast-redact` nor `pino`.
- The advisory is still Disputed on NVD with no patched version — irrelevant, since nothing depends on the package.

## Why not delete the file

`.github/workflows/pr-validation.yml:54` hands `ignore_file: ".trivyignore"` to the shared workflow. The file stays as a comment-only stub, with a header recording the bar for adding an entry back: a reason it is not exploitable here, plus an `exp:` date so the next suppression expires instead of rotting the way these two did.

## Verification

Analysis over `go.mod`, the Go module cache, the current and historical lockfiles, and git history. Trivy was not re-run locally (not installed) — CI's scan on this PR is the live check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed existing vulnerability suppressions from the security scanning policy.
  * Added guidance requiring future suppressions to include exploitability justification and expiration dates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->