### PR TITLE
fix(pkg): clarify streaming broker publication semantics

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -203,12 +203,12 @@ Producer is `github.com/LerianStudio/lib-streaming/v3`. Wire format: CloudEvents
 - Broker security is lib-streaming's: hand the loaded config to `builder.TLSFromConfig(streamingCfg)` and `builder.SASLFromConfig(streamingCfg)`. NEVER bind `STREAMING_TLS_*` / `STREAMING_SASL_*` onto a midaz `Config` struct and NEVER build a franz-go `sasl.Mechanism` by hand — the tracer did, and the duplicate struct simply had no TLS field, so `STREAMING_TLS_ENABLED` had no reader at all and a TLS broker was unreachable while every authenticated deployment was pushed through the unsafe plaintext opt-in. With `DEPLOYMENT_MODE=saas` an ENABLED producer additionally REQUIRES `STREAMING_TLS_ENABLED=true`: a plaintext broker dial REFUSES BOOT (`ValidateSaaSStreamingTLS` in each component's bootstrap, called right after `LoadConfig` — the first point where the flag exists), matching the gate Postgres/Mongo/Redis/RabbitMQ already answer to. BYOC and local keep their plaintext brokers, and `STREAMING_ENABLED=false` never reaches the gate because no broker connection is opened.
 - `STREAMING_ENABLED=true` with an empty `STREAMING_BROKERS` REFUSES BOOT (`pkgStreaming.RequireBrokers`, which validates only the broker list). The tracer additionally refuses boot on an empty event registry via a separate inline check in its `BuildStreamingEmitter`; the ledger has no such catalog gate. There is exactly ONE noop path left: `STREAMING_ENABLED=false`. The tracer's `/readyz` reports that one as `skipped`; the ledger has no streaming readiness prober, so its `/readyz` carries no streaming check in either mode. An enabled producer that fell back to `NoopEmitter` discarded every event while the noop answered the readiness probe healthy: total loss, green dashboards, the same failure class the roster source gate exists to kill.
 - `CloudEventsSource` is owned by the producer Builder at construction (`libStreaming.NewBuilder().Source(cfg.CloudEventsSource)` in bootstrap), not held on the UseCase and not passed per emit. Emit sites never set `Source`; the `EmitRequest` carries only `DefinitionKey`/`TenantID`/`Subject`/`Timestamp`/`Payload`.
-- Tenant value from `pkgStreaming.ResolveTenantID(ctx)` — returns the multi-tenant context value or `pkgStreaming.DefaultTenantID` (literal `"default"`). Reference the constant, not the literal. NEVER hardcode tenants or call `tmcore.GetTenantIDContext` at emit sites. For IMPORTANT events, `pkgStreaming.EmitImportant` resolves the tenant internally and passes it to the typed event builder closure.
+- Tenant value from `pkgStreaming.ResolveTenantID(ctx)` — returns the multi-tenant context value or `pkgStreaming.DefaultTenantID` (literal `"default"`). Reference the constant, not the literal. NEVER hardcode tenants or call `tmcore.GetTenantIDContext` at emit sites. For IMPORTANT events, `pkgStreaming.EmitBrokerBestEffort` resolves the tenant internally and passes it to the typed event builder closure.
 - Service code depends on `libStreaming.Emitter` INTERFACE, never `*libStreaming.Producer`. Nil emitter means "disabled" — guard with `if uc.Streaming != nil`. When `STREAMING_ENABLED=false`, bootstrap injects `libStreaming.NewNoopEmitter()`.
-- IMPORTANT-posture direct emits MUST go through `pkgStreaming.EmitImportant`. Build/emit failures MUST NOT fail the request: log Warn, span-record, return success. `EmitImportant` bounds direct emit latency with `STREAMING_IMPORTANT_EMIT_TIMEOUT_MS` (default 5s) so broker issues cannot hold HTTP responses until client timeout. Durability is the outbox's job. CRITICAL events use outbox-only (atomic with DB), no direct emit.
+- IMPORTANT-posture broker publication MUST go through `pkgStreaming.EmitBrokerBestEffort`. Build/emit failures MUST NOT fail the request: log Warn, span-record, return success. `EmitBrokerBestEffort` bounds the `Emitter.Emit` call with `STREAMING_IMPORTANT_EMIT_TIMEOUT_MS` (default 5s) so broker issues cannot hold HTTP responses until client timeout. It delegates policy and any configured fallback to lib-streaming; Midaz currently wires neither an outbox writer/repository nor a relay, so it provides no product-local transactional fallback or delivery guarantee.
 - Emit POST-COMMIT and PRE-METADATA-WRITE — never at HTTP handlers. `ce-subject` is the aggregate ID, passed as `libStreaming.EmitRequest.Subject`.
 - Register the producer's `Close()` as `libCommons.RunApp("Streaming Producer", ...)` so it drains on SIGTERM (mirror `eventListenerRunnable`).
-- lib-streaming is pinned at v3.1.0 (module path `.../lib-streaming/v3`), which exports the Catalog/policy constants (e.g. `BuildManifest`, `DefaultDeliveryPolicy`, `ResolveDeliveryPolicy`) plus the topic derivations `AppTopic` / `AppDLQTopic`. The producer is assembled with `libStreaming.NewBuilder()` (`.Source()/.Catalog()/.Routes()/.Target()`) around ONE catch-all route to the app topic (empty `DefinitionKey`); a definition needing a different destination is a scoped `RouteOverrides` entry on the same target, which is how the billing event reaches its fixed topic. Wire `WithOutboxRepository(repo)` when outbox lands.
+- lib-streaming is pinned at v3.1.0 (module path `.../lib-streaming/v3`), which exports the Catalog/policy constants (e.g. `BuildManifest`, `DefaultDeliveryPolicy`, `ResolveDeliveryPolicy`) plus the topic derivations `AppTopic` / `AppDLQTopic`. The producer is assembled with `libStreaming.NewBuilder()` (`.Source()/.Catalog()/.Routes()/.Target()`) around ONE catch-all route to the app topic (empty `DefinitionKey`); a definition needing a different destination is a scoped `RouteOverrides` entry on the same target, which is how the billing event reaches its fixed topic. Midaz currently does not pass `WithOutboxRepository` or `WithOutboxWriter`, and does not register an outbox relay; delivery behavior remains lib-streaming's configured policy.
 
 ### Event modeling (`pkg/streaming/events`)
 
@@ -223,7 +223,7 @@ Required unit tests: Definition key lock, minimal-domain mapping, all-optional-f
 
 ### IMPORTANT emission helper pattern
 
-The use-case body MUST NOT inline emission mechanics. Delegate to a private `emit<Event>Event` method on the same UseCase; that method MUST call `pkgStreaming.EmitImportant` for IMPORTANT-posture events:
+The use-case body MUST NOT inline emission mechanics. Delegate to a private `emit<Event>Event` method on the same UseCase; that method MUST call `pkgStreaming.EmitBrokerBestEffort` for IMPORTANT-posture events:
 
 ```go
 // in CreateAccount, at the emission anchor:
@@ -231,16 +231,16 @@ uc.emitAccountCreatedEvent(ctx, span, logger, acc)
 
 // helper alongside other private UseCase methods:
 func (uc *UseCase) emitAccountCreatedEvent(ctx context.Context, span trace.Span, logger libLog.Logger, acc *mmodel.Account) {
-    pkgStreaming.EmitImportant(ctx, span, logger, uc.Streaming, events.AccountCreatedDefinition.Key(),
+    pkgStreaming.EmitBrokerBestEffort(ctx, span, logger, uc.Streaming, events.AccountCreatedDefinition.Key(),
         func(tenantID string) (libStreaming.EmitRequest, error) {
             return events.NewAccountCreated(acc).ToEmitRequest(tenantID, acc.CreatedAt)
         })
 }
 ```
 
-`EmitImportant` owns the common IMPORTANT-posture mechanics: nil-emitter guard, tenant resolution, bounded emit context, `libOpentelemetry.HandleSpanError` (build/emit failures are technical, so per T5 they flip the span red — not `HandleSpanBusinessErrorEvent`), Warn logging with `libLog.Err(err)`, and non-propagation of build/emit failures. Use-case helpers remain explicit only about the typed payload constructor, event definition key, subject, and timestamp.
+`EmitBrokerBestEffort` owns the common IMPORTANT-posture mechanics: nil-emitter guard, tenant resolution, bounded emit context, `libOpentelemetry.HandleSpanError` (build/emit failures are technical, so per T5 they flip the span red — not `HandleSpanBusinessErrorEvent`), Warn logging with `libLog.Err(err)`, and non-propagation of build/emit failures. Use-case helpers remain explicit only about the typed payload constructor, event definition key, subject, and timestamp.
 
-Naming: `emit<Event>Event` (unexported) — the trailing `Event` disambiguates from emitting the domain object itself. Signature: `(ctx, span, logger, <domain>)` — pass span and logger so `EmitImportant` records into the SAME span the use case opened. Return type: none (IMPORTANT posture never propagates).
+Naming: `emit<Event>Event` (unexported) — the trailing `Event` disambiguates from emitting the domain object itself. Signature: `(ctx, span, logger, <domain>)` — pass span and logger so `EmitBrokerBestEffort` records into the SAME span the use case opened. Return type: none (IMPORTANT posture never propagates).
 
 Drift discipline: wire-contract change updates (a) Payload struct, (b) constructor, (c) JSONShape test field count — all in the same PR.
 
@@ -294,9 +294,9 @@ CRM encrypts holder/instrument PII at rest. The seam is the `FieldEncryptor` int
 - Do not use non-request span attributes for input data.
 - Do not log SQL args, payload values, secrets, balances, financial values, or PII.
 - Do not build `libStreaming.Config{}` manually; call `libStreaming.LoadConfig()` so franz-go defaults are applied.
-- Do not hardcode tenant IDs or call `tmcore.GetTenantIDContext` at streaming emit sites; use `pkgStreaming.EmitImportant` for IMPORTANT events or `pkgStreaming.ResolveTenantID(ctx)` inside non-IMPORTANT streaming infrastructure.
+- Do not hardcode tenant IDs or call `tmcore.GetTenantIDContext` at streaming emit sites; use `pkgStreaming.EmitBrokerBestEffort` for IMPORTANT events or `pkgStreaming.ResolveTenantID(ctx)` inside non-IMPORTANT streaming infrastructure.
 - Do not emit streaming events at HTTP handlers; emit at the post-commit, pre-metadata-write slot inside the command UseCase.
-- Do not inline the build-emit-log block in the use-case body; delegate to a dedicated `uc.emit<Event>Event(ctx, span, logger, domain)` helper on the same UseCase, and have that helper call `pkgStreaming.EmitImportant` for IMPORTANT events.
+- Do not inline the build-emit-log block in the use-case body; delegate to a dedicated `uc.emit<Event>Event(ctx, span, logger, domain)` helper on the same UseCase, and have that helper call `pkgStreaming.EmitBrokerBestEffort` for IMPORTANT events.
 - Do not fail HTTP requests on streaming emit errors for IMPORTANT-posture events; log Warn and continue.
 - Do not depend on `*libStreaming.Producer` in service code; depend on `libStreaming.Emitter` interface.
 - Do not build payload maps or call `json.Marshal` inline in use cases; route every payload through `pkg/streaming/events/<event>.go` (`New<Event>(...).ToEmitRequest(...)`).

--- a/components/ledger/.env.example
+++ b/components/ledger/.env.example
@@ -462,17 +462,17 @@ STREAMING_ENABLED=false
 # franz-go ProducerLinger in ms. Default: 5.
 # STREAMING_BATCH_LINGER_MS=5
 
-# --- Per-emit timeout (IMPORTANT-posture events) ---
+# --- Per-emit timeout (best-effort broker publication) ---
 # Per-call deadline applied around emitter.Emit() for IMPORTANT-posture
 # events (organization.*, ledger.*, account.*, asset.*, etc.). When this
-# fires, the emit is logged as a warning and dropped — durability of
-# IMPORTANT events belongs to PG and (eventually) the outbox subsystem,
-# not to the synchronous broker round-trip.
+# fires, the helper logs a warning and returns without failing the request.
+# The helper delegates policy and any configured fallback to lib-streaming;
+# Midaz does not wire a product-local outbox writer or relay.
 #
 # Value is in milliseconds; must be > 0 or the default is used. Default: 5000 (5s).
 # Bump it if your broker is far away (cross-region) or when running
 # end-to-end against a cold/loaded test cluster. Lower it if you want to
-# fail-fast on slow brokers and rely on async/outbox redelivery.
+# fail-fast on slow brokers; this setting does not create a local outbox record.
 # STREAMING_IMPORTANT_EMIT_TIMEOUT_MS=5000
 
 # --- SASL/TLS auth ---

--- a/components/ledger/internal/bootstrap/streaming_integration_test.go
+++ b/components/ledger/internal/bootstrap/streaming_integration_test.go
@@ -6,7 +6,7 @@
 
 // This smoke test exercises the REAL ledger fee-streaming path end-to-end: it
 // builds the producer via BuildStreamingEmitter, emits all 7 fee events through
-// pkgStreaming.EmitImportant with the real event constructors, then consumes
+// pkgStreaming.EmitBrokerBestEffort with the real event constructors, then consumes
 // them back off Kafka with a franz-go consumer and asserts the CloudEvents
 // binary-mode headers (ce-type, ce-source, ce-subject, ce-tenantid) plus the
 // absence of fee-detail / PII keys on every body.
@@ -113,7 +113,7 @@ type streamingITExpectation struct {
 }
 
 // TestStreamingEmitter_Integration_AllSevenFeeEvents emits every fee event
-// through the real BuildStreamingEmitter + EmitImportant path and asserts the
+// through the real BuildStreamingEmitter + EmitBrokerBestEffort path and asserts the
 // wire contract (ce-type / ce-source / ce-subject / ce-tenantid + fee-detail
 // absence) per event.
 func TestStreamingEmitter_Integration_AllSevenFeeEvents(t *testing.T) {
@@ -155,7 +155,7 @@ func TestStreamingEmitter_Integration_AllSevenFeeEvents(t *testing.T) {
 	// cases make). IMPORTANT never propagates errors, so failures surface via
 	// the consumer timing out on a missing record below.
 	for _, e := range expectations {
-		pkgStreaming.EmitImportant(ctx, nil, libLog.NewNop(), emitter, e.ceType, e.emitReq)
+		pkgStreaming.EmitBrokerBestEffort(ctx, nil, libLog.NewNop(), emitter, e.ceType, e.emitReq)
 	}
 
 	// Consume the one application topic and assert the wire contract per event.

--- a/components/ledger/internal/crm/services/create-holder.go
+++ b/components/ledger/internal/crm/services/create-holder.go
@@ -74,7 +74,7 @@ func (uc *UseCase) CreateHolder(ctx context.Context, organizationID string, chi 
 }
 
 func (uc *UseCase) emitHolderCreatedEvent(ctx context.Context, span trace.Span, logger libLog.Logger, h *mmodel.Holder, organizationID string) {
-	pkgStreaming.EmitImportant(ctx, span, logger, uc.Streaming, events.HolderCreatedDefinition.Key(),
+	pkgStreaming.EmitBrokerBestEffort(ctx, span, logger, uc.Streaming, events.HolderCreatedDefinition.Key(),
 		func(tenantID string) (libStreaming.EmitRequest, error) {
 			return events.NewHolderCreated(h, organizationID).ToEmitRequest(tenantID, h.CreatedAt)
 		})

--- a/components/ledger/internal/crm/services/create-instrument.go
+++ b/components/ledger/internal/crm/services/create-instrument.go
@@ -140,7 +140,7 @@ func (uc *UseCase) CreateInstrument(ctx context.Context, organizationID string, 
 }
 
 func (uc *UseCase) emitInstrumentCreatedEvent(ctx context.Context, span trace.Span, logger libLog.Logger, i *mmodel.Instrument, organizationID string) {
-	pkgStreaming.EmitImportant(ctx, span, logger, uc.Streaming, events.InstrumentCreatedDefinition.Key(),
+	pkgStreaming.EmitBrokerBestEffort(ctx, span, logger, uc.Streaming, events.InstrumentCreatedDefinition.Key(),
 		func(tenantID string) (libStreaming.EmitRequest, error) {
 			return events.NewInstrumentCreated(i, organizationID).ToEmitRequest(tenantID, i.CreatedAt)
 		})

--- a/components/ledger/internal/crm/services/delete-holder.go
+++ b/components/ledger/internal/crm/services/delete-holder.go
@@ -85,7 +85,7 @@ func (uc *UseCase) DeleteHolderByID(ctx context.Context, organizationID string, 
 }
 
 func (uc *UseCase) emitHolderDeletedEvent(ctx context.Context, span trace.Span, logger libLog.Logger, id, organizationID string, hardDelete bool, deletedAt time.Time) {
-	pkgStreaming.EmitImportant(ctx, span, logger, uc.Streaming, events.HolderDeletedDefinition.Key(),
+	pkgStreaming.EmitBrokerBestEffort(ctx, span, logger, uc.Streaming, events.HolderDeletedDefinition.Key(),
 		func(tenantID string) (libStreaming.EmitRequest, error) {
 			return events.NewHolderDeleted(id, organizationID, hardDelete, deletedAt).ToEmitRequest(tenantID, deletedAt)
 		})

--- a/components/ledger/internal/crm/services/delete-instrument.go
+++ b/components/ledger/internal/crm/services/delete-instrument.go
@@ -54,7 +54,7 @@ func (uc *UseCase) DeleteInstrumentByID(ctx context.Context, organizationID stri
 }
 
 func (uc *UseCase) emitInstrumentDeletedEvent(ctx context.Context, span trace.Span, logger libLog.Logger, id, holderID, organizationID string, hardDelete bool, deletedAt time.Time) {
-	pkgStreaming.EmitImportant(ctx, span, logger, uc.Streaming, events.InstrumentDeletedDefinition.Key(),
+	pkgStreaming.EmitBrokerBestEffort(ctx, span, logger, uc.Streaming, events.InstrumentDeletedDefinition.Key(),
 		func(tenantID string) (libStreaming.EmitRequest, error) {
 			return events.NewInstrumentDeleted(id, holderID, organizationID, hardDelete, deletedAt).ToEmitRequest(tenantID, deletedAt)
 		})

--- a/components/ledger/internal/crm/services/delete-related-party.go
+++ b/components/ledger/internal/crm/services/delete-related-party.go
@@ -54,7 +54,7 @@ func (uc *UseCase) DeleteRelatedPartyByID(ctx context.Context, organizationID st
 }
 
 func (uc *UseCase) emitInstrumentRelatedPartyDeletedEvent(ctx context.Context, span trace.Span, logger libLog.Logger, instrumentID, holderID, organizationID, relatedPartyID string, deletedAt time.Time) {
-	pkgStreaming.EmitImportant(ctx, span, logger, uc.Streaming, events.InstrumentRelatedPartyDeletedDefinition.Key(),
+	pkgStreaming.EmitBrokerBestEffort(ctx, span, logger, uc.Streaming, events.InstrumentRelatedPartyDeletedDefinition.Key(),
 		func(tenantID string) (libStreaming.EmitRequest, error) {
 			return events.NewInstrumentRelatedPartyDeleted(instrumentID, holderID, organizationID, relatedPartyID, deletedAt).ToEmitRequest(tenantID, deletedAt)
 		})

--- a/components/ledger/internal/crm/services/service.go
+++ b/components/ledger/internal/crm/services/service.go
@@ -38,7 +38,7 @@ type UseCase struct {
 	MetricsFactory *metrics.MetricsFactory
 
 	// Streaming emits IMPORTANT-posture CRM business events (holder.*,
-	// instrument.*) via pkgStreaming.EmitImportant at the post-commit,
+	// instrument.*) via pkgStreaming.EmitBrokerBestEffort at the post-commit,
 	// pre-metadata slot. A nil value disables emission (mirroring the
 	// idempotency nil-guard); bootstrap injects libStreaming.NewNoopEmitter()
 	// when STREAMING_ENABLED=false.

--- a/components/ledger/internal/crm/services/update-holder.go
+++ b/components/ledger/internal/crm/services/update-holder.go
@@ -63,7 +63,7 @@ func (uc *UseCase) UpdateHolderByID(ctx context.Context, organizationID string, 
 }
 
 func (uc *UseCase) emitHolderUpdatedEvent(ctx context.Context, span trace.Span, logger libLog.Logger, h *mmodel.Holder, organizationID string) {
-	pkgStreaming.EmitImportant(ctx, span, logger, uc.Streaming, events.HolderUpdatedDefinition.Key(),
+	pkgStreaming.EmitBrokerBestEffort(ctx, span, logger, uc.Streaming, events.HolderUpdatedDefinition.Key(),
 		func(tenantID string) (libStreaming.EmitRequest, error) {
 			return events.NewHolderUpdated(h, organizationID).ToEmitRequest(tenantID, h.UpdatedAt)
 		})

--- a/components/ledger/internal/crm/services/update-instrument.go
+++ b/components/ledger/internal/crm/services/update-instrument.go
@@ -118,7 +118,7 @@ func (uc *UseCase) UpdateInstrumentByID(ctx context.Context, organizationID stri
 }
 
 func (uc *UseCase) emitInstrumentUpdatedEvent(ctx context.Context, span trace.Span, logger libLog.Logger, i *mmodel.Instrument, organizationID string) {
-	pkgStreaming.EmitImportant(ctx, span, logger, uc.Streaming, events.InstrumentUpdatedDefinition.Key(),
+	pkgStreaming.EmitBrokerBestEffort(ctx, span, logger, uc.Streaming, events.InstrumentUpdatedDefinition.Key(),
 		func(tenantID string) (libStreaming.EmitRequest, error) {
 			return events.NewInstrumentUpdated(i, organizationID).ToEmitRequest(tenantID, i.UpdatedAt)
 		})

--- a/components/ledger/internal/services/command/billing_active_account.go
+++ b/components/ledger/internal/services/command/billing_active_account.go
@@ -40,7 +40,7 @@ const activeAccountMetric = "active_account"
 // Fire-and-forget: a nil emitter or nil serializer means billing is disabled and
 // the call is a clean no-op, and serialize/emit failures are span-recorded,
 // warn-logged and swallowed — this MUST NOT fail the parent transaction. Billing
-// does not use pkgStreaming.EmitImportant/ToEmitRequest (the JSON path); it emits
+// does not use pkgStreaming.EmitBrokerBestEffort/ToEmitRequest (the JSON path); it emits
 // the raw Protobuf bytes directly through the Emitter seam.
 func (uc *UseCase) SendActiveAccountBillingEvents(ctx context.Context, tran *transaction.Transaction, phase string) {
 	logger, tracer, _, _ := libObservability.NewTrackingFromContext(ctx)

--- a/components/ledger/internal/services/command/create_account.go
+++ b/components/ledger/internal/services/command/create_account.go
@@ -231,8 +231,7 @@ func (uc *UseCase) CreateAccount(ctx context.Context, organizationID, ledgerID u
 // emitAccountCreatedEvent publishes the account.created event for a
 // successfully persisted account. IMPORTANT posture: build and emit
 // failures are span-recorded and logged at Warn, never returned.
-// Durability of the event is owned by PG and (follow-up task) the
-// outbox subsystem + DLQ, not by the synchronous Emit call.
+// The persisted database mutation is durable; this helper does not make broker delivery transactional.
 //
 // Anchor: invoked between the default-balance success branch and the
 // metadata-write call in CreateAccount, so a downstream Mongo failure
@@ -242,7 +241,7 @@ func (uc *UseCase) CreateAccount(ctx context.Context, organizationID, ledgerID u
 // changes to the payload contract belong there, not here. This function
 // stays a thin emit-and-log adapter.
 func (uc *UseCase) emitAccountCreatedEvent(ctx context.Context, span trace.Span, logger libLog.Logger, acc *mmodel.Account) {
-	pkgStreaming.EmitImportant(ctx, span, logger, uc.Streaming, events.AccountCreatedDefinition.Key(),
+	pkgStreaming.EmitBrokerBestEffort(ctx, span, logger, uc.Streaming, events.AccountCreatedDefinition.Key(),
 		func(tenantID string) (libStreaming.EmitRequest, error) {
 			return events.NewAccountCreated(acc).ToEmitRequest(tenantID, acc.CreatedAt)
 		})

--- a/components/ledger/internal/services/command/create_account_streaming_test.go
+++ b/components/ledger/internal/services/command/create_account_streaming_test.go
@@ -174,8 +174,7 @@ func TestCreateAccount_NoopEmitterDoesNotPanic(t *testing.T) {
 
 // TestCreateAccount_EmitFailureDoesNotFailRequest verifies the IMPORTANT
 // posture: when Emit returns an error, CreateAccount must still return the
-// successfully-persisted account because durability is owned by PG +
-// future DLQ/outbox, not by the synchronous Emit call.
+// successfully-persisted account because the persisted database mutation is durable; this helper does not make broker delivery transactional.
 func TestCreateAccount_EmitFailureDoesNotFailRequest(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()

--- a/components/ledger/internal/services/command/create_asset.go
+++ b/components/ledger/internal/services/command/create_asset.go
@@ -231,8 +231,7 @@ func (uc *UseCase) validateAssetCode(ctx context.Context, code string) error {
 // emitAssetCreatedEvent publishes the asset.created event for a
 // successfully persisted asset. IMPORTANT posture: build and emit
 // failures are span-recorded and logged at Warn, never returned.
-// Durability of the event is owned by PG and (follow-up task) the
-// outbox subsystem + DLQ, not by the synchronous Emit call.
+// The persisted database mutation is durable; this helper does not make broker delivery transactional.
 //
 // Anchor: invoked immediately after AssetRepo.Create succeeds and
 // before CreateOnboardingMetadata runs, so a downstream Mongo failure
@@ -244,7 +243,7 @@ func (uc *UseCase) validateAssetCode(ctx context.Context, code string) error {
 // Wire-format mapping lives in pkg/streaming/events/asset_created.go;
 // changes to the payload contract belong there, not here.
 func (uc *UseCase) emitAssetCreatedEvent(ctx context.Context, span trace.Span, logger libLog.Logger, a *mmodel.Asset) {
-	pkgStreaming.EmitImportant(ctx, span, logger, uc.Streaming, events.AssetCreatedDefinition.Key(),
+	pkgStreaming.EmitBrokerBestEffort(ctx, span, logger, uc.Streaming, events.AssetCreatedDefinition.Key(),
 		func(tenantID string) (libStreaming.EmitRequest, error) {
 			return events.NewAssetCreated(a).ToEmitRequest(tenantID, a.CreatedAt)
 		})

--- a/components/ledger/internal/services/command/create_asset_streaming_test.go
+++ b/components/ledger/internal/services/command/create_asset_streaming_test.go
@@ -131,8 +131,7 @@ func TestCreateAsset_NoopEmitterDoesNotPanic(t *testing.T) {
 
 // TestCreateAsset_EmitFailureDoesNotFailRequest verifies the IMPORTANT
 // posture: when Emit returns an error, CreateAsset must still return
-// the successfully-persisted asset because durability is owned by PG +
-// future DLQ/outbox, not by the synchronous Emit call.
+// the successfully-persisted asset because the persisted database mutation is durable; this helper does not make broker delivery transactional.
 func TestCreateAsset_EmitFailureDoesNotFailRequest(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()

--- a/components/ledger/internal/services/command/create_balance_additional.go
+++ b/components/ledger/internal/services/command/create_balance_additional.go
@@ -210,7 +210,7 @@ func isPostgresUniqueViolation(err error) bool {
 // balance materialized via CreateAdditionalBalance. IMPORTANT posture:
 // build and emit failures are span-recorded and logged at Warn, never
 // returned. Durability of the event is owned by PG and (follow-up task)
-// the outbox subsystem + DLQ, not by the synchronous Emit call.
+// the configured lib-streaming delivery policy; this helper does not make broker delivery transactional.
 //
 // Anchor: invoked immediately after BalanceRepo.Create succeeds on the
 // public POST .../accounts/:account_id/balances endpoint. The other
@@ -223,7 +223,7 @@ func isPostgresUniqueViolation(err error) bool {
 // Wire-format mapping lives in pkg/streaming/events/balance_created.go;
 // changes to the payload contract belong there, not here.
 func (uc *UseCase) emitBalanceCreatedEvent(ctx context.Context, span trace.Span, logger libLog.Logger, b *mmodel.Balance) {
-	pkgStreaming.EmitImportant(ctx, span, logger, uc.Streaming, events.BalanceCreatedDefinition.Key(),
+	pkgStreaming.EmitBrokerBestEffort(ctx, span, logger, uc.Streaming, events.BalanceCreatedDefinition.Key(),
 		func(tenantID string) (libStreaming.EmitRequest, error) {
 			return events.NewBalanceCreated(b).ToEmitRequest(tenantID, b.CreatedAt)
 		})

--- a/components/ledger/internal/services/command/create_ledger.go
+++ b/components/ledger/internal/services/command/create_ledger.go
@@ -128,7 +128,7 @@ func (uc *UseCase) CreateLedger(ctx context.Context, organizationID uuid.UUID, c
 // successfully persisted ledger. IMPORTANT posture: build and emit
 // failures are span-recorded and logged at Warn, never returned.
 func (uc *UseCase) emitLedgerCreatedEvent(ctx context.Context, span trace.Span, logger libLog.Logger, led *mmodel.Ledger) {
-	pkgStreaming.EmitImportant(ctx, span, logger, uc.Streaming, events.LedgerCreatedDefinition.Key(),
+	pkgStreaming.EmitBrokerBestEffort(ctx, span, logger, uc.Streaming, events.LedgerCreatedDefinition.Key(),
 		func(tenantID string) (libStreaming.EmitRequest, error) {
 			return events.NewLedgerCreated(led).ToEmitRequest(tenantID, led.CreatedAt)
 		})

--- a/components/ledger/internal/services/command/create_operation_route.go
+++ b/components/ledger/internal/services/command/create_operation_route.go
@@ -89,8 +89,7 @@ func (uc *UseCase) CreateOperationRoute(ctx context.Context, organizationID, led
 // event for a successfully persisted operation route. IMPORTANT
 // posture: build and emit failures are span-recorded and logged at
 // Warn, never returned. Durability of the event is owned by PG and
-// (follow-up task) the outbox subsystem + DLQ, not by the synchronous
-// Emit call.
+// the persisted database mutation; this helper does not make broker delivery transactional.
 //
 // Anchor: invoked immediately after OperationRouteRepo.Create succeeds
 // and before the metadata-write call in CreateOperationRoute, so a
@@ -99,7 +98,7 @@ func (uc *UseCase) CreateOperationRoute(ctx context.Context, organizationID, led
 // Wire-format mapping lives in pkg/streaming/events/operation_route_created.go;
 // changes to the payload contract belong there, not here.
 func (uc *UseCase) emitOperationRouteCreatedEvent(ctx context.Context, span trace.Span, logger libLog.Logger, o *mmodel.OperationRoute) {
-	pkgStreaming.EmitImportant(ctx, span, logger, uc.Streaming, events.OperationRouteCreatedDefinition.Key(),
+	pkgStreaming.EmitBrokerBestEffort(ctx, span, logger, uc.Streaming, events.OperationRouteCreatedDefinition.Key(),
 		func(tenantID string) (libStreaming.EmitRequest, error) {
 			return events.NewOperationRouteCreated(o).ToEmitRequest(tenantID, o.CreatedAt)
 		})

--- a/components/ledger/internal/services/command/create_operation_route_streaming_test.go
+++ b/components/ledger/internal/services/command/create_operation_route_streaming_test.go
@@ -124,7 +124,7 @@ func TestCreateOperationRoute_NoopEmitterDoesNotPanic(t *testing.T) {
 // TestCreateOperationRoute_EmitFailureDoesNotFailRequest verifies the
 // IMPORTANT posture: when Emit returns an error, CreateOperationRoute
 // must still return the successfully-persisted operation route because
-// durability is owned by PG + future DLQ/outbox, not by the synchronous
+// durability is owned by PG + the configured lib-streaming policy, not by the synchronous
 // Emit call.
 func TestCreateOperationRoute_EmitFailureDoesNotFailRequest(t *testing.T) {
 	ctrl := gomock.NewController(t)

--- a/components/ledger/internal/services/command/create_organization.go
+++ b/components/ledger/internal/services/command/create_organization.go
@@ -106,7 +106,7 @@ func (uc *UseCase) CreateOrganization(ctx context.Context, coi *mmodel.CreateOrg
 // successfully persisted organization. IMPORTANT posture: build and emit
 // failures are span-recorded and logged at Warn, never returned.
 func (uc *UseCase) emitOrganizationCreatedEvent(ctx context.Context, span trace.Span, logger libLog.Logger, org *mmodel.Organization) {
-	pkgStreaming.EmitImportant(ctx, span, logger, uc.Streaming, events.OrganizationCreatedDefinition.Key(),
+	pkgStreaming.EmitBrokerBestEffort(ctx, span, logger, uc.Streaming, events.OrganizationCreatedDefinition.Key(),
 		func(tenantID string) (libStreaming.EmitRequest, error) {
 			return events.NewOrganizationCreated(org).ToEmitRequest(tenantID, org.CreatedAt)
 		})

--- a/components/ledger/internal/services/command/create_portfolio.go
+++ b/components/ledger/internal/services/command/create_portfolio.go
@@ -95,8 +95,7 @@ func (uc *UseCase) CreatePortfolio(ctx context.Context, organizationID, ledgerID
 // emitPortfolioCreatedEvent publishes the portfolio.created event for a
 // successfully persisted portfolio. IMPORTANT posture: build and emit
 // failures are span-recorded and logged at Warn, never returned.
-// Durability of the event is owned by PG and (follow-up task) the
-// outbox subsystem + DLQ, not by the synchronous Emit call.
+// The persisted database mutation is durable; this helper does not make broker delivery transactional.
 //
 // Anchor: invoked immediately after PortfolioRepo.Create succeeds and
 // before CreateOnboardingMetadata runs, so a downstream Mongo failure
@@ -105,7 +104,7 @@ func (uc *UseCase) CreatePortfolio(ctx context.Context, organizationID, ledgerID
 // Wire-format mapping lives in pkg/streaming/events/portfolio_created.go;
 // changes to the payload contract belong there, not here.
 func (uc *UseCase) emitPortfolioCreatedEvent(ctx context.Context, span trace.Span, logger libLog.Logger, p *mmodel.Portfolio) {
-	pkgStreaming.EmitImportant(ctx, span, logger, uc.Streaming, events.PortfolioCreatedDefinition.Key(),
+	pkgStreaming.EmitBrokerBestEffort(ctx, span, logger, uc.Streaming, events.PortfolioCreatedDefinition.Key(),
 		func(tenantID string) (libStreaming.EmitRequest, error) {
 			return events.NewPortfolioCreated(p).ToEmitRequest(tenantID, p.CreatedAt)
 		})

--- a/components/ledger/internal/services/command/create_portfolio_streaming_test.go
+++ b/components/ledger/internal/services/command/create_portfolio_streaming_test.go
@@ -112,7 +112,7 @@ func TestCreatePortfolio_NoopEmitterDoesNotPanic(t *testing.T) {
 // TestCreatePortfolio_EmitFailureDoesNotFailRequest verifies the IMPORTANT
 // posture: when Emit returns an error, CreatePortfolio must still return
 // the successfully-persisted portfolio because durability is owned by
-// PG + future DLQ/outbox, not by the synchronous Emit call.
+// PG + the configured lib-streaming policy, not by the synchronous Emit call.
 func TestCreatePortfolio_EmitFailureDoesNotFailRequest(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()

--- a/components/ledger/internal/services/command/create_segment.go
+++ b/components/ledger/internal/services/command/create_segment.go
@@ -99,8 +99,7 @@ func (uc *UseCase) CreateSegment(ctx context.Context, organizationID, ledgerID u
 // emitSegmentCreatedEvent publishes the segment.created event for a
 // successfully persisted segment. IMPORTANT posture: build and emit
 // failures are span-recorded and logged at Warn, never returned.
-// Durability of the event is owned by PG and (follow-up task) the
-// outbox subsystem + DLQ, not by the synchronous Emit call.
+// The persisted database mutation is durable; this helper does not make broker delivery transactional.
 //
 // Anchor: invoked immediately after SegmentRepo.Create succeeds and
 // before CreateOnboardingMetadata runs, so a downstream Mongo failure
@@ -109,7 +108,7 @@ func (uc *UseCase) CreateSegment(ctx context.Context, organizationID, ledgerID u
 // Wire-format mapping lives in pkg/streaming/events/segment_created.go;
 // changes to the payload contract belong there, not here.
 func (uc *UseCase) emitSegmentCreatedEvent(ctx context.Context, span trace.Span, logger libLog.Logger, s *mmodel.Segment) {
-	pkgStreaming.EmitImportant(ctx, span, logger, uc.Streaming, events.SegmentCreatedDefinition.Key(),
+	pkgStreaming.EmitBrokerBestEffort(ctx, span, logger, uc.Streaming, events.SegmentCreatedDefinition.Key(),
 		func(tenantID string) (libStreaming.EmitRequest, error) {
 			return events.NewSegmentCreated(s).ToEmitRequest(tenantID, s.CreatedAt)
 		})

--- a/components/ledger/internal/services/command/create_segment_streaming_test.go
+++ b/components/ledger/internal/services/command/create_segment_streaming_test.go
@@ -114,7 +114,7 @@ func TestCreateSegment_NoopEmitterDoesNotPanic(t *testing.T) {
 // TestCreateSegment_EmitFailureDoesNotFailRequest verifies the IMPORTANT
 // posture: when Emit returns an error, CreateSegment must still return
 // the successfully-persisted segment because durability is owned by
-// PG + future DLQ/outbox, not by the synchronous Emit call.
+// PG + the configured lib-streaming policy, not by the synchronous Emit call.
 func TestCreateSegment_EmitFailureDoesNotFailRequest(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()

--- a/components/ledger/internal/services/command/create_transaction_route.go
+++ b/components/ledger/internal/services/command/create_transaction_route.go
@@ -113,8 +113,7 @@ func (uc *UseCase) CreateTransactionRoute(ctx context.Context, organizationID, l
 // event for a successfully persisted transaction route. IMPORTANT
 // posture: build and emit failures are span-recorded and logged at
 // Warn, never returned. Durability of the event is owned by PG and
-// (follow-up task) the outbox subsystem + DLQ, not by the synchronous
-// Emit call.
+// the persisted database mutation; this helper does not make broker delivery transactional.
 //
 // Anchor: invoked immediately after TransactionRouteRepo.Create
 // succeeds and before the metadata-write call in
@@ -128,7 +127,7 @@ func (uc *UseCase) CreateTransactionRoute(ctx context.Context, organizationID, l
 // Wire-format mapping lives in pkg/streaming/events/transaction_route_created.go;
 // changes to the payload contract belong there, not here.
 func (uc *UseCase) emitTransactionRouteCreatedEvent(ctx context.Context, span trace.Span, logger libLog.Logger, tr *mmodel.TransactionRoute) {
-	pkgStreaming.EmitImportant(ctx, span, logger, uc.Streaming, events.TransactionRouteCreatedDefinition.Key(),
+	pkgStreaming.EmitBrokerBestEffort(ctx, span, logger, uc.Streaming, events.TransactionRouteCreatedDefinition.Key(),
 		func(tenantID string) (libStreaming.EmitRequest, error) {
 			return events.NewTransactionRouteCreated(tr).ToEmitRequest(tenantID, tr.CreatedAt)
 		})

--- a/components/ledger/internal/services/command/delete_account.go
+++ b/components/ledger/internal/services/command/delete_account.go
@@ -111,8 +111,7 @@ func (uc *UseCase) DeleteAccountByID(ctx context.Context, organizationID, ledger
 // emitAccountDeletedEvent publishes the account.deleted event for a
 // successfully soft-deleted account. IMPORTANT posture: build and emit
 // failures are span-recorded and logged at Warn, never returned.
-// Durability of the event is owned by PG and (follow-up task) the
-// outbox subsystem + DLQ, not by the synchronous Emit call.
+// The persisted database mutation is durable; this helper does not make broker delivery transactional.
 //
 // Anchor: invoked immediately after AccountRepo.Delete succeeds.
 // AccountRepo.Delete does not return the post-delete record, so the
@@ -125,7 +124,7 @@ func (uc *UseCase) DeleteAccountByID(ctx context.Context, organizationID, ledger
 // Wire-format mapping lives in pkg/streaming/events/account_deleted.go;
 // changes to the payload contract belong there, not here.
 func (uc *UseCase) emitAccountDeletedEvent(ctx context.Context, span trace.Span, logger libLog.Logger, acc *mmodel.Account, deletedAt time.Time) {
-	pkgStreaming.EmitImportant(ctx, span, logger, uc.Streaming, events.AccountDeletedDefinition.Key(),
+	pkgStreaming.EmitBrokerBestEffort(ctx, span, logger, uc.Streaming, events.AccountDeletedDefinition.Key(),
 		func(tenantID string) (libStreaming.EmitRequest, error) {
 			return events.NewAccountDeleted(acc, deletedAt).ToEmitRequest(tenantID, deletedAt)
 		})

--- a/components/ledger/internal/services/command/delete_account_streaming_test.go
+++ b/components/ledger/internal/services/command/delete_account_streaming_test.go
@@ -153,8 +153,7 @@ func TestDeleteAccountByID_NoopEmitterDoesNotPanic(t *testing.T) {
 
 // TestDeleteAccountByID_EmitFailureDoesNotFailRequest verifies the
 // IMPORTANT posture: when Emit returns an error, DeleteAccountByID must
-// still complete successfully because durability is owned by PG +
-// future DLQ/outbox, not by the synchronous Emit call.
+// still complete successfully because the persisted database mutation is durable; this helper does not make broker delivery transactional.
 func TestDeleteAccountByID_EmitFailureDoesNotFailRequest(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()

--- a/components/ledger/internal/services/command/delete_asset.go
+++ b/components/ledger/internal/services/command/delete_asset.go
@@ -102,8 +102,7 @@ func (uc *UseCase) DeleteAssetByID(ctx context.Context, organizationID, ledgerID
 // emitAssetDeletedEvent publishes the asset.deleted event for a
 // successfully soft-deleted asset. IMPORTANT posture: build and emit
 // failures are span-recorded and logged at Warn, never returned.
-// Durability of the event is owned by PG and (follow-up task) the
-// outbox subsystem + DLQ, not by the synchronous Emit call.
+// The persisted database mutation is durable; this helper does not make broker delivery transactional.
 //
 // Anchor: invoked immediately after AssetRepo.Delete succeeds.
 // AssetRepo.Delete does not return the post-delete record, so the
@@ -118,7 +117,7 @@ func (uc *UseCase) DeleteAssetByID(ctx context.Context, organizationID, ledgerID
 // Wire-format mapping lives in pkg/streaming/events/asset_deleted.go;
 // changes to the payload contract belong there, not here.
 func (uc *UseCase) emitAssetDeletedEvent(ctx context.Context, span trace.Span, logger libLog.Logger, a *mmodel.Asset, deletedAt time.Time) {
-	pkgStreaming.EmitImportant(ctx, span, logger, uc.Streaming, events.AssetDeletedDefinition.Key(),
+	pkgStreaming.EmitBrokerBestEffort(ctx, span, logger, uc.Streaming, events.AssetDeletedDefinition.Key(),
 		func(tenantID string) (libStreaming.EmitRequest, error) {
 			return events.NewAssetDeleted(a.ID, a.OrganizationID, a.LedgerID, deletedAt).ToEmitRequest(tenantID, deletedAt)
 		})

--- a/components/ledger/internal/services/command/delete_asset_streaming_test.go
+++ b/components/ledger/internal/services/command/delete_asset_streaming_test.go
@@ -126,8 +126,7 @@ func TestDeleteAssetByID_NoopEmitterDoesNotPanic(t *testing.T) {
 
 // TestDeleteAssetByID_EmitFailureDoesNotFailRequest verifies the
 // IMPORTANT posture: when Emit returns an error, DeleteAssetByID must
-// still complete successfully because durability is owned by PG +
-// future DLQ/outbox, not by the synchronous Emit call.
+// still complete successfully because the persisted database mutation is durable; this helper does not make broker delivery transactional.
 func TestDeleteAssetByID_EmitFailureDoesNotFailRequest(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()

--- a/components/ledger/internal/services/command/delete_balance.go
+++ b/components/ledger/internal/services/command/delete_balance.go
@@ -122,7 +122,7 @@ func (uc *UseCase) emitBalanceDeletedEvent(ctx context.Context, span trace.Span,
 		return
 	}
 
-	pkgStreaming.EmitImportant(ctx, span, logger, uc.Streaming, events.BalanceDeletedDefinition.Key(),
+	pkgStreaming.EmitBrokerBestEffort(ctx, span, logger, uc.Streaming, events.BalanceDeletedDefinition.Key(),
 		func(tenantID string) (libStreaming.EmitRequest, error) {
 			return events.NewBalanceDeleted(b.ID, b.OrganizationID, b.LedgerID, b.AccountID, deletedAt).ToEmitRequest(tenantID, deletedAt)
 		})

--- a/components/ledger/internal/services/command/delete_ledger.go
+++ b/components/ledger/internal/services/command/delete_ledger.go
@@ -63,7 +63,7 @@ func (uc *UseCase) DeleteLedgerByID(ctx context.Context, organizationID, id uuid
 // successfully soft-deleted ledger. IMPORTANT posture: build and emit
 // failures are span-recorded and logged at Warn, never returned.
 func (uc *UseCase) emitLedgerDeletedEvent(ctx context.Context, span trace.Span, logger libLog.Logger, id, organizationID string, deletedAt time.Time) {
-	pkgStreaming.EmitImportant(ctx, span, logger, uc.Streaming, events.LedgerDeletedDefinition.Key(),
+	pkgStreaming.EmitBrokerBestEffort(ctx, span, logger, uc.Streaming, events.LedgerDeletedDefinition.Key(),
 		func(tenantID string) (libStreaming.EmitRequest, error) {
 			return events.NewLedgerDeleted(id, organizationID, deletedAt).ToEmitRequest(tenantID, deletedAt)
 		})

--- a/components/ledger/internal/services/command/delete_operation_route.go
+++ b/components/ledger/internal/services/command/delete_operation_route.go
@@ -110,8 +110,7 @@ func (uc *UseCase) DeleteOperationRouteByID(ctx context.Context, organizationID,
 // event for a successfully soft-deleted operation route. IMPORTANT
 // posture: build and emit failures are span-recorded and logged at
 // Warn, never returned. Durability of the event is owned by PG and
-// (follow-up task) the outbox subsystem + DLQ, not by the synchronous
-// Emit call.
+// the persisted database mutation; this helper does not make broker delivery transactional.
 //
 // Anchor: invoked immediately after OperationRouteRepo.Delete succeeds
 // (post-link-check). OperationRouteRepo.Delete does not return the
@@ -124,7 +123,7 @@ func (uc *UseCase) DeleteOperationRouteByID(ctx context.Context, organizationID,
 // Wire-format mapping lives in pkg/streaming/events/operation_route_deleted.go;
 // changes to the payload contract belong there, not here.
 func (uc *UseCase) emitOperationRouteDeletedEvent(ctx context.Context, span trace.Span, logger libLog.Logger, id, organizationID, ledgerID string, deletedAt time.Time) {
-	pkgStreaming.EmitImportant(ctx, span, logger, uc.Streaming, events.OperationRouteDeletedDefinition.Key(),
+	pkgStreaming.EmitBrokerBestEffort(ctx, span, logger, uc.Streaming, events.OperationRouteDeletedDefinition.Key(),
 		func(tenantID string) (libStreaming.EmitRequest, error) {
 			return events.NewOperationRouteDeleted(id, organizationID, ledgerID, deletedAt).ToEmitRequest(tenantID, deletedAt)
 		})

--- a/components/ledger/internal/services/command/delete_operation_route_streaming_test.go
+++ b/components/ledger/internal/services/command/delete_operation_route_streaming_test.go
@@ -103,7 +103,7 @@ func TestDeleteOperationRouteByID_NoopEmitterDoesNotPanic(t *testing.T) {
 // TestDeleteOperationRouteByID_EmitFailureDoesNotFailRequest verifies
 // the IMPORTANT posture: when Emit returns an error,
 // DeleteOperationRouteByID must still complete successfully because
-// durability is owned by PG + future DLQ/outbox, not by the
+// durability is owned by PG + the configured lib-streaming policy, not by the
 // synchronous Emit call.
 func TestDeleteOperationRouteByID_EmitFailureDoesNotFailRequest(t *testing.T) {
 	ctrl := gomock.NewController(t)

--- a/components/ledger/internal/services/command/delete_organization.go
+++ b/components/ledger/internal/services/command/delete_organization.go
@@ -65,7 +65,7 @@ func (uc *UseCase) DeleteOrganizationByID(ctx context.Context, id uuid.UUID) (er
 // successfully soft-deleted organization. IMPORTANT posture: build and emit
 // failures are span-recorded and logged at Warn, never returned.
 func (uc *UseCase) emitOrganizationDeletedEvent(ctx context.Context, span trace.Span, logger libLog.Logger, id string, deletedAt time.Time) {
-	pkgStreaming.EmitImportant(ctx, span, logger, uc.Streaming, events.OrganizationDeletedDefinition.Key(),
+	pkgStreaming.EmitBrokerBestEffort(ctx, span, logger, uc.Streaming, events.OrganizationDeletedDefinition.Key(),
 		func(tenantID string) (libStreaming.EmitRequest, error) {
 			return events.NewOrganizationDeleted(id, deletedAt).ToEmitRequest(tenantID, deletedAt)
 		})

--- a/components/ledger/internal/services/command/delete_portfolio.go
+++ b/components/ledger/internal/services/command/delete_portfolio.go
@@ -63,8 +63,7 @@ func (uc *UseCase) DeletePortfolioByID(ctx context.Context, organizationID, ledg
 // emitPortfolioDeletedEvent publishes the portfolio.deleted event for a
 // successfully soft-deleted portfolio. IMPORTANT posture: build and emit
 // failures are span-recorded and logged at Warn, never returned.
-// Durability of the event is owned by PG and (follow-up task) the
-// outbox subsystem + DLQ, not by the synchronous Emit call.
+// The persisted database mutation is durable; this helper does not make broker delivery transactional.
 //
 // Anchor: invoked immediately after PortfolioRepo.Delete succeeds.
 // PortfolioRepo.Delete does not return the post-delete record, so the
@@ -77,7 +76,7 @@ func (uc *UseCase) DeletePortfolioByID(ctx context.Context, organizationID, ledg
 // Wire-format mapping lives in pkg/streaming/events/portfolio_deleted.go;
 // changes to the payload contract belong there, not here.
 func (uc *UseCase) emitPortfolioDeletedEvent(ctx context.Context, span trace.Span, logger libLog.Logger, id, organizationID, ledgerID string, deletedAt time.Time) {
-	pkgStreaming.EmitImportant(ctx, span, logger, uc.Streaming, events.PortfolioDeletedDefinition.Key(),
+	pkgStreaming.EmitBrokerBestEffort(ctx, span, logger, uc.Streaming, events.PortfolioDeletedDefinition.Key(),
 		func(tenantID string) (libStreaming.EmitRequest, error) {
 			return events.NewPortfolioDeleted(id, organizationID, ledgerID, deletedAt).ToEmitRequest(tenantID, deletedAt)
 		})

--- a/components/ledger/internal/services/command/delete_portfolio_streaming_test.go
+++ b/components/ledger/internal/services/command/delete_portfolio_streaming_test.go
@@ -96,8 +96,7 @@ func TestDeletePortfolioByID_NoopEmitterDoesNotPanic(t *testing.T) {
 
 // TestDeletePortfolioByID_EmitFailureDoesNotFailRequest verifies the
 // IMPORTANT posture: when Emit returns an error, DeletePortfolioByID
-// must still complete successfully because durability is owned by PG +
-// future DLQ/outbox, not by the synchronous Emit call.
+// must still complete successfully because the persisted database mutation is durable; this helper does not make broker delivery transactional.
 func TestDeletePortfolioByID_EmitFailureDoesNotFailRequest(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()

--- a/components/ledger/internal/services/command/delete_segment.go
+++ b/components/ledger/internal/services/command/delete_segment.go
@@ -63,8 +63,7 @@ func (uc *UseCase) DeleteSegmentByID(ctx context.Context, organizationID, ledger
 // emitSegmentDeletedEvent publishes the segment.deleted event for a
 // successfully soft-deleted segment. IMPORTANT posture: build and emit
 // failures are span-recorded and logged at Warn, never returned.
-// Durability of the event is owned by PG and (follow-up task) the
-// outbox subsystem + DLQ, not by the synchronous Emit call.
+// The persisted database mutation is durable; this helper does not make broker delivery transactional.
 //
 // Anchor: invoked immediately after SegmentRepo.Delete succeeds.
 // SegmentRepo.Delete does not return the post-delete record, so the
@@ -77,7 +76,7 @@ func (uc *UseCase) DeleteSegmentByID(ctx context.Context, organizationID, ledger
 // Wire-format mapping lives in pkg/streaming/events/segment_deleted.go;
 // changes to the payload contract belong there, not here.
 func (uc *UseCase) emitSegmentDeletedEvent(ctx context.Context, span trace.Span, logger libLog.Logger, id, organizationID, ledgerID string, deletedAt time.Time) {
-	pkgStreaming.EmitImportant(ctx, span, logger, uc.Streaming, events.SegmentDeletedDefinition.Key(),
+	pkgStreaming.EmitBrokerBestEffort(ctx, span, logger, uc.Streaming, events.SegmentDeletedDefinition.Key(),
 		func(tenantID string) (libStreaming.EmitRequest, error) {
 			return events.NewSegmentDeleted(id, organizationID, ledgerID, deletedAt).ToEmitRequest(tenantID, deletedAt)
 		})

--- a/components/ledger/internal/services/command/delete_segment_streaming_test.go
+++ b/components/ledger/internal/services/command/delete_segment_streaming_test.go
@@ -96,8 +96,7 @@ func TestDeleteSegmentByID_NoopEmitterDoesNotPanic(t *testing.T) {
 
 // TestDeleteSegmentByID_EmitFailureDoesNotFailRequest verifies the
 // IMPORTANT posture: when Emit returns an error, DeleteSegmentByID
-// must still complete successfully because durability is owned by PG +
-// future DLQ/outbox, not by the synchronous Emit call.
+// must still complete successfully because the persisted database mutation is durable; this helper does not make broker delivery transactional.
 func TestDeleteSegmentByID_EmitFailureDoesNotFailRequest(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()

--- a/components/ledger/internal/services/command/delete_transaction_route.go
+++ b/components/ledger/internal/services/command/delete_transaction_route.go
@@ -85,7 +85,7 @@ func (uc *UseCase) DeleteTransactionRouteByID(ctx context.Context, organizationI
 //
 // Wire-format mapping lives in pkg/streaming/events/transaction_route_deleted.go.
 func (uc *UseCase) emitTransactionRouteDeletedEvent(ctx context.Context, span trace.Span, logger libLog.Logger, id, organizationID, ledgerID string, deletedAt time.Time) {
-	pkgStreaming.EmitImportant(ctx, span, logger, uc.Streaming, events.TransactionRouteDeletedDefinition.Key(),
+	pkgStreaming.EmitBrokerBestEffort(ctx, span, logger, uc.Streaming, events.TransactionRouteDeletedDefinition.Key(),
 		func(tenantID string) (libStreaming.EmitRequest, error) {
 			return events.NewTransactionRouteDeleted(id, organizationID, ledgerID, deletedAt).ToEmitRequest(tenantID, deletedAt)
 		})

--- a/components/ledger/internal/services/command/send_balance_changed_events.go
+++ b/components/ledger/internal/services/command/send_balance_changed_events.go
@@ -23,7 +23,7 @@ import (
 //
 // Fire-and-forget: emission failures are logged/span-recorded but never
 // propagate — this MUST NOT fail the parent transaction (mirrors the
-// EmitImportant contract). Emission happens whenever streaming is enabled:
+// EmitBrokerBestEffort contract). Emission happens whenever streaming is enabled:
 // when STREAMING_ENABLED=false the streaming client is a NoopEmitter, so this
 // simply becomes a no-op — the same posture as balance.created.
 //
@@ -79,7 +79,7 @@ func (uc *UseCase) SendBalanceChangedEvents(ctx context.Context, tran *transacti
 			return events.NewBalanceChanged(src).ToEmitRequest(tenantID, src.OccurredAt)
 		}
 
-		pkgStreaming.EmitImportant(ctxSend, span, logger, uc.Streaming, events.BalanceChangedDefinition.Key(), buildFn)
+		pkgStreaming.EmitBrokerBestEffort(ctxSend, span, logger, uc.Streaming, events.BalanceChangedDefinition.Key(), buildFn)
 	}
 }
 

--- a/components/ledger/internal/services/command/send_overdraft_events.go
+++ b/components/ledger/internal/services/command/send_overdraft_events.go
@@ -307,7 +307,7 @@ func (uc *UseCase) emitBalanceOverdraftEvent(ctx context.Context, span trace.Spa
 		return
 	}
 
-	pkgStreaming.EmitImportant(ctx, span, logger, uc.Streaming, definitionKey, buildFn)
+	pkgStreaming.EmitBrokerBestEffort(ctx, span, logger, uc.Streaming, definitionKey, buildFn)
 }
 
 // classifyOverdraftOperation determines the event action for a companion

--- a/components/ledger/internal/services/command/send_transaction_events.go
+++ b/components/ledger/internal/services/command/send_transaction_events.go
@@ -134,10 +134,9 @@ func (uc *UseCase) SendTransactionEvents(ctx context.Context, tran *transaction.
 // based on the (phase, status, parent) discriminator triple.
 //
 // IMPORTANT posture (catalog says CRITICAL with outbox: always, but the
-// outbox subsystem is not yet wired in midaz — see handoff). Build and
+// Midaz has no local outbox writer or relay). Build and
 // emit failures are span-recorded and logged at Warn, never returned to
-// the caller; durability of these events is owned by PG + (follow-up
-// task) the outbox subsystem, not by this synchronous Emit call.
+// the caller; the persisted database mutation is durable, while this helper does not make broker delivery transactional.
 //
 // Discriminator table:
 //
@@ -238,7 +237,7 @@ func (uc *UseCase) emitTransactionLifecycleEvent(ctx context.Context, span trace
 		return
 	}
 
-	pkgStreaming.EmitImportant(ctx, span, logger, uc.Streaming, definitionKey, buildFn)
+	pkgStreaming.EmitBrokerBestEffort(ctx, span, logger, uc.Streaming, definitionKey, buildFn)
 
 	// fee-charge.applied rides alongside transaction.posted only. Commit/cancel/
 	// revert do NOT re-emit it (the fee charge happened once, at post).
@@ -252,7 +251,7 @@ func (uc *UseCase) emitTransactionLifecycleEvent(ctx context.Context, span trace
 // packageAppliedID are present in metadata (charged-only, set by the fee
 // engine on the real-charge branch); pure exemptions still carry
 // packageAppliedID but omit feeApplied=true, so the feeApplied guard suppresses
-// the emit. IMPORTANT posture: EmitImportant swallows build/emit failures.
+// the emit. IMPORTANT posture: EmitBrokerBestEffort swallows build/emit failures.
 func (uc *UseCase) emitFeesAppliedEvent(ctx context.Context, span trace.Span, logger libLog.Logger, tran *transaction.Transaction) {
 	if applied, _ := tran.Metadata["feeApplied"].(string); applied != "true" {
 		return
@@ -265,7 +264,7 @@ func (uc *UseCase) emitFeesAppliedEvent(ctx context.Context, span trace.Span, lo
 
 	appliedAt := tran.CreatedAt
 
-	pkgStreaming.EmitImportant(ctx, span, logger, uc.Streaming, events.FeesAppliedDefinition.Key(),
+	pkgStreaming.EmitBrokerBestEffort(ctx, span, logger, uc.Streaming, events.FeesAppliedDefinition.Key(),
 		func(tenantID string) (libStreaming.EmitRequest, error) {
 			return events.NewFeesApplied(tran.ID, tran.OrganizationID, tran.LedgerID, packageID, appliedAt).
 				ToEmitRequest(tenantID, appliedAt)

--- a/components/ledger/internal/services/command/send_transaction_events.go
+++ b/components/ledger/internal/services/command/send_transaction_events.go
@@ -133,8 +133,8 @@ func (uc *UseCase) SendTransactionEvents(ctx context.Context, tran *transaction.
 // transaction.{posted,committed,canceled,reverted} lib-streaming events
 // based on the (phase, status, parent) discriminator triple.
 //
-// IMPORTANT posture (catalog says CRITICAL with outbox: always, but the
-// Midaz has no local outbox writer or relay). Build and
+// Best-effort broker publication (catalog says CRITICAL with outbox: always, but
+// Midaz has no local outbox writer or relay. Build and
 // emit failures are span-recorded and logged at Warn, never returned to
 // the caller; the persisted database mutation is durable, while this helper does not make broker delivery transactional.
 //

--- a/components/ledger/internal/services/command/update_account.go
+++ b/components/ledger/internal/services/command/update_account.go
@@ -158,8 +158,7 @@ func mergePatchAccount(pre, in *mmodel.Account, updatedAt time.Time) *mmodel.Acc
 // emitAccountUpdatedEvent publishes the account.updated event for a
 // successfully persisted update. IMPORTANT posture: build and emit
 // failures are span-recorded and logged at Warn, never returned.
-// Durability of the event is owned by PG and (follow-up task) the
-// outbox subsystem + DLQ, not by the synchronous Emit call.
+// The persisted database mutation is durable; this helper does not make broker delivery transactional.
 //
 // Anchor: invoked between the AccountRepo.Update success branch and the
 // metadata-write call in UpdateAccount, so a downstream Mongo failure
@@ -169,7 +168,7 @@ func mergePatchAccount(pre, in *mmodel.Account, updatedAt time.Time) *mmodel.Acc
 // changes to the payload contract belong there, not here. This function
 // stays a thin emit-and-log adapter.
 func (uc *UseCase) emitAccountUpdatedEvent(ctx context.Context, span trace.Span, logger libLog.Logger, acc *mmodel.Account) {
-	pkgStreaming.EmitImportant(ctx, span, logger, uc.Streaming, events.AccountUpdatedDefinition.Key(),
+	pkgStreaming.EmitBrokerBestEffort(ctx, span, logger, uc.Streaming, events.AccountUpdatedDefinition.Key(),
 		func(tenantID string) (libStreaming.EmitRequest, error) {
 			return events.NewAccountUpdated(acc).ToEmitRequest(tenantID, acc.UpdatedAt)
 		})

--- a/components/ledger/internal/services/command/update_account_streaming_test.go
+++ b/components/ledger/internal/services/command/update_account_streaming_test.go
@@ -147,7 +147,7 @@ func TestUpdateAccount_NoopEmitterDoesNotPanic(t *testing.T) {
 // TestUpdateAccount_EmitFailureDoesNotFailRequest verifies the IMPORTANT
 // posture: when Emit returns an error, UpdateAccount must still return
 // the successfully-persisted account because durability is owned by PG
-// + future DLQ/outbox, not by the synchronous Emit call.
+// + the configured lib-streaming policy, not by the synchronous Emit call.
 func TestUpdateAccount_EmitFailureDoesNotFailRequest(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()

--- a/components/ledger/internal/services/command/update_asset.go
+++ b/components/ledger/internal/services/command/update_asset.go
@@ -81,8 +81,7 @@ func (uc *UseCase) UpdateAssetByID(ctx context.Context, organizationID, ledgerID
 // emitAssetUpdatedEvent publishes the asset.updated event for a
 // successfully persisted update. IMPORTANT posture: build and emit
 // failures are span-recorded and logged at Warn, never returned.
-// Durability of the event is owned by PG and (follow-up task) the
-// outbox subsystem + DLQ, not by the synchronous Emit call.
+// The persisted database mutation is durable; this helper does not make broker delivery transactional.
 //
 // Anchor: invoked between the AssetRepo.Update success branch and the
 // metadata-write call in UpdateAssetByID, so a downstream Mongo failure
@@ -97,7 +96,7 @@ func (uc *UseCase) UpdateAssetByID(ctx context.Context, organizationID, ledgerID
 // Wire-format mapping lives in pkg/streaming/events/asset_updated.go;
 // changes to the payload contract belong there, not here.
 func (uc *UseCase) emitAssetUpdatedEvent(ctx context.Context, span trace.Span, logger libLog.Logger, a *mmodel.Asset) {
-	pkgStreaming.EmitImportant(ctx, span, logger, uc.Streaming, events.AssetUpdatedDefinition.Key(),
+	pkgStreaming.EmitBrokerBestEffort(ctx, span, logger, uc.Streaming, events.AssetUpdatedDefinition.Key(),
 		func(tenantID string) (libStreaming.EmitRequest, error) {
 			return events.NewAssetUpdated(a).ToEmitRequest(tenantID, a.UpdatedAt)
 		})

--- a/components/ledger/internal/services/command/update_asset_streaming_test.go
+++ b/components/ledger/internal/services/command/update_asset_streaming_test.go
@@ -140,7 +140,7 @@ func TestUpdateAssetByID_NoopEmitterDoesNotPanic(t *testing.T) {
 // TestUpdateAssetByID_EmitFailureDoesNotFailRequest verifies the
 // IMPORTANT posture: when Emit returns an error, UpdateAssetByID must
 // still return the successfully-persisted asset because durability is
-// owned by PG + future DLQ/outbox, not by the synchronous Emit call.
+// owned by PG + the configured lib-streaming policy, not by the synchronous Emit call.
 func TestUpdateAssetByID_EmitFailureDoesNotFailRequest(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()

--- a/components/ledger/internal/services/command/update_balance.go
+++ b/components/ledger/internal/services/command/update_balance.go
@@ -287,8 +287,7 @@ func (uc *UseCase) Update(ctx context.Context, organizationID, ledgerID, balance
 // event for a successfully persisted balance configuration mutation.
 // IMPORTANT posture: build and emit failures are span-recorded and
 // logged at Warn, never returned. Durability of the event is owned by
-// PG and (follow-up task) the outbox subsystem + DLQ, not by the
-// synchronous Emit call.
+// the persisted database mutation; this helper does not make broker delivery transactional.
 //
 // Anchor (two callers):
 //   - UseCase.Update at the post-Update success branch, with the
@@ -304,7 +303,7 @@ func (uc *UseCase) Update(ctx context.Context, organizationID, ledgerID, balance
 // Wire-format mapping lives in pkg/streaming/events/balance_config_changed.go;
 // changes to the payload contract belong there, not here.
 func (uc *UseCase) emitBalanceConfigChangedEvent(ctx context.Context, span trace.Span, logger libLog.Logger, b *mmodel.Balance, changeType string) {
-	pkgStreaming.EmitImportant(ctx, span, logger, uc.Streaming, events.BalanceConfigChangedDefinition.Key(),
+	pkgStreaming.EmitBrokerBestEffort(ctx, span, logger, uc.Streaming, events.BalanceConfigChangedDefinition.Key(),
 		func(tenantID string) (libStreaming.EmitRequest, error) {
 			return events.NewBalanceConfigChanged(b, changeType).ToEmitRequest(tenantID, b.UpdatedAt)
 		})

--- a/components/ledger/internal/services/command/update_ledger.go
+++ b/components/ledger/internal/services/command/update_ledger.go
@@ -79,7 +79,7 @@ func (uc *UseCase) UpdateLedgerByID(ctx context.Context, organizationID, id uuid
 // successfully persisted update. IMPORTANT posture: build and emit failures
 // are span-recorded and logged at Warn, never returned.
 func (uc *UseCase) emitLedgerUpdatedEvent(ctx context.Context, span trace.Span, logger libLog.Logger, led *mmodel.Ledger) {
-	pkgStreaming.EmitImportant(ctx, span, logger, uc.Streaming, events.LedgerUpdatedDefinition.Key(),
+	pkgStreaming.EmitBrokerBestEffort(ctx, span, logger, uc.Streaming, events.LedgerUpdatedDefinition.Key(),
 		func(tenantID string) (libStreaming.EmitRequest, error) {
 			return events.NewLedgerUpdated(led).ToEmitRequest(tenantID, led.UpdatedAt)
 		})

--- a/components/ledger/internal/services/command/update_operation_route.go
+++ b/components/ledger/internal/services/command/update_operation_route.go
@@ -84,8 +84,7 @@ func (uc *UseCase) UpdateOperationRoute(ctx context.Context, organizationID, led
 // emitOperationRouteUpdatedEvent publishes the operation-route.updated
 // event for a successfully persisted update. IMPORTANT posture: build
 // and emit failures are span-recorded and logged at Warn, never
-// returned. Durability of the event is owned by PG and (follow-up
-// task) the outbox subsystem + DLQ, not by the synchronous Emit call.
+// returned. The persisted database mutation is durable; this helper does not make broker delivery transactional.
 //
 // Anchor: invoked between the OperationRouteRepo.Update success branch
 // and the metadata-write call in UpdateOperationRoute, so a downstream
@@ -100,7 +99,7 @@ func (uc *UseCase) UpdateOperationRoute(ctx context.Context, organizationID, led
 // Wire-format mapping lives in pkg/streaming/events/operation_route_updated.go;
 // changes to the payload contract belong there, not here.
 func (uc *UseCase) emitOperationRouteUpdatedEvent(ctx context.Context, span trace.Span, logger libLog.Logger, o *mmodel.OperationRoute) {
-	pkgStreaming.EmitImportant(ctx, span, logger, uc.Streaming, events.OperationRouteUpdatedDefinition.Key(),
+	pkgStreaming.EmitBrokerBestEffort(ctx, span, logger, uc.Streaming, events.OperationRouteUpdatedDefinition.Key(),
 		func(tenantID string) (libStreaming.EmitRequest, error) {
 			return events.NewOperationRouteUpdated(o).ToEmitRequest(tenantID, o.UpdatedAt)
 		})

--- a/components/ledger/internal/services/command/update_operation_route_streaming_test.go
+++ b/components/ledger/internal/services/command/update_operation_route_streaming_test.go
@@ -148,7 +148,7 @@ func TestUpdateOperationRoute_NoopEmitterDoesNotPanic(t *testing.T) {
 // TestUpdateOperationRoute_EmitFailureDoesNotFailRequest verifies the
 // IMPORTANT posture: when Emit returns an error, UpdateOperationRoute
 // must still return the successfully-persisted operation route because
-// durability is owned by PG + future DLQ/outbox, not by the synchronous
+// durability is owned by PG + the configured lib-streaming policy, not by the synchronous
 // Emit call.
 func TestUpdateOperationRoute_EmitFailureDoesNotFailRequest(t *testing.T) {
 	ctrl := gomock.NewController(t)

--- a/components/ledger/internal/services/command/update_organization.go
+++ b/components/ledger/internal/services/command/update_organization.go
@@ -107,7 +107,7 @@ func (uc *UseCase) UpdateOrganizationByID(ctx context.Context, id uuid.UUID, uoi
 // successfully persisted update. IMPORTANT posture: build and emit failures are
 // span-recorded and logged at Warn, never returned.
 func (uc *UseCase) emitOrganizationUpdatedEvent(ctx context.Context, span trace.Span, logger libLog.Logger, org *mmodel.Organization) {
-	pkgStreaming.EmitImportant(ctx, span, logger, uc.Streaming, events.OrganizationUpdatedDefinition.Key(),
+	pkgStreaming.EmitBrokerBestEffort(ctx, span, logger, uc.Streaming, events.OrganizationUpdatedDefinition.Key(),
 		func(tenantID string) (libStreaming.EmitRequest, error) {
 			return events.NewOrganizationUpdated(org).ToEmitRequest(tenantID, org.UpdatedAt)
 		})

--- a/components/ledger/internal/services/command/update_portfolio.go
+++ b/components/ledger/internal/services/command/update_portfolio.go
@@ -81,8 +81,7 @@ func (uc *UseCase) UpdatePortfolioByID(ctx context.Context, organizationID, ledg
 // emitPortfolioUpdatedEvent publishes the portfolio.updated event for a
 // successfully persisted update. IMPORTANT posture: build and emit
 // failures are span-recorded and logged at Warn, never returned.
-// Durability of the event is owned by PG and (follow-up task) the
-// outbox subsystem + DLQ, not by the synchronous Emit call.
+// The persisted database mutation is durable; this helper does not make broker delivery transactional.
 //
 // Anchor: invoked between the PortfolioRepo.Update success branch and
 // the metadata-write call in UpdatePortfolioByID, so a downstream Mongo
@@ -95,7 +94,7 @@ func (uc *UseCase) UpdatePortfolioByID(ctx context.Context, organizationID, ledg
 // Wire-format mapping lives in pkg/streaming/events/portfolio_updated.go;
 // changes to the payload contract belong there, not here.
 func (uc *UseCase) emitPortfolioUpdatedEvent(ctx context.Context, span trace.Span, logger libLog.Logger, p *mmodel.Portfolio) {
-	pkgStreaming.EmitImportant(ctx, span, logger, uc.Streaming, events.PortfolioUpdatedDefinition.Key(),
+	pkgStreaming.EmitBrokerBestEffort(ctx, span, logger, uc.Streaming, events.PortfolioUpdatedDefinition.Key(),
 		func(tenantID string) (libStreaming.EmitRequest, error) {
 			return events.NewPortfolioUpdated(p).ToEmitRequest(tenantID, p.UpdatedAt)
 		})

--- a/components/ledger/internal/services/command/update_portfolio_streaming_test.go
+++ b/components/ledger/internal/services/command/update_portfolio_streaming_test.go
@@ -145,7 +145,7 @@ func TestUpdatePortfolioByID_NoopEmitterDoesNotPanic(t *testing.T) {
 // TestUpdatePortfolioByID_EmitFailureDoesNotFailRequest verifies the
 // IMPORTANT posture: when Emit returns an error, UpdatePortfolioByID must
 // still return the successfully-persisted portfolio because durability
-// is owned by PG + future DLQ/outbox, not by the synchronous Emit call.
+// is owned by PG + the configured lib-streaming policy, not by the synchronous Emit call.
 func TestUpdatePortfolioByID_EmitFailureDoesNotFailRequest(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()

--- a/components/ledger/internal/services/command/update_segment.go
+++ b/components/ledger/internal/services/command/update_segment.go
@@ -107,8 +107,7 @@ func (uc *UseCase) UpdateSegmentByID(ctx context.Context, organizationID, ledger
 // emitSegmentUpdatedEvent publishes the segment.updated event for a
 // successfully persisted update. IMPORTANT posture: build and emit
 // failures are span-recorded and logged at Warn, never returned.
-// Durability of the event is owned by PG and (follow-up task) the
-// outbox subsystem + DLQ, not by the synchronous Emit call.
+// The persisted database mutation is durable; this helper does not make broker delivery transactional.
 //
 // Anchor: invoked between the SegmentRepo.Update success branch and the
 // metadata-write call in UpdateSegmentByID, so a downstream Mongo
@@ -121,7 +120,7 @@ func (uc *UseCase) UpdateSegmentByID(ctx context.Context, organizationID, ledger
 // Wire-format mapping lives in pkg/streaming/events/segment_updated.go;
 // changes to the payload contract belong there, not here.
 func (uc *UseCase) emitSegmentUpdatedEvent(ctx context.Context, span trace.Span, logger libLog.Logger, s *mmodel.Segment) {
-	pkgStreaming.EmitImportant(ctx, span, logger, uc.Streaming, events.SegmentUpdatedDefinition.Key(),
+	pkgStreaming.EmitBrokerBestEffort(ctx, span, logger, uc.Streaming, events.SegmentUpdatedDefinition.Key(),
 		func(tenantID string) (libStreaming.EmitRequest, error) {
 			return events.NewSegmentUpdated(s).ToEmitRequest(tenantID, s.UpdatedAt)
 		})

--- a/components/ledger/internal/services/command/update_segment_streaming_test.go
+++ b/components/ledger/internal/services/command/update_segment_streaming_test.go
@@ -143,7 +143,7 @@ func TestUpdateSegmentByID_NoopEmitterDoesNotPanic(t *testing.T) {
 // TestUpdateSegmentByID_EmitFailureDoesNotFailRequest verifies the
 // IMPORTANT posture: when Emit returns an error, UpdateSegmentByID must
 // still return the successfully-persisted segment because durability is
-// owned by PG + future DLQ/outbox, not by the synchronous Emit call.
+// owned by PG + the configured lib-streaming policy, not by the synchronous Emit call.
 func TestUpdateSegmentByID_EmitFailureDoesNotFailRequest(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()

--- a/components/ledger/internal/services/command/update_transaction_route.go
+++ b/components/ledger/internal/services/command/update_transaction_route.go
@@ -156,7 +156,7 @@ func (uc *UseCase) UpdateTransactionRoute(ctx context.Context, organizationID, l
 //
 // Wire-format mapping lives in pkg/streaming/events/transaction_route_updated.go.
 func (uc *UseCase) emitTransactionRouteUpdatedEvent(ctx context.Context, span trace.Span, logger libLog.Logger, tr *mmodel.TransactionRoute) {
-	pkgStreaming.EmitImportant(ctx, span, logger, uc.Streaming, events.TransactionRouteUpdatedDefinition.Key(),
+	pkgStreaming.EmitBrokerBestEffort(ctx, span, logger, uc.Streaming, events.TransactionRouteUpdatedDefinition.Key(),
 		func(tenantID string) (libStreaming.EmitRequest, error) {
 			return events.NewTransactionRouteUpdated(tr).ToEmitRequest(tenantID, tr.UpdatedAt)
 		})

--- a/components/ledger/internal/services/fees/billing-package-service.go
+++ b/components/ledger/internal/services/fees/billing-package-service.go
@@ -462,7 +462,7 @@ func (s *BillingPackageService) DeleteBillingPackage(ctx context.Context, id, or
 
 // emitBillingPackageCreatedEvent publishes fee-billing-packages.created. IMPORTANT posture.
 func (s *BillingPackageService) emitBillingPackageCreatedEvent(ctx context.Context, span trace.Span, logger libLog.Logger, bp *model.BillingPackage) {
-	pkgStreaming.EmitImportant(ctx, span, logger, s.Streaming, events.FeesBillingPackageCreatedDefinition.Key(),
+	pkgStreaming.EmitBrokerBestEffort(ctx, span, logger, s.Streaming, events.FeesBillingPackageCreatedDefinition.Key(),
 		func(tenantID string) (libStreaming.EmitRequest, error) {
 			ts, err := time.Parse(time.RFC3339, bp.CreatedAt)
 			if err != nil {
@@ -479,7 +479,7 @@ func (s *BillingPackageService) emitBillingPackageCreatedEvent(ctx context.Conte
 
 // emitBillingPackageUpdatedEvent publishes fee-billing-packages.updated. IMPORTANT posture.
 func (s *BillingPackageService) emitBillingPackageUpdatedEvent(ctx context.Context, span trace.Span, logger libLog.Logger, bp *model.BillingPackage) {
-	pkgStreaming.EmitImportant(ctx, span, logger, s.Streaming, events.FeesBillingPackageUpdatedDefinition.Key(),
+	pkgStreaming.EmitBrokerBestEffort(ctx, span, logger, s.Streaming, events.FeesBillingPackageUpdatedDefinition.Key(),
 		func(tenantID string) (libStreaming.EmitRequest, error) {
 			ts, err := time.Parse(time.RFC3339, bp.UpdatedAt)
 			if err != nil {
@@ -496,7 +496,7 @@ func (s *BillingPackageService) emitBillingPackageUpdatedEvent(ctx context.Conte
 
 // emitBillingPackageDeletedEvent publishes fee-billing-packages.deleted. IMPORTANT posture.
 func (s *BillingPackageService) emitBillingPackageDeletedEvent(ctx context.Context, span trace.Span, logger libLog.Logger, id, organizationID, ledgerID string, deletedAt time.Time) {
-	pkgStreaming.EmitImportant(ctx, span, logger, s.Streaming, events.FeesBillingPackageDeletedDefinition.Key(),
+	pkgStreaming.EmitBrokerBestEffort(ctx, span, logger, s.Streaming, events.FeesBillingPackageDeletedDefinition.Key(),
 		func(tenantID string) (libStreaming.EmitRequest, error) {
 			return events.NewFeesBillingPackageDeleted(id, organizationID, ledgerID, deletedAt).ToEmitRequest(tenantID, deletedAt)
 		})

--- a/components/ledger/internal/services/fees/create-package.go
+++ b/components/ledger/internal/services/fees/create-package.go
@@ -122,7 +122,7 @@ func (uc *UseCase) CreatePackage(ctx context.Context, cpi *model.CreatePackageIn
 
 // emitFeesPackageCreatedEvent publishes fee-packages.created. IMPORTANT posture.
 func (uc *UseCase) emitFeesPackageCreatedEvent(ctx context.Context, span trace.Span, logger libLog.Logger, p *pack.Package, organizationID uuid.UUID) {
-	pkgStreaming.EmitImportant(ctx, span, logger, uc.Streaming, events.FeesPackageCreatedDefinition.Key(),
+	pkgStreaming.EmitBrokerBestEffort(ctx, span, logger, uc.Streaming, events.FeesPackageCreatedDefinition.Key(),
 		func(tenantID string) (libStreaming.EmitRequest, error) {
 			return events.NewFeesPackageCreated(
 				p.ID.String(), organizationID.String(), p.LedgerID.String(),

--- a/components/ledger/internal/services/fees/delete-package-by-id.go
+++ b/components/ledger/internal/services/fees/delete-package-by-id.go
@@ -78,7 +78,7 @@ func (uc *UseCase) DeletePackageByID(ctx context.Context, id, organizationID, le
 
 // emitFeesPackageDeletedEvent publishes fee-packages.deleted. IMPORTANT posture.
 func (uc *UseCase) emitFeesPackageDeletedEvent(ctx context.Context, span trace.Span, logger libLog.Logger, id, organizationID, ledgerID uuid.UUID, deletedAt time.Time) {
-	pkgStreaming.EmitImportant(ctx, span, logger, uc.Streaming, events.FeesPackageDeletedDefinition.Key(),
+	pkgStreaming.EmitBrokerBestEffort(ctx, span, logger, uc.Streaming, events.FeesPackageDeletedDefinition.Key(),
 		func(tenantID string) (libStreaming.EmitRequest, error) {
 			return events.NewFeesPackageDeleted(
 				id.String(), organizationID.String(), ledgerID.String(), deletedAt,

--- a/components/ledger/internal/services/fees/update-package-by-id.go
+++ b/components/ledger/internal/services/fees/update-package-by-id.go
@@ -97,7 +97,7 @@ func (uc *UseCase) UpdatePackageByID(ctx context.Context, id, organizationID, le
 
 // emitFeesPackageUpdatedEvent publishes fee-packages.updated. IMPORTANT posture.
 func (uc *UseCase) emitFeesPackageUpdatedEvent(ctx context.Context, span trace.Span, logger libLog.Logger, p *pack.Package, organizationID uuid.UUID) {
-	pkgStreaming.EmitImportant(ctx, span, logger, uc.Streaming, events.FeesPackageUpdatedDefinition.Key(),
+	pkgStreaming.EmitBrokerBestEffort(ctx, span, logger, uc.Streaming, events.FeesPackageUpdatedDefinition.Key(),
 		func(tenantID string) (libStreaming.EmitRequest, error) {
 			return events.NewFeesPackageUpdated(
 				p.ID.String(), organizationID.String(), p.LedgerID.String(),

--- a/components/tracer/.env.example
+++ b/components/tracer/.env.example
@@ -469,16 +469,16 @@ STREAMING_ENABLED=false
 # franz-go ProducerLinger in ms. Default: 5.
 # STREAMING_BATCH_LINGER_MS=5
 
-# --- Per-emit timeout (IMPORTANT-posture events) ---
+# --- Per-emit timeout (best-effort broker publication) ---
 # Per-call deadline applied around emitter.Emit() for IMPORTANT-posture events.
-# When this fires, the emit is logged as a warning and dropped — durability of
-# IMPORTANT events belongs to PG and (eventually) the outbox subsystem, not to
-# the synchronous broker round-trip.
+# When this fires, the helper logs a warning and returns without failing the
+# request. The helper delegates policy and any configured fallback to
+# lib-streaming; Midaz does not wire a product-local outbox writer or relay.
 #
 # Value is in milliseconds; must be > 0 or the default is used. Default: 5000 (5s).
 # Bump it if your broker is far away (cross-region) or when running end-to-end
 # against a cold/loaded test cluster. Lower it if you want to fail-fast on slow
-# brokers and rely on async/outbox redelivery.
+# brokers; this setting does not create a local outbox record.
 # STREAMING_IMPORTANT_EMIT_TIMEOUT_MS=5000
 
 # --- SASL/TLS auth ---

--- a/components/tracer/internal/services/command/activate_limit.go
+++ b/components/tracer/internal/services/command/activate_limit.go
@@ -224,7 +224,7 @@ func (c *ActivateLimitCommand) Execute(ctx context.Context, id uuid.UUID) (_ *mo
 // not called on the idempotent already-active no-op (which skips the tx).
 // IMPORTANT posture: emit failures never fail the request.
 func (c *ActivateLimitCommand) emitLimitActivatedEvent(ctx context.Context, span trace.Span, logger libLog.Logger, limit *model.Limit) {
-	pkgStreaming.EmitImportant(ctx, span, logger, c.Streaming, events.LimitActivatedDefinition.Key(),
+	pkgStreaming.EmitBrokerBestEffort(ctx, span, logger, c.Streaming, events.LimitActivatedDefinition.Key(),
 		func(tenantID string) (libStreaming.EmitRequest, error) {
 			return events.NewLimitActivated(limit).ToEmitRequest(tenantID, limit.UpdatedAt)
 		})

--- a/components/tracer/internal/services/command/activate_rule.go
+++ b/components/tracer/internal/services/command/activate_rule.go
@@ -327,7 +327,7 @@ func (s *ActivateRuleService) Execute(ctx context.Context, ruleID uuid.UUID) (_ 
 // emitRuleActivatedEvent publishes the rule.activated event post-commit.
 // IMPORTANT posture: emit failures never fail the request.
 func (s *ActivateRuleService) emitRuleActivatedEvent(ctx context.Context, span trace.Span, logger libLog.Logger, rule *model.Rule) {
-	pkgStreaming.EmitImportant(ctx, span, logger, s.Streaming, events.RuleActivatedDefinition.Key(),
+	pkgStreaming.EmitBrokerBestEffort(ctx, span, logger, s.Streaming, events.RuleActivatedDefinition.Key(),
 		func(tenantID string) (libStreaming.EmitRequest, error) {
 			return events.NewRuleActivated(rule).ToEmitRequest(tenantID, rule.UpdatedAt)
 		})

--- a/components/tracer/internal/services/command/create_limit.go
+++ b/components/tracer/internal/services/command/create_limit.go
@@ -333,10 +333,10 @@ func (c *CreateLimitCommand) Execute(ctx context.Context, input *CreateLimitInpu
 }
 
 // emitLimitCreatedEvent publishes the limit.created event post-commit. IMPORTANT
-// posture: EmitImportant nil-guards the emitter, bounds the emit, and never
+// posture: EmitBrokerBestEffort nil-guards the emitter, bounds the emit, and never
 // propagates build/emit failures — so this never fails the request.
 func (c *CreateLimitCommand) emitLimitCreatedEvent(ctx context.Context, span trace.Span, logger libLog.Logger, limit *model.Limit) {
-	pkgStreaming.EmitImportant(ctx, span, logger, c.Streaming, events.LimitCreatedDefinition.Key(),
+	pkgStreaming.EmitBrokerBestEffort(ctx, span, logger, c.Streaming, events.LimitCreatedDefinition.Key(),
 		func(tenantID string) (libStreaming.EmitRequest, error) {
 			return events.NewLimitCreated(limit).ToEmitRequest(tenantID, limit.CreatedAt)
 		})

--- a/components/tracer/internal/services/command/create_rule.go
+++ b/components/tracer/internal/services/command/create_rule.go
@@ -264,10 +264,10 @@ func (c *CreateRuleCommand) Execute(ctx context.Context, input *CreateRuleInput)
 }
 
 // emitRuleCreatedEvent publishes the rule.created event post-commit. IMPORTANT
-// posture: EmitImportant nil-guards the emitter, bounds the emit, and never
+// posture: EmitBrokerBestEffort nil-guards the emitter, bounds the emit, and never
 // propagates build/emit failures — so this never fails the request.
 func (c *CreateRuleCommand) emitRuleCreatedEvent(ctx context.Context, span trace.Span, logger libLog.Logger, rule *model.Rule) {
-	pkgStreaming.EmitImportant(ctx, span, logger, c.Streaming, events.RuleCreatedDefinition.Key(),
+	pkgStreaming.EmitBrokerBestEffort(ctx, span, logger, c.Streaming, events.RuleCreatedDefinition.Key(),
 		func(tenantID string) (libStreaming.EmitRequest, error) {
 			return events.NewRuleCreated(rule).ToEmitRequest(tenantID, rule.CreatedAt)
 		})

--- a/components/tracer/internal/services/command/deactivate_limit.go
+++ b/components/tracer/internal/services/command/deactivate_limit.go
@@ -224,7 +224,7 @@ func (c *DeactivateLimitCommand) Execute(ctx context.Context, id uuid.UUID) (_ *
 // It is not called on the idempotent already-inactive no-op (which skips the
 // tx). IMPORTANT posture: emit failures never fail the request.
 func (c *DeactivateLimitCommand) emitLimitDeactivatedEvent(ctx context.Context, span trace.Span, logger libLog.Logger, limit *model.Limit) {
-	pkgStreaming.EmitImportant(ctx, span, logger, c.Streaming, events.LimitDeactivatedDefinition.Key(),
+	pkgStreaming.EmitBrokerBestEffort(ctx, span, logger, c.Streaming, events.LimitDeactivatedDefinition.Key(),
 		func(tenantID string) (libStreaming.EmitRequest, error) {
 			return events.NewLimitDeactivated(limit).ToEmitRequest(tenantID, limit.UpdatedAt)
 		})

--- a/components/tracer/internal/services/command/deactivate_rule.go
+++ b/components/tracer/internal/services/command/deactivate_rule.go
@@ -275,7 +275,7 @@ func (s *DeactivateRuleService) Execute(ctx context.Context, ruleID uuid.UUID) (
 // emitRuleDeactivatedEvent publishes the rule.deactivated event post-commit.
 // IMPORTANT posture: emit failures never fail the request.
 func (s *DeactivateRuleService) emitRuleDeactivatedEvent(ctx context.Context, span trace.Span, logger libLog.Logger, rule *model.Rule) {
-	pkgStreaming.EmitImportant(ctx, span, logger, s.Streaming, events.RuleDeactivatedDefinition.Key(),
+	pkgStreaming.EmitBrokerBestEffort(ctx, span, logger, s.Streaming, events.RuleDeactivatedDefinition.Key(),
 		func(tenantID string) (libStreaming.EmitRequest, error) {
 			return events.NewRuleDeactivated(rule).ToEmitRequest(tenantID, rule.UpdatedAt)
 		})

--- a/components/tracer/internal/services/command/delete_limit.go
+++ b/components/tracer/internal/services/command/delete_limit.go
@@ -214,7 +214,7 @@ func (c *DeleteLimitCommand) Execute(ctx context.Context, id uuid.UUID) (retErr 
 // emitLimitDeletedEvent publishes the limit.deleted event post-commit.
 // IMPORTANT posture: emit failures never fail the request.
 func (c *DeleteLimitCommand) emitLimitDeletedEvent(ctx context.Context, span trace.Span, logger libLog.Logger, limit *model.Limit) {
-	pkgStreaming.EmitImportant(ctx, span, logger, c.Streaming, events.LimitDeletedDefinition.Key(),
+	pkgStreaming.EmitBrokerBestEffort(ctx, span, logger, c.Streaming, events.LimitDeletedDefinition.Key(),
 		func(tenantID string) (libStreaming.EmitRequest, error) {
 			return events.NewLimitDeleted(limit).ToEmitRequest(tenantID, limit.UpdatedAt)
 		})

--- a/components/tracer/internal/services/command/delete_rule.go
+++ b/components/tracer/internal/services/command/delete_rule.go
@@ -242,7 +242,7 @@ func (s *DeleteRuleService) Execute(ctx context.Context, ruleID uuid.UUID) (retE
 // posture: emit failures never fail the request. deletedAt is the delete moment
 // captured before the transaction.
 func (s *DeleteRuleService) emitRuleDeletedEvent(ctx context.Context, span trace.Span, logger libLog.Logger, ruleID uuid.UUID, deletedAt time.Time) {
-	pkgStreaming.EmitImportant(ctx, span, logger, s.Streaming, events.RuleDeletedDefinition.Key(),
+	pkgStreaming.EmitBrokerBestEffort(ctx, span, logger, s.Streaming, events.RuleDeletedDefinition.Key(),
 		func(tenantID string) (libStreaming.EmitRequest, error) {
 			return events.NewRuleDeleted(ruleID, deletedAt).ToEmitRequest(tenantID, deletedAt)
 		})

--- a/components/tracer/internal/services/command/draft_limit.go
+++ b/components/tracer/internal/services/command/draft_limit.go
@@ -226,7 +226,7 @@ func (c *DraftLimitCommand) Execute(ctx context.Context, id uuid.UUID) (_ *model
 // not called on the idempotent already-draft no-op (which skips the tx).
 // IMPORTANT posture: emit failures never fail the request.
 func (c *DraftLimitCommand) emitLimitDraftedEvent(ctx context.Context, span trace.Span, logger libLog.Logger, limit *model.Limit) {
-	pkgStreaming.EmitImportant(ctx, span, logger, c.Streaming, events.LimitDraftedDefinition.Key(),
+	pkgStreaming.EmitBrokerBestEffort(ctx, span, logger, c.Streaming, events.LimitDraftedDefinition.Key(),
 		func(tenantID string) (libStreaming.EmitRequest, error) {
 			return events.NewLimitDrafted(limit).ToEmitRequest(tenantID, limit.UpdatedAt)
 		})

--- a/components/tracer/internal/services/command/draft_rule.go
+++ b/components/tracer/internal/services/command/draft_rule.go
@@ -245,7 +245,7 @@ func (s *DraftRuleService) Execute(ctx context.Context, ruleID uuid.UUID) (_ *mo
 // emitRuleDraftedEvent publishes the rule.drafted event post-commit. IMPORTANT
 // posture: emit failures never fail the request.
 func (s *DraftRuleService) emitRuleDraftedEvent(ctx context.Context, span trace.Span, logger libLog.Logger, rule *model.Rule) {
-	pkgStreaming.EmitImportant(ctx, span, logger, s.Streaming, events.RuleDraftedDefinition.Key(),
+	pkgStreaming.EmitBrokerBestEffort(ctx, span, logger, s.Streaming, events.RuleDraftedDefinition.Key(),
 		func(tenantID string) (libStreaming.EmitRequest, error) {
 			return events.NewRuleDrafted(rule).ToEmitRequest(tenantID, rule.UpdatedAt)
 		})

--- a/components/tracer/internal/services/command/update_limit.go
+++ b/components/tracer/internal/services/command/update_limit.go
@@ -259,7 +259,7 @@ func (c *UpdateLimitCommand) Execute(ctx context.Context, id uuid.UUID, input *U
 // short-circuit (which skips the tx), so a no-op update emits nothing.
 // IMPORTANT posture: emit failures never fail the request.
 func (c *UpdateLimitCommand) emitLimitUpdatedEvent(ctx context.Context, span trace.Span, logger libLog.Logger, limit *model.Limit) {
-	pkgStreaming.EmitImportant(ctx, span, logger, c.Streaming, events.LimitUpdatedDefinition.Key(),
+	pkgStreaming.EmitBrokerBestEffort(ctx, span, logger, c.Streaming, events.LimitUpdatedDefinition.Key(),
 		func(tenantID string) (libStreaming.EmitRequest, error) {
 			return events.NewLimitUpdated(limit).ToEmitRequest(tenantID, limit.UpdatedAt)
 		})

--- a/components/tracer/internal/services/command/update_rule.go
+++ b/components/tracer/internal/services/command/update_rule.go
@@ -277,7 +277,7 @@ func (c *UpdateRuleCommand) Execute(ctx context.Context, id uuid.UUID, input *Up
 // emitRuleUpdatedEvent publishes the rule.updated event post-commit. IMPORTANT
 // posture: emit failures never fail the request.
 func (c *UpdateRuleCommand) emitRuleUpdatedEvent(ctx context.Context, span trace.Span, logger libLog.Logger, rule *model.Rule) {
-	pkgStreaming.EmitImportant(ctx, span, logger, c.Streaming, events.RuleUpdatedDefinition.Key(),
+	pkgStreaming.EmitBrokerBestEffort(ctx, span, logger, c.Streaming, events.RuleUpdatedDefinition.Key(),
 		func(tenantID string) (libStreaming.EmitRequest, error) {
 			return events.NewRuleUpdated(rule).ToEmitRequest(tenantID, rule.UpdatedAt)
 		})

--- a/docs/architecture/billing-active-account-streaming.md
+++ b/docs/architecture/billing-active-account-streaming.md
@@ -45,14 +45,14 @@ Each payload is a `billing.BillablePayload` with these fields:
 
 The payload is **not JSON**. The billing serializer encodes it as **Confluent-framed Protobuf** — a
 leading `0x00` magic byte plus the schema ID, then the Protobuf body. Billing does **not** use the
-`ToEmitRequest` / `EmitImportant` JSON path that the domain events use; it emits raw Protobuf bytes
+`ToEmitRequest` / `EmitBrokerBestEffort` JSON path that the domain events use; it emits raw Protobuf bytes
 directly through the `Emitter` seam.
 
-> **Approved exception to the "IMPORTANT direct-emits go through `EmitImportant`" convention.**
+> **Approved exception to the `EmitBrokerBestEffort` broker-publication convention.**
 > Billing intentionally calls `Emitter.Emit` directly with a raw Confluent-Protobuf `Payload` rather
-> than routing through `pkgStreaming.EmitImportant` / `ToEmitRequest` (the JSON CloudEvents path),
+> than routing through `pkgStreaming.EmitBrokerBestEffort` / `ToEmitRequest` (the JSON CloudEvents path),
 > because billable events are raw Protobuf and cannot use the JSON payload builder. The IMPORTANT-posture
-> mechanics that `EmitImportant` normally provides — a bounded per-emit context, span-error recording,
+> mechanics that `EmitBrokerBestEffort` normally provides — a bounded per-emit context, span-error recording,
 > warn-and-swallow on failure, and the nil-emitter/nil-serializer guard — are provided **inline at the
 > emit site** in `SendActiveAccountBillingEvents` / `emitActiveAccountBillingEvent`
 > (`billing_active_account.go`). This is a reviewed, deliberate exception, not an oversight.

--- a/docs/streaming/crm-events.md
+++ b/docs/streaming/crm-events.md
@@ -27,14 +27,14 @@ complements — does not duplicate — the producer conventions in `CLAUDE.md`
   `crm` topic, no per-event topic, and no `.v<major>` topic suffix:
   `ce-schemaversion` is the only version carrier on the wire. Consumers subscribe to
   the application and dispatch on the event key.
-- **Posture:** all 7 events are **IMPORTANT** — direct-emit, synchronous, via
-  `pkgStreaming.EmitImportant`. Emit is best-effort at the post-commit slot in
-  the command use case: a build/emit failure logs a Warn and is recorded on the
-  span, but **never fails the HTTP request**. Durability of the mutation itself
-  is owned by the database write, not by the emit.
-- **No outbox.** Emission is direct-emit only, identical to the current ledger
-  state. When an outbox lands, only the emit call sites change; the Definitions
-  and payload contracts below stay put.
+- **Posture:** all 7 events invoke `pkgStreaming.EmitBrokerBestEffort` at the
+  post-commit slot. It bounds the synchronous `Emitter.Emit` call, span-records
+  and Warn-logs build/emit failures, and **never fails the HTTP request**. The
+  library resolves delivery policy and any configured fallback behavior.
+- **No Midaz transactional outbox.** Bootstrap passes neither an outbox writer nor
+  repository, and registers no relay. The helper does not persist a local fallback record or
+  make the database mutation and broker delivery atomic; definitions and payload
+  contracts stay unchanged.
 - **HTTP event-manifest endpoint.** The ledger binary serves
   `GET /v1/streaming/manifest` (auth `streaming-manifest`/`get`) — a catalog-only
   view of the registered event Definitions, including the CRM `holder.*` /
@@ -238,7 +238,7 @@ To exercise the real emit path against a broker, run the build-tagged
   `STREAMING_BROKERS` set it starts a self-contained Redpanda testcontainer
   (needs Docker); set `STREAMING_BROKERS` to an already-running broker to reuse
   it instead. The test emits all 7 events through `BuildStreamingEmitter` +
-  `EmitImportant` and asserts `ce-type`, `ce-subject`, `ce-tenantid`, and PII
+  `EmitBrokerBestEffort` and asserts `ce-type`, `ce-subject`, `ce-tenantid`, and PII
   absence per event.
 
 For a longer-lived local broker (e.g. to point a running CRM service at it),

--- a/docs/streaming/fees-events.md
+++ b/docs/streaming/fees-events.md
@@ -26,14 +26,14 @@ producer conventions in `CLAUDE.md` (Streaming section) and
   `fee` topic, no per-event topic, and no `.v<major>` topic suffix:
   `ce-schemaversion` is the only version carrier on the wire. Consumers subscribe to
   the application and dispatch on the event key.
-- **Posture:** all 7 events are **IMPORTANT** — direct-emit, synchronous, via
-  `pkgStreaming.EmitImportant`. Emit is best-effort at the post-commit slot in
-  the command use case: a build/emit failure logs a Warn and is recorded on the
-  span, but **never fails the HTTP request**. Durability of the mutation itself
-  is owned by the database write, not by the emit.
-- **No outbox.** Emission is direct-emit only, identical to the rest of the
-  ledger streaming surface. When an outbox lands, only the emit call sites
-  change; the Definitions and payload contracts below stay put.
+- **Posture:** all 7 events invoke `pkgStreaming.EmitBrokerBestEffort` at the
+  post-commit slot. It bounds the synchronous `Emitter.Emit` call, span-records
+  and Warn-logs build/emit failures, and **never fails the HTTP request**. The
+  library resolves delivery policy and any configured fallback behavior.
+- **No Midaz transactional outbox.** Bootstrap passes neither an outbox writer nor
+  repository, and registers no relay. The helper does not persist a local fallback record or
+  make the database mutation and broker delivery atomic; definitions and payload
+  contracts stay unchanged.
 - **HTTP event-manifest endpoint.** The ledger binary serves
   `GET /v1/streaming/manifest` (auth `streaming-manifest`/`get`) — a catalog-only
   view of the registered event Definitions, including the `fee_*` events, at
@@ -75,7 +75,7 @@ Catalog (`buildCatalog`) and the manifest:
   One catch-all route carries every fact; nothing fans out per event.
 - **`ce-subject`** = the aggregate ID (`EmitRequest.Subject`).
 - **`ce-tenantid`** = `EmitRequest.TenantID`, resolved by
-  `pkgStreaming.ResolveTenantID(ctx)` inside `EmitImportant` (see
+  `pkgStreaming.ResolveTenantID(ctx)` inside `EmitBrokerBestEffort` (see
   [ce-tenantid](#ce-tenantid)).
 
 ## Event summary

--- a/docs/streaming/ledger-events.md
+++ b/docs/streaming/ledger-events.md
@@ -29,17 +29,16 @@ complements — does not duplicate — the producer conventions in `CLAUDE.md`
   on the event key. (The one destination the binary writes outside this pair is the
   billing event's fixed topic — see
   [`docs/architecture/billing-active-account-streaming.md`](../architecture/billing-active-account-streaming.md).)
-- **Posture:** all 35 events are **IMPORTANT** — direct-emit, synchronous, via
-  `pkgStreaming.EmitImportant`. Emit is best-effort at the post-commit slot in
-  the command use case: a build/emit failure logs a Warn and is recorded on the
-  span, but **never fails the HTTP request**. Durability of the mutation itself
-  is owned by the database write, not by the emit.
-- **No outbox.** Emission is direct-emit only. The `transaction.*`,
-  `balance.changed`, and `balance.overdraft_*` docstrings mark their catalog
-  posture as CRITICAL (outbox: always, direct: skip), but the outbox is not
-  wired today (`WithOutboxRepository` is not passed at build). When an outbox
-  lands, only the emit call sites change; the Definitions and payload contracts
-  below stay put.
+- **Posture:** all 35 events invoke `pkgStreaming.EmitBrokerBestEffort` at the
+  post-commit slot. The helper bounds the synchronous `Emitter.Emit` call, records
+  build/emit failures on the span, logs a Warn, and **never fails the HTTP request**.
+  The library, not the wrapper, resolves the delivery policy and any configured
+  fallback behavior.
+- **No Midaz transactional outbox.** Bootstrap passes neither an outbox writer nor
+  repository, and registers no relay. The helper does not persist a local fallback record or
+  make the database mutation and broker delivery atomic; do not infer a delivery
+  guarantee beyond the configured lib-streaming policy. Definitions and payload
+  contracts remain unchanged.
 - **HTTP event-manifest endpoint.** The ledger binary serves
   `GET /v1/streaming/manifest` (auth `streaming-manifest`/`get`) — a catalog-only
   view of the registered event Definitions, at manifest wire version `1.0.0`. The

--- a/docs/streaming/tracer-events.md
+++ b/docs/streaming/tracer-events.md
@@ -29,13 +29,14 @@ producer conventions in `CLAUDE.md` (Streaming section) and
   dead-letter topic. There is no per-event topic and no `.v<major>` topic suffix:
   `ce-schemaversion` is the only version carrier on the wire. Consumers subscribe to
   the application and dispatch on the event key.
-- **Posture:** all 12 events are **IMPORTANT** — direct-emit, synchronous, via
-  `pkgStreaming.EmitImportant`. Emit is best-effort at the post-commit slot in
-  the command use case: a build/emit failure logs a Warn and is recorded on the
-  span, but **never fails the request**. Durability of the mutation itself is
-  owned by the database write, not by the emit.
-- **No outbox.** Emission is direct-emit only. When an outbox lands, only the
-  emit call sites change; the Definitions and payload contracts below stay put.
+- **Posture:** all 12 events invoke `pkgStreaming.EmitBrokerBestEffort` at the
+  post-commit slot. It bounds the synchronous `Emitter.Emit` call, span-records
+  and Warn-logs build/emit failures, and **never fails the request**. The library
+  resolves delivery policy and any configured fallback behavior.
+- **No Midaz transactional outbox.** Bootstrap passes neither an outbox writer nor
+  repository, and registers no relay. The helper does not persist a local fallback record or
+  make the database mutation and broker delivery atomic; definitions and payload
+  contracts stay unchanged.
 - **HTTP event-manifest endpoint.** The tracer binary serves
   `GET /v1/streaming/manifest` (inside the `/v1` group; auth
   `streaming-manifest`/`get`) — a catalog-only view of the 12 registered event
@@ -82,7 +83,7 @@ Catalog (`buildCatalog`) and the manifest:
 - **`ce-subject`** = the aggregate ID (`EmitRequest.Subject`) — the rule UUID or
   limit UUID.
 - **`ce-tenantid`** = `EmitRequest.TenantID`, resolved by
-  `pkgStreaming.ResolveTenantID(ctx)` inside `EmitImportant`.
+  `pkgStreaming.ResolveTenantID(ctx)` inside `EmitBrokerBestEffort`.
 
 ## Conventions
 

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.26.4
 toolchain go1.26.6
 
 require (
-	github.com/LerianStudio/lib-auth/v3 v3.4.0
+	github.com/LerianStudio/lib-auth/v3 v3.5.0
 	github.com/Masterminds/squirrel v1.5.4
 	github.com/antlr4-go/antlr/v4 v4.13.1 // indirect
 	github.com/go-playground/locales v0.14.1
@@ -123,6 +123,7 @@ require (
 	github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c // indirect
 	github.com/LerianStudio/lib-observability v1.1.0 // indirect
 	github.com/LerianStudio/lib-observability/v3 v3.1.0 // indirect
+	github.com/MicahParks/jwkset v0.11.0 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/XSAM/otelsql v0.43.0 // indirect
 	github.com/armon/go-metrics v0.4.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -17,8 +17,8 @@ github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c/go.mod h1:xomTg6
 github.com/DATA-DOG/go-sqlmock v1.5.2 h1:OcvFkGmslmlZibjAjaHm3L//6LiuBgolP7OputlJIzU=
 github.com/DATA-DOG/go-sqlmock v1.5.2/go.mod h1:88MAG/4G7SMwSE3CeA0ZKzrT5CiOU3OJ+JlNzwDqpNU=
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
-github.com/LerianStudio/lib-auth/v3 v3.4.0 h1:QmKh/ipCovA4PQO5k8sPDVtrZpahL5MXD+F6ikq2jAM=
-github.com/LerianStudio/lib-auth/v3 v3.4.0/go.mod h1:mKU9zG1AeHE7Ux3iu1n+hZlzLA9KHDa5s+vC+XtbOM4=
+github.com/LerianStudio/lib-auth/v3 v3.5.0 h1:LN5VSdLknJavlrpeCejlgPuDFIbrRLwOqGuKUVlez78=
+github.com/LerianStudio/lib-auth/v3 v3.5.0/go.mod h1:ft6Kv781yewrVG7QTAQcOqEmQhfZ3UUL3GqVy8YL8Pc=
 github.com/LerianStudio/lib-commons/v6 v6.8.1 h1:qhKV/y4+3GmwX7wn6DBhtTkSW08MD71X+Wv57m8FjGQ=
 github.com/LerianStudio/lib-commons/v6 v6.8.1/go.mod h1:xnLzD7tvsyemX9ELIOCCBp1biIfml29ScjjPSt9ANbM=
 github.com/LerianStudio/lib-observability v1.1.0 h1:e/OrIoTKo8gI1RKXgKDyDDKcrddR4beh53al5ZmB6vQ=
@@ -33,6 +33,8 @@ github.com/LerianStudio/lib-streaming/v3 v3.1.0 h1:cbB/31ApqOf8aaiknNNtTskvJiz7e
 github.com/LerianStudio/lib-streaming/v3 v3.1.0/go.mod h1:lr1vFffWKYDsgCzzHeA9qLXvWg/PFysXeTEO/fZVALM=
 github.com/Masterminds/squirrel v1.5.4 h1:uUcX/aBc8O7Fg9kaISIUsHXdKuqehiXAMQTYX8afzqM=
 github.com/Masterminds/squirrel v1.5.4/go.mod h1:NNaOrjSoIDfDA40n7sr2tPNZRfjzjA400rg+riTZj10=
+github.com/MicahParks/jwkset v0.11.0 h1:yc0zG+jCvZpWgFDFmvs8/8jqqVBG9oyIbmBtmjOhoyQ=
+github.com/MicahParks/jwkset v0.11.0/go.mod h1:U2oRhRaLgDCLjtpGL2GseNKGmZtLs/3O7p+OZaL5vo0=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/Shopify/toxiproxy/v2 v2.12.0 h1:d1x++lYZg/zijXPPcv7PH0MvHMzEI5aX/YuUi/Sw+yg=

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -817,7 +817,7 @@ before that check, so omission passes it; an enabled producer must still set the
 | STREAMING_SASL_USERNAME | — | SASL username |
 | STREAMING_SASL_PASSWORD | — | SASL password |
 | STREAMING_ALLOW_PLAINTEXT_SASL | — | Allow SASL over plaintext |
-| STREAMING_IMPORTANT_EMIT_TIMEOUT_MS | 5000 | Bound on direct IMPORTANT-event emit latency |
+| STREAMING_IMPORTANT_EMIT_TIMEOUT_MS | 5000 | Bound on best-effort broker-publication latency |
 
 #### Service Discovery (opt-in; no-op when SD_ENABLED=false)
 Consul-backed registration + host resolution. Read by `libsd.ConfigFromEnv()`.

--- a/pkg/streaming/emit.go
+++ b/pkg/streaming/emit.go
@@ -31,16 +31,17 @@ const (
 // tenant ID.
 type EmitRequestBuilder func(tenantID string) (libStreaming.EmitRequest, error)
 
-// EmitImportant centralizes IMPORTANT-posture direct emission mechanics.
-// Build and emit failures are recorded on the provided span and logged at
-// Warn, but never returned to the caller — durability of IMPORTANT events
-// is owned by PG + (follow-up task) the outbox subsystem, not by the
-// synchronous Emit call.
+// EmitBrokerBestEffort centralizes best-effort broker publication mechanics.
+// It delegates delivery-policy handling, including any configured library
+// fallback, to lib-streaming. Midaz does not provide an outbox writer or relay,
+// so this helper does not create a product-local transactional fallback.
+// Build and emit failures are recorded on the provided span and logged at Warn,
+// but never returned to the caller.
 //
 // eventKey is the catalog DefinitionKey (e.g. "account.created"); it is
 // used purely as a log/span attribution string so operators can correlate
 // emit-site logs with the underlying lib-streaming request.
-func EmitImportant(ctx context.Context, span trace.Span, logger libLog.Logger, emitter libStreaming.Emitter, eventKey string, build EmitRequestBuilder) {
+func EmitBrokerBestEffort(ctx context.Context, span trace.Span, logger libLog.Logger, emitter libStreaming.Emitter, eventKey string, build EmitRequestBuilder) {
 	if emitter == nil {
 		return
 	}

--- a/pkg/streaming/emit.go
+++ b/pkg/streaming/emit.go
@@ -63,6 +63,14 @@ func EmitBrokerBestEffort(ctx context.Context, span trace.Span, logger libLog.Lo
 	}
 }
 
+// EmitImportant preserves the former exported API while callers migrate to
+// EmitBrokerBestEffort. The old name implied durability Midaz does not provide.
+//
+// Deprecated: use EmitBrokerBestEffort.
+func EmitImportant(ctx context.Context, span trace.Span, logger libLog.Logger, emitter libStreaming.Emitter, eventKey string, build EmitRequestBuilder) {
+	EmitBrokerBestEffort(ctx, span, logger, emitter, eventKey, build)
+}
+
 func importantEmitTimeout() time.Duration {
 	value := os.Getenv(importantEmitTimeoutEnv)
 	if value == "" {

--- a/pkg/streaming/emit_test.go
+++ b/pkg/streaming/emit_test.go
@@ -140,7 +140,6 @@ func TestEmitBrokerBestEffort_PassesBoundedDeadlineToEmitter(t *testing.T) {
 	t.Setenv(importantEmitTimeoutEnv, "25")
 
 	emitter := &deadlineCapturingEmitter{}
-	startedAt := time.Now()
 
 	EmitBrokerBestEffort(context.Background(), trace.SpanFromContext(context.Background()), emitTestLogger{}, emitter, "account.created",
 		func(tenantID string) (libStreaming.EmitRequest, error) {
@@ -148,15 +147,13 @@ func TestEmitBrokerBestEffort_PassesBoundedDeadlineToEmitter(t *testing.T) {
 		})
 
 	require.True(t, emitter.ok, "important emits must call emitter with a deadline")
-	assert.LessOrEqual(t, emitter.deadline.Sub(startedAt), 100*time.Millisecond)
-	assert.Greater(t, emitter.deadline.Sub(startedAt), 0*time.Millisecond)
+	assert.False(t, emitter.deadline.IsZero())
 }
 
 func TestEmitBrokerBestEffort_BlockingEmitterReturnsAfterConfiguredTimeout(t *testing.T) {
 	t.Setenv(importantEmitTimeoutEnv, "10")
 
 	emitter := &blockingEmitter{}
-	startedAt := time.Now()
 
 	require.NotPanics(t, func() {
 		EmitBrokerBestEffort(context.Background(), trace.SpanFromContext(context.Background()), emitTestLogger{}, emitter, "account.created",
@@ -165,6 +162,5 @@ func TestEmitBrokerBestEffort_BlockingEmitterReturnsAfterConfiguredTimeout(t *te
 			})
 	})
 
-	assert.Less(t, time.Since(startedAt), 500*time.Millisecond)
 	assert.ErrorIs(t, emitter.lastErr(), context.DeadlineExceeded)
 }

--- a/pkg/streaming/emit_test.go
+++ b/pkg/streaming/emit_test.go
@@ -81,10 +81,10 @@ func sampleEmitRequest(tenantID string) libStreaming.EmitRequest {
 	}
 }
 
-func TestEmitImportant_NilEmitterDoesNotCallBuilder(t *testing.T) {
+func TestEmitBrokerBestEffort_NilEmitterDoesNotCallBuilder(t *testing.T) {
 	called := false
 
-	EmitImportant(context.Background(), trace.SpanFromContext(context.Background()), emitTestLogger{}, nil, "account.created",
+	EmitBrokerBestEffort(context.Background(), trace.SpanFromContext(context.Background()), emitTestLogger{}, nil, "account.created",
 		func(_ string) (libStreaming.EmitRequest, error) {
 			called = true
 			return libStreaming.EmitRequest{}, nil
@@ -93,10 +93,10 @@ func TestEmitImportant_NilEmitterDoesNotCallBuilder(t *testing.T) {
 	assert.False(t, called, "nil emitter must skip building the event")
 }
 
-func TestEmitImportant_SuccessfulEmitUsesDefaultTenant(t *testing.T) {
+func TestEmitBrokerBestEffort_SuccessfulEmitUsesDefaultTenant(t *testing.T) {
 	mockEmitter := NewMockEmitter()
 
-	EmitImportant(context.Background(), trace.SpanFromContext(context.Background()), emitTestLogger{}, mockEmitter, "account.created",
+	EmitBrokerBestEffort(context.Background(), trace.SpanFromContext(context.Background()), emitTestLogger{}, mockEmitter, "account.created",
 		func(tenantID string) (libStreaming.EmitRequest, error) {
 			return sampleEmitRequest(tenantID), nil
 		})
@@ -107,11 +107,11 @@ func TestEmitImportant_SuccessfulEmitUsesDefaultTenant(t *testing.T) {
 	assert.Equal(t, "account.created", events[0].DefinitionKey)
 }
 
-func TestEmitImportant_BuildErrorDoesNotEmit(t *testing.T) {
+func TestEmitBrokerBestEffort_BuildErrorDoesNotEmit(t *testing.T) {
 	mockEmitter := NewMockEmitter()
 	buildErr := errors.New("build failed")
 
-	EmitImportant(context.Background(), trace.SpanFromContext(context.Background()), emitTestLogger{}, mockEmitter, "account.created",
+	EmitBrokerBestEffort(context.Background(), trace.SpanFromContext(context.Background()), emitTestLogger{}, mockEmitter, "account.created",
 		func(_ string) (libStreaming.EmitRequest, error) {
 			return libStreaming.EmitRequest{}, buildErr
 		})
@@ -119,12 +119,12 @@ func TestEmitImportant_BuildErrorDoesNotEmit(t *testing.T) {
 	assert.Empty(t, mockEmitter.Events())
 }
 
-func TestEmitImportant_EmitErrorDoesNotPanic(t *testing.T) {
+func TestEmitBrokerBestEffort_EmitErrorDoesNotPanic(t *testing.T) {
 	mockEmitter := NewMockEmitter()
 	mockEmitter.EmitErr = errors.New("emit failed")
 
 	require.NotPanics(t, func() {
-		EmitImportant(context.Background(), trace.SpanFromContext(context.Background()), emitTestLogger{}, mockEmitter, "account.created",
+		EmitBrokerBestEffort(context.Background(), trace.SpanFromContext(context.Background()), emitTestLogger{}, mockEmitter, "account.created",
 			func(tenantID string) (libStreaming.EmitRequest, error) {
 				return sampleEmitRequest(tenantID), nil
 			})
@@ -136,13 +136,13 @@ func TestEmitImportant_EmitErrorDoesNotPanic(t *testing.T) {
 	assert.Empty(t, mockEmitter.Events())
 }
 
-func TestEmitImportant_PassesBoundedDeadlineToEmitter(t *testing.T) {
+func TestEmitBrokerBestEffort_PassesBoundedDeadlineToEmitter(t *testing.T) {
 	t.Setenv(importantEmitTimeoutEnv, "25")
 
 	emitter := &deadlineCapturingEmitter{}
 	startedAt := time.Now()
 
-	EmitImportant(context.Background(), trace.SpanFromContext(context.Background()), emitTestLogger{}, emitter, "account.created",
+	EmitBrokerBestEffort(context.Background(), trace.SpanFromContext(context.Background()), emitTestLogger{}, emitter, "account.created",
 		func(tenantID string) (libStreaming.EmitRequest, error) {
 			return sampleEmitRequest(tenantID), nil
 		})
@@ -152,14 +152,14 @@ func TestEmitImportant_PassesBoundedDeadlineToEmitter(t *testing.T) {
 	assert.Greater(t, emitter.deadline.Sub(startedAt), 0*time.Millisecond)
 }
 
-func TestEmitImportant_BlockingEmitterReturnsAfterConfiguredTimeout(t *testing.T) {
+func TestEmitBrokerBestEffort_BlockingEmitterReturnsAfterConfiguredTimeout(t *testing.T) {
 	t.Setenv(importantEmitTimeoutEnv, "10")
 
 	emitter := &blockingEmitter{}
 	startedAt := time.Now()
 
 	require.NotPanics(t, func() {
-		EmitImportant(context.Background(), trace.SpanFromContext(context.Background()), emitTestLogger{}, emitter, "account.created",
+		EmitBrokerBestEffort(context.Background(), trace.SpanFromContext(context.Background()), emitTestLogger{}, emitter, "account.created",
 			func(tenantID string) (libStreaming.EmitRequest, error) {
 				return sampleEmitRequest(tenantID), nil
 			})

--- a/pkg/streaming/events/account_created.go
+++ b/pkg/streaming/events/account_created.go
@@ -21,7 +21,7 @@ import (
 // compensating-delete window) and the CreateOnboardingMetadata call
 // (pre-metadata-write, so a Mongo metadata failure cannot block the
 // event). IMPORTANT posture: emit failures MUST NOT fail the request;
-// durability is owned by PG + (follow-up task) the outbox subsystem.
+// durability is owned by the persisted database mutation.
 var AccountCreatedDefinition = Definition{
 	ResourceType:  "account",
 	EventType:     "created",

--- a/pkg/streaming/events/account_deleted.go
+++ b/pkg/streaming/events/account_deleted.go
@@ -19,7 +19,7 @@ import (
 // components/ledger/internal/services/command/delete_account.go,
 // immediately after AccountRepo.Delete succeeds (post-commit).
 // IMPORTANT posture: emit failures MUST NOT fail the request;
-// durability is owned by PG + (follow-up task) the outbox subsystem.
+// durability is owned by the persisted database mutation.
 //
 // External-type accounts cannot be deleted and never reach this anchor.
 // The cascade DeleteAllBalancesByAccountID step earlier in the use case

--- a/pkg/streaming/events/account_updated.go
+++ b/pkg/streaming/events/account_updated.go
@@ -20,8 +20,7 @@ import (
 // immediately after AccountRepo.Update succeeds (post-commit) and
 // before UpdateOnboardingMetadata runs (pre-metadata-write), so a
 // downstream Mongo failure cannot mask the event. IMPORTANT posture:
-// emit failures MUST NOT fail the request; durability is owned by PG +
-// (follow-up task) the outbox subsystem.
+// emit failures MUST NOT fail the request; durability is owned by the persisted database mutation.
 //
 // External-type accounts cannot be updated and never reach this anchor.
 var AccountUpdatedDefinition = Definition{

--- a/pkg/streaming/events/holder_created.go
+++ b/pkg/streaming/events/holder_created.go
@@ -16,7 +16,7 @@ import (
 
 // HolderCreatedDefinition is the routing contract for holder.created.
 // IMPORTANT posture: emit failures MUST NOT fail the request; durability is
-// owned by PG + (follow-up task) the outbox subsystem.
+// owned by the persisted database mutation.
 var HolderCreatedDefinition = Definition{
 	ResourceType:  "holder",
 	EventType:     "created",

--- a/pkg/streaming/events/holder_deleted.go
+++ b/pkg/streaming/events/holder_deleted.go
@@ -14,7 +14,7 @@ import (
 
 // HolderDeletedDefinition is the routing contract for holder.deleted.
 // IMPORTANT posture: emit failures MUST NOT fail the request; durability is
-// owned by PG + (follow-up task) the outbox subsystem.
+// owned by the persisted database mutation.
 var HolderDeletedDefinition = Definition{
 	ResourceType:  "holder",
 	EventType:     "deleted",

--- a/pkg/streaming/events/holder_updated.go
+++ b/pkg/streaming/events/holder_updated.go
@@ -16,7 +16,7 @@ import (
 
 // HolderUpdatedDefinition is the routing contract for holder.updated.
 // IMPORTANT posture: emit failures MUST NOT fail the request; durability is
-// owned by PG + (follow-up task) the outbox subsystem.
+// owned by the persisted database mutation.
 var HolderUpdatedDefinition = Definition{
 	ResourceType:  "holder",
 	EventType:     "updated",

--- a/pkg/streaming/events/instrument_created.go
+++ b/pkg/streaming/events/instrument_created.go
@@ -16,7 +16,7 @@ import (
 
 // InstrumentCreatedDefinition is the routing contract for instrument.created.
 // IMPORTANT posture: emit failures MUST NOT fail the request; durability is
-// owned by PG + (follow-up task) the outbox subsystem.
+// owned by the persisted database mutation.
 var InstrumentCreatedDefinition = Definition{
 	ResourceType:  "instrument",
 	EventType:     "created",

--- a/pkg/streaming/events/instrument_deleted.go
+++ b/pkg/streaming/events/instrument_deleted.go
@@ -14,7 +14,7 @@ import (
 
 // InstrumentDeletedDefinition is the routing contract for instrument.deleted.
 // IMPORTANT posture: emit failures MUST NOT fail the request; durability is
-// owned by PG + (follow-up task) the outbox subsystem.
+// owned by the persisted database mutation.
 var InstrumentDeletedDefinition = Definition{
 	ResourceType:  "instrument",
 	EventType:     "deleted",

--- a/pkg/streaming/events/instrument_updated.go
+++ b/pkg/streaming/events/instrument_updated.go
@@ -16,7 +16,7 @@ import (
 
 // InstrumentUpdatedDefinition is the routing contract for instrument.updated.
 // IMPORTANT posture: emit failures MUST NOT fail the request; durability is
-// owned by PG + (follow-up task) the outbox subsystem.
+// owned by the persisted database mutation.
 var InstrumentUpdatedDefinition = Definition{
 	ResourceType:  "instrument",
 	EventType:     "updated",

--- a/pkg/streaming/events/transaction_lifecycle.go
+++ b/pkg/streaming/events/transaction_lifecycle.go
@@ -43,11 +43,9 @@ import (
 // disabled flag RABBITMQ_TRANSACTION_EVENTS_ENABLED=false short-circuits
 // BOTH transports during cutover.
 //
-// Posture note: the catalog marks this event CRITICAL (outbox: always,
-// direct: skip). The outbox subsystem is NOT yet wired in midaz, so
-// emission today goes through pkgStreaming.EmitImportant (direct emit,
-// no atomic guarantee). When the outbox lands the call site is the only
-// place that needs to switch helpers; the Definition stays unchanged.
+// Delivery policy is resolved by lib-streaming when this wire definition is
+// emitted. This definition only declares the event contract; Midaz does not add
+// a product-local transactional outbox or relay at this layer.
 var TransactionPostedDefinition = Definition{
 	ResourceType:  "transaction",
 	EventType:     "posted",


### PR DESCRIPTION
## Description

Renames the IMPORTANT-event wrapper to `EmitBrokerBestEffort` and aligns call sites, tests, configuration guidance, and streaming documentation with its actual responsibility.

The wrapper delegates to lib-streaming's configured policy/fallback behavior; Midaz does not supply a product-local transactional outbox writer, repository, or relay. Delivery policy and event contracts are unchanged.

## Type of Change

- [x] `refactor`: Internal restructuring with no behavior change
- [x] `docs`: Documentation only
- [x] `test`: Adding or updating tests

## Breaking Changes

None.

## Testing

- [x] `make test` passes
- [ ] `make test-int` passes if integration paths are exercised
- [x] `make lint` passes
- [x] `make sec` passes (includes `govulncheck`)
- [x] `CHECK_DOCS_REGEN=1 make check-docs` passes
- [x] `make proto-check` passes

**Test evidence / Actions run:** Local runs completed successfully.

## Architectural Checklist

- [x] No `panic()` in production paths
- [x] Timestamps use `time.Now().UTC()`
- [x] Errors wrapped with `%w`
- [x] Handlers stay thin (parse, validate, call service)
- [x] Infrastructure concerns kept in `internal/bootstrap`

## Related Issues

None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Behavior Changes**
  * Event notifications across ledger, billing, fees, and tracer operations now use bounded, best-effort broker delivery.
  * Broker publication failures are logged and recorded without causing otherwise successful requests or database operations to fail.
  * Event delivery policy and fallback behavior are delegated to the streaming platform, with no local transactional delivery guarantee.

* **Documentation**
  * Clarified timeout behavior, delivery guarantees, durability expectations, and streaming exceptions across configuration and architecture guides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->