### PR TITLE
docs(docs): add balance sync panels to the business dashboard

### DIFF
--- a/docs/dashboards/v4/business-crm/README.md
+++ b/docs/dashboards/v4/business-crm/README.md
@@ -27,9 +27,11 @@ dictionary's `calls_total` entry.
 **Mode resolution** — `legacy` versus `envelope` CRM encryption, selected by `KMS_VENDOR`.
 Under migration to envelope mode, "Legacy-format reads" should trend to zero.
 
-**Sync staleness** — age of the last balance batch sync that ran to completion, from
-`balance_sync_last_success_timestamp_seconds`. This is the panel that catches a silent
-stall, where nothing fails because nothing runs — the failure counters are blind to it.
+**Sync staleness** — age of the stalest scope's last completed batch sync, from
+`balance_sync_last_success_timestamp_seconds` (age computed per series, then max, so one
+stalled scope surfaces even while others keep syncing). This is the panel that catches a
+silent stall, where nothing fails because nothing runs — the failure counters are blind to
+it.
 The gauge only exists for a scope that has completed a batch since the pod booted, so "No
 data" is expected right after boot and on builds that predate the metric.
 

--- a/docs/dashboards/v4/business-crm/README.md
+++ b/docs/dashboards/v4/business-crm/README.md
@@ -9,6 +9,7 @@
 - Are transactions and accounts actually being created?
 - Which domain operations run, and which fail?
 - Is the bulk recorder losing writes?
+- Is the balance sync pipeline persisting, stalling, or dropping deltas?
 - Are reads being served by the replica or the primary?
 - Is CRM field encryption running, in which mode, and is it failing?
 
@@ -25,6 +26,17 @@ dictionary's `calls_total` entry.
 
 **Mode resolution** — `legacy` versus `envelope` CRM encryption, selected by `KMS_VENDOR`.
 Under migration to envelope mode, "Legacy-format reads" should trend to zero.
+
+**Sync staleness** — age of the last balance batch sync that ran to completion, from
+`balance_sync_last_success_timestamp_seconds`. This is the panel that catches a silent
+stall, where nothing fails because nothing runs — the failure counters are blind to it.
+The gauge only exists for a scope that has completed a batch since the pod booted, so "No
+data" is expected right after boot and on builds that predate the metric.
+
+**Deltas lost (expired)** — `balance_sync_orphan_dropped_total{reason="expired"}`. Like the
+insertion gap, this is a correctness check, not an activity chart: each expired orphan is a
+pending balance delta whose Redis value expired before the flush and is unrecoverable. Red
+at 1.
 
 ## Reading it correctly
 
@@ -48,3 +60,8 @@ them again.
 
 The insertion-gap panel is the first candidate for an alert once this dashboard is
 promoted to production, since a nonzero value is unambiguous data loss.
+
+Recommended alert rules for the balance sync panels exist, but live with the operational
+runbooks rather than in this repository — runbooks carry deployment-specific thresholds
+and response procedures that are not versioned with the service. The panel thresholds here
+are starting points, not agreed SLOs.

--- a/docs/dashboards/v4/business-crm/business-crm.libsonnet
+++ b/docs/dashboards/v4/business-crm/business-crm.libsonnet
@@ -186,12 +186,99 @@ d.dashboard(
       { unit: 'ms', decimals: 1, description: 'p95 time to write one batch.' }
     ),
 
-    d.row('Data Access', 41),
+    d.row('Balance Sync', 41),
+
+    d.stat(
+      'Sync staleness',
+      'time() - max(balance_sync_last_success_timestamp_seconds{%s})' % app,
+      pos(0, 42, 6, 4),
+      {
+        unit: 's',
+        decimals: 0,
+        description: 'Age of the last batch sync that ran to completion, from the heartbeat gauge the worker stamps per scope. A failure counter cannot see a silent stall — nothing fails because nothing runs — which is exactly what this panel exists to show. "No data" is expected until the first completed batch since pod boot, and on builds that predate the gauge. Thresholds are starting points, not SLOs: pair with backlog before treating staleness as an incident — an idle environment with nothing scheduled is legitimately stale.',
+        steps: [
+          { color: 'green', value: null },
+          { color: 'orange', value: 900 },
+          { color: 'red', value: 3600 },
+        ],
+      }
+    ),
+
+    d.stat(
+      'Deltas lost (expired)',
+      'round(sum(increase(balance_sync_orphan_dropped_total{%s, reason="expired"}[$__range])))' % app,
+      pos(6, 42, 6, 4),
+      {
+        decimals: 0,
+        description: 'Scheduled sync keys whose Redis value expired before the flush. Each one is a pending balance delta that was never persisted and is unrecoverable — this is data loss, not noise. reason="unparseable" (a key-format regression) is charted on the panel below but excluded here so this stat stays a pure loss signal.',
+        steps: [
+          { color: 'green', value: null },
+          { color: 'red', value: 1 },
+        ],
+      }
+    ),
+
+    d.stat(
+      'Batch failures',
+      'round(%s)' % rangeTotal('balance_sync_batch_failures_total'),
+      pos(12, 42, 6, 4),
+      {
+        decimals: 0,
+        description: 'Batch sync failures over the selected period. Each failure is a batch of balances not persisted to PostgreSQL: reads served from PostgreSQL fall behind until a later batch succeeds. The counter only materialises after its first increment, so blank means "never failed since boot", not "not deployed".',
+        steps: [
+          { color: 'green', value: null },
+          { color: 'red', value: 1 },
+        ],
+      }
+    ),
+
+    d.stat(
+      'Tenant skips',
+      'round(%s)' % rangeTotal('balance_sync_tenant_skip_total'),
+      pos(18, 42, 6, 4),
+      {
+        decimals: 0,
+        description: 'Tenants the multi-tenant worker skipped because their database connection could not be resolved. A tenant counted here is not syncing at all. Always zero (or absent) in single-tenant deployments.',
+        steps: [
+          { color: 'green', value: null },
+          { color: 'red', value: 1 },
+        ],
+      }
+    ),
+
+    d.timeSeries(
+      'Synced vs dropped',
+      [
+        d.promTarget(windowed('balance_synced_total'), 'synced', 'A'),
+        d.promTarget(windowedBy('reason', 'balance_sync_orphan_dropped_total'), 'dropped ({{reason}})', 'B'),
+      ],
+      pos(0, 46, 12, 8),
+      {
+        fill: 0,
+        description: 'Balances persisted versus scheduled keys dropped without persisting. dropped(expired) is lost data; dropped(unparseable) is a key-format regression. Both should sit at zero while the synced line follows write volume.',
+      }
+    ),
+
+    d.timeSeries(
+      'Failure counters',
+      [
+        d.promTarget(windowed('balance_sync_batch_failures_total'), 'batch failures', 'A'),
+        d.promTarget(windowed('balance_sync_cleanup_failures_total'), 'cleanup failures', 'B'),
+        d.promTarget(windowed('balance_sync_tenant_skip_total'), 'tenant skips', 'C'),
+      ],
+      pos(12, 46, 12, 8),
+      {
+        fill: 0,
+        description: 'Cleanup failures mean keys the flush had finished with were not removed from the schedule, so the next cycle reprocesses them — wasteful, not incorrect, and NOT proof the balances were persisted: the all-orphans path also cleans up without writing. Read alongside "Synced vs dropped" to tell the two apart.',
+      }
+    ),
+
+    d.row('Data Access', 54),
 
     d.timeSeries(
       'Reads by source',
       [d.promTarget(windowedBy('source', 'db_read_source_total'), '{{source}}')],
-      pos(0, 42, 12, 8),
+      pos(0, 55, 12, 8),
       {
         stack: true,
         description: 'Read origin, primary versus replica. A drop in replica reads pushes load onto the primary.',
@@ -201,19 +288,19 @@ d.dashboard(
     d.timeSeries(
       'Redis backup queue depth',
       [d.promTarget('redis_backup_queue_depth_ratio{%s}' % app, '{{k8s_pod_name}}')],
-      pos(12, 42, 12, 8),
+      pos(12, 55, 12, 8),
       {
         fill: 4,
         description: 'Despite the _ratio suffix inherited from WithUnit("1"), this value is an absolute count of queued items. Sustained growth means a stalled consumer.',
       }
     ),
 
-    d.row('CRM Protection / KMS', 50),
+    d.row('CRM Protection / KMS', 63),
 
     d.timeSeries(
       'Protection status',
       [d.promTarget(ratedBy('status', 'crm_protection_status_total'), '{{status}}')],
-      pos(0, 51, 12, 8),
+      pos(0, 64, 12, 8),
       {
         unit: 'reqps',
         stack: true,
@@ -224,7 +311,7 @@ d.dashboard(
     d.timeSeries(
       'Mode resolution',
       [d.promTarget(ratedBy('mode', 'crm_protection_mode_resolution_total'), '{{mode}}')],
-      pos(12, 51, 12, 8),
+      pos(12, 64, 12, 8),
       {
         unit: 'reqps',
         stack: true,
@@ -235,7 +322,7 @@ d.dashboard(
     d.timeSeries(
       'Encrypt / decrypt operations',
       [d.promTarget(ratedBy('outcome', 'crm_protection_encrypt_decrypt_total'), '{{outcome}}')],
-      pos(0, 59, 12, 8),
+      pos(0, 72, 12, 8),
       {
         unit: 'reqps',
         stack: true,
@@ -246,7 +333,7 @@ d.dashboard(
     d.timeSeries(
       'Legacy-format reads',
       [d.promTarget('sum(rate(crm_protection_legacy_read_total{%s}[$__rate_interval]))' % app, 'legacy reads')],
-      pos(12, 59, 12, 8),
+      pos(12, 72, 12, 8),
       {
         unit: 'reqps',
         description: 'Reads still served from the legacy format by the unified ledger binary. Under migration to envelope mode this line should trend to zero.',

--- a/docs/dashboards/v4/business-crm/business-crm.libsonnet
+++ b/docs/dashboards/v4/business-crm/business-crm.libsonnet
@@ -190,12 +190,12 @@ d.dashboard(
 
     d.stat(
       'Sync staleness',
-      'time() - max(balance_sync_last_success_timestamp_seconds{%s})' % app,
+      'max(time() - balance_sync_last_success_timestamp_seconds{%s})' % app,
       pos(0, 42, 6, 4),
       {
         unit: 's',
         decimals: 0,
-        description: 'Age of the last batch sync that ran to completion, from the heartbeat gauge the worker stamps per scope. A failure counter cannot see a silent stall — nothing fails because nothing runs — which is exactly what this panel exists to show. "No data" is expected until the first completed batch since pod boot, and on builds that predate the gauge. Thresholds are starting points, not SLOs: pair with backlog before treating staleness as an incident — an idle environment with nothing scheduled is legitimately stale.',
+        description: 'Age of the STALEST scope\'s last completed batch sync, from the heartbeat gauge the worker stamps per scope: age is computed per series before max(), so one stalled scope shows even while others keep syncing. A failure counter cannot see a silent stall — nothing fails because nothing runs — which is exactly what this panel exists to show. "No data" is expected until the first completed batch since pod boot, and on builds that predate the gauge. Thresholds are starting points, not SLOs: pair with backlog before treating staleness as an incident — an idle scope with nothing scheduled is legitimately stale.',
         steps: [
           { color: 'green', value: null },
           { color: 'orange', value: 900 },

--- a/docs/dashboards/v4/telemetry-dictionary.md
+++ b/docs/dashboards/v4/telemetry-dictionary.md
@@ -234,7 +234,7 @@ declared_name: balance_sync_last_success_timestamp
 description: Unix timestamp of the last successful balance batch sync.
 labels: [organization_id, ledger_id, tenant_id]
 label_cardinality_estimate: unbounded
-live_observed: unknown
+live_observed: true
 unit: "s"
 ```
 


### PR DESCRIPTION
<table border="0" cellspacing="0" cellpadding="0">
  <tr>
    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
    <td><h1>Midaz</h1></td>
  </tr>
</table>

---

## Description

Follow-up to #2433: the balance sync observability PR added the metrics; this PR gives them dashboard coverage.

Adds a **Balance Sync** row to the `midaz-v4-business` dashboard (`business-crm.libsonnet`):

- **Sync staleness** stat on `balance_sync_last_success_timestamp_seconds` (`time() - max(...)`) — the panel that catches a silent stall, where nothing fails because nothing runs. Thresholds (15m amber / 1h red) are starting points, not SLOs.
- **Deltas lost (expired)** stat on `balance_sync_orphan_dropped_total{reason="expired"}` — a correctness check like the insertion gap: red at 1, every hit is an unrecoverable pending delta.
- **Batch failures** and **Tenant skips** stats, plus two timeseries (**Synced vs dropped** by `reason`, **Failure counters** for batch/cleanup/skip).

Panel descriptions carry the reading traps from the telemetry dictionary (gauge absent until the first completed batch since boot; failure counters absent until first increment; cleanup failures do not imply persistence).

Also flips `balance_sync_last_success_timestamp_seconds` to `live_observed: true` in the telemetry dictionary: verified against a live multi-tenant staging environment running the first post-#2433 build — the series materialised with the full label contract (`organization_id`, `ledger_id`, `tenant_id` populated with the tenant hash), `balance_synced_total` carries `mode` + `tenant_id`, and the staleness query answered correctly minutes after a load test.

No alert rules are added here — recommended rules live with the operational runbooks (deployment-specific thresholds and response procedures are not versioned with the service), as the dashboard READMEs already state.

## Type of Change

- [ ] `feat`: New feature or capability
- [ ] `fix`: Bug fix
- [ ] `perf`: Performance improvement
- [ ] `refactor`: Internal restructuring with no behavior change
- [x] `docs`: Documentation only
- [ ] `style`: Formatting, whitespace, naming (no logic change)
- [ ] `test`: Adding or updating tests
- [ ] `ci`: CI pipeline or workflow changes
- [ ] `build`: Build system, Dockerfile, Go module dependencies
- [ ] `chore`: Maintenance, config, tooling
- [ ] `revert`: Reverts a previous commit
- [ ] `BREAKING CHANGE`: Consumers must update their integration

## Breaking Changes

None.

## Testing

- [x] `make test` passes
- [ ] `make test-int` passes if integration paths are exercised
- [x] `make lint` passes
- [ ] `make sec` and `make vulncheck` pass

**Test evidence / Actions run:** pre-push hook ran `make test-unit`, `make sec` and `make lint`, all green (`make vulncheck` not run — no Go changes). `make dashboards && make dashboards-verify` green: all 19 metric references in the compiled dashboard are documented in the telemetry dictionary. Every new panel query was executed against a live Mimir with real series before landing here.

## Architectural Checklist

Not applicable — Jsonnet dashboard sources and markdown only; no Go code touched.

- [ ] No `panic()` in production paths
- [ ] Timestamps use `time.Now().UTC()`
- [ ] Errors wrapped with `%w`
- [ ] Handlers stay thin (parse, validate, call service)
- [ ] Infrastructure concerns kept in `internal/bootstrap`

## Related Issues

Related to #2428 (balance sync alerting work) and #2433 (metrics this dashboard binds to).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a Balance Sync dashboard section with panels for staleness, failed batches, skipped tenants, synced versus dropped updates, expired deltas, and failure counters.

- **Documentation**
  - Expanded dashboard guidance for sync persistence, stalls, dropped updates, staleness, and unrecoverable expired deltas.
  - Clarified expected post-boot behavior for the staleness gauge and where alert recommendations are maintained.
  - Updated telemetry documentation to reflect the current live status of the balance sync success metric.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->