### PR TITLE
fix(ci): align workflows with the shared workflows tier-2 boilerplate

### DIFF
--- a/.coderabbit.yml
+++ b/.coderabbit.yml
@@ -1,0 +1,9 @@
+reviews:
+  high_level_summary: false
+  review_status: true
+  auto_review:
+    enabled: false
+    base_branches:
+      - "develop"
+      - "release-candidate"
+      - "main"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,8 +30,6 @@ updates:
     commit-message:
       prefix: "chore"
       include: "scope"
-    ignore:
-      - dependency-name: "LerianStudio/*"
     groups:
       actions-core:
         patterns:

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -120,3 +120,7 @@
 - name: "released on @develop"
   color: "c2e0c6"
   description: Published in a develop pre-release (set by semantic-release)
+
+- name: review-ready
+  color: "0e8a16"
+  description: Checks passed -- CodeRabbit review requested by the gate

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -22,8 +22,6 @@ jobs:
     uses: LerianStudio/github-actions-shared-workflows/.github/workflows/go-pr-validation.yml@tier-2
     with:
       allowed_source_branches: 'hotfix/*|release-candidate'
-      # crm and fees are valid commit scopes even though both now live inside the
-      # ledger binary. Scope is warn-only (require_scope: false).
       pr_title_scopes: |
         crm
         ledger
@@ -42,16 +40,11 @@ jobs:
       go_version: "1.27.0"
       golangci_lint_version: "v2.13.2"
       app_name_prefix: "midaz"
-      # Analysis-class filter: every component dir with in-tree Go code. CRM rolls
-      # up under components/ledger (a ledger package tree, not a standalone
-      # component); reporter was extracted out of this repo entirely.
       filter_paths: |
         components/ledger
         components/tracer
       go_private_modules: "github.com/LerianStudio/*"
       ignore_file: ".trivyignore"
-      # Default plus .coderabbit.yaml: it's a CodeRabbit-only config file,
-      # not something the Go analysis/security pipelines need to react to.
       ignore_globs: "*.md docs/* .github/* LICENSE* .gitignore .coderabbit.yaml"
       shared_paths: |
         go.mod
@@ -61,9 +54,6 @@ jobs:
         Makefile
     secrets: inherit
 
-  # Required gate: regenerate the gRPC stubs from proto/ and fail if the committed
-  # stubs under pkg/proto are stale. buf and the protoc plugins run via pinned
-  # remote plugins (BUF_VERSION + buf.gen.yaml), so no global install is needed.
   check-proto:
     name: Check Proto
     runs-on: blacksmith-4vcpu-ubuntu-2404

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
   validate:
-    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/go-pr-validation.yml@v1.56.0
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/go-pr-validation.yml@tier-2
     with:
       enforce_source_branches: true
       allowed_source_branches: 'hotfix/*|release-candidate'

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -21,9 +21,7 @@ jobs:
   validate:
     uses: LerianStudio/github-actions-shared-workflows/.github/workflows/go-pr-validation.yml@tier-2
     with:
-      enforce_source_branches: true
       allowed_source_branches: 'hotfix/*|release-candidate'
-      target_branches_for_source_check: 'main'
       # crm and fees are valid commit scopes even though both now live inside the
       # ledger binary. Scope is warn-only (require_scope: false).
       pr_title_scopes: |

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -21,7 +21,6 @@ jobs:
   validate:
     uses: LerianStudio/github-actions-shared-workflows/.github/workflows/go-pr-validation.yml@tier-2
     with:
-      allowed_source_branches: 'hotfix/*|release-candidate'
       pr_title_scopes: |
         crm
         ledger

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
 
   pipeline:
     needs: dockerhub-visibility
-    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/go-release.yml@v1.56.0-beta.1
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/go-release.yml@tier-2
     with:
       enable_changelog: ${{ github.ref == 'refs/heads/main' }}
       release_single_app: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,16 +13,6 @@ permissions:
   packages: write
 
 jobs:
-  # Check Docker Hub visibility before the build: repositories are created on first
-  # push with the organization's private default, so without this an image is only
-  # public if someone remembered to flip it by hand. Runs before the push so a
-  # brand-new image never exists private, and derives its image list from the
-  # gitops_yaml_key_mappings below.
-  #
-  # strict: false until DOCKERHUB_REPO_ADMIN_TOKEN holds an organization access token
-  # with repo:admin. The push token can read visibility but not change it (403), so a
-  # strict gate today would only block every release without publishing anything. Flip
-  # to true once the token is in place and this becomes a real gate.
   dockerhub-visibility:
     uses: ./.github/workflows/dockerhub-visibility.yml
     with:
@@ -39,14 +29,8 @@ jobs:
       enable_changelog: ${{ github.ref == 'refs/heads/main' }}
       release_single_app: true
       app_name_prefix: "midaz"
-      # Default plus .coderabbit.yaml: it's a CodeRabbit-only config file,
-      # not something that should trigger a release or contact Ungoliant.
       ignore_globs: "*.md docs/* .github/* LICENSE* .gitignore .coderabbit.yaml"
       ungoliant_skip_globs: ".releaserc.yml .github/* .coderabbit.yaml"
-      # Image/release filter: the two app image-bearing components. CRM rolls up under
-      # components/ledger (a ledger package tree, not a standalone image); reporter
-      # was extracted out of this repo entirely. The dedicated migration-runner images
-      # are built separately via extra_builds below.
       filter_paths: |
         components/ledger
         components/tracer
@@ -55,10 +39,6 @@ jobs:
         go.sum
         pkg/
         Makefile
-      # Dedicated migration-runner images (FROM migrate/migrate), built from the
-      # repo root so the migration SQL is bundled. force_full_matrix ensures the
-      # image tag exists on every release, so the deploy PreSync Job never
-      # ImagePullBackOffs when a release doesn't touch migrations-image/.
       extra_builds: |
         [
           {
@@ -82,24 +62,11 @@ jobs:
       ungoliant_tenancy: st
       enable_helm_dispatch: true
       helm_chart: "midaz"
-      # Maps each midaz-* image to its Helm value-block key (bare keys). The midaz
-      # Helm chart must carry matching ledger/tracer blocks or those images build
-      # but never deploy.
       helm_values_key_mappings: '{"midaz-ledger": "ledger", "midaz-tracer": "tracer"}'
-      # Distinct schema from helm_values_key_mappings: keys carry a .tag suffix and
-      # values are full dotted YAML paths (.image.tag). The *-migrations tags nest
-      # under the parent service block (.ledger/.tracer .migrations.image.tag).
-      # This is also the image list the dockerhub-visibility job reads, so an image
-      # added here is kept public automatically; one added without a mapping is not.
       gitops_yaml_key_mappings: '{"midaz-ledger.tag": ".ledger.image.tag", "midaz-tracer.tag": ".tracer.image.tag", "midaz-ledger-migrations.tag": ".ledger.migrations.image.tag", "midaz-tracer-migrations.tag": ".tracer.migrations.image.tag"}'
       enable_apidog_e2e: true
       enable_e2e_tests: true
       e2e_modules: "midaz-ledger,midaz-crm"
       e2e_tenancy: st
-      # Publish ledger (onboarding + transaction) and tracer migration SQL to S3 for the
-      # managed-Postgres deploy pipeline. Neither app self-migrates at startup anymore
-      # (in-process migration was removed); schema is applied out-of-band — via this S3
-      # pipeline (managed Postgres) or the dedicated migration-runner images / PreSync
-      # Job (see extra_builds above).
       s3_uploads: '[{"s3_bucket":"lerian-migration-files","file_pattern":"components/ledger/migrations/onboarding/*.sql","s3_prefix":"ledger/onboarding/postgresql","strip_prefix":"components/ledger/migrations/onboarding","flatten":false},{"s3_bucket":"lerian-migration-files","file_pattern":"components/ledger/migrations/transaction/*.sql","s3_prefix":"ledger/transaction/postgresql","strip_prefix":"components/ledger/migrations/transaction","flatten":false},{"s3_bucket":"lerian-migration-files","file_pattern":"components/tracer/migrations/*.sql","s3_prefix":"tracer/postgresql","strip_prefix":"components/tracer/migrations","flatten":false}]'
     secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,8 +29,6 @@ jobs:
       enable_changelog: ${{ github.ref == 'refs/heads/main' }}
       release_single_app: true
       app_name_prefix: "midaz"
-      ignore_globs: "*.md docs/* .github/* LICENSE* .gitignore .coderabbit.yaml"
-      ungoliant_skip_globs: ".releaserc.yml .github/* .coderabbit.yaml"
       filter_paths: |
         components/ledger
         components/tracer

--- a/.github/workflows/routine.yml
+++ b/.github/workflows/routine.yml
@@ -41,7 +41,7 @@ jobs:
     # routine.yml@v1.46.5 has no 'backmerge' routine — every child job inside
     # it would skip, wasting the whole call for that workflow_dispatch value.
     if: inputs.routine != 'backmerge'
-    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/routine.yml@v1.46.5
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/routine.yml@tier-2
     with:
       routine: ${{ inputs.routine || 'all' }}
       dry_run: ${{ inputs.dry_run || false }}
@@ -64,7 +64,7 @@ jobs:
       (github.event_name == 'push' && github.ref_name == 'develop')
       || github.event_name == 'schedule'
       || (github.event_name == 'workflow_dispatch' && (inputs.routine == 'all' || inputs.routine == 'backmerge'))
-    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/backmerge.yml@v1.57.0
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/backmerge.yml@tier-2
     with:
       rules: |
         [

--- a/.github/workflows/routine.yml
+++ b/.github/workflows/routine.yml
@@ -5,10 +5,6 @@ on:
     - cron: "0 3 * * 1"
   pull_request:
     types: [closed]
-  # No per-branch paths filter: GitHub Actions doesn't support different
-  # `paths` per branch within one `on.push` block. main pushes gain a
-  # labels_sync run beyond .github/labels.yml changes (idempotent, cheap);
-  # develop pushes exist to trigger the backmerge job below.
   push:
     branches: [main, develop]
   workflow_dispatch:
@@ -38,27 +34,15 @@ permissions:
 
 jobs:
   routine:
-    # routine.yml@v1.46.5 has no 'backmerge' routine — every child job inside
-    # it would skip, wasting the whole call for that workflow_dispatch value.
     if: inputs.routine != 'backmerge'
     uses: LerianStudio/github-actions-shared-workflows/.github/workflows/routine.yml@tier-2
     with:
       routine: ${{ inputs.routine || 'all' }}
       dry_run: ${{ inputs.dry_run || false }}
       merged_branch: ${{ github.head_ref }}
-      # fork is persistent (see fork-pr-notice.yml / fork-pr-promote.yml),
-      # not disposable — without this, branch_cleanup_merged would delete
-      # it the moment the fork -> develop promotion PR (whose head IS
-      # fork) merges, and branch_cleanup_stale could delete it too if it
-      # goes quiet between fork PRs.
       extra_protected_branches: "fork"
     secrets: inherit
 
-  # Keeps the persistent `fork` branch (see fork-pr-notice.yml /
-  # fork-pr-promote.yml) in sync with develop, via the shared org backmerge
-  # orchestrator rather than a bespoke merge script. direct-with-pr-fallback:
-  # merges straight to fork when clean, opens a PR instead of failing
-  # outright when develop and fork's own unpromoted commits conflict.
   backmerge:
     if: |
       (github.event_name == 'push' && github.ref_name == 'develop')

--- a/Makefile
+++ b/Makefile
@@ -729,4 +729,3 @@ dashboards-verify: dashboards
 	$(call print_title,Verifying dashboards against telemetry dictionary)
 	@./scripts/verify-dashboard-primitives.sh
 	@echo "[ok] Every referenced metric is documented"
-


### PR DESCRIPTION
## Description

Migrates this repository from version-pinned shared workflows to the **`@tier-2` channel**, and finishes the standardization items that were still missing.

**Why tier-2.** The channel a repo pins *is* its statement about how fast it wants to receive. `tier-2` receives a stable release only after tier-0 and tier-1 have accepted it, which is the right posture here. It also ends the bump-PR-per-release loop: propagation is now a channel promotion inside `github-actions-shared-workflows` (`tier-promotion.yml`), not a commit in this repo. **This pin is not edited again.**

**Dependabot.** The `ignore: LerianStudio/*` entry existed only to stop Dependabot rewriting the version pins. With a branch ref there is nothing to rewrite — the `github-actions` ecosystem only touches refs it recognises as a version (semver tag or SHA), never a branch. The entry is removed; the `github-actions` ecosystem itself **stays**, since it is what keeps `actions/*`, `docker/*` and third-party actions on current SHAs.

Order matters and is respected here: the pin migration and the `ignore` removal land in the **same commit**. Removing the `ignore` first would have reopened Dependabot on the version pins — the exact opposite of the goal.

**CodeRabbit.** Adds `.coderabbit.yml` so reviews are requested by the CI gate instead of firing on every push:

- `auto_review.enabled: false` — nothing automatic
- `auto_review.base_branches` — the bases this repo actually uses. **Not optional:** absent, only the default branch is eligible and every other PR is refused with *"Auto reviews are disabled on base/target branches other than the default branch"*
- no `labels` key — under `enabled: false` a label becomes a second, competing trigger
- `review_status: true`, `high_level_summary: false`

The gate itself is already enabled by default in the `go-pr-validation` umbrella, so no new job is needed. The `review-ready` label it applies is now declared in `.github/labels.yml`.

## Type of Change

- [ ] `feat`: New feature
- [x] `fix`: Bug fix / CI correction
- [ ] `refactor`: Internal restructuring with no behavior change
- [ ] `docs`: Documentation only
- [ ] `chore`: Dependency bumps, config updates, maintenance
- [ ] `BREAKING CHANGE`

## Breaking Changes

None for this repository's code. Two behavioural notes:

- The workflows this repo runs now change when the **channel** is promoted, not when a version is bumped here. A regression reaching `tier-2` has already been accepted at tier-0 and tier-1.
- The title uses `fix(ci):`, so merging produces a **patch release** via semantic-release. Use `ci(workflows):` instead if a release is not wanted.

## Testing

- [x] YAML syntax validated locally on every changed file
- [x] Verified `tier-0`, `tier-1` and `tier-2` exist as branches on the shared repo
- [x] Confirmed no `enable_coderabbit_gate: false` anywhere — the umbrella default applies
- [x] `base_branches` derived from real usage (`gh pr list --state all --limit 100`), not from which branches merely exist

**Note on the CodeRabbit config:** it takes effect **from the merge, not from this branch**. CodeRabbit reads `.coderabbit.yml` from the base branch, so this PR is judged by the current (absent) config. Validation happens on the *next* PR.

## Rationale moved out of the YAML

The caller workflows now carry configuration only. Every substantive note that lived as an inline comment is reproduced here, verbatim in substance, so nothing is lost by the cleanup.

<details>
<summary><code>.github/workflows/pr-validation.yml</code></summary>

```
crm and fees are valid commit scopes even though both now live inside the
ledger binary. Scope is warn-only (require_scope: false).
Analysis-class filter: every component dir with in-tree Go code. CRM rolls
up under components/ledger (a ledger package tree, not a standalone
component); reporter was extracted out of this repo entirely.
Default plus .coderabbit.yaml: it's a CodeRabbit-only config file,
not something the Go analysis/security pipelines need to react to.
Required gate: regenerate the gRPC stubs from proto/ and fail if the committed
stubs under pkg/proto are stale. buf and the protoc plugins run via pinned
remote plugins (BUF_VERSION + buf.gen.yaml), so no global install is needed.
```

</details>

<details>
<summary><code>.github/workflows/release.yml</code></summary>

```
Check Docker Hub visibility before the build: repositories are created on first
push with the organization's private default, so without this an image is only
public if someone remembered to flip it by hand. Runs before the push so a
brand-new image never exists private, and derives its image list from the
gitops_yaml_key_mappings below.

strict: false until DOCKERHUB_REPO_ADMIN_TOKEN holds an organization access token
with repo:admin. The push token can read visibility but not change it (403), so a
strict gate today would only block every release without publishing anything. Flip
to true once the token is in place and this becomes a real gate.
Default plus .coderabbit.yaml: it's a CodeRabbit-only config file,
not something that should trigger a release or contact Ungoliant.
Image/release filter: the two app image-bearing components. CRM rolls up under
components/ledger (a ledger package tree, not a standalone image); reporter
was extracted out of this repo entirely. The dedicated migration-runner images
are built separately via extra_builds below.
Dedicated migration-runner images (FROM migrate/migrate), built from the
repo root so the migration SQL is bundled. force_full_matrix ensures the
image tag exists on every release, so the deploy PreSync Job never
ImagePullBackOffs when a release doesn't touch migrations-image/.
Maps each midaz-* image to its Helm value-block key (bare keys). The midaz
Helm chart must carry matching ledger/tracer blocks or those images build
but never deploy.
Distinct schema from helm_values_key_mappings: keys carry a .tag suffix and
values are full dotted YAML paths (.image.tag). The *-migrations tags nest
under the parent service block (.ledger/.tracer .migrations.image.tag).
This is also the image list the dockerhub-visibility job reads, so an image
added here is kept public automatically; one added without a mapping is not.
Publish ledger (onboarding + transaction) and tracer migration SQL to S3 for the
managed-Postgres deploy pipeline. Neither app self-migrates at startup anymore
(in-process migration was removed); schema is applied out-of-band — via this S3
pipeline (managed Postgres) or the dedicated migration-runner images / PreSync
Job (see extra_builds above).
```

</details>

<details>
<summary><code>.github/workflows/routine.yml</code></summary>

```
No per-branch paths filter: GitHub Actions doesn't support different
`paths` per branch within one `on.push` block. main pushes gain a
labels_sync run beyond .github/labels.yml changes (idempotent, cheap);
develop pushes exist to trigger the backmerge job below.
routine.yml@v1.46.5 has no 'backmerge' routine — every child job inside
it would skip, wasting the whole call for that workflow_dispatch value.
fork is persistent (see fork-pr-notice.yml / fork-pr-promote.yml),
not disposable — without this, branch_cleanup_merged would delete
it the moment the fork -> develop promotion PR (whose head IS
fork) merges, and branch_cleanup_stale could delete it too if it
goes quiet between fork PRs.
Keeps the persistent `fork` branch (see fork-pr-notice.yml /
fork-pr-promote.yml) in sync with develop, via the shared org backmerge
orchestrator rather than a bespoke merge script. direct-with-pr-fallback:
merges straight to fork when clean, opens a PR instead of failing
outright when develop and fork's own unpromoted commits conflict.
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated shared automation workflows to use the `tier-2` channel for validation, releases, routine tasks, and backmerges.
  * Added a `review-ready` label for changes that pass checks and request automated review.
  * Updated review automation settings for key release branches, enabling review status reporting while disabling automatic summaries and reviews.
  * Updated dependency monitoring to include previously excluded internal dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->