### PR TITLE
build(deps): bump lib-commons to v7.1.0 for baseline error responses

### DIFF
--- a/api/midaz.openapi.json
+++ b/api/midaz.openapi.json
@@ -293,6 +293,26 @@
             },
             "description": "OK"
           },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
           "default": {
             "content": {
               "application/json": {
@@ -338,6 +358,26 @@
             },
             "description": "Created"
           },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
           "default": {
             "content": {
               "application/json": {
@@ -380,6 +420,16 @@
               }
             }
           },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
           "default": {
             "content": {
               "application/json": {
@@ -421,6 +471,26 @@
         "responses": {
           "204": {
             "description": "No Content"
+          },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           },
           "default": {
             "content": {
@@ -468,6 +538,26 @@
               }
             },
             "description": "OK"
+          },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           },
           "default": {
             "content": {
@@ -525,6 +615,26 @@
               }
             },
             "description": "OK"
+          },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           },
           "default": {
             "content": {
@@ -655,6 +765,26 @@
             },
             "description": "OK"
           },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
           "default": {
             "content": {
               "application/json": {
@@ -712,6 +842,26 @@
             },
             "description": "Created"
           },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
           "default": {
             "content": {
               "application/json": {
@@ -766,6 +916,26 @@
               }
             }
           },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
           "default": {
             "content": {
               "application/json": {
@@ -817,6 +987,26 @@
         "responses": {
           "204": {
             "description": "No Content"
+          },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           },
           "default": {
             "content": {
@@ -874,6 +1064,26 @@
               }
             },
             "description": "OK"
+          },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           },
           "default": {
             "content": {
@@ -941,6 +1151,26 @@
               }
             },
             "description": "OK"
+          },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           },
           "default": {
             "content": {
@@ -1081,6 +1311,26 @@
             },
             "description": "OK"
           },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
           "default": {
             "content": {
               "application/json": {
@@ -1148,6 +1398,26 @@
             },
             "description": "Created"
           },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
           "default": {
             "content": {
               "application/json": {
@@ -1209,6 +1479,26 @@
         "responses": {
           "204": {
             "description": "No Content"
+          },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           },
           "default": {
             "content": {
@@ -1276,6 +1566,26 @@
               }
             },
             "description": "OK"
+          },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           },
           "default": {
             "content": {
@@ -1353,6 +1663,26 @@
               }
             },
             "description": "OK"
+          },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           },
           "default": {
             "content": {
@@ -1573,6 +1903,26 @@
             },
             "description": "OK"
           },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
           "default": {
             "content": {
               "application/json": {
@@ -1649,6 +1999,26 @@
             },
             "description": "Created"
           },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
           "default": {
             "content": {
               "application/json": {
@@ -1717,6 +2087,26 @@
               }
             },
             "description": "OK"
+          },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           },
           "default": {
             "content": {
@@ -1787,6 +2177,26 @@
             },
             "description": "OK"
           },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
           "default": {
             "content": {
               "application/json": {
@@ -1855,6 +2265,26 @@
               }
             },
             "description": "OK"
+          },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           },
           "default": {
             "content": {
@@ -1925,6 +2355,26 @@
             },
             "description": "OK"
           },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
           "default": {
             "content": {
               "application/json": {
@@ -1988,6 +2438,26 @@
                 }
               }
             }
+          },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           },
           "default": {
             "content": {
@@ -2108,6 +2578,26 @@
             },
             "description": "OK"
           },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
           "default": {
             "content": {
               "application/json": {
@@ -2184,6 +2674,26 @@
               }
             },
             "description": "Created"
+          },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           },
           "default": {
             "content": {
@@ -2269,6 +2779,26 @@
               }
             },
             "description": "OK"
+          },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           },
           "default": {
             "content": {
@@ -2439,6 +2969,26 @@
             },
             "description": "OK"
           },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
           "default": {
             "content": {
               "application/json": {
@@ -2518,6 +3068,26 @@
             },
             "description": "OK"
           },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
           "default": {
             "content": {
               "application/json": {
@@ -2589,6 +3159,26 @@
           "204": {
             "description": "No Content"
           },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
           "default": {
             "content": {
               "application/json": {
@@ -2655,6 +3245,26 @@
               }
             },
             "description": "OK"
+          },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           },
           "default": {
             "content": {
@@ -2733,6 +3343,26 @@
             },
             "description": "OK"
           },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
           "default": {
             "content": {
               "application/json": {
@@ -2801,6 +3431,26 @@
               }
             },
             "description": "Created"
+          },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           },
           "default": {
             "content": {
@@ -2937,6 +3587,26 @@
             },
             "description": "OK"
           },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
           "default": {
             "content": {
               "application/json": {
@@ -3005,6 +3675,26 @@
               }
             },
             "description": "OK"
+          },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           },
           "default": {
             "content": {
@@ -3125,6 +3815,26 @@
             },
             "description": "OK"
           },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
           "default": {
             "content": {
               "application/json": {
@@ -3201,6 +3911,26 @@
             },
             "description": "Created"
           },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
           "default": {
             "content": {
               "application/json": {
@@ -3265,6 +3995,26 @@
               }
             }
           },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
           "default": {
             "content": {
               "application/json": {
@@ -3326,6 +4076,26 @@
         "responses": {
           "204": {
             "description": "No Content"
+          },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           },
           "default": {
             "content": {
@@ -3393,6 +4163,26 @@
               }
             },
             "description": "OK"
+          },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           },
           "default": {
             "content": {
@@ -3470,6 +4260,26 @@
               }
             },
             "description": "OK"
+          },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           },
           "default": {
             "content": {
@@ -3580,6 +4390,26 @@
             },
             "description": "OK"
           },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
           "default": {
             "content": {
               "application/json": {
@@ -3641,6 +4471,26 @@
         "responses": {
           "204": {
             "description": "No Content"
+          },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           },
           "default": {
             "content": {
@@ -3708,6 +4558,26 @@
               }
             },
             "description": "OK"
+          },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           },
           "default": {
             "content": {
@@ -3785,6 +4655,26 @@
               }
             },
             "description": "OK"
+          },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           },
           "default": {
             "content": {
@@ -3864,6 +4754,26 @@
               }
             },
             "description": "OK"
+          },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           },
           "default": {
             "content": {
@@ -3974,6 +4884,26 @@
             },
             "description": "OK"
           },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
           "default": {
             "content": {
               "application/json": {
@@ -4041,6 +4971,26 @@
             },
             "description": "Created"
           },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
           "default": {
             "content": {
               "application/json": {
@@ -4102,6 +5052,26 @@
         "responses": {
           "204": {
             "description": "No Content"
+          },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           },
           "default": {
             "content": {
@@ -4169,6 +5139,26 @@
               }
             },
             "description": "OK"
+          },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           },
           "default": {
             "content": {
@@ -4246,6 +5236,26 @@
               }
             },
             "description": "OK"
+          },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           },
           "default": {
             "content": {
@@ -4386,6 +5396,26 @@
             },
             "description": "OK"
           },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
           "default": {
             "content": {
               "application/json": {
@@ -4453,6 +5483,26 @@
             },
             "description": "Created"
           },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
           "default": {
             "content": {
               "application/json": {
@@ -4517,6 +5567,26 @@
               }
             }
           },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
           "default": {
             "content": {
               "application/json": {
@@ -4578,6 +5648,26 @@
         "responses": {
           "204": {
             "description": "No Content"
+          },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           },
           "default": {
             "content": {
@@ -4645,6 +5735,26 @@
               }
             },
             "description": "OK"
+          },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           },
           "default": {
             "content": {
@@ -4722,6 +5832,26 @@
               }
             },
             "description": "OK"
+          },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           },
           "default": {
             "content": {
@@ -4842,6 +5972,26 @@
             },
             "description": "OK"
           },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
           "default": {
             "content": {
               "application/json": {
@@ -4909,6 +6059,26 @@
             },
             "description": "Created"
           },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
           "default": {
             "content": {
               "application/json": {
@@ -4973,6 +6143,26 @@
               }
             }
           },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
           "default": {
             "content": {
               "application/json": {
@@ -5034,6 +6224,26 @@
         "responses": {
           "204": {
             "description": "No Content"
+          },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           },
           "default": {
             "content": {
@@ -5101,6 +6311,26 @@
               }
             },
             "description": "OK"
+          },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           },
           "default": {
             "content": {
@@ -5179,6 +6409,26 @@
             },
             "description": "OK"
           },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
           "default": {
             "content": {
               "application/json": {
@@ -5237,6 +6487,26 @@
               }
             },
             "description": "OK"
+          },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           },
           "default": {
             "content": {
@@ -5305,6 +6575,26 @@
               }
             },
             "description": "OK"
+          },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           },
           "default": {
             "content": {
@@ -5415,6 +6705,26 @@
             },
             "description": "OK"
           },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
           "default": {
             "content": {
               "application/json": {
@@ -5482,6 +6792,26 @@
             },
             "description": "Created"
           },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
           "default": {
             "content": {
               "application/json": {
@@ -5543,6 +6873,26 @@
         "responses": {
           "204": {
             "description": "No Content"
+          },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           },
           "default": {
             "content": {
@@ -5610,6 +6960,26 @@
               }
             },
             "description": "OK"
+          },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           },
           "default": {
             "content": {
@@ -5687,6 +7057,26 @@
               }
             },
             "description": "OK"
+          },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           },
           "default": {
             "content": {
@@ -5807,6 +7197,26 @@
             },
             "description": "OK"
           },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
           "default": {
             "content": {
               "application/json": {
@@ -5900,6 +7310,26 @@
                 }
               }
             }
+          },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           },
           "default": {
             "content": {
@@ -5995,6 +7425,26 @@
               }
             }
           },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
           "default": {
             "content": {
               "application/json": {
@@ -6089,6 +7539,26 @@
               }
             }
           },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
           "default": {
             "content": {
               "application/json": {
@@ -6182,6 +7652,26 @@
                 }
               }
             }
+          },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           },
           "default": {
             "content": {
@@ -6287,6 +7777,26 @@
               }
             }
           },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
           "default": {
             "content": {
               "application/json": {
@@ -6380,6 +7890,26 @@
                 }
               }
             }
+          },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           },
           "default": {
             "content": {
@@ -6475,6 +8005,26 @@
               }
             }
           },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
           "default": {
             "content": {
               "application/json": {
@@ -6550,6 +8100,26 @@
                 }
               }
             }
+          },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           },
           "default": {
             "content": {
@@ -6628,6 +8198,26 @@
             },
             "description": "OK"
           },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
           "default": {
             "content": {
               "application/json": {
@@ -6697,6 +8287,26 @@
             },
             "description": "Created"
           },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
           "default": {
             "content": {
               "application/json": {
@@ -6765,6 +8375,26 @@
               }
             },
             "description": "Created"
+          },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           },
           "default": {
             "content": {
@@ -6855,6 +8485,26 @@
             },
             "description": "OK"
           },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
           "default": {
             "content": {
               "application/json": {
@@ -6931,6 +8581,26 @@
               }
             }
           },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
           "default": {
             "content": {
               "application/json": {
@@ -6985,6 +8655,26 @@
               }
             },
             "description": "OK"
+          },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           },
           "default": {
             "content": {
@@ -7045,6 +8735,26 @@
             },
             "description": "Created"
           },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
           "default": {
             "content": {
               "application/json": {
@@ -7096,6 +8806,26 @@
         "responses": {
           "204": {
             "description": "No Content"
+          },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           },
           "default": {
             "content": {
@@ -7235,6 +8965,26 @@
             },
             "description": "OK"
           },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
           "default": {
             "content": {
               "application/problem+json": {
@@ -7279,6 +9029,26 @@
             },
             "description": "Created"
           },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
           "default": {
             "content": {
               "application/problem+json": {
@@ -7320,6 +9090,16 @@
               }
             }
           },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
           "default": {
             "content": {
               "application/problem+json": {
@@ -7360,6 +9140,26 @@
         "responses": {
           "204": {
             "description": "No Content"
+          },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           },
           "default": {
             "content": {
@@ -7406,6 +9206,26 @@
               }
             },
             "description": "OK"
+          },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           },
           "default": {
             "content": {
@@ -7462,6 +9282,26 @@
               }
             },
             "description": "OK"
+          },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           },
           "default": {
             "content": {
@@ -7530,6 +9370,26 @@
             },
             "description": "Created"
           },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
           "default": {
             "content": {
               "application/problem+json": {
@@ -7586,6 +9446,26 @@
               }
             },
             "description": "OK"
+          },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           },
           "default": {
             "content": {
@@ -7705,6 +9585,26 @@
             },
             "description": "OK"
           },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
           "default": {
             "content": {
               "application/problem+json": {
@@ -7785,6 +9685,26 @@
                 }
               }
             }
+          },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           },
           "default": {
             "content": {
@@ -7879,6 +9799,26 @@
               }
             }
           },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
           "default": {
             "content": {
               "application/problem+json": {
@@ -7949,6 +9889,26 @@
         "responses": {
           "204": {
             "description": "No Content"
+          },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           },
           "default": {
             "content": {
@@ -8026,6 +9986,26 @@
             },
             "description": "OK"
           },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
           "default": {
             "content": {
               "application/problem+json": {
@@ -8102,6 +10082,26 @@
             },
             "description": "OK"
           },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
           "default": {
             "content": {
               "application/problem+json": {
@@ -8173,6 +10173,26 @@
           "204": {
             "description": "No Content"
           },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
           "default": {
             "content": {
               "application/problem+json": {
@@ -8233,6 +10253,26 @@
         "responses": {
           "204": {
             "description": "No Content"
+          },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           },
           "default": {
             "content": {
@@ -8300,6 +10340,26 @@
             },
             "description": "OK"
           },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
           "default": {
             "content": {
               "application/problem+json": {
@@ -8365,6 +10425,26 @@
               }
             },
             "description": "OK"
+          },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           },
           "default": {
             "content": {
@@ -8463,6 +10543,26 @@
               }
             },
             "description": "OK"
+          },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           },
           "default": {
             "content": {
@@ -8602,6 +10702,26 @@
             },
             "description": "OK"
           },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
           "default": {
             "content": {
               "application/problem+json": {
@@ -8730,6 +10850,26 @@
             },
             "description": "OK"
           },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
           "default": {
             "content": {
               "application/problem+json": {
@@ -8786,6 +10926,26 @@
             },
             "description": "Created"
           },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
           "default": {
             "content": {
               "application/problem+json": {
@@ -8839,6 +10999,26 @@
               }
             }
           },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
           "default": {
             "content": {
               "application/problem+json": {
@@ -8889,6 +11069,26 @@
         "responses": {
           "204": {
             "description": "No Content"
+          },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           },
           "default": {
             "content": {
@@ -8945,6 +11145,26 @@
               }
             },
             "description": "OK"
+          },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           },
           "default": {
             "content": {
@@ -9011,6 +11231,26 @@
               }
             },
             "description": "OK"
+          },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           },
           "default": {
             "content": {
@@ -9150,6 +11390,26 @@
             },
             "description": "OK"
           },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
           "default": {
             "content": {
               "application/problem+json": {
@@ -9216,6 +11476,26 @@
             },
             "description": "Created"
           },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
           "default": {
             "content": {
               "application/problem+json": {
@@ -9276,6 +11556,26 @@
         "responses": {
           "204": {
             "description": "No Content"
+          },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           },
           "default": {
             "content": {
@@ -9342,6 +11642,26 @@
               }
             },
             "description": "OK"
+          },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           },
           "default": {
             "content": {
@@ -9418,6 +11738,26 @@
               }
             },
             "description": "OK"
+          },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           },
           "default": {
             "content": {
@@ -9637,6 +11977,26 @@
             },
             "description": "OK"
           },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
           "default": {
             "content": {
               "application/problem+json": {
@@ -9712,6 +12072,26 @@
             },
             "description": "Created"
           },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
           "default": {
             "content": {
               "application/problem+json": {
@@ -9779,6 +12159,26 @@
               }
             },
             "description": "OK"
+          },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           },
           "default": {
             "content": {
@@ -9848,6 +12248,26 @@
             },
             "description": "OK"
           },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
           "default": {
             "content": {
               "application/problem+json": {
@@ -9915,6 +12335,26 @@
               }
             },
             "description": "OK"
+          },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           },
           "default": {
             "content": {
@@ -9984,6 +12424,26 @@
             },
             "description": "OK"
           },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
           "default": {
             "content": {
               "application/problem+json": {
@@ -10046,6 +12506,26 @@
                 }
               }
             }
+          },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           },
           "default": {
             "content": {
@@ -10165,6 +12645,26 @@
             },
             "description": "OK"
           },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
           "default": {
             "content": {
               "application/problem+json": {
@@ -10240,6 +12740,26 @@
               }
             },
             "description": "Created"
+          },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           },
           "default": {
             "content": {
@@ -10324,6 +12844,26 @@
               }
             },
             "description": "OK"
+          },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           },
           "default": {
             "content": {
@@ -10493,6 +13033,26 @@
             },
             "description": "OK"
           },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
           "default": {
             "content": {
               "application/problem+json": {
@@ -10571,6 +13131,26 @@
             },
             "description": "OK"
           },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
           "default": {
             "content": {
               "application/problem+json": {
@@ -10641,6 +13221,26 @@
           "204": {
             "description": "No Content"
           },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
           "default": {
             "content": {
               "application/problem+json": {
@@ -10706,6 +13306,26 @@
               }
             },
             "description": "OK"
+          },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           },
           "default": {
             "content": {
@@ -10782,6 +13402,26 @@
               }
             },
             "description": "OK"
+          },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           },
           "default": {
             "content": {
@@ -10901,6 +13541,26 @@
             },
             "description": "OK"
           },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
           "default": {
             "content": {
               "application/problem+json": {
@@ -10976,6 +13636,26 @@
             },
             "description": "Created"
           },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
           "default": {
             "content": {
               "application/problem+json": {
@@ -11039,6 +13719,26 @@
               }
             }
           },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
           "default": {
             "content": {
               "application/problem+json": {
@@ -11099,6 +13799,26 @@
         "responses": {
           "204": {
             "description": "No Content"
+          },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           },
           "default": {
             "content": {
@@ -11165,6 +13885,26 @@
               }
             },
             "description": "OK"
+          },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           },
           "default": {
             "content": {
@@ -11241,6 +13981,26 @@
               }
             },
             "description": "OK"
+          },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           },
           "default": {
             "content": {
@@ -11350,6 +14110,26 @@
             },
             "description": "OK"
           },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
           "default": {
             "content": {
               "application/problem+json": {
@@ -11410,6 +14190,26 @@
         "responses": {
           "204": {
             "description": "No Content"
+          },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           },
           "default": {
             "content": {
@@ -11476,6 +14276,26 @@
               }
             },
             "description": "OK"
+          },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           },
           "default": {
             "content": {
@@ -11552,6 +14372,26 @@
               }
             },
             "description": "OK"
+          },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           },
           "default": {
             "content": {
@@ -11630,6 +14470,26 @@
               }
             },
             "description": "OK"
+          },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           },
           "default": {
             "content": {
@@ -11719,6 +14579,26 @@
             },
             "description": "OK"
           },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
           "default": {
             "content": {
               "application/problem+json": {
@@ -11785,6 +14665,26 @@
             },
             "description": "Created"
           },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
           "default": {
             "content": {
               "application/problem+json": {
@@ -11845,6 +14745,26 @@
         "responses": {
           "204": {
             "description": "No Content"
+          },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           },
           "default": {
             "content": {
@@ -11911,6 +14831,26 @@
               }
             },
             "description": "OK"
+          },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           },
           "default": {
             "content": {
@@ -11988,6 +14928,26 @@
             },
             "description": "OK"
           },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
           "default": {
             "content": {
               "application/problem+json": {
@@ -12055,6 +15015,26 @@
               }
             },
             "description": "OK"
+          },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           },
           "default": {
             "content": {
@@ -12124,6 +15104,26 @@
               }
             },
             "description": "OK"
+          },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           },
           "default": {
             "content": {
@@ -12211,6 +15211,26 @@
               }
             },
             "description": "Created"
+          },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           },
           "default": {
             "content": {
@@ -12320,6 +15340,26 @@
             },
             "description": "OK"
           },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
           "default": {
             "content": {
               "application/problem+json": {
@@ -12386,6 +15426,26 @@
             },
             "description": "Created"
           },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
           "default": {
             "content": {
               "application/problem+json": {
@@ -12446,6 +15506,26 @@
         "responses": {
           "204": {
             "description": "No Content"
+          },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           },
           "default": {
             "content": {
@@ -12512,6 +15592,26 @@
               }
             },
             "description": "OK"
+          },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           },
           "default": {
             "content": {
@@ -12588,6 +15688,26 @@
               }
             },
             "description": "OK"
+          },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           },
           "default": {
             "content": {
@@ -12697,6 +15817,26 @@
             },
             "description": "OK"
           },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
           "default": {
             "content": {
               "application/problem+json": {
@@ -12763,6 +15903,26 @@
             },
             "description": "Created"
           },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
           "default": {
             "content": {
               "application/problem+json": {
@@ -12823,6 +15983,26 @@
         "responses": {
           "204": {
             "description": "No Content"
+          },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           },
           "default": {
             "content": {
@@ -12889,6 +16069,26 @@
               }
             },
             "description": "OK"
+          },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           },
           "default": {
             "content": {
@@ -12965,6 +16165,26 @@
               }
             },
             "description": "OK"
+          },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           },
           "default": {
             "content": {
@@ -13104,6 +16324,26 @@
             },
             "description": "OK"
           },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
           "default": {
             "content": {
               "application/problem+json": {
@@ -13170,6 +16410,26 @@
             },
             "description": "Created"
           },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
           "default": {
             "content": {
               "application/problem+json": {
@@ -13233,6 +16493,26 @@
               }
             }
           },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
           "default": {
             "content": {
               "application/problem+json": {
@@ -13293,6 +16573,26 @@
         "responses": {
           "204": {
             "description": "No Content"
+          },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           },
           "default": {
             "content": {
@@ -13359,6 +16659,26 @@
               }
             },
             "description": "OK"
+          },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           },
           "default": {
             "content": {
@@ -13435,6 +16755,26 @@
               }
             },
             "description": "OK"
+          },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           },
           "default": {
             "content": {
@@ -13554,6 +16894,26 @@
             },
             "description": "OK"
           },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
           "default": {
             "content": {
               "application/problem+json": {
@@ -13620,6 +16980,26 @@
             },
             "description": "Created"
           },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
           "default": {
             "content": {
               "application/problem+json": {
@@ -13683,6 +17063,26 @@
               }
             }
           },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
           "default": {
             "content": {
               "application/problem+json": {
@@ -13743,6 +17143,26 @@
         "responses": {
           "204": {
             "description": "No Content"
+          },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           },
           "default": {
             "content": {
@@ -13809,6 +17229,26 @@
               }
             },
             "description": "OK"
+          },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           },
           "default": {
             "content": {
@@ -13886,6 +17326,26 @@
             },
             "description": "OK"
           },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
           "default": {
             "content": {
               "application/problem+json": {
@@ -13943,6 +17403,26 @@
               }
             },
             "description": "OK"
+          },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           },
           "default": {
             "content": {
@@ -14010,6 +17490,26 @@
               }
             },
             "description": "OK"
+          },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           },
           "default": {
             "content": {
@@ -14119,6 +17619,26 @@
             },
             "description": "OK"
           },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
           "default": {
             "content": {
               "application/problem+json": {
@@ -14185,6 +17705,26 @@
             },
             "description": "Created"
           },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
           "default": {
             "content": {
               "application/problem+json": {
@@ -14245,6 +17785,26 @@
         "responses": {
           "204": {
             "description": "No Content"
+          },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           },
           "default": {
             "content": {
@@ -14311,6 +17871,26 @@
               }
             },
             "description": "OK"
+          },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           },
           "default": {
             "content": {
@@ -14387,6 +17967,26 @@
               }
             },
             "description": "OK"
+          },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           },
           "default": {
             "content": {
@@ -14506,6 +18106,26 @@
             },
             "description": "OK"
           },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
           "default": {
             "content": {
               "application/problem+json": {
@@ -14609,6 +18229,26 @@
               }
             }
           },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
           "default": {
             "content": {
               "application/problem+json": {
@@ -14683,6 +18323,26 @@
                 }
               }
             }
+          },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           },
           "default": {
             "content": {
@@ -14760,6 +18420,26 @@
             },
             "description": "OK"
           },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
           "default": {
             "content": {
               "application/problem+json": {
@@ -14828,6 +18508,26 @@
             },
             "description": "Created"
           },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
           "default": {
             "content": {
               "application/problem+json": {
@@ -14895,6 +18595,26 @@
               }
             },
             "description": "Created"
+          },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           },
           "default": {
             "content": {
@@ -14984,6 +18704,26 @@
             },
             "description": "OK"
           },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
           "default": {
             "content": {
               "application/problem+json": {
@@ -15058,6 +18798,26 @@
                 }
               }
             }
+          },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           },
           "default": {
             "content": {
@@ -15196,6 +18956,26 @@
             },
             "description": "OK"
           },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
           "default": {
             "content": {
               "application/problem+json": {
@@ -15249,6 +19029,26 @@
               }
             },
             "description": "OK"
+          },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           },
           "default": {
             "content": {
@@ -15308,6 +19108,26 @@
             },
             "description": "Created"
           },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
           "default": {
             "content": {
               "application/problem+json": {
@@ -15358,6 +19178,26 @@
         "responses": {
           "204": {
             "description": "No Content"
+          },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           },
           "default": {
             "content": {
@@ -15432,6 +19272,26 @@
               }
             }
           },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
           "default": {
             "content": {
               "application/problem+json": {
@@ -15504,6 +19364,26 @@
                 }
               }
             }
+          },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           },
           "default": {
             "content": {
@@ -15578,6 +19458,26 @@
               }
             }
           },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
           "default": {
             "content": {
               "application/problem+json": {
@@ -15650,6 +19550,26 @@
                 }
               }
             }
+          },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           },
           "default": {
             "content": {
@@ -15869,6 +19789,26 @@
             },
             "description": "OK"
           },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
           "default": {
             "content": {
               "application/problem+json": {
@@ -15920,6 +19860,26 @@
             },
             "description": "OK"
           },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
           "default": {
             "content": {
               "application/problem+json": {
@@ -15970,6 +19930,26 @@
               }
             },
             "description": "OK"
+          },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           },
           "default": {
             "content": {
@@ -16142,6 +20122,26 @@
             },
             "description": "OK"
           },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
           "default": {
             "content": {
               "application/problem+json": {
@@ -16191,6 +20191,26 @@
             },
             "description": "Created"
           },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
           "default": {
             "content": {
               "application/problem+json": {
@@ -16234,6 +20254,26 @@
         "responses": {
           "204": {
             "description": "No Content"
+          },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           },
           "default": {
             "content": {
@@ -16283,6 +20323,26 @@
               }
             },
             "description": "OK"
+          },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           },
           "default": {
             "content": {
@@ -16345,6 +20405,26 @@
             },
             "description": "OK"
           },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
           "default": {
             "content": {
               "application/problem+json": {
@@ -16395,6 +20475,26 @@
               }
             },
             "description": "OK"
+          },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           },
           "default": {
             "content": {
@@ -16447,6 +20547,26 @@
             },
             "description": "OK"
           },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
           "default": {
             "content": {
               "application/problem+json": {
@@ -16497,6 +20617,26 @@
               }
             },
             "description": "OK"
+          },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           },
           "default": {
             "content": {
@@ -16549,6 +20689,26 @@
             },
             "description": "OK"
           },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
           "default": {
             "content": {
               "application/problem+json": {
@@ -16599,6 +20759,26 @@
               }
             },
             "description": "Created"
+          },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           },
           "default": {
             "content": {
@@ -16651,6 +20831,26 @@
             },
             "description": "OK"
           },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
           "default": {
             "content": {
               "application/problem+json": {
@@ -16701,6 +20901,26 @@
               }
             },
             "description": "OK"
+          },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           },
           "default": {
             "content": {
@@ -16753,6 +20973,26 @@
             },
             "description": "OK"
           },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
           "default": {
             "content": {
               "application/problem+json": {
@@ -16803,6 +21043,26 @@
               }
             },
             "description": "OK"
+          },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           },
           "default": {
             "content": {
@@ -16975,6 +21235,26 @@
             },
             "description": "OK"
           },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
           "default": {
             "content": {
               "application/problem+json": {
@@ -17024,6 +21304,26 @@
             },
             "description": "Created"
           },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
           "default": {
             "content": {
               "application/problem+json": {
@@ -17067,6 +21367,26 @@
         "responses": {
           "204": {
             "description": "No Content"
+          },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           },
           "default": {
             "content": {
@@ -17116,6 +21436,26 @@
               }
             },
             "description": "OK"
+          },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           },
           "default": {
             "content": {
@@ -17178,6 +21518,26 @@
             },
             "description": "OK"
           },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
           "default": {
             "content": {
               "application/problem+json": {
@@ -17228,6 +21588,26 @@
               }
             },
             "description": "OK"
+          },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           },
           "default": {
             "content": {
@@ -17280,6 +21660,26 @@
             },
             "description": "OK"
           },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
           "default": {
             "content": {
               "application/problem+json": {
@@ -17330,6 +21730,26 @@
               }
             },
             "description": "OK"
+          },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           },
           "default": {
             "content": {
@@ -17502,6 +21922,26 @@
             },
             "description": "OK"
           },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
           "default": {
             "content": {
               "application/problem+json": {
@@ -17553,6 +21993,26 @@
           },
           "201": {
             "description": "New validation created"
+          },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           }
         },
         "security": [
@@ -17594,6 +22054,26 @@
               }
             },
             "description": "OK"
+          },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           },
           "default": {
             "content": {

--- a/api/midaz.openapi.json
+++ b/api/midaz.openapi.json
@@ -295,9 +295,9 @@
           },
           "422": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -305,9 +305,9 @@
           },
           "500": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -360,9 +360,9 @@
           },
           "422": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -370,9 +370,9 @@
           },
           "500": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -422,9 +422,9 @@
           },
           "500": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -474,9 +474,9 @@
           },
           "422": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -484,9 +484,9 @@
           },
           "500": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -541,9 +541,9 @@
           },
           "422": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -551,9 +551,9 @@
           },
           "500": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -618,9 +618,9 @@
           },
           "422": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -628,9 +628,9 @@
           },
           "500": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -767,9 +767,9 @@
           },
           "422": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -777,9 +777,9 @@
           },
           "500": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -844,9 +844,9 @@
           },
           "422": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -854,9 +854,9 @@
           },
           "500": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -918,9 +918,9 @@
           },
           "422": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -928,9 +928,9 @@
           },
           "500": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -990,9 +990,9 @@
           },
           "422": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -1000,9 +1000,9 @@
           },
           "500": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -1067,9 +1067,9 @@
           },
           "422": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -1077,9 +1077,9 @@
           },
           "500": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -1154,9 +1154,9 @@
           },
           "422": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -1164,9 +1164,9 @@
           },
           "500": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -1313,9 +1313,9 @@
           },
           "422": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -1323,9 +1323,9 @@
           },
           "500": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -1400,9 +1400,9 @@
           },
           "422": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -1410,9 +1410,9 @@
           },
           "500": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -1482,9 +1482,9 @@
           },
           "422": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -1492,9 +1492,9 @@
           },
           "500": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -1569,9 +1569,9 @@
           },
           "422": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -1579,9 +1579,9 @@
           },
           "500": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -1666,9 +1666,9 @@
           },
           "422": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -1676,9 +1676,9 @@
           },
           "500": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -1905,9 +1905,9 @@
           },
           "422": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -1915,9 +1915,9 @@
           },
           "500": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -2001,9 +2001,9 @@
           },
           "422": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -2011,9 +2011,9 @@
           },
           "500": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -2090,9 +2090,9 @@
           },
           "422": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -2100,9 +2100,9 @@
           },
           "500": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -2179,9 +2179,9 @@
           },
           "422": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -2189,9 +2189,9 @@
           },
           "500": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -2268,9 +2268,9 @@
           },
           "422": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -2278,9 +2278,9 @@
           },
           "500": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -2357,9 +2357,9 @@
           },
           "422": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -2367,9 +2367,9 @@
           },
           "500": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -2441,9 +2441,9 @@
           },
           "422": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -2451,9 +2451,9 @@
           },
           "500": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -2580,9 +2580,9 @@
           },
           "422": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -2590,9 +2590,9 @@
           },
           "500": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -2677,9 +2677,9 @@
           },
           "422": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -2687,9 +2687,9 @@
           },
           "500": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -2782,9 +2782,9 @@
           },
           "422": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -2792,9 +2792,9 @@
           },
           "500": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -2971,9 +2971,9 @@
           },
           "422": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -2981,9 +2981,9 @@
           },
           "500": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -3070,9 +3070,9 @@
           },
           "422": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -3080,9 +3080,9 @@
           },
           "500": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -3161,9 +3161,9 @@
           },
           "422": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -3171,9 +3171,9 @@
           },
           "500": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -3248,9 +3248,9 @@
           },
           "422": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -3258,9 +3258,9 @@
           },
           "500": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -3345,9 +3345,9 @@
           },
           "422": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -3355,9 +3355,9 @@
           },
           "500": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -3434,9 +3434,9 @@
           },
           "422": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -3444,9 +3444,9 @@
           },
           "500": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -3589,9 +3589,9 @@
           },
           "422": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -3599,9 +3599,9 @@
           },
           "500": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -3678,9 +3678,9 @@
           },
           "422": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -3688,9 +3688,9 @@
           },
           "500": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -3817,9 +3817,9 @@
           },
           "422": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -3827,9 +3827,9 @@
           },
           "500": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -3913,9 +3913,9 @@
           },
           "422": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -3923,9 +3923,9 @@
           },
           "500": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -3997,9 +3997,9 @@
           },
           "422": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -4007,9 +4007,9 @@
           },
           "500": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -4079,9 +4079,9 @@
           },
           "422": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -4089,9 +4089,9 @@
           },
           "500": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -4166,9 +4166,9 @@
           },
           "422": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -4176,9 +4176,9 @@
           },
           "500": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -4263,9 +4263,9 @@
           },
           "422": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -4273,9 +4273,9 @@
           },
           "500": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -4392,9 +4392,9 @@
           },
           "422": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -4402,9 +4402,9 @@
           },
           "500": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -4474,9 +4474,9 @@
           },
           "422": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -4484,9 +4484,9 @@
           },
           "500": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -4561,9 +4561,9 @@
           },
           "422": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -4571,9 +4571,9 @@
           },
           "500": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -4658,9 +4658,9 @@
           },
           "422": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -4668,9 +4668,9 @@
           },
           "500": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -4757,9 +4757,9 @@
           },
           "422": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -4767,9 +4767,9 @@
           },
           "500": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -4886,9 +4886,9 @@
           },
           "422": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -4896,9 +4896,9 @@
           },
           "500": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -4973,9 +4973,9 @@
           },
           "422": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -4983,9 +4983,9 @@
           },
           "500": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -5055,9 +5055,9 @@
           },
           "422": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -5065,9 +5065,9 @@
           },
           "500": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -5142,9 +5142,9 @@
           },
           "422": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -5152,9 +5152,9 @@
           },
           "500": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -5239,9 +5239,9 @@
           },
           "422": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -5249,9 +5249,9 @@
           },
           "500": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -5398,9 +5398,9 @@
           },
           "422": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -5408,9 +5408,9 @@
           },
           "500": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -5485,9 +5485,9 @@
           },
           "422": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -5495,9 +5495,9 @@
           },
           "500": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -5569,9 +5569,9 @@
           },
           "422": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -5579,9 +5579,9 @@
           },
           "500": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -5651,9 +5651,9 @@
           },
           "422": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -5661,9 +5661,9 @@
           },
           "500": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -5738,9 +5738,9 @@
           },
           "422": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -5748,9 +5748,9 @@
           },
           "500": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -5835,9 +5835,9 @@
           },
           "422": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -5845,9 +5845,9 @@
           },
           "500": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -5974,9 +5974,9 @@
           },
           "422": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -5984,9 +5984,9 @@
           },
           "500": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -6061,9 +6061,9 @@
           },
           "422": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -6071,9 +6071,9 @@
           },
           "500": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -6145,9 +6145,9 @@
           },
           "422": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -6155,9 +6155,9 @@
           },
           "500": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -6227,9 +6227,9 @@
           },
           "422": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -6237,9 +6237,9 @@
           },
           "500": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -6314,9 +6314,9 @@
           },
           "422": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -6324,9 +6324,9 @@
           },
           "500": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -6411,9 +6411,9 @@
           },
           "422": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -6421,9 +6421,9 @@
           },
           "500": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -6490,9 +6490,9 @@
           },
           "422": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -6500,9 +6500,9 @@
           },
           "500": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -6578,9 +6578,9 @@
           },
           "422": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -6588,9 +6588,9 @@
           },
           "500": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -6707,9 +6707,9 @@
           },
           "422": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -6717,9 +6717,9 @@
           },
           "500": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -6794,9 +6794,9 @@
           },
           "422": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -6804,9 +6804,9 @@
           },
           "500": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -6876,9 +6876,9 @@
           },
           "422": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -6886,9 +6886,9 @@
           },
           "500": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -6963,9 +6963,9 @@
           },
           "422": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -6973,9 +6973,9 @@
           },
           "500": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -7060,9 +7060,9 @@
           },
           "422": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -7070,9 +7070,9 @@
           },
           "500": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -7199,9 +7199,9 @@
           },
           "422": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -7209,9 +7209,9 @@
           },
           "500": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -7313,9 +7313,9 @@
           },
           "422": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -7323,9 +7323,9 @@
           },
           "500": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -7427,9 +7427,9 @@
           },
           "422": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -7437,9 +7437,9 @@
           },
           "500": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -7541,9 +7541,9 @@
           },
           "422": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -7551,9 +7551,9 @@
           },
           "500": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -7655,9 +7655,9 @@
           },
           "422": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -7665,9 +7665,9 @@
           },
           "500": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -7779,9 +7779,9 @@
           },
           "422": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -7789,9 +7789,9 @@
           },
           "500": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -7893,9 +7893,9 @@
           },
           "422": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -7903,9 +7903,9 @@
           },
           "500": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -8007,9 +8007,9 @@
           },
           "422": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -8017,9 +8017,9 @@
           },
           "500": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -8103,9 +8103,9 @@
           },
           "422": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -8113,9 +8113,9 @@
           },
           "500": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -8200,9 +8200,9 @@
           },
           "422": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -8210,9 +8210,9 @@
           },
           "500": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -8289,9 +8289,9 @@
           },
           "422": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -8299,9 +8299,9 @@
           },
           "500": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -8378,9 +8378,9 @@
           },
           "422": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -8388,9 +8388,9 @@
           },
           "500": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -8487,9 +8487,9 @@
           },
           "422": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -8497,9 +8497,9 @@
           },
           "500": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -8583,9 +8583,9 @@
           },
           "422": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -8593,9 +8593,9 @@
           },
           "500": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -8658,9 +8658,9 @@
           },
           "422": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -8668,9 +8668,9 @@
           },
           "500": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -8737,9 +8737,9 @@
           },
           "422": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -8747,9 +8747,9 @@
           },
           "500": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -8809,9 +8809,9 @@
           },
           "422": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },
@@ -8819,9 +8819,9 @@
           },
           "500": {
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/LegacyError"
                 }
               }
             },

--- a/api/midaz.openapi.yaml
+++ b/api/midaz.openapi.yaml
@@ -170,6 +170,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/Pagination'
           description: OK
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -197,6 +209,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/Organization'
           description: Created
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -222,6 +246,12 @@ paths:
             X-Total-Count:
               schema:
                 type: string
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -248,6 +278,18 @@ paths:
       responses:
         '204':
           description: No Content
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -277,6 +319,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/Organization'
           description: OK
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -312,6 +366,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/Organization'
           description: OK
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -398,6 +464,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/Pagination'
           description: OK
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -433,6 +511,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/Ledger'
           description: Created
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -466,6 +556,18 @@ paths:
             X-Total-Count:
               schema:
                 type: string
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -499,6 +601,18 @@ paths:
       responses:
         '204':
           description: No Content
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -535,6 +649,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/Ledger'
           description: OK
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -577,6 +703,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/Ledger'
           description: OK
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -670,6 +808,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/Pagination'
           description: OK
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -712,6 +862,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/AccountType'
           description: Created
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -752,6 +914,18 @@ paths:
       responses:
         '204':
           description: No Content
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -795,6 +969,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/AccountType'
           description: OK
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -844,6 +1030,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/AccountType'
           description: OK
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -993,6 +1191,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/Pagination'
           description: OK
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -1041,6 +1251,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/Account'
           description: Created
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -1085,6 +1307,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/Account'
           description: OK
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -1129,6 +1363,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/Pagination'
           description: OK
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -1173,6 +1419,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/Account'
           description: OK
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -1217,6 +1475,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/Pagination'
           description: OK
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -1257,6 +1527,18 @@ paths:
             X-Total-Count:
               schema:
                 type: string
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -1336,6 +1618,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/Pagination'
           description: OK
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -1385,6 +1679,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/Balance'
           description: Created
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -1440,6 +1746,18 @@ paths:
                   - array
                   - 'null'
           description: OK
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -1554,6 +1872,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/Pagination'
           description: OK
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -1605,6 +1935,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/Operation'
           description: OK
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -1651,6 +1993,18 @@ paths:
       responses:
         '204':
           description: No Content
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -1694,6 +2048,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/Account'
           description: OK
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -1743,6 +2109,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/Account'
           description: OK
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -1786,6 +2164,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/AssetRate'
           description: Created
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -1882,6 +2272,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/Pagination'
           description: OK
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -1926,6 +2328,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/AssetRate'
           description: OK
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -2005,6 +2419,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/Pagination'
           description: OK
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -2053,6 +2479,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/Asset'
           description: Created
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -2093,6 +2531,18 @@ paths:
             X-Total-Count:
               schema:
                 type: string
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -2133,6 +2583,18 @@ paths:
       responses:
         '204':
           description: No Content
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -2176,6 +2638,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/Asset'
           description: OK
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -2225,6 +2699,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/Asset'
           description: OK
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -2297,6 +2783,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/Pagination'
           description: OK
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -2337,6 +2835,18 @@ paths:
       responses:
         '204':
           description: No Content
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -2380,6 +2890,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/Balance'
           description: OK
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -2429,6 +2951,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/Balance'
           description: OK
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -2480,6 +3014,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/BalanceHistory'
           description: OK
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -2552,6 +3098,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/Pagination'
           description: OK
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -2594,6 +3152,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/OperationRoute'
           description: Created
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -2634,6 +3204,18 @@ paths:
       responses:
         '204':
           description: No Content
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -2677,6 +3259,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/OperationRoute'
           description: OK
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -2726,6 +3320,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/OperationRoute'
           description: OK
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -2819,6 +3425,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/Pagination'
           description: OK
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -2861,6 +3479,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/Portfolio'
           description: Created
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -2901,6 +3531,18 @@ paths:
             X-Total-Count:
               schema:
                 type: string
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -2941,6 +3583,18 @@ paths:
       responses:
         '204':
           description: No Content
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -2984,6 +3638,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/Portfolio'
           description: OK
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -3033,6 +3699,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/Portfolio'
           description: OK
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -3112,6 +3790,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/Pagination'
           description: OK
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -3154,6 +3844,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/Segment'
           description: Created
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -3194,6 +3896,18 @@ paths:
             X-Total-Count:
               schema:
                 type: string
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -3234,6 +3948,18 @@ paths:
       responses:
         '204':
           description: No Content
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -3277,6 +4003,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/Segment'
           description: OK
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -3326,6 +4064,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/Segment'
           description: OK
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -3363,6 +4113,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/LedgerSettings'
           description: OK
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -3406,6 +4168,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/LedgerSettings'
           description: OK
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -3478,6 +4252,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/Pagination'
           description: OK
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -3520,6 +4306,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/TransactionRoute'
           description: Created
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -3560,6 +4358,18 @@ paths:
       responses:
         '204':
           description: No Content
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -3603,6 +4413,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/TransactionRoute'
           description: OK
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -3652,6 +4474,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/TransactionRoute'
           description: OK
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -3731,6 +4565,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/Pagination'
           description: OK
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -3794,6 +4640,18 @@ paths:
             X-Idempotency-Replayed:
               schema:
                 type: string
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -3857,6 +4715,18 @@ paths:
             X-Idempotency-Replayed:
               schema:
                 type: string
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -3920,6 +4790,18 @@ paths:
             X-Idempotency-Replayed:
               schema:
                 type: string
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -3983,6 +4865,18 @@ paths:
             X-Idempotency-Replayed:
               schema:
                 type: string
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -4055,6 +4949,18 @@ paths:
             X-Total-Count:
               schema:
                 type: string
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -4118,6 +5024,18 @@ paths:
             X-Idempotency-Replayed:
               schema:
                 type: string
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -4181,6 +5099,18 @@ paths:
             X-Idempotency-Replayed:
               schema:
                 type: string
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -4229,6 +5159,18 @@ paths:
             X-Cache-Hit:
               schema:
                 type: string
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -4278,6 +5220,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/Transaction'
           description: OK
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -4322,6 +5276,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/Transaction'
           description: Created
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -4366,6 +5332,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/Transaction'
           description: Created
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -4423,6 +5401,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/Operation'
           description: OK
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -4471,6 +5461,18 @@ paths:
             X-Idempotency-Replayed:
               schema:
                 type: string
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -4505,6 +5507,18 @@ paths:
                   - array
                   - 'null'
           description: OK
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -4547,6 +5561,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/MetadataIndex'
           description: Created
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -4586,6 +5612,18 @@ paths:
       responses:
         '204':
           description: No Content
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -4678,6 +5716,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/Pagination'
           description: OK
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -4704,6 +5754,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/Organization'
           description: Created
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -4728,6 +5790,12 @@ paths:
             X-Total-Count:
               schema:
                 type: string
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -4753,6 +5821,18 @@ paths:
       responses:
         '204':
           description: No Content
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -4781,6 +5861,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/Organization'
           description: OK
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -4815,6 +5907,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/Organization'
           description: OK
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -4856,6 +5960,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/ProvisionEncryptionResponse'
           description: Created
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -4891,6 +6007,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/ProvisioningStatusResponse'
           description: OK
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -4969,6 +6097,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/Pagination'
           description: OK
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -5023,6 +6163,18 @@ paths:
             X-Idempotency-Replayed:
               schema:
                 type: string
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -5085,6 +6237,18 @@ paths:
             X-Idempotency-Replayed:
               schema:
                 type: string
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -5135,6 +6299,18 @@ paths:
       responses:
         '204':
           description: No Content
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -5186,6 +6362,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/Instrument'
           description: OK
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -5234,6 +6422,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/Instrument'
           description: OK
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -5280,6 +6480,18 @@ paths:
       responses:
         '204':
           description: No Content
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -5323,6 +6535,18 @@ paths:
       responses:
         '204':
           description: No Content
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -5365,6 +6589,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/Holder'
           description: OK
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -5406,6 +6642,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/Holder'
           description: OK
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -5474,6 +6722,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/Pagination'
           description: OK
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -5566,6 +6826,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/Pagination'
           description: OK
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -5651,6 +6923,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/Pagination'
           description: OK
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -5685,6 +6969,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/Ledger'
           description: Created
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -5717,6 +7013,18 @@ paths:
             X-Total-Count:
               schema:
                 type: string
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -5749,6 +7057,18 @@ paths:
       responses:
         '204':
           description: No Content
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -5784,6 +7104,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/Ledger'
           description: OK
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -5825,6 +7157,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/Ledger'
           description: OK
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -5917,6 +7261,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/Pagination'
           description: OK
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -5958,6 +7314,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/AccountType'
           description: Created
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -5997,6 +7365,18 @@ paths:
       responses:
         '204':
           description: No Content
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -6039,6 +7419,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/AccountType'
           description: OK
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -6087,6 +7479,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/AccountType'
           description: OK
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -6235,6 +7639,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/Pagination'
           description: OK
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -6282,6 +7698,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/AccountV2'
           description: Created
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -6325,6 +7753,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/AccountV2'
           description: OK
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -6368,6 +7808,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/Pagination'
           description: OK
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -6411,6 +7863,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/AccountV2'
           description: OK
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -6454,6 +7918,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/Pagination'
           description: OK
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -6493,6 +7969,18 @@ paths:
             X-Total-Count:
               schema:
                 type: string
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -6571,6 +8059,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/Pagination'
           description: OK
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -6619,6 +8119,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/Balance'
           description: Created
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -6673,6 +8185,18 @@ paths:
                   - array
                   - 'null'
           description: OK
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -6786,6 +8310,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/Pagination'
           description: OK
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -6836,6 +8372,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/Operation'
           description: OK
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -6881,6 +8429,18 @@ paths:
       responses:
         '204':
           description: No Content
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -6923,6 +8483,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/AccountV2'
           description: OK
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -6971,6 +8543,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/AccountV2'
           description: OK
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -7049,6 +8633,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/Pagination'
           description: OK
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -7096,6 +8692,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/Asset'
           description: Created
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -7135,6 +8743,18 @@ paths:
             X-Total-Count:
               schema:
                 type: string
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -7174,6 +8794,18 @@ paths:
       responses:
         '204':
           description: No Content
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -7216,6 +8848,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/Asset'
           description: OK
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -7264,6 +8908,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/Asset'
           description: OK
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -7335,6 +8991,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/Pagination'
           description: OK
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -7374,6 +9042,18 @@ paths:
       responses:
         '204':
           description: No Content
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -7416,6 +9096,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/Balance'
           description: OK
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -7464,6 +9156,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/Balance'
           description: OK
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -7514,6 +9218,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/BalanceHistory'
           description: OK
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -7571,6 +9287,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/FeePagination'
           description: OK
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -7612,6 +9340,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/FeeBillingPackage'
           description: Created
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -7651,6 +9391,18 @@ paths:
       responses:
         '204':
           description: No Content
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -7693,6 +9445,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/FeeBillingPackage'
           description: OK
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -7741,6 +9505,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/FeeBillingPackage'
           description: OK
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -7783,6 +9559,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/FeeBillingCalculateResponse'
           description: OK
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -7826,6 +9614,18 @@ paths:
                 contentEncoding: base64
                 type: string
           description: OK
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -7881,6 +9681,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/HolderAccountResponse'
           description: Created
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -7952,6 +9764,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/Pagination'
           description: OK
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -7993,6 +9817,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/OperationRoute'
           description: Created
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -8032,6 +9868,18 @@ paths:
       responses:
         '204':
           description: No Content
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -8074,6 +9922,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/OperationRoute'
           description: OK
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -8122,6 +9982,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/OperationRoute'
           description: OK
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -8193,6 +10065,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/FeePagination'
           description: OK
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -8234,6 +10118,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/FeePackage'
           description: Created
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -8273,6 +10169,18 @@ paths:
       responses:
         '204':
           description: No Content
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -8315,6 +10223,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/FeePackage'
           description: OK
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -8363,6 +10283,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/FeePackage'
           description: OK
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -8455,6 +10387,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/Pagination'
           description: OK
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -8496,6 +10440,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/Portfolio'
           description: Created
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -8535,6 +10491,18 @@ paths:
             X-Total-Count:
               schema:
                 type: string
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -8574,6 +10542,18 @@ paths:
       responses:
         '204':
           description: No Content
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -8616,6 +10596,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/Portfolio'
           description: OK
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -8664,6 +10656,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/Portfolio'
           description: OK
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -8742,6 +10746,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/Pagination'
           description: OK
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -8783,6 +10799,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/Segment'
           description: Created
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -8822,6 +10850,18 @@ paths:
             X-Total-Count:
               schema:
                 type: string
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -8861,6 +10901,18 @@ paths:
       responses:
         '204':
           description: No Content
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -8903,6 +10955,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/Segment'
           description: OK
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -8951,6 +11015,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/Segment'
           description: OK
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -8987,6 +11063,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/LedgerSettings'
           description: OK
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -9029,6 +11117,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/LedgerSettings'
           description: OK
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -9100,6 +11200,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/Pagination'
           description: OK
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -9141,6 +11253,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/TransactionRoute'
           description: Created
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -9180,6 +11304,18 @@ paths:
       responses:
         '204':
           description: No Content
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -9222,6 +11358,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/TransactionRoute'
           description: OK
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -9270,6 +11418,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/TransactionRoute'
           description: OK
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -9348,6 +11508,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/TransactionV2ListBody'
           description: OK
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -9419,6 +11591,18 @@ paths:
             X-Total-Count:
               schema:
                 type: string
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -9466,6 +11650,18 @@ paths:
             X-Cache-Hit:
               schema:
                 type: string
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -9514,6 +11710,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/TransactionV2'
           description: OK
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -9557,6 +11765,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/TransactionV2'
           description: Created
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -9600,6 +11820,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/TransactionV2'
           description: Created
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -9656,6 +11888,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/Operation'
           description: OK
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -9703,6 +11947,18 @@ paths:
             X-Idempotency-Replayed:
               schema:
                 type: string
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -9794,6 +12050,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/AuditEventsEnvelope'
           description: OK
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -9827,6 +12095,18 @@ paths:
                   - array
                   - 'null'
           description: OK
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -9868,6 +12148,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/MetadataIndex'
           description: Created
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -9906,6 +12198,18 @@ paths:
       responses:
         '204':
           description: No Content
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -9954,6 +12258,18 @@ paths:
             X-Idempotency-Replayed:
               schema:
                 type: string
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -10002,6 +12318,18 @@ paths:
             X-Idempotency-Replayed:
               schema:
                 type: string
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -10050,6 +12378,18 @@ paths:
             X-Idempotency-Replayed:
               schema:
                 type: string
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -10098,6 +12438,18 @@ paths:
             X-Idempotency-Replayed:
               schema:
                 type: string
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -10250,6 +12602,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/ListAuditEventsResponse'
           description: OK
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -10280,6 +12644,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/AuditEvent'
           description: OK
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -10310,6 +12686,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/HashChainVerificationResult'
           description: OK
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -10428,6 +12816,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/ListLimitsResponse'
           description: OK
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -10457,6 +12857,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/Limit'
           description: Created
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -10483,6 +12895,18 @@ paths:
       responses:
         '204':
           description: No Content
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -10512,6 +12936,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/Limit'
           description: OK
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -10549,6 +12985,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/Limit'
           description: OK
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -10579,6 +13027,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/Limit'
           description: OK
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -10609,6 +13069,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/Limit'
           description: OK
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -10639,6 +13111,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/Limit'
           description: OK
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -10669,6 +13153,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/UsageSnapshot'
           description: OK
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -10699,6 +13195,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/ReserveResponse'
           description: Created
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -10729,6 +13237,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/TransactionActionResponse'
           description: OK
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -10759,6 +13279,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/TransactionActionResponse'
           description: OK
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -10789,6 +13321,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/ReservationActionResponse'
           description: OK
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -10819,6 +13363,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/ReservationActionResponse'
           description: OK
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -10933,6 +13489,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/ListRulesResponse'
           description: OK
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -10962,6 +13530,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/Rule'
           description: Created
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -10988,6 +13568,18 @@ paths:
       responses:
         '204':
           description: No Content
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -11017,6 +13609,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/Rule'
           description: OK
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -11054,6 +13658,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/Rule'
           description: OK
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -11084,6 +13700,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/Rule'
           description: OK
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -11114,6 +13742,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/Rule'
           description: OK
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -11144,6 +13784,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/Rule'
           description: OK
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -11262,6 +13914,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/ListTransactionValidationsResponse'
           description: OK
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -11293,6 +13957,18 @@ paths:
           description: OK
         '201':
           description: New validation created
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
       security:
         - BearerAuth: []
         - ApiKeyAuth: []
@@ -11317,6 +13993,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/TransactionValidation'
           description: OK
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
         default:
           content:
             application/problem+json:

--- a/api/midaz.openapi.yaml
+++ b/api/midaz.openapi.yaml
@@ -172,15 +172,15 @@ paths:
           description: OK
         '422':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Unprocessable Entity
         '500':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Internal Server Error
         default:
           content:
@@ -211,15 +211,15 @@ paths:
           description: Created
         '422':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Unprocessable Entity
         '500':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Internal Server Error
         default:
           content:
@@ -248,9 +248,9 @@ paths:
                 type: string
         '500':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Internal Server Error
         default:
           content:
@@ -280,15 +280,15 @@ paths:
           description: No Content
         '422':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Unprocessable Entity
         '500':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Internal Server Error
         default:
           content:
@@ -321,15 +321,15 @@ paths:
           description: OK
         '422':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Unprocessable Entity
         '500':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Internal Server Error
         default:
           content:
@@ -368,15 +368,15 @@ paths:
           description: OK
         '422':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Unprocessable Entity
         '500':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Internal Server Error
         default:
           content:
@@ -466,15 +466,15 @@ paths:
           description: OK
         '422':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Unprocessable Entity
         '500':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Internal Server Error
         default:
           content:
@@ -513,15 +513,15 @@ paths:
           description: Created
         '422':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Unprocessable Entity
         '500':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Internal Server Error
         default:
           content:
@@ -558,15 +558,15 @@ paths:
                 type: string
         '422':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Unprocessable Entity
         '500':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Internal Server Error
         default:
           content:
@@ -603,15 +603,15 @@ paths:
           description: No Content
         '422':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Unprocessable Entity
         '500':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Internal Server Error
         default:
           content:
@@ -651,15 +651,15 @@ paths:
           description: OK
         '422':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Unprocessable Entity
         '500':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Internal Server Error
         default:
           content:
@@ -705,15 +705,15 @@ paths:
           description: OK
         '422':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Unprocessable Entity
         '500':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Internal Server Error
         default:
           content:
@@ -810,15 +810,15 @@ paths:
           description: OK
         '422':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Unprocessable Entity
         '500':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Internal Server Error
         default:
           content:
@@ -864,15 +864,15 @@ paths:
           description: Created
         '422':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Unprocessable Entity
         '500':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Internal Server Error
         default:
           content:
@@ -916,15 +916,15 @@ paths:
           description: No Content
         '422':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Unprocessable Entity
         '500':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Internal Server Error
         default:
           content:
@@ -971,15 +971,15 @@ paths:
           description: OK
         '422':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Unprocessable Entity
         '500':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Internal Server Error
         default:
           content:
@@ -1032,15 +1032,15 @@ paths:
           description: OK
         '422':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Unprocessable Entity
         '500':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Internal Server Error
         default:
           content:
@@ -1193,15 +1193,15 @@ paths:
           description: OK
         '422':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Unprocessable Entity
         '500':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Internal Server Error
         default:
           content:
@@ -1253,15 +1253,15 @@ paths:
           description: Created
         '422':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Unprocessable Entity
         '500':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Internal Server Error
         default:
           content:
@@ -1309,15 +1309,15 @@ paths:
           description: OK
         '422':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Unprocessable Entity
         '500':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Internal Server Error
         default:
           content:
@@ -1365,15 +1365,15 @@ paths:
           description: OK
         '422':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Unprocessable Entity
         '500':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Internal Server Error
         default:
           content:
@@ -1421,15 +1421,15 @@ paths:
           description: OK
         '422':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Unprocessable Entity
         '500':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Internal Server Error
         default:
           content:
@@ -1477,15 +1477,15 @@ paths:
           description: OK
         '422':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Unprocessable Entity
         '500':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Internal Server Error
         default:
           content:
@@ -1529,15 +1529,15 @@ paths:
                 type: string
         '422':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Unprocessable Entity
         '500':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Internal Server Error
         default:
           content:
@@ -1620,15 +1620,15 @@ paths:
           description: OK
         '422':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Unprocessable Entity
         '500':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Internal Server Error
         default:
           content:
@@ -1681,15 +1681,15 @@ paths:
           description: Created
         '422':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Unprocessable Entity
         '500':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Internal Server Error
         default:
           content:
@@ -1748,15 +1748,15 @@ paths:
           description: OK
         '422':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Unprocessable Entity
         '500':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Internal Server Error
         default:
           content:
@@ -1874,15 +1874,15 @@ paths:
           description: OK
         '422':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Unprocessable Entity
         '500':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Internal Server Error
         default:
           content:
@@ -1937,15 +1937,15 @@ paths:
           description: OK
         '422':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Unprocessable Entity
         '500':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Internal Server Error
         default:
           content:
@@ -1995,15 +1995,15 @@ paths:
           description: No Content
         '422':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Unprocessable Entity
         '500':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Internal Server Error
         default:
           content:
@@ -2050,15 +2050,15 @@ paths:
           description: OK
         '422':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Unprocessable Entity
         '500':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Internal Server Error
         default:
           content:
@@ -2111,15 +2111,15 @@ paths:
           description: OK
         '422':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Unprocessable Entity
         '500':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Internal Server Error
         default:
           content:
@@ -2166,15 +2166,15 @@ paths:
           description: Created
         '422':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Unprocessable Entity
         '500':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Internal Server Error
         default:
           content:
@@ -2274,15 +2274,15 @@ paths:
           description: OK
         '422':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Unprocessable Entity
         '500':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Internal Server Error
         default:
           content:
@@ -2330,15 +2330,15 @@ paths:
           description: OK
         '422':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Unprocessable Entity
         '500':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Internal Server Error
         default:
           content:
@@ -2421,15 +2421,15 @@ paths:
           description: OK
         '422':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Unprocessable Entity
         '500':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Internal Server Error
         default:
           content:
@@ -2481,15 +2481,15 @@ paths:
           description: Created
         '422':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Unprocessable Entity
         '500':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Internal Server Error
         default:
           content:
@@ -2533,15 +2533,15 @@ paths:
                 type: string
         '422':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Unprocessable Entity
         '500':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Internal Server Error
         default:
           content:
@@ -2585,15 +2585,15 @@ paths:
           description: No Content
         '422':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Unprocessable Entity
         '500':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Internal Server Error
         default:
           content:
@@ -2640,15 +2640,15 @@ paths:
           description: OK
         '422':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Unprocessable Entity
         '500':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Internal Server Error
         default:
           content:
@@ -2701,15 +2701,15 @@ paths:
           description: OK
         '422':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Unprocessable Entity
         '500':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Internal Server Error
         default:
           content:
@@ -2785,15 +2785,15 @@ paths:
           description: OK
         '422':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Unprocessable Entity
         '500':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Internal Server Error
         default:
           content:
@@ -2837,15 +2837,15 @@ paths:
           description: No Content
         '422':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Unprocessable Entity
         '500':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Internal Server Error
         default:
           content:
@@ -2892,15 +2892,15 @@ paths:
           description: OK
         '422':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Unprocessable Entity
         '500':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Internal Server Error
         default:
           content:
@@ -2953,15 +2953,15 @@ paths:
           description: OK
         '422':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Unprocessable Entity
         '500':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Internal Server Error
         default:
           content:
@@ -3016,15 +3016,15 @@ paths:
           description: OK
         '422':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Unprocessable Entity
         '500':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Internal Server Error
         default:
           content:
@@ -3100,15 +3100,15 @@ paths:
           description: OK
         '422':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Unprocessable Entity
         '500':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Internal Server Error
         default:
           content:
@@ -3154,15 +3154,15 @@ paths:
           description: Created
         '422':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Unprocessable Entity
         '500':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Internal Server Error
         default:
           content:
@@ -3206,15 +3206,15 @@ paths:
           description: No Content
         '422':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Unprocessable Entity
         '500':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Internal Server Error
         default:
           content:
@@ -3261,15 +3261,15 @@ paths:
           description: OK
         '422':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Unprocessable Entity
         '500':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Internal Server Error
         default:
           content:
@@ -3322,15 +3322,15 @@ paths:
           description: OK
         '422':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Unprocessable Entity
         '500':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Internal Server Error
         default:
           content:
@@ -3427,15 +3427,15 @@ paths:
           description: OK
         '422':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Unprocessable Entity
         '500':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Internal Server Error
         default:
           content:
@@ -3481,15 +3481,15 @@ paths:
           description: Created
         '422':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Unprocessable Entity
         '500':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Internal Server Error
         default:
           content:
@@ -3533,15 +3533,15 @@ paths:
                 type: string
         '422':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Unprocessable Entity
         '500':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Internal Server Error
         default:
           content:
@@ -3585,15 +3585,15 @@ paths:
           description: No Content
         '422':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Unprocessable Entity
         '500':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Internal Server Error
         default:
           content:
@@ -3640,15 +3640,15 @@ paths:
           description: OK
         '422':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Unprocessable Entity
         '500':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Internal Server Error
         default:
           content:
@@ -3701,15 +3701,15 @@ paths:
           description: OK
         '422':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Unprocessable Entity
         '500':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Internal Server Error
         default:
           content:
@@ -3792,15 +3792,15 @@ paths:
           description: OK
         '422':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Unprocessable Entity
         '500':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Internal Server Error
         default:
           content:
@@ -3846,15 +3846,15 @@ paths:
           description: Created
         '422':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Unprocessable Entity
         '500':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Internal Server Error
         default:
           content:
@@ -3898,15 +3898,15 @@ paths:
                 type: string
         '422':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Unprocessable Entity
         '500':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Internal Server Error
         default:
           content:
@@ -3950,15 +3950,15 @@ paths:
           description: No Content
         '422':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Unprocessable Entity
         '500':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Internal Server Error
         default:
           content:
@@ -4005,15 +4005,15 @@ paths:
           description: OK
         '422':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Unprocessable Entity
         '500':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Internal Server Error
         default:
           content:
@@ -4066,15 +4066,15 @@ paths:
           description: OK
         '422':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Unprocessable Entity
         '500':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Internal Server Error
         default:
           content:
@@ -4115,15 +4115,15 @@ paths:
           description: OK
         '422':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Unprocessable Entity
         '500':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Internal Server Error
         default:
           content:
@@ -4170,15 +4170,15 @@ paths:
           description: OK
         '422':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Unprocessable Entity
         '500':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Internal Server Error
         default:
           content:
@@ -4254,15 +4254,15 @@ paths:
           description: OK
         '422':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Unprocessable Entity
         '500':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Internal Server Error
         default:
           content:
@@ -4308,15 +4308,15 @@ paths:
           description: Created
         '422':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Unprocessable Entity
         '500':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Internal Server Error
         default:
           content:
@@ -4360,15 +4360,15 @@ paths:
           description: No Content
         '422':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Unprocessable Entity
         '500':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Internal Server Error
         default:
           content:
@@ -4415,15 +4415,15 @@ paths:
           description: OK
         '422':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Unprocessable Entity
         '500':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Internal Server Error
         default:
           content:
@@ -4476,15 +4476,15 @@ paths:
           description: OK
         '422':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Unprocessable Entity
         '500':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Internal Server Error
         default:
           content:
@@ -4567,15 +4567,15 @@ paths:
           description: OK
         '422':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Unprocessable Entity
         '500':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Internal Server Error
         default:
           content:
@@ -4642,15 +4642,15 @@ paths:
                 type: string
         '422':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Unprocessable Entity
         '500':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Internal Server Error
         default:
           content:
@@ -4717,15 +4717,15 @@ paths:
                 type: string
         '422':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Unprocessable Entity
         '500':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Internal Server Error
         default:
           content:
@@ -4792,15 +4792,15 @@ paths:
                 type: string
         '422':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Unprocessable Entity
         '500':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Internal Server Error
         default:
           content:
@@ -4867,15 +4867,15 @@ paths:
                 type: string
         '422':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Unprocessable Entity
         '500':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Internal Server Error
         default:
           content:
@@ -4951,15 +4951,15 @@ paths:
                 type: string
         '422':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Unprocessable Entity
         '500':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Internal Server Error
         default:
           content:
@@ -5026,15 +5026,15 @@ paths:
                 type: string
         '422':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Unprocessable Entity
         '500':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Internal Server Error
         default:
           content:
@@ -5101,15 +5101,15 @@ paths:
                 type: string
         '422':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Unprocessable Entity
         '500':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Internal Server Error
         default:
           content:
@@ -5161,15 +5161,15 @@ paths:
                 type: string
         '422':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Unprocessable Entity
         '500':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Internal Server Error
         default:
           content:
@@ -5222,15 +5222,15 @@ paths:
           description: OK
         '422':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Unprocessable Entity
         '500':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Internal Server Error
         default:
           content:
@@ -5278,15 +5278,15 @@ paths:
           description: Created
         '422':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Unprocessable Entity
         '500':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Internal Server Error
         default:
           content:
@@ -5334,15 +5334,15 @@ paths:
           description: Created
         '422':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Unprocessable Entity
         '500':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Internal Server Error
         default:
           content:
@@ -5403,15 +5403,15 @@ paths:
           description: OK
         '422':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Unprocessable Entity
         '500':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Internal Server Error
         default:
           content:
@@ -5463,15 +5463,15 @@ paths:
                 type: string
         '422':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Unprocessable Entity
         '500':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Internal Server Error
         default:
           content:
@@ -5509,15 +5509,15 @@ paths:
           description: OK
         '422':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Unprocessable Entity
         '500':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Internal Server Error
         default:
           content:
@@ -5563,15 +5563,15 @@ paths:
           description: Created
         '422':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Unprocessable Entity
         '500':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Internal Server Error
         default:
           content:
@@ -5614,15 +5614,15 @@ paths:
           description: No Content
         '422':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Unprocessable Entity
         '500':
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/LegacyError'
           description: Internal Server Error
         default:
           content:

--- a/components/ledger/api/openapi.huma.yaml
+++ b/components/ledger/api/openapi.huma.yaml
@@ -4758,15 +4758,15 @@ paths:
           description: OK
         "422":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Unprocessable Entity
         "500":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Internal Server Error
         default:
           content:
@@ -4797,15 +4797,15 @@ paths:
           description: Created
         "422":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Unprocessable Entity
         "500":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Internal Server Error
         default:
           content:
@@ -4834,9 +4834,9 @@ paths:
                 type: string
         "500":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Internal Server Error
         default:
           content:
@@ -4866,15 +4866,15 @@ paths:
           description: No Content
         "422":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Unprocessable Entity
         "500":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Internal Server Error
         default:
           content:
@@ -4907,15 +4907,15 @@ paths:
           description: OK
         "422":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Unprocessable Entity
         "500":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Internal Server Error
         default:
           content:
@@ -4954,15 +4954,15 @@ paths:
           description: OK
         "422":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Unprocessable Entity
         "500":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Internal Server Error
         default:
           content:
@@ -5052,15 +5052,15 @@ paths:
           description: OK
         "422":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Unprocessable Entity
         "500":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Internal Server Error
         default:
           content:
@@ -5099,15 +5099,15 @@ paths:
           description: Created
         "422":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Unprocessable Entity
         "500":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Internal Server Error
         default:
           content:
@@ -5144,15 +5144,15 @@ paths:
                 type: string
         "422":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Unprocessable Entity
         "500":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Internal Server Error
         default:
           content:
@@ -5189,15 +5189,15 @@ paths:
           description: No Content
         "422":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Unprocessable Entity
         "500":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Internal Server Error
         default:
           content:
@@ -5237,15 +5237,15 @@ paths:
           description: OK
         "422":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Unprocessable Entity
         "500":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Internal Server Error
         default:
           content:
@@ -5291,15 +5291,15 @@ paths:
           description: OK
         "422":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Unprocessable Entity
         "500":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Internal Server Error
         default:
           content:
@@ -5396,15 +5396,15 @@ paths:
           description: OK
         "422":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Unprocessable Entity
         "500":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Internal Server Error
         default:
           content:
@@ -5450,15 +5450,15 @@ paths:
           description: Created
         "422":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Unprocessable Entity
         "500":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Internal Server Error
         default:
           content:
@@ -5502,15 +5502,15 @@ paths:
           description: No Content
         "422":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Unprocessable Entity
         "500":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Internal Server Error
         default:
           content:
@@ -5557,15 +5557,15 @@ paths:
           description: OK
         "422":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Unprocessable Entity
         "500":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Internal Server Error
         default:
           content:
@@ -5618,15 +5618,15 @@ paths:
           description: OK
         "422":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Unprocessable Entity
         "500":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Internal Server Error
         default:
           content:
@@ -5779,15 +5779,15 @@ paths:
           description: OK
         "422":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Unprocessable Entity
         "500":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Internal Server Error
         default:
           content:
@@ -5839,15 +5839,15 @@ paths:
           description: Created
         "422":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Unprocessable Entity
         "500":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Internal Server Error
         default:
           content:
@@ -5895,15 +5895,15 @@ paths:
           description: OK
         "422":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Unprocessable Entity
         "500":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Internal Server Error
         default:
           content:
@@ -5951,15 +5951,15 @@ paths:
           description: OK
         "422":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Unprocessable Entity
         "500":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Internal Server Error
         default:
           content:
@@ -6007,15 +6007,15 @@ paths:
           description: OK
         "422":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Unprocessable Entity
         "500":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Internal Server Error
         default:
           content:
@@ -6063,15 +6063,15 @@ paths:
           description: OK
         "422":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Unprocessable Entity
         "500":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Internal Server Error
         default:
           content:
@@ -6115,15 +6115,15 @@ paths:
                 type: string
         "422":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Unprocessable Entity
         "500":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Internal Server Error
         default:
           content:
@@ -6206,15 +6206,15 @@ paths:
           description: OK
         "422":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Unprocessable Entity
         "500":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Internal Server Error
         default:
           content:
@@ -6267,15 +6267,15 @@ paths:
           description: Created
         "422":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Unprocessable Entity
         "500":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Internal Server Error
         default:
           content:
@@ -6334,15 +6334,15 @@ paths:
           description: OK
         "422":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Unprocessable Entity
         "500":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Internal Server Error
         default:
           content:
@@ -6460,15 +6460,15 @@ paths:
           description: OK
         "422":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Unprocessable Entity
         "500":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Internal Server Error
         default:
           content:
@@ -6523,15 +6523,15 @@ paths:
           description: OK
         "422":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Unprocessable Entity
         "500":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Internal Server Error
         default:
           content:
@@ -6581,15 +6581,15 @@ paths:
           description: No Content
         "422":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Unprocessable Entity
         "500":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Internal Server Error
         default:
           content:
@@ -6636,15 +6636,15 @@ paths:
           description: OK
         "422":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Unprocessable Entity
         "500":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Internal Server Error
         default:
           content:
@@ -6697,15 +6697,15 @@ paths:
           description: OK
         "422":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Unprocessable Entity
         "500":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Internal Server Error
         default:
           content:
@@ -6752,15 +6752,15 @@ paths:
           description: Created
         "422":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Unprocessable Entity
         "500":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Internal Server Error
         default:
           content:
@@ -6854,15 +6854,15 @@ paths:
           description: OK
         "422":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Unprocessable Entity
         "500":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Internal Server Error
         default:
           content:
@@ -6910,15 +6910,15 @@ paths:
           description: OK
         "422":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Unprocessable Entity
         "500":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Internal Server Error
         default:
           content:
@@ -7001,15 +7001,15 @@ paths:
           description: OK
         "422":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Unprocessable Entity
         "500":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Internal Server Error
         default:
           content:
@@ -7061,15 +7061,15 @@ paths:
           description: Created
         "422":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Unprocessable Entity
         "500":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Internal Server Error
         default:
           content:
@@ -7113,15 +7113,15 @@ paths:
                 type: string
         "422":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Unprocessable Entity
         "500":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Internal Server Error
         default:
           content:
@@ -7165,15 +7165,15 @@ paths:
           description: No Content
         "422":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Unprocessable Entity
         "500":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Internal Server Error
         default:
           content:
@@ -7220,15 +7220,15 @@ paths:
           description: OK
         "422":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Unprocessable Entity
         "500":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Internal Server Error
         default:
           content:
@@ -7281,15 +7281,15 @@ paths:
           description: OK
         "422":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Unprocessable Entity
         "500":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Internal Server Error
         default:
           content:
@@ -7365,15 +7365,15 @@ paths:
           description: OK
         "422":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Unprocessable Entity
         "500":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Internal Server Error
         default:
           content:
@@ -7417,15 +7417,15 @@ paths:
           description: No Content
         "422":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Unprocessable Entity
         "500":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Internal Server Error
         default:
           content:
@@ -7472,15 +7472,15 @@ paths:
           description: OK
         "422":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Unprocessable Entity
         "500":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Internal Server Error
         default:
           content:
@@ -7533,15 +7533,15 @@ paths:
           description: OK
         "422":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Unprocessable Entity
         "500":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Internal Server Error
         default:
           content:
@@ -7596,15 +7596,15 @@ paths:
           description: OK
         "422":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Unprocessable Entity
         "500":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Internal Server Error
         default:
           content:
@@ -7680,15 +7680,15 @@ paths:
           description: OK
         "422":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Unprocessable Entity
         "500":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Internal Server Error
         default:
           content:
@@ -7734,15 +7734,15 @@ paths:
           description: Created
         "422":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Unprocessable Entity
         "500":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Internal Server Error
         default:
           content:
@@ -7786,15 +7786,15 @@ paths:
           description: No Content
         "422":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Unprocessable Entity
         "500":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Internal Server Error
         default:
           content:
@@ -7841,15 +7841,15 @@ paths:
           description: OK
         "422":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Unprocessable Entity
         "500":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Internal Server Error
         default:
           content:
@@ -7902,15 +7902,15 @@ paths:
           description: OK
         "422":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Unprocessable Entity
         "500":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Internal Server Error
         default:
           content:
@@ -8007,15 +8007,15 @@ paths:
           description: OK
         "422":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Unprocessable Entity
         "500":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Internal Server Error
         default:
           content:
@@ -8061,15 +8061,15 @@ paths:
           description: Created
         "422":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Unprocessable Entity
         "500":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Internal Server Error
         default:
           content:
@@ -8113,15 +8113,15 @@ paths:
                 type: string
         "422":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Unprocessable Entity
         "500":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Internal Server Error
         default:
           content:
@@ -8165,15 +8165,15 @@ paths:
           description: No Content
         "422":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Unprocessable Entity
         "500":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Internal Server Error
         default:
           content:
@@ -8220,15 +8220,15 @@ paths:
           description: OK
         "422":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Unprocessable Entity
         "500":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Internal Server Error
         default:
           content:
@@ -8281,15 +8281,15 @@ paths:
           description: OK
         "422":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Unprocessable Entity
         "500":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Internal Server Error
         default:
           content:
@@ -8372,15 +8372,15 @@ paths:
           description: OK
         "422":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Unprocessable Entity
         "500":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Internal Server Error
         default:
           content:
@@ -8426,15 +8426,15 @@ paths:
           description: Created
         "422":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Unprocessable Entity
         "500":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Internal Server Error
         default:
           content:
@@ -8478,15 +8478,15 @@ paths:
                 type: string
         "422":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Unprocessable Entity
         "500":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Internal Server Error
         default:
           content:
@@ -8530,15 +8530,15 @@ paths:
           description: No Content
         "422":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Unprocessable Entity
         "500":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Internal Server Error
         default:
           content:
@@ -8585,15 +8585,15 @@ paths:
           description: OK
         "422":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Unprocessable Entity
         "500":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Internal Server Error
         default:
           content:
@@ -8646,15 +8646,15 @@ paths:
           description: OK
         "422":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Unprocessable Entity
         "500":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Internal Server Error
         default:
           content:
@@ -8695,15 +8695,15 @@ paths:
           description: OK
         "422":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Unprocessable Entity
         "500":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Internal Server Error
         default:
           content:
@@ -8750,15 +8750,15 @@ paths:
           description: OK
         "422":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Unprocessable Entity
         "500":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Internal Server Error
         default:
           content:
@@ -8834,15 +8834,15 @@ paths:
           description: OK
         "422":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Unprocessable Entity
         "500":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Internal Server Error
         default:
           content:
@@ -8888,15 +8888,15 @@ paths:
           description: Created
         "422":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Unprocessable Entity
         "500":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Internal Server Error
         default:
           content:
@@ -8940,15 +8940,15 @@ paths:
           description: No Content
         "422":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Unprocessable Entity
         "500":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Internal Server Error
         default:
           content:
@@ -8995,15 +8995,15 @@ paths:
           description: OK
         "422":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Unprocessable Entity
         "500":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Internal Server Error
         default:
           content:
@@ -9056,15 +9056,15 @@ paths:
           description: OK
         "422":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Unprocessable Entity
         "500":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Internal Server Error
         default:
           content:
@@ -9147,15 +9147,15 @@ paths:
           description: OK
         "422":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Unprocessable Entity
         "500":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Internal Server Error
         default:
           content:
@@ -9218,15 +9218,15 @@ paths:
                 type: string
         "422":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Unprocessable Entity
         "500":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Internal Server Error
         default:
           content:
@@ -9289,15 +9289,15 @@ paths:
                 type: string
         "422":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Unprocessable Entity
         "500":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Internal Server Error
         default:
           content:
@@ -9360,15 +9360,15 @@ paths:
                 type: string
         "422":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Unprocessable Entity
         "500":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Internal Server Error
         default:
           content:
@@ -9431,15 +9431,15 @@ paths:
                 type: string
         "422":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Unprocessable Entity
         "500":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Internal Server Error
         default:
           content:
@@ -9511,15 +9511,15 @@ paths:
                 type: string
         "422":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Unprocessable Entity
         "500":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Internal Server Error
         default:
           content:
@@ -9582,15 +9582,15 @@ paths:
                 type: string
         "422":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Unprocessable Entity
         "500":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Internal Server Error
         default:
           content:
@@ -9653,15 +9653,15 @@ paths:
                 type: string
         "422":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Unprocessable Entity
         "500":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Internal Server Error
         default:
           content:
@@ -9713,15 +9713,15 @@ paths:
                 type: string
         "422":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Unprocessable Entity
         "500":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Internal Server Error
         default:
           content:
@@ -9774,15 +9774,15 @@ paths:
           description: OK
         "422":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Unprocessable Entity
         "500":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Internal Server Error
         default:
           content:
@@ -9830,15 +9830,15 @@ paths:
           description: Created
         "422":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Unprocessable Entity
         "500":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Internal Server Error
         default:
           content:
@@ -9886,15 +9886,15 @@ paths:
           description: Created
         "422":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Unprocessable Entity
         "500":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Internal Server Error
         default:
           content:
@@ -9955,15 +9955,15 @@ paths:
           description: OK
         "422":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Unprocessable Entity
         "500":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Internal Server Error
         default:
           content:
@@ -10015,15 +10015,15 @@ paths:
                 type: string
         "422":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Unprocessable Entity
         "500":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Internal Server Error
         default:
           content:
@@ -10061,15 +10061,15 @@ paths:
           description: OK
         "422":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Unprocessable Entity
         "500":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Internal Server Error
         default:
           content:
@@ -10109,15 +10109,15 @@ paths:
           description: Created
         "422":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Unprocessable Entity
         "500":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Internal Server Error
         default:
           content:
@@ -10154,15 +10154,15 @@ paths:
           description: No Content
         "422":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Unprocessable Entity
         "500":
           content:
-            application/problem+json:
+            application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/LegacyError"
           description: Internal Server Error
         default:
           content:

--- a/components/ledger/api/openapi.huma.yaml
+++ b/components/ledger/api/openapi.huma.yaml
@@ -4756,6 +4756,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/Pagination"
           description: OK
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -4783,6 +4795,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/Organization"
           description: Created
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -4808,6 +4832,12 @@ paths:
             X-Total-Count:
               schema:
                 type: string
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -4834,6 +4864,18 @@ paths:
       responses:
         "204":
           description: No Content
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -4863,6 +4905,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/Organization"
           description: OK
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -4898,6 +4952,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/Organization"
           description: OK
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -4984,6 +5050,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/Pagination"
           description: OK
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -5019,6 +5097,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/Ledger"
           description: Created
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -5052,6 +5142,18 @@ paths:
             X-Total-Count:
               schema:
                 type: string
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -5085,6 +5187,18 @@ paths:
       responses:
         "204":
           description: No Content
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -5121,6 +5235,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/Ledger"
           description: OK
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -5163,6 +5289,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/Ledger"
           description: OK
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -5256,6 +5394,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/Pagination"
           description: OK
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -5298,6 +5448,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/AccountType"
           description: Created
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -5338,6 +5500,18 @@ paths:
       responses:
         "204":
           description: No Content
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -5381,6 +5555,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/AccountType"
           description: OK
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -5430,6 +5616,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/AccountType"
           description: OK
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -5579,6 +5777,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/Pagination"
           description: OK
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -5627,6 +5837,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/Account"
           description: Created
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -5671,6 +5893,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/Account"
           description: OK
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -5715,6 +5949,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/Pagination"
           description: OK
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -5759,6 +6005,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/Account"
           description: OK
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -5803,6 +6061,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/Pagination"
           description: OK
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -5843,6 +6113,18 @@ paths:
             X-Total-Count:
               schema:
                 type: string
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -5922,6 +6204,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/Pagination"
           description: OK
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -5971,6 +6265,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/Balance"
           description: Created
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -6026,6 +6332,18 @@ paths:
                   - array
                   - "null"
           description: OK
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -6140,6 +6458,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/Pagination"
           description: OK
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -6191,6 +6521,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/Operation"
           description: OK
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -6237,6 +6579,18 @@ paths:
       responses:
         "204":
           description: No Content
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -6280,6 +6634,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/Account"
           description: OK
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -6329,6 +6695,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/Account"
           description: OK
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -6372,6 +6750,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/AssetRate"
           description: Created
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -6462,6 +6852,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/Pagination"
           description: OK
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -6506,6 +6908,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/AssetRate"
           description: OK
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -6585,6 +6999,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/Pagination"
           description: OK
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -6633,6 +7059,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/Asset"
           description: Created
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -6673,6 +7111,18 @@ paths:
             X-Total-Count:
               schema:
                 type: string
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -6713,6 +7163,18 @@ paths:
       responses:
         "204":
           description: No Content
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -6756,6 +7218,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/Asset"
           description: OK
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -6805,6 +7279,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/Asset"
           description: OK
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -6877,6 +7363,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/Pagination"
           description: OK
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -6917,6 +7415,18 @@ paths:
       responses:
         "204":
           description: No Content
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -6960,6 +7470,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/Balance"
           description: OK
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -7009,6 +7531,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/Balance"
           description: OK
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -7060,6 +7594,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/BalanceHistory"
           description: OK
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -7132,6 +7678,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/Pagination"
           description: OK
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -7174,6 +7732,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/OperationRoute"
           description: Created
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -7214,6 +7784,18 @@ paths:
       responses:
         "204":
           description: No Content
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -7257,6 +7839,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/OperationRoute"
           description: OK
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -7306,6 +7900,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/OperationRoute"
           description: OK
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -7399,6 +8005,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/Pagination"
           description: OK
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -7441,6 +8059,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/Portfolio"
           description: Created
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -7481,6 +8111,18 @@ paths:
             X-Total-Count:
               schema:
                 type: string
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -7521,6 +8163,18 @@ paths:
       responses:
         "204":
           description: No Content
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -7564,6 +8218,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/Portfolio"
           description: OK
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -7613,6 +8279,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/Portfolio"
           description: OK
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -7692,6 +8370,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/Pagination"
           description: OK
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -7734,6 +8424,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/Segment"
           description: Created
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -7774,6 +8476,18 @@ paths:
             X-Total-Count:
               schema:
                 type: string
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -7814,6 +8528,18 @@ paths:
       responses:
         "204":
           description: No Content
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -7857,6 +8583,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/Segment"
           description: OK
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -7906,6 +8644,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/Segment"
           description: OK
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -7943,6 +8693,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/LedgerSettings"
           description: OK
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -7986,6 +8748,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/LedgerSettings"
           description: OK
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -8058,6 +8832,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/Pagination"
           description: OK
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -8100,6 +8886,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/TransactionRoute"
           description: Created
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -8140,6 +8938,18 @@ paths:
       responses:
         "204":
           description: No Content
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -8183,6 +8993,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/TransactionRoute"
           description: OK
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -8232,6 +9054,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/TransactionRoute"
           description: OK
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -8311,6 +9145,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/Pagination"
           description: OK
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -8370,6 +9216,18 @@ paths:
             X-Idempotency-Replayed:
               schema:
                 type: string
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -8429,6 +9287,18 @@ paths:
             X-Idempotency-Replayed:
               schema:
                 type: string
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -8488,6 +9358,18 @@ paths:
             X-Idempotency-Replayed:
               schema:
                 type: string
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -8547,6 +9429,18 @@ paths:
             X-Idempotency-Replayed:
               schema:
                 type: string
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -8615,6 +9509,18 @@ paths:
             X-Total-Count:
               schema:
                 type: string
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -8674,6 +9580,18 @@ paths:
             X-Idempotency-Replayed:
               schema:
                 type: string
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -8733,6 +9651,18 @@ paths:
             X-Idempotency-Replayed:
               schema:
                 type: string
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -8781,6 +9711,18 @@ paths:
             X-Cache-Hit:
               schema:
                 type: string
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -8830,6 +9772,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/Transaction"
           description: OK
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -8874,6 +9828,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/Transaction"
           description: Created
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -8918,6 +9884,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/Transaction"
           description: Created
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -8975,6 +9953,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/Operation"
           description: OK
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -9023,6 +10013,18 @@ paths:
             X-Idempotency-Replayed:
               schema:
                 type: string
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -9057,6 +10059,18 @@ paths:
                   - array
                   - "null"
           description: OK
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -9093,6 +10107,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/MetadataIndex"
           description: Created
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -9126,6 +10152,18 @@ paths:
       responses:
         "204":
           description: No Content
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/json:
@@ -9218,6 +10256,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/Pagination"
           description: OK
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -9244,6 +10294,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/Organization"
           description: Created
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -9268,6 +10330,12 @@ paths:
             X-Total-Count:
               schema:
                 type: string
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -9293,6 +10361,18 @@ paths:
       responses:
         "204":
           description: No Content
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -9321,6 +10401,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/Organization"
           description: OK
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -9355,6 +10447,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/Organization"
           description: OK
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -9396,6 +10500,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/ProvisionEncryptionResponse"
           description: Created
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -9431,6 +10547,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/ProvisioningStatusResponse"
           description: OK
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -9509,6 +10637,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/Pagination"
           description: OK
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -9559,6 +10699,18 @@ paths:
             X-Idempotency-Replayed:
               schema:
                 type: string
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -9617,6 +10769,18 @@ paths:
             X-Idempotency-Replayed:
               schema:
                 type: string
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -9663,6 +10827,18 @@ paths:
       responses:
         "204":
           description: No Content
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -9712,6 +10888,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/Instrument"
           description: OK
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -9760,6 +10948,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/Instrument"
           description: OK
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -9806,6 +11006,18 @@ paths:
       responses:
         "204":
           description: No Content
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -9845,6 +11057,18 @@ paths:
       responses:
         "204":
           description: No Content
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -9887,6 +11111,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/Holder"
           description: OK
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -9928,6 +11164,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/Holder"
           description: OK
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -9992,6 +11240,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/Pagination"
           description: OK
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -10084,6 +11344,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/Pagination"
           description: OK
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -10169,6 +11441,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/Pagination"
           description: OK
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -10203,6 +11487,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/Ledger"
           description: Created
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -10235,6 +11531,18 @@ paths:
             X-Total-Count:
               schema:
                 type: string
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -10267,6 +11575,18 @@ paths:
       responses:
         "204":
           description: No Content
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -10302,6 +11622,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/Ledger"
           description: OK
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -10343,6 +11675,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/Ledger"
           description: OK
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -10435,6 +11779,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/Pagination"
           description: OK
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -10476,6 +11832,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/AccountType"
           description: Created
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -10515,6 +11883,18 @@ paths:
       responses:
         "204":
           description: No Content
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -10557,6 +11937,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/AccountType"
           description: OK
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -10605,6 +11997,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/AccountType"
           description: OK
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -10753,6 +12157,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/Pagination"
           description: OK
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -10800,6 +12216,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/AccountV2"
           description: Created
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -10843,6 +12271,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/AccountV2"
           description: OK
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -10886,6 +12326,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/Pagination"
           description: OK
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -10929,6 +12381,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/AccountV2"
           description: OK
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -10972,6 +12436,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/Pagination"
           description: OK
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -11011,6 +12487,18 @@ paths:
             X-Total-Count:
               schema:
                 type: string
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -11089,6 +12577,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/Pagination"
           description: OK
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -11137,6 +12637,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/Balance"
           description: Created
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -11191,6 +12703,18 @@ paths:
                   - array
                   - "null"
           description: OK
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -11304,6 +12828,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/Pagination"
           description: OK
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -11354,6 +12890,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/Operation"
           description: OK
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -11399,6 +12947,18 @@ paths:
       responses:
         "204":
           description: No Content
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -11441,6 +13001,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/AccountV2"
           description: OK
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -11489,6 +13061,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/AccountV2"
           description: OK
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -11567,6 +13151,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/Pagination"
           description: OK
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -11614,6 +13210,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/Asset"
           description: Created
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -11653,6 +13261,18 @@ paths:
             X-Total-Count:
               schema:
                 type: string
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -11692,6 +13312,18 @@ paths:
       responses:
         "204":
           description: No Content
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -11734,6 +13366,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/Asset"
           description: OK
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -11782,6 +13426,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/Asset"
           description: OK
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -11853,6 +13509,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/Pagination"
           description: OK
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -11892,6 +13560,18 @@ paths:
       responses:
         "204":
           description: No Content
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -11934,6 +13614,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/Balance"
           description: OK
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -11982,6 +13674,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/Balance"
           description: OK
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -12032,6 +13736,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/BalanceHistory"
           description: OK
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -12089,6 +13805,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/FeePagination"
           description: OK
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -12130,6 +13858,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/FeeBillingPackage"
           description: Created
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -12169,6 +13909,18 @@ paths:
       responses:
         "204":
           description: No Content
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -12211,6 +13963,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/FeeBillingPackage"
           description: OK
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -12259,6 +14023,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/FeeBillingPackage"
           description: OK
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -12301,6 +14077,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/FeeBillingCalculateResponse"
           description: OK
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -12344,6 +14132,18 @@ paths:
                 contentEncoding: base64
                 type: string
           description: OK
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -12399,6 +14199,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/HolderAccountResponse"
           description: Created
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -12470,6 +14282,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/Pagination"
           description: OK
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -12511,6 +14335,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/OperationRoute"
           description: Created
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -12550,6 +14386,18 @@ paths:
       responses:
         "204":
           description: No Content
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -12592,6 +14440,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/OperationRoute"
           description: OK
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -12640,6 +14500,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/OperationRoute"
           description: OK
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -12711,6 +14583,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/FeePagination"
           description: OK
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -12752,6 +14636,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/FeePackage"
           description: Created
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -12791,6 +14687,18 @@ paths:
       responses:
         "204":
           description: No Content
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -12833,6 +14741,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/FeePackage"
           description: OK
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -12881,6 +14801,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/FeePackage"
           description: OK
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -12973,6 +14905,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/Pagination"
           description: OK
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -13014,6 +14958,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/Portfolio"
           description: Created
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -13053,6 +15009,18 @@ paths:
             X-Total-Count:
               schema:
                 type: string
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -13092,6 +15060,18 @@ paths:
       responses:
         "204":
           description: No Content
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -13134,6 +15114,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/Portfolio"
           description: OK
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -13182,6 +15174,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/Portfolio"
           description: OK
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -13260,6 +15264,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/Pagination"
           description: OK
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -13301,6 +15317,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/Segment"
           description: Created
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -13340,6 +15368,18 @@ paths:
             X-Total-Count:
               schema:
                 type: string
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -13379,6 +15419,18 @@ paths:
       responses:
         "204":
           description: No Content
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -13421,6 +15473,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/Segment"
           description: OK
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -13469,6 +15533,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/Segment"
           description: OK
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -13505,6 +15581,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/LedgerSettings"
           description: OK
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -13547,6 +15635,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/LedgerSettings"
           description: OK
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -13618,6 +15718,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/Pagination"
           description: OK
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -13659,6 +15771,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/TransactionRoute"
           description: Created
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -13698,6 +15822,18 @@ paths:
       responses:
         "204":
           description: No Content
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -13740,6 +15876,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/TransactionRoute"
           description: OK
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -13788,6 +15936,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/TransactionRoute"
           description: OK
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -13866,6 +16026,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/TransactionV2ListBody"
           description: OK
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -13933,6 +16105,18 @@ paths:
             X-Total-Count:
               schema:
                 type: string
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -13980,6 +16164,18 @@ paths:
             X-Cache-Hit:
               schema:
                 type: string
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -14028,6 +16224,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/TransactionV2"
           description: OK
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -14071,6 +16279,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/TransactionV2"
           description: Created
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -14114,6 +16334,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/TransactionV2"
           description: Created
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -14170,6 +16402,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/Operation"
           description: OK
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -14217,6 +16461,18 @@ paths:
             X-Idempotency-Replayed:
               schema:
                 type: string
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -14308,6 +16564,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/AuditEventsEnvelope"
           description: OK
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -14341,6 +16609,18 @@ paths:
                   - array
                   - "null"
           description: OK
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -14376,6 +16656,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/MetadataIndex"
           description: Created
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -14408,6 +16700,18 @@ paths:
       responses:
         "204":
           description: No Content
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -14452,6 +16756,18 @@ paths:
             X-Idempotency-Replayed:
               schema:
                 type: string
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -14496,6 +16812,18 @@ paths:
             X-Idempotency-Replayed:
               schema:
                 type: string
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -14540,6 +16868,18 @@ paths:
             X-Idempotency-Replayed:
               schema:
                 type: string
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -14584,6 +16924,18 @@ paths:
             X-Idempotency-Replayed:
               schema:
                 type: string
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:

--- a/components/ledger/internal/adapters/http/in/contract_document_shape_test.go
+++ b/components/ledger/internal/adapters/http/in/contract_document_shape_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	problem "github.com/LerianStudio/lib-commons/v7/commons/net/http/problem"
 	"github.com/danielgtaylor/huma/v2"
 	"github.com/stretchr/testify/require"
 
@@ -34,6 +35,7 @@ func TestContractDocumentShape(t *testing.T) {
 		{"v2 create bodies ref the typed input and carry the prose", assertV2CreateBodiesTyped},
 		{"both prefixes coexist with disjoint operation ids", assertPrefixesCoexist},
 		{"security schemes declared with no dangling reference", assertSecuritySchemesResolve},
+		{"error responses declare the envelope each version serves", assertErrorResponsesMatchServedEnvelope},
 	}
 
 	for _, prop := range properties {
@@ -206,4 +208,107 @@ func assertSecuritySchemesResolve(t *testing.T, doc *huma.OpenAPI) {
 		require.Containsf(t, doc.Components.SecuritySchemes, name,
 			"operation references security scheme %q that Components.SecuritySchemes does not declare (dangling reference)", name)
 	}
+}
+
+// problemErrorMediaType is the RFC 9457 media type a plane serves its error bodies
+// as when no version envelope reshapes them — every /v2 operation, and every tracer
+// operation. Declared here rather than imported because the producer keeps it
+// unexported (pkg/net/http/problem.go).
+const problemErrorMediaType = "application/problem+json"
+
+// assertErrorResponsesMatchServedEnvelope is the parity between what the contract
+// DECLARES for a failure and what the service SERVES for it. Nothing else compares
+// the two, which is how a bump that added baseline error statuses could publish the
+// wrong error body on 87 /v1 operations and pass every gate.
+//
+// /v1 runs behind ErrorEnvelope (middleware/envelope.go), which rewrites EVERY
+// response with status >= 400 into the legacy {code,title,message} body at
+// application/json — the wire side of that is locked by envelope_boundary_test.go.
+// /v2 has no entry in that middleware's version registry, so it serves the RFC 9457
+// problem document unchanged. Declaring one plane's schema or media type on the
+// other tells a code generator to parse a body the service never sends, which is
+// worse than declaring nothing: the caller does not discover it at integration time,
+// the generated client does at runtime.
+//
+// It walks the "default" catch-all AND every numeric status >= 400 (isErrorResponseKey)
+// because the numeric ones are exactly what regressed: the lib-commons baseline hook
+// materializes them at huma.Register time from the RFC 9457 content, and only
+// RepointV1ErrorResponses puts them back on the /v1 envelope.
+func assertErrorResponsesMatchServedEnvelope(t *testing.T, doc *huma.OpenAPI) {
+	require.NotNil(t, doc.Components, "document must carry components")
+	require.NotNil(t, doc.Components.Schemas, "document must carry a schema registry")
+
+	registry := doc.Components.Schemas
+	require.Contains(t, registry.Map(), "Error",
+		"the RFC 9457 error body must be registered as Error before this can compare against it")
+	require.Contains(t, registry.Map(), "LegacyError",
+		"the /v1 error body must be registered as LegacyError before this can compare against it")
+
+	legacyRef := registry.Schema(reflect.TypeFor[LegacyError](), true, "LegacyError").Ref
+	problemRef := registry.Schema(reflect.TypeFor[problem.Detail](), true, "Error").Ref
+	require.NotEmpty(t, legacyRef, "LegacyError must resolve to a component ref")
+	require.NotEmpty(t, problemRef, "the RFC 9457 Error body must resolve to a component ref")
+	require.NotEqual(t, legacyRef, problemRef,
+		"the two planes must publish DISTINCT error components; one ref for both means a pass collapsed them")
+
+	checked := map[string]int{}
+
+	for key, item := range doc.Paths {
+		var (
+			plane     string
+			wantMedia string
+			wantRef   string
+		)
+
+		switch {
+		case strings.HasPrefix(key, "/v1/"):
+			plane, wantMedia, wantRef = "/v1", legacyErrorMediaType, legacyRef
+		case strings.HasPrefix(key, "/v2/"):
+			plane, wantMedia, wantRef = "/v2", problemErrorMediaType, problemRef
+		default:
+			continue
+		}
+
+		for _, op := range operationsOf(item) {
+			for status, response := range op.Responses {
+				if response == nil || len(response.Content) == 0 || !isErrorResponseKey(status) {
+					continue
+				}
+
+				require.Lenf(t, response.Content, 1,
+					"%s %s response %q declares %d media types; an error body is served as exactly one",
+					key, op.OperationID, status, len(response.Content))
+
+				media, ok := response.Content[wantMedia]
+				require.Truef(t, ok,
+					"%s %s response %q must be declared as %s — what the service actually serves on %s — but is declared as %v",
+					key, op.OperationID, status, wantMedia, plane, contentTypesOf(response.Content))
+
+				require.NotNilf(t, media.Schema,
+					"%s %s response %q declares %s with no schema", key, op.OperationID, status, wantMedia)
+				require.Equalf(t, wantRef, media.Schema.Ref,
+					"%s %s response %q must $ref the error body %s serves (%s), not %s",
+					key, op.OperationID, status, plane, wantRef, media.Schema.Ref)
+
+				checked[plane]++
+			}
+		}
+	}
+
+	// Guard against a vacuous pass: a walk that matched nothing would assert nothing.
+	require.NotZerof(t, checked["/v1"], "no /v1 error response was inspected")
+	require.NotZerof(t, checked["/v2"], "no /v2 error response was inspected")
+}
+
+// contentTypesOf returns a response's declared media types, sorted, for a readable
+// failure message.
+func contentTypesOf(content map[string]*huma.MediaType) []string {
+	names := make([]string, 0, len(content))
+	for name := range content {
+		names = append(names, name)
+	}
+
+	sort.Strings(names)
+
+	return names
 }

--- a/components/ledger/internal/adapters/http/in/huma_contract_mount.go
+++ b/components/ledger/internal/adapters/http/in/huma_contract_mount.go
@@ -5,8 +5,10 @@
 package in
 
 import (
+	nethttp "net/http"
 	"reflect"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/LerianStudio/lib-auth/v4/auth/middleware"
@@ -302,9 +304,32 @@ type LegacyError struct {
 	Fields     map[string]any `json:"fields,omitempty" doc:"Per-field validation detail, keyed by field name. The value is the violation message for a known field and the offending value for an unexpected one, so it is not always a string. The /v2 contract carries these as the 'errors' array."`
 }
 
-// RepointV1ErrorResponses rewrites every /v1 operation's default error response to
-// the LegacyError schema at application/json, leaving /v2 on the shared RFC 9457
-// Error schema.
+// legacyErrorMediaType is the media type a /v1 error body is served as. It is the
+// same constant ErrorEnvelope stamps on the rewritten response
+// (middleware/envelope.go), so the declared media type and the served one move
+// together.
+const legacyErrorMediaType = fiber.MIMEApplicationJSON
+
+// RepointV1ErrorResponses rewrites EVERY error response on a /v1 operation to the
+// LegacyError schema at application/json, leaving /v2 on the shared RFC 9457 Error
+// schema.
+//
+// Every error response, not just Huma's "default" catch-all. ErrorEnvelope
+// (middleware/envelope.go) reshapes any /v1 response whose status is >= 400 —
+// including the 500 written while unwinding a recovered panic — so a numeric status
+// left pointing at the problem-details body publishes a document the service never
+// sends, and a generated client cannot parse the response it receives. Until the
+// lib-commons baseline hook landed, "default" was the only error response a /v1
+// operation carried, which is why handling it alone was correct then and is not now:
+// the hook (commons/net/http/openapi, OnAddOperation) adds 500 — and 422 where the
+// operation has validated input — at huma.Register time by CLONING the catch-all's
+// content, which is still the RFC 9457 one at that point. This pass runs afterwards,
+// from FinalizeContract, and corrects them.
+//
+// The rule is "status >= 400", not a list of the statuses that hook happens to add
+// today, so a baseline status added later is repointed without another edit here.
+// A response that declares no content declares no body; giving it one here would
+// publish a body the operation does not send, so those are left alone.
 //
 // Both versions share ONE document and ONE component registry, so this adds a
 // second, distinctly named schema rather than altering Error — which must stay
@@ -313,7 +338,8 @@ type LegacyError struct {
 // scripts/openapi/check-docs.sh.
 //
 // Run it AFTER the last huma.Register and BEFORE the spec is snapshotted, like the
-// sibling passes above.
+// sibling passes above. Running it before the hook would repoint responses that do
+// not exist yet.
 func RepointV1ErrorResponses(api huma.API) {
 	schema := api.OpenAPI().Components.Schemas.Schema(reflect.TypeOf(LegacyError{}), true, "LegacyError")
 
@@ -323,16 +349,31 @@ func RepointV1ErrorResponses(api huma.API) {
 		}
 
 		for _, op := range operationsOf(item) {
-			response, ok := op.Responses["default"]
-			if !ok || response == nil {
-				continue
-			}
+			for status, response := range op.Responses {
+				if response == nil || len(response.Content) == 0 || !isErrorResponseKey(status) {
+					continue
+				}
 
-			response.Content = map[string]*huma.MediaType{
-				"application/json": {Schema: schema},
+				response.Content = map[string]*huma.MediaType{
+					legacyErrorMediaType: {Schema: schema},
+				}
 			}
 		}
 	}
+}
+
+// isErrorResponseKey reports whether an OpenAPI responses key names an error
+// response: Huma's "default" catch-all, or any numeric status ErrorEnvelope
+// reshapes (>= 400). Any other key — a success status, or a non-numeric key that is
+// not the catch-all — is not an error response and is left untouched.
+func isErrorResponseKey(key string) bool {
+	if key == "default" {
+		return true
+	}
+
+	status, err := strconv.Atoi(key)
+
+	return err == nil && status >= nethttp.StatusBadRequest
 }
 
 // operationsOf returns every declared operation on a PathItem, in a fixed order, so a

--- a/components/tracer/api/openapi.huma.yaml
+++ b/components/tracer/api/openapi.huma.yaml
@@ -1094,6 +1094,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/ListAuditEventsResponse"
           description: OK
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -1124,6 +1136,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/AuditEvent"
           description: OK
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -1154,6 +1178,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/HashChainVerificationResult"
           description: OK
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -1268,6 +1304,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/ListLimitsResponse"
           description: OK
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -1297,6 +1345,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/Limit"
           description: Created
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -1323,6 +1383,18 @@ paths:
       responses:
         "204":
           description: No Content
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -1352,6 +1424,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/Limit"
           description: OK
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -1389,6 +1473,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/Limit"
           description: OK
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -1419,6 +1515,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/Limit"
           description: OK
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -1449,6 +1557,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/Limit"
           description: OK
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -1479,6 +1599,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/Limit"
           description: OK
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -1509,6 +1641,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/UsageSnapshot"
           description: OK
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -1539,6 +1683,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/ReserveResponse"
           description: Created
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -1569,6 +1725,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/TransactionActionResponse"
           description: OK
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -1599,6 +1767,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/TransactionActionResponse"
           description: OK
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -1629,6 +1809,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/ReservationActionResponse"
           description: OK
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -1659,6 +1851,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/ReservationActionResponse"
           description: OK
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -1773,6 +1977,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/ListRulesResponse"
           description: OK
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -1802,6 +2018,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/Rule"
           description: Created
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -1828,6 +2056,18 @@ paths:
       responses:
         "204":
           description: No Content
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -1857,6 +2097,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/Rule"
           description: OK
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -1894,6 +2146,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/Rule"
           description: OK
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -1924,6 +2188,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/Rule"
           description: OK
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -1954,6 +2230,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/Rule"
           description: OK
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -1984,6 +2272,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/Rule"
           description: OK
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -2098,6 +2398,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/ListTransactionValidationsResponse"
           description: OK
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:
@@ -2129,6 +2441,18 @@ paths:
           description: OK
         "201":
           description: New validation created
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
       security:
         - BearerAuth: []
         - ApiKeyAuth: []
@@ -2153,6 +2477,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/TransactionValidation"
           description: OK
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Internal Server Error
         default:
           content:
             application/problem+json:

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.27.0
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2
 	github.com/LerianStudio/lib-auth/v4 v4.0.0
-	github.com/LerianStudio/lib-commons/v7 v7.0.0
+	github.com/LerianStudio/lib-commons/v7 v7.1.0
 	github.com/LerianStudio/lib-observability/v4 v4.0.1
 	github.com/LerianStudio/lib-service-discovery/v2 v2.0.0
 	github.com/LerianStudio/lib-streaming/v4 v4.0.0

--- a/go.sum
+++ b/go.sum
@@ -19,8 +19,8 @@ github.com/DATA-DOG/go-sqlmock v1.5.2/go.mod h1:88MAG/4G7SMwSE3CeA0ZKzrT5CiOU3OJ
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/LerianStudio/lib-auth/v4 v4.0.0 h1:uexinsYR3hlTtmgiowNdYGBkXqCW2517eOvie/ta+q8=
 github.com/LerianStudio/lib-auth/v4 v4.0.0/go.mod h1:e78VImnZmsD5k8tZ07RPEEt+/KK4RGy5qzh0OISefyc=
-github.com/LerianStudio/lib-commons/v7 v7.0.0 h1:nZL/fXRyBlXTMcIvMzwAqbQTG4HRNDVi4SoKRY8V1LA=
-github.com/LerianStudio/lib-commons/v7 v7.0.0/go.mod h1:/iFJVftWWVryRxO9YGDW59UIAHMrGJB6EMKJlFeEiKM=
+github.com/LerianStudio/lib-commons/v7 v7.1.0 h1:dbzqIhjhCE+plQ8v53cfEbS5f6tMLabDDNP6i4aSawo=
+github.com/LerianStudio/lib-commons/v7 v7.1.0/go.mod h1:/iFJVftWWVryRxO9YGDW59UIAHMrGJB6EMKJlFeEiKM=
 github.com/LerianStudio/lib-observability/v2 v2.1.3 h1:ZFVIv7VVfSv/Ag9OcxQNqoa6YGV9KpcnRb4ocvM8jvk=
 github.com/LerianStudio/lib-observability/v2 v2.1.3/go.mod h1:iXspGM6PRTf6BDtkTc0Z69R2HEv1GtjBsI/YSvewDgA=
 github.com/LerianStudio/lib-observability/v4 v4.0.1 h1:ZkRfturZ7LV4dXpZ56QFhlce8l7rZT7H6eBLd2ul+4o=


### PR DESCRIPTION
## Description

**The ledger and Tracer contracts now declare the error responses they can actually return — and each one names the envelope its plane really serves.** Before this PR they declared none: across all 225 published operations there was not one numeric `4xx`/`5xx` response, so anyone generating a client from either spec got no branch for the failures the service really sends.

Two commits, deliberately separate:

1. `build(deps)` — moves the `lib-commons` pin to `v7.1.0`, whose baseline hook publishes the error responses.
2. `fix(ledger)` — repairs the `/v1` envelope those new responses would otherwise have got wrong, and adds the guard that was missing. See **The `/v1` envelope** below.

Operations declaring each status, before → after:

| Artifact | Operations | `422` | `500` |
|---|---|---|---|
| `components/ledger/api/openapi.huma.yaml` | 197 | 0 → **195** | 0 → **197** |
| `components/tracer/api/openapi.huma.yaml` | 28 | 0 → **28** | 0 → **28** |
| `api/midaz.openapi.yaml` / `.json` | 225 | 0 → **223** | 0 → **225** |

`500` lands on every operation. `422` lands on every operation with schema-validated input — the two without it are the HEAD organization-count endpoints on `/v1` and `/v2`, which take no parameters and no body and so cannot fail request validation.

### Why a version pin is the whole of commit 1

`lib-commons` `v7.0.0` does not contain the baseline-error-response hook: at that tag `commons/net/http/openapi/openapi.go` ends at `humaConfig.OnAddOperation = nil`. The hook first exists in `v7.1.0`, so moving the pin is what publishes the error responses.

That is worth stating because the failure mode is silent. On `v7.0.0` the build passes, the tests pass, the regenerated spec comes back byte-identical and the drift gate is green — because the committed and generated specs are equally empty. An unchanged artifact after this bump would have meant the change did nothing.

The four generated artifacts were regenerated with the repo's own `make generate-docs`, never by hand.

### The `/v1` envelope

The hook adds `422`/`500` referencing the RFC 9457 `Error` schema at `application/problem+json`. That is accurate for the 110 `/v2` ledger operations and all 28 Tracer operations, and both are left untouched.

It was **not** accurate for the 87 `/v1` ledger operations. The ledger registers `ErrorEnvelope()` (`components/ledger/internal/bootstrap/unified-server.go`), which rewrites every `/v1` response with status ≥ 400 to `application/json` carrying the legacy `{code,title,message}` envelope — the middleware is registered outermost, so even a recovered panic's 500 goes through it. Left alone, those operations would have advertised a problem document they never serve, and a generated `/v1` client would have failed to parse the real response. Declaring nothing, as before, left the caller to find out; declaring the wrong envelope actively misleads a generator, which is why this is repaired here rather than filed as debt.

`RepointV1ErrorResponses` already kept the `default` catch-all on `LegacyError`, and that was complete while `default` was the only error response a `/v1` operation had. Commit 2 extends it to walk **every** error response — the catch-all plus any numeric status ≥ 400 — so a baseline status added later is covered without another edit. It still runs from `FinalizeContract`, after the last `huma.Register`, because the hook materializes those statuses during registration. A response that declares no content is left alone rather than given a body it does not send.

Result on the published contracts: all 260 `/v1` error responses carry `LegacyError` at `application/json`; the 329 `/v2` and 83 Tracer ones stay on `Error` at `application/problem+json`. Status counts are identical to the table above — only the media type and schema each one points at changed.

**The guard that was missing.** Nothing compared what the spec declares for a failure against what the service serves, which is how this could have shipped green. `TestContractDocumentShape` now asserts, per operation on the assembled document, that every `/v1` error response declares the legacy schema at `application/json` and every `/v2` one declares the RFC 9457 schema at `application/problem+json`, with a non-vacuity check on both planes. Verified by mutation: with the pass reverted to its `default`-only form the property fails on the first `/v1` `422`; restored, it passes.

### No business rule changes

Midaz is a double-entry ledger and Tracer sits pre-ledger on the authorization path, so to be explicit: **no accounting logic, no transaction or balance handling, and no authorization logic is touched.** Commit 1 changes only the module pin; commit 2 changes only how the OpenAPI document describes error responses on the `/v1` plane. No runtime behaviour changes on any request path — the envelope the service serves is what it always was, and the contract now matches it.

## Type of Change

- [x] `build`: Build system, Dockerfile, Go module dependencies
- [x] `fix`: Bug fix (the `/v1` error-response contract)

## Breaking Changes

None. Existing responses keep their shape, and the new error responses are added alongside them. The `/v1` error responses describe the envelope `/v1` has always served.

## Testing

- [x] `make test-unit` — **16026 tests, 6 skipped, 0 failures** (the CI-gate unit contract)
- [x] `make test-property` — 0 failures
- [x] `CHECK_DOCS_REGEN=1 make check-docs` — pass (regenerate-and-diff drift over all four artifacts)
- [x] `make test-openapi-locks` — pass
- [x] `make lint` — **0 issues**, at golangci-lint `v2.13.2`, the version `pr-validation.yml` pins. Identical to the pre-change baseline on this branch (0 → 0), so nothing was introduced.
- [ ] `make sec-govulncheck` — **cannot run locally, and not because of this PR.** govulncheck `v1.1.4` panics with `unexpected expr: *ast.KeyValueExpr` in `golang.org/x/tools/go/ssa` (the tool bundles x/tools `v0.29.0`, which predates the Go `1.27.0` toolchain this repo pins). I reproduced the identical panic on `v7.0.0`, so it is a pre-existing tool/toolchain incompatibility, not a vulnerability report and not a consequence of this PR.
- [ ] `make test-integration` — **not run.** Needs the testcontainers stack; no integration path is modified, so this is left to CI.

**Test evidence**

| Gate | Result |
|---|---|
| `go build ./...` | clean |
| `go vet` — untagged, `integration`, `property`, `integration,property`, `libsd`, `unit`, `testhooks`, `e2e`, `integration,chaos` | clean |
| `make test-unit` | 16026 tests, 6 skipped, 0 failures |
| `go test -tags=unit` and `-tags=testhooks` | pass — these cover the six files the untagged run cannot compile in |
| `make test-property` | 0 failures |
| `make test-openapi-locks` | pass — the RFC 9457 `Error` closure stays byte-identical across the ledger and Tracer planes |
| `CHECK_DOCS_REGEN=1 make check-docs` | pass — info parity, security coverage, `Error` singleton, redocly lint, and regenerate-and-diff drift |
| `make lint` | 0 issues (baseline 0) |

`go vet -tags=chaos` alone fails, but identically at `v7.0.0` and `v7.1.0`, so it is unrelated to this PR: `tests/utils/postgres/onboarding_migrations.go` is gated `integration || chaos` while `FindMigrationsPath` in `migrations.go` is gated `integration` only. The chaos lane always runs as `integration,chaos`, which is clean.

## Architectural Checklist

- [x] No `panic()` in production paths
- [x] Timestamps use `time.Now().UTC()`
- [x] Errors wrapped with `%w`
- [x] Handlers stay thin (parse, validate, call service)
- [x] Infrastructure concerns kept in `internal/bootstrap`

## Related Issues

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Expanded Tracer API documentation across 28 operations with explicit responses for validation failures (422) and server errors (500).
  - Standardized these responses using the documented problem-details format and error schema.
  - Existing request definitions and successful response behavior remain unchanged.

- **Bug Fixes**
  - Improved error response consistency across API versions, ensuring legacy endpoints use the expected JSON error format while newer endpoints use problem-details responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->