### PR TITLE
fix(ledger): two-phase destination overdraft and hold draw rejection

### DIFF
--- a/components/ledger/internal/adapters/http/in/transaction_overdraft_enrichment.go
+++ b/components/ledger/internal/adapters/http/in/transaction_overdraft_enrichment.go
@@ -309,9 +309,10 @@ func registerCompanionInValidate(validate *mtransaction.Responses, _ mmodel.Bala
 		validate.From = make(map[string]mtransaction.Amount, 1)
 	}
 
-	// First-wins: double-entry splits can produce two source ops on the same
-	// alias (e.g. DEBIT + ONHOLD for PENDING). Both would lead us here but
-	// only one companion entry is needed — the amount is identical.
+	// First-wins: a batch can carry two source legs on the same alias (a
+	// route-validated cancel splits the restore into RELEASE + CREDIT). Both
+	// would lead us here but only one companion entry is needed — the amount is
+	// identical.
 	if _, exists := validate.From[companionOp.Alias]; !exists {
 		validate.From[companionOp.Alias] = companionOp.Amount
 	}
@@ -435,26 +436,40 @@ func collectOverdraftDebitSplits(balanceOps []mmodel.BalanceOperation) []overdra
 // isOverdraftDebitSplitCandidate reports whether an operation is a debit that
 // draws against Available and may therefore open a fresh overdraft.
 //
-// A DEBIT carrying TransactionType=APPROVED is a commit consuming the OnHold
-// that the pending create already reserved: it never touches Available, so the
-// amount-versus-available comparison downstream would misread the drained
-// Available (funds sit in OnHold at that point) as a new deficit and mirror a
-// companion debit for capacity that was never drawn.
+// Only CONCLUSIVE operations create debt: the direct create, and the revert that
+// is shaped like one. Two shapes are therefore excluded, on every route version:
+//
+//   - PENDING — a hold never draws overdraft. A pending create that would
+//     overdraw is rejected outright by the atomic script, so there is no draw to
+//     mirror onto the companion. This covers both pending shapes: the legacy
+//     single ON_HOLD and the route-validated double-entry DEBIT leg.
+//   - APPROVED — a commit consumes the OnHold the pending already reserved, so it
+//     never touches Available. The amount-versus-available comparison downstream
+//     would otherwise misread the drained Available (funds sit in OnHold at that
+//     point) as a new deficit and mirror a companion debit for capacity that was
+//     never drawn.
+//
+// Repayment is unaffected and keeps its own candidacy rules
+// (isOverdraftRefundSplitCandidate); unwinding a pending that drew overdraft
+// under an earlier build is likewise unaffected and stays with
+// collectOverdraftCancelSplits.
 func isOverdraftDebitSplitCandidate(amount mtransaction.Amount) bool {
-	if amount.Operation == libConstants.DEBIT {
-		return amount.TransactionType != constant.APPROVED
+	if amount.Operation != libConstants.DEBIT {
+		return false
 	}
 
-	return amount.Operation == constant.ONHOLD &&
-		amount.TransactionType == constant.PENDING &&
-		!amount.RouteValidationEnabled
+	return amount.TransactionType != constant.PENDING &&
+		amount.TransactionType != constant.APPROVED
 }
 
 // buildCompanionDebitOp constructs the BalanceOperation that mirrors the
 // overdraft deficit onto the direction=debit companion balance. The operation
-// inherits transaction metadata (TransactionType, route ids, pending flag)
-// from the source op so downstream consumers (aggregation, accounting entries)
-// treat the companion as part of the same logical transaction.
+// inherits transaction metadata (TransactionType, route ids) from the source op
+// so downstream consumers (aggregation, accounting entries) treat the companion
+// as part of the same logical transaction.
+//
+// Only conclusive source debits reach here — a hold never draws overdraft, so
+// this is never built for a pending create.
 //
 // Direction is set to debit explicitly: the companion balance is always
 // direction=debit (TRD 2.2 table row 2), and passing the direction lets the

--- a/components/ledger/internal/adapters/http/in/transaction_overdraft_enrichment.go
+++ b/components/ledger/internal/adapters/http/in/transaction_overdraft_enrichment.go
@@ -545,12 +545,31 @@ func collectOverdraftRefundSplits(balanceOps []mmodel.BalanceOperation) []overdr
 // isOverdraftRefundSplitCandidate reports whether an operation is a credit that
 // actually posts to Available and may therefore repay outstanding overdraft.
 //
-// A CREDIT carrying TransactionType=PENDING is the deferred destination leg of a
-// pending create: it moves no funds until the commit, so mirroring a repayment
-// onto the companion would settle a liability the atomic script left untouched.
+// A two-phase transaction carries its destination CREDIT into every batch of the
+// lifecycle, but the leg only posts on the commit. On the create and on the
+// cancel it is DEFERRED, and mirroring a repayment onto the companion would
+// settle a liability the atomic script leaves untouched — the companion would
+// drain while the primary kept its overdraft, and a spurious overdraft operation
+// row would claim a repayment that never happened.
+//
+// This mirrors the deferred-leg rule the atomic script applies to the same ops:
+// PENDING, and CANCELED with route validation off. That second shape can only be
+// the destination leg, because in a cancel batch the source restore is a RELEASE
+// in the legacy shape and a route-validated CREDIT in the other — so a
+// route-validated CANCELED credit stays a candidate, keeping the source restore's
+// repayment in lock-step with its companion.
+//
 // The cancel override is excluded because collectOverdraftCancelSplits owns it.
 func isOverdraftRefundSplitCandidate(amount mtransaction.Amount) bool {
-	if amount.Operation != libConstants.CREDIT || amount.TransactionType == constant.PENDING {
+	if amount.Operation != libConstants.CREDIT {
+		return false
+	}
+
+	if amount.TransactionType == constant.PENDING {
+		return false
+	}
+
+	if amount.TransactionType == constant.CANCELED && !amount.RouteValidationEnabled {
 		return false
 	}
 

--- a/components/ledger/internal/adapters/http/in/transaction_overdraft_enrichment.go
+++ b/components/ledger/internal/adapters/http/in/transaction_overdraft_enrichment.go
@@ -510,7 +510,7 @@ func collectOverdraftRefundSplits(balanceOps []mmodel.BalanceOperation) []overdr
 			continue
 		}
 
-		if op.Amount.Operation != libConstants.CREDIT || isCancelOverdraftOverride(op.Amount) {
+		if !isOverdraftRefundSplitCandidate(op.Amount) {
 			continue
 		}
 
@@ -532,6 +532,21 @@ func collectOverdraftRefundSplits(balanceOps []mmodel.BalanceOperation) []overdr
 	}
 
 	return refunds
+}
+
+// isOverdraftRefundSplitCandidate reports whether an operation is a credit that
+// actually posts to Available and may therefore repay outstanding overdraft.
+//
+// A CREDIT carrying TransactionType=PENDING is the deferred destination leg of a
+// pending create: it moves no funds until the commit, so mirroring a repayment
+// onto the companion would settle a liability the atomic script left untouched.
+// The cancel override is excluded because collectOverdraftCancelSplits owns it.
+func isOverdraftRefundSplitCandidate(amount mtransaction.Amount) bool {
+	if amount.Operation != libConstants.CREDIT || amount.TransactionType == constant.PENDING {
+		return false
+	}
+
+	return !isCancelOverdraftOverride(amount)
 }
 
 type overdraftCancel struct {

--- a/components/ledger/internal/adapters/http/in/transaction_overdraft_enrichment.go
+++ b/components/ledger/internal/adapters/http/in/transaction_overdraft_enrichment.go
@@ -432,9 +432,17 @@ func collectOverdraftDebitSplits(balanceOps []mmodel.BalanceOperation) []overdra
 	return splits
 }
 
+// isOverdraftDebitSplitCandidate reports whether an operation is a debit that
+// draws against Available and may therefore open a fresh overdraft.
+//
+// A DEBIT carrying TransactionType=APPROVED is a commit consuming the OnHold
+// that the pending create already reserved: it never touches Available, so the
+// amount-versus-available comparison downstream would misread the drained
+// Available (funds sit in OnHold at that point) as a new deficit and mirror a
+// companion debit for capacity that was never drawn.
 func isOverdraftDebitSplitCandidate(amount mtransaction.Amount) bool {
 	if amount.Operation == libConstants.DEBIT {
-		return true
+		return amount.TransactionType != constant.APPROVED
 	}
 
 	return amount.Operation == constant.ONHOLD &&

--- a/components/ledger/internal/adapters/http/in/transaction_overdraft_enrichment_test.go
+++ b/components/ledger/internal/adapters/http/in/transaction_overdraft_enrichment_test.go
@@ -292,6 +292,56 @@ func TestEnrichOverdraftOperations_PendingRouteValidationOnHoldDoesNotDoubleSpli
 	require.Len(t, companionFromTos, 1, "route-validation ON_HOLD leg must not create a duplicate companion")
 }
 
+// TestEnrichOverdraftOperations_PendingDestinationCreditIsNotRefunded locks the
+// deferred-leg rule: a destination CREDIT carrying TransactionType=PENDING is
+// the leg a pending create defers to the commit. It posts nothing now, so
+// mirroring a repayment onto the companion would settle a liability the atomic
+// script leaves untouched — and the same amount would be repaid again when the
+// commit posts the credit for real.
+func TestEnrichOverdraftOperations_PendingDestinationCreditIsNotRefunded(t *testing.T) {
+	orgID := uuid.New()
+	ledgerID := uuid.New()
+
+	destination := overdraftEnabledBalance(t, "@bob", decimal.Zero, "100")
+	destination.OverdraftUsed = decimal.NewFromInt(50)
+
+	primary := mmodel.BalanceOperation{
+		Balance: destination,
+		Alias:   "0#@bob#default",
+		Amount: mtransaction.Amount{
+			Asset:           "BRL",
+			Value:           decimal.NewFromInt(60),
+			Operation:       libConstants.CREDIT,
+			TransactionType: constant.PENDING,
+			Direction:       constant.DirectionCredit,
+		},
+		InternalKey: utils.BalanceInternalKey(orgID, ledgerID, "@bob#default"),
+	}
+
+	loaderCalled := false
+
+	loader := func(_ context.Context, _ uuid.UUID, _ uuid.UUID, _ []string) ([]*mmodel.Balance, error) {
+		loaderCalled = true
+
+		return []*mmodel.Balance{companionOverdraftBalance("@bob")}, nil
+	}
+
+	validate := &mtransaction.Responses{
+		To:           map[string]mtransaction.Amount{"0#@bob#default": primary.Amount},
+		Destinations: []string{"@bob#default"},
+		Aliases:      []string{"@bob#default"},
+	}
+
+	enriched, companionFromTos, err := enrichOverdraftOperations(context.Background(), orgID, ledgerID,
+		[]mmodel.BalanceOperation{primary}, validate, loader)
+	require.NoError(t, err)
+
+	assert.False(t, loaderCalled, "a deferred credit must not even trigger a companion lookup")
+	require.Len(t, enriched, 1, "no repayment companion may be appended for a deferred credit")
+	assert.Empty(t, companionFromTos)
+	assert.NotContains(t, validate.Destinations, "@bob#"+constant.OverdraftBalanceKey)
+}
+
 // TestEnrichOverdraftOperations_NoSplitForNonOverflow guards the common path:
 // when the debit fits within the available balance, no enrichment happens and
 // the loader is not called.

--- a/components/ledger/internal/adapters/http/in/transaction_overdraft_enrichment_test.go
+++ b/components/ledger/internal/adapters/http/in/transaction_overdraft_enrichment_test.go
@@ -194,12 +194,16 @@ func TestEnrichOverdraftOperations_SourceDebitSplit(t *testing.T) {
 	assert.True(t, ft.IsFrom, "debit enrichment companion lives on the source side")
 }
 
-func TestEnrichOverdraftOperations_PendingLegacyOnHoldSplit(t *testing.T) {
+// TestEnrichOverdraftOperations_PendingLegacyOnHoldDoesNotDraw locks the product
+// rule on the enrichment side: a HOLD never draws overdraft, so the legacy
+// single-ON_HOLD pending shape produces no draw companion however far the hold
+// exceeds Available. The atomic script rejects such a hold outright, so there is
+// no balance movement to mirror.
+func TestEnrichOverdraftOperations_PendingLegacyOnHoldDoesNotDraw(t *testing.T) {
 	orgID := uuid.New()
 	ledgerID := uuid.New()
 
 	source := overdraftEnabledBalance(t, "@alice", decimal.NewFromInt(50), "100")
-	companion := companionOverdraftBalance("@alice")
 
 	primary := mmodel.BalanceOperation{
 		Balance: source,
@@ -215,10 +219,12 @@ func TestEnrichOverdraftOperations_PendingLegacyOnHoldSplit(t *testing.T) {
 		InternalKey: utils.BalanceInternalKey(orgID, ledgerID, "@alice#default"),
 	}
 
-	loader := func(_ context.Context, _ uuid.UUID, _ uuid.UUID, aliases []string) ([]*mmodel.Balance, error) {
-		assert.Equal(t, []string{"@alice#overdraft"}, aliases)
+	loaderCalled := false
 
-		return []*mmodel.Balance{companion}, nil
+	loader := func(_ context.Context, _ uuid.UUID, _ uuid.UUID, _ []string) ([]*mmodel.Balance, error) {
+		loaderCalled = true
+
+		return []*mmodel.Balance{companionOverdraftBalance("@alice")}, nil
 	}
 
 	validate := &mtransaction.Responses{
@@ -232,27 +238,22 @@ func TestEnrichOverdraftOperations_PendingLegacyOnHoldSplit(t *testing.T) {
 	enriched, companionFromTos, err := enrichOverdraftOperations(context.Background(), orgID, ledgerID,
 		[]mmodel.BalanceOperation{primary}, validate, loader)
 	require.NoError(t, err)
-	require.Len(t, enriched, 2)
 
-	companionOp := enriched[1]
-	assert.Equal(t, libConstants.DEBIT, companionOp.Amount.Operation,
-		"pending legacy hold must still debit the direction=debit companion")
-	assert.Equal(t, constant.DirectionDebit, companionOp.Amount.Direction)
-	assert.True(t, companionOp.Amount.Value.Equal(decimal.NewFromInt(50)))
-	assert.Equal(t, constant.PENDING, companionOp.Amount.TransactionType)
-
-	require.Len(t, companionFromTos, 1)
-	assert.Equal(t, "0#@alice#overdraft", companionFromTos[0].AccountAlias)
-	assert.True(t, companionFromTos[0].IsFrom)
-	assert.Contains(t, validate.Sources, "@alice#overdraft")
+	assert.False(t, loaderCalled, "a hold must not even trigger a companion lookup")
+	require.Len(t, enriched, 1, "a hold must not produce a draw companion")
+	assert.Empty(t, companionFromTos)
+	assert.NotContains(t, validate.Sources, "@alice#"+constant.OverdraftBalanceKey)
 }
 
-func TestEnrichOverdraftOperations_PendingRouteValidationOnHoldDoesNotDoubleSplit(t *testing.T) {
+// TestEnrichOverdraftOperations_PendingRouteValidationDoesNotDraw is the
+// route-validated sibling: the double-entry hold arrives as a DEBIT plus an
+// ON_HOLD, and neither leg may draw. The DEBIT leg is the one that moves
+// Available, so it is the one that used to produce the companion.
+func TestEnrichOverdraftOperations_PendingRouteValidationDoesNotDraw(t *testing.T) {
 	orgID := uuid.New()
 	ledgerID := uuid.New()
 
 	source := overdraftEnabledBalance(t, "@alice", decimal.NewFromInt(50), "100")
-	companion := companionOverdraftBalance("@alice")
 
 	debit := mmodel.BalanceOperation{
 		Balance: source,
@@ -270,8 +271,12 @@ func TestEnrichOverdraftOperations_PendingRouteValidationOnHoldDoesNotDoubleSpli
 	onHold.Amount.Operation = constant.ONHOLD
 	onHold.Amount.Direction = constant.DirectionCredit
 
+	loaderCalled := false
+
 	loader := func(_ context.Context, _ uuid.UUID, _ uuid.UUID, _ []string) ([]*mmodel.Balance, error) {
-		return []*mmodel.Balance{companion}, nil
+		loaderCalled = true
+
+		return []*mmodel.Balance{companionOverdraftBalance("@alice")}, nil
 	}
 
 	validate := &mtransaction.Responses{
@@ -286,10 +291,10 @@ func TestEnrichOverdraftOperations_PendingRouteValidationOnHoldDoesNotDoubleSpli
 		[]mmodel.BalanceOperation{debit, onHold}, validate, loader)
 	require.NoError(t, err)
 
-	require.Len(t, enriched, 3, "only the generated DEBIT leg may create a companion")
-	assert.Equal(t, libConstants.DEBIT, enriched[2].Amount.Operation)
-	assert.True(t, enriched[2].Amount.Value.Equal(decimal.NewFromInt(50)))
-	require.Len(t, companionFromTos, 1, "route-validation ON_HOLD leg must not create a duplicate companion")
+	assert.False(t, loaderCalled, "neither hold leg may trigger a companion lookup")
+	require.Len(t, enriched, 2, "neither hold leg may produce a draw companion")
+	assert.Empty(t, companionFromTos)
+	assert.NotContains(t, validate.Sources, "@alice#"+constant.OverdraftBalanceKey)
 }
 
 // TestEnrichOverdraftOperations_PendingDestinationCreditIsNotRefunded locks the

--- a/components/ledger/internal/adapters/http/in/transaction_overdraft_enrichment_test.go
+++ b/components/ledger/internal/adapters/http/in/transaction_overdraft_enrichment_test.go
@@ -342,6 +342,120 @@ func TestEnrichOverdraftOperations_PendingDestinationCreditIsNotRefunded(t *test
 	assert.NotContains(t, validate.Destinations, "@bob#"+constant.OverdraftBalanceKey)
 }
 
+// TestEnrichOverdraftOperations_CanceledDestinationCreditIsNotRefunded locks the
+// cancel half of the deferred-leg rule. A cancel batch still carries the
+// destination CREDIT, and that leg is as deferred on a cancel as on the create:
+// the destination never received the pending credit, so a cancel must not repay
+// its overdraft. Mirroring one drains the companion while the primary keeps its
+// overdraft, and persists an overdraft operation row claiming a repayment that
+// never happened.
+//
+// The leg is identified by route validation being off, which is what separates
+// it from the source restore — see the route-validated counterpart below.
+func TestEnrichOverdraftOperations_CanceledDestinationCreditIsNotRefunded(t *testing.T) {
+	orgID := uuid.New()
+	ledgerID := uuid.New()
+
+	destination := overdraftEnabledBalance(t, "@bob", decimal.Zero, "100")
+	destination.OverdraftUsed = decimal.NewFromInt(50)
+
+	primary := mmodel.BalanceOperation{
+		Balance: destination,
+		Alias:   "0#@bob#default",
+		Amount: mtransaction.Amount{
+			Asset:           "BRL",
+			Value:           decimal.NewFromInt(60),
+			Operation:       libConstants.CREDIT,
+			TransactionType: constant.CANCELED,
+			Direction:       constant.DirectionCredit,
+			// Destination legs are never marked by PropagateRouteValidation, and
+			// carry no annotated overdraft amount (only source legs are annotated).
+			RouteValidationEnabled: false,
+			OverdraftAmount:        decimal.Zero,
+		},
+		InternalKey: utils.BalanceInternalKey(orgID, ledgerID, "@bob#default"),
+	}
+
+	loaderCalled := false
+
+	loader := func(_ context.Context, _ uuid.UUID, _ uuid.UUID, _ []string) ([]*mmodel.Balance, error) {
+		loaderCalled = true
+
+		return []*mmodel.Balance{companionOverdraftBalance("@bob")}, nil
+	}
+
+	validate := &mtransaction.Responses{
+		To:           map[string]mtransaction.Amount{"0#@bob#default": primary.Amount},
+		Destinations: []string{"@bob#default"},
+		Aliases:      []string{"@bob#default"},
+	}
+
+	enriched, companionFromTos, err := enrichOverdraftOperations(context.Background(), orgID, ledgerID,
+		[]mmodel.BalanceOperation{primary}, validate, loader)
+	require.NoError(t, err)
+
+	assert.False(t, loaderCalled, "a deferred cancel credit must not even trigger a companion lookup")
+	require.Len(t, enriched, 1, "no repayment companion may be appended for a deferred cancel credit")
+	assert.Empty(t, companionFromTos)
+	assert.NotContains(t, validate.Destinations, "@bob#"+constant.OverdraftBalanceKey)
+}
+
+// TestEnrichOverdraftOperations_CanceledRouteValidatedSourceCreditStillRefunds is
+// the counterpart bound on the rule above: the cancel's SOURCE restore comes
+// through as a route-validated CREDIT, and the atomic script does repay from it
+// when the balance carries overdraft the pending itself did not draw (so no
+// annotated overdraft amount routes it through the cancel-override path). The
+// companion must stay in lock-step with that repayment, so a route-validated
+// CANCELED credit remains a refund candidate. Rejecting every CANCELED credit
+// would desync the companion here.
+func TestEnrichOverdraftOperations_CanceledRouteValidatedSourceCreditStillRefunds(t *testing.T) {
+	orgID := uuid.New()
+	ledgerID := uuid.New()
+
+	source := overdraftEnabledBalance(t, "@alice", decimal.Zero, "100")
+	source.OverdraftUsed = decimal.NewFromInt(50)
+
+	companion := companionOverdraftBalance("@alice")
+	companion.Available = decimal.NewFromInt(50)
+
+	primary := mmodel.BalanceOperation{
+		Balance: source,
+		Alias:   "0#@alice#default",
+		Amount: mtransaction.Amount{
+			Asset:           "BRL",
+			Value:           decimal.NewFromInt(60),
+			Operation:       libConstants.CREDIT,
+			TransactionType: constant.CANCELED,
+			Direction:       constant.DirectionCredit,
+			// PropagateRouteValidation marks every source leg, which is what makes
+			// this the restore rather than the deferred destination leg.
+			RouteValidationEnabled: true,
+			OverdraftAmount:        decimal.Zero,
+		},
+		InternalKey: utils.BalanceInternalKey(orgID, ledgerID, "@alice#default"),
+	}
+
+	loader := func(_ context.Context, _ uuid.UUID, _ uuid.UUID, _ []string) ([]*mmodel.Balance, error) {
+		return []*mmodel.Balance{companion}, nil
+	}
+
+	validate := &mtransaction.Responses{
+		To:           map[string]mtransaction.Amount{"0#@alice#default": primary.Amount},
+		Destinations: []string{"@alice#default"},
+		Aliases:      []string{"@alice#default"},
+	}
+
+	enriched, companionFromTos, err := enrichOverdraftOperations(context.Background(), orgID, ledgerID,
+		[]mmodel.BalanceOperation{primary}, validate, loader)
+	require.NoError(t, err)
+
+	require.Len(t, enriched, 2, "the route-validated cancel restore must keep its repayment companion")
+	assert.Equal(t, libConstants.CREDIT, enriched[1].Amount.Operation)
+	assert.True(t, enriched[1].Amount.Value.Equal(decimal.NewFromInt(50)),
+		"repayment is capped at the outstanding overdraft; got %s", enriched[1].Amount.Value)
+	assert.Len(t, companionFromTos, 1)
+}
+
 // TestEnrichOverdraftOperations_CommitConsumptionDebitIsNotSplit locks the
 // commit-side guard: a DEBIT carrying TransactionType=APPROVED consumes the
 // OnHold the pending create reserved, so it never touches Available. Available

--- a/components/ledger/internal/adapters/http/in/transaction_overdraft_enrichment_test.go
+++ b/components/ledger/internal/adapters/http/in/transaction_overdraft_enrichment_test.go
@@ -342,6 +342,56 @@ func TestEnrichOverdraftOperations_PendingDestinationCreditIsNotRefunded(t *test
 	assert.NotContains(t, validate.Destinations, "@bob#"+constant.OverdraftBalanceKey)
 }
 
+// TestEnrichOverdraftOperations_CommitConsumptionDebitIsNotSplit locks the
+// commit-side guard: a DEBIT carrying TransactionType=APPROVED consumes the
+// OnHold the pending create reserved, so it never touches Available. Available
+// is routinely zero at that point (the funds sit in OnHold), which the deficit
+// detector would otherwise read as a fresh overdraft draw and mirror as a
+// companion debit for capacity nobody used.
+func TestEnrichOverdraftOperations_CommitConsumptionDebitIsNotSplit(t *testing.T) {
+	orgID := uuid.New()
+	ledgerID := uuid.New()
+
+	source := overdraftEnabledBalance(t, "@alice", decimal.Zero, "100")
+	source.OnHold = decimal.NewFromInt(100)
+
+	primary := mmodel.BalanceOperation{
+		Balance: source,
+		Alias:   "0#@alice#default",
+		Amount: mtransaction.Amount{
+			Asset:           "BRL",
+			Value:           decimal.NewFromInt(100),
+			Operation:       libConstants.DEBIT,
+			TransactionType: constant.APPROVED,
+			Direction:       constant.DirectionDebit,
+		},
+		InternalKey: utils.BalanceInternalKey(orgID, ledgerID, "@alice#default"),
+	}
+
+	loaderCalled := false
+
+	loader := func(_ context.Context, _ uuid.UUID, _ uuid.UUID, _ []string) ([]*mmodel.Balance, error) {
+		loaderCalled = true
+
+		return []*mmodel.Balance{companionOverdraftBalance("@alice")}, nil
+	}
+
+	validate := &mtransaction.Responses{
+		From:    map[string]mtransaction.Amount{"0#@alice#default": primary.Amount},
+		Sources: []string{"@alice#default"},
+		Aliases: []string{"@alice#default"},
+	}
+
+	enriched, companionFromTos, err := enrichOverdraftOperations(context.Background(), orgID, ledgerID,
+		[]mmodel.BalanceOperation{primary}, validate, loader)
+	require.NoError(t, err)
+
+	assert.False(t, loaderCalled, "a commit consumption debit must not even trigger a companion lookup")
+	require.Len(t, enriched, 1, "no companion debit may be appended for a commit consumption debit")
+	assert.Empty(t, companionFromTos)
+	assert.NotContains(t, validate.Sources, "@alice#"+constant.OverdraftBalanceKey)
+}
+
 // TestEnrichOverdraftOperations_NoSplitForNonOverflow guards the common path:
 // when the debit fits within the available balance, no enrichment happens and
 // the loader is not called.

--- a/components/ledger/internal/adapters/http/in/transaction_overdraft_route_flow_test.go
+++ b/components/ledger/internal/adapters/http/in/transaction_overdraft_route_flow_test.go
@@ -379,6 +379,27 @@ func TestOverdraftRouteFlow_PendingCreateDefersDestinationRepayment(t *testing.T
 	assert.NotContains(t, result.validate.Destinations, "@bob#"+constant.OverdraftBalanceKey)
 }
 
+// TestOverdraftRouteFlow_CancelDefersDestinationRepayment is the cancel sibling
+// of the pending case: a cancel batch still carries the destination CREDIT, but
+// the destination never received the pending credit, so the cancel must enrich no
+// repayment companion for it. Only the source restore may repay on a cancel.
+func TestOverdraftRouteFlow_CancelDefersDestinationRepayment(t *testing.T) {
+	result := runOverdraftRouteFlow(t, overdraftRouteFlowOptions{
+		balances:          overdraftFlowDestinationBalances(t, decimal.NewFromInt(100)),
+		companion:         overdraftFlowCompanion("@bob", decimal.NewFromInt(50)),
+		transactionStatus: constant.CANCELED,
+		pending:           true,
+		bidirectional:     true,
+	})
+
+	require.NoError(t, result.err)
+	assert.Empty(t, result.companionOps(),
+		"a cancel must not enrich a repayment companion for the destination it never credited")
+	assert.Empty(t, result.companionFromTos,
+		"no overdraft operation record may be built for a deferred cancel credit")
+	assert.NotContains(t, result.validate.Destinations, "@bob#"+constant.OverdraftBalanceKey)
+}
+
 // TestOverdraftRouteFlow_CommitRepaysDestinationOverdraft is the commit half of
 // the two-phase lifecycle: the destination credit posts on APPROVED, so that is
 // where the repayment companion is enriched, registered on the To side, and

--- a/components/ledger/internal/adapters/http/in/transaction_overdraft_route_flow_test.go
+++ b/components/ledger/internal/adapters/http/in/transaction_overdraft_route_flow_test.go
@@ -1,0 +1,484 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+// End-to-end coverage of the overdraft enrichment seam as the handlers reach it,
+// replaying the real create/commit step order:
+// ApplyDefaultBalanceKeys -> MutateConcatAliases -> ValidateSendSourceAndDistribute
+// -> PropagateRouteValidation -> buildBalanceOperations -> enrichOverdraftOperations
+// -> ValidateAccountingRules over a ToCache()-built route cache. Exercising the
+// whole chain is what catches a companion that enriches but fails route
+// validation (or the reverse) — the unit tests around enrichOverdraftOperations
+// alone cannot see the interaction.
+package in
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	libConstants "github.com/LerianStudio/lib-commons/v6/commons/constants"
+
+	"github.com/LerianStudio/midaz/v4/components/ledger/internal/adapters/postgres/ledger"
+	redisadapter "github.com/LerianStudio/midaz/v4/components/ledger/internal/adapters/redis/transaction"
+	"github.com/LerianStudio/midaz/v4/components/ledger/internal/services/query"
+	"github.com/LerianStudio/midaz/v4/pkg/constant"
+	"github.com/LerianStudio/midaz/v4/pkg/mmodel"
+	"github.com/LerianStudio/midaz/v4/pkg/mtransaction"
+	"github.com/LerianStudio/midaz/v4/pkg/utils"
+)
+
+// overdraftRouteFlowOptions describes one replay of the create/commit chain.
+type overdraftRouteFlowOptions struct {
+	balances  []*mmodel.Balance
+	companion *mmodel.Balance
+
+	transactionStatus string
+	// pending mirrors the request body's `pending` flag, which is what makes
+	// DetermineOperation emit the two-phase operations (hold / commit / cancel).
+	pending bool
+	// actionOverride replaces the status-derived accounting action, as the revert
+	// path does at the handler.
+	actionOverride string
+	// bidirectional builds one route pair carrying every action rubric, which is
+	// what the two-phase actions (hold/commit/cancel) need.
+	bidirectional bool
+	// omitOverdraftCredit drops Overdraft.Credit from the route pair so the
+	// repayment companion has no rubric to resolve.
+	omitOverdraftCredit bool
+}
+
+// overdraftRouteFlowResult carries what each assertion needs: the enriched
+// operations, the companion FromTo entries destined for BuildOperations, the
+// mutated validate response, and the route-validation verdict.
+type overdraftRouteFlowResult struct {
+	balanceOps       []mmodel.BalanceOperation
+	companionFromTos []mtransaction.FromTo
+	validate         *mtransaction.Responses
+	err              error
+}
+
+// companionOps returns the enriched operations that landed on the overdraft
+// companion balance.
+func (r overdraftRouteFlowResult) companionOps() []mmodel.BalanceOperation {
+	out := make([]mmodel.BalanceOperation, 0, 1)
+
+	for _, op := range r.balanceOps {
+		if op.Balance != nil && op.Balance.Key == constant.OverdraftBalanceKey {
+			out = append(out, op)
+		}
+	}
+
+	return out
+}
+
+func overdraftFlowRoutePair(t *testing.T, srcRouteID, dstRouteID uuid.UUID, opts overdraftRouteFlowOptions) []byte {
+	t.Helper()
+
+	overdraft := func() *mmodel.AccountingEntry {
+		entry := &mmodel.AccountingEntry{
+			Debit: &mmodel.AccountingRubric{Code: "9001", Description: "Overdraft usage"},
+		}
+
+		if !opts.omitOverdraftCredit {
+			entry.Credit = &mmodel.AccountingRubric{Code: "9002", Description: "Overdraft repayment"}
+		}
+
+		return entry
+	}
+
+	var tr *mmodel.TransactionRoute
+
+	if opts.bidirectional {
+		full := func() *mmodel.AccountingEntries {
+			return &mmodel.AccountingEntries{
+				Direct: &mmodel.AccountingEntry{
+					Debit:  &mmodel.AccountingRubric{Code: "1001", Description: "Cash out"},
+					Credit: &mmodel.AccountingRubric{Code: "2001", Description: "Cash in"},
+				},
+				Hold: &mmodel.AccountingEntry{
+					Debit:  &mmodel.AccountingRubric{Code: "3001", Description: "Hold debit"},
+					Credit: &mmodel.AccountingRubric{Code: "3002", Description: "Hold credit"},
+				},
+				Commit: &mmodel.AccountingEntry{
+					Debit:  &mmodel.AccountingRubric{Code: "4001", Description: "Commit debit"},
+					Credit: &mmodel.AccountingRubric{Code: "4002", Description: "Commit credit"},
+				},
+				Cancel: &mmodel.AccountingEntry{
+					Debit:  &mmodel.AccountingRubric{Code: "5001", Description: "Cancel debit"},
+					Credit: &mmodel.AccountingRubric{Code: "5002", Description: "Cancel credit"},
+				},
+				Revert: &mmodel.AccountingEntry{
+					Debit:  &mmodel.AccountingRubric{Code: "6001", Description: "Revert debit"},
+					Credit: &mmodel.AccountingRubric{Code: "6002", Description: "Revert credit"},
+				},
+				Overdraft: overdraft(),
+			}
+		}
+
+		tr = &mmodel.TransactionRoute{
+			OperationRoutes: []mmodel.OperationRoute{
+				{ID: srcRouteID, OperationType: "bidirectional", AccountingEntries: full()},
+				{ID: dstRouteID, OperationType: "bidirectional", AccountingEntries: full()},
+			},
+		}
+	} else {
+		tr = &mmodel.TransactionRoute{
+			OperationRoutes: []mmodel.OperationRoute{
+				{
+					ID:            srcRouteID,
+					OperationType: "source",
+					AccountingEntries: &mmodel.AccountingEntries{
+						Direct: &mmodel.AccountingEntry{
+							Debit: &mmodel.AccountingRubric{Code: "1001", Description: "Cash out"},
+						},
+						Overdraft: overdraft(),
+					},
+				},
+				{
+					ID:            dstRouteID,
+					OperationType: "destination",
+					AccountingEntries: &mmodel.AccountingEntries{
+						Direct: &mmodel.AccountingEntry{
+							Credit: &mmodel.AccountingRubric{Code: "2001", Description: "Cash in"},
+						},
+						Overdraft: overdraft(),
+					},
+				},
+			},
+		}
+	}
+
+	raw, err := tr.ToCache().ToMsgpack()
+	require.NoError(t, err)
+
+	return raw
+}
+
+// runOverdraftRouteFlow replays the handler chain for one transaction shape and
+// returns everything the assertions need.
+func runOverdraftRouteFlow(t *testing.T, opts overdraftRouteFlowOptions) overdraftRouteFlowResult {
+	t.Helper()
+
+	ctx := context.Background()
+	organizationID := uuid.New()
+	ledgerID := uuid.New()
+
+	txRouteID, srcRouteID, dstRouteID := uuid.New(), uuid.New(), uuid.New()
+
+	txRoute := txRouteID.String()
+	srcRoute := srcRouteID.String()
+	dstRoute := dstRouteID.String()
+
+	body := mtransaction.Transaction{
+		RouteID: &txRoute,
+		Pending: opts.pending,
+		Send: mtransaction.Send{
+			Asset: "BRL",
+			Value: decimal.NewFromInt(100),
+			Source: mtransaction.Source{
+				From: []mtransaction.FromTo{{
+					AccountAlias: "@alice",
+					Amount:       &mtransaction.Amount{Asset: "BRL", Value: decimal.NewFromInt(100)},
+					IsFrom:       true,
+					RouteID:      &srcRoute,
+				}},
+			},
+			Distribute: mtransaction.Distribute{
+				To: []mtransaction.FromTo{{
+					AccountAlias: "@bob",
+					Amount:       &mtransaction.Amount{Asset: "BRL", Value: decimal.NewFromInt(100)},
+					RouteID:      &dstRoute,
+				}},
+			},
+		},
+	}
+
+	mtransaction.ApplyDefaultBalanceKeys(body.Send.Source.From)
+	mtransaction.ApplyDefaultBalanceKeys(body.Send.Distribute.To)
+	mtransaction.MutateConcatAliases(body.Send.Source.From)
+	mtransaction.MutateConcatAliases(body.Send.Distribute.To)
+
+	validate, err := mtransaction.ValidateSendSourceAndDistribute(ctx, body, opts.transactionStatus)
+	require.NoError(t, err)
+
+	mtransaction.PropagateRouteValidation(ctx, validate, opts.transactionStatus)
+
+	balanceOps := buildBalanceOperations(ctx, organizationID, ledgerID, validate, opts.balances)
+	require.NotEmpty(t, balanceOps)
+
+	loader := func(_ context.Context, _, _ uuid.UUID, _ []string) ([]*mmodel.Balance, error) {
+		if opts.companion == nil {
+			return nil, nil
+		}
+
+		return []*mmodel.Balance{opts.companion}, nil
+	}
+
+	balanceOps, companionFromTos, err := enrichOverdraftOperations(ctx, organizationID, ledgerID, balanceOps, validate, loader)
+	require.NoError(t, err)
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockRedis := redisadapter.NewMockRedisRepository(ctrl)
+	mockLedger := ledger.NewMockRepository(ctrl)
+
+	mockLedger.EXPECT().
+		GetSettings(gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(map[string]any{"accounting": map[string]any{"validateRoutes": true}}, nil).
+		AnyTimes()
+
+	cacheKey := utils.AccountingRoutesInternalKey(organizationID, ledgerID, txRouteID)
+	mockRedis.EXPECT().GetBytes(gomock.Any(), cacheKey).
+		Return(overdraftFlowRoutePair(t, srcRouteID, dstRouteID, opts), nil).AnyTimes()
+
+	uc := &query.UseCase{
+		TransactionRedisRepo: mockRedis,
+		LedgerRepo:           mockLedger,
+	}
+
+	action := mtransaction.StatusToAction(opts.transactionStatus)
+	if opts.actionOverride != "" {
+		action = opts.actionOverride
+	}
+
+	_, validationErr := uc.ValidateAccountingRules(ctx, organizationID, ledgerID, balanceOps, validate, action)
+
+	return overdraftRouteFlowResult{
+		balanceOps:       balanceOps,
+		companionFromTos: companionFromTos,
+		validate:         validate,
+		err:              validationErr,
+	}
+}
+
+func overdraftFlowSourceBalances(t *testing.T) []*mmodel.Balance {
+	t.Helper()
+
+	return []*mmodel.Balance{
+		{
+			ID: uuid.New().String(), Alias: "@alice", Key: constant.DefaultBalanceKey, AssetCode: "BRL",
+			Available: decimal.NewFromInt(40), Direction: constant.DirectionCredit,
+			AccountType: "deposit",
+			Settings:    &mmodel.BalanceSettings{AllowOverdraft: true},
+		},
+		{
+			ID: uuid.New().String(), Alias: "@bob", Key: constant.DefaultBalanceKey, AssetCode: "BRL",
+			Available: decimal.Zero, Direction: constant.DirectionCredit,
+			AccountType: "deposit",
+		},
+	}
+}
+
+// overdraftFlowDestinationBalances puts the outstanding overdraft on the
+// destination (@bob), so an incoming credit repays it.
+func overdraftFlowDestinationBalances(t *testing.T, sourceOnHold decimal.Decimal) []*mmodel.Balance {
+	t.Helper()
+
+	return []*mmodel.Balance{
+		{
+			ID: uuid.New().String(), Alias: "@alice", Key: constant.DefaultBalanceKey, AssetCode: "BRL",
+			Available: decimal.NewFromInt(1000), OnHold: sourceOnHold,
+			Direction: constant.DirectionCredit, AccountType: "deposit",
+		},
+		{
+			ID: uuid.New().String(), Alias: "@bob", Key: constant.DefaultBalanceKey, AssetCode: "BRL",
+			Available: decimal.Zero, OverdraftUsed: decimal.NewFromInt(50),
+			Direction: constant.DirectionCredit, AccountType: "deposit",
+			Settings: &mmodel.BalanceSettings{AllowOverdraft: true},
+		},
+	}
+}
+
+func overdraftFlowCompanion(alias string, available decimal.Decimal) *mmodel.Balance {
+	return &mmodel.Balance{
+		ID: uuid.New().String(), Alias: alias, Key: constant.OverdraftBalanceKey, AssetCode: "BRL",
+		Available: available, Direction: constant.DirectionDebit,
+		AccountType: "deposit",
+		Settings:    &mmodel.BalanceSettings{BalanceScope: mmodel.BalanceScopeInternal},
+	}
+}
+
+// TestOverdraftRouteFlow_SourceDrawOnDirectCreate is the control: a direct
+// create drawing overdraft at the source enriches a companion debit that the
+// source route's overdraft.debit rubric covers.
+func TestOverdraftRouteFlow_SourceDrawOnDirectCreate(t *testing.T) {
+	result := runOverdraftRouteFlow(t, overdraftRouteFlowOptions{
+		balances:          overdraftFlowSourceBalances(t),
+		companion:         overdraftFlowCompanion("@alice", decimal.Zero),
+		transactionStatus: constant.CREATED,
+	})
+
+	require.NoError(t, result.err, "source overdraft draw with the overdraft rubric configured must pass")
+	require.Len(t, result.companionOps(), 1, "the source draw must enrich exactly one companion debit")
+	assert.Equal(t, libConstants.DEBIT, result.companionOps()[0].Amount.Operation)
+}
+
+// TestOverdraftRouteFlow_DestinationRepaymentOnDirectCreate covers the mirror
+// case: a direct create crediting an overdrafted destination enriches the
+// repayment companion, validated against the destination route's
+// overdraft.credit rubric.
+func TestOverdraftRouteFlow_DestinationRepaymentOnDirectCreate(t *testing.T) {
+	result := runOverdraftRouteFlow(t, overdraftRouteFlowOptions{
+		balances:          overdraftFlowDestinationBalances(t, decimal.Zero),
+		companion:         overdraftFlowCompanion("@bob", decimal.NewFromInt(50)),
+		transactionStatus: constant.CREATED,
+	})
+
+	require.NoError(t, result.err, "destination overdraft repayment with the overdraft rubric configured must pass")
+
+	companions := result.companionOps()
+	require.Len(t, companions, 1)
+	assert.Equal(t, libConstants.CREDIT, companions[0].Amount.Operation)
+	assert.True(t, companions[0].Amount.Value.Equal(decimal.NewFromInt(50)),
+		"repayment is capped at the outstanding overdraft; got %s", companions[0].Amount.Value)
+}
+
+// TestOverdraftRouteFlow_SourceDrawOnPendingCreate locks the hold half of the
+// source path: a pending create draws the overdraft immediately, because the
+// hold moves funds out of Available right away.
+func TestOverdraftRouteFlow_SourceDrawOnPendingCreate(t *testing.T) {
+	result := runOverdraftRouteFlow(t, overdraftRouteFlowOptions{
+		balances:          overdraftFlowSourceBalances(t),
+		companion:         overdraftFlowCompanion("@alice", decimal.Zero),
+		transactionStatus: constant.PENDING,
+		pending:           true,
+		bidirectional:     true,
+	})
+
+	require.NoError(t, result.err, "pending source overdraft draw with the overdraft rubric configured must pass")
+	assert.Len(t, result.companionOps(), 1, "the hold draws overdraft, so the companion debit belongs on the create")
+}
+
+// TestOverdraftRouteFlow_PendingCreateDefersDestinationRepayment locks the
+// deferred-leg rule on the enrichment side: the destination credit of a pending
+// create posts nothing until the commit, so no repayment companion may be
+// enriched. Mirroring one here would settle a liability the atomic script never
+// touches, and the amount would be double-counted when the commit repays for
+// real.
+func TestOverdraftRouteFlow_PendingCreateDefersDestinationRepayment(t *testing.T) {
+	result := runOverdraftRouteFlow(t, overdraftRouteFlowOptions{
+		balances:          overdraftFlowDestinationBalances(t, decimal.Zero),
+		companion:         overdraftFlowCompanion("@bob", decimal.NewFromInt(50)),
+		transactionStatus: constant.PENDING,
+		pending:           true,
+		bidirectional:     true,
+	})
+
+	require.NoError(t, result.err)
+	assert.Empty(t, result.companionOps(),
+		"a pending create must not enrich a repayment companion for its deferred destination credit")
+	assert.Empty(t, result.companionFromTos,
+		"no companion operation record may be built for a deferred credit")
+	assert.NotContains(t, result.validate.Destinations, "@bob#"+constant.OverdraftBalanceKey)
+}
+
+// TestOverdraftRouteFlow_CommitRepaysDestinationOverdraft is the commit half of
+// the two-phase lifecycle: the destination credit posts on APPROVED, so that is
+// where the repayment companion is enriched, registered on the To side, and
+// validated against the destination route's overdraft.credit rubric.
+func TestOverdraftRouteFlow_CommitRepaysDestinationOverdraft(t *testing.T) {
+	result := runOverdraftRouteFlow(t, overdraftRouteFlowOptions{
+		balances:          overdraftFlowDestinationBalances(t, decimal.NewFromInt(100)),
+		companion:         overdraftFlowCompanion("@bob", decimal.NewFromInt(50)),
+		transactionStatus: constant.APPROVED,
+		pending:           true,
+		bidirectional:     true,
+	})
+
+	require.NoError(t, result.err, "commit repayment with the overdraft rubric configured must pass")
+
+	companions := result.companionOps()
+	require.Len(t, companions, 1, "the commit must enrich exactly one repayment companion")
+	assert.Equal(t, libConstants.CREDIT, companions[0].Amount.Operation)
+	assert.Equal(t, constant.DirectionCredit, companions[0].Amount.Direction)
+	assert.True(t, companions[0].Amount.Value.Equal(decimal.NewFromInt(50)),
+		"repayment is capped at the outstanding overdraft; got %s", companions[0].Amount.Value)
+
+	// The companion must reach validate.To (not From): the repayment rides the
+	// destination leg, and validateOverdraftRoutes resolves its route from there.
+	entry, ok := result.validate.To["0#@bob#"+constant.OverdraftBalanceKey]
+	require.True(t, ok, "the repayment companion must be registered in validate.To; got %v", result.validate.To)
+	assert.True(t, entry.Value.Equal(decimal.NewFromInt(50)))
+
+	require.Len(t, result.companionFromTos, 1,
+		"the companion must reach BuildOperations so the overdraft leg is persisted")
+	assert.False(t, result.companionFromTos[0].IsFrom)
+	assert.Equal(t, constant.OverdraftBalanceKey, result.companionFromTos[0].BalanceKey)
+}
+
+// TestOverdraftRouteFlow_CommitRejectsMissingOverdraftCreditRubric pins the
+// validation half of the commit fix: enriching the repayment companion is what
+// puts it in front of validateOverdraftRoutes, so a destination route without an
+// overdraft.credit rubric now fails the commit with 0492 instead of silently
+// repaying without a general-ledger classification.
+func TestOverdraftRouteFlow_CommitRejectsMissingOverdraftCreditRubric(t *testing.T) {
+	result := runOverdraftRouteFlow(t, overdraftRouteFlowOptions{
+		balances:            overdraftFlowDestinationBalances(t, decimal.NewFromInt(100)),
+		companion:           overdraftFlowCompanion("@bob", decimal.NewFromInt(50)),
+		transactionStatus:   constant.APPROVED,
+		pending:             true,
+		bidirectional:       true,
+		omitOverdraftCredit: true,
+	})
+
+	require.Len(t, result.companionOps(), 1, "the companion must be enriched for the rubric check to reach it")
+	require.Error(t, result.err)
+	assert.ErrorContains(t, result.err, "0492")
+}
+
+// TestOverdraftRouteFlow_CommitDrawsNoOverdraftOnSource locks the commit-side
+// guard: at commit the source leg consumes the OnHold reserved at create, so
+// even with Available at zero it opens no overdraft and must enrich no companion
+// debit.
+func TestOverdraftRouteFlow_CommitDrawsNoOverdraftOnSource(t *testing.T) {
+	balances := []*mmodel.Balance{
+		{
+			ID: uuid.New().String(), Alias: "@alice", Key: constant.DefaultBalanceKey, AssetCode: "BRL",
+			// Available drained into OnHold by the pending create: the funds are
+			// reserved, not overdrawn.
+			Available: decimal.Zero, OnHold: decimal.NewFromInt(100),
+			Direction: constant.DirectionCredit, AccountType: "deposit",
+			Settings: &mmodel.BalanceSettings{AllowOverdraft: true},
+		},
+		{
+			ID: uuid.New().String(), Alias: "@bob", Key: constant.DefaultBalanceKey, AssetCode: "BRL",
+			Available: decimal.Zero, Direction: constant.DirectionCredit, AccountType: "deposit",
+		},
+	}
+
+	result := runOverdraftRouteFlow(t, overdraftRouteFlowOptions{
+		balances:          balances,
+		companion:         overdraftFlowCompanion("@alice", decimal.Zero),
+		transactionStatus: constant.APPROVED,
+		pending:           true,
+		bidirectional:     true,
+	})
+
+	require.NoError(t, result.err)
+	assert.Empty(t, result.companionOps(),
+		"a commit consuming its own hold must not be read as an overdraft draw")
+	assert.Empty(t, result.companionFromTos)
+}
+
+// TestOverdraftRouteFlow_RevertRepaysDestinationOverdraft covers the revert
+// shape: the account that drew the overdraft becomes the revert's destination
+// and repays through the companion, resolved against the revert action.
+func TestOverdraftRouteFlow_RevertRepaysDestinationOverdraft(t *testing.T) {
+	result := runOverdraftRouteFlow(t, overdraftRouteFlowOptions{
+		balances:          overdraftFlowDestinationBalances(t, decimal.Zero),
+		companion:         overdraftFlowCompanion("@bob", decimal.NewFromInt(50)),
+		transactionStatus: constant.CREATED,
+		bidirectional:     true,
+		actionOverride:    constant.ActionRevert,
+	})
+
+	require.NoError(t, result.err, "revert repaying overdraft at the destination must pass")
+	assert.Len(t, result.companionOps(), 1)
+}

--- a/components/ledger/internal/adapters/http/in/transaction_overdraft_route_flow_test.go
+++ b/components/ledger/internal/adapters/http/in/transaction_overdraft_route_flow_test.go
@@ -340,10 +340,16 @@ func TestOverdraftRouteFlow_DestinationRepaymentOnDirectCreate(t *testing.T) {
 		"repayment is capped at the outstanding overdraft; got %s", companions[0].Amount.Value)
 }
 
-// TestOverdraftRouteFlow_SourceDrawOnPendingCreate locks the hold half of the
-// source path: a pending create draws the overdraft immediately, because the
-// hold moves funds out of Available right away.
-func TestOverdraftRouteFlow_SourceDrawOnPendingCreate(t *testing.T) {
+// TestOverdraftRouteFlow_PendingCreateDrawsNoOverdraftOnSource locks the product
+// rule through the handler chain: a HOLD never draws overdraft, so a pending
+// create whose source hold exceeds Available enriches no draw companion — on
+// either route version, since this is a product rule and not a version rule.
+//
+// The chain stops at ValidateAccountingRules, so the rejection itself is not
+// observable here; that a hold exceeding Available is refused with 0018 and moves
+// nothing is locked at the atomic script in
+// TestIntegration_Overdraft_PendingHoldRejectsOverdraftDraw.
+func TestOverdraftRouteFlow_PendingCreateDrawsNoOverdraftOnSource(t *testing.T) {
 	result := runOverdraftRouteFlow(t, overdraftRouteFlowOptions{
 		balances:          overdraftFlowSourceBalances(t),
 		companion:         overdraftFlowCompanion("@alice", decimal.Zero),
@@ -352,8 +358,11 @@ func TestOverdraftRouteFlow_SourceDrawOnPendingCreate(t *testing.T) {
 		bidirectional:     true,
 	})
 
-	require.NoError(t, result.err, "pending source overdraft draw with the overdraft rubric configured must pass")
-	assert.Len(t, result.companionOps(), 1, "the hold draws overdraft, so the companion debit belongs on the create")
+	require.NoError(t, result.err)
+	assert.Empty(t, result.companionOps(),
+		"a hold must not draw overdraft, so no companion debit may be enriched on a pending create")
+	assert.Empty(t, result.companionFromTos)
+	assert.NotContains(t, result.validate.Sources, "@alice#"+constant.OverdraftBalanceKey)
 }
 
 // TestOverdraftRouteFlow_PendingCreateDefersDestinationRepayment locks the

--- a/components/ledger/internal/adapters/http/in/transaction_state_handlers.go
+++ b/components/ledger/internal/adapters/http/in/transaction_state_handlers.go
@@ -372,7 +372,7 @@ func (handler *TransactionHandler) commitOrCancelTransaction(ctx context.Context
 	// Route ONLY the pre-write balance reads to the primary via a dedicated ctx:
 	// their result seeds the authoritative balance via the NX-seed, so a stale
 	// replica read here corrupts money. The mark lives on readCtx, scoped to the
-	// direct balance read and the cancel overdraft-enrichment read; the unmarked
+	// direct balance read and the overdraft-enrichment read; the unmarked
 	// ctx flows to everything else (validation, Redis seed, balance processing,
 	// write) so those keep their default routing. The flag governs the effect; the
 	// mark is unconditional.
@@ -391,13 +391,21 @@ func (handler *TransactionHandler) commitOrCancelTransaction(ctx context.Context
 	balanceOps := buildBalanceOperations(ctx, organizationID, ledgerID, validate, balances)
 	balanceOps = annotateCanceledOverdraftAmounts(balanceOps, tran)
 
+	// Both transitions move funds on the overdrafted balance, so both need the
+	// companion mirrored: a cancel restores the held capacity, and a commit posts
+	// the destination credit that repays outstanding overdraft. Enriching here is
+	// what puts the companion leg in front of ValidateAccountingRules (so the
+	// route's overdraft rubric is enforced), into the atomic batch (so the
+	// companion balance moves in lock-step with the primary's repayment) and into
+	// BuildOperations (so the overdraft leg is persisted).
 	var companionFromTos []mtransaction.FromTo
-	if transactionStatus == constant.CANCELED {
+
+	if transactionStatus == constant.APPROVED || transactionStatus == constant.CANCELED {
 		balanceOps, companionFromTos, err = enrichOverdraftOperations(readCtx, organizationID, ledgerID, balanceOps,
 			validate, handler.Query.GetBalances)
 		if err != nil {
-			libOpentelemetry.HandleSpanError(span, "Failed to enrich canceled overdraft operations", err)
-			logger.Log(ctx, libLog.LevelError, "Failed to enrich canceled overdraft operations", libLog.Err(err))
+			libOpentelemetry.HandleSpanError(span, "Failed to enrich overdraft operations", err)
+			logger.Log(ctx, libLog.LevelError, "Failed to enrich overdraft operations", libLog.Err(err))
 
 			deleteLockOnError()
 

--- a/components/ledger/internal/adapters/http/in/transaction_state_handlers_test.go
+++ b/components/ledger/internal/adapters/http/in/transaction_state_handlers_test.go
@@ -367,6 +367,185 @@ func (handler *TransactionHandler) commitOrCancelTransaction() error {
 	assert.Less(t, mc.settingsPos, mc.resolveSkipPos, "fixture sanity: settings re-fetch precedes the re-resolution")
 }
 
+// commitCancelOverdraftMetrics captures the overdraft-enrichment wiring facts of
+// commitOrCancelTransaction.
+type commitCancelOverdraftMetrics struct {
+	// enrichStatuses holds the transaction-status constants named in the
+	// condition guarding the enrichOverdraftOperations call.
+	enrichStatuses map[string]bool
+	// enrichPos is the index of the guarded enrichment statement (-1 if absent).
+	enrichPos int
+	// validatePos is the index of the ValidateAccountingRules call (-1).
+	validatePos int
+	// companionsReachFromTo reports whether companionFromTos is appended into the
+	// fromTo slice that BuildOperations consumes.
+	companionsReachFromTo bool
+}
+
+// analyzeCommitCancelOverdraftSeam walks commitOrCancelTransaction and extracts
+// which transitions enrich overdraft companions and whether those companions
+// reach validation and the operation-record builder.
+func analyzeCommitCancelOverdraftSeam(t *testing.T, src string) commitCancelOverdraftMetrics {
+	t.Helper()
+
+	fn := findFuncDecl(t, src, commitCancelFuncName)
+
+	m := commitCancelOverdraftMetrics{
+		enrichStatuses: map[string]bool{},
+		enrichPos:      -1,
+		validatePos:    -1,
+	}
+
+	for i, stmt := range fn.Body.List {
+		if m.enrichPos == -1 {
+			if ifStmt, ok := stmt.(*ast.IfStmt); ok && stmtCallsFunc(ifStmt.Body, "enrichOverdraftOperations") {
+				m.enrichPos = i
+
+				for _, name := range constantSelectorNames(ifStmt.Cond) {
+					m.enrichStatuses[name] = true
+				}
+			}
+		}
+
+		if m.validatePos == -1 && stmtCallsMethod(stmt, "ValidateAccountingRules") {
+			m.validatePos = i
+		}
+
+		if stmtAppendsIdentInto(stmt, "fromTo", "companionFromTos") {
+			m.companionsReachFromTo = true
+		}
+	}
+
+	return m
+}
+
+// constantSelectorNames returns the selector names of every `constant.X`
+// reference in the expression.
+func constantSelectorNames(expr ast.Expr) []string {
+	names := make([]string, 0, 2)
+
+	ast.Inspect(expr, func(n ast.Node) bool {
+		sel, ok := n.(*ast.SelectorExpr)
+		if !ok {
+			return true
+		}
+
+		if pkg, ok := sel.X.(*ast.Ident); ok && pkg.Name == "constant" {
+			names = append(names, sel.Sel.Name)
+		}
+
+		return true
+	})
+
+	return names
+}
+
+// stmtAppendsIdentInto reports whether stmt assigns to `target` the result of an
+// append that spreads `source` (i.e. target = append(target, source...)).
+func stmtAppendsIdentInto(stmt ast.Stmt, target, source string) bool {
+	assign, ok := stmt.(*ast.AssignStmt)
+	if !ok || len(assign.Lhs) != 1 || len(assign.Rhs) != 1 {
+		return false
+	}
+
+	lhs, ok := assign.Lhs[0].(*ast.Ident)
+	if !ok || lhs.Name != target {
+		return false
+	}
+
+	call, ok := assign.Rhs[0].(*ast.CallExpr)
+	if !ok {
+		return false
+	}
+
+	fun, ok := call.Fun.(*ast.Ident)
+	if !ok || fun.Name != "append" || call.Ellipsis == token.NoPos {
+		return false
+	}
+
+	for _, arg := range call.Args {
+		if id, ok := arg.(*ast.Ident); ok && id.Name == source {
+			return true
+		}
+	}
+
+	return false
+}
+
+// TestCommitCancel_OverdraftEnrichmentCoversBothTransitions — the two-phase
+// overdraft wiring proof. Both transitions move funds on an overdrafted balance:
+// a cancel restores the held capacity, and a commit posts the destination credit
+// that repays outstanding overdraft. Enriching is what puts the companion leg in
+// front of ValidateAccountingRules (so the route's overdraft rubric is enforced),
+// into the atomic batch (so the companion balance moves in lock-step) and into
+// the fromTo slice (so BuildOperations persists the overdraft leg). Gating the
+// enrichment on the cancel alone silently drops all three on commit, which is a
+// money-correctness bug the enrichment unit tests cannot see — they never reach
+// this call site. Asserted over the live source AST.
+func TestCommitCancel_OverdraftEnrichmentCoversBothTransitions(t *testing.T) {
+	src := readStateHandlersSource(t)
+
+	m := analyzeCommitCancelOverdraftSeam(t, src)
+
+	require.NotEqual(t, -1, m.enrichPos, "guarded enrichOverdraftOperations call not found in commitOrCancelTransaction")
+	require.NotEqual(t, -1, m.validatePos, "ValidateAccountingRules call not found")
+
+	assert.True(t, m.enrichStatuses["APPROVED"],
+		"the commit transition must enrich overdraft companions: its destination credit is what repays outstanding overdraft")
+	assert.True(t, m.enrichStatuses["CANCELED"],
+		"the cancel transition must enrich overdraft companions: it restores the capacity the hold consumed")
+
+	assert.Less(t, m.enrichPos, m.validatePos,
+		"enrichment must precede ValidateAccountingRules so the companion is subject to the route's overdraft rubric")
+	assert.True(t, m.companionsReachFromTo,
+		"companionFromTos must be appended into fromTo so BuildOperations persists the overdraft operation")
+}
+
+// TestCommitCancel_OverdraftEnrichmentCoversBothTransitions_Bites proves the
+// analyzer bites on a seam that enriches on cancel only, validates before
+// enriching, or never threads the companions into fromTo.
+func TestCommitCancel_OverdraftEnrichmentCoversBothTransitions_Bites(t *testing.T) {
+	leaky := `package in
+func (handler *TransactionHandler) commitOrCancelTransaction() error {
+	routeCache, _ := handler.Query.ValidateAccountingRules(ctx, balanceOps, validate, action)
+	var companionFromTos []mtransaction.FromTo
+	if transactionStatus == constant.CANCELED { // BUG: commit is not enriched
+		balanceOps, companionFromTos, _ = enrichOverdraftOperations(readCtx, balanceOps, validate)
+	}
+	_, _ = routeCache, companionFromTos
+	return nil
+}`
+
+	m := analyzeCommitCancelOverdraftSeam(t, leaky)
+
+	require.NotEqual(t, -1, m.enrichPos, "fixture sanity: the guarded enrichment must be present")
+
+	assert.False(t, m.enrichStatuses["APPROVED"],
+		"gate failed to bite: a cancel-only guard was reported as covering the commit")
+	assert.True(t, m.enrichStatuses["CANCELED"], "fixture sanity: the cancel status must be detected")
+	assert.Greater(t, m.enrichPos, m.validatePos,
+		"fixture sanity: this fixture validates before enriching")
+	assert.False(t, m.companionsReachFromTo,
+		"gate failed to bite: companions never appended into fromTo were reported as reaching it")
+
+	correct := `package in
+func (handler *TransactionHandler) commitOrCancelTransaction() error {
+	var companionFromTos []mtransaction.FromTo
+	if transactionStatus == constant.APPROVED || transactionStatus == constant.CANCELED {
+		balanceOps, companionFromTos, _ = enrichOverdraftOperations(readCtx, balanceOps, validate)
+	}
+	routeCache, _ := handler.Query.ValidateAccountingRules(ctx, balanceOps, validate, action)
+	fromTo = append(fromTo, companionFromTos...)
+	_ = routeCache
+	return nil
+}`
+
+	mc := analyzeCommitCancelOverdraftSeam(t, correct)
+	assert.True(t, mc.enrichStatuses["APPROVED"] && mc.enrichStatuses["CANCELED"] && mc.companionsReachFromTo,
+		"fixture sanity: the correct shape must satisfy every fact")
+	assert.Less(t, mc.enrichPos, mc.validatePos, "fixture sanity: enrichment precedes validation")
+}
+
 // readStateHandlersSource reads transaction_state_handlers.go from disk so the
 // commit/cancel wiring gate runs against the live source.
 func readStateHandlersSource(t *testing.T) string {

--- a/components/ledger/internal/adapters/redis/transaction/consumer_overdraft_pending_integration_test.go
+++ b/components/ledger/internal/adapters/redis/transaction/consumer_overdraft_pending_integration_test.go
@@ -99,46 +99,97 @@ func findLatestBalanceByKey(t *testing.T, balances []*mmodel.Balance, key string
 	return latest
 }
 
-func TestIntegration_Overdraft_PendingLegacyHoldMutatesCompanion(t *testing.T) {
+// TestIntegration_Overdraft_PendingHoldRejectsOverdraftDraw locks the product
+// rule: a HOLD never draws overdraft. Debt is created only by conclusive
+// operations, so a pending create whose hold exceeds Available is rejected with
+// the classic insufficient-funds error even on an allowOverdraft balance, and
+// nothing is persisted. Both pending shapes are covered — the legacy single
+// ON_HOLD and the route-validated DEBIT + ON_HOLD double entry, where the DEBIT
+// leg is the one that would go negative.
+func TestIntegration_Overdraft_PendingHoldRejectsOverdraftDraw(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode")
 	}
 
-	infra := setupRedisIntegrationInfra(t)
-	ctx := context.Background()
-	orgID := uuid.New()
-	ledgerID := uuid.New()
-	alias := "@t17-pending-hold"
-
-	settings := &mmodel.BalanceSettings{
-		BalanceScope:          mmodel.BalanceScopeTransactional,
-		AllowOverdraft:        true,
-		OverdraftLimitEnabled: true,
-		OverdraftLimit:        ptrString("100"),
+	settings := func() *mmodel.BalanceSettings {
+		return &mmodel.BalanceSettings{
+			BalanceScope:          mmodel.BalanceScopeTransactional,
+			AllowOverdraft:        true,
+			OverdraftLimitEnabled: true,
+			OverdraftLimit:        ptrString("100"),
+		}
 	}
 
-	defaultOp := pendingOverdraftBalanceOp(orgID, ledgerID, alias, constant.DefaultBalanceKey, constant.DirectionCredit,
-		decimal.NewFromInt(50), decimal.Zero, decimal.Zero, 1, settings,
-		constant.ONHOLD, constant.PENDING, decimal.NewFromInt(100), decimal.Zero, false)
-	companionOp := pendingOverdraftBalanceOp(orgID, ledgerID, alias, constant.OverdraftBalanceKey, constant.DirectionDebit,
-		decimal.Zero, decimal.Zero, decimal.Zero, 1, nil,
-		constant.DEBIT, constant.PENDING, decimal.NewFromInt(50), decimal.Zero, false)
+	// assertUntouched proves the rejection moved nothing: the rollback restores
+	// every balance the batch touched to the state the caller read.
+	assertUntouched := func(t *testing.T, infra *integrationTestInfra, orgID, ledgerID uuid.UUID, alias string) {
+		t.Helper()
 
-	result, err := infra.repo.ProcessBalanceAtomicOperation(ctx, orgID, ledgerID,
-		uuid.New(), constant.PENDING, true, []mmodel.BalanceOperation{defaultOp, companionOp})
+		def := readCachedBalance(t, infra, utils.BalanceInternalKey(orgID, ledgerID, alias+"#"+constant.DefaultBalanceKey))
+		assert.Equal(t, "50", def.Available, "a rejected hold must not move available")
+		assert.Equal(t, "0", def.OnHold, "a rejected hold must not place a hold")
+		assert.Equal(t, "0", def.OverdraftUsed, "a rejected hold must not accrue overdraft")
+		assert.Equal(t, int64(1), def.Version, "a rejected hold must not consume a version")
+	}
 
-	require.NoError(t, err)
-	require.Len(t, result.After, 2)
+	t.Run("legacy_shape", func(t *testing.T) {
+		infra := setupRedisIntegrationInfra(t)
+		ctx := context.Background()
+		orgID := uuid.New()
+		ledgerID := uuid.New()
+		alias := "@pending-hold-reject-legacy"
 
-	defaultAfter := findBalanceByKey(t, result.After, constant.DefaultBalanceKey)
-	companionAfter := findBalanceByKey(t, result.After, constant.OverdraftBalanceKey)
+		onHold := pendingOverdraftBalanceOp(orgID, ledgerID, alias, constant.DefaultBalanceKey, constant.DirectionCredit,
+			decimal.NewFromInt(50), decimal.Zero, decimal.Zero, 1, settings(),
+			constant.ONHOLD, constant.PENDING, decimal.NewFromInt(100), decimal.Zero, false)
 
-	assert.True(t, defaultAfter.Available.IsZero())
-	assert.True(t, defaultAfter.OnHold.Equal(decimal.NewFromInt(100)))
-	assert.True(t, defaultAfter.OverdraftUsed.Equal(decimal.NewFromInt(50)))
-	assert.True(t, companionAfter.Available.Equal(decimal.NewFromInt(50)))
+		_, err := infra.repo.ProcessBalanceAtomicOperation(ctx, orgID, ledgerID,
+			uuid.New(), constant.PENDING, true, []mmodel.BalanceOperation{onHold})
+
+		require.Error(t, err, "a hold exceeding available must be rejected, not floored into overdraft")
+		assert.Contains(t, err.Error(), "0018")
+
+		assertUntouched(t, infra, orgID, ledgerID, alias)
+	})
+
+	t.Run("route_validated_shape", func(t *testing.T) {
+		infra := setupRedisIntegrationInfra(t)
+		ctx := context.Background()
+		orgID := uuid.New()
+		ledgerID := uuid.New()
+		alias := "@pending-hold-reject-rv"
+
+		// Route validation splits the hold: the DEBIT drops Available (and is
+		// what would overdraw), the ON_HOLD raises OnHold.
+		debit := pendingOverdraftBalanceOp(orgID, ledgerID, alias, constant.DefaultBalanceKey, constant.DirectionCredit,
+			decimal.NewFromInt(50), decimal.Zero, decimal.Zero, 1, settings(),
+			constant.DEBIT, constant.PENDING, decimal.NewFromInt(100), decimal.Zero, true)
+		onHold := pendingOverdraftBalanceOp(orgID, ledgerID, alias, constant.DefaultBalanceKey, constant.DirectionCredit,
+			decimal.NewFromInt(50), decimal.Zero, decimal.Zero, 1, settings(),
+			constant.ONHOLD, constant.PENDING, decimal.NewFromInt(100), decimal.Zero, true)
+
+		_, err := infra.repo.ProcessBalanceAtomicOperation(ctx, orgID, ledgerID,
+			uuid.New(), constant.PENDING, true, []mmodel.BalanceOperation{debit, onHold})
+
+		require.Error(t, err, "a hold exceeding available must be rejected, not floored into overdraft")
+		assert.Contains(t, err.Error(), "0018")
+
+		assertUntouched(t, infra, orgID, ledgerID, alias)
+	})
 }
 
+// TestIntegration_Overdraft_PendingLegacyCancelRestoresCompanion locks the
+// UNWIND path, which must keep working unchanged: holds no longer draw overdraft,
+// but a pending created under an earlier build did, and those pendings still have
+// to be cancelable after deploy.
+//
+// The drawn state is therefore SEEDED directly rather than produced by running a
+// hold — a hold that draws is now rejected, so the old setup could not reach this
+// path at all. The seeded values are exactly what an earlier build left behind: a
+// 100 hold against 50 available floored Available at 0, put 100 in OnHold, accrued
+// 50 of overdraft, and moved the mirrored 50 onto the companion. The Lua NX-seed
+// materializes the cache from these incoming values on first touch, so the cancel
+// batch runs against the same state it would have read in production.
 func TestIntegration_Overdraft_PendingLegacyCancelRestoresCompanion(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode")
@@ -157,25 +208,18 @@ func TestIntegration_Overdraft_PendingLegacyCancelRestoresCompanion(t *testing.T
 		OverdraftLimit:        ptrString("100"),
 	}
 
-	pendingDefault := pendingOverdraftBalanceOp(orgID, ledgerID, alias, constant.DefaultBalanceKey, constant.DirectionCredit,
-		decimal.NewFromInt(50), decimal.Zero, decimal.Zero, 1, settings,
-		constant.ONHOLD, constant.PENDING, decimal.NewFromInt(100), decimal.Zero, false)
-	pendingCompanion := pendingOverdraftBalanceOp(orgID, ledgerID, alias, constant.OverdraftBalanceKey, constant.DirectionDebit,
-		decimal.Zero, decimal.Zero, decimal.Zero, 1, nil,
-		constant.DEBIT, constant.PENDING, decimal.NewFromInt(50), decimal.Zero, false)
+	// Drawn state left by a hold under an earlier build (version already bumped
+	// once by that hold).
+	const drawnVersion = 2
 
-	pendingResult, err := infra.repo.ProcessBalanceAtomicOperation(ctx, orgID, ledgerID,
-		uuid.New(), constant.PENDING, true, []mmodel.BalanceOperation{pendingDefault, pendingCompanion})
-	require.NoError(t, err)
-
-	defaultAfterPending := findLatestBalanceByKey(t, pendingResult.After, constant.DefaultBalanceKey)
-	companionAfterPending := findBalanceByKey(t, pendingResult.After, constant.OverdraftBalanceKey)
+	drawnAvailable, drawnOnHold, drawnOverdraftUsed := decimal.Zero, decimal.NewFromInt(100), decimal.NewFromInt(50)
+	companionAvailable := decimal.NewFromInt(50)
 
 	cancelDefault := pendingOverdraftBalanceOp(orgID, ledgerID, alias, constant.DefaultBalanceKey, constant.DirectionCredit,
-		defaultAfterPending.Available, defaultAfterPending.OnHold, defaultAfterPending.OverdraftUsed, defaultAfterPending.Version, settings,
+		drawnAvailable, drawnOnHold, drawnOverdraftUsed, drawnVersion, settings,
 		constant.RELEASE, constant.CANCELED, decimal.NewFromInt(100), decimal.NewFromInt(50), false)
 	cancelCompanion := pendingOverdraftBalanceOp(orgID, ledgerID, alias, constant.OverdraftBalanceKey, constant.DirectionDebit,
-		companionAfterPending.Available, companionAfterPending.OnHold, companionAfterPending.OverdraftUsed, companionAfterPending.Version, nil,
+		companionAvailable, decimal.Zero, decimal.Zero, drawnVersion, nil,
 		constant.CREDIT, constant.CANCELED, decimal.NewFromInt(50), decimal.Zero, false)
 
 	cancelResult, err := infra.repo.ProcessBalanceAtomicOperation(ctx, orgID, ledgerID,
@@ -192,6 +236,17 @@ func TestIntegration_Overdraft_PendingLegacyCancelRestoresCompanion(t *testing.T
 	assert.True(t, companionAfterCancel.Available.IsZero())
 }
 
+// TestIntegration_Overdraft_PendingRouteValidationCancelAllowsSameBatchVersionChain
+// is the route-validated sibling of the unwind test above, and locks the
+// same-batch version chain: the RELEASE bumps the version, so the CREDIT that
+// follows it in the same batch reads a version one ahead of the one it carried
+// and must not be treated as stale.
+//
+// The drawn state is SEEDED for the same reason given above — a hold that draws
+// is now rejected, so it cannot be produced by running one. In the
+// route-validated shape the earlier build's hold mutated the default balance
+// twice (DEBIT then ON_HOLD), which is why its seeded version is one higher than
+// the companion's.
 func TestIntegration_Overdraft_PendingRouteValidationCancelAllowsSameBatchVersionChain(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode")
@@ -210,31 +265,24 @@ func TestIntegration_Overdraft_PendingRouteValidationCancelAllowsSameBatchVersio
 		OverdraftLimit:        ptrString("100"),
 	}
 
-	pendingDebit := pendingOverdraftBalanceOp(orgID, ledgerID, alias, constant.DefaultBalanceKey, constant.DirectionCredit,
-		decimal.NewFromInt(50), decimal.Zero, decimal.Zero, 1, settings,
-		constant.DEBIT, constant.PENDING, decimal.NewFromInt(100), decimal.Zero, true)
-	pendingOnHold := pendingOverdraftBalanceOp(orgID, ledgerID, alias, constant.DefaultBalanceKey, constant.DirectionCredit,
-		decimal.NewFromInt(50), decimal.Zero, decimal.Zero, 1, settings,
-		constant.ONHOLD, constant.PENDING, decimal.NewFromInt(100), decimal.Zero, true)
-	pendingCompanion := pendingOverdraftBalanceOp(orgID, ledgerID, alias, constant.OverdraftBalanceKey, constant.DirectionDebit,
-		decimal.Zero, decimal.Zero, decimal.Zero, 1, nil,
-		constant.DEBIT, constant.PENDING, decimal.NewFromInt(50), decimal.Zero, true)
+	// Drawn state left by a route-validated hold under an earlier build: the
+	// default balance was mutated twice (DEBIT then ON_HOLD), the companion once.
+	const (
+		drawnDefaultVersion   = 3
+		drawnCompanionVersion = 2
+	)
 
-	pendingResult, err := infra.repo.ProcessBalanceAtomicOperation(ctx, orgID, ledgerID,
-		uuid.New(), constant.PENDING, true, []mmodel.BalanceOperation{pendingDebit, pendingOnHold, pendingCompanion})
-	require.NoError(t, err)
-
-	defaultAfterPending := findLatestBalanceByKey(t, pendingResult.After, constant.DefaultBalanceKey)
-	companionAfterPending := findBalanceByKey(t, pendingResult.After, constant.OverdraftBalanceKey)
+	drawnAvailable, drawnOnHold, drawnOverdraftUsed := decimal.Zero, decimal.NewFromInt(100), decimal.NewFromInt(50)
+	companionAvailable := decimal.NewFromInt(50)
 
 	cancelRelease := pendingOverdraftBalanceOp(orgID, ledgerID, alias, constant.DefaultBalanceKey, constant.DirectionCredit,
-		defaultAfterPending.Available, defaultAfterPending.OnHold, defaultAfterPending.OverdraftUsed, defaultAfterPending.Version, settings,
+		drawnAvailable, drawnOnHold, drawnOverdraftUsed, drawnDefaultVersion, settings,
 		constant.RELEASE, constant.CANCELED, decimal.NewFromInt(100), decimal.Zero, true)
 	cancelCredit := pendingOverdraftBalanceOp(orgID, ledgerID, alias, constant.DefaultBalanceKey, constant.DirectionCredit,
-		defaultAfterPending.Available, defaultAfterPending.OnHold, defaultAfterPending.OverdraftUsed, defaultAfterPending.Version, settings,
+		drawnAvailable, drawnOnHold, drawnOverdraftUsed, drawnDefaultVersion, settings,
 		constant.CREDIT, constant.CANCELED, decimal.NewFromInt(100), decimal.NewFromInt(50), true)
 	cancelCompanion := pendingOverdraftBalanceOp(orgID, ledgerID, alias, constant.OverdraftBalanceKey, constant.DirectionDebit,
-		companionAfterPending.Available, companionAfterPending.OnHold, companionAfterPending.OverdraftUsed, companionAfterPending.Version, nil,
+		companionAvailable, decimal.Zero, decimal.Zero, drawnCompanionVersion, nil,
 		constant.CREDIT, constant.CANCELED, decimal.NewFromInt(50), decimal.Zero, true)
 
 	cancelResult, err := infra.repo.ProcessBalanceAtomicOperation(ctx, orgID, ledgerID,

--- a/components/ledger/internal/adapters/redis/transaction/consumer_overdraft_repayment_integration_test.go
+++ b/components/ledger/internal/adapters/redis/transaction/consumer_overdraft_repayment_integration_test.go
@@ -1,0 +1,100 @@
+//go:build integration
+
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package redis
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	libConstants "github.com/LerianStudio/lib-commons/v6/commons/constants"
+
+	"github.com/LerianStudio/midaz/v4/pkg/constant"
+	"github.com/LerianStudio/midaz/v4/pkg/mmodel"
+	"github.com/LerianStudio/midaz/v4/pkg/utils"
+)
+
+// findBalanceByAliasKey resolves a balance by its "<alias>#<key>" identity,
+// which is what disambiguates the legs when a batch carries several balances
+// sharing an alias or a balance key.
+func findBalanceByAliasKey(t *testing.T, balances []*mmodel.Balance, aliasKey string) *mmodel.Balance {
+	t.Helper()
+
+	for _, balance := range balances {
+		if balance != nil && balance.Alias == aliasKey {
+			return balance
+		}
+	}
+
+	require.Failf(t, "balance not found", "alias key %q not found", aliasKey)
+
+	return nil
+}
+
+// TestIntegration_Overdraft_PendingDestinationCreditDefersRepayment locks the
+// deferred-leg contract: a PENDING create carries the destination CREDIT into
+// the atomic batch, but that credit only posts at commit. When the destination
+// already carries outstanding overdraft the script must leave it completely
+// alone — repaying against an Available the credit never reached drives the
+// result negative, and the floor block then re-accrues the deficit on top of
+// the outstanding OverdraftUsed, doubling it.
+func TestIntegration_Overdraft_PendingDestinationCreditDefersRepayment(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	infra := setupRedisIntegrationInfra(t)
+	ctx := context.Background()
+	orgID := uuid.New()
+	ledgerID := uuid.New()
+	sourceAliasKey := "@pending-defer-src" + "#" + constant.DefaultBalanceKey
+	destAliasKey := "@pending-defer-dst" + "#" + constant.DefaultBalanceKey
+
+	destSettings := &mmodel.BalanceSettings{
+		BalanceScope:          mmodel.BalanceScopeTransactional,
+		AllowOverdraft:        true,
+		OverdraftLimitEnabled: true,
+		OverdraftLimit:        ptrString("100"),
+	}
+
+	sourceOp := pendingOverdraftBalanceOp(orgID, ledgerID, "@pending-defer-src", constant.DefaultBalanceKey, constant.DirectionCredit,
+		decimal.NewFromInt(1000), decimal.Zero, decimal.Zero, 1, nil,
+		constant.ONHOLD, constant.PENDING, decimal.NewFromInt(60), decimal.Zero, false)
+
+	destOp := pendingOverdraftBalanceOp(orgID, ledgerID, "@pending-defer-dst", constant.DefaultBalanceKey, constant.DirectionCredit,
+		decimal.Zero, decimal.Zero, decimal.NewFromInt(50), 1, destSettings,
+		libConstants.CREDIT, constant.PENDING, decimal.NewFromInt(60), decimal.Zero, false)
+
+	result, err := infra.repo.ProcessBalanceAtomicOperation(ctx, orgID, ledgerID,
+		uuid.New(), constant.PENDING, true, []mmodel.BalanceOperation{sourceOp, destOp})
+	require.NoError(t, err)
+
+	sourceAfter := findBalanceByAliasKey(t, result.After, sourceAliasKey)
+	assert.True(t, sourceAfter.Available.Equal(decimal.NewFromInt(940)), "got %s", sourceAfter.Available.String())
+	assert.True(t, sourceAfter.OnHold.Equal(decimal.NewFromInt(60)), "got %s", sourceAfter.OnHold.String())
+
+	for _, balance := range result.After {
+		if balance != nil {
+			assert.NotEqual(t, destAliasKey, balance.Alias,
+				"the deferred destination credit changed nothing, so it must not report a mutation")
+		}
+	}
+
+	// An unchanged balance is deliberately absent from the atomic result, so the
+	// cache entry is the only place its final values can be read back.
+	destCached := readCachedBalance(t, infra, utils.BalanceInternalKey(orgID, ledgerID, destAliasKey))
+
+	assert.Equal(t, "0", destCached.Available,
+		"a pending create must not move the destination available")
+	assert.Equal(t, "50", destCached.OverdraftUsed,
+		"a pending create must neither repay nor re-accrue the destination overdraft")
+	assert.Equal(t, int64(1), destCached.Version, "an untouched balance must not consume a version")
+}

--- a/components/ledger/internal/adapters/redis/transaction/consumer_overdraft_repayment_integration_test.go
+++ b/components/ledger/internal/adapters/redis/transaction/consumer_overdraft_repayment_integration_test.go
@@ -39,6 +39,29 @@ func findBalanceByAliasKey(t *testing.T, balances []*mmodel.Balance, aliasKey st
 	return nil
 }
 
+// findLatestBalanceByAliasKey returns the highest-version snapshot for an alias
+// key, which is what a batch mutating the same balance twice requires (the
+// route-validated cancel splits the source restore into RELEASE + CREDIT).
+func findLatestBalanceByAliasKey(t *testing.T, balances []*mmodel.Balance, aliasKey string) *mmodel.Balance {
+	t.Helper()
+
+	var latest *mmodel.Balance
+
+	for _, balance := range balances {
+		if balance == nil || balance.Alias != aliasKey {
+			continue
+		}
+
+		if latest == nil || balance.Version > latest.Version {
+			latest = balance
+		}
+	}
+
+	require.NotNilf(t, latest, "alias key %q not found", aliasKey)
+
+	return latest
+}
+
 // TestIntegration_Overdraft_PendingDestinationCreditDefersRepayment locks the
 // deferred-leg contract: a PENDING create carries the destination CREDIT into
 // the atomic batch, but that credit only posts at commit. When the destination
@@ -157,4 +180,120 @@ func TestIntegration_Overdraft_CommitDestinationCreditRepaysOnce(t *testing.T) {
 	companionAfter := findBalanceByAliasKey(t, result.After, companionAliasKey)
 	assert.True(t, companionAfter.Available.IsZero(),
 		"the companion must shed the repaid liability in lock-step; got %s", companionAfter.Available.String())
+}
+
+// TestIntegration_Overdraft_CancelDefersDestinationCredit locks the third batch
+// of the two-phase lifecycle. A cancel batch still carries the destination
+// CREDIT (only the operation-record slice drops the destination legs, not the
+// validate maps that drive the balance operations), and that credit is as
+// deferred on a cancel as it is on the create — the destination never received
+// anything, so a cancel must leave it completely alone.
+//
+// The destination credit is the one leg route validation never marks
+// ("destinations always use plain CREDIT"), which is exactly what separates it
+// from the source restore: the source comes through as a RELEASE in the legacy
+// shape and as a route-validated CREDIT in the other, and both must keep
+// repaying. Both shapes are covered here.
+func TestIntegration_Overdraft_CancelDefersDestinationCredit(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	destSettings := func() *mmodel.BalanceSettings {
+		return &mmodel.BalanceSettings{
+			BalanceScope:          mmodel.BalanceScopeTransactional,
+			AllowOverdraft:        true,
+			OverdraftLimitEnabled: true,
+			OverdraftLimit:        ptrString("100"),
+		}
+	}
+
+	// assertDestinationUntouched is the shared verdict: the deferred leg reports
+	// no mutation and its cached state is byte-for-byte what it was.
+	assertDestinationUntouched := func(ctx context.Context, t *testing.T, infra *integrationTestInfra,
+		result *mmodel.BalanceAtomicResult, orgID, ledgerID uuid.UUID, destAliasKey string,
+	) {
+		t.Helper()
+
+		for _, balance := range result.After {
+			if balance != nil {
+				assert.NotEqual(t, destAliasKey, balance.Alias,
+					"the deferred destination credit changed nothing, so it must not report a mutation")
+			}
+		}
+
+		cached := readCachedBalance(t, infra, utils.BalanceInternalKey(orgID, ledgerID, destAliasKey))
+
+		assert.Equal(t, "0", cached.Available,
+			"a cancel must not move the destination available")
+		assert.Equal(t, "50", cached.OverdraftUsed,
+			"a cancel must neither repay nor re-accrue the destination overdraft")
+		assert.Equal(t, int64(1), cached.Version, "an untouched balance must not consume a version")
+	}
+
+	t.Run("route_validated_shape", func(t *testing.T) {
+		infra := setupRedisIntegrationInfra(t)
+		ctx := context.Background()
+		orgID := uuid.New()
+		ledgerID := uuid.New()
+		payerAliasKey := "@cancel-defer-rv-payer" + "#" + constant.DefaultBalanceKey
+		destAliasKey := "@cancel-defer-rv-dst" + "#" + constant.DefaultBalanceKey
+
+		// Route-validated cancel splits the source restore in two: RELEASE drops
+		// the hold, a sibling CREDIT gives Available back.
+		release := pendingOverdraftBalanceOp(orgID, ledgerID, "@cancel-defer-rv-payer", constant.DefaultBalanceKey, constant.DirectionCredit,
+			decimal.NewFromInt(940), decimal.NewFromInt(60), decimal.Zero, 1, nil,
+			constant.RELEASE, constant.CANCELED, decimal.NewFromInt(60), decimal.Zero, true)
+
+		restore := pendingOverdraftBalanceOp(orgID, ledgerID, "@cancel-defer-rv-payer", constant.DefaultBalanceKey, constant.DirectionCredit,
+			decimal.NewFromInt(940), decimal.NewFromInt(60), decimal.Zero, 1, nil,
+			libConstants.CREDIT, constant.CANCELED, decimal.NewFromInt(60), decimal.Zero, true)
+
+		// The destination carries outstanding overdraft and never received the
+		// pending credit. Route validation does not mark destination legs.
+		destOp := pendingOverdraftBalanceOp(orgID, ledgerID, "@cancel-defer-rv-dst", constant.DefaultBalanceKey, constant.DirectionCredit,
+			decimal.Zero, decimal.Zero, decimal.NewFromInt(50), 1, destSettings(),
+			libConstants.CREDIT, constant.CANCELED, decimal.NewFromInt(60), decimal.Zero, false)
+
+		result, err := infra.repo.ProcessBalanceAtomicOperation(ctx, orgID, ledgerID,
+			uuid.New(), constant.CANCELED, true, []mmodel.BalanceOperation{release, restore, destOp})
+		require.NoError(t, err)
+
+		payerAfter := findLatestBalanceByAliasKey(t, result.After, payerAliasKey)
+		assert.True(t, payerAfter.Available.Equal(decimal.NewFromInt(1000)),
+			"the cancel must restore the payer in full; got %s", payerAfter.Available.String())
+		assert.True(t, payerAfter.OnHold.IsZero(), "got %s", payerAfter.OnHold.String())
+
+		assertDestinationUntouched(ctx, t, infra, result, orgID, ledgerID, destAliasKey)
+	})
+
+	t.Run("legacy_shape", func(t *testing.T) {
+		infra := setupRedisIntegrationInfra(t)
+		ctx := context.Background()
+		orgID := uuid.New()
+		ledgerID := uuid.New()
+		payerAliasKey := "@cancel-defer-lg-payer" + "#" + constant.DefaultBalanceKey
+		destAliasKey := "@cancel-defer-lg-dst" + "#" + constant.DefaultBalanceKey
+
+		// Without route validation the RELEASE both drops the hold and restores
+		// Available in one operation.
+		release := pendingOverdraftBalanceOp(orgID, ledgerID, "@cancel-defer-lg-payer", constant.DefaultBalanceKey, constant.DirectionCredit,
+			decimal.NewFromInt(940), decimal.NewFromInt(60), decimal.Zero, 1, nil,
+			constant.RELEASE, constant.CANCELED, decimal.NewFromInt(60), decimal.Zero, false)
+
+		destOp := pendingOverdraftBalanceOp(orgID, ledgerID, "@cancel-defer-lg-dst", constant.DefaultBalanceKey, constant.DirectionCredit,
+			decimal.Zero, decimal.Zero, decimal.NewFromInt(50), 1, destSettings(),
+			libConstants.CREDIT, constant.CANCELED, decimal.NewFromInt(60), decimal.Zero, false)
+
+		result, err := infra.repo.ProcessBalanceAtomicOperation(ctx, orgID, ledgerID,
+			uuid.New(), constant.CANCELED, true, []mmodel.BalanceOperation{release, destOp})
+		require.NoError(t, err)
+
+		payerAfter := findLatestBalanceByAliasKey(t, result.After, payerAliasKey)
+		assert.True(t, payerAfter.Available.Equal(decimal.NewFromInt(1000)),
+			"the cancel must restore the payer in full; got %s", payerAfter.Available.String())
+		assert.True(t, payerAfter.OnHold.IsZero(), "got %s", payerAfter.OnHold.String())
+
+		assertDestinationUntouched(ctx, t, infra, result, orgID, ledgerID, destAliasKey)
+	})
 }

--- a/components/ledger/internal/adapters/redis/transaction/consumer_overdraft_repayment_integration_test.go
+++ b/components/ledger/internal/adapters/redis/transaction/consumer_overdraft_repayment_integration_test.go
@@ -98,3 +98,63 @@ func TestIntegration_Overdraft_PendingDestinationCreditDefersRepayment(t *testin
 		"a pending create must neither repay nor re-accrue the destination overdraft")
 	assert.Equal(t, int64(1), destCached.Version, "an untouched balance must not consume a version")
 }
+
+// TestIntegration_Overdraft_CommitDestinationCreditRepaysOnce locks the commit
+// half of the same lifecycle: the destination credit posts on the APPROVED
+// transition, so that is where the overdraft repayment happens. The enrichment
+// layer queues a sibling CREDIT on the direction=debit companion, and the two
+// legs must settle exactly one repayment between them — the primary keeps the
+// remainder, the companion sheds the repaid liability.
+func TestIntegration_Overdraft_CommitDestinationCreditRepaysOnce(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	infra := setupRedisIntegrationInfra(t)
+	ctx := context.Background()
+	orgID := uuid.New()
+	ledgerID := uuid.New()
+	sourceAliasKey := "@commit-repay-src" + "#" + constant.DefaultBalanceKey
+	destAliasKey := "@commit-repay-dst" + "#" + constant.DefaultBalanceKey
+	companionAliasKey := "@commit-repay-dst" + "#" + constant.OverdraftBalanceKey
+
+	destSettings := &mmodel.BalanceSettings{
+		BalanceScope:          mmodel.BalanceScopeTransactional,
+		AllowOverdraft:        true,
+		OverdraftLimitEnabled: true,
+		OverdraftLimit:        ptrString("100"),
+	}
+
+	// Commit consumes the hold the pending create reserved: the source leg is an
+	// ON_HOLD under route validation and never touches Available.
+	sourceOp := pendingOverdraftBalanceOp(orgID, ledgerID, "@commit-repay-src", constant.DefaultBalanceKey, constant.DirectionCredit,
+		decimal.NewFromInt(940), decimal.NewFromInt(60), decimal.Zero, 1, nil,
+		constant.ONHOLD, constant.APPROVED, decimal.NewFromInt(60), decimal.Zero, true)
+
+	destOp := pendingOverdraftBalanceOp(orgID, ledgerID, "@commit-repay-dst", constant.DefaultBalanceKey, constant.DirectionCredit,
+		decimal.Zero, decimal.Zero, decimal.NewFromInt(50), 1, destSettings,
+		libConstants.CREDIT, constant.APPROVED, decimal.NewFromInt(60), decimal.Zero, false)
+
+	companionOp := pendingOverdraftBalanceOp(orgID, ledgerID, "@commit-repay-dst", constant.OverdraftBalanceKey, constant.DirectionDebit,
+		decimal.NewFromInt(50), decimal.Zero, decimal.Zero, 1, nil,
+		libConstants.CREDIT, constant.APPROVED, decimal.NewFromInt(50), decimal.Zero, false)
+
+	result, err := infra.repo.ProcessBalanceAtomicOperation(ctx, orgID, ledgerID,
+		uuid.New(), constant.APPROVED, true, []mmodel.BalanceOperation{sourceOp, destOp, companionOp})
+	require.NoError(t, err)
+
+	sourceAfter := findBalanceByAliasKey(t, result.After, sourceAliasKey)
+	assert.True(t, sourceAfter.Available.Equal(decimal.NewFromInt(940)),
+		"a commit consumes the hold, not available; got %s", sourceAfter.Available.String())
+	assert.True(t, sourceAfter.OnHold.IsZero(), "got %s", sourceAfter.OnHold.String())
+
+	destAfter := findBalanceByAliasKey(t, result.After, destAliasKey)
+	assert.True(t, destAfter.Available.Equal(decimal.NewFromInt(10)),
+		"available must receive credit minus repayment; got %s", destAfter.Available.String())
+	assert.True(t, destAfter.OverdraftUsed.IsZero(),
+		"the credit must repay the outstanding overdraft exactly once; got %s", destAfter.OverdraftUsed.String())
+
+	companionAfter := findBalanceByAliasKey(t, result.After, companionAliasKey)
+	assert.True(t, companionAfter.Available.IsZero(),
+		"the companion must shed the repaid liability in lock-step; got %s", companionAfter.Available.String())
+}

--- a/components/ledger/internal/adapters/redis/transaction/scripts/balance_atomic_operation.lua
+++ b/components/ledger/internal/adapters/redis/transaction/scripts/balance_atomic_operation.lua
@@ -498,8 +498,19 @@ local function main()
         -- concurrent transaction already reduced OverdraftUsed), the whole
         -- batch rolls back with 0174 so the caller re-reads state and
         -- retries with a consistent split.
+        --
+        -- A destination CREDIT on a PENDING create is excluded: that leg is
+        -- DEFERRED to the commit, so the ladder above leaves `result` at the
+        -- untouched Available. Repaying here would subtract from a balance
+        -- that never received the credit, pushing `result` negative so the
+        -- floor block below re-accrues the deficit on top of the outstanding
+        -- OverdraftUsed. The repayment belongs to the APPROVED transition,
+        -- where the credit actually posts.
+        local isDeferredPendingLeg = isPending == 1 and transactionStatus == "PENDING"
+
         if operation == "CREDIT" and not isDebitDirection and
             balance.AccountType ~= "external" and
+            not isDeferredPendingLeg and
             isPositive(balance.OverdraftUsed) then
             local sameBatchCancelCredit = operation == "CREDIT" and transactionStatus == "CANCELED" and
                 routeValidationEnabled == 1 and tonumber(balance.Version) == (tonumber(incomingVersion) + 1)

--- a/components/ledger/internal/adapters/redis/transaction/scripts/balance_atomic_operation.lua
+++ b/components/ledger/internal/adapters/redis/transaction/scripts/balance_atomic_operation.lua
@@ -499,18 +499,32 @@ local function main()
         -- batch rolls back with 0174 so the caller re-reads state and
         -- retries with a consistent split.
         --
-        -- A destination CREDIT on a PENDING create is excluded: that leg is
-        -- DEFERRED to the commit, so the ladder above leaves `result` at the
-        -- untouched Available. Repaying here would subtract from a balance
-        -- that never received the credit, pushing `result` negative so the
-        -- floor block below re-accrues the deficit on top of the outstanding
-        -- OverdraftUsed. The repayment belongs to the APPROVED transition,
-        -- where the credit actually posts.
-        local isDeferredPendingLeg = isPending == 1 and transactionStatus == "PENDING"
+        -- DEFERRED destination legs are excluded. A two-phase transaction
+        -- carries its destination CREDIT into every batch of the lifecycle, but
+        -- the leg only POSTS on the commit. On the create and on the cancel the
+        -- ladder above matches no branch, so `result` stays at the untouched
+        -- Available; repaying from it would subtract from a balance that never
+        -- received the credit, pushing `result` negative so the floor block
+        -- below re-accrues the deficit on top of the outstanding OverdraftUsed
+        -- and DOUBLES it on a leg that moved no money.
+        --
+        -- Enumerating the ladder, a CREDIT on a direction=credit balance posts
+        -- to Available in exactly two cases: CANCELED with route validation ON
+        -- (the source restore) and APPROVED (the commit). There is no
+        -- CREDIT+PENDING branch at all, and the CANCELED+isDebitDirection branch
+        -- cannot reach here because the repayment requires not isDebitDirection.
+        -- So the deferred legs are PENDING, and CANCELED with route validation
+        -- OFF — a shape only the destination leg can have, because in a cancel
+        -- batch the source restore is the RELEASE branch in the legacy shape and
+        -- the route-validated CREDIT in the other. The Go enrichment layer gates
+        -- refund collection on the SAME rule so the two sides cannot drift.
+        local isDeferredCreditLeg = isPending == 1 and
+            (transactionStatus == "PENDING" or
+                (transactionStatus == "CANCELED" and routeValidationEnabled == 0))
 
         if operation == "CREDIT" and not isDebitDirection and
             balance.AccountType ~= "external" and
-            not isDeferredPendingLeg and
+            not isDeferredCreditLeg and
             isPositive(balance.OverdraftUsed) then
             local sameBatchCancelCredit = operation == "CREDIT" and transactionStatus == "CANCELED" and
                 routeValidationEnabled == 1 and tonumber(balance.Version) == (tonumber(incomingVersion) + 1)

--- a/components/ledger/internal/adapters/redis/transaction/scripts/balance_atomic_operation.lua
+++ b/components/ledger/internal/adapters/redis/transaction/scripts/balance_atomic_operation.lua
@@ -407,10 +407,12 @@ local function main()
                     result = sub_decimal(balance.Available, amount)
                 end
             elseif operation == "DEBIT" and transactionStatus == "PENDING" and isDebitDirection then
-                -- Legacy pending overdraft companion: the user-facing source
-                -- is an ON_HOLD, but the internal direction=debit companion
-                -- receives a synthetic DEBIT so liability state matches the
-                -- one-phase overdraft path.
+                -- Pending overdraft companion. Holds no longer draw overdraft,
+                -- so no new pending emits this leg; the branch is retained
+                -- because a pending created under an earlier build may still
+                -- replay through the backup consumer. It grows a
+                -- direction=debit balance, so it never reaches the accrual
+                -- block below.
                 result = add_decimal(balance.Available, amount)
             elseif operation == "ON_HOLD" and transactionStatus == "PENDING" and routeValidationEnabled == 1 then
                 -- Double-entry: ON_HOLD only increments OnHold.
@@ -563,15 +565,33 @@ local function main()
             result = sub_decimal(result, repay)
         end
 
+        -- A HOLD never draws overdraft. Debt is created only by CONCLUSIVE
+        -- operations — the direct create, and the revert that is shaped like
+        -- one — so a pending create that would overdraw falls through to the
+        -- 0018 rejection below and moves nothing, on every route version.
+        --
+        -- Only the source hold can go negative in a PENDING batch: the legacy
+        -- shape's single ON_HOLD and the route-validated shape's DEBIT leg both
+        -- subtract from Available. Nothing else there reaches this block — the
+        -- pending companion DEBIT lands on a direction=debit balance and grows
+        -- it, and the deferred destination credit leaves Available untouched.
+        --
+        -- This gates the CREATE side only. A pending that already drew overdraft
+        -- under an earlier build still has to be committed or canceled, so the
+        -- unwind branches above (the pending companion, the RELEASE overdraft
+        -- reversal, the same-batch cancel credit) are deliberately retained.
+        local isHold = transactionStatus == "PENDING"
+
         if startsWithMinus(result) and balance.AccountType ~= "external" then
             -- Direction-aware overdraft: credit-direction balances with
             -- AllowOverdraft=1 may go temporarily negative. The shortfall
             -- is floored at zero in Available and accrued in OverdraftUsed,
             -- subject to OverdraftLimit when enabled.
             --
-            -- Debit-direction balances and credit-direction balances without
-            -- AllowOverdraft fall through to the legacy 0018 rejection.
-            if balance.Direction == "credit" and (balance.AllowOverdraft or 0) == 1 then
+            -- Debit-direction balances, credit-direction balances without
+            -- AllowOverdraft, and every hold fall through to the legacy 0018
+            -- rejection.
+            if balance.Direction == "credit" and (balance.AllowOverdraft or 0) == 1 and not isHold then
                 -- deficit = abs(result). Because result is negative,
                 -- sub_decimal("0", result) produces the absolute value.
                 local deficit = sub_decimal("0", result)


### PR DESCRIPTION
## Description

Destination-side overdraft was only handled correctly on the direct create path. Across the two-phase lifecycle it corrupted balances:

- **Pending create** to a destination with outstanding overdraft: the Lua repayment block ran on the deferred destination credit (a leg that must not post until commit), driving available negative; the overdraft accrual block then floored it and re-accrued the deficit — `overdraftUsed` doubled.
- **Commit**: the repayment happened in Lua but the state handler never ran overdraft enrichment for APPROVED, so no companion credit, no `overdraft.credit` route validation (0492), no OVERDRAFT audit row — and the primary credit clipped to the observed movement (0), losing the repaid amount from the trail.
- **Cancel**: the destination credit leg of a canceled pending (never marked `RouteValidationEnabled`, which only applies to From legs) hit the same deferred-leg fall-through and corrupted the destination again.

This PR fixes all of the above and lands one product decision: **pending holds never draw overdraft**. Both behavior changes ride the v4 line this branch targets. A hold exceeding available rejects with `0018` even on `allowOverdraft` balances, on both route mounts — debt is created only by conclusive operations (direct create; revert is direct-shaped). Destination repayment stays on direct and commit. Commit/cancel unwind of pendings that drew overdraft under earlier builds is preserved (Lua replay branches retained), so in-flight pendings keep working across the deploy.

Commits (each individually RED-verified):

1. `fix(ledger): keep deferred pending credits out of the overdraft repayment path`
2. `fix(ledger): enrich and validate overdraft repayment on commit`
3. `test(ledger): cover the overdraft seam through the full handler chain`
4. `fix(ledger): keep canceled destination credits out of the overdraft repayment path`
5. `fix(ledger): reject overdraft draws on pending holds`

## Type of Change

- [ ] `feat`: New feature or capability
- [x] `fix`: Bug fix
- [ ] `perf`: Performance improvement
- [ ] `refactor`: Internal restructuring with no behavior change
- [ ] `docs`: Documentation only
- [ ] `style`: Formatting, whitespace, naming (no logic change)
- [x] `test`: Adding or updating tests
- [ ] `ci`: CI pipeline or workflow changes
- [ ] `build`: Build system, Dockerfile, Go module dependencies
- [ ] `chore`: Maintenance, config, tooling
- [ ] `revert`: Reverts a previous commit
- [ ] `BREAKING CHANGE`: Consumers must update their integration

## Breaking Changes

None flagged — develop is already the breaking v4 line, and these ship within it. Two deliberate behavior changes for the release notes:

- A pending transaction whose hold exceeds available now rejects `422/0018` even when the balance has `allowOverdraft` (previously it drew overdraft at hold time). Applies to both route mounts.
- With `validateRoutes` enabled, a commit whose destination credit repays outstanding overdraft now requires the destination operation route to define an `overdraft.credit` rubric (`422/0492` otherwise) and emits the OVERDRAFT companion operation — previously the repayment posted unvalidated and without an audit row.

## Testing

- [x] `make test` passes
- [x] `make test-int` passes if integration paths are exercised
- [x] `make lint` passes
- [x] `make sec` and `make vulncheck` pass

**Test evidence / Actions run:** pre-push hook ran the full unit suite, security and lint gates. Integration suites (`-tags integration`) green for `adapters/http/in` (1842) and `adapters/redis/transaction` (163), including new tests for each fixed layer (RED-verified by reverting each fix individually). Behavior additionally verified end-to-end against a local stack: direct draw/repayment, pending→commit, pending→cancel, and the new 0018 hold rejection.

## Architectural Checklist

- [x] No `panic()` in production paths
- [x] Timestamps use `time.Now().UTC()`
- [x] Errors wrapped with `%w`
- [x] Handlers stay thin (parse, validate, call service)
- [x] Infrastructure concerns kept in `internal/bootstrap`

## Related Issues

None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Pending holds no longer draw overdraft funds or create overdraft debt.
  * Deferred pending and canceled credits no longer trigger premature repayments.
  * Approved commits and eligible reversals now correctly repay destination overdrafts.
  * Canceled, route-validated source credits continue to receive capped repayment handling.
  * Balance updates remain unchanged when overdraft activity is deferred or rejected.

* **Tests**
  * Added comprehensive coverage for pending, approved, canceled, reverted, and route-validated transaction flows, including insufficient-funds and accounting validation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->