### PR TITLE
fix(ledger): string-based decimal comparison in balance Lua script

### DIFF
--- a/components/ledger/internal/adapters/redis/transaction/consumer_decimal_arithmetic_integration_test.go
+++ b/components/ledger/internal/adapters/redis/transaction/consumer_decimal_arithmetic_integration_test.go
@@ -1,0 +1,296 @@
+//go:build integration
+
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package redis
+
+import (
+	"context"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/redis/go-redis/v9"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// =============================================================================
+// DECIMAL ARITHMETIC INTEGRATION TESTS
+//
+// These tests exercise sub_decimal/add_decimal/min_decimal/cmp_decimal from
+// balance_atomic_operation.lua directly against the real engine (Valkey via
+// testcontainers), independent of the balance-mutation path that main()
+// drives. They lock the string-based comparison fix (cmp_decimal replacing
+// the IEEE-754 double comparison) and the borrow-invariant tripwire.
+// =============================================================================
+
+// decimalArithmeticHarnessLua dispatches to the pure arithmetic helpers
+// defined earlier in balance_atomic_operation.lua. It is appended to the
+// embedded script after main()'s entrypoint is stripped, so the helpers run
+// unmodified against the real Lua engine without invoking any balance
+// mutation.
+const decimalArithmeticHarnessLua = `
+local op = ARGV[1]
+local a = ARGV[2]
+local b = ARGV[3]
+
+if op == "sub" then
+    return sub_decimal(a, b)
+elseif op == "add" then
+    return add_decimal(a, b)
+elseif op == "min" then
+    return min_decimal(a, b)
+elseif op == "cmp" then
+    return tostring(cmp_decimal(a, b))
+end
+
+return redis.error_reply("decimal harness: unknown op " .. tostring(op))
+`
+
+// decimalArithmeticScript strips the "return main()" entrypoint from the
+// embedded script and appends decimalArithmeticHarnessLua, exposing the pure
+// arithmetic helpers for direct EVAL.
+func decimalArithmeticScript(t *testing.T) string {
+	t.Helper()
+
+	idx := strings.LastIndex(balanceAtomicOperationLua, "return main()")
+	require.Greaterf(t, idx, -1, "expected balance_atomic_operation.lua to contain the main() entrypoint")
+
+	return balanceAtomicOperationLua[:idx] + decimalArithmeticHarnessLua
+}
+
+// newDecimalArithmeticHarness builds the *redis.Script once for a test, so
+// repeated evaluations benefit from server-side script caching (EVALSHA)
+// instead of re-sending the source on every call.
+func newDecimalArithmeticHarness(t *testing.T) *redis.Script {
+	t.Helper()
+
+	return redis.NewScript(decimalArithmeticScript(t))
+}
+
+// evalDecimalOp runs one of sub/add/min/cmp against the real engine and
+// returns the raw string result the script produced.
+func evalDecimalOp(t *testing.T, harness *redis.Script, client redis.Scripter, op, a, b string) (string, error) {
+	t.Helper()
+
+	result, err := harness.Run(context.Background(), client, []string{}, op, a, b).Result()
+	if err != nil {
+		return "", err
+	}
+
+	s, ok := result.(string)
+	require.Truef(t, ok, "expected string result for op %q, got %T", op, result)
+
+	return s, nil
+}
+
+// assertDecimalEquivalent cross-checks the script's canonical string result
+// against shopspring/decimal as a numeric oracle, guarding against a golden
+// case whose expected literal drifted from the value it names.
+func assertDecimalEquivalent(t *testing.T, want, got string, expectedValue decimal.Decimal) {
+	t.Helper()
+
+	gotDec, err := decimal.NewFromString(got)
+	require.NoErrorf(t, err, "script result %q for expected %q must parse as a decimal", got, want)
+	assert.Truef(t, gotDec.Equal(expectedValue),
+		"script result %q (%s) must equal the oracle value %s", got, gotDec, expectedValue)
+}
+
+func TestIntegration_DecimalArithmetic_SubDecimal_GoldenCases(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	infra := setupRedisIntegrationInfra(t)
+	harness := newDecimalArithmeticHarness(t)
+
+	cases := []struct {
+		name string
+		a, b string
+		want string
+	}{
+		// Audit repro cases (finding G1): the IEEE-754 double comparison in
+		// the pre-fix sub_decimal broke at these magnitudes/scales.
+		{"repro_18_decimal_places", "1.000000000000000001", "1.000000000000000002", "-0.000000000000000001"},
+		{"repro_19_digit_integers", "1000000000000000000", "1000000000000000001", "-1"},
+		{"repro_8_decimals_at_1e9", "1000000000.00000001", "1000000000.00000002", "-0.00000001"},
+		{"repro_2_decimals_at_1e14", "100000000000000.01", "100000000000000.02", "-0.01"},
+
+		// Small values that already worked pre-fix; must not regress.
+		{"small_positive_result", "10.50", "3.25", "7.25"},
+		{"small_negative_result", "3.25", "10.50", "-7.25"},
+
+		// Both signs.
+		{"both_negative_a_more_negative", "-10", "-3", "-7"},
+		{"both_negative_b_more_negative", "-3", "-10", "7"},
+		{"negative_minus_positive", "-5", "3", "-8"},
+		{"positive_minus_negative", "5", "-3", "8"},
+
+		// Zeros and equal values.
+		{"zero_minus_zero", "0", "0", "0"},
+		{"equal_decimals_result_zero", "42.5", "42.5", "0"},
+		{"equal_integers_result_zero", "100", "100", "0"},
+
+		// Leading zeros in the integer part.
+		{"leading_zeros_positive_result", "007", "003", "4"},
+		{"leading_zeros_negative_result", "003", "007", "-4"},
+
+		// Fraction-only and integer-only operands.
+		{"fraction_only_positive_result", "0.5", "0.25", "0.25"},
+		{"fraction_only_negative_result", "0.25", "0.5", "-0.25"},
+		{"integer_only", "1000000", "1", "999999"},
+
+		// Mixed scales.
+		{"mixed_scale_a_more_decimals", "1.23456", "1.2", "0.03456"},
+		{"mixed_scale_b_more_decimals", "1.2", "1.23456", "-0.03456"},
+
+		// High magnitude beyond double precision, no fraction.
+		{"high_magnitude_integer", "999999999999999999999999999999", "1", "999999999999999999999999999998"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := evalDecimalOp(t, harness, infra.redisContainer.Client, "sub", tc.a, tc.b)
+			require.NoError(t, err)
+			assert.Equalf(t, tc.want, got, "sub_decimal(%s, %s)", tc.a, tc.b)
+
+			aDec, err := decimal.NewFromString(tc.a)
+			require.NoError(t, err)
+			bDec, err := decimal.NewFromString(tc.b)
+			require.NoError(t, err)
+			assertDecimalEquivalent(t, tc.want, got, aDec.Sub(bDec))
+		})
+	}
+}
+
+func TestIntegration_DecimalArithmetic_AddDecimal_GoldenCases(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	infra := setupRedisIntegrationInfra(t)
+	harness := newDecimalArithmeticHarness(t)
+
+	cases := []struct {
+		name string
+		a, b string
+		want string
+	}{
+		{"high_magnitude_carries_a_new_digit", "999999999999999999999999999999", "1", "1000000000000000000000000000000"},
+		{"repro_18_decimal_places", "1.000000000000000001", "1.000000000000000002", "2.000000000000000003"},
+		{"repro_19_digit_integers", "1000000000000000000", "1000000000000000001", "2000000000000000001"},
+		{"both_negative", "-5", "-3", "-8"},
+		{"negative_plus_positive", "-5", "3", "-2"},
+		{"positive_plus_negative", "5", "-3", "2"},
+		{"small_values", "10.50", "3.25", "13.75"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := evalDecimalOp(t, harness, infra.redisContainer.Client, "add", tc.a, tc.b)
+			require.NoError(t, err)
+			assert.Equalf(t, tc.want, got, "add_decimal(%s, %s)", tc.a, tc.b)
+
+			aDec, err := decimal.NewFromString(tc.a)
+			require.NoError(t, err)
+			bDec, err := decimal.NewFromString(tc.b)
+			require.NoError(t, err)
+			assertDecimalEquivalent(t, tc.want, got, aDec.Add(bDec))
+		})
+	}
+}
+
+func TestIntegration_DecimalArithmetic_MinDecimal_GoldenCases(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	infra := setupRedisIntegrationInfra(t)
+	harness := newDecimalArithmeticHarness(t)
+
+	cases := []struct {
+		name string
+		a, b string
+		want string
+	}{
+		// Audit repro: pre-fix min_decimal (built on the buggy sub_decimal)
+		// returned the LARGER operand at this magnitude.
+		{"repro_min_18_digit_integers_a_smaller", "100000000000000001", "100000000000000002", "100000000000000001"},
+		{"repro_min_18_digit_integers_b_smaller", "100000000000000002", "100000000000000001", "100000000000000001"},
+
+		{"small_a_smaller", "3.25", "10.50", "3.25"},
+		{"small_b_smaller", "10.50", "3.25", "3.25"},
+		{"equal_returns_b", "5", "5", "5"},
+		{"negative_a_smaller", "-5", "3", "-5"},
+		{"negative_b_smaller", "5", "-3", "-3"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := evalDecimalOp(t, harness, infra.redisContainer.Client, "min", tc.a, tc.b)
+			require.NoError(t, err)
+			assert.Equalf(t, tc.want, got, "min_decimal(%s, %s)", tc.a, tc.b)
+
+			aDec, err := decimal.NewFromString(tc.a)
+			require.NoError(t, err)
+			bDec, err := decimal.NewFromString(tc.b)
+			require.NoError(t, err)
+			assertDecimalEquivalent(t, tc.want, got, decimal.Min(aDec, bDec))
+		})
+	}
+}
+
+func TestIntegration_DecimalArithmetic_CmpDecimal_GoldenCases(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	infra := setupRedisIntegrationInfra(t)
+	harness := newDecimalArithmeticHarness(t)
+
+	cases := []struct {
+		name string
+		a, b string
+		want int
+	}{
+		{"repro_19_digit_integers_a_smaller", "1000000000000000000", "1000000000000000001", -1},
+		{"repro_18_decimal_places_a_smaller", "1.000000000000000001", "1.000000000000000002", -1},
+		{"equal_integers", "100", "100", 0},
+		{"equal_decimals", "42.50", "42.5", 0},
+		{"a_greater", "10.50", "3.25", 1},
+		{"a_smaller", "3.25", "10.50", -1},
+		{"both_negative_a_greater", "-3", "-10", 1},
+		{"both_negative_a_smaller", "-10", "-3", -1},
+
+		// Zero normalization: -0, 0.00 and 0 all compare equal to zero,
+		// regardless of the literal sign carried in the string.
+		{"negative_zero_equals_zero", "-0", "0", 0},
+		{"zero_equals_padded_zero", "0.00", "0", 0},
+		{"negative_padded_zero_equals_zero", "-0.00", "0", 0},
+		{"zero_equals_negative_zero_reversed", "0", "-0", 0},
+
+		{"leading_zeros_equal", "007", "7", 0},
+		{"leading_zeros_a_smaller", "007", "008", -1},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := evalDecimalOp(t, harness, infra.redisContainer.Client, "cmp", tc.a, tc.b)
+			require.NoError(t, err)
+
+			gotInt, err := strconv.Atoi(got)
+			require.NoErrorf(t, err, "cmp_decimal(%s, %s) must return an integer, got %q", tc.a, tc.b, got)
+			assert.Equalf(t, tc.want, gotInt, "cmp_decimal(%s, %s)", tc.a, tc.b)
+
+			aDec, err := decimal.NewFromString(tc.a)
+			require.NoError(t, err)
+			bDec, err := decimal.NewFromString(tc.b)
+			require.NoError(t, err)
+			assert.Equal(t, aDec.Cmp(bDec), gotInt, "cmp_decimal must agree with the shopspring/decimal oracle")
+		})
+	}
+}

--- a/components/ledger/internal/adapters/redis/transaction/consumer_decimal_arithmetic_property_test.go
+++ b/components/ledger/internal/adapters/redis/transaction/consumer_decimal_arithmetic_property_test.go
@@ -1,0 +1,122 @@
+//go:build integration && property
+
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package redis
+
+// This test needs testcontainers (redistestutil), which in this package is
+// gated behind the `integration` tag, not `property` — every other
+// `property`-tagged file here runs pure in-process logic with no container.
+// It carries both tags so it stays out of a bare `-tags property` run (and
+// out of `-tags integration`, which would otherwise pull it into the default
+// integration suite); run it explicitly with `-tags "integration property"`.
+
+import (
+	"math/rand"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/require"
+)
+
+// =============================================================================
+// PROPERTY-BASED TESTS — Decimal Arithmetic vs shopspring/decimal
+//
+// Random (a, b) decimal string pairs (integer part 1-30 digits, fractional
+// part 0-24 digits, either sign) are run through sub_decimal/add_decimal/
+// min_decimal/cmp_decimal on the real engine and checked against
+// shopspring/decimal as the arbitrary-precision oracle.
+//
+// Run with:
+//
+//	go test -tags "integration property" -run TestProperty_DecimalArithmetic -v -count=1 \
+//	    ./components/ledger/internal/adapters/redis/transaction/
+// =============================================================================
+
+const (
+	decimalPropertySeed       = 1337
+	decimalPropertyIterations = 300
+	decimalPropertyMaxIntLen  = 30
+	decimalPropertyMaxFracLen = 24
+)
+
+// randomDecimalString generates an arbitrary-magnitude, arbitrary-scale
+// decimal string: 1-30 integer digits (leading zeros allowed, matching what
+// split_decimal accepts), 0-24 fractional digits, either sign.
+func randomDecimalString(r *rand.Rand) string {
+	intLen := r.Intn(decimalPropertyMaxIntLen) + 1
+	fracLen := r.Intn(decimalPropertyMaxFracLen + 1)
+	negative := r.Intn(2) == 0
+
+	var sb strings.Builder
+
+	if negative {
+		sb.WriteByte('-')
+	}
+
+	for i := 0; i < intLen; i++ {
+		sb.WriteByte(byte('0' + r.Intn(10)))
+	}
+
+	if fracLen > 0 {
+		sb.WriteByte('.')
+
+		for i := 0; i < fracLen; i++ {
+			sb.WriteByte(byte('0' + r.Intn(10)))
+		}
+	}
+
+	return sb.String()
+}
+
+func TestProperty_DecimalArithmetic_MatchesShopspringOracle(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping property test in short mode")
+	}
+
+	infra := setupRedisIntegrationInfra(t)
+	harness := newDecimalArithmeticHarness(t)
+
+	r := rand.New(rand.NewSource(decimalPropertySeed))
+
+	for i := 0; i < decimalPropertyIterations; i++ {
+		a := randomDecimalString(r)
+		b := randomDecimalString(r)
+
+		aDec, err := decimal.NewFromString(a)
+		require.NoErrorf(t, err, "iteration %d: generated operand %q must parse", i, a)
+		bDec, err := decimal.NewFromString(b)
+		require.NoErrorf(t, err, "iteration %d: generated operand %q must parse", i, b)
+
+		gotSub, err := evalDecimalOp(t, harness, infra.redisContainer.Client, "sub", a, b)
+		require.NoError(t, err)
+		gotSubDec, err := decimal.NewFromString(gotSub)
+		require.NoErrorf(t, err, "iteration %d: sub_decimal(%s, %s) = %q must parse", i, a, b, gotSub)
+		require.Truef(t, gotSubDec.Equal(aDec.Sub(bDec)),
+			"iteration %d: sub_decimal(%s, %s) = %s, want %s", i, a, b, gotSubDec, aDec.Sub(bDec))
+
+		gotAdd, err := evalDecimalOp(t, harness, infra.redisContainer.Client, "add", a, b)
+		require.NoError(t, err)
+		gotAddDec, err := decimal.NewFromString(gotAdd)
+		require.NoErrorf(t, err, "iteration %d: add_decimal(%s, %s) = %q must parse", i, a, b, gotAdd)
+		require.Truef(t, gotAddDec.Equal(aDec.Add(bDec)),
+			"iteration %d: add_decimal(%s, %s) = %s, want %s", i, a, b, gotAddDec, aDec.Add(bDec))
+
+		gotMin, err := evalDecimalOp(t, harness, infra.redisContainer.Client, "min", a, b)
+		require.NoError(t, err)
+		gotMinDec, err := decimal.NewFromString(gotMin)
+		require.NoErrorf(t, err, "iteration %d: min_decimal(%s, %s) = %q must parse", i, a, b, gotMin)
+		require.Truef(t, gotMinDec.Equal(decimal.Min(aDec, bDec)),
+			"iteration %d: min_decimal(%s, %s) = %s, want %s", i, a, b, gotMinDec, decimal.Min(aDec, bDec))
+
+		gotCmp, err := evalDecimalOp(t, harness, infra.redisContainer.Client, "cmp", a, b)
+		require.NoError(t, err)
+		gotCmpInt, err := strconv.Atoi(gotCmp)
+		require.NoErrorf(t, err, "iteration %d: cmp_decimal(%s, %s) = %q must be an integer", i, a, b, gotCmp)
+		require.Equalf(t, aDec.Cmp(bDec), gotCmpInt, "iteration %d: cmp_decimal(%s, %s)", i, a, b)
+	}
+}

--- a/components/ledger/internal/adapters/redis/transaction/consumer_high_magnitude_regression_integration_test.go
+++ b/components/ledger/internal/adapters/redis/transaction/consumer_high_magnitude_regression_integration_test.go
@@ -1,0 +1,354 @@
+//go:build integration
+
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package redis
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/LerianStudio/midaz/v4/pkg/constant"
+	"github.com/LerianStudio/midaz/v4/pkg/mmodel"
+	"github.com/LerianStudio/midaz/v4/pkg/utils"
+)
+
+// =============================================================================
+// HIGH-MAGNITUDE FAIL-CLOSED REGRESSION TESTS
+//
+// Finding G1: sub_decimal compared operands via tonumber (IEEE-754 double),
+// which mis-orders the subtraction above ~15-17 significant digits and
+// discarded the integer loop's final borrow, so a negative result could come
+// back as a huge positive number. min_decimal inherited the bug. Consequence:
+// the 0018 (insufficient funds) and 0167 (overdraft limit) gates, overdraft
+// repayment, and OnHold arithmetic all failed OPEN above double precision.
+//
+// These tests exercise ProcessBalanceAtomicOperation end to end (real engine,
+// not the pure arithmetic harness) at magnitudes/scales drawn from the audit
+// repro table, proving the consumers are fail-closed post-fix.
+// =============================================================================
+
+// TestIntegration_HighMagnitude_InsufficientFunds_Returns0018 proves the 0018
+// gate rejects a debit that exceeds Available only once precision goes past
+// what an IEEE-754 double can represent exactly, and that rejection leaves
+// the cached balance untouched.
+func TestIntegration_HighMagnitude_InsufficientFunds_Returns0018(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	t.Run("decimal_scale_at_1e9_direct_debit", func(t *testing.T) {
+		infra := setupRedisIntegrationInfra(t)
+		ctx := context.Background()
+		orgID := uuid.New()
+		ledgerID := uuid.New()
+
+		// Available and the debit differ by 1e-8, past the point where the
+		// pre-fix double comparison in sub_decimal broke (repro table: 8
+		// decimals at ~1e9).
+		op := overdraftOp(orgID, ledgerID, "@0018-scale-1e9", "deposit", constant.DirectionCredit,
+			decimal.RequireFromString("1000000000.00000001"), decimal.Zero, 1, nil,
+			constant.DEBIT, decimal.RequireFromString("1000000000.00000002"))
+
+		_, err := infra.repo.ProcessBalanceAtomicOperation(ctx, orgID, ledgerID,
+			uuid.New(), constant.APPROVED, false, []mmodel.BalanceOperation{op})
+
+		require.Error(t, err, "a debit exceeding available by 1e-8 at 1e9 magnitude must be rejected")
+		assert.Contains(t, err.Error(), constant.ErrInsufficientFunds.Error())
+
+		cached := readCachedBalance(t, infra, op.InternalKey)
+		assert.Equal(t, "1000000000.00000001", cached.Available, "rejected debit must not move available")
+		assert.Equal(t, int64(1), cached.Version, "rejected debit must not consume a version")
+	})
+
+	t.Run("integer_19_digits_direct_debit", func(t *testing.T) {
+		infra := setupRedisIntegrationInfra(t)
+		ctx := context.Background()
+		orgID := uuid.New()
+		ledgerID := uuid.New()
+
+		// 19-digit integers one unit apart: repro table entry where the
+		// double comparison broke by exactly 1 unit.
+		op := overdraftOp(orgID, ledgerID, "@0018-int19", "deposit", constant.DirectionCredit,
+			decimal.RequireFromString("1000000000000000000"), decimal.Zero, 1, nil,
+			constant.DEBIT, decimal.RequireFromString("1000000000000000001"))
+
+		_, err := infra.repo.ProcessBalanceAtomicOperation(ctx, orgID, ledgerID,
+			uuid.New(), constant.APPROVED, false, []mmodel.BalanceOperation{op})
+
+		require.Error(t, err, "a debit exceeding a 19-digit available by 1 must be rejected")
+		assert.Contains(t, err.Error(), constant.ErrInsufficientFunds.Error())
+
+		cached := readCachedBalance(t, infra, op.InternalKey)
+		assert.Equal(t, "1000000000000000000", cached.Available, "rejected debit must not move available")
+		assert.Equal(t, int64(1), cached.Version, "rejected debit must not consume a version")
+	})
+
+	t.Run("pending_hold_legacy_shape", func(t *testing.T) {
+		infra := setupRedisIntegrationInfra(t)
+		ctx := context.Background()
+		orgID := uuid.New()
+		ledgerID := uuid.New()
+		alias := "@0018-pending-legacy"
+
+		onHold := pendingOverdraftBalanceOp(orgID, ledgerID, alias, constant.DefaultBalanceKey, constant.DirectionCredit,
+			decimal.RequireFromString("100000000000000.01"), decimal.Zero, decimal.Zero, 1, nil,
+			constant.ONHOLD, constant.PENDING, decimal.RequireFromString("100000000000000.02"), decimal.Zero, false)
+
+		_, err := infra.repo.ProcessBalanceAtomicOperation(ctx, orgID, ledgerID,
+			uuid.New(), constant.PENDING, true, []mmodel.BalanceOperation{onHold})
+
+		require.Error(t, err, "a hold exceeding available at high magnitude must be rejected")
+		assert.Contains(t, err.Error(), constant.ErrInsufficientFunds.Error())
+
+		cached := readCachedBalance(t, infra, utils.BalanceInternalKey(orgID, ledgerID, alias+"#"+constant.DefaultBalanceKey))
+		assert.Equal(t, "100000000000000.01", cached.Available, "rejected hold must not move available")
+		assert.Equal(t, "0", cached.OnHold, "rejected hold must not place a hold")
+		assert.Equal(t, int64(1), cached.Version, "rejected hold must not consume a version")
+	})
+
+	t.Run("pending_hold_route_validated_shape", func(t *testing.T) {
+		infra := setupRedisIntegrationInfra(t)
+		ctx := context.Background()
+		orgID := uuid.New()
+		ledgerID := uuid.New()
+		alias := "@0018-pending-rv"
+
+		debit := pendingOverdraftBalanceOp(orgID, ledgerID, alias, constant.DefaultBalanceKey, constant.DirectionCredit,
+			decimal.RequireFromString("100000000000000.01"), decimal.Zero, decimal.Zero, 1, nil,
+			constant.DEBIT, constant.PENDING, decimal.RequireFromString("100000000000000.02"), decimal.Zero, true)
+		onHold := pendingOverdraftBalanceOp(orgID, ledgerID, alias, constant.DefaultBalanceKey, constant.DirectionCredit,
+			decimal.RequireFromString("100000000000000.01"), decimal.Zero, decimal.Zero, 1, nil,
+			constant.ONHOLD, constant.PENDING, decimal.RequireFromString("100000000000000.02"), decimal.Zero, true)
+
+		_, err := infra.repo.ProcessBalanceAtomicOperation(ctx, orgID, ledgerID,
+			uuid.New(), constant.PENDING, true, []mmodel.BalanceOperation{debit, onHold})
+
+		require.Error(t, err, "a hold exceeding available at high magnitude must be rejected")
+		assert.Contains(t, err.Error(), constant.ErrInsufficientFunds.Error())
+
+		cached := readCachedBalance(t, infra, utils.BalanceInternalKey(orgID, ledgerID, alias+"#"+constant.DefaultBalanceKey))
+		assert.Equal(t, "100000000000000.01", cached.Available, "rejected hold must not move available")
+		assert.Equal(t, "0", cached.OnHold, "rejected hold must not place a hold")
+		assert.Equal(t, int64(1), cached.Version, "rejected hold must not consume a version")
+	})
+}
+
+// TestIntegration_HighMagnitude_OverdraftLimit_Returns0167 proves the 0167
+// gate rejects a projected OverdraftUsed that exceeds the configured limit
+// only at high magnitude/scale, and that the at-limit boundary (deficit ==
+// limit) is still inclusive and allowed.
+func TestIntegration_HighMagnitude_OverdraftLimit_Returns0167(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	settings := func() *mmodel.BalanceSettings {
+		return &mmodel.BalanceSettings{
+			BalanceScope:          mmodel.BalanceScopeTransactional,
+			AllowOverdraft:        true,
+			OverdraftLimitEnabled: true,
+			OverdraftLimit:        ptrString("100000000000000.01"),
+		}
+	}
+
+	t.Run("exceeded_by_a_cent_at_1e14_rejected", func(t *testing.T) {
+		infra := setupRedisIntegrationInfra(t)
+		ctx := context.Background()
+		orgID := uuid.New()
+		ledgerID := uuid.New()
+
+		op := overdraftOp(orgID, ledgerID, "@0167-rejected", "deposit", constant.DirectionCredit,
+			decimal.Zero, decimal.Zero, 1, settings(),
+			constant.DEBIT, decimal.RequireFromString("100000000000000.02"))
+
+		_, err := infra.repo.ProcessBalanceAtomicOperation(ctx, orgID, ledgerID,
+			uuid.New(), constant.APPROVED, false, []mmodel.BalanceOperation{op})
+
+		require.Error(t, err, "deficit=100000000000000.02 with limit=100000000000000.01 must be rejected")
+		assert.Contains(t, err.Error(), constant.ErrOverdraftLimitExceeded.Error())
+
+		cached := readCachedBalance(t, infra, op.InternalKey)
+		assert.Equal(t, "0", cached.Available, "rollback must restore available")
+		assert.Equal(t, "0", cached.OverdraftUsed, "rollback must restore overdraft used")
+		assert.Equal(t, int64(1), cached.Version, "rejected overdraft must not consume a version")
+	})
+
+	t.Run("at_limit_at_1e14_allowed", func(t *testing.T) {
+		infra := setupRedisIntegrationInfra(t)
+		ctx := context.Background()
+		orgID := uuid.New()
+		ledgerID := uuid.New()
+
+		op := overdraftOp(orgID, ledgerID, "@0167-boundary", "deposit", constant.DirectionCredit,
+			decimal.Zero, decimal.Zero, 1, settings(),
+			constant.DEBIT, decimal.RequireFromString("100000000000000.01"))
+
+		result, err := infra.repo.ProcessBalanceAtomicOperation(ctx, orgID, ledgerID,
+			uuid.New(), constant.APPROVED, false, []mmodel.BalanceOperation{op})
+
+		require.NoError(t, err, "deficit==limit is inclusive and must be allowed")
+		require.Len(t, result.After, 1)
+		assert.True(t, result.After[0].Available.IsZero(), "available should floor at zero")
+		assert.True(t, result.After[0].OverdraftUsed.Equal(decimal.RequireFromString("100000000000000.01")),
+			"overdraft used should equal the limit, got %s", result.After[0].OverdraftUsed)
+	})
+
+	t.Run("exceeded_at_19_digit_integers_rejected", func(t *testing.T) {
+		infra := setupRedisIntegrationInfra(t)
+		ctx := context.Background()
+		orgID := uuid.New()
+		ledgerID := uuid.New()
+
+		intSettings := &mmodel.BalanceSettings{
+			BalanceScope:          mmodel.BalanceScopeTransactional,
+			AllowOverdraft:        true,
+			OverdraftLimitEnabled: true,
+			OverdraftLimit:        ptrString("1000000000000000000"),
+		}
+
+		op := overdraftOp(orgID, ledgerID, "@0167-int19", "deposit", constant.DirectionCredit,
+			decimal.Zero, decimal.Zero, 1, intSettings,
+			constant.DEBIT, decimal.RequireFromString("1000000000000000001"))
+
+		_, err := infra.repo.ProcessBalanceAtomicOperation(ctx, orgID, ledgerID,
+			uuid.New(), constant.APPROVED, false, []mmodel.BalanceOperation{op})
+
+		require.Error(t, err, "deficit exceeding a 19-digit limit by 1 must be rejected")
+		assert.Contains(t, err.Error(), constant.ErrOverdraftLimitExceeded.Error())
+	})
+}
+
+// TestIntegration_HighMagnitude_OverdraftRepayment_ExactSplit proves a credit
+// repaying outstanding overdraft at high magnitude/scale splits exactly: the
+// repayable portion decrements OverdraftUsed and only the remainder reaches
+// Available.
+func TestIntegration_HighMagnitude_OverdraftRepayment_ExactSplit(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	infra := setupRedisIntegrationInfra(t)
+	ctx := context.Background()
+	orgID := uuid.New()
+	ledgerID := uuid.New()
+
+	overdraftUsed := decimal.RequireFromString("100000000000000.02")
+	credit := decimal.RequireFromString("100000000000000.03")
+
+	op := overdraftOp(orgID, ledgerID, "@repay-high-magnitude", "deposit", constant.DirectionCredit,
+		decimal.Zero, overdraftUsed, 1, nil,
+		constant.CREDIT, credit)
+
+	result, err := infra.repo.ProcessBalanceAtomicOperation(ctx, orgID, ledgerID,
+		uuid.New(), constant.APPROVED, false, []mmodel.BalanceOperation{op})
+
+	require.NoError(t, err)
+	require.Len(t, result.After, 1)
+
+	assert.True(t, result.After[0].OverdraftUsed.IsZero(),
+		"the credit exceeds outstanding overdraft, so it must fully repay it; got %s",
+		result.After[0].OverdraftUsed)
+	assert.True(t, result.After[0].Available.Equal(decimal.RequireFromString("0.01")),
+		"the remainder after repayment (100000000000000.03-100000000000000.02) must land in available; got %s",
+		result.After[0].Available)
+
+	// Conservation: the credit is fully accounted for between the repayment
+	// (OverdraftUsed decrement) and the remainder (Available increment).
+	overdraftDelta := overdraftUsed.Sub(result.After[0].OverdraftUsed)
+	availableDelta := result.After[0].Available.Sub(decimal.Zero)
+	assert.True(t, overdraftDelta.Add(availableDelta).Equal(credit),
+		"overdraft repaid (%s) + available credited (%s) must equal the credit (%s)",
+		overdraftDelta, availableDelta, credit)
+}
+
+// TestIntegration_HighMagnitude_OnHoldLifecycle_CommitConservesAmount proves
+// a route-validated commit at high magnitude/scale moves the held amount
+// off the source's OnHold and onto the destination's Available with no
+// leakage: the two legs' deltas sum to zero.
+func TestIntegration_HighMagnitude_OnHoldLifecycle_CommitConservesAmount(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	infra := setupRedisIntegrationInfra(t)
+	ctx := context.Background()
+	orgID := uuid.New()
+	ledgerID := uuid.New()
+
+	amount := decimal.RequireFromString("1000000000.00000001")
+	sourceAvailable := decimal.RequireFromString("500")
+	destAvailableBefore := decimal.RequireFromString("1000000000.00000002")
+
+	sourceOp := pendingOverdraftBalanceOp(orgID, ledgerID, "@commit-hold-src", constant.DefaultBalanceKey, constant.DirectionCredit,
+		sourceAvailable, amount, decimal.Zero, 1, nil,
+		constant.ONHOLD, constant.APPROVED, amount, decimal.Zero, true)
+
+	destOp := pendingOverdraftBalanceOp(orgID, ledgerID, "@commit-hold-dst", constant.DefaultBalanceKey, constant.DirectionCredit,
+		destAvailableBefore, decimal.Zero, decimal.Zero, 1, nil,
+		constant.CREDIT, constant.APPROVED, amount, decimal.Zero, true)
+
+	result, err := infra.repo.ProcessBalanceAtomicOperation(ctx, orgID, ledgerID,
+		uuid.New(), constant.APPROVED, true, []mmodel.BalanceOperation{sourceOp, destOp})
+	require.NoError(t, err)
+
+	sourceAfter := findBalanceByAliasKey(t, result.After, "@commit-hold-src#"+constant.DefaultBalanceKey)
+	destAfter := findBalanceByAliasKey(t, result.After, "@commit-hold-dst#"+constant.DefaultBalanceKey)
+
+	assert.True(t, sourceAfter.OnHold.IsZero(), "the commit must fully drop the hold; got %s", sourceAfter.OnHold)
+	assert.True(t, sourceAfter.Available.Equal(sourceAvailable),
+		"a commit consumes the hold, not available; got %s", sourceAfter.Available)
+	assert.True(t, destAfter.Available.Equal(destAvailableBefore.Add(amount)),
+		"destination available must receive exactly the committed amount; got %s", destAfter.Available)
+
+	sourceOnHoldDelta := sourceAfter.OnHold.Sub(amount)
+	destAvailableDelta := destAfter.Available.Sub(destAvailableBefore)
+	assert.True(t, sourceOnHoldDelta.Add(destAvailableDelta).IsZero(),
+		"conservation: source OnHold delta (%s) + destination Available delta (%s) must sum to zero",
+		sourceOnHoldDelta, destAvailableDelta)
+}
+
+// TestIntegration_HighMagnitude_OnHoldLifecycle_CancelConservesAmount proves
+// a legacy-shape cancel at high magnitude/scale releases the hold back into
+// Available with no leakage on the same balance: the Available and OnHold
+// deltas sum to zero.
+func TestIntegration_HighMagnitude_OnHoldLifecycle_CancelConservesAmount(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	infra := setupRedisIntegrationInfra(t)
+	ctx := context.Background()
+	orgID := uuid.New()
+	ledgerID := uuid.New()
+
+	availableBefore := decimal.RequireFromString("300000000000000.02")
+	onHoldBefore := decimal.RequireFromString("100000000000000.01")
+	releaseAmount := onHoldBefore
+
+	release := pendingOverdraftBalanceOp(orgID, ledgerID, "@cancel-hold", constant.DefaultBalanceKey, constant.DirectionCredit,
+		availableBefore, onHoldBefore, decimal.Zero, 1, nil,
+		constant.RELEASE, constant.CANCELED, releaseAmount, decimal.Zero, false)
+
+	result, err := infra.repo.ProcessBalanceAtomicOperation(ctx, orgID, ledgerID,
+		uuid.New(), constant.CANCELED, true, []mmodel.BalanceOperation{release})
+	require.NoError(t, err)
+	require.Len(t, result.After, 1)
+
+	after := result.After[0]
+	assert.True(t, after.OnHold.IsZero(), "the cancel must fully release the hold; got %s", after.OnHold)
+	assert.True(t, after.Available.Equal(availableBefore.Add(releaseAmount)),
+		"the cancel must restore the full released amount to available; got %s", after.Available)
+
+	availableDelta := after.Available.Sub(availableBefore)
+	onHoldDelta := after.OnHold.Sub(onHoldBefore)
+	assert.True(t, availableDelta.Add(onHoldDelta).IsZero(),
+		"conservation: available delta (%s) + onHold delta (%s) must sum to zero", availableDelta, onHoldDelta)
+}

--- a/components/ledger/internal/adapters/redis/transaction/scripts/balance_atomic_operation.lua
+++ b/components/ledger/internal/adapters/redis/transaction/scripts/balance_atomic_operation.lua
@@ -19,6 +19,53 @@ local function rtrim_zeros(frac)
     return (frac == "" and "0") or frac
 end
 
+-- cmp_decimal compares two decimal strings and returns -1, 0, or 1 for
+-- a<b, a==b, a>b. String-based (no tonumber) so magnitudes and scales
+-- beyond IEEE-754 double precision still compare correctly.
+local function cmp_decimal(a, b)
+    a = tostring(a)
+    b = tostring(b)
+    local ai, af, a_negative = split_decimal(a)
+    local bi, bf, b_negative = split_decimal(b)
+
+    if a_negative then ai = ai:sub(2) end
+    if b_negative then bi = bi:sub(2) end
+
+    ai = ai:gsub("^0+", "")
+    if ai == "" then ai = "0" end
+    bi = bi:gsub("^0+", "")
+    if bi == "" then bi = "0" end
+
+    -- Zero has no sign: -0, 0.00, and 0 all compare equal to zero.
+    if a_negative and ai == "0" and rtrim_zeros(af) == "0" then a_negative = false end
+    if b_negative and bi == "0" and rtrim_zeros(bf) == "0" then b_negative = false end
+
+    if a_negative ~= b_negative then
+        if a_negative then return -1 end
+        return 1
+    end
+
+    local maxFrac = math.max(#af, #bf)
+    local afPadded = af .. string.rep("0", maxFrac - #af)
+    local bfPadded = bf .. string.rep("0", maxFrac - #bf)
+
+    local unsigned
+    if #ai ~= #bi then
+        unsigned = (#ai < #bi) and -1 or 1
+    elseif ai ~= bi then
+        unsigned = (ai < bi) and -1 or 1
+    elseif afPadded ~= bfPadded then
+        unsigned = (afPadded < bfPadded) and -1 or 1
+    else
+        unsigned = 0
+    end
+
+    if a_negative then
+        return -unsigned
+    end
+    return unsigned
+end
+
 local sub_decimal
 
 local function add_decimal(a, b)
@@ -103,9 +150,7 @@ sub_decimal = function(a, b)
         return add_decimal(a, b:sub(2))
     end
 
-    local a_num = tonumber(a)
-    local b_num = tonumber(b)
-    if a_num < b_num then
+    if cmp_decimal(a, b) < 0 then
         local result = sub_decimal(b, a)
         return "-" .. result
     end
@@ -151,6 +196,12 @@ sub_decimal = function(a, b)
         int_res_tbl[i] = tostring(diff)
     end
 
+    -- cmp_decimal above guarantees a >= b at this point, so the integer loop
+    -- can never underflow past the most significant digit.
+    if borrow ~= 0 then
+        error("sub_decimal: borrow invariant violated")
+    end
+
     local res_int_rev = table.concat(int_res_tbl)
     local res_int = res_int_rev:reverse():gsub("^0+", "")
     if res_int == "" then
@@ -189,12 +240,12 @@ local function cloneBalance(tbl)
     return copy
 end
 
--- min_decimal returns the smaller of two decimal strings. Implemented via
--- sub_decimal so the caller does not need a numeric coercion step — this
--- keeps the precision behavior identical to add_decimal/sub_decimal for
--- values that overflow Lua's double representation.
+-- min_decimal returns the smaller of two decimal strings, comparing
+-- directly via cmp_decimal — no subtraction step — so precision matches
+-- add_decimal/sub_decimal for values that overflow Lua's double
+-- representation.
 local function min_decimal(a, b)
-    if startsWithMinus(sub_decimal(a, b)) then
+    if cmp_decimal(a, b) < 0 then
         return a
     end
     return b

--- a/pkg/mtransaction/overdraft.go
+++ b/pkg/mtransaction/overdraft.go
@@ -7,7 +7,6 @@ package mtransaction
 import (
 	"github.com/shopspring/decimal"
 
-	"github.com/LerianStudio/midaz/v4/pkg"
 	pkgConstant "github.com/LerianStudio/midaz/v4/pkg/constant"
 
 	constant "github.com/LerianStudio/lib-commons/v6/commons/constants"
@@ -31,29 +30,6 @@ func CalculateOverdraftSplit(available, debitAmount decimal.Decimal) (debitOnDef
 	debitOnOverdraft = debitAmount.Sub(debitOnDefault)
 
 	return debitOnDefault, debitOnOverdraft
-}
-
-// ValidateOverdraftLimit checks whether adding a deficit to the currently
-// consumed overdraft would breach the configured overdraft limit.
-//
-//   - When limitEnabled is false the balance is treated as having unlimited
-//     overdraft and the function always returns nil.
-//   - When the resulting cumulative usage (currentOverdraftUsed + deficit)
-//     is less than or equal to the limit the function returns nil.
-//   - Otherwise the function returns an error wrapping the canonical
-//     constant.ErrOverdraftLimitExceeded sentinel (code 0167) so callers
-//     can branch with errors.Is.
-func ValidateOverdraftLimit(currentOverdraftUsed, deficit, overdraftLimit decimal.Decimal, limitEnabled bool) error {
-	if !limitEnabled {
-		return nil
-	}
-
-	projected := currentOverdraftUsed.Add(deficit)
-	if projected.GreaterThan(overdraftLimit) {
-		return pkg.ValidateBusinessError(pkgConstant.ErrOverdraftLimitExceeded, pkgConstant.EntityTransaction)
-	}
-
-	return nil
 }
 
 // NOTE: Empty-direction balances (Direction="") return (false, decimal.Zero)

--- a/pkg/mtransaction/overdraft_test.go
+++ b/pkg/mtransaction/overdraft_test.go
@@ -7,10 +7,8 @@ package mtransaction
 import (
 	"testing"
 
-	pkgConstant "github.com/LerianStudio/midaz/v4/pkg/constant"
 	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 // TestCalculateOverdraftSplit verifies the pure-function debit-split helper
@@ -95,119 +93,4 @@ func TestCalculateOverdraftSplit(t *testing.T) {
 			assert.False(t, gotOverdraft.IsNegative(), "debitOnOverdraft must never be negative")
 		})
 	}
-}
-
-// TestValidateOverdraftLimit verifies the pure-function limit check that
-// rejects a debit whose resulting overdraft usage would exceed the
-// configured limit. When the limit is disabled the function MUST treat
-// the balance as having unlimited overdraft.
-func TestValidateOverdraftLimit(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name                 string
-		currentOverdraftUsed decimal.Decimal
-		deficit              decimal.Decimal
-		overdraftLimit       decimal.Decimal
-		limitEnabled         bool
-		wantErr              bool
-		wantErrCode          string
-	}{
-		{
-			name:                 "limit disabled allows any deficit",
-			currentOverdraftUsed: decimal.NewFromInt(500),
-			deficit:              decimal.NewFromInt(1000000),
-			overdraftLimit:       decimal.NewFromInt(100),
-			limitEnabled:         false,
-			wantErr:              false,
-		},
-		{
-			name:                 "deficit within remaining limit allowed",
-			currentOverdraftUsed: decimal.NewFromInt(200),
-			deficit:              decimal.NewFromInt(300),
-			overdraftLimit:       decimal.NewFromInt(1000),
-			limitEnabled:         true,
-			wantErr:              false,
-		},
-		{
-			name:                 "deficit plus usage exactly at limit allowed",
-			currentOverdraftUsed: decimal.NewFromInt(400),
-			deficit:              decimal.NewFromInt(600),
-			overdraftLimit:       decimal.NewFromInt(1000),
-			limitEnabled:         true,
-			wantErr:              false,
-		},
-		{
-			name:                 "deficit exceeds limit is rejected with 0167",
-			currentOverdraftUsed: decimal.NewFromInt(800),
-			deficit:              decimal.NewFromInt(500),
-			overdraftLimit:       decimal.NewFromInt(1000),
-			limitEnabled:         true,
-			wantErr:              true,
-			wantErrCode:          "0167",
-		},
-		{
-			name:                 "first use of overdraft within limit allowed",
-			currentOverdraftUsed: decimal.NewFromInt(0),
-			deficit:              decimal.NewFromInt(500),
-			overdraftLimit:       decimal.NewFromInt(500),
-			limitEnabled:         true,
-			wantErr:              false,
-		},
-		{
-			name:                 "first use of overdraft exceeds limit rejected",
-			currentOverdraftUsed: decimal.NewFromInt(0),
-			deficit:              decimal.NewFromInt(501),
-			overdraftLimit:       decimal.NewFromInt(500),
-			limitEnabled:         true,
-			wantErr:              true,
-			wantErrCode:          "0167",
-		},
-		{
-			name:                 "cumulative usage precision preserved",
-			currentOverdraftUsed: decimal.RequireFromString("99.995"),
-			deficit:              decimal.RequireFromString("0.010"),
-			overdraftLimit:       decimal.RequireFromString("100.000"),
-			limitEnabled:         true,
-			wantErr:              true,
-			wantErrCode:          "0167",
-		},
-	}
-
-	for _, tt := range tests {
-		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			err := ValidateOverdraftLimit(tt.currentOverdraftUsed, tt.deficit, tt.overdraftLimit, tt.limitEnabled)
-
-			if tt.wantErr {
-				require.Error(t, err, "expected limit violation to return error")
-				if tt.wantErrCode != "" {
-					assert.Equal(t, tt.wantErrCode, codeFromError(err),
-						"expected error code %s, got %s from %v", tt.wantErrCode, codeFromError(err), err)
-				}
-				return
-			}
-			require.NoError(t, err, "expected success but got error: %v", err)
-		})
-	}
-}
-
-// TestValidateOverdraftLimit_SentinelMatches ensures the returned error
-// wraps the canonical overdraft-limit sentinel so downstream callers can
-// branch on the error with errors.Is.
-func TestValidateOverdraftLimit_SentinelMatches(t *testing.T) {
-	t.Parallel()
-
-	err := ValidateOverdraftLimit(
-		decimal.NewFromInt(0),
-		decimal.NewFromInt(10),
-		decimal.NewFromInt(5),
-		true,
-	)
-
-	require.Error(t, err)
-	assert.Equal(t, pkgConstant.ErrOverdraftLimitExceeded.Error(), codeFromError(err),
-		"returned error must carry the 0167 sentinel code")
 }

--- a/pkg/mtransaction/transaction.go
+++ b/pkg/mtransaction/transaction.go
@@ -45,7 +45,7 @@ type Balance struct {
 	// Only meaningful when OverdraftLimitEnabled is true.
 	//
 	// Type asymmetry note: this field is decimal.Decimal for runtime
-	// arithmetic (comparison, subtraction in ValidateOverdraftLimit). The
+	// arithmetic (comparison against cumulative overdraft usage). The
 	// corresponding BalanceSettings.OverdraftLimit is *string to preserve
 	// JSON precision across marshal/unmarshal cycles. ToTransactionBalance()
 	// in pkg/mmodel/balance.go bridges the two: it parses the *string into


### PR DESCRIPTION
## Description

`sub_decimal` in `balance_atomic_operation.lua` decided operand order by comparing `tonumber()` values — IEEE-754 doubles — so above ~15-17 significant digits the comparison could mis-order the subtraction, and the integer loop's final borrow was silently discarded: a result that should be negative could come back as a large positive value. `min_decimal`, built on `sub_decimal`, inherited the defect and could return the larger operand.

Since the Lua script is the sole authority for these gates (there is no Go-side pre-check), the consequences at high magnitude were fail-open:

- **0018 insufficient funds**: a debit exceeding `Available` was accepted (e.g. available `1000000000.00000001`, debit `1000000000.00000002` → accepted, balance corrupted to `9999999999.99999999`).
- **0167 overdraft limit**: a deficit exceeding the configured limit was accepted.
- **Overdraft repayment** and **on-hold arithmetic**: wrong splits/values.

Practical thresholds: 18-decimal amounts broke at ~1 unit, 8-decimal at ~1e9 units, 2-decimal from ~7e13 units.

### Fix

- New `cmp_decimal(a, b)`: pure string comparison — sign handling, `-0`/`0.00` zero normalization, integer compare by length then lexicographic after leading-zero strip, right-padded fraction compare.
- `sub_decimal` operand ordering now uses `cmp_decimal` instead of the double round-trip.
- `min_decimal` rewritten directly on `cmp_decimal` (no subtraction step), preserving the original tie-break.
- Borrow-invariant tripwire after the integer subtraction loop (unreachable by construction; fails loud instead of returning wrong money math).
- `add_decimal` audited: digit-wise operations are safe; its sign recursion delegates to the fixed `sub_decimal`. No change needed.
- Removed the dead `ValidateOverdraftLimit` Go helper (zero production callers) so the limit check keeps a single authority in the Lua script.

Note on behavior: operations that were previously (incorrectly) accepted at high magnitude are now rejected with 0018/0167 — this is the intended fail-closed behavior.

### Tests

- `consumer_decimal_arithmetic_integration_test.go`: golden cases for `sub`/`add`/`min`/`cmp` executed via EVAL against a real engine (testcontainers), asserting canonical strings plus `shopspring/decimal` equivalence.
- `consumer_high_magnitude_regression_integration_test.go`: fail-closed consumer regressions through `ProcessBalanceAtomicOperation` — 0018 (direct and pending, both shapes) with untouched-balance assertions, 0167 exceeded and at-limit inclusive, exact repayment split, on-hold commit/cancel conservation.
- `consumer_decimal_arithmetic_property_test.go` (`-tags "integration property"`): 300 random pairs (up to 30 integer digits, scale 0-24, both signs) against `shopspring/decimal` as the oracle.

## Type of Change

- [x] `fix`: Bug fix
- [x] `refactor`: Internal restructuring with no behavior change
- [x] `test`: Adding or updating tests

## Breaking Changes

None. The `(code, HTTP status)` error contract is unchanged; previously-accepted invalid operations are now correctly rejected.

## Testing

- [x] `make test` passes
- [x] `make test-int` passes if integration paths are exercised
- [x] `make lint` passes
- [x] `make sec` and `make vulncheck` pass

**Test evidence / Actions run:** Full `redis/transaction` integration suite: 228 passed, 0 failed (no existing test changed). Unit suites green. Property test: 300 iterations × 4 operations, no counterexample. Black-box e2e regression net added in LerianStudio/end-to-end#170, run both ways against a local stack: the fail-closed scenarios fail against a pre-fix ledger build and all pass against a build of this branch.

## Architectural Checklist

- [x] No `panic()` in production paths
- [x] Timestamps use `time.Now().UTC()`
- [x] Errors wrapped with `%w`
- [x] Handlers stay thin (parse, validate, call service)
- [x] Infrastructure concerns kept in `internal/bootstrap`

## Related Issues

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved decimal arithmetic for very large values and high-precision amounts.
  * Strengthened balance, overdraft, repayment, and on-hold transaction handling.
  * Ensured rejected operations leave balances and versions unchanged.

* **Tests**
  * Added broad coverage for decimal calculations, comparisons, boundary conditions, and transaction lifecycles.
  * Added deterministic property testing across randomly generated decimal values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->