### PR TITLE
fix(ledger): stop declaring an error body on HEAD responses

### DIFF
--- a/api/midaz.openapi.json
+++ b/api/midaz.openapi.json
@@ -421,23 +421,9 @@
             }
           },
           "500": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/LegacyError"
-                }
-              }
-            },
             "description": "Internal Server Error"
           },
           "default": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/LegacyError"
-                }
-              }
-            },
             "description": "Error"
           }
         },
@@ -917,33 +903,12 @@
             }
           },
           "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/LegacyError"
-                }
-              }
-            },
             "description": "Unprocessable Entity"
           },
           "500": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/LegacyError"
-                }
-              }
-            },
             "description": "Internal Server Error"
           },
           "default": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/LegacyError"
-                }
-              }
-            },
             "description": "Error"
           }
         },
@@ -2440,33 +2405,12 @@
             }
           },
           "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/LegacyError"
-                }
-              }
-            },
             "description": "Unprocessable Entity"
           },
           "500": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/LegacyError"
-                }
-              }
-            },
             "description": "Internal Server Error"
           },
           "default": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/LegacyError"
-                }
-              }
-            },
             "description": "Error"
           }
         },
@@ -3996,33 +3940,12 @@
             }
           },
           "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/LegacyError"
-                }
-              }
-            },
             "description": "Unprocessable Entity"
           },
           "500": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/LegacyError"
-                }
-              }
-            },
             "description": "Internal Server Error"
           },
           "default": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/LegacyError"
-                }
-              }
-            },
             "description": "Error"
           }
         },
@@ -5568,33 +5491,12 @@
             }
           },
           "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/LegacyError"
-                }
-              }
-            },
             "description": "Unprocessable Entity"
           },
           "500": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/LegacyError"
-                }
-              }
-            },
             "description": "Internal Server Error"
           },
           "default": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/LegacyError"
-                }
-              }
-            },
             "description": "Error"
           }
         },
@@ -6144,33 +6046,12 @@
             }
           },
           "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/LegacyError"
-                }
-              }
-            },
             "description": "Unprocessable Entity"
           },
           "500": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/LegacyError"
-                }
-              }
-            },
             "description": "Internal Server Error"
           },
           "default": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/LegacyError"
-                }
-              }
-            },
             "description": "Error"
           }
         },
@@ -7778,33 +7659,12 @@
             }
           },
           "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/LegacyError"
-                }
-              }
-            },
             "description": "Unprocessable Entity"
           },
           "500": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/LegacyError"
-                }
-              }
-            },
             "description": "Internal Server Error"
           },
           "default": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/LegacyError"
-                }
-              }
-            },
             "description": "Error"
           }
         },
@@ -9091,23 +8951,9 @@
             }
           },
           "500": {
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            },
             "description": "Internal Server Error"
           },
           "default": {
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            },
             "description": "Error"
           }
         },
@@ -11000,33 +10846,12 @@
             }
           },
           "422": {
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            },
             "description": "Unprocessable Entity"
           },
           "500": {
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            },
             "description": "Internal Server Error"
           },
           "default": {
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            },
             "description": "Error"
           }
         },
@@ -12508,33 +12333,12 @@
             }
           },
           "422": {
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            },
             "description": "Unprocessable Entity"
           },
           "500": {
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            },
             "description": "Internal Server Error"
           },
           "default": {
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            },
             "description": "Error"
           }
         },
@@ -13720,33 +13524,12 @@
             }
           },
           "422": {
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            },
             "description": "Unprocessable Entity"
           },
           "500": {
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            },
             "description": "Internal Server Error"
           },
           "default": {
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            },
             "description": "Error"
           }
         },
@@ -16494,33 +16277,12 @@
             }
           },
           "422": {
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            },
             "description": "Unprocessable Entity"
           },
           "500": {
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            },
             "description": "Internal Server Error"
           },
           "default": {
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            },
             "description": "Error"
           }
         },
@@ -17064,33 +16826,12 @@
             }
           },
           "422": {
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            },
             "description": "Unprocessable Entity"
           },
           "500": {
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            },
             "description": "Internal Server Error"
           },
           "default": {
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            },
             "description": "Error"
           }
         },
@@ -18230,33 +17971,12 @@
             }
           },
           "422": {
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            },
             "description": "Unprocessable Entity"
           },
           "500": {
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            },
             "description": "Internal Server Error"
           },
           "default": {
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            },
             "description": "Error"
           }
         },

--- a/api/midaz.openapi.yaml
+++ b/api/midaz.openapi.yaml
@@ -247,16 +247,8 @@ paths:
               schema:
                 type: string
         '500':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/LegacyError'
           description: Internal Server Error
         default:
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/LegacyError'
           description: Error
       security:
         - BearerAuth: []
@@ -557,22 +549,10 @@ paths:
               schema:
                 type: string
         '422':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/LegacyError'
           description: Unprocessable Entity
         '500':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/LegacyError'
           description: Internal Server Error
         default:
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/LegacyError'
           description: Error
       security:
         - BearerAuth: []
@@ -1528,22 +1508,10 @@ paths:
               schema:
                 type: string
         '422':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/LegacyError'
           description: Unprocessable Entity
         '500':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/LegacyError'
           description: Internal Server Error
         default:
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/LegacyError'
           description: Error
       security:
         - BearerAuth: []
@@ -2532,22 +2500,10 @@ paths:
               schema:
                 type: string
         '422':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/LegacyError'
           description: Unprocessable Entity
         '500':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/LegacyError'
           description: Internal Server Error
         default:
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/LegacyError'
           description: Error
       security:
         - BearerAuth: []
@@ -3532,22 +3488,10 @@ paths:
               schema:
                 type: string
         '422':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/LegacyError'
           description: Unprocessable Entity
         '500':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/LegacyError'
           description: Internal Server Error
         default:
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/LegacyError'
           description: Error
       security:
         - BearerAuth: []
@@ -3897,22 +3841,10 @@ paths:
               schema:
                 type: string
         '422':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/LegacyError'
           description: Unprocessable Entity
         '500':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/LegacyError'
           description: Internal Server Error
         default:
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/LegacyError'
           description: Error
       security:
         - BearerAuth: []
@@ -4950,22 +4882,10 @@ paths:
               schema:
                 type: string
         '422':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/LegacyError'
           description: Unprocessable Entity
         '500':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/LegacyError'
           description: Internal Server Error
         default:
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/LegacyError'
           description: Error
       security:
         - BearerAuth: []
@@ -5791,16 +5711,8 @@ paths:
               schema:
                 type: string
         '500':
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Error'
           description: Internal Server Error
         default:
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Error'
           description: Error
       security:
         - BearerAuth: []
@@ -7014,22 +6926,10 @@ paths:
               schema:
                 type: string
         '422':
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Error'
           description: Unprocessable Entity
         '500':
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Error'
           description: Internal Server Error
         default:
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Error'
           description: Error
       security:
         - BearerAuth: []
@@ -7970,22 +7870,10 @@ paths:
               schema:
                 type: string
         '422':
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Error'
           description: Unprocessable Entity
         '500':
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Error'
           description: Internal Server Error
         default:
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Error'
           description: Error
       security:
         - BearerAuth: []
@@ -8744,22 +8632,10 @@ paths:
               schema:
                 type: string
         '422':
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Error'
           description: Unprocessable Entity
         '500':
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Error'
           description: Internal Server Error
         default:
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Error'
           description: Error
       security:
         - BearerAuth: []
@@ -10492,22 +10368,10 @@ paths:
               schema:
                 type: string
         '422':
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Error'
           description: Unprocessable Entity
         '500':
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Error'
           description: Internal Server Error
         default:
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Error'
           description: Error
       security:
         - BearerAuth: []
@@ -10851,22 +10715,10 @@ paths:
               schema:
                 type: string
         '422':
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Error'
           description: Unprocessable Entity
         '500':
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Error'
           description: Internal Server Error
         default:
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Error'
           description: Error
       security:
         - BearerAuth: []
@@ -11592,22 +11444,10 @@ paths:
               schema:
                 type: string
         '422':
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Error'
           description: Unprocessable Entity
         '500':
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Error'
           description: Internal Server Error
         default:
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Error'
           description: Error
       security:
         - BearerAuth: []

--- a/components/ledger/api/openapi.huma.yaml
+++ b/components/ledger/api/openapi.huma.yaml
@@ -4833,16 +4833,8 @@ paths:
               schema:
                 type: string
         "500":
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/LegacyError"
           description: Internal Server Error
         default:
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/LegacyError"
           description: Error
       security:
         - BearerAuth: []
@@ -5143,22 +5135,10 @@ paths:
               schema:
                 type: string
         "422":
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/LegacyError"
           description: Unprocessable Entity
         "500":
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/LegacyError"
           description: Internal Server Error
         default:
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/LegacyError"
           description: Error
       security:
         - BearerAuth: []
@@ -6114,22 +6094,10 @@ paths:
               schema:
                 type: string
         "422":
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/LegacyError"
           description: Unprocessable Entity
         "500":
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/LegacyError"
           description: Internal Server Error
         default:
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/LegacyError"
           description: Error
       security:
         - BearerAuth: []
@@ -7112,22 +7080,10 @@ paths:
               schema:
                 type: string
         "422":
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/LegacyError"
           description: Unprocessable Entity
         "500":
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/LegacyError"
           description: Internal Server Error
         default:
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/LegacyError"
           description: Error
       security:
         - BearerAuth: []
@@ -8112,22 +8068,10 @@ paths:
               schema:
                 type: string
         "422":
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/LegacyError"
           description: Unprocessable Entity
         "500":
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/LegacyError"
           description: Internal Server Error
         default:
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/LegacyError"
           description: Error
       security:
         - BearerAuth: []
@@ -8477,22 +8421,10 @@ paths:
               schema:
                 type: string
         "422":
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/LegacyError"
           description: Unprocessable Entity
         "500":
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/LegacyError"
           description: Internal Server Error
         default:
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/LegacyError"
           description: Error
       security:
         - BearerAuth: []
@@ -9510,22 +9442,10 @@ paths:
               schema:
                 type: string
         "422":
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/LegacyError"
           description: Unprocessable Entity
         "500":
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/LegacyError"
           description: Internal Server Error
         default:
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/LegacyError"
           description: Error
       security:
         - BearerAuth: []
@@ -10331,16 +10251,8 @@ paths:
               schema:
                 type: string
         "500":
-          content:
-            application/problem+json:
-              schema:
-                $ref: "#/components/schemas/Error"
           description: Internal Server Error
         default:
-          content:
-            application/problem+json:
-              schema:
-                $ref: "#/components/schemas/Error"
           description: Error
       security:
         - BearerAuth: []
@@ -11532,22 +11444,10 @@ paths:
               schema:
                 type: string
         "422":
-          content:
-            application/problem+json:
-              schema:
-                $ref: "#/components/schemas/Error"
           description: Unprocessable Entity
         "500":
-          content:
-            application/problem+json:
-              schema:
-                $ref: "#/components/schemas/Error"
           description: Internal Server Error
         default:
-          content:
-            application/problem+json:
-              schema:
-                $ref: "#/components/schemas/Error"
           description: Error
       security:
         - BearerAuth: []
@@ -12488,22 +12388,10 @@ paths:
               schema:
                 type: string
         "422":
-          content:
-            application/problem+json:
-              schema:
-                $ref: "#/components/schemas/Error"
           description: Unprocessable Entity
         "500":
-          content:
-            application/problem+json:
-              schema:
-                $ref: "#/components/schemas/Error"
           description: Internal Server Error
         default:
-          content:
-            application/problem+json:
-              schema:
-                $ref: "#/components/schemas/Error"
           description: Error
       security:
         - BearerAuth: []
@@ -13262,22 +13150,10 @@ paths:
               schema:
                 type: string
         "422":
-          content:
-            application/problem+json:
-              schema:
-                $ref: "#/components/schemas/Error"
           description: Unprocessable Entity
         "500":
-          content:
-            application/problem+json:
-              schema:
-                $ref: "#/components/schemas/Error"
           description: Internal Server Error
         default:
-          content:
-            application/problem+json:
-              schema:
-                $ref: "#/components/schemas/Error"
           description: Error
       security:
         - BearerAuth: []
@@ -15010,22 +14886,10 @@ paths:
               schema:
                 type: string
         "422":
-          content:
-            application/problem+json:
-              schema:
-                $ref: "#/components/schemas/Error"
           description: Unprocessable Entity
         "500":
-          content:
-            application/problem+json:
-              schema:
-                $ref: "#/components/schemas/Error"
           description: Internal Server Error
         default:
-          content:
-            application/problem+json:
-              schema:
-                $ref: "#/components/schemas/Error"
           description: Error
       security:
         - BearerAuth: []
@@ -15369,22 +15233,10 @@ paths:
               schema:
                 type: string
         "422":
-          content:
-            application/problem+json:
-              schema:
-                $ref: "#/components/schemas/Error"
           description: Unprocessable Entity
         "500":
-          content:
-            application/problem+json:
-              schema:
-                $ref: "#/components/schemas/Error"
           description: Internal Server Error
         default:
-          content:
-            application/problem+json:
-              schema:
-                $ref: "#/components/schemas/Error"
           description: Error
       security:
         - BearerAuth: []
@@ -16106,22 +15958,10 @@ paths:
               schema:
                 type: string
         "422":
-          content:
-            application/problem+json:
-              schema:
-                $ref: "#/components/schemas/Error"
           description: Unprocessable Entity
         "500":
-          content:
-            application/problem+json:
-              schema:
-                $ref: "#/components/schemas/Error"
           description: Internal Server Error
         default:
-          content:
-            application/problem+json:
-              schema:
-                $ref: "#/components/schemas/Error"
           description: Error
       security:
         - BearerAuth: []

--- a/components/ledger/internal/adapters/http/in/contract_document_shape_test.go
+++ b/components/ledger/internal/adapters/http/in/contract_document_shape_test.go
@@ -36,6 +36,7 @@ func TestContractDocumentShape(t *testing.T) {
 		{"both prefixes coexist with disjoint operation ids", assertPrefixesCoexist},
 		{"security schemes declared with no dangling reference", assertSecuritySchemesResolve},
 		{"error responses declare the envelope each version serves", assertErrorResponsesMatchServedEnvelope},
+		{"HEAD operations declare no response body", assertHeadOperationsDeclareNoBody},
 	}
 
 	for _, prop := range properties {
@@ -208,6 +209,56 @@ func assertSecuritySchemesResolve(t *testing.T, doc *huma.OpenAPI) {
 		require.Containsf(t, doc.Components.SecuritySchemes, name,
 			"operation references security scheme %q that Components.SecuritySchemes does not declare (dangling reference)", name)
 	}
+}
+
+// assertHeadOperationsDeclareNoBody locks the one thing HTTP decides for a HEAD
+// operation whatever the contract says: the response carries no body. fasthttp sets
+// Response.SkipBody for every HEAD request, so a declared body is a shape the
+// service is unable to send. A generated client believes the declaration instead —
+// an oapi-codegen-style client leaves the typed field nil on a 500, so a failed
+// count reads as success, and a strict generator throws a parse error and loses the
+// status the caller needed for backoff.
+//
+// It walks EVERY response, not only the error ones, and both planes, because the
+// rule comes from the METHOD: a body declared on the 204 is as wrong as one on the
+// 500, and the /v2 half of the metrics/count family has the same constraint as the
+// /v1 half. StripHeadResponseContent is what holds it.
+func assertHeadOperationsDeclareNoBody(t *testing.T, doc *huma.OpenAPI) {
+	heads := map[string]int{}
+
+	for key, item := range doc.Paths {
+		if item == nil || item.Head == nil {
+			continue
+		}
+
+		var plane string
+
+		switch {
+		case strings.HasPrefix(key, "/v1/"):
+			plane = "/v1"
+		case strings.HasPrefix(key, "/v2/"):
+			plane = "/v2"
+		default:
+			continue
+		}
+
+		heads[plane]++
+
+		for status, response := range item.Head.Responses {
+			if response == nil {
+				continue
+			}
+
+			require.Emptyf(t, response.Content,
+				"%s %s is a HEAD operation, so response %q can never carry a body, but it declares %v",
+				key, item.Head.OperationID, status, contentTypesOf(response.Content))
+		}
+	}
+
+	// Non-vacuity: both planes publish the metrics/count HEAD family, so a walk that
+	// found no HEAD operation asserted nothing.
+	require.NotZerof(t, heads["/v1"], "no /v1 HEAD operation was inspected")
+	require.NotZerof(t, heads["/v2"], "no /v2 HEAD operation was inspected")
 }
 
 // problemErrorMediaType is the RFC 9457 media type a plane serves its error bodies

--- a/components/ledger/internal/adapters/http/in/contract_document_shape_test.go
+++ b/components/ledger/internal/adapters/http/in/contract_document_shape_test.go
@@ -7,6 +7,7 @@ package in
 import (
 	"reflect"
 	"sort"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -281,10 +282,16 @@ const problemErrorMediaType = "application/problem+json"
 // worse than declaring nothing: the caller does not discover it at integration time,
 // the generated client does at runtime.
 //
-// It walks the "default" catch-all AND every numeric status >= 400 (isErrorResponseKey)
+// It walks the "default" catch-all AND every numeric status in the 4xx/5xx range
 // because the numeric ones are exactly what regressed: the lib-commons baseline hook
 // materializes them at huma.Register time from the RFC 9457 content, and only
 // RepointV1ErrorResponses puts them back on the /v1 envelope.
+//
+// Which responses to walk, and how many there must be, are decided HERE — see
+// isErrorStatusKey and the counters below. Asking isErrorResponseKey, the predicate
+// RepointV1ErrorResponses itself applies, made the gate blind to that predicate
+// narrowing its own reach, because test and fix then skipped the same responses in
+// lockstep.
 func assertErrorResponsesMatchServedEnvelope(t *testing.T, doc *huma.OpenAPI) {
 	require.NotNil(t, doc.Components, "document must carry components")
 	require.NotNil(t, doc.Components.Schemas, "document must carry a schema registry")
@@ -302,7 +309,13 @@ func assertErrorResponsesMatchServedEnvelope(t *testing.T, doc *huma.OpenAPI) {
 	require.NotEqual(t, legacyRef, problemRef,
 		"the two planes must publish DISTINCT error components; one ref for both means a pass collapsed them")
 
-	checked := map[string]int{}
+	var (
+		checked           = map[string]int{} // error bodies this property asserted on
+		operations        = map[string]int{} // operations on the plane
+		headOperations    = map[string]int{} // of those, the ones serving HEAD
+		universalDeclared = map[string]int{} // "default" + "500" keys seen
+		universalChecked  = map[string]int{} // of those, the ones carrying a body
+	)
 
 	for key, item := range doc.Paths {
 		var (
@@ -321,8 +334,34 @@ func assertErrorResponsesMatchServedEnvelope(t *testing.T, doc *huma.OpenAPI) {
 		}
 
 		for _, op := range operationsOf(item) {
+			operations[plane]++
+
+			if op == item.Head {
+				headOperations[plane]++
+			}
+
 			for status, response := range op.Responses {
-				if response == nil || len(response.Content) == 0 || !isErrorResponseKey(status) {
+				if !isErrorStatusKey(status) {
+					continue
+				}
+
+				universal := status == "default" || status == serverErrorStatusKey
+				if universal {
+					universalDeclared[plane]++
+				}
+
+				require.NotNilf(t, response, "%s %s declares a nil %q response", key, op.OperationID, status)
+
+				if len(response.Content) == 0 {
+					// No content declares no body. Only a HEAD operation may reach
+					// here: HTTP forbids it a body, so StripHeadResponseContent drops
+					// the declaration. On any other method this is a response the
+					// property would silently skip, which is how a narrowed pass
+					// hides.
+					require.Truef(t, op == item.Head,
+						"%s %s response %q declares no body; only a HEAD operation may, because HTTP forbids it one",
+						key, op.OperationID, status)
+
 					continue
 				}
 
@@ -341,14 +380,58 @@ func assertErrorResponsesMatchServedEnvelope(t *testing.T, doc *huma.OpenAPI) {
 					"%s %s response %q must $ref the error body %s serves (%s), not %s",
 					key, op.OperationID, status, plane, wantRef, media.Schema.Ref)
 
+				if universal {
+					universalChecked[plane]++
+				}
+
 				checked[plane]++
 			}
 		}
 	}
 
-	// Guard against a vacuous pass: a walk that matched nothing would assert nothing.
-	require.NotZerof(t, checked["/v1"], "no /v1 error response was inspected")
-	require.NotZerof(t, checked["/v2"], "no /v2 error response was inspected")
+	// Independent expectation for how much this property must have reached. Two
+	// statuses are universal and neither is decided by a pass under test: huma writes
+	// one "default" catch-all per operation, and the lib-commons baseline hook adds
+	// one 500 per operation. So each plane declares exactly two per operation, and
+	// exactly the non-HEAD ones carry a body — a HEAD operation can never send one
+	// (assertHeadOperationsDeclareNoBody). Both totals are read off the document's own
+	// operation list, so a response skipped for any reason shows up as a shortfall
+	// instead of a quiet pass. require.NotZero alone could not see that: it rules out
+	// the empty walk, not a narrowed one.
+	for _, plane := range []string{"/v1", "/v2"} {
+		require.Equalf(t, 2*operations[plane], universalDeclared[plane],
+			`every %s operation must declare both a "default" and a "500" error response; %d operations, %d such responses`,
+			plane, operations[plane], universalDeclared[plane])
+
+		require.Equalf(t, 2*(operations[plane]-headOperations[plane]), universalChecked[plane],
+			`every non-HEAD %s operation must have had both its "default" and its "500" error body inspected; %d operations (%d HEAD), %d inspected`,
+			plane, operations[plane], headOperations[plane], universalChecked[plane])
+
+		require.NotZerof(t, checked[plane], "no %s error response was inspected", plane)
+	}
+}
+
+// serverErrorStatusKey is the 500 the lib-commons baseline hook adds to every
+// operation (commons/net/http/openapi, baselineResponses). Together with huma's
+// "default" catch-all it is the pair the counters above use as their per-operation
+// yardstick.
+const serverErrorStatusKey = "500"
+
+// isErrorStatusKey reports whether an OpenAPI responses key names an error response.
+// It deliberately RESTATES the rule RepointV1ErrorResponses applies instead of
+// calling isErrorResponseKey: a gate that asks the code under test which responses
+// to inspect cannot see that code narrowing its own reach. Narrowing
+// isErrorResponseKey to 500-and-up leaves 86 /v1 operations declaring the /v2
+// problem document, and the version of this property that called it still passed.
+// The bounds are literals here for the same reason.
+func isErrorStatusKey(key string) bool {
+	if key == "default" {
+		return true
+	}
+
+	status, err := strconv.Atoi(key)
+
+	return err == nil && status >= 400 && status <= 599
 }
 
 // contentTypesOf returns a response's declared media types, sorted, for a readable

--- a/components/ledger/internal/adapters/http/in/huma_contract_mount.go
+++ b/components/ledger/internal/adapters/http/in/huma_contract_mount.go
@@ -269,6 +269,7 @@ func AssembleHumaContract(app *fiber.App, group fiber.Router, cfg openapi.Config
 func FinalizeContract(api huma.API) {
 	MarkV1OperationsDeprecated(api)
 	RepointV1ErrorResponses(api)
+	StripHeadResponseContent(api)
 	ApplyVersionTagGroups(api)
 }
 
@@ -374,6 +375,53 @@ func isErrorResponseKey(key string) bool {
 	status, err := strconv.Atoi(key)
 
 	return err == nil && status >= nethttp.StatusBadRequest
+}
+
+// StripHeadResponseContent removes the declared body from EVERY response on EVERY
+// HEAD operation, on both planes.
+//
+// A HEAD response cannot carry a body, ever: fasthttp sets Response.SkipBody
+// unconditionally for a HEAD request, so whatever an operation writes is discarded
+// before the wire. Declaring a body there publishes a shape the service is
+// physically unable to send. A generated client believes it: an oapi-codegen-style
+// client leaves the typed field nil on a 500, so a failed count reads as success,
+// and a strict generator throws a parse error instead and loses the status the
+// caller needed.
+//
+// The rule keys off the METHOD, not off a status list and not off a plane. Every
+// response of a HEAD operation loses its content, so a HEAD route registered later
+// is covered without another edit here, and a body declared on a success status is
+// as wrong as one declared on an error. The HEAD operation is read off the PathItem
+// because the method is not part of the path key.
+//
+// Content is dropped by replacing the response with a shallow copy that carries no
+// content map, rather than by writing through the existing one. Baseline error
+// responses are materialized by CLONING the catch-all's media types
+// (lib-commons commons/net/http/openapi, cloneErrorContent), which share their
+// *huma.Schema pointers across statuses and planes, so nothing here may mutate a
+// MediaType a sibling response also holds.
+//
+// Order relative to the sibling passes does not matter: RepointV1ErrorResponses
+// skips a response that declares no content, and this pass drops content whatever
+// schema it points at. Run it AFTER the last huma.Register and BEFORE the spec is
+// snapshotted, like the sibling passes.
+func StripHeadResponseContent(api huma.API) {
+	for _, item := range api.OpenAPI().Paths {
+		if item == nil || item.Head == nil {
+			continue
+		}
+
+		for status, response := range item.Head.Responses {
+			if response == nil || len(response.Content) == 0 {
+				continue
+			}
+
+			bodyless := *response
+			bodyless.Content = nil
+
+			item.Head.Responses[status] = &bodyless
+		}
+	}
 }
 
 // operationsOf returns every declared operation on a PathItem, in a fixed order, so a


### PR DESCRIPTION
Two defects that arrived with the `lib-commons v7.1.0` baseline-error hook in #2465 and are live on `develop` now. An adversarial review of that PR found them after it merged.

## 1. Fourteen operations declare an error body that HTTP forbids them to send

The `/metrics/count` family is registered with `Method: http.MethodHead, DefaultStatus: http.StatusNoContent` (`count_routes.go:29-38`), and its own comment says "X-Total-Count header + empty 204 body". fasthttp enforces that unconditionally — `server.go:2631-2632`, `if ctx.IsHead() { ctx.Response.SkipBody = true }`.

The baseline hook added `422`/`500` to every registered operation, so these now declare a body they can never send. Measured live: HEAD 500 on `/v1` returns `Content-Length: 74` with **zero bytes of body**. Seven operations on `/v1`, seven on `/v2`.

**Why this is worse than a cosmetic spec problem.** A generated client is the consumer:

- An `oapi-codegen`-style client leaves `JSON500 *LegacyError` nil, so `if resp.JSON500 != nil` never fires and **a 500 on the transaction-count endpoint reads as success**.
- Strict generators (Java, C#, Kotlin) throw a parse exception instead, losing the status the caller needed for backoff.

The document was already self-contradictory: the `204` on the same operation correctly declares no content while the `500` declared a body.

**Fixed by class, not by enumerating the fourteen.** `StripHeadResponseContent` keys off `item.Head != nil` on the PathItem — the method is not part of the path key — and strips content from every response on both planes. A HEAD route registered later is covered with no further edit. It runs from `FinalizeContract`, the only supported home for a post-registration pass: after the last `huma.Register`, and reaching both production's mount and the golden-spec test seam.

Content is dropped by swapping in a shallow copy of the `huma.Response` with `Content = nil`. Nothing writes through `Content[ct]`, so the `*huma.Schema` pointers that `cloneErrorContent` shares across statuses and planes stay untouched.

### Counts, every unit reconciled

Error-response **status keys are unchanged** — 260 on `/v1`, 329 on `/v2`. Only bodies went away:

| plane | bodies before | bodies after | removed |
|---|---|---|---|
| `/v1` | 260 (86×422, 87×500, 87×default) | 240 (80/80/80) | 20 = 6×422 + 7×500 + 7×default |
| `/v2` | 329 (109/110/110) | 309 (103/103/103) | 20 = same breakdown |

The 422 delta is 6 rather than 7 because `countOrganizations` / `countOrganizationsV2` never declared a 422 — they render no parameters, so the hook skipped them. That was already true before this branch, and it is the one operation behind the 86-vs-87 asymmetry.

Success responses untouched: `/v1` 87 keys / 69 with bodies before and after, `/v2` 110 / 87.

The artifact diff is **pure deletion, zero added lines**. Only three of the four artifacts changed: `components/tracer/api/openapi.huma.yaml` is byte-identical, because the tracer publishes no HEAD operation.

## 2. The error-envelope gate used the function under test as its own oracle

`TestContractDocumentShape` called `isErrorResponseKey` — the very function `RepointV1ErrorResponses` uses — and repeated its other two decisions verbatim. The test and the fix skipped in lockstep.

**Proven by mutation.** Narrowing `isErrorResponseKey` from `status >= StatusBadRequest` to `>= StatusInternalServerError` makes the regenerated ledger spec declare `422: application/problem+json → Error` on **86 `/v1` operations** — precisely the false contract #2465 existed to remove — and the old test **still passed**. A gate that passes with the defect restored is worse than no gate, because it counts as coverage.

Two changes:

1. The walk applies a test-local `isErrorStatusKey` with literal `400`–`599` bounds instead of calling the production predicate.
2. The expectation is now computed independently of any pass under test. Two statuses are universal: huma writes one `default` catch-all per operation, and the baseline hook adds one `500` per operation. So the test asserts `universalDeclared == 2 × operations` and `universalChecked == 2 × (operations − headOperations)`, both counters read off the document's own operation list. It also fails on a bodyless error response that is not on a HEAD operation, so a silently skipped response is a failure rather than a quiet pass.

**Mutation result against the hardened file: it FAILS**, naming a specific operation — `listSegments response "422" must be declared as application/json ... but is declared as [application/problem+json]`.

## Verification

- `go build ./...` in `components/ledger`: OK.
- **`make coverage-unit`** — the real CI path for this test file, run with no build tags: exit 0, zero failures. Both properties appear in the log by name, including `HEAD_operations_declare_no_response_body`.
- `scripts/openapi/check-docs.sh` with `CHECK_DOCS_REGEN=1`: "Regeneration reproduces committed docs artifacts (no drift)".
- The new guard verified by mutation: disabling the pass fails the property, naming `countPortfolios response "422" can never carry a body, but it declares [application/json]`.

## Not in scope

Three other findings from the same review are filed as issues rather than fixed here: #2466 (`/v1` declares 422 for validation but serves 400, and 400 is not declared), #2467 (the OpenAPI drift gate never runs on pull requests, and a workflow comment claims it does), and LerianStudio/lib-commons#641 (the upstream cause — the hook triggers 422 on parameter presence rather than on a constraint that can fail).

The review found **no defect in the money path or in double-entry correctness**, and confirmed the `v7.0.0 → v7.1.0` bump touches exactly one non-test file in the library, nothing near balance arithmetic, transaction routing or idempotency.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **API Documentation**
  * Updated HEAD count endpoint specifications so error responses no longer advertise response bodies.
  * Applied consistently across v1 and v2 count metrics endpoints.

* **Contract Validation**
  * Added checks to ensure HEAD responses remain bodyless and consistently define expected error responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->