### PR TITLE
fix(deps): bump lib-observability to v4.0.2-beta.3 for tenant.id on the access log

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2
 	github.com/LerianStudio/lib-auth/v4 v4.0.0
 	github.com/LerianStudio/lib-commons/v7 v7.1.0
-	github.com/LerianStudio/lib-observability/v4 v4.0.2-beta.2
+	github.com/LerianStudio/lib-observability/v4 v4.0.2-beta.3
 	github.com/LerianStudio/lib-service-discovery/v2 v2.0.0
 	github.com/LerianStudio/lib-streaming/v4 v4.0.0
 	github.com/Masterminds/squirrel v1.5.4

--- a/go.sum
+++ b/go.sum
@@ -23,8 +23,8 @@ github.com/LerianStudio/lib-commons/v7 v7.1.0 h1:dbzqIhjhCE+plQ8v53cfEbS5f6tMLab
 github.com/LerianStudio/lib-commons/v7 v7.1.0/go.mod h1:/iFJVftWWVryRxO9YGDW59UIAHMrGJB6EMKJlFeEiKM=
 github.com/LerianStudio/lib-observability/v2 v2.1.3 h1:ZFVIv7VVfSv/Ag9OcxQNqoa6YGV9KpcnRb4ocvM8jvk=
 github.com/LerianStudio/lib-observability/v2 v2.1.3/go.mod h1:iXspGM6PRTf6BDtkTc0Z69R2HEv1GtjBsI/YSvewDgA=
-github.com/LerianStudio/lib-observability/v4 v4.0.2-beta.2 h1:ZrS2ILZ5s/kyiicID22kYvecWM6H/U66WyJ5yjmWxFs=
-github.com/LerianStudio/lib-observability/v4 v4.0.2-beta.2/go.mod h1:h2bmpC2iOJjgDSLtaMognNAg3asfEczkYQ74xlHZ6Hs=
+github.com/LerianStudio/lib-observability/v4 v4.0.2-beta.3 h1:9cFzke3kk0yG69LFo7iIsxepDFQUZr0XxuSj8I6B/6M=
+github.com/LerianStudio/lib-observability/v4 v4.0.2-beta.3/go.mod h1:h2bmpC2iOJjgDSLtaMognNAg3asfEczkYQ74xlHZ6Hs=
 github.com/LerianStudio/lib-service-discovery/v2 v2.0.0 h1:R8TrYI44/8joTbmZIBB8PNQmQwA7r53VeMPTiF9LtHM=
 github.com/LerianStudio/lib-service-discovery/v2 v2.0.0/go.mod h1:E1BIudjK8h0QGRTxFJZzFV3XBFp3s3dYuw7eqezsjug=
 github.com/LerianStudio/lib-streaming/v4 v4.0.0 h1:HeCzcglV3i+xZeWsA3YLkAWfsRSYI0o/Y+lF1idlJn0=


### PR DESCRIPTION
Bumps `lib-observability/v4` from `v4.0.2-beta.2` to **`v4.0.2-beta.3`**, which carries LerianStudio/lib-observability#70. `go.mod` and `go.sum` only — no source change.

## What it adds

`tenant.id` on the **HTTP access-log line** — the record carrying `http_status_code`, `http_method`, `http_path` and `http_latency_ms`.

Verified the tag actually contains it: the PR's commit is an ancestor of `v4.0.2-beta.3`, and `middleware/logging.go:256` in that tag has the resolver call.

## Why this could not be fixed in midaz

`WithHTTPLogging` binds its request logger **before** `c.Next()`, and the tenant is attested by a route-level middleware that runs **inside** `c.Next()` — behind `auth.Authorize`. So at bind time the tenant does not exist yet. The library now resolves it **after** `c.Next()`, from the request AttrBag and OTel baggage, both written by `MarkTrustedAuthAssertion` through `c.SetContext`. That way the access log agrees with the span attribute rather than deriving a second, independent notion of tenant.

It reuses `resolveTenantIDForTelemetry`, which already existed and was already used by the gRPC logging path — the HTTP path simply never called it.

## Relationship to the other log PR

Two different log lines, and neither substitutes for the other:

| | fixes | scope |
|---|---|---|
| this bump | the access-log line | every service using `WithHTTPLogging` |
| LerianStudio/midaz#2473 | logs emitted by handlers during the request | midaz only |

**#2473 does not depend on this bump** — it touches no `go.mod` and works against the currently pinned version. Merge order between them is free.

## Not spoofable

A client-supplied `tenant.id` cannot reach the field. `tracing.ExtractTraceContext` strips inbound `tenant.id` baggage and restores only a trusted member, and `middleware.ExtractHTTPContext` is the single HTTP funnel through it. Verified on a local stack: with a forged `baggage: tenant.id=FORGED-EVIL-TENANT` header sent alongside a real JWT, the logged tenant was the JWT's, and the forged string appeared nowhere in the ledger log.

## Verification

`gofmt` clean · `go build ./...` 0 · `go vet ./...` 0 · unit **97 packages ok / 0 FAIL** · `make check-telemetry` 0 · `tests/modulegraph` 0 (unmodified, no allowlist entry added).

## Note

This is a **pre-release** pin, which is fine on `develop` but will block a PR targeting `main` at the pre-release gate. A stable `v4.0.2` already exists but predates #70, so reaching `main` with this needs a `develop`→`main` release on lib-observability first.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated an underlying component to its latest compatible maintenance release.
  - No changes were made to the product’s user-facing features, behavior, or public interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->