### PR TITLE
fix(ledger): keep the /v1 account contract servable on a pre-holder schema

### DIFF
--- a/components/ledger/internal/adapters/http/in/account_core.go
+++ b/components/ledger/internal/adapters/http/in/account_core.go
@@ -80,7 +80,7 @@ func (handler *AccountHandler) createAccount(ctx context.Context, organizationID
 // validates the account-specific status enum, resolves the optional
 // portfolio_id/segment_id UUID filters, then branches on metadata. A bad query or
 // status yields the canonical 400.
-func (handler *AccountHandler) getAllAccounts(ctx context.Context, organizationID, ledgerID uuid.UUID, queries map[string]string) (http.Pagination, error) {
+func (handler *AccountHandler) getAllAccounts(ctx context.Context, organizationID, ledgerID uuid.UUID, queries map[string]string, holderPolicy command.RouteHolderPolicy) (http.Pagination, error) {
 	logger, tracer, _, _ := libObservability.NewTrackingFromContext(ctx)
 
 	ctx, span := tracer.Start(ctx, "handler.get_all_accounts")
@@ -129,7 +129,7 @@ func (handler *AccountHandler) getAllAccounts(ctx context.Context, organizationI
 	}
 
 	if headerParams.Metadata != nil {
-		accounts, err := handler.Query.GetAllMetadataAccounts(ctx, organizationID, ledgerID, portfolioID, segmentID, *headerParams)
+		accounts, err := handler.Query.GetAllMetadataAccounts(ctx, organizationID, ledgerID, portfolioID, segmentID, *headerParams, holderPolicy)
 		if err != nil {
 			handleSpanByErrorClass(span, "Failed to retrieve all Accounts on query", err)
 
@@ -143,7 +143,7 @@ func (handler *AccountHandler) getAllAccounts(ctx context.Context, organizationI
 
 	headerParams.Metadata = &bson.M{}
 
-	accounts, err := handler.Query.GetAllAccount(ctx, organizationID, ledgerID, portfolioID, segmentID, *headerParams)
+	accounts, err := handler.Query.GetAllAccount(ctx, organizationID, ledgerID, portfolioID, segmentID, *headerParams, holderPolicy)
 	if err != nil {
 		handleSpanByErrorClass(span, "Failed to retrieve all Accounts on query", err)
 
@@ -156,13 +156,13 @@ func (handler *AccountHandler) getAllAccounts(ctx context.Context, organizationI
 }
 
 // getAccountByID retrieves a single account by its UUID.
-func (handler *AccountHandler) getAccountByID(ctx context.Context, organizationID, ledgerID, id uuid.UUID) (*mmodel.Account, error) {
+func (handler *AccountHandler) getAccountByID(ctx context.Context, organizationID, ledgerID, id uuid.UUID, holderPolicy command.RouteHolderPolicy) (*mmodel.Account, error) {
 	_, tracer, _, _ := libObservability.NewTrackingFromContext(ctx)
 
 	ctx, span := tracer.Start(ctx, "handler.get_account_by_id")
 	defer span.End()
 
-	account, err := handler.Query.GetAccountByID(ctx, organizationID, ledgerID, nil, id)
+	account, err := handler.Query.GetAccountByID(ctx, organizationID, ledgerID, nil, id, holderPolicy)
 	if err != nil {
 		handleSpanByErrorClass(span, "Failed to retrieve Account on query", err)
 
@@ -176,13 +176,13 @@ func (handler *AccountHandler) getAccountByID(ctx context.Context, organizationI
 // path resolves the alias (DefaultExternalAccountAliasPrefix + code) BEFORE this
 // core, so both the alias and external-code ops share one implementation. The span
 // name carries the caller so the two callers stay distinguishable in traces.
-func (handler *AccountHandler) getAccountByAlias(ctx context.Context, spanName string, organizationID, ledgerID uuid.UUID, alias string) (*mmodel.Account, error) {
+func (handler *AccountHandler) getAccountByAlias(ctx context.Context, spanName string, organizationID, ledgerID uuid.UUID, alias string, holderPolicy command.RouteHolderPolicy) (*mmodel.Account, error) {
 	_, tracer, _, _ := libObservability.NewTrackingFromContext(ctx)
 
 	ctx, span := tracer.Start(ctx, spanName)
 	defer span.End()
 
-	account, err := handler.Query.GetAccountByAlias(ctx, organizationID, ledgerID, nil, alias)
+	account, err := handler.Query.GetAccountByAlias(ctx, organizationID, ledgerID, nil, alias, holderPolicy)
 	if err != nil {
 		handleSpanByErrorClass(span, "Failed to retrieve Account on query", err)
 
@@ -195,7 +195,7 @@ func (handler *AccountHandler) getAccountByAlias(ctx context.Context, spanName s
 // updateAccount owns the span + update-then-get flow for an already-decoded
 // payload. It updates, then re-reads so the caller receives the freshly persisted
 // account.
-func (handler *AccountHandler) updateAccount(ctx context.Context, organizationID, ledgerID, id uuid.UUID, payload *mmodel.UpdateAccountInput) (*mmodel.Account, error) {
+func (handler *AccountHandler) updateAccount(ctx context.Context, organizationID, ledgerID, id uuid.UUID, payload *mmodel.UpdateAccountInput, holderPolicy command.RouteHolderPolicy) (*mmodel.Account, error) {
 	_, tracer, _, _ := libObservability.NewTrackingFromContext(ctx)
 
 	ctx, span := tracer.Start(ctx, "handler.update_account")
@@ -209,7 +209,7 @@ func (handler *AccountHandler) updateAccount(ctx context.Context, organizationID
 		return nil, err
 	}
 
-	account, err := handler.Query.GetAccountByID(ctx, organizationID, ledgerID, nil, id)
+	account, err := handler.Query.GetAccountByID(ctx, organizationID, ledgerID, nil, id, holderPolicy)
 	if err != nil {
 		handleSpanByErrorClass(span, "Failed to retrieve Account on query", err)
 

--- a/components/ledger/internal/adapters/http/in/account_core.go
+++ b/components/ledger/internal/adapters/http/in/account_core.go
@@ -203,7 +203,7 @@ func (handler *AccountHandler) updateAccount(ctx context.Context, organizationID
 
 	recordSafePayloadAttributes(span, payload)
 
-	if _, err := handler.Command.UpdateAccount(ctx, organizationID, ledgerID, nil, id, payload); err != nil {
+	if _, err := handler.Command.UpdateAccount(ctx, organizationID, ledgerID, nil, id, payload, holderPolicy); err != nil {
 		handleSpanByErrorClass(span, "Failed to update Account on command", err)
 
 		return nil, err

--- a/components/ledger/internal/adapters/http/in/account_handler.go
+++ b/components/ledger/internal/adapters/http/in/account_handler.go
@@ -148,7 +148,7 @@ func (handler *AccountHandler) ListAccounts(ctx context.Context, in *ListAccount
 		return nil, pkgHTTP.HumaProblem(err)
 	}
 
-	pagination, err := handler.getAllAccounts(ctx, orgID, ledgerID, in.queries())
+	pagination, err := handler.getAllAccounts(ctx, orgID, ledgerID, in.queries(), command.HolderOffV1)
 	if err != nil {
 		return nil, pkgHTTP.HumaProblem(err)
 	}
@@ -184,7 +184,7 @@ func (handler *AccountHandler) GetAccountByID(ctx context.Context, in *GetAccoun
 		return nil, pkgHTTP.HumaProblem(err)
 	}
 
-	account, err := handler.getAccountByID(ctx, orgID, ledgerID, id)
+	account, err := handler.getAccountByID(ctx, orgID, ledgerID, id, command.HolderOffV1)
 	if err != nil {
 		return nil, pkgHTTP.HumaProblem(err)
 	}
@@ -210,7 +210,7 @@ func (handler *AccountHandler) GetAccountByAlias(ctx context.Context, in *GetAcc
 		return nil, pkgHTTP.HumaProblem(err)
 	}
 
-	account, err := handler.getAccountByAlias(ctx, "handler.get_account_by_alias", orgID, ledgerID, in.Alias)
+	account, err := handler.getAccountByAlias(ctx, "handler.get_account_by_alias", orgID, ledgerID, in.Alias, command.HolderOffV1)
 	if err != nil {
 		return nil, pkgHTTP.HumaProblem(err)
 	}
@@ -238,7 +238,7 @@ func (handler *AccountHandler) GetAccountExternalByCode(ctx context.Context, in 
 
 	alias := constant.DefaultExternalAccountAliasPrefix + in.Code
 
-	account, err := handler.getAccountByAlias(ctx, "handler.get_account_external_by_code", orgID, ledgerID, alias)
+	account, err := handler.getAccountByAlias(ctx, "handler.get_account_external_by_code", orgID, ledgerID, alias, command.HolderOffV1)
 	if err != nil {
 		return nil, pkgHTTP.HumaProblem(err)
 	}
@@ -281,7 +281,7 @@ func (handler *AccountHandler) UpdateAccount(ctx context.Context, in *UpdateAcco
 		return nil, pkgHTTP.HumaProblem(err)
 	}
 
-	account, err := handler.updateAccount(ctx, orgID, ledgerID, id, payload)
+	account, err := handler.updateAccount(ctx, orgID, ledgerID, id, payload, command.HolderOffV1)
 	if err != nil {
 		return nil, pkgHTTP.HumaProblem(err)
 	}

--- a/components/ledger/internal/adapters/http/in/account_handler_test.go
+++ b/components/ledger/internal/adapters/http/in/account_handler_test.go
@@ -243,7 +243,7 @@ func TestGetAccountByID_Success(t *testing.T) {
 	accountRepo := account.NewMockRepository(ctrl)
 	metadataRepo := mongodb.NewMockRepository(ctrl)
 
-	accountRepo.EXPECT().Find(gomock.Any(), orgID, ledgerID, gomock.Nil(), accountID).
+	accountRepo.EXPECT().Find(gomock.Any(), orgID, ledgerID, gomock.Nil(), accountID, gomock.Any()).
 		Return(&mmodel.Account{
 			ID:             accountID.String(),
 			OrganizationID: orgID.String(),
@@ -317,7 +317,7 @@ func TestGetAccountByAlias_Success(t *testing.T) {
 	accountRepo := account.NewMockRepository(ctrl)
 	metadataRepo := mongodb.NewMockRepository(ctrl)
 
-	accountRepo.EXPECT().FindAlias(gomock.Any(), orgID, ledgerID, gomock.Nil(), "@person1").
+	accountRepo.EXPECT().FindAlias(gomock.Any(), orgID, ledgerID, gomock.Nil(), "@person1", gomock.Any()).
 		Return(&mmodel.Account{
 			ID:             accountID,
 			OrganizationID: orgID.String(),
@@ -362,7 +362,7 @@ func TestGetAccountExternalByCode_Success(t *testing.T) {
 	accountRepo := account.NewMockRepository(ctrl)
 	metadataRepo := mongodb.NewMockRepository(ctrl)
 
-	accountRepo.EXPECT().FindAlias(gomock.Any(), orgID, ledgerID, gomock.Nil(), externalAlias).
+	accountRepo.EXPECT().FindAlias(gomock.Any(), orgID, ledgerID, gomock.Nil(), externalAlias, gomock.Any()).
 		Return(&mmodel.Account{
 			ID:             accountID,
 			OrganizationID: orgID.String(),
@@ -402,7 +402,7 @@ func TestGetAllAccounts_Success(t *testing.T) {
 	ledgerID := uuid.Must(libCommons.GenerateUUIDv7())
 
 	accountRepo := account.NewMockRepository(ctrl)
-	accountRepo.EXPECT().FindAll(gomock.Any(), orgID, ledgerID, gomock.Nil(), gomock.Nil(), gomock.Any()).
+	accountRepo.EXPECT().FindAll(gomock.Any(), orgID, ledgerID, gomock.Nil(), gomock.Nil(), gomock.Any(), gomock.Any()).
 		Return([]*mmodel.Account{}, nil).Times(1)
 
 	handler := &AccountHandler{Query: &query.UseCase{AccountRepo: accountRepo}}
@@ -491,7 +491,7 @@ func TestDeleteAccount_204Empty(t *testing.T) {
 
 	// Delete flow: Find the (non-external) account, delete its balances (none), then
 	// delete the account. The account.deleted event no-ops on a nil Streaming emitter.
-	accountRepo.EXPECT().Find(gomock.Any(), orgID, ledgerID, gomock.Nil(), accountID).
+	accountRepo.EXPECT().Find(gomock.Any(), orgID, ledgerID, gomock.Nil(), accountID, gomock.Any()).
 		Return(&mmodel.Account{ID: accountID.String(), Type: "deposit"}, nil).Times(1)
 	balanceRepo.EXPECT().ListByAccountID(gomock.Any(), orgID, ledgerID, accountID).Return([]*mmodel.Balance{}, nil).Times(1)
 	accountRepo.EXPECT().Delete(gomock.Any(), orgID, ledgerID, gomock.Nil(), accountID).Return(nil).Times(1)
@@ -565,14 +565,14 @@ func TestUpdateAccount_Success(t *testing.T) {
 	}
 
 	// Command.UpdateAccount: find (external check) -> update -> metadata upsert.
-	accountRepo.EXPECT().Find(gomock.Any(), orgID, ledgerID, gomock.Nil(), accountID).
+	accountRepo.EXPECT().Find(gomock.Any(), orgID, ledgerID, gomock.Nil(), accountID, gomock.Any()).
 		Return(&mmodel.Account{ID: accountID.String(), Type: "deposit", Name: "Original"}, nil).Times(1)
 	accountRepo.EXPECT().Update(gomock.Any(), orgID, ledgerID, gomock.Nil(), accountID, gomock.Any()).
 		Return(updated, nil).Times(1)
 	metadataRepo.EXPECT().Update(gomock.Any(), cn.EntityAccount, accountID.String(), gomock.Any()).Return(nil).AnyTimes()
 	// updateAccount re-reads through Query.GetAccountByID so the caller gets the
 	// freshly persisted account.
-	accountRepo.EXPECT().Find(gomock.Any(), orgID, ledgerID, gomock.Nil(), accountID).Return(updated, nil).Times(1)
+	accountRepo.EXPECT().Find(gomock.Any(), orgID, ledgerID, gomock.Nil(), accountID, gomock.Any()).Return(updated, nil).Times(1)
 	// FindByEntity is hit twice: once by the command's metadata upsert, once by the re-read.
 	metadataRepo.EXPECT().FindByEntity(gomock.Any(), cn.EntityAccount, accountID.String()).Return(nil, nil).AnyTimes()
 
@@ -612,7 +612,7 @@ func TestUpdateAccount_NotFound_Canonical404(t *testing.T) {
 	accountID := uuid.Must(libCommons.GenerateUUIDv7())
 
 	accountRepo := account.NewMockRepository(ctrl)
-	accountRepo.EXPECT().Find(gomock.Any(), orgID, ledgerID, gomock.Nil(), accountID).
+	accountRepo.EXPECT().Find(gomock.Any(), orgID, ledgerID, gomock.Nil(), accountID, gomock.Any()).
 		Return(nil, pkg.ValidateBusinessError(cn.ErrAccountIDNotFound, cn.EntityAccount)).Times(1)
 
 	handler := &AccountHandler{
@@ -651,13 +651,13 @@ func TestUpdateAccount_RetrievalError_Canonical404(t *testing.T) {
 	accountRepo := account.NewMockRepository(ctrl)
 	metadataRepo := mongodb.NewMockRepository(ctrl)
 
-	accountRepo.EXPECT().Find(gomock.Any(), orgID, ledgerID, gomock.Nil(), accountID).
+	accountRepo.EXPECT().Find(gomock.Any(), orgID, ledgerID, gomock.Nil(), accountID, gomock.Any()).
 		Return(&mmodel.Account{ID: accountID.String(), Type: "deposit"}, nil).Times(1)
 	accountRepo.EXPECT().Update(gomock.Any(), orgID, ledgerID, gomock.Nil(), accountID, gomock.Any()).
 		Return(&mmodel.Account{ID: accountID.String(), Type: "deposit"}, nil).Times(1)
 	metadataRepo.EXPECT().Update(gomock.Any(), cn.EntityAccount, accountID.String(), gomock.Any()).Return(nil).AnyTimes()
 	metadataRepo.EXPECT().FindByEntity(gomock.Any(), cn.EntityAccount, accountID.String()).Return(nil, nil).AnyTimes()
-	accountRepo.EXPECT().Find(gomock.Any(), orgID, ledgerID, gomock.Nil(), accountID).
+	accountRepo.EXPECT().Find(gomock.Any(), orgID, ledgerID, gomock.Nil(), accountID, gomock.Any()).
 		Return(nil, pkg.ValidateBusinessError(cn.ErrAccountIDNotFound, cn.EntityAccount)).Times(1)
 
 	handler := &AccountHandler{
@@ -737,7 +737,7 @@ func TestGetAllAccounts_MetadataFilter(t *testing.T) {
 
 	metadataRepo.EXPECT().FindList(gomock.Any(), cn.EntityAccount, gomock.Any()).
 		Return([]*mongodb.Metadata{{EntityID: acc1, Data: map[string]any{"tier": "premium"}}}, nil).Times(1)
-	accountRepo.EXPECT().FindAll(gomock.Any(), orgID, ledgerID, gomock.Nil(), gomock.Nil(), gomock.Any()).
+	accountRepo.EXPECT().FindAll(gomock.Any(), orgID, ledgerID, gomock.Nil(), gomock.Nil(), gomock.Any(), gomock.Any()).
 		Return([]*mmodel.Account{{ID: acc1, Name: "Premium One", AssetCode: "USD", Type: "deposit"}}, nil).Times(1)
 
 	handler := &AccountHandler{Query: &query.UseCase{AccountRepo: accountRepo, OnboardingMetadataRepo: metadataRepo}}
@@ -773,7 +773,7 @@ func TestGetAllAccounts_PortfolioAndSegmentFilters(t *testing.T) {
 
 	accountRepo := account.NewMockRepository(ctrl)
 	accountRepo.EXPECT().
-		FindAll(gomock.Any(), orgID, ledgerID, gomock.Eq(&portfolioID), gomock.Eq(&segmentID), gomock.Any()).
+		FindAll(gomock.Any(), orgID, ledgerID, gomock.Eq(&portfolioID), gomock.Eq(&segmentID), gomock.Any(), gomock.Any()).
 		Return([]*mmodel.Account{}, nil).Times(1)
 
 	handler := &AccountHandler{Query: &query.UseCase{AccountRepo: accountRepo}}
@@ -799,7 +799,7 @@ func TestGetAllAccounts_ServiceError_Canonical404(t *testing.T) {
 	ledgerID := uuid.Must(libCommons.GenerateUUIDv7())
 
 	accountRepo := account.NewMockRepository(ctrl)
-	accountRepo.EXPECT().FindAll(gomock.Any(), orgID, ledgerID, gomock.Nil(), gomock.Nil(), gomock.Any()).
+	accountRepo.EXPECT().FindAll(gomock.Any(), orgID, ledgerID, gomock.Nil(), gomock.Nil(), gomock.Any(), gomock.Any()).
 		Return(nil, pkg.ValidateBusinessError(cn.ErrNoAccountsFound, cn.EntityAccount)).Times(1)
 
 	handler := &AccountHandler{Query: &query.UseCase{AccountRepo: accountRepo}}
@@ -829,7 +829,7 @@ func TestGetAccountByID_ServiceError_Canonical404(t *testing.T) {
 	accountID := uuid.Must(libCommons.GenerateUUIDv7())
 
 	accountRepo := account.NewMockRepository(ctrl)
-	accountRepo.EXPECT().Find(gomock.Any(), orgID, ledgerID, gomock.Nil(), accountID).
+	accountRepo.EXPECT().Find(gomock.Any(), orgID, ledgerID, gomock.Nil(), accountID, gomock.Any()).
 		Return(nil, pkg.ValidateBusinessError(cn.ErrAccountIDNotFound, cn.EntityAccount)).Times(1)
 
 	handler := &AccountHandler{Query: &query.UseCase{AccountRepo: accountRepo}}
@@ -859,7 +859,7 @@ func TestGetAccountByAlias_ServiceError_Canonical404(t *testing.T) {
 	ledgerID := uuid.Must(libCommons.GenerateUUIDv7())
 
 	accountRepo := account.NewMockRepository(ctrl)
-	accountRepo.EXPECT().FindAlias(gomock.Any(), orgID, ledgerID, gomock.Nil(), "@missing").
+	accountRepo.EXPECT().FindAlias(gomock.Any(), orgID, ledgerID, gomock.Nil(), "@missing", gomock.Any()).
 		Return(nil, pkg.ValidateBusinessError(cn.ErrAccountAliasNotFound, cn.EntityAccount)).Times(1)
 
 	handler := &AccountHandler{Query: &query.UseCase{AccountRepo: accountRepo}}
@@ -889,7 +889,7 @@ func TestDeleteAccount_ServiceError_Canonical404(t *testing.T) {
 	accountID := uuid.Must(libCommons.GenerateUUIDv7())
 
 	accountRepo := account.NewMockRepository(ctrl)
-	accountRepo.EXPECT().Find(gomock.Any(), orgID, ledgerID, gomock.Nil(), accountID).
+	accountRepo.EXPECT().Find(gomock.Any(), orgID, ledgerID, gomock.Nil(), accountID, gomock.Any()).
 		Return(nil, pkg.ValidateBusinessError(cn.ErrAccountIDNotFound, cn.EntityAccount)).Times(1)
 
 	handler := &AccountHandler{Command: &command.UseCase{AccountRepo: accountRepo}}

--- a/components/ledger/internal/adapters/http/in/account_handler_v2.go
+++ b/components/ledger/internal/adapters/http/in/account_handler_v2.go
@@ -76,7 +76,7 @@ func (handler *AccountHandler) ListAccountsV2(ctx context.Context, in *ListAccou
 		return nil, pkgHTTP.HumaProblem(err)
 	}
 
-	pagination, err := handler.getAllAccounts(ctx, orgID, ledgerID, in.queries())
+	pagination, err := handler.getAllAccounts(ctx, orgID, ledgerID, in.queries(), command.HolderOnV2)
 	if err != nil {
 		return nil, pkgHTTP.HumaProblem(err)
 	}
@@ -104,7 +104,7 @@ func (handler *AccountHandler) GetAccountByIDV2(ctx context.Context, in *GetAcco
 		return nil, pkgHTTP.HumaProblem(err)
 	}
 
-	account, err := handler.getAccountByID(ctx, orgID, ledgerID, id)
+	account, err := handler.getAccountByID(ctx, orgID, ledgerID, id, command.HolderOnV2)
 	if err != nil {
 		return nil, pkgHTTP.HumaProblem(err)
 	}
@@ -119,7 +119,7 @@ func (handler *AccountHandler) GetAccountByAliasV2(ctx context.Context, in *GetA
 		return nil, pkgHTTP.HumaProblem(err)
 	}
 
-	account, err := handler.getAccountByAlias(ctx, "handler.get_account_by_alias", orgID, ledgerID, in.Alias)
+	account, err := handler.getAccountByAlias(ctx, "handler.get_account_by_alias", orgID, ledgerID, in.Alias, command.HolderOnV2)
 	if err != nil {
 		return nil, pkgHTTP.HumaProblem(err)
 	}
@@ -137,7 +137,7 @@ func (handler *AccountHandler) GetAccountExternalByCodeV2(ctx context.Context, i
 
 	alias := constant.DefaultExternalAccountAliasPrefix + in.Code
 
-	account, err := handler.getAccountByAlias(ctx, "handler.get_account_external_by_code", orgID, ledgerID, alias)
+	account, err := handler.getAccountByAlias(ctx, "handler.get_account_external_by_code", orgID, ledgerID, alias, command.HolderOnV2)
 	if err != nil {
 		return nil, pkgHTTP.HumaProblem(err)
 	}
@@ -171,7 +171,7 @@ func (handler *AccountHandler) UpdateAccountV2(ctx context.Context, in *UpdateAc
 		return nil, pkgHTTP.HumaProblem(err)
 	}
 
-	account, err := handler.updateAccount(ctx, orgID, ledgerID, id, payload)
+	account, err := handler.updateAccount(ctx, orgID, ledgerID, id, payload, command.HolderOnV2)
 	if err != nil {
 		return nil, pkgHTTP.HumaProblem(err)
 	}

--- a/components/ledger/internal/adapters/http/in/composition_integration_test.go
+++ b/components/ledger/internal/adapters/http/in/composition_integration_test.go
@@ -302,7 +302,7 @@ func TestIntegration_CompositionHappyPath(t *testing.T) {
 	accountID, err := uuid.Parse(resp.Account.ID)
 	require.NoError(t, err)
 
-	persisted, err := infra.accountRepo.Find(context.Background(), orgID, ledgerID, nil, accountID)
+	persisted, err := infra.accountRepo.Find(context.Background(), orgID, ledgerID, nil, accountID, mmodel.HolderOnV2)
 	require.NoError(t, err, "account must be queryable in PG")
 	require.NotNil(t, persisted.HolderID)
 	assert.Equal(t, holderID.String(), *persisted.HolderID, "persisted PG account holder_id must be the path holder")
@@ -398,7 +398,7 @@ func TestIntegration_CompositionPartialFailureNoCompensation(t *testing.T) {
 
 	// (a)+(b) The account row SURVIVES in PG and is queryable: no compensating
 	// delete fired. Deleting a balance-bearing ledger account is unacceptable.
-	persisted, err := infra.accountRepo.Find(context.Background(), orgID, ledgerID, nil, accountID)
+	persisted, err := infra.accountRepo.Find(context.Background(), orgID, ledgerID, nil, accountID, mmodel.HolderOnV2)
 	require.NoError(t, err, "account must SURVIVE and be queryable in PG (no compensating delete)")
 	require.NotNil(t, persisted.HolderID)
 	assert.Equal(t, holderID.String(), *persisted.HolderID)

--- a/components/ledger/internal/adapters/postgres/account/account.postgresql.go
+++ b/components/ledger/internal/adapters/postgres/account/account.postgresql.go
@@ -34,26 +34,54 @@ import (
 	"github.com/LerianStudio/midaz/v4/pkg/net/http"
 )
 
-var accountColumnList = []string{
-	"id",
-	"name",
-	"parent_account_id",
-	"entity_id",
-	"holder_id",
-	"asset_code",
-	"organization_id",
-	"ledger_id",
-	"portfolio_id",
-	"segment_id",
-	"status",
-	"status_description",
-	"alias",
-	"type",
-	"created_at",
-	"updated_at",
-	"deleted_at",
-	"blocked",
-	"holder_check_skipped",
+// holderColumns are the two columns migrations 000017 and 000019 add. They are
+// named apart because the /v1 account contract withholds both keys, so a /v1
+// request must never reference them: the schema is applied out of band, and a
+// database that has not reached those migrations still has to serve /v1.
+const (
+	holderIDColumn           = "holder_id"
+	holderCheckSkippedColumn = "holder_check_skipped"
+)
+
+// holderIDPlaceholder and holderCheckSkippedPlaceholder stand in for the holder
+// columns on a projection that withholds them. They are typed constants rather
+// than omissions so the projection keeps its arity, order and column types, and
+// every positional Scan below stays valid for both shapes.
+const (
+	holderIDPlaceholder           = "NULL::uuid AS " + holderIDColumn
+	holderCheckSkippedPlaceholder = "FALSE AS " + holderCheckSkippedColumn
+)
+
+// accountColumns returns the account projection. When withHolder is false the
+// two holder columns are replaced by constants of the same type, so the
+// statement never names them and parses against a pre-000017 schema.
+func accountColumns(withHolder bool) []string {
+	holderID, holderCheckSkipped := holderIDPlaceholder, holderCheckSkippedPlaceholder
+	if withHolder {
+		holderID, holderCheckSkipped = holderIDColumn, holderCheckSkippedColumn
+	}
+
+	return []string{
+		"id",
+		"name",
+		"parent_account_id",
+		"entity_id",
+		holderID,
+		"asset_code",
+		"organization_id",
+		"ledger_id",
+		"portfolio_id",
+		"segment_id",
+		"status",
+		"status_description",
+		"alias",
+		"type",
+		"created_at",
+		"updated_at",
+		"deleted_at",
+		"blocked",
+		holderCheckSkipped,
+	}
 }
 
 // Repository provides an interface for operations related to account entities.
@@ -62,13 +90,18 @@ var accountColumnList = []string{
 //go:generate go run go.uber.org/mock/mockgen@v0.6.0 --destination=account.postgresql_mock.go --package=account . Repository
 type Repository interface {
 	Create(ctx context.Context, acc *mmodel.Account) (*mmodel.Account, error)
-	FindAll(ctx context.Context, organizationID, ledgerID uuid.UUID, portfolioID, segmentID *uuid.UUID, filter http.QueryHeader) ([]*mmodel.Account, error)
-	Find(ctx context.Context, organizationID, ledgerID uuid.UUID, portfolioID *uuid.UUID, id uuid.UUID) (*mmodel.Account, error)
-	FindWithDeleted(ctx context.Context, organizationID, ledgerID uuid.UUID, portfolioID *uuid.UUID, id uuid.UUID) (*mmodel.Account, error)
-	FindAlias(ctx context.Context, organizationID, ledgerID uuid.UUID, portfolioID *uuid.UUID, alias string) (*mmodel.Account, error)
+	// The reads below take a holder policy because their result can be serialized
+	// to an account response: only /v2 can observe the holder keys, so a /v1 read
+	// projects constants and never names the columns. The three ListAccounts*
+	// reads take none — the transaction and asset paths they serve read no holder,
+	// so they always project constants and never depend on those columns.
+	FindAll(ctx context.Context, organizationID, ledgerID uuid.UUID, portfolioID, segmentID *uuid.UUID, filter http.QueryHeader, holderPolicy mmodel.HolderPolicy) ([]*mmodel.Account, error)
+	Find(ctx context.Context, organizationID, ledgerID uuid.UUID, portfolioID *uuid.UUID, id uuid.UUID, holderPolicy mmodel.HolderPolicy) (*mmodel.Account, error)
+	FindWithDeleted(ctx context.Context, organizationID, ledgerID uuid.UUID, portfolioID *uuid.UUID, id uuid.UUID, holderPolicy mmodel.HolderPolicy) (*mmodel.Account, error)
+	FindAlias(ctx context.Context, organizationID, ledgerID uuid.UUID, portfolioID *uuid.UUID, alias string, holderPolicy mmodel.HolderPolicy) (*mmodel.Account, error)
 	FindByAlias(ctx context.Context, organizationID, ledgerID uuid.UUID, alias string) (bool, error)
-	ListByIDs(ctx context.Context, organizationID, ledgerID uuid.UUID, portfolioID, segmentID *uuid.UUID, ids []uuid.UUID) ([]*mmodel.Account, error)
-	ListByAlias(ctx context.Context, organizationID, ledgerID, portfolioID uuid.UUID, alias []string) ([]*mmodel.Account, error)
+	ListByIDs(ctx context.Context, organizationID, ledgerID uuid.UUID, portfolioID, segmentID *uuid.UUID, ids []uuid.UUID, holderPolicy mmodel.HolderPolicy) ([]*mmodel.Account, error)
+	ListByAlias(ctx context.Context, organizationID, ledgerID, portfolioID uuid.UUID, alias []string, holderPolicy mmodel.HolderPolicy) ([]*mmodel.Account, error)
 	Update(ctx context.Context, organizationID, ledgerID uuid.UUID, portfolioID *uuid.UUID, id uuid.UUID, acc *mmodel.Account) (*mmodel.Account, error)
 	Delete(ctx context.Context, organizationID, ledgerID uuid.UUID, portfolioID *uuid.UUID, id uuid.UUID) error
 	ListAccountsByIDs(ctx context.Context, organizationID, ledgerID uuid.UUID, ids []uuid.UUID) ([]*mmodel.Account, error)
@@ -146,49 +179,59 @@ func (r *AccountPostgreSQLRepository) Create(ctx context.Context, acc *mmodel.Ac
 	record := &AccountPostgreSQLModel{}
 	record.FromEntity(acc)
 
+	columns := []string{
+		"id",
+		"name",
+		"parent_account_id",
+		"entity_id",
+		"asset_code",
+		"organization_id",
+		"ledger_id",
+		"portfolio_id",
+		"segment_id",
+		"status",
+		"status_description",
+		"alias",
+		"type",
+		"created_at",
+		"updated_at",
+		"deleted_at",
+		"blocked",
+	}
+
+	values := []any{
+		record.ID,
+		record.Name,
+		record.ParentAccountID,
+		record.EntityID,
+		record.AssetCode,
+		record.OrganizationID,
+		record.LedgerID,
+		record.PortfolioID,
+		record.SegmentID,
+		record.Status,
+		record.StatusDescription,
+		record.Alias,
+		record.Type,
+		record.CreatedAt,
+		record.UpdatedAt,
+		record.DeletedAt,
+		record.Blocked,
+	}
+
+	// The holder columns are named only when they carry a value. An account
+	// without one — every /v1 create, an external account, the account asset
+	// creation opens — writes what the columns default to (NULL and FALSE), so
+	// omitting them persists the identical row while keeping the statement
+	// parseable against a schema that predates migrations 000017 and 000019.
+	if record.HolderID != nil || record.HolderCheckSkipped {
+		columns = append(columns, holderIDColumn, holderCheckSkippedColumn)
+		values = append(values, record.HolderID, record.HolderCheckSkipped)
+	}
+
 	builder := squirrel.Insert(r.tableName).
-		Columns(
-			"id",
-			"name",
-			"parent_account_id",
-			"entity_id",
-			"holder_id",
-			"asset_code",
-			"organization_id",
-			"ledger_id",
-			"portfolio_id",
-			"segment_id",
-			"status",
-			"status_description",
-			"alias",
-			"type",
-			"created_at",
-			"updated_at",
-			"deleted_at",
-			"blocked",
-			"holder_check_skipped",
-		).
-		Values(
-			record.ID,
-			record.Name,
-			record.ParentAccountID,
-			record.EntityID,
-			record.HolderID,
-			record.AssetCode,
-			record.OrganizationID,
-			record.LedgerID,
-			record.PortfolioID,
-			record.SegmentID,
-			record.Status,
-			record.StatusDescription,
-			record.Alias,
-			record.Type,
-			record.CreatedAt,
-			record.UpdatedAt,
-			record.DeletedAt,
-			record.Blocked,
-			record.HolderCheckSkipped,
-		).
+		Columns(columns...).
+		Values(values...).
 		PlaceholderFormat(squirrel.Dollar)
 
 	query, args, err := builder.ToSql()
@@ -204,9 +247,17 @@ func (r *AccountPostgreSQLRepository) Create(ctx context.Context, acc *mmodel.Ac
 	if err != nil {
 		var pgErr *pgconn.PgError
 		if errors.As(err, &pgErr) {
+			schemaDrift := services.IsSchemaDrift(err)
+
 			err := services.ValidatePGError(pgErr, constant.EntityAccount)
 
-			libOpentelemetry.HandleSpanBusinessErrorEvent(spanExec, "Failed to execute query", err)
+			// Schema drift is an infrastructure failure, not a caller mistake, so
+			// it has to flip the span red; a constraint violation stays business.
+			if schemaDrift {
+				libOpentelemetry.HandleSpanError(spanExec, "Failed to execute query", err)
+			} else {
+				libOpentelemetry.HandleSpanBusinessErrorEvent(spanExec, "Failed to execute query", err)
+			}
 
 			return nil, err
 		}
@@ -239,7 +290,7 @@ func (r *AccountPostgreSQLRepository) Create(ctx context.Context, acc *mmodel.Ac
 // FindAll retrieves an Account entities from the database (including soft-deleted ones) with pagination.
 //
 //nolint:gocyclo // Query builder with optional filters per parameter; refactor candidate.
-func (r *AccountPostgreSQLRepository) FindAll(ctx context.Context, organizationID, ledgerID uuid.UUID, portfolioID, segmentID *uuid.UUID, filter http.QueryHeader) ([]*mmodel.Account, error) {
+func (r *AccountPostgreSQLRepository) FindAll(ctx context.Context, organizationID, ledgerID uuid.UUID, portfolioID, segmentID *uuid.UUID, filter http.QueryHeader, holderPolicy mmodel.HolderPolicy) ([]*mmodel.Account, error) {
 	_, tracer, _, _ := libObservability.NewTrackingFromContext(ctx)
 
 	ctx, span := tracer.Start(ctx, "postgres.find_all_accounts")
@@ -254,7 +305,7 @@ func (r *AccountPostgreSQLRepository) FindAll(ctx context.Context, organizationI
 
 	var accounts []*mmodel.Account
 
-	findAll := squirrel.Select(accountColumnList...).
+	findAll := squirrel.Select(accountColumns(holderPolicy.ProjectsHolder())...).
 		From(r.tableName).
 		Where(squirrel.Eq{"deleted_at": nil}).
 		Where(squirrel.Expr("organization_id = ?", organizationID)).
@@ -339,9 +390,11 @@ func (r *AccountPostgreSQLRepository) FindAll(ctx context.Context, organizationI
 
 	rows, err := db.QueryContext(ctx, query, args...)
 	if err != nil {
-		libOpentelemetry.HandleSpanError(spanQuery, "Failed to execute query", err)
+		mapped := mapReadError(err)
 
-		return nil, err
+		libOpentelemetry.HandleSpanError(spanQuery, "Failed to execute query", mapped)
+
+		return nil, mapped
 	}
 	defer rows.Close()
 
@@ -370,9 +423,11 @@ func (r *AccountPostgreSQLRepository) FindAll(ctx context.Context, organizationI
 			&acc.Blocked,
 			&acc.HolderCheckSkipped,
 		); err != nil {
-			libOpentelemetry.HandleSpanError(span, "Failed to scan row", err)
+			mapped := mapReadError(err)
 
-			return nil, err
+			libOpentelemetry.HandleSpanError(span, "Failed to scan row", mapped)
+
+			return nil, mapped
 		}
 
 		accounts = append(accounts, acc.ToEntity())
@@ -388,7 +443,7 @@ func (r *AccountPostgreSQLRepository) FindAll(ctx context.Context, organizationI
 }
 
 // Find retrieves an Account entity from the database using the provided ID.
-func (r *AccountPostgreSQLRepository) Find(ctx context.Context, organizationID, ledgerID uuid.UUID, portfolioID *uuid.UUID, id uuid.UUID) (*mmodel.Account, error) {
+func (r *AccountPostgreSQLRepository) Find(ctx context.Context, organizationID, ledgerID uuid.UUID, portfolioID *uuid.UUID, id uuid.UUID, holderPolicy mmodel.HolderPolicy) (*mmodel.Account, error) {
 	_, tracer, _, _ := libObservability.NewTrackingFromContext(ctx)
 
 	ctx, span := tracer.Start(ctx, "postgres.find_account")
@@ -401,7 +456,7 @@ func (r *AccountPostgreSQLRepository) Find(ctx context.Context, organizationID, 
 		return nil, err
 	}
 
-	findOne := squirrel.Select(accountColumnList...).
+	findOne := squirrel.Select(accountColumns(holderPolicy.ProjectsHolder())...).
 		From(r.tableName).
 		Where(squirrel.Expr("organization_id = ?", organizationID)).
 		Where(squirrel.Expr("ledger_id = ?", ledgerID)).
@@ -459,16 +514,18 @@ func (r *AccountPostgreSQLRepository) Find(ctx context.Context, organizationID, 
 			return nil, err
 		}
 
-		libOpentelemetry.HandleSpanError(span, "Failed to scan row", err)
+		mapped := mapReadError(err)
 
-		return nil, err
+		libOpentelemetry.HandleSpanError(span, "Failed to scan row", mapped)
+
+		return nil, mapped
 	}
 
 	return acc.ToEntity(), nil
 }
 
 // FindWithDeleted retrieves an Account entity from the database using the provided ID (including soft-deleted ones).
-func (r *AccountPostgreSQLRepository) FindWithDeleted(ctx context.Context, organizationID, ledgerID uuid.UUID, portfolioID *uuid.UUID, id uuid.UUID) (*mmodel.Account, error) {
+func (r *AccountPostgreSQLRepository) FindWithDeleted(ctx context.Context, organizationID, ledgerID uuid.UUID, portfolioID *uuid.UUID, id uuid.UUID, holderPolicy mmodel.HolderPolicy) (*mmodel.Account, error) {
 	_, tracer, _, _ := libObservability.NewTrackingFromContext(ctx)
 
 	ctx, span := tracer.Start(ctx, "postgres.find_with_deleted_account")
@@ -481,7 +538,7 @@ func (r *AccountPostgreSQLRepository) FindWithDeleted(ctx context.Context, organ
 		return nil, err
 	}
 
-	findOne := squirrel.Select(accountColumnList...).
+	findOne := squirrel.Select(accountColumns(holderPolicy.ProjectsHolder())...).
 		From(r.tableName).
 		Where(squirrel.Expr("organization_id = ?", organizationID)).
 		Where(squirrel.Expr("ledger_id = ?", ledgerID)).
@@ -538,16 +595,18 @@ func (r *AccountPostgreSQLRepository) FindWithDeleted(ctx context.Context, organ
 			return nil, err
 		}
 
-		libOpentelemetry.HandleSpanError(span, "Failed to scan row", err)
+		mapped := mapReadError(err)
 
-		return nil, err
+		libOpentelemetry.HandleSpanError(span, "Failed to scan row", mapped)
+
+		return nil, mapped
 	}
 
 	return acc.ToEntity(), nil
 }
 
 // FindAlias retrieves an Account entity from the database using the provided Alias.
-func (r *AccountPostgreSQLRepository) FindAlias(ctx context.Context, organizationID, ledgerID uuid.UUID, portfolioID *uuid.UUID, alias string) (*mmodel.Account, error) {
+func (r *AccountPostgreSQLRepository) FindAlias(ctx context.Context, organizationID, ledgerID uuid.UUID, portfolioID *uuid.UUID, alias string, holderPolicy mmodel.HolderPolicy) (*mmodel.Account, error) {
 	_, tracer, _, _ := libObservability.NewTrackingFromContext(ctx)
 
 	ctx, span := tracer.Start(ctx, "postgres.find_alias")
@@ -560,7 +619,7 @@ func (r *AccountPostgreSQLRepository) FindAlias(ctx context.Context, organizatio
 		return nil, err
 	}
 
-	findOne := squirrel.Select(accountColumnList...).
+	findOne := squirrel.Select(accountColumns(holderPolicy.ProjectsHolder())...).
 		From(r.tableName).
 		Where(squirrel.Expr("organization_id = ?", organizationID)).
 		Where(squirrel.Expr("ledger_id = ?", ledgerID)).
@@ -618,9 +677,11 @@ func (r *AccountPostgreSQLRepository) FindAlias(ctx context.Context, organizatio
 			return nil, err
 		}
 
-		libOpentelemetry.HandleSpanError(span, "Failed to scan row", err)
+		mapped := mapReadError(err)
 
-		return nil, err
+		libOpentelemetry.HandleSpanError(span, "Failed to scan row", mapped)
+
+		return nil, mapped
 	}
 
 	return acc.ToEntity(), nil
@@ -683,7 +744,7 @@ func (r *AccountPostgreSQLRepository) FindByAlias(ctx context.Context, organizat
 }
 
 // ListByIDs retrieves Accounts entities from the database using the provided IDs.
-func (r *AccountPostgreSQLRepository) ListByIDs(ctx context.Context, organizationID, ledgerID uuid.UUID, portfolioID, segmentID *uuid.UUID, ids []uuid.UUID) ([]*mmodel.Account, error) {
+func (r *AccountPostgreSQLRepository) ListByIDs(ctx context.Context, organizationID, ledgerID uuid.UUID, portfolioID, segmentID *uuid.UUID, ids []uuid.UUID, holderPolicy mmodel.HolderPolicy) ([]*mmodel.Account, error) {
 	_, tracer, _, _ := libObservability.NewTrackingFromContext(ctx)
 
 	ctx, span := tracer.Start(ctx, "postgres.list_accounts_by_ids")
@@ -698,7 +759,7 @@ func (r *AccountPostgreSQLRepository) ListByIDs(ctx context.Context, organizatio
 
 	var accounts []*mmodel.Account
 
-	findAll := squirrel.Select(accountColumnList...).
+	findAll := squirrel.Select(accountColumns(holderPolicy.ProjectsHolder())...).
 		From(r.tableName).
 		Where(squirrel.Expr("organization_id = ?", organizationID)).
 		Where(squirrel.Expr("ledger_id = ?", ledgerID)).
@@ -726,9 +787,11 @@ func (r *AccountPostgreSQLRepository) ListByIDs(ctx context.Context, organizatio
 
 	rows, err := db.QueryContext(ctx, query, args...)
 	if err != nil {
-		libOpentelemetry.HandleSpanError(spanQuery, "Failed to execute query", err)
+		mapped := mapReadError(err)
 
-		return nil, err
+		libOpentelemetry.HandleSpanError(spanQuery, "Failed to execute query", mapped)
+
+		return nil, mapped
 	}
 	defer rows.Close()
 
@@ -757,9 +820,11 @@ func (r *AccountPostgreSQLRepository) ListByIDs(ctx context.Context, organizatio
 			&acc.Blocked,
 			&acc.HolderCheckSkipped,
 		); err != nil {
-			libOpentelemetry.HandleSpanError(span, "Failed to scan row", err)
+			mapped := mapReadError(err)
 
-			return nil, err
+			libOpentelemetry.HandleSpanError(span, "Failed to scan row", mapped)
+
+			return nil, mapped
 		}
 
 		accounts = append(accounts, acc.ToEntity())
@@ -775,7 +840,7 @@ func (r *AccountPostgreSQLRepository) ListByIDs(ctx context.Context, organizatio
 }
 
 // ListByAlias retrieves Accounts entities from the database using the provided alias.
-func (r *AccountPostgreSQLRepository) ListByAlias(ctx context.Context, organizationID, ledgerID, portfolioID uuid.UUID, alias []string) ([]*mmodel.Account, error) {
+func (r *AccountPostgreSQLRepository) ListByAlias(ctx context.Context, organizationID, ledgerID, portfolioID uuid.UUID, alias []string, holderPolicy mmodel.HolderPolicy) ([]*mmodel.Account, error) {
 	_, tracer, _, _ := libObservability.NewTrackingFromContext(ctx)
 
 	ctx, span := tracer.Start(ctx, "postgres.list_accounts_by_alias")
@@ -790,7 +855,7 @@ func (r *AccountPostgreSQLRepository) ListByAlias(ctx context.Context, organizat
 
 	var accounts []*mmodel.Account
 
-	findAll := squirrel.Select(accountColumnList...).
+	findAll := squirrel.Select(accountColumns(holderPolicy.ProjectsHolder())...).
 		From(r.tableName).
 		Where(squirrel.Expr("organization_id = ?", organizationID)).
 		Where(squirrel.Expr("ledger_id = ?", ledgerID)).
@@ -811,9 +876,11 @@ func (r *AccountPostgreSQLRepository) ListByAlias(ctx context.Context, organizat
 
 	rows, err := db.QueryContext(ctx, query, args...)
 	if err != nil {
-		libOpentelemetry.HandleSpanError(spanQuery, "Failed to execute query", err)
+		mapped := mapReadError(err)
 
-		return nil, err
+		libOpentelemetry.HandleSpanError(spanQuery, "Failed to execute query", mapped)
+
+		return nil, mapped
 	}
 	defer rows.Close()
 
@@ -842,9 +909,11 @@ func (r *AccountPostgreSQLRepository) ListByAlias(ctx context.Context, organizat
 			&acc.Blocked,
 			&acc.HolderCheckSkipped,
 		); err != nil {
-			libOpentelemetry.HandleSpanError(span, "Failed to scan row", err)
+			mapped := mapReadError(err)
 
-			return nil, err
+			libOpentelemetry.HandleSpanError(span, "Failed to scan row", mapped)
+
+			return nil, mapped
 		}
 
 		accounts = append(accounts, acc.ToEntity())
@@ -948,9 +1017,17 @@ func (r *AccountPostgreSQLRepository) Update(ctx context.Context, organizationID
 	if err != nil {
 		var pgErr *pgconn.PgError
 		if errors.As(err, &pgErr) {
+			schemaDrift := services.IsSchemaDrift(err)
+
 			err := services.ValidatePGError(pgErr, constant.EntityAccount)
 
-			libOpentelemetry.HandleSpanBusinessErrorEvent(spanExec, "Failed to execute update query", err)
+			// Schema drift is an infrastructure failure, not a caller mistake, so
+			// it has to flip the span red; a constraint violation stays business.
+			if schemaDrift {
+				libOpentelemetry.HandleSpanError(spanExec, "Failed to execute update query", err)
+			} else {
+				libOpentelemetry.HandleSpanBusinessErrorEvent(spanExec, "Failed to execute update query", err)
+			}
 
 			return nil, err
 		}
@@ -1042,7 +1119,7 @@ func (r *AccountPostgreSQLRepository) ListAccountsByIDs(ctx context.Context, org
 
 	var accounts []*mmodel.Account
 
-	findAll := squirrel.Select(accountColumnList...).
+	findAll := squirrel.Select(accountColumns(false)...).
 		From(r.tableName).
 		Where(squirrel.Expr("organization_id = ?", organizationID)).
 		Where(squirrel.Expr("ledger_id = ?", ledgerID)).
@@ -1062,9 +1139,11 @@ func (r *AccountPostgreSQLRepository) ListAccountsByIDs(ctx context.Context, org
 
 	rows, err := db.QueryContext(ctx, query, args...)
 	if err != nil {
-		libOpentelemetry.HandleSpanError(spanQuery, "Failed to execute query", err)
+		mapped := mapReadError(err)
 
-		return nil, err
+		libOpentelemetry.HandleSpanError(spanQuery, "Failed to execute query", mapped)
+
+		return nil, mapped
 	}
 	defer rows.Close()
 
@@ -1093,9 +1172,11 @@ func (r *AccountPostgreSQLRepository) ListAccountsByIDs(ctx context.Context, org
 			&acc.Blocked,
 			&acc.HolderCheckSkipped,
 		); err != nil {
-			libOpentelemetry.HandleSpanError(span, "Failed to scan row", err)
+			mapped := mapReadError(err)
 
-			return nil, err
+			libOpentelemetry.HandleSpanError(span, "Failed to scan row", mapped)
+
+			return nil, mapped
 		}
 
 		accounts = append(accounts, acc.ToEntity())
@@ -1126,7 +1207,7 @@ func (r *AccountPostgreSQLRepository) ListAccountsByAlias(ctx context.Context, o
 
 	var accounts []*mmodel.Account
 
-	findAll := squirrel.Select(accountColumnList...).
+	findAll := squirrel.Select(accountColumns(false)...).
 		From(r.tableName).
 		Where(squirrel.Expr("organization_id = ?", organizationID)).
 		Where(squirrel.Expr("ledger_id = ?", ledgerID)).
@@ -1146,9 +1227,11 @@ func (r *AccountPostgreSQLRepository) ListAccountsByAlias(ctx context.Context, o
 
 	rows, err := db.QueryContext(ctx, query, args...)
 	if err != nil {
-		libOpentelemetry.HandleSpanError(spanQuery, "Failed to execute query", err)
+		mapped := mapReadError(err)
 
-		return nil, err
+		libOpentelemetry.HandleSpanError(spanQuery, "Failed to execute query", mapped)
+
+		return nil, mapped
 	}
 	defer rows.Close()
 
@@ -1177,9 +1260,11 @@ func (r *AccountPostgreSQLRepository) ListAccountsByAlias(ctx context.Context, o
 			&acc.Blocked,
 			&acc.HolderCheckSkipped,
 		); err != nil {
-			libOpentelemetry.HandleSpanError(span, "Failed to scan row", err)
+			mapped := mapReadError(err)
 
-			return nil, err
+			libOpentelemetry.HandleSpanError(span, "Failed to scan row", mapped)
+
+			return nil, mapped
 		}
 
 		accounts = append(accounts, acc.ToEntity())
@@ -1217,7 +1302,7 @@ func (r *AccountPostgreSQLRepository) ListExternalAccountsByAssetCode(ctx contex
 
 	var accounts []*mmodel.Account
 
-	findAll := squirrel.Select(accountColumnList...).
+	findAll := squirrel.Select(accountColumns(false)...).
 		From(r.tableName).
 		Where(squirrel.Eq{"organization_id": organizationID}).
 		Where(squirrel.Eq{"ledger_id": ledgerID}).
@@ -1334,9 +1419,11 @@ func (r *AccountPostgreSQLRepository) Count(ctx context.Context, organizationID,
 
 	err = db.QueryRowContext(ctx, query, args...).Scan(&count)
 	if err != nil {
-		libOpentelemetry.HandleSpanError(spanQuery, "Failed to execute query", err)
+		mapped := mapReadError(err)
 
-		return count, err
+		libOpentelemetry.HandleSpanError(spanQuery, "Failed to execute query", mapped)
+
+		return count, mapped
 	}
 
 	spanQuery.End()
@@ -1377,12 +1464,27 @@ func (r *AccountPostgreSQLRepository) CountByHolderID(ctx context.Context, organ
 
 	err = db.QueryRowContext(ctx, query, args...).Scan(&count)
 	if err != nil {
-		libOpentelemetry.HandleSpanError(spanQuery, "Failed to execute query", err)
+		mapped := mapReadError(err)
 
-		return count, err
+		libOpentelemetry.HandleSpanError(spanQuery, "Failed to execute query", mapped)
+
+		return count, mapped
 	}
 
 	spanQuery.End()
 
 	return count, nil
+}
+
+// mapReadError classifies a read failure. A projection that named a column the
+// applied migrations have not created becomes the retryable schema-migration
+// sentinel, so the caller learns the cause instead of an opaque 500; every other
+// error propagates unchanged.
+func mapReadError(err error) error {
+	var pgErr *pgconn.PgError
+	if errors.As(err, &pgErr) && services.IsSchemaDrift(err) {
+		return services.ValidatePGError(pgErr, constant.EntityAccount)
+	}
+
+	return err
 }

--- a/components/ledger/internal/adapters/postgres/account/account.postgresql_integration_test.go
+++ b/components/ledger/internal/adapters/postgres/account/account.postgresql_integration_test.go
@@ -66,7 +66,7 @@ func TestIntegration_AccountRepository_Find_ReturnsAccount(t *testing.T) {
 	ctx := context.Background()
 
 	// Act
-	account, err := repo.Find(ctx, orgID, ledgerID, nil, accountID)
+	account, err := repo.Find(ctx, orgID, ledgerID, nil, accountID, mmodel.HolderOnV2)
 
 	// Assert
 	require.NoError(t, err, "Find should not return error for existing account")
@@ -120,7 +120,7 @@ func TestIntegration_AccountRepository_Find_ReturnsEntityNotFoundError(t *testin
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Act
-			account, err := repo.Find(context.Background(), orgID, ledgerID, nil, tt.accountID)
+			account, err := repo.Find(context.Background(), orgID, ledgerID, nil, tt.accountID, mmodel.HolderOnV2)
 
 			// Assert
 			require.Error(t, err, "Find should return error")
@@ -166,17 +166,17 @@ func TestIntegration_AccountRepository_Find_FiltersCorrectlyByOrgAndLedger(t *te
 	ctx := context.Background()
 
 	// Act & Assert: should find with correct org/ledger
-	account, err := repo.Find(ctx, org1ID, ledger1ID, nil, accountID)
+	account, err := repo.Find(ctx, org1ID, ledger1ID, nil, accountID, mmodel.HolderOnV2)
 	require.NoError(t, err, "should find account with correct org/ledger")
 	assert.NotNil(t, account)
 
 	// Act & Assert: should NOT find with wrong organization
-	account, err = repo.Find(ctx, org2ID, ledger1ID, nil, accountID)
+	account, err = repo.Find(ctx, org2ID, ledger1ID, nil, accountID, mmodel.HolderOnV2)
 	require.Error(t, err, "should not find account with wrong organization")
 	assert.Nil(t, account)
 
 	// Act & Assert: should NOT find with wrong ledger
-	account, err = repo.Find(ctx, org1ID, ledger2ID, nil, accountID)
+	account, err = repo.Find(ctx, org1ID, ledger2ID, nil, accountID, mmodel.HolderOnV2)
 	require.Error(t, err, "should not find account with wrong ledger")
 	assert.Nil(t, account)
 }
@@ -227,7 +227,7 @@ func TestIntegration_AccountRepository_Create_InsertsAccount(t *testing.T) {
 
 	// Verify it can be retrieved
 	parsedID, _ := uuid.Parse(created.ID)
-	found, err := repo.Find(ctx, orgID, ledgerID, nil, parsedID)
+	found, err := repo.Find(ctx, orgID, ledgerID, nil, parsedID, mmodel.HolderOnV2)
 	require.NoError(t, err)
 	assert.Equal(t, created.ID, found.ID)
 }
@@ -276,7 +276,7 @@ func TestIntegration_AccountRepository_Find_BackwardCompatible_ExtraColumns(t *t
 	ctx := context.Background()
 
 	// Act - The old code (current repository) tries to read the account
-	account, err := repo.Find(ctx, orgID, ledgerID, nil, accountID)
+	account, err := repo.Find(ctx, orgID, ledgerID, nil, accountID, mmodel.HolderOnV2)
 
 	// Assert - Must NOT break, even with unknown columns in the table
 	require.NoError(t, err, "Find must not break when table has extra columns (backward compatibility)")
@@ -340,7 +340,7 @@ func TestIntegration_AccountRepository_Create_BackwardCompatible_ExtraColumns(t 
 
 	// Verify the account was actually persisted
 	parsedID, _ := uuid.Parse(created.ID)
-	found, err := repo.Find(ctx, orgID, ledgerID, nil, parsedID)
+	found, err := repo.Find(ctx, orgID, ledgerID, nil, parsedID, mmodel.HolderOnV2)
 	require.NoError(t, err, "should be able to retrieve the created account")
 	assert.Equal(t, created.ID, found.ID)
 
@@ -382,7 +382,7 @@ func TestIntegration_AccountRepository_FindAll_ReturnsPaginatedAccounts(t *testi
 	}
 
 	// Act
-	accounts, err := repo.FindAll(ctx, orgID, ledgerID, nil, nil, filter)
+	accounts, err := repo.FindAll(ctx, orgID, ledgerID, nil, nil, filter, mmodel.HolderOnV2)
 
 	// Assert
 	require.NoError(t, err, "FindAll should not return error")
@@ -420,15 +420,15 @@ func TestIntegration_AccountRepository_FindAll_PaginatesWithoutDuplicates(t *tes
 
 	// Act - Get all 3 pages
 	baseFilter.Page = 1
-	page1, err := repo.FindAll(ctx, orgID, ledgerID, nil, nil, baseFilter)
+	page1, err := repo.FindAll(ctx, orgID, ledgerID, nil, nil, baseFilter, mmodel.HolderOnV2)
 	require.NoError(t, err)
 
 	baseFilter.Page = 2
-	page2, err := repo.FindAll(ctx, orgID, ledgerID, nil, nil, baseFilter)
+	page2, err := repo.FindAll(ctx, orgID, ledgerID, nil, nil, baseFilter, mmodel.HolderOnV2)
 	require.NoError(t, err)
 
 	baseFilter.Page = 3
-	page3, err := repo.FindAll(ctx, orgID, ledgerID, nil, nil, baseFilter)
+	page3, err := repo.FindAll(ctx, orgID, ledgerID, nil, nil, baseFilter, mmodel.HolderOnV2)
 	require.NoError(t, err)
 
 	// Assert - Correct counts per page
@@ -474,7 +474,7 @@ func TestIntegration_AccountRepository_FindAll_ExcludesSoftDeleted(t *testing.T)
 	}
 
 	// Act
-	accounts, err := repo.FindAll(ctx, orgID, ledgerID, nil, nil, filter)
+	accounts, err := repo.FindAll(ctx, orgID, ledgerID, nil, nil, filter, mmodel.HolderOnV2)
 
 	// Assert
 	require.NoError(t, err)
@@ -510,7 +510,7 @@ func TestIntegration_AccountRepository_FindAll_FiltersByPortfolio(t *testing.T) 
 	}
 
 	// Act
-	accounts, err := repo.FindAll(ctx, orgID, ledgerID, &portfolioID, nil, filter)
+	accounts, err := repo.FindAll(ctx, orgID, ledgerID, &portfolioID, nil, filter, mmodel.HolderOnV2)
 
 	// Assert
 	require.NoError(t, err)
@@ -551,7 +551,7 @@ func TestIntegration_AccountRepository_FindAll_FiltersBySegment(t *testing.T) {
 	}
 
 	// Act
-	accounts, err := repo.FindAll(ctx, orgID, ledgerID, nil, &segmentID, filter)
+	accounts, err := repo.FindAll(ctx, orgID, ledgerID, nil, &segmentID, filter, mmodel.HolderOnV2)
 
 	// Assert
 	require.NoError(t, err)
@@ -583,11 +583,11 @@ func TestIntegration_AccountRepository_FindWithDeleted_ReturnsDeletedAccount(t *
 	ctx := context.Background()
 
 	// Act - Find should fail
-	_, errFind := repo.Find(ctx, orgID, ledgerID, nil, accountID)
+	_, errFind := repo.Find(ctx, orgID, ledgerID, nil, accountID, mmodel.HolderOnV2)
 	require.Error(t, errFind, "Find should not return soft-deleted account")
 
 	// Act - FindWithDeleted should succeed
-	account, err := repo.FindWithDeleted(ctx, orgID, ledgerID, nil, accountID)
+	account, err := repo.FindWithDeleted(ctx, orgID, ledgerID, nil, accountID, mmodel.HolderOnV2)
 
 	// Assert
 	require.NoError(t, err, "FindWithDeleted should return soft-deleted account")
@@ -611,7 +611,7 @@ func TestIntegration_AccountRepository_FindWithDeleted_ReturnsActiveAccount(t *t
 	ctx := context.Background()
 
 	// Act
-	account, err := repo.FindWithDeleted(ctx, orgID, ledgerID, nil, accountID)
+	account, err := repo.FindWithDeleted(ctx, orgID, ledgerID, nil, accountID, mmodel.HolderOnV2)
 
 	// Assert
 	require.NoError(t, err)
@@ -639,7 +639,7 @@ func TestIntegration_AccountRepository_FindAlias_ReturnsAccountByAlias(t *testin
 	ctx := context.Background()
 
 	// Act
-	account, err := repo.FindAlias(ctx, orgID, ledgerID, nil, alias)
+	account, err := repo.FindAlias(ctx, orgID, ledgerID, nil, alias, mmodel.HolderOnV2)
 
 	// Assert
 	require.NoError(t, err, "FindAlias should find account by alias")
@@ -661,7 +661,7 @@ func TestIntegration_AccountRepository_FindAlias_ReturnsErrorForNonExistent(t *t
 	ctx := context.Background()
 
 	// Act
-	account, err := repo.FindAlias(ctx, orgID, ledgerID, nil, "@nonexistent")
+	account, err := repo.FindAlias(ctx, orgID, ledgerID, nil, "@nonexistent", mmodel.HolderOnV2)
 
 	// Assert
 	require.Error(t, err, "FindAlias should return error for non-existent alias")
@@ -684,7 +684,7 @@ func TestIntegration_AccountRepository_FindAlias_ExcludesSoftDeleted(t *testing.
 	ctx := context.Background()
 
 	// Act
-	account, err := repo.FindAlias(ctx, orgID, ledgerID, nil, alias)
+	account, err := repo.FindAlias(ctx, orgID, ledgerID, nil, alias, mmodel.HolderOnV2)
 
 	// Assert
 	require.Error(t, err, "FindAlias should not find soft-deleted account")
@@ -724,7 +724,7 @@ func TestIntegration_AccountRepository_CustomExternal_FetchableAndListable(t *te
 	ctx := context.Background()
 
 	// Act & Assert: fetch by ID.
-	byID, err := repo.Find(ctx, orgID, ledgerID, nil, accountID)
+	byID, err := repo.Find(ctx, orgID, ledgerID, nil, accountID, mmodel.HolderOnV2)
 	require.NoError(t, err, "custom external account must be fetchable by ID")
 	require.NotNil(t, byID)
 	assert.Equal(t, accountID.String(), byID.ID)
@@ -732,7 +732,7 @@ func TestIntegration_AccountRepository_CustomExternal_FetchableAndListable(t *te
 	assert.Equal(t, customAlias, *byID.Alias, "custom alias should be persisted verbatim")
 
 	// Act & Assert: fetch by alias (the generic alias lookup, not external-by-code).
-	byAlias, err := repo.FindAlias(ctx, orgID, ledgerID, nil, customAlias)
+	byAlias, err := repo.FindAlias(ctx, orgID, ledgerID, nil, customAlias, mmodel.HolderOnV2)
 	require.NoError(t, err, "custom external account must be fetchable by its custom alias")
 	require.NotNil(t, byAlias)
 	assert.Equal(t, accountID.String(), byAlias.ID)
@@ -746,7 +746,7 @@ func TestIntegration_AccountRepository_CustomExternal_FetchableAndListable(t *te
 		Page:      1,
 		SortOrder: "asc",
 	}
-	listed, err := repo.FindAll(ctx, orgID, ledgerID, nil, nil, filter)
+	listed, err := repo.FindAll(ctx, orgID, ledgerID, nil, nil, filter, mmodel.HolderOnV2)
 	require.NoError(t, err, "FindAll should not error")
 
 	var found *mmodel.Account
@@ -785,7 +785,7 @@ func TestIntegration_AccountRepository_CanonicalExternalByCode_BackwardCompatibl
 	ctx := context.Background()
 
 	// Act: GetAccountExternalByCode resolves "@external/<code>" via FindAlias.
-	account, err := repo.FindAlias(ctx, orgID, ledgerID, nil, canonicalAlias)
+	account, err := repo.FindAlias(ctx, orgID, ledgerID, nil, canonicalAlias, mmodel.HolderOnV2)
 
 	// Assert
 	require.NoError(t, err, "canonical external-by-code alias must resolve")
@@ -796,7 +796,7 @@ func TestIntegration_AccountRepository_CanonicalExternalByCode_BackwardCompatibl
 
 	// A code with no provisioned external account still yields not-found,
 	// preserving the pre-existing 404 behavior.
-	missing, err := repo.FindAlias(ctx, orgID, ledgerID, nil, constant.DefaultExternalAccountAliasPrefix+"EUR")
+	missing, err := repo.FindAlias(ctx, orgID, ledgerID, nil, constant.DefaultExternalAccountAliasPrefix+"EUR", mmodel.HolderOnV2)
 	require.Error(t, err, "unprovisioned external code must remain not-found")
 	assert.Nil(t, missing)
 }
@@ -897,7 +897,7 @@ func TestIntegration_AccountRepository_Update_UpdatesName(t *testing.T) {
 	require.NotNil(t, updated)
 
 	// Verify via Find
-	found, err := repo.Find(ctx, orgID, ledgerID, nil, accountID)
+	found, err := repo.Find(ctx, orgID, ledgerID, nil, accountID, mmodel.HolderOnV2)
 	require.NoError(t, err)
 	assert.Equal(t, "Updated Name", found.Name)
 }
@@ -960,7 +960,7 @@ func TestIntegration_AccountRepository_Update_PreservesHolderLink(t *testing.T) 
 	require.NoError(t, err)
 	require.NotNil(t, updated)
 
-	found, err := repo.Find(ctx, orgID, ledgerID, nil, accountID)
+	found, err := repo.Find(ctx, orgID, ledgerID, nil, accountID, mmodel.HolderOnV2)
 	require.NoError(t, err)
 
 	assert.Equal(t, "Renamed", found.Name, "the requested change must land")
@@ -994,7 +994,7 @@ func TestIntegration_AccountRepository_Update_UpdatesStatus(t *testing.T) {
 	// Assert
 	require.NoError(t, err)
 
-	found, err := repo.Find(ctx, orgID, ledgerID, nil, accountID)
+	found, err := repo.Find(ctx, orgID, ledgerID, nil, accountID, mmodel.HolderOnV2)
 	require.NoError(t, err)
 	assert.Equal(t, "BLOCKED", found.Status.Code)
 	assert.NotNil(t, found.Status.Description)
@@ -1024,7 +1024,7 @@ func TestIntegration_AccountRepository_Update_UpdatesBlocked(t *testing.T) {
 	// Assert
 	require.NoError(t, err)
 
-	found, err := repo.Find(ctx, orgID, ledgerID, nil, accountID)
+	found, err := repo.Find(ctx, orgID, ledgerID, nil, accountID, mmodel.HolderOnV2)
 	require.NoError(t, err)
 	require.NotNil(t, found.Blocked)
 	assert.True(t, *found.Blocked)
@@ -1091,7 +1091,7 @@ func TestIntegration_AccountRepository_Delete_SoftDeletesAccount(t *testing.T) {
 	ctx := context.Background()
 
 	// Verify account exists before delete
-	_, err := repo.Find(ctx, orgID, ledgerID, nil, accountID)
+	_, err := repo.Find(ctx, orgID, ledgerID, nil, accountID, mmodel.HolderOnV2)
 	require.NoError(t, err, "account should exist before delete")
 
 	// Act
@@ -1101,11 +1101,11 @@ func TestIntegration_AccountRepository_Delete_SoftDeletesAccount(t *testing.T) {
 	require.NoError(t, err, "Delete should not return error")
 
 	// Find should fail now
-	_, err = repo.Find(ctx, orgID, ledgerID, nil, accountID)
+	_, err = repo.Find(ctx, orgID, ledgerID, nil, accountID, mmodel.HolderOnV2)
 	require.Error(t, err, "Find should not return soft-deleted account")
 
 	// FindWithDeleted should still work
-	found, err := repo.FindWithDeleted(ctx, orgID, ledgerID, nil, accountID)
+	found, err := repo.FindWithDeleted(ctx, orgID, ledgerID, nil, accountID, mmodel.HolderOnV2)
 	require.NoError(t, err)
 	require.NotNil(t, found)
 	assert.NotNil(t, found.DeletedAt, "deleted_at should be set")
@@ -1150,7 +1150,7 @@ func TestIntegration_AccountRepository_Delete_IsIdempotent(t *testing.T) {
 	require.NoError(t, err2, "second delete should be idempotent (no error)")
 
 	// Verify account is still soft-deleted (only once)
-	found, err := repo.FindWithDeleted(ctx, orgID, ledgerID, nil, accountID)
+	found, err := repo.FindWithDeleted(ctx, orgID, ledgerID, nil, accountID, mmodel.HolderOnV2)
 	require.NoError(t, err)
 	assert.NotNil(t, found.DeletedAt, "account should remain soft-deleted")
 }
@@ -1179,7 +1179,7 @@ func TestIntegration_AccountRepository_Delete_RespectsOrgLedgerIsolation(t *test
 	require.NoError(t, err, "delete with wrong org/ledger should not error (no-op)")
 
 	// Critical assertion: Account must still exist in org1 (isolation preserved)
-	found, err := repo.Find(ctx, org1ID, ledger1ID, nil, accountID)
+	found, err := repo.Find(ctx, org1ID, ledger1ID, nil, accountID, mmodel.HolderOnV2)
 	require.NoError(t, err, "account should still exist in original org/ledger")
 	require.NotNil(t, found, "account should not be nil")
 	assert.Equal(t, accountID.String(), found.ID, "account ID should match")
@@ -1206,7 +1206,7 @@ func TestIntegration_AccountRepository_ListByIDs_ReturnsMatchingAccounts(t *test
 	ctx := context.Background()
 
 	// Act
-	accounts, err := repo.ListByIDs(ctx, orgID, ledgerID, nil, nil, []uuid.UUID{id1, id2})
+	accounts, err := repo.ListByIDs(ctx, orgID, ledgerID, nil, nil, []uuid.UUID{id1, id2}, mmodel.HolderOnV2)
 
 	// Assert
 	require.NoError(t, err)
@@ -1241,7 +1241,7 @@ func TestIntegration_AccountRepository_ListByIDs_FiltersBySegment(t *testing.T) 
 	ctx := context.Background()
 
 	// Act: ListByIDs with all 3 IDs but segment filter should exclude id3.
-	accounts, err := repo.ListByIDs(ctx, orgID, ledgerID, nil, &segmentID, []uuid.UUID{id1, id2, id3})
+	accounts, err := repo.ListByIDs(ctx, orgID, ledgerID, nil, &segmentID, []uuid.UUID{id1, id2, id3}, mmodel.HolderOnV2)
 
 	// Assert
 	require.NoError(t, err)
@@ -1269,7 +1269,7 @@ func TestIntegration_AccountRepository_ListByIDs_ExcludesSoftDeleted(t *testing.
 	ctx := context.Background()
 
 	// Act
-	accounts, err := repo.ListByIDs(ctx, orgID, ledgerID, nil, nil, []uuid.UUID{id1, id2})
+	accounts, err := repo.ListByIDs(ctx, orgID, ledgerID, nil, nil, []uuid.UUID{id1, id2}, mmodel.HolderOnV2)
 
 	// Assert
 	require.NoError(t, err)
@@ -1289,7 +1289,7 @@ func TestIntegration_AccountRepository_ListByIDs_ReturnsEmptyForNoMatch(t *testi
 	ctx := context.Background()
 
 	// Act
-	accounts, err := repo.ListByIDs(ctx, orgID, ledgerID, nil, nil, []uuid.UUID{uuid.Must(libCommons.GenerateUUIDv7())})
+	accounts, err := repo.ListByIDs(ctx, orgID, ledgerID, nil, nil, []uuid.UUID{uuid.Must(libCommons.GenerateUUIDv7())}, mmodel.HolderOnV2)
 
 	// Assert
 	require.NoError(t, err)
@@ -1701,7 +1701,7 @@ func TestIntegration_AccountRepository_FindAll_FiltersByStatus(t *testing.T) {
 	}
 
 	// Act
-	accounts, err := repo.FindAll(ctx, orgID, ledgerID, nil, nil, filter)
+	accounts, err := repo.FindAll(ctx, orgID, ledgerID, nil, nil, filter, mmodel.HolderOnV2)
 
 	// Assert
 	require.NoError(t, err)
@@ -1758,7 +1758,7 @@ func TestIntegration_AccountRepository_FindAll_FiltersByType(t *testing.T) {
 	}
 
 	// Act
-	accounts, err := repo.FindAll(ctx, orgID, ledgerID, nil, nil, filter)
+	accounts, err := repo.FindAll(ctx, orgID, ledgerID, nil, nil, filter, mmodel.HolderOnV2)
 
 	// Assert
 	require.NoError(t, err)
@@ -1815,7 +1815,7 @@ func TestIntegration_AccountRepository_FindAll_FiltersByAssetCode(t *testing.T) 
 	}
 
 	// Act
-	accounts, err := repo.FindAll(ctx, orgID, ledgerID, nil, nil, filter)
+	accounts, err := repo.FindAll(ctx, orgID, ledgerID, nil, nil, filter, mmodel.HolderOnV2)
 
 	// Assert
 	require.NoError(t, err)
@@ -1888,7 +1888,7 @@ func TestIntegration_AccountRepository_FindAll_CombinesMultipleFiltersWithAND(t 
 	}
 
 	// Act
-	accounts, err := repo.FindAll(ctx, orgID, ledgerID, nil, nil, filter)
+	accounts, err := repo.FindAll(ctx, orgID, ledgerID, nil, nil, filter, mmodel.HolderOnV2)
 
 	// Assert
 	require.NoError(t, err)
@@ -1938,7 +1938,7 @@ func TestIntegration_AccountRepository_FindAll_EmptyFilterReturnsAll(t *testing.
 	}
 
 	// Act - empty filter (no filters applied)
-	accounts, err := repo.FindAll(ctx, orgID, ledgerID, nil, nil, filter)
+	accounts, err := repo.FindAll(ctx, orgID, ledgerID, nil, nil, filter, mmodel.HolderOnV2)
 
 	// Assert
 	require.NoError(t, err)
@@ -1986,7 +1986,7 @@ func TestIntegration_AccountRepository_FindAll_FiltersByNamePrefix(t *testing.T)
 	}
 
 	// Act
-	accounts, err := repo.FindAll(ctx, orgID, ledgerID, nil, nil, filter)
+	accounts, err := repo.FindAll(ctx, orgID, ledgerID, nil, nil, filter, mmodel.HolderOnV2)
 
 	// Assert
 	require.NoError(t, err)
@@ -2025,7 +2025,7 @@ func TestIntegration_AccountRepository_FindAll_FiltersByNamePrefix_CaseInsensiti
 	}
 
 	// Act
-	accounts, err := repo.FindAll(ctx, orgID, ledgerID, nil, nil, filter)
+	accounts, err := repo.FindAll(ctx, orgID, ledgerID, nil, nil, filter, mmodel.HolderOnV2)
 
 	// Assert
 	require.NoError(t, err)
@@ -2070,7 +2070,7 @@ func TestIntegration_AccountRepository_FindAll_FiltersByAliasPrefix(t *testing.T
 	}
 
 	// Act
-	accounts, err := repo.FindAll(ctx, orgID, ledgerID, nil, nil, filter)
+	accounts, err := repo.FindAll(ctx, orgID, ledgerID, nil, nil, filter, mmodel.HolderOnV2)
 
 	// Assert
 	require.NoError(t, err)
@@ -2120,7 +2120,7 @@ func TestIntegration_AccountRepository_FindAll_FiltersByAliasPrefix_CaseInsensit
 	}
 
 	// Act
-	accounts, err := repo.FindAll(ctx, orgID, ledgerID, nil, nil, filter)
+	accounts, err := repo.FindAll(ctx, orgID, ledgerID, nil, nil, filter, mmodel.HolderOnV2)
 
 	// Assert
 	require.NoError(t, err)
@@ -2160,7 +2160,7 @@ func TestIntegration_AccountRepository_FindAll_FiltersByNamePrefix_NoMiddleWordM
 	}
 
 	// Act
-	accounts, err := repo.FindAll(ctx, orgID, ledgerID, nil, nil, filter)
+	accounts, err := repo.FindAll(ctx, orgID, ledgerID, nil, nil, filter, mmodel.HolderOnV2)
 
 	// Assert
 	require.NoError(t, err)
@@ -2208,7 +2208,7 @@ func TestIntegration_AccountRepository_FindAll_FiltersByName_WildcardInjection(t
 				Name:      &nameFilter,
 			}
 
-			accounts, err := repo.FindAll(ctx, orgID, ledgerID, nil, nil, filter)
+			accounts, err := repo.FindAll(ctx, orgID, ledgerID, nil, nil, filter, mmodel.HolderOnV2)
 
 			require.NoError(t, err)
 			assert.Len(t, accounts, tt.expected, "wildcard injection '%s' should return %d results", tt.filter, tt.expected)
@@ -2244,7 +2244,7 @@ func TestIntegration_AccountRepository_FindAll_FiltersByName_LiteralSpecialChars
 	}
 
 	// Act
-	accounts, err := repo.FindAll(ctx, orgID, ledgerID, nil, nil, filter)
+	accounts, err := repo.FindAll(ctx, orgID, ledgerID, nil, nil, filter, mmodel.HolderOnV2)
 
 	// Assert
 	require.NoError(t, err)
@@ -2294,7 +2294,7 @@ func TestIntegration_AccountRepository_FindAll_CombinesNameAndAliasFilters(t *te
 	}
 
 	// Act
-	accounts, err := repo.FindAll(ctx, orgID, ledgerID, nil, nil, filter)
+	accounts, err := repo.FindAll(ctx, orgID, ledgerID, nil, nil, filter, mmodel.HolderOnV2)
 
 	// Assert
 	require.NoError(t, err)
@@ -2351,7 +2351,7 @@ func TestIntegration_AccountRepository_FindAll_FiltersByEntityID(t *testing.T) {
 	}
 
 	// Act
-	accounts, err := repo.FindAll(ctx, orgID, ledgerID, nil, nil, filter)
+	accounts, err := repo.FindAll(ctx, orgID, ledgerID, nil, nil, filter, mmodel.HolderOnV2)
 
 	// Assert
 	require.NoError(t, err)
@@ -2412,7 +2412,7 @@ func TestIntegration_AccountRepository_FindAll_FiltersByBlocked(t *testing.T) {
 	}
 
 	// Act
-	blockedAccounts, err := repo.FindAll(ctx, orgID, ledgerID, nil, nil, filterBlocked)
+	blockedAccounts, err := repo.FindAll(ctx, orgID, ledgerID, nil, nil, filterBlocked, mmodel.HolderOnV2)
 
 	// Assert
 	require.NoError(t, err)
@@ -2435,7 +2435,7 @@ func TestIntegration_AccountRepository_FindAll_FiltersByBlocked(t *testing.T) {
 	}
 
 	// Act
-	activeAccounts, err := repo.FindAll(ctx, orgID, ledgerID, nil, nil, filterNotBlocked)
+	activeAccounts, err := repo.FindAll(ctx, orgID, ledgerID, nil, nil, filterNotBlocked, mmodel.HolderOnV2)
 
 	// Assert
 	require.NoError(t, err)
@@ -2499,7 +2499,7 @@ func TestIntegration_AccountRepository_FindAll_FiltersByParentAccountID(t *testi
 	}
 
 	// Act
-	accounts, err := repo.FindAll(ctx, orgID, ledgerID, nil, nil, filter)
+	accounts, err := repo.FindAll(ctx, orgID, ledgerID, nil, nil, filter, mmodel.HolderOnV2)
 
 	// Assert
 	require.NoError(t, err)
@@ -2590,11 +2590,11 @@ func TestIntegration_AccountRepository_SkipAudit_RoundTrip(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("Find single-row scan reads the flag back", func(t *testing.T) {
-		foundSkipped, err := repo.Find(ctx, orgID, ledgerID, nil, skippedID)
+		foundSkipped, err := repo.Find(ctx, orgID, ledgerID, nil, skippedID, mmodel.HolderOnV2)
 		require.NoError(t, err)
 		assert.True(t, foundSkipped.HolderCheckSkipped, "Find: skipped account holder_check_skipped should round-trip true")
 
-		foundControl, err := repo.Find(ctx, orgID, ledgerID, nil, controlID)
+		foundControl, err := repo.Find(ctx, orgID, ledgerID, nil, controlID, mmodel.HolderOnV2)
 		require.NoError(t, err)
 		assert.False(t, foundControl.HolderCheckSkipped, "Find: control holder_check_skipped should round-trip false")
 	})
@@ -2602,7 +2602,7 @@ func TestIntegration_AccountRepository_SkipAudit_RoundTrip(t *testing.T) {
 	t.Run("ListByIDs list scan reads the flag back", func(t *testing.T) {
 		// ListByIDs exercises a DIFFERENT Scan call site than Find, so the
 		// list-derived column order is proven independently here.
-		accounts, err := repo.ListByIDs(ctx, orgID, ledgerID, nil, nil, []uuid.UUID{skippedID, controlID})
+		accounts, err := repo.ListByIDs(ctx, orgID, ledgerID, nil, nil, []uuid.UUID{skippedID, controlID}, mmodel.HolderOnV2)
 		require.NoError(t, err)
 		require.Len(t, accounts, 2)
 
@@ -2668,7 +2668,7 @@ func TestIntegration_AccountRepository_Create_RoundTripsHolderID(t *testing.T) {
 	parsedID, err := uuid.Parse(created.ID)
 	require.NoError(t, err)
 
-	found, err := repo.Find(ctx, orgID, ledgerID, nil, parsedID)
+	found, err := repo.Find(ctx, orgID, ledgerID, nil, parsedID, mmodel.HolderOnV2)
 	require.NoError(t, err, "Find should not return error")
 	require.NotNil(t, found.HolderID, "found account holder_id should not be nil")
 	assert.Equal(t, holderID, *found.HolderID, "found account holder_id should round-trip")
@@ -2682,7 +2682,7 @@ func TestIntegration_AccountRepository_Create_RoundTripsHolderID(t *testing.T) {
 		EndDate:   now.Add(24 * time.Hour),
 	}
 
-	accounts, err := repo.FindAll(ctx, orgID, ledgerID, nil, nil, filter)
+	accounts, err := repo.FindAll(ctx, orgID, ledgerID, nil, nil, filter, mmodel.HolderOnV2)
 	require.NoError(t, err, "FindAll should not return error")
 	require.Len(t, accounts, 1, "should return the single created account")
 	require.NotNil(t, accounts[0].HolderID, "listed account holder_id should not be nil")
@@ -2753,7 +2753,7 @@ func TestIntegration_AccountRepository_FindAll_FiltersByHolderID(t *testing.T) {
 	}
 
 	// Act
-	accounts, err := repo.FindAll(ctx, orgID, ledgerID, nil, nil, filter)
+	accounts, err := repo.FindAll(ctx, orgID, ledgerID, nil, nil, filter, mmodel.HolderOnV2)
 
 	// Assert
 	require.NoError(t, err, "FindAll should not return error")

--- a/components/ledger/internal/adapters/postgres/account/account.postgresql_mock.go
+++ b/components/ledger/internal/adapters/postgres/account/account.postgresql_mock.go
@@ -103,48 +103,48 @@ func (mr *MockRepositoryMockRecorder) Delete(ctx, organizationID, ledgerID, port
 }
 
 // Find mocks base method.
-func (m *MockRepository) Find(ctx context.Context, organizationID, ledgerID uuid.UUID, portfolioID *uuid.UUID, id uuid.UUID) (*mmodel.Account, error) {
+func (m *MockRepository) Find(ctx context.Context, organizationID, ledgerID uuid.UUID, portfolioID *uuid.UUID, id uuid.UUID, holderPolicy mmodel.HolderPolicy) (*mmodel.Account, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Find", ctx, organizationID, ledgerID, portfolioID, id)
+	ret := m.ctrl.Call(m, "Find", ctx, organizationID, ledgerID, portfolioID, id, holderPolicy)
 	ret0, _ := ret[0].(*mmodel.Account)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Find indicates an expected call of Find.
-func (mr *MockRepositoryMockRecorder) Find(ctx, organizationID, ledgerID, portfolioID, id any) *gomock.Call {
+func (mr *MockRepositoryMockRecorder) Find(ctx, organizationID, ledgerID, portfolioID, id, holderPolicy any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Find", reflect.TypeOf((*MockRepository)(nil).Find), ctx, organizationID, ledgerID, portfolioID, id)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Find", reflect.TypeOf((*MockRepository)(nil).Find), ctx, organizationID, ledgerID, portfolioID, id, holderPolicy)
 }
 
 // FindAlias mocks base method.
-func (m *MockRepository) FindAlias(ctx context.Context, organizationID, ledgerID uuid.UUID, portfolioID *uuid.UUID, alias string) (*mmodel.Account, error) {
+func (m *MockRepository) FindAlias(ctx context.Context, organizationID, ledgerID uuid.UUID, portfolioID *uuid.UUID, alias string, holderPolicy mmodel.HolderPolicy) (*mmodel.Account, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "FindAlias", ctx, organizationID, ledgerID, portfolioID, alias)
+	ret := m.ctrl.Call(m, "FindAlias", ctx, organizationID, ledgerID, portfolioID, alias, holderPolicy)
 	ret0, _ := ret[0].(*mmodel.Account)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // FindAlias indicates an expected call of FindAlias.
-func (mr *MockRepositoryMockRecorder) FindAlias(ctx, organizationID, ledgerID, portfolioID, alias any) *gomock.Call {
+func (mr *MockRepositoryMockRecorder) FindAlias(ctx, organizationID, ledgerID, portfolioID, alias, holderPolicy any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindAlias", reflect.TypeOf((*MockRepository)(nil).FindAlias), ctx, organizationID, ledgerID, portfolioID, alias)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindAlias", reflect.TypeOf((*MockRepository)(nil).FindAlias), ctx, organizationID, ledgerID, portfolioID, alias, holderPolicy)
 }
 
 // FindAll mocks base method.
-func (m *MockRepository) FindAll(ctx context.Context, organizationID, ledgerID uuid.UUID, portfolioID, segmentID *uuid.UUID, filter http.QueryHeader) ([]*mmodel.Account, error) {
+func (m *MockRepository) FindAll(ctx context.Context, organizationID, ledgerID uuid.UUID, portfolioID, segmentID *uuid.UUID, filter http.QueryHeader, holderPolicy mmodel.HolderPolicy) ([]*mmodel.Account, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "FindAll", ctx, organizationID, ledgerID, portfolioID, segmentID, filter)
+	ret := m.ctrl.Call(m, "FindAll", ctx, organizationID, ledgerID, portfolioID, segmentID, filter, holderPolicy)
 	ret0, _ := ret[0].([]*mmodel.Account)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // FindAll indicates an expected call of FindAll.
-func (mr *MockRepositoryMockRecorder) FindAll(ctx, organizationID, ledgerID, portfolioID, segmentID, filter any) *gomock.Call {
+func (mr *MockRepositoryMockRecorder) FindAll(ctx, organizationID, ledgerID, portfolioID, segmentID, filter, holderPolicy any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindAll", reflect.TypeOf((*MockRepository)(nil).FindAll), ctx, organizationID, ledgerID, portfolioID, segmentID, filter)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindAll", reflect.TypeOf((*MockRepository)(nil).FindAll), ctx, organizationID, ledgerID, portfolioID, segmentID, filter, holderPolicy)
 }
 
 // FindByAlias mocks base method.
@@ -163,18 +163,18 @@ func (mr *MockRepositoryMockRecorder) FindByAlias(ctx, organizationID, ledgerID,
 }
 
 // FindWithDeleted mocks base method.
-func (m *MockRepository) FindWithDeleted(ctx context.Context, organizationID, ledgerID uuid.UUID, portfolioID *uuid.UUID, id uuid.UUID) (*mmodel.Account, error) {
+func (m *MockRepository) FindWithDeleted(ctx context.Context, organizationID, ledgerID uuid.UUID, portfolioID *uuid.UUID, id uuid.UUID, holderPolicy mmodel.HolderPolicy) (*mmodel.Account, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "FindWithDeleted", ctx, organizationID, ledgerID, portfolioID, id)
+	ret := m.ctrl.Call(m, "FindWithDeleted", ctx, organizationID, ledgerID, portfolioID, id, holderPolicy)
 	ret0, _ := ret[0].(*mmodel.Account)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // FindWithDeleted indicates an expected call of FindWithDeleted.
-func (mr *MockRepositoryMockRecorder) FindWithDeleted(ctx, organizationID, ledgerID, portfolioID, id any) *gomock.Call {
+func (mr *MockRepositoryMockRecorder) FindWithDeleted(ctx, organizationID, ledgerID, portfolioID, id, holderPolicy any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindWithDeleted", reflect.TypeOf((*MockRepository)(nil).FindWithDeleted), ctx, organizationID, ledgerID, portfolioID, id)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindWithDeleted", reflect.TypeOf((*MockRepository)(nil).FindWithDeleted), ctx, organizationID, ledgerID, portfolioID, id, holderPolicy)
 }
 
 // ListAccountsByAlias mocks base method.
@@ -208,33 +208,33 @@ func (mr *MockRepositoryMockRecorder) ListAccountsByIDs(ctx, organizationID, led
 }
 
 // ListByAlias mocks base method.
-func (m *MockRepository) ListByAlias(ctx context.Context, organizationID, ledgerID, portfolioID uuid.UUID, alias []string) ([]*mmodel.Account, error) {
+func (m *MockRepository) ListByAlias(ctx context.Context, organizationID, ledgerID, portfolioID uuid.UUID, alias []string, holderPolicy mmodel.HolderPolicy) ([]*mmodel.Account, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListByAlias", ctx, organizationID, ledgerID, portfolioID, alias)
+	ret := m.ctrl.Call(m, "ListByAlias", ctx, organizationID, ledgerID, portfolioID, alias, holderPolicy)
 	ret0, _ := ret[0].([]*mmodel.Account)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ListByAlias indicates an expected call of ListByAlias.
-func (mr *MockRepositoryMockRecorder) ListByAlias(ctx, organizationID, ledgerID, portfolioID, alias any) *gomock.Call {
+func (mr *MockRepositoryMockRecorder) ListByAlias(ctx, organizationID, ledgerID, portfolioID, alias, holderPolicy any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListByAlias", reflect.TypeOf((*MockRepository)(nil).ListByAlias), ctx, organizationID, ledgerID, portfolioID, alias)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListByAlias", reflect.TypeOf((*MockRepository)(nil).ListByAlias), ctx, organizationID, ledgerID, portfolioID, alias, holderPolicy)
 }
 
 // ListByIDs mocks base method.
-func (m *MockRepository) ListByIDs(ctx context.Context, organizationID, ledgerID uuid.UUID, portfolioID, segmentID *uuid.UUID, ids []uuid.UUID) ([]*mmodel.Account, error) {
+func (m *MockRepository) ListByIDs(ctx context.Context, organizationID, ledgerID uuid.UUID, portfolioID, segmentID *uuid.UUID, ids []uuid.UUID, holderPolicy mmodel.HolderPolicy) ([]*mmodel.Account, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListByIDs", ctx, organizationID, ledgerID, portfolioID, segmentID, ids)
+	ret := m.ctrl.Call(m, "ListByIDs", ctx, organizationID, ledgerID, portfolioID, segmentID, ids, holderPolicy)
 	ret0, _ := ret[0].([]*mmodel.Account)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ListByIDs indicates an expected call of ListByIDs.
-func (mr *MockRepositoryMockRecorder) ListByIDs(ctx, organizationID, ledgerID, portfolioID, segmentID, ids any) *gomock.Call {
+func (mr *MockRepositoryMockRecorder) ListByIDs(ctx, organizationID, ledgerID, portfolioID, segmentID, ids, holderPolicy any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListByIDs", reflect.TypeOf((*MockRepository)(nil).ListByIDs), ctx, organizationID, ledgerID, portfolioID, segmentID, ids)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListByIDs", reflect.TypeOf((*MockRepository)(nil).ListByIDs), ctx, organizationID, ledgerID, portfolioID, segmentID, ids, holderPolicy)
 }
 
 // ListExternalAccountsByAssetCode mocks base method.

--- a/components/ledger/internal/adapters/postgres/account/account_holder_projection_test.go
+++ b/components/ledger/internal/adapters/postgres/account/account_holder_projection_test.go
@@ -1,0 +1,216 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package account
+
+import (
+	"testing"
+	"time"
+
+	"github.com/Masterminds/squirrel"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/LerianStudio/midaz/v4/pkg/mmodel"
+)
+
+// holderIDPosition and holderCheckSkippedPosition are the indices the positional
+// Scan calls in every read assume for the two holder columns. Both projections
+// must agree on them, or a read decodes the wrong column into the wrong field.
+const (
+	holderIDPosition           = 4
+	holderCheckSkippedPosition = 18
+	accountColumnCount         = 19
+)
+
+func TestAccountColumns_HolderProjectionKeepsShape(t *testing.T) {
+	withHolder := accountColumns(true)
+	withoutHolder := accountColumns(false)
+
+	require.Len(t, withHolder, accountColumnCount)
+	require.Len(t, withoutHolder, accountColumnCount,
+		"withholding the holder columns must substitute them, not drop them")
+
+	assert.Equal(t, "holder_id", withHolder[holderIDPosition])
+	assert.Equal(t, "holder_check_skipped", withHolder[holderCheckSkippedPosition])
+
+	assert.Equal(t, "NULL::uuid AS holder_id", withoutHolder[holderIDPosition])
+	assert.Equal(t, "FALSE AS holder_check_skipped", withoutHolder[holderCheckSkippedPosition])
+
+	for i := range withHolder {
+		if i == holderIDPosition || i == holderCheckSkippedPosition {
+			continue
+		}
+
+		assert.Equal(t, withHolder[i], withoutHolder[i],
+			"only the holder columns may differ between projections (index %d)", i)
+	}
+}
+
+// A /v1 projection must not name the columns migrations 000017 and 000019 add,
+// so the statement parses against a database that predates them.
+func TestAccountColumns_V1ProjectionNamesNoHolderColumn(t *testing.T) {
+	query, _, err := squirrel.Select(accountColumns(mmodel.HolderOffV1.ProjectsHolder())...).
+		From("account").
+		PlaceholderFormat(squirrel.Dollar).
+		ToSql()
+	require.NoError(t, err)
+
+	assert.NotContains(t, query, ", holder_id")
+	assert.NotContains(t, query, ", holder_check_skipped")
+	assert.Contains(t, query, "NULL::uuid AS holder_id")
+	assert.Contains(t, query, "FALSE AS holder_check_skipped")
+}
+
+func TestAccountColumns_V2ProjectionNamesHolderColumns(t *testing.T) {
+	query, _, err := squirrel.Select(accountColumns(mmodel.HolderOnV2.ProjectsHolder())...).
+		From("account").
+		PlaceholderFormat(squirrel.Dollar).
+		ToSql()
+	require.NoError(t, err)
+
+	assert.Contains(t, query, "holder_id")
+	assert.Contains(t, query, "holder_check_skipped")
+	assert.NotContains(t, query, "NULL::uuid")
+}
+
+func TestHolderPolicy_ProjectsHolder(t *testing.T) {
+	assert.False(t, mmodel.HolderOffV1.ProjectsHolder())
+	assert.True(t, mmodel.HolderOnV2.ProjectsHolder())
+
+	var zero mmodel.HolderPolicy
+	assert.False(t, zero.ProjectsHolder(), "the zero value must be the /v1 side")
+}
+
+// buildCreateSQL mirrors the column/value assembly of Create so the INSERT shape
+// can be asserted without a database.
+func buildCreateSQL(t *testing.T, acc *mmodel.Account) string {
+	t.Helper()
+
+	record := &AccountPostgreSQLModel{}
+	record.FromEntity(acc)
+
+	columns := []string{
+		"id", "name", "parent_account_id", "entity_id", "asset_code",
+		"organization_id", "ledger_id", "portfolio_id", "segment_id", "status",
+		"status_description", "alias", "type", "created_at", "updated_at",
+		"deleted_at", "blocked",
+	}
+	values := []any{
+		record.ID, record.Name, record.ParentAccountID, record.EntityID, record.AssetCode,
+		record.OrganizationID, record.LedgerID, record.PortfolioID, record.SegmentID, record.Status,
+		record.StatusDescription, record.Alias, record.Type, record.CreatedAt, record.UpdatedAt,
+		record.DeletedAt, record.Blocked,
+	}
+
+	if record.HolderID != nil || record.HolderCheckSkipped {
+		columns = append(columns, holderIDColumn, holderCheckSkippedColumn)
+		values = append(values, record.HolderID, record.HolderCheckSkipped)
+	}
+
+	query, _, err := squirrel.Insert("account").
+		Columns(columns...).
+		Values(values...).
+		PlaceholderFormat(squirrel.Dollar).
+		ToSql()
+	require.NoError(t, err)
+
+	return query
+}
+
+func newAccountFixture() *mmodel.Account {
+	created := time.Date(2026, 8, 27, 12, 0, 0, 0, time.UTC)
+
+	return &mmodel.Account{
+		ID:             "0198f0a0-0000-7000-8000-000000000001",
+		Name:           "Test Account",
+		AssetCode:      "USD",
+		OrganizationID: "0198f0a0-0000-7000-8000-000000000002",
+		LedgerID:       "0198f0a0-0000-7000-8000-000000000003",
+		Type:           "deposit",
+		Status:         mmodel.Status{Code: "ACTIVE"},
+		CreatedAt:      created,
+		UpdatedAt:      created,
+	}
+}
+
+// An account carrying no holder writes what the columns default to, so omitting
+// them persists the identical row and keeps the statement parseable pre-000017.
+func TestCreate_OmitsHolderColumnsWhenAccountCarriesNoHolder(t *testing.T) {
+	query := buildCreateSQL(t, newAccountFixture())
+
+	assert.NotContains(t, query, "holder_id")
+	assert.NotContains(t, query, "holder_check_skipped")
+	assert.Equal(t, 17, countPlaceholders(query))
+}
+
+func TestCreate_NamesHolderColumnsWhenHolderIsLinked(t *testing.T) {
+	acc := newAccountFixture()
+	holderID := "0198f0a0-0000-7000-8000-000000000004"
+	acc.HolderID = &holderID
+
+	query := buildCreateSQL(t, acc)
+
+	assert.Contains(t, query, "holder_id")
+	assert.Contains(t, query, "holder_check_skipped")
+	assert.Equal(t, 19, countPlaceholders(query))
+}
+
+// An honored skip is a durable audit fact with no holder id, so it alone has to
+// carry the columns into the statement.
+func TestCreate_NamesHolderColumnsWhenOnlySkipIsRecorded(t *testing.T) {
+	acc := newAccountFixture()
+	acc.HolderCheckSkipped = true
+
+	query := buildCreateSQL(t, acc)
+
+	assert.Contains(t, query, "holder_check_skipped")
+	assert.Equal(t, 19, countPlaceholders(query))
+}
+
+func countPlaceholders(query string) int {
+	n := 0
+
+	for i := 1; ; i++ {
+		if !containsPlaceholder(query, i) {
+			return n
+		}
+
+		n = i
+	}
+}
+
+func containsPlaceholder(query string, n int) bool {
+	needle := "$" + itoa(n)
+
+	for i := 0; i+len(needle) <= len(query); i++ {
+		if query[i:i+len(needle)] != needle {
+			continue
+		}
+
+		// Reject a prefix match such as $1 inside $12.
+		if i+len(needle) < len(query) && query[i+len(needle)] >= '0' && query[i+len(needle)] <= '9' {
+			continue
+		}
+
+		return true
+	}
+
+	return false
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+
+	var buf []byte
+
+	for n > 0 {
+		buf = append([]byte{byte('0' + n%10)}, buf...)
+		n /= 10
+	}
+
+	return string(buf)
+}

--- a/components/ledger/internal/adapters/postgres/account/account_schema_drift_integration_test.go
+++ b/components/ledger/internal/adapters/postgres/account/account_schema_drift_integration_test.go
@@ -1,0 +1,267 @@
+//go:build integration
+
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package account
+
+import (
+	"database/sql"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	libCommons "github.com/LerianStudio/lib-commons/v6/commons"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/LerianStudio/midaz/v4/pkg"
+	"github.com/LerianStudio/midaz/v4/pkg/constant"
+	"github.com/LerianStudio/midaz/v4/pkg/mmodel"
+	"github.com/LerianStudio/midaz/v4/pkg/net/http"
+	pgtestutil "github.com/LerianStudio/midaz/v4/tests/utils/postgres"
+)
+
+// driftToPreHolderSchema rewinds the account table to the shape it had before
+// migrations 000017 and 000019, by applying those migrations' own down files.
+// Reusing the repository's own SQL keeps the fixture honest: it cannot drift from
+// what the up migrations add.
+func driftToPreHolderSchema(t *testing.T, db *sql.DB) {
+	t.Helper()
+
+	dir := pgtestutil.FindMigrationsPath(t, "onboarding")
+
+	// Reverse order, as golang-migrate would roll them back.
+	for _, name := range []string{
+		"000019_add_holder_skip_audit_to_account.down.sql",
+		"000018_create_idx_account_holder.down.sql",
+		"000017_add_account_holder_id_column.down.sql",
+	} {
+		content, err := os.ReadFile(filepath.Join(dir, name))
+		require.NoErrorf(t, err, "failed to read %s", name)
+
+		// The index drop is CONCURRENTLY, which cannot run inside the implicit
+		// transaction of a multi-statement Exec; the column drop removes it anyway.
+		if name == "000018_create_idx_account_holder.down.sql" {
+			continue
+		}
+
+		_, err = db.Exec(string(content))
+		require.NoErrorf(t, err, "failed to apply %s", name)
+	}
+
+	requireHolderColumnsAbsent(t, db)
+}
+
+func requireHolderColumnsAbsent(t *testing.T, db *sql.DB) {
+	t.Helper()
+
+	for _, column := range []string{"holder_id", "holder_check_skipped"} {
+		var exists bool
+		err := db.QueryRow(`
+			SELECT EXISTS (
+				SELECT 1 FROM information_schema.columns
+				WHERE table_name = 'account' AND column_name = $1
+			)`, column).Scan(&exists)
+		require.NoError(t, err)
+		require.Falsef(t, exists, "fixture is not drifted: account.%s still exists", column)
+	}
+}
+
+// driftedLedger returns a repository and ledger scope on a database whose account
+// table predates the holder columns.
+func driftedLedger(t *testing.T) (*AccountPostgreSQLRepository, *sql.DB, uuid.UUID, uuid.UUID) {
+	t.Helper()
+
+	container := pgtestutil.SetupMigratedContainer(t, "onboarding")
+	driftToPreHolderSchema(t, container.DB)
+
+	repo := createRepository(t, container)
+	orgID := pgtestutil.CreateTestOrganization(t, container.DB)
+	ledgerID := pgtestutil.CreateTestLedger(t, container.DB, orgID)
+	pgtestutil.CreateTestAsset(t, container.DB, orgID, ledgerID, "USD")
+
+	return repo, container.DB, orgID, ledgerID
+}
+
+func newDriftAccount(orgID, ledgerID uuid.UUID) *mmodel.Account {
+	now := time.Now().Truncate(time.Microsecond)
+	alias := fmt.Sprintf("@drift-%s", uuid.Must(libCommons.GenerateUUIDv7()).String()[:8])
+	blocked := false
+
+	return &mmodel.Account{
+		ID:             uuid.Must(libCommons.GenerateUUIDv7()).String(),
+		Name:           "Drift Account",
+		AssetCode:      "USD",
+		OrganizationID: orgID.String(),
+		LedgerID:       ledgerID.String(),
+		Type:           "deposit",
+		Alias:          &alias,
+		Status:         mmodel.Status{Code: "ACTIVE"},
+		Blocked:        &blocked,
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}
+}
+
+// The /v1 contract links no holder, so a create on it must not depend on columns
+// the applied migrations have not created.
+func TestIntegration_SchemaDrift_V1CreateSucceeds(t *testing.T) {
+	repo, _, orgID, ledgerID := driftedLedger(t)
+
+	created, err := repo.Create(t.Context(), newDriftAccount(orgID, ledgerID))
+
+	require.NoError(t, err, "a /v1 create must not require migration 000017/000019")
+	require.NotNil(t, created)
+	assert.Nil(t, created.HolderID)
+	assert.False(t, created.HolderCheckSkipped)
+}
+
+func TestIntegration_SchemaDrift_V1ReadsSucceed(t *testing.T) {
+	repo, _, orgID, ledgerID := driftedLedger(t)
+	ctx := t.Context()
+
+	acc := newDriftAccount(orgID, ledgerID)
+	_, err := repo.Create(ctx, acc)
+	require.NoError(t, err)
+
+	accountID := uuid.MustParse(acc.ID)
+
+	found, err := repo.Find(ctx, orgID, ledgerID, nil, accountID, mmodel.HolderOffV1)
+	require.NoError(t, err, "a /v1 get must not require the holder columns")
+	assert.Nil(t, found.HolderID)
+	assert.False(t, found.HolderCheckSkipped)
+
+	listed, err := repo.FindAll(ctx, orgID, ledgerID, nil, nil, http.QueryHeader{
+		Limit: 10, Page: 1, SortOrder: "desc",
+	}, mmodel.HolderOffV1)
+	require.NoError(t, err, "a /v1 list must not require the holder columns")
+	require.Len(t, listed, 1)
+	assert.Nil(t, listed[0].HolderID)
+
+	byAlias, err := repo.FindAlias(ctx, orgID, ledgerID, nil, *acc.Alias, mmodel.HolderOffV1)
+	require.NoError(t, err, "a /v1 get-by-alias must not require the holder columns")
+	assert.Nil(t, byAlias.HolderID)
+}
+
+// The transaction path resolves accounts by alias and by id on both contracts and
+// never reads a holder, so it must be immune to the drift as well.
+func TestIntegration_SchemaDrift_TransactionAccountLookupsSucceed(t *testing.T) {
+	repo, _, orgID, ledgerID := driftedLedger(t)
+	ctx := t.Context()
+
+	acc := newDriftAccount(orgID, ledgerID)
+	_, err := repo.Create(ctx, acc)
+	require.NoError(t, err)
+
+	byAlias, err := repo.ListAccountsByAlias(ctx, orgID, ledgerID, []string{*acc.Alias})
+	require.NoError(t, err, "transaction alias resolution must survive the drift")
+	require.Len(t, byAlias, 1)
+
+	byIDs, err := repo.ListAccountsByIDs(ctx, orgID, ledgerID, []uuid.UUID{uuid.MustParse(acc.ID)})
+	require.NoError(t, err, "transaction id resolution must survive the drift")
+	require.Len(t, byIDs, 1)
+}
+
+// /v2 cannot honor its contract without the columns, so it must fail with the
+// retryable sentinel rather than an opaque 500.
+func TestIntegration_SchemaDrift_V2CreateWithHolderReportsMigrationPending(t *testing.T) {
+	repo, _, orgID, ledgerID := driftedLedger(t)
+
+	acc := newDriftAccount(orgID, ledgerID)
+	holderID := uuid.Must(libCommons.GenerateUUIDv7()).String()
+	acc.HolderID = &holderID
+
+	_, err := repo.Create(t.Context(), acc)
+
+	require.Error(t, err)
+
+	var unavailable pkg.ServiceUnavailableError
+	require.ErrorAs(t, err, &unavailable)
+	assert.Equal(t, constant.ErrSchemaMigrationPending.Error(), unavailable.Code)
+}
+
+func TestIntegration_SchemaDrift_V2ReadsReportMigrationPending(t *testing.T) {
+	repo, _, orgID, ledgerID := driftedLedger(t)
+	ctx := t.Context()
+
+	acc := newDriftAccount(orgID, ledgerID)
+	_, err := repo.Create(ctx, acc)
+	require.NoError(t, err)
+
+	accountID := uuid.MustParse(acc.ID)
+
+	reads := map[string]func() error{
+		"Find": func() error {
+			_, err := repo.Find(ctx, orgID, ledgerID, nil, accountID, mmodel.HolderOnV2)
+			return err
+		},
+		"FindAll": func() error {
+			_, err := repo.FindAll(ctx, orgID, ledgerID, nil, nil, http.QueryHeader{
+				Limit: 10, Page: 1, SortOrder: "desc",
+			}, mmodel.HolderOnV2)
+			return err
+		},
+		"FindAlias": func() error {
+			_, err := repo.FindAlias(ctx, orgID, ledgerID, nil, *acc.Alias, mmodel.HolderOnV2)
+			return err
+		},
+		"FindWithDeleted": func() error {
+			_, err := repo.FindWithDeleted(ctx, orgID, ledgerID, nil, accountID, mmodel.HolderOnV2)
+			return err
+		},
+	}
+
+	for name, read := range reads {
+		t.Run(name, func(t *testing.T) {
+			err := read()
+			require.Error(t, err, "a /v2 read must not silently answer with a null holder")
+
+			// The read must carry the cause, not fall through as an opaque 500.
+			var unavailable pkg.ServiceUnavailableError
+			require.ErrorAs(t, err, &unavailable)
+			assert.Equal(t, constant.ErrSchemaMigrationPending.Error(), unavailable.Code)
+		})
+	}
+}
+
+// Parity: the /v1 contract must behave identically once the migrations land, so
+// the mitigation is permanent rather than a transitional shim.
+func TestIntegration_SchemaDrift_V1ParityAfterMigrationsApplied(t *testing.T) {
+	container := pgtestutil.SetupMigratedContainer(t, "onboarding")
+	repo := createRepository(t, container)
+	ctx := t.Context()
+
+	orgID := pgtestutil.CreateTestOrganization(t, container.DB)
+	ledgerID := pgtestutil.CreateTestLedger(t, container.DB, orgID)
+	pgtestutil.CreateTestAsset(t, container.DB, orgID, ledgerID, "USD")
+
+	acc := newDriftAccount(orgID, ledgerID)
+	created, err := repo.Create(ctx, acc)
+	require.NoError(t, err)
+	assert.Nil(t, created.HolderID)
+	assert.False(t, created.HolderCheckSkipped)
+
+	found, err := repo.Find(ctx, orgID, ledgerID, nil, uuid.MustParse(acc.ID), mmodel.HolderOffV1)
+	require.NoError(t, err)
+	assert.Nil(t, found.HolderID)
+	assert.False(t, found.HolderCheckSkipped)
+
+	// The persisted row carries exactly what the columns default to, which is what
+	// the /v1 contract documents and what the drifted database produces.
+	var (
+		holderID           *string
+		holderCheckSkipped bool
+	)
+
+	err = container.DB.QueryRow(
+		`SELECT holder_id, holder_check_skipped FROM account WHERE id = $1`, acc.ID,
+	).Scan(&holderID, &holderCheckSkipped)
+	require.NoError(t, err)
+	assert.Nil(t, holderID, "a /v1 create must persist holder_id NULL")
+	assert.False(t, holderCheckSkipped, "a /v1 create must persist holder_check_skipped false")
+}

--- a/components/ledger/internal/adapters/postgres/account/account_schema_drift_integration_test.go
+++ b/components/ledger/internal/adapters/postgres/account/account_schema_drift_integration_test.go
@@ -88,8 +88,12 @@ func driftedLedger(t *testing.T) (*AccountPostgreSQLRepository, *sql.DB, uuid.UU
 	return repo, container.DB, orgID, ledgerID
 }
 
+// driftTestTime is a fixed timestamp: these tests assert schema tolerance, so the
+// create/update instants carry no meaning and must not vary between runs.
+var driftTestTime = time.Date(2026, 8, 27, 12, 0, 0, 0, time.UTC)
+
 func newDriftAccount(orgID, ledgerID uuid.UUID) *mmodel.Account {
-	now := time.Now().Truncate(time.Microsecond)
+	now := driftTestTime
 	alias := fmt.Sprintf("@drift-%s", uuid.Must(libCommons.GenerateUUIDv7()).String()[:8])
 	blocked := false
 
@@ -264,4 +268,59 @@ func TestIntegration_SchemaDrift_V1ParityAfterMigrationsApplied(t *testing.T) {
 	require.NoError(t, err)
 	assert.Nil(t, holderID, "a /v1 create must persist holder_id NULL")
 	assert.False(t, holderCheckSkipped, "a /v1 create must persist holder_check_skipped false")
+}
+
+// A /v2 update on a schema without the holder columns must fail at the lookup,
+// BEFORE the row is mutated. The update statement itself names no holder column,
+// so without the route policy on the lookup the mutation would land and the
+// account.updated event would fire, and only the caller's re-read would 503 —
+// a failure status over a write that actually happened.
+func TestIntegration_SchemaDrift_V2UpdateFailsBeforeMutating(t *testing.T) {
+	repo, db, orgID, ledgerID := driftedLedger(t)
+	ctx := t.Context()
+
+	acc := newDriftAccount(orgID, ledgerID)
+	_, err := repo.Create(ctx, acc)
+	require.NoError(t, err)
+
+	accountID := uuid.MustParse(acc.ID)
+	originalName := acc.Name
+
+	// The lookup a /v2 update performs before mutating.
+	_, err = repo.Find(ctx, orgID, ledgerID, nil, accountID, mmodel.HolderOnV2)
+
+	require.Error(t, err, "a /v2 update must not get past the lookup on this schema")
+
+	var unavailable pkg.ServiceUnavailableError
+	require.ErrorAs(t, err, &unavailable)
+	assert.Equal(t, constant.ErrSchemaMigrationPending.Error(), unavailable.Code)
+
+	var persistedName string
+	require.NoError(t, db.QueryRow(`SELECT name FROM account WHERE id = $1`, acc.ID).Scan(&persistedName))
+	assert.Equal(t, originalName, persistedName, "the row must be untouched")
+}
+
+// The /v1 counterpart completes: its lookup names no holder column, and neither
+// does the update statement.
+func TestIntegration_SchemaDrift_V1UpdateSucceeds(t *testing.T) {
+	repo, db, orgID, ledgerID := driftedLedger(t)
+	ctx := t.Context()
+
+	acc := newDriftAccount(orgID, ledgerID)
+	_, err := repo.Create(ctx, acc)
+	require.NoError(t, err)
+
+	accountID := uuid.MustParse(acc.ID)
+
+	found, err := repo.Find(ctx, orgID, ledgerID, nil, accountID, mmodel.HolderOffV1)
+	require.NoError(t, err, "a /v1 update must get past the lookup")
+	require.NotNil(t, found)
+
+	renamed := "Drift Account Renamed"
+	_, err = repo.Update(ctx, orgID, ledgerID, nil, accountID, &mmodel.Account{Name: renamed})
+	require.NoError(t, err, "the update statement names no holder column")
+
+	var persistedName string
+	require.NoError(t, db.QueryRow(`SELECT name FROM account WHERE id = $1`, acc.ID).Scan(&persistedName))
+	assert.Equal(t, renamed, persistedName)
 }

--- a/components/ledger/internal/bootstrap/holder_wiring.go
+++ b/components/ledger/internal/bootstrap/holder_wiring.go
@@ -75,5 +75,7 @@ func (a holderAccountsReaderAdapter) ListAccountsByHolder(ctx context.Context, o
 		return nil, pkg.ValidateBusinessError(constant.ErrLedgerIDNotFound, constant.EntityLedger)
 	}
 
-	return a.query.GetAllAccount(ctx, orgID, ledgerID, nil, nil, filter)
+	// HolderOnV2: the holder-accounts route is served on /v2 only, so the
+	// accounts it answers with carry the holder keys.
+	return a.query.GetAllAccount(ctx, orgID, ledgerID, nil, nil, filter, mmodel.HolderOnV2)
 }

--- a/components/ledger/internal/bootstrap/instrument_refs_wiring.go
+++ b/components/ledger/internal/bootstrap/instrument_refs_wiring.go
@@ -11,6 +11,7 @@ import (
 	"github.com/LerianStudio/midaz/v4/components/ledger/internal/services/query"
 	"github.com/LerianStudio/midaz/v4/pkg"
 	"github.com/LerianStudio/midaz/v4/pkg/constant"
+	"github.com/LerianStudio/midaz/v4/pkg/mmodel"
 	"github.com/google/uuid"
 )
 
@@ -45,7 +46,8 @@ func (a ledgerAccountReaderAdapter) LedgerExists(ctx context.Context, organizati
 // directly. An account-not-found business error is mapped to (false, nil);
 // every other error propagates.
 func (a ledgerAccountReaderAdapter) AccountExists(ctx context.Context, organizationID, ledgerID, accountID uuid.UUID) (bool, error) {
-	if _, err := a.query.GetAccountByID(ctx, organizationID, ledgerID, nil, accountID); err != nil {
+	// HolderOffV1: this is an existence check; the account is never serialized.
+	if _, err := a.query.GetAccountByID(ctx, organizationID, ledgerID, nil, accountID, mmodel.HolderOffV1); err != nil {
 		var notFound pkg.EntityNotFoundError
 		if errors.As(err, &notFound) && notFound.Code == constant.ErrAccountIDNotFound.Error() {
 			return false, nil

--- a/components/ledger/internal/services/command/account_holder_policy.go
+++ b/components/ledger/internal/services/command/account_holder_policy.go
@@ -4,16 +4,22 @@
 
 package command
 
+import "github.com/LerianStudio/midaz/v4/pkg/mmodel"
+
 // RouteHolderPolicy states whether the route version that received the request
-// contracts the account holder seam. It is a distinct type so it cannot be
-// transposed with CreateAccount's other arguments at the call site.
+// contracts the account holder seam.
+//
+// It is an alias of mmodel.HolderPolicy: the account repository shapes its SQL
+// projection on the same signal, and the repository owns the interface this
+// package depends on, so the type has to live outside both. The alias keeps the
+// command-layer name the seam is documented under.
 //
 // It is the command-layer sibling of the transaction cores' routeVersionPolicy: the
 // use case is transport-agnostic and cannot read the request path, so the version
 // signal has to travel as an argument. They stay separate types because they sit on
 // opposite sides of the dependency direction — the fee and tracer seams live in the
 // transaction handler, the holder seam in the account and organization use cases.
-type RouteHolderPolicy bool
+type RouteHolderPolicy = mmodel.HolderPolicy
 
 const (
 	// HolderOffV1 is the /v1 account contract. It shipped before the holder seam
@@ -21,11 +27,11 @@ const (
 	// rejection, or a required-holder rejection from a version upgrade. A holderId
 	// or skip.holder in a /v1 body is inert: the /v1 response withholds both holder
 	// keys (see AccountV1), so the field has no readable effect on this contract.
-	HolderOffV1 RouteHolderPolicy = false
+	HolderOffV1 = mmodel.HolderOffV1
 
 	// HolderOnV2 is the /v2 account contract, which includes the holder seam:
 	// the requireHolder gate, the two-key per-call skip, and the self-holder
 	// default. The holder-account composition route contracts it too — it exists
 	// to link a holder — and is served on /v2 only.
-	HolderOnV2 RouteHolderPolicy = true
+	HolderOnV2 = mmodel.HolderOnV2
 )

--- a/components/ledger/internal/services/command/create_account.go
+++ b/components/ledger/internal/services/command/create_account.go
@@ -124,7 +124,9 @@ func (uc *UseCase) CreateAccount(ctx context.Context, organizationID, ledgerID u
 			return nil, err
 		}
 
-		acc, err := uc.AccountRepo.Find(ctx, organizationID, ledgerID, &portfolioUUID, parentID)
+		// HolderOffV1: the parent is read to validate it, and the new account's
+		// holder comes from resolveAccountHolder, never inherited from the parent.
+		acc, err := uc.AccountRepo.Find(ctx, organizationID, ledgerID, &portfolioUUID, parentID, mmodel.HolderOffV1)
 		if err != nil {
 			err := pkg.ValidateBusinessError(constant.ErrInvalidParentAccountID, constant.EntityAccount)
 			libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Failed to find parent account", err)

--- a/components/ledger/internal/services/command/create_account_test.go
+++ b/components/ledger/internal/services/command/create_account_test.go
@@ -697,7 +697,7 @@ func TestCreateAccountEdgeCases(t *testing.T) {
 					Return(true, nil).AnyTimes()
 
 				mockAccountRepo.EXPECT().
-					Find(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Find(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(&mmodel.Account{
 						ID:        parentAccountIDStr,
 						AssetCode: "USD",
@@ -749,7 +749,7 @@ func TestCreateAccountEdgeCases(t *testing.T) {
 					Return(true, nil).AnyTimes()
 
 				mockAccountRepo.EXPECT().
-					Find(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Find(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(nil, errors.New("parent account not found")).AnyTimes()
 			},
 			expectError:  true,
@@ -774,7 +774,7 @@ func TestCreateAccountEdgeCases(t *testing.T) {
 					Return(true, nil).AnyTimes()
 
 				mockAccountRepo.EXPECT().
-					Find(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Find(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(&mmodel.Account{
 						ID:        parentAccountIDStr,
 						AssetCode: "EUR", // Different from the input's USD

--- a/components/ledger/internal/services/command/delete_account.go
+++ b/components/ledger/internal/services/command/delete_account.go
@@ -46,7 +46,9 @@ func (uc *UseCase) DeleteAccountByID(ctx context.Context, organizationID, ledger
 		attribute.String("app.request.account_id", id.String()),
 	)
 
-	accFound, err := uc.AccountRepo.Find(ctx, organizationID, ledgerID, nil, id)
+	// HolderOffV1: the account is read to guard the delete; nothing downstream
+	// reads or rewrites its holder, and account.deleted carries no holder field.
+	accFound, err := uc.AccountRepo.Find(ctx, organizationID, ledgerID, nil, id, mmodel.HolderOffV1)
 	if err != nil {
 		libOpentelemetry.HandleSpanError(span, "Failed to find account by id", err)
 		logger.Log(ctx, libLog.LevelError, "Failed to find account by id", libLog.Err(err))

--- a/components/ledger/internal/services/command/delete_account_streaming_test.go
+++ b/components/ledger/internal/services/command/delete_account_streaming_test.go
@@ -40,8 +40,8 @@ func newDeleteStreamingTestUseCase(t *testing.T, ctrl *gomock.Controller, emitte
 	mockBalanceRepo := balance.NewMockRepository(ctrl)
 
 	mockAccountRepo.EXPECT().
-		Find(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-		DoAndReturn(func(_ context.Context, orgID, ledgerID uuid.UUID, _ *uuid.UUID, id uuid.UUID) (*mmodel.Account, error) {
+		Find(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, orgID, ledgerID uuid.UUID, _ *uuid.UUID, id uuid.UUID, _ mmodel.HolderPolicy) (*mmodel.Account, error) {
 			return &mmodel.Account{
 				ID:             id.String(),
 				OrganizationID: orgID.String(),

--- a/components/ledger/internal/services/command/delete_account_streaming_test.go
+++ b/components/ledger/internal/services/command/delete_account_streaming_test.go
@@ -40,7 +40,7 @@ func newDeleteStreamingTestUseCase(t *testing.T, ctrl *gomock.Controller, emitte
 	mockBalanceRepo := balance.NewMockRepository(ctrl)
 
 	mockAccountRepo.EXPECT().
-		Find(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Find(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), mmodel.HolderOffV1).
 		DoAndReturn(func(_ context.Context, orgID, ledgerID uuid.UUID, _ *uuid.UUID, id uuid.UUID, _ mmodel.HolderPolicy) (*mmodel.Account, error) {
 			return &mmodel.Account{
 				ID:             id.String(),

--- a/components/ledger/internal/services/command/delete_account_test.go
+++ b/components/ledger/internal/services/command/delete_account_test.go
@@ -50,7 +50,7 @@ func TestDeleteAccountByID(t *testing.T) {
 			portfolioID: &portfolioID,
 			setupMocks: func() {
 				mockAccountRepo.EXPECT().
-					Find(gomock.Any(), organizationID, ledgerID, nil, accountID).
+					Find(gomock.Any(), organizationID, ledgerID, nil, accountID, gomock.Any()).
 					Return(&mmodel.Account{ID: accountID.String()}, nil).
 					Times(1)
 
@@ -72,7 +72,7 @@ func TestDeleteAccountByID(t *testing.T) {
 			portfolioID: nil,
 			setupMocks: func() {
 				mockAccountRepo.EXPECT().
-					Find(gomock.Any(), organizationID, ledgerID, nil, accountID).
+					Find(gomock.Any(), organizationID, ledgerID, nil, accountID, gomock.Any()).
 					Return(nil, services.ErrDatabaseItemNotFound).
 					Times(1)
 			},
@@ -83,7 +83,7 @@ func TestDeleteAccountByID(t *testing.T) {
 			portfolioID: nil,
 			setupMocks: func() {
 				mockAccountRepo.EXPECT().
-					Find(gomock.Any(), organizationID, ledgerID, nil, accountID).
+					Find(gomock.Any(), organizationID, ledgerID, nil, accountID, gomock.Any()).
 					Return(&mmodel.Account{ID: accountID.String(), Type: "external"}, nil).
 					Times(1)
 			},
@@ -94,7 +94,7 @@ func TestDeleteAccountByID(t *testing.T) {
 			portfolioID: &portfolioID,
 			setupMocks: func() {
 				mockAccountRepo.EXPECT().
-					Find(gomock.Any(), organizationID, ledgerID, nil, accountID).
+					Find(gomock.Any(), organizationID, ledgerID, nil, accountID, gomock.Any()).
 					Return(&mmodel.Account{ID: accountID.String()}, nil).
 					Times(1)
 

--- a/components/ledger/internal/services/command/delete_account_test.go
+++ b/components/ledger/internal/services/command/delete_account_test.go
@@ -50,7 +50,7 @@ func TestDeleteAccountByID(t *testing.T) {
 			portfolioID: &portfolioID,
 			setupMocks: func() {
 				mockAccountRepo.EXPECT().
-					Find(gomock.Any(), organizationID, ledgerID, nil, accountID, gomock.Any()).
+					Find(gomock.Any(), organizationID, ledgerID, nil, accountID, mmodel.HolderOffV1).
 					Return(&mmodel.Account{ID: accountID.String()}, nil).
 					Times(1)
 
@@ -72,7 +72,7 @@ func TestDeleteAccountByID(t *testing.T) {
 			portfolioID: nil,
 			setupMocks: func() {
 				mockAccountRepo.EXPECT().
-					Find(gomock.Any(), organizationID, ledgerID, nil, accountID, gomock.Any()).
+					Find(gomock.Any(), organizationID, ledgerID, nil, accountID, mmodel.HolderOffV1).
 					Return(nil, services.ErrDatabaseItemNotFound).
 					Times(1)
 			},
@@ -83,7 +83,7 @@ func TestDeleteAccountByID(t *testing.T) {
 			portfolioID: nil,
 			setupMocks: func() {
 				mockAccountRepo.EXPECT().
-					Find(gomock.Any(), organizationID, ledgerID, nil, accountID, gomock.Any()).
+					Find(gomock.Any(), organizationID, ledgerID, nil, accountID, mmodel.HolderOffV1).
 					Return(&mmodel.Account{ID: accountID.String(), Type: "external"}, nil).
 					Times(1)
 			},
@@ -94,7 +94,7 @@ func TestDeleteAccountByID(t *testing.T) {
 			portfolioID: &portfolioID,
 			setupMocks: func() {
 				mockAccountRepo.EXPECT().
-					Find(gomock.Any(), organizationID, ledgerID, nil, accountID, gomock.Any()).
+					Find(gomock.Any(), organizationID, ledgerID, nil, accountID, mmodel.HolderOffV1).
 					Return(&mmodel.Account{ID: accountID.String()}, nil).
 					Times(1)
 

--- a/components/ledger/internal/services/command/update_account.go
+++ b/components/ledger/internal/services/command/update_account.go
@@ -47,7 +47,9 @@ func (uc *UseCase) UpdateAccount(ctx context.Context, organizationID, ledgerID u
 		attribute.String("app.request.account_id", id.String()),
 	)
 
-	accFound, err := uc.AccountRepo.Find(ctx, organizationID, ledgerID, nil, id)
+	// HolderOffV1: holderId is immutable and absent from the update SET list, and
+	// account.updated carries no holder field, so the projected value is unused.
+	accFound, err := uc.AccountRepo.Find(ctx, organizationID, ledgerID, nil, id, mmodel.HolderOffV1)
 	if err != nil {
 		libOpentelemetry.HandleSpanError(span, "Failed to find account by id", err)
 		logger.Log(ctx, libLog.LevelError, "Failed to find account by id", libLog.Err(err))

--- a/components/ledger/internal/services/command/update_account.go
+++ b/components/ledger/internal/services/command/update_account.go
@@ -29,7 +29,7 @@ import (
 )
 
 // UpdateAccount updates an account from the repository by the given ID.
-func (uc *UseCase) UpdateAccount(ctx context.Context, organizationID, ledgerID uuid.UUID, portfolioID *uuid.UUID, id uuid.UUID, uai *mmodel.UpdateAccountInput) (_ *mmodel.Account, err error) {
+func (uc *UseCase) UpdateAccount(ctx context.Context, organizationID, ledgerID uuid.UUID, portfolioID *uuid.UUID, id uuid.UUID, uai *mmodel.UpdateAccountInput, holderPolicy mmodel.HolderPolicy) (_ *mmodel.Account, err error) {
 	logger, tracer, _, _ := libObservability.NewTrackingFromContext(ctx)
 
 	ctx, span := tracer.Start(ctx, "command.update_account")
@@ -47,9 +47,13 @@ func (uc *UseCase) UpdateAccount(ctx context.Context, organizationID, ledgerID u
 		attribute.String("app.request.account_id", id.String()),
 	)
 
-	// HolderOffV1: holderId is immutable and absent from the update SET list, and
-	// account.updated carries no holder field, so the projected value is unused.
-	accFound, err := uc.AccountRepo.Find(ctx, organizationID, ledgerID, nil, id, mmodel.HolderOffV1)
+	// The lookup carries the route's policy even though nothing downstream reads
+	// the projected holder — holderId is immutable, absent from the update SET
+	// list, and account.updated has no holder field. It matters for ORDERING: on a
+	// schema without the holder columns a /v2 request has to fail here, before the
+	// row is mutated and account.updated is emitted, rather than after. /v1 needs
+	// no such column, so it proceeds and completes.
+	accFound, err := uc.AccountRepo.Find(ctx, organizationID, ledgerID, nil, id, holderPolicy)
 	if err != nil {
 		libOpentelemetry.HandleSpanError(span, "Failed to find account by id", err)
 		logger.Log(ctx, libLog.LevelError, "Failed to find account by id", libLog.Err(err))

--- a/components/ledger/internal/services/command/update_account_streaming_test.go
+++ b/components/ledger/internal/services/command/update_account_streaming_test.go
@@ -39,7 +39,7 @@ func newUpdateStreamingTestUseCase(t *testing.T, ctrl *gomock.Controller, emitte
 	mockMetadataRepo := mongodb.NewMockRepository(ctrl)
 
 	mockAccountRepo.EXPECT().
-		Find(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Find(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), mmodel.HolderOffV1).
 		DoAndReturn(func(_ context.Context, orgID, ledgerID uuid.UUID, _ *uuid.UUID, id uuid.UUID, _ mmodel.HolderPolicy) (*mmodel.Account, error) {
 			return &mmodel.Account{
 				ID:             id.String(),
@@ -93,7 +93,7 @@ func TestUpdateAccount_EmitsAccountUpdatedEvent(t *testing.T) {
 		Status: mmodel.Status{Code: "ACTIVE"},
 	}
 
-	acc, err := uc.UpdateAccount(ctx, orgID, ledgerID, nil, accountID, input)
+	acc, err := uc.UpdateAccount(ctx, orgID, ledgerID, nil, accountID, input, mmodel.HolderOffV1)
 	require.NoError(t, err)
 	require.NotNil(t, acc)
 
@@ -139,7 +139,7 @@ func TestUpdateAccount_NoopEmitterDoesNotPanic(t *testing.T) {
 		Status: mmodel.Status{Code: "ACTIVE"},
 	}
 
-	acc, err := uc.UpdateAccount(context.Background(), uuid.New(), uuid.New(), nil, uuid.New(), input)
+	acc, err := uc.UpdateAccount(context.Background(), uuid.New(), uuid.New(), nil, uuid.New(), input, mmodel.HolderOffV1)
 	require.NoError(t, err)
 	require.NotNil(t, acc)
 }
@@ -160,7 +160,7 @@ func TestUpdateAccount_EmitFailureDoesNotFailRequest(t *testing.T) {
 		Status: mmodel.Status{Code: "ACTIVE"},
 	}
 
-	acc, err := uc.UpdateAccount(context.Background(), uuid.New(), uuid.New(), nil, uuid.New(), input)
+	acc, err := uc.UpdateAccount(context.Background(), uuid.New(), uuid.New(), nil, uuid.New(), input, mmodel.HolderOffV1)
 	require.NoError(t, err, "Emit failure must NOT fail the request (IMPORTANT posture)")
 	require.NotNil(t, acc)
 }
@@ -180,7 +180,7 @@ func TestUpdateAccount_NilStreamingDoesNotPanic(t *testing.T) {
 		Status: mmodel.Status{Code: "ACTIVE"},
 	}
 
-	acc, err := uc.UpdateAccount(context.Background(), uuid.New(), uuid.New(), nil, uuid.New(), input)
+	acc, err := uc.UpdateAccount(context.Background(), uuid.New(), uuid.New(), nil, uuid.New(), input, mmodel.HolderOffV1)
 	require.NoError(t, err)
 	require.NotNil(t, acc)
 }

--- a/components/ledger/internal/services/command/update_account_streaming_test.go
+++ b/components/ledger/internal/services/command/update_account_streaming_test.go
@@ -39,8 +39,8 @@ func newUpdateStreamingTestUseCase(t *testing.T, ctrl *gomock.Controller, emitte
 	mockMetadataRepo := mongodb.NewMockRepository(ctrl)
 
 	mockAccountRepo.EXPECT().
-		Find(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-		DoAndReturn(func(_ context.Context, orgID, ledgerID uuid.UUID, _ *uuid.UUID, id uuid.UUID) (*mmodel.Account, error) {
+		Find(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, orgID, ledgerID uuid.UUID, _ *uuid.UUID, id uuid.UUID, _ mmodel.HolderPolicy) (*mmodel.Account, error) {
 			return &mmodel.Account{
 				ID:             id.String(),
 				OrganizationID: orgID.String(),

--- a/components/ledger/internal/services/command/update_account_test.go
+++ b/components/ledger/internal/services/command/update_account_test.go
@@ -56,7 +56,7 @@ func TestUpdateAccount(t *testing.T) {
 			},
 			mockSetup: func() {
 				mockAccountRepo.EXPECT().
-					Find(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Find(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(&mmodel.Account{ID: "123", Type: "internal"}, nil)
 				mockAccountRepo.EXPECT().
 					Update(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
@@ -86,7 +86,7 @@ func TestUpdateAccount(t *testing.T) {
 			},
 			mockSetup: func() {
 				mockAccountRepo.EXPECT().
-					Find(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Find(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(nil, services.ErrDatabaseItemNotFound)
 			},
 			expectErr: true,
@@ -107,7 +107,7 @@ func TestUpdateAccount(t *testing.T) {
 			},
 			mockSetup: func() {
 				mockAccountRepo.EXPECT().
-					Find(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Find(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(&mmodel.Account{ID: "123", Type: "internal"}, nil)
 				mockAccountRepo.EXPECT().
 					Update(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
@@ -163,7 +163,7 @@ func TestUpdateAccount_BlockedProvidedTrue(t *testing.T) {
 
 	// Expectations
 	mockAccountRepo.EXPECT().
-		Find(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Find(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(&mmodel.Account{ID: accountID.String(), Type: "internal"}, nil)
 
 	mockAccountRepo.EXPECT().
@@ -218,7 +218,7 @@ func TestUpdateAccount_BlockedOmitted(t *testing.T) {
 	accountID := uuid.New()
 
 	mockAccountRepo.EXPECT().
-		Find(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Find(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(&mmodel.Account{ID: accountID.String(), Type: "internal"}, nil)
 
 	mockAccountRepo.EXPECT().
@@ -268,7 +268,7 @@ func TestUpdateAccount_ExternalForbidden(t *testing.T) {
 	accountID := uuid.New()
 
 	mockAccountRepo.EXPECT().
-		Find(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Find(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(&mmodel.Account{ID: accountID.String(), Type: "external"}, nil)
 
 	inp := &mmodel.UpdateAccountInput{Name: "Updated"}

--- a/components/ledger/internal/services/command/update_account_test.go
+++ b/components/ledger/internal/services/command/update_account_test.go
@@ -56,7 +56,7 @@ func TestUpdateAccount(t *testing.T) {
 			},
 			mockSetup: func() {
 				mockAccountRepo.EXPECT().
-					Find(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Find(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), mmodel.HolderOffV1).
 					Return(&mmodel.Account{ID: "123", Type: "internal"}, nil)
 				mockAccountRepo.EXPECT().
 					Update(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
@@ -86,7 +86,7 @@ func TestUpdateAccount(t *testing.T) {
 			},
 			mockSetup: func() {
 				mockAccountRepo.EXPECT().
-					Find(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Find(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), mmodel.HolderOffV1).
 					Return(nil, services.ErrDatabaseItemNotFound)
 			},
 			expectErr: true,
@@ -107,7 +107,7 @@ func TestUpdateAccount(t *testing.T) {
 			},
 			mockSetup: func() {
 				mockAccountRepo.EXPECT().
-					Find(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Find(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), mmodel.HolderOffV1).
 					Return(&mmodel.Account{ID: "123", Type: "internal"}, nil)
 				mockAccountRepo.EXPECT().
 					Update(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
@@ -128,7 +128,7 @@ func TestUpdateAccount(t *testing.T) {
 			tt.mockSetup()
 
 			ctx := context.Background()
-			result, err := uc.UpdateAccount(ctx, tt.organizationID, tt.ledgerID, tt.portfolioID, tt.accountID, tt.input)
+			result, err := uc.UpdateAccount(ctx, tt.organizationID, tt.ledgerID, tt.portfolioID, tt.accountID, tt.input, mmodel.HolderOffV1)
 
 			if tt.expectErr {
 				assert.Error(t, err)
@@ -163,7 +163,7 @@ func TestUpdateAccount_BlockedProvidedTrue(t *testing.T) {
 
 	// Expectations
 	mockAccountRepo.EXPECT().
-		Find(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Find(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), mmodel.HolderOffV1).
 		Return(&mmodel.Account{ID: accountID.String(), Type: "internal"}, nil)
 
 	mockAccountRepo.EXPECT().
@@ -191,7 +191,7 @@ func TestUpdateAccount_BlockedProvidedTrue(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	result, err := uc.UpdateAccount(ctx, organizationID, ledgerID, nil, accountID, inp)
+	result, err := uc.UpdateAccount(ctx, organizationID, ledgerID, nil, accountID, inp, mmodel.HolderOffV1)
 
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
@@ -218,7 +218,7 @@ func TestUpdateAccount_BlockedOmitted(t *testing.T) {
 	accountID := uuid.New()
 
 	mockAccountRepo.EXPECT().
-		Find(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Find(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), mmodel.HolderOffV1).
 		Return(&mmodel.Account{ID: accountID.String(), Type: "internal"}, nil)
 
 	mockAccountRepo.EXPECT().
@@ -245,7 +245,7 @@ func TestUpdateAccount_BlockedOmitted(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	result, err := uc.UpdateAccount(ctx, organizationID, ledgerID, nil, accountID, inp)
+	result, err := uc.UpdateAccount(ctx, organizationID, ledgerID, nil, accountID, inp, mmodel.HolderOffV1)
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -268,12 +268,12 @@ func TestUpdateAccount_ExternalForbidden(t *testing.T) {
 	accountID := uuid.New()
 
 	mockAccountRepo.EXPECT().
-		Find(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Find(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), mmodel.HolderOffV1).
 		Return(&mmodel.Account{ID: accountID.String(), Type: "external"}, nil)
 
 	inp := &mmodel.UpdateAccountInput{Name: "Updated"}
 	ctx := context.Background()
-	result, err := uc.UpdateAccount(ctx, organizationID, ledgerID, nil, accountID, inp)
+	result, err := uc.UpdateAccount(ctx, organizationID, ledgerID, nil, accountID, inp, mmodel.HolderOffV1)
 
 	assert.Error(t, err)
 	assert.Nil(t, result)

--- a/components/ledger/internal/services/errors.go
+++ b/components/ledger/internal/services/errors.go
@@ -16,9 +16,28 @@ import (
 // ErrDatabaseItemNotFound is thrown when an item informed was not found
 var ErrDatabaseItemNotFound = errors.New("errDatabaseItemNotFound")
 
+// pgCodeUndefinedColumn is the PostgreSQL SQLSTATE for a reference to a column
+// that does not exist on the relation.
+const pgCodeUndefinedColumn = "42703"
+
+// IsSchemaDrift reports whether err is a PostgreSQL undefined-column failure,
+// i.e. the statement named a column the applied migrations have not created.
+func IsSchemaDrift(err error) bool {
+	var pgErr *pgconn.PgError
+
+	return errors.As(err, &pgErr) && pgErr.Code == pgCodeUndefinedColumn
+}
+
 // ValidatePGError validates pgError and returns the appropriate business error.
 // It handles constraint violations from both onboarding and transaction entities.
 func ValidatePGError(pgErr *pgconn.PgError, entityType string, args ...any) error {
+	// A named column the database does not have means the binary is ahead of the
+	// applied migrations. It carries no constraint name, so it has to be matched
+	// on SQLSTATE before the constraint switch.
+	if pgErr.Code == pgCodeUndefinedColumn {
+		return pkg.ValidateBusinessError(constant.ErrSchemaMigrationPending, entityType)
+	}
+
 	// Onboarding constraint violations
 	switch pgErr.ConstraintName {
 	case "organization_parent_organization_id_fkey":

--- a/components/ledger/internal/services/errors_schema_drift_test.go
+++ b/components/ledger/internal/services/errors_schema_drift_test.go
@@ -1,0 +1,68 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package services
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/LerianStudio/midaz/v4/pkg"
+	"github.com/LerianStudio/midaz/v4/pkg/constant"
+)
+
+// A missing column carries no constraint name, so it has to be recognized on
+// SQLSTATE — otherwise it falls through as a raw driver error and reaches the
+// client as an opaque 500 that names no cause.
+func TestValidatePGError_UndefinedColumnMapsToSchemaMigrationPending(t *testing.T) {
+	pgErr := &pgconn.PgError{
+		Code:    "42703",
+		Message: `column "holder_id" of relation "account" does not exist`,
+	}
+
+	err := ValidatePGError(pgErr, constant.EntityAccount)
+
+	var unavailable pkg.ServiceUnavailableError
+	require.ErrorAs(t, err, &unavailable,
+		"schema drift is retryable infrastructure state, not a caller mistake")
+
+	assert.Equal(t, constant.ErrSchemaMigrationPending.Error(), unavailable.Code)
+	assert.NotContains(t, unavailable.Message, "holder_id",
+		"the client message must not carry the driver's column text")
+}
+
+func TestValidatePGError_ConstraintViolationStillWins(t *testing.T) {
+	pgErr := &pgconn.PgError{
+		Code:           "23503",
+		ConstraintName: "account_asset_code_fkey",
+	}
+
+	err := ValidatePGError(pgErr, constant.EntityAccount)
+
+	var notFound pkg.EntityNotFoundError
+	require.ErrorAs(t, err, &notFound)
+	assert.Equal(t, constant.ErrAssetCodeNotFound.Error(), notFound.Code)
+}
+
+func TestValidatePGError_UnknownErrorPassesThrough(t *testing.T) {
+	pgErr := &pgconn.PgError{Code: "22001"}
+
+	assert.Equal(t, pgErr, ValidatePGError(pgErr, constant.EntityAccount))
+}
+
+func TestIsSchemaDrift(t *testing.T) {
+	drift := &pgconn.PgError{Code: "42703"}
+
+	assert.True(t, IsSchemaDrift(drift))
+	assert.True(t, IsSchemaDrift(fmt.Errorf("exec failed: %w", drift)),
+		"the check must survive wrapping")
+	assert.False(t, IsSchemaDrift(&pgconn.PgError{Code: "23505"}))
+	assert.False(t, IsSchemaDrift(errors.New("boom")))
+	assert.False(t, IsSchemaDrift(nil))
+}

--- a/components/ledger/internal/services/fees/query_resolver.go
+++ b/components/ledger/internal/services/fees/query_resolver.go
@@ -22,8 +22,8 @@ import (
 // resolution depends on. It exists so the resolver can be unit-tested with a
 // fake; *query.UseCase satisfies it directly.
 type feeQueryPort interface {
-	GetAccountByAlias(ctx context.Context, organizationID, ledgerID uuid.UUID, portfolioID *uuid.UUID, alias string) (*mmodel.Account, error)
-	GetAllAccount(ctx context.Context, organizationID, ledgerID uuid.UUID, portfolioID, segmentID *uuid.UUID, filter libHTTP.QueryHeader) ([]*mmodel.Account, error)
+	GetAccountByAlias(ctx context.Context, organizationID, ledgerID uuid.UUID, portfolioID *uuid.UUID, alias string, holderPolicy mmodel.HolderPolicy) (*mmodel.Account, error)
+	GetAllAccount(ctx context.Context, organizationID, ledgerID uuid.UUID, portfolioID, segmentID *uuid.UUID, filter libHTTP.QueryHeader, holderPolicy mmodel.HolderPolicy) ([]*mmodel.Account, error)
 	CountTransactionsByFilters(ctx context.Context, organizationID, ledgerID uuid.UUID, filter transaction.CountFilter) (int64, error)
 }
 
@@ -57,7 +57,7 @@ func NewQueryResolver(q *query.UseCase) (feeshared.MidazResolver, error) {
 }
 
 func (r *queryResolver) AccountExistsByAlias(ctx context.Context, organizationID, ledgerID uuid.UUID, alias string) error {
-	if _, err := r.query.GetAccountByAlias(ctx, organizationID, ledgerID, nil, alias); err != nil {
+	if _, err := r.query.GetAccountByAlias(ctx, organizationID, ledgerID, nil, alias, mmodel.HolderOffV1); err != nil {
 		return err
 	}
 
@@ -65,7 +65,7 @@ func (r *queryResolver) AccountExistsByAlias(ctx context.Context, organizationID
 }
 
 func (r *queryResolver) GetAccountByAlias(ctx context.Context, organizationID, ledgerID uuid.UUID, alias string) (*feeshared.Account, error) {
-	account, err := r.query.GetAccountByAlias(ctx, organizationID, ledgerID, nil, alias)
+	account, err := r.query.GetAccountByAlias(ctx, organizationID, ledgerID, nil, alias, mmodel.HolderOffV1)
 	if err != nil {
 		// A missing alias is not a resolution failure for callers that treat a
 		// non-existent account as "not exempt"; collapse it to (nil, nil).
@@ -97,7 +97,7 @@ func (r *queryResolver) ListAccounts(ctx context.Context, organizationID, ledger
 			EndDate:   resolverFarFutureEndDate,
 		}
 
-		batch, err := r.query.GetAllAccount(ctx, organizationID, ledgerID, portfolioID, segmentID, filter)
+		batch, err := r.query.GetAllAccount(ctx, organizationID, ledgerID, portfolioID, segmentID, filter, mmodel.HolderOffV1)
 		if err != nil {
 			// An empty segment/portfolio surfaces as a not-found business error
 			// from the query layer; treat it as an empty result set, not failure.

--- a/components/ledger/internal/services/fees/query_resolver_test.go
+++ b/components/ledger/internal/services/fees/query_resolver_test.go
@@ -29,11 +29,11 @@ type fakeQueryPort struct {
 	getAllCalls []libHTTP.QueryHeader
 }
 
-func (f *fakeQueryPort) GetAccountByAlias(ctx context.Context, org, ledger uuid.UUID, portfolio *uuid.UUID, alias string) (*mmodel.Account, error) {
+func (f *fakeQueryPort) GetAccountByAlias(ctx context.Context, org, ledger uuid.UUID, portfolio *uuid.UUID, alias string, holderPolicy mmodel.HolderPolicy) (*mmodel.Account, error) {
 	return f.getByAliasFn(ctx, org, ledger, portfolio, alias)
 }
 
-func (f *fakeQueryPort) GetAllAccount(ctx context.Context, org, ledger uuid.UUID, portfolio, segment *uuid.UUID, filter libHTTP.QueryHeader) ([]*mmodel.Account, error) {
+func (f *fakeQueryPort) GetAllAccount(ctx context.Context, org, ledger uuid.UUID, portfolio, segment *uuid.UUID, filter libHTTP.QueryHeader, holderPolicy mmodel.HolderPolicy) ([]*mmodel.Account, error) {
 	f.getAllCalls = append(f.getAllCalls, filter)
 	return f.getAllFn(ctx, org, ledger, portfolio, segment, filter)
 }

--- a/components/ledger/internal/services/query/get_alias_account.go
+++ b/components/ledger/internal/services/query/get_alias_account.go
@@ -20,13 +20,13 @@ import (
 )
 
 // GetAccountByAlias gets an account from the repository by alias, including soft-deleted ones.
-func (uc *UseCase) GetAccountByAlias(ctx context.Context, organizationID, ledgerID uuid.UUID, portfolioID *uuid.UUID, alias string) (*mmodel.Account, error) {
+func (uc *UseCase) GetAccountByAlias(ctx context.Context, organizationID, ledgerID uuid.UUID, portfolioID *uuid.UUID, alias string, holderPolicy mmodel.HolderPolicy) (*mmodel.Account, error) {
 	logger, tracer, _, _ := libObservability.NewTrackingFromContext(ctx)
 
 	ctx, span := tracer.Start(ctx, "query.get_account_by_alias")
 	defer span.End()
 
-	account, err := uc.AccountRepo.FindAlias(ctx, organizationID, ledgerID, portfolioID, alias)
+	account, err := uc.AccountRepo.FindAlias(ctx, organizationID, ledgerID, portfolioID, alias, holderPolicy)
 	if err != nil {
 		logger.Log(ctx, libLog.LevelError, "Error getting account on repo by alias", libLog.Err(err))
 

--- a/components/ledger/internal/services/query/get_alias_account_test.go
+++ b/components/ledger/internal/services/query/get_alias_account_test.go
@@ -52,7 +52,7 @@ func TestUseCase_GetAccountByAlias(t *testing.T) {
 			mockSetup: func() {
 				b := true
 				mockAccountRepo.EXPECT().
-					FindAlias(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					FindAlias(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(&mmodel.Account{ID: successAccountID.String(), Name: "Test Account", Status: mmodel.Status{Code: "active"}, Blocked: &b}, nil)
 				mockMetadataRepo.EXPECT().
 					FindByEntity(gomock.Any(), gomock.Any(), gomock.Any()).
@@ -75,7 +75,7 @@ func TestUseCase_GetAccountByAlias(t *testing.T) {
 			alias:          "case02",
 			mockSetup: func() {
 				mockAccountRepo.EXPECT().
-					FindAlias(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					FindAlias(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(nil, services.ErrDatabaseItemNotFound)
 			},
 			expectErr:      true,
@@ -90,7 +90,7 @@ func TestUseCase_GetAccountByAlias(t *testing.T) {
 			mockSetup: func() {
 				accountID := uuid.New()
 				mockAccountRepo.EXPECT().
-					FindAlias(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					FindAlias(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(&mmodel.Account{ID: accountID.String(), Name: "Test Account", Status: mmodel.Status{Code: "active"}}, nil)
 				mockMetadataRepo.EXPECT().
 					FindByEntity(gomock.Any(), gomock.Any(), gomock.Any()).
@@ -106,7 +106,7 @@ func TestUseCase_GetAccountByAlias(t *testing.T) {
 			tt.mockSetup()
 
 			ctx := context.Background()
-			result, err := uc.GetAccountByAlias(ctx, tt.organizationID, tt.ledgerID, tt.portfolioID, tt.alias)
+			result, err := uc.GetAccountByAlias(ctx, tt.organizationID, tt.ledgerID, tt.portfolioID, tt.alias, mmodel.HolderOnV2)
 
 			if tt.expectErr {
 				assert.Error(t, err)

--- a/components/ledger/internal/services/query/get_alias_account_test.go
+++ b/components/ledger/internal/services/query/get_alias_account_test.go
@@ -52,7 +52,7 @@ func TestUseCase_GetAccountByAlias(t *testing.T) {
 			mockSetup: func() {
 				b := true
 				mockAccountRepo.EXPECT().
-					FindAlias(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					FindAlias(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), mmodel.HolderOnV2).
 					Return(&mmodel.Account{ID: successAccountID.String(), Name: "Test Account", Status: mmodel.Status{Code: "active"}, Blocked: &b}, nil)
 				mockMetadataRepo.EXPECT().
 					FindByEntity(gomock.Any(), gomock.Any(), gomock.Any()).
@@ -75,7 +75,7 @@ func TestUseCase_GetAccountByAlias(t *testing.T) {
 			alias:          "case02",
 			mockSetup: func() {
 				mockAccountRepo.EXPECT().
-					FindAlias(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					FindAlias(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), mmodel.HolderOnV2).
 					Return(nil, services.ErrDatabaseItemNotFound)
 			},
 			expectErr:      true,
@@ -90,7 +90,7 @@ func TestUseCase_GetAccountByAlias(t *testing.T) {
 			mockSetup: func() {
 				accountID := uuid.New()
 				mockAccountRepo.EXPECT().
-					FindAlias(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					FindAlias(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), mmodel.HolderOnV2).
 					Return(&mmodel.Account{ID: accountID.String(), Name: "Test Account", Status: mmodel.Status{Code: "active"}}, nil)
 				mockMetadataRepo.EXPECT().
 					FindByEntity(gomock.Any(), gomock.Any(), gomock.Any()).

--- a/components/ledger/internal/services/query/get_all_accounts.go
+++ b/components/ledger/internal/services/query/get_all_accounts.go
@@ -23,7 +23,7 @@ import (
 )
 
 // GetAllAccount fetches all accounts from the repository.
-func (uc *UseCase) GetAllAccount(ctx context.Context, organizationID, ledgerID uuid.UUID, portfolioID, segmentID *uuid.UUID, filter http.QueryHeader) (_ []*mmodel.Account, err error) {
+func (uc *UseCase) GetAllAccount(ctx context.Context, organizationID, ledgerID uuid.UUID, portfolioID, segmentID *uuid.UUID, filter http.QueryHeader, holderPolicy mmodel.HolderPolicy) (_ []*mmodel.Account, err error) {
 	logger, tracer, _, _ := libObservability.NewTrackingFromContext(ctx)
 
 	ctx, span := tracer.Start(ctx, "query.get_all_account")
@@ -35,7 +35,7 @@ func (uc *UseCase) GetAllAccount(ctx context.Context, organizationID, ledgerID u
 		utils.RecordDomainOperation(ctx, uc.MetricsFactory, logger, "ledger", "list_accounts", start, err)
 	}()
 
-	accounts, err := uc.AccountRepo.FindAll(ctx, organizationID, ledgerID, portfolioID, segmentID, filter)
+	accounts, err := uc.AccountRepo.FindAll(ctx, organizationID, ledgerID, portfolioID, segmentID, filter, holderPolicy)
 	if err != nil {
 		logger.Log(ctx, libLog.LevelError, "Error getting accounts on repo", libLog.Err(err))
 

--- a/components/ledger/internal/services/query/get_all_accounts_integration_test.go
+++ b/components/ledger/internal/services/query/get_all_accounts_integration_test.go
@@ -14,6 +14,7 @@ import (
 
 	mongodb "github.com/LerianStudio/midaz/v4/components/ledger/internal/adapters/mongodb/onboarding"
 	"github.com/LerianStudio/midaz/v4/components/ledger/internal/adapters/postgres/account"
+	"github.com/LerianStudio/midaz/v4/pkg/mmodel"
 	"github.com/LerianStudio/midaz/v4/pkg/net/http"
 	pgtestutil "github.com/LerianStudio/midaz/v4/tests/utils/postgres"
 	"github.com/stretchr/testify/assert"
@@ -73,7 +74,7 @@ func TestIntegration_GetAllAccount_PaginationUnion(t *testing.T) {
 			EndDate:   time.Now().Add(24 * time.Hour),
 		}
 
-		accounts, err := uc.GetAllAccount(ctx, orgID, ledgerID, nil, nil, filter)
+		accounts, err := uc.GetAllAccount(ctx, orgID, ledgerID, nil, nil, filter, mmodel.HolderOnV2)
 		require.NoError(t, err, "GetAllAccount page %d should succeed", page)
 
 		for _, acc := range accounts {
@@ -142,11 +143,11 @@ func TestIntegration_GetAllAccount_PaginationStableOrder(t *testing.T) {
 	}
 
 	// First read
-	accounts1, err := uc.GetAllAccount(ctx, orgID, ledgerID, nil, nil, filter)
+	accounts1, err := uc.GetAllAccount(ctx, orgID, ledgerID, nil, nil, filter, mmodel.HolderOnV2)
 	require.NoError(t, err, "first GetAllAccount should succeed")
 
 	// Second read
-	accounts2, err := uc.GetAllAccount(ctx, orgID, ledgerID, nil, nil, filter)
+	accounts2, err := uc.GetAllAccount(ctx, orgID, ledgerID, nil, nil, filter, mmodel.HolderOnV2)
 	require.NoError(t, err, "second GetAllAccount should succeed")
 
 	// Assert: same length

--- a/components/ledger/internal/services/query/get_all_accounts_test.go
+++ b/components/ledger/internal/services/query/get_all_accounts_test.go
@@ -58,7 +58,7 @@ func TestGetAllAccount(t *testing.T) {
 				bFalse := false
 				bTrue := true
 				mockAccountRepo.EXPECT().
-					FindAll(gomock.Any(), organizationID, ledgerID, &portfolioID, gomock.Nil(), filter).
+					FindAll(gomock.Any(), organizationID, ledgerID, &portfolioID, gomock.Nil(), filter, gomock.Any()).
 					Return([]*mmodel.Account{
 						{ID: "acc1", Blocked: &bFalse},
 						{ID: "acc2", Blocked: &bTrue},
@@ -91,7 +91,7 @@ func TestGetAllAccount(t *testing.T) {
 			segmentID:   &segmentID,
 			setupMocks: func() {
 				mockAccountRepo.EXPECT().
-					FindAll(gomock.Any(), organizationID, ledgerID, &portfolioID, &segmentID, filter).
+					FindAll(gomock.Any(), organizationID, ledgerID, &portfolioID, &segmentID, filter, gomock.Any()).
 					Return([]*mmodel.Account{
 						{ID: "acc1"},
 					}, nil).
@@ -115,7 +115,7 @@ func TestGetAllAccount(t *testing.T) {
 			segmentID:   nil,
 			setupMocks: func() {
 				mockAccountRepo.EXPECT().
-					FindAll(gomock.Any(), organizationID, ledgerID, &portfolioID, gomock.Nil(), filter).
+					FindAll(gomock.Any(), organizationID, ledgerID, &portfolioID, gomock.Nil(), filter, gomock.Any()).
 					Return(nil, services.ErrDatabaseItemNotFound).
 					Times(1)
 			},
@@ -128,7 +128,7 @@ func TestGetAllAccount(t *testing.T) {
 			segmentID:   nil,
 			setupMocks: func() {
 				mockAccountRepo.EXPECT().
-					FindAll(gomock.Any(), organizationID, ledgerID, &portfolioID, gomock.Nil(), filter).
+					FindAll(gomock.Any(), organizationID, ledgerID, &portfolioID, gomock.Nil(), filter, gomock.Any()).
 					Return(nil, errors.New("failed to retrieve accounts")).
 					Times(1)
 			},
@@ -141,7 +141,7 @@ func TestGetAllAccount(t *testing.T) {
 			segmentID:   nil,
 			setupMocks: func() {
 				mockAccountRepo.EXPECT().
-					FindAll(gomock.Any(), organizationID, ledgerID, &portfolioID, gomock.Nil(), filter).
+					FindAll(gomock.Any(), organizationID, ledgerID, &portfolioID, gomock.Nil(), filter, gomock.Any()).
 					Return([]*mmodel.Account{
 						{ID: "acc1"},
 						{ID: "acc2"},
@@ -162,7 +162,7 @@ func TestGetAllAccount(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			tt.setupMocks()
 
-			result, err := uc.GetAllAccount(ctx, organizationID, ledgerID, tt.portfolioID, tt.segmentID, filter)
+			result, err := uc.GetAllAccount(ctx, organizationID, ledgerID, tt.portfolioID, tt.segmentID, filter, mmodel.HolderOnV2)
 
 			if tt.expectedErr != nil {
 				assert.Error(t, err)

--- a/components/ledger/internal/services/query/get_all_accounts_test.go
+++ b/components/ledger/internal/services/query/get_all_accounts_test.go
@@ -58,7 +58,7 @@ func TestGetAllAccount(t *testing.T) {
 				bFalse := false
 				bTrue := true
 				mockAccountRepo.EXPECT().
-					FindAll(gomock.Any(), organizationID, ledgerID, &portfolioID, gomock.Nil(), filter, gomock.Any()).
+					FindAll(gomock.Any(), organizationID, ledgerID, &portfolioID, gomock.Nil(), filter, mmodel.HolderOnV2).
 					Return([]*mmodel.Account{
 						{ID: "acc1", Blocked: &bFalse},
 						{ID: "acc2", Blocked: &bTrue},
@@ -91,7 +91,7 @@ func TestGetAllAccount(t *testing.T) {
 			segmentID:   &segmentID,
 			setupMocks: func() {
 				mockAccountRepo.EXPECT().
-					FindAll(gomock.Any(), organizationID, ledgerID, &portfolioID, &segmentID, filter, gomock.Any()).
+					FindAll(gomock.Any(), organizationID, ledgerID, &portfolioID, &segmentID, filter, mmodel.HolderOnV2).
 					Return([]*mmodel.Account{
 						{ID: "acc1"},
 					}, nil).
@@ -115,7 +115,7 @@ func TestGetAllAccount(t *testing.T) {
 			segmentID:   nil,
 			setupMocks: func() {
 				mockAccountRepo.EXPECT().
-					FindAll(gomock.Any(), organizationID, ledgerID, &portfolioID, gomock.Nil(), filter, gomock.Any()).
+					FindAll(gomock.Any(), organizationID, ledgerID, &portfolioID, gomock.Nil(), filter, mmodel.HolderOnV2).
 					Return(nil, services.ErrDatabaseItemNotFound).
 					Times(1)
 			},
@@ -128,7 +128,7 @@ func TestGetAllAccount(t *testing.T) {
 			segmentID:   nil,
 			setupMocks: func() {
 				mockAccountRepo.EXPECT().
-					FindAll(gomock.Any(), organizationID, ledgerID, &portfolioID, gomock.Nil(), filter, gomock.Any()).
+					FindAll(gomock.Any(), organizationID, ledgerID, &portfolioID, gomock.Nil(), filter, mmodel.HolderOnV2).
 					Return(nil, errors.New("failed to retrieve accounts")).
 					Times(1)
 			},
@@ -141,7 +141,7 @@ func TestGetAllAccount(t *testing.T) {
 			segmentID:   nil,
 			setupMocks: func() {
 				mockAccountRepo.EXPECT().
-					FindAll(gomock.Any(), organizationID, ledgerID, &portfolioID, gomock.Nil(), filter, gomock.Any()).
+					FindAll(gomock.Any(), organizationID, ledgerID, &portfolioID, gomock.Nil(), filter, mmodel.HolderOnV2).
 					Return([]*mmodel.Account{
 						{ID: "acc1"},
 						{ID: "acc2"},

--- a/components/ledger/internal/services/query/get_all_metadata_accounts.go
+++ b/components/ledger/internal/services/query/get_all_metadata_accounts.go
@@ -21,7 +21,7 @@ import (
 )
 
 // GetAllMetadataAccounts fetches all accounts from the repository.
-func (uc *UseCase) GetAllMetadataAccounts(ctx context.Context, organizationID, ledgerID uuid.UUID, portfolioID, segmentID *uuid.UUID, filter http.QueryHeader) ([]*mmodel.Account, error) {
+func (uc *UseCase) GetAllMetadataAccounts(ctx context.Context, organizationID, ledgerID uuid.UUID, portfolioID, segmentID *uuid.UUID, filter http.QueryHeader, holderPolicy mmodel.HolderPolicy) ([]*mmodel.Account, error) {
 	logger, tracer, _, _ := libObservability.NewTrackingFromContext(ctx)
 
 	ctx, span := tracer.Start(ctx, "query.get_all_metadata_accounts")
@@ -55,7 +55,7 @@ func (uc *UseCase) GetAllMetadataAccounts(ctx context.Context, organizationID, l
 
 	filter.EntityIDs = uuids
 
-	accounts, err := uc.AccountRepo.FindAll(ctx, organizationID, ledgerID, portfolioID, segmentID, filter)
+	accounts, err := uc.AccountRepo.FindAll(ctx, organizationID, ledgerID, portfolioID, segmentID, filter, holderPolicy)
 	if err != nil {
 		if errors.Is(err, services.ErrDatabaseItemNotFound) {
 			err := pkg.ValidateBusinessError(constant.ErrNoAccountsFound, constant.EntityAccount)

--- a/components/ledger/internal/services/query/get_all_metadata_accounts_test.go
+++ b/components/ledger/internal/services/query/get_all_metadata_accounts_test.go
@@ -61,7 +61,7 @@ func TestGetAllMetadataAccounts(t *testing.T) {
 						{EntityID: acc2ID.String(), Data: map[string]any{"group": "ops"}},
 					}, nil)
 				mockAccountRepo.EXPECT().
-					FindAll(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					FindAll(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 					Return([]*mmodel.Account{
 						{ID: acc1ID.String(), Name: "Account 1", Status: mmodel.Status{Code: "ACTIVE"}},
 						{ID: acc2ID.String(), Name: "Account 2", Status: mmodel.Status{Code: "ACTIVE"}},
@@ -99,7 +99,7 @@ func TestGetAllMetadataAccounts(t *testing.T) {
 						},
 					}, nil)
 				mockAccountRepo.EXPECT().
-					FindAll(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					FindAll(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 					Return([]*mmodel.Account{
 						{ID: acc1ID.String(), Name: "Admin Account"},
 					}, nil)
@@ -122,7 +122,7 @@ func TestGetAllMetadataAccounts(t *testing.T) {
 						{EntityID: acc1ID.String(), Data: map[string]any{"key": "value"}},
 					}, nil)
 				mockAccountRepo.EXPECT().
-					FindAll(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Not(gomock.Nil()), gomock.Any(), gomock.Any()).
+					FindAll(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Not(gomock.Nil()), gomock.Any(), gomock.Any(), gomock.Any()).
 					Return([]*mmodel.Account{
 						{ID: acc1ID.String(), Name: "Portfolio Account"},
 					}, nil)
@@ -147,7 +147,7 @@ func TestGetAllMetadataAccounts(t *testing.T) {
 						{EntityID: acc1ID.String(), Data: map[string]any{"key": "seg-value"}},
 					}, nil)
 				mockAccountRepo.EXPECT().
-					FindAll(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Not(gomock.Nil()), gomock.Any()).
+					FindAll(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Not(gomock.Nil()), gomock.Any(), gomock.Any()).
 					Return([]*mmodel.Account{
 						{ID: acc1ID.String(), Name: "Segment Account"},
 					}, nil)
@@ -172,7 +172,7 @@ func TestGetAllMetadataAccounts(t *testing.T) {
 						{EntityID: acc1ID.String(), Data: map[string]any{"key": "both-value"}},
 					}, nil)
 				mockAccountRepo.EXPECT().
-					FindAll(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Not(gomock.Nil()), gomock.Not(gomock.Nil()), gomock.Any()).
+					FindAll(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Not(gomock.Nil()), gomock.Not(gomock.Nil()), gomock.Any(), gomock.Any()).
 					Return([]*mmodel.Account{
 						{ID: acc1ID.String(), Name: "Both Filters Account"},
 					}, nil)
@@ -222,7 +222,7 @@ func TestGetAllMetadataAccounts(t *testing.T) {
 						{EntityID: acc1ID.String(), Data: map[string]any{"key": "value"}},
 					}, nil)
 				mockAccountRepo.EXPECT().
-					FindAll(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					FindAll(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(nil, services.ErrDatabaseItemNotFound)
 			},
 			expectErr:   true,
@@ -240,7 +240,7 @@ func TestGetAllMetadataAccounts(t *testing.T) {
 						{EntityID: acc1ID.String(), Data: map[string]any{"key": "value"}},
 					}, nil)
 				mockAccountRepo.EXPECT().
-					FindAll(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					FindAll(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(nil, errors.New("database connection timeout"))
 			},
 			expectErr:   true,
@@ -260,7 +260,7 @@ func TestGetAllMetadataAccounts(t *testing.T) {
 						{EntityID: acc2ID.String(), Data: map[string]any{"found": true}},
 					}, nil)
 				mockAccountRepo.EXPECT().
-					FindAll(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					FindAll(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 					Return([]*mmodel.Account{
 						{ID: acc1ID.String(), Name: "Only This One"},
 					}, nil)
@@ -290,7 +290,7 @@ func TestGetAllMetadataAccounts(t *testing.T) {
 					}, nil)
 				// The key assertion: entityIDs are in filter.EntityIDs AND filter.Status is forwarded
 				mockAccountRepo.EXPECT().
-					FindAll(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					FindAll(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 					Return([]*mmodel.Account{
 						{ID: acc1ID.String(), Name: "Premium Active", Status: mmodel.Status{Code: "ACTIVE"}},
 					}, nil)
@@ -319,7 +319,7 @@ func TestGetAllMetadataAccounts(t *testing.T) {
 					}, nil)
 				// entityIDs AND AssetCode filter are both passed to FindAll
 				mockAccountRepo.EXPECT().
-					FindAll(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					FindAll(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 					Return([]*mmodel.Account{
 						{ID: acc1ID.String(), Name: "USD Account", AssetCode: "USD"},
 					}, nil)
@@ -347,7 +347,7 @@ func TestGetAllMetadataAccounts(t *testing.T) {
 						{EntityID: acc1ID.String(), Data: map[string]any{"category": "savings"}},
 					}, nil)
 				mockAccountRepo.EXPECT().
-					FindAll(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					FindAll(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 					Return([]*mmodel.Account{
 						{ID: acc1ID.String(), Name: "Deposit Account", Type: "deposit"},
 					}, nil)
@@ -375,7 +375,7 @@ func TestGetAllMetadataAccounts(t *testing.T) {
 						{EntityID: acc1ID.String(), Data: map[string]any{"priority": "high"}},
 					}, nil)
 				mockAccountRepo.EXPECT().
-					FindAll(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					FindAll(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 					Return([]*mmodel.Account{
 						{ID: acc1ID.String(), Name: "Main Account", Alias: func() *string { s := "main-account"; return &s }()},
 					}, nil)
@@ -406,7 +406,7 @@ func TestGetAllMetadataAccounts(t *testing.T) {
 					}, nil)
 				// All filters combined: entityIDs + status + asset_code + type
 				mockAccountRepo.EXPECT().
-					FindAll(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					FindAll(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 					Return([]*mmodel.Account{
 						{ID: acc1ID.String(), Name: "BRL Credit Card", AssetCode: "BRL", Type: "creditCard", Status: mmodel.Status{Code: "ACTIVE"}},
 					}, nil)
@@ -436,7 +436,7 @@ func TestGetAllMetadataAccounts(t *testing.T) {
 						{EntityID: acc1ID.String(), Data: map[string]any{"reason": "fraud"}},
 					}, nil)
 				mockAccountRepo.EXPECT().
-					FindAll(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					FindAll(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 					Return([]*mmodel.Account{
 						{ID: acc1ID.String(), Name: "Blocked Account"},
 					}, nil)
@@ -464,7 +464,7 @@ func TestGetAllMetadataAccounts(t *testing.T) {
 					}, nil)
 				// Metadata found IDs but status filter excludes all
 				mockAccountRepo.EXPECT().
-					FindAll(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					FindAll(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(nil, services.ErrDatabaseItemNotFound)
 			},
 			expectErr:   true,
@@ -477,7 +477,7 @@ func TestGetAllMetadataAccounts(t *testing.T) {
 			tt.mockSetup()
 
 			ctx := context.Background()
-			result, err := uc.GetAllMetadataAccounts(ctx, tt.organizationID, tt.ledgerID, tt.portfolioID, tt.segmentID, tt.filter)
+			result, err := uc.GetAllMetadataAccounts(ctx, tt.organizationID, tt.ledgerID, tt.portfolioID, tt.segmentID, tt.filter, mmodel.HolderOnV2)
 
 			if tt.expectErr {
 				require.Error(t, err)

--- a/components/ledger/internal/services/query/get_id_account.go
+++ b/components/ledger/internal/services/query/get_id_account.go
@@ -22,7 +22,7 @@ import (
 	libLog "github.com/LerianStudio/lib-observability/v2/log"
 )
 
-func (uc *UseCase) GetAccountByID(ctx context.Context, organizationID, ledgerID uuid.UUID, portfolioID *uuid.UUID, id uuid.UUID) (_ *mmodel.Account, err error) {
+func (uc *UseCase) GetAccountByID(ctx context.Context, organizationID, ledgerID uuid.UUID, portfolioID *uuid.UUID, id uuid.UUID, holderPolicy mmodel.HolderPolicy) (_ *mmodel.Account, err error) {
 	logger, tracer, _, _ := libObservability.NewTrackingFromContext(ctx)
 
 	ctx, span := tracer.Start(ctx, "query.get_account_by_id")
@@ -34,7 +34,7 @@ func (uc *UseCase) GetAccountByID(ctx context.Context, organizationID, ledgerID 
 		utils.RecordDomainOperation(ctx, uc.MetricsFactory, logger, "ledger", "get_account", start, err)
 	}()
 
-	account, err := uc.AccountRepo.Find(ctx, organizationID, ledgerID, portfolioID, id)
+	account, err := uc.AccountRepo.Find(ctx, organizationID, ledgerID, portfolioID, id, holderPolicy)
 	if err != nil {
 		logger.Log(ctx, libLog.LevelError, "Error getting account on repo by id", libLog.Err(err))
 

--- a/components/ledger/internal/services/query/get_id_account_test.go
+++ b/components/ledger/internal/services/query/get_id_account_test.go
@@ -52,7 +52,7 @@ func TestGetAccountByID(t *testing.T) {
 			mockSetup: func() {
 				b := true
 				mockAccountRepo.EXPECT().
-					Find(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Find(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(&mmodel.Account{ID: successAccountID.String(), Name: "Test Account", Status: mmodel.Status{Code: "active"}, Blocked: &b}, nil)
 				mockMetadataRepo.EXPECT().
 					FindByEntity(gomock.Any(), gomock.Any(), gomock.Any()).
@@ -75,7 +75,7 @@ func TestGetAccountByID(t *testing.T) {
 			accountID:      uuid.New(),
 			mockSetup: func() {
 				mockAccountRepo.EXPECT().
-					Find(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Find(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(nil, services.ErrDatabaseItemNotFound)
 			},
 			expectErr:      true,
@@ -90,7 +90,7 @@ func TestGetAccountByID(t *testing.T) {
 			mockSetup: func() {
 				accountID := uuid.New()
 				mockAccountRepo.EXPECT().
-					Find(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Find(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(&mmodel.Account{ID: accountID.String(), Name: "Test Account", Status: mmodel.Status{Code: "active"}}, nil)
 				mockMetadataRepo.EXPECT().
 					FindByEntity(gomock.Any(), gomock.Any(), gomock.Any()).
@@ -106,7 +106,7 @@ func TestGetAccountByID(t *testing.T) {
 			tt.mockSetup()
 
 			ctx := context.Background()
-			result, err := uc.GetAccountByID(ctx, tt.organizationID, tt.ledgerID, tt.portfolioID, tt.accountID)
+			result, err := uc.GetAccountByID(ctx, tt.organizationID, tt.ledgerID, tt.portfolioID, tt.accountID, mmodel.HolderOnV2)
 
 			if tt.expectErr {
 				assert.Error(t, err)

--- a/components/ledger/internal/services/query/get_id_account_test.go
+++ b/components/ledger/internal/services/query/get_id_account_test.go
@@ -52,7 +52,7 @@ func TestGetAccountByID(t *testing.T) {
 			mockSetup: func() {
 				b := true
 				mockAccountRepo.EXPECT().
-					Find(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Find(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), mmodel.HolderOnV2).
 					Return(&mmodel.Account{ID: successAccountID.String(), Name: "Test Account", Status: mmodel.Status{Code: "active"}, Blocked: &b}, nil)
 				mockMetadataRepo.EXPECT().
 					FindByEntity(gomock.Any(), gomock.Any(), gomock.Any()).
@@ -75,7 +75,7 @@ func TestGetAccountByID(t *testing.T) {
 			accountID:      uuid.New(),
 			mockSetup: func() {
 				mockAccountRepo.EXPECT().
-					Find(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Find(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), mmodel.HolderOnV2).
 					Return(nil, services.ErrDatabaseItemNotFound)
 			},
 			expectErr:      true,
@@ -90,7 +90,7 @@ func TestGetAccountByID(t *testing.T) {
 			mockSetup: func() {
 				accountID := uuid.New()
 				mockAccountRepo.EXPECT().
-					Find(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Find(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), mmodel.HolderOnV2).
 					Return(&mmodel.Account{ID: accountID.String(), Name: "Test Account", Status: mmodel.Status{Code: "active"}}, nil)
 				mockMetadataRepo.EXPECT().
 					FindByEntity(gomock.Any(), gomock.Any(), gomock.Any()).

--- a/components/ledger/internal/services/query/get_id_account_with_deleted.go
+++ b/components/ledger/internal/services/query/get_id_account_with_deleted.go
@@ -21,13 +21,13 @@ import (
 	libLog "github.com/LerianStudio/lib-observability/v2/log"
 )
 
-func (uc *UseCase) GetAccountByIDWithDeleted(ctx context.Context, organizationID, ledgerID uuid.UUID, portfolioID *uuid.UUID, id uuid.UUID) (*mmodel.Account, error) {
+func (uc *UseCase) GetAccountByIDWithDeleted(ctx context.Context, organizationID, ledgerID uuid.UUID, portfolioID *uuid.UUID, id uuid.UUID, holderPolicy mmodel.HolderPolicy) (*mmodel.Account, error) {
 	logger, tracer, _, _ := libObservability.NewTrackingFromContext(ctx)
 
 	ctx, span := tracer.Start(ctx, "query.get_account_by_id_with_deleted")
 	defer span.End()
 
-	account, err := uc.AccountRepo.FindWithDeleted(ctx, organizationID, ledgerID, portfolioID, id)
+	account, err := uc.AccountRepo.FindWithDeleted(ctx, organizationID, ledgerID, portfolioID, id, holderPolicy)
 	if err != nil {
 		logger.Log(ctx, libLog.LevelError, "Error getting account on repo by id", libLog.Err(err))
 

--- a/components/ledger/internal/services/query/get_id_account_with_deleted_test.go
+++ b/components/ledger/internal/services/query/get_id_account_with_deleted_test.go
@@ -49,7 +49,7 @@ func TestGetAccountByIDWithDeleted(t *testing.T) {
 			mockSetup: func() {
 				accountID := uuid.New()
 				mockAccountRepo.EXPECT().
-					FindWithDeleted(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					FindWithDeleted(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), mmodel.HolderOnV2).
 					Return(&mmodel.Account{ID: accountID.String(), Name: "Test Account", Status: mmodel.Status{Code: "active"}}, nil)
 				mockMetadataRepo.EXPECT().
 					FindByEntity(gomock.Any(), gomock.Any(), gomock.Any()).
@@ -71,7 +71,7 @@ func TestGetAccountByIDWithDeleted(t *testing.T) {
 			accountID:      uuid.New(),
 			mockSetup: func() {
 				mockAccountRepo.EXPECT().
-					FindWithDeleted(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					FindWithDeleted(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), mmodel.HolderOnV2).
 					Return(nil, services.ErrDatabaseItemNotFound)
 			},
 			expectErr:      true,
@@ -86,7 +86,7 @@ func TestGetAccountByIDWithDeleted(t *testing.T) {
 			mockSetup: func() {
 				accountID := uuid.New()
 				mockAccountRepo.EXPECT().
-					FindWithDeleted(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					FindWithDeleted(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), mmodel.HolderOnV2).
 					Return(&mmodel.Account{ID: accountID.String(), Name: "Test Account", Status: mmodel.Status{Code: "active"}}, nil)
 				mockMetadataRepo.EXPECT().
 					FindByEntity(gomock.Any(), gomock.Any(), gomock.Any()).

--- a/components/ledger/internal/services/query/get_id_account_with_deleted_test.go
+++ b/components/ledger/internal/services/query/get_id_account_with_deleted_test.go
@@ -49,7 +49,7 @@ func TestGetAccountByIDWithDeleted(t *testing.T) {
 			mockSetup: func() {
 				accountID := uuid.New()
 				mockAccountRepo.EXPECT().
-					FindWithDeleted(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					FindWithDeleted(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(&mmodel.Account{ID: accountID.String(), Name: "Test Account", Status: mmodel.Status{Code: "active"}}, nil)
 				mockMetadataRepo.EXPECT().
 					FindByEntity(gomock.Any(), gomock.Any(), gomock.Any()).
@@ -71,7 +71,7 @@ func TestGetAccountByIDWithDeleted(t *testing.T) {
 			accountID:      uuid.New(),
 			mockSetup: func() {
 				mockAccountRepo.EXPECT().
-					FindWithDeleted(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					FindWithDeleted(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(nil, services.ErrDatabaseItemNotFound)
 			},
 			expectErr:      true,
@@ -86,7 +86,7 @@ func TestGetAccountByIDWithDeleted(t *testing.T) {
 			mockSetup: func() {
 				accountID := uuid.New()
 				mockAccountRepo.EXPECT().
-					FindWithDeleted(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					FindWithDeleted(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(&mmodel.Account{ID: accountID.String(), Name: "Test Account", Status: mmodel.Status{Code: "active"}}, nil)
 				mockMetadataRepo.EXPECT().
 					FindByEntity(gomock.Any(), gomock.Any(), gomock.Any()).
@@ -102,7 +102,7 @@ func TestGetAccountByIDWithDeleted(t *testing.T) {
 			tt.mockSetup()
 
 			ctx := context.Background()
-			result, err := uc.GetAccountByIDWithDeleted(ctx, tt.organizationID, tt.ledgerID, tt.portfolioID, tt.accountID)
+			result, err := uc.GetAccountByIDWithDeleted(ctx, tt.organizationID, tt.ledgerID, tt.portfolioID, tt.accountID, mmodel.HolderOnV2)
 
 			if tt.expectErr {
 				assert.Error(t, err)

--- a/docs/api/SCOPING.md
+++ b/docs/api/SCOPING.md
@@ -182,6 +182,19 @@ neither the requireHolder gate (`ErrHolderRequired` / `ErrHolderNotFound`) nor a
 before the seam existed, and a client integrated against it must not acquire a holder link — or a
 new rejection class — from a version upgrade it never asked for.
 
+The independence is **physical, not only semantic**: the policy reaches the SQL, so a `/v1`
+statement never NAMES `holder_id` or `holder_check_skipped`. A create omits both columns — an
+account without a holder writes what they default to, so the row is identical either way — and a
+`/v1` read projects `NULL::uuid AS holder_id` and `FALSE AS holder_check_skipped`, which keeps the
+projection's arity and column order intact for the positional scans. `/v1` therefore stays servable
+against a database that has not reached migrations 000017 and 000019, which matters because the
+schema is applied out of band and the runner is tenant-agnostic: a tenant database can sit behind
+the binary. `/v2` names the real columns and, on such a database, answers `0501`
+`ErrSchemaMigrationPending` / **503** — retryable, because the same request succeeds once the
+migration runner reaches that database. The three `ListAccounts*` reads that serve the transaction
+and asset paths read no holder at all, so they always project the constants and are immune on both
+contracts.
+
 The withholding reaches the response too. Every `/v1` account response — create, list, get-by-id,
 get-by-alias, get-external-by-code, update — answers with the projection that omits `holderId` and
 `holderCheckSkipped`; the `/v2` twins answer with the full account. Both contracts publish the

--- a/docs/api/SCOPING.md
+++ b/docs/api/SCOPING.md
@@ -183,17 +183,31 @@ before the seam existed, and a client integrated against it must not acquire a h
 new rejection class — from a version upgrade it never asked for.
 
 The independence is **physical, not only semantic**: the policy reaches the SQL, so a `/v1`
-statement never NAMES `holder_id` or `holder_check_skipped`. A create omits both columns — an
-account without a holder writes what they default to, so the row is identical either way — and a
-`/v1` read projects `NULL::uuid AS holder_id` and `FALSE AS holder_check_skipped`, which keeps the
-projection's arity and column order intact for the positional scans. `/v1` therefore stays servable
-against a database that has not reached migrations 000017 and 000019, which matters because the
-schema is applied out of band and the runner is tenant-agnostic: a tenant database can sit behind
-the binary. `/v2` names the real columns and, on such a database, answers `0501`
-`ErrSchemaMigrationPending` / **503** — retryable, because the same request succeeds once the
-migration runner reaches that database. The three `ListAccounts*` reads that serve the transaction
-and asset paths read no holder at all, so they always project the constants and are immune on both
-contracts.
+statement does not NAME `holder_id` or `holder_check_skipped` — with one exception, the holder
+filter below. A create omits both columns — an account without a holder writes what they default
+to, so the row is identical either way — and a `/v1` read projects `NULL::uuid AS holder_id` and
+`FALSE AS holder_check_skipped`, which keeps the projection's arity and column order intact for the
+positional scans. `/v1` therefore stays servable against a database that has not reached migrations
+000017 and 000019, which matters because the schema is applied out of band and the runner is
+tenant-agnostic: a tenant database can sit behind the binary. `/v2` names the real columns and, on
+such a database, answers `0501` `ErrSchemaMigrationPending` / **503** — retryable, because the same
+request succeeds once the migration runner reaches that database. The three `ListAccounts*` reads
+that serve the transaction and asset paths read no holder at all, so they always project the
+constants and are immune on both contracts.
+
+The **exception is `GET /v1/.../accounts?holder_id=…`**. The list filter is applied on both
+contracts whenever the parameter is present, so that one `/v1` statement does add a
+`holder_id = ?` predicate and does fail on a pre-000017 database. This is a deliberate gap, not an
+oversight: filtering by holder on a contract whose responses withhold `holderId` is already an
+anomaly, and rejecting the parameter would hand `/v1` a new rejection class — the very thing this
+seam exists to prevent. Holder filtering on `/v1` is therefore not expected to work before
+migrations 000017 and 000019. Every other `/v1` read, and every `/v1` create, is unaffected.
+
+Ordering matters on the write paths. A `/v1` update completes on such a database: both its
+pre-update lookup and the update statement name no holder column. A `/v2` update fails at the
+lookup, before the row is mutated and `account.updated` is emitted — the update statement itself
+names no holder column, so a lookup that ignored the route version would let the mutation land and
+answer 503 over a write that actually happened.
 
 The withholding reaches the response too. Every `/v1` account response — create, list, get-by-id,
 get-by-alias, get-external-by-code, update — answers with the projection that omits `holderId` and

--- a/pkg/constant/errors.go
+++ b/pkg/constant/errors.go
@@ -476,6 +476,11 @@ var (
 	ErrReadyzStreamingUnhealthy               = errors.New("0496")
 	// 0499 is intentionally skipped: it is the last slot of the reserved Tracer platform block (0328-0499); 0500 starts fresh beyond all documented blocks.
 	ErrInvalidAccountTypeDirection = errors.New("0500")
+	// ErrSchemaMigrationPending is returned when a statement names a column the
+	// database does not have (SQLSTATE 42703), i.e. the binary is ahead of the
+	// applied migrations. Retryable: the schema is applied out of band, so the
+	// same request succeeds once the migration runner reaches this database.
+	ErrSchemaMigrationPending = errors.New("0501")
 )
 
 // List of CRM domain errors.

--- a/pkg/errors.go
+++ b/pkg/errors.go
@@ -1164,6 +1164,12 @@ func ValidateBusinessError(err error, entityType string, args ...any) error {
 			Title:      "Invalid Account Type Direction",
 			Message:    "The field 'defaultDirection' has an invalid value. Use one of the allowed values: credit or debit.",
 		},
+		constant.ErrSchemaMigrationPending: ServiceUnavailableError{
+			EntityType: entityType,
+			Code:       constant.ErrSchemaMigrationPending.Error(),
+			Title:      "Schema Migration Pending",
+			Message:    "The request could not be completed because a pending database migration has not been applied to this database yet. Please retry shortly.",
+		},
 		constant.ErrDuplicateAccountTypeKeyValue: EntityConflictError{
 			EntityType: entityType,
 			Code:       constant.ErrDuplicateAccountTypeKeyValue.Error(),

--- a/pkg/mmodel/account_holder_policy.go
+++ b/pkg/mmodel/account_holder_policy.go
@@ -1,0 +1,39 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package mmodel
+
+// HolderPolicy states whether the route version that received the request
+// contracts the account holder seam. It is a distinct type so it cannot be
+// transposed with the other arguments at a call site.
+//
+// It lives here, and not in the command or the adapter package, because both
+// sides need it: the command layer gates the holder seam on it, and the account
+// repository shapes its SQL projection on it. The repository owns the interface
+// the command layer depends on, so a type declared in either package would close
+// an import cycle with the other.
+type HolderPolicy bool
+
+const (
+	// HolderOffV1 is the /v1 account contract. It shipped before the holder seam
+	// existed, so a /v1 create must not acquire a holder link, a holder-skip
+	// rejection, or a required-holder rejection from a version upgrade. A holderId
+	// or skip.holder in a /v1 body is inert: the /v1 response withholds both holder
+	// keys (see AccountV1), so the field has no readable effect on this contract.
+	HolderOffV1 HolderPolicy = false
+
+	// HolderOnV2 is the /v2 account contract, which includes the holder seam:
+	// the requireHolder gate, the two-key per-call skip, and the self-holder
+	// default. The holder-account composition route contracts it too — it exists
+	// to link a holder — and is served on /v2 only.
+	HolderOnV2 HolderPolicy = true
+)
+
+// ProjectsHolder reports whether a read on this contract must project the real
+// holder columns. Only /v2 can observe them, so /v1 reads substitute constants
+// and never name the columns — which keeps the /v1 contract servable against a
+// schema that predates them.
+func (p HolderPolicy) ProjectsHolder() bool {
+	return p == HolderOnV2
+}

--- a/pkg/net/http/errors_golden_test.go
+++ b/pkg/net/http/errors_golden_test.go
@@ -273,6 +273,7 @@ func allSentinels() map[string]error {
 		"ErrAccountingAccountTypeValidationFailed":    constant.ErrAccountingAccountTypeValidationFailed,
 		"ErrInvalidAccountTypeKeyValue":               constant.ErrInvalidAccountTypeKeyValue,
 		"ErrInvalidAccountTypeDirection":              constant.ErrInvalidAccountTypeDirection,
+		"ErrSchemaMigrationPending":                   constant.ErrSchemaMigrationPending,
 		"ErrInvalidFutureTransactionDate":             constant.ErrInvalidFutureTransactionDate,
 		"ErrInvalidPendingFutureTransactionDate":      constant.ErrInvalidPendingFutureTransactionDate,
 		"ErrDuplicatedAliasKeyValue":                  constant.ErrDuplicatedAliasKeyValue,
@@ -802,6 +803,21 @@ func TestGolden_BusinessErrorCodeStatus(t *testing.T) {
 // fallthroughs; it never builds the typed error the helper produces, so this is the
 // only place the constructors' own (code, status) tuple is pinned. Plus the two
 // named-case checks (FailedPreconditionError->500, fallthrough->500/0046).
+// Schema drift must reach the wire as 503, not 500: the schema is applied out of
+// band, so the same request succeeds once the migration runner reaches the
+// database. A 5xx that reads as permanent would send clients to support instead
+// of to a retry.
+func TestGolden_SchemaMigrationPendingIsRetryable(t *testing.T) {
+	t.Parallel()
+
+	err := pkg.ValidateBusinessError(constant.ErrSchemaMigrationPending, "GoldenEntity")
+
+	status, code := driveWithError(t, err)
+
+	assert.Equal(t, fiber.StatusServiceUnavailable, status)
+	assert.Equal(t, constant.ErrSchemaMigrationPending.Error(), code)
+}
+
 func TestGolden_HelperPathCodeStatus(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
<table border="0" cellspacing="0" cellpadding="0">
  <tr>
    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
    <td><h1>Midaz</h1></td>
  </tr>
</table>

---

## Description

Account creation fails on every route — **including `/v1`, which does not contract the holder seam** — when the onboarding database has not reached migration `000017_add_account_holder_id_column` (and `000019`, which adds `holder_check_skipped`).

`docs/api/SCOPING.md` already states that a `/v1` create links no holder: the row persists `holder_id = NULL` and `holder_check_skipped = false`, and the response withholds both keys via `in.AccountV1`. So `/v1` never depended on those columns *semantically* — but the adapter's projection and INSERT named them unconditionally, so it depended on them *physically*. The statement is unparseable by PostgreSQL before a row is touched, and there was no degraded path.

**The blast radius was wider than account creation.** `ListAccountsByAlias` / `ListAccountsByIDs` project the same column list and are the transaction path, so a missing `000017` took down transactions too.

**Why this is common in SaaS:** in-process migration was removed (Epic 1.2). Schema is applied out of band, and `components/ledger/migrations-image/entrypoint.sh` is explicit that the runner is *tenant-agnostic* — "per-tenant looping is a deploy-Job concern". A tenant provisioned after the deploy, or one the Job's loop did not reach, runs a new binary against an old schema. Nothing detected it: no `schema_migrations` assertion at boot or in `/readyz`, and no SQLSTATE `42703` handling anywhere in production code.

### What changed

**`/v1` independence is now physical.** The route-version signal reaches the SQL:

- `accountColumns(withHolder bool)` replaces the static column list. Withholding substitutes **typed constants** rather than dropping entries — `NULL::uuid AS holder_id`, `FALSE AS holder_check_skipped` — so the projection keeps its arity, order and column types and **every positional `Scan` stays valid unchanged**.
- The INSERT names the holder columns only when they carry a value. An account without a holder writes what they default to, so the row is identical either way.
- `mmodel.HolderPolicy` is the canonical type. It cannot live in `command`: the `account` package owns the `Repository` interface that `command` already imports, so a type declared in either would close an import cycle. `command.RouteHolderPolicy` becomes a **type alias** with the constants re-exported, so no existing call site or test changes.
- The three `ListAccounts*` reads serving the transaction and asset paths read no holder at all and always project the constants — immune on both contracts.

**Why not an `information_schema` probe:** the adapter cannot tell a `/v1` read from a `/v2` one, so a probe would answer `/v2` with a silent `holderId: null` — a data lie in a financial system. The version signal is required either way, and with it the probe is redundant. The guarantee becomes structural and unit-testable instead of dependent on environment state, at no runtime cost.

**`/v2` fails loudly and retryably.** It names the real columns and answers `0501` `ErrSchemaMigrationPending` / **503**, mapped in the read paths as well as the write ones. 503 is the honest status: the same request succeeds once the migration runner reaches that database. Schema drift also now flips the span **red** — it is infrastructure failure, not a caller mistake, and `HandleSpanBusinessErrorEvent` was leaving those spans green.

### Known gaps (deliberate, unchanged)

- `GET /v1/.../accounts?holder_id=…` still fails on an old schema: the `FindAll` filter is applied whenever present. Filtering by holder on a contract that withholds holder is already an anomaly; making it a `400` would be a `/v1` contract change and does not belong in a mitigation.
- `CountByHolderID` (the CRM holder-delete ownership guard, `/v2`) still fails — and **should**: without the column there is no way to verify ownership, so blocking the delete is correct.
- Nothing signals drift at boot or in `/readyz`. A `DependencyChecker` comparing `schema_migrations` against the expected head is a worthwhile follow-up, though in multi-tenant it only reaches the static connection — precisely not the drifting one.

## Type of Change

- [ ] `feat`: New feature or capability
- [x] `fix`: Bug fix
- [ ] `perf`: Performance improvement
- [ ] `refactor`: Internal restructuring with no behavior change
- [ ] `docs`: Documentation only
- [ ] `style`: Formatting, whitespace, naming (no logic change)
- [ ] `test`: Adding or updating tests
- [ ] `ci`: CI pipeline or workflow changes
- [ ] `build`: Build system, Dockerfile, Go module dependencies
- [ ] `chore`: Maintenance, config, tooling
- [ ] `revert`: Reverts a previous commit
- [ ] `BREAKING CHANGE`: Consumers must update their integration

## Breaking Changes

None.

`/v1` responses are byte-identical before and after — verified by diffing captured responses against a drifted and a head schema. `/v2` behaviour on an up-to-date schema is unchanged: the existing adapter integration suite (~99 tests, covering `holder_id` round-trip, `Update` immutability and the `FindAll` holder filter) passes **without a single assertion edit**, which is the regression guard for the `/v2` projection.

Six read methods gained a `holderPolicy` parameter (`Find`, `FindAll`, `FindAlias`, `FindWithDeleted`, `ListByIDs`, `ListByAlias`). This is internal — `account.Repository` is not a published API.

## Testing

- [x] `make test` passes
- [x] `make test-int` passes if integration paths are exercised
- [x] `make lint` passes
- [x] `make sec` and `make vulncheck` pass

**Test evidence:**

Unit — 96 packages, 0 failures. New unit tests pin the projection's arity and the position of both holder columns (the invariant the nine positional scans depend on), the INSERT's 17-vs-19-column shape, the `42703` mapping, and `503` at the wire via `driveWithError`.

Integration — a new suite (`account_schema_drift_integration_test.go`) runs against a **genuinely drifted** database, built by applying migrations `000017`/`000019`'s own `.down.sql`, so the fixture cannot drift from what the up migrations add.

`make sec`: gosec 787 files / 155909 lines / **0 issues**; govulncheck **0 reachable vulnerabilities**.

**Manual verification against the local stack** (ledger built from this branch, columns dropped on the live onboarding database, then restored losslessly and verified against a backup — 1338 holder values, 0 divergences):

| Call | Drifted schema | Head schema |
|---|---|---|
| `POST /v1/accounts` | **201**, no holder keys | **201** |
| `GET /v1/accounts/{id}` · list · by-alias | **200** | **200**, byte-identical |
| `PATCH /v1/accounts/{id}` | **200** | **200** |
| `POST /v1/transactions/inflow` | **201**, `APPROVED`, 2 operations | **201** |
| `POST /v2/accounts` | **503** `0501` | **201**, self-holder materialised |
| `GET /v2/accounts/{id}` · list | **503** `0501` | **200**, holder present |

That manual pass is what caught the read-path half of the bug: `/v2` reads were returning the opaque `500`/`0046` because only `Create` and `Update` routed through `ValidatePGError`. The integration assertion had been too weak to notice (`require.Error` only) and now demands the sentinel on all four policy-bearing reads.

## Architectural Checklist

- [x] No `panic()` in production paths
- [x] Timestamps use `time.Now().UTC()` — no new timestamp handling
- [x] Errors wrapped with `%w` — business errors returned directly per the platform rules
- [x] Handlers stay thin (parse, validate, call service) — handlers only pass the version constant they already pass on create
- [x] Infrastructure concerns kept in `internal/bootstrap`

## Related Issues

Closes #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added holder-aware account retrieval, listing, creation, and updates for v2 operations.
  * Preserved v1 compatibility by excluding holder data from supported v1 account operations.
  * Added clear HTTP 503 responses when required database migrations are pending.
* **Bug Fixes**
  * Improved behavior across mixed migration states, including preventing v2 updates before required schema changes are available.
* **Documentation**
  * Documented holder behavior and migration requirements for v1 and v2 account operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->