### PR TITLE
fix(ledger): recover the balance sync worker from tenant pool loss

### DIFF
--- a/components/ledger/internal/bootstrap/balance_sync.collector.go
+++ b/components/ledger/internal/bootstrap/balance_sync.collector.go
@@ -225,7 +225,7 @@ func (c *BalanceSyncCollector) handleIdleMode(ctx context.Context, timer *time.T
 }
 
 // flushRemaining drains any leftover buffer on shutdown.
-// ctx carries context values (tenant ID, PG connection) needed by the flush callback.
+// ctx carries the context values (e.g. tenant ID) the flush callback needs.
 // The cancellation signal is stripped via context.WithoutCancel so the final flush
 // can complete even after the parent context has been cancelled.
 const shutdownFlushTimeout = 30 * time.Second
@@ -237,8 +237,8 @@ func (c *BalanceSyncCollector) flushRemaining(ctx context.Context) {
 	c.mu.Unlock()
 
 	if len(remaining) > 0 && c.flushFn != nil {
-		// Use WithoutCancel to preserve context values (tenant ID, PG connection)
-		// while removing the cancellation signal that already fired.
+		// Use WithoutCancel to preserve context values (e.g. tenant ID) while
+		// removing the cancellation signal that already fired.
 		flushCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), shutdownFlushTimeout)
 		defer cancel()
 

--- a/components/ledger/internal/bootstrap/balance_sync.mt_lifecycle_test.go
+++ b/components/ledger/internal/bootstrap/balance_sync.mt_lifecycle_test.go
@@ -24,6 +24,7 @@ import (
 
 	redisTransaction "github.com/LerianStudio/midaz/v4/components/ledger/internal/adapters/redis/transaction"
 	"github.com/LerianStudio/midaz/v4/components/ledger/internal/services/command"
+	"github.com/LerianStudio/midaz/v4/pkg/constant"
 )
 
 // --------------------------------------------------------------------
@@ -661,4 +662,40 @@ func TestStopAllCollectors_CancelsBeforeWaiting(t *testing.T) {
 		"stop should be fast since cancels happen before waits")
 
 	assert.Empty(t, collectors, "map should be cleared")
+}
+
+// --------------------------------------------------------------------
+// Tests for resolveTenantPG
+// --------------------------------------------------------------------
+
+func TestResolveTenantPG_InjectsModuleTransactionHandle(t *testing.T) {
+	t.Parallel()
+
+	stub := newStubDB()
+	resolver := &fakePGResolver{db: stub}
+	w := newTestWorkerWithResolver(t, tenantcache.NewTenantCache(), resolver)
+
+	pgCtx, err := w.resolveTenantPG(context.Background(), "tenant-1")
+
+	require.NoError(t, err)
+	require.NotNil(t, pgCtx)
+	assert.Equal(t, stub, tmcore.GetPGContext(pgCtx, constant.ModuleTransaction),
+		"the module-specific entry must carry the resolved handle")
+	assert.Nil(t, tmcore.GetPGContext(pgCtx),
+		"the generic entry must stay unset; getDB looks up the module one first")
+	assert.Equal(t, int32(1), resolver.calls.Load(),
+		"resolveTenantPG must resolve exactly once per call")
+}
+
+func TestResolveTenantPG_Error(t *testing.T) {
+	t.Parallel()
+
+	wantErr := errors.New("pool gone")
+	resolver := &fakePGResolver{err: wantErr}
+	w := newTestWorkerWithResolver(t, tenantcache.NewTenantCache(), resolver)
+
+	pgCtx, err := w.resolveTenantPG(context.Background(), "tenant-1")
+
+	require.ErrorIs(t, err, wantErr, "the resolver error must surface unwrapped")
+	assert.Nil(t, pgCtx, "no context must be returned when resolution fails")
 }

--- a/components/ledger/internal/bootstrap/balance_sync.mt_lifecycle_test.go
+++ b/components/ledger/internal/bootstrap/balance_sync.mt_lifecycle_test.go
@@ -6,6 +6,9 @@ package bootstrap
 
 import (
 	"context"
+	"database/sql"
+	"database/sql/driver"
+	"errors"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -15,6 +18,7 @@ import (
 	tmcore "github.com/LerianStudio/lib-commons/v6/commons/tenant-manager/core"
 	tmpostgres "github.com/LerianStudio/lib-commons/v6/commons/tenant-manager/postgres"
 	"github.com/LerianStudio/lib-commons/v6/commons/tenant-manager/tenantcache"
+	"github.com/bxcodec/dbresolver/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -72,6 +76,70 @@ func newTestWorkerWithCache(t *testing.T, cache *tenantcache.TenantCache) *Balan
 		logger, useCase, BalanceSyncConfig{},
 		true, cache, pgMgr, "transaction",
 	)
+}
+
+// newTestWorkerWithResolver creates an MT-ready BalanceSyncWorker whose tenant PG
+// resolution is driven by resolver, so a test can both control what a flush sees
+// and count how often the handle is resolved.
+func newTestWorkerWithResolver(t *testing.T, cache *tenantcache.TenantCache, resolver tenantPGResolver) *BalanceSyncWorker {
+	t.Helper()
+
+	w := NewBalanceSyncWorkerMT(
+		newTestLogger(), &command.UseCase{}, BalanceSyncConfig{},
+		true, cache, nil, "transaction",
+	)
+	w.pgResolver = resolver
+
+	return w
+}
+
+// fakePGResolver is a tenantPGResolver whose result a test can swap between
+// flushes, standing in for a tenant manager that closed and rebuilt a pool.
+type fakePGResolver struct {
+	mu    sync.Mutex
+	calls atomic.Int32
+	db    dbresolver.DB
+	err   error
+}
+
+func (f *fakePGResolver) GetDB(_ context.Context, _ string) (dbresolver.DB, error) {
+	f.calls.Add(1)
+
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	return f.db, f.err
+}
+
+// set swaps the pair GetDB returns from the next call onwards.
+func (f *fakePGResolver) set(db dbresolver.DB, err error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	f.db = db
+	f.err = err
+}
+
+// newStubDB mints a dbresolver.DB backed by a *sql.DB that never dials. Resolver
+// tests compare handle identity, so the handle must be distinguishable but is
+// never queried.
+func newStubDB() dbresolver.DB {
+	return dbresolver.New(dbresolver.WithPrimaryDBs(sql.OpenDB(stubConnector{})))
+}
+
+// stubConnector satisfies driver.Connector without opening a connection.
+type stubConnector struct{}
+
+func (stubConnector) Connect(context.Context) (driver.Conn, error) {
+	return nil, errors.New("stub connector: not a real database")
+}
+
+func (stubConnector) Driver() driver.Driver { return stubDriver{} }
+
+type stubDriver struct{}
+
+func (stubDriver) Open(string) (driver.Conn, error) {
+	return nil, errors.New("stub driver: not a real database")
 }
 
 // --------------------------------------------------------------------

--- a/components/ledger/internal/bootstrap/balance_sync.mt_lifecycle_test.go
+++ b/components/ledger/internal/bootstrap/balance_sync.mt_lifecycle_test.go
@@ -79,6 +79,21 @@ func newTestWorkerWithCache(t *testing.T, cache *tenantcache.TenantCache) *Balan
 	)
 }
 
+// collectorTenantIDs returns the tenants with a running collector. It lives here
+// because only assertions need to enumerate the map; production reads one tenant
+// at a time through HasCollector.
+func (w *BalanceSyncWorker) collectorTenantIDs() []string {
+	w.collectorsMu.Lock()
+	defer w.collectorsMu.Unlock()
+
+	ids := make([]string, 0, len(w.collectors))
+	for id := range w.collectors {
+		ids = append(ids, id)
+	}
+
+	return ids
+}
+
 // newTestWorkerWithResolver creates an MT-ready BalanceSyncWorker whose tenant PG
 // resolution is driven by resolver, so a test can both control what a flush sees
 // and count how often the handle is resolved.
@@ -156,16 +171,16 @@ func TestReconcileCollectors_ReapsDeadCollector(t *testing.T) {
 	w := newTestWorkerWithCache(t, cache)
 
 	// Pre-populate with a dead collector (goroutine already exited)
-	collectors := map[string]*tenantCollector{
+	w.collectors = map[string]*tenantCollector{
 		"tenant-1": newDeadTenantCollector("tenant-1"),
 	}
 
 	ctx := context.Background()
-	w.reconcileCollectors(ctx, collectors)
+	w.reconcileCollectors(ctx)
 
 	// Dead collector should be reaped. PG failure prevents restart,
 	// so the map should be empty.
-	assert.Empty(t, collectors, "dead collector should be reaped; PG failure prevents restart")
+	assert.Empty(t, w.collectorTenantIDs(), "dead collector should be reaped; PG failure prevents restart")
 }
 
 func TestReconcileCollectors_StopsRemovedTenant(t *testing.T) {
@@ -177,12 +192,12 @@ func TestReconcileCollectors_StopsRemovedTenant(t *testing.T) {
 	w := newTestWorkerWithCache(t, cache)
 
 	tc := newFakeTenantCollector("tenant-1")
-	collectors := map[string]*tenantCollector{
+	w.collectors = map[string]*tenantCollector{
 		"tenant-1": tc,
 	}
 
 	ctx := context.Background()
-	w.reconcileCollectors(ctx, collectors)
+	w.reconcileCollectors(ctx)
 
 	// Collector should have been cancelled and awaited
 	select {
@@ -192,7 +207,7 @@ func TestReconcileCollectors_StopsRemovedTenant(t *testing.T) {
 		t.Fatal("collector goroutine should have exited after cancel")
 	}
 
-	assert.Empty(t, collectors, "removed tenant's collector should be deleted from map")
+	assert.Empty(t, w.collectorTenantIDs(), "removed tenant's collector should be deleted from map")
 }
 
 func TestReconcileCollectors_StopsMultipleRemovedTenants(t *testing.T) {
@@ -208,14 +223,14 @@ func TestReconcileCollectors_StopsMultipleRemovedTenants(t *testing.T) {
 	tc3 := newFakeTenantCollector("tenant-3")
 	tc2 := newFakeTenantCollector("tenant-2")
 
-	collectors := map[string]*tenantCollector{
+	w.collectors = map[string]*tenantCollector{
 		"tenant-1": tc1,
 		"tenant-2": tc2,
 		"tenant-3": tc3,
 	}
 
 	ctx := context.Background()
-	w.reconcileCollectors(ctx, collectors)
+	w.reconcileCollectors(ctx)
 
 	// tenant-1 and tenant-3 should be stopped
 	select {
@@ -237,8 +252,8 @@ func TestReconcileCollectors_StopsMultipleRemovedTenants(t *testing.T) {
 	default:
 	}
 
-	assert.Len(t, collectors, 1, "only tenant-2 should remain")
-	assert.Contains(t, collectors, "tenant-2")
+	assert.Len(t, w.collectorTenantIDs(), 1, "only tenant-2 should remain")
+	assert.Contains(t, w.collectorTenantIDs(), "tenant-2")
 
 	// Cleanup
 	tc2.cancel()
@@ -254,16 +269,16 @@ func TestReconcileCollectors_NoOpWhenCollectorsMatchCache(t *testing.T) {
 	w := newTestWorkerWithCache(t, cache)
 
 	tc := newFakeTenantCollector("tenant-1")
-	collectors := map[string]*tenantCollector{
+	w.collectors = map[string]*tenantCollector{
 		"tenant-1": tc,
 	}
 
 	ctx := context.Background()
-	w.reconcileCollectors(ctx, collectors)
+	w.reconcileCollectors(ctx)
 
 	// Collector should still be running, map unchanged
-	assert.Len(t, collectors, 1)
-	assert.Contains(t, collectors, "tenant-1")
+	assert.Len(t, w.collectorTenantIDs(), 1)
+	assert.Contains(t, w.collectorTenantIDs(), "tenant-1")
 
 	select {
 	case <-tc.done:
@@ -284,12 +299,10 @@ func TestReconcileCollectors_EmptyCache(t *testing.T) {
 
 	w := newTestWorkerWithCache(t, cache)
 
-	collectors := make(map[string]*tenantCollector)
-
 	ctx := context.Background()
-	w.reconcileCollectors(ctx, collectors)
+	w.reconcileCollectors(ctx)
 
-	assert.Empty(t, collectors, "no tenants = no collectors")
+	assert.Empty(t, w.collectorTenantIDs(), "no tenants = no collectors")
 }
 
 func TestReconcileCollectors_NewTenantPGFails(t *testing.T) {
@@ -300,13 +313,11 @@ func TestReconcileCollectors_NewTenantPGFails(t *testing.T) {
 
 	w := newTestWorkerWithCache(t, cache) // unreachable pgManager
 
-	collectors := make(map[string]*tenantCollector)
-
 	ctx := context.Background()
-	w.reconcileCollectors(ctx, collectors)
+	w.reconcileCollectors(ctx)
 
 	// startTenantCollector should have failed (PG unreachable) — not added to map
-	assert.Empty(t, collectors, "PG failure should prevent collector from starting")
+	assert.Empty(t, w.collectorTenantIDs(), "PG failure should prevent collector from starting")
 }
 
 func TestReconcileCollectors_DeadCollectorRestartedButPGFails(t *testing.T) {
@@ -318,15 +329,15 @@ func TestReconcileCollectors_DeadCollectorRestartedButPGFails(t *testing.T) {
 	w := newTestWorkerWithCache(t, cache)
 
 	// Dead collector
-	collectors := map[string]*tenantCollector{
+	w.collectors = map[string]*tenantCollector{
 		"tenant-1": newDeadTenantCollector("tenant-1"),
 	}
 
 	ctx := context.Background()
-	w.reconcileCollectors(ctx, collectors)
+	w.reconcileCollectors(ctx)
 
 	// Dead collector reaped (Phase 1), restart attempted (Phase 3) but PG fails
-	assert.Empty(t, collectors, "restart should fail due to PG, leaving map empty")
+	assert.Empty(t, w.collectorTenantIDs(), "restart should fail due to PG, leaving map empty")
 }
 
 // --------------------------------------------------------------------
@@ -342,14 +353,14 @@ func TestStopAllCollectors_CancelsAndWaitsForAll(t *testing.T) {
 	tc2 := newFakeTenantCollector("tenant-2")
 	tc3 := newFakeTenantCollector("tenant-3")
 
-	collectors := map[string]*tenantCollector{
+	w.collectors = map[string]*tenantCollector{
 		"tenant-1": tc1,
 		"tenant-2": tc2,
 		"tenant-3": tc3,
 	}
 
 	ctx := context.Background()
-	w.stopAllCollectors(ctx, collectors)
+	w.stopAllCollectors(ctx)
 
 	// All should be stopped
 	for name, tc := range map[string]*tenantCollector{
@@ -364,7 +375,7 @@ func TestStopAllCollectors_CancelsAndWaitsForAll(t *testing.T) {
 		}
 	}
 
-	assert.Empty(t, collectors, "map should be cleared")
+	assert.Empty(t, w.collectorTenantIDs(), "map should be cleared")
 }
 
 func TestStopAllCollectors_EmptyMap(t *testing.T) {
@@ -372,12 +383,10 @@ func TestStopAllCollectors_EmptyMap(t *testing.T) {
 
 	w := &BalanceSyncWorker{logger: newTestLogger()}
 
-	collectors := make(map[string]*tenantCollector)
-
 	// Should not panic or block
-	w.stopAllCollectors(context.Background(), collectors)
+	w.stopAllCollectors(context.Background())
 
-	assert.Empty(t, collectors)
+	assert.Empty(t, w.collectorTenantIDs())
 }
 
 // --------------------------------------------------------------------
@@ -531,33 +540,32 @@ func TestReconcileCollectors_FullLifecycle(t *testing.T) {
 	cache := tenantcache.NewTenantCache()
 	w := newTestWorkerWithCache(t, cache)
 	ctx := context.Background()
-	collectors := make(map[string]*tenantCollector)
 
 	// Round 1: Empty cache → nothing happens
-	w.reconcileCollectors(ctx, collectors)
-	assert.Empty(t, collectors)
+	w.reconcileCollectors(ctx)
+	assert.Empty(t, w.collectorTenantIDs())
 
 	// Round 2: Add tenant-1 (PG fails, so won't start, but no crash)
 	cache.Set("tenant-1", &tmcore.TenantConfig{ID: "tenant-1"}, 1*time.Hour)
-	w.reconcileCollectors(ctx, collectors)
-	assert.Empty(t, collectors, "PG failure prevents start")
+	w.reconcileCollectors(ctx)
+	assert.Empty(t, w.collectorTenantIDs(), "PG failure prevents start")
 
 	// Round 3: Manually inject a running collector (simulating successful PG)
 	tc1 := newFakeTenantCollector("tenant-1")
-	collectors["tenant-1"] = tc1
-	w.reconcileCollectors(ctx, collectors)
-	assert.Len(t, collectors, 1, "existing collector left running")
+	w.collectors["tenant-1"] = tc1
+	w.reconcileCollectors(ctx)
+	assert.Len(t, w.collectorTenantIDs(), 1, "existing collector left running")
 
 	// Round 4: Add tenant-2 (PG fails), tenant-1 still running
 	cache.Set("tenant-2", &tmcore.TenantConfig{ID: "tenant-2"}, 1*time.Hour)
-	w.reconcileCollectors(ctx, collectors)
-	assert.Len(t, collectors, 1, "tenant-1 still running, tenant-2 failed to start")
-	assert.Contains(t, collectors, "tenant-1")
+	w.reconcileCollectors(ctx)
+	assert.Len(t, w.collectorTenantIDs(), 1, "tenant-1 still running, tenant-2 failed to start")
+	assert.Contains(t, w.collectorTenantIDs(), "tenant-1")
 
 	// Round 5: Remove tenant-1 from cache → collector stopped
 	cache.Delete("tenant-1")
-	w.reconcileCollectors(ctx, collectors)
-	assert.Empty(t, collectors, "tenant-1 removed, tenant-2 PG still failing")
+	w.reconcileCollectors(ctx)
+	assert.Empty(t, w.collectorTenantIDs(), "tenant-1 removed, tenant-2 PG still failing")
 
 	select {
 	case <-tc1.done:
@@ -578,8 +586,6 @@ func TestReconcileCollectors_ConcurrentSafety(t *testing.T) {
 	w := newTestWorkerWithCache(t, cache)
 	ctx := context.Background()
 
-	collectors := make(map[string]*tenantCollector)
-
 	// Simulates a collector that crashes/exits on its own
 	shortLived := func() *tenantCollector {
 		done := make(chan struct{})
@@ -593,16 +599,16 @@ func TestReconcileCollectors_ConcurrentSafety(t *testing.T) {
 		return &tenantCollector{tenantID: "tenant-1", cancel: func() {}, done: done}
 	}
 
-	collectors["tenant-1"] = shortLived()
+	w.collectors["tenant-1"] = shortLived()
 
 	// Wait for the collector to die
-	<-collectors["tenant-1"].done
+	<-w.collectors["tenant-1"].done
 
 	// Reconcile should detect the dead collector and attempt restart
-	w.reconcileCollectors(ctx, collectors)
+	w.reconcileCollectors(ctx)
 
 	// Should be empty (reap + PG failure on restart)
-	assert.Empty(t, collectors)
+	assert.Empty(t, w.collectorTenantIDs())
 }
 
 // --------------------------------------------------------------------
@@ -641,14 +647,14 @@ func TestStopAllCollectors_CancelsBeforeWaiting(t *testing.T) {
 		return &tenantCollector{tenantID: id, cancel: wrappedCancel, done: done}
 	}
 
-	collectors := map[string]*tenantCollector{
+	w.collectors = map[string]*tenantCollector{
 		"t1": makeCollector("t1"),
 		"t2": makeCollector("t2"),
 		"t3": makeCollector("t3"),
 	}
 
 	start := time.Now()
-	w.stopAllCollectors(context.Background(), collectors)
+	w.stopAllCollectors(context.Background())
 	elapsed := time.Since(start)
 
 	// All three should have been cancelled
@@ -661,7 +667,7 @@ func TestStopAllCollectors_CancelsBeforeWaiting(t *testing.T) {
 	assert.Less(t, elapsed, 200*time.Millisecond,
 		"stop should be fast since cancels happen before waits")
 
-	assert.Empty(t, collectors, "map should be cleared")
+	assert.Empty(t, w.collectorTenantIDs(), "map should be cleared")
 }
 
 // --------------------------------------------------------------------

--- a/components/ledger/internal/bootstrap/balance_sync.worker.go
+++ b/components/ledger/internal/bootstrap/balance_sync.worker.go
@@ -67,6 +67,9 @@ type BalanceSyncWorker struct {
 	tenantCache    *tenantcache.TenantCache
 	pgResolver     tenantPGResolver
 	serviceName    string
+	// flushBatchFn is the flush body the collectors call. It defaults to
+	// flushBatch; tests replace it to observe the context a flush receives.
+	flushBatchFn func(ctx context.Context, keys []redisTransaction.SyncKey) bool
 }
 
 // tenantCollector tracks a running BalanceSyncCollector goroutine for a specific tenant.
@@ -114,12 +117,15 @@ func NewBalanceSyncWorker(logger libLog.Logger, useCase *command.UseCase, syncCf
 		idleWait = 1 * time.Second
 	}
 
-	return &BalanceSyncWorker{
+	w := &BalanceSyncWorker{
 		logger:     logger,
 		idleWait:   idleWait,
 		syncConfig: syncCfg,
 		useCase:    useCase,
 	}
+	w.flushBatchFn = w.flushBatch
+
+	return w
 }
 
 // NewBalanceSyncWorkerMT creates a BalanceSyncWorker with MT (multi-tenant) fields populated.
@@ -224,7 +230,7 @@ func (w *BalanceSyncWorker) runWorker() error {
 		ctx,
 		// FlushFunc: batch flush grouped by org/ledger, then persisted to PostgreSQL
 		func(flushCtx context.Context, keys []redisTransaction.SyncKey) bool {
-			return w.flushBatch(flushCtx, keys)
+			return w.flushBatchFn(flushCtx, keys)
 		},
 		// FetchKeysFunc: claims due keys from the ZSET via Lua (ZRANGEBYSCORE + SET NX)
 		func(fetchCtx context.Context, limit int64) ([]redisTransaction.SyncKey, error) {
@@ -407,7 +413,7 @@ func (w *BalanceSyncWorker) startTenantCollector(parentCtx context.Context, tena
 					return false
 				}
 
-				return w.flushBatch(pgCtx, keys)
+				return w.flushBatchFn(pgCtx, keys)
 			},
 			// FetchKeysFunc: tenant context enables Redis key namespacing via tmvalkey.GetKeyContext
 			func(fetchCtx context.Context, limit int64) ([]redisTransaction.SyncKey, error) {

--- a/components/ledger/internal/bootstrap/balance_sync.worker.go
+++ b/components/ledger/internal/bootstrap/balance_sync.worker.go
@@ -350,14 +350,16 @@ func (w *BalanceSyncWorker) reconcileCollectors(ctx context.Context, collectors 
 	}
 }
 
-// startTenantCollector resolves the tenant's PostgreSQL connection, creates a
-// BalanceSyncCollector with tenant-scoped fetch/flush functions, and launches it
+// startTenantCollector checks that the tenant's PostgreSQL is resolvable, creates
+// a BalanceSyncCollector with tenant-scoped fetch/flush functions, and launches it
 // as a goroutine. Returns nil if the tenant's PG connection cannot be established.
+// The collector context carries only the tenant ID; the PG handle is resolved per
+// flush (see resolveTenantPG).
 func (w *BalanceSyncWorker) startTenantCollector(parentCtx context.Context, tenantID string) *tenantCollector {
 	tenantCtx := tmcore.ContextWithTenantID(parentCtx, tenantID)
 
-	db, err := w.pgResolver.GetDB(tenantCtx, tenantID)
-	if err != nil {
+	// Preflight: a tenant whose PG cannot be resolved gets no collector at all.
+	if _, err := w.pgResolver.GetDB(tenantCtx, tenantID); err != nil {
 		w.logger.Log(parentCtx, libLog.LevelError, "BalanceSyncWorker: failed to get PG connection for tenant",
 			libLog.String("tenant_id", tenantID), libLog.Err(err))
 
@@ -365,11 +367,6 @@ func (w *BalanceSyncWorker) startTenantCollector(parentCtx context.Context, tena
 
 		return nil
 	}
-
-	// Set the PG connection for the transaction module. The worker only operates
-	// on the transaction database — the generic (no-module) context entry is not
-	// needed because getDB always finds the module-specific one first.
-	tenantCtx = tmcore.ContextWithPG(tenantCtx, db, constant.ModuleTransaction)
 
 	collectorCtx, cancel := context.WithCancel(tenantCtx)
 
@@ -397,9 +394,20 @@ func (w *BalanceSyncWorker) startTenantCollector(parentCtx context.Context, tena
 
 		collector.Run(
 			collectorCtx,
-			// FlushFunc: batch flush grouped by org/ledger
+			// FlushFunc: resolve this tenant's PG handle, then batch flush grouped by org/ledger
 			func(flushCtx context.Context, keys []redisTransaction.SyncKey) bool {
-				return w.flushBatch(flushCtx, keys)
+				pgCtx, err := w.resolveTenantPG(flushCtx, tenantID)
+				if err != nil {
+					w.logger.Log(flushCtx, libLog.LevelWarn,
+						"BalanceSyncWorker: failed to resolve tenant PG for flush, skipping batch",
+						libLog.String("tenant_id", tenantID), libLog.Err(err))
+
+					w.emitTenantSkip(flushCtx, tenantID)
+
+					return false
+				}
+
+				return w.flushBatch(pgCtx, keys)
 			},
 			// FetchKeysFunc: tenant context enables Redis key namespacing via tmvalkey.GetKeyContext
 			func(fetchCtx context.Context, limit int64) ([]redisTransaction.SyncKey, error) {
@@ -420,6 +428,20 @@ func (w *BalanceSyncWorker) startTenantCollector(parentCtx context.Context, tena
 		cancel:   cancel,
 		done:     done,
 	}
+}
+
+// resolveTenantPG returns ctx carrying a freshly resolved transaction-module PG
+// handle for tenantID. Resolution is per call: the tenant manager may close or
+// swap a tenant's pool at any time, so a handle captured once would dangle.
+// The worker only touches the transaction database, so only the module-specific
+// context entry is set — getDB looks that one up first.
+func (w *BalanceSyncWorker) resolveTenantPG(ctx context.Context, tenantID string) (context.Context, error) {
+	db, err := w.pgResolver.GetDB(ctx, tenantID)
+	if err != nil {
+		return nil, err
+	}
+
+	return tmcore.ContextWithPG(ctx, db, constant.ModuleTransaction), nil
 }
 
 // stopAllCollectors cancels all running tenant collectors and waits for them to finish.

--- a/components/ledger/internal/bootstrap/balance_sync.worker.go
+++ b/components/ledger/internal/bootstrap/balance_sync.worker.go
@@ -570,9 +570,19 @@ func (w *BalanceSyncWorker) processSyncBatch(ctx context.Context, organizationID
 	ctx, span := tracer.Start(ctx, "balance.worker.process_batch")
 	defer span.End()
 
+	// Empty in single-tenant. Prometheus treats an empty label as absent, so the
+	// existing single-tenant series keep their identity.
+	tenantID := tmcore.GetTenantIDContext(ctx)
+
 	result, err := w.useCase.SyncBalancesBatch(ctx, organizationID, ledgerID, keys)
 	if err != nil {
-		w.logger.Log(ctx, libLog.LevelError, "BalanceSyncWorker: batch sync failed", libLog.Err(err))
+		// The worker's span carries no scope IDs, so a stuck tenant is not
+		// locatable from the log line without them.
+		w.logger.Log(ctx, libLog.LevelError, "BalanceSyncWorker: batch sync failed",
+			libLog.String("tenant_id", tenantID),
+			libLog.String("organization_id", organizationID.String()),
+			libLog.String("ledger_id", ledgerID.String()),
+			libLog.Err(err))
 
 		// Emit failure metric for monitoring
 		counter, counterErr := metricFactory.Counter(utils.BalanceSyncBatchFailures)
@@ -582,6 +592,7 @@ func (w *BalanceSyncWorker) processSyncBatch(ctx context.Context, organizationID
 			if metricErr := counter.WithLabels(map[string]string{
 				"organization_id": organizationID.String(),
 				"ledger_id":       ledgerID.String(),
+				"tenant_id":       tenantID,
 			}).AddOne(ctx); metricErr != nil {
 				w.logger.Log(ctx, libLog.LevelWarn, "BalanceSyncWorker: failed to emit failure counter", libLog.Err(metricErr))
 			}

--- a/components/ledger/internal/bootstrap/balance_sync.worker.go
+++ b/components/ledger/internal/bootstrap/balance_sync.worker.go
@@ -19,6 +19,7 @@ import (
 	libObservability "github.com/LerianStudio/lib-observability/v2"
 	libLog "github.com/LerianStudio/lib-observability/v2/log"
 	"github.com/LerianStudio/lib-observability/v2/metrics"
+	"github.com/bxcodec/dbresolver/v2"
 	"github.com/google/uuid"
 
 	redisTransaction "github.com/LerianStudio/midaz/v4/components/ledger/internal/adapters/redis/transaction"
@@ -47,6 +48,12 @@ func (c BalanceSyncConfig) PollInterval() time.Duration {
 	return time.Duration(c.PollIntervalMs) * time.Millisecond
 }
 
+// tenantPGResolver resolves a tenant's transaction-module PostgreSQL handle.
+// Satisfied by *tmpostgres.Manager.
+type tenantPGResolver interface {
+	GetDB(ctx context.Context, tenantID string) (dbresolver.DB, error)
+}
+
 // BalanceSyncWorker continuously processes balance keys using a dual-trigger collector.
 // Keys become eligible immediately after balance mutation (Lua ZADD with dueAt=now).
 // The worker accumulates keys and flushes based on batch size OR timeout, whichever comes first.
@@ -58,7 +65,7 @@ type BalanceSyncWorker struct {
 	metricsFactory *metrics.MetricsFactory
 	mtEnabled      bool
 	tenantCache    *tenantcache.TenantCache
-	pgManager      *tmpostgres.Manager
+	pgResolver     tenantPGResolver
 	serviceName    string
 }
 
@@ -133,8 +140,13 @@ func NewBalanceSyncWorkerMT(
 	w := NewBalanceSyncWorker(logger, useCase, syncCfg)
 	w.mtEnabled = mtEnabled
 	w.tenantCache = cache
-	w.pgManager = pgManager
 	w.serviceName = serviceName
+
+	// Guard against a typed-nil pointer being boxed into a non-nil interface,
+	// which would make isMTReady report ready with no resolver behind it.
+	if pgManager != nil {
+		w.pgResolver = pgManager
+	}
 
 	return w
 }
@@ -169,10 +181,10 @@ func (w *BalanceSyncWorker) emitTenantSkip(ctx context.Context, tenantID string)
 }
 
 // isMTReady returns true when the worker is configured for MT (multi-tenant)
-// dispatching. mtEnabled, pgManager, and tenantCache must all be set;
+// dispatching. mtEnabled, pgResolver, and tenantCache must all be set;
 // if any is missing the worker falls back to default (single-tenant) behavior.
 func (w *BalanceSyncWorker) isMTReady() bool {
-	return w.mtEnabled && w.pgManager != nil && w.tenantCache != nil
+	return w.mtEnabled && w.pgResolver != nil && w.tenantCache != nil
 }
 
 // Run dispatches to multi-tenant or single-tenant execution based on configuration.
@@ -344,19 +356,9 @@ func (w *BalanceSyncWorker) reconcileCollectors(ctx context.Context, collectors 
 func (w *BalanceSyncWorker) startTenantCollector(parentCtx context.Context, tenantID string) *tenantCollector {
 	tenantCtx := tmcore.ContextWithTenantID(parentCtx, tenantID)
 
-	conn, err := w.pgManager.GetConnection(tenantCtx, tenantID)
+	db, err := w.pgResolver.GetDB(tenantCtx, tenantID)
 	if err != nil {
 		w.logger.Log(parentCtx, libLog.LevelError, "BalanceSyncWorker: failed to get PG connection for tenant",
-			libLog.String("tenant_id", tenantID), libLog.Err(err))
-
-		w.emitTenantSkip(parentCtx, tenantID)
-
-		return nil
-	}
-
-	db, err := conn.GetDB()
-	if err != nil {
-		w.logger.Log(parentCtx, libLog.LevelError, "BalanceSyncWorker: failed to get DB for tenant",
 			libLog.String("tenant_id", tenantID), libLog.Err(err))
 
 		w.emitTenantSkip(parentCtx, tenantID)

--- a/components/ledger/internal/bootstrap/balance_sync.worker.go
+++ b/components/ledger/internal/bootstrap/balance_sync.worker.go
@@ -6,6 +6,7 @@ package bootstrap
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/signal"
@@ -68,11 +69,15 @@ type BalanceSyncWorker struct {
 	tenantCache    *tenantcache.TenantCache
 	pgResolver     tenantPGResolver
 	serviceName    string
-	// collectorsMu guards collectors. The reconcile loop, the tenant-eviction
-	// callback and the ownership checker all reach the map from different
-	// goroutines.
+	// collectorsMu guards collectors and evictions. The reconcile loop, the
+	// tenant-eviction callback and the ownership checker all reach them from
+	// different goroutines.
 	collectorsMu sync.Mutex
 	collectors   map[string]*tenantCollector
+	// evictions counts StopTenantCollector calls per tenant, including those that
+	// found no collector. reconcileCollectors samples it before spawning and
+	// re-checks it before registering, so an eviction landing mid-spawn still wins.
+	evictions map[string]uint64
 	// flushBatchFn is the flush body the collectors call. It defaults to
 	// flushBatch; tests replace it to observe the context a flush receives.
 	flushBatchFn func(ctx context.Context, keys []redisTransaction.SyncKey) bool
@@ -129,6 +134,7 @@ func NewBalanceSyncWorker(logger libLog.Logger, useCase *command.UseCase, syncCf
 		syncConfig: syncCfg,
 		useCase:    useCase,
 		collectors: make(map[string]*tenantCollector),
+		evictions:  make(map[string]uint64),
 	}
 	w.flushBatchFn = w.flushBatch
 
@@ -342,9 +348,14 @@ func (w *BalanceSyncWorker) reconcileCollectors(ctx context.Context) {
 		}
 	}
 
+	// Sampled under the lock alongside the membership check so the pair is
+	// consistent with the map state we based the spawn decision on.
+	spawnGen := make(map[string]uint64, len(tenantIDs))
+
 	for _, id := range tenantIDs {
 		if _, ok := w.collectors[id]; !ok {
 			missing = append(missing, id)
+			spawnGen[id] = w.evictions[id]
 		}
 	}
 
@@ -361,12 +372,20 @@ func (w *BalanceSyncWorker) reconcileCollectors(ctx context.Context) {
 
 		w.collectorsMu.Lock()
 
-		if _, taken := w.collectors[id]; taken {
+		_, taken := w.collectors[id]
+		evicted := w.evictions[id] != spawnGen[id]
+
+		if taken || evicted {
 			w.collectorsMu.Unlock()
 
-			// Another goroutine registered a collector for this tenant while we were
-			// spawning. Drop ours; its buffer is still empty, so the final flush is
-			// a no-op.
+			// Either another goroutine registered a collector for this tenant while we
+			// were spawning, or an eviction landed in that window — registering now
+			// would resurrect a collector the eviction is about to close the pool
+			// under. Drop ours; its buffer is still empty, so the final flush is a
+			// no-op.
+			w.logger.Log(ctx, libLog.LevelDebug, "BalanceSyncWorker: discarding collector that lost the registration race",
+				libLog.String("tenant_id", id), libLog.Bool("evicted", evicted))
+
 			tc.cancel()
 			<-tc.done
 
@@ -398,6 +417,15 @@ func (w *BalanceSyncWorker) reconcileCollectors(ctx context.Context) {
 // flush (see resolveTenantPG).
 func (w *BalanceSyncWorker) startTenantCollector(parentCtx context.Context, tenantID string) *tenantCollector {
 	tenantCtx := tmcore.ContextWithTenantID(parentCtx, tenantID)
+
+	// A shutdown racing the reconcile loop must not pay for a PG round-trip, nor
+	// report the tenant as skipped for a reason the operator cannot act on.
+	if err := parentCtx.Err(); err != nil {
+		w.logger.Log(parentCtx, libLog.LevelDebug, "BalanceSyncWorker: context done before collector start",
+			libLog.String("tenant_id", tenantID))
+
+		return nil
+	}
 
 	// Preflight: a tenant whose PG cannot be resolved gets no collector at all.
 	if _, err := w.pgResolver.GetDB(tenantCtx, tenantID); err != nil {
@@ -439,6 +467,17 @@ func (w *BalanceSyncWorker) startTenantCollector(parentCtx context.Context, tena
 			func(flushCtx context.Context, keys []redisTransaction.SyncKey) bool {
 				pgCtx, err := w.resolveTenantPG(flushCtx, tenantID)
 				if err != nil {
+					// Shutdown is not a degraded tenant: counting it would add one bogus
+					// skip per tenant to the metric on every graceful stop. The drain
+					// flush runs with cancellation stripped, so it never lands here.
+					if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+						w.logger.Log(flushCtx, libLog.LevelDebug,
+							"BalanceSyncWorker: flush context done before PG resolution",
+							libLog.String("tenant_id", tenantID))
+
+						return false
+					}
+
 					w.logger.Log(flushCtx, libLog.LevelWarn,
 						"BalanceSyncWorker: failed to resolve tenant PG for flush, skipping batch",
 						libLog.String("tenant_id", tenantID), libLog.Err(err))
@@ -477,6 +516,10 @@ func (w *BalanceSyncWorker) startTenantCollector(parentCtx context.Context, tena
 // The worker only touches the transaction database, so only the module-specific
 // context entry is set — getDB looks that one up first.
 func (w *BalanceSyncWorker) resolveTenantPG(ctx context.Context, tenantID string) (context.Context, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
 	db, err := w.pgResolver.GetDB(ctx, tenantID)
 	if err != nil {
 		return nil, err
@@ -485,12 +528,28 @@ func (w *BalanceSyncWorker) resolveTenantPG(ctx context.Context, tenantID string
 	return tmcore.ContextWithPG(ctx, db, constant.ModuleTransaction), nil
 }
 
+// collectorDrainDeadline bounds how long StopTenantCollector waits for a cancelled
+// collector. The collector's own flushRemaining budget (shutdownFlushTimeout) starts
+// only once it observes the cancel, so a deadline equal to that budget could fire
+// while a legitimate final flush was still inside it — and the caller closes the
+// tenant's pool as soon as we return. The margin puts this deadline strictly after
+// the collector's, so we only abandon a collector that blew its own.
+const collectorDrainDeadline = shutdownFlushTimeout + 10*time.Second
+
 // StopTenantCollector cancels the collector for tenantID, waits for its final flush
 // to drain, and forgets it. Call it BEFORE closing the tenant's PostgreSQL pool so
 // that flush lands in a live pool. A tenant with no collector is a no-op. The next
 // reconcile restarts the collector when the tenant is still in the TenantCache.
 func (w *BalanceSyncWorker) StopTenantCollector(tenantID string) {
 	w.collectorsMu.Lock()
+
+	if w.evictions == nil {
+		w.evictions = make(map[string]uint64)
+	}
+
+	// Counted even when no collector is present: that is precisely the case where a
+	// reconcile is mid-spawn and must not register its collector afterwards.
+	w.evictions[tenantID]++
 
 	tc, ok := w.collectors[tenantID]
 	if ok {
@@ -510,11 +569,7 @@ func (w *BalanceSyncWorker) StopTenantCollector(tenantID string) {
 
 	tc.cancel()
 
-	// Bound the wait by the collector's own drain deadline: giving up earlier would
-	// guarantee the truncated final flush this ordering exists to avoid, and waiting
-	// longer would hold the tenant-event goroutine past the point the collector
-	// itself has given up.
-	timer := time.NewTimer(shutdownFlushTimeout)
+	timer := time.NewTimer(collectorDrainDeadline)
 	defer timer.Stop()
 
 	select {
@@ -524,7 +579,7 @@ func (w *BalanceSyncWorker) StopTenantCollector(tenantID string) {
 	case <-timer.C:
 		w.logger.Log(ctx, libLog.LevelWarn, "BalanceSyncWorker: collector did not drain before deadline",
 			libLog.String("tenant_id", tenantID),
-			libLog.String("deadline", shutdownFlushTimeout.String()))
+			libLog.String("deadline", collectorDrainDeadline.String()))
 	}
 }
 

--- a/components/ledger/internal/bootstrap/balance_sync.worker.go
+++ b/components/ledger/internal/bootstrap/balance_sync.worker.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"sync"
 	"syscall"
 	"time"
 
@@ -67,6 +68,11 @@ type BalanceSyncWorker struct {
 	tenantCache    *tenantcache.TenantCache
 	pgResolver     tenantPGResolver
 	serviceName    string
+	// collectorsMu guards collectors. The reconcile loop, the tenant-eviction
+	// callback and the ownership checker all reach the map from different
+	// goroutines.
+	collectorsMu sync.Mutex
+	collectors   map[string]*tenantCollector
 	// flushBatchFn is the flush body the collectors call. It defaults to
 	// flushBatch; tests replace it to observe the context a flush receives.
 	flushBatchFn func(ctx context.Context, keys []redisTransaction.SyncKey) bool
@@ -122,6 +128,7 @@ func NewBalanceSyncWorker(logger libLog.Logger, useCase *command.UseCase, syncCf
 		idleWait:   idleWait,
 		syncConfig: syncCfg,
 		useCase:    useCase,
+		collectors: make(map[string]*tenantCollector),
 	}
 	w.flushBatchFn = w.flushBatch
 
@@ -266,13 +273,12 @@ func (w *BalanceSyncWorker) runWorkerMT() error {
 		libLog.String("reconcile_interval", tenantReconcileInterval.String()),
 	)
 
-	collectors := make(map[string]*tenantCollector)
-	defer w.stopAllCollectors(ctx, collectors)
+	defer w.stopAllCollectors(ctx)
 
 	// Reconcile immediately on startup so collectors start without waiting for the
 	// first tick (10s). On the first call the map is empty, so phases 1-2 are no-ops
 	// and phase 3 launches a collector for every tenant in the cache.
-	w.reconcileCollectors(ctx, collectors)
+	w.reconcileCollectors(ctx)
 
 	ticker := time.NewTicker(tenantReconcileInterval)
 	defer ticker.Stop()
@@ -284,7 +290,7 @@ func (w *BalanceSyncWorker) runWorkerMT() error {
 
 			return nil
 		case <-ticker.C:
-			w.reconcileCollectors(ctx, collectors)
+			w.reconcileCollectors(ctx)
 		}
 	}
 }
@@ -294,7 +300,7 @@ func (w *BalanceSyncWorker) runWorkerMT() error {
 //  1. Reap: detect collectors whose goroutines exited unexpectedly (e.g., panic)
 //  2. Stop: cancel collectors for tenants no longer in the cache
 //  3. Start: launch collectors for newly discovered tenants
-func (w *BalanceSyncWorker) reconcileCollectors(ctx context.Context, collectors map[string]*tenantCollector) {
+func (w *BalanceSyncWorker) reconcileCollectors(ctx context.Context) {
 	tenantIDs := w.tenantCache.TenantIDs()
 
 	activeSet := make(map[string]struct{}, len(tenantIDs))
@@ -302,23 +308,28 @@ func (w *BalanceSyncWorker) reconcileCollectors(ctx context.Context, collectors 
 		activeSet[id] = struct{}{}
 	}
 
+	var (
+		removed []*tenantCollector
+		missing []string
+	)
+
+	w.collectorsMu.Lock()
+
 	// Phase 1: Reap dead collectors (goroutine exited unexpectedly).
 	// Removing them from the map allows Phase 3 to restart them if the tenant is still active.
-	for id, tc := range collectors {
+	for id, tc := range w.collectors {
 		select {
 		case <-tc.done:
 			w.logger.Log(ctx, libLog.LevelWarn, "BalanceSyncWorker: collector exited unexpectedly, will restart",
 				libLog.String("tenant_id", id))
 
-			delete(collectors, id)
+			delete(w.collectors, id)
 		default:
 		}
 	}
 
 	// Phase 2: Cancel collectors for removed tenants (non-blocking cancel, deferred wait).
-	var removed []*tenantCollector
-
-	for id, tc := range collectors {
+	for id, tc := range w.collectors {
 		if _, ok := activeSet[id]; !ok {
 			w.logger.Log(ctx, libLog.LevelInfo, "BalanceSyncWorker: tenant removed from cache, stopping collector",
 				libLog.String("tenant_id", id))
@@ -327,20 +338,44 @@ func (w *BalanceSyncWorker) reconcileCollectors(ctx context.Context, collectors 
 
 			removed = append(removed, tc)
 
-			delete(collectors, id)
+			delete(w.collectors, id)
 		}
 	}
 
-	// Phase 3: Start collectors for new tenants.
 	for _, id := range tenantIDs {
-		if _, ok := collectors[id]; ok {
-			continue // already running
+		if _, ok := w.collectors[id]; !ok {
+			missing = append(missing, id)
+		}
+	}
+
+	w.collectorsMu.Unlock()
+
+	// Phase 3: Start collectors for new tenants. Spawning happens outside the lock
+	// because the PG preflight reaches the network, and StopTenantCollector runs on
+	// the tenant-event goroutine.
+	for _, id := range missing {
+		tc := w.startTenantCollector(ctx, id)
+		if tc == nil {
+			continue
 		}
 
-		tc := w.startTenantCollector(ctx, id)
-		if tc != nil {
-			collectors[id] = tc
+		w.collectorsMu.Lock()
+
+		if _, taken := w.collectors[id]; taken {
+			w.collectorsMu.Unlock()
+
+			// Another goroutine registered a collector for this tenant while we were
+			// spawning. Drop ours; its buffer is still empty, so the final flush is
+			// a no-op.
+			tc.cancel()
+			<-tc.done
+
+			continue
 		}
+
+		w.collectors[id] = tc
+
+		w.collectorsMu.Unlock()
 	}
 
 	// Phase 4: Wait for removed collectors to finish (all cancellations already sent in Phase 2).
@@ -450,29 +485,93 @@ func (w *BalanceSyncWorker) resolveTenantPG(ctx context.Context, tenantID string
 	return tmcore.ContextWithPG(ctx, db, constant.ModuleTransaction), nil
 }
 
+// StopTenantCollector cancels the collector for tenantID, waits for its final flush
+// to drain, and forgets it. Call it BEFORE closing the tenant's PostgreSQL pool so
+// that flush lands in a live pool. A tenant with no collector is a no-op. The next
+// reconcile restarts the collector when the tenant is still in the TenantCache.
+func (w *BalanceSyncWorker) StopTenantCollector(tenantID string) {
+	w.collectorsMu.Lock()
+
+	tc, ok := w.collectors[tenantID]
+	if ok {
+		delete(w.collectors, tenantID)
+	}
+
+	w.collectorsMu.Unlock()
+
+	if !ok {
+		return
+	}
+
+	ctx := context.Background()
+
+	w.logger.Log(ctx, libLog.LevelInfo, "BalanceSyncWorker: tenant evicted, stopping collector",
+		libLog.String("tenant_id", tenantID))
+
+	tc.cancel()
+
+	// Bound the wait by the collector's own drain deadline: giving up earlier would
+	// guarantee the truncated final flush this ordering exists to avoid, and waiting
+	// longer would hold the tenant-event goroutine past the point the collector
+	// itself has given up.
+	timer := time.NewTimer(shutdownFlushTimeout)
+	defer timer.Stop()
+
+	select {
+	case <-tc.done:
+		w.logger.Log(ctx, libLog.LevelInfo, "BalanceSyncWorker: collector stopped",
+			libLog.String("tenant_id", tenantID))
+	case <-timer.C:
+		w.logger.Log(ctx, libLog.LevelWarn, "BalanceSyncWorker: collector did not drain before deadline",
+			libLog.String("tenant_id", tenantID),
+			libLog.String("deadline", shutdownFlushTimeout.String()))
+	}
+}
+
+// HasCollector reports whether a collector is running for tenantID. The tenant
+// ownership checker reads it so an eviction still sees midaz as owning a tenant
+// whose cache entry has TTL-expired while its collector runs.
+func (w *BalanceSyncWorker) HasCollector(tenantID string) bool {
+	w.collectorsMu.Lock()
+	defer w.collectorsMu.Unlock()
+
+	_, ok := w.collectors[tenantID]
+
+	return ok
+}
+
 // stopAllCollectors cancels all running tenant collectors and waits for them to finish.
 // Each collector's deferred flushRemaining runs on cancellation, draining any buffered keys.
-func (w *BalanceSyncWorker) stopAllCollectors(ctx context.Context, collectors map[string]*tenantCollector) {
-	if len(collectors) == 0 {
+func (w *BalanceSyncWorker) stopAllCollectors(ctx context.Context) {
+	w.collectorsMu.Lock()
+
+	running := make(map[string]*tenantCollector, len(w.collectors))
+	for id, tc := range w.collectors {
+		running[id] = tc
+
+		delete(w.collectors, id)
+	}
+
+	w.collectorsMu.Unlock()
+
+	if len(running) == 0 {
 		return
 	}
 
 	w.logger.Log(ctx, libLog.LevelInfo, "BalanceSyncWorker: stopping all tenant collectors",
-		libLog.Int("count", len(collectors)))
+		libLog.Int("count", len(running)))
 
 	// Cancel all collectors concurrently
-	for _, tc := range collectors {
+	for _, tc := range running {
 		tc.cancel()
 	}
 
 	// Wait for all to finish (each flushes its remaining buffer)
-	for id, tc := range collectors {
+	for id, tc := range running {
 		<-tc.done
 
 		w.logger.Log(ctx, libLog.LevelInfo, "BalanceSyncWorker: collector stopped",
 			libLog.String("tenant_id", id))
-
-		delete(collectors, id)
 	}
 }
 

--- a/components/ledger/internal/bootstrap/balance_sync.worker_metrics_test.go
+++ b/components/ledger/internal/bootstrap/balance_sync.worker_metrics_test.go
@@ -6,14 +6,22 @@ package bootstrap
 
 import (
 	"context"
+	"errors"
 	"testing"
 
+	tmcore "github.com/LerianStudio/lib-commons/v6/commons/tenant-manager/core"
+	libObservability "github.com/LerianStudio/lib-observability/v2"
 	"github.com/LerianStudio/lib-observability/v2/metrics"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+	"go.uber.org/mock/gomock"
 
+	redisTransaction "github.com/LerianStudio/midaz/v4/components/ledger/internal/adapters/redis/transaction"
 	"github.com/LerianStudio/midaz/v4/components/ledger/internal/services/command"
+	"github.com/LerianStudio/midaz/v4/pkg/utils"
 )
 
 // TestBalanceSyncWorker_WithMetricsFactory verifies the fluent setter wires the
@@ -61,4 +69,98 @@ func TestBalanceSyncWorker_EmitTenantSkip(t *testing.T) {
 			worker.emitTenantSkip(context.Background(), "tenant-123")
 		})
 	})
+}
+
+// TestProcessSyncBatch_FailureCounterCarriesTenantID verifies a batch failure is
+// attributable to a tenant: the failure counter carries tenant_id, empty in
+// single-tenant so existing series keep their identity.
+func TestProcessSyncBatch_FailureCounterCarriesTenantID(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+	ledgerID := uuid.MustParse("22222222-2222-2222-2222-222222222222")
+
+	tests := []struct {
+		name       string
+		tenantID   string
+		wantTenant string
+	}{
+		{name: "multi_tenant_carries_tenant_id", tenantID: "acme", wantTenant: "acme"},
+		{name: "single_tenant_carries_empty_tenant_id", tenantID: "", wantTenant: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			reader, factory := newBalanceSyncReaderFactory(t)
+
+			ctrl := gomock.NewController(t)
+			repo := redisTransaction.NewMockRedisRepository(ctrl)
+			repo.EXPECT().
+				GetBalancesByKeys(gomock.Any(), gomock.Any()).
+				Return(nil, errors.New("sql: database is closed")).
+				Times(1)
+
+			w := NewBalanceSyncWorker(
+				newTestLogger(),
+				&command.UseCase{TransactionRedisRepo: repo},
+				BalanceSyncConfig{},
+			)
+
+			ctx := libObservability.ContextWithMetricFactory(context.Background(), factory)
+			if tt.tenantID != "" {
+				ctx = tmcore.ContextWithTenantID(ctx, tt.tenantID)
+			}
+
+			ok := w.processSyncBatch(ctx, orgID, ledgerID, []redisTransaction.SyncKey{
+				{Key: "balance:{transactions}:org:ledger:alias#key"},
+			})
+
+			require.False(t, ok, "a failed batch must not report progress")
+
+			labels := failureCounterLabels(t, reader)
+			require.Len(t, labels, 1, "exactly one failure point must be recorded")
+			assert.Equal(t, orgID.String(), labels[0]["organization_id"])
+			assert.Equal(t, ledgerID.String(), labels[0]["ledger_id"])
+			require.Contains(t, labels[0], "tenant_id",
+				"the label must be emitted on both modes, not conditionally")
+			assert.Equal(t, tt.wantTenant, labels[0]["tenant_id"],
+				"tenant_id must carry the tenant, empty in single-tenant")
+		})
+	}
+}
+
+// failureCounterLabels returns the label sets recorded on the batch-failure counter.
+func failureCounterLabels(t *testing.T, reader *sdkmetric.ManualReader) []map[string]string {
+	t.Helper()
+
+	var rm metricdata.ResourceMetrics
+
+	require.NoError(t, reader.Collect(context.Background(), &rm))
+
+	var out []map[string]string
+
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name != utils.BalanceSyncBatchFailures.Name {
+				continue
+			}
+
+			sum, ok := m.Data.(metricdata.Sum[int64])
+			require.True(t, ok, "failure counter data type must be Sum[int64], got %T", m.Data)
+
+			for _, dp := range sum.DataPoints {
+				labels := make(map[string]string, dp.Attributes.Len())
+
+				for _, kv := range dp.Attributes.ToSlice() {
+					labels[string(kv.Key)] = kv.Value.AsString()
+				}
+
+				out = append(out, labels)
+			}
+		}
+	}
+
+	return out
 }

--- a/components/ledger/internal/bootstrap/balance_sync.worker_mt_fuzz_test.go
+++ b/components/ledger/internal/bootstrap/balance_sync.worker_mt_fuzz_test.go
@@ -65,10 +65,10 @@ func FuzzNewBalanceSyncWorkerMT(f *testing.F) {
 		}
 
 		// Property: isMTReady() equals the conjunction of all three conditions.
-		expectedReady := mtEnabled && worker.pgManager != nil && worker.tenantCache != nil
+		expectedReady := mtEnabled && worker.pgResolver != nil && worker.tenantCache != nil
 		if worker.isMTReady() != expectedReady {
-			t.Fatalf("isMTReady() = %v, want %v (mtEnabled=%v, pgManager=%v, tenantCache=%v)",
-				worker.isMTReady(), expectedReady, mtEnabled, worker.pgManager != nil, worker.tenantCache != nil)
+			t.Fatalf("isMTReady() = %v, want %v (mtEnabled=%v, pgResolver=%v, tenantCache=%v)",
+				worker.isMTReady(), expectedReady, mtEnabled, worker.pgResolver != nil, worker.tenantCache != nil)
 		}
 	})
 }

--- a/components/ledger/internal/bootstrap/balance_sync.worker_mt_integration_test.go
+++ b/components/ledger/internal/bootstrap/balance_sync.worker_mt_integration_test.go
@@ -59,103 +59,20 @@ func TestIntegration_BalanceSyncWorkerMT_RecoversFromClosedPool(t *testing.T) {
 		t.Skip("skipping integration test in short mode")
 	}
 
-	const tenantID = "acme"
+	h := newSyncHarness(t, "healthy", "dead", "healed")
 
-	pg := pgtestutil.SetupLedgerContainer(t)
-	redisContainer := redistestutil.SetupReusableContainer(t)
-	redisConn := redistestutil.CreateConnectionWithDB(t, redisContainer.Addr, redisContainer.DB)
+	healthy, dead, healed := h.targets[0], h.targets[1], h.targets[2]
 
-	redisRepo, err := redisTx.NewConsumerRedis(redisConn)
-	require.NoError(t, err, "should create the Redis repository")
-
-	// Two independent pools over the same database. dbA is the one the test kills;
-	// dbB stands in for the pool the tenant manager rebuilds on the next GetDB.
-	sqlA := openIntegrationPool(t, pg.DSN)
-	sqlB := openIntegrationPool(t, pg.DSN)
-	dbA := dbresolver.New(dbresolver.WithPrimaryDBs(sqlA))
-	dbB := dbresolver.New(dbresolver.WithPrimaryDBs(sqlB))
-
-	// Seed through the schema directly rather than HTTP, so the test owns exactly
-	// the three balances it syncs.
-	orgID := pgtestutil.CreateTestOrganization(t, pg.DB)
-	ledgerID := pgtestutil.CreateTestLedger(t, pg.DB, orgID)
-	pgtestutil.CreateTestAsset(t, pg.DB, orgID, ledgerID, "USD")
-
-	healthy := seedSyncTarget(t, pg.DB, orgID, ledgerID, "healthy")
-	dead := seedSyncTarget(t, pg.DB, orgID, ledgerID, "dead")
-	healed := seedSyncTarget(t, pg.DB, orgID, ledgerID, "healed")
-
-	reader, factory := newBalanceSyncReaderFactory(t)
-
-	resolver := &fakePGResolver{db: dbA}
-
-	w := newTestWorkerWithResolver(t, tenantcache.NewTenantCache(), resolver).
-		WithMetricsFactory(factory)
-
-	// requireTenant makes the repository resolve its handle from the context only,
-	// which is the multi-tenant contract this test exercises.
-	w.useCase = &command.UseCase{
-		TransactionRedisRepo: redisRepo,
-		BalanceRepo:          balancePG.NewBalancePostgreSQLRepository(nil, false, true),
-	}
-	// The default batch size is deliberate: the claim script reads the schedule
-	// with LIMIT 0 <batchSize>, so a batch of 1 would let the locked key left
-	// behind by stage 2 sit at the head of the window and hide every later key
-	// until its claim TTL expired. The 500ms TIMEOUT trigger flushes each stage.
-
-	tenantCtx := tmcore.ContextWithTenantID(context.Background(), tenantID)
-
-	scheduleKey, err := tmvalkey.GetKey(tenantID, utils.BalanceSyncScheduleKey)
-	require.NoError(t, err, "should namespace the schedule key")
-
-	// enqueue publishes a balance and schedules it as due. The ZSET member is the
-	// tenant-namespaced key, matching what balance_atomic_operation.lua writes:
-	// GetBalancesByKeys MGETs the members as-is.
-	enqueue := func(target syncTarget, available int64) {
-		t.Helper()
-
-		unprefixed := utils.BalanceInternalKey(orgID, ledgerID, target.alias+"#default")
-
-		member, keyErr := tmvalkey.GetKey(tenantID, unprefixed)
-		require.NoError(t, keyErr, "should namespace the balance key")
-
-		payload := marshalBalanceRedis(t, target, available)
-		require.NoError(t, redisRepo.Set(tenantCtx, unprefixed, payload, 3600),
-			"should store the balance payload")
-
-		_, zErr := redisContainer.Client.ZAdd(context.Background(), scheduleKey, goredis.Z{
-			Score:  float64(time.Now().Add(-time.Minute).Unix()),
-			Member: member,
-		}).Result()
-		require.NoError(t, zErr, "should schedule the balance key as due")
-	}
-
-	// availableInPG reads through dbB, which stays healthy for the whole test so
-	// the assertion never depends on the pool under test.
-	availableInPG := func(target syncTarget) decimal.Decimal {
-		t.Helper()
-
-		var available decimal.Decimal
-		require.NoError(t,
-			sqlB.QueryRow(`SELECT available FROM balance WHERE id = $1`, target.balanceID).Scan(&available),
-			"should read the balance back")
-
-		return available
-	}
-
-	// processSyncBatch reads its metric factory off the context, not off the
-	// worker, so the collector must be started from a context carrying it.
-	ctx, cancel := context.WithCancel(
-		libObservability.ContextWithMetricFactory(context.Background(), factory),
-	)
-
-	tc := w.startTenantCollector(ctx, tenantID)
+	tc := h.worker.startTenantCollector(h.ctx, h.tenantID)
 	require.NotNil(t, tc, "the tenant's PG resolves, so the collector must start")
 
 	t.Cleanup(func() {
-		cancel()
+		h.cancel()
 		<-tc.done
 	})
+
+	enqueue, availableInPG := h.enqueue, h.availableInPG
+	reader, resolver, sqlA, dbB := h.reader, h.resolver, h.sqlA, h.dbB
 
 	// Stage 1: a healthy collector persists.
 	t.Log("Stage 1: syncing on a healthy pool")
@@ -198,6 +115,134 @@ func TestIntegration_BalanceSyncWorkerMT_RecoversFromClosedPool(t *testing.T) {
 	case <-tc.done:
 		t.Fatal("recovery must happen inside the original collector")
 	default:
+	}
+}
+
+// syncHarness is the shared setup for the balance-sync MT integration tests:
+// a migrated PostgreSQL, a Valkey, two independent pools over the same database,
+// a worker whose tenant PG resolution the test drives, and one seeded balance per
+// stage.
+type syncHarness struct {
+	tenantID string
+	worker   *BalanceSyncWorker
+	resolver *fakePGResolver
+	reader   *sdkmetric.ManualReader
+	cache    *tenantcache.TenantCache
+	targets  []syncTarget
+
+	// sqlA backs dbA, the pool a test kills. dbB stands in for the pool the tenant
+	// manager rebuilds on the next GetDB and also serves the assertion reads, so
+	// no assertion depends on the pool under test.
+	sqlA *sql.DB
+	dbB  dbresolver.DB
+
+	ctx    context.Context
+	cancel context.CancelFunc
+
+	enqueue       func(target syncTarget, available int64)
+	availableInPG func(target syncTarget) decimal.Decimal
+}
+
+func newSyncHarness(t *testing.T, targetNames ...string) *syncHarness {
+	t.Helper()
+
+	const tenantID = "acme"
+
+	pg := pgtestutil.SetupLedgerContainer(t)
+	redisContainer := redistestutil.SetupReusableContainer(t)
+	redisConn := redistestutil.CreateConnectionWithDB(t, redisContainer.Addr, redisContainer.DB)
+
+	redisRepo, err := redisTx.NewConsumerRedis(redisConn)
+	require.NoError(t, err, "should create the Redis repository")
+
+	sqlA := openIntegrationPool(t, pg.DSN)
+	sqlB := openIntegrationPool(t, pg.DSN)
+	dbA := dbresolver.New(dbresolver.WithPrimaryDBs(sqlA))
+	dbB := dbresolver.New(dbresolver.WithPrimaryDBs(sqlB))
+
+	// Seed through the schema directly rather than HTTP, so the test owns exactly
+	// the balances it syncs.
+	orgID := pgtestutil.CreateTestOrganization(t, pg.DB)
+	ledgerID := pgtestutil.CreateTestLedger(t, pg.DB, orgID)
+	pgtestutil.CreateTestAsset(t, pg.DB, orgID, ledgerID, "USD")
+
+	targets := make([]syncTarget, 0, len(targetNames))
+	for _, name := range targetNames {
+		targets = append(targets, seedSyncTarget(t, pg.DB, orgID, ledgerID, name))
+	}
+
+	reader, factory := newBalanceSyncReaderFactory(t)
+
+	resolver := &fakePGResolver{db: dbA}
+	cache := tenantcache.NewTenantCache()
+
+	w := newTestWorkerWithResolver(t, cache, resolver).WithMetricsFactory(factory)
+
+	// requireTenant makes the repository resolve its handle from the context only,
+	// which is the multi-tenant contract these tests exercise.
+	w.useCase = &command.UseCase{
+		TransactionRedisRepo: redisRepo,
+		BalanceRepo:          balancePG.NewBalancePostgreSQLRepository(nil, false, true),
+	}
+	// The batch size stays at its default on purpose: the claim script reads the
+	// schedule with LIMIT 0 <batchSize>, so a batch of 1 would let a key whose
+	// flush failed sit at the head of the window and hide every later key until
+	// its claim TTL expired. The 500ms TIMEOUT trigger flushes each stage.
+
+	tenantCtx := tmcore.ContextWithTenantID(context.Background(), tenantID)
+
+	scheduleKey, err := tmvalkey.GetKey(tenantID, utils.BalanceSyncScheduleKey)
+	require.NoError(t, err, "should namespace the schedule key")
+
+	enqueue := func(target syncTarget, available int64) {
+		t.Helper()
+
+		unprefixed := utils.BalanceInternalKey(orgID, ledgerID, target.alias+"#default")
+
+		member, keyErr := tmvalkey.GetKey(tenantID, unprefixed)
+		require.NoError(t, keyErr, "should namespace the balance key")
+
+		payload := marshalBalanceRedis(t, target, available)
+		require.NoError(t, redisRepo.Set(tenantCtx, unprefixed, payload, 3600),
+			"should store the balance payload")
+
+		_, zErr := redisContainer.Client.ZAdd(context.Background(), scheduleKey, goredis.Z{
+			Score:  float64(time.Now().Add(-time.Minute).Unix()),
+			Member: member,
+		}).Result()
+		require.NoError(t, zErr, "should schedule the balance key as due")
+	}
+
+	availableInPG := func(target syncTarget) decimal.Decimal {
+		t.Helper()
+
+		var available decimal.Decimal
+		require.NoError(t,
+			sqlB.QueryRow(`SELECT available FROM balance WHERE id = $1`, target.balanceID).Scan(&available),
+			"should read the balance back")
+
+		return available
+	}
+
+	// processSyncBatch reads its metric factory off the context, not off the worker,
+	// so the collector must be started from a context carrying it.
+	ctx, cancel := context.WithCancel(
+		libObservability.ContextWithMetricFactory(context.Background(), factory),
+	)
+
+	return &syncHarness{
+		tenantID:      tenantID,
+		worker:        w,
+		resolver:      resolver,
+		reader:        reader,
+		cache:         cache,
+		targets:       targets,
+		sqlA:          sqlA,
+		dbB:           dbB,
+		ctx:           ctx,
+		cancel:        cancel,
+		enqueue:       enqueue,
+		availableInPG: availableInPG,
 	}
 }
 
@@ -288,4 +333,61 @@ func batchFailureCount(t *testing.T, reader *sdkmetric.ManualReader) int64 {
 	}
 
 	return total
+}
+
+// TestIntegration_BalanceSyncWorkerMT_TenantEvictionRestartsCollector is acceptance
+// (B): a tenant eviction stops the tenant's collector before its pool closes, and
+// the next reconcile brings the collector back on a freshly resolved pool — no
+// process restart.
+//
+// The stages run the same order the WithOnTenantRemoved callback does: stop the
+// collector, then close the tenant's pool.
+func TestIntegration_BalanceSyncWorkerMT_TenantEvictionRestartsCollector(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	h := newSyncHarness(t, "before-eviction", "after-eviction")
+
+	before, after := h.targets[0], h.targets[1]
+	w := h.worker
+
+	// The tenant stays in the cache across the eviction: tenant.cache.invalidate
+	// evicts connections, not the tenant.
+	h.cache.Set(h.tenantID, &tmcore.TenantConfig{ID: h.tenantID}, 1*time.Hour)
+
+	t.Cleanup(func() {
+		h.cancel()
+		w.stopAllCollectors(context.Background())
+	})
+
+	// Stage 1: the reconcile loop starts the collector and it syncs.
+	t.Log("Stage 1: reconcile starts the collector")
+	w.reconcileCollectors(h.ctx)
+	require.True(t, w.HasCollector(h.tenantID), "the cached tenant must get a collector")
+
+	h.enqueue(before, 1500)
+	require.Eventually(t, func() bool { return h.availableInPG(before).Equal(decimal.NewFromInt(1500)) },
+		syncRoundTimeout, 100*time.Millisecond,
+		"the collector must sync before the eviction")
+
+	// Stage 2: the eviction, in the callback's order.
+	t.Log("Stage 2: evicting the tenant — stop the collector, then close its pool")
+	w.StopTenantCollector(h.tenantID)
+	require.False(t, w.HasCollector(h.tenantID), "the eviction must stop the collector")
+	require.NoError(t, h.sqlA.Close(), "the evicted pool closes after the collector stopped")
+
+	// Stage 3: the manager rebuilt the pool. The reconcile must bring the collector
+	// back and it must land on the new pool, not the closed one.
+	t.Log("Stage 3: reconcile restarts the collector on the rebuilt pool")
+	h.resolver.set(h.dbB, nil)
+
+	w.reconcileCollectors(h.ctx)
+	require.True(t, w.HasCollector(h.tenantID),
+		"the tenant is still cached, so the reconcile must restart the collector")
+
+	h.enqueue(after, 3500)
+	require.Eventually(t, func() bool { return h.availableInPG(after).Equal(decimal.NewFromInt(3500)) },
+		syncRoundTimeout, 100*time.Millisecond,
+		"the restarted collector must sync on the rebuilt pool")
 }

--- a/components/ledger/internal/bootstrap/balance_sync.worker_mt_integration_test.go
+++ b/components/ledger/internal/bootstrap/balance_sync.worker_mt_integration_test.go
@@ -1,0 +1,291 @@
+//go:build integration
+
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package bootstrap
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"testing"
+	"time"
+
+	tmcore "github.com/LerianStudio/lib-commons/v6/commons/tenant-manager/core"
+	"github.com/LerianStudio/lib-commons/v6/commons/tenant-manager/tenantcache"
+	tmvalkey "github.com/LerianStudio/lib-commons/v6/commons/tenant-manager/valkey"
+	libObservability "github.com/LerianStudio/lib-observability/v2"
+	"github.com/bxcodec/dbresolver/v2"
+	"github.com/google/uuid"
+	_ "github.com/jackc/pgx/v5/stdlib" // register the "pgx" database/sql driver
+	goredis "github.com/redis/go-redis/v9"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+
+	balancePG "github.com/LerianStudio/midaz/v4/components/ledger/internal/adapters/postgres/balance"
+	redisTx "github.com/LerianStudio/midaz/v4/components/ledger/internal/adapters/redis/transaction"
+	"github.com/LerianStudio/midaz/v4/components/ledger/internal/services/command"
+	"github.com/LerianStudio/midaz/v4/pkg/mmodel"
+	"github.com/LerianStudio/midaz/v4/pkg/utils"
+	pgtestutil "github.com/LerianStudio/midaz/v4/tests/utils/postgres"
+	redistestutil "github.com/LerianStudio/midaz/v4/tests/utils/redis"
+)
+
+// syncRoundTimeout bounds each stage. The collector's default flush timeout is
+// 500ms, so a stage that has not happened in this long is not going to.
+const syncRoundTimeout = 30 * time.Second
+
+// TestIntegration_BalanceSyncWorkerMT_RecoversFromClosedPool reproduces the
+// production incident end to end and proves the cure.
+//
+// A tenant's pool is closed underneath a running collector — what the tenant
+// manager does on a credentials rotation or a tenant.cache.invalidate event.
+// With the handle frozen in the collector context the collector held that dead
+// pool for the rest of the process's life: every flush failed with
+// "sql: database is closed" and only a restart recovered. With per-flush
+// resolution the flush after the pool is replaced persists, in the same
+// collector and with no external action.
+//
+// Each stage syncs its own balance. A flush that fails leaves the claim lock in
+// place for claimTTLSeconds, so re-enqueueing one balance across stages would
+// stall on that lock rather than on the pool under test.
+func TestIntegration_BalanceSyncWorkerMT_RecoversFromClosedPool(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	const tenantID = "acme"
+
+	pg := pgtestutil.SetupLedgerContainer(t)
+	redisContainer := redistestutil.SetupReusableContainer(t)
+	redisConn := redistestutil.CreateConnectionWithDB(t, redisContainer.Addr, redisContainer.DB)
+
+	redisRepo, err := redisTx.NewConsumerRedis(redisConn)
+	require.NoError(t, err, "should create the Redis repository")
+
+	// Two independent pools over the same database. dbA is the one the test kills;
+	// dbB stands in for the pool the tenant manager rebuilds on the next GetDB.
+	sqlA := openIntegrationPool(t, pg.DSN)
+	sqlB := openIntegrationPool(t, pg.DSN)
+	dbA := dbresolver.New(dbresolver.WithPrimaryDBs(sqlA))
+	dbB := dbresolver.New(dbresolver.WithPrimaryDBs(sqlB))
+
+	// Seed through the schema directly rather than HTTP, so the test owns exactly
+	// the three balances it syncs.
+	orgID := pgtestutil.CreateTestOrganization(t, pg.DB)
+	ledgerID := pgtestutil.CreateTestLedger(t, pg.DB, orgID)
+	pgtestutil.CreateTestAsset(t, pg.DB, orgID, ledgerID, "USD")
+
+	healthy := seedSyncTarget(t, pg.DB, orgID, ledgerID, "healthy")
+	dead := seedSyncTarget(t, pg.DB, orgID, ledgerID, "dead")
+	healed := seedSyncTarget(t, pg.DB, orgID, ledgerID, "healed")
+
+	reader, factory := newBalanceSyncReaderFactory(t)
+
+	resolver := &fakePGResolver{db: dbA}
+
+	w := newTestWorkerWithResolver(t, tenantcache.NewTenantCache(), resolver).
+		WithMetricsFactory(factory)
+
+	// requireTenant makes the repository resolve its handle from the context only,
+	// which is the multi-tenant contract this test exercises.
+	w.useCase = &command.UseCase{
+		TransactionRedisRepo: redisRepo,
+		BalanceRepo:          balancePG.NewBalancePostgreSQLRepository(nil, false, true),
+	}
+	// The default batch size is deliberate: the claim script reads the schedule
+	// with LIMIT 0 <batchSize>, so a batch of 1 would let the locked key left
+	// behind by stage 2 sit at the head of the window and hide every later key
+	// until its claim TTL expired. The 500ms TIMEOUT trigger flushes each stage.
+
+	tenantCtx := tmcore.ContextWithTenantID(context.Background(), tenantID)
+
+	scheduleKey, err := tmvalkey.GetKey(tenantID, utils.BalanceSyncScheduleKey)
+	require.NoError(t, err, "should namespace the schedule key")
+
+	// enqueue publishes a balance and schedules it as due. The ZSET member is the
+	// tenant-namespaced key, matching what balance_atomic_operation.lua writes:
+	// GetBalancesByKeys MGETs the members as-is.
+	enqueue := func(target syncTarget, available int64) {
+		t.Helper()
+
+		unprefixed := utils.BalanceInternalKey(orgID, ledgerID, target.alias+"#default")
+
+		member, keyErr := tmvalkey.GetKey(tenantID, unprefixed)
+		require.NoError(t, keyErr, "should namespace the balance key")
+
+		payload := marshalBalanceRedis(t, target, available)
+		require.NoError(t, redisRepo.Set(tenantCtx, unprefixed, payload, 3600),
+			"should store the balance payload")
+
+		_, zErr := redisContainer.Client.ZAdd(context.Background(), scheduleKey, goredis.Z{
+			Score:  float64(time.Now().Add(-time.Minute).Unix()),
+			Member: member,
+		}).Result()
+		require.NoError(t, zErr, "should schedule the balance key as due")
+	}
+
+	// availableInPG reads through dbB, which stays healthy for the whole test so
+	// the assertion never depends on the pool under test.
+	availableInPG := func(target syncTarget) decimal.Decimal {
+		t.Helper()
+
+		var available decimal.Decimal
+		require.NoError(t,
+			sqlB.QueryRow(`SELECT available FROM balance WHERE id = $1`, target.balanceID).Scan(&available),
+			"should read the balance back")
+
+		return available
+	}
+
+	// processSyncBatch reads its metric factory off the context, not off the
+	// worker, so the collector must be started from a context carrying it.
+	ctx, cancel := context.WithCancel(
+		libObservability.ContextWithMetricFactory(context.Background(), factory),
+	)
+
+	tc := w.startTenantCollector(ctx, tenantID)
+	require.NotNil(t, tc, "the tenant's PG resolves, so the collector must start")
+
+	t.Cleanup(func() {
+		cancel()
+		<-tc.done
+	})
+
+	// Stage 1: a healthy collector persists.
+	t.Log("Stage 1: syncing on a healthy pool")
+	enqueue(healthy, 1500)
+	require.Eventually(t, func() bool { return availableInPG(healthy).Equal(decimal.NewFromInt(1500)) },
+		syncRoundTimeout, 100*time.Millisecond,
+		"the first sync must reach PostgreSQL")
+
+	// Stage 2: close the pool underneath the running collector. The resolver keeps
+	// handing back the same dead handle, exactly as a frozen context would.
+	t.Log("Stage 2: closing the pool underneath the collector")
+	require.NoError(t, sqlA.Close(), "should close the pool under test")
+
+	failuresBefore := batchFailureCount(t, reader)
+
+	enqueue(dead, 2500)
+	require.Eventually(t, func() bool { return batchFailureCount(t, reader) > failuresBefore },
+		syncRoundTimeout, 100*time.Millisecond,
+		"a flush on the closed pool must fail and be counted")
+	assert.True(t, availableInPG(dead).Equal(decimal.NewFromInt(1000)),
+		"nothing must persist while the pool is closed")
+
+	select {
+	case <-tc.done:
+		t.Fatal("the collector must survive the closed pool")
+	default:
+	}
+
+	// Stage 3: the manager rebuilds the pool. Per-flush resolution is what lets the
+	// next flush pick it up; a handle frozen at spawn would stay dead forever.
+	t.Log("Stage 3: replacing the pool and expecting the next flush to heal")
+	resolver.set(dbB, nil)
+
+	enqueue(healed, 3500)
+	require.Eventually(t, func() bool { return availableInPG(healed).Equal(decimal.NewFromInt(3500)) },
+		syncRoundTimeout, 100*time.Millisecond,
+		"the collector must persist again on the replaced pool, with no restart")
+
+	select {
+	case <-tc.done:
+		t.Fatal("recovery must happen inside the original collector")
+	default:
+	}
+}
+
+// syncTarget is one seeded balance the test syncs, kept together with the alias
+// its Redis key is built from.
+type syncTarget struct {
+	balanceID uuid.UUID
+	accountID uuid.UUID
+	alias     string
+}
+
+// seedSyncTarget inserts an account and its balance, seeded at version 0 and
+// available 1000, so any sync the test drives is visible as a change.
+func seedSyncTarget(t *testing.T, db *sql.DB, orgID, ledgerID uuid.UUID, name string) syncTarget {
+	t.Helper()
+
+	alias := "@sync-" + name
+
+	accountID := pgtestutil.CreateTestAccount(t, db, orgID, ledgerID, nil, name, alias, "USD", nil)
+	balanceID := pgtestutil.CreateTestBalanceSimple(t, db, orgID, ledgerID, accountID, alias, "USD")
+
+	return syncTarget{balanceID: balanceID, accountID: accountID, alias: alias}
+}
+
+// openIntegrationPool opens an independent pool against dsn and closes it with
+// the test unless the test closed it first.
+func openIntegrationPool(t *testing.T, dsn string) *sql.DB {
+	t.Helper()
+
+	db, err := sql.Open("pgx", dsn)
+	require.NoError(t, err, "should open a PostgreSQL pool")
+	require.NoError(t, db.PingContext(context.Background()), "the pool must be reachable")
+
+	t.Cleanup(func() { _ = db.Close() })
+
+	return db
+}
+
+// marshalBalanceRedis builds the Redis payload the sync reads. Version 1 clears
+// the seeded 0 so UpdateMany's version guard admits the write, and OverdraftUsed
+// must be a parseable decimal string: UpdateMany SKIPS a row whose value is
+// malformed, which would surface as a missing write rather than an error.
+func marshalBalanceRedis(t *testing.T, target syncTarget, available int64) string {
+	t.Helper()
+
+	payload, err := json.Marshal(mmodel.BalanceRedis{
+		ID:             target.balanceID.String(),
+		Alias:          target.alias,
+		Key:            "default",
+		AccountID:      target.accountID.String(),
+		AssetCode:      "USD",
+		Available:      decimal.NewFromInt(available),
+		OnHold:         decimal.Zero,
+		Version:        1,
+		AccountType:    "deposit",
+		AllowSending:   1,
+		AllowReceiving: 1,
+		OverdraftUsed:  "0",
+	})
+	require.NoError(t, err, "should marshal the balance payload")
+
+	return string(payload)
+}
+
+// batchFailureCount sums the batch-failure counter across all label sets.
+func batchFailureCount(t *testing.T, reader *sdkmetric.ManualReader) int64 {
+	t.Helper()
+
+	var rm metricdata.ResourceMetrics
+
+	require.NoError(t, reader.Collect(context.Background(), &rm))
+
+	var total int64
+
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name != utils.BalanceSyncBatchFailures.Name {
+				continue
+			}
+
+			sum, ok := m.Data.(metricdata.Sum[int64])
+			require.True(t, ok, "failure counter data type must be Sum[int64], got %T", m.Data)
+
+			for _, dp := range sum.DataPoints {
+				total += dp.Value
+			}
+		}
+	}
+
+	return total
+}

--- a/components/ledger/internal/bootstrap/balance_sync.worker_mt_integration_test.go
+++ b/components/ledger/internal/bootstrap/balance_sync.worker_mt_integration_test.go
@@ -40,6 +40,13 @@ import (
 // 500ms, so a stage that has not happened in this long is not going to.
 const syncRoundTimeout = 30 * time.Second
 
+// dueScorePast is the ZSET score every scheduled key gets: 2026-01-01T00:00:00Z.
+// The claim script selects members scoring at or below Redis's own clock with no
+// lower bound, so any fixed past value is due, and a fixed one keeps the schedule
+// state identical from run to run. Each stage schedules a distinct member, so the
+// shared score cannot collide with the conditional ZREM's score comparison.
+const dueScorePast = float64(1767225600)
+
 // TestIntegration_BalanceSyncWorkerMT_RecoversFromClosedPool reproduces the
 // production incident end to end and proves the cure.
 //
@@ -207,7 +214,7 @@ func newSyncHarness(t *testing.T, targetNames ...string) *syncHarness {
 			"should store the balance payload")
 
 		_, zErr := redisContainer.Client.ZAdd(context.Background(), scheduleKey, goredis.Z{
-			Score:  float64(time.Now().Add(-time.Minute).Unix()),
+			Score:  dueScorePast,
 			Member: member,
 		}).Result()
 		require.NoError(t, zErr, "should schedule the balance key as due")

--- a/components/ledger/internal/bootstrap/balance_sync.worker_mt_property_test.go
+++ b/components/ledger/internal/bootstrap/balance_sync.worker_mt_property_test.go
@@ -37,9 +37,9 @@ func TestProperty_BalanceSyncWorker_PredicateEqualsEnabledAndPGManagerNonNil(t *
 		worker.mtEnabled = enabled
 
 		if hasPGManager {
-			worker.pgManager = pgMgr
+			worker.pgResolver = pgMgr
 		} else {
-			worker.pgManager = nil
+			worker.pgResolver = nil
 		}
 
 		if hasTenantCache {
@@ -62,7 +62,7 @@ func TestProperty_BalanceSyncWorker_PredicateEqualsEnabledAndPGManagerNonNil(t *
 
 	err = quick.Check(property, &quick.Config{MaxCount: 200})
 	require.NoError(t, err,
-		"Property violated: BalanceSyncWorker.isMTReady() != (mtEnabled && pgManager != nil && tenantCache != nil)")
+		"Property violated: BalanceSyncWorker.isMTReady() != (mtEnabled && pgResolver != nil && tenantCache != nil)")
 }
 
 // TestNewBalanceSyncWorkerMT_PreservesBaseFields verifies that
@@ -97,7 +97,7 @@ func TestNewBalanceSyncWorkerMT_PreservesBaseFields(t *testing.T) {
 			require.Equal(t, useCase, worker.useCase, "base field useCase must be preserved")
 			require.Equal(t, tt.enabled, worker.mtEnabled, "mtEnabled must match input")
 			require.Equal(t, cache, worker.tenantCache, "tenantCache must be set")
-			require.Equal(t, pgMgr, worker.pgManager, "pgManager must be set")
+			require.Equal(t, pgMgr, worker.pgResolver, "pgResolver must be set")
 		})
 	}
 }

--- a/components/ledger/internal/bootstrap/balance_sync.worker_mt_resolve_test.go
+++ b/components/ledger/internal/bootstrap/balance_sync.worker_mt_resolve_test.go
@@ -1,0 +1,291 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package bootstrap
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	tmcore "github.com/LerianStudio/lib-commons/v6/commons/tenant-manager/core"
+	"github.com/LerianStudio/lib-commons/v6/commons/tenant-manager/tenantcache"
+	"github.com/LerianStudio/lib-observability/v2/metrics"
+	"github.com/bxcodec/dbresolver/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+	"go.uber.org/mock/gomock"
+
+	redisTransaction "github.com/LerianStudio/midaz/v4/components/ledger/internal/adapters/redis/transaction"
+	"github.com/LerianStudio/midaz/v4/components/ledger/internal/services/command"
+	"github.com/LerianStudio/midaz/v4/pkg/constant"
+	"github.com/LerianStudio/midaz/v4/pkg/utils"
+)
+
+// resolveTestTimeout bounds every Eventually in this file. The collector's default
+// flush timeout is 500ms, so a handful of flush cycles fit comfortably inside it.
+const resolveTestTimeout = 5 * time.Second
+
+// flushHandleRecorder captures the PG handle each flush saw, in order.
+type flushHandleRecorder struct {
+	mu      sync.Mutex
+	handles []dbresolver.DB
+}
+
+// record stores the transaction-module handle carried by a flush context.
+func (r *flushHandleRecorder) record(ctx context.Context) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.handles = append(r.handles, tmcore.GetPGContext(ctx, constant.ModuleTransaction))
+}
+
+func (r *flushHandleRecorder) count() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	return len(r.handles)
+}
+
+// sawHandle reports whether any recorded flush received want.
+func (r *flushHandleRecorder) sawHandle(want dbresolver.DB) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	for _, h := range r.handles {
+		if h == want {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (r *flushHandleRecorder) first() dbresolver.DB {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if len(r.handles) == 0 {
+		return nil
+	}
+
+	return r.handles[0]
+}
+
+// newAlwaysOneKeyRepo returns a RedisRepository mock whose GetBalanceSyncKeys
+// always yields exactly one key, so a collector with BatchSize 1 flushes on
+// every fetch and the loop never goes idle.
+func newAlwaysOneKeyRepo(t *testing.T) *redisTransaction.MockRedisRepository {
+	t.Helper()
+
+	ctrl := gomock.NewController(t)
+	repo := redisTransaction.NewMockRedisRepository(ctrl)
+
+	repo.EXPECT().
+		GetBalanceSyncKeys(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ int64) ([]redisTransaction.SyncKey, error) {
+			return []redisTransaction.SyncKey{{Key: "balance:{transactions}:org:ledger:alias#key"}}, nil
+		}).
+		AnyTimes()
+
+	return repo
+}
+
+// newResolveTestWorker wires an MT-ready worker whose flushes are recorded rather
+// than executed, so a test observes exactly which PG handle each flush received.
+func newResolveTestWorker(
+	t *testing.T,
+	resolver tenantPGResolver,
+) (*BalanceSyncWorker, *flushHandleRecorder, *sdkmetric.ManualReader) {
+	t.Helper()
+
+	reader, factory := newBalanceSyncReaderFactory(t)
+
+	w := newTestWorkerWithResolver(t, tenantcache.NewTenantCache(), resolver).
+		WithMetricsFactory(factory)
+	w.useCase = &command.UseCase{TransactionRedisRepo: newAlwaysOneKeyRepo(t)}
+
+	// BatchSize 1 makes every fetch fire the SIZE trigger, so flushes are immediate.
+	w.syncConfig.BatchSize = 1
+
+	rec := &flushHandleRecorder{}
+	w.flushBatchFn = func(ctx context.Context, _ []redisTransaction.SyncKey) bool {
+		rec.record(ctx)
+
+		return true
+	}
+
+	return w, rec, reader
+}
+
+// newBalanceSyncReaderFactory builds a MetricsFactory backed by a manual reader so
+// a test can read back the counters the worker emitted.
+func newBalanceSyncReaderFactory(t *testing.T) (*sdkmetric.ManualReader, *metrics.MetricsFactory) {
+	t.Helper()
+
+	reader := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+
+	t.Cleanup(func() { _ = mp.Shutdown(context.Background()) })
+
+	factory, err := metrics.NewMetricsFactory(mp.Meter("balance-sync-resolve-test"), nil)
+	require.NoError(t, err)
+
+	return reader, factory
+}
+
+// tenantSkipCount sums the tenant-skip counter across all label sets.
+func tenantSkipCount(t *testing.T, reader *sdkmetric.ManualReader) int64 {
+	t.Helper()
+
+	var rm metricdata.ResourceMetrics
+
+	require.NoError(t, reader.Collect(context.Background(), &rm))
+
+	var total int64
+
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name != utils.BalanceSyncTenantSkip.Name {
+				continue
+			}
+
+			sum, ok := m.Data.(metricdata.Sum[int64])
+			require.True(t, ok, "tenant skip data type must be Sum[int64], got %T", m.Data)
+
+			for _, dp := range sum.DataPoints {
+				total += dp.Value
+			}
+		}
+	}
+
+	return total
+}
+
+// TestStartTenantCollector_ResolvesPGPerFlush proves the handle is resolved on
+// every flush rather than captured once at spawn: swapping the resolver's return
+// value mid-flight makes the next flush see the new handle.
+func TestStartTenantCollector_ResolvesPGPerFlush(t *testing.T) {
+	t.Parallel()
+
+	dbA, dbB := newStubDB(), newStubDB()
+	resolver := &fakePGResolver{db: dbA}
+
+	w, rec, _ := newResolveTestWorker(t, resolver)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	tc := w.startTenantCollector(ctx, "tenant-1")
+	require.NotNil(t, tc, "preflight succeeds, so the collector must start")
+
+	require.Eventually(t, func() bool { return rec.count() >= 1 }, resolveTestTimeout, 10*time.Millisecond,
+		"the first flush must run")
+	assert.Equal(t, dbA, rec.first(), "the first flush must see the handle resolved for it")
+
+	resolver.set(dbB, nil)
+
+	require.Eventually(t, func() bool { return rec.sawHandle(dbB) }, resolveTestTimeout, 10*time.Millisecond,
+		"a flush after the swap must see the new handle, which only per-flush resolution gives")
+
+	// One preflight plus at least one resolution per observed flush.
+	assert.GreaterOrEqual(t, resolver.calls.Load(), int32(3),
+		"resolution must happen once per flush, not once per collector")
+
+	cancel()
+	<-tc.done
+}
+
+// TestStartTenantCollector_ResolveFailsSkipsFlushKeepsCollectorAlive proves a
+// resolution failure is degraded-but-recoverable: the batch is skipped and
+// counted, and the collector keeps running.
+func TestStartTenantCollector_ResolveFailsSkipsFlushKeepsCollectorAlive(t *testing.T) {
+	t.Parallel()
+
+	dbA := newStubDB()
+	resolver := &fakePGResolver{db: dbA}
+
+	w, rec, reader := newResolveTestWorker(t, resolver)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	tc := w.startTenantCollector(ctx, "tenant-1")
+	require.NotNil(t, tc, "preflight succeeds, so the collector must start")
+
+	require.Eventually(t, func() bool { return rec.count() >= 1 }, resolveTestTimeout, 10*time.Millisecond,
+		"the first flush must run while the resolver is healthy")
+
+	resolver.set(nil, errors.New("pool gone"))
+
+	flushesBeforeFailure := rec.count()
+	callsBeforeFailure := resolver.calls.Load()
+
+	// Wait for several further resolution attempts to confirm the loop is still
+	// turning, then assert none of them reached the flush body.
+	require.Eventually(t, func() bool { return resolver.calls.Load() >= callsBeforeFailure+3 },
+		resolveTestTimeout, 10*time.Millisecond,
+		"the collector must keep attempting resolution after a failure")
+
+	assert.LessOrEqual(t, rec.count(), flushesBeforeFailure+1,
+		"a failed resolution must skip the flush rather than call it with no handle")
+	assert.Positive(t, tenantSkipCount(t, reader),
+		"a skipped flush must be counted on the tenant-skip counter")
+
+	select {
+	case <-tc.done:
+		t.Fatal("the collector must stay alive across resolution failures")
+	default:
+	}
+
+	cancel()
+	<-tc.done
+}
+
+// TestStartTenantCollector_RecoversWhenResolverHeals proves the auto-heal: once
+// the resolver hands back a working pool the same collector resumes flushing,
+// with no restart and no external action.
+func TestStartTenantCollector_RecoversWhenResolverHeals(t *testing.T) {
+	t.Parallel()
+
+	dbA := newStubDB()
+	resolver := &fakePGResolver{err: errors.New("pool gone"), db: newStubDB()}
+
+	w, rec, _ := newResolveTestWorker(t, resolver)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// The preflight resolves before the failure is installed, mirroring a pool
+	// that dies underneath a collector that started healthy.
+	resolver.set(newStubDB(), nil)
+
+	tc := w.startTenantCollector(ctx, "tenant-1")
+	require.NotNil(t, tc, "preflight succeeds, so the collector must start")
+
+	resolver.set(nil, errors.New("pool gone"))
+
+	callsAtFailure := resolver.calls.Load()
+	require.Eventually(t, func() bool { return resolver.calls.Load() >= callsAtFailure+2 },
+		resolveTestTimeout, 10*time.Millisecond,
+		"at least two flushes must fail to resolve before the pool heals")
+
+	resolver.set(dbA, nil)
+
+	require.Eventually(t, func() bool { return rec.sawHandle(dbA) }, resolveTestTimeout, 10*time.Millisecond,
+		"the collector must flush again on the healed handle without being restarted")
+
+	select {
+	case <-tc.done:
+		t.Fatal("recovery must happen inside the original collector, not after a restart")
+	default:
+	}
+
+	cancel()
+	<-tc.done
+}

--- a/components/ledger/internal/bootstrap/balance_sync.worker_mt_stop_test.go
+++ b/components/ledger/internal/bootstrap/balance_sync.worker_mt_stop_test.go
@@ -6,13 +6,19 @@ package bootstrap
 
 import (
 	"context"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	tmcore "github.com/LerianStudio/lib-commons/v6/commons/tenant-manager/core"
 	"github.com/LerianStudio/lib-commons/v6/commons/tenant-manager/tenantcache"
+	"github.com/bxcodec/dbresolver/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	redisTransaction "github.com/LerianStudio/midaz/v4/components/ledger/internal/adapters/redis/transaction"
 )
 
 // TestStopTenantCollector_CancelsAndForgets covers the eviction path: the
@@ -129,12 +135,24 @@ func TestHasCollector_FalseForUnknownAndZeroValue(t *testing.T) {
 // wiring rests on: the callback calls StopTenantCollector and then closes the
 // tenant's pools, so the final flush must have finished by the time the call
 // returns — not eventually, afterwards.
+//
+// Neither trigger is allowed to fire during the run: the batch size is far above
+// what the collector can accumulate and the flush timeout outlasts the test. The
+// buffer therefore only grows, and the single flush the recorder sees is
+// unambiguously the one flushRemaining drove. Sizing it any other way makes the
+// assertion a coin toss, because with an immediate SIZE trigger the buffer is
+// empty most of the time and flushRemaining skips an empty buffer.
 func TestStopTenantCollector_DrainsBeforeReturning(t *testing.T) {
 	t.Parallel()
 
 	resolver := &fakePGResolver{db: newStubDB()}
 
 	w, rec, _ := newResolveTestWorker(t, resolver)
+	w.syncConfig.BatchSize = 1_000_000
+	w.syncConfig.FlushTimeoutMs = int(resolveTestTimeout.Milliseconds()) * 10
+
+	fetches := &atomic.Int32{}
+	w.useCase.TransactionRedisRepo = newCountingOneKeyRepo(t, fetches)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -146,11 +164,10 @@ func TestStopTenantCollector_DrainsBeforeReturning(t *testing.T) {
 	w.collectors["tenant-1"] = tc
 	w.collectorsMu.Unlock()
 
-	// Let the collector claim keys so its shutdown has a buffer worth draining.
-	require.Eventually(t, func() bool { return rec.count() >= 1 }, resolveTestTimeout, 10*time.Millisecond,
-		"the collector must be flushing before the eviction")
-
-	flushesBeforeStop := rec.count()
+	// Two fetches mean at least one key is buffered and no flush has been triggered.
+	require.Eventually(t, func() bool { return fetches.Load() >= 2 }, resolveTestTimeout, 10*time.Millisecond,
+		"the collector must accumulate keys before the eviction")
+	require.Zero(t, rec.count(), "no trigger may fire before the eviction")
 
 	w.StopTenantCollector("tenant-1")
 
@@ -162,7 +179,99 @@ func TestStopTenantCollector_DrainsBeforeReturning(t *testing.T) {
 		t.Fatal("StopTenantCollector must not return while the collector is still running")
 	}
 
-	assert.GreaterOrEqual(t, rec.count(), flushesBeforeStop,
-		"the final flush must have run before the pools are closed")
+	assert.Equal(t, 1, rec.count(),
+		"the buffered keys must be flushed before StopTenantCollector returns")
 	assert.False(t, w.HasCollector("tenant-1"))
+}
+
+// newCountingOneKeyRepo is newAlwaysOneKeyRepo with an observable fetch count, so a
+// test can wait for the collector to have buffered keys without a flush to observe.
+func newCountingOneKeyRepo(t *testing.T, fetches *atomic.Int32) *redisTransaction.MockRedisRepository {
+	t.Helper()
+
+	ctrl := gomock.NewController(t)
+	repo := redisTransaction.NewMockRedisRepository(ctrl)
+
+	repo.EXPECT().
+		GetBalanceSyncKeys(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ int64) ([]redisTransaction.SyncKey, error) {
+			fetches.Add(1)
+
+			return []redisTransaction.SyncKey{{Key: "balance:{transactions}:org:ledger:alias#key"}}, nil
+		}).
+		AnyTimes()
+
+	return repo
+}
+
+// blockingPGResolver holds its first GetDB open until released, which is how a test
+// lands an eviction inside the reconcile's spawn window.
+type blockingPGResolver struct {
+	db      dbresolver.DB
+	entered chan struct{}
+	release chan struct{}
+	once    sync.Once
+}
+
+func (b *blockingPGResolver) GetDB(context.Context, string) (dbresolver.DB, error) {
+	b.once.Do(func() {
+		close(b.entered)
+		<-b.release
+	})
+
+	return b.db, nil
+}
+
+// TestStopTenantCollector_EvictionDuringSpawnWins covers the registration race the
+// spawn-outside-the-lock design opens: reconcileCollectors spawns without holding
+// collectorsMu, so an eviction can land while a collector is being built. That
+// eviction finds no collector to cancel, and registering the in-flight one
+// afterwards would resurrect a collector whose pool the eviction callback is about
+// to close.
+func TestStopTenantCollector_EvictionDuringSpawnWins(t *testing.T) {
+	t.Parallel()
+
+	cache := tenantcache.NewTenantCache()
+	cache.Set("tenant-1", &tmcore.TenantConfig{ID: "tenant-1"}, 1*time.Hour)
+
+	blocker := &blockingPGResolver{
+		db:      newStubDB(),
+		entered: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+
+	w, _, _ := newResolveTestWorker(t, &fakePGResolver{db: newStubDB()})
+	w.tenantCache = cache
+	w.pgResolver = blocker
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	reconciled := make(chan struct{})
+
+	go func() {
+		defer close(reconciled)
+
+		w.reconcileCollectors(ctx)
+	}()
+
+	// The reconcile is now inside startTenantCollector's preflight.
+	<-blocker.entered
+
+	// The eviction finds no collector yet — exactly the window under test.
+	w.StopTenantCollector("tenant-1")
+
+	close(blocker.release)
+	<-reconciled
+
+	assert.False(t, w.HasCollector("tenant-1"),
+		"the eviction must win the race; registering the in-flight collector would resurrect it")
+	assert.Empty(t, w.collectorTenantIDs(), "no collector may survive the eviction")
+
+	// The next reconcile is a fresh decision and may start a collector again.
+	w.reconcileCollectors(ctx)
+	assert.True(t, w.HasCollector("tenant-1"),
+		"the tenant is still cached, so a later reconcile must be free to start one")
+
+	w.stopAllCollectors(ctx)
 }

--- a/components/ledger/internal/bootstrap/balance_sync.worker_mt_stop_test.go
+++ b/components/ledger/internal/bootstrap/balance_sync.worker_mt_stop_test.go
@@ -124,3 +124,45 @@ func TestHasCollector_FalseForUnknownAndZeroValue(t *testing.T) {
 	var zero BalanceSyncWorker
 	assert.False(t, zero.HasCollector("nobody"), "a nil map must read as no collector")
 }
+
+// TestStopTenantCollector_DrainsBeforeReturning is the contract the tenant-eviction
+// wiring rests on: the callback calls StopTenantCollector and then closes the
+// tenant's pools, so the final flush must have finished by the time the call
+// returns — not eventually, afterwards.
+func TestStopTenantCollector_DrainsBeforeReturning(t *testing.T) {
+	t.Parallel()
+
+	resolver := &fakePGResolver{db: newStubDB()}
+
+	w, rec, _ := newResolveTestWorker(t, resolver)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	tc := w.startTenantCollector(ctx, "tenant-1")
+	require.NotNil(t, tc)
+
+	w.collectorsMu.Lock()
+	w.collectors["tenant-1"] = tc
+	w.collectorsMu.Unlock()
+
+	// Let the collector claim keys so its shutdown has a buffer worth draining.
+	require.Eventually(t, func() bool { return rec.count() >= 1 }, resolveTestTimeout, 10*time.Millisecond,
+		"the collector must be flushing before the eviction")
+
+	flushesBeforeStop := rec.count()
+
+	w.StopTenantCollector("tenant-1")
+
+	// Read the goroutine's state with no waiting at all: anything StopTenantCollector
+	// left running would make these racy, and -race would say so.
+	select {
+	case <-tc.done:
+	default:
+		t.Fatal("StopTenantCollector must not return while the collector is still running")
+	}
+
+	assert.GreaterOrEqual(t, rec.count(), flushesBeforeStop,
+		"the final flush must have run before the pools are closed")
+	assert.False(t, w.HasCollector("tenant-1"))
+}

--- a/components/ledger/internal/bootstrap/balance_sync.worker_mt_stop_test.go
+++ b/components/ledger/internal/bootstrap/balance_sync.worker_mt_stop_test.go
@@ -1,0 +1,126 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package bootstrap
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	tmcore "github.com/LerianStudio/lib-commons/v6/commons/tenant-manager/core"
+	"github.com/LerianStudio/lib-commons/v6/commons/tenant-manager/tenantcache"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestStopTenantCollector_CancelsAndForgets covers the eviction path: the
+// collector is cancelled, awaited, and removed from the worker.
+func TestStopTenantCollector_CancelsAndForgets(t *testing.T) {
+	t.Parallel()
+
+	w := newTestWorkerWithCache(t, tenantcache.NewTenantCache())
+
+	tc := newFakeTenantCollector("tenant-1")
+	w.collectors["tenant-1"] = tc
+
+	require.True(t, w.HasCollector("tenant-1"), "the seeded collector must be visible")
+
+	w.StopTenantCollector("tenant-1")
+
+	select {
+	case <-tc.done:
+	default:
+		t.Fatal("StopTenantCollector must wait for the collector goroutine to exit")
+	}
+
+	assert.False(t, w.HasCollector("tenant-1"), "the stopped collector must be forgotten")
+	assert.Empty(t, w.collectorTenantIDs(), "no collector must remain")
+}
+
+// TestStopTenantCollector_UnknownTenantIsNoop covers the ordinary case of an
+// eviction for a tenant this worker never collected.
+func TestStopTenantCollector_UnknownTenantIsNoop(t *testing.T) {
+	t.Parallel()
+
+	w := newTestWorkerWithCache(t, tenantcache.NewTenantCache())
+
+	require.NotPanics(t, func() { w.StopTenantCollector("never-started") })
+
+	assert.Empty(t, w.collectorTenantIDs(), "a no-op must not invent a collector")
+}
+
+// TestStopTenantCollector_LeavesOtherTenantsRunning proves the eviction is scoped
+// to one tenant.
+func TestStopTenantCollector_LeavesOtherTenantsRunning(t *testing.T) {
+	t.Parallel()
+
+	w := newTestWorkerWithCache(t, tenantcache.NewTenantCache())
+
+	stopped := newFakeTenantCollector("tenant-1")
+	kept := newFakeTenantCollector("tenant-2")
+	w.collectors["tenant-1"] = stopped
+	w.collectors["tenant-2"] = kept
+
+	t.Cleanup(func() { w.StopTenantCollector("tenant-2") })
+
+	w.StopTenantCollector("tenant-1")
+
+	assert.False(t, w.HasCollector("tenant-1"))
+	assert.True(t, w.HasCollector("tenant-2"), "the other tenant must keep collecting")
+
+	select {
+	case <-kept.done:
+		t.Fatal("the other tenant's collector must not be cancelled")
+	default:
+	}
+}
+
+// TestStopTenantCollector_ReconcileRecreatesCollector is the point of the whole
+// epic: a tenant.removed event stops the collector, and because the tenant is
+// still in the cache the next reconcile brings it back on a freshly resolved
+// pool — no process restart.
+func TestStopTenantCollector_ReconcileRecreatesCollector(t *testing.T) {
+	t.Parallel()
+
+	cache := tenantcache.NewTenantCache()
+	cache.Set("tenant-1", &tmcore.TenantConfig{ID: "tenant-1"}, 1*time.Hour)
+
+	resolver := &fakePGResolver{db: newStubDB()}
+
+	w, _, _ := newResolveTestWorker(t, resolver)
+	w.tenantCache = cache
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	w.reconcileCollectors(ctx)
+	require.True(t, w.HasCollector("tenant-1"), "the first reconcile must start the collector")
+
+	w.StopTenantCollector("tenant-1")
+	require.False(t, w.HasCollector("tenant-1"), "the eviction must stop the collector")
+
+	callsAfterStop := resolver.calls.Load()
+
+	w.reconcileCollectors(ctx)
+
+	assert.True(t, w.HasCollector("tenant-1"),
+		"the tenant is still cached, so the reconcile must bring the collector back")
+	assert.Greater(t, resolver.calls.Load(), callsAfterStop,
+		"the restarted collector must resolve the pool again rather than reuse the evicted one")
+
+	w.stopAllCollectors(ctx)
+}
+
+// TestHasCollector_FalseForUnknownAndZeroValue guards the ownership checker's
+// reads against a worker that never entered multi-tenant mode.
+func TestHasCollector_FalseForUnknownAndZeroValue(t *testing.T) {
+	t.Parallel()
+
+	w := newTestWorkerWithCache(t, tenantcache.NewTenantCache())
+	assert.False(t, w.HasCollector("nobody"))
+
+	var zero BalanceSyncWorker
+	assert.False(t, zero.HasCollector("nobody"), "a nil map must read as no collector")
+}

--- a/components/ledger/internal/bootstrap/balance_sync.worker_mt_test.go
+++ b/components/ledger/internal/bootstrap/balance_sync.worker_mt_test.go
@@ -35,14 +35,14 @@ func TestNewBalanceSyncWorkerMT(t *testing.T) {
 		"mtEnabled should be true")
 	assert.Same(t, cache, worker.tenantCache,
 		"tenantCache should be the same instance")
-	assert.Same(t, pgMgr, worker.pgManager,
-		"pgManager should be the same instance")
+	assert.Same(t, pgMgr, worker.pgResolver,
+		"pgResolver should be the same instance")
 	assert.Equal(t, "transaction", worker.serviceName,
 		"serviceName should be set correctly")
 }
 
 // TestBalanceSyncWorker_IsMTReady exercises the isMTReady()
-// predicate across all combinations of mtEnabled x pgManager x tenantCache,
+// predicate across all combinations of mtEnabled x pgResolver x tenantCache,
 // plus the zero-value struct edge case.
 func TestBalanceSyncWorker_IsMTReady(t *testing.T) {
 	t.Parallel()
@@ -57,42 +57,42 @@ func TestBalanceSyncWorker_IsMTReady(t *testing.T) {
 	tests := []struct {
 		name        string
 		mtEnabled   bool
-		pgManager   *tmpostgres.Manager
+		pgResolver  tenantPGResolver
 		tenantCache *tenantcache.TenantCache
 		want        bool
 	}{
 		{
-			name:        "true_when_enabled_pgManager_and_tenantCache_set",
+			name:        "true_when_enabled_pgResolver_and_tenantCache_set",
 			mtEnabled:   true,
-			pgManager:   pgMgr,
+			pgResolver:  pgMgr,
 			tenantCache: cache,
 			want:        true,
 		},
 		{
-			name:        "false_when_enabled_but_pgManager_nil",
+			name:        "false_when_enabled_but_pgResolver_nil",
 			mtEnabled:   true,
-			pgManager:   nil,
+			pgResolver:  nil,
 			tenantCache: cache,
 			want:        false,
 		},
 		{
 			name:        "false_when_enabled_but_tenantCache_nil",
 			mtEnabled:   true,
-			pgManager:   pgMgr,
+			pgResolver:  pgMgr,
 			tenantCache: nil,
 			want:        false,
 		},
 		{
-			name:        "false_when_disabled_but_pgManager_set",
+			name:        "false_when_disabled_but_pgResolver_set",
 			mtEnabled:   false,
-			pgManager:   pgMgr,
+			pgResolver:  pgMgr,
 			tenantCache: cache,
 			want:        false,
 		},
 		{
-			name:        "false_when_disabled_and_pgManager_nil",
+			name:        "false_when_disabled_and_pgResolver_nil",
 			mtEnabled:   false,
-			pgManager:   nil,
+			pgResolver:  nil,
 			tenantCache: nil,
 			want:        false,
 		},
@@ -104,7 +104,7 @@ func TestBalanceSyncWorker_IsMTReady(t *testing.T) {
 
 			worker := NewBalanceSyncWorker(logger, useCase, BalanceSyncConfig{})
 			worker.mtEnabled = tt.mtEnabled
-			worker.pgManager = tt.pgManager
+			worker.pgResolver = tt.pgResolver
 			worker.tenantCache = tt.tenantCache
 
 			got := worker.isMTReady()
@@ -199,8 +199,8 @@ func TestNewBalanceSyncWorker_ZeroValueMultiTenantFields(t *testing.T) {
 		"mtEnabled should default to false")
 	assert.Nil(t, worker.tenantCache,
 		"tenantCache should default to nil")
-	assert.Nil(t, worker.pgManager,
-		"pgManager should default to nil")
+	assert.Nil(t, worker.pgResolver,
+		"pgResolver should default to nil")
 	assert.False(t, worker.isMTReady(),
 		"isMTReady() should be false for base constructor")
 }

--- a/components/ledger/internal/bootstrap/config.go
+++ b/components/ledger/internal/bootstrap/config.go
@@ -642,6 +642,11 @@ func InitServersWithOptions(opts *Options) (*Service, error) {
 		rmq.mongoManager = txnMgo.mongoManager
 	}
 
+	// Declared ahead of the worker section so the dispatcher callbacks below can
+	// reach it. They only run once Service.Run starts the event listener, long
+	// after the assignment.
+	var balanceSyncWorker *BalanceSyncWorker
+
 	// === Event Dispatcher & Listener (multi-tenant only) ===
 	// Created AFTER infrastructure init so the dispatcher receives the PG, Mongo, and RabbitMQ
 	// managers. This allows removeTenant to close infrastructure connections when a tenant is
@@ -656,6 +661,13 @@ func InitServersWithOptions(opts *Options) (*Service, error) {
 			// entry has TTL-expired (the default cache-based check would miss it and skip
 			// the reload that restarts the consumer, leaving it stopped).
 			tmevent.WithTenantOwnershipChecker(func(tenantID string) bool {
+				// A balance-sync collector is as much a live consumer goroutine as a
+				// RabbitMQ one: without this a tenant whose only activity is balance
+				// sync would be reported unowned and its reload skipped.
+				if balanceSyncWorker != nil && balanceSyncWorker.HasCollector(tenantID) {
+					return true
+				}
+
 				if rmq == nil || rmq.multiTenantConsumer == nil {
 					return false
 				}
@@ -680,6 +692,12 @@ func InitServersWithOptions(opts *Options) (*Service, error) {
 			tmevent.WithOnTenantRemoved(func(ctx context.Context, tenantID string) {
 				if rmq != nil && rmq.multiTenantConsumer != nil {
 					rmq.multiTenantConsumer.StopConsumer(tenantID)
+				}
+
+				// MUST precede the transaction PG close: stopping the collector drains
+				// its buffered keys, and that final flush needs a live pool.
+				if balanceSyncWorker != nil {
+					balanceSyncWorker.StopTenantCollector(tenantID)
 				}
 
 				// Close ALL postgres managers (onboarding + transaction)
@@ -1150,7 +1168,7 @@ func InitServersWithOptions(opts *Options) (*Service, error) {
 		WithMetricsFactory(metricsFactory)
 
 	// BalanceSyncWorker: multi-tenant or single-tenant
-	balanceSyncWorker := initBalanceSyncWorker(internalOpts, cfg, logger, commandUseCase, txnPG.pgManager, tenantServiceName)
+	balanceSyncWorker = initBalanceSyncWorker(internalOpts, cfg, logger, commandUseCase, txnPG.pgManager, tenantServiceName)
 	balanceSyncWorker.WithMetricsFactory(metricsFactory)
 
 	// Legacy drainer: drains pre-v3.6.2 ZSET entries (balance-sync key with seconds/microsecond scores).

--- a/components/ledger/internal/bootstrap/redis_consumer.worker_mt_fuzz_test.go
+++ b/components/ledger/internal/bootstrap/redis_consumer.worker_mt_fuzz_test.go
@@ -111,9 +111,9 @@ func FuzzIsMultiTenantReady_FieldCombinations(f *testing.F) {
 		worker.mtEnabled = workerEnabled
 
 		if workerHasPGMgr {
-			worker.pgManager = pgMgr
+			worker.pgResolver = pgMgr
 		} else {
-			worker.pgManager = nil
+			worker.pgResolver = nil
 		}
 
 		// Property: never panics.

--- a/docs/PROJECT_RULES.md
+++ b/docs/PROJECT_RULES.md
@@ -1057,6 +1057,42 @@ type BalanceSyncConfig struct {
 **Naming convention:** Multi-tenant code uses the `MT` suffix (`NewBalanceSyncWorkerMT`,
 `isMTReady`, `mtEnabled`, `runWorkerMT`). Default (single-tenant) code uses no qualifier.
 
+**Rule — a long-lived MT worker resolves its tenant connection per cycle, never at spawn.**
+A tenant manager may close or swap a tenant's pool at any time (credentials rotation,
+`tenant.cache.invalidate`, `tenant.removed`), so a handle captured once into a
+goroutine's context dangles for the rest of the process's life. Resolve it inside the
+unit of work and inject it into that call's context only:
+
+```go
+// balance_sync.worker.go — resolved per flush, injected into the flush context
+pgCtx, err := w.resolveTenantPG(flushCtx, tenantID)
+if err != nil {
+    // degraded but recoverable: skip this batch, keep the collector running
+    return false
+}
+
+return w.flushBatchFn(pgCtx, keys)
+```
+
+`tmpostgres.Manager.GetConnection` pings the cached pool and rebuilds it when the ping
+fails, so per-call resolution is self-healing with no extra logic. The cost is one ping
+per call. A resolution failure is a `Warn`, not an `Error` (T7): the next cycle retries,
+and claimed keys return to the ZSET when their claim TTL expires.
+
+The same rule holds across the monorepo: `RedisQueueConsumer` resolves per cycle,
+the MT RabbitMQ consumer per message, and the tracer's workers per cycle through
+`workers/pool_resolver.go`.
+
+**Rule — a tenant eviction stops the tenant's worker goroutine before its pool closes.**
+A worker owning per-tenant goroutines exposes a per-tenant stop, and the eviction
+callback calls it ahead of `CloseConnection` so the final flush drains into a live
+pool (`BalanceSyncWorker.StopTenantCollector`, wired in `WithOnTenantRemoved`;
+the tracer does the same through `supervisor.StopWorkers`). Stopping is not removal —
+a tenant still in the `TenantCache` gets its goroutine back on the next reconcile.
+Such a worker also answers `WithTenantOwnershipChecker`: a live per-tenant goroutine
+means midaz owns the tenant even when the cache entry has TTL-expired, and without
+that the reload which restarts the goroutine is skipped.
+
 ### Redis Queue Consumer (Transaction Component)
 
 Backup/retry queue for transaction operations when async processing via RabbitMQ fails:

--- a/pkg/utils/metrics.go
+++ b/pkg/utils/metrics.go
@@ -88,7 +88,8 @@ var (
 		Description: "Measures the number of balances synced.",
 	}
 
-	// BalanceSyncBatchFailures counts batch sync operation failures.
+	// BalanceSyncBatchFailures counts batch sync operation failures, labelled by
+	// organization_id, ledger_id and tenant_id (empty in single-tenant).
 	BalanceSyncBatchFailures = metrics.Metric{
 		Name:        "balance_sync_batch_failures_total",
 		Unit:        "1",


### PR DESCRIPTION
<table border="0" cellspacing="0" cellpadding="0">
  <tr>
    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
    <td><h1>Midaz</h1></td>
  </tr>
</table>

---

## Description

In multi-tenant mode the `BalanceSyncWorker` froze each tenant's `*sql.DB` into its collector's context at spawn (`tmcore.ContextWithPG` in `startTenantCollector`). The tenant manager closes and rebuilds a tenant's pool whenever credentials rotate or a `tenant.cache.invalidate` / `tenant.removed` event arrives — so the collector was left holding a dead handle for the rest of the process's life. Every flush failed with `sql: database is closed` and only a process restart recovered. The failure log carried no tenant, so the stuck tenant was not even locatable.

Two fronts:

**Per-flush resolution (self-healing).** The collector context now carries only `tenantID`. Each flush resolves the handle through `resolveTenantPG` and injects it into that flush's context alone. `tmpostgres.Manager.GetConnection` pings the cached pool and rebuilds it when the ping fails, so a closed pool heals on the next flush with no external action. `startTenantCollector` keeps a preflight resolution, so a tenant with no reachable PG still gets no collector. A resolution failure is degraded-but-recoverable (T7): `Warn`, tenant-skip counter, batch skipped, collector alive. Cost is one ping per flush per tenant — the same cost the HTTP middleware pays per request. `BalancePostgreSQLRepository.getDB` is unchanged.

**Eviction reaches the worker.** The collectors map moves from a local in `runWorkerMT` onto the worker behind a mutex, and `StopTenantCollector` / `HasCollector` are exposed. `WithOnTenantRemoved` stops the tenant's collector **before** any pool is closed, so the final flush drains into a live pool; the next reconcile restarts it on a freshly resolved one. `WithTenantOwnershipChecker` also reports a tenant as owned while a collector runs for it — a balance-sync collector is as much a live consumer goroutine as a RabbitMQ one, and without this a tenant whose only activity is balance sync would be reported unowned and the reload that restarts the collector skipped. Same shape the tracer already uses (`workers/pool_resolver.go`, `supervisor.StopWorkers`).

**Observability.** The batch-failure log and `balance_sync_batch_failures_total` now carry `tenant_id` (plus `organization_id` / `ledger_id` on the log line — the worker's span carries no scope IDs). `tenant_id` is emitted on both modes and is empty in single-tenant, which Prometheus treats as absent, so existing single-tenant series keep their identity. The high-volume success counter is deliberately untouched.

### Findings worth a reviewer's attention

1. **The sync ZSET member is the tenant-namespaced balance key.** `GetBalancesByKeys` MGETs the members as-is ("already namespaced") and `balance_atomic_operation.lua` does `SET redisBalanceKey` + `ZADD scheduleKey, dueAt, redisBalanceKey` with that same prefixed key. An unprefixed member reads back nil and the key is retired as *orphaned* instead of synced — `BalancesAggregated: 0`, `KeysRemoved: 1`, **no error at all**. Anything enqueueing by hand must prefix.

2. **Head-of-line blocking in the claim script — pre-existing, out of scope, worth its own issue.** `claim_balance_sync_keys.lua` reads the schedule with `ZRANGEBYSCORE ... LIMIT 0 <batchSize>` and only claims what it can lock with `SET NX EX claimTTL`. A failed flush does **not** call `RemoveBalanceSyncKeysBatch` for valid keys, so the claim lock stands for the full 600s. Locked keys at the head of the window **hide every later key** until that TTL expires. At the default batch size (50) it takes 50 locked keys to block the window, but under a sustained PG outage each failed flush locks up to `batchSize` keys — reachable. Adjacent to the already-known "a `false` flush return is discarded by the collector".

3. **`processSyncBatch` reads its metric factory off the context**, not off `w.metricsFactory` (which only feeds `emitTenantSkip`). Relevant to anyone wiring metrics assertions.

4. **`UpdateMany` SKIPS a balance whose `OverdraftUsed` is not a parseable decimal string** (empty string included), preserving the last good value rather than zeroing overdraft debt. Surfaces as a missing write, never an error.

5. **`setupAllContainers` in `config_integration_test.go` does not run migrations** — they run inside `InitServers`. The harness for seeding through repositories is `pgtestutil.SetupLedgerContainer`, which clones a template already migrated with both the transaction and onboarding schemas.

### Audit of the remaining tenant-PG injection sites — no changes needed

| Site | Resolution scope | Verdict |
|---|---|---|
| `redis.consumer.go:234-235` | per cycle, inside the tenant loop | OK |
| `config.rabbitmq.go:255-256` | per message (`resolveTenantConnections`) | OK |
| `holder_backfill.go:150,206` | one-shot, one pass per tenant | OK |
| `components/tracer/...` | per cycle via `workers/pool_resolver.go` | OK — the precedent this PR followed |

### Known limitations, unchanged by this PR

- A `false` return from the flush is still discarded by the collector. No data is lost: claimed keys return to the ZSET after `claimTTLSeconds` (600s), so a failed flush delays the sync rather than losing it.
- LRU/idle eviction on the ledger's tenant PG manager is still disabled, and the `TenantCache` is not preloaded — a tenant with no HTTP traffic disappears after `MULTI_TENANT_CACHE_TTL_SEC` and loses its collector.

## Type of Change

- [ ] `feat`: New feature or capability
- [x] `fix`: Bug fix
- [ ] `perf`: Performance improvement
- [ ] `refactor`: Internal restructuring with no behavior change
- [ ] `docs`: Documentation only
- [ ] `style`: Formatting, whitespace, naming (no logic change)
- [ ] `test`: Adding or updating tests
- [ ] `ci`: CI pipeline or workflow changes
- [ ] `build`: Build system, Dockerfile, Go module dependencies
- [ ] `chore`: Maintenance, config, tooling
- [ ] `revert`: Reverts a previous commit
- [ ] `BREAKING CHANGE`: Consumers must update their integration

## Breaking Changes

None. `NewBalanceSyncWorkerMT`'s signature is unchanged; the seam is an unexported interface satisfied by `*tmpostgres.Manager` with no adapter. `balance_sync_batch_failures_total` gains a `tenant_id` label that is empty in single-tenant, which Prometheus treats as absent, so existing series keep their identity.

## Testing

- [x] `make test` passes — 6515 tests across 70 packages; the `bootstrap` package green with `-race` (1070 tests)
- [ ] `make test-int` passes if integration paths are exercised — **only the two MT integration tests added here were run** (`go test -tags integration -run TestIntegration_BalanceSyncWorkerMT`, both green, re-run with `-count=2`). The repo's full integration suite was **not** run locally.
- [x] `make lint` passes — `golangci-lint` v2.12.2 with the repo config, 0 issues on the changed files, also with `--build-tags integration`. The 3 pre-existing issues in the repo-wide run are all in `components/tracer` (`cel/adapter.go`, `http/in/readyz.go`, `bootstrap/config.go`), outside this diff.
- [x] `make sec` and `make vulncheck` pass — gosec: 786 files, 0 issues; govulncheck: 0 vulnerabilities reachable from this code.

**Every behavioural change was RED-proved**, by reverting the fix and confirming the test fails on the intended assertion:

| Reverted to | Test that goes RED |
|---|---|
| handle frozen at spawn | `TestStartTenantCollector_ResolvesPGPerFlush`, `..._RecoversWhenResolverHeals` (swap assertion) |
| handle frozen at spawn | `TestIntegration_..._RecoversFromClosedPool` — stages 1-2 still pass (the incident reproduces), stage 3 never heals |
| `StopTenantCollector` as a no-op | `TestIntegration_..._TenantEvictionRestartsCollector` fails on `HasCollector` |

**Not done — needs a running environment:** the manual E2E in a local MT stack (bring the stack up, generate transactions for a tenant, publish `tenant.cache.invalidate`, and confirm at most one `Warn failed to resolve tenant PG for flush` followed by `balance_synced` climbing and `balance_sync_batch_failures_total{tenant_id=...}` flat).

## Architectural Checklist

- [x] No `panic()` in production paths
- [x] Timestamps use `time.Now().UTC()` — no new timestamp is taken; no `time.Now()` in the new tests either
- [x] Errors wrapped with `%w` — `resolveTenantPG` returns the resolver error unwrapped on purpose, so the caller picks the log level; nothing is swallowed
- [x] Handlers stay thin (parse, validate, call service) — no handler touched
- [x] Infrastructure concerns kept in `internal/bootstrap`

`docs/PROJECT_RULES.md` gains the two rules this fix generalises, in the Balance Sync Worker section: a long-lived MT worker resolves its tenant connection per cycle rather than at spawn, and a tenant eviction stops the tenant's worker goroutine before its pool closes. Both cite the tracer's equivalents.

## Related Issues

Closes #2415


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved multi-tenant balance synchronization lifecycle management.
  * Tenant database connections refresh for each sync cycle, enabling recovery after replacement.
  * Tenant collectors stop cleanly during eviction and can restart during reconciliation.
  * Sync failure metrics now include tenant identification.

* **Bug Fixes**
  * Improved handling of temporary connection-resolution failures with automatic retry.
  * Prevented startup and eviction races from leaving collectors active.
  * Ensured pending synchronization work drains before shutdown completes.

* **Documentation**
  * Clarified connection resolution, eviction, shutdown, and recovery behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->