### PR TITLE
refactor(pkg): remove test-only DefaultLedgerSettingsMap

### DIFF
--- a/pkg/mmodel/settings.go
+++ b/pkg/mmodel/settings.go
@@ -169,29 +169,6 @@ func DefaultLedgerSettings() LedgerSettings {
 	}
 }
 
-// DefaultLedgerSettingsMap returns the default ledger settings as a map[string]any.
-// This is useful for API responses where the typed struct needs to be serialized.
-// Uses the same canonical defaults as DefaultLedgerSettings.
-func DefaultLedgerSettingsMap() map[string]any {
-	return map[string]any{
-		"accounting": map[string]any{
-			"validateAccountType": defaultAccountingValidation.ValidateAccountType,
-			"validateRoutes":      defaultAccountingValidation.ValidateRoutes,
-			"requireHolder":       defaultAccountingValidation.RequireHolder,
-		},
-		"tracer": map[string]any{
-			"mode":        defaultTracerSettings.Mode,
-			"failPosture": defaultTracerSettings.FailPosture,
-			"timeoutMs":   defaultTracerSettings.TimeoutMs,
-		},
-		"overrides": map[string]any{
-			"allowFeeSkip":    defaultOverridePolicy.AllowFeeSkip,
-			"allowTracerSkip": defaultOverridePolicy.AllowTracerSkip,
-			"allowHolderSkip": defaultOverridePolicy.AllowHolderSkip,
-		},
-	}
-}
-
 // LedgerSettingsToMap converts LedgerSettings to a map[string]any suitable for persistence.
 // The result matches the LedgerSettings schema and can be passed to ValidateSettings or stored as JSONB.
 func LedgerSettingsToMap(s LedgerSettings) map[string]any {
@@ -303,7 +280,7 @@ func parseSettingsNumber(value any) (int, bool) {
 // To add new settings:
 //  1. Add the field to LedgerSettings struct
 //  2. Add the corresponding entry here with the appropriate type ("bool", "string", "number")
-//  3. Update DefaultLedgerSettings() and DefaultLedgerSettingsMap()
+//  3. Update DefaultLedgerSettings(), LedgerSettingsToMap() and ParseLedgerSettings()
 //  4. Add the matching pointer field to the *Input mirror in ledger_settings_input.go and
 //     emit it from ToSparseMap; without both, the field is PATCH-able but rejected on POST
 //     as an unknown field. TestSettingsSchema_HasMatchingInputField and

--- a/pkg/mmodel/settings_test.go
+++ b/pkg/mmodel/settings_test.go
@@ -53,8 +53,11 @@ func TestLedgerSettings_Comparable(t *testing.T) {
 	assert.False(t, a == b, "settings differing in Tracer.Mode must not be == equal")
 }
 
-func TestDefaultLedgerSettingsMap(t *testing.T) {
-	settings := DefaultLedgerSettingsMap()
+// TestLedgerSettingsToMap_DefaultsShape locks the JSONB-persisted key names and default
+// values produced from the typed defaults; renaming a key here breaks reading ledgers
+// already stored.
+func TestLedgerSettingsToMap_DefaultsShape(t *testing.T) {
+	settings := LedgerSettingsToMap(DefaultLedgerSettings())
 
 	assert.NotNil(t, settings)
 	accounting, ok := settings["accounting"].(map[string]any)
@@ -70,24 +73,10 @@ func TestDefaultLedgerSettingsMap(t *testing.T) {
 	assert.Equal(t, 250, tracer["timeoutMs"])
 }
 
-// TestDefaultLedgerSettingsMap_SerializesIdenticallyForExistingLedgers asserts that the
-// default map is deterministic and round-trips through JSON to a stable shape. Existing
-// ledgers that never set tracer settings must resolve to these defaults, so the default
-// map serialization is the contract their stored/absent settings are compared against.
-func TestDefaultLedgerSettingsMap_SerializesIdenticallyForExistingLedgers(t *testing.T) {
-	// The default map and the map produced from default typed settings must be identical.
-	assert.Equal(t, DefaultLedgerSettingsMap(), LedgerSettingsToMap(DefaultLedgerSettings()),
-		"DefaultLedgerSettingsMap must equal LedgerSettingsToMap(DefaultLedgerSettings())")
-
-	// JSON serialization must be stable across repeated calls (deterministic keys).
-	first, err := json.Marshal(DefaultLedgerSettingsMap())
-	require.NoError(t, err)
-	second, err := json.Marshal(DefaultLedgerSettingsMap())
-	require.NoError(t, err)
-	assert.JSONEq(t, string(first), string(second))
-
-	// An existing ledger with no tracer group parses to the tracer defaults: behavior
-	// is unchanged for settings written before the tracer group existed.
+// TestParseLedgerSettings_LegacyWithoutTracerGroupResolvesToTracerDefaults asserts that
+// settings stored before the tracer group existed (a map with only accounting) parse to
+// defaultTracerSettings.
+func TestParseLedgerSettings_LegacyWithoutTracerGroupResolvesToTracerDefaults(t *testing.T) {
 	legacy := ParseLedgerSettings(map[string]any{
 		"accounting": map[string]any{
 			"validateAccountType": true,
@@ -789,7 +778,7 @@ func TestSettingsDefaultOverridePolicyIsAllFalse(t *testing.T) {
 	assert.False(t, settings.Overrides.AllowTracerSkip, "AllowTracerSkip must default to false")
 	assert.False(t, settings.Overrides.AllowHolderSkip, "AllowHolderSkip must default to false")
 
-	overrides, ok := DefaultLedgerSettingsMap()["overrides"].(map[string]any)
+	overrides, ok := LedgerSettingsToMap(DefaultLedgerSettings())["overrides"].(map[string]any)
 	require.True(t, ok, "overrides section must exist in default map")
 	assert.Equal(t, false, overrides["allowFeeSkip"])
 	assert.Equal(t, false, overrides["allowTracerSkip"])


### PR DESCRIPTION
<table border="0" cellspacing="0" cellpadding="0">
  <tr>
    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
    <td><h1>Midaz</h1></td>
  </tr>
</table>

---

## Description

`mmodel.DefaultLedgerSettingsMap` (`pkg/mmodel/settings.go`) was a hand-written `map[string]any` of the default ledger settings with zero production callers. Its only references were in `pkg/mmodel/settings_test.go`, where it served as the fixture for a drift assertion against `LedgerSettingsToMap(DefaultLedgerSettings())`. Without the hand-written map there is no drift to guard, so the function goes away rather than becoming unexported.

Nothing flagged this automatically because `unused` never reports exported identifiers in non-`main` packages and `.golangci.yml` sets `run.tests: false`, so test-only use of an exported symbol is invisible from both directions. Surfaced by a dead-code review on a recent PR; the symbol was already test-only at that PR's base.

Changes:

- `pkg/mmodel/settings.go`: remove `DefaultLedgerSettingsMap`; step 3 of the `settingsSchema` checklist comment now names the three functions that actually change when a setting is added (`DefaultLedgerSettings`, `LedgerSettingsToMap`, `ParseLedgerSettings`).
- `pkg/mmodel/settings_test.go`: the default-shape test is renamed `TestLedgerSettingsToMap_DefaultsShape` and reads `LedgerSettingsToMap(DefaultLedgerSettings())`, keeping every key-name and value assertion (it is the lock on the JSONB-persisted shape). The map-vs-map equality and the `json.Marshal` determinism assertions are dropped (the first is meaningless without the hand-written map, the second is tautological for a Go map). The legacy case, a stored map with only `accounting` parsing to the tracer defaults, is kept as its own test, `TestParseLedgerSettings_LegacyWithoutTracerGroupResolvesToTracerDefaults`. The overrides-default test reads the same expression.

No behavior change. `git grep DefaultLedgerSettingsMap` returns nothing; a GitHub code search across the organization and globally finds no importers outside this repository.

## Type of Change

- [ ] `feat`: New feature or capability
- [ ] `fix`: Bug fix
- [ ] `perf`: Performance improvement
- [x] `refactor`: Internal restructuring with no behavior change
- [ ] `docs`: Documentation only
- [ ] `style`: Formatting, whitespace, naming (no logic change)
- [x] `test`: Adding or updating tests
- [ ] `ci`: CI pipeline or workflow changes
- [ ] `build`: Build system, Dockerfile, Go module dependencies
- [ ] `chore`: Maintenance, config, tooling
- [ ] `revert`: Reverts a previous commit
- [ ] `BREAKING CHANGE`: Consumers must update their integration

## Breaking Changes

Removes an exported symbol from `pkg/mmodel`. GitHub code search finds no consumers outside this repository, so this is treated as non-breaking for the module's users.

## Testing

- [x] `make test-unit` passes (15690 tests, 6 skipped, 0 failed)
- [ ] `make test-int` passes if integration paths are exercised (not run: no integration path touched)
- [x] `make lint` passes (golangci-lint v2.13.2, `./pkg/mmodel/...`: 0 issues; the pre-push hook's full `make lint` also passed)
- [x] `make sec` passes (run by the pre-push hook); `make vulncheck` was not run separately

**Test evidence / Actions run:** See CI on this PR.

## Architectural Checklist

- [x] No `panic()` in production paths
- [x] Timestamps use `time.Now().UTC()`
- [x] Errors wrapped with `%w`
- [x] Handlers stay thin (parse, validate, call service)
- [x] Infrastructure concerns kept in `internal/bootstrap`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed the legacy default ledger-settings map helper.
  * Updated settings handling to use the current typed conversion and parsing paths.

* **Bug Fixes**
  * Legacy settings without a tracer group now correctly resolve to tracer defaults.

* **Tests**
  * Updated coverage for default settings shape, conversion, overrides, and legacy compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->