### PR TITLE
chore(release): merge main into develop after the v3.8.3 hotfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Midaz Changelog
 
+## [3.8.3](https://github.com/LerianStudio/midaz/releases/tag/v3.8.3)
+
+Fixes:
+
+- Increased the balance cache TTL to 1 day to improve performance and reliability. (@Ygohr)
+
+[Compare changes](https://github.com/LerianStudio/midaz/compare/v3.8.2...v3.8.3)
+
+---
+
 ## [3.8.0](https://github.com/LerianStudio/midaz/releases/tag/v3.8.0)
 
 Features:

--- a/components/ledger/internal/services/command/create_balance_additional.go
+++ b/components/ledger/internal/services/command/create_balance_additional.go
@@ -143,6 +143,27 @@ func (uc *UseCase) CreateAdditionalBalance(ctx context.Context, organizationID, 
 		UpdatedAt:      time.Now(),
 	}
 
+	// Companion-first: provision the system-managed overdraft balance BEFORE
+	// persisting the parent, so a provisioning failure never leaves a parent
+	// with AllowOverdraft=true and no companion. The inverse partial state —
+	// companion without parent, if the parent Create fails below — is inert
+	// (internal scope blocks direct operations) and is reused idempotently on
+	// retry. The synthetic current carries nil Settings so the enable check
+	// observes a false→true transition.
+	var overdraftCompanion *mmodel.Balance
+
+	if cbi.Settings != nil {
+		syntheticCurrent := *additionalBalance
+		syntheticCurrent.Settings = nil
+
+		companion, oerr := uc.ensureOverdraftBalance(ctx, logger, span, organizationID, ledgerID, &syntheticCurrent, cbi.Settings)
+		if oerr != nil {
+			return nil, oerr
+		}
+
+		overdraftCompanion = companion
+	}
+
 	created, err := uc.BalanceRepo.Create(ctx, additionalBalance)
 	if err != nil {
 		// Migration 032 adds a unique balance key index. If another pod wins the
@@ -170,6 +191,10 @@ func (uc *UseCase) CreateAdditionalBalance(ctx context.Context, organizationID, 
 	}
 
 	uc.emitBalanceCreatedEvent(ctx, span, logger, created)
+
+	if overdraftCompanion != nil {
+		uc.emitBalanceConfigChangedEvent(ctx, span, logger, overdraftCompanion, events.BalanceConfigChangeTypeOverdraftEnabled)
+	}
 
 	return created, nil
 }

--- a/components/ledger/internal/services/command/create_balance_overdraft_test.go
+++ b/components/ledger/internal/services/command/create_balance_overdraft_test.go
@@ -6,13 +6,17 @@ package command
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	"testing"
 
 	"github.com/LerianStudio/midaz/v3/components/ledger/internal/adapters/postgres/balance"
 	"github.com/LerianStudio/midaz/v3/pkg"
 	"github.com/LerianStudio/midaz/v3/pkg/constant"
 	"github.com/LerianStudio/midaz/v3/pkg/mmodel"
+	pkgStreaming "github.com/LerianStudio/midaz/v3/pkg/streaming"
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
@@ -267,4 +271,534 @@ func TestCreateAdditionalBalance_RejectsInternalScope(t *testing.T) {
 	assert.Nil(t, result, "no balance should be returned when scope is internal")
 	assert.Contains(t, err.Error(), constant.ErrInvalidBalanceSettings.Error(),
 		"error must reference the invalid-settings code")
+}
+
+// expectAdditionalBalancePrechecks wires the two lookups every successful
+// CreateAdditionalBalance performs: the requested key (not found) and the
+// default balance (found, supplies the inherited fields).
+func expectAdditionalBalancePrechecks(mockBalanceRepo *balance.MockRepository, orgID, ledgerID, accountID uuid.UUID, key string, defaultBalance *mmodel.Balance) {
+	mockBalanceRepo.EXPECT().
+		FindByAccountIDAndKey(gomock.Any(), orgID, ledgerID, accountID, key).
+		Return(nil, pkg.ValidateBusinessError(constant.ErrEntityNotFound, constant.EntityBalance)).
+		Times(1)
+
+	mockBalanceRepo.EXPECT().
+		FindByAccountIDAndKey(gomock.Any(), orgID, ledgerID, accountID, constant.DefaultBalanceKey).
+		Return(defaultBalance, nil).
+		Times(1)
+}
+
+// TestCreateAdditionalBalance_AllowOverdraft_CreatesCompanionBeforeParent
+// verifies the companion-first invariant on the POST path: when the request
+// carries settings.allowOverdraft=true, the system-managed "overdraft"
+// companion balance is created BEFORE the parent, with the expected shape,
+// and the request emits balance.created (parent) followed by
+// balance.config_changed{overdraft_enabled} (companion).
+func TestCreateAdditionalBalance_AllowOverdraft_CreatesCompanionBeforeParent(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
+	ctx := context.Background()
+	orgID := uuid.New()
+	ledgerID := uuid.New()
+	accountID := uuid.New()
+	alias := "@overdraft-holder"
+
+	cbi := &mmodel.CreateAdditionalBalance{
+		Key: "savings",
+		Settings: &mmodel.BalanceSettings{
+			BalanceScope:   mmodel.BalanceScopeTransactional,
+			AllowOverdraft: true,
+		},
+	}
+
+	defaultBalance := defaultBalanceForOverdraft(orgID, ledgerID, accountID, alias)
+
+	mockBalanceRepo := balance.NewMockRepository(ctrl)
+	mockEmitter := pkgStreaming.NewMockEmitter()
+
+	expectAdditionalBalancePrechecks(mockBalanceRepo, orgID, ledgerID, accountID, "savings", defaultBalance)
+
+	mockBalanceRepo.EXPECT().
+		FindByAccountIDAndKey(gomock.Any(), orgID, ledgerID, accountID, constant.OverdraftBalanceKey).
+		Return(nil, pkg.ValidateBusinessError(constant.ErrEntityNotFound, constant.EntityBalance)).
+		Times(1)
+
+	gomock.InOrder(
+		mockBalanceRepo.EXPECT().
+			Create(gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, b *mmodel.Balance) (*mmodel.Balance, error) {
+				assert.Equal(t, constant.OverdraftBalanceKey, b.Key,
+					"companion MUST be created BEFORE the parent")
+				assert.Equal(t, constant.DirectionDebit, b.Direction,
+					"companion MUST have debit direction")
+				require.NotNil(t, b.Settings, "companion MUST carry settings")
+				assert.Equal(t, mmodel.BalanceScopeInternal, b.Settings.BalanceScope,
+					"companion MUST be scoped as internal")
+				assert.Equal(t, alias, b.Alias, "companion MUST inherit the parent alias")
+				assert.Equal(t, defaultBalance.AssetCode, b.AssetCode,
+					"companion MUST inherit the parent asset code")
+				assert.Equal(t, accountID.String(), b.AccountID,
+					"companion MUST belong to the same account")
+				out := *b
+				return &out, nil
+			}).
+			Times(1),
+		mockBalanceRepo.EXPECT().
+			Create(gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, b *mmodel.Balance) (*mmodel.Balance, error) {
+				assert.Equal(t, "savings", b.Key,
+					"parent MUST be created after the companion")
+				out := *b
+				return &out, nil
+			}).
+			Times(1),
+	)
+
+	uc := &UseCase{BalanceRepo: mockBalanceRepo, Streaming: mockEmitter}
+
+	result, err := uc.CreateAdditionalBalance(ctx, orgID, ledgerID, accountID, cbi)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	emitted := mockEmitter.Events()
+	require.Len(t, emitted, 2,
+		"expected balance.created (parent) then balance.config_changed (companion)")
+
+	assert.Equal(t, "balance.created", emitted[0].DefinitionKey)
+	assert.Equal(t, result.ID, emitted[0].Subject)
+
+	assert.Equal(t, "balance.config-changed", emitted[1].DefinitionKey)
+	assert.NotEmpty(t, emitted[1].Subject)
+	assert.NotEqual(t, result.ID, emitted[1].Subject,
+		"config_changed subject MUST be the companion, not the parent")
+
+	var payload map[string]any
+	require.NoError(t, json.Unmarshal(emitted[1].Payload, &payload))
+	assert.Equal(t, "overdraft_enabled", payload["changeType"])
+	assert.Equal(t, constant.OverdraftBalanceKey, payload["key"])
+}
+
+// TestCreateAdditionalBalance_AllowOverdraft_IdempotentCompanion verifies
+// that when the companion already exists, only the parent is created and
+// no overdraft_enabled event is emitted.
+func TestCreateAdditionalBalance_AllowOverdraft_IdempotentCompanion(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
+	ctx := context.Background()
+	orgID := uuid.New()
+	ledgerID := uuid.New()
+	accountID := uuid.New()
+	alias := "@idempotent-holder"
+
+	cbi := &mmodel.CreateAdditionalBalance{
+		Key: "savings",
+		Settings: &mmodel.BalanceSettings{
+			BalanceScope:   mmodel.BalanceScopeTransactional,
+			AllowOverdraft: true,
+		},
+	}
+
+	defaultBalance := defaultBalanceForOverdraft(orgID, ledgerID, accountID, alias)
+
+	existingCompanion := &mmodel.Balance{
+		ID:             uuid.New().String(),
+		OrganizationID: orgID.String(),
+		LedgerID:       ledgerID.String(),
+		AccountID:      accountID.String(),
+		Alias:          alias,
+		Key:            constant.OverdraftBalanceKey,
+		AssetCode:      "USD",
+		Direction:      constant.DirectionDebit,
+		Settings: &mmodel.BalanceSettings{
+			BalanceScope: mmodel.BalanceScopeInternal,
+		},
+	}
+
+	mockBalanceRepo := balance.NewMockRepository(ctrl)
+	mockEmitter := pkgStreaming.NewMockEmitter()
+
+	expectAdditionalBalancePrechecks(mockBalanceRepo, orgID, ledgerID, accountID, "savings", defaultBalance)
+
+	mockBalanceRepo.EXPECT().
+		FindByAccountIDAndKey(gomock.Any(), orgID, ledgerID, accountID, constant.OverdraftBalanceKey).
+		Return(existingCompanion, nil).
+		Times(1)
+
+	// Only the parent is created — the companion already exists.
+	mockBalanceRepo.EXPECT().
+		Create(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, b *mmodel.Balance) (*mmodel.Balance, error) {
+			assert.Equal(t, "savings", b.Key)
+			out := *b
+			return &out, nil
+		}).
+		Times(1)
+
+	uc := &UseCase{BalanceRepo: mockBalanceRepo, Streaming: mockEmitter}
+
+	result, err := uc.CreateAdditionalBalance(ctx, orgID, ledgerID, accountID, cbi)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	emitted := mockEmitter.Events()
+	require.Len(t, emitted, 1, "existing companion MUST NOT re-emit overdraft_enabled")
+	assert.Equal(t, "balance.created", emitted[0].DefinitionKey)
+}
+
+// TestCreateAdditionalBalance_AllowOverdraft_CompanionRaceIsBenign verifies
+// that a 23505 on the companion Create resolved by a follow-up Find is
+// treated as idempotent success: the parent is still created and no
+// overdraft_enabled event is emitted (the race winner emits it).
+func TestCreateAdditionalBalance_AllowOverdraft_CompanionRaceIsBenign(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
+	ctx := context.Background()
+	orgID := uuid.New()
+	ledgerID := uuid.New()
+	accountID := uuid.New()
+	alias := "@race-holder"
+
+	cbi := &mmodel.CreateAdditionalBalance{
+		Key: "savings",
+		Settings: &mmodel.BalanceSettings{
+			BalanceScope:   mmodel.BalanceScopeTransactional,
+			AllowOverdraft: true,
+		},
+	}
+
+	defaultBalance := defaultBalanceForOverdraft(orgID, ledgerID, accountID, alias)
+
+	peerCompanion := &mmodel.Balance{
+		ID:             uuid.New().String(),
+		OrganizationID: orgID.String(),
+		LedgerID:       ledgerID.String(),
+		AccountID:      accountID.String(),
+		Alias:          alias,
+		Key:            constant.OverdraftBalanceKey,
+		AssetCode:      "USD",
+		Direction:      constant.DirectionDebit,
+	}
+
+	mockBalanceRepo := balance.NewMockRepository(ctrl)
+	mockEmitter := pkgStreaming.NewMockEmitter()
+
+	expectAdditionalBalancePrechecks(mockBalanceRepo, orgID, ledgerID, accountID, "savings", defaultBalance)
+
+	gomock.InOrder(
+		// First companion lookup: peer request has not committed yet.
+		mockBalanceRepo.EXPECT().
+			FindByAccountIDAndKey(gomock.Any(), orgID, ledgerID, accountID, constant.OverdraftBalanceKey).
+			Return(nil, pkg.ValidateBusinessError(constant.ErrEntityNotFound, constant.EntityBalance)).
+			Times(1),
+		// Companion Create loses the race on the partial UNIQUE index.
+		mockBalanceRepo.EXPECT().
+			Create(gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, b *mmodel.Balance) (*mmodel.Balance, error) {
+				assert.Equal(t, constant.OverdraftBalanceKey, b.Key)
+				return nil, &pgconn.PgError{Code: constant.UniqueViolationCode}
+			}).
+			Times(1),
+		// Reload resolves the peer-created row: benign race.
+		mockBalanceRepo.EXPECT().
+			FindByAccountIDAndKey(gomock.Any(), orgID, ledgerID, accountID, constant.OverdraftBalanceKey).
+			Return(peerCompanion, nil).
+			Times(1),
+		// Parent Create proceeds normally.
+		mockBalanceRepo.EXPECT().
+			Create(gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, b *mmodel.Balance) (*mmodel.Balance, error) {
+				assert.Equal(t, "savings", b.Key)
+				out := *b
+				return &out, nil
+			}).
+			Times(1),
+	)
+
+	uc := &UseCase{BalanceRepo: mockBalanceRepo, Streaming: mockEmitter}
+
+	result, err := uc.CreateAdditionalBalance(ctx, orgID, ledgerID, accountID, cbi)
+
+	require.NoError(t, err, "a benign 23505 race MUST NOT surface as an error")
+	require.NotNil(t, result)
+
+	emitted := mockEmitter.Events()
+	require.Len(t, emitted, 1, "race loser MUST NOT emit overdraft_enabled")
+	assert.Equal(t, "balance.created", emitted[0].DefinitionKey)
+}
+
+// TestCreateAdditionalBalance_AllowOverdraft_CompanionFailureBlocksParent
+// verifies the companion-first ordering guarantee: when the companion
+// Create fails with a technical error, the request fails and the parent
+// is NEVER created.
+func TestCreateAdditionalBalance_AllowOverdraft_CompanionFailureBlocksParent(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
+	ctx := context.Background()
+	orgID := uuid.New()
+	ledgerID := uuid.New()
+	accountID := uuid.New()
+	alias := "@failure-holder"
+
+	cbi := &mmodel.CreateAdditionalBalance{
+		Key: "savings",
+		Settings: &mmodel.BalanceSettings{
+			BalanceScope:   mmodel.BalanceScopeTransactional,
+			AllowOverdraft: true,
+		},
+	}
+
+	defaultBalance := defaultBalanceForOverdraft(orgID, ledgerID, accountID, alias)
+
+	mockBalanceRepo := balance.NewMockRepository(ctrl)
+	mockEmitter := pkgStreaming.NewMockEmitter()
+
+	expectAdditionalBalancePrechecks(mockBalanceRepo, orgID, ledgerID, accountID, "savings", defaultBalance)
+
+	mockBalanceRepo.EXPECT().
+		FindByAccountIDAndKey(gomock.Any(), orgID, ledgerID, accountID, constant.OverdraftBalanceKey).
+		Return(nil, pkg.ValidateBusinessError(constant.ErrEntityNotFound, constant.EntityBalance)).
+		Times(1)
+
+	createErr := errors.New("connection reset by peer")
+
+	// Exactly ONE Create happens (the companion) and it fails. The parent
+	// Create MUST NOT run — Times(1) makes a second call fail the test.
+	mockBalanceRepo.EXPECT().
+		Create(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, b *mmodel.Balance) (*mmodel.Balance, error) {
+			assert.Equal(t, constant.OverdraftBalanceKey, b.Key,
+				"the only Create attempt MUST be the companion")
+			return nil, createErr
+		}).
+		Times(1)
+
+	uc := &UseCase{BalanceRepo: mockBalanceRepo, Streaming: mockEmitter}
+
+	result, err := uc.CreateAdditionalBalance(ctx, orgID, ledgerID, accountID, cbi)
+
+	require.Error(t, err, "companion provisioning failure MUST fail the request")
+	assert.ErrorIs(t, err, createErr, "the original Create error MUST be preserved")
+	assert.Nil(t, result)
+	assert.Empty(t, mockEmitter.Events(), "no events on a failed request")
+}
+
+// TestCreateAdditionalBalance_AllowOverdraft_CompanionLookupError_BlocksParent
+// verifies the companion-first guarantee at the earliest failure point:
+// when the pre-create existence lookup for the "overdraft" companion fails
+// with a technical (infrastructure) error — not an EntityNotFoundError and
+// not a 23505 unique violation — ensureOverdraftBalance propagates it, the
+// request fails, and NEITHER the companion NOR the parent is created. This is
+// exactly the case companion-first exists to guard: a swallowed lookup error
+// would let the parent be created with AllowOverdraft=true and no companion.
+func TestCreateAdditionalBalance_AllowOverdraft_CompanionLookupError_BlocksParent(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
+	ctx := context.Background()
+	orgID := uuid.New()
+	ledgerID := uuid.New()
+	accountID := uuid.New()
+	alias := "@lookup-failure-holder"
+
+	cbi := &mmodel.CreateAdditionalBalance{
+		Key: "savings",
+		Settings: &mmodel.BalanceSettings{
+			BalanceScope:   mmodel.BalanceScopeTransactional,
+			AllowOverdraft: true,
+		},
+	}
+
+	defaultBalance := defaultBalanceForOverdraft(orgID, ledgerID, accountID, alias)
+
+	mockBalanceRepo := balance.NewMockRepository(ctrl)
+	mockEmitter := pkgStreaming.NewMockEmitter()
+
+	expectAdditionalBalancePrechecks(mockBalanceRepo, orgID, ledgerID, accountID, "savings", defaultBalance)
+
+	// Infrastructure failure on the companion existence lookup: a generic db
+	// error that is neither EntityNotFoundError nor a 23505 unique violation,
+	// so ensureOverdraftBalance takes the propagation branch.
+	lookupErr := errors.New("dial tcp 127.0.0.1:5432: connect: connection refused")
+
+	mockBalanceRepo.EXPECT().
+		FindByAccountIDAndKey(gomock.Any(), orgID, ledgerID, accountID, constant.OverdraftBalanceKey).
+		Return(nil, lookupErr).
+		Times(1)
+
+	// The flow aborts at the companion lookup: NO Create runs — neither the
+	// companion nor the parent. Times(0) makes any Create attempt fail the test.
+	mockBalanceRepo.EXPECT().
+		Create(gomock.Any(), gomock.Any()).
+		Times(0)
+
+	uc := &UseCase{BalanceRepo: mockBalanceRepo, Streaming: mockEmitter}
+
+	result, err := uc.CreateAdditionalBalance(ctx, orgID, ledgerID, accountID, cbi)
+
+	require.Error(t, err, "a technical companion-lookup failure MUST fail the request")
+	assert.ErrorIs(t, err, lookupErr, "the original lookup error MUST be propagated")
+	assert.Nil(t, result, "no balance should be returned when the companion lookup fails")
+	assert.Empty(t, mockEmitter.Events(), "no events on a failed request")
+}
+
+// TestCreateAdditionalBalance_NoOverdraft_SkipsCompanion verifies that
+// requests without settings, or with allowOverdraft=false, take the
+// original single-Create path: no companion lookup, no companion Create,
+// no extra event.
+func TestCreateAdditionalBalance_NoOverdraft_SkipsCompanion(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		settings *mmodel.BalanceSettings
+	}{
+		{name: "nil settings", settings: nil},
+		{
+			name: "allowOverdraft false",
+			settings: &mmodel.BalanceSettings{
+				BalanceScope:   mmodel.BalanceScopeTransactional,
+				AllowOverdraft: false,
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctrl := gomock.NewController(t)
+			t.Cleanup(ctrl.Finish)
+
+			ctx := context.Background()
+			orgID := uuid.New()
+			ledgerID := uuid.New()
+			accountID := uuid.New()
+			alias := "@no-overdraft"
+
+			cbi := &mmodel.CreateAdditionalBalance{
+				Key:      "savings",
+				Settings: tc.settings,
+			}
+
+			defaultBalance := defaultBalanceForOverdraft(orgID, ledgerID, accountID, alias)
+
+			mockBalanceRepo := balance.NewMockRepository(ctrl)
+			mockEmitter := pkgStreaming.NewMockEmitter()
+
+			expectAdditionalBalancePrechecks(mockBalanceRepo, orgID, ledgerID, accountID, "savings", defaultBalance)
+
+			// The companion lookup MUST NOT run.
+			mockBalanceRepo.EXPECT().
+				FindByAccountIDAndKey(gomock.Any(), orgID, ledgerID, accountID, constant.OverdraftBalanceKey).
+				Times(0)
+
+			mockBalanceRepo.EXPECT().
+				Create(gomock.Any(), gomock.Any()).
+				DoAndReturn(func(_ context.Context, b *mmodel.Balance) (*mmodel.Balance, error) {
+					assert.Equal(t, "savings", b.Key)
+					out := *b
+					return &out, nil
+				}).
+				Times(1)
+
+			uc := &UseCase{BalanceRepo: mockBalanceRepo, Streaming: mockEmitter}
+
+			result, err := uc.CreateAdditionalBalance(ctx, orgID, ledgerID, accountID, cbi)
+
+			require.NoError(t, err)
+			require.NotNil(t, result)
+
+			emitted := mockEmitter.Events()
+			require.Len(t, emitted, 1, "only balance.created is emitted without an overdraft transition")
+			assert.Equal(t, "balance.created", emitted[0].DefinitionKey)
+		})
+	}
+}
+
+// TestCreateAdditionalBalance_AllowOverdraft_WithLimit verifies that a POST
+// carrying overdraftLimitEnabled=true and a valid overdraftLimit still
+// provisions the companion normally.
+func TestCreateAdditionalBalance_AllowOverdraft_WithLimit(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
+	ctx := context.Background()
+	orgID := uuid.New()
+	ledgerID := uuid.New()
+	accountID := uuid.New()
+	alias := "@limit-holder"
+
+	cbi := &mmodel.CreateAdditionalBalance{
+		Key: "savings",
+		Settings: &mmodel.BalanceSettings{
+			BalanceScope:          mmodel.BalanceScopeTransactional,
+			AllowOverdraft:        true,
+			OverdraftLimitEnabled: true,
+			OverdraftLimit:        strPtr("1000"),
+		},
+	}
+
+	defaultBalance := defaultBalanceForOverdraft(orgID, ledgerID, accountID, alias)
+
+	mockBalanceRepo := balance.NewMockRepository(ctrl)
+	mockEmitter := pkgStreaming.NewMockEmitter()
+
+	expectAdditionalBalancePrechecks(mockBalanceRepo, orgID, ledgerID, accountID, "savings", defaultBalance)
+
+	mockBalanceRepo.EXPECT().
+		FindByAccountIDAndKey(gomock.Any(), orgID, ledgerID, accountID, constant.OverdraftBalanceKey).
+		Return(nil, pkg.ValidateBusinessError(constant.ErrEntityNotFound, constant.EntityBalance)).
+		Times(1)
+
+	gomock.InOrder(
+		mockBalanceRepo.EXPECT().
+			Create(gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, b *mmodel.Balance) (*mmodel.Balance, error) {
+				assert.Equal(t, constant.OverdraftBalanceKey, b.Key)
+				out := *b
+				return &out, nil
+			}).
+			Times(1),
+		mockBalanceRepo.EXPECT().
+			Create(gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, b *mmodel.Balance) (*mmodel.Balance, error) {
+				assert.Equal(t, "savings", b.Key)
+				out := *b
+				return &out, nil
+			}).
+			Times(1),
+	)
+
+	uc := &UseCase{BalanceRepo: mockBalanceRepo, Streaming: mockEmitter}
+
+	result, err := uc.CreateAdditionalBalance(ctx, orgID, ledgerID, accountID, cbi)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.NotNil(t, result.Settings)
+	assert.True(t, result.Settings.OverdraftLimitEnabled)
+
+	emitted := mockEmitter.Events()
+	require.Len(t, emitted, 2, "companion provisioning with a limit still emits both events")
+	assert.Equal(t, "balance.created", emitted[0].DefinitionKey)
+	assert.Equal(t, "balance.config-changed", emitted[1].DefinitionKey)
 }

--- a/components/ledger/internal/services/command/create_balance_overdraft_test.go
+++ b/components/ledger/internal/services/command/create_balance_overdraft_test.go
@@ -679,7 +679,6 @@ func TestCreateAdditionalBalance_NoOverdraft_SkipsCompanion(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/components/ledger/internal/services/command/create_balance_overdraft_test.go
+++ b/components/ledger/internal/services/command/create_balance_overdraft_test.go
@@ -488,6 +488,9 @@ func TestCreateAdditionalBalance_AllowOverdraft_CompanionRaceIsBenign(t *testing
 		Key:            constant.OverdraftBalanceKey,
 		AssetCode:      "USD",
 		Direction:      constant.DirectionDebit,
+		Settings: &mmodel.BalanceSettings{
+			BalanceScope: mmodel.BalanceScopeInternal,
+		},
 	}
 
 	mockBalanceRepo := balance.NewMockRepository(ctrl)

--- a/docs/streaming/ledger-events.md
+++ b/docs/streaming/ledger-events.md
@@ -470,24 +470,35 @@ committed transaction (3-goroutine post-commit cascade), gated by
 
 #### `balance.config-changed` — no pinned count (11 in fixture)
 
-Source: `pkg/streaming/events/balance_config_changed.go`. Trigger: `UseCase.Update`
-(`update_balance.go`), with **two emission branches**:
+Source: `pkg/streaming/events/balance_config_changed.go`. Emitted from two use
+cases with **two emission branches**:
 
-1. **`changeType = settings_updated`** — ordinary settings PATCH
-   (`AllowSending`, `AllowReceiving`, `Settings.*`). `id` = the updated parent
-   balance.
-2. **`changeType = overdraft_enabled`** — emitted exactly once on the
-   false→true overdraft transition, from `ensureOverdraftBalance`. `id` = the
-   **newly-materialized companion overdraft balance** (the companion's identity
-   becoming known IS the "config changed" signal). This event substitutes for a
-   `balance.created` on the companion (suppressed because companions are
-   system-managed).
+1. **`changeType = settings_updated`** — ordinary settings PATCH via
+   `UseCase.Update` (`update_balance.go`): `AllowSending`, `AllowReceiving`,
+   `Settings.*`. `id` = the updated parent balance.
+2. **`changeType = overdraft_enabled`** — emitted exactly once per
+   materialization of the companion overdraft balance, from
+   `ensureOverdraftBalance`. Two verbs reach that path: a PATCH flipping
+   `AllowOverdraft` false→true, and a POST additional balance carrying
+   `settings.allowOverdraft=true`. `id` = the **newly-materialized companion
+   overdraft balance** (the companion's identity becoming known IS the "config
+   changed" signal). This event substitutes for a `balance.created` on the
+   companion (suppressed because companions are system-managed). Idempotent
+   reuse of an existing companion and race-loser paths do not emit.
 
 > A single PATCH flipping `AllowOverdraft` false→true produces **TWO**
 > `config-changed` events: `overdraft_enabled` (companion) then
 > `settings_updated` (parent). Ordering enforced by the use case
 > (`ensureOverdraftBalance` runs before `BalanceRepo.Update`). Internal-scope
 > balances cannot be updated via the public API (rejected by the scope guard).
+
+> On the create path, a POST additional balance with
+> `settings.allowOverdraft=true` provisions the companion before persisting the
+> parent, then emits in parent→companion order: `balance.created` (parent)
+> followed by `config-changed` with `changeType=overdraft_enabled` (companion).
+> This inverts the PATCH ordering: on create, `balance.created` is the
+> aggregate's birth event, so consumers observe the parent before the
+> companion's config signal.
 
 | Key | Type | Notes |
 |-----|------|-------|

--- a/docs/streaming/ledger-events.md
+++ b/docs/streaming/ledger-events.md
@@ -476,9 +476,12 @@ cases with **two emission branches**:
 1. **`changeType = settings_updated`** — ordinary settings PATCH via
    `UseCase.Update` (`update_balance.go`): `AllowSending`, `AllowReceiving`,
    `Settings.*`. `id` = the updated parent balance.
-2. **`changeType = overdraft_enabled`** — emitted exactly once per
-   materialization of the companion overdraft balance, from
-   `ensureOverdraftBalance`. Two verbs reach that path: a PATCH flipping
+2. **`changeType = overdraft_enabled`** — emitted only AFTER the parent
+   balance persists successfully: `BalanceRepo.Create` on the POST path,
+   `BalanceRepo.Update` on the PATCH path. `ensureOverdraftBalance`
+   materializes the companion first, but the emit lives in the caller,
+   post-persist — so if the parent persistence fails, no event is emitted.
+   Two verbs reach that path: a PATCH flipping
    `AllowOverdraft` false→true, and a POST additional balance carrying
    `settings.allowOverdraft=true`. `id` = the **newly-materialized companion
    overdraft balance** (the companion's identity becoming known IS the "config

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -137,6 +137,7 @@ All models live in `pkg/mmodel/`. Key entities:
 - Optimistic concurrency via Version field (lock version)
 - Supports additional balances per account (e.g., multi-currency)
 - Balance history queries via timestamp
+- POST additional balance with `settings.allowOverdraft=true` provisions the system-managed `overdraft` companion balance (key=`overdraft`, direction=`debit`, scope=`internal`)
 
 ### 3.7 Operation Route / Transaction Route
 - Operation routes define per-operation rules (source/destination/bidirectional)

--- a/pkg/mmodel/balance.go
+++ b/pkg/mmodel/balance.go
@@ -328,6 +328,8 @@ type CreateAdditionalBalance struct {
 
 	// Settings is the optional per-balance configuration (overdraft,
 	// balance scope). When omitted, platform defaults are applied.
+	// Setting allowOverdraft=true provisions the system-managed "overdraft"
+	// companion balance for this account.
 	// required: false
 	Settings *BalanceSettings `json:"settings,omitempty"`
 } // @name CreateAdditionalBalance


### PR DESCRIPTION
## Description

Backmerge of `main` into `develop` after the v3.8.3 hotfix, carrying the
overdraft-companion fix for `POST` additional balance and the v3.8.3 release
notes.

The automated `backmerge-sync` action could not resolve the conflicts and left
#2423 open. This PR resolves them by hand. #2423 is untouched.

### Conflicts resolved

| File | Conflict | Resolution |
|------|----------|------------|
| `CHANGELOG.md` | `develop`'s `[Unreleased]` vs `main`'s `[3.8.3]` section | Both kept, chronological: `[Unreleased]` → `[3.8.3]` → `[3.8.0]` |
| `create_balance_overdraft_test.go` | imports on `midaz/v3` (`main`) vs `midaz/v4` (`develop`) | `/v4` paths, keeping `main`'s new `pkgStreaming` import repointed to `/v4` |

### Semantic conflict git merged without a marker

`main`'s new tests and the streaming doc assert the event key
`balance.config-changed`. `develop` has since renamed it to
`balance.config_changed`, and git merged both sides cleanly — the mismatch
surfaced only as two failing tests, not as a conflict.

Resolved in favour of `develop`: event keys are underscore-preserving
(`Definition.Key()`, `ResourceType`, `EventType`, and `ce-type` alike), so
nothing is folded to hyphens. Three call sites updated:

- `create_balance_overdraft_test.go` — two `DefinitionKey` assertions
- `docs/streaming/ledger-events.md` — one prose reference

## Type of Change

- [x] `chore`: Maintenance, config, tooling

## Breaking Changes

None. `develop`'s existing `[Unreleased]` breaking change (removal of the
`/transactions/dsl` endpoint) is carried through unmodified.

## Testing

- [x] `make test` passes — full unit suite, **6558 tests across 70 packages**, 0 failures
- [ ] `make test-int` — not run; no integration paths changed by the resolution
- [x] `make lint` passes
- [x] `make sec` passes

Also verified: `go build ./...` and `go vet` on the touched packages, both clean.

## Architectural Checklist

- [x] No `panic()` in production paths
- [x] Timestamps use `time.Now().UTC()`
- [x] Errors wrapped with `%w`
- [x] Handlers stay thin (parse, validate, call service)
- [x] Infrastructure concerns kept in `internal/bootstrap`

No new code is authored here beyond the conflict resolution; the checklist
reflects the merged content from `main`.

## Related Issues

Supersedes the automated backmerge in #2423.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Creating an additional balance with overdraft enabled now provisions a system-managed overdraft companion balance.
  * Overdraft setup is handled safely during creation, including duplicate and concurrent requests.
  * Successful overdraft provisioning emits the appropriate balance configuration event.

* **Documentation**
  * Updated balance event and API documentation to describe overdraft companion balances, event ordering, and behavior.
  * Added release notes for version 3.8.3, including a one-day increase to the balance cache duration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->