### PR TITLE
fix(pkg): carry tenant.id on logs emitted during an authenticated request

### DIFF
--- a/pkg/net/http/protected_routes.go
+++ b/pkg/net/http/protected_routes.go
@@ -78,6 +78,22 @@ func MarkTrustedAuthAssertion() fiber.Handler {
 		if tenantID := firstNonEmptyStringClaim(claims, "tenantId"); tenantID != "" && tmcore.IsValidTenantID(tenantID) {
 			ctx := withTenantIDBaggage(tmcore.ContextWithTenantID(c.Context(), tenantID), tenantID)
 
+			// Re-seeds the context logger so every log emitted downstream of
+			// this point — the warning below included — carries the tenant.
+			// The access-log line cannot be fixed from here:
+			// lib-observability's WithHTTPLogging binds its request logger
+			// before c.Next() and this middleware runs inside it, so that line
+			// resolves its own tenant field after c.Next() (needs a
+			// lib-observability release carrying that change).
+			//
+			// The raw claim, not the parsed UUID: logs must agree with the
+			// span attribute seeded into baggage above, and the two per-tenant
+			// channels deliberately differ in form. Seeded before the UUID
+			// branch on purpose — a non-UUID tenant carries no metric
+			// attestation, so this field is the only tenant signal it gets.
+			ctx = libObservability.ContextWithLogger(ctx,
+				libObservability.NewLoggerFromContext(ctx).With(libLog.String(obsconst.AttrKeyTenantID, tenantID)))
+
 			// The telemetry middleware labels per-tenant metrics only from an
 			// identity attested here; a client-supplied header or baggage member
 			// is never promoted to that trust level. tmcore.IsValidTenantID

--- a/pkg/net/http/protected_routes_test.go
+++ b/pkg/net/http/protected_routes_test.go
@@ -5,13 +5,17 @@
 package http
 
 import (
+	"context"
 	"fmt"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 
 	tmcore "github.com/LerianStudio/lib-commons/v7/commons/tenant-manager/core"
 	libObservability "github.com/LerianStudio/lib-observability/v4"
+	obsconst "github.com/LerianStudio/lib-observability/v4/constants"
+	libLog "github.com/LerianStudio/lib-observability/v4/log"
 	"github.com/gofiber/fiber/v3"
 	jwt "github.com/golang-jwt/jwt/v5"
 	"github.com/google/uuid"
@@ -214,4 +218,181 @@ func TestMarkTrustedAuthAssertion_SetsTenantIDContextAlongsideAttestation(t *tes
 	require.NoError(t, err)
 	require.Equal(t, fiber.StatusNoContent, resp.StatusCode)
 	assert.Equal(t, slugTenant, got)
+}
+
+// tenantFieldLogger records the fields bound to each logger derived from it,
+// so a test can assert what a handler's log record carried. Every derived
+// logger shares one sink because the middleware hands the handler a logger
+// two With calls removed from the one seeded here.
+type tenantFieldLogger struct {
+	sink  *tenantFieldSink
+	bound []libLog.Field
+}
+
+type tenantFieldSink struct {
+	mu      sync.Mutex
+	records []tenantFieldRecord
+}
+
+type tenantFieldRecord struct {
+	message string
+	fields  []libLog.Field
+}
+
+func newTenantFieldLogger() *tenantFieldLogger {
+	return &tenantFieldLogger{sink: &tenantFieldSink{}}
+}
+
+func (l *tenantFieldLogger) Log(_ context.Context, _ int, msg string, fields ...any) {
+	l.sink.mu.Lock()
+	defer l.sink.mu.Unlock()
+
+	l.sink.records = append(l.sink.records, tenantFieldRecord{
+		message: msg,
+		fields:  append(append([]libLog.Field(nil), l.bound...), libLog.Fields(fields...)...),
+	})
+}
+
+func (l *tenantFieldLogger) With(fields ...any) libLog.Logger {
+	return &tenantFieldLogger{
+		sink:  l.sink,
+		bound: append(append([]libLog.Field(nil), l.bound...), libLog.Fields(fields...)...),
+	}
+}
+
+func (l *tenantFieldLogger) WithGroup(_ string) libLog.Logger { return l }
+
+func (l *tenantFieldLogger) Enabled(_ int) bool { return true }
+
+func (l *tenantFieldLogger) Sync(_ context.Context) error { return nil }
+
+func (l *tenantFieldLogger) records() []tenantFieldRecord {
+	l.sink.mu.Lock()
+	defer l.sink.mu.Unlock()
+
+	return append([]tenantFieldRecord(nil), l.sink.records...)
+}
+
+// recordsWithMessage isolates the records a specific emitter produced. The
+// non-UUID path also logs a one-time attestation warning, so selecting by
+// position would make the assertion depend on which subtest tripped the
+// sync.Once first.
+func (l *tenantFieldLogger) recordsWithMessage(msg string) []tenantFieldRecord {
+	var out []tenantFieldRecord
+
+	for _, rec := range l.records() {
+		if rec.message == msg {
+			out = append(out, rec)
+		}
+	}
+
+	return out
+}
+
+func tenantFieldsOf(record []libLog.Field) []string {
+	var values []string
+
+	for _, field := range record {
+		if field.Key != obsconst.AttrKeyTenantID {
+			continue
+		}
+
+		value, _ := field.Value.(string)
+		values = append(values, value)
+	}
+
+	return values
+}
+
+func TestMarkTrustedAuthAssertion_ReseedsContextLoggerWithTenantID(t *testing.T) {
+	t.Parallel()
+
+	// Both tenant shapes, because the re-seed sits outside the UUID branch on
+	// purpose: a non-UUID tenant gets no metric attestation, so the log field
+	// is the only per-tenant signal it has.
+	cases := []struct {
+		name     string
+		tenantID string
+	}{
+		{name: "uuid tenant", tenantID: "0f6e2b3a-1c4d-4e5f-8a9b-0c1d2e3f4a5b"},
+		{name: "non-uuid tenant", tenantID: "org_01KHVKQQP6D2N4RDJK0ADEKQX1"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			logger := newTenantFieldLogger()
+
+			app := fiber.New()
+
+			// Stands in for lib-observability's WithHTTPLogging, which binds
+			// the request logger into the context BEFORE the auth chain runs.
+			app.Use(func(c fiber.Ctx) error {
+				c.SetContext(libObservability.ContextWithLogger(c.Context(), logger))
+
+				return c.Next()
+			})
+			app.Use(MarkTrustedAuthAssertion())
+			app.Get("/test", func(c fiber.Ctx) error {
+				libObservability.NewLoggerFromContext(c.Context()).
+					Log(c.Context(), libLog.LevelInfo, "handler ran")
+
+				return c.SendStatus(fiber.StatusNoContent)
+			})
+
+			req := httptest.NewRequest("GET", "/test", nil)
+			req.Header.Set("Authorization", fmt.Sprintf("Bearer %s",
+				mustUnsignedToken(t, jwt.MapClaims{"sub": "u", "tenantId": tc.tenantID})))
+
+			resp, err := app.Test(req)
+			require.NoError(t, err)
+			require.Equal(t, fiber.StatusNoContent, resp.StatusCode)
+
+			records := logger.recordsWithMessage("handler ran")
+			require.Len(t, records, 1, "the handler must emit exactly one record")
+			assert.Equal(t, []string{tc.tenantID}, tenantFieldsOf(records[0].fields),
+				"a handler log must carry the raw tenantId claim once, matching the span attribute")
+
+			// The non-UUID warning is itself about this tenant, so it must be
+			// attributable to it too - the re-seed sits above that branch.
+			for _, warned := range logger.recordsWithMessage(
+				"Tenant claim is not a UUID; per-tenant metrics will not be labelled for it") {
+				assert.Equal(t, []string{tc.tenantID}, tenantFieldsOf(warned.fields))
+			}
+		})
+	}
+}
+
+func TestMarkTrustedAuthAssertion_LeavesContextLoggerAloneWithoutTenantClaim(t *testing.T) {
+	t.Parallel()
+
+	logger := newTenantFieldLogger()
+
+	app := fiber.New()
+	app.Use(func(c fiber.Ctx) error {
+		c.SetContext(libObservability.ContextWithLogger(c.Context(), logger))
+
+		return c.Next()
+	})
+	app.Use(MarkTrustedAuthAssertion())
+	app.Get("/test", func(c fiber.Ctx) error {
+		libObservability.NewLoggerFromContext(c.Context()).
+			Log(c.Context(), libLog.LevelInfo, "handler ran")
+
+		return c.SendStatus(fiber.StatusNoContent)
+	})
+
+	req := httptest.NewRequest("GET", "/test", nil)
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s",
+		mustUnsignedToken(t, jwt.MapClaims{"sub": "u"})))
+
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	require.Equal(t, fiber.StatusNoContent, resp.StatusCode)
+
+	records := logger.recordsWithMessage("handler ran")
+	require.Len(t, records, 1)
+	assert.Empty(t, tenantFieldsOf(records[0].fields),
+		"a token without a tenantId claim must add no tenant.id field, not an empty one")
 }


### PR DESCRIPTION
## What

`MarkTrustedAuthAssertion` now re-seeds the request's context logger with `tenant.id`, so logs emitted downstream of the attestation carry the tenant.

The attested tenant already reached metrics (the parsed UUID) and spans (the raw claim, via the OTel baggage seeded a few lines above). Logs got nothing: `obsconst.AttrKeyTenantID` appeared in exactly one productive place in this repo — the baggage member — and on no logging path.

## The ordering constraint (why this is half the fix)

lib-observability's `WithHTTPLogging` binds its request logger **before** `c.Next()`, and this middleware runs inside `c.Next()` (a route-level middleware behind `auth.Authorize`). That splits the fix in two:

- **handler logs** during the request can be fixed from here, by re-seeding the context logger at attestation time — this PR;
- the **access-log line** (`http_status_code` / `http_method` / `http_path` / `http_latency_ms`) cannot: it is emitted from the logger bound before `c.Next()`, so it has to resolve its own tenant field after `c.Next()`, inside the library — LerianStudio/lib-observability#70.

**This PR's benefit is therefore only partial until a lib-observability release carrying that change is pinned here.** Handler logs get the field immediately; the access-log line gets it on the bump.

## How

```go
ctx = libObservability.ContextWithLogger(ctx,
    libObservability.NewLoggerFromContext(ctx).With(libLog.String(obsconst.AttrKeyTenantID, tenantID)))
```

Two placement decisions worth reviewing:

- **Above the UUID branch, not inside it.** A non-UUID `tenantId` claim carries no UUID anywhere else in the token, so it gets no metric attestation (see the `TODO(#2450)` right below) — for those tenants this log field is the *only* per-tenant signal, which is the point rather than an accident. Placing it above the branch also means the "claim is not a UUID" warning, which is about that very tenant, is itself attributable to it.
- **The raw claim, not the parsed UUID.** Logs must agree with the span attribute seeded into baggage; the two per-tenant channels deliberately differ in form (raw claim on spans and logs, attested UUID on metrics), and a log that disagreed with the trace it belongs to would be worse than no log field.

No adapter is needed: `NewLoggerFromContext` returns `log.Logger`, which satisfies the single-method `log.Universal` that `ContextWithLogger` takes. All three import aliases were already present in the file.

## Verified end to end

Local stack, real JWT minted against Caradhras (tenant app → `tenantId` claim), multi-tenant ledger:

```
DEBUG log/tenant_logger.go:41 tenant context resolved
  {... "tenant.id": "03fb5615b8f04c56983826a13d9aadef", ...}          <- this PR
INFO  middleware/logging.go:269 "GET /v1/organizations" 200
  {... "http_status_code": 200, "http_latency_ms": 3,
       "tenant.id": "03fb5615b8f04c56983826a13d9aadef", ...}          <- lib PR
```

Negative and adversarial cases, same stack:

- no token → 401, **no** `tenant.id` field at all (not an empty one);
- a real, signature-valid token with **no** `tenantId` claim → 401 `MISSING_TENANT`, no field;
- `baggage: tenant.id=FORGED-EVIL-TENANT` from the client, with and without a real token → the real tenant is logged, never the forged one; the string `FORGED` appears nowhere in the service log. The forgery is stripped by `ExtractHTTPContext` before anything can read it, so the log channel is no more spoofable than metrics.

## Tests

`pkg/net/http/protected_routes_test.go`, failing without the change:

- a handler-emitted log carries the raw claim exactly once, for both a UUID and a non-UUID tenant;
- the non-UUID attestation warning carries it too;
- a token with no `tenantId` claim adds no field, not an empty one.

`go build ./... && go vet ./pkg/... && go test ./pkg/... ./components/ledger/... -count=1` green. e2e slice (`cases/midaz-ledger/api/{ledger,account,asset}` from LerianStudio/end-to-end) run against this build and against unmodified `origin/develop`: same failure sets, all pre-existing (`%`-as-LIKE-wildcard, settings-PATCH merge, replica read-after-write), each divergence confirmed by 3x isolation on the baseline.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tenant identifiers are now included in downstream logs after successful authentication.
  * Tenant-related warnings consistently include the relevant tenant identifier, including for non-UUID tenant claims.
  * Requests without a tenant claim continue to preserve existing logger fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->