### PR TITLE
fix(fees): resolve tenant postgres on fee routes

### DIFF
--- a/components/ledger/internal/bootstrap/config.go
+++ b/components/ledger/internal/bootstrap/config.go
@@ -1478,6 +1478,11 @@ type unifiedRouteSetup struct {
 	crmRouteOptions         *midazhttp.ProtectedRouteOptions
 	feesRouteOptions        *midazhttp.ProtectedRouteOptions
 	compositionRouteOptions *midazhttp.ProtectedRouteOptions
+
+	// feesTenantMiddleware is the fee-route tenant middleware instance, exposed so
+	// its configured module managers stay pinnable by a same-package regression
+	// test. Nil in single-tenant mode, where no tenant middleware is built.
+	feesTenantMiddleware *tmmiddleware.TenantMiddleware
 }
 
 func buildUnifiedRouteSetup(
@@ -1556,27 +1561,38 @@ func buildUnifiedRouteSetup(
 		tmmiddleware.WithTenantLoader(tenantLoader),
 	)
 
-	// Fees tenant middleware is its own SEPARATE instance carrying ONLY the
-	// fees Mongo manager, for the same isolation reason as CRM: mounting
-	// the fee WithTenantDB on the onboarding/transaction middleware (or globally)
-	// would overwrite the tenant Mongo that ledger handlers resolve. It is
-	// attached only to fee routes via feesRouteOptions below.
+	// Fees tenant middleware is its own SEPARATE instance, attached only to fee
+	// routes via feesRouteOptions below (never global, never on ledger routes),
+	// for the same isolation reason as CRM: mounting a generic-key WithTenantDB
+	// globally would overwrite the tenant Mongo that ledger handlers resolve.
+	// Route scoping keeps every key this instance writes off ledger routes, so
+	// the generic-key fees MB write cannot collide with the module-keyed
+	// onboarding/transaction injection ledger routes carry.
 	//
-	// WithMB is called WITHOUT a module name (single-manager mode) on purpose:
-	// the fee pack/billing_package repos read tmcore.GetMBContext(ctx) on the
-	// GENERIC key (the standalone fees service ran single-module — it registered
-	// its manager under the SERVICE name with no WithModule). A module-keyed
-	// WithMB would write the fee module key while the repos read the generic
-	// key, so MT fee requests would fail DB resolution. Route scoping keeps the
-	// generic-key write from colliding with the module-keyed onboarding/
-	// transaction injection on ledger routes. (The manager itself still carries
-	// WithModule(ModuleFees) for tenant-manager DB resolution; that is a separate
-	// concern from the request-context key.) Same cache/loader are reused.
+	// WithMB(feesMongoManager) stays WITHOUT a module name (generic key): the fee
+	// pack/billing_package repos read tmcore.GetMBContext(ctx) on the GENERIC key,
+	// so a module-keyed fees MB would fail their DB resolution.
+	//
+	// The module-keyed injections cover the stores the fee paths reach beyond the
+	// fee Mongo: fee package create/update and estimate validate account aliases
+	// through the onboarding account repo (onboarding PG); billing/calculate
+	// counts transactions through the transaction repo (transaction PG, volume
+	// branch); account enrichment reads the onboarding metadata repo (onboarding
+	// MB). These module keys are distinct from the generic key, so they coexist
+	// with the fees MB on this instance without collision.
+	//
+	// Fee routes therefore hard-depend on the tenant having both onboarding and
+	// transaction PG provisioning, because this middleware eagerly resolves every
+	// registered manager on each fee request.
 	feesTenantMiddleware := tmmiddleware.NewTenantMiddleware(
+		tmmiddleware.WithPG(onboardingPGManager, constant.ModuleOnboarding),
+		tmmiddleware.WithPG(transactionPGManager, constant.ModuleTransaction),
+		tmmiddleware.WithMB(onboardingMongoManager, constant.ModuleOnboarding),
 		tmmiddleware.WithMB(feesMongoManager),
 		tmmiddleware.WithTenantCache(tenantCache),
 		tmmiddleware.WithTenantLoader(tenantLoader),
 	)
+	setup.feesTenantMiddleware = feesTenantMiddleware
 
 	// Composition tenant middleware is its own SEPARATE instance spanning BOTH
 	// stores the holder-account composition touches: the onboarding PostgreSQL

--- a/components/ledger/internal/bootstrap/fees_tenant_wiring_test.go
+++ b/components/ledger/internal/bootstrap/fees_tenant_wiring_test.go
@@ -1,0 +1,96 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package bootstrap
+
+import (
+	"reflect"
+	"testing"
+
+	tmmongo "github.com/LerianStudio/lib-commons/v6/commons/tenant-manager/mongo"
+	tmpostgres "github.com/LerianStudio/lib-commons/v6/commons/tenant-manager/postgres"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/LerianStudio/midaz/v4/pkg/constant"
+)
+
+// TestFeesTenantMiddlewareWiring pins the fee-route tenant middleware to the managers the
+// fee/billing paths actually reach in multi-tenant mode. The fee create/update/estimate and
+// billing paths resolve the onboarding account repo (onboarding PG), the transaction repo
+// (transaction PG, billing volume branch) and the onboarding metadata repo (onboarding MB);
+// the fee pack/billing_package repos read the generic Mongo key. A middleware missing any of
+// those injections returns the 500 "tenant postgres connection missing from context" this test
+// exists to prevent.
+//
+// The TenantMiddleware fields are unexported in lib-commons v6, so the module maps are read via
+// reflect. A module-keyed WithPG/WithMB lands in pgModules/mongoModules; a no-module WithMB
+// (the generic fees MB) lands in the single-manager mongo field, not the map. Both are asserted.
+func TestFeesTenantMiddlewareWiring(t *testing.T) {
+	t.Parallel()
+
+	logger := newTestLogger()
+
+	// Multi-tenant: non-nil managers make buildUnifiedRouteSetup build the fee middleware. The
+	// managers are zero-value structs because the wiring only registers them into the middleware;
+	// no DB connection is opened here (pure, no-I/O unit test).
+	mtSetup, err := buildUnifiedRouteSetup(
+		&Config{MultiTenantEnabled: true}, logger,
+		&tmpostgres.Manager{}, &tmpostgres.Manager{},
+		&tmmongo.Manager{}, &tmmongo.Manager{}, &tmmongo.Manager{}, &tmmongo.Manager{},
+		nil, nil,
+	)
+	require.NoError(t, err, "multi-tenant setup must not error")
+	require.NotNil(t, mtSetup, "multi-tenant setup must be non-nil")
+	require.NotNil(t, mtSetup.feesTenantMiddleware, "fees tenant middleware must be built in multi-tenant mode")
+
+	mw := reflect.ValueOf(mtSetup.feesTenantMiddleware).Elem()
+
+	pgKeys := mapKeys(t, mw, "pgModules")
+	assert.ElementsMatch(t, []string{constant.ModuleOnboarding, constant.ModuleTransaction}, pgKeys,
+		"fees middleware must carry module-keyed onboarding+transaction PostgreSQL managers: fee paths reach the "+
+			"onboarding account repo and the transaction volume repo, both requiring the tenant PG in context")
+
+	mbKeys := mapKeys(t, mw, "mongoModules")
+	assert.ElementsMatch(t, []string{constant.ModuleOnboarding}, mbKeys,
+		"fees middleware must carry exactly the module-keyed onboarding Mongo manager: account metadata enrichment "+
+			"reads the onboarding metadata repo on the module key, and no transaction Mongo module is injected")
+
+	// The generic fees MB is registered with a no-module WithMB, which lib-commons stores in the
+	// single-manager mongo field (not mongoModules). The fee pack/billing_package repos read the
+	// generic key, so this manager must remain present.
+	genericMB := mw.FieldByName("mongo")
+	if !genericMB.IsValid() {
+		t.Fatalf("lib-commons TenantMiddleware renamed field %q; update this test", "mongo")
+	}
+	assert.False(t, genericMB.IsNil(), "fees middleware must keep the generic (no-module) fees Mongo manager: fee "+
+		"pack/billing_package repos read tmcore.GetMBContext(ctx) on the generic key")
+
+	// Single-tenant: buildUnifiedRouteSetup short-circuits to a zero-value setup before it builds
+	// any tenant middleware, so the seam is nil (parallel to the nil route options).
+	stSetup, err := buildUnifiedRouteSetup(&Config{}, logger, nil, nil, nil, nil, nil, nil, nil, nil)
+	require.NoError(t, err, "single-tenant setup must not error")
+	require.NotNil(t, stSetup, "single-tenant setup is a zero value, not nil")
+	assert.Nil(t, stSetup.feesTenantMiddleware, "single-tenant fees tenant middleware must be nil")
+}
+
+// mapKeys reads the string keys of an unexported map[string]* field on the reflected middleware.
+// The fields are unexported in lib-commons v6; reflect can enumerate a map's keys and read string
+// values without the unexported-access restriction that blocks Interface(). A renamed field yields
+// an invalid Value, which fails loud so a lib-commons bump does not silently pass this test.
+func mapKeys(t *testing.T, v reflect.Value, field string) []string {
+	t.Helper()
+
+	f := v.FieldByName(field)
+	if !f.IsValid() {
+		t.Fatalf("lib-commons TenantMiddleware renamed field %q; update this test", field)
+	}
+
+	keys := make([]string, 0, f.Len())
+	for _, k := range f.MapKeys() {
+		keys = append(keys, k.String())
+	}
+
+	return keys
+}


### PR DESCRIPTION
<table border="0" cellspacing="0" cellpadding="0">
  <tr>
    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
    <td><h1>Midaz</h1></td>
  </tr>
</table>

---

## Description

In multi-tenant mode, fee/billing routes returned HTTP 500 `tenant postgres connection missing from context`. The `feesTenantMiddleware` (`components/ledger/internal/bootstrap/config.go`) injected only the fees Mongo manager on the generic context key, but fee flows reach tenant-scoped PostgreSQL repositories: `CreatePackage`/`UpdatePackageByID`, `CreateBillingPackage` and `EstimateFeeCalculation` validate accounts (onboarding PG), and `CalculateBilling` counts transactions (transaction PG); account metadata enrichment reads the onboarding Mongo.

The fix injects module-keyed `WithPG(onboarding, ModuleOnboarding)`, `WithPG(transaction, ModuleTransaction)` and `WithMB(onboarding, ModuleOnboarding)` into `feesTenantMiddleware`, keeping `WithMB(feesMongoManager)` on the generic key (the fee pack/billing-package repositories read the generic key). It mirrors the pattern already used by `tenantMiddleware` and `compositionTenantMiddleware`. A regression test pins the wiring.

## Type of Change

- [x] `fix`: Bug fix

## Breaking Changes

None. This is internal wiring: no change to HTTP contracts, env vars, schemas, or exported API (only an unexported field on the setup struct). Single-tenant mode is unaffected (it falls back to the static connection). Rolling update is safe.

## Testing

- [ ] `make test` passes  (bootstrap package unit tests pass locally; full suite runs in CI)
- [ ] `make test-int` passes if integration paths are exercised  (n/a - wiring change)
- [x] `make lint` passes  (golangci-lint v2, no issues on changed files)
- [ ] `make sec` and `make vulncheck` pass  (no dependency change; runs in CI)

**Test evidence / Actions run:** TDD RED->GREEN on `TestFeesTenantMiddlewareWiring`; `TestRouteOptionsBinding` and `TestRouteRoles` (197 golden routes) green.

## Architectural Checklist

- [x] No `panic()` in production paths
- [ ] Timestamps use `time.Now().UTC()`  (n/a)
- [ ] Errors wrapped with `%w`  (n/a)
- [ ] Handlers stay thin (parse, validate, call service)  (n/a)
- [x] Infrastructure concerns kept in `internal/bootstrap`

## Related Issues

Tracked in Lerian Map - card #4667 (no GitHub issue).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fee-route tenant handling across multi-tenant configurations.
  * Ensured fee processing can access the required onboarding, transaction, and fee data services.
  * Preserved streamlined behavior for single-tenant configurations.

* **Tests**
  * Added coverage validating fee-service setup in both multi-tenant and single-tenant environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->