### PR TITLE
fix(ledger): resolve tenant stores on composition routes

### DIFF
--- a/components/ledger/internal/bootstrap/composition_mt_integration_test.go
+++ b/components/ledger/internal/bootstrap/composition_mt_integration_test.go
@@ -1,0 +1,555 @@
+//go:build integration
+
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package bootstrap
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	stdhttp "net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/LerianStudio/lib-auth/v3/auth/middleware"
+	libHTTP "github.com/LerianStudio/lib-commons/v6/commons/net/http"
+	openapi "github.com/LerianStudio/lib-commons/v6/commons/net/http/openapi"
+	libProblem "github.com/LerianStudio/lib-commons/v6/commons/net/http/problem"
+	tmclient "github.com/LerianStudio/lib-commons/v6/commons/tenant-manager/client"
+	tmcore "github.com/LerianStudio/lib-commons/v6/commons/tenant-manager/core"
+	tmmongo "github.com/LerianStudio/lib-commons/v6/commons/tenant-manager/mongo"
+	tmpostgres "github.com/LerianStudio/lib-commons/v6/commons/tenant-manager/postgres"
+	libLog "github.com/LerianStudio/lib-observability/v2/log"
+	"github.com/gofiber/fiber/v3"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+	"golang.org/x/sync/errgroup"
+
+	httpin "github.com/LerianStudio/midaz/v4/components/ledger/internal/adapters/http/in"
+	onbMongo "github.com/LerianStudio/midaz/v4/components/ledger/internal/adapters/mongodb/onboarding"
+	"github.com/LerianStudio/midaz/v4/components/ledger/internal/adapters/postgres/account"
+	"github.com/LerianStudio/midaz/v4/components/ledger/internal/adapters/postgres/asset"
+	"github.com/LerianStudio/midaz/v4/components/ledger/internal/adapters/postgres/balance"
+	"github.com/LerianStudio/midaz/v4/components/ledger/internal/adapters/postgres/ledger"
+	"github.com/LerianStudio/midaz/v4/components/ledger/internal/services/command"
+	"github.com/LerianStudio/midaz/v4/components/ledger/internal/services/composition"
+	"github.com/LerianStudio/midaz/v4/pkg/constant"
+	"github.com/LerianStudio/midaz/v4/pkg/mmodel"
+	"github.com/LerianStudio/midaz/v4/pkg/net/http"
+	testutils "github.com/LerianStudio/midaz/v4/tests/utils"
+	mongotestutil "github.com/LerianStudio/midaz/v4/tests/utils/mongodb"
+	postgrestestutil "github.com/LerianStudio/midaz/v4/tests/utils/postgres"
+)
+
+// compositionTenant is one tenant's fixture for the holder-account composition
+// POST. Every store the path touches gets its OWN database, so an assertion can
+// tell which one a write actually landed in: the onboarding PostgreSQL (account),
+// the transaction PostgreSQL (default balance), the onboarding Mongo (account
+// metadata) and the CRM Mongo (instrument). Same-database fixtures would hide the
+// two defects this test exists to catch.
+type compositionTenant struct {
+	tenantID string
+
+	// authToken is signed once at seed time: the POST runs inside errgroup
+	// goroutines, where a require-based helper must not be called.
+	authToken string
+
+	onboardingPG  *postgrestestutil.ContainerResult
+	transactionPG *postgrestestutil.ContainerResult
+
+	onboardingMongo *mongo.Database
+	crmMongo        *mongo.Database
+
+	orgID    uuid.UUID
+	ledgerID uuid.UUID
+	holderID uuid.UUID
+
+	// metadataValue is unique per tenant, so a document read from the wrong
+	// tenant's store is visible rather than merely plausible.
+	metadataValue string
+}
+
+// TestIntegration_CompositionMultiTenantStores drives the holder-account POST
+// through the REAL composition root — the real buildUnifiedRouteSetup, the real
+// route registrar and the real CreateAccount use case — against two tenants whose
+// four stores are four distinct databases.
+//
+// It is the end-to-end counterpart of TestCompositionTenantMiddlewareWiring, and it
+// pins the two defects that shipped together on this route in multi-tenant mode:
+//
+//   - the composition middleware carried no transaction PostgreSQL, so the default
+//     balance CreateAccount always writes failed requireTenant and the whole POST
+//     returned 500/0127;
+//   - the middleware carried no MODULE-keyed onboarding Mongo, so the account
+//     metadata write fell through to the generic key — the CRM Mongo — and would
+//     have landed in the wrong store silently once the balance stopped failing
+//     first.
+func TestIntegration_CompositionMultiTenantStores(t *testing.T) {
+	// Both the setup connections and the per-tenant connections the managers open
+	// lazily go through the lib-commons clients, which reject plaintext URIs
+	// unless ALLOW_INSECURE_TLS=true. The testcontainers speak plaintext.
+	t.Setenv("ALLOW_INSECURE_TLS", "true")
+
+	logger := &libLog.GoLogger{}
+
+	mongoContainer := mongotestutil.SetupReusableContainer(t)
+
+	tenantA := seedCompositionTenant(t, mongoContainer, "tenanta")
+	tenantB := seedCompositionTenant(t, mongoContainer, "tenantb")
+
+	tenants := map[string]*compositionTenant{
+		tenantA.tenantID: tenantA,
+		tenantB.tenantID: tenantB,
+	}
+
+	// Fake tenant-manager control plane: per tenant it serves one config whose
+	// onboarding, transaction and crm modules each point at that tenant's own
+	// database — the shape the composition middleware resolves.
+	tmServer := newFakeTenantManagerCompositionStores(t, mongoContainer, tenants)
+	defer tmServer.Close()
+
+	tenantClient, err := tmclient.NewClient(tmServer.URL, logger,
+		tmclient.WithAllowInsecureHTTP(), tmclient.WithServiceAPIKey("test-api-key"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = tenantClient.Close() })
+
+	onboardingPGManager := tmpostgres.NewManager(tenantClient, constant.ModuleOnboarding,
+		tmpostgres.WithModule(constant.ModuleOnboarding), tmpostgres.WithLogger(logger))
+	t.Cleanup(func() { _ = onboardingPGManager.Close(context.Background()) })
+
+	transactionPGManager := tmpostgres.NewManager(tenantClient, constant.ModuleTransaction,
+		tmpostgres.WithModule(constant.ModuleTransaction), tmpostgres.WithLogger(logger))
+	t.Cleanup(func() { _ = transactionPGManager.Close(context.Background()) })
+
+	onboardingMongoManager := tmmongo.NewManager(tenantClient, constant.ModuleOnboarding,
+		tmmongo.WithModule(constant.ModuleOnboarding), tmmongo.WithLogger(logger))
+	t.Cleanup(func() { _ = onboardingMongoManager.Close(context.Background()) })
+
+	crmMongoManager := tmmongo.NewManager(tenantClient, constant.ModuleCRM,
+		tmmongo.WithModule(constant.ModuleCRM), tmmongo.WithLogger(logger))
+	t.Cleanup(func() { _ = crmMongoManager.Close(context.Background()) })
+
+	// The REAL composition root, not a hand-rolled middleware: this is what makes
+	// the test fail if buildUnifiedRouteSetup stops binding one of the four stores.
+	setup, err := buildUnifiedRouteSetup(
+		&Config{MultiTenantEnabled: true}, logger,
+		onboardingPGManager, transactionPGManager,
+		onboardingMongoManager, &tmmongo.Manager{}, crmMongoManager, &tmmongo.Manager{},
+		nil, nil,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, setup.compositionRouteOptions, "composition options must be built in multi-tenant mode")
+
+	// MT-style repositories: nil static connection with requireTenant set, so every
+	// store must come from the request context the middleware populates.
+	uc := &command.UseCase{
+		LedgerRepo:             ledger.NewLedgerPostgreSQLRepository(nil, true),
+		AssetRepo:              asset.NewAssetPostgreSQLRepository(nil, true),
+		AccountRepo:            account.NewAccountPostgreSQLRepository(nil, true),
+		BalanceRepo:            balance.NewBalancePostgreSQLRepository(nil, false, true),
+		OnboardingMetadataRepo: onbMongo.NewMetadataMongoDBRepository(nil),
+	}
+
+	handler := &httpin.CompositionHandler{
+		Service: composition.NewService(uc, compositionInstrumentProbe{}),
+	}
+
+	newApp := func(routeOptions *http.ProtectedRouteOptions) *fiber.App {
+		app := fiber.New(fiber.Config{
+			ErrorHandler: func(ctx fiber.Ctx, err error) error {
+				return libHTTP.FiberErrorHandler(ctx, err)
+			},
+		})
+		app.Use(http.WithRecover(http.WithRecoverLogger(logger)))
+		t.Cleanup(func() { _ = app.Shutdown() })
+
+		// Auth disabled: Authorize is a pass-through, so the post-auth chain the
+		// options carry is what the request actually runs.
+		mountCompositionHuma(app, middleware.NewAuthClient("", false, nil), handler, routeOptions)
+
+		return app
+	}
+
+	app := newApp(setup.compositionRouteOptions)
+
+	t.Run("concurrent_tenants_each_write_all_four_of_their_own_stores", func(t *testing.T) {
+		var g errgroup.Group
+
+		created := make(map[string]string, len(tenants))
+
+		for _, tn := range []*compositionTenant{tenantA, tenantB} {
+			tn := tn
+			g.Go(func() error {
+				body, status, err := postHolderAccount(app, tn, tn.alias("ok"))
+				if err != nil {
+					return err
+				}
+
+				if status != stdhttp.StatusCreated {
+					return fmt.Errorf("tenant %s: got status %d, body %s", tn.tenantID, status, body)
+				}
+
+				accountID, err := accountIDFromComposition(body)
+				if err != nil {
+					return fmt.Errorf("tenant %s: %w", tn.tenantID, err)
+				}
+
+				created[tn.tenantID] = accountID
+
+				return nil
+			})
+		}
+
+		require.NoError(t, g.Wait(), "the composition POST must succeed for both tenants concurrently")
+
+		for _, tn := range []*compositionTenant{tenantA, tenantB} {
+			accountID := created[tn.tenantID]
+			require.NotEmpty(t, accountID, "tenant %s: response carried no account id", tn.tenantID)
+
+			// 1. The account, in this tenant's onboarding PostgreSQL, owned by the path holder.
+			var holderID string
+			require.NoError(t,
+				tn.onboardingPG.DB.QueryRow(`SELECT holder_id FROM account WHERE id = $1`, accountID).Scan(&holderID),
+				"tenant %s: the account must be persisted in its own onboarding PostgreSQL", tn.tenantID)
+			assert.Equal(t, tn.holderID.String(), holderID,
+				"tenant %s: ownership is path-sourced, so the account must carry the path holder", tn.tenantID)
+
+			// 2. The default balance, in this tenant's TRANSACTION PostgreSQL. This is the
+			// regression pin: the composition middleware used to carry no transaction PG,
+			// so this write failed requireTenant and the POST returned 500/0127.
+			var balances int
+			require.NoError(t,
+				tn.transactionPG.DB.QueryRow(
+					`SELECT count(*) FROM balance WHERE account_id = $1 AND key = $2`,
+					accountID, constant.DefaultBalanceKey,
+				).Scan(&balances),
+				"tenant %s: failed to read its transaction PostgreSQL", tn.tenantID)
+			assert.Equal(t, 1, balances,
+				"tenant %s: CreateAccount always writes the default balance, and it must land in the tenant's "+
+					"transaction PostgreSQL", tn.tenantID)
+
+			// 3. The account metadata, in this tenant's ONBOARDING Mongo, read back by the
+			// tenant-unique marker.
+			metaDoc := tn.onboardingMongo.Collection(strings.ToLower(constant.EntityAccount)).
+				FindOne(context.Background(), bson.M{"entity_id": accountID})
+
+			var meta struct {
+				Metadata map[string]any `bson:"metadata"`
+			}
+			require.NoError(t, metaDoc.Decode(&meta),
+				"tenant %s: the account metadata must be written to its own onboarding Mongo", tn.tenantID)
+			assert.Equal(t, tn.metadataValue, meta.Metadata["tenant_marker"],
+				"tenant %s: metadata must round-trip from its own onboarding Mongo", tn.tenantID)
+
+			// 4. The anti-cross-store assertion, and the reason the module-keyed onboarding
+			// Mongo is not optional: the metadata repo resolves the module key FIRST and
+			// falls back to the generic key. With only the CRM Mongo on the generic key, this
+			// document would have landed in the CRM store — no error, wrong store.
+			crmMetadata, err := tn.crmMongo.Collection(strings.ToLower(constant.EntityAccount)).
+				CountDocuments(context.Background(), bson.M{"entity_id": accountID})
+			require.NoError(t, err, "tenant %s: failed to read its CRM Mongo", tn.tenantID)
+			assert.Zero(t, crmMetadata,
+				"tenant %s: account metadata must never reach the CRM Mongo — the module-keyed onboarding Mongo is "+
+					"what keeps the generic-key fallback from writing to the wrong store", tn.tenantID)
+
+			// 5. The instrument, on the GENERIC Mongo key, which must still resolve to the
+			// CRM store now that a module-keyed Mongo shares the middleware.
+			instruments, err := tn.crmMongo.Collection(compositionInstrumentCollection).
+				CountDocuments(context.Background(), bson.M{"account_id": accountID})
+			require.NoError(t, err, "tenant %s: failed to read its CRM Mongo", tn.tenantID)
+			assert.Equal(t, int64(1), instruments,
+				"tenant %s: the instrument write reads the generic Mongo key, which must still resolve to the CRM "+
+					"store alongside the module-keyed onboarding Mongo", tn.tenantID)
+		}
+	})
+
+	t.Run("no_store_carries_the_other_tenants_account", func(t *testing.T) {
+		body, status, err := postHolderAccount(app, tenantA, tenantA.alias("iso"))
+		require.NoError(t, err)
+		require.Equal(t, stdhttp.StatusCreated, status, "body: %s", body)
+
+		accountID, err := accountIDFromComposition(body)
+		require.NoError(t, err)
+
+		var accounts int
+		require.NoError(t, tenantB.onboardingPG.DB.QueryRow(
+			`SELECT count(*) FROM account WHERE id = $1`, accountID,
+		).Scan(&accounts))
+		assert.Zero(t, accounts, "tenant B's onboarding PostgreSQL must not carry tenant A's account")
+
+		var balances int
+		require.NoError(t, tenantB.transactionPG.DB.QueryRow(
+			`SELECT count(*) FROM balance WHERE account_id = $1`, accountID,
+		).Scan(&balances))
+		assert.Zero(t, balances, "tenant B's transaction PostgreSQL must not carry tenant A's balance")
+
+		metadata, err := tenantB.onboardingMongo.Collection(strings.ToLower(constant.EntityAccount)).
+			CountDocuments(context.Background(), bson.M{"entity_id": accountID})
+		require.NoError(t, err)
+		assert.Zero(t, metadata, "tenant B's onboarding Mongo must not carry tenant A's account metadata")
+
+		instruments, err := tenantB.crmMongo.Collection(compositionInstrumentCollection).
+			CountDocuments(context.Background(), bson.M{"account_id": accountID})
+		require.NoError(t, err)
+		assert.Zero(t, instruments, "tenant B's CRM Mongo must not carry tenant A's instrument")
+	})
+
+	// The compensation regression: the holder-accounts options carry the onboarding
+	// stores but NO transaction PostgreSQL, which is exactly the context the
+	// composition route ran in before the fix. The balance write fails, the POST is
+	// 500/0127, and the compensating delete must leave no account behind.
+	t.Run("without_the_transaction_pg_the_post_is_500_0127_and_the_account_is_compensated", func(t *testing.T) {
+		require.NotNil(t, setup.holderAccountsRouteOptions)
+
+		alias := tenantA.alias("nobalance")
+
+		body, status, err := postHolderAccount(newApp(setup.holderAccountsRouteOptions), tenantA, alias)
+		require.NoError(t, err)
+
+		require.Equalf(t, stdhttp.StatusInternalServerError, status,
+			"a context without the transaction PostgreSQL fails the default balance, which is the "+
+				"\"tenant postgres connection missing from context\" 500 this route's own middleware exists to "+
+				"prevent; body: %s", body)
+
+		var problem map[string]any
+		require.NoError(t, json.Unmarshal([]byte(body), &problem), "body: %s", body)
+		assert.Equal(t, constant.ErrAccountCreationFailed.Error(), problem["code"],
+			"a failed default balance must surface as the account-creation-failed code")
+
+		var accounts int
+		require.NoError(t, tenantA.onboardingPG.DB.QueryRow(
+			`SELECT count(*) FROM account WHERE alias = $1 AND deleted_at IS NULL`, alias,
+		).Scan(&accounts))
+		assert.Zero(t, accounts,
+			"the balance failure must compensate the account: a persisted account with no default balance is "+
+				"unusable and invisible to the client that got the 500")
+	})
+}
+
+// compositionInstrumentCollection is where the instrument probe writes. The name
+// only has to be stable between the probe and its assertions.
+const compositionInstrumentCollection = "instrument"
+
+// compositionInstrumentProbe stands in for the CRM instrument use case at the one
+// axis this test is about: which store the write resolves to. It reads the GENERIC
+// Mongo key exactly as the real CRM instrument repository does, so a middleware
+// that stopped binding the CRM Mongo on the generic key fails here. Instrument
+// validation, encryption and the CRM domain rules are covered by
+// TestIntegration_CRMCollapse; reproducing them here would test the CRM, not the
+// store wiring.
+type compositionInstrumentProbe struct{}
+
+func (compositionInstrumentProbe) CreateInstrument(ctx context.Context, organizationID string, holderID uuid.UUID, in *mmodel.CreateInstrumentInput) (*mmodel.Instrument, error) {
+	db := tmcore.GetMBContext(ctx)
+	if db == nil {
+		return nil, fmt.Errorf("tenant mongo database missing from context on the generic key")
+	}
+
+	id := uuid.New()
+
+	_, err := db.Collection(compositionInstrumentCollection).InsertOne(ctx, bson.M{
+		"id":              id.String(),
+		"organization_id": organizationID,
+		"holder_id":       holderID.String(),
+		"account_id":      in.AccountID,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return &mmodel.Instrument{ID: &id, LedgerID: &in.LedgerID, AccountID: &in.AccountID}, nil
+}
+
+// alias builds a per-tenant, per-case account alias so two cases in the same
+// tenant's database cannot collide on the alias uniqueness check.
+func (tn *compositionTenant) alias(purpose string) string {
+	return fmt.Sprintf("@%s-%s-%s", tn.tenantID, purpose, uuid.NewString()[:8])
+}
+
+// seedCompositionTenant provisions one tenant's four databases: the onboarding
+// PostgreSQL (organization, ledger and the USD asset the create path validates),
+// the transaction PostgreSQL (migrated, empty — the balance is what the POST
+// writes), and one Mongo database each for onboarding metadata and CRM.
+func seedCompositionTenant(t *testing.T, mongoContainer *mongotestutil.ContainerResult, tenantID string) *compositionTenant {
+	t.Helper()
+
+	onboardingPG := postgrestestutil.SetupMigratedContainer(t, "onboarding")
+	transactionPG := postgrestestutil.SetupMigratedContainer(t, "transaction")
+
+	orgID := postgrestestutil.CreateTestOrganization(t, onboardingPG.DB)
+	ledgerID := postgrestestutil.CreateTestLedger(t, onboardingPG.DB, orgID)
+	postgrestestutil.CreateTestAsset(t, onboardingPG.DB, orgID, ledgerID, "USD")
+
+	return &compositionTenant{
+		tenantID:        tenantID,
+		authToken:       tenantJWT(t, tenantID),
+		onboardingPG:    onboardingPG,
+		transactionPG:   transactionPG,
+		onboardingMongo: mongotestutil.CreateOwnedDatabase(t, mongoContainer),
+		crmMongo:        mongotestutil.CreateOwnedDatabase(t, mongoContainer),
+		orgID:           orgID,
+		ledgerID:        ledgerID,
+		holderID:        uuid.New(),
+		metadataValue:   "marker-" + tenantID,
+	}
+}
+
+// mountCompositionHuma mounts the REAL composition registrar on a bare Fiber app,
+// mirroring how NewUnifiedServer hosts the route: the Fiber guard chain from
+// routeOptions runs before the Huma terminal.
+func mountCompositionHuma(app *fiber.App, auth *middleware.AuthClient, ch *httpin.CompositionHandler, routeOptions *http.ProtectedRouteOptions) {
+	libProblem.Install()
+	apiV2 := app.Group("/v2")
+	hAPI := openapi.New(app, apiV2, openapi.Config{Title: "composition-integration", Version: "test", Servers: []string{"/v2"}})
+	http.InstallLedgerSchemaNamer(hAPI)
+
+	httpin.RegisterCompositionV2RoutesToApp(apiV2, hAPI, auth, ch, routeOptions)
+}
+
+// postHolderAccount issues the composition POST for a tenant, authenticated by the
+// JWT tenantId claim the trusted-auth assertion reads. The body carries metadata
+// (so the onboarding metadata write actually happens — a nil map short-circuits it)
+// and banking details (so the instrument write happens).
+func postHolderAccount(app *fiber.App, tn *compositionTenant, alias string) (string, int, error) {
+	payload, err := json.Marshal(mmodel.CreateHolderAccountInput{
+		Name:      "composition account",
+		AssetCode: "USD",
+		Type:      "deposit",
+		Alias:     &alias,
+		Metadata:  map[string]any{"tenant_marker": tn.metadataValue},
+		BankingDetails: &mmodel.BankingDetails{
+			Branch:  testutils.Ptr("0001"),
+			Account: testutils.Ptr("123450"),
+		},
+	})
+	if err != nil {
+		return "", 0, err
+	}
+
+	url := fmt.Sprintf("/v2/organizations/%s/ledgers/%s/holders/%s/accounts", tn.orgID, tn.ledgerID, tn.holderID)
+
+	req := httptest.NewRequest(stdhttp.MethodPost, url, strings.NewReader(string(payload)))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+tn.authToken)
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: 60 * time.Second})
+	if err != nil {
+		return "", 0, err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", 0, err
+	}
+
+	return string(body), resp.StatusCode, nil
+}
+
+// accountIDFromComposition reads the created account's ID out of the composite
+// 201 body.
+func accountIDFromComposition(body string) (string, error) {
+	var envelope struct {
+		Account *struct {
+			ID string `json:"id"`
+		} `json:"account"`
+		InstrumentError *struct {
+			Reason string `json:"reason"`
+		} `json:"instrumentError"`
+	}
+
+	if err := json.Unmarshal([]byte(body), &envelope); err != nil {
+		return "", fmt.Errorf("decode composition response: %w (body %s)", err, body)
+	}
+
+	if envelope.InstrumentError != nil {
+		return "", fmt.Errorf("instrument write failed with reason %q (body %s)", envelope.InstrumentError.Reason, body)
+	}
+
+	if envelope.Account == nil || envelope.Account.ID == "" {
+		return "", fmt.Errorf("composition response carries no account (body %s)", body)
+	}
+
+	return envelope.Account.ID, nil
+}
+
+// newFakeTenantManagerCompositionStores serves, per tenant, one TenantConfig whose
+// onboarding module carries the onboarding PostgreSQL AND the onboarding MongoDB,
+// whose transaction module carries the transaction PostgreSQL, and whose crm module
+// carries the CRM MongoDB — four distinct databases, so an assertion can tell which
+// store a write reached.
+func newFakeTenantManagerCompositionStores(t *testing.T, mongoContainer *mongotestutil.ContainerResult, tenants map[string]*compositionTenant) *httptest.Server {
+	t.Helper()
+
+	mux := stdhttp.NewServeMux()
+	mux.HandleFunc("/v1/tenants/", func(w stdhttp.ResponseWriter, r *stdhttp.Request) {
+		// Path: /v1/tenants/{tenantID}/associations/{service}/connections
+		parts := strings.FieldsFunc(r.URL.Path, func(c rune) bool { return c == '/' })
+		if len(parts) < 5 || parts[0] != "v1" || parts[1] != "tenants" || parts[3] != "associations" {
+			stdhttp.Error(w, "invalid path", stdhttp.StatusBadRequest)
+			return
+		}
+
+		tn, ok := tenants[parts[2]]
+		if !ok {
+			stdhttp.Error(w, "tenant not found", stdhttp.StatusNotFound)
+			return
+		}
+
+		config := &tmcore.TenantConfig{
+			ID:         tn.tenantID,
+			TenantSlug: tn.tenantID,
+			Status:     "active",
+			Databases: map[string]tmcore.DatabaseConfig{
+				constant.ModuleOnboarding: {
+					PostgreSQL: compositionPGConfig(t, tn.onboardingPG),
+					MongoDB: &tmcore.MongoDBConfig{
+						URI:      mongoContainer.URI,
+						Database: tn.onboardingMongo.Name(),
+					},
+				},
+				constant.ModuleTransaction: {
+					PostgreSQL: compositionPGConfig(t, tn.transactionPG),
+				},
+				constant.ModuleCRM: {
+					MongoDB: &tmcore.MongoDBConfig{
+						URI:      mongoContainer.URI,
+						Database: tn.crmMongo.Name(),
+					},
+				},
+			},
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+
+		if err := json.NewEncoder(w).Encode(config); err != nil {
+			stdhttp.Error(w, "encode failed", stdhttp.StatusInternalServerError)
+		}
+	})
+
+	return httptest.NewServer(mux)
+}
+
+// compositionPGConfig projects a test container onto the tenant-manager PostgreSQL
+// coordinates.
+func compositionPGConfig(t *testing.T, pg *postgrestestutil.ContainerResult) *tmcore.PostgreSQLConfig {
+	t.Helper()
+
+	return &tmcore.PostgreSQLConfig{
+		Host:     pg.Host,
+		Port:     mustAtoiPort(t, pg.Port),
+		Database: pg.Config.DBName,
+		Username: pg.Config.DBUser,
+		Password: pg.Config.DBPassword,
+		SSLMode:  "disable",
+	}
+}

--- a/components/ledger/internal/bootstrap/composition_mt_integration_test.go
+++ b/components/ledger/internal/bootstrap/composition_mt_integration_test.go
@@ -14,6 +14,7 @@ import (
 	stdhttp "net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -184,6 +185,11 @@ func TestIntegration_CompositionMultiTenantStores(t *testing.T) {
 	t.Run("concurrent_tenants_each_write_all_four_of_their_own_stores", func(t *testing.T) {
 		var g errgroup.Group
 
+		// created is written from the errgroup workers and read after Wait, so the
+		// writes are mutex-guarded: two goroutines assigning into the same map is a
+		// data race regardless of the keys being distinct.
+		var createdMu sync.Mutex
+
 		created := make(map[string]string, len(tenants))
 
 		for _, tn := range []*compositionTenant{tenantA, tenantB} {
@@ -203,7 +209,9 @@ func TestIntegration_CompositionMultiTenantStores(t *testing.T) {
 					return fmt.Errorf("tenant %s: %w", tn.tenantID, err)
 				}
 
+				createdMu.Lock()
 				created[tn.tenantID] = accountID
+				createdMu.Unlock()
 
 				return nil
 			})

--- a/components/ledger/internal/bootstrap/composition_tenant_wiring_test.go
+++ b/components/ledger/internal/bootstrap/composition_tenant_wiring_test.go
@@ -1,0 +1,83 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package bootstrap
+
+import (
+	"reflect"
+	"testing"
+
+	tmmongo "github.com/LerianStudio/lib-commons/v6/commons/tenant-manager/mongo"
+	tmpostgres "github.com/LerianStudio/lib-commons/v6/commons/tenant-manager/postgres"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/LerianStudio/midaz/v4/pkg/constant"
+)
+
+// TestCompositionTenantMiddlewareWiring pins the composition tenant middleware to every store the
+// holder-account POST reaches: the account row and the ledger/alias reads (onboarding PG), the
+// default balance CreateAccount always writes (transaction PG), the account metadata write
+// (onboarding MB, module-keyed) and the instrument write plus holder-existence read (CRM MB,
+// generic key).
+//
+// Two failure modes are pinned here, both observed in multi-tenant staging:
+//
+//   - a missing transaction PG makes the balance repo fail requireTenant with "tenant postgres
+//     connection missing from context", so the whole POST 500s;
+//   - a missing module-keyed onboarding Mongo makes the metadata repo fall back to the generic key
+//     and write the account metadata into the CRM store — silent, not an error.
+//
+// The TenantMiddleware fields are unexported in lib-commons v6, so the module maps are read via
+// reflect (see mapKeys in fees_tenant_wiring_test.go).
+func TestCompositionTenantMiddlewareWiring(t *testing.T) {
+	t.Parallel()
+
+	logger := newTestLogger()
+
+	// Multi-tenant: non-nil managers make buildUnifiedRouteSetup build the middleware. The
+	// managers are zero-value structs because the wiring only registers them; no DB connection
+	// is opened here (pure, no-I/O unit test).
+	mtSetup, err := buildUnifiedRouteSetup(
+		&Config{MultiTenantEnabled: true}, logger,
+		&tmpostgres.Manager{}, &tmpostgres.Manager{},
+		&tmmongo.Manager{}, &tmmongo.Manager{}, &tmmongo.Manager{}, &tmmongo.Manager{},
+		nil, nil,
+	)
+	require.NoError(t, err, "multi-tenant setup must not error")
+	require.NotNil(t, mtSetup, "multi-tenant setup must be non-nil")
+	require.NotNil(t, mtSetup.compositionTenantMiddleware,
+		"composition tenant middleware must be built in multi-tenant mode")
+
+	mw := reflect.ValueOf(mtSetup.compositionTenantMiddleware).Elem()
+
+	pgKeys := mapKeys(t, mw, "pgModules")
+	assert.ElementsMatch(t, []string{constant.ModuleOnboarding, constant.ModuleTransaction}, pgKeys,
+		"composition middleware must carry module-keyed onboarding+transaction PostgreSQL managers: the account "+
+			"write resolves the onboarding module key and the default balance the transaction module key, the "+
+			"latter with requireTenant so its absence is a hard 500")
+
+	mbKeys := mapKeys(t, mw, "mongoModules")
+	assert.ElementsMatch(t, []string{constant.ModuleOnboarding}, mbKeys,
+		"composition middleware must carry the module-keyed onboarding Mongo manager: the account metadata write "+
+			"resolves the module key first and would otherwise fall back to the generic key and land in the CRM store")
+
+	// The CRM Mongo is registered with a no-module WithMB, which lib-commons stores in the
+	// single-manager mongo field (not mongoModules). The CRM instrument/holder repos read the
+	// generic key, so this manager must remain present.
+	genericMB := mw.FieldByName("mongo")
+	if !genericMB.IsValid() {
+		t.Fatalf("lib-commons TenantMiddleware renamed field %q; update this test", "mongo")
+	}
+
+	assert.False(t, genericMB.IsNil(), "composition middleware must keep the generic (no-module) CRM Mongo manager: "+
+		"the instrument repo and the holder-existence read use tmcore.GetMBContext(ctx) on the generic key")
+
+	// Single-tenant: buildUnifiedRouteSetup short-circuits to a zero-value setup before it builds
+	// any tenant middleware, so the seam is nil (parallel to the nil route options).
+	stSetup, err := buildUnifiedRouteSetup(&Config{}, logger, nil, nil, nil, nil, nil, nil, nil, nil)
+	require.NoError(t, err, "single-tenant setup must not error")
+	require.NotNil(t, stSetup, "single-tenant setup is a zero value, not nil")
+	assert.Nil(t, stSetup.compositionTenantMiddleware, "single-tenant composition tenant middleware must be nil")
+}

--- a/components/ledger/internal/bootstrap/config.go
+++ b/components/ledger/internal/bootstrap/config.go
@@ -1488,6 +1488,10 @@ type unifiedRouteSetup struct {
 	// holderAccountsTenantMiddleware is the holder-accounts tenant middleware
 	// instance, exposed on the same terms as feesTenantMiddleware.
 	holderAccountsTenantMiddleware *tmmiddleware.TenantMiddleware
+
+	// compositionTenantMiddleware is the holder-account composition tenant
+	// middleware instance, exposed on the same terms as feesTenantMiddleware.
+	compositionTenantMiddleware *tmmiddleware.TenantMiddleware
 }
 
 func buildUnifiedRouteSetup(
@@ -1599,33 +1603,46 @@ func buildUnifiedRouteSetup(
 	)
 	setup.feesTenantMiddleware = feesTenantMiddleware
 
-	// Composition tenant middleware is its own SEPARATE instance spanning BOTH
-	// stores the holder-account composition touches: the onboarding PostgreSQL
-	// (module-keyed) for the account write AND the CRM Mongo (generic key) for
-	// the instrument write. It is attached ONLY to composition routes via
-	// compositionRouteOptions below — never global, never on ledger routes.
-	// Mounting it globally (or on the onboarding/transaction middleware) would
-	// bleed the generic CRM Mongo key onto ledger routes and overwrite the
-	// tenant Mongo that ledger handlers resolve, leaking one tenant's CRM DB
-	// into a concurrent ledger request — the precise cross-store leak this
-	// instance exists to prevent.
+	// Composition tenant middleware is its own SEPARATE instance carrying every
+	// store the holder-account composition writes or reads. It is attached ONLY
+	// to composition routes via compositionRouteOptions below — never global,
+	// never on ledger routes. Mounting it globally (or on the
+	// onboarding/transaction middleware) would bleed the generic CRM Mongo key
+	// onto ledger routes and overwrite the tenant Mongo that ledger handlers
+	// resolve, leaking one tenant's CRM DB into a concurrent ledger request —
+	// the precise cross-store leak this instance exists to prevent.
 	//
-	// WithPG carries constant.ModuleOnboarding because composition writes the
-	// account through the onboarding account repo, which resolves the
-	// module-keyed PG context. WithMB is called WITHOUT a module name
-	// (single-manager mode), matching the CRM block above: the CRM instrument
-	// repo reads tmcore.GetMBContext(ctx) on the GENERIC key. Route scoping
-	// keeps that generic-key write from colliding with the module-keyed
-	// onboarding/transaction injection on ledger routes. The transaction PG
-	// manager is DELIBERATELY excluded: composition writes the onboarding
-	// account and the CRM instrument only and never touches the transaction PG.
+	// The composition POST reaches four stores, and each key below answers one:
+	//
+	//  1. onboarding PG (module-keyed) — the account row, plus the ledger
+	//     settings and parent/alias reads the create path performs.
+	//  2. transaction PG (module-keyed) — CreateAccount ALWAYS creates the
+	//     default balance, and the balance repo resolves the transaction module
+	//     key with requireTenant set, so a missing injection is a hard 500.
+	//  3. onboarding Mongo (module-keyed) — the account metadata write. The
+	//     metadata repo looks the module key up FIRST and falls back to the
+	//     generic key, so omitting it would send the write to whichever store
+	//     owns the generic key (the CRM Mongo below): a silent cross-store write,
+	//     not an error.
+	//  4. CRM Mongo (generic key) — the instrument write and the holder-existence
+	//     read, which predate module-keyed resolution and read
+	//     tmcore.GetMBContext(ctx) on the GENERIC key. Route scoping keeps that
+	//     generic-key write from colliding with the module-keyed
+	//     onboarding/transaction injection on ledger routes.
+	//
+	// Nothing on the path resolves a tenant Valkey: the ledger-settings cache is
+	// best-effort over the static client, so no cache manager is registered here.
+	//
 	// Same tenantCache/tenantLoader are reused (no second cache/loader).
 	compositionTenantMiddleware := tmmiddleware.NewTenantMiddleware(
 		tmmiddleware.WithPG(onboardingPGManager, constant.ModuleOnboarding),
+		tmmiddleware.WithPG(transactionPGManager, constant.ModuleTransaction),
+		tmmiddleware.WithMB(onboardingMongoManager, constant.ModuleOnboarding),
 		tmmiddleware.WithMB(crmMongoManager),
 		tmmiddleware.WithTenantCache(tenantCache),
 		tmmiddleware.WithTenantLoader(tenantLoader),
 	)
+	setup.compositionTenantMiddleware = compositionTenantMiddleware
 
 	// The holder-accounts listing reads onboarding stores only: the account rows
 	// come from the onboarding PG account repo and their metadata from the


### PR DESCRIPTION
## Description

`POST /v2/organizations/{org}/ledgers/{ledger}/holders/{id}/accounts` returned
`500` / code `0127` on every multi-tenant deployment. Single-tenant was unaffected.

The composition tenant middleware (`bootstrap/config.go`) bound only the
module-keyed onboarding PostgreSQL and the generic-key CRM Mongo, on the stated
premise that composition "never touches the transaction PG". That premise is
false: `CreateAccount` **always** creates the default balance, and the balance
repository resolves the transaction module key with `requireTenant` set, so the
write failed with `tenant postgres connection missing from context`. Single-tenant
survived because `getDB` falls through to the static connection; multi-tenant has
no such fallback.

A second defect sat behind the first, and is why both keys ship in one PR. The
account metadata write resolves the onboarding Mongo **module key first** and falls
back to the **generic key** — which held the CRM Mongo. Fixing the PostgreSQL alone
would have unblocked that path and turned a loud `500` into a silent write into the
CRM store. Today it never happened only because the balance failed a few lines
earlier.

The middleware now carries all four stores the route reaches:

| # | Write/read | Store | Key |
|---|---|---|---|
| 1 | account row, ledger settings, asset/alias/parent reads | onboarding PostgreSQL | module-keyed |
| 2 | **default balance** | transaction PostgreSQL | module-keyed (added) |
| 3 | **account metadata** | onboarding Mongo | module-keyed (added) |
| 4 | instrument write, holder-existence read | CRM Mongo | generic |

Nothing on the path resolves a tenant Valkey (the ledger-settings cache is
best-effort over the static client), so no cache manager was added. The comment at
the wiring site now lists the four stores instead of asserting the premise that
caused the bug.

Third instance of the same class ("a route whose middleware lacks a manager its
write path uses"), after the fee routes and the holder-accounts listing. No route,
RBAC, HTTP contract, or migration changes; single-tenant behaviour is untouched.

## Type of Change

- [x] `fix`: Bug fix

## Breaking Changes

None. No HTTP contract change, no migration, no RBAC change — the route keeps
authorizing under `midaz`/`accounts`/`post`.

## Testing

- [x] `make test` passes
- [x] `make test-int` passes if integration paths are exercised
- [x] `make lint` passes
- [ ] `make sec` and `make vulncheck` pass

**Test evidence / Actions run:**

- `make test-unit` — 15679 tests, 0 failures (6 fuzz-seed skips).
- `go test -tags integration ./components/ledger/internal/bootstrap/` — whole package
  green, including the pre-existing multi-tenant sibling test.
- `golangci-lint v2.13.2` (the version pinned in `mk/quality.mk`) on the touched
  package, with and without `-tags integration` — 0 issues. The pre-push hook's
  linter also passed.
- `make sec` / `make vulncheck` not run locally — left to CI. No dependency change
  in this PR.

Both new tests were verified to **fail** on the pre-fix wiring, one defect at a time:

- dropping the transaction PostgreSQL injection reproduces the exact production
  symptom, `500 {"code":"0127"}`;
- dropping the module-keyed onboarding Mongo lands the account metadata in the CRM
  store — no error, wrong store.

New tests:

1. `composition_tenant_wiring_test.go` — pins `pgModules = {onboarding, transaction}`,
   `mongoModules = {onboarding}` and the generic Mongo manager still present, plus the
   single-tenant twin being nil. Same shape as the fee and holder-accounts wiring tests.
2. `composition_mt_integration_test.go` — drives the POST through the real
   `buildUnifiedRouteSetup`, the real route registrar and the real `CreateAccount`
   use case, for two concurrent tenants whose four stores are **four distinct
   databases** — so an assertion can say which store a write actually reached.
   Asserts the account in the onboarding PostgreSQL owned by the path holder, the
   default balance in the transaction PostgreSQL, the metadata in the onboarding
   Mongo, **zero** metadata documents in the CRM Mongo (the anti-cross-store pin),
   the instrument still resolving on the generic key, tenant A/B isolation across
   all four stores, and the compensation path: without the transaction PostgreSQL
   the POST is `500`/`0127` **and** no account is left behind.

## Architectural Checklist

- [x] No `panic()` in production paths
- [x] Timestamps use `time.Now().UTC()`
- [x] Errors wrapped with `%w`
- [x] Handlers stay thin (parse, validate, call service)
- [x] Infrastructure concerns kept in `internal/bootstrap`

## Related Issues

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Composition routes now support tenant-specific onboarding and transaction data across PostgreSQL and MongoDB.
  - Multi-tenant account, balance, metadata, and instrument records remain isolated to the correct tenant.
  - Single-tenant deployments continue to operate with the appropriate middleware configuration.

- **Bug Fixes**
  - Improved failure handling when required transaction storage is unavailable, including account compensation and a clear server error response.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->