### PR TITLE
fix(ledger): accept per-leg description on v2 transaction creates

### DIFF
--- a/components/ledger/api/openapi.huma.yaml
+++ b/components/ledger/api/openapi.huma.yaml
@@ -4622,6 +4622,9 @@ components:
           type: string
         amount:
           type: string
+        description:
+          maxLength: 256
+          type: string
         ledgerId:
           examples:
             - 00000000-0000-0000-0000-000000000000

--- a/components/ledger/internal/adapters/http/in/transaction_handler_v2_integration_test.go
+++ b/components/ledger/internal/adapters/http/in/transaction_handler_v2_integration_test.go
@@ -185,6 +185,52 @@ func fetchOperationRows(t *testing.T, db *sql.DB, txID uuid.UUID) []operationEco
 	return out
 }
 
+// operationDescriptionKey spells the key a persisted operation description is indexed by. The
+// alias alone is not a key across a lifecycle: one account carries both an ON_HOLD and a DEBIT
+// of the same transaction, so the type has to join it.
+func operationDescriptionKey(alias, opType string) string {
+	return alias + "/" + opType
+}
+
+// fetchOperationDescriptions returns the persisted description of every operation of a
+// transaction, keyed by operationDescriptionKey.
+//
+// It reads the column on its own instead of widening operationEconomicRow: that projection is
+// the v1↔v2 parity envelope, every field on it feeds sortOperationRows' total order and
+// assertOperationSetsEqual's comparison, and a description is not one of the economic
+// quantities those assertions are about.
+func fetchOperationDescriptions(t *testing.T, db *sql.DB, txID uuid.UUID) map[string]string {
+	t.Helper()
+
+	rows, err := db.Query(`
+		SELECT account_alias, type, description
+		FROM operation
+		WHERE transaction_id = $1
+	`, txID)
+	require.NoError(t, err, "failed to query operation descriptions")
+
+	defer func() { _ = rows.Close() }()
+
+	out := make(map[string]string)
+
+	for rows.Next() {
+		var alias, opType, description string
+
+		require.NoError(t, rows.Scan(&alias, &opType, &description), "failed to scan operation description row")
+
+		key := operationDescriptionKey(alias, opType)
+
+		_, dup := out[key]
+		require.Falsef(t, dup, "two operations share alias %s and type %s", alias, opType)
+
+		out[key] = description
+	}
+
+	require.NoError(t, rows.Err(), "operation description row iteration error")
+
+	return out
+}
+
 // requireProblemCode asserts the RFC 9457 problem body carries EXACTLY the expected
 // canonical code. A substring check over the raw body would also match the code appearing
 // inside `type` or a message, so the field is read out of the parsed envelope.
@@ -2926,4 +2972,134 @@ func TestIntegration_TransactionV2Direct_BodyScopeDecidesTheLedger(t *testing.T)
 		"a ledger the body never named must be untouched")
 	requireDecimalEqual(t, decimal.Zero, postgrestestutil.GetBalanceAvailable(t, infra.pgContainer.DB, unnamedDst),
 		"a ledger the body never named must be untouched")
+}
+
+// advancedLegDescribedV2Body is advancedLegV2Body with a DISTINCT description on all four legs
+// and a fifth, different one on the transaction. Five distinct values is what makes the per-leg
+// claim falsifiable: a builder that stamped one leg's description onto its siblings, or the
+// transaction's onto every operation, cannot pass. Both value expressions are represented, so
+// carrying the description is not conditional on how a leg states its value.
+const advancedLegDescribedV2Body = `{"description":"v2 transaction-level note","asset":"USD","amount":"100",` +
+	`"debits":[{"alias":"@srcA",` + v2ScopeJSON + `,"amount":"60","description":"srcA leg note"},` +
+	`{"alias":"@srcB",` + v2ScopeJSON + `,"amount":"40","description":"srcB leg note"}],` +
+	`"credits":[{"alias":"@dstA",` + v2ScopeJSON + `,"share":{"percentage":50},"description":"dstA leg note"},` +
+	`{"alias":"@dstB",` + v2ScopeJSON + `,"share":{"percentage":50},"description":"dstB leg note"}]}`
+
+// =============================================================================
+// 25. PER-LEG OPERATION DESCRIPTION ON THE DIRECT ACTION: a v2 leg may describe the operation
+//     it produces, and the description it names must land on THAT operation and no other. The
+//     claim spans four layers — the decode boundary that admits the field, Translate, the shared
+//     operation builders, and the persisted rows — and any one of them collapsing the per-leg
+//     values onto a single sentence leaves a transaction whose operations no longer say which
+//     half of it they are. Only an end-to-end read-back can see that, which is why the
+//     assertion is on the rows rather than on the response envelope.
+// =============================================================================
+
+func TestIntegration_TransactionV2Direct_PerLegOperationDescriptions(t *testing.T) {
+	// NOT parallel: process-global huma state (see file header).
+	t.Setenv("ALLOW_INSECURE_TLS", "true")
+
+	infra := setupTestInfra(t)
+	t.Setenv("RABBITMQ_TRANSACTION_ASYNC", "false")
+
+	seedAdvancedLegBalances(t, infra.pgContainer.DB, infra.orgID, infra.ledgerID, 1000)
+
+	v2App := buildHumaV2DirectApp(t, infra.handler)
+
+	resp := decodeTxResponse(t,
+		postV2Create(t, v2App, "direct", infra.orgID, infra.ledgerID, advancedLegDescribedV2Body, ""),
+		nethttp.StatusCreated)
+
+	txID := uuid.MustParse(resp["id"].(string))
+	assert.Equal(t, cn.APPROVED, postgrestestutil.GetTransactionStatus(t, infra.pgContainer.DB, txID),
+		"a body carrying per-leg descriptions must settle like any other direct create")
+
+	assert.Equal(t, "v2 transaction-level note", resp["description"],
+		"the transaction keeps its own description; the legs describe their operations")
+
+	got := fetchOperationDescriptions(t, infra.pgContainer.DB, txID)
+
+	assert.Equal(t, map[string]string{
+		operationDescriptionKey("@srcA", cn.DEBIT):  "srcA leg note",
+		operationDescriptionKey("@srcB", cn.DEBIT):  "srcB leg note",
+		operationDescriptionKey("@dstA", cn.CREDIT): "dstA leg note",
+		operationDescriptionKey("@dstB", cn.CREDIT): "dstB leg note",
+	}, got, "each operation must carry the description of the leg that produced it")
+}
+
+// =============================================================================
+// 26. A LEG THAT NAMES NO DESCRIPTION INHERITS THE TRANSACTION'S. The fallback is contract, not
+//     an accident of the builders: a client that describes only the transaction still gets
+//     readable operations. It is also the fragile half of the pair — an omitted leg description
+//     and an explicitly empty one are the same empty string by the time the builders see it — so
+//     the inheritance is pinned next to the override rather than left to the override's absence.
+// =============================================================================
+
+func TestIntegration_TransactionV2Direct_LegsWithoutDescriptionInheritTheTransactions(t *testing.T) {
+	// NOT parallel: process-global huma state (see file header).
+	t.Setenv("ALLOW_INSECURE_TLS", "true")
+
+	infra := setupTestInfra(t)
+	t.Setenv("RABBITMQ_TRANSACTION_ASYNC", "false")
+
+	seedAdvancedLegBalances(t, infra.pgContainer.DB, infra.orgID, infra.ledgerID, 1000)
+
+	v2App := buildHumaV2DirectApp(t, infra.handler)
+
+	// advancedLegV2Body names a transaction description and no leg description at all.
+	resp := decodeTxResponse(t,
+		postV2Create(t, v2App, "direct", infra.orgID, infra.ledgerID, advancedLegV2Body, ""),
+		nethttp.StatusCreated)
+
+	txID := uuid.MustParse(resp["id"].(string))
+	assert.Equal(t, cn.APPROVED, postgrestestutil.GetTransactionStatus(t, infra.pgContainer.DB, txID))
+
+	got := fetchOperationDescriptions(t, infra.pgContainer.DB, txID)
+
+	assert.Equal(t, map[string]string{
+		operationDescriptionKey("@srcA", cn.DEBIT):  "v2 advanced multi-leg",
+		operationDescriptionKey("@srcB", cn.DEBIT):  "v2 advanced multi-leg",
+		operationDescriptionKey("@dstA", cn.CREDIT): "v2 advanced multi-leg",
+		operationDescriptionKey("@dstB", cn.CREDIT): "v2 advanced multi-leg",
+	}, got, "a leg naming no description must inherit the transaction-level one")
+}
+
+// =============================================================================
+// 27. PER-LEG OPERATION DESCRIPTION ON THE HOLD ACTION: the pending create path builds its
+//     operations through its own builder, not the one the direct action uses, so "the leg's
+//     description reaches the operation" has to be proven there too. A hold reserves the SOURCE
+//     side only, so the two reservations are what carry a description at this point in the
+//     lifecycle — one per source leg, each its own.
+// =============================================================================
+
+func TestIntegration_TransactionV2Hold_PerLegOperationDescriptions(t *testing.T) {
+	// NOT parallel: process-global huma state (see file header).
+	t.Setenv("ALLOW_INSECURE_TLS", "true")
+
+	infra := setupTestInfra(t)
+	t.Setenv("RABBITMQ_TRANSACTION_ASYNC", "false")
+
+	seedAdvancedLegBalances(t, infra.pgContainer.DB, infra.orgID, infra.ledgerID, 1000)
+
+	v2App := buildHumaV2DirectApp(t, infra.handler)
+
+	resp := decodeTxResponse(t,
+		postV2Create(t, v2App, "hold", infra.orgID, infra.ledgerID, advancedLegDescribedV2Body, ""),
+		nethttp.StatusCreated)
+
+	txID := uuid.MustParse(resp["id"].(string))
+	assert.Equal(t, cn.PENDING, postgrestestutil.GetTransactionStatus(t, infra.pgContainer.DB, txID),
+		"the hold action opens the transaction as PENDING")
+
+	got := fetchOperationDescriptions(t, infra.pgContainer.DB, txID)
+
+	assert.Equal(t, "srcA leg note", got[operationDescriptionKey("@srcA", cn.ONHOLD)],
+		"the @srcA reservation must carry the @srcA leg's own description")
+	assert.Equal(t, "srcB leg note", got[operationDescriptionKey("@srcB", cn.ONHOLD)],
+		"the @srcB reservation must carry the @srcB leg's own description")
+
+	for key, description := range got {
+		assert.NotEqual(t, "v2 transaction-level note", description,
+			"operation %s described its leg, so it must not fall back to the transaction description", key)
+	}
 }

--- a/components/ledger/internal/adapters/http/in/transaction_handler_v2_integration_test.go
+++ b/components/ledger/internal/adapters/http/in/transaction_handler_v2_integration_test.go
@@ -199,10 +199,10 @@ func operationDescriptionKey(alias, opType string) string {
 // the v1↔v2 parity envelope, every field on it feeds sortOperationRows' total order and
 // assertOperationSetsEqual's comparison, and a description is not one of the economic
 // quantities those assertions are about.
-func fetchOperationDescriptions(t *testing.T, db *sql.DB, txID uuid.UUID) map[string]string {
+func fetchOperationDescriptions(ctx context.Context, t *testing.T, db *sql.DB, txID uuid.UUID) map[string]string {
 	t.Helper()
 
-	rows, err := db.Query(`
+	rows, err := db.QueryContext(ctx, `
 		SELECT account_alias, type, description
 		FROM operation
 		WHERE transaction_id = $1
@@ -3017,7 +3017,7 @@ func TestIntegration_TransactionV2Direct_PerLegOperationDescriptions(t *testing.
 	assert.Equal(t, "v2 transaction-level note", resp["description"],
 		"the transaction keeps its own description; the legs describe their operations")
 
-	got := fetchOperationDescriptions(t, infra.pgContainer.DB, txID)
+	got := fetchOperationDescriptions(t.Context(), t, infra.pgContainer.DB, txID)
 
 	assert.Equal(t, map[string]string{
 		operationDescriptionKey("@srcA", cn.DEBIT):  "srcA leg note",
@@ -3054,7 +3054,7 @@ func TestIntegration_TransactionV2Direct_LegsWithoutDescriptionInheritTheTransac
 	txID := uuid.MustParse(resp["id"].(string))
 	assert.Equal(t, cn.APPROVED, postgrestestutil.GetTransactionStatus(t, infra.pgContainer.DB, txID))
 
-	got := fetchOperationDescriptions(t, infra.pgContainer.DB, txID)
+	got := fetchOperationDescriptions(t.Context(), t, infra.pgContainer.DB, txID)
 
 	assert.Equal(t, map[string]string{
 		operationDescriptionKey("@srcA", cn.DEBIT):  "v2 advanced multi-leg",
@@ -3091,7 +3091,7 @@ func TestIntegration_TransactionV2Hold_PerLegOperationDescriptions(t *testing.T)
 	assert.Equal(t, cn.PENDING, postgrestestutil.GetTransactionStatus(t, infra.pgContainer.DB, txID),
 		"the hold action opens the transaction as PENDING")
 
-	got := fetchOperationDescriptions(t, infra.pgContainer.DB, txID)
+	got := fetchOperationDescriptions(t.Context(), t, infra.pgContainer.DB, txID)
 
 	assert.Equal(t, "srcA leg note", got[operationDescriptionKey("@srcA", cn.ONHOLD)],
 		"the @srcA reservation must carry the @srcA leg's own description")

--- a/components/ledger/internal/adapters/http/in/transaction_handler_v2_test.go
+++ b/components/ledger/internal/adapters/http/in/transaction_handler_v2_test.go
@@ -685,6 +685,50 @@ func TestDecodeAndBuildV2Transaction_AdvancedFormAcrossActions(t *testing.T) {
 	}
 }
 
+// v2PerLegDescriptionBody spells a v2 body whose transaction description differs from every
+// leg's, and whose last credit leg names none at all. The three values are distinct so a seam
+// that collapsed them onto one — or onto the transaction's — cannot pass.
+const v2PerLegDescriptionBody = `{"description":"v2 transaction note","asset":"BRL","amount":"100",` +
+	`"debits":[{"alias":"@srcA",` + v2ScopeJSON + `,"amount":"60","description":"srcA leg note"},` +
+	`{"alias":"@srcB",` + v2ScopeJSON + `,"amount":"40","description":"srcB leg note"}],` +
+	`"credits":[{"alias":"@dstA",` + v2ScopeJSON + `,"amount":"70","description":"dstA leg note"},` +
+	`{"alias":"@dstB",` + v2ScopeJSON + `,"amount":"30"}]}`
+
+// TestDecodeAndBuildV2Transaction_CarriesPerLegDescriptions proves a v2 body carrying a
+// `description` on its legs clears the decode boundary — a field the struct does not publish is
+// answered with a 400, so acceptance is worth pinning — and that each leg's own value reaches the
+// transaction the funnel is handed, keyed to the leg that spelled it.
+//
+// The leg that names none stays EMPTY here: the transaction-level description is substituted by
+// the operation builders downstream, and filling it at this seam would make an inherited
+// description indistinguishable from an authored one.
+func TestDecodeAndBuildV2Transaction_CarriesPerLegDescriptions(t *testing.T) {
+	t.Parallel()
+
+	var probe mtransaction.CreateTransactionV2Input
+
+	_, decodeErr := pkgHTTP.DecodeAndValidate([]byte(v2PerLegDescriptionBody), &probe)
+	require.NoError(t, decodeErr, "a per-leg description must not be answered as an unknown field")
+
+	tx, _, err := decodeAndBuildV2Transaction([]byte(v2PerLegDescriptionBody), false, "")
+	require.NoError(t, err)
+
+	assert.Equal(t, "v2 transaction note", tx.Description,
+		"the transaction keeps its own description alongside the legs'")
+
+	from := tx.Send.Source.From
+	to := tx.Send.Distribute.To
+
+	require.Len(t, from, 2)
+	require.Len(t, to, 2)
+
+	assert.Equal(t, "srcA leg note", from[0].Description)
+	assert.Equal(t, "srcB leg note", from[1].Description)
+	assert.Equal(t, "dstA leg note", to[0].Description)
+	assert.Empty(t, to[1].Description,
+		"a leg naming no description reaches the operation builders empty, which is what makes the fallback theirs to apply")
+}
+
 // TestDecodeV2Body_RemainingLegRejectionIsSpellingSensitive pins what the decode boundary
 // ACTUALLY does with a `remaining` key on a v2 leg. The v2 leg publishes no such field, so
 // the intended answer is the unknown-field rejection (0053) — and that is what the truthy

--- a/pkg/mtransaction/v2_input.go
+++ b/pkg/mtransaction/v2_input.go
@@ -78,11 +78,21 @@ type CreateTransactionV2Input struct {
 
 // V2LegInput is one leg of a transaction side. Exactly ONE value expression per leg:
 // an explicit Amount or a Share of the transaction total. The leg exposes no
-// balance key, chart of accounts, description or metadata.
+// balance key, chart of accounts or metadata.
 type V2LegInput struct {
 	// Alias is the leg's account alias. The obligation is enforced BOTH by this tag and by
 	// an imperative check in Translate; see buildLeg for why the two are complementary.
 	Alias string `json:"alias" validate:"required"`
+
+	// Description is the leg's own operation description, persisted on the operation this leg
+	// produces. A leg that omits it produces an operation carrying the TRANSACTION-level
+	// description instead — the same inheritance rule the v1 surface has always applied, decided
+	// downstream by the operation builders rather than here.
+	//
+	// `max=256` bounds the value at the decode boundary so an oversized string is a clean 400
+	// naming the field rather than a persistence-layer failure; `maxLength` publishes that bound
+	// in the contract so a client reads it instead of discovering it by rejection.
+	Description string `json:"description,omitempty" validate:"max=256" maxLength:"256"`
 
 	// OrganizationID is the organization the leg's account belongs to. The `required` tag
 	// makes an absent value a clean 400 at decode; the `uuid` tag does the same for a
@@ -410,6 +420,7 @@ func (in CreateTransactionV2Input) buildLeg(leg V2LegInput, isFrom bool, legRef 
 
 	built := FromTo{
 		AccountAlias: leg.Alias,
+		Description:  leg.Description,
 		RouteID:      cloneStringPtr(route),
 		IsFrom:       isFrom,
 	}

--- a/pkg/mtransaction/v2_input_test.go
+++ b/pkg/mtransaction/v2_input_test.go
@@ -660,6 +660,48 @@ func TestCreateTransactionV2Input_Translate(t *testing.T) {
 			},
 		},
 		{
+			// A leg's description is the description of the operation that leg produces, and
+			// each side carries its own: a debit and a credit of one transaction describe
+			// opposite halves of it, so the two must not be collapsed into one value.
+			name: "each leg's description reaches its own built leg",
+			input: arrayV2Input(
+				[]mtransaction.V2LegInput{{Alias: "@person1", Amount: "1000", Description: "debit leg note"}},
+				[]mtransaction.V2LegInput{{Alias: "@person2", Amount: "1000", Description: "credit leg note"}},
+			),
+			verify: func(t *testing.T, got mtransaction.Transaction) {
+				t.Helper()
+
+				require.Len(t, got.Send.Source.From, 1)
+				assert.Equal(t, "debit leg note", got.Send.Source.From[0].Description)
+
+				require.Len(t, got.Send.Distribute.To, 1)
+				assert.Equal(t, "credit leg note", got.Send.Distribute.To[0].Description)
+
+				assert.Equal(t, "New Transaction", got.Description,
+					"a leg description must not overwrite the transaction-level one")
+			},
+		},
+		{
+			// Translate itself does NOT inherit: a leg that names no description reaches the
+			// operation builders empty, and THEY substitute the transaction-level description.
+			// Filling it here instead would make the two indistinguishable downstream.
+			name: "leg without a description leaves it empty at translate",
+			input: arrayV2Input(
+				[]mtransaction.V2LegInput{{Alias: "@person1", Amount: "1000"}},
+				[]mtransaction.V2LegInput{{Alias: "@person2", Amount: "1000"}},
+			),
+			verify: func(t *testing.T, got mtransaction.Transaction) {
+				t.Helper()
+
+				require.Len(t, got.Send.Source.From, 1)
+				require.Len(t, got.Send.Distribute.To, 1)
+				assert.Empty(t, got.Send.Source.From[0].Description)
+				assert.Empty(t, got.Send.Distribute.To[0].Description)
+				assert.Equal(t, "New Transaction", got.Description,
+					"the transaction description the legs inherit downstream is still set")
+			},
+		},
+		{
 			name: "leg operation route wins over the request-level one",
 			input: arrayV2Input(
 				[]mtransaction.V2LegInput{{Alias: "@person1", Amount: "1000", OperationRouteID: &legRoute}},

--- a/pkg/mtransaction/v2_input_validation_test.go
+++ b/pkg/mtransaction/v2_input_validation_test.go
@@ -88,6 +88,77 @@ func TestV2LegInput_NoRemainingExpression(t *testing.T) {
 		"the rejection must point the caller at the unsupported expression")
 }
 
+// TestV2LegInput_DescriptionIsAKnownField pins that a leg may spell its own `description`: the
+// description the operation that leg produces is persisted with.
+//
+// The decoder answers any field the struct does not publish with the unknown-field rejection, so
+// a leg description is only reachable while the field stays on the struct — dropping it turns
+// every describing body into a 400. Both sides are swept because a debit and a credit produce
+// separate operations, so each has to carry its own value rather than share one.
+func TestV2LegInput_DescriptionIsAKnownField(t *testing.T) {
+	t.Parallel()
+
+	body := `{"asset":"BRL","amount":"100","description":"transaction note",` +
+		`"debits":[{"alias":"@srcA",` + scopeJSON + `,"amount":"100","description":"debit leg note"}],` +
+		`"credits":[{"alias":"@dstA",` + scopeJSON + `,"amount":"100","description":"credit leg note"}]}`
+
+	var in mtransaction.CreateTransactionV2Input
+
+	_, err := nethttp.DecodeAndValidate([]byte(body), &in)
+	require.NoError(t, err, "a leg spelling `description` must decode as a known field")
+
+	require.Len(t, in.Debits, 1)
+	assert.Equal(t, "debit leg note", in.Debits[0].Description)
+
+	require.Len(t, in.Credits, 1)
+	assert.Equal(t, "credit leg note", in.Credits[0].Description)
+
+	assert.Equal(t, "transaction note", in.Description,
+		"a leg description must decode alongside the transaction-level one, not over it")
+}
+
+// TestV2LegInput_DescriptionLengthBound locks the published 256-character ceiling on a leg
+// description. The bound is what keeps an oversized value a clean 400 naming the field instead of
+// a persistence failure raised after the transaction has already been assembled.
+func TestV2LegInput_DescriptionLengthBound(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		length  int
+		wantErr bool
+	}{
+		{name: "at the cap", length: 256},
+		{name: "one past the cap", length: 257, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			body := `{"asset":"BRL","amount":"100",` +
+				`"debits":[{"alias":"@srcA",` + scopeJSON + `,"amount":"100",` +
+				`"description":"` + strings.Repeat("d", tt.length) + `"}],` +
+				`"credits":[{"alias":"@dstA",` + scopeJSON + `,"amount":"100"}]}`
+
+			var in mtransaction.CreateTransactionV2Input
+
+			_, err := nethttp.DecodeAndValidate([]byte(body), &in)
+			if tt.wantErr {
+				require.Error(t, err, "a %d-character leg description must be rejected", tt.length)
+
+				fields := requireKnownFieldsError(t, err, constant.ErrBadRequest)
+				assert.Contains(t, fields, "description",
+					"the rejection must name the field the caller has to shorten")
+
+				return
+			}
+
+			require.NoError(t, err, "a %d-character leg description must be accepted", tt.length)
+		})
+	}
+}
+
 // TestCreateTransactionV2Input_LegArrayCap locks the published per-side leg cap. It is the only
 // bound on the leg count: the request-body byte limit alone admits tens of thousands of legs,
 // each carrying its own downstream cost.

--- a/postman/specs/ledger/openapi.huma.yaml
+++ b/postman/specs/ledger/openapi.huma.yaml
@@ -4622,6 +4622,9 @@ components:
           type: string
         amount:
           type: string
+        description:
+          maxLength: 256
+          type: string
         ledgerId:
           examples:
             - 00000000-0000-0000-0000-000000000000

--- a/postman/specs/midaz.openapi.json
+++ b/postman/specs/midaz.openapi.json
@@ -24137,6 +24137,10 @@
           "amount": {
             "type": "string"
           },
+          "description": {
+            "maxLength": 256,
+            "type": "string"
+          },
           "ledgerId": {
             "examples": [
               "00000000-0000-0000-0000-000000000000"

--- a/postman/specs/midaz.openapi.yaml
+++ b/postman/specs/midaz.openapi.yaml
@@ -15997,6 +15997,9 @@ components:
           type: string
         amount:
           type: string
+        description:
+          maxLength: 256
+          type: string
         ledgerId:
           examples:
             - 00000000-0000-0000-0000-000000000000


### PR DESCRIPTION
## Description

The v2 transaction create routes (`/v2/transactions/{direct,hold,block,unblock}`) rejected a `description` inside a leg (`debits[]`/`credits[]`) as an unknown field (400), and every persisted operation inherited the transaction-level description with no way to override it.

`V2LegInput` now publishes a `description` (bounded at 256 to match the `OperationV2` response contract) and `Translate` maps it onto the canonical `FromTo.Description`, so each operation persists its own description — v1 parity. A leg that omits it keeps inheriting the transaction description, which is the long-standing v1 fallback, now locked as contract by an integration test.

The OpenAPI specs are regenerated (`make generate-docs`); the only schema drift is the new `V2LegInput.description`.

## Type of Change

- [ ] `feat`: New feature or capability
- [x] `fix`: Bug fix
- [ ] `perf`: Performance improvement
- [ ] `refactor`: Internal restructuring with no behavior change
- [ ] `docs`: Documentation only
- [ ] `style`: Formatting, whitespace, naming (no logic change)
- [ ] `test`: Adding or updating tests
- [ ] `ci`: CI pipeline or workflow changes
- [ ] `build`: Build system, Dockerfile, Go module dependencies
- [ ] `chore`: Maintenance, config, tooling
- [ ] `revert`: Reverts a previous commit
- [ ] `BREAKING CHANGE`: Consumers must update their integration

## Breaking Changes

None. The new leg-level `description` is an additive optional field; omitted legs behave exactly as before.

## Testing

- [x] `make test` passes (unit suites for `pkg/mtransaction`, `pkg/net/http`, and the ledger HTTP adapters)
- [x] `make test-int` passes if integration paths are exercised (`TestIntegration_TransactionV2*` set in the affected package, including the 3 new tests covering per-leg descriptions, the inheritance fallback, and the hold/pending path)
- [x] `make lint` passes (golangci-lint v2.13.2, including `--build-tags=integration`)
- [x] `make sec` and `make vulncheck` pass (`make sec` via pre-push checks; `vulncheck` not exercised for this change)

## Architectural Checklist

- [x] No `panic()` in production paths
- [x] Timestamps use `time.Now().UTC()` (no timestamp changes in this PR)
- [x] Errors wrapped with `%w` (no new error paths introduced)
- [x] Handlers stay thin (change lives in the input model; handlers untouched)
- [x] Infrastructure concerns kept in `internal/bootstrap` (not applicable — no infra changes)

## Related Issues



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional descriptions for individual transaction legs.
  * Leg descriptions support up to 256 characters and are preserved independently for debit and credit operations.
  * Undescribed legs continue to support existing fallback behavior.

* **Documentation**
  * Updated API specifications to include the new leg-level description field.

* **Tests**
  * Added coverage for description handling, validation limits, direct transactions, and hold reservations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->