### PR TITLE
fix(ledger): reject balance delete when redis snapshot has funds

### DIFF
--- a/components/ledger/internal/adapters/http/in/balance_delete_cache_eviction_integration_test.go
+++ b/components/ledger/internal/adapters/http/in/balance_delete_cache_eviction_integration_test.go
@@ -18,6 +18,7 @@ import (
 
 	libCommons "github.com/LerianStudio/lib-commons/v7/commons"
 	"github.com/LerianStudio/midaz/v4/components/ledger/internal/adapters/postgres/ledger"
+	"github.com/LerianStudio/midaz/v4/pkg"
 	cn "github.com/LerianStudio/midaz/v4/pkg/constant"
 	"github.com/LerianStudio/midaz/v4/pkg/utils"
 	postgrestestutil "github.com/LerianStudio/midaz/v4/tests/utils/postgres"
@@ -37,9 +38,10 @@ import (
 // survived the delete, so a later transaction kept operating on the removed
 // balance ("phantom" activity on a deleted account).
 //
-// With the fix, a delete plants a short-lived "<balanceKey>:deleted" delete marker,
-// soft-deletes the PostgreSQL row, then evicts (Del) the balance cache key. A
-// later transaction can no longer find the balance (cache evicted + row
+// With the fix, a delete dual-writes a long-lived dedicated marker and the legacy
+// "<balanceKey>:deleted" marker for the rolling-deploy window, soft-deletes the
+// PostgreSQL row, evicts (Del) the balance cache key, and shortens both owned markers.
+// A later transaction can no longer find the balance (cache evicted + row
 // soft-deleted, which the PG query filters out), so it is rejected with
 // ErrAccountIneligibility (0019 / HTTP 422) instead of succeeding.
 //
@@ -119,9 +121,17 @@ func wireEmptyLedgerSettings(t *testing.T, infra *testInfra) {
 }
 
 // deleteMarkerCacheKey returns the delete marker key Redis holds for a balance while a
-// delete is armed: the balance's internal cache key plus the ":deleted" suffix.
+// delete is armed. It mirrors the production marker namespace while leaving tenant
+// namespacing to the Redis repository wrapper.
 func deleteMarkerCacheKey(orgID, ledgerID uuid.UUID, alias, key string) string {
-	return utils.BalanceInternalKey(orgID, ledgerID, alias+"#"+key) + ":deleted"
+	const (
+		balanceCacheNamespacePrefix = "balance:{transactions}:"
+		deleteMarkerNamespacePrefix = "balance_delete_marker:{transactions}:"
+	)
+
+	balanceKey := utils.BalanceInternalKey(orgID, ledgerID, alias+"#"+key)
+
+	return deleteMarkerNamespacePrefix + strings.TrimPrefix(balanceKey, balanceCacheNamespacePrefix)
 }
 
 // TestIntegration_BalanceDeleteCacheEviction_AccountCascade drives the account
@@ -189,10 +199,14 @@ func TestIntegration_BalanceDeleteCacheEviction_AccountCascade(t *testing.T) {
 	evicted := getBalanceFromRedis(t, ctx, infra.redisRepo, infra.orgID, infra.ledgerID, deletedAlias, "default")
 	assert.Nil(t, evicted, "balance cache key must be evicted after delete")
 
-	// (ii) The honored-lock delete marker is armed on the separate ":deleted" key.
+	// (ii) The honored-lock delete marker is armed in the dedicated namespace (and its
+	// one-release legacy compatibility key).
 	deleteMarker, err := infra.redisRepo.Get(ctx, deleteMarkerCacheKey(infra.orgID, infra.ledgerID, deletedAlias, "default"))
 	require.NoError(t, err)
-	assert.Equal(t, "1", deleteMarker, "delete marker must be present after delete")
+	assert.NotEmpty(t, deleteMarker, "delete marker must be present after delete")
+	parsedToken, parseErr := uuid.Parse(deleteMarker)
+	assert.NoError(t, parseErr, "delete marker must contain a valid UUID ownership token")
+	assert.NotEqual(t, uuid.Nil, parsedToken, "delete marker ownership token must be non-nil")
 
 	// (iii) A crediting transaction to the deleted balance is rejected with 0019.
 	// Pre-fix this would have succeeded on the lingering cache entry.
@@ -206,6 +220,63 @@ func TestIntegration_BalanceDeleteCacheEviction_AccountCascade(t *testing.T) {
 	require.NotNil(t, counterparty, "counterparty balance should still exist")
 	assert.True(t, counterparty.Available.Equal(decimal.NewFromInt(100)),
 		"counterparty available must be unchanged (100) after the rejected transaction, got %s", counterparty.Available.String())
+}
+
+// TestIntegration_BalanceDeleteCascadeRejectsRedisOnlyOverdraftDebt verifies the
+// cascade path reads OverdraftUsed from the real Redis snapshot mapper. PostgreSQL
+// remains at zero, but outstanding overdraft debt in Redis must still veto deletion.
+func TestIntegration_BalanceDeleteCascadeRejectsRedisOnlyOverdraftDebt(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	infra := setupTestInfra(t)
+	ctx := context.Background()
+	accountID := uuid.Must(libCommons.GenerateUUIDv7())
+	const alias = "@cascade-overdraft"
+
+	params := postgrestestutil.DefaultBalanceParams()
+	params.Alias = alias
+	params.AssetCode = balanceCacheDeleteAsset
+	params.Available = decimal.Zero
+	params.OnHold = decimal.Zero
+	balanceID := postgrestestutil.CreateTestBalance(t, infra.pgContainer.DB,
+		infra.orgID, infra.ledgerID, accountID, params)
+
+	cacheKey := utils.BalanceInternalKey(infra.orgID, infra.ledgerID, alias+"#default")
+	cacheValue := fmt.Sprintf(`{
+		"ID":%q,
+		"AccountID":%q,
+		"Alias":%q,
+		"Key":"default",
+		"AssetCode":%q,
+		"Available":"0",
+		"OnHold":"0",
+		"Version":0,
+		"AccountType":"deposit",
+		"AllowSending":1,
+		"AllowReceiving":1,
+		"OverdraftUsed":"25"
+	}`, balanceID.String(), accountID.String(), alias, balanceCacheDeleteAsset)
+	require.NoError(t, infra.redisRepo.Set(ctx, cacheKey, cacheValue, 24*60*60))
+
+	// This call exercises the production ListBalanceByKey mapping directly, rather
+	// than injecting a domain Balance into the cascade guard.
+	cached, err := infra.redisRepo.ListBalanceByKey(ctx, infra.orgID, infra.ledgerID, alias+"#default")
+	require.NoError(t, err)
+	require.NotNil(t, cached)
+	assert.True(t, cached.OverdraftUsed.Equal(decimal.NewFromInt(25)))
+
+	err = infra.handler.Command.DeleteAllBalancesByAccountID(ctx,
+		infra.orgID, infra.ledgerID, accountID, "integration-cascade-overdraft-delete")
+	require.Error(t, err, "Redis-only overdraft debt must reject cascade deletion")
+	var conflictErr pkg.EntityConflictError
+	require.ErrorAs(t, err, &conflictErr)
+	assert.Equal(t, cn.ErrBalancesCantBeDeleted.Error(), conflictErr.Code)
+
+	remaining, err := infra.handler.Query.BalanceRepo.Find(ctx, infra.orgID, infra.ledgerID, balanceID)
+	require.NoError(t, err)
+	assert.NotNil(t, remaining, "rejected cascade must preserve the PostgreSQL balance")
 }
 
 // TestIntegration_BalanceDeleteCacheEviction_SingleBalance drives the
@@ -269,12 +340,126 @@ func TestIntegration_BalanceDeleteCacheEviction_SingleBalance(t *testing.T) {
 	evicted := getBalanceFromRedis(t, ctx, infra.redisRepo, infra.orgID, infra.ledgerID, deletedAlias, "default")
 	assert.Nil(t, evicted, "balance cache key must be evicted after delete")
 
-	// (ii) The honored-lock delete marker is armed.
+	// (ii) The honored-lock delete marker is armed in the dedicated namespace (and its
+	// one-release legacy compatibility key).
 	deleteMarker, err := infra.redisRepo.Get(ctx, deleteMarkerCacheKey(infra.orgID, infra.ledgerID, deletedAlias, "default"))
 	require.NoError(t, err)
-	assert.Equal(t, "1", deleteMarker, "delete marker must be present after delete")
+	assert.NotEmpty(t, deleteMarker, "delete marker must be present after delete")
+	parsedToken, parseErr := uuid.Parse(deleteMarker)
+	assert.NoError(t, parseErr, "delete marker must contain a valid UUID ownership token")
+	assert.NotEqual(t, uuid.Nil, parsedToken, "delete marker ownership token must be non-nil")
 
 	// (iii) A crediting transaction to the deleted balance is rejected with 0019.
+	status, respBody = postTransactionJSON(t, infra, counterpartyAlias, deletedAlias, balanceCacheDeleteAsset, "100")
+	assert.Equal(t, 422, status, "transaction on a deleted balance must be rejected, got %d: %s", status, respBody)
+	assert.True(t, strings.Contains(respBody, cn.ErrAccountIneligibility.Error()),
+		"rejection should carry 0019, got: %s", respBody)
+
+	counterparty := getBalanceFromRedis(t, ctx, infra.redisRepo, infra.orgID, infra.ledgerID, counterpartyAlias, "default")
+	require.NotNil(t, counterparty, "counterparty balance should still exist")
+	assert.True(t, counterparty.Available.Equal(decimal.NewFromInt(100)),
+		"counterparty available must be unchanged (100) after the rejected transaction, got %s", counterparty.Available.String())
+}
+
+// TestIntegration_BalanceDeleteRejectsRedisFundsWhenPostgresIsZero reproduces
+// the write-behind divergence that previously allowed a funded balance to be
+// deleted: the HTTP credit updates Redis immediately while the test harness's
+// balance-sync worker is not running, so PostgreSQL remains at zero.
+func TestIntegration_BalanceDeleteRejectsRedisFundsWhenPostgresIsZero(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	infra := setupTestInfra(t)
+	t.Setenv("RABBITMQ_TRANSACTION_ASYNC", "false")
+	wireEmptyLedgerSettings(t, infra)
+
+	ctx := context.Background()
+
+	deletedAccountID := uuid.Must(libCommons.GenerateUUIDv7())
+	counterpartyAccountID := uuid.Must(libCommons.GenerateUUIDv7())
+
+	const deletedAlias = "@redis-funded"
+	const counterpartyAlias = "@redis-funder"
+
+	deletedParams := postgrestestutil.DefaultBalanceParams()
+	deletedParams.Alias = deletedAlias
+	deletedParams.AssetCode = balanceCacheDeleteAsset
+	deletedParams.Available = decimal.Zero
+	deletedParams.OnHold = decimal.Zero
+	deletedBalanceID := postgrestestutil.CreateTestBalance(t, infra.pgContainer.DB,
+		infra.orgID, infra.ledgerID, deletedAccountID, deletedParams)
+
+	counterpartyParams := postgrestestutil.DefaultBalanceParams()
+	counterpartyParams.Alias = counterpartyAlias
+	counterpartyParams.AssetCode = balanceCacheDeleteAsset
+	counterpartyParams.Available = decimal.NewFromInt(100)
+	counterpartyParams.OnHold = decimal.Zero
+	postgrestestutil.CreateTestBalance(t, infra.pgContainer.DB,
+		infra.orgID, infra.ledgerID, counterpartyAccountID, counterpartyParams)
+
+	// The credit changes Redis immediately, but no balance-sync worker is
+	// running in this handler-level fixture. This deliberately leaves PG=0 and
+	// Redis=50 without polling or sleeping.
+	status, respBody := postTransactionJSON(t, infra, counterpartyAlias, deletedAlias, balanceCacheDeleteAsset, "50")
+	require.Equal(t, 201, status, "funding transaction should succeed: %s", respBody)
+
+	assert.True(t,
+		postgrestestutil.GetBalanceAvailable(t, infra.pgContainer.DB, deletedBalanceID).IsZero(),
+		"PostgreSQL available must remain zero before balance sync")
+	assert.True(t,
+		postgrestestutil.GetBalanceOnHold(t, infra.pgContainer.DB, deletedBalanceID).IsZero(),
+		"PostgreSQL on_hold must remain zero before balance sync")
+	cached := getBalanceFromRedis(t, ctx, infra.redisRepo, infra.orgID, infra.ledgerID, deletedAlias, "default")
+	require.NotNil(t, cached, "funded balance must exist in Redis before delete")
+	assert.True(t, cached.Available.Equal(decimal.NewFromInt(50)),
+		"Redis available must be 50 before delete, got %s", cached.Available.String())
+
+	// The live Redis snapshot must veto deletion even though PostgreSQL still
+	// reports zero. The marker acquired for this attempt is released, while the
+	// funded cache entry and PostgreSQL row remain untouched.
+	err := infra.handler.Command.DeleteBalance(ctx, infra.orgID, infra.ledgerID, deletedBalanceID)
+	require.Error(t, err, "funds present only in Redis must reject delete")
+	var conflictErr pkg.EntityConflictError
+	require.ErrorAs(t, err, &conflictErr)
+	assert.Equal(t, cn.ErrBalancesCantBeDeleted.Error(), conflictErr.Code)
+
+	pgBalance, err := infra.handler.Query.BalanceRepo.Find(ctx, infra.orgID, infra.ledgerID, deletedBalanceID)
+	require.NoError(t, err, "PostgreSQL balance row must survive rejected delete")
+	assert.True(t, pgBalance.Available.IsZero(), "PostgreSQL balance must remain zero")
+
+	cached = getBalanceFromRedis(t, ctx, infra.redisRepo, infra.orgID, infra.ledgerID, deletedAlias, "default")
+	require.NotNil(t, cached, "Redis balance must survive rejected delete")
+	assert.True(t, cached.Available.Equal(decimal.NewFromInt(50)),
+		"Redis available must remain 50 after rejected delete, got %s", cached.Available.String())
+	deleteMarker, err := infra.redisRepo.Get(ctx, deleteMarkerCacheKey(infra.orgID, infra.ledgerID, deletedAlias, "default"))
+	require.NoError(t, err)
+	assert.Empty(t, deleteMarker, "rejected delete must release its own marker")
+
+	// Drain the live funds through the normal transaction path. Redis is now
+	// zero while PostgreSQL is still zero, so the next delete is valid.
+	status, respBody = postTransactionJSON(t, infra, deletedAlias, counterpartyAlias, balanceCacheDeleteAsset, "50")
+	require.Equal(t, 201, status, "draining transaction should succeed: %s", respBody)
+	cached = getBalanceFromRedis(t, ctx, infra.redisRepo, infra.orgID, infra.ledgerID, deletedAlias, "default")
+	require.NotNil(t, cached, "drained balance should remain cached before successful delete")
+	assert.True(t, cached.Available.IsZero(), "Redis available must be zero after draining funds")
+
+	err = infra.handler.Command.DeleteBalance(ctx, infra.orgID, infra.ledgerID, deletedBalanceID)
+	require.NoError(t, err, "delete should succeed after Redis funds are drained")
+
+	// A successful delete keeps its marker as the post-commit protection and
+	// evicts the now-stale balance snapshot.
+	evicted := getBalanceFromRedis(t, ctx, infra.redisRepo, infra.orgID, infra.ledgerID, deletedAlias, "default")
+	assert.Nil(t, evicted, "balance cache key must be evicted after delete")
+	deleteMarker, err = infra.redisRepo.Get(ctx, deleteMarkerCacheKey(infra.orgID, infra.ledgerID, deletedAlias, "default"))
+	require.NoError(t, err)
+	assert.NotEmpty(t, deleteMarker, "delete marker must be present after delete")
+	parsedToken, parseErr := uuid.Parse(deleteMarker)
+	assert.NoError(t, parseErr, "delete marker must contain a valid UUID ownership token")
+	assert.NotEqual(t, uuid.Nil, parsedToken, "delete marker ownership token must be non-nil")
+
+	// The removed balance remains protected from subsequent transaction
+	// mutations, and the rejected transaction must not debit its counterparty.
 	status, respBody = postTransactionJSON(t, infra, counterpartyAlias, deletedAlias, balanceCacheDeleteAsset, "100")
 	assert.Equal(t, 422, status, "transaction on a deleted balance must be rejected, got %d: %s", status, respBody)
 	assert.True(t, strings.Contains(respBody, cn.ErrAccountIneligibility.Error()),

--- a/components/ledger/internal/adapters/http/in/balance_handler_test.go
+++ b/components/ledger/internal/adapters/http/in/balance_handler_test.go
@@ -163,7 +163,9 @@ func TestDeleteBalance_204Empty(t *testing.T) {
 	// guard. Lenient expectations keep this a transport-level test.
 	redisRepo := redis.NewMockRedisRepository(ctrl)
 	redisRepo.EXPECT().SetNX(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil).AnyTimes()
+	redisRepo.EXPECT().Get(gomock.Any(), gomock.Any()).Return("", nil).Times(1)
 	redisRepo.EXPECT().Del(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	redisRepo.EXPECT().ExpireIfValue(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil).Times(2)
 
 	handler := &BalanceHandler{Command: &command.UseCase{BalanceRepo: balanceRepo, TransactionRedisRepo: redisRepo}}
 

--- a/components/ledger/internal/adapters/redis/transaction/consumer.redis.go
+++ b/components/ledger/internal/adapters/redis/transaction/consumer.redis.go
@@ -45,17 +45,26 @@ var updateBalanceSettingsLua string
 //go:embed scripts/update_balance_blocked.lua
 var updateBalanceBlockedLua string
 
-// balanceAtomicScript, claimBalanceSyncScript, updateBalanceSettingsScript, and
-// updateBalanceBlockedScript are built once at package init. redis.NewScript
-// computes the source SHA1 eagerly, so hoisting these out of the per-call hot
-// paths (runBalanceAtomicScript, GetBalanceSyncKeys, GetBalanceSyncKeysLegacy,
-// UpdateBalanceCacheSettings, UpdateBalanceCacheBlocked) avoids re-hashing on
+//go:embed scripts/delete_if_value.lua
+var deleteIfValueLua string
+
+//go:embed scripts/expire_if_value.lua
+var expireIfValueLua string
+
+// balanceAtomicScript, claimBalanceSyncScript, updateBalanceSettingsScript,
+// updateBalanceBlockedScript, deleteIfValueScript and expireIfValueScript are
+// built once at package init. redis.NewScript computes the source SHA1 eagerly,
+// so hoisting these out of the per-call hot paths (runBalanceAtomicScript,
+// GetBalanceSyncKeys, GetBalanceSyncKeysLegacy, UpdateBalanceCacheSettings,
+// UpdateBalanceCacheBlocked, DeleteIfValue, ExpireIfValue) avoids re-hashing on
 // every invocation. *redis.Script is safe for concurrent use.
 var (
 	balanceAtomicScript         = redis.NewScript(balanceAtomicOperationLua)
 	claimBalanceSyncScript      = redis.NewScript(claimBalanceSyncKeysLua)
 	updateBalanceSettingsScript = redis.NewScript(updateBalanceSettingsLua)
 	updateBalanceBlockedScript  = redis.NewScript(updateBalanceBlockedLua)
+	deleteIfValueScript         = redis.NewScript(deleteIfValueLua)
+	expireIfValueScript         = redis.NewScript(expireIfValueLua)
 )
 
 //go:embed scripts/remove_balance_sync_keys_batch.lua
@@ -104,6 +113,14 @@ type RedisRepository interface {
 	MGet(ctx context.Context, keys []string) (map[string]string, error)
 	// Del removes a key from Redis.
 	Del(ctx context.Context, key string) error
+	// DeleteIfValue atomically removes a key only when its current value equals value.
+	// It returns true when the key was removed and false when it was missing or owned by
+	// another caller.
+	DeleteIfValue(ctx context.Context, key, value string) (bool, error)
+	// ExpireIfValue atomically shortens a key's TTL only when its current value equals value.
+	// It returns true when the owned key's expiry was updated and false when it was missing or
+	// owned by another caller. ttl is expressed as a whole-second count, matching SetNX.
+	ExpireIfValue(ctx context.Context, key, value string, ttl time.Duration) (bool, error)
 	// Incr atomically increments a key's integer value and returns the new value.
 	// Returns 0 on error (connection failure, namespace failure).
 	Incr(ctx context.Context, key string) int64
@@ -154,6 +171,9 @@ type RedisRepository interface {
 	ScheduleBalanceSyncBatch(ctx context.Context, members []redis.Z) error
 	// ListBalanceByKey retrieves a single balance from Redis by its internal key
 	// and converts it from the cache format (BalanceRedis) to the domain model (Balance).
+	// An empty cached OverdraftUsed reads as zero (pre-overdraft snapshot shape), while a
+	// non-empty value that does not parse as a decimal returns an error so callers guarding
+	// money never read unreadable debt as zero.
 	ListBalanceByKey(ctx context.Context, organizationID, ledgerID uuid.UUID, key string) (*mmodel.Balance, error)
 	// GetBalancesByKeys retrieves multiple balance values by their Redis keys using MGET.
 	// Returns a map of key -> *mmodel.BalanceRedis (nil if key does not exist).
@@ -407,6 +427,87 @@ func (rr *RedisConsumerRepository) Del(ctx context.Context, key string) error {
 	logger.Log(ctx, libLog.LevelDebug, "Key deleted from Redis", libLog.Any("deleted_count", val))
 
 	return nil
+}
+
+// DeleteIfValue atomically removes key only when its current value matches value.
+// This prevents an expired marker owner's late rollback from deleting a newer owner's
+// marker that was acquired under the same key.
+func (rr *RedisConsumerRepository) DeleteIfValue(ctx context.Context, key, value string) (bool, error) {
+	_, tracer, _, _ := libObservability.NewTrackingFromContext(ctx)
+
+	ctx, span := tracer.Start(ctx, "redis.delete_if_value")
+	defer span.End()
+
+	key, err := tenantKeyFromContextOrError(ctx, key)
+	if err != nil {
+		libOpentelemetry.HandleSpanError(span, "Failed to namespace redis key", err)
+
+		return false, err
+	}
+
+	rds, err := rr.conn.GetClient(ctx)
+	if err != nil {
+		libOpentelemetry.HandleSpanError(span, "Failed to connect on redis", err)
+
+		return false, err
+	}
+
+	result, err := deleteIfValueScript.Run(ctx, rds, []string{key}, value).Result()
+	if err != nil {
+		libOpentelemetry.HandleSpanError(span, "Failed to delete key by value on redis", err)
+
+		return false, err
+	}
+
+	deleted, ok := result.(int64)
+	if !ok {
+		err = fmt.Errorf("unexpected result type from delete-if-value script: %T", result)
+		libOpentelemetry.HandleSpanError(span, "Unexpected result type", err)
+
+		return false, err
+	}
+
+	return deleted == 1, nil
+}
+
+// ExpireIfValue atomically shortens key's TTL only when its current value matches value.
+// This keeps the successful-delete marker barrier in place without a release/reacquire gap.
+func (rr *RedisConsumerRepository) ExpireIfValue(ctx context.Context, key, value string, ttl time.Duration) (bool, error) {
+	_, tracer, _, _ := libObservability.NewTrackingFromContext(ctx)
+
+	ctx, span := tracer.Start(ctx, "redis.expire_if_value")
+	defer span.End()
+
+	key, err := tenantKeyFromContextOrError(ctx, key)
+	if err != nil {
+		libOpentelemetry.HandleSpanError(span, "Failed to namespace redis key", err)
+
+		return false, err
+	}
+
+	rds, err := rr.conn.GetClient(ctx)
+	if err != nil {
+		libOpentelemetry.HandleSpanError(span, "Failed to connect on redis", err)
+
+		return false, err
+	}
+
+	result, err := expireIfValueScript.Run(ctx, rds, []string{key}, value, strconv.FormatInt(int64(ttl), 10)).Result()
+	if err != nil {
+		libOpentelemetry.HandleSpanError(span, "Failed to expire key by value on redis", err)
+
+		return false, err
+	}
+
+	expired, ok := result.(int64)
+	if !ok {
+		err = fmt.Errorf("unexpected result type from expire-if-value script: %T", result)
+		libOpentelemetry.HandleSpanError(span, "Unexpected result type", err)
+
+		return false, err
+	}
+
+	return expired == 1, nil
 }
 
 func (rr *RedisConsumerRepository) Incr(ctx context.Context, key string) int64 {
@@ -1638,6 +1739,27 @@ func (rr *RedisConsumerRepository) ListBalanceByKey(ctx context.Context, organiz
 		return nil, err
 	}
 
+	// OverdraftUsed is stored as a decimal string in Redis. An empty value is the
+	// pre-overdraft snapshot shape and reads as zero; a non-empty malformed value is
+	// unreadable debt, so it is reported as an error instead of being flattened to zero
+	// and letting a funds guard clear a balance that still owes money.
+	overdraftUsed := decimal.Zero
+
+	if balanceRedis.OverdraftUsed != "" {
+		parsed, parseErr := decimal.NewFromString(balanceRedis.OverdraftUsed)
+		if parseErr != nil {
+			wrappedErr := fmt.Errorf("failed to parse overdraft used from balance cache: %w", parseErr)
+
+			libOpentelemetry.HandleSpanError(span, "Failed to parse overdraft used from balance cache", wrappedErr)
+
+			logger.Log(ctx, libLog.LevelError, "Failed to parse overdraft used from balance cache", libLog.Err(wrappedErr))
+
+			return nil, wrappedErr
+		}
+
+		overdraftUsed = parsed
+	}
+
 	balance := &mmodel.Balance{
 		ID:             balanceRedis.ID,
 		AccountID:      balanceRedis.AccountID,
@@ -1653,6 +1775,7 @@ func (rr *RedisConsumerRepository) ListBalanceByKey(ctx context.Context, organiz
 		Key:            balanceRedis.Key,
 		OrganizationID: organizationID.String(),
 		LedgerID:       ledgerID.String(),
+		OverdraftUsed:  overdraftUsed,
 	}
 
 	return balance, nil

--- a/components/ledger/internal/adapters/redis/transaction/consumer.redis_delete_if_value_integration_test.go
+++ b/components/ledger/internal/adapters/redis/transaction/consumer.redis_delete_if_value_integration_test.go
@@ -1,0 +1,110 @@
+//go:build integration
+
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package redis
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	tmcore "github.com/LerianStudio/lib-commons/v7/commons/tenant-manager/core"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIntegration_DeleteIfValue_AtomicOwnershipAndExpiry(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	infra := setupRedisIntegrationInfra(t)
+
+	t.Run("matching token deletes marker", func(t *testing.T) {
+		ctx := context.Background()
+		key := "delete-if-value:" + uuid.NewString()
+		owner := "owner-" + uuid.NewString()
+
+		require.NoError(t, infra.repo.Set(ctx, key, owner, 30))
+		deleted, err := infra.repo.DeleteIfValue(ctx, key, owner)
+
+		require.NoError(t, err)
+		assert.True(t, deleted)
+		exists, existsErr := infra.redisContainer.Client.Exists(ctx, key).Result()
+		require.NoError(t, existsErr)
+		assert.Zero(t, exists)
+	})
+
+	t.Run("mismatched token preserves marker", func(t *testing.T) {
+		ctx := context.Background()
+		key := "delete-if-value:" + uuid.NewString()
+		owner := "owner-" + uuid.NewString()
+
+		require.NoError(t, infra.repo.Set(ctx, key, owner, 30))
+		deleted, err := infra.repo.DeleteIfValue(ctx, key, "different-owner")
+
+		require.NoError(t, err)
+		assert.False(t, deleted)
+		value, getErr := infra.repo.Get(ctx, key)
+		require.NoError(t, getErr)
+		assert.Equal(t, owner, value)
+	})
+
+	t.Run("tenant namespacing is preserved while deleting", func(t *testing.T) {
+		tenantID := "delete-if-value-tenant-" + uuid.NewString()
+		ctx := tmcore.ContextWithTenantID(context.Background(), tenantID)
+		key := "delete-if-value:" + uuid.NewString()
+		owner := "owner-" + uuid.NewString()
+
+		require.NoError(t, infra.repo.Set(ctx, key, owner, 30))
+		deleted, err := infra.repo.DeleteIfValue(ctx, key, owner)
+
+		require.NoError(t, err)
+		assert.True(t, deleted)
+		physicalKey := "tenant:" + tenantID + ":" + key
+		exists, existsErr := infra.redisContainer.Client.Exists(context.Background(), physicalKey).Result()
+		require.NoError(t, existsErr)
+		assert.Zero(t, exists)
+	})
+
+	t.Run("expired marker is not deleted", func(t *testing.T) {
+		ctx := context.Background()
+		key := "delete-if-value:" + uuid.NewString()
+		owner := "owner-" + uuid.NewString()
+
+		require.NoError(t, infra.repo.Set(ctx, key, owner, 1))
+		require.Eventually(t, func() bool {
+			exists, err := infra.redisContainer.Client.Exists(ctx, key).Result()
+
+			return err == nil && exists == 0
+		}, 3*time.Second, 100*time.Millisecond, "marker should expire before the ownership check")
+
+		deleted, err := infra.repo.DeleteIfValue(ctx, key, owner)
+		require.NoError(t, err)
+		assert.False(t, deleted, "an expired marker must report that no owned key was deleted")
+	})
+
+	t.Run("owned marker can be shortened and recreated after the short window", func(t *testing.T) {
+		ctx := context.Background()
+		key := "delete-if-value-recreate:" + uuid.NewString()
+		owner := "owner-" + uuid.NewString()
+
+		require.NoError(t, infra.repo.Set(ctx, key, owner, 30))
+		shortened, err := infra.repo.ExpireIfValue(ctx, key, owner, 1)
+		require.NoError(t, err)
+		assert.True(t, shortened)
+		require.Eventually(t, func() bool {
+			exists, existsErr := infra.redisContainer.Client.Exists(ctx, key).Result()
+
+			return existsErr == nil && exists == 0
+		}, 3*time.Second, 100*time.Millisecond, "shortened marker should expire")
+
+		recreated, recreateErr := infra.repo.SetNX(ctx, key, "new-owner", 30)
+		require.NoError(t, recreateErr)
+		assert.True(t, recreated, "a balance can be recreated after the short marker window")
+	})
+}

--- a/components/ledger/internal/adapters/redis/transaction/consumer.redis_delete_if_value_test.go
+++ b/components/ledger/internal/adapters/redis/transaction/consumer.redis_delete_if_value_test.go
@@ -1,0 +1,224 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package redis
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	tmcore "github.com/LerianStudio/lib-commons/v7/commons/tenant-manager/core"
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type deleteIfValueEvalClient struct {
+	redis.UniversalClient
+	evalFunc func(ctx context.Context, script string, keys []string, args ...any) *redis.Cmd
+}
+
+func (m *deleteIfValueEvalClient) EvalSha(ctx context.Context, _ string, _ []string, _ ...any) *redis.Cmd {
+	cmd := redis.NewCmd(ctx)
+	cmd.SetErr(noscriptErr{})
+
+	return cmd
+}
+
+func (m *deleteIfValueEvalClient) Eval(ctx context.Context, script string, keys []string, args ...any) *redis.Cmd {
+	return m.evalFunc(ctx, script, keys, args...)
+}
+
+func newDeleteIfValueConnection(client *deleteIfValueEvalClient) *staticRedisProvider {
+	return &staticRedisProvider{client: client}
+}
+
+func TestDeleteIfValueUsesAtomicOwnershipScript(t *testing.T) {
+	t.Parallel()
+
+	const markerKey = "balance_delete_marker:{transactions}:org:ledger:alias#key"
+	const ownerToken = "owner-a"
+
+	var capturedScript string
+	var capturedKeys []string
+	var capturedArgs []any
+	mockClient := &deleteIfValueEvalClient{
+		evalFunc: func(ctx context.Context, script string, keys []string, args ...any) *redis.Cmd {
+			capturedScript = script
+			capturedKeys = append([]string(nil), keys...)
+			capturedArgs = append([]any(nil), args...)
+
+			cmd := redis.NewCmd(ctx)
+			cmd.SetVal(int64(1))
+
+			return cmd
+		},
+	}
+	repo := &RedisConsumerRepository{conn: newDeleteIfValueConnection(mockClient)}
+
+	deleted, err := repo.DeleteIfValue(context.Background(), markerKey, ownerToken)
+
+	require.NoError(t, err)
+	assert.True(t, deleted)
+	assert.Equal(t, deleteIfValueLua, capturedScript)
+	assert.Equal(t, []string{markerKey}, capturedKeys)
+	assert.Equal(t, []any{ownerToken}, capturedArgs)
+}
+
+func TestDeleteIfValueReturnsFalseWhenTokenDoesNotOwnMarker(t *testing.T) {
+	t.Parallel()
+
+	mockClient := &deleteIfValueEvalClient{
+		evalFunc: func(ctx context.Context, _ string, _ []string, _ ...any) *redis.Cmd {
+			cmd := redis.NewCmd(ctx)
+			cmd.SetVal(int64(0))
+
+			return cmd
+		},
+	}
+	repo := &RedisConsumerRepository{conn: newDeleteIfValueConnection(mockClient)}
+
+	deleted, err := repo.DeleteIfValue(context.Background(), "marker", "owner-a")
+
+	require.NoError(t, err)
+	assert.False(t, deleted)
+}
+
+func TestDeleteIfValueNamespacesKeyBeforeEval(t *testing.T) {
+	t.Parallel()
+
+	const markerKey = "balance_delete_marker:{transactions}:org:ledger:alias#key"
+	const ownerToken = "owner-a"
+	const tenantID = "acme"
+
+	var capturedKeys []string
+	mockClient := &deleteIfValueEvalClient{
+		evalFunc: func(ctx context.Context, _ string, keys []string, _ ...any) *redis.Cmd {
+			capturedKeys = append([]string(nil), keys...)
+
+			cmd := redis.NewCmd(ctx)
+			cmd.SetVal(int64(0))
+
+			return cmd
+		},
+	}
+	repo := &RedisConsumerRepository{conn: newDeleteIfValueConnection(mockClient)}
+
+	ctx := tmcore.ContextWithTenantID(context.Background(), tenantID)
+	deleted, err := repo.DeleteIfValue(ctx, markerKey, ownerToken)
+
+	require.NoError(t, err)
+	assert.False(t, deleted)
+	assert.Equal(t, []string{"tenant:" + tenantID + ":" + markerKey}, capturedKeys)
+}
+
+func TestDeleteIfValuePropagatesRedisErrors(t *testing.T) {
+	t.Parallel()
+
+	expectedErr := errors.New("redis unavailable")
+	mockClient := &deleteIfValueEvalClient{
+		evalFunc: func(ctx context.Context, _ string, _ []string, _ ...any) *redis.Cmd {
+			cmd := redis.NewCmd(ctx)
+			cmd.SetErr(expectedErr)
+
+			return cmd
+		},
+	}
+	repo := &RedisConsumerRepository{conn: newDeleteIfValueConnection(mockClient)}
+
+	deleted, err := repo.DeleteIfValue(context.Background(), "marker", "owner-a")
+
+	assert.False(t, deleted)
+	assert.ErrorIs(t, err, expectedErr)
+}
+
+func TestDeleteIfValueRejectsMalformedTenantBeforeEval(t *testing.T) {
+	t.Parallel()
+
+	mockClient := &deleteIfValueEvalClient{
+		evalFunc: func(ctx context.Context, _ string, _ []string, _ ...any) *redis.Cmd {
+			t.Fatal("DeleteIfValue must fail closed before EVAL for malformed tenant IDs")
+
+			return nil
+		},
+	}
+	repo := &RedisConsumerRepository{conn: newDeleteIfValueConnection(mockClient)}
+
+	ctx := tmcore.ContextWithTenantID(context.Background(), "tenant:invalid")
+	deleted, err := repo.DeleteIfValue(ctx, "marker", "owner-a")
+
+	assert.False(t, deleted)
+	assert.Error(t, err)
+}
+
+func TestDeleteIfValueFailsClosedOnUnexpectedScriptResult(t *testing.T) {
+	t.Parallel()
+
+	mockClient := &deleteIfValueEvalClient{
+		evalFunc: func(ctx context.Context, _ string, _ []string, _ ...any) *redis.Cmd {
+			cmd := redis.NewCmd(ctx)
+			cmd.SetVal("unexpected")
+
+			return cmd
+		},
+	}
+	repo := &RedisConsumerRepository{conn: newDeleteIfValueConnection(mockClient)}
+
+	deleted, err := repo.DeleteIfValue(context.Background(), "marker", "owner-a")
+
+	assert.False(t, deleted)
+	assert.Error(t, err)
+}
+
+func TestExpireIfValueUsesAtomicOwnershipScript(t *testing.T) {
+	t.Parallel()
+
+	const markerKey = "balance_delete_marker:{transactions}:org:ledger:alias#key"
+	const ownerToken = "owner-a"
+
+	var capturedScript string
+	var capturedKeys []string
+	var capturedArgs []any
+	mockClient := &deleteIfValueEvalClient{
+		evalFunc: func(ctx context.Context, script string, keys []string, args ...any) *redis.Cmd {
+			capturedScript = script
+			capturedKeys = append([]string(nil), keys...)
+			capturedArgs = append([]any(nil), args...)
+
+			cmd := redis.NewCmd(ctx)
+			cmd.SetVal(int64(1))
+
+			return cmd
+		},
+	}
+	repo := &RedisConsumerRepository{conn: newDeleteIfValueConnection(mockClient)}
+
+	shortened, err := repo.ExpireIfValue(context.Background(), markerKey, ownerToken, 30)
+
+	require.NoError(t, err)
+	assert.True(t, shortened)
+	assert.Equal(t, expireIfValueLua, capturedScript)
+	assert.Equal(t, []string{markerKey}, capturedKeys)
+	assert.Equal(t, []any{ownerToken, "30"}, capturedArgs)
+}
+
+func TestExpireIfValueReturnsFalseWhenTokenDoesNotOwnMarker(t *testing.T) {
+	t.Parallel()
+
+	mockClient := &deleteIfValueEvalClient{
+		evalFunc: func(ctx context.Context, _ string, _ []string, _ ...any) *redis.Cmd {
+			cmd := redis.NewCmd(ctx)
+			cmd.SetVal(int64(0))
+
+			return cmd
+		},
+	}
+	repo := &RedisConsumerRepository{conn: newDeleteIfValueConnection(mockClient)}
+
+	shortened, err := repo.ExpireIfValue(context.Background(), "marker", "owner-a", 30)
+
+	require.NoError(t, err)
+	assert.False(t, shortened)
+}

--- a/components/ledger/internal/adapters/redis/transaction/consumer.redis_mock.go
+++ b/components/ledger/internal/adapters/redis/transaction/consumer.redis_mock.go
@@ -101,6 +101,36 @@ func (mr *MockRedisRepositoryMockRecorder) Del(ctx, key any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Del", reflect.TypeOf((*MockRedisRepository)(nil).Del), ctx, key)
 }
 
+// DeleteIfValue mocks base method.
+func (m *MockRedisRepository) DeleteIfValue(ctx context.Context, key, value string) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteIfValue", ctx, key, value)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ExpireIfValue mocks base method.
+func (m *MockRedisRepository) ExpireIfValue(ctx context.Context, key, value string, ttl time.Duration) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ExpireIfValue", ctx, key, value, ttl)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ExpireIfValue indicates an expected call of ExpireIfValue.
+func (mr *MockRedisRepositoryMockRecorder) ExpireIfValue(ctx, key, value, ttl any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExpireIfValue", reflect.TypeOf((*MockRedisRepository)(nil).ExpireIfValue), ctx, key, value, ttl)
+}
+
+// DeleteIfValue indicates an expected call of DeleteIfValue.
+func (mr *MockRedisRepositoryMockRecorder) DeleteIfValue(ctx, key, value any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteIfValue", reflect.TypeOf((*MockRedisRepository)(nil).DeleteIfValue), ctx, key, value)
+}
+
 // Get mocks base method.
 func (m *MockRedisRepository) Get(ctx context.Context, key string) (string, error) {
 	m.ctrl.T.Helper()

--- a/components/ledger/internal/adapters/redis/transaction/consumer.redis_test.go
+++ b/components/ledger/internal/adapters/redis/transaction/consumer.redis_test.go
@@ -220,6 +220,85 @@ func newRecordingConnection(t *testing.T) (*testClientProvider, *recordingRedisC
 	return &testClientProvider{client: client}, client
 }
 
+func TestListBalanceByKeyMapsOverdraftUsed(t *testing.T) {
+	t.Parallel()
+
+	provider, client := newRecordingConnection(t)
+	client.getReturnVal = `{
+		"id":"balance-id",
+		"accountId":"account-id",
+		"alias":"@alice",
+		"key":"default",
+		"assetCode":"USD",
+		"available":0,
+		"onHold":0,
+		"version":7,
+		"accountType":"deposit",
+		"allowSending":1,
+		"allowReceiving":1,
+		"overdraftUsed":"50.00"
+	}`
+
+	repo := &RedisConsumerRepository{conn: provider}
+	balance, err := repo.ListBalanceByKey(context.Background(), uuid.New(), uuid.New(), "@alice#default")
+
+	require.NoError(t, err)
+	require.NotNil(t, balance)
+	assert.True(t, balance.OverdraftUsed.Equal(decimal.NewFromInt(50)))
+}
+
+// TestListBalanceByKeyOverdraftUsedEmptyIsZeroMalformedFailsClosed locks the cached
+// OverdraftUsed contract: the pre-overdraft snapshot shape (empty) reads as zero debt, while an
+// unreadable value is reported so a caller guarding money cannot mistake it for zero.
+func TestListBalanceByKeyOverdraftUsedEmptyIsZeroMalformedFailsClosed(t *testing.T) {
+	t.Parallel()
+
+	for _, testCase := range []struct {
+		name          string
+		overdraftUsed string
+		wantErr       bool
+	}{
+		{name: "empty", overdraftUsed: ""},
+		{name: "malformed", overdraftUsed: "not-a-number", wantErr: true},
+	} {
+		testCase := testCase
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			provider, client := newRecordingConnection(t)
+			client.getReturnVal = `{
+				"id":"balance-id",
+				"accountId":"account-id",
+				"alias":"@alice",
+				"key":"default",
+				"assetCode":"USD",
+				"available":0,
+				"onHold":0,
+				"version":7,
+				"accountType":"deposit",
+				"allowSending":1,
+				"allowReceiving":1,
+				"overdraftUsed":"` + testCase.overdraftUsed + `"
+			}`
+
+			repo := &RedisConsumerRepository{conn: provider}
+			balance, err := repo.ListBalanceByKey(context.Background(), uuid.New(), uuid.New(), "@alice#default")
+
+			if testCase.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "failed to parse overdraft used from balance cache")
+				assert.Nil(t, balance)
+
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, balance)
+			assert.True(t, balance.OverdraftUsed.IsZero())
+		})
+	}
+}
+
 // scriptCapturingRedisClient extends recordingRedisClient with the ability to capture
 // Lua script calls (EvalSha / Eval / ScriptExists) so tests can assert which KEYS
 // and ARGV values were passed to the Redis scripting interface.

--- a/components/ledger/internal/adapters/redis/transaction/consumer_delete_marker_integration_test.go
+++ b/components/ledger/internal/adapters/redis/transaction/consumer_delete_marker_integration_test.go
@@ -12,8 +12,12 @@ import (
 	"strings"
 	"testing"
 
+	tmcore "github.com/LerianStudio/lib-commons/v7/commons/tenant-manager/core"
+
 	"github.com/LerianStudio/midaz/v4/pkg/constant"
 	"github.com/LerianStudio/midaz/v4/pkg/mmodel"
+	"github.com/LerianStudio/midaz/v4/pkg/mtransaction"
+	"github.com/LerianStudio/midaz/v4/pkg/utils"
 
 	"github.com/google/uuid"
 	"github.com/shopspring/decimal"
@@ -26,7 +30,17 @@ import (
 // =============================================================================
 // These tests cover the Lua pre-pass in balance_atomic_operation.lua that
 // rejects a batch with ErrAccountIneligibility (0019) when any balance in it
-// carries a live "<balanceKey>:deleted" delete marker, before any mutation runs.
+// carries a live marker in the dedicated delete-marker namespace, before any mutation runs.
+
+const deleteMarkerNamespacePrefix = "balance_delete_marker:{transactions}:"
+
+func deleteMarkerKeyForIntegration(balanceKey string) string {
+	return deleteMarkerNamespacePrefix + strings.TrimPrefix(balanceKey, "balance:{transactions}:")
+}
+
+func legacyDeleteMarkerKeyForIntegration(balanceKey string) string {
+	return balanceKey + ":deleted"
+}
 
 // readCachedBalance fetches and decodes the balance cache entry written by the
 // Lua script for the given key. It fails the test if the key is missing.
@@ -67,8 +81,11 @@ func TestIntegration_DeleteMarker_RejectsAndDoesNotMutate(t *testing.T) {
 	before := readCachedBalance(t, infra, primeOp.InternalKey)
 
 	// Lay down the delete marker on the SEPARATE key; the balance key is untouched.
-	deleteMarkerKey := primeOp.InternalKey + ":deleted"
+	deleteMarkerKey := deleteMarkerKeyForIntegration(primeOp.InternalKey)
 	require.NoError(t, infra.redisContainer.Client.Set(ctx, deleteMarkerKey, "1", 0).Err())
+	markerExists, markerErr := infra.redisContainer.Client.Exists(ctx, deleteMarkerKey).Result()
+	require.NoError(t, markerErr)
+	require.Equal(t, int64(1), markerExists, "the dedicated marker must be present before the guarded operation")
 
 	// A subsequent op on the balance carrying a delete marker must be rejected with 0019.
 	rejectOp := overdraftOp(orgID, ledgerID, "@ts-single", "deposit", "credit",
@@ -88,6 +105,66 @@ func TestIntegration_DeleteMarker_RejectsAndDoesNotMutate(t *testing.T) {
 		"Available must be unchanged when the batch is rejected")
 	assert.Equal(t, before.Version, after.Version,
 		"Version must not increment when the batch is rejected")
+}
+
+func TestIntegration_DeleteMarker_MixedLegacyAndNamespacedMarkersReject(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	infra := setupRedisIntegrationInfra(t)
+	ctx := context.Background()
+	orgID := uuid.New()
+	ledgerID := uuid.New()
+	op := overdraftOp(orgID, ledgerID, "@ts-mixed-marker", "deposit", "credit",
+		decimal.NewFromInt(500), decimal.Zero, 1, nil,
+		constant.DEBIT, decimal.NewFromInt(100))
+
+	for _, markerKey := range []string{
+		legacyDeleteMarkerKeyForIntegration(op.InternalKey),
+		deleteMarkerKeyForIntegration(op.InternalKey),
+	} {
+		_, err := infra.repo.ProcessBalanceAtomicOperation(ctx, orgID, ledgerID,
+			uuid.New(), constant.APPROVED, false, []mmodel.BalanceOperation{op}, nil)
+		require.NoError(t, err)
+		require.NoError(t, infra.redisContainer.Client.Set(ctx, markerKey, "owner", 0).Err())
+
+		_, err = infra.repo.ProcessBalanceAtomicOperation(ctx, orgID, ledgerID,
+			uuid.New(), constant.APPROVED, false, []mmodel.BalanceOperation{op}, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), constant.ErrAccountIneligibility.Error())
+		require.NoError(t, infra.redisContainer.Client.Del(ctx, markerKey).Err())
+	}
+}
+
+func TestIntegration_DeleteMarker_TenantNamespaceRejectsMatchingBalance(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	infra := setupRedisIntegrationInfra(t)
+	tenantID := "delete-marker-tenant-" + uuid.NewString()
+	ctx := tmcore.ContextWithTenantID(context.Background(), tenantID)
+	orgID := uuid.New()
+	ledgerID := uuid.New()
+	op := overdraftOp(orgID, ledgerID, "@ts-tenant-marker", "deposit", "credit",
+		decimal.NewFromInt(500), decimal.Zero, 1, nil,
+		constant.DEBIT, decimal.NewFromInt(100))
+
+	// SetNX in the command layer would namespace this logical marker as below.
+	// The Lua operation receives the tenant-prefixed balance key and must replace
+	// its balance namespace in-place to find this physical marker.
+	physicalMarkerKey := "tenant:" + tenantID + ":" + deleteMarkerKeyForIntegration(op.InternalKey)
+	require.NoError(t, infra.redisContainer.Client.Set(ctx, physicalMarkerKey, "owner", 0).Err())
+	markerExists, markerErr := infra.redisContainer.Client.Exists(context.Background(), physicalMarkerKey).Result()
+	require.NoError(t, markerErr)
+	require.Equal(t, int64(1), markerExists, "the tenant-prefixed marker must be present before the guarded operation")
+
+	_, err := infra.repo.ProcessBalanceAtomicOperation(ctx, orgID, ledgerID,
+		uuid.New(), constant.APPROVED, false, []mmodel.BalanceOperation{op}, nil)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), constant.ErrAccountIneligibility.Error())
 }
 
 // TestIntegration_DeleteMarker_NoMarker_ProceedsNormally exercises case
@@ -145,7 +222,7 @@ func TestIntegration_DeleteMarker_BatchAtomicity(t *testing.T) {
 	beforeA := readCachedBalance(t, infra, opA.InternalKey)
 
 	// Delete marker ONLY balance B.
-	require.NoError(t, infra.redisContainer.Client.Set(ctx, opB.InternalKey+":deleted", "1", 0).Err())
+	require.NoError(t, infra.redisContainer.Client.Set(ctx, deleteMarkerKeyForIntegration(opB.InternalKey), "1", 0).Err())
 
 	// Re-run the batch (A first, then B carrying a delete marker). The pre-pass must
 	// reject the whole batch before A is mutated.
@@ -169,6 +246,56 @@ func TestIntegration_DeleteMarker_BatchAtomicity(t *testing.T) {
 		"balance without a delete marker Available must be unchanged")
 	assert.Equal(t, beforeA.Version, afterA.Version,
 		"balance without a delete marker Version must not increment")
+}
+
+func TestIntegration_DeleteMarkerNamespaceCannotCollideWithSiblingBalanceKey(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	infra := setupRedisIntegrationInfra(t)
+	ctx := context.Background()
+	orgID := uuid.New()
+	ledgerID := uuid.New()
+	alias := "@ts-collision"
+	baseInternalKey := utils.BalanceInternalKey(orgID, ledgerID, alias+"#usd")
+	siblingInternalKey := utils.BalanceInternalKey(orgID, ledgerID, alias+"#usd:deleted")
+	markerKey := deleteMarkerKeyForIntegration(baseInternalKey)
+
+	// This is the marker for balance "usd". A valid sibling balance is allowed to
+	// use "usd:deleted" as its key and must remain independently mutable.
+	assert.NotEqual(t, markerKey, siblingInternalKey)
+	require.NoError(t, infra.redisContainer.Client.Set(ctx, markerKey, "owner", 0).Err())
+
+	sibling := mmodel.BalanceOperation{
+		Balance: &mmodel.Balance{
+			ID:             uuid.NewString(),
+			OrganizationID: orgID.String(),
+			LedgerID:       ledgerID.String(),
+			AccountID:      uuid.NewString(),
+			Alias:          alias,
+			Key:            "usd:deleted",
+			AssetCode:      "USD",
+			Available:      decimal.NewFromInt(500),
+			OnHold:         decimal.Zero,
+			Version:        1,
+			AccountType:    "deposit",
+			AllowSending:   true,
+			AllowReceiving: true,
+			Direction:      "credit",
+			OverdraftUsed:  decimal.Zero,
+		},
+		Alias:       alias + "#usd:deleted",
+		Amount:      mtransaction.Amount{Asset: "USD", Value: decimal.NewFromInt(100), Operation: constant.DEBIT},
+		InternalKey: siblingInternalKey,
+	}
+
+	result, err := infra.repo.ProcessBalanceAtomicOperation(ctx, orgID, ledgerID,
+		uuid.New(), constant.APPROVED, false, []mmodel.BalanceOperation{sibling}, nil)
+
+	require.NoError(t, err, "a marker for usd must not block the valid sibling balance usd:deleted")
+	require.Len(t, result.After, 1)
+	assert.True(t, result.After[0].Available.Equal(decimal.NewFromInt(400)))
 }
 
 // availableDecimal parses the cached Available string into a decimal for reuse

--- a/components/ledger/internal/adapters/redis/transaction/consumer_settings_script_integration_test.go
+++ b/components/ledger/internal/adapters/redis/transaction/consumer_settings_script_integration_test.go
@@ -52,6 +52,85 @@ func TestIntegration_UpdateBalanceSettingsScript_AbsentKeyIsNoOp(t *testing.T) {
 	assert.Zero(t, exists, "the script must not create the key on a no-op")
 }
 
+func TestIntegration_UpdateBalanceSettingsScript_DeleteMarkerBlocksMutation(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	infra := setupRedisIntegrationInfra(t)
+	ctx := context.Background()
+	key := "balance:{transactions}:settings-script-test:" + uuid.NewString()
+	markerKey := deleteMarkerKeyForIntegration(key)
+	original := `{"Available":"100","OnHold":"0","Version":1}`
+
+	require.NoError(t, infra.redisContainer.Client.Set(ctx, key, original, time.Hour).Err())
+	require.NoError(t, infra.redisContainer.Client.Set(ctx, markerKey, "owner", time.Hour).Err())
+
+	result, err := updateBalanceSettingsScript.Run(ctx, infra.redisContainer.Client,
+		[]string{key}, 1, 1, "500.00", mmodel.BalanceScopeTransactional, "86400").Result()
+
+	require.Error(t, err, "a live delete marker must reject settings mutation")
+	assert.Contains(t, err.Error(), constant.ErrAccountIneligibility.Error())
+	assert.Nil(t, result)
+
+	unchanged, getErr := infra.redisContainer.Client.Get(ctx, key).Result()
+	require.NoError(t, getErr)
+	assert.Equal(t, original, unchanged, "the guarded settings update must leave the balance intact")
+}
+
+func TestIntegration_UpdateBalanceSettingsScript_LegacyDeleteMarkerBlocksMutation(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	infra := setupRedisIntegrationInfra(t)
+	ctx := context.Background()
+	key := "balance:{transactions}:settings-script-legacy-marker-test:" + uuid.NewString()
+	original := `{"Available":"100","OnHold":"0","Version":1}`
+
+	require.NoError(t, infra.redisContainer.Client.Set(ctx, key, original, time.Hour).Err())
+	require.NoError(t, infra.redisContainer.Client.Set(ctx, legacyDeleteMarkerKeyForIntegration(key), "owner", time.Hour).Err())
+
+	result, err := updateBalanceSettingsScript.Run(ctx, infra.redisContainer.Client,
+		[]string{key}, 1, 1, "500.00", mmodel.BalanceScopeTransactional, "86400").Result()
+
+	require.Error(t, err, "a live legacy delete marker must reject settings mutation")
+	assert.Contains(t, err.Error(), constant.ErrAccountIneligibility.Error())
+	assert.Nil(t, result)
+
+	unchanged, getErr := infra.redisContainer.Client.Get(ctx, key).Result()
+	require.NoError(t, getErr)
+	assert.Equal(t, original, unchanged, "the legacy-guarded settings update must leave the balance intact")
+}
+
+func TestIntegration_UpdateBalanceSettingsScript_TenantMarkerBlocksMutation(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	infra := setupRedisIntegrationInfra(t)
+	tenantID := "settings-marker-tenant-" + uuid.NewString()
+	ctx := context.Background()
+	key := "balance:{transactions}:settings-script-test:" + uuid.NewString()
+	physicalKey := "tenant:" + tenantID + ":" + key
+	physicalMarkerKey := "tenant:" + tenantID + ":" + deleteMarkerKeyForIntegration(key)
+	original := `{"Available":"100","OnHold":"0","Version":1}`
+
+	require.NoError(t, infra.redisContainer.Client.Set(ctx, physicalKey, original, time.Hour).Err())
+	require.NoError(t, infra.redisContainer.Client.Set(ctx, physicalMarkerKey, "owner", time.Hour).Err())
+
+	result, err := updateBalanceSettingsScript.Run(ctx, infra.redisContainer.Client,
+		[]string{physicalKey}, 1, 1, "500.00", mmodel.BalanceScopeTransactional, "86400").Result()
+
+	require.Error(t, err, "a tenant-prefixed delete marker must reject settings mutation")
+	assert.Contains(t, err.Error(), constant.ErrAccountIneligibility.Error())
+	assert.Nil(t, result)
+
+	unchanged, getErr := infra.redisContainer.Client.Get(ctx, physicalKey).Result()
+	require.NoError(t, getErr)
+	assert.Equal(t, original, unchanged, "the tenant-guarded settings update must leave the balance intact")
+}
+
 func TestIntegration_UpdateBalanceSettingsScript_CorruptBlobReturnsErrorCodeAndLeavesValueIntact(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode")

--- a/components/ledger/internal/adapters/redis/transaction/scripts/balance_atomic_operation.lua
+++ b/components/ledger/internal/adapters/redis/transaction/scripts/balance_atomic_operation.lua
@@ -290,7 +290,11 @@ local function rollback(rollbackBalances, ttl)
 end
 
 local function main()
-    local ttl = 86400 -- 1 day
+    -- Balance snapshots live for 86400 seconds. The command-layer delete marker
+    -- deliberately lives longer than this snapshot lifetime, so a failed
+    -- post-commit cache eviction cannot expose a deleted balance to a later
+    -- atomic operation after the marker expires.
+    local ttl = 86400 -- 1 day; keep in sync with balanceCacheSnapshotTTLSeconds
 
     local groupSize = 25
     local returnBalances = {}
@@ -394,16 +398,25 @@ local function main()
     local dueAt = tonumber(timeNow[1]) + tonumber(timeNow[2]) / 1000000
 
     -- Delete marker guard: reject the whole batch before any mutation if any balance
-    -- in it carries a live deletion marker. The delete marker is a SEPARATE key
-    -- "<balanceKey>:deleted" that never overwrites the balance itself, and it
-    -- shares the balance key's {transactions} hash slot. Running this pre-pass
+    -- in it carries a live deletion marker. New writers use a dedicated top-level namespace,
+    -- while the legacy :deleted marker remains honored during one rolling-deploy release.
+    -- The namespace shares the balance key's {transactions} hash slot. Running this pre-pass
     -- ahead of the first SET below means a rejection here leaves zero side
     -- effects across the batch, so no rollback is required. The stride mirrors
     -- the main loop below (groupSize=25; ARGV[i] is the balance key). A bounded
     -- per-key EXISTS check early-returns on the first delete marker found, so the
     -- whole batch is rejected without unpacking a client-influenced number of keys.
+    local deleteMarkerNamespacePrefix = "balance_delete_marker:{transactions}:"
+    local balanceNamespacePrefix = "balance:{transactions}:"
     for i = argvHeader + 1, #ARGV, groupSize do
-        if redis.call("EXISTS", ARGV[i] .. ":deleted") == 1 then
+        local markerKey, replacements = string.gsub(ARGV[i], balanceNamespacePrefix, deleteMarkerNamespacePrefix, 1)
+        if replacements == 0 then
+            markerKey = deleteMarkerNamespacePrefix .. ARGV[i]
+        end
+
+        -- Keep this legacy check until all old binaries are retired. New writers dual-write both
+        -- markers so old Lua, which only checks this suffix, remains safe in the mixed fleet.
+        if redis.call("EXISTS", markerKey) == 1 or redis.call("EXISTS", ARGV[i] .. ":deleted") == 1 then
             return redis.error_reply("0019")
         end
     end

--- a/components/ledger/internal/adapters/redis/transaction/scripts/delete_if_value.lua
+++ b/components/ledger/internal/adapters/redis/transaction/scripts/delete_if_value.lua
@@ -1,0 +1,12 @@
+-- delete_if_value.lua
+-- Atomically delete a key only when its value matches the expected owner token.
+--
+-- KEYS[1]: key to delete
+-- ARGV[1]: expected value
+-- Returns 1 when the key was deleted, otherwise 0.
+
+if redis.call('GET', KEYS[1]) == ARGV[1] then
+    return redis.call('DEL', KEYS[1])
+end
+
+return 0

--- a/components/ledger/internal/adapters/redis/transaction/scripts/expire_if_value.lua
+++ b/components/ledger/internal/adapters/redis/transaction/scripts/expire_if_value.lua
@@ -1,0 +1,13 @@
+-- expire_if_value.lua
+-- Atomically shorten a key's TTL only when its value matches the expected owner token.
+--
+-- KEYS[1]: key whose expiry is being shortened
+-- ARGV[1]: expected value
+-- ARGV[2]: expiry in seconds
+-- Returns 1 when the expiry was updated, otherwise 0.
+
+if redis.call('GET', KEYS[1]) == ARGV[1] then
+    return redis.call('EXPIRE', KEYS[1], ARGV[2])
+end
+
+return 0

--- a/components/ledger/internal/adapters/redis/transaction/scripts/update_balance_settings.lua
+++ b/components/ledger/internal/adapters/redis/transaction/scripts/update_balance_settings.lua
@@ -15,12 +15,30 @@
 -- ARGV[2] = OverdraftLimitEnabled (0/1)
 -- ARGV[3] = OverdraftLimit (string; "0" when disabled/unset)
 -- ARGV[4] = BalanceScope (string)
--- ARGV[5] = TTL in seconds
+-- ARGV[5] = TTL in seconds (86400, the balance snapshot lifetime). The
+-- command-layer delete marker is intentionally longer than this lifetime so a
+-- failed post-commit eviction cannot leave a deleted balance mutable after the
+-- marker expires.
 --
 -- Returns:
 --    1  = written
 --    0  = key absent (no-op; the next transaction reloads from PostgreSQL)
 --   -2  = cached value was not valid JSON (corrupt blob)
+
+-- Delete markers use a dedicated top-level namespace in new releases. Honor the legacy
+-- :deleted key during one rolling-deploy release as well; new writers dual-write both markers
+-- so old Lua remains safe while the fleet is mixed. The legacy suffix has a known collision
+-- tradeoff and must be removed after all old binaries are retired.
+local deleteMarkerNamespacePrefix = "balance_delete_marker:{transactions}:"
+local balanceNamespacePrefix = "balance:{transactions}:"
+local markerKey, replacements = string.gsub(KEYS[1], balanceNamespacePrefix, deleteMarkerNamespacePrefix, 1)
+if replacements == 0 then
+    markerKey = deleteMarkerNamespacePrefix .. KEYS[1]
+end
+
+if redis.call('EXISTS', markerKey) == 1 or redis.call('EXISTS', KEYS[1] .. ':deleted') == 1 then
+    return redis.error_reply("0019")
+end
 
 local cur = redis.call('GET', KEYS[1])
 

--- a/components/ledger/internal/services/command/balance_cache_delete_guard.go
+++ b/components/ledger/internal/services/command/balance_cache_delete_guard.go
@@ -6,34 +6,66 @@ package command
 
 import (
 	"context"
+	"fmt"
+	"strings"
 	"time"
 
 	libObservability "github.com/LerianStudio/lib-observability/v4"
 	libLog "github.com/LerianStudio/lib-observability/v4/log"
 	libOpentelemetry "github.com/LerianStudio/lib-observability/v4/tracing"
+	"github.com/LerianStudio/midaz/v4/pkg"
+	"github.com/LerianStudio/midaz/v4/pkg/constant"
 	"github.com/LerianStudio/midaz/v4/pkg/mmodel"
 	"github.com/LerianStudio/midaz/v4/pkg/utils"
 	"github.com/google/uuid"
+	"go.opentelemetry.io/otel/attribute"
 )
 
 const (
+	// balanceCacheSnapshotTTLSeconds must stay in lock-step with the 86400-second TTL
+	// used by balance_atomic_operation.lua and update_balance_settings.lua. A cache
+	// snapshot can be stale for this entire period when post-commit eviction fails.
+	balanceCacheSnapshotTTLSeconds = 24 * 60 * 60
+
 	// balanceDeleteMarkerTTLSeconds is the lifetime, in whole seconds, of a balance
-	// delete marker key. It is deliberately short: it must outlive the worst-case
-	// duration of a delete so the honored-lock pre-pass keeps rejecting mutations for the
-	// whole operation, yet expire quickly so a process that crashes mid-delete self-heals
-	// instead of leaving a permanently poisoned balance key. It is intentionally NOT the
-	// 3600s balance cache TTL. SetNX multiplies its ttl argument by time.Second, so it is
-	// passed as a whole-second count via time.Duration(balanceDeleteMarkerTTLSeconds).
-	balanceDeleteMarkerTTLSeconds = 30
+	// delete marker key. It covers one complete balance snapshot lifetime plus an
+	// equally sized operation grace period. The grace period matters because markers
+	// are planted before the funds guard and soft delete, while successful deletes
+	// intentionally retain the marker when best-effort cache eviction fails. Thus a
+	// marker cannot expire while a stale snapshot that existed at acquisition can still
+	// be used, and a slow single or cascade delete has a full snapshot lifetime to
+	// finish. SetNX multiplies its ttl argument by time.Second, so this is passed as a
+	// whole-second count via time.Duration(balanceDeleteMarkerTTLSeconds).
+	balanceDeleteMarkerTTLSeconds = 2 * balanceCacheSnapshotTTLSeconds
 
-	// deleteMarkerKeySuffix is appended to a balance's internal cache key to form its delete marker
-	// key. It MUST match the suffix the Redis Lua pre-pass derives (ARGV[i] .. ":deleted").
-	deleteMarkerKeySuffix = ":deleted"
+	// balanceDeleteMarkerShortTTLSeconds is the 30-second post-eviction in-flight window. A successful
+	// eviction no longer needs snapshot-lifetime protection, but the marker remains owned briefly
+	// so a concurrent operation cannot race a just-committed delete. ExpireIfValue changes it
+	// atomically without releasing and reacquiring the marker.
+	balanceDeleteMarkerShortTTLSeconds = 30
 
-	// deleteMarkerValue is the placeholder stored under a delete marker key. The value is
-	// never read: only the key's existence is meaningful to the honored-lock pre-pass.
-	deleteMarkerValue = "1"
+	// deleteMarkerNamespacePrefix is a top-level key namespace reserved for delete markers. It
+	// intentionally differs from the balance cache namespace: balance keys allow arbitrary ':'
+	// characters, so appending a suffix to a balance key could collide with a valid sibling balance
+	// key. The {transactions} hash tag keeps markers colocated with their balance keys in Redis
+	// Cluster. The same prefix is used by the transaction Lua scripts.
+	deleteMarkerNamespacePrefix = "balance_delete_marker:{transactions}:"
+	balanceCacheNamespacePrefix = "balance:{transactions}:"
+	deleteMarkerLegacySuffix    = ":deleted"
+
+	// balanceDeleteMarkerCleanupTimeout bounds every best-effort Redis cleanup that runs after
+	// the delete decision is made: marker rollback, cache eviction and marker shortening.
+	// WithoutCancel preserves the opportunity to finish that cleanup after the request context
+	// is canceled, while this timeout prevents a stuck Redis call from holding the caller
+	// indefinitely.
+	balanceDeleteMarkerCleanupTimeout = 5 * time.Second
 )
+
+type balanceDeleteMarker struct {
+	key       string
+	legacyKey string
+	token     string
+}
 
 // balanceCacheKeyFor returns the un-prefixed internal cache key for a balance. The
 // TransactionRedisRepo wrappers apply tenant namespacing to the whole key, so callers pass
@@ -42,84 +74,193 @@ func balanceCacheKeyFor(organizationID, ledgerID uuid.UUID, balance *mmodel.Bala
 	return utils.BalanceInternalKey(organizationID, ledgerID, balance.Alias+"#"+balance.Key)
 }
 
-// deleteMarkerKeyFor returns the delete marker key for a balance: its internal cache key plus the
-// ":deleted" suffix. The delete marker is a SEPARATE key from the balance cache key.
+// deleteMarkerKeyFor returns a delete marker in the dedicated marker namespace. Replacing the
+// balance namespace keeps the tenant prefix (added by the Redis adapter) in front of the marker
+// namespace and preserves the balance key's Redis hash slot.
 func deleteMarkerKeyFor(organizationID, ledgerID uuid.UUID, balance *mmodel.Balance) string {
-	return balanceCacheKeyFor(organizationID, ledgerID, balance) + deleteMarkerKeySuffix
+	cacheKey := balanceCacheKeyFor(organizationID, ledgerID, balance)
+
+	return deleteMarkerNamespacePrefix + strings.TrimPrefix(cacheKey, balanceCacheNamespacePrefix)
 }
 
-// plantBalanceDeleteMarkers best-effort writes a short-lived delete marker key for each balance so
-// the Redis honored-lock pre-pass rejects concurrent mutations while a delete is in flight.
-// A failed SetNX is logged and skipped (it weakens the guard but must not crash the delete).
-// The returned release closure Dels exactly the delete marker keys that were planted, for
-// defer-on-error rollback by the caller.
-func (uc *UseCase) plantBalanceDeleteMarkers(ctx context.Context, organizationID, ledgerID uuid.UUID, balances []*mmodel.Balance) func() {
-	logger, tracer, _, _ := libObservability.NewTrackingFromContext(ctx)
+// legacyDeleteMarkerKeyFor returns the marker key used by the pre-namespace release. It remains
+// dual-written for one rolling-deploy release so old Lua consumers cannot mutate a balance while
+// a new command owns only the namespaced marker. The suffix has a known collision tradeoff: a
+// legitimate sibling balance whose key ends in ":deleted" occupies this key, so deletion fails
+// closed rather than risk mutating through an old consumer. Legacy rollback still uses an
+// unconditional DEL, so draining old pods is required before new traffic can acquire this key.
+// Remove this helper and the legacy Lua checks after every old deployment is retired.
+func legacyDeleteMarkerKeyFor(organizationID, ledgerID uuid.UUID, balance *mmodel.Balance) string {
+	return balanceCacheKeyFor(organizationID, ledgerID, balance) + deleteMarkerLegacySuffix
+}
+
+// plantBalanceDeleteMarkerLease acquires both the current namespaced marker and the legacy
+// :deleted marker for each balance. Both are needed while old and new binaries can be live: new
+// Lua honors legacy markers, while old Lua only honors legacy markers. Acquisition is fail-closed;
+// if either key is unavailable, all keys acquired by this invocation are compare-and-deleted.
+func (uc *UseCase) plantBalanceDeleteMarkerLease(ctx context.Context, organizationID, ledgerID uuid.UUID, balances []*mmodel.Balance) ([]balanceDeleteMarker, error) {
+	_, tracer, _, _ := libObservability.NewTrackingFromContext(ctx)
 
 	spanCtx, span := tracer.Start(ctx, "exec.plant_balance_delete_markers")
 	defer span.End()
 
-	planted := make([]string, 0, len(balances))
+	span.SetAttributes(
+		attribute.String("app.request.organization_id", organizationID.String()),
+		attribute.String("app.request.ledger_id", ledgerID.String()),
+		attribute.Int("app.balance_delete.marker_count", len(balances)),
+	)
+
+	planted := make([]balanceDeleteMarker, 0, len(balances))
+	ownerToken := uuid.NewString()
 
 	for _, balance := range balances {
 		deleteMarkerKey := deleteMarkerKeyFor(organizationID, ledgerID, balance)
+		legacyMarkerKey := legacyDeleteMarkerKeyFor(organizationID, ledgerID, balance)
 
-		set, err := uc.TransactionRedisRepo.SetNX(spanCtx, deleteMarkerKey, deleteMarkerValue, time.Duration(balanceDeleteMarkerTTLSeconds))
+		set, err := uc.TransactionRedisRepo.SetNX(spanCtx, deleteMarkerKey, ownerToken, time.Duration(balanceDeleteMarkerTTLSeconds))
 		if err != nil {
 			libOpentelemetry.HandleSpanError(span, "Failed to plant balance delete marker", err)
 
-			logger.Log(spanCtx, libLog.LevelWarn, "Failed to plant balance delete marker", libLog.Err(err))
+			// This call owns only the markers in planted. Do not attempt to remove the
+			// marker whose SetNX failed: it may belong to another delete operation.
+			uc.releaseBalanceDeleteMarkers(ctx, planted)
 
-			continue
+			return nil, fmt.Errorf("failed to plant balance delete marker: %w", err)
 		}
 
-		// Track only a delete marker THIS operation acquired (SetNX true). A (false, nil)
-		// means a concurrent delete already owns the key: the guard is armed either
-		// way, so the delete proceeds, but releasing here would Del a sibling's
-		// delete marker and reopen the honored-lock hole. Only acquired keys are releasable.
-		if set {
-			planted = append(planted, deleteMarkerKey)
+		if !set {
+			// A marker owned by a concurrent delete is not ours to release, and this
+			// operation cannot safely proceed without an exclusive barrier of its own.
+			releaseErr := pkg.ValidateBusinessError(constant.ErrBalancesCantBeDeleted, constant.EntityBalance)
+			libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Balance delete marker is already owned", releaseErr)
+
+			uc.releaseBalanceDeleteMarkers(ctx, planted)
+
+			return nil, releaseErr
 		}
+
+		legacySet, legacyErr := uc.TransactionRedisRepo.SetNX(spanCtx, legacyMarkerKey, ownerToken, time.Duration(balanceDeleteMarkerTTLSeconds))
+		if legacyErr != nil {
+			libOpentelemetry.HandleSpanError(span, "Failed to plant legacy balance delete marker", legacyErr)
+
+			// The current marker is ours; compare its token before deleting it. The failed legacy
+			// SetNX may belong to another owner and is never released here.
+			uc.releaseBalanceDeleteMarkers(ctx, append(planted, balanceDeleteMarker{key: deleteMarkerKey, legacyKey: legacyMarkerKey, token: ownerToken}))
+
+			return nil, fmt.Errorf("failed to plant legacy balance delete marker: %w", legacyErr)
+		}
+
+		if !legacySet {
+			conflictErr := pkg.ValidateBusinessError(constant.ErrBalancesCantBeDeleted, constant.EntityBalance)
+			libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Legacy balance delete marker is already owned", conflictErr)
+
+			uc.releaseBalanceDeleteMarkers(ctx, append(planted, balanceDeleteMarker{key: deleteMarkerKey, legacyKey: legacyMarkerKey, token: ownerToken}))
+
+			return nil, conflictErr
+		}
+
+		planted = append(planted, balanceDeleteMarker{key: deleteMarkerKey, legacyKey: legacyMarkerKey, token: ownerToken})
 	}
 
-	return func() {
-		uc.releaseBalanceDeleteMarkers(ctx, planted)
-	}
+	return planted, nil
 }
 
-// releaseBalanceDeleteMarkers Dels each previously planted delete marker key, logging a Warn on
-// error and continuing. A no-op Del on a missing key is safe.
-func (uc *UseCase) releaseBalanceDeleteMarkers(ctx context.Context, deleteMarkerKeys []string) {
+// releaseBalanceDeleteMarkers atomically compare-and-deletes each previously planted marker,
+// logging a Warn on Redis errors and continuing. A false result means the marker is already
+// missing or belongs to a different owner and is intentionally not treated as an error.
+func (uc *UseCase) releaseBalanceDeleteMarkers(ctx context.Context, markers []balanceDeleteMarker) {
 	logger, tracer, _, _ := libObservability.NewTrackingFromContext(ctx)
 
-	ctx, span := tracer.Start(ctx, "exec.release_balance_delete_markers")
+	releaseCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), balanceDeleteMarkerCleanupTimeout)
+	defer cancel()
+
+	releaseCtx, span := tracer.Start(releaseCtx, "exec.release_balance_delete_markers")
 	defer span.End()
 
-	for _, deleteMarkerKey := range deleteMarkerKeys {
-		if err := uc.TransactionRedisRepo.Del(ctx, deleteMarkerKey); err != nil {
-			libOpentelemetry.HandleSpanError(span, "Failed to release balance delete marker", err)
+	for _, marker := range markers {
+		for _, key := range []string{marker.key, marker.legacyKey} {
+			deleted, err := uc.TransactionRedisRepo.DeleteIfValue(releaseCtx, key, marker.token)
+			if err != nil {
+				libOpentelemetry.HandleSpanError(span, "Failed to release balance delete marker", err)
 
-			logger.Log(ctx, libLog.LevelWarn, "Failed to release balance delete marker", libLog.Err(err))
+				logger.Log(releaseCtx, libLog.LevelWarn, "Failed to release balance delete marker", libLog.Err(err))
+
+				continue
+			}
+
+			if !deleted {
+				logger.Log(releaseCtx, libLog.LevelDebug, "Balance delete marker was not owned at release")
+			}
 		}
 	}
 }
 
 // evictBalanceCaches Dels each balance's internal cache key after a committed delete. A
-// lingering cache key after a persisted delete is the bug this guards against, so a failed
-// Del is Warn-worthy but must not fail the already-committed delete.
-func (uc *UseCase) evictBalanceCaches(ctx context.Context, organizationID, ledgerID uuid.UUID, balances []*mmodel.Balance) {
+// lingering cache key after a persisted delete is the bug this guards against, so a failed Del is
+// Warn-worthy but must not fail the already-committed delete. The whole cleanup runs on a bounded
+// context detached from the caller: the row is already gone, so a canceled request must not be
+// able to leave a stale snapshot and a long-lived marker behind.
+//
+// A nil markers slice means no shortening. Otherwise markers[i] must be the lease planted for
+// balances[i]; a length mismatch cannot be resolved safely, so shortening is skipped for every
+// balance and all markers keep their long TTL. Each successful Del is followed by token-checked
+// shortening of both marker namespaces, and a shortening failure likewise leaves the long marker
+// in place for fail-closed protection.
+func (uc *UseCase) evictBalanceCaches(ctx context.Context, organizationID, ledgerID uuid.UUID, balances []*mmodel.Balance, markers []balanceDeleteMarker) {
 	logger, tracer, _, _ := libObservability.NewTrackingFromContext(ctx)
 
-	ctx, span := tracer.Start(ctx, "exec.evict_balance_caches")
+	evictCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), balanceDeleteMarkerCleanupTimeout)
+	defer cancel()
+
+	evictCtx, span := tracer.Start(evictCtx, "exec.evict_balance_caches")
 	defer span.End()
 
-	for _, balance := range balances {
+	if len(markers) > 0 && len(markers) != len(balances) {
+		mismatchErr := fmt.Errorf("balance delete marker count %d does not match balance count %d", len(markers), len(balances))
+
+		libOpentelemetry.HandleSpanError(span, "Balance delete marker count does not match balance count", mismatchErr)
+
+		logger.Log(evictCtx, libLog.LevelWarn, "Skipping balance delete marker shortening", libLog.Err(mismatchErr))
+
+		markers = nil
+	}
+
+	for i, balance := range balances {
 		cacheKey := balanceCacheKeyFor(organizationID, ledgerID, balance)
 
-		if err := uc.TransactionRedisRepo.Del(ctx, cacheKey); err != nil {
+		if err := uc.TransactionRedisRepo.Del(evictCtx, cacheKey); err != nil {
 			libOpentelemetry.HandleSpanError(span, "Failed to evict balance cache key", err)
 
-			logger.Log(ctx, libLog.LevelWarn, "Failed to evict balance cache key", libLog.Err(err))
+			logger.Log(evictCtx, libLog.LevelWarn, "Failed to evict balance cache key", libLog.Err(err))
+
+			continue
+		}
+
+		if i < len(markers) {
+			uc.shortenBalanceDeleteMarker(evictCtx, markers[i])
+		}
+	}
+}
+
+// shortenBalanceDeleteMarker keeps the marker barrier for a short in-flight window after cache
+// eviction. Every expiry is token-checked; a missing/foreign marker is never modified.
+func (uc *UseCase) shortenBalanceDeleteMarker(ctx context.Context, marker balanceDeleteMarker) {
+	logger, tracer, _, _ := libObservability.NewTrackingFromContext(ctx)
+
+	ctx, span := tracer.Start(ctx, "exec.shorten_balance_delete_marker")
+	defer span.End()
+
+	for _, key := range []string{marker.key, marker.legacyKey} {
+		ok, err := uc.TransactionRedisRepo.ExpireIfValue(ctx, key, marker.token, time.Duration(balanceDeleteMarkerShortTTLSeconds))
+		if err != nil {
+			libOpentelemetry.HandleSpanError(span, "Failed to shorten balance delete marker", err)
+			logger.Log(ctx, libLog.LevelWarn, "Failed to shorten balance delete marker", libLog.Err(err))
+
+			continue
+		}
+
+		if !ok {
+			logger.Log(ctx, libLog.LevelDebug, "Balance delete marker was not owned while shortening")
 		}
 	}
 }

--- a/components/ledger/internal/services/command/balance_cache_delete_guard_test.go
+++ b/components/ledger/internal/services/command/balance_cache_delete_guard_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 	"time"
 
+	midazpkg "github.com/LerianStudio/midaz/v4/pkg"
+	"github.com/LerianStudio/midaz/v4/pkg/constant"
 	"github.com/LerianStudio/midaz/v4/pkg/mmodel"
 	"github.com/LerianStudio/midaz/v4/pkg/utils"
 	"github.com/google/uuid"
@@ -19,6 +21,20 @@ import (
 
 func deleteMarkerTestBalance(alias, key string) *mmodel.Balance {
 	return &mmodel.Balance{Alias: alias, Key: key}
+}
+
+// plantDeleteMarkersForTest plants a marker lease and hands back the release closure the
+// production paths install in a deferred function, so a test can assert plant and release
+// as one pair.
+func plantDeleteMarkersForTest(ctx context.Context, uc *UseCase, organizationID, ledgerID uuid.UUID, balances []*mmodel.Balance) (func(), error) {
+	markers, err := uc.plantBalanceDeleteMarkerLease(ctx, organizationID, ledgerID, balances)
+	if err != nil {
+		return nil, err
+	}
+
+	return func() {
+		uc.releaseBalanceDeleteMarkers(ctx, markers)
+	}, nil
 }
 
 func TestDeleteMarkerKeyFor(t *testing.T) {
@@ -34,6 +50,7 @@ func TestDeleteMarkerKeyFor(t *testing.T) {
 	}{
 		{name: "simple alias and key", alias: "alias", key: "key"},
 		{name: "distinct alias and key", alias: "@person1", key: "usd"},
+		{name: "key containing marker suffix cannot collide with sibling balance", alias: "@person1", key: "usd:deleted"},
 	}
 
 	for _, tt := range tests {
@@ -44,15 +61,37 @@ func TestDeleteMarkerKeyFor(t *testing.T) {
 
 			got := deleteMarkerKeyFor(organizationID, ledgerID, balance)
 
-			want := utils.BalanceInternalKey(organizationID, ledgerID, tt.alias+"#"+tt.key) + deleteMarkerKeySuffix
+			want := deleteMarkerNamespacePrefix + organizationID.String() + ":" + ledgerID.String() + ":" + tt.alias + "#" + tt.key
 
 			assert.Equal(t, want, got)
 			// Delete marker MUST be a separate key from the balance cache key.
 			assert.NotEqual(t, utils.BalanceInternalKey(organizationID, ledgerID, tt.alias+"#"+tt.key), got)
-			assert.Contains(t, got, "balance:{transactions}:")
-			assert.Contains(t, got, tt.alias+"#"+tt.key+deleteMarkerKeySuffix)
+			assert.Contains(t, got, deleteMarkerNamespacePrefix)
 		})
 	}
+}
+
+func TestDeleteMarkerKeyForDoesNotCollideWithValidSiblingBalanceKey(t *testing.T) {
+	t.Parallel()
+
+	organizationID := uuid.New()
+	ledgerID := uuid.New()
+	base := deleteMarkerTestBalance("@person1", "usd")
+	sibling := deleteMarkerTestBalance("@person1", "usd:deleted")
+
+	assert.NotEqual(t,
+		deleteMarkerKeyFor(organizationID, ledgerID, base),
+		balanceCacheKeyFor(organizationID, ledgerID, sibling),
+		"a valid sibling balance key must never occupy the marker namespace")
+}
+
+func TestBalanceDeleteMarkerTTLProtectsBalanceSnapshotLifetime(t *testing.T) {
+	t.Parallel()
+
+	const balanceSnapshotTTLSeconds = 24 * 60 * 60
+
+	assert.GreaterOrEqual(t, balanceDeleteMarkerTTLSeconds, 2*balanceSnapshotTTLSeconds,
+		"the delete marker must outlive the 24-hour balance snapshot by an operation-sized grace period")
 }
 
 func TestPlantBalanceDeleteMarkers(t *testing.T) {
@@ -68,25 +107,90 @@ func TestPlantBalanceDeleteMarkers(t *testing.T) {
 	second := deleteMarkerTestBalance("@bob", "brl")
 	balances := []*mmodel.Balance{first, second}
 
-	firstTomb := utils.BalanceInternalKey(organizationID, ledgerID, "@alice#usd") + deleteMarkerKeySuffix
-	secondTomb := utils.BalanceInternalKey(organizationID, ledgerID, "@bob#brl") + deleteMarkerKeySuffix
+	firstTomb := deleteMarkerKeyFor(organizationID, ledgerID, first)
+	secondTomb := deleteMarkerKeyFor(organizationID, ledgerID, second)
+	firstLegacyTomb := legacyDeleteMarkerKeyFor(organizationID, ledgerID, first)
+	secondLegacyTomb := legacyDeleteMarkerKeyFor(organizationID, ledgerID, second)
 
-	// SetNX is called once per balance, with the correct delete marker key, a marker value,
+	// SetNX is called once per balance, with the correct delete marker key, an opaque owner token,
 	// and the whole-second TTL constant (SetNX multiplies it by time.Second internally).
+	var firstToken, secondToken string
 	mockRedisRepo.EXPECT().
-		SetNX(gomock.Any(), firstTomb, "1", time.Duration(balanceDeleteMarkerTTLSeconds)).
-		Return(true, nil)
-	mockRedisRepo.EXPECT().
-		SetNX(gomock.Any(), secondTomb, "1", time.Duration(balanceDeleteMarkerTTLSeconds)).
-		Return(true, nil)
+		SetNX(gomock.Any(), firstTomb, gomock.Any(), time.Duration(balanceDeleteMarkerTTLSeconds)).
+		DoAndReturn(func(_ context.Context, _ string, token string, _ time.Duration) (bool, error) {
+			firstToken = token
 
-	release := uc.plantBalanceDeleteMarkers(ctx, organizationID, ledgerID, balances)
+			return true, nil
+		})
+	mockRedisRepo.EXPECT().
+		SetNX(gomock.Any(), firstLegacyTomb, gomock.Any(), time.Duration(balanceDeleteMarkerTTLSeconds)).
+		DoAndReturn(func(_ context.Context, _ string, token string, _ time.Duration) (bool, error) {
+			assert.Equal(t, firstToken, token)
+			return true, nil
+		})
+	mockRedisRepo.EXPECT().
+		SetNX(gomock.Any(), secondTomb, gomock.Any(), time.Duration(balanceDeleteMarkerTTLSeconds)).
+		DoAndReturn(func(_ context.Context, _ string, token string, _ time.Duration) (bool, error) {
+			secondToken = token
+
+			return true, nil
+		})
+	mockRedisRepo.EXPECT().
+		SetNX(gomock.Any(), secondLegacyTomb, gomock.Any(), time.Duration(balanceDeleteMarkerTTLSeconds)).
+		DoAndReturn(func(_ context.Context, _ string, token string, _ time.Duration) (bool, error) {
+			assert.Equal(t, secondToken, token)
+			return true, nil
+		})
+
+	release, err := plantDeleteMarkersForTest(ctx, uc, organizationID, ledgerID, balances)
+	assert.NoError(t, err)
 	assert.NotNil(t, release)
+	assert.NotEmpty(t, firstToken)
+	assert.Equal(t, firstToken, secondToken)
 
-	// The release closure must Del exactly the planted delete marker keys.
-	mockRedisRepo.EXPECT().Del(gomock.Any(), firstTomb).Return(nil)
-	mockRedisRepo.EXPECT().Del(gomock.Any(), secondTomb).Return(nil)
+	// The release closure must compare-and-delete exactly the planted delete marker keys.
+	mockRedisRepo.EXPECT().DeleteIfValue(gomock.Any(), firstTomb, firstToken).Return(true, nil)
+	mockRedisRepo.EXPECT().DeleteIfValue(gomock.Any(), firstLegacyTomb, firstToken).Return(true, nil)
+	mockRedisRepo.EXPECT().DeleteIfValue(gomock.Any(), secondTomb, secondToken).Return(true, nil)
+	mockRedisRepo.EXPECT().DeleteIfValue(gomock.Any(), secondLegacyTomb, secondToken).Return(true, nil)
 
+	release()
+}
+
+func TestPlantBalanceDeleteMarkersReleasesOnlyMatchingOwnerToken(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	organizationID := uuid.New()
+	ledgerID := uuid.New()
+
+	uc, _, mockRedisRepo := setupDeleteAllBalancesUseCase(t)
+
+	balance := deleteMarkerTestBalance("@alice", "usd")
+	tomb := deleteMarkerKeyFor(organizationID, ledgerID, balance)
+
+	var acquiredToken string
+	mockRedisRepo.EXPECT().
+		SetNX(gomock.Any(), tomb, gomock.Any(), time.Duration(balanceDeleteMarkerTTLSeconds)).
+		DoAndReturn(func(_ context.Context, _ string, token string, _ time.Duration) (bool, error) {
+			acquiredToken = token
+			return true, nil
+		})
+	mockRedisRepo.EXPECT().
+		SetNX(gomock.Any(), legacyDeleteMarkerKeyFor(organizationID, ledgerID, balance), gomock.Any(), time.Duration(balanceDeleteMarkerTTLSeconds)).
+		Return(true, nil)
+
+	release, err := plantDeleteMarkersForTest(ctx, uc, organizationID, ledgerID, []*mmodel.Balance{balance})
+	assert.NoError(t, err)
+	assert.NotNil(t, release)
+	assert.NotEmpty(t, acquiredToken)
+	parsedToken, parseErr := uuid.Parse(acquiredToken)
+	assert.NoError(t, parseErr)
+	assert.NotEqual(t, uuid.Nil, parsedToken)
+
+	// The owner token is supplied to Redis' atomic compare-and-delete operation.
+	mockRedisRepo.EXPECT().DeleteIfValue(gomock.Any(), tomb, acquiredToken).Return(true, nil)
+	mockRedisRepo.EXPECT().DeleteIfValue(gomock.Any(), legacyDeleteMarkerKeyFor(organizationID, ledgerID, balance), acquiredToken).Return(true, nil)
 	release()
 }
 
@@ -100,21 +204,27 @@ func TestPlantBalanceDeleteMarkersReleaseDelErrorSwallowed(t *testing.T) {
 	uc, _, mockRedisRepo := setupDeleteAllBalancesUseCase(t)
 
 	balance := deleteMarkerTestBalance("@alice", "usd")
-	tomb := utils.BalanceInternalKey(organizationID, ledgerID, "@alice#usd") + deleteMarkerKeySuffix
+	tomb := deleteMarkerKeyFor(organizationID, ledgerID, balance)
 
 	mockRedisRepo.EXPECT().
-		SetNX(gomock.Any(), tomb, "1", time.Duration(balanceDeleteMarkerTTLSeconds)).
+		SetNX(gomock.Any(), tomb, gomock.Any(), time.Duration(balanceDeleteMarkerTTLSeconds)).
+		Return(true, nil)
+	mockRedisRepo.EXPECT().
+		SetNX(gomock.Any(), legacyDeleteMarkerKeyFor(organizationID, ledgerID, balance), gomock.Any(), time.Duration(balanceDeleteMarkerTTLSeconds)).
 		Return(true, nil)
 
-	release := uc.plantBalanceDeleteMarkers(ctx, organizationID, ledgerID, []*mmodel.Balance{balance})
+	release, err := plantDeleteMarkersForTest(ctx, uc, organizationID, ledgerID, []*mmodel.Balance{balance})
+	assert.NoError(t, err)
+	assert.NotNil(t, release)
 
-	// A failed Del during release is logged and swallowed; it must not panic or propagate.
-	mockRedisRepo.EXPECT().Del(gomock.Any(), tomb).Return(errors.New("redis down"))
+	// A failed compare-and-delete during release is logged and swallowed; it must not panic or propagate.
+	mockRedisRepo.EXPECT().DeleteIfValue(gomock.Any(), tomb, gomock.Any()).Return(false, errors.New("redis down"))
+	mockRedisRepo.EXPECT().DeleteIfValue(gomock.Any(), legacyDeleteMarkerKeyFor(organizationID, ledgerID, balance), gomock.Any()).Return(false, errors.New("redis down"))
 
 	assert.NotPanics(t, func() { release() })
 }
 
-func TestPlantBalanceDeleteMarkersSetNXErrorContinues(t *testing.T) {
+func TestPlantBalanceDeleteMarkersSetNXErrorRollsBackOwnedMarkers(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
@@ -127,80 +237,211 @@ func TestPlantBalanceDeleteMarkersSetNXErrorContinues(t *testing.T) {
 	second := deleteMarkerTestBalance("@bob", "brl")
 	balances := []*mmodel.Balance{first, second}
 
-	firstTomb := utils.BalanceInternalKey(organizationID, ledgerID, "@alice#usd") + deleteMarkerKeySuffix
-	secondTomb := utils.BalanceInternalKey(organizationID, ledgerID, "@bob#brl") + deleteMarkerKeySuffix
+	firstTomb := deleteMarkerKeyFor(organizationID, ledgerID, first)
+	secondTomb := deleteMarkerKeyFor(organizationID, ledgerID, second)
 
-	// First SetNX fails: it is logged and skipped, not planted. Second succeeds.
-	mockRedisRepo.EXPECT().
-		SetNX(gomock.Any(), firstTomb, "1", time.Duration(balanceDeleteMarkerTTLSeconds)).
-		Return(false, errors.New("redis unavailable"))
-	mockRedisRepo.EXPECT().
-		SetNX(gomock.Any(), secondTomb, "1", time.Duration(balanceDeleteMarkerTTLSeconds)).
+	firstSet := mockRedisRepo.EXPECT().
+		SetNX(gomock.Any(), firstTomb, gomock.Any(), time.Duration(balanceDeleteMarkerTTLSeconds)).
 		Return(true, nil)
+	firstLegacySet := mockRedisRepo.EXPECT().
+		SetNX(gomock.Any(), legacyDeleteMarkerKeyFor(organizationID, ledgerID, first), gomock.Any(), time.Duration(balanceDeleteMarkerTTLSeconds)).
+		Return(true, nil)
+	expectedErr := errors.New("redis unavailable")
+	secondSet := mockRedisRepo.EXPECT().
+		SetNX(gomock.Any(), secondTomb, gomock.Any(), time.Duration(balanceDeleteMarkerTTLSeconds)).
+		Return(false, expectedErr)
+	rollback := mockRedisRepo.EXPECT().DeleteIfValue(gomock.Any(), firstTomb, gomock.Any()).Return(false, errors.New("rollback unavailable"))
+	legacyRollback := mockRedisRepo.EXPECT().DeleteIfValue(gomock.Any(), legacyDeleteMarkerKeyFor(organizationID, ledgerID, first), gomock.Any()).Return(false, errors.New("rollback unavailable"))
+	gomock.InOrder(firstSet, firstLegacySet, secondSet, rollback, legacyRollback)
 
-	release := uc.plantBalanceDeleteMarkers(ctx, organizationID, ledgerID, balances)
+	release, err := plantDeleteMarkersForTest(ctx, uc, organizationID, ledgerID, balances)
 
-	// Release must Del ONLY the successfully planted key; the failed one is never Del'd.
-	mockRedisRepo.EXPECT().Del(gomock.Any(), firstTomb).Times(0)
-	mockRedisRepo.EXPECT().Del(gomock.Any(), secondTomb).Return(nil)
-
-	assert.NotPanics(t, func() { release() })
+	assert.Nil(t, release)
+	assert.ErrorIs(t, err, expectedErr)
+	// The failed marker is not ours and is never released. The first marker is ours
+	// and is released before the helper returns.
+	mockRedisRepo.EXPECT().DeleteIfValue(gomock.Any(), secondTomb, gomock.Any()).Times(0)
 }
 
-func TestPlantBalanceDeleteMarkersTracksOnlyAcquiredKeys(t *testing.T) {
+func TestPlantBalanceDeleteMarkersRejectsAlreadyOwnedMarker(t *testing.T) {
 	t.Parallel()
 
 	organizationID := uuid.New()
 	ledgerID := uuid.New()
 
-	tests := []struct {
-		name        string
-		setNXResult bool
-		released    bool
-	}{
-		{
-			// (true, nil): this operation acquired the delete marker, so it owns and
-			// releases the key on rollback.
-			name:        "acquired delete marker is released",
-			setNXResult: true,
-			released:    true,
-		},
-		{
-			// (false, nil): a concurrent delete already owns the delete marker. The
-			// guard is armed either way, so this operation proceeds, but it must
-			// NOT release a sibling's key.
-			name:        "already-owned delete marker is not released",
-			setNXResult: false,
-			released:    false,
-		},
-	}
+	ctx := context.Background()
+	uc, _, mockRedisRepo := setupDeleteAllBalancesUseCase(t)
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
+	balance := deleteMarkerTestBalance("@alice", "usd")
+	tomb := deleteMarkerKeyFor(organizationID, ledgerID, balance)
 
-			ctx := context.Background()
-			uc, _, mockRedisRepo := setupDeleteAllBalancesUseCase(t)
+	mockRedisRepo.EXPECT().
+		SetNX(gomock.Any(), tomb, gomock.Any(), time.Duration(balanceDeleteMarkerTTLSeconds)).
+		Return(false, nil)
+	mockRedisRepo.EXPECT().DeleteIfValue(gomock.Any(), tomb, gomock.Any()).Times(0)
 
-			balance := deleteMarkerTestBalance("@alice", "usd")
-			tomb := utils.BalanceInternalKey(organizationID, ledgerID, "@alice#usd") + deleteMarkerKeySuffix
+	release, err := plantDeleteMarkersForTest(ctx, uc, organizationID, ledgerID, []*mmodel.Balance{balance})
+	assert.Nil(t, release)
 
-			mockRedisRepo.EXPECT().
-				SetNX(gomock.Any(), tomb, deleteMarkerValue, time.Duration(balanceDeleteMarkerTTLSeconds)).
-				Return(tt.setNXResult, nil)
+	var conflictErr midazpkg.EntityConflictError
+	assert.Error(t, err)
+	assert.True(t, errors.As(err, &conflictErr))
+	assert.Equal(t, constant.ErrBalancesCantBeDeleted.Error(), conflictErr.Code)
+}
 
-			release := uc.plantBalanceDeleteMarkers(ctx, organizationID, ledgerID, []*mmodel.Balance{balance})
-			assert.NotNil(t, release)
+func TestPlantBalanceDeleteMarkersLegacyCollisionFailsClosed(t *testing.T) {
+	t.Parallel()
 
-			if tt.released {
-				mockRedisRepo.EXPECT().Del(gomock.Any(), tomb).Return(nil)
-			} else {
-				mockRedisRepo.EXPECT().Del(gomock.Any(), tomb).Times(0)
-			}
+	organizationID := uuid.New()
+	ledgerID := uuid.New()
+	balance := deleteMarkerTestBalance("@alice", "usd")
+	currentMarker := deleteMarkerKeyFor(organizationID, ledgerID, balance)
+	legacyMarker := legacyDeleteMarkerKeyFor(organizationID, ledgerID, balance)
+	uc, _, mockRedisRepo := setupDeleteAllBalancesUseCase(t)
 
-			assert.NotPanics(t, func() { release() })
+	mockRedisRepo.EXPECT().SetNX(gomock.Any(), currentMarker, gomock.Any(), time.Duration(balanceDeleteMarkerTTLSeconds)).Return(true, nil)
+	mockRedisRepo.EXPECT().SetNX(gomock.Any(), legacyMarker, gomock.Any(), time.Duration(balanceDeleteMarkerTTLSeconds)).Return(false, nil)
+	mockRedisRepo.EXPECT().DeleteIfValue(gomock.Any(), currentMarker, gomock.Any()).Return(true, nil)
+	mockRedisRepo.EXPECT().DeleteIfValue(gomock.Any(), legacyMarker, gomock.Any()).Return(false, nil)
+
+	markers, err := uc.plantBalanceDeleteMarkerLease(context.Background(), organizationID, ledgerID, []*mmodel.Balance{balance})
+	assert.Nil(t, markers)
+	var conflictErr midazpkg.EntityConflictError
+	assert.ErrorAs(t, err, &conflictErr)
+	assert.Equal(t, constant.ErrBalancesCantBeDeleted.Error(), conflictErr.Code)
+}
+
+func TestPlantBalanceDeleteMarkersReleaseOwnsOnlyAcquiredMarkers(t *testing.T) {
+	t.Parallel()
+
+	organizationID := uuid.New()
+	ledgerID := uuid.New()
+	ctx := context.Background()
+	uc, _, mockRedisRepo := setupDeleteAllBalancesUseCase(t)
+
+	balance := deleteMarkerTestBalance("@alice", "usd")
+	tomb := deleteMarkerKeyFor(organizationID, ledgerID, balance)
+
+	mockRedisRepo.EXPECT().
+		SetNX(gomock.Any(), tomb, gomock.Any(), time.Duration(balanceDeleteMarkerTTLSeconds)).
+		Return(true, nil)
+	mockRedisRepo.EXPECT().
+		SetNX(gomock.Any(), legacyDeleteMarkerKeyFor(organizationID, ledgerID, balance), gomock.Any(), time.Duration(balanceDeleteMarkerTTLSeconds)).
+		Return(true, nil)
+	release, err := plantDeleteMarkersForTest(ctx, uc, organizationID, ledgerID, []*mmodel.Balance{balance})
+	assert.NoError(t, err)
+	assert.NotNil(t, release)
+
+	mockRedisRepo.EXPECT().DeleteIfValue(gomock.Any(), tomb, gomock.Any()).Return(true, nil)
+	mockRedisRepo.EXPECT().DeleteIfValue(gomock.Any(), legacyDeleteMarkerKeyFor(organizationID, ledgerID, balance), gomock.Any()).Return(true, nil)
+	release()
+}
+
+func TestPlantBalanceDeleteMarkersExpiredOwnerCannotReleaseNewOwnerMarker(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	organizationID := uuid.New()
+	ledgerID := uuid.New()
+	balance := deleteMarkerTestBalance("@alice", "usd")
+	tomb := deleteMarkerKeyFor(organizationID, ledgerID, balance)
+
+	uc, _, mockRedisRepo := setupDeleteAllBalancesUseCase(t)
+
+	var firstOwnerToken string
+	firstSet := mockRedisRepo.EXPECT().
+		SetNX(gomock.Any(), tomb, gomock.Any(), time.Duration(balanceDeleteMarkerTTLSeconds)).
+		DoAndReturn(func(_ context.Context, _ string, token string, _ time.Duration) (bool, error) {
+			firstOwnerToken = token
+			return true, nil
 		})
-	}
+	firstLegacySet := mockRedisRepo.EXPECT().
+		SetNX(gomock.Any(), legacyDeleteMarkerKeyFor(organizationID, ledgerID, balance), gomock.Any(), time.Duration(balanceDeleteMarkerTTLSeconds)).
+		DoAndReturn(func(_ context.Context, _ string, token string, _ time.Duration) (bool, error) {
+			assert.Equal(t, firstOwnerToken, token)
+			return true, nil
+		})
+
+	firstRelease, err := plantDeleteMarkersForTest(ctx, uc, organizationID, ledgerID, []*mmodel.Balance{balance})
+	assert.NoError(t, err)
+	assert.NotNil(t, firstRelease)
+
+	// Simulate the marker TTL expiring, followed by a new owner acquiring the same key.
+	var secondOwnerToken string
+	secondSet := mockRedisRepo.EXPECT().
+		SetNX(gomock.Any(), tomb, gomock.Any(), time.Duration(balanceDeleteMarkerTTLSeconds)).
+		DoAndReturn(func(_ context.Context, _ string, token string, _ time.Duration) (bool, error) {
+			secondOwnerToken = token
+
+			return true, nil
+		})
+	secondLegacySet := mockRedisRepo.EXPECT().
+		SetNX(gomock.Any(), legacyDeleteMarkerKeyFor(organizationID, ledgerID, balance), gomock.Any(), time.Duration(balanceDeleteMarkerTTLSeconds)).
+		DoAndReturn(func(_ context.Context, _ string, token string, _ time.Duration) (bool, error) {
+			assert.Equal(t, secondOwnerToken, token)
+			return true, nil
+		})
+	gomock.InOrder(firstSet, firstLegacySet, secondSet, secondLegacySet)
+
+	secondRelease, err := plantDeleteMarkersForTest(ctx, uc, organizationID, ledgerID, []*mmodel.Balance{balance})
+	assert.NoError(t, err)
+	assert.NotNil(t, secondRelease)
+	assert.NotEqual(t, firstOwnerToken, secondOwnerToken)
+
+	// The old owner must not delete the new owner's marker. Redis reports that the old token
+	// no longer owns the marker, so no unconditional Del is permitted.
+	mockRedisRepo.EXPECT().DeleteIfValue(gomock.Any(), tomb, firstOwnerToken).Return(false, nil)
+	mockRedisRepo.EXPECT().DeleteIfValue(gomock.Any(), legacyDeleteMarkerKeyFor(organizationID, ledgerID, balance), firstOwnerToken).Return(false, nil)
+	mockRedisRepo.EXPECT().Del(gomock.Any(), tomb).Times(0)
+	firstRelease()
+
+	mockRedisRepo.EXPECT().DeleteIfValue(gomock.Any(), tomb, secondOwnerToken).Return(true, nil)
+	mockRedisRepo.EXPECT().DeleteIfValue(gomock.Any(), legacyDeleteMarkerKeyFor(organizationID, ledgerID, balance), secondOwnerToken).Return(true, nil)
+	secondRelease()
+}
+
+func TestPlantBalanceDeleteMarkersReleaseUsesBoundedContextAfterParentCancellation(t *testing.T) {
+	t.Parallel()
+
+	organizationID := uuid.New()
+	ledgerID := uuid.New()
+	parentCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	uc, _, mockRedisRepo := setupDeleteAllBalancesUseCase(t)
+	balance := deleteMarkerTestBalance("@alice", "usd")
+	tomb := deleteMarkerKeyFor(organizationID, ledgerID, balance)
+
+	mockRedisRepo.EXPECT().
+		SetNX(gomock.Any(), tomb, gomock.Any(), time.Duration(balanceDeleteMarkerTTLSeconds)).
+		Return(true, nil)
+	mockRedisRepo.EXPECT().
+		SetNX(gomock.Any(), legacyDeleteMarkerKeyFor(organizationID, ledgerID, balance), gomock.Any(), time.Duration(balanceDeleteMarkerTTLSeconds)).
+		Return(true, nil)
+
+	release, err := plantDeleteMarkersForTest(parentCtx, uc, organizationID, ledgerID, []*mmodel.Balance{balance})
+	assert.NoError(t, err)
+	assert.NotNil(t, release)
+
+	mockRedisRepo.EXPECT().DeleteIfValue(gomock.Any(), tomb, gomock.Any()).DoAndReturn(
+		func(ctx context.Context, _ string, _ string) (bool, error) {
+			assert.NoError(t, ctx.Err(), "marker rollback must not inherit parent cancellation")
+			_, hasDeadline := ctx.Deadline()
+			assert.True(t, hasDeadline, "marker rollback must have a bounded deadline")
+
+			return true, nil
+		},
+	)
+	mockRedisRepo.EXPECT().DeleteIfValue(gomock.Any(), legacyDeleteMarkerKeyFor(organizationID, ledgerID, balance), gomock.Any()).DoAndReturn(
+		func(ctx context.Context, _ string, _ string) (bool, error) {
+			assert.NoError(t, ctx.Err())
+			_, hasDeadline := ctx.Deadline()
+			assert.True(t, hasDeadline)
+			return true, nil
+		},
+	)
+
+	release()
 }
 
 func TestEvictBalanceCaches(t *testing.T) {
@@ -225,7 +466,7 @@ func TestEvictBalanceCaches(t *testing.T) {
 		mockRedisRepo.EXPECT().Del(gomock.Any(), secondKey).Return(nil)
 
 		assert.NotPanics(t, func() {
-			uc.evictBalanceCaches(ctx, organizationID, ledgerID, []*mmodel.Balance{first, second})
+			uc.evictBalanceCaches(ctx, organizationID, ledgerID, []*mmodel.Balance{first, second}, nil)
 		})
 	})
 
@@ -242,7 +483,151 @@ func TestEvictBalanceCaches(t *testing.T) {
 
 		// A failed Del after a committed PG delete must not panic or propagate.
 		assert.NotPanics(t, func() {
-			uc.evictBalanceCaches(ctx, organizationID, ledgerID, []*mmodel.Balance{balance})
+			uc.evictBalanceCaches(ctx, organizationID, ledgerID, []*mmodel.Balance{balance}, nil)
 		})
 	})
+}
+
+func TestEvictBalanceCachesShortensOwnedMarkersAfterSuccessfulEviction(t *testing.T) {
+	t.Parallel()
+
+	organizationID := uuid.New()
+	ledgerID := uuid.New()
+	balance := deleteMarkerTestBalance("@alice", "usd")
+	marker := balanceDeleteMarker{
+		key:       deleteMarkerKeyFor(organizationID, ledgerID, balance),
+		legacyKey: legacyDeleteMarkerKeyFor(organizationID, ledgerID, balance),
+		token:     "owner-token",
+	}
+
+	uc, _, mockRedisRepo := setupDeleteAllBalancesUseCase(t)
+	mockRedisRepo.EXPECT().Del(gomock.Any(), balanceCacheKeyFor(organizationID, ledgerID, balance)).Return(nil)
+	mockRedisRepo.EXPECT().
+		ExpireIfValue(gomock.Any(), marker.key, marker.token, time.Duration(balanceDeleteMarkerShortTTLSeconds)).
+		Return(true, nil)
+	mockRedisRepo.EXPECT().
+		ExpireIfValue(gomock.Any(), marker.legacyKey, marker.token, time.Duration(balanceDeleteMarkerShortTTLSeconds)).
+		Return(true, nil)
+
+	uc.evictBalanceCaches(context.Background(), organizationID, ledgerID, []*mmodel.Balance{balance}, []balanceDeleteMarker{marker})
+}
+
+func TestEvictBalanceCachesReportsFailureAndKeepsLongMarkerWhenEvictionFails(t *testing.T) {
+	t.Parallel()
+
+	organizationID := uuid.New()
+	ledgerID := uuid.New()
+	balance := deleteMarkerTestBalance("@alice", "usd")
+	marker := balanceDeleteMarker{
+		key:       deleteMarkerKeyFor(organizationID, ledgerID, balance),
+		legacyKey: legacyDeleteMarkerKeyFor(organizationID, ledgerID, balance),
+		token:     "owner-token",
+	}
+
+	uc, _, mockRedisRepo := setupDeleteAllBalancesUseCase(t)
+	mockRedisRepo.EXPECT().
+		Del(gomock.Any(), balanceCacheKeyFor(organizationID, ledgerID, balance)).
+		Return(errors.New("redis unavailable"))
+	mockRedisRepo.EXPECT().
+		ExpireIfValue(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Times(0)
+
+	uc.evictBalanceCaches(context.Background(), organizationID, ledgerID, []*mmodel.Balance{balance}, []balanceDeleteMarker{marker})
+}
+
+func TestEvictBalanceCachesKeepsLongMarkerWhenShorteningFails(t *testing.T) {
+	t.Parallel()
+
+	organizationID := uuid.New()
+	ledgerID := uuid.New()
+	balance := deleteMarkerTestBalance("@alice", "usd")
+	marker := balanceDeleteMarker{
+		key:       deleteMarkerKeyFor(organizationID, ledgerID, balance),
+		legacyKey: legacyDeleteMarkerKeyFor(organizationID, ledgerID, balance),
+		token:     "owner-token",
+	}
+
+	uc, _, mockRedisRepo := setupDeleteAllBalancesUseCase(t)
+	mockRedisRepo.EXPECT().Del(gomock.Any(), balanceCacheKeyFor(organizationID, ledgerID, balance)).Return(nil)
+	mockRedisRepo.EXPECT().
+		ExpireIfValue(gomock.Any(), marker.key, marker.token, time.Duration(balanceDeleteMarkerShortTTLSeconds)).
+		Return(false, errors.New("redis unavailable"))
+	mockRedisRepo.EXPECT().
+		ExpireIfValue(gomock.Any(), marker.legacyKey, marker.token, time.Duration(balanceDeleteMarkerShortTTLSeconds)).
+		Return(false, nil)
+
+	uc.evictBalanceCaches(context.Background(), organizationID, ledgerID, []*mmodel.Balance{balance}, []balanceDeleteMarker{marker})
+}
+
+func TestEvictBalanceCachesUsesBoundedContextAfterParentCancellation(t *testing.T) {
+	t.Parallel()
+
+	organizationID := uuid.New()
+	ledgerID := uuid.New()
+	parentCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	balance := deleteMarkerTestBalance("@alice", "usd")
+	marker := balanceDeleteMarker{
+		key:       deleteMarkerKeyFor(organizationID, ledgerID, balance),
+		legacyKey: legacyDeleteMarkerKeyFor(organizationID, ledgerID, balance),
+		token:     "owner-token",
+	}
+
+	assertDetachedAndBounded := func(ctx context.Context, operation string) {
+		assert.NoError(t, ctx.Err(), operation+" must not inherit parent cancellation")
+		_, hasDeadline := ctx.Deadline()
+		assert.True(t, hasDeadline, operation+" must have a bounded deadline")
+	}
+
+	uc, _, mockRedisRepo := setupDeleteAllBalancesUseCase(t)
+	mockRedisRepo.EXPECT().
+		Del(gomock.Any(), balanceCacheKeyFor(organizationID, ledgerID, balance)).
+		DoAndReturn(func(ctx context.Context, _ string) error {
+			assertDetachedAndBounded(ctx, "cache eviction")
+
+			return nil
+		})
+	mockRedisRepo.EXPECT().
+		ExpireIfValue(gomock.Any(), marker.key, marker.token, time.Duration(balanceDeleteMarkerShortTTLSeconds)).
+		DoAndReturn(func(ctx context.Context, _ string, _ string, _ time.Duration) (bool, error) {
+			assertDetachedAndBounded(ctx, "marker shortening")
+
+			return true, nil
+		})
+	mockRedisRepo.EXPECT().
+		ExpireIfValue(gomock.Any(), marker.legacyKey, marker.token, time.Duration(balanceDeleteMarkerShortTTLSeconds)).
+		DoAndReturn(func(ctx context.Context, _ string, _ string, _ time.Duration) (bool, error) {
+			assertDetachedAndBounded(ctx, "legacy marker shortening")
+
+			return true, nil
+		})
+
+	uc.evictBalanceCaches(parentCtx, organizationID, ledgerID, []*mmodel.Balance{balance}, []balanceDeleteMarker{marker})
+}
+
+func TestEvictBalanceCachesSkipsShorteningOnMarkerLengthMismatch(t *testing.T) {
+	t.Parallel()
+
+	organizationID := uuid.New()
+	ledgerID := uuid.New()
+	first := deleteMarkerTestBalance("@alice", "usd")
+	second := deleteMarkerTestBalance("@bob", "brl")
+	marker := balanceDeleteMarker{
+		key:       deleteMarkerKeyFor(organizationID, ledgerID, first),
+		legacyKey: legacyDeleteMarkerKeyFor(organizationID, ledgerID, first),
+		token:     "owner-token",
+	}
+
+	uc, _, mockRedisRepo := setupDeleteAllBalancesUseCase(t)
+	mockRedisRepo.EXPECT().Del(gomock.Any(), balanceCacheKeyFor(organizationID, ledgerID, first)).Return(nil)
+	mockRedisRepo.EXPECT().Del(gomock.Any(), balanceCacheKeyFor(organizationID, ledgerID, second)).Return(nil)
+	// A marker slice that does not line up with the balance slice cannot be attributed to a
+	// balance, so every marker keeps its long TTL.
+	mockRedisRepo.EXPECT().
+		ExpireIfValue(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Times(0)
+
+	uc.evictBalanceCaches(context.Background(), organizationID, ledgerID,
+		[]*mmodel.Balance{first, second}, []balanceDeleteMarker{marker})
 }

--- a/components/ledger/internal/services/command/delete_all_balances_by_account_id.go
+++ b/components/ledger/internal/services/command/delete_all_balances_by_account_id.go
@@ -17,6 +17,7 @@ import (
 	"github.com/redis/go-redis/v9"
 	"go.opentelemetry.io/otel/attribute"
 
+	"github.com/LerianStudio/midaz/v4/components/ledger/pkg/readrouting"
 	"github.com/LerianStudio/midaz/v4/pkg"
 	"github.com/LerianStudio/midaz/v4/pkg/constant"
 	"github.com/LerianStudio/midaz/v4/pkg/mmodel"
@@ -37,10 +38,15 @@ func (uc *UseCase) DeleteAllBalancesByAccountID(ctx context.Context, organizatio
 	}()
 
 	span.SetAttributes(
+		attribute.String("app.request.organization_id", organizationID.String()),
+		attribute.String("app.request.ledger_id", ledgerID.String()),
+		attribute.String("app.request.account_id", accountID.String()),
 		attribute.String("app.request.request_id", requestID),
 	)
 
-	balances, err := uc.BalanceRepo.ListByAccountID(ctx, organizationID, ledgerID, accountID)
+	readCtx := readrouting.WithPrimaryRead(ctx)
+
+	balances, err := uc.BalanceRepo.ListByAccountID(readCtx, organizationID, ledgerID, accountID)
 	if err != nil {
 		libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Failed to get balances by account id on repo", err)
 
@@ -55,20 +61,32 @@ func (uc *UseCase) DeleteAllBalancesByAccountID(ctx context.Context, organizatio
 
 	// Plant delete markers so the honored-lock pre-pass rejects concurrent mutations for the
 	// whole delete. Release them only when the delete fails, so a rejected guard, permission
-	// flip, or soft-delete leaves the account usable; a successful delete lets the delete marker
-	// expire by its own TTL.
-	release := uc.plantBalanceDeleteMarkers(ctx, organizationID, ledgerID, balances)
+	// flip, or soft-delete leaves the account usable; a successful delete evicts each cache and
+	// shortens only the marker whose eviction succeeded.
+	markerLease, markerErr := uc.plantBalanceDeleteMarkerLease(ctx, organizationID, ledgerID, balances)
+	if markerErr != nil {
+		err = markerErr
+
+		var conflictErr pkg.EntityConflictError
+		if errors.As(err, &conflictErr) {
+			logger.Log(ctx, libLog.LevelWarn, "Balance delete marker is already owned", libLog.Err(err))
+		} else {
+			logger.Log(ctx, libLog.LevelError, "Error planting balance delete markers", libLog.Err(err))
+		}
+
+		return err
+	}
 
 	defer func() {
 		if err != nil {
-			release()
+			uc.releaseBalanceDeleteMarkers(ctx, markerLease)
 		}
 	}()
 
 	for _, balance := range balances {
 		cacheBalance, cacheErr := uc.TransactionRedisRepo.ListBalanceByKey(ctx, organizationID, ledgerID, fmt.Sprintf("%s#%s", balance.Alias, balance.Key))
 		if cacheErr != nil && !errors.Is(cacheErr, redis.Nil) {
-			libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Failed to get balance by key on redis", cacheErr)
+			libOpentelemetry.HandleSpanError(span, "Failed to get balance by key on redis", cacheErr)
 
 			logger.Log(ctx, libLog.LevelError, "Error getting balance by key on redis", libLog.Err(cacheErr))
 
@@ -76,7 +94,7 @@ func (uc *UseCase) DeleteAllBalancesByAccountID(ctx context.Context, organizatio
 		}
 
 		if cacheBalance != nil {
-			if !cacheBalance.Available.IsZero() || !cacheBalance.OnHold.IsZero() {
+			if balanceHasFunds(cacheBalance) {
 				err = pkg.ValidateBusinessError(constant.ErrBalancesCantBeDeleted, "ListBalanceByAccountIDAndKey")
 
 				libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Balance cannot be deleted because it still has funds in it.", err)
@@ -87,7 +105,7 @@ func (uc *UseCase) DeleteAllBalancesByAccountID(ctx context.Context, organizatio
 			}
 		}
 
-		if !balance.Available.IsZero() || !balance.OnHold.IsZero() {
+		if balanceHasFunds(balance) {
 			err = pkg.ValidateBusinessError(constant.ErrBalancesCantBeDeleted, "DeleteAllBalancesByAccountID")
 
 			libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Balance cannot be deleted because it still has funds in it.", err)
@@ -128,7 +146,7 @@ func (uc *UseCase) DeleteAllBalancesByAccountID(ctx context.Context, organizatio
 
 	// Drop the stale cache entries now that the rows are soft-deleted. Non-fatal: a failed
 	// eviction is logged and never fails the already-committed delete.
-	uc.evictBalanceCaches(ctx, organizationID, ledgerID, balances)
+	uc.evictBalanceCaches(ctx, organizationID, ledgerID, balances, markerLease)
 
 	return nil
 }

--- a/components/ledger/internal/services/command/delete_all_balances_by_account_id_test.go
+++ b/components/ledger/internal/services/command/delete_all_balances_by_account_id_test.go
@@ -20,30 +20,50 @@ import (
 
 	"github.com/LerianStudio/midaz/v4/components/ledger/internal/adapters/postgres/balance"
 	redis "github.com/LerianStudio/midaz/v4/components/ledger/internal/adapters/redis/transaction"
+	"github.com/LerianStudio/midaz/v4/components/ledger/pkg/readrouting"
 	midazpkg "github.com/LerianStudio/midaz/v4/pkg"
 	"github.com/LerianStudio/midaz/v4/pkg/constant"
 	"github.com/LerianStudio/midaz/v4/pkg/mmodel"
 )
 
-// expectDeleteMarkerPlant expects the delete marker SetNX write that precedes the funds guard.
+// expectDeleteMarkerPlant expects the current and legacy marker writes that precede the funds guard.
 func expectDeleteMarkerPlant(m *redis.MockRedisRepository, org, ledger uuid.UUID, b *mmodel.Balance) *gomock.Call {
-	return m.EXPECT().
-		SetNX(gomock.Any(), deleteMarkerKeyFor(org, ledger, b), deleteMarkerValue, time.Duration(balanceDeleteMarkerTTLSeconds)).
+	current := m.EXPECT().
+		SetNX(gomock.Any(), deleteMarkerKeyFor(org, ledger, b), gomock.Any(), time.Duration(balanceDeleteMarkerTTLSeconds)).
 		Return(true, nil)
+	m.EXPECT().
+		SetNX(gomock.Any(), legacyDeleteMarkerKeyFor(org, ledger, b), gomock.Any(), time.Duration(balanceDeleteMarkerTTLSeconds)).
+		Return(true, nil)
+	return current
 }
 
 // expectCacheEvict expects the cache-key Del that follows a committed soft-delete.
 func expectCacheEvict(m *redis.MockRedisRepository, org, ledger uuid.UUID, b *mmodel.Balance) *gomock.Call {
-	return m.EXPECT().
+	del := m.EXPECT().
 		Del(gomock.Any(), balanceCacheKeyFor(org, ledger, b)).
 		Return(nil)
+	expectMarkerShorten(m, org, ledger, b)
+	return del
 }
 
-// expectDeleteMarkerRelease expects the delete marker-key Del that runs only when the delete fails.
+func expectMarkerShorten(m *redis.MockRedisRepository, org, ledger uuid.UUID, b *mmodel.Balance) {
+	m.EXPECT().
+		ExpireIfValue(gomock.Any(), deleteMarkerKeyFor(org, ledger, b), gomock.Any(), time.Duration(balanceDeleteMarkerShortTTLSeconds)).
+		Return(true, nil)
+	m.EXPECT().
+		ExpireIfValue(gomock.Any(), legacyDeleteMarkerKeyFor(org, ledger, b), gomock.Any(), time.Duration(balanceDeleteMarkerShortTTLSeconds)).
+		Return(true, nil)
+}
+
+// expectDeleteMarkerRelease expects the ownership-checked marker release that runs only when the delete fails.
 func expectDeleteMarkerRelease(m *redis.MockRedisRepository, org, ledger uuid.UUID, b *mmodel.Balance) *gomock.Call {
-	return m.EXPECT().
-		Del(gomock.Any(), deleteMarkerKeyFor(org, ledger, b)).
-		Return(nil)
+	current := m.EXPECT().
+		DeleteIfValue(gomock.Any(), deleteMarkerKeyFor(org, ledger, b), gomock.Any()).
+		Return(true, nil)
+	m.EXPECT().
+		DeleteIfValue(gomock.Any(), legacyDeleteMarkerKeyFor(org, ledger, b), gomock.Any()).
+		Return(true, nil)
+	return current
 }
 
 func TestDeleteAllBalancesByAccountID(t *testing.T) {
@@ -74,6 +94,111 @@ func TestDeleteAllBalancesByAccountID(t *testing.T) {
 
 		err := uc.DeleteAllBalancesByAccountID(ctx, organizationID, ledgerID, accountID, requestID.String())
 		assert.NoError(t, err)
+	})
+
+	t.Run("already-owned marker aborts before cache guard", func(t *testing.T) {
+		uc, mockBalanceRepo, mockRedisRepo := setupDeleteAllBalancesUseCase(t)
+		balanceItem := newTestBalance(decimal.Zero, decimal.Zero)
+		markerKey := deleteMarkerKeyFor(organizationID, ledgerID, balanceItem)
+
+		mockBalanceRepo.EXPECT().
+			ListByAccountID(gomock.Any(), organizationID, ledgerID, accountID).
+			Return([]*mmodel.Balance{balanceItem}, nil)
+		mockRedisRepo.EXPECT().
+			SetNX(gomock.Any(), markerKey, gomock.Any(), time.Duration(balanceDeleteMarkerTTLSeconds)).
+			Return(false, nil)
+		mockRedisRepo.EXPECT().
+			DeleteIfValue(gomock.Any(), markerKey, gomock.Any()).
+			Times(0)
+		mockRedisRepo.EXPECT().
+			ListBalanceByKey(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			Times(0)
+		mockBalanceRepo.EXPECT().
+			UpdateAllByAccountID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			Times(0)
+		mockBalanceRepo.EXPECT().
+			DeleteAllByIDs(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			Times(0)
+
+		err := uc.DeleteAllBalancesByAccountID(ctx, organizationID, ledgerID, accountID, requestID.String())
+
+		var conflictErr midazpkg.EntityConflictError
+		assert.Error(t, err)
+		assert.True(t, errors.As(err, &conflictErr))
+		assert.Equal(t, constant.ErrBalancesCantBeDeleted.Error(), conflictErr.Code)
+	})
+
+	t.Run("marker redis error aborts before cache guard", func(t *testing.T) {
+		uc, mockBalanceRepo, mockRedisRepo := setupDeleteAllBalancesUseCase(t)
+		balanceItem := newTestBalance(decimal.Zero, decimal.Zero)
+		markerKey := deleteMarkerKeyFor(organizationID, ledgerID, balanceItem)
+		expectedErr := errors.New("marker redis unavailable")
+
+		mockBalanceRepo.EXPECT().
+			ListByAccountID(gomock.Any(), organizationID, ledgerID, accountID).
+			Return([]*mmodel.Balance{balanceItem}, nil)
+		mockRedisRepo.EXPECT().
+			SetNX(gomock.Any(), markerKey, gomock.Any(), time.Duration(balanceDeleteMarkerTTLSeconds)).
+			Return(false, expectedErr)
+		mockRedisRepo.EXPECT().
+			DeleteIfValue(gomock.Any(), markerKey, gomock.Any()).
+			Times(0)
+		mockRedisRepo.EXPECT().
+			ListBalanceByKey(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			Times(0)
+		mockBalanceRepo.EXPECT().
+			UpdateAllByAccountID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			Times(0)
+		mockBalanceRepo.EXPECT().
+			DeleteAllByIDs(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			Times(0)
+
+		err := uc.DeleteAllBalancesByAccountID(ctx, organizationID, ledgerID, accountID, requestID.String())
+		assert.ErrorIs(t, err, expectedErr)
+	})
+
+	t.Run("partial marker acquisition rolls back only owned marker", func(t *testing.T) {
+		uc, mockBalanceRepo, mockRedisRepo := setupDeleteAllBalancesUseCase(t)
+		first := newTestBalanceWithIdentity(decimal.Zero, decimal.Zero, "first", "default")
+		second := newTestBalanceWithIdentity(decimal.Zero, decimal.Zero, "second", "default")
+		firstMarker := deleteMarkerKeyFor(organizationID, ledgerID, first)
+		secondMarker := deleteMarkerKeyFor(organizationID, ledgerID, second)
+		expectedErr := errors.New("marker redis unavailable")
+
+		mockBalanceRepo.EXPECT().
+			ListByAccountID(gomock.Any(), organizationID, ledgerID, accountID).
+			Return([]*mmodel.Balance{first, second}, nil)
+		firstSet := mockRedisRepo.EXPECT().
+			SetNX(gomock.Any(), firstMarker, gomock.Any(), time.Duration(balanceDeleteMarkerTTLSeconds)).
+			Return(true, nil)
+		firstLegacySet := mockRedisRepo.EXPECT().
+			SetNX(gomock.Any(), legacyDeleteMarkerKeyFor(organizationID, ledgerID, first), gomock.Any(), time.Duration(balanceDeleteMarkerTTLSeconds)).
+			Return(true, nil)
+		secondSet := mockRedisRepo.EXPECT().
+			SetNX(gomock.Any(), secondMarker, gomock.Any(), time.Duration(balanceDeleteMarkerTTLSeconds)).
+			Return(false, expectedErr)
+		rollback := mockRedisRepo.EXPECT().
+			DeleteIfValue(gomock.Any(), firstMarker, gomock.Any()).
+			Return(true, nil)
+		legacyRollback := mockRedisRepo.EXPECT().
+			DeleteIfValue(gomock.Any(), legacyDeleteMarkerKeyFor(organizationID, ledgerID, first), gomock.Any()).
+			Return(true, nil)
+		gomock.InOrder(firstSet, firstLegacySet, secondSet, rollback, legacyRollback)
+		mockRedisRepo.EXPECT().
+			DeleteIfValue(gomock.Any(), secondMarker, gomock.Any()).
+			Times(0)
+		mockRedisRepo.EXPECT().
+			ListBalanceByKey(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			Times(0)
+		mockBalanceRepo.EXPECT().
+			UpdateAllByAccountID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			Times(0)
+		mockBalanceRepo.EXPECT().
+			DeleteAllByIDs(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			Times(0)
+
+		err := uc.DeleteAllBalancesByAccountID(ctx, organizationID, ledgerID, accountID, requestID.String())
+		assert.ErrorIs(t, err, expectedErr)
 	})
 
 	t.Run("redis lookup error", func(t *testing.T) {
@@ -120,6 +245,27 @@ func TestDeleteAllBalancesByAccountID(t *testing.T) {
 	t.Run("balances with funds remaining prevent deletion", func(t *testing.T) {
 		uc, mockBalanceRepo, mockRedisRepo := setupDeleteAllBalancesUseCase(t)
 		balanceItem := newTestBalance(decimal.NewFromInt(10), decimal.Zero)
+
+		mockBalanceRepo.EXPECT().
+			ListByAccountID(gomock.Any(), organizationID, ledgerID, accountID).
+			Return([]*mmodel.Balance{balanceItem}, nil)
+		expectDeleteMarkerPlant(mockRedisRepo, organizationID, ledgerID, balanceItem)
+		mockRedisRepo.EXPECT().
+			ListBalanceByKey(gomock.Any(), organizationID, ledgerID, balanceRedisKey(balanceItem)).
+			Return(nil, nil)
+		expectDeleteMarkerRelease(mockRedisRepo, organizationID, ledgerID, balanceItem)
+
+		err := uc.DeleteAllBalancesByAccountID(ctx, organizationID, ledgerID, accountID, requestID.String())
+
+		var conflictErr midazpkg.EntityConflictError
+		assert.Error(t, err)
+		assert.True(t, errors.As(err, &conflictErr))
+		assert.Equal(t, constant.ErrBalancesCantBeDeleted.Error(), conflictErr.Code)
+	})
+
+	t.Run("overdraft debt prevents deletion", func(t *testing.T) {
+		uc, mockBalanceRepo, mockRedisRepo := setupDeleteAllBalancesUseCase(t)
+		balanceItem := newTestBalanceWithOverdraft(decimal.Zero, decimal.Zero, decimal.NewFromInt(25))
 
 		mockBalanceRepo.EXPECT().
 			ListByAccountID(gomock.Any(), organizationID, ledgerID, accountID).
@@ -245,6 +391,30 @@ func TestDeleteAllBalancesByAccountID(t *testing.T) {
 	})
 }
 
+func TestDeleteAllBalancesByAccountID_InitialReadUsesPrimaryIntent(t *testing.T) {
+	organizationID := uuid.New()
+	ledgerID := uuid.New()
+	accountID := uuid.New()
+	requestID := uuid.Must(libCommons.GenerateUUIDv7())
+
+	uc, mockBalanceRepo, _ := setupDeleteAllBalancesUseCase(t)
+	var observedCtx context.Context
+
+	mockBalanceRepo.EXPECT().
+		ListByAccountID(gomock.Any(), organizationID, ledgerID, accountID).
+		DoAndReturn(func(ctx context.Context, _, _, _ uuid.UUID) ([]*mmodel.Balance, error) {
+			observedCtx = ctx
+
+			return nil, nil
+		})
+
+	err := uc.DeleteAllBalancesByAccountID(context.Background(), organizationID, ledgerID, accountID, requestID.String())
+
+	assert.NoError(t, err)
+	assert.True(t, readrouting.IsPrimaryRead(observedCtx),
+		"the initial balance read must carry the primary-read intent")
+}
+
 // TestDeleteAllBalancesByAccountIDBlockThenEvict locks the block-then-evict ordering: the
 // delete marker is planted BEFORE the funds guard reads, the cache is evicted AFTER the soft
 // delete commits, the delete marker is released ONLY when the delete fails, and a failed eviction
@@ -269,7 +439,10 @@ func TestDeleteAllBalancesByAccountIDBlockThenEvict(t *testing.T) {
 			Return([]*mmodel.Balance{balanceItem}, nil)
 
 		plant := mockRedisRepo.EXPECT().
-			SetNX(gomock.Any(), deleteMarkerKeyFor(organizationID, ledgerID, balanceItem), deleteMarkerValue, time.Duration(balanceDeleteMarkerTTLSeconds)).
+			SetNX(gomock.Any(), deleteMarkerKeyFor(organizationID, ledgerID, balanceItem), gomock.Any(), time.Duration(balanceDeleteMarkerTTLSeconds)).
+			Return(true, nil)
+		legacyPlant := mockRedisRepo.EXPECT().
+			SetNX(gomock.Any(), legacyDeleteMarkerKeyFor(organizationID, ledgerID, balanceItem), gomock.Any(), time.Duration(balanceDeleteMarkerTTLSeconds)).
 			Return(true, nil)
 		guard := mockRedisRepo.EXPECT().
 			ListBalanceByKey(gomock.Any(), organizationID, ledgerID, balanceRedisKey(balanceItem)).
@@ -283,9 +456,10 @@ func TestDeleteAllBalancesByAccountIDBlockThenEvict(t *testing.T) {
 		evict := mockRedisRepo.EXPECT().
 			Del(gomock.Any(), balanceCacheKeyFor(organizationID, ledgerID, balanceItem)).
 			Return(nil)
+		expectMarkerShorten(mockRedisRepo, organizationID, ledgerID, balanceItem)
 
 		// delete marker-before-guard and evict-after-soft-delete.
-		gomock.InOrder(plant, guard)
+		gomock.InOrder(plant, legacyPlant, guard)
 		gomock.InOrder(del, evict)
 
 		err := uc.DeleteAllBalancesByAccountID(ctx, organizationID, ledgerID, accountID, requestID.String())
@@ -414,6 +588,13 @@ func TestDeleteAllBalancesByAccountIDCacheMissFundsGuard(t *testing.T) {
 			expectProceed: false,
 		},
 		{
+			name:          "cached overdraft debt prevents deletion",
+			balance:       newTestBalance(decimal.Zero, decimal.Zero),
+			cacheBalance:  newTestBalanceWithOverdraft(decimal.Zero, decimal.Zero, decimal.NewFromInt(25)),
+			cacheErr:      nil,
+			expectProceed: false,
+		},
+		{
 			name:          "cached zero-funds but postgres funds prevents deletion",
 			balance:       newTestBalance(decimal.NewFromInt(3), decimal.Zero),
 			cacheBalance:  &mmodel.Balance{},
@@ -473,8 +654,8 @@ func TestDeleteAllBalancesByAccountIDCacheMissFundsGuard(t *testing.T) {
 
 		uc, mockBalanceRepo, mockRedisRepo := setupDeleteAllBalancesUseCase(t)
 
-		zeroFundsBalance := newTestBalance(decimal.Zero, decimal.Zero)
-		onHoldFundsBalance := newTestBalance(decimal.Zero, decimal.NewFromInt(5))
+		zeroFundsBalance := newTestBalanceWithIdentity(decimal.Zero, decimal.Zero, "zero", "default")
+		onHoldFundsBalance := newTestBalanceWithIdentity(decimal.Zero, decimal.NewFromInt(5), "on-hold", "default")
 
 		mockBalanceRepo.EXPECT().
 			ListByAccountID(gomock.Any(), organizationID, ledgerID, accountID).
@@ -532,6 +713,21 @@ func newTestBalance(available, onHold decimal.Decimal) *mmodel.Balance {
 		Available: available,
 		OnHold:    onHold,
 	}
+}
+
+func newTestBalanceWithOverdraft(available, onHold, overdraftUsed decimal.Decimal) *mmodel.Balance {
+	balance := newTestBalance(available, onHold)
+	balance.OverdraftUsed = overdraftUsed
+
+	return balance
+}
+
+func newTestBalanceWithIdentity(available, onHold decimal.Decimal, alias, key string) *mmodel.Balance {
+	balance := newTestBalance(available, onHold)
+	balance.Alias = alias
+	balance.Key = key
+
+	return balance
 }
 
 func balanceRedisKey(b *mmodel.Balance) string {
@@ -628,4 +824,94 @@ func TestUpdateBalanceTransferPermissions(t *testing.T) {
 
 func boolPtr(v bool) *bool {
 	return &v
+}
+
+// TestDeleteAllBalancesByAccountIDShortensOnlyEvictedMarkers locks the per-balance alignment
+// between an eviction and its marker lease: the balance whose cache key survived a failed Del
+// keeps its long marker, while the balance that was evicted has both of its markers shortened.
+func TestDeleteAllBalancesByAccountIDShortensOnlyEvictedMarkers(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	organizationID := uuid.New()
+	ledgerID := uuid.New()
+	accountID := uuid.New()
+	requestID := uuid.Must(libCommons.GenerateUUIDv7())
+
+	uc, mockBalanceRepo, mockRedisRepo := setupDeleteAllBalancesUseCase(t)
+
+	first := newTestBalanceWithIdentity(decimal.Zero, decimal.Zero, "evict-fails", "default")
+	second := newTestBalanceWithIdentity(decimal.Zero, decimal.Zero, "evict-succeeds", "default")
+
+	mockBalanceRepo.EXPECT().
+		ListByAccountID(gomock.Any(), organizationID, ledgerID, accountID).
+		Return([]*mmodel.Balance{first, second}, nil)
+	expectDeleteMarkerPlant(mockRedisRepo, organizationID, ledgerID, first)
+	expectDeleteMarkerPlant(mockRedisRepo, organizationID, ledgerID, second)
+	mockRedisRepo.EXPECT().
+		ListBalanceByKey(gomock.Any(), organizationID, ledgerID, balanceRedisKey(first)).
+		Return(nil, goredis.Nil)
+	mockRedisRepo.EXPECT().
+		ListBalanceByKey(gomock.Any(), organizationID, ledgerID, balanceRedisKey(second)).
+		Return(nil, goredis.Nil)
+	mockBalanceRepo.EXPECT().
+		UpdateAllByAccountID(gomock.Any(), organizationID, ledgerID, accountID, gomock.Any()).
+		Return(nil)
+	mockBalanceRepo.EXPECT().
+		DeleteAllByIDs(gomock.Any(), organizationID, ledgerID, gomock.Any()).
+		Return(nil)
+
+	mockRedisRepo.EXPECT().
+		Del(gomock.Any(), balanceCacheKeyFor(organizationID, ledgerID, first)).
+		Return(errors.New("evict failed"))
+	mockRedisRepo.EXPECT().
+		Del(gomock.Any(), balanceCacheKeyFor(organizationID, ledgerID, second)).
+		Return(nil)
+
+	// A surviving cache snapshot must keep its long marker, so the failed eviction shortens nothing.
+	mockRedisRepo.EXPECT().
+		ExpireIfValue(gomock.Any(), deleteMarkerKeyFor(organizationID, ledgerID, first), gomock.Any(), gomock.Any()).
+		Times(0)
+	mockRedisRepo.EXPECT().
+		ExpireIfValue(gomock.Any(), legacyDeleteMarkerKeyFor(organizationID, ledgerID, first), gomock.Any(), gomock.Any()).
+		Times(0)
+	expectMarkerShorten(mockRedisRepo, organizationID, ledgerID, second)
+
+	err := uc.DeleteAllBalancesByAccountID(ctx, organizationID, ledgerID, accountID, requestID.String())
+	assert.NoError(t, err)
+}
+
+// TestDeleteAllBalancesByAccountIDMalformedCachedOverdraftFailsClosed locks the cascade half of
+// the shared rule: an unreadable cached OverdraftUsed is reported by ListBalanceByKey and must
+// abort the delete with the markers released, never be flattened to zero debt.
+func TestDeleteAllBalancesByAccountIDMalformedCachedOverdraftFailsClosed(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	organizationID := uuid.New()
+	ledgerID := uuid.New()
+	accountID := uuid.New()
+	requestID := uuid.Must(libCommons.GenerateUUIDv7())
+
+	uc, mockBalanceRepo, mockRedisRepo := setupDeleteAllBalancesUseCase(t)
+	balanceItem := newTestBalance(decimal.Zero, decimal.Zero)
+	expectedErr := errors.New("failed to parse overdraft used from balance cache: can't convert not-a-decimal to decimal")
+
+	mockBalanceRepo.EXPECT().
+		ListByAccountID(gomock.Any(), organizationID, ledgerID, accountID).
+		Return([]*mmodel.Balance{balanceItem}, nil)
+	expectDeleteMarkerPlant(mockRedisRepo, organizationID, ledgerID, balanceItem)
+	mockRedisRepo.EXPECT().
+		ListBalanceByKey(gomock.Any(), organizationID, ledgerID, balanceRedisKey(balanceItem)).
+		Return(nil, expectedErr)
+	expectDeleteMarkerRelease(mockRedisRepo, organizationID, ledgerID, balanceItem)
+	mockBalanceRepo.EXPECT().
+		UpdateAllByAccountID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Times(0)
+	mockBalanceRepo.EXPECT().
+		DeleteAllByIDs(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Times(0)
+
+	err := uc.DeleteAllBalancesByAccountID(ctx, organizationID, ledgerID, accountID, requestID.String())
+	assert.ErrorIs(t, err, expectedErr)
 }

--- a/components/ledger/internal/services/command/delete_balance.go
+++ b/components/ledger/internal/services/command/delete_balance.go
@@ -6,6 +6,9 @@ package command
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
 	"time"
 
 	libObservability "github.com/LerianStudio/lib-observability/v4"
@@ -13,8 +16,11 @@ import (
 	libOpentelemetry "github.com/LerianStudio/lib-observability/v4/tracing"
 	libStreaming "github.com/LerianStudio/lib-streaming/v4"
 	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 
+	"github.com/LerianStudio/midaz/v4/components/ledger/pkg/readrouting"
 	"github.com/LerianStudio/midaz/v4/pkg"
 	"github.com/LerianStudio/midaz/v4/pkg/constant"
 	"github.com/LerianStudio/midaz/v4/pkg/mmodel"
@@ -29,13 +35,21 @@ func (uc *UseCase) DeleteBalance(ctx context.Context, organizationID, ledgerID, 
 	ctx, span := tracer.Start(ctx, "exec.delete_balance")
 	defer span.End()
 
+	span.SetAttributes(
+		attribute.String("app.request.organization_id", organizationID.String()),
+		attribute.String("app.request.ledger_id", ledgerID.String()),
+		attribute.String("app.request.balance_id", balanceID.String()),
+	)
+
 	start := time.Now()
 
 	defer func() {
 		utils.RecordDomainOperation(ctx, uc.MetricsFactory, logger, "ledger", "delete_balance", start, err)
 	}()
 
-	balance, err := uc.BalanceRepo.Find(ctx, organizationID, ledgerID, balanceID)
+	readCtx := readrouting.WithPrimaryRead(ctx)
+
+	balance, err := uc.BalanceRepo.Find(readCtx, organizationID, ledgerID, balanceID)
 	if err != nil {
 		libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Failed to get balance on repo by id", err)
 		logger.Log(ctx, libLog.LevelError, "Error getting balance", libLog.Err(err))
@@ -57,24 +71,84 @@ func (uc *UseCase) DeleteBalance(ctx context.Context, organizationID, ledgerID, 
 
 	// Plant a delete marker so the honored-lock pre-pass rejects concurrent mutations while the
 	// delete is in flight. Release it only when the delete fails, so a rejected guard or a
-	// failed soft-delete leaves the balance usable; a successful delete lets the delete marker
-	// expire by its own TTL.
+	// failed soft-delete leaves the balance usable. Successful deletion evicts the cache and then
+	// shortens the owned marker atomically; a failed eviction deliberately keeps the long TTL.
+	var markerLease []balanceDeleteMarker
+
 	if balance != nil {
-		release := uc.plantBalanceDeleteMarkers(ctx, organizationID, ledgerID, []*mmodel.Balance{balance})
+		markers, markerErr := uc.plantBalanceDeleteMarkerLease(ctx, organizationID, ledgerID, []*mmodel.Balance{balance})
+		if markerErr != nil {
+			err = markerErr
+
+			var conflictErr pkg.EntityConflictError
+			if errors.As(err, &conflictErr) {
+				logger.Log(ctx, libLog.LevelWarn, "Balance delete marker is already owned", libLog.Err(err))
+			} else {
+				logger.Log(ctx, libLog.LevelError, "Error planting balance delete marker", libLog.Err(err))
+			}
+
+			return err
+		}
+
+		markerLease = markers
 
 		defer func() {
 			if err != nil {
-				release()
+				uc.releaseBalanceDeleteMarkers(ctx, markers)
 			}
 		}()
 	}
 
-	if balance != nil && (!balance.Available.IsZero() || !balance.OnHold.IsZero()) {
+	if balanceHasFunds(balance) {
 		err = pkg.ValidateBusinessError(constant.ErrBalancesCantBeDeleted, constant.EntityBalance)
 		libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Balance cannot be deleted because it still has funds in it.", err)
 		logger.Log(ctx, libLog.LevelWarn, "Error deleting balance", libLog.Err(err))
 
 		return err
+	}
+
+	if balance != nil {
+		// The Redis snapshot may contain a newer balance than PostgreSQL while its
+		// transaction is waiting for asynchronous synchronization. A cache hit must
+		// therefore pass the same funds guard before the persisted row is deleted.
+		cacheKey := balanceCacheKeyFor(organizationID, ledgerID, balance)
+
+		cacheValue, cacheErr := uc.TransactionRedisRepo.Get(ctx, cacheKey)
+		if cacheErr != nil {
+			err = fmt.Errorf("failed to get balance cache value: %w", cacheErr)
+			libOpentelemetry.HandleSpanError(span, "Failed to get balance cache value on redis", err)
+			logger.Log(ctx, libLog.LevelError, "Error getting balance cache value", libLog.Err(err))
+
+			return err
+		}
+
+		if cacheValue != "" {
+			cachedBalance := mmodel.BalanceRedis{}
+			if decodeErr := json.Unmarshal([]byte(cacheValue), &cachedBalance); decodeErr != nil {
+				err = fmt.Errorf("failed to decode balance cache value: %w", decodeErr)
+				libOpentelemetry.HandleSpanError(span, "Failed to decode balance cache value from redis", err)
+				logger.Log(ctx, libLog.LevelError, "Error decoding balance cache value", libLog.Err(err))
+
+				return err
+			}
+
+			hasFunds, overdraftErr := balanceRedisHasFunds(cachedBalance)
+			if overdraftErr != nil {
+				err = fmt.Errorf("failed to parse overdraft used from balance cache: %w", overdraftErr)
+				libOpentelemetry.HandleSpanError(span, "Failed to parse overdraft used from balance cache", err)
+				logger.Log(ctx, libLog.LevelError, "Error parsing overdraft used from balance cache", libLog.Err(err))
+
+				return err
+			}
+
+			if hasFunds {
+				err = pkg.ValidateBusinessError(constant.ErrBalancesCantBeDeleted, constant.EntityBalance)
+				libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Balance cannot be deleted because it still has funds in its cache snapshot", err)
+				logger.Log(ctx, libLog.LevelWarn, "Error deleting balance", libLog.Err(err))
+
+				return err
+			}
+		}
 	}
 
 	err = uc.BalanceRepo.Delete(ctx, organizationID, ledgerID, balanceID)
@@ -88,12 +162,39 @@ func (uc *UseCase) DeleteBalance(ctx context.Context, organizationID, ledgerID, 
 	// Drop the stale cache entry now that the row is soft-deleted. Non-fatal: a failed eviction
 	// is logged and never fails the already-committed delete.
 	if balance != nil {
-		uc.evictBalanceCaches(ctx, organizationID, ledgerID, []*mmodel.Balance{balance})
+		uc.evictBalanceCaches(ctx, organizationID, ledgerID, []*mmodel.Balance{balance}, markerLease)
 	}
 
 	uc.emitBalanceDeletedEvent(ctx, span, logger, balance, time.Now())
 
 	return nil
+}
+
+// balanceHasFunds reports whether a persisted balance still carries spendable, held, or
+// overdraft debt. OverdraftUsed is part of the balance position, so a zero available amount does
+// not make the balance safe to delete while overdraft debt remains outstanding.
+func balanceHasFunds(balance *mmodel.Balance) bool {
+	return balance != nil &&
+		(!balance.Available.IsZero() || !balance.OnHold.IsZero() || !balance.OverdraftUsed.IsZero())
+}
+
+// balanceRedisHasFunds applies the same deletion guard to a Redis snapshot. BalanceRedis stores
+// OverdraftUsed as a decimal string for Lua compatibility: an empty value is the pre-overdraft
+// snapshot shape and reads as zero, while a non-empty malformed value returns an error so the
+// delete fails closed rather than silently treating unreadable debt as zero.
+func balanceRedisHasFunds(balance mmodel.BalanceRedis) (bool, error) {
+	parsedOverdraftUsed := decimal.Zero
+
+	if balance.OverdraftUsed != "" {
+		parsed, err := decimal.NewFromString(balance.OverdraftUsed)
+		if err != nil {
+			return false, err
+		}
+
+		parsedOverdraftUsed = parsed
+	}
+
+	return !balance.Available.IsZero() || !balance.OnHold.IsZero() || !parsedOverdraftUsed.IsZero(), nil
 }
 
 // emitBalanceDeletedEvent publishes the balance.deleted event for a

--- a/components/ledger/internal/services/command/delete_balance.go
+++ b/components/ledger/internal/services/command/delete_balance.go
@@ -29,6 +29,8 @@ import (
 	"github.com/LerianStudio/midaz/v4/pkg/utils"
 )
 
+// DeleteBalance soft-deletes a balance once both its persisted row and its Redis snapshot
+// show no funds, holding a delete marker so no transaction mutates the balance meanwhile.
 func (uc *UseCase) DeleteBalance(ctx context.Context, organizationID, ledgerID, balanceID uuid.UUID) (err error) {
 	logger, tracer, _, _ := libObservability.NewTrackingFromContext(ctx)
 

--- a/components/ledger/internal/services/command/delete_balance_streaming_test.go
+++ b/components/ledger/internal/services/command/delete_balance_streaming_test.go
@@ -58,8 +58,16 @@ func newDeleteBalanceStreamingTestUseCase(t *testing.T, ctrl *gomock.Controller,
 		Return(true, nil).
 		AnyTimes()
 	mockRedisRepo.EXPECT().
+		Get(gomock.Any(), gomock.Any()).
+		Return("", nil).
+		AnyTimes()
+	mockRedisRepo.EXPECT().
 		Del(gomock.Any(), gomock.Any()).
 		Return(nil).
+		AnyTimes()
+	mockRedisRepo.EXPECT().
+		ExpireIfValue(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(true, nil).
 		AnyTimes()
 
 	return &UseCase{

--- a/components/ledger/internal/services/command/delete_balance_test.go
+++ b/components/ledger/internal/services/command/delete_balance_test.go
@@ -6,11 +6,14 @@ package command
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/LerianStudio/midaz/v4/components/ledger/internal/adapters/postgres/balance"
 	redis "github.com/LerianStudio/midaz/v4/components/ledger/internal/adapters/redis/transaction"
+	"github.com/LerianStudio/midaz/v4/components/ledger/pkg/readrouting"
 	midazpkg "github.com/LerianStudio/midaz/v4/pkg"
 	"github.com/LerianStudio/midaz/v4/pkg/constant"
 	"github.com/LerianStudio/midaz/v4/pkg/mmodel"
@@ -42,23 +45,26 @@ func TestDeleteBalance(t *testing.T) {
 
 	t.Run("balance with funds cannot be deleted", func(t *testing.T) {
 		cases := []struct {
-			name      string
-			available decimal.Decimal
-			onHold    decimal.Decimal
+			name          string
+			available     decimal.Decimal
+			onHold        decimal.Decimal
+			overdraftUsed decimal.Decimal
 		}{
-			{"available only", decimal.NewFromInt(100), decimal.Zero},
-			{"on-hold only", decimal.Zero, decimal.NewFromInt(50)},
+			{name: "available only", available: decimal.NewFromInt(100)},
+			{name: "on-hold only", onHold: decimal.NewFromInt(50)},
+			{name: "overdraft used", overdraftUsed: decimal.NewFromInt(25)},
 		}
 
 		for _, tc := range cases {
 			t.Run(tc.name, func(t *testing.T) {
 				uc, mockBalanceRepo, mockRedisRepo := setupDeleteBalanceUseCase(t)
 				bal := &mmodel.Balance{
-					ID:        balanceID.String(),
-					Alias:     "alias",
-					Key:       "key",
-					Available: tc.available,
-					OnHold:    tc.onHold,
+					ID:            balanceID.String(),
+					Alias:         "alias",
+					Key:           "key",
+					Available:     tc.available,
+					OnHold:        tc.onHold,
+					OverdraftUsed: tc.overdraftUsed,
 				}
 
 				mockBalanceRepo.EXPECT().
@@ -92,6 +98,9 @@ func TestDeleteBalance(t *testing.T) {
 			Find(gomock.Any(), organizationID, ledgerID, balanceID).
 			Return(zeroBalance, nil)
 		expectDeleteMarkerPlant(mockRedisRepo, organizationID, ledgerID, zeroBalance)
+		mockRedisRepo.EXPECT().
+			Get(gomock.Any(), balanceCacheKeyFor(organizationID, ledgerID, zeroBalance)).
+			Return("", nil)
 		mockBalanceRepo.EXPECT().
 			Delete(gomock.Any(), organizationID, ledgerID, balanceID).
 			Return(expectedErr)
@@ -133,6 +142,9 @@ func TestDeleteBalance(t *testing.T) {
 			Find(gomock.Any(), organizationID, ledgerID, balanceID).
 			Return(zeroBalance, nil)
 		expectDeleteMarkerPlant(mockRedisRepo, organizationID, ledgerID, zeroBalance)
+		mockRedisRepo.EXPECT().
+			Get(gomock.Any(), balanceCacheKeyFor(organizationID, ledgerID, zeroBalance)).
+			Return("", nil)
 		mockBalanceRepo.EXPECT().
 			Delete(gomock.Any(), organizationID, ledgerID, balanceID).
 			Return(nil)
@@ -142,6 +154,32 @@ func TestDeleteBalance(t *testing.T) {
 
 		assert.NoError(t, err)
 	})
+}
+
+func TestDeleteBalance_InitialReadUsesPrimaryIntent(t *testing.T) {
+	organizationID := uuid.New()
+	ledgerID := uuid.New()
+	balanceID := uuid.New()
+
+	uc, mockBalanceRepo, _ := setupDeleteBalanceUseCase(t)
+	var observedCtx context.Context
+
+	mockBalanceRepo.EXPECT().
+		Find(gomock.Any(), organizationID, ledgerID, balanceID).
+		DoAndReturn(func(ctx context.Context, _, _, _ uuid.UUID) (*mmodel.Balance, error) {
+			observedCtx = ctx
+
+			return nil, nil
+		})
+	mockBalanceRepo.EXPECT().
+		Delete(gomock.Any(), organizationID, ledgerID, balanceID).
+		Return(nil)
+
+	err := uc.DeleteBalance(context.Background(), organizationID, ledgerID, balanceID)
+
+	assert.NoError(t, err)
+	assert.True(t, readrouting.IsPrimaryRead(observedCtx),
+		"the initial balance read must carry the primary-read intent")
 }
 
 // TestDeleteBalanceBlockThenEvict locks the block-then-evict ordering for the single-balance
@@ -176,13 +214,16 @@ func TestDeleteBalanceBlockThenEvict(t *testing.T) {
 			Find(gomock.Any(), organizationID, ledgerID, balanceID).
 			Return(bal, nil)
 		plant := expectDeleteMarkerPlant(mockRedisRepo, organizationID, ledgerID, bal)
+		get := mockRedisRepo.EXPECT().
+			Get(gomock.Any(), balanceCacheKeyFor(organizationID, ledgerID, bal)).
+			Return("", nil)
 		del := mockBalanceRepo.EXPECT().
 			Delete(gomock.Any(), organizationID, ledgerID, balanceID).
 			Return(nil)
 		evict := expectCacheEvict(mockRedisRepo, organizationID, ledgerID, bal)
 
 		// plant-before-delete and evict-after-soft-delete.
-		gomock.InOrder(plant, del, evict)
+		gomock.InOrder(plant, get, del, evict)
 
 		err := uc.DeleteBalance(ctx, organizationID, ledgerID, balanceID)
 		assert.NoError(t, err)
@@ -231,6 +272,9 @@ func TestDeleteBalanceBlockThenEvict(t *testing.T) {
 			Find(gomock.Any(), organizationID, ledgerID, balanceID).
 			Return(bal, nil)
 		expectDeleteMarkerPlant(mockRedisRepo, organizationID, ledgerID, bal)
+		mockRedisRepo.EXPECT().
+			Get(gomock.Any(), balanceCacheKeyFor(organizationID, ledgerID, bal)).
+			Return("", nil)
 		mockBalanceRepo.EXPECT().
 			Delete(gomock.Any(), organizationID, ledgerID, balanceID).
 			Return(expectedErr)
@@ -251,6 +295,9 @@ func TestDeleteBalanceBlockThenEvict(t *testing.T) {
 			Find(gomock.Any(), organizationID, ledgerID, balanceID).
 			Return(bal, nil)
 		expectDeleteMarkerPlant(mockRedisRepo, organizationID, ledgerID, bal)
+		mockRedisRepo.EXPECT().
+			Get(gomock.Any(), balanceCacheKeyFor(organizationID, ledgerID, bal)).
+			Return("", nil)
 		mockBalanceRepo.EXPECT().
 			Delete(gomock.Any(), organizationID, ledgerID, balanceID).
 			Return(nil)
@@ -261,6 +308,211 @@ func TestDeleteBalanceBlockThenEvict(t *testing.T) {
 		err := uc.DeleteBalance(ctx, organizationID, ledgerID, balanceID)
 		assert.NoError(t, err)
 	})
+
+	t.Run("redis funds reject deletion and release marker", func(t *testing.T) {
+		cases := []struct {
+			name          string
+			available     decimal.Decimal
+			onHold        decimal.Decimal
+			overdraftUsed string
+		}{
+			{name: "available", available: decimal.NewFromInt(50)},
+			{name: "negative available", available: decimal.NewFromInt(-1)},
+			{name: "on hold", onHold: decimal.NewFromInt(5)},
+			{name: "negative on hold", onHold: decimal.NewFromInt(-2)},
+			{name: "overdraft used", overdraftUsed: "25"},
+		}
+
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				uc, mockBalanceRepo, mockRedisRepo := setupDeleteBalanceUseCase(t)
+				overdraftUsed := tc.overdraftUsed
+				if overdraftUsed == "" {
+					overdraftUsed = "0"
+				}
+
+				bal := &mmodel.Balance{
+					ID:        balanceID.String(),
+					Alias:     "alias",
+					Key:       "key",
+					Available: decimal.Zero,
+					OnHold:    decimal.Zero,
+				}
+
+				mockBalanceRepo.EXPECT().
+					Find(gomock.Any(), organizationID, ledgerID, balanceID).
+					Return(bal, nil)
+				plant := expectDeleteMarkerPlant(mockRedisRepo, organizationID, ledgerID, bal)
+				get := mockRedisRepo.EXPECT().
+					Get(gomock.Any(), balanceCacheKeyFor(organizationID, ledgerID, bal)).
+					Return(balanceRedisSnapshotWithOverdraft(tc.available, tc.onHold, overdraftUsed), nil)
+				release := expectDeleteMarkerRelease(mockRedisRepo, organizationID, ledgerID, bal)
+				gomock.InOrder(plant, get, release)
+				mockBalanceRepo.EXPECT().
+					Delete(gomock.Any(), organizationID, ledgerID, balanceID).
+					Times(0)
+
+				err := uc.DeleteBalance(ctx, organizationID, ledgerID, balanceID)
+
+				var conflictErr midazpkg.EntityConflictError
+				assert.Error(t, err)
+				assert.True(t, errors.As(err, &conflictErr))
+				assert.Equal(t, constant.ErrBalancesCantBeDeleted.Error(), conflictErr.Code)
+			})
+		}
+	})
+
+	t.Run("invalid cached overdraft fails closed and releases marker", func(t *testing.T) {
+		uc, mockBalanceRepo, mockRedisRepo := setupDeleteBalanceUseCase(t)
+		bal := &mmodel.Balance{ID: balanceID.String(), Alias: "alias", Key: "key"}
+
+		mockBalanceRepo.EXPECT().
+			Find(gomock.Any(), organizationID, ledgerID, balanceID).
+			Return(bal, nil)
+		expectDeleteMarkerPlant(mockRedisRepo, organizationID, ledgerID, bal)
+		mockRedisRepo.EXPECT().
+			Get(gomock.Any(), balanceCacheKeyFor(organizationID, ledgerID, bal)).
+			Return(balanceRedisSnapshotWithOverdraft(decimal.Zero, decimal.Zero, "not-a-decimal"), nil)
+		expectDeleteMarkerRelease(mockRedisRepo, organizationID, ledgerID, bal)
+		mockBalanceRepo.EXPECT().
+			Delete(gomock.Any(), organizationID, ledgerID, balanceID).
+			Times(0)
+
+		err := uc.DeleteBalance(ctx, organizationID, ledgerID, balanceID)
+
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to parse overdraft used")
+	})
+
+	t.Run("redis cache zero snapshot permits deletion", func(t *testing.T) {
+		uc, mockBalanceRepo, mockRedisRepo := setupDeleteBalanceUseCase(t)
+		bal := &mmodel.Balance{
+			ID:        balanceID.String(),
+			Alias:     "alias",
+			Key:       "key",
+			Available: decimal.Zero,
+			OnHold:    decimal.Zero,
+		}
+
+		mockBalanceRepo.EXPECT().
+			Find(gomock.Any(), organizationID, ledgerID, balanceID).
+			Return(bal, nil)
+		expectDeleteMarkerPlant(mockRedisRepo, organizationID, ledgerID, bal)
+		mockRedisRepo.EXPECT().
+			Get(gomock.Any(), balanceCacheKeyFor(organizationID, ledgerID, bal)).
+			Return(balanceRedisSnapshot(decimal.Zero, decimal.Zero), nil)
+		mockBalanceRepo.EXPECT().
+			Delete(gomock.Any(), organizationID, ledgerID, balanceID).
+			Return(nil)
+		expectCacheEvict(mockRedisRepo, organizationID, ledgerID, bal)
+
+		assert.NoError(t, uc.DeleteBalance(ctx, organizationID, ledgerID, balanceID))
+	})
+
+	t.Run("redis get error fails closed and releases marker", func(t *testing.T) {
+		uc, mockBalanceRepo, mockRedisRepo := setupDeleteBalanceUseCase(t)
+		bal := &mmodel.Balance{ID: balanceID.String(), Alias: "alias", Key: "key"}
+		expectedErr := errors.New("redis unavailable")
+
+		mockBalanceRepo.EXPECT().
+			Find(gomock.Any(), organizationID, ledgerID, balanceID).
+			Return(bal, nil)
+		expectDeleteMarkerPlant(mockRedisRepo, organizationID, ledgerID, bal)
+		mockRedisRepo.EXPECT().
+			Get(gomock.Any(), balanceCacheKeyFor(organizationID, ledgerID, bal)).
+			Return("", expectedErr)
+		expectDeleteMarkerRelease(mockRedisRepo, organizationID, ledgerID, bal)
+		mockBalanceRepo.EXPECT().
+			Delete(gomock.Any(), organizationID, ledgerID, balanceID).
+			Times(0)
+
+		err := uc.DeleteBalance(ctx, organizationID, ledgerID, balanceID)
+		assert.ErrorIs(t, err, expectedErr)
+	})
+
+	t.Run("invalid redis json fails closed and releases marker", func(t *testing.T) {
+		uc, mockBalanceRepo, mockRedisRepo := setupDeleteBalanceUseCase(t)
+		bal := &mmodel.Balance{ID: balanceID.String(), Alias: "alias", Key: "key"}
+
+		mockBalanceRepo.EXPECT().
+			Find(gomock.Any(), organizationID, ledgerID, balanceID).
+			Return(bal, nil)
+		expectDeleteMarkerPlant(mockRedisRepo, organizationID, ledgerID, bal)
+		mockRedisRepo.EXPECT().
+			Get(gomock.Any(), balanceCacheKeyFor(organizationID, ledgerID, bal)).
+			Return("not-json", nil)
+		expectDeleteMarkerRelease(mockRedisRepo, organizationID, ledgerID, bal)
+		mockBalanceRepo.EXPECT().
+			Delete(gomock.Any(), organizationID, ledgerID, balanceID).
+			Times(0)
+
+		err := uc.DeleteBalance(ctx, organizationID, ledgerID, balanceID)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to decode balance cache value")
+	})
+
+	t.Run("already-owned marker fails before cache read", func(t *testing.T) {
+		uc, mockBalanceRepo, mockRedisRepo := setupDeleteBalanceUseCase(t)
+		bal := &mmodel.Balance{ID: balanceID.String(), Alias: "alias", Key: "key"}
+
+		mockBalanceRepo.EXPECT().
+			Find(gomock.Any(), organizationID, ledgerID, balanceID).
+			Return(bal, nil)
+		mockRedisRepo.EXPECT().
+			SetNX(gomock.Any(), deleteMarkerKeyFor(organizationID, ledgerID, bal), gomock.Any(), time.Duration(balanceDeleteMarkerTTLSeconds)).
+			Return(false, nil)
+		mockRedisRepo.EXPECT().
+			Get(gomock.Any(), gomock.Any()).
+			Times(0)
+		mockRedisRepo.EXPECT().
+			DeleteIfValue(gomock.Any(), deleteMarkerKeyFor(organizationID, ledgerID, bal), gomock.Any()).
+			Times(0)
+		mockBalanceRepo.EXPECT().
+			Delete(gomock.Any(), organizationID, ledgerID, balanceID).
+			Times(0)
+
+		err := uc.DeleteBalance(ctx, organizationID, ledgerID, balanceID)
+		var conflictErr midazpkg.EntityConflictError
+		assert.Error(t, err)
+		assert.True(t, errors.As(err, &conflictErr))
+		assert.Equal(t, constant.ErrBalancesCantBeDeleted.Error(), conflictErr.Code)
+	})
+
+	t.Run("marker redis error fails before cache read", func(t *testing.T) {
+		uc, mockBalanceRepo, mockRedisRepo := setupDeleteBalanceUseCase(t)
+		bal := &mmodel.Balance{ID: balanceID.String(), Alias: "alias", Key: "key"}
+		expectedErr := errors.New("marker redis unavailable")
+
+		mockBalanceRepo.EXPECT().
+			Find(gomock.Any(), organizationID, ledgerID, balanceID).
+			Return(bal, nil)
+		mockRedisRepo.EXPECT().
+			SetNX(gomock.Any(), deleteMarkerKeyFor(organizationID, ledgerID, bal), gomock.Any(), time.Duration(balanceDeleteMarkerTTLSeconds)).
+			Return(false, expectedErr)
+		mockRedisRepo.EXPECT().
+			Get(gomock.Any(), gomock.Any()).
+			Times(0)
+		mockBalanceRepo.EXPECT().
+			Delete(gomock.Any(), organizationID, ledgerID, balanceID).
+			Times(0)
+
+		err := uc.DeleteBalance(ctx, organizationID, ledgerID, balanceID)
+		assert.ErrorIs(t, err, expectedErr)
+	})
+}
+
+func balanceRedisSnapshot(available, onHold decimal.Decimal) string {
+	return balanceRedisSnapshotWithOverdraft(available, onHold, "0")
+}
+
+func balanceRedisSnapshotWithOverdraft(available, onHold decimal.Decimal, overdraftUsed string) string {
+	data, _ := json.Marshal(mmodel.BalanceRedis{
+		Available:     available,
+		OnHold:        onHold,
+		OverdraftUsed: overdraftUsed,
+	})
+
+	return string(data)
 }
 
 func setupDeleteBalanceUseCase(t *testing.T) (*UseCase, *balance.MockRepository, *redis.MockRedisRepository) {
@@ -276,4 +528,39 @@ func setupDeleteBalanceUseCase(t *testing.T) (*UseCase, *balance.MockRepository,
 		BalanceRepo:          mockBalanceRepo,
 		TransactionRedisRepo: mockRedisRepo,
 	}, mockBalanceRepo, mockRedisRepo
+}
+
+// TestDeleteBalanceLegacyEmptyCachedOverdraftPermitsDeletion locks the single-delete half of the
+// shared cached-OverdraftUsed rule: the pre-overdraft snapshot shape carries no debt, so it must
+// not fail closed the way an unreadable value does.
+func TestDeleteBalanceLegacyEmptyCachedOverdraftPermitsDeletion(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	organizationID := uuid.New()
+	ledgerID := uuid.New()
+	balanceID := uuid.New()
+
+	uc, mockBalanceRepo, mockRedisRepo := setupDeleteBalanceUseCase(t)
+	bal := &mmodel.Balance{
+		ID:        balanceID.String(),
+		Alias:     "alias",
+		Key:       "key",
+		Available: decimal.Zero,
+		OnHold:    decimal.Zero,
+	}
+
+	mockBalanceRepo.EXPECT().
+		Find(gomock.Any(), organizationID, ledgerID, balanceID).
+		Return(bal, nil)
+	expectDeleteMarkerPlant(mockRedisRepo, organizationID, ledgerID, bal)
+	mockRedisRepo.EXPECT().
+		Get(gomock.Any(), balanceCacheKeyFor(organizationID, ledgerID, bal)).
+		Return(balanceRedisSnapshotWithOverdraft(decimal.Zero, decimal.Zero, ""), nil)
+	mockBalanceRepo.EXPECT().
+		Delete(gomock.Any(), organizationID, ledgerID, balanceID).
+		Return(nil)
+	expectCacheEvict(mockRedisRepo, organizationID, ledgerID, bal)
+
+	assert.NoError(t, uc.DeleteBalance(ctx, organizationID, ledgerID, balanceID))
 }

--- a/docs/architecture/balance-delete-marker-compatibility.md
+++ b/docs/architecture/balance-delete-marker-compatibility.md
@@ -1,0 +1,89 @@
+# Balance delete-marker compatibility
+
+The current release uses `balance_delete_marker:{transactions}:<balance>` as the
+dedicated marker namespace. During the compatibility window, delete commands also
+write the pre-namespace `<balance>:deleted` marker with the same owner token. Both
+transaction Lua scripts reject either marker, so normal old/new operations cannot
+cross a live delete barrier. The sections below state what that bridge guarantees
+in a mixed fleet and the one hazard it does not cover.
+
+The legacy suffix has an intentional collision tradeoff, because a balance key can
+itself contain `:`. Three effects follow from a valid sibling balance whose key is
+`<balance>:deleted`. While that sibling is cached it occupies the old marker key,
+so dual acquisition fails closed and rolls back the namespaced marker: the delete
+of `<balance>` is rejected, but no unsafe delete is allowed. While that sibling is
+cached, the legacy Lua check also rejects every transaction on `<balance>` with
+`0019`. When the sibling is not cached, the legacy `SetNX` succeeds and writes the
+owner token into the sibling's own cache key, poisoning it for the marker lifetime:
+30 seconds after a successful eviction, up to 48 hours when eviction failed. All
+three effects belong to the suffix itself, pre-date this release, and disappear
+with the bridge. The dedicated namespace is collision-free.
+
+The two `SET NX` calls are deliberately kept behind the same lease and the
+delete proceeds only after both succeed, but they are still separate Redis
+round-trips. There is a small acquisition interval in which only one marker is
+present; a future multi-key Lua acquisition can remove that interval if the
+deployment needs a stronger guarantee. Do not describe this one-release bridge
+as atomic cross-namespace locking.
+
+Marker lifetime is conditional. Acquisition uses the long snapshot-protection TTL
+of 48 hours. If cache eviction fails, that TTL is retained so a stale snapshot
+cannot be used after the delete. If eviction succeeds, `ExpireIfValue` shortens
+both owned markers atomically to the 30-second in-flight window; there is no
+release/reacquire gap. Cascade deletes report one eviction status per balance and
+shorten only the markers for balances whose cache eviction succeeded.
+
+## Rolling deploy
+
+A normal rolling deploy is supported. The bridge covers both directions of a mixed
+fleet: old Lua honors the legacy `<balance>:deleted` marker that new pods
+dual-write, and new Lua honors the namespaced marker and the legacy one. A delete
+issued by a new pod raises a barrier that old transaction scripts respect, and a
+delete issued by an old pod raises a barrier that new transaction scripts respect.
+
+One residual hazard remains, and it requires every one of these conditions at once:
+
+1. an old-binary delete stays in flight longer than its 30-second legacy marker
+   TTL, so its marker expires while the request is still running;
+2. a new pod acquires that same legacy key after it expires and owns it;
+3. the old request then rolls back and releases with its unconditional `DEL`,
+   removing the new pod's legacy marker — new code cannot make an already-running
+   old binary compare an owner token; and
+4. a third old pod mutates the balance in the window between the new pod's
+   snapshot read and its cache `Del`, because the namespaced marker still exists
+   but old Lua checks only `:deleted`.
+
+Assess this as negligible. It needs a delete slower than 30 seconds, a legacy
+expiry landing inside it, a rollback after that expiry, and a concurrent old-pod
+mutation inside a window of a few Redis round-trips. Weigh it against the baseline
+of any rollout: old binaries still carry the original defect for the deletes they
+issue themselves, regardless of markers. The bridge closes the window only for
+deletes issued by new pods.
+
+## Rolling back
+
+Rolling back to the previous release is allowed. What is lost is the namespaced
+barrier: `balance_delete_marker:{transactions}:<balance>` is invisible to the old
+binary, so a stale snapshot left by a failed eviction can be mutated by it. That is
+the pre-existing defect class, not a new one, and its exposure is bounded by the
+snapshot TTL.
+
+During either handoff, monitor marker rejections (`0019`), marker release and
+shortening warnings, and failed cache evictions. Failed evictions are the signal
+that stale snapshots are being left behind.
+
+## Legacy bridge retirement
+
+Remove the legacy bridge only after both gates are satisfied:
+
+- every old binary is retired, including as a rollback target; and
+- one long marker TTL (`balanceDeleteMarkerTTLSeconds`, 48 hours) has elapsed
+  since the last bridge write.
+
+No Redis scan is required. Legacy markers always carry a TTL — 48 hours on
+acquisition, 30 seconds after a successful eviction — so they expire on their own.
+
+Then remove the legacy `SetNX`, the legacy release and expiry calls, the legacy
+checks from both Lua scripts, and the legacy helper and fields. Retain the
+dedicated namespace and the token-checked operations. Keep the rollback target
+namespace-aware; do not reintroduce a legacy-only rollback path.

--- a/docs/architecture/balance-delete-marker-compatibility.md
+++ b/docs/architecture/balance-delete-marker-compatibility.md
@@ -43,8 +43,10 @@ delete issued by an old pod raises a barrier that new transaction scripts respec
 
 One residual hazard remains, and it requires every one of these conditions at once:
 
-1. an old-binary delete stays in flight longer than its 30-second legacy marker
-   TTL, so its marker expires while the request is still running;
+1. an old-binary delete stays in flight longer than the 30-second TTL the
+   previous release gave its legacy marker (this release plants both markers
+   with a 48-hour TTL), so its marker expires while the request is still
+   running;
 2. a new pod acquires that same legacy key after it expires and owns it;
 3. the old request then rolls back and releases with its unconditional `DEL`,
    removing the new pod's legacy marker — new code cannot make an already-running
@@ -53,12 +55,12 @@ One residual hazard remains, and it requires every one of these conditions at on
    snapshot read and its cache `Del`, because the namespaced marker still exists
    but old Lua checks only `:deleted`.
 
-Assess this as negligible. It needs a delete slower than 30 seconds, a legacy
-expiry landing inside it, a rollback after that expiry, and a concurrent old-pod
-mutation inside a window of a few Redis round-trips. Weigh it against the baseline
-of any rollout: old binaries still carry the original defect for the deletes they
-issue themselves, regardless of markers. The bridge closes the window only for
-deletes issued by new pods.
+Assess this as negligible. It needs a delete slower than the old binary's
+30-second marker TTL, a legacy expiry landing inside it, a rollback after that
+expiry, and a concurrent old-pod mutation inside a window of a few Redis
+round-trips. Weigh it against the baseline of any rollout: old binaries still
+carry the original defect for the deletes they issue themselves, regardless of
+markers. The bridge closes the window only for deletes issued by new pods.
 
 ## Rolling back
 


### PR DESCRIPTION
## Description

`DELETE /v1/organizations/{id}/ledgers/{id}/balances/{id}` compared only the PostgreSQL row before soft-deleting a balance and evicting its Redis cache key. Funds already credited to the Redis snapshot but not yet flushed by the balance-sync worker were discarded with the key: the worker later saw a missing key, treated it as orphaned and dropped it from the schedule at Debug level. No concurrent request is needed, only the normal flush interval between the Redis write and the PostgreSQL sync.

This PR makes both delete paths (single balance and the account cascade) decide under an exclusive barrier and read the live snapshot before deleting anything:

- **Exclusive delete markers with an owner token.** `SetNX` acquires the marker before any read; an already-owned marker or a Redis error fails the request closed (`0093`/409 or 500). Release (`DeleteIfValue`) and TTL shortening (`ExpireIfValue`) are Lua compare-and-act scripts that check the token, so a late rollback never touches a marker another owner acquired.
- **Redis snapshot funds guard.** After the PostgreSQL funds guard, the single delete reads the cached snapshot and rejects when `Available`, `OnHold` or `OverdraftUsed` is non-zero. Cache miss passes; an undecodable snapshot or a non-numeric `OverdraftUsed` fails closed. The cascade reads the same fields through `ListBalanceByKey`, which now maps `OverdraftUsed`.
- **Marker lifetime tied to the outcome.** Acquired with a 48h TTL (longer than the 24h snapshot TTL). After a successful cache eviction the owned markers are shortened to 30s so the same alias#key can be recreated quickly; a failed eviction keeps the 48h TTL so a stale snapshot cannot be mutated. A rejected or failed delete releases its markers immediately. Post-commit cleanup runs on a bounded context detached from the request.
- **Dedicated marker namespace.** Markers live under `balance_delete_marker:{transactions}:` instead of the `<balanceKey>:deleted` suffix, which collided with a legitimate sibling balance whose key ends in `:deleted`. Both Lua scripts (`balance_atomic_operation.lua`, `update_balance_settings.lua`) reject a mutation while either marker exists. For one release the command dual-writes the legacy suffix so a mixed fleet keeps the barrier in both directions; `docs/architecture/balance-delete-marker-compatibility.md` describes the bridge, the rolling-deploy guarantees, the residual hazard and the retirement gates.
- Balance reads on both delete paths are routed to the primary.

Internal tracking: card 4938 (this fix); card 5087 (retire the legacy marker bridge after one release).

## Type of Change

- [ ] `feat`: New feature or capability
- [x] `fix`: Bug fix
- [ ] `perf`: Performance improvement
- [ ] `refactor`: Internal restructuring with no behavior change
- [x] `docs`: Documentation only
- [ ] `style`: Formatting, whitespace, naming (no logic change)
- [x] `test`: Adding or updating tests
- [ ] `ci`: CI pipeline or workflow changes
- [ ] `build`: Build system, Dockerfile, Go module dependencies
- [ ] `chore`: Maintenance, config, tooling
- [ ] `revert`: Reverts a previous commit
- [ ] `BREAKING CHANGE`: Consumers must update their integration

## Breaking Changes

None. Two new rejection cases on the delete endpoints, both already-documented codes: `0093`/409 when a concurrent delete owns the marker or when funds exist only in the Redis snapshot, and 500 when Redis is unavailable or the snapshot cannot be decoded (previously the delete proceeded on PostgreSQL data alone). Transactions and settings updates on a balance under deletion keep receiving `0019`/422.

## Testing

- [x] `make test` passes (`make test-unit` via the pre-push hook)
- [x] `make test-int` passes if integration paths are exercised (targeted suites run locally with testcontainers: `TestIntegration_DeleteMarker*`, `TestIntegration_UpdateBalanceSettingsScript*`, `TestIntegration_DeleteIfValue*`, `TestIntegration_BalanceDelete*` in `adapters/redis/transaction` and `adapters/http/in`)
- [x] `make lint` passes (golangci-lint v2.13.2, CI shape, 0 issues)
- [x] `make sec` and `make vulncheck` pass (via the pre-push hook)

**Test evidence / Actions run:** `TestIntegration_BalanceDeleteRejectsRedisFundsWhenPostgresIsZero` reproduces the defect end to end: PostgreSQL at zero, Redis at 50 without a running sync worker, delete rejected with `0093`, snapshot and row untouched, then a successful delete after the funds are drained. `TestIntegration_BalanceDeleteCascadeRejectsRedisOnlyOverdraftDebt` covers the cascade reading `OverdraftUsed` from the real snapshot mapper. Coverage: `services/command` 82.0%, `adapters/http/in` 95.1%.

## Architectural Checklist

- [x] No `panic()` in production paths
- [x] Timestamps use `time.Now().UTC()` (no new timestamps introduced)
- [x] Errors wrapped with `%w`
- [x] Handlers stay thin (parse, validate, call service)
- [x] Infrastructure concerns kept in `internal/bootstrap`

## Related Issues

None on GitHub; tracked internally (cards 4938 and 5087).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Authorized account-block exceptions can now permit eligible balance operations.
  - Balance cache data now preserves blocked status and overdraft information.

- **Bug Fixes**
  - Balance deletion checks stored and cached funds, including overdraft debt.
  - Failed deletions preserve balance data and release temporary protection.
  - Updates are blocked while deletion is in progress.
  - Cache eviction and deletion protection expire more reliably after successful removal.
  - Tenant-specific deletion protection prevents marker conflicts across balances.

- **Documentation**
  - Added guidance for compatibility during rolling deployments and mixed-version operation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->