### PR TITLE
chore(deps): bump lib-observability to v4.0.2-beta.2 for dashless tenant.id

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2
 	github.com/LerianStudio/lib-auth/v4 v4.0.0
 	github.com/LerianStudio/lib-commons/v7 v7.1.0
-	github.com/LerianStudio/lib-observability/v4 v4.0.1
+	github.com/LerianStudio/lib-observability/v4 v4.0.2-beta.2
 	github.com/LerianStudio/lib-service-discovery/v2 v2.0.0
 	github.com/LerianStudio/lib-streaming/v4 v4.0.0
 	github.com/Masterminds/squirrel v1.5.4

--- a/go.sum
+++ b/go.sum
@@ -23,8 +23,8 @@ github.com/LerianStudio/lib-commons/v7 v7.1.0 h1:dbzqIhjhCE+plQ8v53cfEbS5f6tMLab
 github.com/LerianStudio/lib-commons/v7 v7.1.0/go.mod h1:/iFJVftWWVryRxO9YGDW59UIAHMrGJB6EMKJlFeEiKM=
 github.com/LerianStudio/lib-observability/v2 v2.1.3 h1:ZFVIv7VVfSv/Ag9OcxQNqoa6YGV9KpcnRb4ocvM8jvk=
 github.com/LerianStudio/lib-observability/v2 v2.1.3/go.mod h1:iXspGM6PRTf6BDtkTc0Z69R2HEv1GtjBsI/YSvewDgA=
-github.com/LerianStudio/lib-observability/v4 v4.0.1 h1:ZkRfturZ7LV4dXpZ56QFhlce8l7rZT7H6eBLd2ul+4o=
-github.com/LerianStudio/lib-observability/v4 v4.0.1/go.mod h1:h2bmpC2iOJjgDSLtaMognNAg3asfEczkYQ74xlHZ6Hs=
+github.com/LerianStudio/lib-observability/v4 v4.0.2-beta.2 h1:ZrS2ILZ5s/kyiicID22kYvecWM6H/U66WyJ5yjmWxFs=
+github.com/LerianStudio/lib-observability/v4 v4.0.2-beta.2/go.mod h1:h2bmpC2iOJjgDSLtaMognNAg3asfEczkYQ74xlHZ6Hs=
 github.com/LerianStudio/lib-service-discovery/v2 v2.0.0 h1:R8TrYI44/8joTbmZIBB8PNQmQwA7r53VeMPTiF9LtHM=
 github.com/LerianStudio/lib-service-discovery/v2 v2.0.0/go.mod h1:E1BIudjK8h0QGRTxFJZzFV3XBFp3s3dYuw7eqezsjug=
 github.com/LerianStudio/lib-streaming/v4 v4.0.0 h1:HeCzcglV3i+xZeWsA3YLkAWfsRSYI0o/Y+lF1idlJn0=

--- a/pkg/net/http/tenant_metrics_wiring_test.go
+++ b/pkg/net/http/tenant_metrics_wiring_test.go
@@ -6,6 +6,7 @@ package http_test
 
 import (
 	"context"
+	"encoding/hex"
 	"fmt"
 	"net/http/httptest"
 	"testing"
@@ -223,7 +224,10 @@ func assertTenantAttrs(t *testing.T, attrs attribute.Set, tenantID uuid.UUID, na
 
 	got, ok := attrs.Value(attribute.Key(obsconst.AttrKeyTenantID))
 	require.True(t, ok, "%s attribute missing", obsconst.AttrKeyTenantID)
-	assert.Equal(t, tenantID.String(), got.AsString())
+	// lib-observability renders tenant.id in the platform canonical dashless
+	// form, so the metric label matches the baggage member and every
+	// tenant-keyed pool, cache and Redis namespace.
+	assert.Equal(t, hex.EncodeToString(tenantID[:]), got.AsString())
 
 	gotName, ok := attrs.Value(attribute.Key(obsconst.AttrKeyTenantName))
 	require.True(t, ok, "%s attribute missing", obsconst.AttrKeyTenantName)


### PR DESCRIPTION
<table border="0" cellspacing="0" cellpadding="0">
  <tr>
    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
    <td><h1>Midaz</h1></td>
  </tr>
</table>

---

## Description

Bumps `lib-observability/v4` from `v4.0.1` to `v4.0.2-beta.2`, which picks up [lib-observability#68](https://github.com/LerianStudio/lib-observability/pull/68).

**The problem it fixes.** The tenant id reached our telemetry in two different spellings:

| Channel | Source | Form |
|---|---|---|
| Span attribute | OTel baggage, written by `withTenantIDBaggage` in `MarkTrustedAuthAssertion` — the claim verbatim | 32-char dashless |
| Metric label `tenant.id` on `lerian.http.server.*.by_tenant` | the attestation built at `pkg/net/http/protected_routes.go:86` via `uuid.Parse`, rendered by lib-observability as `uuid.UUID.String()` | **36-char hyphenated** |

The dashless form is the platform canonical spelling — it is what the JWT `tenantId` claim carries, what `lib-commons` `core.CanonicalTenantID` produces, and what keys the Postgres/Mongo connection pools, the tenant cache and the Redis namespaces. So one tenant occupied two time series that no query could reconcile.

`v4.0.2-beta.2` renders both from a single canonical helper. No API change: `AuthenticatedTenant.ID` stays a `uuid.UUID` (a `[16]byte` carries no spelling of its own — only the rendering did).

**Why the test change is part of this PR, not scope creep.** The bump alone leaves `TestTenantHTTPMetrics_LabelledFromJWTClaim` red — it pinned the hyphenated label. `assertTenantAttrs` now expects the canonical form. Verified: with the bump and without the assert update, 4 subtests fail with `expected: 0f6e2b3a-1c4d-4e5f-8a9b-0c1d2e3f4a5b`, `actual: 0f6e2b3a1c4d4e5f8a9b0c1d2e3f4a5b`.

## Type of Change

- [x] `chore`: Maintenance, config, tooling
- [x] `build`: Go module dependencies

## Breaking Changes

None to the API surface.

**Operational, and it needs coordination:** dashboards and alerts filtering on `tenant.id` must be updated in the same deploy window. The SDK default is cumulative temporality, so the renamed label value creates a new attribute set per tenant while the old one lingers in SDK state until the process restarts — expect a transient doubling of active per-tenant attribute sets and check it against the configured cardinality limit before rollout.

## Testing

- [ ] `make test` passes
- [ ] `make test-int` passes if integration paths are exercised
- [x] `make lint` passes
- [ ] `make sec` and `make vulncheck` pass

**Test evidence — what was actually run locally** (the unchecked boxes above were not run; CI covers them):

- `go test -tags unit ./pkg/...` → **3065 passed** in 20 packages
- `go test -tags unit ./components/ledger/internal/bootstrap/... ./components/tracer/internal/services/...` → **2250 passed** in 12 packages
- `go build ./...` → success
- `make lint` → `0 issues`

## Architectural Checklist

- [x] No `panic()` in production paths
- [x] Timestamps use `time.Now().UTC()`
- [x] Errors wrapped with `%w`
- [x] Handlers stay thin (parse, validate, call service)
- [x] Infrastructure concerns kept in `internal/bootstrap`

## Known follow-up, deliberately not in this PR

`TestTenantSpanAttribute_SeededForEveryAuthenticatedRequest` still asserts a **hyphenated** span attribute for its `uuid tenant` case, and it passes — correctly, because the baggage path takes the claim verbatim and this bump does not touch it.

So the two channels now agree only while the claim itself is dashless (which it is in production today). If a token ever arrives with the 36-char spelling, the drift simply inverts: dashless metric, hyphenated span. Making the invariant unconditional is two lines on our side — `CanonicalTenantID` in `MarkTrustedAuthAssertion` (`pkg/net/http/protected_routes.go:78`, which matters because the ledger route chain has no `WithTenantDB` to canonicalize for it) and in the tracer's `seamtenant` resolver (`components/tracer/internal/adapters/seamtenant/resolver.go:112`, the entry point for the client-supplied `X-Tenant-Id` header and gRPC metadata). Left out to keep this bump trivially reviewable.

## Related Issues

Closes #

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved tenant metric label consistency by using a standardized UUID format.
  - Updated metric validation to correctly recognize the canonical tenant identifiers.

- **Observability**
  - Tenant metrics now provide more reliable and consistent labels for monitoring and analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->