### PR TITLE
fix(ledger): raise balance cache TTL to 1 day

### DIFF
--- a/components/ledger/internal/adapters/redis/transaction/consumer.redis.go
+++ b/components/ledger/internal/adapters/redis/transaction/consumer.redis.go
@@ -1473,11 +1473,11 @@ func luaBalanceSettingKey(m map[string]any, primary string, aliases ...string) {
 }
 
 // balanceCacheSettingsTTL matches the TTL the balance atomic Lua script applies
-// to each cached balance key (`local ttl = 3600 -- 1 hour` in
+// to each cached balance key (`local ttl = 86400 -- 1 day` in
 // scripts/balance_atomic_operation.lua). Keeping the two in lock-step ensures
 // a settings-only rewrite does not silently extend or shrink the lifetime of
 // an entry relative to the transactional refreshes driven by Lua.
-const balanceCacheSettingsTTL = 3600 * time.Second
+const balanceCacheSettingsTTL = 86400 * time.Second
 
 // UpdateBalanceCacheSettings rewrites the settings fields of a cached balance
 // JSON blob in-place, preserving the live transactional state (Available,

--- a/components/ledger/internal/adapters/redis/transaction/consumer.redis_settings_update_test.go
+++ b/components/ledger/internal/adapters/redis/transaction/consumer.redis_settings_update_test.go
@@ -150,7 +150,7 @@ func TestUpdateBalanceCacheSettings_PreservesLiveTransactionalState(t *testing.T
 	assert.Equal(t, expectedKey, stub.getCalls[0])
 	assert.Equal(t, expectedKey, stub.setCalls[0].Key)
 	assert.Equal(t, balanceCacheSettingsTTL, stub.setCalls[0].TTL,
-		"TTL must match the Lua script's 1-hour canonical value to avoid silent lifetime drift")
+		"TTL must match the Lua script's 1-day canonical value to avoid silent lifetime drift")
 
 	// Decode the written payload and pin every invariant.
 	raw, ok := stub.setCalls[0].Value.(string)

--- a/components/ledger/internal/adapters/redis/transaction/scripts/balance_atomic_operation.lua
+++ b/components/ledger/internal/adapters/redis/transaction/scripts/balance_atomic_operation.lua
@@ -239,7 +239,7 @@ local function rollback(rollbackBalances, ttl)
 end
 
 local function main()
-    local ttl = 3600 -- 1 hour
+    local ttl = 86400 -- 1 day
 
     local groupSize = 24
     local returnBalances = {}


### PR DESCRIPTION
## Description

Raises the Redis/Valkey balance-cache TTL from 3600s (1h) to 86400s
(1 day). The balance cache TTL is the effective safety window for the
async flush-to-Postgres worker: if the worker backlogs longer than the
TTL, the cached balance key expires, its scheduled sync entry is treated
as orphaned and dropped, and readers fall back to the stale Postgres
value — losing the in-flight delta from the sync path. Widening the
window reduces that risk under worker backlog.

The value lives in two lock-step spots (no env var), both updated here
and kept in seconds:
- `scripts/balance_atomic_operation.lua` — `local ttl = 86400`, applied
  on every balance mutation.
- `consumer.redis.go` — `const balanceCacheSettingsTTL = 86400 * time.Second`,
  the Go mirror used by the settings-only rewrite path.

The lock/claim (600s) and delete-marker (30s) TTLs are intentionally
left untouched. Operational note: cache entries now live up to 24h,
increasing the Valkey memory footprint for balance keys.

## Type of Change

- [x] `fix`: Bug fix

## Breaking Changes

None. No API, contract, or storage-format change.

## Testing

- [x] `make lint` passes (golangci-lint v2.4.0, scoped to changed package: 0 issues)
- [ ] `make test` passes
- [ ] `make test-int` passes if integration paths are exercised
- [ ] `make sec` and `make vulncheck` pass

**Test evidence / Actions run:** locally ran `go build` + `go vet` + coupled unit tests (`Settings|TTL|Update`, `-short`) — all pass. Full suite, integration, sec and vulncheck run in CI.

## Architectural Checklist

- [x] No `panic()` in production paths
- [x] Errors wrapped with `%w`

## Related Issues

N/A
