### PR TITLE
fix(pkg): carry tenant.id on HTTP logs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2
 	github.com/LerianStudio/lib-auth/v4 v4.0.0
 	github.com/LerianStudio/lib-commons/v7 v7.1.0
-	github.com/LerianStudio/lib-observability/v4 v4.0.2
+	github.com/LerianStudio/lib-observability/v4 v4.0.3
 	github.com/LerianStudio/lib-service-discovery/v2 v2.0.0
 	github.com/LerianStudio/lib-streaming/v4 v4.0.0
 	github.com/Masterminds/squirrel v1.5.4

--- a/go.sum
+++ b/go.sum
@@ -23,8 +23,8 @@ github.com/LerianStudio/lib-commons/v7 v7.1.0 h1:dbzqIhjhCE+plQ8v53cfEbS5f6tMLab
 github.com/LerianStudio/lib-commons/v7 v7.1.0/go.mod h1:/iFJVftWWVryRxO9YGDW59UIAHMrGJB6EMKJlFeEiKM=
 github.com/LerianStudio/lib-observability/v2 v2.1.3 h1:ZFVIv7VVfSv/Ag9OcxQNqoa6YGV9KpcnRb4ocvM8jvk=
 github.com/LerianStudio/lib-observability/v2 v2.1.3/go.mod h1:iXspGM6PRTf6BDtkTc0Z69R2HEv1GtjBsI/YSvewDgA=
-github.com/LerianStudio/lib-observability/v4 v4.0.2 h1:id3glG8eiSOvvaM4PfGebWv9ywlpQ5mmjT3W6Psum6g=
-github.com/LerianStudio/lib-observability/v4 v4.0.2/go.mod h1:h2bmpC2iOJjgDSLtaMognNAg3asfEczkYQ74xlHZ6Hs=
+github.com/LerianStudio/lib-observability/v4 v4.0.3 h1:GRt/xLDrVT1x5K7JthjQQSEKcrhzqEbS6VMpg4BEl4w=
+github.com/LerianStudio/lib-observability/v4 v4.0.3/go.mod h1:h2bmpC2iOJjgDSLtaMognNAg3asfEczkYQ74xlHZ6Hs=
 github.com/LerianStudio/lib-service-discovery/v2 v2.0.0 h1:R8TrYI44/8joTbmZIBB8PNQmQwA7r53VeMPTiF9LtHM=
 github.com/LerianStudio/lib-service-discovery/v2 v2.0.0/go.mod h1:E1BIudjK8h0QGRTxFJZzFV3XBFp3s3dYuw7eqezsjug=
 github.com/LerianStudio/lib-streaming/v4 v4.0.0 h1:HeCzcglV3i+xZeWsA3YLkAWfsRSYI0o/Y+lF1idlJn0=

--- a/pkg/net/http/protected_routes.go
+++ b/pkg/net/http/protected_routes.go
@@ -78,6 +78,22 @@ func MarkTrustedAuthAssertion() fiber.Handler {
 		if tenantID := firstNonEmptyStringClaim(claims, "tenantId"); tenantID != "" && tmcore.IsValidTenantID(tenantID) {
 			ctx := withTenantIDBaggage(tmcore.ContextWithTenantID(c.Context(), tenantID), tenantID)
 
+			// Re-seeds the context logger so every log emitted downstream of
+			// this point — the warning below included — carries the tenant.
+			// The access-log line cannot be fixed from here:
+			// lib-observability's WithHTTPLogging binds its request logger
+			// before c.Next() and this middleware runs inside it, so that line
+			// resolves its own tenant field after c.Next() (needs a
+			// lib-observability release carrying that change).
+			//
+			// The raw claim, not the parsed UUID: logs must agree with the
+			// span attribute seeded into baggage above, and the two per-tenant
+			// channels deliberately differ in form. Seeded before the UUID
+			// branch on purpose — a non-UUID tenant carries no metric
+			// attestation, so this field is the only tenant signal it gets.
+			ctx = libObservability.ContextWithLogger(ctx,
+				libObservability.NewLoggerFromContext(ctx).With(libLog.String(obsconst.AttrKeyTenantID, tenantID)))
+
 			// The telemetry middleware labels per-tenant metrics only from an
 			// identity attested here; a client-supplied header or baggage member
 			// is never promoted to that trust level. tmcore.IsValidTenantID

--- a/pkg/net/http/protected_routes_test.go
+++ b/pkg/net/http/protected_routes_test.go
@@ -5,13 +5,17 @@
 package http
 
 import (
+	"context"
 	"fmt"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 
 	tmcore "github.com/LerianStudio/lib-commons/v7/commons/tenant-manager/core"
 	libObservability "github.com/LerianStudio/lib-observability/v4"
+	obsconst "github.com/LerianStudio/lib-observability/v4/constants"
+	libLog "github.com/LerianStudio/lib-observability/v4/log"
 	"github.com/gofiber/fiber/v3"
 	jwt "github.com/golang-jwt/jwt/v5"
 	"github.com/google/uuid"
@@ -214,4 +218,181 @@ func TestMarkTrustedAuthAssertion_SetsTenantIDContextAlongsideAttestation(t *tes
 	require.NoError(t, err)
 	require.Equal(t, fiber.StatusNoContent, resp.StatusCode)
 	assert.Equal(t, slugTenant, got)
+}
+
+// tenantFieldLogger records the fields bound to each logger derived from it,
+// so a test can assert what a handler's log record carried. Every derived
+// logger shares one sink because the middleware hands the handler a logger
+// two With calls removed from the one seeded here.
+type tenantFieldLogger struct {
+	sink  *tenantFieldSink
+	bound []libLog.Field
+}
+
+type tenantFieldSink struct {
+	mu      sync.Mutex
+	records []tenantFieldRecord
+}
+
+type tenantFieldRecord struct {
+	message string
+	fields  []libLog.Field
+}
+
+func newTenantFieldLogger() *tenantFieldLogger {
+	return &tenantFieldLogger{sink: &tenantFieldSink{}}
+}
+
+func (l *tenantFieldLogger) Log(_ context.Context, _ int, msg string, fields ...any) {
+	l.sink.mu.Lock()
+	defer l.sink.mu.Unlock()
+
+	l.sink.records = append(l.sink.records, tenantFieldRecord{
+		message: msg,
+		fields:  append(append([]libLog.Field(nil), l.bound...), libLog.Fields(fields...)...),
+	})
+}
+
+func (l *tenantFieldLogger) With(fields ...any) libLog.Logger {
+	return &tenantFieldLogger{
+		sink:  l.sink,
+		bound: append(append([]libLog.Field(nil), l.bound...), libLog.Fields(fields...)...),
+	}
+}
+
+func (l *tenantFieldLogger) WithGroup(_ string) libLog.Logger { return l }
+
+func (l *tenantFieldLogger) Enabled(_ int) bool { return true }
+
+func (l *tenantFieldLogger) Sync(_ context.Context) error { return nil }
+
+func (l *tenantFieldLogger) records() []tenantFieldRecord {
+	l.sink.mu.Lock()
+	defer l.sink.mu.Unlock()
+
+	return append([]tenantFieldRecord(nil), l.sink.records...)
+}
+
+// recordsWithMessage isolates the records a specific emitter produced. The
+// non-UUID path also logs a one-time attestation warning, so selecting by
+// position would make the assertion depend on which subtest tripped the
+// sync.Once first.
+func (l *tenantFieldLogger) recordsWithMessage(msg string) []tenantFieldRecord {
+	var out []tenantFieldRecord
+
+	for _, rec := range l.records() {
+		if rec.message == msg {
+			out = append(out, rec)
+		}
+	}
+
+	return out
+}
+
+func tenantFieldsOf(record []libLog.Field) []string {
+	var values []string
+
+	for _, field := range record {
+		if field.Key != obsconst.AttrKeyTenantID {
+			continue
+		}
+
+		value, _ := field.Value.(string)
+		values = append(values, value)
+	}
+
+	return values
+}
+
+func TestMarkTrustedAuthAssertion_ReseedsContextLoggerWithTenantID(t *testing.T) {
+	t.Parallel()
+
+	// Both tenant shapes, because the re-seed sits outside the UUID branch on
+	// purpose: a non-UUID tenant gets no metric attestation, so the log field
+	// is the only per-tenant signal it has.
+	cases := []struct {
+		name     string
+		tenantID string
+	}{
+		{name: "uuid tenant", tenantID: "0f6e2b3a-1c4d-4e5f-8a9b-0c1d2e3f4a5b"},
+		{name: "non-uuid tenant", tenantID: "org_01KHVKQQP6D2N4RDJK0ADEKQX1"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			logger := newTenantFieldLogger()
+
+			app := fiber.New()
+
+			// Stands in for lib-observability's WithHTTPLogging, which binds
+			// the request logger into the context BEFORE the auth chain runs.
+			app.Use(func(c fiber.Ctx) error {
+				c.SetContext(libObservability.ContextWithLogger(c.Context(), logger))
+
+				return c.Next()
+			})
+			app.Use(MarkTrustedAuthAssertion())
+			app.Get("/test", func(c fiber.Ctx) error {
+				libObservability.NewLoggerFromContext(c.Context()).
+					Log(c.Context(), libLog.LevelInfo, "handler ran")
+
+				return c.SendStatus(fiber.StatusNoContent)
+			})
+
+			req := httptest.NewRequest("GET", "/test", nil)
+			req.Header.Set("Authorization", fmt.Sprintf("Bearer %s",
+				mustUnsignedToken(t, jwt.MapClaims{"sub": "u", "tenantId": tc.tenantID})))
+
+			resp, err := app.Test(req)
+			require.NoError(t, err)
+			require.Equal(t, fiber.StatusNoContent, resp.StatusCode)
+
+			records := logger.recordsWithMessage("handler ran")
+			require.Len(t, records, 1, "the handler must emit exactly one record")
+			assert.Equal(t, []string{tc.tenantID}, tenantFieldsOf(records[0].fields),
+				"a handler log must carry the raw tenantId claim once, matching the span attribute")
+
+			// The non-UUID warning is itself about this tenant, so it must be
+			// attributable to it too - the re-seed sits above that branch.
+			for _, warned := range logger.recordsWithMessage(
+				"Tenant claim is not a UUID; per-tenant metrics will not be labelled for it") {
+				assert.Equal(t, []string{tc.tenantID}, tenantFieldsOf(warned.fields))
+			}
+		})
+	}
+}
+
+func TestMarkTrustedAuthAssertion_LeavesContextLoggerAloneWithoutTenantClaim(t *testing.T) {
+	t.Parallel()
+
+	logger := newTenantFieldLogger()
+
+	app := fiber.New()
+	app.Use(func(c fiber.Ctx) error {
+		c.SetContext(libObservability.ContextWithLogger(c.Context(), logger))
+
+		return c.Next()
+	})
+	app.Use(MarkTrustedAuthAssertion())
+	app.Get("/test", func(c fiber.Ctx) error {
+		libObservability.NewLoggerFromContext(c.Context()).
+			Log(c.Context(), libLog.LevelInfo, "handler ran")
+
+		return c.SendStatus(fiber.StatusNoContent)
+	})
+
+	req := httptest.NewRequest("GET", "/test", nil)
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s",
+		mustUnsignedToken(t, jwt.MapClaims{"sub": "u"})))
+
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	require.Equal(t, fiber.StatusNoContent, resp.StatusCode)
+
+	records := logger.recordsWithMessage("handler ran")
+	require.Len(t, records, 1)
+	assert.Empty(t, tenantFieldsOf(records[0].fields),
+		"a token without a tenantId claim must add no tenant.id field, not an empty one")
 }


### PR DESCRIPTION
Brings `tenant.id` to HTTP logs on `main`. One `fix:` commit, so the release computes a **patch** on top of `v4.0.1`.

Contents: the `MarkTrustedAuthAssertion` change from `develop` (LerianStudio/midaz#2473, cherry-picked clean) plus the `lib-observability` bump `v4.0.2` → **`v4.0.3`**.

## What this closes

Metrics have carried the attested UUID and spans the raw claim via OTel baggage since `v4.0.1`. **No log line carried the tenant at all.** This was the last of the three per-tenant channels.

Two halves were needed, and the split follows from middleware ordering rather than preference:

**The access-log line** — the record with `http_status_code`, `http_method`, `http_path`, `http_latency_ms` — is emitted by lib-observability, which binds its request logger **before** `c.Next()`. The tenant is attested by a route-level middleware running **inside** `c.Next()`, behind `auth.Authorize`, so it does not exist yet at bind time. The library now resolves it **after** `c.Next()` from the request AttrBag and OTel baggage, both written by `MarkTrustedAuthAssertion` through `c.SetContext` — so the log agrees with the span attribute rather than deriving a second, independent notion of tenant. It reuses `resolveTenantIDForTelemetry`, which already existed and was already used by the gRPC logging path. That arrives here as the bump.

**Handler logs** during the request come from the midaz change: `MarkTrustedAuthAssertion` re-seeds the context logger at attestation time. It uses the **raw claim**, matching baggage, and sits **above** the UUID branch deliberately — a non-UUID tenant carries no metric attestation, so this field is the only tenant signal it gets, the warning about that very claim included.

## Verified in production, on stg-mt

`stg-mt` has been running `4.1.0-beta.15` — which carries both halves — since it rolled out. Live access-log lines there:

```
440339a0d5f2  GET  200  246ms  /v1/organizations/:organization_id/ledgers/:ledger_id/transactions/:transaction_id
440339a0d5f2  GET  200   11ms  /v1/organizations
440339a0d5f2  GET  200  108ms  /v1/organizations/:organization_id/ledgers/:ledger_id/assets
```

- **11 of 11** access-log lines labelled with `tenant.id`, none unlabelled;
- **zero** probe paths (`/health`, `/readyz`, `/metrics`) in the log at all, while 1440 `/readyz` hits were served;
- `http_path` recorded as the **route template**, not the raw path — bounded cardinality.

Earlier, on a local stack with a real Caradhras JWT: a handler log and the access-log line carried `tenant.id` in the same correlated request; a request with no token, and one with a signature-valid token carrying no `tenantId` claim, both produced **no** field and no empty-string field; and the same binary restarted single-tenant emitted no field, confirming the label is a property of an attested multi-tenant request rather than of the code being present.

## Not spoofable

A client-supplied `tenant.id` cannot reach the field. `tracing.ExtractTraceContext` strips inbound `tenant.id` baggage and restores only a trusted member, and `middleware.ExtractHTTPContext` is the single HTTP funnel through it. Tested: a forged `baggage: tenant.id=FORGED-EVIL-TENANT` header sent alongside a real token logged the JWT's tenant, and the forged string appeared nowhere in the ledger log.

## Verification on this branch

`gofmt` clean · `go build ./...` 0 · `go vet ./...` 0 · unit **96 packages ok / 0 FAIL** · `make check-telemetry` 0 · `tests/modulegraph` 0, unmodified and with no allowlist entry added.

**No pre-release pins remain in `go.mod`** — `v4.0.3` is a stable release and resolves from `proxy.golang.org`, so the pre-release gate that blocks `main` has nothing to flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved authenticated request logging so tenant identifiers are consistently included in handler and warning logs.
  - Tenant identifiers are preserved for both UUID and non-UUID formats.
  - Requests without a tenant identifier continue to retain their existing logging context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->