### PR TITLE
refactor(ledger): drop the postgres and redis spans the drivers already emit

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,7 +143,9 @@ Binding standard: `docs/standards/telemetry.md` (T1–T13). The span-error helpe
 Span lifecycle:
 
 - Always `defer span.End()` immediately after `tracer.Start`.
-- For child I/O spans, preserve parent context: use `_, spanExec := tracer.Start(ctx, "...")`, not `ctx, spanExec := ...`.
+- Open a child I/O span only where the driver is not auto-instrumented: MongoDB and RabbitMQ yes, PostgreSQL and Redis/Valkey no — `lib-commons` instruments both of those pools (`sqlobs`/`redisobs`), so a hand-rolled `postgres.<op>.query`/`.exec` or one-command `redis.<cmd>` span only duplicates the driver's. See T2 for the full table.
+- When a child I/O span is not opened, its error handling and attributes belong on the parent domain span — the driver span carries no business-vs-technical class and does not see client-side scan/mapping failures.
+- For the child I/O spans that remain, preserve parent context: use `_, spanInsert := tracer.Start(ctx, "...")`, not `ctx, spanInsert := ...`.
 - Do not create child spans for in-memory mapping/validation.
 - Do not add redundant "Initiating..." logs; spans already mark operation starts.
 
@@ -160,7 +162,7 @@ span.SetAttributes(
     attribute.String("app.request.organization_id", organizationID.String()),
     attribute.String("app.request.ledger_id", ledgerID.String()),
 )
-spanExec.SetAttributes(attribute.Int64("db.rows_affected", rowsAffected))
+span.SetAttributes(attribute.Int64("db.rows_affected", rowsAffected))
 ```
 
 ## Errors

--- a/components/ledger/internal/adapters/postgres/account/account.postgresql.go
+++ b/components/ledger/internal/adapters/postgres/account/account.postgresql.go
@@ -245,8 +245,6 @@ func (r *AccountPostgreSQLRepository) Create(ctx context.Context, acc *mmodel.Ac
 		return nil, err
 	}
 
-	_, spanExec := tracer.Start(ctx, "postgres.create.exec")
-
 	result, err := db.ExecContext(ctx, query, args...)
 	if err != nil {
 		var pgErr *pgconn.PgError
@@ -258,20 +256,18 @@ func (r *AccountPostgreSQLRepository) Create(ctx context.Context, acc *mmodel.Ac
 			// Schema drift is an infrastructure failure, not a caller mistake, so
 			// it has to flip the span red; a constraint violation stays business.
 			if schemaDrift {
-				libOpentelemetry.HandleSpanError(spanExec, "Failed to execute query", err)
+				libOpentelemetry.HandleSpanError(span, "Failed to execute query", err)
 			} else {
-				libOpentelemetry.HandleSpanBusinessErrorEvent(spanExec, "Failed to execute query", err)
+				libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Failed to execute query", err)
 			}
 
 			return nil, err
 		}
 
-		libOpentelemetry.HandleSpanError(spanExec, "Failed to execute query", err)
+		libOpentelemetry.HandleSpanError(span, "Failed to execute query", err)
 
 		return nil, err
 	}
-
-	spanExec.End()
 
 	rowsAffected, err := result.RowsAffected()
 	if err != nil {
@@ -443,19 +439,15 @@ func (r *AccountPostgreSQLRepository) FindAll(ctx context.Context, organizationI
 		return nil, err
 	}
 
-	_, spanQuery := tracer.Start(ctx, "postgres.find_all.query")
-
 	rows, err := db.QueryContext(ctx, query, args...)
 	if err != nil {
 		mapped := mapReadError(err)
 
-		libOpentelemetry.HandleSpanError(spanQuery, "Failed to execute query", mapped)
+		libOpentelemetry.HandleSpanError(span, "Failed to execute query", mapped)
 
 		return nil, mapped
 	}
 	defer rows.Close()
-
-	spanQuery.End()
 
 	accounts, err := scanAccountRows(rows)
 	if err != nil {
@@ -515,19 +507,15 @@ func (r *AccountPostgreSQLRepository) FindAllByHolder(ctx context.Context, organ
 		return nil, err
 	}
 
-	_, spanQuery := tracer.Start(ctx, "postgres.find_all_accounts_by_holder.query")
-
 	rows, err := db.QueryContext(ctx, query, args...)
 	if err != nil {
 		mapped := mapReadError(err)
 
-		libOpentelemetry.HandleSpanError(spanQuery, "Failed to execute query", mapped)
+		libOpentelemetry.HandleSpanError(span, "Failed to execute query", mapped)
 
 		return nil, mapped
 	}
 	defer rows.Close()
-
-	spanQuery.End()
 
 	accounts, err := scanAccountRows(rows)
 	if err != nil {
@@ -576,11 +564,7 @@ func (r *AccountPostgreSQLRepository) Find(ctx context.Context, organizationID, 
 
 	acc := &AccountPostgreSQLModel{}
 
-	_, spanQuery := tracer.Start(ctx, "postgres.find.query")
-
 	row := db.QueryRowContext(ctx, query, args...)
-
-	spanQuery.End()
 
 	if err := row.Scan(
 		&acc.ID,
@@ -657,11 +641,7 @@ func (r *AccountPostgreSQLRepository) FindWithDeleted(ctx context.Context, organ
 
 	acc := &AccountPostgreSQLModel{}
 
-	_, spanQuery := tracer.Start(ctx, "postgres.find_with_deleted.query")
-
 	row := db.QueryRowContext(ctx, query, args...)
-
-	spanQuery.End()
 
 	if err := row.Scan(
 		&acc.ID,
@@ -739,11 +719,7 @@ func (r *AccountPostgreSQLRepository) FindAlias(ctx context.Context, organizatio
 
 	acc := &AccountPostgreSQLModel{}
 
-	_, spanQuery := tracer.Start(ctx, "postgres.find_alias.query")
-
 	row := db.QueryRowContext(ctx, query, args...)
-
-	spanQuery.End()
 
 	if err := row.Scan(
 		&acc.ID,
@@ -815,23 +791,18 @@ func (r *AccountPostgreSQLRepository) FindByAlias(ctx context.Context, organizat
 		return false, err
 	}
 
-	_, spanQuery := tracer.Start(ctx, "postgres.find_by_alias.query")
-
 	var exists int
 
 	err = db.QueryRowContext(ctx, query, args...).Scan(&exists)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			spanQuery.End()
 			return false, nil
 		}
 
-		libOpentelemetry.HandleSpanError(spanQuery, "Failed to execute query", err)
+		libOpentelemetry.HandleSpanError(span, "Failed to execute query", err)
 
 		return false, err
 	}
-
-	spanQuery.End()
 
 	err = pkg.ValidateBusinessError(constant.ErrAliasUnavailability, constant.EntityAccount, alias)
 
@@ -880,19 +851,15 @@ func (r *AccountPostgreSQLRepository) ListByIDs(ctx context.Context, organizatio
 		return nil, err
 	}
 
-	_, spanQuery := tracer.Start(ctx, "postgres.list_by_ids.query")
-
 	rows, err := db.QueryContext(ctx, query, args...)
 	if err != nil {
 		mapped := mapReadError(err)
 
-		libOpentelemetry.HandleSpanError(spanQuery, "Failed to execute query", mapped)
+		libOpentelemetry.HandleSpanError(span, "Failed to execute query", mapped)
 
 		return nil, mapped
 	}
 	defer rows.Close()
-
-	spanQuery.End()
 
 	for rows.Next() {
 		var acc AccountPostgreSQLModel
@@ -969,19 +936,15 @@ func (r *AccountPostgreSQLRepository) ListByAlias(ctx context.Context, organizat
 		return nil, err
 	}
 
-	_, spanQuery := tracer.Start(ctx, "postgres.list_by_alias.query")
-
 	rows, err := db.QueryContext(ctx, query, args...)
 	if err != nil {
 		mapped := mapReadError(err)
 
-		libOpentelemetry.HandleSpanError(spanQuery, "Failed to execute query", mapped)
+		libOpentelemetry.HandleSpanError(span, "Failed to execute query", mapped)
 
 		return nil, mapped
 	}
 	defer rows.Close()
-
-	spanQuery.End()
 
 	for rows.Next() {
 		var acc AccountPostgreSQLModel
@@ -1108,8 +1071,6 @@ func (r *AccountPostgreSQLRepository) Update(ctx context.Context, organizationID
 		return nil, err
 	}
 
-	_, spanExec := tracer.Start(ctx, "postgres.update.exec")
-
 	result, err := db.ExecContext(ctx, query, args...)
 	if err != nil {
 		var pgErr *pgconn.PgError
@@ -1121,20 +1082,18 @@ func (r *AccountPostgreSQLRepository) Update(ctx context.Context, organizationID
 			// Schema drift is an infrastructure failure, not a caller mistake, so
 			// it has to flip the span red; a constraint violation stays business.
 			if schemaDrift {
-				libOpentelemetry.HandleSpanError(spanExec, "Failed to execute update query", err)
+				libOpentelemetry.HandleSpanError(span, "Failed to execute update query", err)
 			} else {
-				libOpentelemetry.HandleSpanBusinessErrorEvent(spanExec, "Failed to execute update query", err)
+				libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Failed to execute update query", err)
 			}
 
 			return nil, err
 		}
 
-		libOpentelemetry.HandleSpanError(spanExec, "Failed to execute update query", err)
+		libOpentelemetry.HandleSpanError(span, "Failed to execute update query", err)
 
 		return nil, err
 	}
-
-	spanExec.End()
 
 	rowsAffected, err := result.RowsAffected()
 	if err != nil {
@@ -1187,15 +1146,11 @@ func (r *AccountPostgreSQLRepository) Delete(ctx context.Context, organizationID
 		return err
 	}
 
-	_, spanExec := tracer.Start(ctx, "postgres.delete.exec")
-
 	if _, err := db.ExecContext(ctx, query, args...); err != nil {
-		libOpentelemetry.HandleSpanError(spanExec, "Failed to execute query", err)
+		libOpentelemetry.HandleSpanError(span, "Failed to execute query", err)
 
 		return pkg.ValidateBusinessError(constant.ErrEntityNotFound, constant.EntityAccount)
 	}
-
-	spanExec.End()
 
 	return nil
 }
@@ -1232,19 +1187,15 @@ func (r *AccountPostgreSQLRepository) ListAccountsByIDs(ctx context.Context, org
 		return nil, err
 	}
 
-	_, spanQuery := tracer.Start(ctx, "postgres.list_by_ids.query")
-
 	rows, err := db.QueryContext(ctx, query, args...)
 	if err != nil {
 		mapped := mapReadError(err)
 
-		libOpentelemetry.HandleSpanError(spanQuery, "Failed to execute query", mapped)
+		libOpentelemetry.HandleSpanError(span, "Failed to execute query", mapped)
 
 		return nil, mapped
 	}
 	defer rows.Close()
-
-	spanQuery.End()
 
 	for rows.Next() {
 		var acc AccountPostgreSQLModel
@@ -1320,19 +1271,15 @@ func (r *AccountPostgreSQLRepository) ListAccountsByAlias(ctx context.Context, o
 		return nil, err
 	}
 
-	_, spanQuery := tracer.Start(ctx, "postgres.list_by_alias.query")
-
 	rows, err := db.QueryContext(ctx, query, args...)
 	if err != nil {
 		mapped := mapReadError(err)
 
-		libOpentelemetry.HandleSpanError(spanQuery, "Failed to execute query", mapped)
+		libOpentelemetry.HandleSpanError(span, "Failed to execute query", mapped)
 
 		return nil, mapped
 	}
 	defer rows.Close()
-
-	spanQuery.End()
 
 	for rows.Next() {
 		var acc AccountPostgreSQLModel
@@ -1420,21 +1367,15 @@ func (r *AccountPostgreSQLRepository) ListExternalAccountsByAssetCode(ctx contex
 
 	logger.Log(ctx, libLog.LevelDebug, "Executing query", libLog.String("query", query))
 
-	_, spanQuery := tracer.Start(ctx, "postgres.list_external_accounts_by_asset_code.query")
-
 	rows, err := db.QueryContext(ctx, query, args...)
 	if err != nil {
-		libOpentelemetry.HandleSpanError(spanQuery, "Failed to execute query", err)
+		libOpentelemetry.HandleSpanError(span, "Failed to execute query", err)
 
 		logger.Log(ctx, libLog.LevelError, "Failed to execute query", libLog.Err(err))
-
-		spanQuery.End()
 
 		return nil, err
 	}
 	defer rows.Close()
-
-	spanQuery.End()
 
 	for rows.Next() {
 		var acc AccountPostgreSQLModel
@@ -1512,18 +1453,14 @@ func (r *AccountPostgreSQLRepository) Count(ctx context.Context, organizationID,
 		return count, err
 	}
 
-	_, spanQuery := tracer.Start(ctx, "postgres.count.query")
-
 	err = db.QueryRowContext(ctx, query, args...).Scan(&count)
 	if err != nil {
 		mapped := mapReadError(err)
 
-		libOpentelemetry.HandleSpanError(spanQuery, "Failed to execute query", mapped)
+		libOpentelemetry.HandleSpanError(span, "Failed to execute query", mapped)
 
 		return count, mapped
 	}
-
-	spanQuery.End()
 
 	return count, nil
 }
@@ -1557,18 +1494,14 @@ func (r *AccountPostgreSQLRepository) CountByHolderID(ctx context.Context, organ
 		return count, err
 	}
 
-	_, spanQuery := tracer.Start(ctx, "postgres.count_by_holder.query")
-
 	err = db.QueryRowContext(ctx, query, args...).Scan(&count)
 	if err != nil {
 		mapped := mapReadError(err)
 
-		libOpentelemetry.HandleSpanError(spanQuery, "Failed to execute query", mapped)
+		libOpentelemetry.HandleSpanError(span, "Failed to execute query", mapped)
 
 		return count, mapped
 	}
-
-	spanQuery.End()
 
 	return count, nil
 }

--- a/components/ledger/internal/adapters/postgres/accounttype/accounttype.postgresql.go
+++ b/components/ledger/internal/adapters/postgres/accounttype/accounttype.postgresql.go
@@ -152,9 +152,6 @@ func (r *AccountTypePostgreSQLRepository) Create(ctx context.Context, organizati
 		return nil, err
 	}
 
-	_, spanExec := tracer.Start(ctx, "postgres.create.exec")
-	defer spanExec.End()
-
 	inserted := &AccountTypePostgreSQLModel{}
 
 	row := db.QueryRowContext(ctx, query, args...)
@@ -173,13 +170,13 @@ func (r *AccountTypePostgreSQLRepository) Create(ctx context.Context, organizati
 		var pgErr *pgconn.PgError
 		if errors.As(err, &pgErr) {
 			err := services.ValidatePGError(pgErr, constant.EntityAccountType)
-			libOpentelemetry.HandleSpanBusinessErrorEvent(spanExec, "Failed to execute insert account type query", err)
+			libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Failed to execute insert account type query", err)
 			logger.Log(ctx, libLog.LevelWarn, "Failed to execute insert account type query", libLog.Err(err))
 
 			return nil, err
 		}
 
-		libOpentelemetry.HandleSpanError(spanExec, "Failed to execute insert account type query", err)
+		libOpentelemetry.HandleSpanError(span, "Failed to execute insert account type query", err)
 		logger.Log(ctx, libLog.LevelError, "Failed to execute insert account type query", libLog.Err(err))
 
 		return nil, err
@@ -206,8 +203,6 @@ func (r *AccountTypePostgreSQLRepository) FindByID(ctx context.Context, organiza
 	}
 
 	var record AccountTypePostgreSQLModel
-
-	_, spanQuery := tracer.Start(ctx, "postgres.find_by_id.query")
 
 	row := db.QueryRowContext(ctx, `
 		SELECT 
@@ -241,7 +236,7 @@ func (r *AccountTypePostgreSQLRepository) FindByID(ctx context.Context, organiza
 		&record.DeletedAt,
 	)
 	if err != nil {
-		libOpentelemetry.HandleSpanError(spanQuery, "Failed to scan account type record", err)
+		libOpentelemetry.HandleSpanError(span, "Failed to scan account type record", err)
 
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, services.ErrDatabaseItemNotFound
@@ -249,8 +244,6 @@ func (r *AccountTypePostgreSQLRepository) FindByID(ctx context.Context, organiza
 
 		return nil, err
 	}
-
-	spanQuery.End()
 
 	return record.ToEntity(), nil
 }
@@ -273,8 +266,6 @@ func (r *AccountTypePostgreSQLRepository) FindByKey(ctx context.Context, organiz
 	}
 
 	var record AccountTypePostgreSQLModel
-
-	_, spanQuery := tracer.Start(ctx, "postgres.find_by_key.query")
 
 	row := db.QueryRowContext(ctx, `
 		SELECT 
@@ -308,7 +299,7 @@ func (r *AccountTypePostgreSQLRepository) FindByKey(ctx context.Context, organiz
 		&record.DeletedAt,
 	)
 	if err != nil {
-		libOpentelemetry.HandleSpanError(spanQuery, "Failed to scan account type record", err)
+		libOpentelemetry.HandleSpanError(span, "Failed to scan account type record", err)
 
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, services.ErrDatabaseItemNotFound
@@ -316,8 +307,6 @@ func (r *AccountTypePostgreSQLRepository) FindByKey(ctx context.Context, organiz
 
 		return nil, err
 	}
-
-	spanQuery.End()
 
 	return record.ToEntity(), nil
 }
@@ -372,9 +361,6 @@ func (r *AccountTypePostgreSQLRepository) Update(ctx context.Context, organizati
 		return nil, err
 	}
 
-	_, spanExec := tracer.Start(ctx, "postgres.update.exec")
-	defer spanExec.End()
-
 	updated := &AccountTypePostgreSQLModel{}
 
 	row := db.QueryRowContext(ctx, query, args...)
@@ -391,7 +377,7 @@ func (r *AccountTypePostgreSQLRepository) Update(ctx context.Context, organizati
 		&updated.DeletedAt,
 	); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			libOpentelemetry.HandleSpanBusinessErrorEvent(spanExec, "Failed to update account type. Rows affected is 0", services.ErrDatabaseItemNotFound)
+			libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Failed to update account type. Rows affected is 0", services.ErrDatabaseItemNotFound)
 			logger.Log(ctx, libLog.LevelWarn, "Failed to update account type. Rows affected is 0", libLog.String("account_type_id", id.String()))
 
 			return nil, services.ErrDatabaseItemNotFound
@@ -400,13 +386,13 @@ func (r *AccountTypePostgreSQLRepository) Update(ctx context.Context, organizati
 		var pgErr *pgconn.PgError
 		if errors.As(err, &pgErr) {
 			err := services.ValidatePGError(pgErr, constant.EntityAccountType)
-			libOpentelemetry.HandleSpanBusinessErrorEvent(spanExec, "Failed to execute update query", err)
+			libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Failed to execute update query", err)
 			logger.Log(ctx, libLog.LevelWarn, "Failed to execute update query", libLog.Err(err), libLog.String("account_type_id", id.String()))
 
 			return nil, err
 		}
 
-		libOpentelemetry.HandleSpanError(spanExec, "Failed to execute update query", err)
+		libOpentelemetry.HandleSpanError(span, "Failed to execute update query", err)
 		logger.Log(ctx, libLog.LevelError, "Failed to execute update query", libLog.Err(err), libLog.String("account_type_id", id.String()))
 
 		return nil, err
@@ -490,12 +476,9 @@ func (r *AccountTypePostgreSQLRepository) FindAll(ctx context.Context, organizat
 		return nil, libHTTP.CursorPagination{}, err
 	}
 
-	_, spanQuery := tracer.Start(ctx, "postgres.find_all.query")
-	defer spanQuery.End()
-
 	rows, err := db.QueryContext(ctx, query, args...)
 	if err != nil {
-		libOpentelemetry.HandleSpanError(spanQuery, "Failed to execute query", err)
+		libOpentelemetry.HandleSpanError(span, "Failed to execute query", err)
 
 		logger.Log(ctx, libLog.LevelError, "Failed to execute query", libLog.Err(err))
 
@@ -567,8 +550,6 @@ func (r *AccountTypePostgreSQLRepository) ListByIDs(ctx context.Context, organiz
 
 	var accountTypes []*mmodel.AccountType
 
-	_, spanQuery := tracer.Start(ctx, "postgres.list_by_ids.query")
-
 	query := `SELECT 
 		id, 
 		organization_id, 
@@ -589,15 +570,13 @@ func (r *AccountTypePostgreSQLRepository) ListByIDs(ctx context.Context, organiz
 
 	rows, err := db.QueryContext(ctx, query, organizationID, ledgerID, pq.Array(ids))
 	if err != nil {
-		libOpentelemetry.HandleSpanError(spanQuery, "Failed to execute query", err)
+		libOpentelemetry.HandleSpanError(span, "Failed to execute query", err)
 
 		logger.Log(ctx, libLog.LevelError, "Failed to execute query", libLog.Err(err))
 
 		return nil, err
 	}
 	defer rows.Close()
-
-	spanQuery.End()
 
 	for rows.Next() {
 		var record AccountTypePostgreSQLModel
@@ -650,18 +629,14 @@ func (r *AccountTypePostgreSQLRepository) Delete(ctx context.Context, organizati
 	query := "UPDATE account_type SET deleted_at = now() WHERE organization_id = $1 AND ledger_id = $2 AND id = $3 AND deleted_at IS NULL"
 	args := []any{organizationID, ledgerID, id}
 
-	_, spanExec := tracer.Start(ctx, "postgres.delete.exec")
-
 	result, err := db.ExecContext(ctx, query, args...)
 	if err != nil {
-		libOpentelemetry.HandleSpanError(spanExec, "Failed to execute delete query", err)
+		libOpentelemetry.HandleSpanError(span, "Failed to execute delete query", err)
 
 		logger.Log(ctx, libLog.LevelError, "Failed to execute delete query", libLog.Err(err))
 
 		return err
 	}
-
-	spanExec.End()
 
 	rowsAffected, err := result.RowsAffected()
 	if err != nil {

--- a/components/ledger/internal/adapters/postgres/asset/asset.postgresql.go
+++ b/components/ledger/internal/adapters/postgres/asset/asset.postgresql.go
@@ -122,9 +122,6 @@ func (r *AssetPostgreSQLRepository) Create(ctx context.Context, asset *mmodel.As
 	record := &AssetPostgreSQLModel{}
 	record.FromEntity(asset)
 
-	_, spanExec := tracer.Start(ctx, "postgres.create.exec")
-	defer spanExec.End()
-
 	insertQuery := `INSERT INTO asset VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11) RETURNING ` + strings.Join(assetColumnList, ", ")
 
 	inserted := &AssetPostgreSQLModel{}
@@ -160,12 +157,12 @@ func (r *AssetPostgreSQLRepository) Create(ctx context.Context, asset *mmodel.As
 		if errors.As(err, &pgErr) {
 			err := services.ValidatePGError(pgErr, constant.EntityAsset)
 
-			libOpentelemetry.HandleSpanBusinessErrorEvent(spanExec, "Failed to execute insert query", err)
+			libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Failed to execute insert query", err)
 
 			return nil, err
 		}
 
-		libOpentelemetry.HandleSpanError(spanExec, "Failed to execute insert query", err)
+		libOpentelemetry.HandleSpanError(span, "Failed to execute insert query", err)
 
 		return nil, err
 	}
@@ -187,8 +184,6 @@ func (r *AssetPostgreSQLRepository) FindByNameOrCode(ctx context.Context, organi
 		return false, err
 	}
 
-	_, spanQuery := tracer.Start(ctx, "postgres.find_by_name_or_code.query")
-
 	query, args, err := squirrel.Select(assetColumnList...).
 		From("asset").
 		Where(squirrel.Eq{"organization_id": organizationID}).
@@ -199,22 +194,18 @@ func (r *AssetPostgreSQLRepository) FindByNameOrCode(ctx context.Context, organi
 		PlaceholderFormat(squirrel.Dollar).
 		ToSql()
 	if err != nil {
-		libOpentelemetry.HandleSpanError(spanQuery, "Failed to build query", err)
-
-		spanQuery.End()
+		libOpentelemetry.HandleSpanError(span, "Failed to build query", err)
 
 		return false, err
 	}
 
 	rows, err := db.QueryContext(ctx, query, args...)
 	if err != nil {
-		libOpentelemetry.HandleSpanError(spanQuery, "Failed to execute query", err)
+		libOpentelemetry.HandleSpanError(span, "Failed to execute query", err)
 
 		return false, err
 	}
 	defer rows.Close()
-
-	spanQuery.End()
 
 	if rows.Next() {
 		err := pkg.ValidateBusinessError(constant.ErrAssetNameOrCodeDuplicate, constant.EntityAsset)
@@ -273,17 +264,13 @@ func (r *AssetPostgreSQLRepository) FindAll(ctx context.Context, organizationID,
 		return nil, err
 	}
 
-	_, spanQuery := tracer.Start(ctx, "postgres.find_all.query")
-
 	rows, err := db.QueryContext(ctx, query, args...)
 	if err != nil {
-		libOpentelemetry.HandleSpanError(spanQuery, "Failed to execute query", err)
+		libOpentelemetry.HandleSpanError(span, "Failed to execute query", err)
 
 		return nil, err
 	}
 	defer rows.Close()
-
-	spanQuery.End()
 
 	for rows.Next() {
 		var asset AssetPostgreSQLModel
@@ -322,8 +309,6 @@ func (r *AssetPostgreSQLRepository) ListByIDs(ctx context.Context, organizationI
 
 	var assets []*mmodel.Asset
 
-	_, spanQuery := tracer.Start(ctx, "postgres.list_assets_by_ids.query")
-
 	query, args, err := squirrel.Select(assetColumnList...).
 		From("asset").
 		Where(squirrel.Eq{"organization_id": organizationID}).
@@ -334,22 +319,18 @@ func (r *AssetPostgreSQLRepository) ListByIDs(ctx context.Context, organizationI
 		PlaceholderFormat(squirrel.Dollar).
 		ToSql()
 	if err != nil {
-		libOpentelemetry.HandleSpanError(spanQuery, "Failed to build query", err)
-
-		spanQuery.End()
+		libOpentelemetry.HandleSpanError(span, "Failed to build query", err)
 
 		return nil, err
 	}
 
 	rows, err := db.QueryContext(ctx, query, args...)
 	if err != nil {
-		libOpentelemetry.HandleSpanError(spanQuery, "Failed to execute query", err)
+		libOpentelemetry.HandleSpanError(span, "Failed to execute query", err)
 
 		return nil, err
 	}
 	defer rows.Close()
-
-	spanQuery.End()
 
 	for rows.Next() {
 		var asset AssetPostgreSQLModel
@@ -388,8 +369,6 @@ func (r *AssetPostgreSQLRepository) Find(ctx context.Context, organizationID, le
 
 	asset := &AssetPostgreSQLModel{}
 
-	_, spanQuery := tracer.Start(ctx, "postgres.find.query")
-
 	query, args, err := squirrel.Select(assetColumnList...).
 		From("asset").
 		Where(squirrel.Eq{"organization_id": organizationID}).
@@ -399,20 +378,16 @@ func (r *AssetPostgreSQLRepository) Find(ctx context.Context, organizationID, le
 		PlaceholderFormat(squirrel.Dollar).
 		ToSql()
 	if err != nil {
-		libOpentelemetry.HandleSpanError(spanQuery, "Failed to build query", err)
-
-		spanQuery.End()
+		libOpentelemetry.HandleSpanError(span, "Failed to build query", err)
 
 		return nil, err
 	}
 
 	row := db.QueryRowContext(ctx, query, args...)
 
-	spanQuery.End()
-
 	if err := row.Scan(&asset.ID, &asset.Name, &asset.Type, &asset.Code, &asset.Status, &asset.StatusDescription,
 		&asset.LedgerID, &asset.OrganizationID, &asset.CreatedAt, &asset.UpdatedAt, &asset.DeletedAt); err != nil {
-		libOpentelemetry.HandleSpanError(spanQuery, "Failed to execute query", err)
+		libOpentelemetry.HandleSpanError(span, "Failed to execute query", err)
 
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, pkg.ValidateBusinessError(constant.ErrEntityNotFound, constant.EntityAsset)
@@ -469,9 +444,6 @@ func (r *AssetPostgreSQLRepository) Update(ctx context.Context, organizationID, 
 		return nil, err
 	}
 
-	_, spanExec := tracer.Start(ctx, "postgres.update.exec")
-	defer spanExec.End()
-
 	updated := &AssetPostgreSQLModel{}
 
 	row := db.QueryRowContext(ctx, query, args...)
@@ -491,7 +463,7 @@ func (r *AssetPostgreSQLRepository) Update(ctx context.Context, organizationID, 
 		if errors.Is(err, sql.ErrNoRows) {
 			err := pkg.ValidateBusinessError(constant.ErrEntityNotFound, constant.EntityAsset)
 
-			libOpentelemetry.HandleSpanBusinessErrorEvent(spanExec, "Failed to update asset. Rows affected is 0", err)
+			libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Failed to update asset. Rows affected is 0", err)
 
 			return nil, err
 		}
@@ -500,12 +472,12 @@ func (r *AssetPostgreSQLRepository) Update(ctx context.Context, organizationID, 
 		if errors.As(err, &pgErr) {
 			err := services.ValidatePGError(pgErr, constant.EntityAsset)
 
-			libOpentelemetry.HandleSpanBusinessErrorEvent(spanExec, "Failed to execute update query", err)
+			libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Failed to execute update query", err)
 
 			return nil, err
 		}
 
-		libOpentelemetry.HandleSpanError(spanExec, "Failed to execute update query", err)
+		libOpentelemetry.HandleSpanError(span, "Failed to execute update query", err)
 
 		return nil, err
 	}
@@ -527,17 +499,13 @@ func (r *AssetPostgreSQLRepository) Delete(ctx context.Context, organizationID, 
 		return err
 	}
 
-	_, spanExec := tracer.Start(ctx, "postgres.delete.exec")
-
 	result, err := db.ExecContext(ctx, `UPDATE asset SET deleted_at = now() WHERE organization_id = $1 AND ledger_id = $2 AND id = $3 AND deleted_at IS NULL`,
 		organizationID, ledgerID, id)
 	if err != nil {
-		libOpentelemetry.HandleSpanError(spanExec, "Failed to execute delete query", err)
+		libOpentelemetry.HandleSpanError(span, "Failed to execute delete query", err)
 
 		return err
 	}
-
-	spanExec.End()
 
 	rowsAffected, err := result.RowsAffected()
 	if err != nil {
@@ -573,13 +541,10 @@ func (r *AssetPostgreSQLRepository) Count(ctx context.Context, organizationID, l
 		return count, err
 	}
 
-	_, spanQuery := tracer.Start(ctx, "postgres.count.query")
-	defer spanQuery.End()
-
 	err = db.QueryRowContext(ctx, "SELECT COUNT(*) FROM asset WHERE organization_id = $1 AND ledger_id = $2 AND deleted_at IS NULL",
 		organizationID, ledgerID).Scan(&count)
 	if err != nil {
-		libOpentelemetry.HandleSpanError(spanQuery, "Failed to execute query", err)
+		libOpentelemetry.HandleSpanError(span, "Failed to execute query", err)
 
 		return count, err
 	}

--- a/components/ledger/internal/adapters/postgres/assetrate/assetrate.postgresql.go
+++ b/components/ledger/internal/adapters/postgres/assetrate/assetrate.postgresql.go
@@ -121,8 +121,6 @@ func (r *AssetRatePostgreSQLRepository) Create(ctx context.Context, assetRate *A
 		return nil, err
 	}
 
-	_, spanExec := tracer.Start(ctx, "postgres.create.exec")
-
 	result, err := db.ExecContext(
 		ctx, `INSERT INTO asset_rate VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12) RETURNING *`,
 		&record.ID,
@@ -139,12 +137,10 @@ func (r *AssetRatePostgreSQLRepository) Create(ctx context.Context, assetRate *A
 		&record.UpdatedAt,
 	)
 	if err != nil {
-		libOpentelemetry.HandleSpanError(spanExec, "Failed to execute insert query", err)
+		libOpentelemetry.HandleSpanError(span, "Failed to execute insert query", err)
 
 		return nil, err
 	}
-
-	spanExec.End()
 
 	rowsAffected, err := result.RowsAffected()
 	if err != nil {
@@ -180,8 +176,6 @@ func (r *AssetRatePostgreSQLRepository) FindByExternalID(ctx context.Context, or
 
 	record := &AssetRatePostgreSQLModel{}
 
-	_, spanQuery := tracer.Start(ctx, "postgres.find.query")
-
 	findQuery := squirrel.Select(assetRateColumnList...).
 		From("asset_rate").
 		Where(squirrel.Eq{"organization_id": organizationID}).
@@ -192,16 +186,12 @@ func (r *AssetRatePostgreSQLRepository) FindByExternalID(ctx context.Context, or
 
 	query, args, err := findQuery.ToSql()
 	if err != nil {
-		libOpentelemetry.HandleSpanError(spanQuery, "Failed to build query", err)
-
-		spanQuery.End()
+		libOpentelemetry.HandleSpanError(span, "Failed to build query", err)
 
 		return nil, err
 	}
 
 	row := db.QueryRowContext(ctx, query, args...)
-
-	spanQuery.End()
 
 	if err := row.Scan(
 		&record.ID,
@@ -249,8 +239,6 @@ func (r *AssetRatePostgreSQLRepository) FindByCurrencyPair(ctx context.Context, 
 
 	record := &AssetRatePostgreSQLModel{}
 
-	_, spanQuery := tracer.Start(ctx, "postgres.find.query")
-
 	findQuery := squirrel.Select(assetRateColumnList...).
 		From("asset_rate").
 		Where(squirrel.Eq{"organization_id": organizationID}).
@@ -262,16 +250,12 @@ func (r *AssetRatePostgreSQLRepository) FindByCurrencyPair(ctx context.Context, 
 
 	query, args, err := findQuery.ToSql()
 	if err != nil {
-		libOpentelemetry.HandleSpanError(spanQuery, "Failed to build query", err)
-
-		spanQuery.End()
+		libOpentelemetry.HandleSpanError(span, "Failed to build query", err)
 
 		return nil, err
 	}
 
 	row := db.QueryRowContext(ctx, query, args...)
-
-	spanQuery.End()
 
 	if err := row.Scan(
 		&record.ID,
@@ -364,17 +348,13 @@ func (r *AssetRatePostgreSQLRepository) FindAllByAssetCodes(ctx context.Context,
 		return nil, libHTTP.CursorPagination{}, err
 	}
 
-	_, spanQuery := tracer.Start(ctx, "postgres.find_all.query")
-
 	rows, err := db.QueryContext(ctx, query, args...)
 	if err != nil {
-		libOpentelemetry.HandleSpanError(spanQuery, "Failed to execute query", err)
+		libOpentelemetry.HandleSpanError(span, "Failed to execute query", err)
 
 		return nil, libHTTP.CursorPagination{}, pkg.ValidateBusinessError(constant.ErrEntityNotFound, constant.EntityAssetRate)
 	}
 	defer rows.Close()
-
-	spanQuery.End()
 
 	for rows.Next() {
 		var assetRate AssetRatePostgreSQLModel
@@ -470,16 +450,12 @@ func (r *AssetRatePostgreSQLRepository) Update(ctx context.Context, organization
 		` AND ledger_id = $` + strconv.Itoa(len(args)-1) +
 		` AND id = $` + strconv.Itoa(len(args))
 
-	_, spanExec := tracer.Start(ctx, "postgres.update.exec")
-
 	result, err := db.ExecContext(ctx, query, args...)
 	if err != nil {
-		libOpentelemetry.HandleSpanError(spanExec, "Failed to execute query", err)
+		libOpentelemetry.HandleSpanError(span, "Failed to execute query", err)
 
 		return nil, err
 	}
-
-	spanExec.End()
 
 	rowsAffected, err := result.RowsAffected()
 	if err != nil {

--- a/components/ledger/internal/adapters/postgres/balance/balance.postgresql.go
+++ b/components/ledger/internal/adapters/postgres/balance/balance.postgresql.go
@@ -241,9 +241,6 @@ func (r *BalancePostgreSQLRepository) Create(ctx context.Context, balance *mmode
 		return nil, err
 	}
 
-	_, spanExec := tracer.Start(ctx, "postgres.create_balance.exec")
-	defer spanExec.End()
-
 	row := db.QueryRowContext(ctx, query, args...)
 
 	var created BalancePostgreSQLModel
@@ -268,7 +265,7 @@ func (r *BalancePostgreSQLRepository) Create(ctx context.Context, balance *mmode
 		&created.OverdraftUsed,
 		&created.Settings,
 	); err != nil {
-		libOpentelemetry.HandleSpanError(spanExec, "Failed to execute insert query", err)
+		libOpentelemetry.HandleSpanError(span, "Failed to execute insert query", err)
 		return nil, err
 	}
 
@@ -292,8 +289,6 @@ func (r *BalancePostgreSQLRepository) ListByAccountIDs(ctx context.Context, orga
 
 	var balances []*mmodel.Balance
 
-	_, spanQuery := tracer.Start(ctx, "postgres.list_by_ids.query")
-
 	query := squirrel.Select(balanceColumnList...).
 		From(r.tableName).
 		Where(squirrel.Eq{"organization_id": organizationID}).
@@ -305,20 +300,18 @@ func (r *BalancePostgreSQLRepository) ListByAccountIDs(ctx context.Context, orga
 
 	sqlQuery, args, err := query.ToSql()
 	if err != nil {
-		libOpentelemetry.HandleSpanError(spanQuery, "Failed to build query", err)
+		libOpentelemetry.HandleSpanError(span, "Failed to build query", err)
 
 		return nil, err
 	}
 
 	rows, err := db.QueryContext(ctx, sqlQuery, args...)
 	if err != nil {
-		libOpentelemetry.HandleSpanError(spanQuery, "Failed to execute query", err)
+		libOpentelemetry.HandleSpanError(span, "Failed to execute query", err)
 
 		return nil, err
 	}
 	defer rows.Close()
-
-	spanQuery.End()
 
 	for rows.Next() {
 		var balance BalancePostgreSQLModel
@@ -380,8 +373,6 @@ func (r *BalancePostgreSQLRepository) ListByIDs(ctx context.Context, organizatio
 
 	var balances []*mmodel.Balance
 
-	_, spanQuery := tracer.Start(ctx, "postgres.list_by_balance_ids.query")
-
 	query := squirrel.Select(balanceColumnList...).
 		From(r.tableName).
 		Where(squirrel.Eq{"organization_id": organizationID}).
@@ -393,7 +384,7 @@ func (r *BalancePostgreSQLRepository) ListByIDs(ctx context.Context, organizatio
 
 	sqlQuery, args, err := query.ToSql()
 	if err != nil {
-		libOpentelemetry.HandleSpanError(spanQuery, "Failed to build query", err)
+		libOpentelemetry.HandleSpanError(span, "Failed to build query", err)
 		return nil, err
 	}
 
@@ -401,13 +392,11 @@ func (r *BalancePostgreSQLRepository) ListByIDs(ctx context.Context, organizatio
 
 	rows, err := db.QueryContext(ctx, sqlQuery, args...)
 	if err != nil {
-		libOpentelemetry.HandleSpanError(spanQuery, "Failed to execute query", err)
+		libOpentelemetry.HandleSpanError(span, "Failed to execute query", err)
 		return nil, err
 	}
 
 	defer rows.Close()
-
-	spanQuery.End()
 
 	for rows.Next() {
 		var balance BalancePostgreSQLModel
@@ -503,17 +492,13 @@ func (r *BalancePostgreSQLRepository) ListAll(ctx context.Context, organizationI
 		return nil, libHTTP.CursorPagination{}, err
 	}
 
-	_, spanQuery := tracer.Start(ctx, "postgres.list_all.query")
-
 	rows, err := db.QueryContext(ctx, query, args...)
 	if err != nil {
-		libOpentelemetry.HandleSpanError(spanQuery, "Failed to get operations on repo", err)
+		libOpentelemetry.HandleSpanError(span, "Failed to get operations on repo", err)
 
 		return nil, libHTTP.CursorPagination{}, err
 	}
 	defer rows.Close()
-
-	spanQuery.End()
 
 	for rows.Next() {
 		var balance BalancePostgreSQLModel
@@ -627,17 +612,13 @@ func (r *BalancePostgreSQLRepository) ListAllByAccountID(ctx context.Context, or
 		return nil, libHTTP.CursorPagination{}, err
 	}
 
-	_, spanQuery := tracer.Start(ctx, "postgres.list_all_by_account_id.query")
-
 	rows, err := db.QueryContext(ctx, query, args...)
 	if err != nil {
-		libOpentelemetry.HandleSpanError(spanQuery, "Failed to get operations on repo", err)
+		libOpentelemetry.HandleSpanError(span, "Failed to get operations on repo", err)
 
 		return nil, libHTTP.CursorPagination{}, err
 	}
 	defer rows.Close()
-
-	spanQuery.End()
 
 	for rows.Next() {
 		var balance BalancePostgreSQLModel
@@ -711,8 +692,6 @@ func (r *BalancePostgreSQLRepository) ListByAliases(ctx context.Context, organiz
 
 	var balances []*mmodel.Balance
 
-	_, spanQuery := tracer.Start(ctx, "postgres.list_by_aliases.query")
-
 	query := squirrel.Select(balanceColumnList...).
 		From(r.tableName).
 		Where(squirrel.Eq{"organization_id": organizationID}).
@@ -724,20 +703,18 @@ func (r *BalancePostgreSQLRepository) ListByAliases(ctx context.Context, organiz
 
 	sqlQuery, args, err := query.ToSql()
 	if err != nil {
-		libOpentelemetry.HandleSpanError(spanQuery, "Failed to build query", err)
+		libOpentelemetry.HandleSpanError(span, "Failed to build query", err)
 
 		return nil, err
 	}
 
 	rows, err := db.QueryContext(ctx, sqlQuery, args...)
 	if err != nil {
-		libOpentelemetry.HandleSpanError(spanQuery, "Failed to execute query", err)
+		libOpentelemetry.HandleSpanError(span, "Failed to execute query", err)
 
 		return nil, err
 	}
 	defer rows.Close()
-
-	spanQuery.End()
 
 	for rows.Next() {
 		var balance BalancePostgreSQLModel
@@ -832,12 +809,9 @@ func (r *BalancePostgreSQLRepository) ListByAliasesWithKeys(ctx context.Context,
 
 	var balances []*mmodel.Balance
 
-	_, spanQuery := tracer.Start(ctx, "postgres.list_by_aliases_with_keys.query")
-	defer spanQuery.End()
-
 	rows, err := db.QueryContext(ctx, query, args...)
 	if err != nil {
-		libOpentelemetry.HandleSpanError(spanQuery, "Failed to execute query", err)
+		libOpentelemetry.HandleSpanError(span, "Failed to execute query", err)
 		return nil, err
 	}
 	defer rows.Close()
@@ -998,8 +972,6 @@ func (r *BalancePostgreSQLRepository) Find(ctx context.Context, organizationID, 
 
 	balance := &BalancePostgreSQLModel{}
 
-	_, spanQuery := tracer.Start(ctx, "postgres.find.query")
-
 	query := squirrel.Select(balanceColumnList...).
 		From(r.tableName).
 		Where(squirrel.Eq{"organization_id": organizationID}).
@@ -1010,14 +982,12 @@ func (r *BalancePostgreSQLRepository) Find(ctx context.Context, organizationID, 
 
 	sqlQuery, args, err := query.ToSql()
 	if err != nil {
-		libOpentelemetry.HandleSpanError(spanQuery, "Failed to build query", err)
+		libOpentelemetry.HandleSpanError(span, "Failed to build query", err)
 
 		return nil, err
 	}
 
 	row := db.QueryRowContext(ctx, sqlQuery, args...)
-
-	spanQuery.End()
 
 	if err = row.Scan(
 		&balance.ID,
@@ -1073,8 +1043,6 @@ func (r *BalancePostgreSQLRepository) FindByAccountIDAndKey(ctx context.Context,
 
 	balance := &BalancePostgreSQLModel{}
 
-	_, spanQuery := tracer.Start(ctx, "postgres.find.query")
-
 	query := `SELECT ` + strings.Join(balanceColumnList, ", ") + `
 			FROM balance 
 			WHERE organization_id = $1 
@@ -1084,8 +1052,6 @@ func (r *BalancePostgreSQLRepository) FindByAccountIDAndKey(ctx context.Context,
 			   AND deleted_at IS NULL`
 
 	row := db.QueryRowContext(ctx, query, organizationID, ledgerID, accountID, key)
-
-	spanQuery.End()
 
 	if err = row.Scan(
 		&balance.ID,
@@ -1139,8 +1105,6 @@ func (r *BalancePostgreSQLRepository) ExistsByAccountIDAndKey(ctx context.Contex
 	}
 	defer releaseRead(span, release)
 
-	_, spanQuery := tracer.Start(ctx, "postgres.exists.query")
-
 	existsQuery := squirrel.Select("1").
 		Prefix("SELECT EXISTS (").
 		From(r.tableName).
@@ -1154,14 +1118,12 @@ func (r *BalancePostgreSQLRepository) ExistsByAccountIDAndKey(ctx context.Contex
 
 	query, args, err := existsQuery.ToSql()
 	if err != nil {
-		libOpentelemetry.HandleSpanError(spanQuery, "Failed to build query", err)
+		libOpentelemetry.HandleSpanError(span, "Failed to build query", err)
 
 		return false, err
 	}
 
 	row := db.QueryRowContext(ctx, query, args...)
-
-	spanQuery.End()
 
 	var exists bool
 	if err := row.Scan(&exists); err != nil {
@@ -1187,8 +1149,6 @@ func (r *BalancePostgreSQLRepository) Delete(ctx context.Context, organizationID
 		return err
 	}
 
-	_, spanQuery := tracer.Start(ctx, "postgres.delete.exec")
-
 	result, err := db.ExecContext(
 		ctx, `
 		UPDATE balance 
@@ -1201,8 +1161,6 @@ func (r *BalancePostgreSQLRepository) Delete(ctx context.Context, organizationID
 
 		return err
 	}
-
-	spanQuery.End()
 
 	rowsAffected, err := result.RowsAffected()
 	if err != nil {
@@ -1259,11 +1217,8 @@ func (r *BalancePostgreSQLRepository) DeleteAllByIDs(ctx context.Context, organi
 		}
 	}()
 
-	ctxExec, spanExec := tracer.Start(ctx, "postgres.delete_balances.exec")
-	defer spanExec.End()
-
 	result, err := tx.ExecContext(
-		ctxExec, `
+		ctx, `
 		UPDATE balance
 		SET deleted_at = NOW()
 		WHERE organization_id = $1
@@ -1273,7 +1228,7 @@ func (r *BalancePostgreSQLRepository) DeleteAllByIDs(ctx context.Context, organi
 		organizationID, ledgerID, pq.Array(ids),
 	)
 	if err != nil {
-		libOpentelemetry.HandleSpanError(spanExec, "failed to execute bulk delete query", err)
+		libOpentelemetry.HandleSpanError(span, "failed to execute bulk delete query", err)
 
 		return err
 	}
@@ -1363,9 +1318,6 @@ func (r *BalancePostgreSQLRepository) Update(ctx context.Context, organizationID
 		libOpentelemetry.HandleSpanError(span, "Failed to build update query", err)
 		return nil, err
 	}
-
-	_, spanExec := tracer.Start(ctx, "postgres.update.exec")
-	defer spanExec.End()
 
 	record := &BalancePostgreSQLModel{}
 
@@ -1562,13 +1514,10 @@ func (r *BalancePostgreSQLRepository) UpdateAllByAccountID(ctx context.Context, 
 		return err
 	}
 
-	_, spanExec := tracer.Start(ctx, "postgres.update_all_by_account_id.exec")
-	defer spanExec.End()
-
 	if balance.AllowSending == nil {
 		err := errors.New("allow_sending value is required")
 
-		libOpentelemetry.HandleSpanError(spanExec, "allow_sending value is required", err)
+		libOpentelemetry.HandleSpanError(span, "allow_sending value is required", err)
 
 		return err
 	}
@@ -1576,7 +1525,7 @@ func (r *BalancePostgreSQLRepository) UpdateAllByAccountID(ctx context.Context, 
 	if balance.AllowReceiving == nil {
 		err := errors.New("allow_receiving value is required")
 
-		libOpentelemetry.HandleSpanError(spanExec, "allow_receiving value is required", err)
+		libOpentelemetry.HandleSpanError(span, "allow_receiving value is required", err)
 
 		return err
 	}
@@ -1585,7 +1534,7 @@ func (r *BalancePostgreSQLRepository) UpdateAllByAccountID(ctx context.Context, 
 
 	result, err := db.ExecContext(ctx, query, *balance.AllowSending, *balance.AllowReceiving, organizationID, ledgerID, accountID)
 	if err != nil {
-		libOpentelemetry.HandleSpanError(spanExec, "Failed to execute query", err)
+		libOpentelemetry.HandleSpanError(span, "Failed to execute query", err)
 
 		return err
 	}
@@ -1600,7 +1549,7 @@ func (r *BalancePostgreSQLRepository) UpdateAllByAccountID(ctx context.Context, 
 	if rowsAffected == 0 {
 		err := pkg.ValidateBusinessError(constant.ErrEntityNotFound, constant.EntityBalance)
 
-		libOpentelemetry.HandleSpanBusinessErrorEvent(spanExec, "Failed to update balances. Rows affected is 0", err)
+		libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Failed to update balances. Rows affected is 0", err)
 
 		return err
 	}
@@ -1625,8 +1574,6 @@ func (r *BalancePostgreSQLRepository) ListByAccountID(ctx context.Context, organ
 
 	var balances []*mmodel.Balance
 
-	_, spanQuery := tracer.Start(ctx, "postgres.list_by_account_id.query")
-
 	query := squirrel.Select(balanceColumnList...).
 		From(r.tableName).
 		Where(squirrel.Eq{"organization_id": organizationID}).
@@ -1638,18 +1585,16 @@ func (r *BalancePostgreSQLRepository) ListByAccountID(ctx context.Context, organ
 
 	sqlQuery, args, err := query.ToSql()
 	if err != nil {
-		libOpentelemetry.HandleSpanError(spanQuery, "Failed to build query", err)
+		libOpentelemetry.HandleSpanError(span, "Failed to build query", err)
 		return nil, err
 	}
 
 	rows, err := db.QueryContext(ctx, sqlQuery, args...)
 	if err != nil {
-		libOpentelemetry.HandleSpanError(spanQuery, "Failed to execute query", err)
+		libOpentelemetry.HandleSpanError(span, "Failed to execute query", err)
 		return nil, err
 	}
 	defer rows.Close()
-
-	spanQuery.End()
 
 	for rows.Next() {
 		var balance BalancePostgreSQLModel
@@ -1767,16 +1712,12 @@ func (r *BalancePostgreSQLRepository) ListByAccountIDAtTimestamp(ctx context.Con
 
 	logger.Log(ctx, libLog.LevelDebug, "ListByAccountIDAtTimestamp query assembled", libLog.String("query", sqlQuery))
 
-	_, spanQuery := tracer.Start(ctx, "postgres.list_balances_by_account_id_at_timestamp.query")
-
 	rows, err := db.QueryContext(ctx, sqlQuery, args...)
 	if err != nil {
-		libOpentelemetry.HandleSpanError(spanQuery, "Failed to execute query", err)
+		libOpentelemetry.HandleSpanError(span, "Failed to execute query", err)
 		return nil, err
 	}
 	defer rows.Close()
-
-	spanQuery.End()
 
 	for rows.Next() {
 		var balance BalanceAtTimestampModel

--- a/components/ledger/internal/adapters/postgres/ledger/ledger.postgresql.go
+++ b/components/ledger/internal/adapters/postgres/ledger/ledger.postgresql.go
@@ -189,9 +189,6 @@ func (r *LedgerPostgreSQLRepository) Create(ctx context.Context, ledger *mmodel.
 		return nil, err
 	}
 
-	_, spanExec := tracer.Start(ctx, "postgres.create.exec")
-	defer spanExec.End()
-
 	// NOTE (v3.5.4 backport): explicit columns keep this INSERT working when future
 	// migrations add columns to ledger. Do not collapse this to table-wide VALUES.
 	ledgerColumns := strings.Join(ledgerColumnList, ", ")
@@ -231,12 +228,12 @@ func (r *LedgerPostgreSQLRepository) Create(ctx context.Context, ledger *mmodel.
 		if errors.As(err, &pgErr) && pgErr != nil {
 			err := services.ValidatePGError(pgErr, constant.EntityLedger)
 
-			libOpentelemetry.HandleSpanBusinessErrorEvent(spanExec, "Failed to execute update query", err)
+			libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Failed to execute update query", err)
 
 			return nil, err
 		}
 
-		libOpentelemetry.HandleSpanError(spanExec, "Failed to execute update query", err)
+		libOpentelemetry.HandleSpanError(span, "Failed to execute update query", err)
 
 		return nil, err
 	}
@@ -266,8 +263,6 @@ func (r *LedgerPostgreSQLRepository) Find(ctx context.Context, organizationID, i
 
 	ledger := &LedgerPostgreSQLModel{}
 
-	_, spanQuery := tracer.Start(ctx, "postgres.find.query")
-
 	query, args, err := squirrel.Select(ledgerColumnList...).
 		From("ledger").
 		Where(squirrel.Eq{"organization_id": organizationID}).
@@ -276,16 +271,12 @@ func (r *LedgerPostgreSQLRepository) Find(ctx context.Context, organizationID, i
 		PlaceholderFormat(squirrel.Dollar).
 		ToSql()
 	if err != nil {
-		libOpentelemetry.HandleSpanError(spanQuery, "Failed to build query", err)
-
-		spanQuery.End()
+		libOpentelemetry.HandleSpanError(span, "Failed to build query", err)
 
 		return nil, err
 	}
 
 	row := db.QueryRowContext(ctx, query, args...)
-
-	spanQuery.End()
 
 	var settingsJSON []byte
 	if err := row.Scan(&ledger.ID, &ledger.Name, &ledger.OrganizationID, &ledger.Status, &ledger.StatusDescription,
@@ -369,17 +360,13 @@ func (r *LedgerPostgreSQLRepository) FindAll(ctx context.Context, organizationID
 		return nil, err
 	}
 
-	_, spanQuery := tracer.Start(ctx, "postgres.find_all.query")
-
 	rows, err := db.QueryContext(ctx, query, args...)
 	if err != nil {
-		libOpentelemetry.HandleSpanError(spanQuery, "Failed to query database", err)
+		libOpentelemetry.HandleSpanError(span, "Failed to query database", err)
 
 		return nil, err
 	}
 	defer rows.Close()
-
-	spanQuery.End()
 
 	for rows.Next() {
 		var ledger LedgerPostgreSQLModel
@@ -424,8 +411,6 @@ func (r *LedgerPostgreSQLRepository) FindByName(ctx context.Context, organizatio
 		return false, err
 	}
 
-	_, spanQuery := tracer.Start(ctx, "postgres.find_by_name.query")
-
 	query, args, err := squirrel.Select(ledgerColumnList...).
 		From("ledger").
 		Where(squirrel.Eq{"organization_id": organizationID}).
@@ -434,22 +419,18 @@ func (r *LedgerPostgreSQLRepository) FindByName(ctx context.Context, organizatio
 		PlaceholderFormat(squirrel.Dollar).
 		ToSql()
 	if err != nil {
-		libOpentelemetry.HandleSpanError(spanQuery, "Failed to build query", err)
-
-		spanQuery.End()
+		libOpentelemetry.HandleSpanError(span, "Failed to build query", err)
 
 		return false, err
 	}
 
 	rows, err := db.QueryContext(ctx, query, args...)
 	if err != nil {
-		libOpentelemetry.HandleSpanError(spanQuery, "Failed to query database", err)
+		libOpentelemetry.HandleSpanError(span, "Failed to query database", err)
 
 		return false, err
 	}
 	defer rows.Close()
-
-	spanQuery.End()
 
 	if rows.Next() {
 		err := pkg.ValidateBusinessError(constant.ErrLedgerNameConflict, constant.EntityLedger, name)
@@ -481,8 +462,6 @@ func (r *LedgerPostgreSQLRepository) ListByIDs(ctx context.Context, organization
 
 	var ledgers []*mmodel.Ledger
 
-	_, spanQuery := tracer.Start(ctx, "postgres.list_ledgers_by_ids.query")
-
 	query, args, err := squirrel.Select(ledgerColumnList...).
 		From("ledger").
 		Where(squirrel.Eq{"organization_id": organizationID}).
@@ -492,22 +471,18 @@ func (r *LedgerPostgreSQLRepository) ListByIDs(ctx context.Context, organization
 		PlaceholderFormat(squirrel.Dollar).
 		ToSql()
 	if err != nil {
-		libOpentelemetry.HandleSpanError(spanQuery, "Failed to build query", err)
-
-		spanQuery.End()
+		libOpentelemetry.HandleSpanError(span, "Failed to build query", err)
 
 		return nil, err
 	}
 
 	rows, err := db.QueryContext(ctx, query, args...)
 	if err != nil {
-		libOpentelemetry.HandleSpanError(spanQuery, "Failed to query database", err)
+		libOpentelemetry.HandleSpanError(span, "Failed to query database", err)
 
 		return nil, err
 	}
 	defer rows.Close()
-
-	spanQuery.End()
 
 	for rows.Next() {
 		var ledger LedgerPostgreSQLModel
@@ -582,9 +557,6 @@ func (r *LedgerPostgreSQLRepository) Update(ctx context.Context, organizationID,
 		return nil, err
 	}
 
-	_, spanExec := tracer.Start(ctx, "postgres.update.exec")
-	defer spanExec.End()
-
 	updated := &LedgerPostgreSQLModel{}
 
 	var settingsJSON []byte
@@ -604,7 +576,7 @@ func (r *LedgerPostgreSQLRepository) Update(ctx context.Context, organizationID,
 		if errors.Is(err, sql.ErrNoRows) {
 			err := pkg.ValidateBusinessError(constant.ErrEntityNotFound, constant.EntityLedger)
 
-			libOpentelemetry.HandleSpanBusinessErrorEvent(spanExec, "Failed to update ledger. Rows affected is 0", err)
+			libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Failed to update ledger. Rows affected is 0", err)
 
 			return nil, err
 		}
@@ -613,12 +585,12 @@ func (r *LedgerPostgreSQLRepository) Update(ctx context.Context, organizationID,
 		if errors.As(err, &pgErr) {
 			err := services.ValidatePGError(pgErr, constant.EntityLedger)
 
-			libOpentelemetry.HandleSpanBusinessErrorEvent(spanExec, "Failed to execute update query", err)
+			libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Failed to execute update query", err)
 
 			return nil, err
 		}
 
-		libOpentelemetry.HandleSpanError(spanExec, "Failed to execute update query", err)
+		libOpentelemetry.HandleSpanError(span, "Failed to execute update query", err)
 
 		return nil, err
 	}
@@ -646,16 +618,12 @@ func (r *LedgerPostgreSQLRepository) Delete(ctx context.Context, organizationID,
 		return err
 	}
 
-	_, spanExec := tracer.Start(ctx, "postgres.delete.exec")
-
 	result, err := db.ExecContext(ctx, `UPDATE ledger SET deleted_at = now() WHERE organization_id = $1 AND id = $2 AND deleted_at IS NULL`, organizationID, id)
 	if err != nil {
-		libOpentelemetry.HandleSpanError(spanExec, "Failed to execute database query", err)
+		libOpentelemetry.HandleSpanError(span, "Failed to execute database query", err)
 
 		return err
 	}
-
-	spanExec.End()
 
 	rowsAffected, err := result.RowsAffected()
 	if err != nil {
@@ -690,12 +658,9 @@ func (r *LedgerPostgreSQLRepository) Count(ctx context.Context, organizationID u
 		return count, err
 	}
 
-	_, spanQuery := tracer.Start(ctx, "postgres.count.query")
-	defer spanQuery.End()
-
 	err = db.QueryRowContext(ctx, "SELECT COUNT(*) FROM ledger WHERE organization_id = $1 AND deleted_at IS NULL", organizationID).Scan(&count)
 	if err != nil {
-		libOpentelemetry.HandleSpanError(spanQuery, "Failed to query database", err)
+		libOpentelemetry.HandleSpanError(span, "Failed to query database", err)
 
 		return count, err
 	}
@@ -717,13 +682,9 @@ func (r *LedgerPostgreSQLRepository) GetSettings(ctx context.Context, organizati
 
 	var settingsJSON []byte
 
-	_, spanQuery := tracer.Start(ctx, "postgres.get_settings.query")
-
 	query := `SELECT settings FROM ledger WHERE organization_id = $1 AND id = $2 AND deleted_at IS NULL`
 
 	row := db.QueryRowContext(ctx, query, organizationID, ledgerID)
-
-	spanQuery.End()
 
 	if err := row.Scan(&settingsJSON); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
@@ -779,8 +740,6 @@ func (r *LedgerPostgreSQLRepository) UpdateSettings(ctx context.Context, organiz
 		return nil, err
 	}
 
-	_, spanExec := tracer.Start(ctx, "postgres.update_settings.exec")
-
 	// Use JSONB merge operator (||) to merge new settings with existing.
 	//
 	// NOTE: PostgreSQL || performs SHALLOW merge at top level only.
@@ -801,9 +760,6 @@ func (r *LedgerPostgreSQLRepository) UpdateSettings(ctx context.Context, organiz
 	var updatedSettingsJSON []byte
 
 	err = db.QueryRowContext(ctx, query, settingsJSON, organizationID, ledgerID).Scan(&updatedSettingsJSON)
-
-	spanExec.End()
-
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			err := pkg.ValidateBusinessError(constant.ErrEntityNotFound, constant.EntityLedger)
@@ -856,8 +812,6 @@ func (r *LedgerPostgreSQLRepository) ReplaceSettings(ctx context.Context, organi
 		return nil, err
 	}
 
-	_, spanExec := tracer.Start(ctx, "postgres.replace_settings.exec")
-
 	// Direct assignment (=) instead of merge (||) - complete replacement
 	query := `
 		UPDATE ledger
@@ -869,9 +823,6 @@ func (r *LedgerPostgreSQLRepository) ReplaceSettings(ctx context.Context, organi
 	var updatedSettingsJSON []byte
 
 	err = db.QueryRowContext(ctx, query, settingsJSON, organizationID, ledgerID).Scan(&updatedSettingsJSON)
-
-	spanExec.End()
-
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			err := pkg.ValidateBusinessError(constant.ErrEntityNotFound, constant.EntityLedger)

--- a/components/ledger/internal/adapters/postgres/operation/operation.postgresql.go
+++ b/components/ledger/internal/adapters/postgres/operation/operation.postgresql.go
@@ -184,8 +184,6 @@ func (r *OperationPostgreSQLRepository) Create(ctx context.Context, operation *O
 	record := &OperationPostgreSQLModel{}
 	record.FromEntity(operation)
 
-	_, spanExec := tracer.Start(ctx, "postgres.create.exec")
-
 	insert := squirrel.
 		Insert(r.tableName).
 		Columns(operationColumnList...).
@@ -226,7 +224,7 @@ func (r *OperationPostgreSQLRepository) Create(ctx context.Context, operation *O
 
 	query, args, err := insert.ToSql()
 	if err != nil {
-		libOpentelemetry.HandleSpanError(spanExec, "Failed to build insert query", err)
+		libOpentelemetry.HandleSpanError(span, "Failed to build insert query", err)
 
 		return nil, err
 	}
@@ -235,17 +233,15 @@ func (r *OperationPostgreSQLRepository) Create(ctx context.Context, operation *O
 	if err != nil {
 		var pgErr *pgconn.PgError
 		if errors.As(err, &pgErr) && pgErr.Code == constant.UniqueViolationCode {
-			libOpentelemetry.HandleSpanEvent(spanExec, "Operation already exists, skipping duplicate insert (idempotent retry)")
+			libOpentelemetry.HandleSpanEvent(span, "Operation already exists, skipping duplicate insert (idempotent retry)")
 
 			return nil, err
 		}
 
-		libOpentelemetry.HandleSpanError(spanExec, "Failed to execute query", err)
+		libOpentelemetry.HandleSpanError(span, "Failed to execute query", err)
 
 		return nil, err
 	}
-
-	spanExec.End()
 
 	rowsAffected, err := result.RowsAffected()
 	if err != nil {
@@ -558,17 +554,13 @@ func (r *OperationPostgreSQLRepository) FindAll(ctx context.Context, organizatio
 		return nil, libHTTP.CursorPagination{}, err
 	}
 
-	_, spanQuery := tracer.Start(ctx, "postgres.find_all.query")
-
 	rows, err := db.QueryContext(ctx, query, args...)
 	if err != nil {
-		libOpentelemetry.HandleSpanError(spanQuery, "Failed to get operations on repo", err)
+		libOpentelemetry.HandleSpanError(span, "Failed to get operations on repo", err)
 
 		return nil, libHTTP.CursorPagination{}, err
 	}
 	defer rows.Close()
-
-	spanQuery.End()
 
 	for rows.Next() {
 		var (
@@ -675,17 +667,13 @@ func (r *OperationPostgreSQLRepository) ListByIDs(ctx context.Context, organizat
 		return nil, err
 	}
 
-	_, spanQuery := tracer.Start(ctx, "postgres.list_all_by_ids.query")
-
 	rows, err := db.QueryContext(ctx, query, args...)
 	if err != nil {
-		libOpentelemetry.HandleSpanError(spanQuery, "Failed to get operations on repo", err)
+		libOpentelemetry.HandleSpanError(span, "Failed to get operations on repo", err)
 
 		return nil, err
 	}
 	defer rows.Close()
-
-	spanQuery.End()
 
 	for rows.Next() {
 		var (
@@ -779,11 +767,7 @@ func (r *OperationPostgreSQLRepository) Find(ctx context.Context, organizationID
 
 	var direction sql.NullString
 
-	_, spanQuery := tracer.Start(ctx, "postgres.find.query")
-
 	row := db.QueryRowContext(ctx, query, args...)
-
-	spanQuery.End()
 
 	if err := row.Scan(
 		&operation.ID,
@@ -870,11 +854,7 @@ func (r *OperationPostgreSQLRepository) FindByAccount(ctx context.Context, organ
 
 	var direction sql.NullString
 
-	_, spanQuery := tracer.Start(ctx, "postgres.find_all_by_account.query")
-
 	row := db.QueryRowContext(ctx, query, args...)
-
-	spanQuery.End()
 
 	if err := row.Scan(
 		&operation.ID,
@@ -964,16 +944,12 @@ func (r *OperationPostgreSQLRepository) Update(ctx context.Context, organization
 		return nil, err
 	}
 
-	_, spanExec := tracer.Start(ctx, "postgres.update.exec")
-
 	result, err := db.ExecContext(ctx, query, args...)
 	if err != nil {
-		libOpentelemetry.HandleSpanError(spanExec, "Failed to execute query", err)
+		libOpentelemetry.HandleSpanError(span, "Failed to execute query", err)
 
 		return nil, err
 	}
-
-	spanExec.End()
 
 	rowsAffected, err := result.RowsAffected()
 	if err != nil {
@@ -1020,16 +996,12 @@ func (r *OperationPostgreSQLRepository) Delete(ctx context.Context, organization
 		return err
 	}
 
-	_, spanExec := tracer.Start(ctx, "postgres.delete.exec")
-
 	result, err := db.ExecContext(ctx, query, args...)
 	if err != nil {
-		libOpentelemetry.HandleSpanError(spanExec, "Failed to execute database query", err)
+		libOpentelemetry.HandleSpanError(span, "Failed to execute database query", err)
 
 		return err
 	}
-
-	spanExec.End()
 
 	rowsAffected, err := result.RowsAffected()
 	if err != nil {
@@ -1144,17 +1116,13 @@ func (r *OperationPostgreSQLRepository) FindAllByAccount(ctx context.Context, or
 
 	logger.Log(ctx, libLog.LevelDebug, "FindAllByAccount query assembled", libLog.String("query", query))
 
-	_, spanQuery := tracer.Start(ctx, "postgres.find_all_by_account.query")
-
 	rows, err := db.QueryContext(ctx, query, args...)
 	if err != nil {
-		libOpentelemetry.HandleSpanError(spanQuery, "Failed to query database", err)
+		libOpentelemetry.HandleSpanError(span, "Failed to query database", err)
 
 		return nil, libHTTP.CursorPagination{}, err
 	}
 	defer rows.Close()
-
-	spanQuery.End()
 
 	for rows.Next() {
 		var (
@@ -1265,11 +1233,7 @@ func (r *OperationPostgreSQLRepository) FindLastOperationBeforeTimestamp(ctx con
 
 	logger.Log(ctx, libLog.LevelDebug, "FindLastOperationBeforeTimestamp query assembled", libLog.String("query", query))
 
-	_, spanQuery := tracer.Start(ctx, "postgres.find_last_operation_before_timestamp.query")
-
 	row := db.QueryRowContext(ctx, query, args...)
-
-	spanQuery.End()
 
 	var operation OperationPointInTimeModel
 	if err := row.Scan(
@@ -1358,16 +1322,12 @@ func (r *OperationPostgreSQLRepository) FindLastOperationsForAccountBeforeTimest
 
 	logger.Log(ctx, libLog.LevelDebug, "FindLastOperationsForAccountBeforeTimestamp query assembled", libLog.String("query", query))
 
-	_, spanQuery := tracer.Start(ctx, "postgres.find_last_operations_for_account_before_timestamp.query")
-
 	rows, err := db.QueryContext(ctx, query, args...)
 	if err != nil {
-		libOpentelemetry.HandleSpanError(spanQuery, "Failed to query database", err)
+		libOpentelemetry.HandleSpanError(span, "Failed to query database", err)
 		return nil, libHTTP.CursorPagination{}, err
 	}
 	defer rows.Close()
-
-	spanQuery.End()
 
 	for rows.Next() {
 		var operation OperationPointInTimeModel

--- a/components/ledger/internal/adapters/postgres/operationroute/operationroute.postgresql.go
+++ b/components/ledger/internal/adapters/postgres/operationroute/operationroute.postgresql.go
@@ -204,9 +204,6 @@ func (r *OperationRoutePostgreSQLRepository) Create(ctx context.Context, organiz
 
 	logger.Log(ctx, libLog.LevelDebug, "Built create operation route query", libLog.String("query", query))
 
-	_, spanExec := tracer.Start(ctx, "postgres.create.exec")
-	defer spanExec.End()
-
 	inserted := &OperationRoutePostgreSQLModel{}
 
 	row := db.QueryRowContext(ctx, query, args...)
@@ -215,12 +212,12 @@ func (r *OperationRoutePostgreSQLRepository) Create(ctx context.Context, organiz
 		if errors.As(err, &pgErr) {
 			err := services.ValidatePGError(pgErr, constant.EntityOperationRoute)
 
-			libOpentelemetry.HandleSpanBusinessErrorEvent(spanExec, "Failed to execute create query", err)
+			libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Failed to execute create query", err)
 
 			return nil, err
 		}
 
-		libOpentelemetry.HandleSpanError(spanExec, "Failed to execute create query", err)
+		libOpentelemetry.HandleSpanError(span, "Failed to execute create query", err)
 
 		return nil, err
 	}
@@ -268,9 +265,6 @@ func (r *OperationRoutePostgreSQLRepository) FindByID(ctx context.Context, organ
 
 	operationRoute := &OperationRoutePostgreSQLModel{}
 
-	_, spanQuery := tracer.Start(ctx, "postgres.find.query")
-	defer spanQuery.End()
-
 	row := db.QueryRowContext(ctx, query, args...)
 
 	if err := row.Scan(
@@ -291,12 +285,12 @@ func (r *OperationRoutePostgreSQLRepository) FindByID(ctx context.Context, organ
 		if errors.Is(err, sql.ErrNoRows) {
 			err := pkg.ValidateBusinessError(constant.ErrOperationRouteNotFound, constant.EntityOperationRoute)
 
-			libOpentelemetry.HandleSpanBusinessErrorEvent(spanQuery, "Operation route not found", err)
+			libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Operation route not found", err)
 
 			return nil, err
 		}
 
-		libOpentelemetry.HandleSpanError(spanQuery, "Failed to scan operation route", err)
+		libOpentelemetry.HandleSpanError(span, "Failed to scan operation route", err)
 
 		return nil, err
 	}
@@ -350,12 +344,9 @@ func (r *OperationRoutePostgreSQLRepository) FindByIDs(ctx context.Context, orga
 
 	logger.Log(ctx, libLog.LevelDebug, "Built find operation routes by IDs query", libLog.String("query", findByIDsSql))
 
-	_, spanQuery := tracer.Start(ctx, "postgres.find_by_ids.query")
-	defer spanQuery.End()
-
 	rows, err := db.QueryContext(ctx, findByIDsSql, args...)
 	if err != nil {
-		libOpentelemetry.HandleSpanError(spanQuery, "Failed to execute query", err)
+		libOpentelemetry.HandleSpanError(span, "Failed to execute query", err)
 
 		return nil, err
 	}
@@ -383,7 +374,7 @@ func (r *OperationRoutePostgreSQLRepository) FindByIDs(ctx context.Context, orga
 			&operationRoute.UpdatedAt,
 			&operationRoute.DeletedAt,
 		); err != nil {
-			libOpentelemetry.HandleSpanError(spanQuery, "Failed to scan operation route", err)
+			libOpentelemetry.HandleSpanError(span, "Failed to scan operation route", err)
 			return nil, err
 		}
 
@@ -392,11 +383,11 @@ func (r *OperationRoutePostgreSQLRepository) FindByIDs(ctx context.Context, orga
 	}
 
 	if err := rows.Err(); err != nil {
-		libOpentelemetry.HandleSpanError(spanQuery, "Failed to iterate rows", err)
+		libOpentelemetry.HandleSpanError(span, "Failed to iterate rows", err)
 		return nil, err
 	}
 
-	spanQuery.SetAttributes(attribute.Int("db.rows_returned", len(operationRoutes)))
+	span.SetAttributes(attribute.Int("db.rows_returned", len(operationRoutes)))
 
 	var missingIDs []string
 
@@ -501,15 +492,12 @@ func (r *OperationRoutePostgreSQLRepository) Update(ctx context.Context, organiz
 
 	logger.Log(ctx, libLog.LevelDebug, "Built update operation route query", libLog.String("query", query))
 
-	_, spanExec := tracer.Start(ctx, "postgres.update.exec")
-	defer spanExec.End()
-
 	updated := &OperationRoutePostgreSQLModel{}
 
 	row := db.QueryRowContext(ctx, query, args...)
 	if err := scanOperationRoute(row, updated); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			libOpentelemetry.HandleSpanBusinessErrorEvent(spanExec, "Failed to update operation route. Rows affected is 0", services.ErrDatabaseItemNotFound)
+			libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Failed to update operation route. Rows affected is 0", services.ErrDatabaseItemNotFound)
 
 			return nil, services.ErrDatabaseItemNotFound
 		}
@@ -518,12 +506,12 @@ func (r *OperationRoutePostgreSQLRepository) Update(ctx context.Context, organiz
 		if errors.As(err, &pgErr) {
 			err := services.ValidatePGError(pgErr, constant.EntityOperationRoute)
 
-			libOpentelemetry.HandleSpanBusinessErrorEvent(spanExec, "Failed to execute update query", err)
+			libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Failed to execute update query", err)
 
 			return nil, err
 		}
 
-		libOpentelemetry.HandleSpanError(spanExec, "Failed to execute update query", err)
+		libOpentelemetry.HandleSpanError(span, "Failed to execute update query", err)
 
 		return nil, err
 	}
@@ -573,29 +561,26 @@ func (r *OperationRoutePostgreSQLRepository) Delete(ctx context.Context, organiz
 
 	logger.Log(ctx, libLog.LevelDebug, "Built delete operation route query", libLog.String("query", query))
 
-	_, spanExec := tracer.Start(ctx, "postgres.delete.exec")
-	defer spanExec.End()
-
 	result, err := db.ExecContext(ctx, query, args...)
 	if err != nil {
-		libOpentelemetry.HandleSpanError(spanExec, "Failed to execute delete query", err)
+		libOpentelemetry.HandleSpanError(span, "Failed to execute delete query", err)
 
 		return err
 	}
 
 	rowsAffected, err := result.RowsAffected()
 	if err != nil {
-		libOpentelemetry.HandleSpanError(spanExec, "Failed to get rows affected", err)
+		libOpentelemetry.HandleSpanError(span, "Failed to get rows affected", err)
 
 		return err
 	}
 
-	spanExec.SetAttributes(attribute.Int64("db.rows_affected", rowsAffected))
+	span.SetAttributes(attribute.Int64("db.rows_affected", rowsAffected))
 
 	if rowsAffected == 0 {
 		err := services.ErrDatabaseItemNotFound
 
-		libOpentelemetry.HandleSpanBusinessErrorEvent(spanExec, "Failed to delete operation route. Rows affected is 0", err)
+		libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Failed to delete operation route. Rows affected is 0", err)
 
 		return err
 	}
@@ -671,12 +656,9 @@ func (r *OperationRoutePostgreSQLRepository) FindAll(ctx context.Context, organi
 
 	logger.Log(ctx, libLog.LevelDebug, "Built find all operation routes query", libLog.String("query", query))
 
-	_, spanQuery := tracer.Start(ctx, "postgres.find_all.query")
-	defer spanQuery.End()
-
 	rows, err := db.QueryContext(ctx, query, args...)
 	if err != nil {
-		libOpentelemetry.HandleSpanError(spanQuery, "Failed to execute query", err)
+		libOpentelemetry.HandleSpanError(span, "Failed to execute query", err)
 		return nil, libHTTP.CursorPagination{}, err
 	}
 	defer rows.Close()
@@ -699,7 +681,7 @@ func (r *OperationRoutePostgreSQLRepository) FindAll(ctx context.Context, organi
 			&operationRoute.DeletedAt,
 			&operationRoute.Code,
 		); err != nil {
-			libOpentelemetry.HandleSpanError(spanQuery, "Failed to scan operation route", err)
+			libOpentelemetry.HandleSpanError(span, "Failed to scan operation route", err)
 			return nil, libHTTP.CursorPagination{}, err
 		}
 
@@ -707,11 +689,11 @@ func (r *OperationRoutePostgreSQLRepository) FindAll(ctx context.Context, organi
 	}
 
 	if err := rows.Err(); err != nil {
-		libOpentelemetry.HandleSpanError(spanQuery, "Failed to iterate rows", err)
+		libOpentelemetry.HandleSpanError(span, "Failed to iterate rows", err)
 		return nil, libHTTP.CursorPagination{}, err
 	}
 
-	spanQuery.SetAttributes(attribute.Int("db.rows_returned", len(operationRoutes)))
+	span.SetAttributes(attribute.Int("db.rows_returned", len(operationRoutes)))
 
 	hasPagination := len(operationRoutes) > filter.Limit
 	isFirstPage := libCommons.IsNilOrEmpty(&filter.Cursor)
@@ -776,20 +758,17 @@ func (r *OperationRoutePostgreSQLRepository) HasTransactionRouteLinks(ctx contex
 
 	logger.Log(ctx, libLog.LevelDebug, "Built transaction route link query", libLog.String("query", query))
 
-	_, spanQuery := tracer.Start(ctx, "postgres.has_transaction_route_links.query")
-	defer spanQuery.End()
-
 	var exists bool
 
 	row := db.QueryRowContext(ctx, query, args...)
 
 	if err := row.Scan(&exists); err != nil {
-		libOpentelemetry.HandleSpanError(spanQuery, "Failed to scan transaction route link result", err)
+		libOpentelemetry.HandleSpanError(span, "Failed to scan transaction route link result", err)
 
 		return false, err
 	}
 
-	spanQuery.SetAttributes(attribute.Bool("app.operation_route_has_transaction_route_links", exists))
+	span.SetAttributes(attribute.Bool("app.operation_route_has_transaction_route_links", exists))
 
 	return exists, nil
 }
@@ -829,12 +808,9 @@ func (r *OperationRoutePostgreSQLRepository) FindTransactionRouteIDs(ctx context
 
 	logger.Log(ctx, libLog.LevelDebug, "Built transaction route IDs query", libLog.String("query", query))
 
-	_, spanQuery := tracer.Start(ctx, "postgres.find_transaction_route_ids.query")
-	defer spanQuery.End()
-
 	rows, err := db.QueryContext(ctx, query, args...)
 	if err != nil {
-		libOpentelemetry.HandleSpanError(spanQuery, "Failed to execute query", err)
+		libOpentelemetry.HandleSpanError(span, "Failed to execute query", err)
 
 		return nil, err
 	}
@@ -846,7 +822,7 @@ func (r *OperationRoutePostgreSQLRepository) FindTransactionRouteIDs(ctx context
 		var transactionRouteID uuid.UUID
 
 		if err := rows.Scan(&transactionRouteID); err != nil {
-			libOpentelemetry.HandleSpanError(spanQuery, "Failed to scan transaction route ID", err)
+			libOpentelemetry.HandleSpanError(span, "Failed to scan transaction route ID", err)
 
 			return nil, err
 		}
@@ -855,12 +831,12 @@ func (r *OperationRoutePostgreSQLRepository) FindTransactionRouteIDs(ctx context
 	}
 
 	if err := rows.Err(); err != nil {
-		libOpentelemetry.HandleSpanError(spanQuery, "Failed to iterate rows", err)
+		libOpentelemetry.HandleSpanError(span, "Failed to iterate rows", err)
 
 		return nil, err
 	}
 
-	spanQuery.SetAttributes(attribute.Int("db.rows_returned", len(transactionRouteIDs)))
+	span.SetAttributes(attribute.Int("db.rows_returned", len(transactionRouteIDs)))
 
 	return transactionRouteIDs, nil
 }

--- a/components/ledger/internal/adapters/postgres/organization/organization.postgresql.go
+++ b/components/ledger/internal/adapters/postgres/organization/organization.postgresql.go
@@ -169,20 +169,17 @@ func (r *OrganizationPostgreSQLRepository) Create(ctx context.Context, organizat
 		return nil, err
 	}
 
-	_, spanExec := tracer.Start(ctx, "postgres.create_organization.exec")
-	defer spanExec.End()
-
 	result, err := db.ExecContext(ctx, query, args...)
 	if err != nil {
 		var pgErr *pgconn.PgError
 		if errors.As(err, &pgErr) {
 			err := services.ValidatePGError(pgErr, constant.EntityOrganization)
-			libOpentelemetry.HandleSpanBusinessErrorEvent(spanExec, "Failed to execute insert query", err)
+			libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Failed to execute insert query", err)
 
 			return nil, err
 		}
 
-		libOpentelemetry.HandleSpanError(spanExec, "Failed to execute insert query", err)
+		libOpentelemetry.HandleSpanError(span, "Failed to execute insert query", err)
 
 		return nil, err
 	}
@@ -262,9 +259,6 @@ func (r *OrganizationPostgreSQLRepository) Update(ctx context.Context, id uuid.U
 		return nil, err
 	}
 
-	_, spanExec := tracer.Start(ctx, "postgres.update_organization.exec")
-	defer spanExec.End()
-
 	var address string
 
 	updated := &OrganizationPostgreSQLModel{}
@@ -285,7 +279,7 @@ func (r *OrganizationPostgreSQLRepository) Update(ctx context.Context, id uuid.U
 	); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			err := pkg.ValidateBusinessError(constant.ErrEntityNotFound, constant.EntityOrganization)
-			libOpentelemetry.HandleSpanBusinessErrorEvent(spanExec, "Failed to update organization: no rows affected", err)
+			libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Failed to update organization: no rows affected", err)
 
 			return nil, err
 		}
@@ -293,12 +287,12 @@ func (r *OrganizationPostgreSQLRepository) Update(ctx context.Context, id uuid.U
 		var pgErr *pgconn.PgError
 		if errors.As(err, &pgErr) {
 			err := services.ValidatePGError(pgErr, constant.EntityOrganization)
-			libOpentelemetry.HandleSpanBusinessErrorEvent(spanExec, "Failed to execute update query", err)
+			libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Failed to execute update query", err)
 
 			return nil, err
 		}
 
-		libOpentelemetry.HandleSpanError(spanExec, "Failed to execute update query", err)
+		libOpentelemetry.HandleSpanError(span, "Failed to execute update query", err)
 
 		return nil, err
 	}
@@ -329,8 +323,6 @@ func (r *OrganizationPostgreSQLRepository) Find(ctx context.Context, id uuid.UUI
 
 	var address string
 
-	_, spanQuery := tracer.Start(ctx, "postgres.find.query")
-
 	findQuery := squirrel.Select(organizationColumnList...).
 		From("organization").
 		Where(squirrel.Eq{"id": id}).
@@ -339,16 +331,12 @@ func (r *OrganizationPostgreSQLRepository) Find(ctx context.Context, id uuid.UUI
 
 	query, args, err := findQuery.ToSql()
 	if err != nil {
-		libOpentelemetry.HandleSpanError(spanQuery, "Failed to build query", err)
-
-		spanQuery.End()
+		libOpentelemetry.HandleSpanError(span, "Failed to build query", err)
 
 		return nil, err
 	}
 
 	row := db.QueryRowContext(ctx, query, args...)
-
-	spanQuery.End()
 
 	if err := row.Scan(&organization.ID, &organization.ParentOrganizationID, &organization.LegalName,
 		&organization.DoingBusinessAs, &organization.LegalDocument, &address, &organization.Status, &organization.StatusDescription,
@@ -442,16 +430,12 @@ func (r *OrganizationPostgreSQLRepository) FindAll(ctx context.Context, filter h
 		return nil, err
 	}
 
-	_, spanQuery := tracer.Start(ctx, "postgres.find_all.query")
-
 	rows, err := db.QueryContext(ctx, query, args...)
 	if err != nil {
-		libOpentelemetry.HandleSpanError(spanQuery, "Failed to execute query", err)
+		libOpentelemetry.HandleSpanError(span, "Failed to execute query", err)
 
 		return nil, err
 	}
-
-	spanQuery.End()
 
 	defer rows.Close()
 
@@ -506,8 +490,6 @@ func (r *OrganizationPostgreSQLRepository) ListByIDs(ctx context.Context, ids []
 
 	var organizations []*mmodel.Organization
 
-	_, spanQuery := tracer.Start(ctx, "postgres.list_organizations_by_ids.query")
-
 	listQuery := squirrel.Select(organizationColumnList...).
 		From("organization").
 		Where(squirrel.Expr("id = ANY(?)", pq.Array(ids))).
@@ -517,22 +499,18 @@ func (r *OrganizationPostgreSQLRepository) ListByIDs(ctx context.Context, ids []
 
 	query, args, err := listQuery.ToSql()
 	if err != nil {
-		libOpentelemetry.HandleSpanError(spanQuery, "Failed to build query", err)
-
-		spanQuery.End()
+		libOpentelemetry.HandleSpanError(span, "Failed to build query", err)
 
 		return nil, err
 	}
 
 	rows, err := db.QueryContext(ctx, query, args...)
 	if err != nil {
-		libOpentelemetry.HandleSpanError(spanQuery, "Failed to execute query", err)
+		libOpentelemetry.HandleSpanError(span, "Failed to execute query", err)
 
 		return nil, err
 	}
 	defer rows.Close()
-
-	spanQuery.End()
 
 	for rows.Next() {
 		var organization OrganizationPostgreSQLModel
@@ -579,16 +557,12 @@ func (r *OrganizationPostgreSQLRepository) Delete(ctx context.Context, id uuid.U
 		return err
 	}
 
-	_, spanExec := tracer.Start(ctx, "postgres.delete.exec")
-
 	result, err := db.ExecContext(ctx, `UPDATE organization SET deleted_at = now() WHERE id = $1 AND deleted_at IS NULL`, id)
 	if err != nil {
-		libOpentelemetry.HandleSpanError(spanExec, "Failed to execute query", err)
+		libOpentelemetry.HandleSpanError(span, "Failed to execute query", err)
 
 		return err
 	}
-
-	spanExec.End()
 
 	rowsAffected, err := result.RowsAffected()
 	if err != nil {
@@ -623,12 +597,9 @@ func (r *OrganizationPostgreSQLRepository) Count(ctx context.Context) (int64, er
 		return count, err
 	}
 
-	_, spanQuery := tracer.Start(ctx, "postgres.count.query")
-	defer spanQuery.End()
-
 	err = db.QueryRowContext(ctx, `SELECT COUNT(*) FROM organization WHERE deleted_at IS NULL`).Scan(&count)
 	if err != nil {
-		libOpentelemetry.HandleSpanError(spanQuery, "Failed to execute query", err)
+		libOpentelemetry.HandleSpanError(span, "Failed to execute query", err)
 
 		return count, err
 	}

--- a/components/ledger/internal/adapters/postgres/portfolio/portfolio.postgresql.go
+++ b/components/ledger/internal/adapters/postgres/portfolio/portfolio.postgresql.go
@@ -121,9 +121,6 @@ func (r *PortfolioPostgreSQLRepository) Create(ctx context.Context, portfolio *m
 	record := &PortfolioPostgreSQLModel{}
 	record.FromEntity(portfolio)
 
-	_, spanExec := tracer.Start(ctx, "postgres.create.exec")
-	defer spanExec.End()
-
 	insertQuery := `INSERT INTO portfolio VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10) RETURNING ` + strings.Join(portfolioColumnList, ", ")
 
 	inserted := &PortfolioPostgreSQLModel{}
@@ -157,12 +154,12 @@ func (r *PortfolioPostgreSQLRepository) Create(ctx context.Context, portfolio *m
 		if errors.As(err, &pgErr) {
 			err := services.ValidatePGError(pgErr, constant.EntityPortfolio)
 
-			libOpentelemetry.HandleSpanBusinessErrorEvent(spanExec, "Failed to execute insert query", err)
+			libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Failed to execute insert query", err)
 
 			return nil, err
 		}
 
-		libOpentelemetry.HandleSpanError(spanExec, "Failed to execute insert query", err)
+		libOpentelemetry.HandleSpanError(span, "Failed to execute insert query", err)
 
 		return nil, err
 	}
@@ -186,8 +183,6 @@ func (r *PortfolioPostgreSQLRepository) FindByIDEntity(ctx context.Context, orga
 
 	portfolio := &PortfolioPostgreSQLModel{}
 
-	_, spanQuery := tracer.Start(ctx, "postgres.find_by_id_entity.query")
-
 	query, args, err := squirrel.Select(portfolioColumnList...).
 		From("portfolio").
 		Where(squirrel.Eq{"organization_id": organizationID}).
@@ -198,16 +193,12 @@ func (r *PortfolioPostgreSQLRepository) FindByIDEntity(ctx context.Context, orga
 		PlaceholderFormat(squirrel.Dollar).
 		ToSql()
 	if err != nil {
-		libOpentelemetry.HandleSpanError(spanQuery, "Failed to build query", err)
-
-		spanQuery.End()
+		libOpentelemetry.HandleSpanError(span, "Failed to build query", err)
 
 		return nil, err
 	}
 
 	row := db.QueryRowContext(ctx, query, args...)
-
-	spanQuery.End()
 
 	if err := row.Scan(
 		&portfolio.ID,
@@ -288,17 +279,13 @@ func (r *PortfolioPostgreSQLRepository) FindAll(ctx context.Context, organizatio
 		return nil, err
 	}
 
-	_, spanQuery := tracer.Start(ctx, "postgres.find_all.query")
-
 	rows, err := db.QueryContext(ctx, query, args...)
 	if err != nil {
-		libOpentelemetry.HandleSpanError(spanQuery, "Failed to execute query", err)
+		libOpentelemetry.HandleSpanError(span, "Failed to execute query", err)
 
 		return nil, pkg.ValidateBusinessError(constant.ErrEntityNotFound, constant.EntityPortfolio)
 	}
 	defer rows.Close()
-
-	spanQuery.End()
 
 	for rows.Next() {
 		var portfolio PortfolioPostgreSQLModel
@@ -347,8 +334,6 @@ func (r *PortfolioPostgreSQLRepository) Find(ctx context.Context, organizationID
 
 	portfolio := &PortfolioPostgreSQLModel{}
 
-	_, spanQuery := tracer.Start(ctx, "postgres.find.query")
-
 	query, args, err := squirrel.Select(portfolioColumnList...).
 		From("portfolio").
 		Where(squirrel.Eq{"organization_id": organizationID}).
@@ -359,16 +344,12 @@ func (r *PortfolioPostgreSQLRepository) Find(ctx context.Context, organizationID
 		PlaceholderFormat(squirrel.Dollar).
 		ToSql()
 	if err != nil {
-		libOpentelemetry.HandleSpanError(spanQuery, "Failed to build query", err)
-
-		spanQuery.End()
+		libOpentelemetry.HandleSpanError(span, "Failed to build query", err)
 
 		return nil, err
 	}
 
 	row := db.QueryRowContext(ctx, query, args...)
-
-	spanQuery.End()
 
 	if err := row.Scan(
 		&portfolio.ID,
@@ -410,8 +391,6 @@ func (r *PortfolioPostgreSQLRepository) ListByIDs(ctx context.Context, organizat
 
 	var portfolios []*mmodel.Portfolio
 
-	_, spanQuery := tracer.Start(ctx, "postgres.list_portfolios_by_ids.query")
-
 	query, args, err := squirrel.Select(portfolioColumnList...).
 		From("portfolio").
 		Where(squirrel.Eq{"organization_id": organizationID}).
@@ -422,22 +401,18 @@ func (r *PortfolioPostgreSQLRepository) ListByIDs(ctx context.Context, organizat
 		PlaceholderFormat(squirrel.Dollar).
 		ToSql()
 	if err != nil {
-		libOpentelemetry.HandleSpanError(spanQuery, "Failed to build query", err)
-
-		spanQuery.End()
+		libOpentelemetry.HandleSpanError(span, "Failed to build query", err)
 
 		return nil, err
 	}
 
 	rows, err := db.QueryContext(ctx, query, args...)
 	if err != nil {
-		libOpentelemetry.HandleSpanError(spanQuery, "Failed to execute query", err)
+		libOpentelemetry.HandleSpanError(span, "Failed to execute query", err)
 
 		return nil, err
 	}
 	defer rows.Close()
-
-	spanQuery.End()
 
 	for rows.Next() {
 		var portfolio PortfolioPostgreSQLModel
@@ -519,9 +494,6 @@ func (r *PortfolioPostgreSQLRepository) Update(ctx context.Context, organization
 		return nil, err
 	}
 
-	_, spanExec := tracer.Start(ctx, "postgres.update.exec")
-	defer spanExec.End()
-
 	updated := &PortfolioPostgreSQLModel{}
 
 	row := db.QueryRowContext(ctx, query, args...)
@@ -540,7 +512,7 @@ func (r *PortfolioPostgreSQLRepository) Update(ctx context.Context, organization
 		if errors.Is(err, sql.ErrNoRows) {
 			err := pkg.ValidateBusinessError(constant.ErrEntityNotFound, constant.EntityPortfolio)
 
-			libOpentelemetry.HandleSpanBusinessErrorEvent(spanExec, "Failed to update portfolio. Rows affected is 0", err)
+			libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Failed to update portfolio. Rows affected is 0", err)
 
 			return nil, err
 		}
@@ -549,12 +521,12 @@ func (r *PortfolioPostgreSQLRepository) Update(ctx context.Context, organization
 		if errors.As(err, &pgErr) {
 			err := services.ValidatePGError(pgErr, constant.EntityPortfolio)
 
-			libOpentelemetry.HandleSpanBusinessErrorEvent(spanExec, "Failed to execute update query", err)
+			libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Failed to execute update query", err)
 
 			return nil, err
 		}
 
-		libOpentelemetry.HandleSpanError(spanExec, "Failed to execute update query", err)
+		libOpentelemetry.HandleSpanError(span, "Failed to execute update query", err)
 
 		return nil, err
 	}
@@ -576,17 +548,13 @@ func (r *PortfolioPostgreSQLRepository) Delete(ctx context.Context, organization
 		return err
 	}
 
-	_, spanExec := tracer.Start(ctx, "postgres.delete.exec")
-
 	result, err := db.ExecContext(ctx, `UPDATE portfolio SET deleted_at = now() WHERE organization_id = $1 AND ledger_id = $2 AND id = $3 AND deleted_at IS NULL`,
 		organizationID, ledgerID, id)
 	if err != nil {
-		libOpentelemetry.HandleSpanError(spanExec, "Failed to execute delete query", err)
+		libOpentelemetry.HandleSpanError(span, "Failed to execute delete query", err)
 
 		return err
 	}
-
-	spanExec.End()
 
 	rowsAffected, err := result.RowsAffected()
 	if err != nil {
@@ -621,9 +589,6 @@ func (r *PortfolioPostgreSQLRepository) Count(ctx context.Context, organizationI
 
 		return count, err
 	}
-
-	_, spanQuery := tracer.Start(ctx, "postgres.count.query")
-	defer spanQuery.End()
 
 	err = db.QueryRowContext(ctx, "SELECT COUNT(*) FROM portfolio WHERE organization_id = $1 AND ledger_id = $2 AND deleted_at IS NULL", organizationID, ledgerID).Scan(&count)
 	if err != nil {

--- a/components/ledger/internal/adapters/postgres/segment/segment.postgresql.go
+++ b/components/ledger/internal/adapters/postgres/segment/segment.postgresql.go
@@ -152,9 +152,6 @@ func (p *SegmentPostgreSQLRepository) Create(ctx context.Context, segment *mmode
 		return nil, err
 	}
 
-	_, spanExec := tracer.Start(ctx, "postgres.create.exec")
-	defer spanExec.End()
-
 	inserted := &SegmentPostgreSQLModel{}
 
 	row := db.QueryRowContext(ctx, query, args...)
@@ -172,12 +169,12 @@ func (p *SegmentPostgreSQLRepository) Create(ctx context.Context, segment *mmode
 		var pgErr *pgconn.PgError
 		if errors.As(err, &pgErr) {
 			err := services.ValidatePGError(pgErr, constant.EntitySegment)
-			libOpentelemetry.HandleSpanBusinessErrorEvent(spanExec, "Failed to execute create query", err)
+			libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Failed to execute create query", err)
 
 			return nil, err
 		}
 
-		libOpentelemetry.HandleSpanError(spanExec, "Failed to execute create query", err)
+		libOpentelemetry.HandleSpanError(span, "Failed to execute create query", err)
 
 		return nil, err
 	}
@@ -201,9 +198,6 @@ func (p *SegmentPostgreSQLRepository) ExistsByName(ctx context.Context, organiza
 		return false, err
 	}
 
-	_, spanQuery := tracer.Start(ctx, "postgres.exists_segment_by_name.query")
-	defer spanQuery.End()
-
 	query, args, err := squirrel.Select(segmentColumnList...).
 		From(p.tableName).
 		Where(squirrel.Eq{"organization_id": organizationID}).
@@ -214,13 +208,13 @@ func (p *SegmentPostgreSQLRepository) ExistsByName(ctx context.Context, organiza
 		PlaceholderFormat(squirrel.Dollar).
 		ToSql()
 	if err != nil {
-		libOpentelemetry.HandleSpanError(spanQuery, "Failed to build query", err)
+		libOpentelemetry.HandleSpanError(span, "Failed to build query", err)
 		return false, err
 	}
 
 	rows, err := db.QueryContext(ctx, query, args...)
 	if err != nil {
-		libOpentelemetry.HandleSpanError(spanQuery, "Failed to execute query", err)
+		libOpentelemetry.HandleSpanError(span, "Failed to execute query", err)
 		return false, err
 	}
 	defer rows.Close()
@@ -281,12 +275,9 @@ func (p *SegmentPostgreSQLRepository) FindAll(ctx context.Context, organizationI
 		return nil, err
 	}
 
-	_, spanQuery := tracer.Start(ctx, "postgres.find_all.query")
-	defer spanQuery.End()
-
 	rows, err := db.QueryContext(ctx, query, args...)
 	if err != nil {
-		libOpentelemetry.HandleSpanError(spanQuery, "Failed to execute query", err)
+		libOpentelemetry.HandleSpanError(span, "Failed to execute query", err)
 		return nil, err
 	}
 	defer rows.Close()
@@ -328,9 +319,6 @@ func (p *SegmentPostgreSQLRepository) FindByIDs(ctx context.Context, organizatio
 
 	var segments []*mmodel.Segment
 
-	_, spanQuery := tracer.Start(ctx, "postgres.find_segments_by_ids.query")
-	defer spanQuery.End()
-
 	query, args, err := squirrel.Select(segmentColumnList...).
 		From(p.tableName).
 		Where(squirrel.Eq{"organization_id": organizationID}).
@@ -341,13 +329,13 @@ func (p *SegmentPostgreSQLRepository) FindByIDs(ctx context.Context, organizatio
 		PlaceholderFormat(squirrel.Dollar).
 		ToSql()
 	if err != nil {
-		libOpentelemetry.HandleSpanError(spanQuery, "Failed to build query", err)
+		libOpentelemetry.HandleSpanError(span, "Failed to build query", err)
 		return nil, err
 	}
 
 	rows, err := db.QueryContext(ctx, query, args...)
 	if err != nil {
-		libOpentelemetry.HandleSpanError(spanQuery, "Failed to execute query", err)
+		libOpentelemetry.HandleSpanError(span, "Failed to execute query", err)
 		return nil, err
 	}
 	defer rows.Close()
@@ -389,9 +377,6 @@ func (p *SegmentPostgreSQLRepository) Find(ctx context.Context, organizationID, 
 
 	segment := &SegmentPostgreSQLModel{}
 
-	_, spanQuery := tracer.Start(ctx, "postgres.find.query")
-	defer spanQuery.End()
-
 	query, args, err := squirrel.Select(segmentColumnList...).
 		From(p.tableName).
 		Where(squirrel.Eq{"organization_id": organizationID}).
@@ -402,7 +387,7 @@ func (p *SegmentPostgreSQLRepository) Find(ctx context.Context, organizationID, 
 		PlaceholderFormat(squirrel.Dollar).
 		ToSql()
 	if err != nil {
-		libOpentelemetry.HandleSpanError(spanQuery, "Failed to build query", err)
+		libOpentelemetry.HandleSpanError(span, "Failed to build query", err)
 		return nil, err
 	}
 
@@ -471,9 +456,6 @@ func (p *SegmentPostgreSQLRepository) Update(ctx context.Context, organizationID
 		return nil, err
 	}
 
-	_, spanExec := tracer.Start(ctx, "postgres.update.exec")
-	defer spanExec.End()
-
 	updated := &SegmentPostgreSQLModel{}
 
 	row := db.QueryRowContext(ctx, query, args...)
@@ -490,7 +472,7 @@ func (p *SegmentPostgreSQLRepository) Update(ctx context.Context, organizationID
 	); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			err := pkg.ValidateBusinessError(constant.ErrEntityNotFound, constant.EntitySegment)
-			libOpentelemetry.HandleSpanBusinessErrorEvent(spanExec, "Failed to update segment. Rows affected is 0", err)
+			libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Failed to update segment. Rows affected is 0", err)
 
 			return nil, err
 		}
@@ -498,12 +480,12 @@ func (p *SegmentPostgreSQLRepository) Update(ctx context.Context, organizationID
 		var pgErr *pgconn.PgError
 		if errors.As(err, &pgErr) {
 			err := services.ValidatePGError(pgErr, constant.EntitySegment)
-			libOpentelemetry.HandleSpanBusinessErrorEvent(spanExec, "Failed to execute update query", err)
+			libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Failed to execute update query", err)
 
 			return nil, err
 		}
 
-		libOpentelemetry.HandleSpanError(spanExec, "Failed to execute update query", err)
+		libOpentelemetry.HandleSpanError(span, "Failed to execute update query", err)
 
 		return nil, err
 	}
@@ -540,12 +522,9 @@ func (p *SegmentPostgreSQLRepository) Delete(ctx context.Context, organizationID
 		return err
 	}
 
-	_, spanExec := tracer.Start(ctx, "postgres.delete.exec")
-	defer spanExec.End()
-
 	result, err := db.ExecContext(ctx, query, args...)
 	if err != nil {
-		libOpentelemetry.HandleSpanError(spanExec, "Failed to execute delete query", err)
+		libOpentelemetry.HandleSpanError(span, "Failed to execute delete query", err)
 		return err
 	}
 
@@ -593,9 +572,6 @@ func (p *SegmentPostgreSQLRepository) Count(ctx context.Context, organizationID,
 		libOpentelemetry.HandleSpanError(span, "Failed to build query", err)
 		return count, err
 	}
-
-	_, spanQuery := tracer.Start(ctx, "postgres.count.query")
-	defer spanQuery.End()
 
 	err = db.QueryRowContext(ctx, query, args...).Scan(&count)
 	if err != nil {

--- a/components/ledger/internal/adapters/postgres/transaction/transaction.postgresql.go
+++ b/components/ledger/internal/adapters/postgres/transaction/transaction.postgresql.go
@@ -211,9 +211,6 @@ func (r *TransactionPostgreSQLRepository) Create(ctx context.Context, transactio
 	record := &TransactionPostgreSQLModel{}
 	record.FromEntity(transaction)
 
-	_, spanExec := tracer.Start(ctx, "postgres.create.exec")
-	defer spanExec.End()
-
 	// NOTE (v3.5.4 backport): explicit columns keep this INSERT working when future
 	// migrations add columns to transaction. Do not collapse this to table-wide VALUES.
 	insertQuery := fmt.Sprintf(
@@ -247,12 +244,12 @@ func (r *TransactionPostgreSQLRepository) Create(ctx context.Context, transactio
 		// Only PK violations are treated as idempotent retries. Other unique
 		// violations (e.g. business indexes) must surface as errors. (v3.5.4 backport)
 		if errors.As(err, &pgErr) && pgErr != nil && pgErr.Code == constant.UniqueViolationCode && pgErr.ConstraintName == "transaction_pkey" {
-			libOpentelemetry.HandleSpanEvent(spanExec, "Transaction already exists, skipping duplicate insert (idempotent retry)")
+			libOpentelemetry.HandleSpanEvent(span, "Transaction already exists, skipping duplicate insert (idempotent retry)")
 
 			return nil, err
 		}
 
-		libOpentelemetry.HandleSpanError(spanExec, "Failed to execute query", err)
+		libOpentelemetry.HandleSpanError(span, "Failed to execute query", err)
 
 		return nil, err
 	}
@@ -735,12 +732,9 @@ func (r *TransactionPostgreSQLRepository) FindAll(ctx context.Context, organizat
 		return nil, libHTTP.CursorPagination{}, err
 	}
 
-	_, spanQuery := tracer.Start(ctx, "postgres.find_all.query")
-	defer spanQuery.End()
-
 	rows, err := db.QueryContext(ctx, query, args...)
 	if err != nil {
-		libOpentelemetry.HandleSpanError(spanQuery, "Failed to execute query", err)
+		libOpentelemetry.HandleSpanError(span, "Failed to execute query", err)
 
 		return nil, libHTTP.CursorPagination{}, err
 	}
@@ -844,12 +838,9 @@ func (r *TransactionPostgreSQLRepository) ListByIDs(ctx context.Context, organiz
 		return nil, err
 	}
 
-	_, spanQuery := tracer.Start(ctx, "postgres.list_by_ids.query")
-	defer spanQuery.End()
-
 	rows, err := db.QueryContext(ctx, query, args...)
 	if err != nil {
-		libOpentelemetry.HandleSpanError(spanQuery, "Failed to execute query", err)
+		libOpentelemetry.HandleSpanError(span, "Failed to execute query", err)
 
 		return nil, err
 	}
@@ -939,9 +930,6 @@ func (r *TransactionPostgreSQLRepository) Find(ctx context.Context, organization
 
 	var body *string
 
-	_, spanQuery := tracer.Start(ctx, "postgres.find.query")
-	defer spanQuery.End()
-
 	row := db.QueryRowContext(ctx, query, args...)
 
 	if err := row.Scan(
@@ -1021,9 +1009,6 @@ func (r *TransactionPostgreSQLRepository) FindByParentID(ctx context.Context, or
 	transaction := &TransactionPostgreSQLModel{}
 
 	var body *string
-
-	_, spanQuery := tracer.Start(ctx, "postgres.find.query")
-	defer spanQuery.End()
 
 	row := db.QueryRowContext(ctx, query, args...)
 
@@ -1121,12 +1106,9 @@ func (r *TransactionPostgreSQLRepository) Update(ctx context.Context, organizati
 		` AND id = $` + strconv.Itoa(len(args)) +
 		` AND deleted_at IS NULL`
 
-	_, spanExec := tracer.Start(ctx, "postgres.update.exec")
-	defer spanExec.End()
-
 	result, err := db.ExecContext(ctx, query, args...)
 	if err != nil {
-		libOpentelemetry.HandleSpanError(spanExec, "Failed to execute query", err)
+		libOpentelemetry.HandleSpanError(span, "Failed to execute query", err)
 
 		return nil, err
 	}
@@ -1163,13 +1145,10 @@ func (r *TransactionPostgreSQLRepository) Delete(ctx context.Context, organizati
 		return err
 	}
 
-	_, spanExec := tracer.Start(ctx, "postgres.delete.exec")
-	defer spanExec.End()
-
 	result, err := db.ExecContext(ctx, "UPDATE transaction SET deleted_at = now() WHERE organization_id = $1 AND ledger_id = $2 AND id = $3 AND deleted_at IS NULL",
 		organizationID, ledgerID, id)
 	if err != nil {
-		libOpentelemetry.HandleSpanError(spanExec, "Failed to execute query", err)
+		libOpentelemetry.HandleSpanError(span, "Failed to execute query", err)
 
 		return err
 	}
@@ -1206,9 +1185,6 @@ func (r *TransactionPostgreSQLRepository) FindWithOperations(ctx context.Context
 		return nil, err
 	}
 
-	_, spanQuery := tracer.Start(ctx, "postgres.find_transaction_with_operations.query")
-	defer spanQuery.End()
-
 	selectColumns := append(transactionColumnListPrefixed, operationColumnListPrefixed...)
 
 	findWithOps := squirrel.Select(selectColumns...).
@@ -1222,14 +1198,14 @@ func (r *TransactionPostgreSQLRepository) FindWithOperations(ctx context.Context
 
 	query, args, err := findWithOps.ToSql()
 	if err != nil {
-		libOpentelemetry.HandleSpanError(spanQuery, "Failed to build query", err)
+		libOpentelemetry.HandleSpanError(span, "Failed to build query", err)
 
 		return nil, err
 	}
 
 	rows, err := db.QueryContext(ctx, query, args...)
 	if err != nil {
-		libOpentelemetry.HandleSpanError(spanQuery, "Failed to execute query", err)
+		libOpentelemetry.HandleSpanError(span, "Failed to execute query", err)
 
 		return nil, err
 	}
@@ -1396,12 +1372,9 @@ func (r *TransactionPostgreSQLRepository) FindOrListAllWithOperations(ctx contex
 
 	logger.Log(ctx, libLog.LevelDebug, "FindOrListAllWithOperations query assembled", libLog.String("query", query))
 
-	_, spanQuery := tracer.Start(ctx, "postgres.find_all.query")
-	defer spanQuery.End()
-
 	rows, err := db.QueryContext(ctx, query, args...)
 	if err != nil {
-		libOpentelemetry.HandleSpanError(spanQuery, "Failed to execute query", err)
+		libOpentelemetry.HandleSpanError(span, "Failed to execute query", err)
 
 		return nil, libHTTP.CursorPagination{}, err
 	}
@@ -1614,14 +1587,11 @@ func (r *TransactionPostgreSQLRepository) CountByFilters(ctx context.Context, or
 		return 0, err
 	}
 
-	_, spanQuery := tracer.Start(ctx, "postgres.count_transactions_by_filters.query")
-	defer spanQuery.End()
-
 	var count int64
 
 	err = db.QueryRowContext(ctx, query, args...).Scan(&count)
 	if err != nil {
-		libOpentelemetry.HandleSpanError(spanQuery, "Failed to execute count query", err)
+		libOpentelemetry.HandleSpanError(span, "Failed to execute count query", err)
 
 		return 0, err
 	}

--- a/components/ledger/internal/adapters/postgres/transactionquarantine/transactionquarantine.postgresql.go
+++ b/components/ledger/internal/adapters/postgres/transactionquarantine/transactionquarantine.postgresql.go
@@ -164,24 +164,21 @@ func (r *QuarantinePostgreSQLRepository) Insert(ctx context.Context, record *Qua
 		return err
 	}
 
-	_, spanExec := tracer.Start(ctx, "postgres.insert_transaction_backup_quarantine.exec")
-	defer spanExec.End()
-
 	result, err := db.ExecContext(ctx, query, args...)
 	if err != nil {
-		libOpentelemetry.HandleSpanError(spanExec, "Failed to insert quarantine record", err)
+		libOpentelemetry.HandleSpanError(span, "Failed to insert quarantine record", err)
 
 		return err
 	}
 
 	rowsAffected, err := result.RowsAffected()
 	if err != nil {
-		libOpentelemetry.HandleSpanError(spanExec, "Failed to read rows affected", err)
+		libOpentelemetry.HandleSpanError(span, "Failed to read rows affected", err)
 
 		return err
 	}
 
-	spanExec.SetAttributes(attribute.Int64("db.rows_affected", rowsAffected))
+	span.SetAttributes(attribute.Int64("db.rows_affected", rowsAffected))
 
 	// rowsAffected == 0 means the record was already quarantined (ON CONFLICT
 	// DO NOTHING). That is a successful, idempotent outcome: the durable copy

--- a/components/ledger/internal/adapters/postgres/transactionroute/transactionroute.postgresql.go
+++ b/components/ledger/internal/adapters/postgres/transactionroute/transactionroute.postgresql.go
@@ -168,8 +168,6 @@ func (r *TransactionRoutePostgreSQLRepository) Create(ctx context.Context, organ
 		}
 	}()
 
-	_, spanExec := tracer.Start(ctx, "postgres.create.exec")
-
 	// Insert transaction route via squirrel + RETURNING and scan the
 	// post-commit row back into `inserted`. The RETURNING clause
 	// guarantees identity + timestamps reflect the persisted state
@@ -182,7 +180,7 @@ func (r *TransactionRoutePostgreSQLRepository) Create(ctx context.Context, organ
 		PlaceholderFormat(squirrel.Dollar).
 		ToSql()
 	if err != nil {
-		libOpentelemetry.HandleSpanError(spanExec, "Failed to build insert transaction route query", err)
+		libOpentelemetry.HandleSpanError(span, "Failed to build insert transaction route query", err)
 		return nil, err
 	}
 
@@ -194,17 +192,15 @@ func (r *TransactionRoutePostgreSQLRepository) Create(ctx context.Context, organ
 		if errors.As(err, &pgErr) {
 			err := services.ValidatePGError(pgErr, constant.EntityTransactionRoute)
 
-			libOpentelemetry.HandleSpanBusinessErrorEvent(spanExec, "Failed to execute insert transaction route query", err)
+			libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Failed to execute insert transaction route query", err)
 
 			return nil, err
 		}
 
-		libOpentelemetry.HandleSpanError(spanExec, "Failed to execute insert transaction route query", err)
+		libOpentelemetry.HandleSpanError(span, "Failed to execute insert transaction route query", err)
 
 		return nil, err
 	}
-
-	spanExec.End()
 
 	// Insert operation route relations
 	if len(transactionRoute.OperationRoutes) > 0 {
@@ -299,12 +295,9 @@ func (r *TransactionRoutePostgreSQLRepository) FindByID(ctx context.Context, org
 		return nil, err
 	}
 
-	_, spanQuery := tracer.Start(ctx, "postgres.find_by_id.query")
-	defer spanQuery.End()
-
 	rows, err := db.QueryContext(ctx, sqlQuery, args...)
 	if err != nil {
-		libOpentelemetry.HandleSpanError(spanQuery, "Failed to execute query", err)
+		libOpentelemetry.HandleSpanError(span, "Failed to execute query", err)
 
 		return nil, err
 	}
@@ -479,14 +472,12 @@ func (r *TransactionRoutePostgreSQLRepository) Update(ctx context.Context, organ
 		return nil, err
 	}
 
-	_, spanExec := tracer.Start(ctx, "postgres.update.exec")
-
 	updated := &TransactionRoutePostgreSQLModel{}
 
 	row := tx.QueryRowContext(ctx, updateSQL, updateArgs...)
 	if err := scanTransactionRoute(row, updated); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			libOpentelemetry.HandleSpanBusinessErrorEvent(spanExec, "Failed to update transaction route. Rows affected is 0", services.ErrDatabaseItemNotFound)
+			libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Failed to update transaction route. Rows affected is 0", services.ErrDatabaseItemNotFound)
 			return nil, services.ErrDatabaseItemNotFound
 		}
 
@@ -494,17 +485,15 @@ func (r *TransactionRoutePostgreSQLRepository) Update(ctx context.Context, organ
 		if errors.As(err, &pgErr) {
 			err := services.ValidatePGError(pgErr, constant.EntityTransactionRoute)
 
-			libOpentelemetry.HandleSpanBusinessErrorEvent(spanExec, "Failed to execute update query", err)
+			libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Failed to execute update query", err)
 
 			return nil, err
 		}
 
-		libOpentelemetry.HandleSpanError(spanExec, "Failed to execute update query", err)
+		libOpentelemetry.HandleSpanError(span, "Failed to execute update query", err)
 
 		return nil, err
 	}
-
-	spanExec.End()
 
 	if len(toAdd) > 0 || len(toRemove) > 0 {
 		err = r.updateOperationRouteRelationships(ctx, tx, id, toAdd, toRemove)
@@ -538,9 +527,6 @@ func (r *TransactionRoutePostgreSQLRepository) Delete(ctx context.Context, organ
 		return err
 	}
 
-	_, spanExec := tracer.Start(ctx, "postgres.delete.exec")
-	defer spanExec.End()
-
 	tx, err := db.BeginTx(ctx, nil)
 	if err != nil {
 		libOpentelemetry.HandleSpanError(span, "Failed to begin transaction", err)
@@ -558,14 +544,14 @@ func (r *TransactionRoutePostgreSQLRepository) Delete(ctx context.Context, organ
 
 	_, err = tx.ExecContext(ctx, `UPDATE transaction_route SET deleted_at = NOW() WHERE organization_id = $1 AND ledger_id = $2 AND id = $3 AND deleted_at IS NULL`, organizationID, ledgerID, id)
 	if err != nil {
-		libOpentelemetry.HandleSpanError(spanExec, "Failed to execute delete query", err)
+		libOpentelemetry.HandleSpanError(span, "Failed to execute delete query", err)
 
 		return err
 	}
 
 	err = r.updateOperationRouteRelationships(ctx, tx, id, nil, toRemove)
 	if err != nil {
-		libOpentelemetry.HandleSpanError(spanExec, "Failed to update operation route relationships", err)
+		libOpentelemetry.HandleSpanError(span, "Failed to update operation route relationships", err)
 
 		return err
 	}
@@ -638,12 +624,9 @@ func (r *TransactionRoutePostgreSQLRepository) FindAll(ctx context.Context, orga
 		return nil, libHTTP.CursorPagination{}, err
 	}
 
-	_, spanQuery := tracer.Start(ctx, "postgres.find_all.query")
-	defer spanQuery.End()
-
 	rows, err := db.QueryContext(ctx, query, args...)
 	if err != nil {
-		libOpentelemetry.HandleSpanError(spanQuery, "Failed to execute query", err)
+		libOpentelemetry.HandleSpanError(span, "Failed to execute query", err)
 
 		return nil, libHTTP.CursorPagination{}, err
 	}
@@ -730,12 +713,9 @@ func (r *TransactionRoutePostgreSQLRepository) FindOperationRouteIDsByTransactio
 		return nil, err
 	}
 
-	_, spanQuery := tracer.Start(ctx, "postgres.find_operation_route_ids.query")
-	defer spanQuery.End()
-
 	rows, err := db.QueryContext(ctx, sqlQuery, args...)
 	if err != nil {
-		libOpentelemetry.HandleSpanError(spanQuery, "Failed to execute query", err)
+		libOpentelemetry.HandleSpanError(span, "Failed to execute query", err)
 
 		return nil, err
 	}

--- a/components/ledger/internal/adapters/redis/onboarding/consumer.redis.go
+++ b/components/ledger/internal/adapters/redis/onboarding/consumer.redis.go
@@ -13,7 +13,6 @@ import (
 	tmvalkey "github.com/LerianStudio/lib-commons/v7/commons/tenant-manager/valkey"
 	libObservability "github.com/LerianStudio/lib-observability/v4"
 	libLog "github.com/LerianStudio/lib-observability/v4/log"
-	libOpentelemetry "github.com/LerianStudio/lib-observability/v4/tracing"
 	"github.com/redis/go-redis/v9"
 )
 
@@ -55,21 +54,18 @@ func NewConsumerRedis(rc redisClientProvider) (*RedisConsumerRepository, error) 
 }
 
 func (rr *RedisConsumerRepository) Set(ctx context.Context, key, value string, ttl time.Duration) error {
-	logger, tracer, _, _ := libObservability.NewTrackingFromContext(ctx)
-
-	ctx, span := tracer.Start(ctx, "redis.set")
-	defer span.End()
+	logger, _, _, _ := libObservability.NewTrackingFromContext(ctx)
 
 	key, err := tmvalkey.GetKeyContext(ctx, key)
 	if err != nil {
-		libOpentelemetry.HandleSpanError(span, "Failed to build tenant key", err)
+		logger.Log(ctx, libLog.LevelError, "Failed to build tenant key", libLog.Err(err))
 
 		return err
 	}
 
 	rds, err := rr.conn.GetClient(ctx)
 	if err != nil {
-		libOpentelemetry.HandleSpanError(span, "Failed to get redis", err)
+		logger.Log(ctx, libLog.LevelError, "Failed to get redis", libLog.Err(err))
 
 		return err
 	}
@@ -82,7 +78,7 @@ func (rr *RedisConsumerRepository) Set(ctx context.Context, key, value string, t
 
 	statusCMD := rds.Set(ctx, key, value, ttl)
 	if statusCMD.Err() != nil {
-		libOpentelemetry.HandleSpanError(span, "Failed to set on redis", statusCMD.Err())
+		logger.Log(ctx, libLog.LevelError, "Failed to set on redis", libLog.Err(statusCMD.Err()))
 
 		return statusCMD.Err()
 	}
@@ -91,22 +87,17 @@ func (rr *RedisConsumerRepository) Set(ctx context.Context, key, value string, t
 }
 
 func (rr *RedisConsumerRepository) Get(ctx context.Context, key string) (string, error) {
-	logger, tracer, _, _ := libObservability.NewTrackingFromContext(ctx)
-
-	ctx, span := tracer.Start(ctx, "redis.get")
-	defer span.End()
+	logger, _, _, _ := libObservability.NewTrackingFromContext(ctx)
 
 	key, err := tmvalkey.GetKeyContext(ctx, key)
 	if err != nil {
-		libOpentelemetry.HandleSpanError(span, "Failed to build tenant key", err)
+		logger.Log(ctx, libLog.LevelError, "Failed to build tenant key", libLog.Err(err))
 
 		return "", err
 	}
 
 	rds, err := rr.conn.GetClient(ctx)
 	if err != nil {
-		libOpentelemetry.HandleSpanError(span, "Failed to connect on redis", err)
-
 		logger.Log(ctx, libLog.LevelError, "Failed to connect on redis", libLog.Err(err))
 
 		return "", err
@@ -114,8 +105,6 @@ func (rr *RedisConsumerRepository) Get(ctx context.Context, key string) (string,
 
 	val, err := rds.Get(ctx, key).Result()
 	if err != nil && !errors.Is(err, redis.Nil) {
-		libOpentelemetry.HandleSpanError(span, "Failed to get on redis", err)
-
 		logger.Log(ctx, libLog.LevelError, "Failed to get on redis", libLog.Err(err))
 
 		return "", err
@@ -125,22 +114,17 @@ func (rr *RedisConsumerRepository) Get(ctx context.Context, key string) (string,
 }
 
 func (rr *RedisConsumerRepository) Del(ctx context.Context, key string) error {
-	logger, tracer, _, _ := libObservability.NewTrackingFromContext(ctx)
-
-	ctx, span := tracer.Start(ctx, "redis.del")
-	defer span.End()
+	logger, _, _, _ := libObservability.NewTrackingFromContext(ctx)
 
 	key, err := tmvalkey.GetKeyContext(ctx, key)
 	if err != nil {
-		libOpentelemetry.HandleSpanError(span, "Failed to build tenant key", err)
+		logger.Log(ctx, libLog.LevelError, "Failed to build tenant key", libLog.Err(err))
 
 		return err
 	}
 
 	rds, err := rr.conn.GetClient(ctx)
 	if err != nil {
-		libOpentelemetry.HandleSpanError(span, "Failed to connect on redis", err)
-
 		logger.Log(ctx, libLog.LevelError, "Failed to connect on redis", libLog.Err(err))
 
 		return err
@@ -148,8 +132,6 @@ func (rr *RedisConsumerRepository) Del(ctx context.Context, key string) error {
 
 	val, err := rds.Del(ctx, key).Result()
 	if err != nil {
-		libOpentelemetry.HandleSpanError(span, "Failed to del on redis", err)
-
 		logger.Log(ctx, libLog.LevelError, "Failed to del on redis", libLog.Err(err))
 
 		return err

--- a/components/ledger/internal/adapters/redis/transaction/consumer.redis.go
+++ b/components/ledger/internal/adapters/redis/transaction/consumer.redis.go
@@ -188,20 +188,17 @@ func NewConsumerRedis(rc redisClientProvider) (*RedisConsumerRepository, error) 
 }
 
 func (rr *RedisConsumerRepository) Set(ctx context.Context, key, value string, ttl time.Duration) error {
-	logger, tracer, _, _ := libObservability.NewTrackingFromContext(ctx)
-
-	ctx, span := tracer.Start(ctx, "redis.set")
-	defer span.End()
+	logger, _, _, _ := libObservability.NewTrackingFromContext(ctx)
 
 	key, err := tenantKeyFromContextOrError(ctx, key)
 	if err != nil {
-		libOpentelemetry.HandleSpanError(span, "Failed to namespace redis key", err)
+		logger.Log(ctx, libLog.LevelError, "Failed to namespace redis key", libLog.Err(err))
 		return err
 	}
 
 	rds, err := rr.conn.GetClient(ctx)
 	if err != nil {
-		libOpentelemetry.HandleSpanError(span, "Failed to get redis", err)
+		logger.Log(ctx, libLog.LevelError, "Failed to get redis", libLog.Err(err))
 
 		return err
 	}
@@ -210,7 +207,7 @@ func (rr *RedisConsumerRepository) Set(ctx context.Context, key, value string, t
 
 	err = rds.Set(ctx, key, value, ttl*time.Second).Err()
 	if err != nil {
-		libOpentelemetry.HandleSpanError(span, "Failed to set on redis", err)
+		logger.Log(ctx, libLog.LevelError, "Failed to set on redis", libLog.Err(err))
 
 		return err
 	}
@@ -250,14 +247,10 @@ func (rr *RedisConsumerRepository) SetNX(ctx context.Context, key, value string,
 }
 
 func (rr *RedisConsumerRepository) Get(ctx context.Context, key string) (string, error) {
-	logger, tracer, _, _ := libObservability.NewTrackingFromContext(ctx)
-
-	ctx, span := tracer.Start(ctx, "redis.get")
-	defer span.End()
+	logger, _, _, _ := libObservability.NewTrackingFromContext(ctx)
 
 	key, err := tenantKeyFromContextOrError(ctx, key)
 	if err != nil {
-		libOpentelemetry.HandleSpanError(span, "Failed to namespace redis key", err)
 		logger.Log(ctx, libLog.LevelError, "Failed to namespace Redis key", libLog.Err(err))
 
 		return "", err
@@ -265,8 +258,6 @@ func (rr *RedisConsumerRepository) Get(ctx context.Context, key string) (string,
 
 	rds, err := rr.conn.GetClient(ctx)
 	if err != nil {
-		libOpentelemetry.HandleSpanError(span, "Failed to connect on redis", err)
-
 		logger.Log(ctx, libLog.LevelError, "Failed to connect to Redis", libLog.Err(err))
 
 		return "", err
@@ -274,8 +265,6 @@ func (rr *RedisConsumerRepository) Get(ctx context.Context, key string) (string,
 
 	val, err := rds.Get(ctx, key).Result()
 	if err != nil && !errors.Is(err, redis.Nil) {
-		libOpentelemetry.HandleSpanError(span, "Failed to get on redis", err)
-
 		logger.Log(ctx, libLog.LevelError, "Failed to get key from Redis", libLog.Err(err))
 
 		return "", err
@@ -287,21 +276,16 @@ func (rr *RedisConsumerRepository) Get(ctx context.Context, key string) (string,
 // MGet retrieves multiple values from redis.
 // Large inputs are processed in chunks of maxRedisBatchSize to prevent oversized payloads.
 func (rr *RedisConsumerRepository) MGet(ctx context.Context, keys []string) (map[string]string, error) {
-	logger, tracer, _, _ := libObservability.NewTrackingFromContext(ctx)
-
-	ctx, span := tracer.Start(ctx, "redis.mget")
-	defer span.End()
+	logger, _, _, _ := libObservability.NewTrackingFromContext(ctx)
 
 	if len(keys) == 0 {
-		libOpentelemetry.HandleSpanEvent(span, "mget called with empty keys")
+		logger.Log(ctx, libLog.LevelDebug, "mget called with empty keys")
 
 		return map[string]string{}, nil
 	}
 
 	rds, err := rr.conn.GetClient(ctx)
 	if err != nil {
-		libOpentelemetry.HandleSpanError(span, "Failed to get redis", err)
-
 		logger.Log(ctx, libLog.LevelError, "Failed to get Redis client", libLog.Err(err))
 
 		return nil, err
@@ -309,7 +293,6 @@ func (rr *RedisConsumerRepository) MGet(ctx context.Context, keys []string) (map
 
 	prefixedKeys, err := tenantKeysFromContext(ctx, keys)
 	if err != nil {
-		libOpentelemetry.HandleSpanError(span, "Failed to namespace redis keys", err)
 		logger.Log(ctx, libLog.LevelError, "Failed to namespace Redis keys", libLog.Err(err))
 
 		return nil, err
@@ -325,8 +308,6 @@ func (rr *RedisConsumerRepository) MGet(ctx context.Context, keys []string) (map
 
 		res, err := rds.MGet(ctx, chunk...).Result()
 		if err != nil {
-			libOpentelemetry.HandleSpanError(span, "Failed to mget on redis", err)
-
 			logger.Log(ctx, libLog.LevelError, "Failed to MGET from Redis", libLog.Err(err))
 
 			return nil, err
@@ -354,14 +335,10 @@ func (rr *RedisConsumerRepository) MGet(ctx context.Context, keys []string) (map
 }
 
 func (rr *RedisConsumerRepository) Del(ctx context.Context, key string) error {
-	logger, tracer, _, _ := libObservability.NewTrackingFromContext(ctx)
-
-	ctx, span := tracer.Start(ctx, "redis.del")
-	defer span.End()
+	logger, _, _, _ := libObservability.NewTrackingFromContext(ctx)
 
 	key, err := tenantKeyFromContextOrError(ctx, key)
 	if err != nil {
-		libOpentelemetry.HandleSpanError(span, "Failed to namespace redis key", err)
 		logger.Log(ctx, libLog.LevelError, "Failed to namespace Redis key", libLog.Err(err))
 
 		return err
@@ -369,8 +346,6 @@ func (rr *RedisConsumerRepository) Del(ctx context.Context, key string) error {
 
 	rds, err := rr.conn.GetClient(ctx)
 	if err != nil {
-		libOpentelemetry.HandleSpanError(span, "Failed to connect on redis", err)
-
 		logger.Log(ctx, libLog.LevelError, "Failed to connect to Redis", libLog.Err(err))
 
 		return err
@@ -378,8 +353,6 @@ func (rr *RedisConsumerRepository) Del(ctx context.Context, key string) error {
 
 	val, err := rds.Del(ctx, key).Result()
 	if err != nil {
-		libOpentelemetry.HandleSpanError(span, "Failed to del on redis", err)
-
 		logger.Log(ctx, libLog.LevelError, "Failed to delete key from Redis", libLog.Err(err))
 
 		return err
@@ -391,15 +364,10 @@ func (rr *RedisConsumerRepository) Del(ctx context.Context, key string) error {
 }
 
 func (rr *RedisConsumerRepository) Incr(ctx context.Context, key string) int64 {
-	logger, tracer, _, _ := libObservability.NewTrackingFromContext(ctx)
-
-	ctx, span := tracer.Start(ctx, "redis.incr")
-	defer span.End()
+	logger, _, _, _ := libObservability.NewTrackingFromContext(ctx)
 
 	key, err := tenantKeyFromContextOrError(ctx, key)
 	if err != nil {
-		libOpentelemetry.HandleSpanError(span, "Failed to namespace redis key", err)
-
 		logger.Log(ctx, libLog.LevelError, "Failed to namespace Redis key", libLog.Err(err))
 
 		return 0
@@ -407,8 +375,6 @@ func (rr *RedisConsumerRepository) Incr(ctx context.Context, key string) int64 {
 
 	rds, err := rr.conn.GetClient(ctx)
 	if err != nil {
-		libOpentelemetry.HandleSpanError(span, "Failed to get redis", err)
-
 		logger.Log(ctx, libLog.LevelError, "Failed to get Redis client", libLog.Err(err))
 
 		return 0

--- a/docs/standards/telemetry.md
+++ b/docs/standards/telemetry.md
@@ -20,13 +20,24 @@ Two rules — **T5** (span-error helper by class) and **T8** (single-point loggi
 
 ## T2 — Span naming
 
-**Rule:** Span names MUST be `<layer>.<operation>` in dotted snake_case (e.g. `command.create_account`, `mongodb.update_holder`). Child I/O spans MUST extend the parent name with a `.exec` / `.query` / `.find` (etc.) suffix. MUST NOT use bespoke prefixes or free-form names.
+**Rule:** Span names MUST be `<layer>.<operation>` in dotted snake_case (e.g. `command.create_account`, `mongodb.update_holder`). A child I/O span MUST be opened **only where the driver is not auto-instrumented**; where one is opened it MUST extend the parent name with a `.exec` / `.query` / `.find` / `.insert` (etc.) suffix. MUST NOT use bespoke prefixes or free-form names.
 
-**Rationale:** A predictable two-segment scheme makes spans groupable by layer and operation across services and lets dashboards and trace search rely on a stable naming contract instead of per-author conventions.
+Current driver coverage in this repo:
 
-**Canonical example:** [`components/ledger/internal/adapters/postgres/account/account.postgresql.go:187`](../../components/ledger/internal/adapters/postgres/account/account.postgresql.go) — `_, spanExec := tracer.Start(ctx, "postgres.create.exec")` (child I/O span with `.exec` suffix under the `postgres.create_account` parent).
+| Store | Driver auto-instrumentation | Child I/O span |
+|-------|-----------------------------|----------------|
+| MongoDB | none (`lib-commons` has no `commons/mongo/observability.go`) | **REQUIRED** |
+| PostgreSQL | `lib-commons/commons/postgres` → `instrumentPool()` → `sqlobs.Setup()`, which passes `otelsql.WithTracerProvider` (since lib-commons v6.8.1) | **FORBIDDEN** — otelsql already emits `sql.connector.connect` / `sql.conn.query` / `sql.rows` per statement |
+| Redis / Valkey | `lib-commons/commons/redis` → `instrumentClient()` → `redisobs.Setup()` (since lib-commons v6.8.1) | **FORBIDDEN** for spans that mirror one driver command; semantic spans that span several commands or carry domain meaning (`redis.run_balance_atomic_script`, `redis.schedule_balance_sync_batch`, `redis.set_nx`) stay |
+| RabbitMQ | none (`messagingobs` is wired nowhere) | **REQUIRED** |
 
-**Enforcement:** `review-only` — naming intent is not mechanically distinguishable from valid free text; gate at code review.
+**Rationale:** A predictable two-segment scheme makes spans groupable by layer and operation across services and lets dashboards and trace search rely on a stable naming contract instead of per-author conventions. Once the driver emits its own span per statement, a hand-rolled sibling doubles the span volume on the hottest path in the system without adding a single fact: one `GET /v1/organizations` was observed emitting `sql.connector.connect`, `sql.conn.query` and `sql.rows` from `github.com/XSAM/otelsql` alongside midaz's own `postgres.find_all.query`. Error attribution does not move to the driver span, however — otelsql cannot express the business-vs-technical class T5 requires and does not see client-side `Scan`/mapping failures — so when a child I/O span is deleted its `HandleSpanError` / `HandleSpanBusinessErrorEvent` / `SetAttributes` calls move onto the surviving parent domain span rather than disappearing.
+
+**Canonical example:** [`components/ledger/internal/crm/adapters/mongodb/holder/holder.mongodb.go:138`](../../components/ledger/internal/crm/adapters/mongodb/holder/holder.mongodb.go) — `_, spanInsert := tracer.Start(ctx, "mongodb.create_holder.insert")` (child I/O span with `.insert` suffix under the `mongodb.create_holder` parent, on a driver with no auto-instrumentation).
+
+**Counter-example (forbidden duplicate):** the shape to reject is `_, spanExec := tracer.Start(ctx, "postgres.create.exec")` wrapping a `db.ExecContext` call. The 121 `postgres.<op>.query` / `postgres.<op>.exec` spans under `components/ledger/internal/adapters/postgres/` and the 8 one-command Redis spans (`redis.set`/`get`/`del`/`mget`/`incr`) were removed for this reason; `components/tracer/internal/adapters/postgres/` still carries its own set pending a separate analysis.
+
+**Enforcement:** `review-only` — naming intent is not mechanically distinguishable from valid free text, and whether a driver is instrumented depends on the lib-commons version in `go.mod`; gate at code review.
 
 ---
 
@@ -38,7 +49,7 @@ Two rules — **T5** (span-error helper by class) and **T8** (single-point loggi
 
 **Canonical example (sanctioned detach):** [`components/tracer/internal/services/validation_service.go:614`](../../components/tracer/internal/services/validation_service.go) — `context.WithTimeout(context.WithoutCancel(ctx), validationPersistTimeout)` with the preceding intent comment (lines 611–613) explaining the SOX/GLBA audit-trail persistence budget.
 
-**Counter-example (forbidden leaf rebind):** the shape to reject is `ctx, spanExec := tracer.Start(ctx, "postgres.create.exec")` — rebinding `ctx` on a leaf exec/query span with no detach intent, which nests sibling I/O spans under each other instead of the parent. The audit's 135+ leaf rebinds were converted to the non-rebinding `_, spanX :=` form (see the canonical example above); the lint gate keeps them from reappearing.
+**Counter-example (forbidden leaf rebind):** the shape to reject is `ctx, spanInsert := tracer.Start(ctx, "mongodb.create_holder.insert")` — rebinding `ctx` on a leaf insert/find span with no detach intent, which nests sibling I/O spans under each other instead of the parent. The audit's 135+ leaf rebinds were converted to the non-rebinding `_, spanX :=` form (see the canonical example above); the PostgreSQL and Redis leaves it covered have since been deleted outright under T2, so the surviving population is the MongoDB and RabbitMQ leaves, and the lint gate keeps the rebind from reappearing on them.
 
 **Enforcement:** `custom-lint` — flag `ctx, span\w* := .*tracer.Start` on leaf spans; allowlist requires an adjacent `WithoutCancel` or an intent comment (per-file review where ambiguous).
 

--- a/pkg/utils/metrics.go
+++ b/pkg/utils/metrics.go
@@ -14,6 +14,19 @@ import (
 	"github.com/LerianStudio/midaz/v4/pkg"
 )
 
+// msLatencyBuckets is the millisecond bucket ladder for every `*_ms`
+// histogram declared here. It MUST be supplied explicitly: MetricsFactory
+// falls back to selectDefaultBuckets, which name-matches "duration" and hands
+// back DefaultLatencyBuckets — a SECONDS ladder ({0.001…10}) — while the
+// backing instrument is an Int64Histogram, so every observation below 1000 ms
+// would collapse into the `le=10` bucket and the quantiles would be
+// meaningless. The values are identical to the ladder pinned in
+// components/tracer/internal/observability/recorder.go, which declares the
+// same `readyz_check_duration_ms` metric name: two declarations of one metric
+// name must not diverge, and the tracer's boundaries are public contract that
+// dashboards and SLO alerts hard-code.
+var msLatencyBuckets = []float64{1, 5, 10, 25, 50, 100, 250, 500, 1000, 2000, 5000}
+
 var (
 	// DomainOperationsTotal counts business-operation outcomes across all
 	// components (D6 mandate). Labels: component, operation, result — all
@@ -30,6 +43,7 @@ var (
 		Name:        "domain_operation_duration_ms",
 		Unit:        "ms",
 		Description: "Business operation duration in milliseconds by component and operation.",
+		Buckets:     msLatencyBuckets,
 	}
 )
 
@@ -280,6 +294,7 @@ var (
 		Name:        "bulk_recorder_bulk_duration_ms",
 		Unit:        "ms",
 		Description: "Time taken for bulk processing in milliseconds.",
+		Buckets:     msLatencyBuckets,
 	}
 
 	// BulkRecorderFallbackTotal counts fallback activations when bulk fails.
@@ -296,6 +311,7 @@ var (
 		Name:        "readyz_check_duration_ms",
 		Unit:        "ms",
 		Description: "Duration of individual health check probes in milliseconds.",
+		Buckets:     msLatencyBuckets,
 	}
 
 	// ReadyzCheckStatus counts health check outcomes by checker and status.
@@ -350,6 +366,7 @@ var (
 		Name:        "crm_protection_provider_operation_ms",
 		Unit:        "ms",
 		Description: "Duration of provider wrap/unwrap operations in milliseconds by operation and provider.",
+		Buckets:     msLatencyBuckets,
 	}
 
 	// CRMProtectionProviderOperationFailuresTotal counts provider operation failures.


### PR DESCRIPTION
> **Stacked on #2458.** Base is `fix/deps-stable-pins-lib-commons-v7`, not `develop`. Review the 19-file diff here; #2458 is the mechanical 511-file `/v6`->`/v7` rename. **Merge #2458 first**, then this retargets to `develop` automatically.

## Summary

Midaz hand-rolls child I/O spans around PostgreSQL and Redis calls that the drivers **already instrument**, doubling span volume on the hottest paths in the system without adding a single fact.

`lib-commons` auto-instruments both pools:

- `commons/postgres/postgres.go` -> `instrumentPool()` -> `sqlobs.Setup()`, which passes `otelsql.WithTracerProvider`
- `commons/redis/redis.go` -> `instrumentClient()` -> `redisobs.Setup()`

A live trace of one `GET /v1/organizations` carried `sql.connector.connect`, `sql.conn.query` and `sql.rows` from `github.com/XSAM/otelsql` **alongside** midaz's own `postgres.find_all.query`.

## What is removed

**121 postgres child spans** (78 `.query` + 43 `.exec`) across the 14 ledger postgres packages — balance 16, account 16, ledger 11, transaction 10, operation 10, segment 8, portfolio 8, operationroute 8, asset 8, organization 7, accounttype 7, transactionroute 6, assetrate 5, transactionquarantine 1.

**8 redis spans** that mirror one driver command one-for-one: `redis.set`, `redis.get`, `redis.del` in both the transaction and onboarding repositories, plus `redis.mget` and `redis.incr`.

## What is deliberately kept

The parent domain spans all stay (`postgres.create_account`, `postgres.find_all_transactions`, ...). So do the **semantic** redis spans — `set_nx`, `set_bytes`, `get_bytes`, `run_balance_atomic_script`, `schedule_balance_sync_batch`, the queue helpers, and the CPU-only `build_balance_atomic_operation_plan` / `decode_balance_atomic_result`. They span more than one command or carry meaning no driver span can.

`components/tracer/internal/adapters/postgres` is **untouched**: its overlap needs its own analysis.

## Error handling moves, it does not disappear

This is the part worth reviewing closely. otelsql/redisobs spans **cannot replace** the deleted ones for error reporting:

- they cannot express the **business-vs-technical class T5 mandates** — otelsql flips its span red for a constraint violation the repository deliberately classifies as a business event
- they never see **client-side `Scan` or error-mapping failures**

So every `HandleSpanError`, `HandleSpanBusinessErrorEvent` and `SetAttributes` call is **retargeted at the surviving parent** rather than dropped — which also puts the error status on the span dashboards actually query. Moved with them: `db.rows_affected` in operationroute and transactionquarantine, three `db.rows_returned` and the `app.operation_route_has_transaction_route_links` flag in operationroute, and the two idempotent-retry span events in transaction and operation.

On the redis side, two removed spans covered **pre-command failures the driver never sees** (tenant-key namespacing and client acquisition). Where such a branch had no log of its own it now logs at Error instead of going silent, and MGet's empty-keys span event becomes a Debug log.

`balance.postgresql.go` also loses a T3-violating leaf rebind (`ctxExec, spanExec := ...`) along with its span.

## Histogram buckets (`fix(pkg)`)

Separate real bug found in the same area. Four `*_ms` histograms — `domain_operation_duration_ms`, `bulk_recorder_bulk_duration_ms`, `readyz_check_duration_ms` and `crm_protection_provider_operation_ms` — declared `Unit: "ms"` with **no `Buckets`**, so `MetricsFactory.Histogram` fell back to `selectDefaultBuckets`, which name-matches `"duration"` and hands back `DefaultLatencyBuckets` — a **SECONDS** ladder of `{0.001..10}`. The backing instrument is an `Int64Histogram`, so **every observation under 1000 ms collapsed into `le=10`** and the quantiles were meaningless.

All four now take an explicit `msLatencyBuckets` ladder `{1,5,10,25,50,100,250,500,1000,2000,5000}` — identical to the boundaries already pinned in `components/tracer/internal/observability/recorder.go`, which declares the same `readyz_check_duration_ms` name. Two declarations of one metric name must not diverge, and the tracer's set is public contract asserted by its tests. `DefaultAccountBuckets` was rejected: it has 2500 where the tracer has 2000, and its name describes account counts, not latency.

## Docs (`docs(docs)`)

T2 previously **required** the spans these commits delete, citing `account.postgresql.go:187` as canonical. Rewritten: open a child I/O span **only where the driver is not auto-instrumented**. T2 now carries a per-store coverage table (MongoDB and RabbitMQ yes; PostgreSQL and Redis no), states that a deleted child span's error handling and attributes move to the parent, and takes `holder.mongodb.go:138` (`mongodb.create_holder.insert`) as its canonical example. T3's forbidden-leaf-rebind counter-example moves to the MongoDB shape, since the postgres leaves it was written against no longer exist. `CLAUDE.md`'s Observability quick reference gets the same rule.

## Verification

Run on this branch (the full stacked state). `tests/modulegraph/` and `make check-telemetry` pass **unmodified**, no new allowlist entries.

| step | exit | result |
|---|---|---|
| `go mod tidy` | 0 | clean, no diff after |
| `go mod edit -json` | 0 | parses; `Replace` and `Exclude` both empty |
| `go list -m all` | 0 | four stables, zero `/v6`, single major each |
| `gofmt -l .` | 0 | empty |
| `go build ./...` | 0 | success |
| `go vet ./...` | 0 | no issues |
| `ALLOW_INSECURE_TLS=true go test ./pkg/... ./components/...` | 0 | all pass |
| `make check-telemetry` | 0 | all gates ok |
| `go test ./tests/modulegraph/` | 0 | ok |

Additionally exercised end-to-end against a local stack with the ledger rebuilt from this branch — see the e2e note in the review thread.
