### PR TITLE
refactor(pkg): mirror BalanceSettings on balance event payloads

### DIFF
--- a/docs/streaming/ledger-events.md
+++ b/docs/streaming/ledger-events.md
@@ -461,7 +461,7 @@ Source: `pkg/streaming/events/balance_created.go`. Trigger: `CreateAdditionalBal
 | `allowSending` | bool | |
 | `allowReceiving` | bool | |
 | `direction` | string | `omitempty` when empty. |
-| `settings` | object \| null | `omitempty` when nil. `balanceScope` (string, `omitempty`), `allowOverdraft` (bool), `overdraftLimitEnabled` (bool), `overdraftLimit` (string\|null, `omitempty`). |
+| `settings` | object | Omitted (not `null`) when nil. `balanceScope` (string, `omitempty`), `allowOverdraft` (bool), `overdraftLimitEnabled` (bool), `overdraftLimit` (string, `omitempty`). (`BalanceSettingsPayload`, `pkg/streaming/events/balance_created.go`) |
 | `createdAt` | string | RFC3339. |
 | `updatedAt` | string | RFC3339. |
 
@@ -542,7 +542,7 @@ Source: `pkg/streaming/events/balance_config_changed.go`. Trigger: `UseCase.Upda
 | `allowSending` | bool | |
 | `allowReceiving` | bool | |
 | `direction` | string | `omitempty` when empty. |
-| `settings` | object \| null | `omitempty` when nil. Same nested shape as `balance.created`. |
+| `settings` | object | Omitted (not `null`) when nil. Same nested shape as `balance.created`. |
 | `changeType` | string | `settings_updated` or `overdraft_enabled`. Snake_case value is payload data, not a routing identifier. |
 | `updatedAt` | string | RFC3339. |
 

--- a/pkg/streaming/events/balance_config_changed.go
+++ b/pkg/streaming/events/balance_config_changed.go
@@ -79,10 +79,12 @@ var BalanceConfigChangedDefinition = Definition{
 // signal. Money movement lives inside transaction.{posted,committed,...}
 // in the transaction-engine segment.
 //
-// Settings uses the *BalanceSettings pointer because the wire shape
-// distinguishes "settings was cleared" (settings:null) from "settings
-// was left unchanged on this PATCH" (consumers cannot disambiguate that
-// from this event alone — they must merge with the prior known state).
+// Settings is a *BalanceSettingsPayload carrying omitempty, so a nil
+// pointer is OMITTED from the payload — the key never reaches the wire as
+// settings:null. "Settings was cleared" and "settings was left untouched by
+// this PATCH" are therefore indistinguishable from this event alone;
+// consumers must merge the payload with the prior known state instead of
+// reading an absent settings as a clear.
 type BalanceConfigChangedPayload struct {
 	ID             string                  `json:"id"`
 	OrganizationID string                  `json:"organizationId"`
@@ -93,7 +95,7 @@ type BalanceConfigChangedPayload struct {
 	AllowSending   bool                    `json:"allowSending"`
 	AllowReceiving bool                    `json:"allowReceiving"`
 	Direction      string                  `json:"direction,omitempty"`
-	Settings       *mmodel.BalanceSettings `json:"settings,omitempty"`
+	Settings       *BalanceSettingsPayload `json:"settings,omitempty"`
 	ChangeType     string                  `json:"changeType"`
 	UpdatedAt      string                  `json:"updatedAt"`
 }
@@ -120,7 +122,7 @@ func NewBalanceConfigChanged(b *mmodel.Balance, changeType string) BalanceConfig
 		AllowSending:   b.AllowSending,
 		AllowReceiving: b.AllowReceiving,
 		Direction:      b.Direction,
-		Settings:       b.Settings,
+		Settings:       newBalanceSettingsPayload(b.Settings),
 		ChangeType:     changeType,
 		UpdatedAt:      b.UpdatedAt.Format(time.RFC3339),
 	}

--- a/pkg/streaming/events/balance_config_changed_test.go
+++ b/pkg/streaming/events/balance_config_changed_test.go
@@ -117,3 +117,50 @@ func TestBalanceConfigChangedPayload_JSONShape_MinimalIncludesRequiredFields(t *
 
 	assert.Lenf(t, generic, 11, "expected 11 top-level fields, got %d (drift?)", len(generic))
 }
+
+// TestBalanceConfigChangedPayload_JSONShape_SettingsSubobjectLocked pins the
+// nested settings object on balance.config_changed. BalanceSettingsPayload is
+// declared in balance_created.go but reaches the wire through both events, so
+// each event locks the subobject on its own side.
+func TestBalanceConfigChangedPayload_JSONShape_SettingsSubobjectLocked(t *testing.T) {
+	t.Run("full settings carries every key", func(t *testing.T) {
+		b := minimalBalance()
+		b.Settings = fullBalanceSettings()
+
+		req, err := events.NewBalanceConfigChanged(b, events.BalanceConfigChangeTypeSettingsUpdated).
+			ToEmitRequest("tenant-7", fixedTime)
+		require.NoError(t, err)
+
+		settings := settingsSubobject(t, req.Payload)
+
+		assert.Lenf(t, settings, 4, "expected 4 settings keys, got %d (drift?)", len(settings))
+
+		for _, key := range []string{"balanceScope", "allowOverdraft", "overdraftLimitEnabled", "overdraftLimit"} {
+			assert.Containsf(t, settings, key, "settings must include %q", key)
+		}
+	})
+
+	t.Run("minimal settings keeps only the two bools", func(t *testing.T) {
+		b := minimalBalance()
+		b.Settings = &mmodel.BalanceSettings{
+			BalanceScope:   "",
+			OverdraftLimit: nil,
+		}
+
+		req, err := events.NewBalanceConfigChanged(b, events.BalanceConfigChangeTypeSettingsUpdated).
+			ToEmitRequest("tenant-7", fixedTime)
+		require.NoError(t, err)
+
+		settings := settingsSubobject(t, req.Payload)
+
+		assert.Lenf(t, settings, 2, "expected 2 settings keys, got %d (drift?)", len(settings))
+
+		for _, key := range []string{"allowOverdraft", "overdraftLimitEnabled"} {
+			assert.Containsf(t, settings, key, "settings.%s is not omitempty and must always be present", key)
+		}
+
+		for _, key := range []string{"balanceScope", "overdraftLimit"} {
+			assert.NotContainsf(t, settings, key, "settings.%s must omitempty when empty", key)
+		}
+	})
+}

--- a/pkg/streaming/events/balance_created.go
+++ b/pkg/streaming/events/balance_created.go
@@ -37,6 +37,15 @@ var BalanceCreatedDefinition = Definition{
 	SchemaVersion: "1.0.0",
 }
 
+// BalanceSettingsPayload mirrors mmodel.BalanceSettings for balance events
+// without embedding the domain type into the wire contract.
+type BalanceSettingsPayload struct {
+	BalanceScope          string  `json:"balanceScope,omitempty"`
+	AllowOverdraft        bool    `json:"allowOverdraft"`
+	OverdraftLimitEnabled bool    `json:"overdraftLimitEnabled"`
+	OverdraftLimit        *string `json:"overdraftLimit,omitempty"`
+}
+
 // BalanceCreatedPayload is the wire payload for balance.created.
 //
 // Available/OnHold are decimal.Decimal so the wire encodes them as a
@@ -68,7 +77,7 @@ type BalanceCreatedPayload struct {
 	AllowSending   bool                    `json:"allowSending"`
 	AllowReceiving bool                    `json:"allowReceiving"`
 	Direction      string                  `json:"direction,omitempty"`
-	Settings       *mmodel.BalanceSettings `json:"settings,omitempty"`
+	Settings       *BalanceSettingsPayload `json:"settings,omitempty"`
 	CreatedAt      string                  `json:"createdAt"`
 	UpdatedAt      string                  `json:"updatedAt"`
 }
@@ -93,7 +102,7 @@ func NewBalanceCreated(b *mmodel.Balance) BalanceCreatedPayload {
 		AllowSending:   b.AllowSending,
 		AllowReceiving: b.AllowReceiving,
 		Direction:      b.Direction,
-		Settings:       b.Settings,
+		Settings:       newBalanceSettingsPayload(b.Settings),
 		CreatedAt:      b.CreatedAt.Format(time.RFC3339),
 		UpdatedAt:      b.UpdatedAt.Format(time.RFC3339),
 	}
@@ -115,4 +124,27 @@ func (p BalanceCreatedPayload) ToEmitRequest(tenantID string, ts time.Time) (lib
 		Timestamp:     ts,
 		Payload:       data,
 	}, nil
+}
+
+// newBalanceSettingsPayload copies the domain settings onto the wire type.
+// Returns nil when s is nil, so the parent field stays omitted. The
+// OverdraftLimit pointer is reallocated so the payload never aliases the
+// domain struct's memory.
+func newBalanceSettingsPayload(s *mmodel.BalanceSettings) *BalanceSettingsPayload {
+	if s == nil {
+		return nil
+	}
+
+	p := &BalanceSettingsPayload{
+		BalanceScope:          s.BalanceScope,
+		AllowOverdraft:        s.AllowOverdraft,
+		OverdraftLimitEnabled: s.OverdraftLimitEnabled,
+	}
+
+	if s.OverdraftLimit != nil {
+		limit := *s.OverdraftLimit
+		p.OverdraftLimit = &limit
+	}
+
+	return p
 }

--- a/pkg/streaming/events/balance_created_test.go
+++ b/pkg/streaming/events/balance_created_test.go
@@ -6,6 +6,8 @@ package events_test
 
 import (
 	"encoding/json"
+	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/LerianStudio/midaz/v4/pkg/mmodel"
@@ -41,6 +43,32 @@ func minimalBalance() *mmodel.Balance {
 		CreatedAt:      fixedTime,
 		UpdatedAt:      fixedTime,
 	}
+}
+
+// fullBalanceSettings returns settings with every field populated, so the
+// settings subobject reaches the wire at its maximum key set.
+func fullBalanceSettings() *mmodel.BalanceSettings {
+	limit := "1000"
+
+	return &mmodel.BalanceSettings{
+		BalanceScope:          "transactional",
+		AllowOverdraft:        true,
+		OverdraftLimitEnabled: true,
+		OverdraftLimit:        &limit,
+	}
+}
+
+// settingsSubobject decodes an emitted payload and returns its settings object.
+func settingsSubobject(t *testing.T, raw []byte) map[string]any {
+	t.Helper()
+
+	var generic map[string]any
+	require.NoError(t, json.Unmarshal(raw, &generic))
+
+	settings, ok := generic["settings"].(map[string]any)
+	require.True(t, ok, "settings must serialize as an object")
+
+	return settings
 }
 
 func TestBalanceCreatedDefinition_Key(t *testing.T) {
@@ -158,4 +186,156 @@ func TestBalanceCreatedPayload_JSONShape_OmitsEmptyOptionals(t *testing.T) {
 		_, has := generic[key]
 		assert.Falsef(t, has, "%q must omitempty when empty", key)
 	}
+}
+
+func TestNewBalanceCreated_SettingsOverdraftLimitNilStaysNil(t *testing.T) {
+	b := minimalBalance()
+	b.Settings = &mmodel.BalanceSettings{
+		AllowOverdraft: true,
+		OverdraftLimit: nil,
+	}
+
+	payload := events.NewBalanceCreated(b)
+
+	require.NotNil(t, payload.Settings)
+	assert.True(t, payload.Settings.AllowOverdraft)
+	assert.Nil(t, payload.Settings.OverdraftLimit)
+}
+
+func TestNewBalanceCreated_SettingsDoesNotAliasDomainOverdraftLimit(t *testing.T) {
+	b := minimalBalance()
+	limit := "1000"
+	b.Settings = &mmodel.BalanceSettings{
+		AllowOverdraft:        true,
+		OverdraftLimitEnabled: true,
+		OverdraftLimit:        &limit,
+	}
+
+	payload := events.NewBalanceCreated(b)
+
+	require.NotNil(t, payload.Settings)
+	require.NotNil(t, payload.Settings.OverdraftLimit)
+	assert.NotSame(t, b.Settings.OverdraftLimit, payload.Settings.OverdraftLimit,
+		"wire payload must not alias the domain OverdraftLimit pointer")
+	assert.Equal(t, *b.Settings.OverdraftLimit, *payload.Settings.OverdraftLimit)
+}
+
+// jsonTagNames returns the wire key every field of v contributes, in
+// declaration order. Unexported fields and fields tagged `json:"-"` carry no
+// wire key and are skipped; an untagged exported field marshals under its Go
+// name, so that is what it contributes.
+func jsonTagNames(v any) []string {
+	typ := reflect.TypeOf(v)
+	names := make([]string, 0, typ.NumField())
+
+	for i := range typ.NumField() {
+		field := typ.Field(i)
+		if !field.IsExported() {
+			continue
+		}
+
+		tag := field.Tag.Get("json")
+		if tag == "-" {
+			continue
+		}
+
+		name, _, _ := strings.Cut(tag, ",")
+		if name == "" {
+			name = field.Name
+		}
+
+		names = append(names, name)
+	}
+
+	return names
+}
+
+// TestBalanceSettingsPayload_MirrorsDomainJSONTags locks the wire mirror to the
+// domain type it mirrors, comparing the JSON key each side contributes rather
+// than field arity: a same-arity domain refactor — one field dropped, another
+// added — has to surface here. The JSON shape locks only pin the payload's own
+// key set, which does not move when mmodel.BalanceSettings grows a field, so
+// without this test a new domain field is silently dropped from both
+// balance.created and balance.config_changed with the whole suite green.
+func TestBalanceSettingsPayload_MirrorsDomainJSONTags(t *testing.T) {
+	domain := jsonTagNames(mmodel.BalanceSettings{})
+	mirror := jsonTagNames(events.BalanceSettingsPayload{})
+
+	assert.ElementsMatch(t, domain, mirror,
+		"events.BalanceSettingsPayload must carry the same wire keys as mmodel.BalanceSettings. "+
+			"A domain field must either be mirrored onto BalanceSettingsPayload — updating the settings "+
+			"key-count assertions in both balance event tests and docs/streaming/ledger-events.md — or be "+
+			"consciously withheld from the wire, in which case allowlist it here with the reason it is "+
+			"withheld. A changed wire shape needs a ce-schemaversion bump on balance.created and "+
+			"balance.config_changed.")
+}
+
+// TestBalanceCreatedPayload_JSONShape_SettingsSubobjectLocked pins the nested
+// settings object on balance.created: its full key set, the two omitempty tags,
+// and that it decodes to the same document as the domain type.
+func TestBalanceCreatedPayload_JSONShape_SettingsSubobjectLocked(t *testing.T) {
+	t.Run("full settings carries every key", func(t *testing.T) {
+		b := minimalBalance()
+		b.Settings = fullBalanceSettings()
+
+		req, err := events.NewBalanceCreated(b).ToEmitRequest("tenant-1", fixedTime)
+		require.NoError(t, err)
+
+		settings := settingsSubobject(t, req.Payload)
+
+		assert.Lenf(t, settings, 4, "expected 4 settings keys, got %d (drift?)", len(settings))
+
+		for _, key := range []string{"balanceScope", "allowOverdraft", "overdraftLimitEnabled", "overdraftLimit"} {
+			assert.Containsf(t, settings, key, "settings must include %q", key)
+		}
+	})
+
+	t.Run("minimal settings keeps only the two bools", func(t *testing.T) {
+		b := minimalBalance()
+		b.Settings = &mmodel.BalanceSettings{
+			BalanceScope:   "",
+			OverdraftLimit: nil,
+		}
+
+		req, err := events.NewBalanceCreated(b).ToEmitRequest("tenant-1", fixedTime)
+		require.NoError(t, err)
+
+		settings := settingsSubobject(t, req.Payload)
+
+		assert.Lenf(t, settings, 2, "expected 2 settings keys, got %d (drift?)", len(settings))
+
+		for _, key := range []string{"allowOverdraft", "overdraftLimitEnabled"} {
+			assert.Containsf(t, settings, key, "settings.%s is not omitempty and must always be present", key)
+		}
+
+		for _, key := range []string{"balanceScope", "overdraftLimit"} {
+			assert.NotContainsf(t, settings, key, "settings.%s must omitempty when empty", key)
+		}
+	})
+
+	// Decoded documents, not raw bytes: JSON object key order carries no
+	// meaning, so reordering the mirror's fields must not fail here.
+	t.Run("settings serializes to the same document as the domain", func(t *testing.T) {
+		b := minimalBalance()
+		b.Settings = fullBalanceSettings()
+
+		payload := events.NewBalanceCreated(b)
+
+		mirroredRaw, err := json.Marshal(payload.Settings)
+		require.NoError(t, err)
+
+		domainRaw, err := json.Marshal(b.Settings)
+		require.NoError(t, err)
+
+		var mirrored, domain map[string]any
+		require.NoError(t, json.Unmarshal(mirroredRaw, &mirrored))
+		require.NoError(t, json.Unmarshal(domainRaw, &domain))
+
+		assert.Equal(t, domain, mirrored,
+			"events.BalanceSettingsPayload must serialize to the same JSON document as "+
+				"mmodel.BalanceSettings. This assertion is permanent: it documents that the wire mirror "+
+				"has not diverged from the domain. Divergence is allowed, but it is a wire change — bump "+
+				"ce-schemaversion on balance.created and balance.config_changed and update "+
+				"docs/streaming/ledger-events.md before relaxing this.")
+	})
 }


### PR DESCRIPTION
<table border="0" cellspacing="0" cellpadding="0">
  <tr>
    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
    <td><h1>Midaz</h1></td>
  </tr>
</table>

---

## Description

`BalanceCreatedPayload` and `BalanceConfigChangedPayload` embedded `mmodel.BalanceSettings` directly, violating the event-modeling rule in `CLAUDE.md`: *"Do not embed `mmodel.*` types directly in event Payload structs; mirror the shape explicitly so domain evolution does not leak onto the wire."* Any field added to the domain type would have auto-published to the broker on the next deploy, with no review touching `pkg/streaming`.

Both events now carry an explicit `BalanceSettingsPayload` mirror, built by `newBalanceSettingsPayload`, which reallocates the `OverdraftLimit` pointer so the payload never aliases the domain struct's memory.

**The wire is unchanged.** The mirror reproduces `mmodel.BalanceSettings` field-for-field in declaration order with identical JSON tags (`encoding/json` emits in declaration order; the domain's extra `example:` tags are inert). This was verified empirically across 10 input classes — nil, zero-value, empty-string pointer, negative, escaping/unicode — all byte-identical. Both definitions therefore correctly stay at `ce-schemaversion 1.0.0`.

### Drift protection

Removing the embed closes a leak but opens the opposite hole: a new domain field would now be silently *dropped* rather than silently published. Three complementary locks close it, each uniquely decisive (confirmed by mutation testing):

| Lock | Catches |
|------|---------|
| Per-event `settings` key-set assertions (4-key full, 2-key minimal) | A mirror field renamed, dropped, or losing `omitempty` — including a rename applied to domain *and* mirror together |
| Decoded-document comparison against the domain | Value or key divergence between mirror and domain |
| JSON tag-name parity test | A domain field the mirror does not carry — the **only** lock that catches this, and it also catches same-arity field swaps |

Key-set locks are duplicated per event (each marshals through its own `ToEmitRequest`, so each independently locks its own wire document). The type-level comparisons live once.

### Also corrected

The `balance.config_changed` contract comment claimed the wire distinguishes `settings:null` from omitted. `omitempty` on a nil pointer makes `null` unreachable, so that disambiguation was never possible; the comment now states consumers must merge with prior state. The same false `object | null` claim is corrected on both `settings` rows in `docs/streaming/ledger-events.md`, along with the inner `overdraftLimit (string|null)`.

## Type of Change

- [ ] `feat`: New feature or capability
- [ ] `fix`: Bug fix
- [ ] `perf`: Performance improvement
- [x] `refactor`: Internal restructuring with no behavior change
- [ ] `docs`: Documentation only
- [ ] `style`: Formatting, whitespace, naming (no logic change)
- [ ] `test`: Adding or updating tests
- [ ] `ci`: CI pipeline or workflow changes
- [ ] `build`: Build system, Dockerfile, Go module dependencies
- [ ] `chore`: Maintenance, config, tooling
- [ ] `revert`: Reverts a previous commit
- [ ] `BREAKING CHANGE`: Consumers must update their integration

## Breaking Changes

None. The emitted JSON is byte-identical for every input, so no consumer sees a change and no `ce-schemaversion` bump is warranted.

## Testing

- [ ] `make test` passes
- [ ] `make test-int` passes if integration paths are exercised
- [x] `make lint` passes
- [ ] `make sec` and `make vulncheck` pass

**Test evidence / Actions run:** `make test`, `make test-int`, `make sec` and `make vulncheck` are not root Makefile targets in this repo, so they are left unchecked rather than ticked by default. Run directly instead:

- `go test ./pkg/...` — **2981 passed**, 20 packages
- `go test ./components/ledger/internal/services/command/...` — **887 passed**
- `go test ./pkg/streaming/... -count=2 -race -shuffle=on` — **688 passed**, no data race, no order dependency
- `go build ./...`, `go vet ./pkg/streaming/events/`, `gofmt -l` — all clean
- `make lint` — 0 issues across `components/ledger`, `components/tracer`, `tests`, `pkg`

Each new lock was verified to actually fail when it should: removing a JSON tag fails the key-set assertions in both files; adding a domain field fails the parity test; a same-arity field swap fails the parity test (the case a field-count check could not see).

## Architectural Checklist

- [x] No `panic()` in production paths
- [x] Timestamps use `time.Now().UTC()`
- [x] Errors wrapped with `%w`
- [x] Handlers stay thin (parse, validate, call service)
- [x] Infrastructure concerns kept in `internal/bootstrap`

## Related Issues

Lerian Map card [#4411](https://map.benedita.lerian.net/tarefas/4411) — originated from a `ring:streaming-reviewer` finding in the Review gate of [#4390](https://map.benedita.lerian.net/tarefas/4390).

### Follow-ups deliberately out of scope

- `operation_route_created.go:52-53`, `operation_route_updated.go:47-48` and `transaction_lifecycle.go:133` still embed `mmodel.*` types on the wire. Each needs its own mirror, shape lock and schemaversion judgement; `transaction_lifecycle.go` is cheapest, since `mmodel.Status` is already mirrored elsewhere in the package.
- `docs/streaming/ledger-events.md:387-388` carries the same `object | null` inaccuracy on the operation-route rows.
- The other nested mirrors in `pkg/streaming/events` have no parity lock, and six alias their `*string` where this one copies.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected balance event payloads so optional settings are omitted when unavailable.
  * Ensured overdraft limits serialize consistently as strings and preserve omission rules.
  * Standardized settings data across balance-created and balance-configuration events.

* **Documentation**
  * Updated streaming event documentation to reflect the revised settings and overdraft-limit formats.

* **Tests**
  * Added coverage for settings serialization, omitted fields, nil values, and payload consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->