### PR TITLE
fix(tracer): rename module name for multi-tenant resolution

### DIFF
--- a/components/tracer/pkg/constant/modules.go
+++ b/components/tracer/pkg/constant/modules.go
@@ -8,4 +8,4 @@ package constant
 // registering with the multi-tenant Tenant Manager.
 // The Tenant Manager uses the hierarchy Service → Module → Resource.
 // Tracer is a single-module service; this constant is the only module name.
-const ModuleName = "tracer"
+const ModuleName = "tracer-api"


### PR DESCRIPTION
<table border="0" cellspacing="0" cellpadding="0">
  <tr>
    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
    <td><h1>Midaz</h1></td>
  </tr>
</table>

---

## Description

Renames the tracer's canonical `ModuleName` constant from `tracer` to
`tracer-api`. This is the module identifier the tracer registers with the
multi-tenant Tenant Manager under the `Service → Module → Resource`
hierarchy, so the value must match the module name the Tenant Manager
expects for tenant resolution to succeed.

## Type of Change

- [x] `fix`: Bug fix

## Breaking Changes

None.

## Testing

- [ ] `make test` passes
- [ ] `make test-int` passes if integration paths are exercised
- [ ] `make lint` passes
- [ ] `make sec` and `make vulncheck` pass

**Test evidence / Actions run:** <!-- Optional: link to a CI run or screenshot -->

## Architectural Checklist

- [x] No `panic()` in production paths
- [x] Timestamps use `time.Now().UTC()`
- [x] Errors wrapped with `%w`
- [x] Handlers stay thin (parse, validate, call service)
- [x] Infrastructure concerns kept in `internal/bootstrap`

## Related Issues

Closes #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the tracer module identifier to `tracer-api` for improved consistency and recognition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->