### PR TITLE
feat(ledger): list holder accounts org-wide across ledgers

### DIFF
--- a/components/ledger/api/openapi.huma.yaml
+++ b/components/ledger/api/openapi.huma.yaml
@@ -9979,6 +9979,13 @@ paths:
           schema:
             description: Sort direction (asc, desc)
             type: string
+        - description: Optional ledger ID (UUID). Narrows the org-wide listing to one ledger.
+          explode: false
+          in: query
+          name: ledger_id
+          schema:
+            description: Optional ledger ID (UUID). Narrows the org-wide listing to one ledger.
+            type: string
       responses:
         "200":
           content:

--- a/components/ledger/internal/adapters/http/in/holder_accounts_routes.go
+++ b/components/ledger/internal/adapters/http/in/holder_accounts_routes.go
@@ -48,8 +48,8 @@ func RegisterHolderAccountsV2RoutesToApp(group fiber.Router, api huma.API, auth 
 }
 
 // registerHolderAccountsRoutesToApp is the single description of the holder-accounts
-// route surface. It attaches auth.Authorize("midaz","holders","get") + the CRM-scoped
-// tenant PostAuthMiddlewares + ParseUUIDPathParameters("holder") as MIDDLEWARE ONLY on
+// route surface. It attaches auth.Authorize("midaz","holders","get") + the
+// holder-accounts-scoped tenant PostAuthMiddlewares + ParseUUIDPathParameters("holder") as MIDDLEWARE ONLY on
 // the versioned group, then registers the Huma terminal on the same group's Huma API.
 func registerHolderAccountsRoutesToApp(group fiber.Router, api huma.API, auth *middleware.AuthClient, h *HolderAccountsHandler, routeOptions *pkgHTTP.ProtectedRouteOptions, opSuffix string) {
 	const acctsPath = "/organizations/:organization_id/holders/:id/accounts"

--- a/components/ledger/internal/adapters/http/in/holder_handler.go
+++ b/components/ledger/internal/adapters/http/in/holder_handler.go
@@ -311,6 +311,7 @@ type ListHolderAccountsRequest struct {
 	Limit          string `query:"limit" doc:"Max items per page (1-100, default 10)"`
 	Page           string `query:"page" doc:"Page number (default 1)"`
 	SortOrder      string `query:"sort_order" doc:"Sort direction (asc, desc)"`
+	LedgerID       string `query:"ledger_id" doc:"Optional ledger ID (UUID). Narrows the org-wide listing to one ledger."`
 
 	rawQuery url.Values
 }

--- a/components/ledger/internal/adapters/http/in/holder_handler_test.go
+++ b/components/ledger/internal/adapters/http/in/holder_handler_test.go
@@ -1014,12 +1014,66 @@ type stubHolderAccountsReader struct {
 	gotOrganizationID string
 	gotHolderID       uuid.UUID
 	gotHolderFilter   *string
+	gotLedgerID       *string
 }
 
 func (s *stubHolderAccountsReader) ListAccountsByHolder(_ context.Context, organizationID string, holderID uuid.UUID, filter pkgHTTP.QueryHeader) ([]*mmodel.Account, error) {
 	s.gotOrganizationID = organizationID
 	s.gotHolderID = holderID
 	s.gotHolderFilter = filter.HolderID
+	s.gotLedgerID = filter.LedgerID
 
 	return s.accounts, s.err
+}
+
+// TestGetAccountsByHolder_LedgerIDFilter_PassedThrough pins the ledger_id query
+// parameter reaching the reader: the listing is org-wide, so ledger_id is the
+// only way a caller narrows it, and a transport that drops it silently widens
+// every narrowed request.
+func TestGetAccountsByHolder_LedgerIDFilter_PassedThrough(t *testing.T) {
+	// NOT parallel: process-global huma state.
+	orgID := uuid.Must(libCommons.GenerateUUIDv7())
+	holderID := uuid.Must(libCommons.GenerateUUIDv7())
+	ledgerID := uuid.Must(libCommons.GenerateUUIDv7())
+
+	reader := &stubHolderAccountsReader{accounts: []*mmodel.Account{}}
+	handler := &HolderAccountsHandler{Reader: reader}
+
+	app := buildHumaHolderAccountsApp(t, handler)
+
+	req := httptest.NewRequest(http.MethodGet,
+		"/v2/organizations/"+orgID.String()+"/holders/"+holderID.String()+"/accounts?limit=10&page=1&ledger_id="+ledgerID.String(), nil)
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: 0})
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	respBody, _ := io.ReadAll(resp.Body)
+	require.Equal(t, http.StatusOK, resp.StatusCode, "body: %s", string(respBody))
+
+	require.NotNil(t, reader.gotLedgerID, "ledger_id must reach the reader")
+	assert.Equal(t, ledgerID.String(), *reader.gotLedgerID)
+}
+
+// TestGetAccountsByHolder_NoLedgerID_ReaderGetsNil pins the absent case: with no
+// ledger_id the reader must see nil, which is what makes the listing org-wide.
+func TestGetAccountsByHolder_NoLedgerID_ReaderGetsNil(t *testing.T) {
+	// NOT parallel: process-global huma state.
+	orgID := uuid.Must(libCommons.GenerateUUIDv7())
+	holderID := uuid.Must(libCommons.GenerateUUIDv7())
+
+	reader := &stubHolderAccountsReader{accounts: []*mmodel.Account{}}
+	handler := &HolderAccountsHandler{Reader: reader}
+
+	app := buildHumaHolderAccountsApp(t, handler)
+
+	req := httptest.NewRequest(http.MethodGet,
+		"/v2/organizations/"+orgID.String()+"/holders/"+holderID.String()+"/accounts?limit=10&page=1", nil)
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: 0})
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	respBody, _ := io.ReadAll(resp.Body)
+	require.Equal(t, http.StatusOK, resp.StatusCode, "body: %s", string(respBody))
+
+	assert.Nil(t, reader.gotLedgerID, "an absent ledger_id must reach the reader as nil, not an empty string")
 }

--- a/components/ledger/internal/adapters/http/in/huma_contract_mount.go
+++ b/components/ledger/internal/adapters/http/in/huma_contract_mount.go
@@ -20,7 +20,7 @@ import (
 
 // HumaMountDeps is the single source of truth for the ledger's Huma mount list. It
 // carries, by name, the auth client, every handler the registrars consume, and the
-// six route-scoped ProtectedRouteOptions the guard chains attach. Production and
+// seven route-scoped ProtectedRouteOptions the guard chains attach. Production and
 // every offline harness build one of these and mount through MountV1/MountV2, so a
 // registrar added to the mount reaches all of them at once instead of drifting
 // across four hand-maintained copies.
@@ -71,7 +71,7 @@ type HumaMountDeps struct {
 	Composition *CompositionHandler
 
 	// Route-scoped protected options, one instance per role. In multi-tenant mode
-	// buildUnifiedRouteSetup builds six distinct instances drawn from four tenant
+	// buildUnifiedRouteSetup builds seven distinct instances drawn from five tenant
 	// middlewares; in single-tenant mode every field is nil.
 	OnboardingOptions  *pkgHTTP.ProtectedRouteOptions
 	LedgerOptions      *pkgHTTP.ProtectedRouteOptions
@@ -79,6 +79,10 @@ type HumaMountDeps struct {
 	CRMOptions         *pkgHTTP.ProtectedRouteOptions
 	FeesOptions        *pkgHTTP.ProtectedRouteOptions
 	CompositionOptions *pkgHTTP.ProtectedRouteOptions
+
+	// HolderAccountsOptions scopes the org-wide holder account listing, which reads
+	// onboarding stores rather than the CRM ones CRMOptions binds.
+	HolderAccountsOptions *pkgHTTP.ProtectedRouteOptions
 }
 
 // MountV1 registers the /v1 Huma terminals + Fiber auth/tenant chain on the shared
@@ -178,7 +182,8 @@ func (d HumaMountDeps) registerMoneyReadRoutes(group fiber.Router, api huma.API)
 // CRM carries its OWN CRMOptions and authorizes against the "midaz" holders/instruments/
 // encryption/protection tuples; it is served ONLY on this /v2 contract. The nil-guards
 // (holder-accounts, encryption, audit) leave a route unregistered when its handler is
-// nil. The fee/billing ops carry FeesOptions and authorize against the "midaz"
+// nil. holder-accounts is the exception to CRMOptions: it lists ledger accounts from
+// the onboarding stores, so it carries its own HolderAccountsOptions. The fee/billing ops carry FeesOptions and authorize against the "midaz"
 // tuples at ledger scope: the path names the ledger, so a package another ledger owns
 // is out of reach. Fees/billing are served ONLY on this /v2 contract. composition
 // carries CompositionOptions and authorizes under the "midaz" appName's "accounts"
@@ -204,7 +209,7 @@ func (d HumaMountDeps) MountV2(group fiber.Router, api huma.API) {
 	RegisterBalanceV2RoutesToApp(group, api, d.Auth, d.Balance, d.TransactionOptions)
 	RegisterOperationV2RoutesToApp(group, api, d.Auth, d.Operation, d.TransactionOptions)
 	RegisterHolderV2RoutesToApp(group, api, d.Auth, d.Holder, d.CRMOptions)
-	RegisterHolderAccountsV2RoutesToApp(group, api, d.Auth, d.HolderAccounts, d.CRMOptions)
+	RegisterHolderAccountsV2RoutesToApp(group, api, d.Auth, d.HolderAccounts, d.HolderAccountsOptions)
 	RegisterInstrumentV2RoutesToApp(group, api, d.Auth, d.Instrument, d.CRMOptions)
 	RegisterEncryptionV2RoutesToApp(group, api, d.Auth, d.Encryption, d.CRMOptions)
 	RegisterAuditV2RoutesToApp(group, api, d.Auth, d.Audit, d.CRMOptions)

--- a/components/ledger/internal/adapters/postgres/account/account.postgresql.go
+++ b/components/ledger/internal/adapters/postgres/account/account.postgresql.go
@@ -96,6 +96,10 @@ type Repository interface {
 	// reads take none — the transaction and asset paths they serve read no holder,
 	// so they always project constants and never depend on those columns.
 	FindAll(ctx context.Context, organizationID, ledgerID uuid.UUID, portfolioID, segmentID *uuid.UUID, filter http.QueryHeader, holderPolicy mmodel.HolderPolicy) ([]*mmodel.Account, error)
+	// FindAllByHolder lists the live accounts owned by holderID within the organization,
+	// across every ledger; a non-nil ledgerID narrows to one ledger. Ordered by
+	// created_at then id in filter.SortOrder, paged by filter.Limit/Page.
+	FindAllByHolder(ctx context.Context, organizationID, holderID uuid.UUID, ledgerID *uuid.UUID, filter http.QueryHeader, holderPolicy mmodel.HolderPolicy) ([]*mmodel.Account, error)
 	Find(ctx context.Context, organizationID, ledgerID uuid.UUID, portfolioID *uuid.UUID, id uuid.UUID, holderPolicy mmodel.HolderPolicy) (*mmodel.Account, error)
 	FindWithDeleted(ctx context.Context, organizationID, ledgerID uuid.UUID, portfolioID *uuid.UUID, id uuid.UUID, holderPolicy mmodel.HolderPolicy) (*mmodel.Account, error)
 	FindAlias(ctx context.Context, organizationID, ledgerID uuid.UUID, portfolioID *uuid.UUID, alias string, holderPolicy mmodel.HolderPolicy) (*mmodel.Account, error)
@@ -287,118 +291,80 @@ func (r *AccountPostgreSQLRepository) Create(ctx context.Context, acc *mmodel.Ac
 	return record.ToEntity(), nil
 }
 
-// FindAll retrieves an Account entities from the database (including soft-deleted ones) with pagination.
-//
-//nolint:gocyclo // Query builder with optional filters per parameter; refactor candidate.
-func (r *AccountPostgreSQLRepository) FindAll(ctx context.Context, organizationID, ledgerID uuid.UUID, portfolioID, segmentID *uuid.UUID, filter http.QueryHeader, holderPolicy mmodel.HolderPolicy) ([]*mmodel.Account, error) {
-	_, tracer, _, _ := libObservability.NewTrackingFromContext(ctx)
-
-	ctx, span := tracer.Start(ctx, "postgres.find_all_accounts")
-	defer span.End()
-
-	db, err := r.getDB(ctx)
-	if err != nil {
-		libOpentelemetry.HandleSpanError(span, "Failed to get database connection", err)
-
-		return nil, err
-	}
-
-	var accounts []*mmodel.Account
-
-	findAll := squirrel.Select(accountColumns(holderPolicy.ProjectsHolder())...).
-		From(r.tableName).
-		Where(squirrel.Eq{"deleted_at": nil}).
-		Where(squirrel.Expr("organization_id = ?", organizationID)).
-		Where(squirrel.Expr("ledger_id = ?", ledgerID))
-
-	if portfolioID != nil && *portfolioID != uuid.Nil {
-		findAll = findAll.Where(squirrel.Expr("portfolio_id = ?", *portfolioID))
-	}
-
-	if segmentID != nil && *segmentID != uuid.Nil {
-		findAll = findAll.Where(squirrel.Expr("segment_id = ?", *segmentID))
-	}
-
+// applyAccountListFilters applies the account list query header — the optional
+// column filters and the created_at range — to a select builder. Shared by the
+// ledger-scoped and holder-scoped listings so both honour the same filter set.
+func applyAccountListFilters(b squirrel.SelectBuilder, filter http.QueryHeader) squirrel.SelectBuilder {
 	// Filter by entity IDs when provided (metadata composition)
 	if len(filter.EntityIDs) > 0 {
-		findAll = findAll.Where(squirrel.Expr("id = ANY(?)", pq.Array(filter.EntityIDs)))
+		b = b.Where(squirrel.Expr("id = ANY(?)", pq.Array(filter.EntityIDs)))
 	}
 
-	// Apply account-specific filters (status, type, asset_code, entity_id, blocked, parent_account_id)
 	if !libCommons.IsNilOrEmpty(filter.Status) {
-		findAll = findAll.Where(squirrel.Expr("status = ?", *filter.Status))
+		b = b.Where(squirrel.Expr("status = ?", *filter.Status))
 	}
 
 	if !libCommons.IsNilOrEmpty(filter.Type) {
-		findAll = findAll.Where(squirrel.Expr("type = ?", *filter.Type))
+		b = b.Where(squirrel.Expr("type = ?", *filter.Type))
 	}
 
 	if !libCommons.IsNilOrEmpty(filter.AssetCode) {
-		findAll = findAll.Where(squirrel.Expr("asset_code = ?", *filter.AssetCode))
+		b = b.Where(squirrel.Expr("asset_code = ?", *filter.AssetCode))
 	}
 
 	if !libCommons.IsNilOrEmpty(filter.EntityID) {
-		findAll = findAll.Where(squirrel.Expr("entity_id = ?", *filter.EntityID))
+		b = b.Where(squirrel.Expr("entity_id = ?", *filter.EntityID))
 	}
 
 	if !libCommons.IsNilOrEmpty(filter.HolderID) {
-		findAll = findAll.Where(squirrel.Expr("holder_id = ?", *filter.HolderID))
+		b = b.Where(squirrel.Expr("holder_id = ?", *filter.HolderID))
 	}
 
 	if filter.Blocked != nil {
-		findAll = findAll.Where(squirrel.Expr("blocked = ?", *filter.Blocked))
+		b = b.Where(squirrel.Expr("blocked = ?", *filter.Blocked))
 	}
 
 	if !libCommons.IsNilOrEmpty(filter.ParentAccountID) {
-		findAll = findAll.Where(squirrel.Expr("parent_account_id = ?", *filter.ParentAccountID))
+		b = b.Where(squirrel.Expr("parent_account_id = ?", *filter.ParentAccountID))
 	}
 
 	if filter.Name != nil && *filter.Name != "" {
 		sanitized := http.EscapeSearchMetacharacters(*filter.Name)
-		findAll = findAll.Where(
+		b = b.Where(
 			squirrel.Expr("lower(name) LIKE lower(?) || '%' ESCAPE '\\'", sanitized),
 		)
 	}
 
 	if filter.Alias != nil && *filter.Alias != "" {
 		sanitized := http.EscapeSearchMetacharacters(*filter.Alias)
-		findAll = findAll.Where(
+		b = b.Where(
 			squirrel.Expr("lower(alias) LIKE lower(?) || '%' ESCAPE '\\'", sanitized),
 		)
 	}
 
-	findAll = findAll.OrderBy("created_at " + strings.ToUpper(filter.SortOrder))
-
 	if !filter.StartDate.IsZero() {
-		findAll = findAll.
+		b = b.
 			Where(squirrel.GtOrEq{"created_at": libCommons.NormalizeDateTime(filter.StartDate, libPointers.Int(0), false)}).
 			Where(squirrel.LtOrEq{"created_at": libCommons.NormalizeDateTime(filter.EndDate, libPointers.Int(0), true)})
 	}
 
-	findAll = findAll.Limit(libCommons.SafeIntToUint64(filter.Limit)).
-		Offset(libCommons.SafeIntToUint64((filter.Page - 1) * filter.Limit)).
-		PlaceholderFormat(squirrel.Dollar)
+	return b
+}
 
-	query, args, err := findAll.ToSql()
-	if err != nil {
-		libOpentelemetry.HandleSpanError(span, "Failed to build query", err)
+// accountListOrderBy orders a listing by created_at with id as tiebreaker, both
+// in the requested direction. The tiebreaker makes paging total: accounts written
+// in the same transaction share a created_at, and without it a row can repeat on
+// one page and be missing from another.
+func accountListOrderBy(filter http.QueryHeader) []string {
+	dir := strings.ToUpper(filter.SortOrder)
 
-		return nil, err
-	}
+	return []string{"created_at " + dir, "id " + dir}
+}
 
-	_, spanQuery := tracer.Start(ctx, "postgres.find_all.query")
-
-	rows, err := db.QueryContext(ctx, query, args...)
-	if err != nil {
-		mapped := mapReadError(err)
-
-		libOpentelemetry.HandleSpanError(spanQuery, "Failed to execute query", mapped)
-
-		return nil, mapped
-	}
-	defer rows.Close()
-
-	spanQuery.End()
+// scanAccountRows drains an account projection into domain entities. The scan
+// order mirrors accountColumns.
+func scanAccountRows(rows *sql.Rows) ([]*mmodel.Account, error) {
+	var accounts []*mmodel.Account
 
 	for rows.Next() {
 		var acc AccountPostgreSQLModel
@@ -423,18 +389,149 @@ func (r *AccountPostgreSQLRepository) FindAll(ctx context.Context, organizationI
 			&acc.Blocked,
 			&acc.HolderCheckSkipped,
 		); err != nil {
-			mapped := mapReadError(err)
-
-			libOpentelemetry.HandleSpanError(span, "Failed to scan row", mapped)
-
-			return nil, mapped
+			return nil, mapReadError(err)
 		}
 
 		accounts = append(accounts, acc.ToEntity())
 	}
 
 	if err := rows.Err(); err != nil {
-		libOpentelemetry.HandleSpanError(span, "Failed to iterate rows", err)
+		return nil, err
+	}
+
+	return accounts, nil
+}
+
+// FindAll retrieves the live Account entities of a ledger with pagination.
+func (r *AccountPostgreSQLRepository) FindAll(ctx context.Context, organizationID, ledgerID uuid.UUID, portfolioID, segmentID *uuid.UUID, filter http.QueryHeader, holderPolicy mmodel.HolderPolicy) ([]*mmodel.Account, error) {
+	_, tracer, _, _ := libObservability.NewTrackingFromContext(ctx)
+
+	ctx, span := tracer.Start(ctx, "postgres.find_all_accounts")
+	defer span.End()
+
+	db, err := r.getDB(ctx)
+	if err != nil {
+		libOpentelemetry.HandleSpanError(span, "Failed to get database connection", err)
+
+		return nil, err
+	}
+
+	findAll := squirrel.Select(accountColumns(holderPolicy.ProjectsHolder())...).
+		From(r.tableName).
+		Where(squirrel.Eq{"deleted_at": nil}).
+		Where(squirrel.Expr("organization_id = ?", organizationID)).
+		Where(squirrel.Expr("ledger_id = ?", ledgerID))
+
+	if portfolioID != nil && *portfolioID != uuid.Nil {
+		findAll = findAll.Where(squirrel.Expr("portfolio_id = ?", *portfolioID))
+	}
+
+	if segmentID != nil && *segmentID != uuid.Nil {
+		findAll = findAll.Where(squirrel.Expr("segment_id = ?", *segmentID))
+	}
+
+	findAll = applyAccountListFilters(findAll, filter).
+		OrderBy(accountListOrderBy(filter)...).
+		Limit(libCommons.SafeIntToUint64(filter.Limit)).
+		Offset(libCommons.SafeIntToUint64((filter.Page - 1) * filter.Limit)).
+		PlaceholderFormat(squirrel.Dollar)
+
+	query, args, err := findAll.ToSql()
+	if err != nil {
+		libOpentelemetry.HandleSpanError(span, "Failed to build query", err)
+
+		return nil, err
+	}
+
+	_, spanQuery := tracer.Start(ctx, "postgres.find_all.query")
+
+	rows, err := db.QueryContext(ctx, query, args...)
+	if err != nil {
+		mapped := mapReadError(err)
+
+		libOpentelemetry.HandleSpanError(spanQuery, "Failed to execute query", mapped)
+
+		return nil, mapped
+	}
+	defer rows.Close()
+
+	spanQuery.End()
+
+	accounts, err := scanAccountRows(rows)
+	if err != nil {
+		libOpentelemetry.HandleSpanError(span, "Failed to read rows", err)
+
+		return nil, err
+	}
+
+	return accounts, nil
+}
+
+// FindAllByHolder retrieves the live accounts owned by a holder across every
+// ledger of the organization, narrowed to one ledger when ledgerID is non-nil.
+func (r *AccountPostgreSQLRepository) FindAllByHolder(ctx context.Context, organizationID, holderID uuid.UUID, ledgerID *uuid.UUID, filter http.QueryHeader, holderPolicy mmodel.HolderPolicy) ([]*mmodel.Account, error) {
+	_, tracer, _, _ := libObservability.NewTrackingFromContext(ctx)
+
+	ctx, span := tracer.Start(ctx, "postgres.find_all_accounts_by_holder")
+	defer span.End()
+
+	span.SetAttributes(
+		attribute.String("app.request.organization_id", organizationID.String()),
+		attribute.String("app.request.holder_id", holderID.String()),
+		attribute.Bool("app.request.has_ledger_id", ledgerID != nil && *ledgerID != uuid.Nil),
+	)
+
+	db, err := r.getDB(ctx)
+	if err != nil {
+		libOpentelemetry.HandleSpanError(span, "Failed to get database connection", err)
+
+		return nil, err
+	}
+
+	findAll := squirrel.Select(accountColumns(holderPolicy.ProjectsHolder())...).
+		From(r.tableName).
+		Where(squirrel.Eq{"deleted_at": nil}).
+		Where(squirrel.Expr("organization_id = ?", organizationID)).
+		Where(squirrel.Expr("holder_id = ?", holderID))
+
+	if ledgerID != nil && *ledgerID != uuid.Nil {
+		findAll = findAll.Where(squirrel.Expr("ledger_id = ?", *ledgerID))
+	}
+
+	// The path holder is authoritative; a holder_id query filter cannot widen or
+	// contradict it.
+	filter.HolderID = nil
+
+	findAll = applyAccountListFilters(findAll, filter).
+		OrderBy(accountListOrderBy(filter)...).
+		Limit(libCommons.SafeIntToUint64(filter.Limit)).
+		Offset(libCommons.SafeIntToUint64((filter.Page - 1) * filter.Limit)).
+		PlaceholderFormat(squirrel.Dollar)
+
+	query, args, err := findAll.ToSql()
+	if err != nil {
+		libOpentelemetry.HandleSpanError(span, "Failed to build query", err)
+
+		return nil, err
+	}
+
+	_, spanQuery := tracer.Start(ctx, "postgres.find_all_accounts_by_holder.query")
+
+	rows, err := db.QueryContext(ctx, query, args...)
+	if err != nil {
+		mapped := mapReadError(err)
+
+		libOpentelemetry.HandleSpanError(spanQuery, "Failed to execute query", mapped)
+
+		return nil, mapped
+	}
+	defer rows.Close()
+
+	spanQuery.End()
+
+	accounts, err := scanAccountRows(rows)
+	if err != nil {
+		libOpentelemetry.HandleSpanError(span, "Failed to read rows", err)
 
 		return nil, err
 	}

--- a/components/ledger/internal/adapters/postgres/account/account.postgresql_integration_test.go
+++ b/components/ledger/internal/adapters/postgres/account/account.postgresql_integration_test.go
@@ -8,7 +8,9 @@ package account
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -2763,4 +2765,249 @@ func TestIntegration_AccountRepository_FindAll_FiltersByHolderID(t *testing.T) {
 		require.NotNil(t, acc.HolderID, "account holder_id should not be nil")
 		assert.Equal(t, holderA, *acc.HolderID, "all returned accounts should be owned by holderA")
 	}
+}
+
+// ============================================================================
+// FindAllByHolder Tests
+// ============================================================================
+
+// holderListFilter returns a query header for a holder listing page.
+func holderListFilter(limit, page int, sortOrder string) http.QueryHeader {
+	return http.QueryHeader{Limit: limit, Page: page, SortOrder: sortOrder}
+}
+
+// seedHolderAccount inserts a live account owned by holderID in the given ledger
+// and returns its alias, which the assertions use as the row's identity.
+func seedHolderAccount(t *testing.T, db *sql.DB, orgID, ledgerID uuid.UUID, holderID *uuid.UUID, prefix string, deletedAt *time.Time, createdAt *time.Time) (uuid.UUID, string) {
+	t.Helper()
+
+	alias := fmt.Sprintf("@%s-%s", prefix, uuid.Must(libCommons.GenerateUUIDv7()).String()[:8])
+
+	params := pgtestutil.DefaultAccountParams()
+	params.Alias = alias
+	params.Name = prefix
+	params.HolderID = holderID
+	params.DeletedAt = deletedAt
+	params.CreatedAt = createdAt
+
+	id := pgtestutil.CreateTestAccountWithParams(t, db, orgID, ledgerID, params)
+
+	return id, alias
+}
+
+// idsOf projects a result set onto its ids, in result order.
+func idsOf(accounts []*mmodel.Account) []string {
+	out := make([]string, 0, len(accounts))
+	for _, a := range accounts {
+		out = append(out, a.ID)
+	}
+
+	return out
+}
+
+// aliasesOf projects a result set onto its aliases, for set comparison.
+func aliasesOf(accounts []*mmodel.Account) []string {
+	out := make([]string, 0, len(accounts))
+	for _, a := range accounts {
+		if a.Alias != nil {
+			out = append(out, *a.Alias)
+		}
+	}
+
+	return out
+}
+
+func TestIntegration_AccountRepository_FindAllByHolder_CrossLedger_ReturnsAllLedgers(t *testing.T) {
+	// Arrange
+	container := pgtestutil.SetupMigratedContainer(t, "onboarding")
+
+	repo := createRepository(t, container)
+
+	orgID := pgtestutil.CreateTestOrganization(t, container.DB)
+	ledger1ID := pgtestutil.CreateTestLedger(t, container.DB, orgID)
+	ledger2ID := pgtestutil.CreateTestLedger(t, container.DB, orgID)
+
+	holderID := uuid.Must(libCommons.GenerateUUIDv7())
+	otherHolderID := uuid.Must(libCommons.GenerateUUIDv7())
+
+	deletedAt := time.Now().Truncate(time.Microsecond)
+
+	// Two accounts in ledger 1 and one in ledger 2 for the target holder.
+	_, a1 := seedHolderAccount(t, container.DB, orgID, ledger1ID, &holderID, "l1a", nil, nil)
+	_, a2 := seedHolderAccount(t, container.DB, orgID, ledger1ID, &holderID, "l1b", nil, nil)
+	_, a3 := seedHolderAccount(t, container.DB, orgID, ledger2ID, &holderID, "l2a", nil, nil)
+	// Must not appear: another holder, and a soft-deleted account of the target holder.
+	_, _ = seedHolderAccount(t, container.DB, orgID, ledger1ID, &otherHolderID, "other", nil, nil)
+	_, _ = seedHolderAccount(t, container.DB, orgID, ledger2ID, &holderID, "gone", &deletedAt, nil)
+
+	// Act
+	accounts, err := repo.FindAllByHolder(context.Background(), orgID, holderID, nil, holderListFilter(10, 1, "asc"), mmodel.HolderOnV2)
+
+	// Assert
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{a1, a2, a3}, aliasesOf(accounts))
+
+	ledgers := map[string]bool{}
+	for _, a := range accounts {
+		ledgers[a.LedgerID] = true
+
+		require.NotNil(t, a.HolderID)
+		assert.Equal(t, holderID.String(), *a.HolderID)
+	}
+
+	assert.Truef(t, ledgers[ledger1ID.String()] && ledgers[ledger2ID.String()],
+		"result must span both ledgers, got %v", ledgers)
+}
+
+func TestIntegration_AccountRepository_FindAllByHolder_LedgerIDNarrows(t *testing.T) {
+	// Arrange
+	container := pgtestutil.SetupMigratedContainer(t, "onboarding")
+
+	repo := createRepository(t, container)
+
+	orgID := pgtestutil.CreateTestOrganization(t, container.DB)
+	ledger1ID := pgtestutil.CreateTestLedger(t, container.DB, orgID)
+	ledger2ID := pgtestutil.CreateTestLedger(t, container.DB, orgID)
+
+	holderID := uuid.Must(libCommons.GenerateUUIDv7())
+
+	_, a1 := seedHolderAccount(t, container.DB, orgID, ledger1ID, &holderID, "l1a", nil, nil)
+	_, a2 := seedHolderAccount(t, container.DB, orgID, ledger1ID, &holderID, "l1b", nil, nil)
+	_, _ = seedHolderAccount(t, container.DB, orgID, ledger2ID, &holderID, "l2a", nil, nil)
+
+	ctx := context.Background()
+	unknownLedger := uuid.Must(libCommons.GenerateUUIDv7())
+
+	// Act
+	narrowed, err := repo.FindAllByHolder(ctx, orgID, holderID, &ledger1ID, holderListFilter(10, 1, "asc"), mmodel.HolderOnV2)
+	require.NoError(t, err)
+
+	empty, err := repo.FindAllByHolder(ctx, orgID, holderID, &unknownLedger, holderListFilter(10, 1, "asc"), mmodel.HolderOnV2)
+	require.NoError(t, err)
+
+	// Assert
+	assert.ElementsMatch(t, []string{a1, a2}, aliasesOf(narrowed))
+	assert.Empty(t, empty, "an unknown ledger narrows to nothing, without erroring")
+}
+
+func TestIntegration_AccountRepository_FindAllByHolder_IsolatesByOrg(t *testing.T) {
+	// Arrange
+	container := pgtestutil.SetupMigratedContainer(t, "onboarding")
+
+	repo := createRepository(t, container)
+
+	org1ID := pgtestutil.CreateTestOrganization(t, container.DB)
+	ledger1ID := pgtestutil.CreateTestLedger(t, container.DB, org1ID)
+
+	org2ID := pgtestutil.CreateTestOrganization(t, container.DB)
+	ledger2ID := pgtestutil.CreateTestLedger(t, container.DB, org2ID)
+
+	// The same holder id value under two organizations.
+	holderID := uuid.Must(libCommons.GenerateUUIDv7())
+
+	_, own := seedHolderAccount(t, container.DB, org1ID, ledger1ID, &holderID, "o1", nil, nil)
+	_, _ = seedHolderAccount(t, container.DB, org2ID, ledger2ID, &holderID, "o2a", nil, nil)
+	_, _ = seedHolderAccount(t, container.DB, org2ID, ledger2ID, &holderID, "o2b", nil, nil)
+
+	ctx := context.Background()
+
+	// Act
+	fromOrg1, err := repo.FindAllByHolder(ctx, org1ID, holderID, nil, holderListFilter(10, 1, "asc"), mmodel.HolderOnV2)
+
+	// Assert
+	require.NoError(t, err)
+	assert.Equal(t, []string{own}, aliasesOf(fromOrg1))
+}
+
+// TestIntegration_AccountRepository_FindAllByHolder_PaginationUnion_IdenticalCreatedAt
+// pins the ORDER BY tiebreaker: with every row sharing one created_at, created_at
+// alone is not a total order, so paging could repeat a row on one page and drop it
+// from another. The id tiebreaker makes the order total, which is what lets the
+// pages partition the set and makes descending the exact reverse of ascending.
+func TestIntegration_AccountRepository_FindAllByHolder_PaginationUnion_IdenticalCreatedAt(t *testing.T) {
+	// Arrange
+	container := pgtestutil.SetupMigratedContainer(t, "onboarding")
+
+	repo := createRepository(t, container)
+
+	orgID := pgtestutil.CreateTestOrganization(t, container.DB)
+	ledgerID := pgtestutil.CreateTestLedger(t, container.DB, orgID)
+
+	holderID := uuid.Must(libCommons.GenerateUUIDv7())
+	sharedCreatedAt := time.Date(2026, 2, 3, 4, 5, 6, 0, time.UTC)
+
+	seeded := make([]string, 0, 7)
+	for i := 0; i < 7; i++ {
+		id, _ := seedHolderAccount(t, container.DB, orgID, ledgerID, &holderID, fmt.Sprintf("tie%d", i), nil, &sharedCreatedAt)
+		seeded = append(seeded, id.String())
+	}
+
+	page := func(sortOrder string, n int) []string {
+		accounts, err := repo.FindAllByHolder(context.Background(), orgID, holderID, nil, holderListFilter(3, n, sortOrder), mmodel.HolderOnV2)
+		require.NoError(t, err)
+
+		return idsOf(accounts)
+	}
+
+	// Act & Assert
+	assertPagedTotalOrder(t, seeded, page)
+}
+
+// TestIntegration_AccountRepository_FindAll_PaginationUnion_IdenticalCreatedAt is
+// the ledger-scoped sibling of the holder pagination pin.
+func TestIntegration_AccountRepository_FindAll_PaginationUnion_IdenticalCreatedAt(t *testing.T) {
+	// Arrange
+	container := pgtestutil.SetupMigratedContainer(t, "onboarding")
+
+	repo := createRepository(t, container)
+
+	orgID := pgtestutil.CreateTestOrganization(t, container.DB)
+	ledgerID := pgtestutil.CreateTestLedger(t, container.DB, orgID)
+
+	sharedCreatedAt := time.Date(2026, 2, 3, 4, 5, 6, 0, time.UTC)
+
+	seeded := make([]string, 0, 7)
+	for i := 0; i < 7; i++ {
+		id, _ := seedHolderAccount(t, container.DB, orgID, ledgerID, nil, fmt.Sprintf("flat%d", i), nil, &sharedCreatedAt)
+		seeded = append(seeded, id.String())
+	}
+
+	page := func(sortOrder string, n int) []string {
+		accounts, err := repo.FindAll(context.Background(), orgID, ledgerID, nil, nil, holderListFilter(3, n, sortOrder), mmodel.HolderOnV2)
+		require.NoError(t, err)
+
+		return idsOf(accounts)
+	}
+
+	// Act & Assert
+	assertPagedTotalOrder(t, seeded, page)
+}
+
+// assertPagedTotalOrder walks a 7-row set three at a time in both directions and
+// asserts the listing is a total order on id: ascending pages must come back in id
+// order, and descending must be the exact reverse. Without the id tiebreaker the
+// two directions return the same physical order, which this catches.
+func assertPagedTotalOrder(t *testing.T, seeded []string, page func(sortOrder string, n int) []string) {
+	t.Helper()
+
+	wantAsc := slices.Clone(seeded)
+	slices.Sort(wantAsc)
+
+	wantDesc := slices.Clone(wantAsc)
+	slices.Reverse(wantDesc)
+
+	walk := func(sortOrder string) []string {
+		var got []string
+		for n := 1; n <= 3; n++ {
+			got = append(got, page(sortOrder, n)...)
+		}
+
+		return got
+	}
+
+	gotAsc, gotDesc := walk("asc"), walk("desc")
+
+	assert.Equal(t, wantAsc, gotAsc, "ascending pages must walk the set in id order")
+	assert.Equal(t, wantDesc, gotDesc, "descending pages must be the exact reverse of ascending")
+	assert.ElementsMatch(t, seeded, gotAsc, "paging must be a partition of the result set")
 }

--- a/components/ledger/internal/adapters/postgres/account/account.postgresql_mock.go
+++ b/components/ledger/internal/adapters/postgres/account/account.postgresql_mock.go
@@ -147,6 +147,21 @@ func (mr *MockRepositoryMockRecorder) FindAll(ctx, organizationID, ledgerID, por
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindAll", reflect.TypeOf((*MockRepository)(nil).FindAll), ctx, organizationID, ledgerID, portfolioID, segmentID, filter, holderPolicy)
 }
 
+// FindAllByHolder mocks base method.
+func (m *MockRepository) FindAllByHolder(ctx context.Context, organizationID, holderID uuid.UUID, ledgerID *uuid.UUID, filter http.QueryHeader, holderPolicy mmodel.HolderPolicy) ([]*mmodel.Account, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FindAllByHolder", ctx, organizationID, holderID, ledgerID, filter, holderPolicy)
+	ret0, _ := ret[0].([]*mmodel.Account)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// FindAllByHolder indicates an expected call of FindAllByHolder.
+func (mr *MockRepositoryMockRecorder) FindAllByHolder(ctx, organizationID, holderID, ledgerID, filter, holderPolicy any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindAllByHolder", reflect.TypeOf((*MockRepository)(nil).FindAllByHolder), ctx, organizationID, holderID, ledgerID, filter, holderPolicy)
+}
+
 // FindByAlias mocks base method.
 func (m *MockRepository) FindByAlias(ctx context.Context, organizationID, ledgerID uuid.UUID, alias string) (bool, error) {
 	m.ctrl.T.Helper()

--- a/components/ledger/internal/adapters/postgres/account/account_schema_drift_integration_test.go
+++ b/components/ledger/internal/adapters/postgres/account/account_schema_drift_integration_test.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -37,6 +38,7 @@ func driftToPreHolderSchema(t *testing.T, db *sql.DB) {
 
 	// Reverse order, as golang-migrate would roll them back.
 	for _, name := range []string{
+		"000021_create_idx_account_org_holder.down.sql",
 		"000019_add_holder_skip_audit_to_account.down.sql",
 		"000018_create_idx_account_holder.down.sql",
 		"000017_add_account_holder_id_column.down.sql",
@@ -44,9 +46,9 @@ func driftToPreHolderSchema(t *testing.T, db *sql.DB) {
 		content, err := os.ReadFile(filepath.Join(dir, name))
 		require.NoErrorf(t, err, "failed to read %s", name)
 
-		// The index drop is CONCURRENTLY, which cannot run inside the implicit
-		// transaction of a multi-statement Exec; the column drop removes it anyway.
-		if name == "000018_create_idx_account_holder.down.sql" {
+		// Index drops are CONCURRENTLY, which cannot run inside the implicit
+		// transaction of a multi-statement Exec; the column drop removes them anyway.
+		if strings.Contains(strings.ToUpper(string(content)), "CONCURRENTLY") {
 			continue
 		}
 

--- a/components/ledger/internal/bootstrap/backward_compat_test.go
+++ b/components/ledger/internal/bootstrap/backward_compat_test.go
@@ -101,6 +101,8 @@ func TestMultiTenant_BackwardCompatibility(t *testing.T) {
 			"CRM routes must carry no tenant middleware in single-tenant mode")
 		assert.Nil(t, setup.feesRouteOptions,
 			"fee routes must carry no tenant middleware in single-tenant mode")
+		assert.Nil(t, setup.holderAccountsRouteOptions,
+			"holder-accounts routes must carry no tenant middleware in single-tenant mode")
 	})
 
 	t.Run("crm_config_fields_present_with_correct_tags", func(t *testing.T) {

--- a/components/ledger/internal/bootstrap/config.go
+++ b/components/ledger/internal/bootstrap/config.go
@@ -1068,7 +1068,8 @@ func InitServersWithOptions(opts *Options) (*Service, error) {
 	// (midaz:{holders,instruments}, encoded in the route definitions). The CRM-scoped
 	// tenant middleware travels via routeSetup.crmRouteOptions. The holder-accounts
 	// handler reads ledger accounts through a thin adapter over the query UseCase so the
-	// CRM HTTP layer never imports ledger internals.
+	// CRM HTTP layer never imports ledger internals; because it reads onboarding stores
+	// rather than CRM ones, its route carries routeSetup.holderAccountsRouteOptions.
 	holderAccountsHandler := &httpin.HolderAccountsHandler{
 		Reader: holderAccountsReaderAdapter{query: queryUseCase},
 	}
@@ -1495,10 +1496,16 @@ type unifiedRouteSetup struct {
 	feesRouteOptions        *midazhttp.ProtectedRouteOptions
 	compositionRouteOptions *midazhttp.ProtectedRouteOptions
 
+	holderAccountsRouteOptions *midazhttp.ProtectedRouteOptions
+
 	// feesTenantMiddleware is the fee-route tenant middleware instance, exposed so
 	// its configured module managers stay pinnable by a same-package regression
 	// test. Nil in single-tenant mode, where no tenant middleware is built.
 	feesTenantMiddleware *tmmiddleware.TenantMiddleware
+
+	// holderAccountsTenantMiddleware is the holder-accounts tenant middleware
+	// instance, exposed on the same terms as feesTenantMiddleware.
+	holderAccountsTenantMiddleware *tmmiddleware.TenantMiddleware
 }
 
 func buildUnifiedRouteSetup(
@@ -1638,6 +1645,24 @@ func buildUnifiedRouteSetup(
 		tmmiddleware.WithTenantLoader(tenantLoader),
 	)
 
+	// The holder-accounts listing reads onboarding stores only: the account rows
+	// come from the onboarding PG account repo and their metadata from the
+	// onboarding Mongo metadata repo. Both are MODULE-keyed — the metadata repo
+	// looks up the module key first, so binding onboarding Mongo to the generic
+	// key instead would send the lookup to whichever store owns that key.
+	//
+	// The CRM Mongo manager is deliberately absent: this route never reads a CRM
+	// collection, and this middleware resolves every registered manager eagerly,
+	// so including it would make the listing depend on CRM provisioning it does
+	// not use. A holder-existence gate on this route would change that.
+	holderAccountsTenantMiddleware := tmmiddleware.NewTenantMiddleware(
+		tmmiddleware.WithPG(onboardingPGManager, constant.ModuleOnboarding),
+		tmmiddleware.WithMB(onboardingMongoManager, constant.ModuleOnboarding),
+		tmmiddleware.WithTenantCache(tenantCache),
+		tmmiddleware.WithTenantLoader(tenantLoader),
+	)
+	setup.holderAccountsTenantMiddleware = holderAccountsTenantMiddleware
+
 	// Built from the module constants rather than spelled out: an operator provisions a
 	// tenant from this line, and a literal that drifts from constant.Module* hands them a
 	// database key the resolver will never look up.
@@ -1677,6 +1702,13 @@ func buildUnifiedRouteSetup(
 	// routes only.
 	setup.compositionRouteOptions = &midazhttp.ProtectedRouteOptions{
 		PostAuthMiddlewares: []fiber.Handler{authAssertion, compositionTenantMiddleware.WithTenantDB},
+	}
+
+	// The holder-accounts route gets its own onboarding-only tenant middleware
+	// instance rather than the CRM one, which binds the CRM Mongo on the generic
+	// key and no onboarding PG at all.
+	setup.holderAccountsRouteOptions = &midazhttp.ProtectedRouteOptions{
+		PostAuthMiddlewares: []fiber.Handler{authAssertion, holderAccountsTenantMiddleware.WithTenantDB},
 	}
 
 	return setup, nil
@@ -1755,6 +1787,8 @@ func buildHumaMountDeps(
 		CRMOptions:         setup.crmRouteOptions,
 		FeesOptions:        setup.feesRouteOptions,
 		CompositionOptions: setup.compositionRouteOptions,
+
+		HolderAccountsOptions: setup.holderAccountsRouteOptions,
 	}
 }
 

--- a/components/ledger/internal/bootstrap/holder_accounts_mt_isolation_integration_test.go
+++ b/components/ledger/internal/bootstrap/holder_accounts_mt_isolation_integration_test.go
@@ -1,0 +1,495 @@
+//go:build integration
+
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package bootstrap
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	stdhttp "net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/LerianStudio/lib-auth/v3/auth/middleware"
+	libHTTP "github.com/LerianStudio/lib-commons/v6/commons/net/http"
+	tmclient "github.com/LerianStudio/lib-commons/v6/commons/tenant-manager/client"
+	tmcore "github.com/LerianStudio/lib-commons/v6/commons/tenant-manager/core"
+	tmmongo "github.com/LerianStudio/lib-commons/v6/commons/tenant-manager/mongo"
+	tmpostgres "github.com/LerianStudio/lib-commons/v6/commons/tenant-manager/postgres"
+	libLog "github.com/LerianStudio/lib-observability/v2/log"
+	"github.com/gofiber/fiber/v3"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+	"golang.org/x/sync/errgroup"
+
+	httpin "github.com/LerianStudio/midaz/v4/components/ledger/internal/adapters/http/in"
+	mongodb "github.com/LerianStudio/midaz/v4/components/ledger/internal/adapters/mongodb/onboarding"
+	"github.com/LerianStudio/midaz/v4/components/ledger/internal/adapters/postgres/account"
+	"github.com/LerianStudio/midaz/v4/components/ledger/internal/services/query"
+	"github.com/LerianStudio/midaz/v4/pkg/constant"
+	"github.com/LerianStudio/midaz/v4/pkg/net/http"
+	mongotestutil "github.com/LerianStudio/midaz/v4/tests/utils/mongodb"
+	postgrestestutil "github.com/LerianStudio/midaz/v4/tests/utils/postgres"
+)
+
+// holderAccountsTenant is one tenant's fixture: its own onboarding PostgreSQL
+// database and its own onboarding Mongo database, seeded with a holder owning
+// accounts in TWO ledgers plus one metadata document.
+type holderAccountsTenant struct {
+	tenantID    string
+	pgDBName    string
+	mongoDBName string
+
+	// authToken is signed once at seed time: getHolderAccounts runs inside
+	// errgroup goroutines, where a require-based helper must not be called.
+	authToken string
+
+	pg *postgrestestutil.ContainerResult
+
+	orgID    uuid.UUID
+	ledger1  uuid.UUID
+	ledger2  uuid.UUID
+	holderID uuid.UUID
+
+	// aliasL1, aliasL2 are the holder's accounts, one per ledger. aliasOther
+	// belongs to a different holder in the same organization.
+	aliasL1    string
+	aliasL2    string
+	aliasOther string
+
+	// metadataAccountID is the account whose metadata document is seeded in this
+	// tenant's onboarding Mongo, and metadataValue the value only it carries.
+	metadataAccountID string
+	metadataValue     string
+}
+
+// TestIntegration_HolderAccountsConcurrentTenantIsolation drives the org-scoped
+// holder-accounts listing through the REAL composition seam — the real
+// buildUnifiedRouteSetup, the real holderAccountsReaderAdapter and the real
+// route registrar — against two tenants concurrently.
+//
+// It is the end-to-end counterpart of TestHolderAccountsTenantMiddlewareWiring:
+// that test pins which managers the middleware registers, this one proves the
+// resulting request actually resolves both per-tenant stores. The final subtest
+// pins the negative — the same request on the CRM options does NOT succeed —
+// which is the whole reason the holder-accounts role exists.
+func TestIntegration_HolderAccountsConcurrentTenantIsolation(t *testing.T) {
+	// Both the setup connections and the per-tenant connections the managers open
+	// lazily go through the lib-commons clients, which reject plaintext URIs
+	// unless ALLOW_INSECURE_TLS=true. The testcontainers speak plaintext.
+	t.Setenv("ALLOW_INSECURE_TLS", "true")
+
+	logger := &libLog.GoLogger{}
+
+	tenantAPG := postgrestestutil.SetupMigratedContainer(t, "onboarding")
+	tenantBPG := postgrestestutil.SetupMigratedContainer(t, "onboarding")
+	mongoContainer := mongotestutil.SetupReusableContainer(t)
+	tenantAMongo := mongotestutil.CreateOwnedDatabase(t, mongoContainer)
+	tenantBMongo := mongotestutil.CreateOwnedDatabase(t, mongoContainer)
+
+	tenantA := seedHolderAccountsTenant(t, tenantAPG, tenantAMongo, "tenanta")
+	tenantB := seedHolderAccountsTenant(t, tenantBPG, tenantBMongo, "tenantb")
+
+	tenants := map[string]*holderAccountsTenant{
+		tenantA.tenantID: tenantA,
+		tenantB.tenantID: tenantB,
+	}
+
+	// Fake tenant-manager control plane: per tenant it serves ONE config carrying
+	// the onboarding PostgreSQL AND the onboarding MongoDB under the SAME module
+	// key, which is what the holder-accounts middleware resolves.
+	tmServer := newFakeTenantManagerOnboardingStores(t, mongoContainer, tenants)
+	defer tmServer.Close()
+
+	tenantClient, err := tmclient.NewClient(tmServer.URL, logger,
+		tmclient.WithAllowInsecureHTTP(), tmclient.WithServiceAPIKey("test-api-key"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = tenantClient.Close() })
+
+	onboardingPGManager := tmpostgres.NewManager(tenantClient, constant.ModuleOnboarding,
+		tmpostgres.WithModule(constant.ModuleOnboarding), tmpostgres.WithLogger(logger))
+	t.Cleanup(func() { _ = onboardingPGManager.Close(context.Background()) })
+
+	onboardingMongoManager := tmmongo.NewManager(tenantClient, constant.ModuleOnboarding,
+		tmmongo.WithModule(constant.ModuleOnboarding), tmmongo.WithLogger(logger))
+	t.Cleanup(func() { _ = onboardingMongoManager.Close(context.Background()) })
+
+	// The CRM Mongo manager is built only so the CRM options exist for the
+	// negative subtest below; the holder-accounts path never resolves it.
+	crmMongoManager := tmmongo.NewManager(tenantClient, constant.ModuleCRM,
+		tmmongo.WithModule(constant.ModuleCRM), tmmongo.WithLogger(logger))
+	t.Cleanup(func() { _ = crmMongoManager.Close(context.Background()) })
+
+	// The REAL composition root, not a hand-rolled middleware: this is what makes
+	// the test fail if buildUnifiedRouteSetup stops binding the onboarding stores.
+	setup, err := buildUnifiedRouteSetup(
+		&Config{MultiTenantEnabled: true}, logger,
+		onboardingPGManager, &tmpostgres.Manager{},
+		onboardingMongoManager, &tmmongo.Manager{}, crmMongoManager, &tmmongo.Manager{},
+		nil, nil,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, setup.holderAccountsRouteOptions, "holder-accounts options must be built in multi-tenant mode")
+
+	// MT-style repositories: nil static connection, so every store must come from
+	// the request context the middleware populates.
+	uc := &query.UseCase{
+		AccountRepo:            account.NewAccountPostgreSQLRepository(nil, true),
+		OnboardingMetadataRepo: mongodb.NewMetadataMongoDBRepository(nil),
+	}
+	handler := &httpin.HolderAccountsHandler{Reader: holderAccountsReaderAdapter{query: uc}}
+
+	newApp := func(routeOptions *http.ProtectedRouteOptions) *fiber.App {
+		app := fiber.New(fiber.Config{
+			ErrorHandler: func(ctx fiber.Ctx, err error) error {
+				return libHTTP.FiberErrorHandler(ctx, err)
+			},
+		})
+		app.Use(http.WithRecover(http.WithRecoverLogger(logger)))
+		t.Cleanup(func() { _ = app.Shutdown() })
+
+		// Auth disabled: Authorize is a pass-through, so the post-auth chain the
+		// options carry is what the request actually runs.
+		mountCRMHuma(app, middleware.NewAuthClient("", false, nil), nil, nil, handler, nil, nil, routeOptions)
+
+		return app
+	}
+
+	app := newApp(setup.holderAccountsRouteOptions)
+
+	t.Run("concurrent_tenants_see_only_their_own_accounts_across_ledgers", func(t *testing.T) {
+		var g errgroup.Group
+
+		for _, tn := range []*holderAccountsTenant{tenantA, tenantB} {
+			tn := tn
+			g.Go(func() error {
+				body, status, err := getHolderAccounts(app, tn, "")
+				if err != nil {
+					return err
+				}
+
+				if status != stdhttp.StatusOK {
+					return fmt.Errorf("tenant %s: got status %d, body %s", tn.tenantID, status, body)
+				}
+
+				aliases, err := aliasesFromListing(body)
+				if err != nil {
+					return fmt.Errorf("tenant %s: %w", tn.tenantID, err)
+				}
+
+				want := []string{tn.aliasL1, tn.aliasL2}
+				if !sameSet(aliases, want) {
+					return fmt.Errorf("tenant %s: got aliases %v, want %v", tn.tenantID, aliases, want)
+				}
+
+				// Stated explicitly rather than implied by the set size: the
+				// listing is scoped by holder, not merely by organization.
+				for _, alias := range aliases {
+					if alias == tn.aliasOther {
+						return fmt.Errorf("tenant %s: listing leaked another holder's account %s", tn.tenantID, alias)
+					}
+				}
+
+				return nil
+			})
+		}
+
+		require.NoError(t, g.Wait(), "each tenant must see exactly its own holder's accounts, from both of its ledgers")
+	})
+
+	t.Run("ledger_id_narrows_within_the_tenant", func(t *testing.T) {
+		body, status, err := getHolderAccounts(app, tenantA, tenantA.ledger1.String())
+		require.NoError(t, err)
+		require.Equal(t, stdhttp.StatusOK, status, "body: %s", body)
+
+		aliases, err := aliasesFromListing(body)
+		require.NoError(t, err)
+		assert.Equal(t, []string{tenantA.aliasL1}, aliases, "?ledger_id= must narrow the org-wide listing to one ledger")
+	})
+
+	t.Run("metadata_comes_from_the_tenants_own_onboarding_mongo", func(t *testing.T) {
+		for _, tn := range []*holderAccountsTenant{tenantA, tenantB} {
+			body, status, err := getHolderAccounts(app, tn, "")
+			require.NoError(t, err)
+			require.Equal(t, stdhttp.StatusOK, status, "body: %s", body)
+
+			items, err := itemsFromListing(body)
+			require.NoError(t, err)
+
+			var seen int
+
+			for _, item := range items {
+				if item["id"] != tn.metadataAccountID {
+					continue
+				}
+
+				seen++
+
+				meta, ok := item["metadata"].(map[string]any)
+				require.Truef(t, ok, "tenant %s: account %s carries no metadata object: %v", tn.tenantID, item["id"], item)
+				assert.Equal(t, tn.metadataValue, meta["tenant_marker"],
+					"tenant %s must read its metadata from its OWN onboarding Mongo", tn.tenantID)
+			}
+
+			assert.Equalf(t, 1, seen, "tenant %s: expected its metadata-bearing account in the listing", tn.tenantID)
+		}
+	})
+
+	t.Run("ledger_id_from_another_org_narrows_to_empty", func(t *testing.T) {
+		// tenantB's ledger is a real UUID that tenantA's organization does not own.
+		body, status, err := getHolderAccounts(app, tenantA, tenantB.ledger1.String())
+		require.NoError(t, err)
+		require.Equal(t, stdhttp.StatusOK, status, "an unowned ledger narrows to nothing, it is not an error; body: %s", body)
+
+		aliases, err := aliasesFromListing(body)
+		require.NoError(t, err)
+		assert.Empty(t, aliases)
+	})
+
+	t.Run("malformed_ledger_id_is_400_with_code_0082", func(t *testing.T) {
+		body, status, err := getHolderAccounts(app, tenantA, "not-a-uuid")
+		require.NoError(t, err)
+
+		require.Equalf(t, stdhttp.StatusBadRequest, status,
+			"a malformed ledger_id is a query-parameter format error, not a missing ledger (404); body: %s", body)
+
+		var problem map[string]any
+		require.NoError(t, json.Unmarshal([]byte(body), &problem), "body: %s", body)
+		assert.Equal(t, constant.ErrInvalidQueryParameter.Error(), problem["code"],
+			"malformed ledger_id must carry the invalid-query-parameter code")
+	})
+
+	// The regression pin: this route used to run on crmRouteOptions, whose
+	// middleware binds no onboarding PostgreSQL at all, so the account read failed
+	// with "tenant postgres connection missing from context". Serving 200 here
+	// would mean the holder-accounts role has stopped being load-bearing.
+	t.Run("same_request_on_crm_options_does_not_succeed", func(t *testing.T) {
+		require.NotNil(t, setup.crmRouteOptions)
+
+		crmApp := newApp(setup.crmRouteOptions)
+
+		body, status, err := getHolderAccounts(crmApp, tenantA, "")
+		require.NoError(t, err)
+
+		assert.Equalf(t, stdhttp.StatusInternalServerError, status,
+			"the CRM options carry no onboarding PostgreSQL, so the account read fails with the "+
+				"\"tenant postgres connection missing from context\" 500 the holder-accounts role exists to prevent; body: %s", body)
+	})
+}
+
+// seedHolderAccountsTenant provisions one tenant's onboarding stores: an
+// organization with two ledgers, a holder owning one account in each, a second
+// holder's account that must never appear, and one metadata document in the
+// tenant's own onboarding Mongo.
+func seedHolderAccountsTenant(t *testing.T, pg *postgrestestutil.ContainerResult, mongoDB *mongo.Database, tenantID string) *holderAccountsTenant {
+	t.Helper()
+
+	orgID := postgrestestutil.CreateTestOrganization(t, pg.DB)
+	ledger1 := postgrestestutil.CreateTestLedger(t, pg.DB, orgID)
+	ledger2 := postgrestestutil.CreateTestLedger(t, pg.DB, orgID)
+
+	holderID := uuid.New()
+	otherHolderID := uuid.New()
+
+	seed := func(ledgerID uuid.UUID, holder *uuid.UUID, prefix string) (uuid.UUID, string) {
+		alias := fmt.Sprintf("@%s-%s-%s", tenantID, prefix, uuid.NewString()[:8])
+
+		params := postgrestestutil.DefaultAccountParams()
+		params.Alias = alias
+		params.Name = prefix
+		params.HolderID = holder
+
+		return postgrestestutil.CreateTestAccountWithParams(t, pg.DB, orgID, ledgerID, params), alias
+	}
+
+	idL1, aliasL1 := seed(ledger1, &holderID, "l1")
+	_, aliasL2 := seed(ledger2, &holderID, "l2")
+	_, aliasOther := seed(ledger1, &otherHolderID, "other")
+
+	// One metadata document, in this tenant's own onboarding Mongo, carrying a
+	// value unique to the tenant so a cross-tenant read is visible.
+	metadataValue := "marker-" + tenantID
+	now := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+
+	_, err := mongoDB.Collection(strings.ToLower(constant.EntityAccount)).InsertOne(context.Background(), map[string]any{
+		"entity_id":   idL1.String(),
+		"entity_name": constant.EntityAccount,
+		"metadata":    map[string]any{"tenant_marker": metadataValue},
+		"created_at":  now,
+		"updated_at":  now,
+	})
+	require.NoError(t, err, "failed to seed onboarding metadata for %s", tenantID)
+
+	return &holderAccountsTenant{
+		tenantID:          tenantID,
+		authToken:         tenantJWT(t, tenantID),
+		pgDBName:          pg.Config.DBName,
+		mongoDBName:       mongoDB.Name(),
+		pg:                pg,
+		orgID:             orgID,
+		ledger1:           ledger1,
+		ledger2:           ledger2,
+		holderID:          holderID,
+		aliasL1:           aliasL1,
+		aliasL2:           aliasL2,
+		aliasOther:        aliasOther,
+		metadataAccountID: idL1.String(),
+		metadataValue:     metadataValue,
+	}
+}
+
+// getHolderAccounts issues the org-scoped listing for a tenant, authenticated by
+// the JWT tenantId claim the trusted-auth assertion reads.
+func getHolderAccounts(app *fiber.App, tn *holderAccountsTenant, ledgerID string) (string, int, error) {
+	url := fmt.Sprintf("/v2/organizations/%s/holders/%s/accounts", tn.orgID, tn.holderID)
+	if ledgerID != "" {
+		url += "?ledger_id=" + ledgerID
+	}
+
+	req := httptest.NewRequest(stdhttp.MethodGet, url, nil)
+	req.Header.Set("Authorization", "Bearer "+tn.authToken)
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: 30 * time.Second})
+	if err != nil {
+		return "", 0, err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", 0, err
+	}
+
+	return string(body), resp.StatusCode, nil
+}
+
+// itemsFromListing decodes the paginated listing envelope into its items.
+func itemsFromListing(body string) ([]map[string]any, error) {
+	var envelope struct {
+		Items []map[string]any `json:"items"`
+	}
+
+	if err := json.Unmarshal([]byte(body), &envelope); err != nil {
+		return nil, fmt.Errorf("decode listing: %w (body %s)", err, body)
+	}
+
+	return envelope.Items, nil
+}
+
+func aliasesFromListing(body string) ([]string, error) {
+	items, err := itemsFromListing(body)
+	if err != nil {
+		return nil, err
+	}
+
+	out := make([]string, 0, len(items))
+
+	for _, item := range items {
+		alias, _ := item["alias"].(string)
+		out = append(out, alias)
+	}
+
+	return out, nil
+}
+
+func sameSet(got, want []string) bool {
+	if len(got) != len(want) {
+		return false
+	}
+
+	seen := make(map[string]int, len(got))
+	for _, g := range got {
+		seen[g]++
+	}
+
+	for _, w := range want {
+		if seen[w] == 0 {
+			return false
+		}
+
+		seen[w]--
+	}
+
+	return true
+}
+
+// newFakeTenantManagerOnboardingStores serves, per tenant, one TenantConfig whose
+// onboarding module carries BOTH the PostgreSQL and the MongoDB coordinates — the
+// exact shape the holder-accounts middleware resolves. The CRM module carries the
+// Mongo only, matching production, so the negative subtest exercises a realistic
+// CRM config rather than an empty one.
+func newFakeTenantManagerOnboardingStores(t *testing.T, mongoContainer *mongotestutil.ContainerResult, tenants map[string]*holderAccountsTenant) *httptest.Server {
+	t.Helper()
+
+	mux := stdhttp.NewServeMux()
+	mux.HandleFunc("/v1/tenants/", func(w stdhttp.ResponseWriter, r *stdhttp.Request) {
+		// Path: /v1/tenants/{tenantID}/associations/{service}/connections
+		parts := strings.FieldsFunc(r.URL.Path, func(c rune) bool { return c == '/' })
+		if len(parts) < 5 || parts[0] != "v1" || parts[1] != "tenants" || parts[3] != "associations" {
+			stdhttp.Error(w, "invalid path", stdhttp.StatusBadRequest)
+			return
+		}
+
+		tn, ok := tenants[parts[2]]
+		if !ok {
+			stdhttp.Error(w, "tenant not found", stdhttp.StatusNotFound)
+			return
+		}
+
+		config := &tmcore.TenantConfig{
+			ID:         tn.tenantID,
+			TenantSlug: tn.tenantID,
+			Status:     "active",
+			Databases: map[string]tmcore.DatabaseConfig{
+				constant.ModuleOnboarding: {
+					PostgreSQL: &tmcore.PostgreSQLConfig{
+						Host:     tn.pg.Host,
+						Port:     mustAtoiPort(t, tn.pg.Port),
+						Database: tn.pgDBName,
+						Username: tn.pg.Config.DBUser,
+						Password: tn.pg.Config.DBPassword,
+						SSLMode:  "disable",
+					},
+					MongoDB: &tmcore.MongoDBConfig{
+						URI:      mongoContainer.URI,
+						Database: tn.mongoDBName,
+					},
+				},
+				constant.ModuleCRM: {
+					MongoDB: &tmcore.MongoDBConfig{
+						URI:      mongoContainer.URI,
+						Database: tn.mongoDBName,
+					},
+				},
+			},
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+
+		if err := json.NewEncoder(w).Encode(config); err != nil {
+			stdhttp.Error(w, "encode failed", stdhttp.StatusInternalServerError)
+		}
+	})
+
+	return httptest.NewServer(mux)
+}
+
+func mustAtoiPort(t *testing.T, s string) int {
+	t.Helper()
+
+	var n int
+
+	_, err := fmt.Sscanf(s, "%d", &n)
+	require.NoErrorf(t, err, "failed to parse port %q", s)
+
+	return n
+}

--- a/components/ledger/internal/bootstrap/holder_accounts_tenant_wiring_test.go
+++ b/components/ledger/internal/bootstrap/holder_accounts_tenant_wiring_test.go
@@ -1,0 +1,78 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package bootstrap
+
+import (
+	"reflect"
+	"testing"
+
+	tmmongo "github.com/LerianStudio/lib-commons/v6/commons/tenant-manager/mongo"
+	tmpostgres "github.com/LerianStudio/lib-commons/v6/commons/tenant-manager/postgres"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/LerianStudio/midaz/v4/pkg/constant"
+)
+
+// TestHolderAccountsTenantMiddlewareWiring pins the holder-accounts tenant middleware to the
+// two stores the org-wide holder account listing reads: the onboarding account repo (onboarding
+// PG) and the onboarding metadata repo (onboarding MB). Both must be MODULE-keyed — the metadata
+// repo looks the module key up first, so binding the onboarding Mongo on the generic key sends
+// the metadata read to whichever store owns that key.
+//
+// This route previously ran on the CRM options, whose middleware carries no onboarding PG at all;
+// the account read then failed with "tenant postgres connection missing from context". The
+// assertions below are what keeps the route off that instance.
+//
+// The TenantMiddleware fields are unexported in lib-commons v6, so the module maps are read via
+// reflect (see mapKeys in fees_tenant_wiring_test.go).
+func TestHolderAccountsTenantMiddlewareWiring(t *testing.T) {
+	t.Parallel()
+
+	logger := newTestLogger()
+
+	// Multi-tenant: non-nil managers make buildUnifiedRouteSetup build the middleware. The
+	// managers are zero-value structs because the wiring only registers them; no DB connection
+	// is opened here (pure, no-I/O unit test).
+	mtSetup, err := buildUnifiedRouteSetup(
+		&Config{MultiTenantEnabled: true}, logger,
+		&tmpostgres.Manager{}, &tmpostgres.Manager{},
+		&tmmongo.Manager{}, &tmmongo.Manager{}, &tmmongo.Manager{}, &tmmongo.Manager{},
+		nil, nil,
+	)
+	require.NoError(t, err, "multi-tenant setup must not error")
+	require.NotNil(t, mtSetup, "multi-tenant setup must be non-nil")
+	require.NotNil(t, mtSetup.holderAccountsTenantMiddleware,
+		"holder-accounts tenant middleware must be built in multi-tenant mode")
+
+	mw := reflect.ValueOf(mtSetup.holderAccountsTenantMiddleware).Elem()
+
+	pgKeys := mapKeys(t, mw, "pgModules")
+	assert.ElementsMatch(t, []string{constant.ModuleOnboarding}, pgKeys,
+		"holder-accounts middleware must carry exactly the module-keyed onboarding PostgreSQL manager: the listing "+
+			"reads the onboarding account repo, which requires the tenant PG in context on the module key")
+
+	mbKeys := mapKeys(t, mw, "mongoModules")
+	assert.ElementsMatch(t, []string{constant.ModuleOnboarding}, mbKeys,
+		"holder-accounts middleware must carry exactly the module-keyed onboarding Mongo manager: account metadata "+
+			"enrichment reads the onboarding metadata repo on the module key")
+
+	// No generic (no-module) Mongo manager: the listing never reads a CRM collection, and this
+	// middleware resolves every registered manager eagerly, so a generic CRM Mongo would make the
+	// route depend on provisioning it does not use.
+	genericMB := mw.FieldByName("mongo")
+	if !genericMB.IsValid() {
+		t.Fatalf("lib-commons TenantMiddleware renamed field %q; update this test", "mongo")
+	}
+	assert.True(t, genericMB.IsNil(), "holder-accounts middleware must register no generic (no-module) Mongo manager: "+
+		"the listing reads no CRM collection, so binding the CRM Mongo would add an unused eager resolution")
+
+	// Single-tenant: buildUnifiedRouteSetup short-circuits to a zero-value setup before it builds
+	// any tenant middleware, so the seam is nil (parallel to the nil route options).
+	stSetup, err := buildUnifiedRouteSetup(&Config{}, logger, nil, nil, nil, nil, nil, nil, nil, nil)
+	require.NoError(t, err, "single-tenant setup must not error")
+	require.NotNil(t, stSetup, "single-tenant setup is a zero value, not nil")
+	assert.Nil(t, stSetup.holderAccountsTenantMiddleware, "single-tenant holder-accounts tenant middleware must be nil")
+}

--- a/components/ledger/internal/bootstrap/holder_wiring.go
+++ b/components/ledger/internal/bootstrap/holder_wiring.go
@@ -8,6 +8,8 @@ import (
 	"context"
 	"errors"
 
+	libCommons "github.com/LerianStudio/lib-commons/v6/commons"
+
 	"github.com/LerianStudio/midaz/v4/components/ledger/internal/services/query"
 	"github.com/LerianStudio/midaz/v4/pkg"
 	"github.com/LerianStudio/midaz/v4/pkg/constant"
@@ -48,34 +50,34 @@ func (a holderReaderAdapter) Exists(ctx context.Context, organizationID string, 
 }
 
 // holderAccountsReaderAdapter satisfies httpin.HolderAccountsReader over the
-// ledger account query use case. Ownership is org-global (the holder collection
-// is per-organization), so the account-list query is scoped by holder_id; the
-// existing account-list read path is ledger-partitioned, so the caller supplies
-// the ledger via the ledger_id query parameter.
+// ledger account query use case. Ownership is org-global — the holder collection
+// is per-organization — so the listing spans every ledger of the organization and
+// ledger_id is an optional narrowing filter rather than a scoping key.
 type holderAccountsReaderAdapter struct {
 	query *query.UseCase
 }
 
-// ListAccountsByHolder lists the accounts owned by a holder. The holder_id
-// filter (set by the handler) performs the ownership scoping; ledger_id narrows
-// the read to one ledger. The underlying account-list read is ledger-scoped, so
-// ledger_id is required and its absence is reported as a missing-parameter error.
+// ListAccountsByHolder lists the accounts a holder owns across the organization.
+// A ledger_id query parameter narrows the result to one ledger; a malformed one
+// is a query-parameter validation error.
 func (a holderAccountsReaderAdapter) ListAccountsByHolder(ctx context.Context, organizationID string, holderID uuid.UUID, filter http.QueryHeader) ([]*mmodel.Account, error) {
 	orgID, err := uuid.Parse(organizationID)
 	if err != nil {
 		return nil, pkg.ValidateBusinessError(constant.ErrOrganizationIDNotFound, constant.EntityOrganization)
 	}
 
-	if filter.LedgerID == nil || *filter.LedgerID == "" {
-		return nil, pkg.ValidateBusinessError(constant.ErrMissingRequiredQueryParameter, constant.EntityAccount, "ledger_id")
-	}
+	var ledgerID *uuid.UUID
 
-	ledgerID, err := uuid.Parse(*filter.LedgerID)
-	if err != nil {
-		return nil, pkg.ValidateBusinessError(constant.ErrLedgerIDNotFound, constant.EntityLedger)
+	if !libCommons.IsNilOrEmpty(filter.LedgerID) {
+		parsed, err := uuid.Parse(*filter.LedgerID)
+		if err != nil {
+			return nil, pkg.ValidateBusinessError(constant.ErrInvalidQueryParameter, constant.EntityAccount, "ledger_id")
+		}
+
+		ledgerID = &parsed
 	}
 
 	// HolderOnV2: the holder-accounts route is served on /v2 only, so the
 	// accounts it answers with carry the holder keys.
-	return a.query.GetAllAccount(ctx, orgID, ledgerID, nil, nil, filter, mmodel.HolderOnV2)
+	return a.query.GetAllAccountsByHolder(ctx, orgID, holderID, ledgerID, filter, mmodel.HolderOnV2)
 }

--- a/components/ledger/internal/bootstrap/holder_wiring_test.go
+++ b/components/ledger/internal/bootstrap/holder_wiring_test.go
@@ -9,12 +9,19 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/LerianStudio/midaz/v4/pkg"
-	"github.com/LerianStudio/midaz/v4/pkg/constant"
-	"github.com/LerianStudio/midaz/v4/pkg/mmodel"
+	libPointers "github.com/LerianStudio/lib-commons/v6/commons/pointers"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	mongodb "github.com/LerianStudio/midaz/v4/components/ledger/internal/adapters/mongodb/onboarding"
+	"github.com/LerianStudio/midaz/v4/components/ledger/internal/adapters/postgres/account"
+	"github.com/LerianStudio/midaz/v4/components/ledger/internal/services/query"
+	"github.com/LerianStudio/midaz/v4/pkg"
+	"github.com/LerianStudio/midaz/v4/pkg/constant"
+	"github.com/LerianStudio/midaz/v4/pkg/mmodel"
+	"github.com/LerianStudio/midaz/v4/pkg/net/http"
 )
 
 // fakeHolderByIDReader stubs GetHolderByID for the Exists discrimination test.
@@ -89,4 +96,141 @@ func TestHolderReaderAdapter_Exists(t *testing.T) {
 			require.NoError(t, err)
 		})
 	}
+}
+
+func TestHolderAccountsReaderAdapter_ListAccountsByHolder(t *testing.T) {
+	organizationID := uuid.New()
+	holderID := uuid.New()
+	ledgerID := uuid.New()
+
+	found := []*mmodel.Account{{ID: "acc1"}}
+	repoErr := errors.New("connection refused")
+
+	tests := []struct {
+		name string
+		// ledgerIDParam is the raw ?ledger_id= value; nil means the parameter was absent.
+		ledgerIDParam *string
+		expect        func(*account.MockRepository)
+		wantAccounts  []*mmodel.Account
+		wantErrCode   string
+		wantErrText   string
+	}{
+		{
+			name:          "no ledger_id lists across every ledger",
+			ledgerIDParam: nil,
+			expect: func(repo *account.MockRepository) {
+				repo.EXPECT().
+					FindAllByHolder(gomock.Any(), organizationID, holderID, gomock.Nil(), gomock.Any(), mmodel.HolderOnV2).
+					Return(found, nil).
+					Times(1)
+			},
+			wantAccounts: found,
+		},
+		{
+			name:          "empty ledger_id counts as absent",
+			ledgerIDParam: libPointers.String(""),
+			expect: func(repo *account.MockRepository) {
+				repo.EXPECT().
+					FindAllByHolder(gomock.Any(), organizationID, holderID, gomock.Nil(), gomock.Any(), mmodel.HolderOnV2).
+					Return(found, nil).
+					Times(1)
+			},
+			wantAccounts: found,
+		},
+		{
+			name:          "valid ledger_id narrows the listing",
+			ledgerIDParam: libPointers.String(ledgerID.String()),
+			expect: func(repo *account.MockRepository) {
+				repo.EXPECT().
+					FindAllByHolder(gomock.Any(), organizationID, holderID, matchLedgerIDPtr(ledgerID), gomock.Any(), mmodel.HolderOnV2).
+					Return(found, nil).
+					Times(1)
+			},
+			wantAccounts: found,
+		},
+		{
+			name:          "malformed ledger_id is a query parameter validation error",
+			ledgerIDParam: libPointers.String("not-a-uuid"),
+			expect: func(repo *account.MockRepository) {
+				repo.EXPECT().FindAllByHolder(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+			},
+			wantErrCode: constant.ErrInvalidQueryParameter.Error(),
+		},
+		{
+			name:          "repository error propagates",
+			ledgerIDParam: nil,
+			expect: func(repo *account.MockRepository) {
+				repo.EXPECT().
+					FindAllByHolder(gomock.Any(), organizationID, holderID, gomock.Nil(), gomock.Any(), mmodel.HolderOnV2).
+					Return(nil, repoErr).
+					Times(1)
+			},
+			wantErrText: repoErr.Error(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			accountRepo := account.NewMockRepository(ctrl)
+			metadataRepo := mongodb.NewMockRepository(ctrl)
+
+			tt.expect(accountRepo)
+
+			if len(tt.wantAccounts) > 0 {
+				metadataRepo.EXPECT().
+					FindByEntityIDs(gomock.Any(), constant.EntityAccount, gomock.Any()).
+					Return(nil, nil).
+					Times(1)
+			}
+
+			adapter := holderAccountsReaderAdapter{
+				query: &query.UseCase{AccountRepo: accountRepo, OnboardingMetadataRepo: metadataRepo},
+			}
+
+			filter := http.QueryHeader{Limit: 10, Page: 1, SortOrder: "asc", LedgerID: tt.ledgerIDParam}
+
+			got, err := adapter.ListAccountsByHolder(context.Background(), organizationID.String(), holderID, filter)
+
+			switch {
+			case tt.wantErrCode != "":
+				require.Error(t, err)
+
+				var validation pkg.ValidationError
+				require.ErrorAs(t, err, &validation)
+				assert.Equal(t, tt.wantErrCode, validation.Code)
+				assert.Nil(t, got)
+			case tt.wantErrText != "":
+				require.EqualError(t, err, tt.wantErrText)
+				assert.Nil(t, got)
+			default:
+				require.NoError(t, err)
+				assert.Equal(t, tt.wantAccounts, got)
+			}
+		})
+	}
+}
+
+// TestHolderAccountsReaderAdapter_RejectsMalformedOrganizationID pins the org
+// parse guard, which runs before any ledger_id handling.
+func TestHolderAccountsReaderAdapter_RejectsMalformedOrganizationID(t *testing.T) {
+	adapter := holderAccountsReaderAdapter{query: &query.UseCase{}}
+
+	got, err := adapter.ListAccountsByHolder(context.Background(), "not-a-uuid", uuid.New(), http.QueryHeader{})
+
+	require.Error(t, err)
+	assert.Nil(t, got)
+
+	var notFound pkg.EntityNotFoundError
+	require.ErrorAs(t, err, &notFound)
+	assert.Equal(t, constant.ErrOrganizationIDNotFound.Error(), notFound.Code)
+}
+
+// matchLedgerIDPtr matches a *uuid.UUID by the value it points at.
+func matchLedgerIDPtr(want uuid.UUID) gomock.Matcher {
+	return gomock.Cond(func(arg *uuid.UUID) bool {
+		return arg != nil && *arg == want
+	})
 }

--- a/components/ledger/internal/bootstrap/route_options_binding_test.go
+++ b/components/ledger/internal/bootstrap/route_options_binding_test.go
@@ -28,7 +28,7 @@ import (
 )
 
 // This file pins the registrar -> ProtectedRouteOptions binding, the one relationship the
-// route-table golden cannot capture: five of the six route-scoped options carry exactly two
+// route-table golden cannot capture: six of the seven route-scoped options carry exactly two
 // post-auth handlers, so a positional swap moves neither path nor handler count. The crm and
 // fees options both write the GENERIC tenant-context key over different Mongo managers, so
 // swapping that pair resolves CRM holder PII against the fees tenant database with every other
@@ -42,13 +42,13 @@ import (
 // TestRouteOptionsBinding asserts that buildHumaMountDeps threads each route-scoped option to
 // the correctly named field, by pointer identity. It exercises buildUnifiedRouteSetup in both
 // modes: single-tenant returns a zero-value setup whose six options are nil (the product
-// default), multi-tenant returns six pairwise-distinct instances. A crm<->fees swap in the
+// default), multi-tenant returns seven pairwise-distinct instances. A crm<->fees swap in the
 // mapper fails the two named assertions here because those two instances are distinct pointers.
 func TestRouteOptionsBinding(t *testing.T) {
 	logger := newTestLogger()
 
 	// Single-tenant: buildUnifiedRouteSetup short-circuits to a zero-value setup before it
-	// looks at any manager, so nil managers are the correct inputs and all six options are nil.
+	// looks at any manager, so nil managers are the correct inputs and all seven options are nil.
 	stSetup, err := buildUnifiedRouteSetup(&Config{}, logger, nil, nil, nil, nil, nil, nil, nil, nil)
 	require.NoError(t, err, "single-tenant setup must not error")
 	require.NotNil(t, stSetup, "single-tenant setup is a zero value, not nil")
@@ -59,14 +59,16 @@ func TestRouteOptionsBinding(t *testing.T) {
 	assert.Nil(t, stSetup.crmRouteOptions, "single-tenant crm option must be nil")
 	assert.Nil(t, stSetup.feesRouteOptions, "single-tenant fees option must be nil")
 	assert.Nil(t, stSetup.compositionRouteOptions, "single-tenant composition option must be nil")
+	assert.Nil(t, stSetup.holderAccountsRouteOptions, "single-tenant holder-accounts option must be nil")
 
 	stDeps := buildHumaMountDepsWithNilHandlers(stSetup)
 	assert.Nil(t, stDeps.OnboardingOptions, "single-tenant deps onboarding option must be nil")
 	assert.Nil(t, stDeps.CRMOptions, "single-tenant deps crm option must be nil")
 	assert.Nil(t, stDeps.FeesOptions, "single-tenant deps fees option must be nil")
+	assert.Nil(t, stDeps.HolderAccountsOptions, "single-tenant deps holder-accounts option must be nil")
 
-	// Multi-tenant: non-nil managers make buildUnifiedRouteSetup build six distinct options
-	// drawn from four separate tenant middlewares. The managers are zero-value structs because
+	// Multi-tenant: non-nil managers make buildUnifiedRouteSetup build seven distinct options
+	// drawn from five separate tenant middlewares. The managers are zero-value structs because
 	// buildUnifiedRouteSetup only wires them into middleware options; nothing connects here.
 	mtSetup, err := buildUnifiedRouteSetup(
 		&Config{MultiTenantEnabled: true}, logger,
@@ -87,6 +89,7 @@ func TestRouteOptionsBinding(t *testing.T) {
 		{"crm", mtSetup.crmRouteOptions},
 		{"fees", mtSetup.feesRouteOptions},
 		{"composition", mtSetup.compositionRouteOptions},
+		{"holder-accounts", mtSetup.holderAccountsRouteOptions},
 	}
 
 	for _, ri := range roleInstances {
@@ -117,6 +120,9 @@ func TestRouteOptionsBinding(t *testing.T) {
 			"against the CRM tenant database")
 	assert.Samef(t, mtSetup.compositionRouteOptions, deps.CompositionOptions,
 		"composition option must bind to the composition route setup")
+	assert.Samef(t, mtSetup.holderAccountsRouteOptions, deps.HolderAccountsOptions,
+		"holder-accounts option must bind to the holder-accounts route setup, not the crm one: the crm middleware binds "+
+			"the CRM Mongo on the generic key and no onboarding PG, so this swap fails the listing's account read")
 }
 
 // buildHumaMountDepsWithNilHandlers exercises the mapper with the setup under test and nil
@@ -148,7 +154,7 @@ const routeRolesGoldenPath = "testdata/route_roles.golden"
 // routeRolesGoldenHeader prefixes the golden so a reader knows what the third column means and how
 // to regenerate. It is part of the compared bytes, so it cannot drift from the rows it describes.
 const routeRolesGoldenHeader = `# Route -> role map: METHOD<TAB>RAW PATH<TAB>ROLE.
-# ROLE is which of the six route-scoped ProtectedRouteOptions a registered route runs, observed by
+# ROLE is which of the seven route-scoped ProtectedRouteOptions a registered route runs, observed by
 # threading a distinct sentinel post-auth handler per role and recording which one executed.
 # It pins the registrar -> options pairing the route table cannot: swapping the crm and fees
 # options moves neither path nor handler count, but flips the role recorded here.
@@ -199,17 +205,17 @@ func TestRouteRoles(t *testing.T) {
 		}
 
 		_, ok := observed[group.key]
-		assert.Truef(t, ok, "%s ran no role sentinel: it is mounted outside all six route-scoped options, or its chain "+
+		assert.Truef(t, ok, "%s ran no role sentinel: it is mounted outside all seven route-scoped options, or its chain "+
 			"never reached the post-auth handler", group.display())
 	}
 
-	// 2. All six roles appear at least once, so no role's registrars silently vanished.
-	rolesSeen := make(map[string]bool, 6)
+	// 2. All seven roles appear at least once, so no role's registrars silently vanished.
+	rolesSeen := make(map[string]bool, 7)
 	for _, role := range observed {
 		rolesSeen[role] = true
 	}
 
-	for _, role := range []string{"onboarding", "ledger", "transaction", "crm", "fees", "composition"} {
+	for _, role := range []string{"onboarding", "ledger", "transaction", "crm", "fees", "composition", "holder-accounts"} {
 		assert.Truef(t, rolesSeen[role], "no route ran the %q sentinel: that role's registrars are missing from the surface", role)
 	}
 
@@ -262,7 +268,7 @@ func TestRouteRoles(t *testing.T) {
 	t.Logf("route roles match golden: %d routes", len(observed))
 }
 
-// probeRouteRoles mounts the full surface with six distinct sentinel options and returns the
+// probeRouteRoles mounts the full surface with seven distinct sentinel options and returns the
 // observed route -> role map plus the route groups. Auth is DISABLED so the authorizer passes and
 // the sentinel is the handler that answers; each sentinel records its role and short-circuits with
 // 204 so no terminal runs.
@@ -293,6 +299,8 @@ func probeRouteRoles(t *testing.T) (map[string]string, []routeGroup) {
 		crmRouteOptions:         sentinel("crm"),
 		feesRouteOptions:        sentinel("fees"),
 		compositionRouteOptions: sentinel("composition"),
+
+		holderAccountsRouteOptions: sentinel("holder-accounts"),
 	}
 
 	logger := newTestLogger()

--- a/components/ledger/internal/bootstrap/route_table_crm_v1_absence_test.go
+++ b/components/ledger/internal/bootstrap/route_table_crm_v1_absence_test.go
@@ -70,6 +70,8 @@ func mountV1OnlySurface(t *testing.T) *fiber.App {
 		CRMOptions:         routeOptions,
 		FeesOptions:        routeOptions,
 		CompositionOptions: routeOptions,
+
+		HolderAccountsOptions: routeOptions,
 	}
 
 	api := httpin.AssembleHumaContract(app, app, openapi.Config{

--- a/components/ledger/internal/bootstrap/route_table_golden_test.go
+++ b/components/ledger/internal/bootstrap/route_table_golden_test.go
@@ -208,6 +208,8 @@ func buildFullSurfaceServer(t *testing.T) *UnifiedServer {
 		CRMOptions:         routeOptions,
 		FeesOptions:        routeOptions,
 		CompositionOptions: routeOptions,
+
+		HolderAccountsOptions: routeOptions,
 	}
 
 	// The streaming manifest route is mounted on the full-surface harness through

--- a/components/ledger/internal/bootstrap/testdata/route_roles.golden
+++ b/components/ledger/internal/bootstrap/testdata/route_roles.golden
@@ -1,5 +1,5 @@
 # Route -> role map: METHOD<TAB>RAW PATH<TAB>ROLE.
-# ROLE is which of the six route-scoped ProtectedRouteOptions a registered route runs, observed by
+# ROLE is which of the seven route-scoped ProtectedRouteOptions a registered route runs, observed by
 # threading a distinct sentinel post-auth handler per role and recording which one executed.
 # It pins the registrar -> options pairing the route table cannot: swapping the crm and fees
 # options moves neither path nor handler count, but flips the role recorded here.
@@ -76,7 +76,7 @@ GET	/v2/organizations/:organization_id/encryption/status	crm
 GET	/v2/organizations/:organization_id/holders	crm
 GET	/v2/organizations/:organization_id/holders/:holder_id/instruments/:instrument_id	crm
 GET	/v2/organizations/:organization_id/holders/:id	crm
-GET	/v2/organizations/:organization_id/holders/:id/accounts	crm
+GET	/v2/organizations/:organization_id/holders/:id/accounts	holder-accounts
 GET	/v2/organizations/:organization_id/instruments	crm
 GET	/v2/organizations/:organization_id/ledgers	onboarding
 GET	/v2/organizations/:organization_id/ledgers/:ledger_id	onboarding

--- a/components/ledger/internal/services/query/get_all_accounts.go
+++ b/components/ledger/internal/services/query/get_all_accounts.go
@@ -13,6 +13,7 @@ import (
 	libLog "github.com/LerianStudio/lib-observability/v2/log"
 	libOpentelemetry "github.com/LerianStudio/lib-observability/v2/tracing"
 	"github.com/google/uuid"
+	"go.opentelemetry.io/otel/trace"
 
 	"github.com/LerianStudio/midaz/v4/components/ledger/internal/services"
 	"github.com/LerianStudio/midaz/v4/pkg"
@@ -54,6 +55,13 @@ func (uc *UseCase) GetAllAccount(ctx context.Context, organizationID, ledgerID u
 		return nil, err
 	}
 
+	return uc.attachAccountMetadata(ctx, span, accounts)
+}
+
+// attachAccountMetadata enriches a page of accounts with their onboarding
+// metadata. A metadata lookup failure surfaces as ErrNoAccountsFound, the same
+// class both account listings report.
+func (uc *UseCase) attachAccountMetadata(ctx context.Context, span trace.Span, accounts []*mmodel.Account) ([]*mmodel.Account, error) {
 	if len(accounts) == 0 {
 		return accounts, nil
 	}

--- a/components/ledger/internal/services/query/get_all_accounts_by_holder.go
+++ b/components/ledger/internal/services/query/get_all_accounts_by_holder.go
@@ -1,0 +1,59 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package query
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	libObservability "github.com/LerianStudio/lib-observability/v2"
+	libLog "github.com/LerianStudio/lib-observability/v2/log"
+	libOpentelemetry "github.com/LerianStudio/lib-observability/v2/tracing"
+	"github.com/google/uuid"
+
+	"github.com/LerianStudio/midaz/v4/components/ledger/internal/services"
+	"github.com/LerianStudio/midaz/v4/pkg"
+	"github.com/LerianStudio/midaz/v4/pkg/constant"
+	"github.com/LerianStudio/midaz/v4/pkg/mmodel"
+	"github.com/LerianStudio/midaz/v4/pkg/net/http"
+	"github.com/LerianStudio/midaz/v4/pkg/utils"
+)
+
+// GetAllAccountsByHolder fetches the accounts a holder owns across every ledger of
+// the organization. A non-nil ledgerID narrows the listing to a single ledger.
+func (uc *UseCase) GetAllAccountsByHolder(ctx context.Context, organizationID, holderID uuid.UUID, ledgerID *uuid.UUID, filter http.QueryHeader, holderPolicy mmodel.HolderPolicy) (_ []*mmodel.Account, err error) {
+	logger, tracer, _, _ := libObservability.NewTrackingFromContext(ctx)
+
+	ctx, span := tracer.Start(ctx, "query.get_all_accounts_by_holder")
+	defer span.End()
+
+	start := time.Now()
+
+	defer func() {
+		utils.RecordDomainOperation(ctx, uc.MetricsFactory, logger, "ledger", "list_accounts_by_holder", start, err)
+	}()
+
+	accounts, err := uc.AccountRepo.FindAllByHolder(ctx, organizationID, holderID, ledgerID, filter, holderPolicy)
+	if err != nil {
+		logger.Log(ctx, libLog.LevelError, "Error getting accounts by holder on repo", libLog.Err(err))
+
+		if errors.Is(err, services.ErrDatabaseItemNotFound) {
+			err = pkg.ValidateBusinessError(constant.ErrNoAccountsFound, constant.EntityAccount)
+
+			logger.Log(ctx, libLog.LevelWarn, "No accounts found")
+
+			libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Failed to get accounts by holder on repo", err)
+
+			return nil, err
+		}
+
+		libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Failed to get accounts by holder on repo", err)
+
+		return nil, err
+	}
+
+	return uc.attachAccountMetadata(ctx, span, accounts)
+}

--- a/components/ledger/internal/services/query/get_all_accounts_by_holder_test.go
+++ b/components/ledger/internal/services/query/get_all_accounts_by_holder_test.go
@@ -1,0 +1,173 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package query
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	mongodb "github.com/LerianStudio/midaz/v4/components/ledger/internal/adapters/mongodb/onboarding"
+	"github.com/LerianStudio/midaz/v4/components/ledger/internal/adapters/postgres/account"
+	"github.com/LerianStudio/midaz/v4/components/ledger/internal/services"
+	"github.com/LerianStudio/midaz/v4/pkg"
+	"github.com/LerianStudio/midaz/v4/pkg/constant"
+	"github.com/LerianStudio/midaz/v4/pkg/mmodel"
+	"github.com/LerianStudio/midaz/v4/pkg/net/http"
+)
+
+func TestGetAllAccountsByHolder(t *testing.T) {
+	organizationID := uuid.New()
+	holderID := uuid.New()
+	ledgerID := uuid.New()
+
+	filter := http.QueryHeader{Limit: 10, Page: 1, SortOrder: "asc"}
+
+	tests := []struct {
+		name             string
+		ledgerID         *uuid.UUID
+		setupMocks       func(*account.MockRepository, *mongodb.MockRepository)
+		expectedErrCode  string
+		expectedErrText  string
+		expectedAccounts []*mmodel.Account
+	}{
+		{
+			name:     "success - org-wide listing enriched with metadata",
+			ledgerID: nil,
+			setupMocks: func(accounts *account.MockRepository, metadata *mongodb.MockRepository) {
+				accounts.EXPECT().
+					FindAllByHolder(gomock.Any(), organizationID, holderID, gomock.Nil(), filter, mmodel.HolderOnV2).
+					Return([]*mmodel.Account{{ID: "acc1"}, {ID: "acc2"}}, nil).
+					Times(1)
+
+				metadata.EXPECT().
+					FindByEntityIDs(gomock.Any(), constant.EntityAccount, []string{"acc1", "acc2"}).
+					Return([]*mongodb.Metadata{{EntityID: "acc1", Data: map[string]any{"k": "v"}}}, nil).
+					Times(1)
+			},
+			expectedAccounts: []*mmodel.Account{
+				{ID: "acc1", Metadata: map[string]any{"k": "v"}},
+				{ID: "acc2"},
+			},
+		},
+		{
+			name:     "success - ledger id narrows the listing",
+			ledgerID: &ledgerID,
+			setupMocks: func(accounts *account.MockRepository, metadata *mongodb.MockRepository) {
+				accounts.EXPECT().
+					FindAllByHolder(gomock.Any(), organizationID, holderID, matchLedgerID(ledgerID), filter, mmodel.HolderOnV2).
+					Return([]*mmodel.Account{{ID: "acc1"}}, nil).
+					Times(1)
+
+				metadata.EXPECT().
+					FindByEntityIDs(gomock.Any(), constant.EntityAccount, []string{"acc1"}).
+					Return([]*mongodb.Metadata{}, nil).
+					Times(1)
+			},
+			expectedAccounts: []*mmodel.Account{{ID: "acc1"}},
+		},
+		{
+			name:     "empty result skips the metadata lookup",
+			ledgerID: nil,
+			setupMocks: func(accounts *account.MockRepository, metadata *mongodb.MockRepository) {
+				accounts.EXPECT().
+					FindAllByHolder(gomock.Any(), organizationID, holderID, gomock.Nil(), filter, mmodel.HolderOnV2).
+					Return([]*mmodel.Account{}, nil).
+					Times(1)
+
+				metadata.EXPECT().FindByEntityIDs(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+			},
+			expectedAccounts: []*mmodel.Account{},
+		},
+		{
+			name:     "database item not found becomes ErrNoAccountsFound",
+			ledgerID: nil,
+			setupMocks: func(accounts *account.MockRepository, metadata *mongodb.MockRepository) {
+				accounts.EXPECT().
+					FindAllByHolder(gomock.Any(), organizationID, holderID, gomock.Nil(), filter, mmodel.HolderOnV2).
+					Return(nil, services.ErrDatabaseItemNotFound).
+					Times(1)
+			},
+			expectedErrCode: constant.ErrNoAccountsFound.Error(),
+		},
+		{
+			name:     "generic repository error propagates",
+			ledgerID: nil,
+			setupMocks: func(accounts *account.MockRepository, metadata *mongodb.MockRepository) {
+				accounts.EXPECT().
+					FindAllByHolder(gomock.Any(), organizationID, holderID, gomock.Nil(), filter, mmodel.HolderOnV2).
+					Return(nil, errors.New("connection refused")).
+					Times(1)
+			},
+			expectedErrText: "connection refused",
+		},
+		{
+			name:     "metadata failure becomes ErrNoAccountsFound",
+			ledgerID: nil,
+			setupMocks: func(accounts *account.MockRepository, metadata *mongodb.MockRepository) {
+				accounts.EXPECT().
+					FindAllByHolder(gomock.Any(), organizationID, holderID, gomock.Nil(), filter, mmodel.HolderOnV2).
+					Return([]*mmodel.Account{{ID: "acc1"}}, nil).
+					Times(1)
+
+				metadata.EXPECT().
+					FindByEntityIDs(gomock.Any(), constant.EntityAccount, []string{"acc1"}).
+					Return(nil, errors.New("mongo down")).
+					Times(1)
+			},
+			expectedErrCode: constant.ErrNoAccountsFound.Error(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			accountRepo := account.NewMockRepository(ctrl)
+			metadataRepo := mongodb.NewMockRepository(ctrl)
+
+			tt.setupMocks(accountRepo, metadataRepo)
+
+			uc := &UseCase{AccountRepo: accountRepo, OnboardingMetadataRepo: metadataRepo}
+
+			got, err := uc.GetAllAccountsByHolder(context.Background(), organizationID, holderID, tt.ledgerID, filter, mmodel.HolderOnV2)
+
+			if tt.expectedErrCode != "" {
+				require.Error(t, err)
+
+				var notFound pkg.EntityNotFoundError
+				require.ErrorAs(t, err, &notFound)
+				assert.Equal(t, tt.expectedErrCode, notFound.Code)
+				assert.Nil(t, got)
+
+				return
+			}
+
+			if tt.expectedErrText != "" {
+				require.EqualError(t, err, tt.expectedErrText)
+				assert.Nil(t, got)
+
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectedAccounts, got)
+		})
+	}
+}
+
+// matchLedgerID matches a *uuid.UUID argument by the value it points at, so the
+// expectation pins the narrowing ledger rather than the pointer identity.
+func matchLedgerID(want uuid.UUID) gomock.Matcher {
+	return gomock.Cond(func(arg *uuid.UUID) bool {
+		return arg != nil && *arg == want
+	})
+}

--- a/components/ledger/migrations/onboarding/000021_create_idx_account_org_holder.down.sql
+++ b/components/ledger/migrations/onboarding/000021_create_idx_account_org_holder.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX CONCURRENTLY IF EXISTS idx_account_org_holder;

--- a/components/ledger/migrations/onboarding/000021_create_idx_account_org_holder.up.sql
+++ b/components/ledger/migrations/onboarding/000021_create_idx_account_org_holder.up.sql
@@ -1,0 +1,3 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_account_org_holder
+    ON account (organization_id, holder_id)
+    WHERE deleted_at IS NULL;

--- a/components/ledger/migrations/onboarding/000021_create_idx_account_org_holder_test.go
+++ b/components/ledger/migrations/onboarding/000021_create_idx_account_org_holder_test.go
@@ -1,0 +1,124 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package migrations
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestMigration000021_FilesExist verifies that migration 000021 ships both
+// up and down SQL files and that neither is empty.
+func TestMigration000021_FilesExist(t *testing.T) {
+	t.Parallel()
+
+	dir := migrationsDir(t)
+
+	tests := []struct {
+		name     string
+		filename string
+	}{
+		{
+			name:     "up migration file exists",
+			filename: "000021_create_idx_account_org_holder.up.sql",
+		},
+		{
+			name:     "down migration file exists",
+			filename: "000021_create_idx_account_org_holder.down.sql",
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			path := filepath.Join(dir, tc.filename)
+			_, err := os.Stat(path)
+			require.NoError(t, err, "migration file %s must exist", tc.filename)
+
+			content, err := os.ReadFile(path)
+			require.NoError(t, err, "migration file %s must be readable", tc.filename)
+			assert.NotEmpty(t, string(content), "migration file %s must not be empty", tc.filename)
+		})
+	}
+}
+
+// TestMigration000021_UpSQL_CreatesOrgHolderIndex verifies the up migration
+// creates the partial (organization_id, holder_id) index that backs the
+// org-wide holder account listing.
+func TestMigration000021_UpSQL_CreatesOrgHolderIndex(t *testing.T) {
+	t.Parallel()
+
+	dir := migrationsDir(t)
+	path := filepath.Join(dir, "000021_create_idx_account_org_holder.up.sql")
+
+	content, err := os.ReadFile(path)
+	require.NoError(t, err, "up migration file must be readable")
+
+	sql := strings.ToLower(string(content))
+
+	tests := []struct {
+		name        string
+		substring   string
+		description string
+	}{
+		{name: "creates an index", substring: "create index", description: "must create an index"},
+		{name: "creates it concurrently", substring: "concurrently", description: "must build the index CONCURRENTLY to avoid locking writes"},
+		{name: "uses IF NOT EXISTS for idempotency", substring: "if not exists", description: "must use IF NOT EXISTS for idempotent re-runs"},
+		{name: "names the index idx_account_org_holder", substring: "idx_account_org_holder", description: "must name the index idx_account_org_holder"},
+		{name: "targets the account table", substring: "on account", description: "must index the account table"},
+		{name: "keys on organization_id then holder_id", substring: "(organization_id, holder_id)", description: "must key on organization_id then holder_id, in that order"},
+		{name: "is partial on live rows", substring: "where deleted_at is null", description: "must be partial on live rows only"},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Contains(t, sql, tc.substring, tc.description)
+		})
+	}
+}
+
+// TestMigration000021_DownSQL_DropsIndex verifies the down migration removes
+// the index added by the up migration.
+func TestMigration000021_DownSQL_DropsIndex(t *testing.T) {
+	t.Parallel()
+
+	dir := migrationsDir(t)
+	path := filepath.Join(dir, "000021_create_idx_account_org_holder.down.sql")
+
+	content, err := os.ReadFile(path)
+	require.NoError(t, err, "down migration file must be readable")
+
+	sql := strings.ToLower(string(content))
+
+	tests := []struct {
+		name        string
+		substring   string
+		description string
+	}{
+		{name: "drops an index", substring: "drop index", description: "must drop an index"},
+		{name: "drops it concurrently", substring: "concurrently", description: "must drop the index CONCURRENTLY to avoid locking writes"},
+		{name: "uses IF EXISTS for idempotency", substring: "if exists", description: "must use IF EXISTS for idempotent rollback"},
+		{name: "targets idx_account_org_holder", substring: "idx_account_org_holder", description: "must drop the idx_account_org_holder index"},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Contains(t, sql, tc.substring, tc.description)
+		})
+	}
+}

--- a/docs/PROJECT_RULES.md
+++ b/docs/PROJECT_RULES.md
@@ -66,7 +66,7 @@ There is no standalone "microservices" deployment of onboarding, transaction, CR
 
 ### Component Communication
 
-The `ledger` component composes all four surfaces in-process — there is no gRPC anywhere in the ledger binary. Onboarding and transaction share a single `command.UseCase` and a single `query.UseCase` constructed over the same repo set; all handlers receive the same use-case pointers. Every one of the six route-scoped mount groups (onboarding, transaction, ledger metadata, CRM, fees, composition) mounts onto one Fiber app through the two `HumaRouteRegistrar` mounts that `buildHumaMountDeps` assembles; the variadic `RouteRegistrar` takes app-root routes that sit outside the versioned groups. The composition below runs inside package `bootstrap`, where the unexported `buildHumaMountDeps` is in scope:
+The `ledger` component composes all four surfaces in-process — there is no gRPC anywhere in the ledger binary. Onboarding and transaction share a single `command.UseCase` and a single `query.UseCase` constructed over the same repo set; all handlers receive the same use-case pointers. Every one of the seven route-scoped mount groups (onboarding, transaction, ledger metadata, CRM, fees, composition, holder-accounts) mounts onto one Fiber app through the two `HumaRouteRegistrar` mounts that `buildHumaMountDeps` assembles; the variadic `RouteRegistrar` takes app-root routes that sit outside the versioned groups. The composition below runs inside package `bootstrap`, where the unexported `buildHumaMountDeps` is in scope:
 
 ```go
 // buildHumaMountDeps threads every handler and its route-scoped

--- a/docs/api/SCOPING.md
+++ b/docs/api/SCOPING.md
@@ -55,11 +55,18 @@ not match and Fiber returns `404`. The former "missing scoping header" error cla
   a validated UUID rather than a raw header string.
 - **`X-Ledger-Id` was removed entirely.** It is no longer a live contract on any CRM or composition
   route. The single route that legitimately needs a ledger — composition account-open — now carries
-  `:ledger_id` in its path (`/v1/organizations/{organization_id}/ledgers/{ledger_id}/holders/{id}/accounts`),
+  `:ledger_id` in its path (`/v2/organizations/{organization_id}/ledgers/{ledger_id}/holders/{id}/accounts`),
   because it creates a real ledger account.
 - **`ledger_id` keeps two non-scoping roles.** It remains a **create-body field** on instrument
-  creation, and an **optional list filter** (`?ledger_id=`) on `GET .../instruments`. In neither
-  role is it a scoping input for pure-CRM routes.
+  creation, and an **optional list filter** (`?ledger_id=`) on `GET .../instruments` and on
+  `GET .../holders/{id}/accounts`. In neither role is it a scoping input for pure-CRM routes.
+
+  `GET /v2/organizations/{organization_id}/holders/{id}/accounts` is org-scoped by its path, and
+  holder ownership is org-global, so the listing spans **every ledger of the organization**;
+  `?ledger_id=` narrows it to one. A malformed value is `0082` / 400, not a 404: it is a
+  query-parameter format error, not a missing ledger. Because the read touches the onboarding
+  stores rather than the CRM ones, the route carries its own `holder-accounts` route options
+  instead of the CRM ones — see `components/ledger/internal/bootstrap/config.go`.
 
 The service layer keeps its `organizationID string` signatures; only the source and validation of
 the value moved (path UUID → `.String()`), so the Mongo partition is unchanged.

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -338,7 +338,7 @@ an instrument create-body field and an optional `GET .../instruments` list filte
 | GET | /v2/organizations/{organization_id}/holders/{id} | Get a holder (authz `midaz`/`holders`) |
 | PATCH | /v2/organizations/{organization_id}/holders/{id} | Update a holder (authz `midaz`/`holders`) |
 | DELETE | /v2/organizations/{organization_id}/holders/{id} | Delete a holder (authz `midaz`/`holders`) |
-| GET | /v2/organizations/{organization_id}/holders/{id}/accounts | List a holder's accounts org-wide (authz `midaz`/`holders`; mounted only when the ledger account-query backing is non-nil) |
+| GET | /v2/organizations/{organization_id}/holders/{id}/accounts | List a holder's accounts org-wide across every ledger, with an optional `?ledger_id=` narrowing filter (authz `midaz`/`holders`; mounted only when the ledger account-query backing is non-nil) |
 | GET | /v2/organizations/{organization_id}/instruments | List instruments (authz `midaz`/`instruments`) |
 | POST | /v2/organizations/{organization_id}/holders/{holder_id}/instruments | Create an instrument for a holder (authz `midaz`/`instruments`) |
 | GET | /v2/organizations/{organization_id}/holders/{holder_id}/instruments/{instrument_id} | Get an instrument (authz `midaz`/`instruments`) |
@@ -355,8 +355,10 @@ in legacy mode their handlers are nil and the routes are never mounted.
 
 The holder-account composition (`POST`) carries an extra `:ledger_id` segment because it creates a
 real ledger account; the holder-accounts `GET` (`HolderAccountsHandler.GetAccountsByHolder`, mounted
-only when the ledger account-query backing is non-nil) lists a holder's accounts org-wide and needs
-no ledger. The `POST` (`CompositionHandler.CreateHolderAccount`, in `composition_routes.go`) is
+only when the ledger account-query backing is non-nil) lists a holder's accounts across every ledger
+of the organization and needs no ledger. It accepts an optional `?ledger_id=` narrowing filter; a
+malformed value is `0082` / 400. Because it reads the onboarding stores rather than the CRM ones, it
+is the one CRM-path route carrying its own `holder-accounts` route options. The `POST` (`CompositionHandler.CreateHolderAccount`, in `composition_routes.go`) is
 always mounted. Holder ownership is org-scoped (matching Mongo storage), not ledger-scoped.
 
 CRM error responses carry **canonical midaz codes** (e.g. `0009`, `0046`, `0047`, `0094`) — the

--- a/postman/MIDAZ.postman_collection.json
+++ b/postman/MIDAZ.postman_collection.json
@@ -37510,6 +37510,12 @@
                   "value": "",
                   "description": "Sort direction (asc, desc)",
                   "disabled": true
+                },
+                {
+                  "key": "ledger_id",
+                  "value": "",
+                  "description": "Optional ledger ID (UUID). Narrows the org-wide listing to one ledger.",
+                  "disabled": true
                 }
               ]
             },
@@ -37576,6 +37582,12 @@
                       "key": "sort_order",
                       "value": "",
                       "description": "Sort direction (asc, desc)",
+                      "disabled": true
+                    },
+                    {
+                      "key": "ledger_id",
+                      "value": "",
+                      "description": "Optional ledger ID (UUID). Narrows the org-wide listing to one ledger.",
                       "disabled": true
                     }
                   ]

--- a/postman/specs/ledger/openapi.huma.yaml
+++ b/postman/specs/ledger/openapi.huma.yaml
@@ -9979,6 +9979,13 @@ paths:
           schema:
             description: Sort direction (asc, desc)
             type: string
+        - description: Optional ledger ID (UUID). Narrows the org-wide listing to one ledger.
+          explode: false
+          in: query
+          name: ledger_id
+          schema:
+            description: Optional ledger ID (UUID). Narrows the org-wide listing to one ledger.
+            type: string
       responses:
         "200":
           content:

--- a/postman/specs/midaz.openapi.json
+++ b/postman/specs/midaz.openapi.json
@@ -8441,6 +8441,16 @@
               "description": "Sort direction (asc, desc)",
               "type": "string"
             }
+          },
+          {
+            "description": "Optional ledger ID (UUID). Narrows the org-wide listing to one ledger.",
+            "explode": false,
+            "in": "query",
+            "name": "ledger_id",
+            "schema": {
+              "description": "Optional ledger ID (UUID). Narrows the org-wide listing to one ledger.",
+              "type": "string"
+            }
           }
         ],
         "responses": {

--- a/postman/specs/midaz.openapi.yaml
+++ b/postman/specs/midaz.openapi.yaml
@@ -5456,6 +5456,17 @@ paths:
           schema:
             description: Sort direction (asc, desc)
             type: string
+        - description: >-
+            Optional ledger ID (UUID). Narrows the org-wide listing to one
+            ledger.
+          explode: false
+          in: query
+          name: ledger_id
+          schema:
+            description: >-
+              Optional ledger ID (UUID). Narrows the org-wide listing to one
+              ledger.
+            type: string
       responses:
         '200':
           content:

--- a/tests/utils/postgres/fixtures.go
+++ b/tests/utils/postgres/fixtures.go
@@ -875,7 +875,11 @@ type AccountParams struct {
 	ParentAccountID *uuid.UUID
 	PortfolioID     *uuid.UUID
 	SegmentID       *uuid.UUID
+	HolderID        *uuid.UUID
 	DeletedAt       *time.Time
+	// CreatedAt overrides the insert timestamp. Seeding rows that share one
+	// created_at is what exercises the ORDER BY tiebreaker.
+	CreatedAt *time.Time
 }
 
 // DefaultAccountParams returns default parameters for creating a test account.
@@ -895,9 +899,13 @@ func CreateTestAccountWithParams(t *testing.T, db *sql.DB, orgID, ledgerID uuid.
 	t.Helper()
 
 	id := uuid.Must(libCommons.GenerateUUIDv7())
-	now := time.Now().Truncate(time.Microsecond)
 
-	var portfolioIDVal, segmentIDVal, parentAccountIDVal, entityIDVal any
+	now := time.Now().Truncate(time.Microsecond)
+	if params.CreatedAt != nil {
+		now = *params.CreatedAt
+	}
+
+	var portfolioIDVal, segmentIDVal, parentAccountIDVal, entityIDVal, holderIDVal any
 	if params.PortfolioID != nil {
 		portfolioIDVal = *params.PortfolioID
 	}
@@ -914,10 +922,14 @@ func CreateTestAccountWithParams(t *testing.T, db *sql.DB, orgID, ledgerID uuid.
 		entityIDVal = *params.EntityID
 	}
 
+	if params.HolderID != nil {
+		holderIDVal = *params.HolderID
+	}
+
 	_, err := db.Exec(`
-		INSERT INTO account (id, name, asset_code, organization_id, ledger_id, portfolio_id, segment_id, status, alias, type, blocked, entity_id, parent_account_id, created_at, updated_at, deleted_at)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)
-	`, id, params.Name, params.AssetCode, orgID, ledgerID, portfolioIDVal, segmentIDVal, params.Status, params.Alias, params.Type, params.Blocked, entityIDVal, parentAccountIDVal, now, now, params.DeletedAt)
+		INSERT INTO account (id, name, asset_code, organization_id, ledger_id, portfolio_id, segment_id, status, alias, type, blocked, entity_id, parent_account_id, holder_id, created_at, updated_at, deleted_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)
+	`, id, params.Name, params.AssetCode, orgID, ledgerID, portfolioIDVal, segmentIDVal, params.Status, params.Alias, params.Type, params.Blocked, entityIDVal, parentAccountIDVal, holderIDVal, now, now, params.DeletedAt)
 	require.NoError(t, err, "failed to insert test account with params")
 
 	return id


### PR DESCRIPTION
<table border="0" cellspacing="0" cellpadding="0">
  <tr>
    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
    <td><h1>Midaz</h1></td>
  </tr>
</table>

---

## Description

`GET /v2/organizations/{organization_id}/holders/{id}/accounts` now does what its path
promises. Two defects are fixed.

**1. It was broken in multi-tenant mode — even with `ledger_id`.** The route was mounted on
the CRM route options, whose tenant middleware binds the CRM Mongo on the generic key and no
onboarding PostgreSQL at all. The account repository requires the tenant PG in context, so
every multi-tenant request failed with `500 tenant postgres connection missing from context`.
Had the read reached Postgres, the onboarding metadata lookup would still have resolved
against the CRM database.

The route now carries its own `holder-accounts` options over a middleware binding exactly the
two stores it reads — onboarding PG and onboarding Mongo, both module-keyed because the
metadata repository looks the module key up first. The CRM Mongo is deliberately excluded:
this route reads no CRM collection, and the middleware resolves every registered manager
eagerly, so including it would make the listing depend on provisioning it does not use.

**2. `ledger_id` was required**, which duplicated the ledger-scoped listing and contradicted
the published contract (`ListHolderAccountsRequest` advertised only `limit`/`page`/`sort_order`
while the wiring rejected a missing `ledger_id` with `0142`). Holder ownership is org-global,
so the listing now spans **every ledger of the organization** and `ledger_id` becomes an
optional narrowing filter — the same non-scoping role it already plays on
`GET .../instruments` (`docs/api/SCOPING.md`). A malformed value is `0082` / 400, not a 404:
it is a query-parameter format error, not a missing ledger.

### Notable implementation details

- `FindAllByHolder` joins `FindAll` behind two extracted helpers, so both listings share one
  filter set and one row scan rather than a second 19-column copy.
- **Both** listings now order by `created_at` then `id`. Accounts written in the same
  transaction share a `created_at`, so `created_at` alone is not a total order and paging
  could repeat a row on one page while dropping it from another. The pagination tests assert
  ascending pages walk in id order and descending is their exact reverse; they fail without
  the tiebreaker (verified by reverting it).
- New partial index `idx_account_org_holder (organization_id, holder_id) WHERE deleted_at IS
  NULL`, built `CONCURRENTLY`. The existing `idx_account_holder` leads with `ledger_id` and
  cannot serve the new predicate. `EXPLAIN` on a 3000-row table confirms the planner uses it;
  `CountByHolderID` benefits too.

## Type of Change

- [x] `feat`: New feature or capability
- [x] `fix`: Bug fix
- [ ] `perf`: Performance improvement
- [ ] `refactor`: Internal restructuring with no behavior change
- [x] `docs`: Documentation only
- [ ] `style`: Formatting, whitespace, naming (no logic change)
- [x] `test`: Adding or updating tests
- [ ] `ci`: CI pipeline or workflow changes
- [ ] `build`: Build system, Dockerfile, Go module dependencies
- [ ] `chore`: Maintenance, config, tooling
- [ ] `revert`: Reverts a previous commit
- [ ] `BREAKING CHANGE`: Consumers must update their integration

## Breaking Changes

None for working integrations. `ledger_id` changes from required to optional, so every
request that succeeded before still succeeds and returns the same rows. Requests that
previously got `0142` for omitting it now get the org-wide listing — which is the documented
intent of the route. Callers relying on the `0142` rejection as a validation signal would see
the change; none are known.

## Testing

- [x] `make test` passes — `make test-unit`: 15682 tests, 6 skipped, 0 failures
- [x] `make test-int` passes if integration paths are exercised — account and bootstrap
      suites under `-race`
- [x] `make lint` passes — 0 issues, re-run with `--build-tags=integration` over the touched
      packages
- [x] `make sec` and `make vulncheck` pass — `make sec` (gosec + govulncheck) exits 0; this
      repo has no separate `vulncheck` target, it is folded into `sec`

Also run: `make migrate-lint` (0 errors), `make generate-docs` + `make check-docs`. After
rebasing onto `develop`, regenerating the specs produced a zero diff, confirming the
auto-merged OpenAPI artifacts match a fresh generation.

**New coverage**

- `FindAllByHolder`: cross-ledger, ledger narrowing, unknown ledger, org isolation, and the
  pagination total-order pins (for both listings).
- `GetAllAccountsByHolder` use case and the wiring adapter, including `0082` on a malformed
  `ledger_id` and nil-vs-pointer narrowing.
- `holder_accounts_tenant_wiring_test.go` pins which managers the middleware registers.
- `holder_accounts_mt_isolation_integration_test.go` drives two tenants concurrently through
  the **real** `buildUnifiedRouteSetup` and adapter, asserting cross-ledger results, narrowing,
  per-tenant metadata, the 400, and — as a regression pin — that the same request on the CRM
  options still returns 500, so the new role cannot quietly stop being load-bearing.

## Architectural Checklist

- [x] No `panic()` in production paths
- [x] Timestamps use `time.Now().UTC()`
- [x] Errors wrapped with `%w`
- [x] Handlers stay thin (parse, validate, call service)
- [x] Infrastructure concerns kept in `internal/bootstrap`

## Related Issues

Closes #2405
