### PR TITLE
fix: stop losing a committed spend on the tracer reservation path

### DIFF
--- a/components/ledger/internal/adapters/tracer/client.go
+++ b/components/ledger/internal/adapters/tracer/client.go
@@ -258,7 +258,7 @@ func (c *TracerClient) ReleaseByTransaction(ctx context.Context, transactionID u
 // transitionByTransaction is the shared by-transaction confirm/release body: POST
 // the action under the /reservations/transaction/{id}/{action} path and require a
 // 200. Availability failures return ErrTracerUnavailable so the caller's
-// best-effort post-commit transport can swallow them (the TTL reaper backstops).
+// non-blocking post-commit transport can swallow them and retry off the request path.
 func (c *TracerClient) transitionByTransaction(ctx context.Context, action string, transactionID uuid.UUID) error {
 	_, tracer, _, _ := libObservability.NewTrackingFromContext(ctx)
 

--- a/components/ledger/internal/bootstrap/unified-server.go
+++ b/components/ledger/internal/bootstrap/unified-server.go
@@ -21,6 +21,7 @@ import (
 
 	httpin "github.com/LerianStudio/midaz/v4/components/ledger/internal/adapters/http/in"
 	ledgerMiddleware "github.com/LerianStudio/midaz/v4/components/ledger/internal/adapters/http/in/middleware"
+	"github.com/LerianStudio/midaz/v4/components/ledger/internal/services/command"
 	"github.com/LerianStudio/midaz/v4/pkg/buildinfo"
 	midazhttp "github.com/LerianStudio/midaz/v4/pkg/net/http"
 )
@@ -192,6 +193,12 @@ func NewUnifiedServer(
 				libLog.String("drain_delay", DefaultDrainDelay.String()))
 			time.Sleep(DefaultDrainDelay)
 			logger.Log(context.Background(), libLog.LevelInfo, "Drain delay complete, proceeding with shutdown")
+
+			// Name any confirm/release still owed to the tracer. The retry that
+			// redelivers them is in-process, so whatever is still in flight here
+			// dies with the process; a rolling deploy would otherwise drop
+			// uncounted spends and held capacity with no log line at all.
+			command.ReportOutstandingReservationRetries(context.Background(), logger)
 
 			return nil
 		})

--- a/components/ledger/internal/services/command/commit_transaction.go
+++ b/components/ledger/internal/services/command/commit_transaction.go
@@ -162,11 +162,13 @@ func (uc *UseCase) transitionPendingV2(ctx context.Context, run *pendingTransiti
 		return nil, err
 	}
 
+	identity := run.reservationIdentity()
+
 	switch run.status {
 	case constant.APPROVED:
-		uc.confirmReservationsByTransaction(ctx, span, logger, run.ledgerSettings.Tracer, run.tran.IDtoUUID(), run.honoredTracerSkip)
+		uc.confirmReservationsByTransaction(ctx, span, logger, run.ledgerSettings.Tracer, identity, run.honoredTracerSkip)
 	case constant.CANCELED:
-		uc.releaseReservationsByTransaction(ctx, span, logger, run.ledgerSettings.Tracer, run.tran.IDtoUUID(), run.honoredTracerSkip)
+		uc.releaseReservationsByTransaction(ctx, span, logger, run.ledgerSettings.Tracer, identity, run.honoredTracerSkip)
 	}
 
 	return uc.finalizePendingTransition(ctx, span, logger, run, unlock)

--- a/components/ledger/internal/services/command/commit_transaction.go
+++ b/components/ledger/internal/services/command/commit_transaction.go
@@ -141,8 +141,9 @@ func (uc *UseCase) transitionPendingV1(ctx context.Context, run *pendingTransiti
 // capacity but deferred the confirm/release to this state transition; /commit and
 // /cancel carry only the transaction id, so the tracer is addressed by transaction id
 // and flips every RESERVED reservation the transaction holds. Non-blocking: a transport
-// failure never fails the request — the TTL reaper reconciles. The long-lived TTL hint
-// set at create-pending keeps these reservations alive until this transition.
+// failure never fails the request; it is retried off the request path instead. The
+// long-lived TTL hint set at create-pending keeps these reservations alive until this
+// transition.
 func (uc *UseCase) transitionPendingV2(ctx context.Context, run *pendingTransitionRun) (*transaction.Transaction, error) {
 	logger, tracer, _, _ := libObservability.NewTrackingFromContext(ctx)
 

--- a/components/ledger/internal/services/command/create_transaction_v2.go
+++ b/components/ledger/internal/services/command/create_transaction_v2.go
@@ -235,8 +235,9 @@ func (uc *UseCase) CreateTransactionV2(ctx context.Context, in CreateTransaction
 		uc.rollbackCreateSeed(ctx, logger, run)
 
 		// The balance commit failed (no funds moved), so return the held
-		// reservation capacity. Best-effort: a transport failure here is
-		// reconciled by the TTL reaper.
+		// reservation capacity. Non-blocking: a transport failure here is
+		// retried off the request path, and the hold's expiry sweep returns
+		// the capacity anyway if every attempt fails.
 		uc.releaseReservations(ctx, span, logger, reservation.Handle)
 
 		return nil, false, err

--- a/components/ledger/internal/services/command/transaction_reservation_anchor.go
+++ b/components/ledger/internal/services/command/transaction_reservation_anchor.go
@@ -54,8 +54,36 @@ type reservationOutcome struct {
 // reserve so the post-commit transport (confirm on success, release on abort)
 // can address them. An empty handle means there is nothing to confirm or
 // release (tracer skipped or no capacity-backed limit applied).
+//
+// It also carries the transaction the capacity was held for and the amount that
+// was held. Neither is needed to address the transition — the reservation id
+// alone does that — but both are needed to REPORT one that could not be
+// delivered: an operator reading a lost confirm has to know which transaction
+// and how much spending went uncounted, and the reservation id alone says
+// neither.
 type reservationHandle struct {
 	ReservationIDs []uuid.UUID
+	TransactionID  uuid.UUID
+	Amount         decimal.Decimal
+	Asset          string
+}
+
+// transitions expands the handle into one addressable transition per held
+// reservation, each carrying the full identity of what is being settled.
+func (h reservationHandle) transitions(action string) []reservationTransition {
+	out := make([]reservationTransition, 0, len(h.ReservationIDs))
+
+	for _, id := range h.ReservationIDs {
+		out = append(out, reservationTransition{
+			Action:        action,
+			TransactionID: h.TransactionID,
+			ReservationID: id,
+			Amount:        h.Amount,
+			Asset:         h.Asset,
+		})
+	}
+
+	return out
 }
 
 // reservationTTLPolicy selects the reservation lifetime hint passed to the
@@ -141,8 +169,13 @@ func (uc *UseCase) reserveTransaction(
 	}
 
 	return reservationOutcome{
-		Kind:   reservationProceed,
-		Handle: reservationHandle{ReservationIDs: result.ReservationIDs},
+		Kind: reservationProceed,
+		Handle: reservationHandle{
+			ReservationIDs: result.ReservationIDs,
+			TransactionID:  transactionID,
+			Amount:         amount,
+			Asset:          asset,
+		},
 	}
 }
 
@@ -259,9 +292,9 @@ func (uc *UseCase) confirmReservations(ctx context.Context, span trace.Span, log
 		return
 	}
 
-	for _, id := range handle.ReservationIDs {
-		if err := uc.TracerReserver.Confirm(ctx, id); err != nil {
-			uc.recordReservationTransportFailure(ctx, span, logger, "confirm", id, err)
+	for _, transition := range handle.transitions(reservationActionConfirm) {
+		if err := uc.TracerReserver.Confirm(ctx, transition.ReservationID); err != nil {
+			uc.recordReservationTransportFailure(ctx, span, logger, transition, err)
 		}
 	}
 }
@@ -273,9 +306,9 @@ func (uc *UseCase) releaseReservations(ctx context.Context, span trace.Span, log
 		return
 	}
 
-	for _, id := range handle.ReservationIDs {
-		if err := uc.TracerReserver.Release(ctx, id); err != nil {
-			uc.recordReservationTransportFailure(ctx, span, logger, "release", id, err)
+	for _, transition := range handle.transitions(reservationActionRelease) {
+		if err := uc.TracerReserver.Release(ctx, transition.ReservationID); err != nil {
+			uc.recordReservationTransportFailure(ctx, span, logger, transition, err)
 		}
 	}
 }
@@ -283,15 +316,19 @@ func (uc *UseCase) releaseReservations(ctx context.Context, span trace.Span, log
 // recordReservationTransportFailure logs and span-records a confirm/release
 // transport failure without propagating it. Both an availability failure
 // (tracer.ErrTracerUnavailable) and any other transport error are the
-// lost-transport case the reaper backstops at TTL, so both are Warn-logged and
-// swallowed.
-func (uc *UseCase) recordReservationTransportFailure(ctx context.Context, span trace.Span, logger libLog.Logger, action string, id uuid.UUID, err error) {
-	libOpentelemetry.HandleSpanError(span, "Tracer reservation "+action+" transport failed", err)
+// lost-transport case, so both are Warn-logged and swallowed here rather than
+// failing a transaction whose money has already moved.
+//
+// The record names the transaction and the amount, not only the reservation id.
+// A lost confirm means a committed spend the limit never counted; an operator
+// reading this line has to be able to say WHICH transaction and HOW MUCH
+// without joining against the tracer's own store, which may be the thing that
+// is down.
+func (uc *UseCase) recordReservationTransportFailure(ctx context.Context, span trace.Span, logger libLog.Logger, transition reservationTransition, err error) {
+	libOpentelemetry.HandleSpanError(span, "Tracer reservation "+transition.Action+" transport failed", err)
 
-	logger.Log(ctx, libLog.LevelWarn, "Tracer reservation transport failed; reaper will reconcile at TTL",
-		libLog.String("reservation_action", action),
-		libLog.String("reservation_id", id.String()),
-		libLog.Err(err))
+	logger.Log(ctx, libLog.LevelWarn, "Tracer reservation transport failed on the first attempt",
+		append(transition.logFields(), libLog.Err(err)))
 }
 
 // confirmReservationsByTransaction commits a transaction's held reservations at
@@ -313,26 +350,26 @@ func (uc *UseCase) recordReservationTransportFailure(ctx context.Context, span t
 // Mixing mounts across one transaction lifecycle is therefore unsupported — see
 // docs/api/SCOPING.md. Closing it needs create-time reservation state persisted on the
 // transaction row for the /v1 pipeline to read.
-func (uc *UseCase) confirmReservationsByTransaction(ctx context.Context, span trace.Span, logger libLog.Logger, settings mmodel.TracerSettings, transactionID uuid.UUID, honoredTracerSkip bool) {
+func (uc *UseCase) confirmReservationsByTransaction(ctx context.Context, span trace.Span, logger libLog.Logger, settings mmodel.TracerSettings, identity reservationHandle, honoredTracerSkip bool) {
 	if honoredTracerSkip || !uc.tracerReservationEnabled(settings) {
 		return
 	}
 
-	if err := uc.TracerReserver.ConfirmByTransaction(ctx, transactionID); err != nil {
-		uc.recordReservationByTransactionFailure(ctx, span, logger, "confirm", transactionID, err)
+	if err := uc.TracerReserver.ConfirmByTransaction(ctx, identity.TransactionID); err != nil {
+		uc.recordReservationByTransactionFailure(ctx, span, logger, identity.transitionByTransaction(reservationActionConfirm), err)
 	}
 }
 
 // releaseReservationsByTransaction returns a transaction's held reservations at
 // /cancel (F3-T15, PENDING abort phase). Same transaction-id addressing, gating,
 // and non-blocking posture as confirmReservationsByTransaction.
-func (uc *UseCase) releaseReservationsByTransaction(ctx context.Context, span trace.Span, logger libLog.Logger, settings mmodel.TracerSettings, transactionID uuid.UUID, honoredTracerSkip bool) {
+func (uc *UseCase) releaseReservationsByTransaction(ctx context.Context, span trace.Span, logger libLog.Logger, settings mmodel.TracerSettings, identity reservationHandle, honoredTracerSkip bool) {
 	if honoredTracerSkip || !uc.tracerReservationEnabled(settings) {
 		return
 	}
 
-	if err := uc.TracerReserver.ReleaseByTransaction(ctx, transactionID); err != nil {
-		uc.recordReservationByTransactionFailure(ctx, span, logger, "release", transactionID, err)
+	if err := uc.TracerReserver.ReleaseByTransaction(ctx, identity.TransactionID); err != nil {
+		uc.recordReservationByTransactionFailure(ctx, span, logger, identity.transitionByTransaction(reservationActionRelease), err)
 	}
 }
 
@@ -346,15 +383,14 @@ func (uc *UseCase) tracerReservationEnabled(settings mmodel.TracerSettings) bool
 }
 
 // recordReservationByTransactionFailure logs and span-records a by-transaction
-// confirm/release transport failure without propagating it — the reaper reconciles
-// any lost transition at TTL.
-func (uc *UseCase) recordReservationByTransactionFailure(ctx context.Context, span trace.Span, logger libLog.Logger, action string, transactionID uuid.UUID, err error) {
-	libOpentelemetry.HandleSpanError(span, "Tracer reservation "+action+" by transaction transport failed", err)
+// confirm/release transport failure without propagating it. Like the by-id
+// record it names the amount as well as the transaction, so a lost confirm is
+// legible as "this much spending went uncounted" rather than as an opaque id.
+func (uc *UseCase) recordReservationByTransactionFailure(ctx context.Context, span trace.Span, logger libLog.Logger, transition reservationTransition, err error) {
+	libOpentelemetry.HandleSpanError(span, "Tracer reservation "+transition.Action+" by transaction transport failed", err)
 
-	logger.Log(ctx, libLog.LevelWarn, "Tracer reservation by-transaction transport failed; reaper will reconcile at TTL",
-		libLog.String("reservation_action", action),
-		libLog.String("transaction_id", transactionID.String()),
-		libLog.Err(err))
+	logger.Log(ctx, libLog.LevelWarn, "Tracer reservation by-transaction transport failed on the first attempt",
+		append(transition.logFields(), libLog.Err(err)))
 }
 
 // reservationTTLForStatus selects the TTL policy from the transaction status:

--- a/components/ledger/internal/services/command/transaction_reservation_anchor.go
+++ b/components/ledger/internal/services/command/transaction_reservation_anchor.go
@@ -302,7 +302,11 @@ func (uc *UseCase) confirmReservations(ctx context.Context, span trace.Span, log
 }
 
 // releaseReservations returns held reservations on an aborted transaction
-// (F3-T14, the abort phase). Same best-effort posture as confirmReservations.
+// (F3-T14, the abort phase). Same non-blocking, retried posture as
+// confirmReservations: a failure never fails the request and is redelivered off
+// the request path. The direction of the loss is the opposite one — a release
+// that never lands leaves capacity held against a transaction that moved no
+// money — which is why the report distinguishes them.
 func (uc *UseCase) releaseReservations(ctx context.Context, span trace.Span, logger libLog.Logger, handle reservationHandle) {
 	if uc.TracerReserver == nil {
 		return

--- a/components/ledger/internal/services/command/transaction_reservation_anchor.go
+++ b/components/ledger/internal/services/command/transaction_reservation_anchor.go
@@ -283,10 +283,12 @@ func firstSourceAccountID(sources []string, balances []*mmodel.Balance) string {
 }
 
 // confirmReservations commits held reservations after a successful balance
-// commit (F3-T14, the success phase). Transport is best-effort: a failure is
-// logged at Warn, span-recorded, and never propagated — the TTL reaper is the
-// durability backstop (design call G). A nil reserver or empty handle is a
-// no-op.
+// commit (F3-T14, the success phase). Transport never blocks the request: a
+// failure is logged at Warn, span-recorded, and never propagated, because the
+// money has already moved and the response is owed now. The failure is NOT
+// dropped, though — it is handed to the retrier, which keeps trying off the
+// request path until the tracer accepts it or the budget runs out. A nil
+// reserver or empty handle is a no-op.
 func (uc *UseCase) confirmReservations(ctx context.Context, span trace.Span, logger libLog.Logger, handle reservationHandle) {
 	if uc.TracerReserver == nil {
 		return
@@ -327,8 +329,10 @@ func (uc *UseCase) releaseReservations(ctx context.Context, span trace.Span, log
 func (uc *UseCase) recordReservationTransportFailure(ctx context.Context, span trace.Span, logger libLog.Logger, transition reservationTransition, err error) {
 	libOpentelemetry.HandleSpanError(span, "Tracer reservation "+transition.Action+" transport failed", err)
 
-	logger.Log(ctx, libLog.LevelWarn, "Tracer reservation transport failed on the first attempt",
+	logger.Log(ctx, libLog.LevelWarn, "Tracer reservation transport failed on the first attempt; retrying off the request path",
 		append(transition.logFields(), libLog.Err(err)))
+
+	uc.scheduleReservationRetry(ctx, logger, transition, err)
 }
 
 // confirmReservationsByTransaction commits a transaction's held reservations at
@@ -339,9 +343,8 @@ func (uc *UseCase) recordReservationTransportFailure(ctx context.Context, span t
 // the /v1 contract carries no tracer. Beyond that it is gated on the per-ledger tracer
 // settings (off / nil reserver → no call) and on an honored per-call tracer skip (so a
 // skip honored at create removes the gRPC cost here rather than relocating it to
-// commit); same best-effort, non-blocking posture as the by-id transport: a failure is
-// logged at Warn, span-recorded, and never propagated, with the TTL reaper as the
-// durability backstop.
+// commit); same non-blocking posture as the by-id transport: a failure is logged at
+// Warn, span-recorded and never propagated, and then retried off the request path.
 //
 // Living only on the /v2 pipeline carries an accepted cost. A by-transaction call cannot
 // tell whether the transaction holds reservations, so a PENDING created on /v2 and
@@ -389,8 +392,10 @@ func (uc *UseCase) tracerReservationEnabled(settings mmodel.TracerSettings) bool
 func (uc *UseCase) recordReservationByTransactionFailure(ctx context.Context, span trace.Span, logger libLog.Logger, transition reservationTransition, err error) {
 	libOpentelemetry.HandleSpanError(span, "Tracer reservation "+transition.Action+" by transaction transport failed", err)
 
-	logger.Log(ctx, libLog.LevelWarn, "Tracer reservation by-transaction transport failed on the first attempt",
+	logger.Log(ctx, libLog.LevelWarn, "Tracer reservation by-transaction transport failed on the first attempt; retrying off the request path",
 		append(transition.logFields(), libLog.Err(err)))
+
+	uc.scheduleReservationRetry(ctx, logger, transition, err)
 }
 
 // reservationTTLForStatus selects the TTL policy from the transaction status:

--- a/components/ledger/internal/services/command/transaction_reservation_anchor_test.go
+++ b/components/ledger/internal/services/command/transaction_reservation_anchor_test.go
@@ -31,6 +31,17 @@ var fixedReserveTimestamp = time.Date(2026, 6, 5, 12, 0, 0, 0, time.UTC)
 
 const fixedReserveAccountID = "acc-source-1"
 
+// byTxnIdentity builds the identity the by-transaction confirm/release is
+// addressed and reported with: a handle carrying no reservation ids, because
+// the create-time handle does not survive into /commit or /cancel.
+func byTxnIdentity(transactionID uuid.UUID) reservationHandle {
+	return reservationHandle{
+		TransactionID: transactionID,
+		Amount:        decimal.NewFromInt(1000),
+		Asset:         "BRL",
+	}
+}
+
 // stubReserver is a scripted TracerReserver: it records calls and returns the
 // configured reserve result/error and per-action transition errors so each
 // branch of the anchor and the post-commit transport can be asserted without a
@@ -416,7 +427,7 @@ func TestConfirmReservationsByTransaction(t *testing.T) {
 		reserver := &stubReserver{}
 		uc := &UseCase{TracerReserver: reserver}
 
-		uc.confirmReservationsByTransaction(ctx, sp, logger, enforce, txID, false)
+		uc.confirmReservationsByTransaction(ctx, sp, logger, enforce, byTxnIdentity(txID), false)
 
 		assert.Equal(t, []uuid.UUID{txID}, reserver.confirmedTxns)
 		assert.Empty(t, reserver.releasedTxns)
@@ -428,7 +439,7 @@ func TestConfirmReservationsByTransaction(t *testing.T) {
 		uc := &UseCase{TracerReserver: reserver}
 
 		uc.confirmReservationsByTransaction(ctx, sp, logger,
-			mmodel.TracerSettings{Mode: mmodel.TracerModeAdvisory}, txID, false)
+			mmodel.TracerSettings{Mode: mmodel.TracerModeAdvisory}, byTxnIdentity(txID), false)
 
 		assert.Equal(t, []uuid.UUID{txID}, reserver.confirmedTxns)
 	})
@@ -438,7 +449,7 @@ func TestConfirmReservationsByTransaction(t *testing.T) {
 		uc := &UseCase{TracerReserver: reserver}
 
 		uc.confirmReservationsByTransaction(ctx, sp, logger,
-			mmodel.TracerSettings{Mode: mmodel.TracerModeOff}, uuid.New(), false)
+			mmodel.TracerSettings{Mode: mmodel.TracerModeOff}, byTxnIdentity(uuid.New()), false)
 
 		assert.Empty(t, reserver.confirmedTxns, "mode=off must not confirm")
 	})
@@ -447,14 +458,14 @@ func TestConfirmReservationsByTransaction(t *testing.T) {
 		reserver := &stubReserver{}
 		uc := &UseCase{TracerReserver: reserver}
 
-		uc.confirmReservationsByTransaction(ctx, sp, logger, mmodel.TracerSettings{}, uuid.New(), false)
+		uc.confirmReservationsByTransaction(ctx, sp, logger, mmodel.TracerSettings{}, byTxnIdentity(uuid.New()), false)
 
 		assert.Empty(t, reserver.confirmedTxns)
 	})
 
 	t.Run("nil reserver is a no-op", func(t *testing.T) {
 		uc := &UseCase{TracerReserver: nil}
-		uc.confirmReservationsByTransaction(ctx, sp, logger, enforce, uuid.New(), false)
+		uc.confirmReservationsByTransaction(ctx, sp, logger, enforce, byTxnIdentity(uuid.New()), false)
 		// no panic, nothing to assert beyond not crashing
 	})
 
@@ -465,7 +476,7 @@ func TestConfirmReservationsByTransaction(t *testing.T) {
 
 		// The contract is that the request still succeeds: the helper returns
 		// nothing, swallows the error, and the caller proceeds.
-		uc.confirmReservationsByTransaction(ctx, sp, logger, enforce, txID, false)
+		uc.confirmReservationsByTransaction(ctx, sp, logger, enforce, byTxnIdentity(txID), false)
 
 		assert.Equal(t, []uuid.UUID{txID}, reserver.confirmedTxns, "the transition is attempted despite transport failure")
 	})
@@ -474,7 +485,7 @@ func TestConfirmReservationsByTransaction(t *testing.T) {
 		reserver := &stubReserver{}
 		uc := &UseCase{TracerReserver: reserver}
 
-		uc.confirmReservationsByTransaction(ctx, sp, logger, enforce, uuid.New(), true)
+		uc.confirmReservationsByTransaction(ctx, sp, logger, enforce, byTxnIdentity(uuid.New()), true)
 
 		assert.Empty(t, reserver.confirmedTxns, "an honored tracer skip must make zero ConfirmByTransaction")
 	})
@@ -490,7 +501,7 @@ func TestReleaseReservationsByTransaction(t *testing.T) {
 		reserver := &stubReserver{}
 		uc := &UseCase{TracerReserver: reserver}
 
-		uc.releaseReservationsByTransaction(ctx, sp, logger, enforce, txID, false)
+		uc.releaseReservationsByTransaction(ctx, sp, logger, enforce, byTxnIdentity(txID), false)
 
 		assert.Equal(t, []uuid.UUID{txID}, reserver.releasedTxns)
 		assert.Empty(t, reserver.confirmedTxns)
@@ -501,14 +512,14 @@ func TestReleaseReservationsByTransaction(t *testing.T) {
 		uc := &UseCase{TracerReserver: reserver}
 
 		uc.releaseReservationsByTransaction(ctx, sp, logger,
-			mmodel.TracerSettings{Mode: mmodel.TracerModeOff}, uuid.New(), false)
+			mmodel.TracerSettings{Mode: mmodel.TracerModeOff}, byTxnIdentity(uuid.New()), false)
 
 		assert.Empty(t, reserver.releasedTxns)
 	})
 
 	t.Run("nil reserver is a no-op", func(t *testing.T) {
 		uc := &UseCase{TracerReserver: nil}
-		uc.releaseReservationsByTransaction(ctx, sp, logger, enforce, uuid.New(), false)
+		uc.releaseReservationsByTransaction(ctx, sp, logger, enforce, byTxnIdentity(uuid.New()), false)
 	})
 
 	t.Run("transport failure does not propagate", func(t *testing.T) {
@@ -516,7 +527,7 @@ func TestReleaseReservationsByTransaction(t *testing.T) {
 		reserver := &stubReserver{releaseByTxnErr: fmt.Errorf("down: %w", tracer.ErrTracerUnavailable)}
 		uc := &UseCase{TracerReserver: reserver}
 
-		uc.releaseReservationsByTransaction(ctx, sp, logger, enforce, txID, false)
+		uc.releaseReservationsByTransaction(ctx, sp, logger, enforce, byTxnIdentity(txID), false)
 
 		assert.Equal(t, []uuid.UUID{txID}, reserver.releasedTxns, "the transition is attempted despite transport failure")
 	})
@@ -525,7 +536,7 @@ func TestReleaseReservationsByTransaction(t *testing.T) {
 		reserver := &stubReserver{}
 		uc := &UseCase{TracerReserver: reserver}
 
-		uc.releaseReservationsByTransaction(ctx, sp, logger, enforce, uuid.New(), true)
+		uc.releaseReservationsByTransaction(ctx, sp, logger, enforce, byTxnIdentity(uuid.New()), true)
 
 		assert.Empty(t, reserver.releasedTxns, "an honored tracer skip must make zero ReleaseByTransaction")
 	})

--- a/components/ledger/internal/services/command/transaction_reservation_anchor_test.go
+++ b/components/ledger/internal/services/command/transaction_reservation_anchor_test.go
@@ -7,6 +7,7 @@ package command
 import (
 	"context"
 	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -47,6 +48,11 @@ func byTxnIdentity(transactionID uuid.UUID) reservationHandle {
 // branch of the anchor and the post-commit transport can be asserted without a
 // live tracer.
 type stubReserver struct {
+	// mu guards the recorded calls. A transition the tracer refuses is now
+	// retried on a background goroutine, so the stub is written from there
+	// while the test body reads it.
+	mu sync.Mutex
+
 	reserveCalls int
 	confirmedIDs []uuid.UUID
 	releasedIDs  []uuid.UUID
@@ -65,6 +71,9 @@ type stubReserver struct {
 }
 
 func (s *stubReserver) Reserve(_ context.Context, _ tracer.ReserveRequest) (*tracer.ReserveResult, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
 	s.reserveCalls++
 
 	if s.reserveErr != nil {
@@ -75,23 +84,77 @@ func (s *stubReserver) Reserve(_ context.Context, _ tracer.ReserveRequest) (*tra
 }
 
 func (s *stubReserver) Confirm(_ context.Context, id uuid.UUID) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
 	s.confirmedIDs = append(s.confirmedIDs, id)
+
 	return s.confirmErr
 }
 
 func (s *stubReserver) Release(_ context.Context, id uuid.UUID) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
 	s.releasedIDs = append(s.releasedIDs, id)
+
 	return s.releaseErr
 }
 
 func (s *stubReserver) ConfirmByTransaction(_ context.Context, transactionID uuid.UUID) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
 	s.confirmedTxns = append(s.confirmedTxns, transactionID)
+
 	return s.confirmByTxnErr
 }
 
 func (s *stubReserver) ReleaseByTransaction(_ context.Context, transactionID uuid.UUID) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
 	s.releasedTxns = append(s.releasedTxns, transactionID)
+
 	return s.releaseByTxnErr
+}
+
+// The recorded-call accessors below return copies under the lock. Tests read
+// through them rather than touching the slices directly.
+
+func (s *stubReserver) reserves() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return s.reserveCalls
+}
+
+func (s *stubReserver) confirmed() []uuid.UUID {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return append([]uuid.UUID(nil), s.confirmedIDs...)
+}
+
+func (s *stubReserver) released() []uuid.UUID {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return append([]uuid.UUID(nil), s.releasedIDs...)
+}
+
+func (s *stubReserver) confirmedTransactions() []uuid.UUID {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return append([]uuid.UUID(nil), s.confirmedTxns...)
+}
+
+func (s *stubReserver) releasedTransactions() []uuid.UUID {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return append([]uuid.UUID(nil), s.releasedTxns...)
 }
 
 // anchorDeps returns the ctx, noop span, and a nil logger used by every anchor
@@ -128,7 +191,7 @@ func TestReserveTransaction_OffOrNilReserver_Proceeds(t *testing.T) {
 			decimal.NewFromInt(1000), "BRL", fixedReserveAccountID, fixedReserveTimestamp, reservationTTLDefault, false)
 
 		assert.Equal(t, reservationProceed, out.Kind)
-		assert.Equal(t, 0, reserver.reserveCalls, "mode=off must not call the tracer")
+		assert.Equal(t, 0, reserver.reserves(), "mode=off must not call the tracer")
 	})
 
 	t.Run("empty mode treated as off", func(t *testing.T) {
@@ -140,7 +203,7 @@ func TestReserveTransaction_OffOrNilReserver_Proceeds(t *testing.T) {
 			decimal.NewFromInt(1000), "BRL", fixedReserveAccountID, fixedReserveTimestamp, reservationTTLDefault, false)
 
 		assert.Equal(t, reservationProceed, out.Kind)
-		assert.Equal(t, 0, reserver.reserveCalls)
+		assert.Equal(t, 0, reserver.reserves())
 	})
 }
 
@@ -168,7 +231,7 @@ func TestReserveTransaction_HonoredSkip_Proceeds(t *testing.T) {
 				decimal.NewFromInt(1000), "BRL", fixedReserveAccountID, fixedReserveTimestamp, reservationTTLDefault, true)
 
 			assert.Equal(t, reservationProceed, out.Kind, "honored skip must proceed without gating")
-			assert.Equal(t, 0, reserver.reserveCalls, "honored skip must NOT call the tracer Reserve")
+			assert.Equal(t, 0, reserver.reserves(), "honored skip must NOT call the tracer Reserve")
 			assert.Empty(t, out.Handle.ReservationIDs, "an honored skip holds no reservation")
 		})
 	}
@@ -182,7 +245,7 @@ func TestReserveTransaction_HonoredSkip_Proceeds(t *testing.T) {
 			uuid.New(), decimal.NewFromInt(1000), "BRL", fixedReserveAccountID, fixedReserveTimestamp, reservationTTLDefault, false)
 
 		assert.Equal(t, reservationProceed, out.Kind)
-		assert.Equal(t, 1, reserver.reserveCalls, "without a skip the reserve fires exactly once, as today")
+		assert.Equal(t, 1, reserver.reserves(), "without a skip the reserve fires exactly once, as today")
 	})
 }
 
@@ -198,7 +261,7 @@ func TestReserveTransaction_EnforceAllow_Proceeds(t *testing.T) {
 		uuid.New(), decimal.NewFromInt(1000), "BRL", fixedReserveAccountID, fixedReserveTimestamp, reservationTTLDefault, false)
 
 	assert.Equal(t, reservationProceed, out.Kind)
-	assert.Equal(t, 1, reserver.reserveCalls)
+	assert.Equal(t, 1, reserver.reserves())
 	assert.Equal(t, ids, out.Handle.ReservationIDs, "the handle carries the reservation ids for post-commit confirm")
 }
 
@@ -232,7 +295,7 @@ func TestReserveTransaction_Advisory_NeverBlocks(t *testing.T) {
 			uuid.New(), decimal.NewFromInt(1000), "BRL", fixedReserveAccountID, fixedReserveTimestamp, reservationTTLDefault, false)
 
 		assert.Equal(t, reservationProceed, out.Kind, "advisory must never block, even on deny")
-		assert.Equal(t, 1, reserver.reserveCalls, "advisory still calls the tracer")
+		assert.Equal(t, 1, reserver.reserves(), "advisory still calls the tracer")
 	})
 
 	t.Run("advisory + unavailable proceeds", func(t *testing.T) {
@@ -375,6 +438,8 @@ func TestReservationTTLForStatus(t *testing.T) {
 }
 
 func TestConfirmReservations(t *testing.T) {
+	withFastSharedRetrier(t)
+
 	ctx, sp, logger := anchorDeps()
 
 	t.Run("confirms every id", func(t *testing.T) {
@@ -384,7 +449,7 @@ func TestConfirmReservations(t *testing.T) {
 
 		uc.confirmReservations(ctx, sp, logger, reservationHandle{ReservationIDs: ids})
 
-		assert.Equal(t, ids, reserver.confirmedIDs)
+		assert.Equal(t, ids, reserver.confirmed())
 	})
 
 	t.Run("nil reserver is a no-op", func(t *testing.T) {
@@ -393,19 +458,27 @@ func TestConfirmReservations(t *testing.T) {
 		// no panic, nothing to assert beyond not crashing
 	})
 
-	t.Run("transport failure does not propagate", func(t *testing.T) {
+	t.Run("transport failure does not propagate, and is retried", func(t *testing.T) {
+		ids := []uuid.UUID{uuid.New(), uuid.New()}
 		reserver := &stubReserver{confirmErr: fmt.Errorf("down: %w", tracer.ErrTracerUnavailable)}
 		uc := &UseCase{TracerReserver: reserver}
 
 		// confirmReservations returns nothing; the contract is that it must not
 		// panic and must attempt every id despite the error.
-		uc.confirmReservations(ctx, sp, logger, reservationHandle{ReservationIDs: []uuid.UUID{uuid.New(), uuid.New()}})
+		uc.confirmReservations(ctx, sp, logger, reservationHandle{ReservationIDs: ids})
 
-		assert.Len(t, reserver.confirmedIDs, 2, "every id is attempted even when transport fails")
+		sharedReservationRetrier.wait()
+
+		attempted := reserver.confirmed()
+		assert.Subset(t, attempted, ids, "every id is attempted inline even when transport fails")
+		assert.Greater(t, len(attempted), len(ids),
+			"a refused confirm is retried off the request path, not dropped after one attempt")
 	})
 }
 
 func TestReleaseReservations(t *testing.T) {
+	withFastSharedRetrier(t)
+
 	ctx, sp, logger := anchorDeps()
 
 	ids := []uuid.UUID{uuid.New(), uuid.New()}
@@ -414,10 +487,17 @@ func TestReleaseReservations(t *testing.T) {
 
 	uc.releaseReservations(ctx, sp, logger, reservationHandle{ReservationIDs: ids})
 
-	assert.Equal(t, ids, reserver.releasedIDs, "release is attempted for every id despite transport failure")
+	sharedReservationRetrier.wait()
+
+	attempted := reserver.released()
+	assert.Subset(t, attempted, ids, "release is attempted for every id despite transport failure")
+	assert.Greater(t, len(attempted), len(ids),
+		"a refused release is retried too: capacity a customer is not spending must come back")
 }
 
 func TestConfirmReservationsByTransaction(t *testing.T) {
+	withFastSharedRetrier(t)
+
 	ctx, sp, logger := anchorDeps()
 
 	enforce := mmodel.TracerSettings{Mode: mmodel.TracerModeEnforce, FailPosture: mmodel.TracerFailPostureOpen}
@@ -429,8 +509,8 @@ func TestConfirmReservationsByTransaction(t *testing.T) {
 
 		uc.confirmReservationsByTransaction(ctx, sp, logger, enforce, byTxnIdentity(txID), false)
 
-		assert.Equal(t, []uuid.UUID{txID}, reserver.confirmedTxns)
-		assert.Empty(t, reserver.releasedTxns)
+		assert.Equal(t, []uuid.UUID{txID}, reserver.confirmedTransactions())
+		assert.Empty(t, reserver.releasedTransactions())
 	})
 
 	t.Run("advisory still confirms (lifecycle observed, never blocks)", func(t *testing.T) {
@@ -441,7 +521,7 @@ func TestConfirmReservationsByTransaction(t *testing.T) {
 		uc.confirmReservationsByTransaction(ctx, sp, logger,
 			mmodel.TracerSettings{Mode: mmodel.TracerModeAdvisory}, byTxnIdentity(txID), false)
 
-		assert.Equal(t, []uuid.UUID{txID}, reserver.confirmedTxns)
+		assert.Equal(t, []uuid.UUID{txID}, reserver.confirmedTransactions())
 	})
 
 	t.Run("mode off does not call the tracer", func(t *testing.T) {
@@ -451,7 +531,7 @@ func TestConfirmReservationsByTransaction(t *testing.T) {
 		uc.confirmReservationsByTransaction(ctx, sp, logger,
 			mmodel.TracerSettings{Mode: mmodel.TracerModeOff}, byTxnIdentity(uuid.New()), false)
 
-		assert.Empty(t, reserver.confirmedTxns, "mode=off must not confirm")
+		assert.Empty(t, reserver.confirmedTransactions(), "mode=off must not confirm")
 	})
 
 	t.Run("empty mode does not call the tracer", func(t *testing.T) {
@@ -460,7 +540,7 @@ func TestConfirmReservationsByTransaction(t *testing.T) {
 
 		uc.confirmReservationsByTransaction(ctx, sp, logger, mmodel.TracerSettings{}, byTxnIdentity(uuid.New()), false)
 
-		assert.Empty(t, reserver.confirmedTxns)
+		assert.Empty(t, reserver.confirmedTransactions())
 	})
 
 	t.Run("nil reserver is a no-op", func(t *testing.T) {
@@ -478,7 +558,11 @@ func TestConfirmReservationsByTransaction(t *testing.T) {
 		// nothing, swallows the error, and the caller proceeds.
 		uc.confirmReservationsByTransaction(ctx, sp, logger, enforce, byTxnIdentity(txID), false)
 
-		assert.Equal(t, []uuid.UUID{txID}, reserver.confirmedTxns, "the transition is attempted despite transport failure")
+		sharedReservationRetrier.wait()
+
+		attempted := reserver.confirmedTransactions()
+		assert.Contains(t, attempted, txID, "the transition is attempted despite transport failure")
+		assert.Greater(t, len(attempted), 1, "and it is retried rather than dropped after one attempt")
 	})
 
 	t.Run("honored skip does not confirm even under enforce", func(t *testing.T) {
@@ -487,11 +571,13 @@ func TestConfirmReservationsByTransaction(t *testing.T) {
 
 		uc.confirmReservationsByTransaction(ctx, sp, logger, enforce, byTxnIdentity(uuid.New()), true)
 
-		assert.Empty(t, reserver.confirmedTxns, "an honored tracer skip must make zero ConfirmByTransaction")
+		assert.Empty(t, reserver.confirmedTransactions(), "an honored tracer skip must make zero ConfirmByTransaction")
 	})
 }
 
 func TestReleaseReservationsByTransaction(t *testing.T) {
+	withFastSharedRetrier(t)
+
 	ctx, sp, logger := anchorDeps()
 
 	enforce := mmodel.TracerSettings{Mode: mmodel.TracerModeEnforce, FailPosture: mmodel.TracerFailPostureOpen}
@@ -503,8 +589,8 @@ func TestReleaseReservationsByTransaction(t *testing.T) {
 
 		uc.releaseReservationsByTransaction(ctx, sp, logger, enforce, byTxnIdentity(txID), false)
 
-		assert.Equal(t, []uuid.UUID{txID}, reserver.releasedTxns)
-		assert.Empty(t, reserver.confirmedTxns)
+		assert.Equal(t, []uuid.UUID{txID}, reserver.releasedTransactions())
+		assert.Empty(t, reserver.confirmedTransactions())
 	})
 
 	t.Run("mode off does not call the tracer", func(t *testing.T) {
@@ -514,7 +600,7 @@ func TestReleaseReservationsByTransaction(t *testing.T) {
 		uc.releaseReservationsByTransaction(ctx, sp, logger,
 			mmodel.TracerSettings{Mode: mmodel.TracerModeOff}, byTxnIdentity(uuid.New()), false)
 
-		assert.Empty(t, reserver.releasedTxns)
+		assert.Empty(t, reserver.releasedTransactions())
 	})
 
 	t.Run("nil reserver is a no-op", func(t *testing.T) {
@@ -529,7 +615,11 @@ func TestReleaseReservationsByTransaction(t *testing.T) {
 
 		uc.releaseReservationsByTransaction(ctx, sp, logger, enforce, byTxnIdentity(txID), false)
 
-		assert.Equal(t, []uuid.UUID{txID}, reserver.releasedTxns, "the transition is attempted despite transport failure")
+		sharedReservationRetrier.wait()
+
+		attempted := reserver.releasedTransactions()
+		assert.Contains(t, attempted, txID, "the transition is attempted despite transport failure")
+		assert.Greater(t, len(attempted), 1, "and it is retried rather than dropped after one attempt")
 	})
 
 	t.Run("honored skip does not release even under enforce", func(t *testing.T) {
@@ -538,7 +628,7 @@ func TestReleaseReservationsByTransaction(t *testing.T) {
 
 		uc.releaseReservationsByTransaction(ctx, sp, logger, enforce, byTxnIdentity(uuid.New()), true)
 
-		assert.Empty(t, reserver.releasedTxns, "an honored tracer skip must make zero ReleaseByTransaction")
+		assert.Empty(t, reserver.releasedTransactions(), "an honored tracer skip must make zero ReleaseByTransaction")
 	})
 }
 

--- a/components/ledger/internal/services/command/transaction_reservation_retry.go
+++ b/components/ledger/internal/services/command/transaction_reservation_retry.go
@@ -26,12 +26,23 @@ const reservationRetryComponent = "ledger.tracer-reservation-retry"
 // trying to hand the tracer a confirm or release the first attempt could not
 // deliver.
 //
-// Budget is deliberately LONGER than the tracer's default reservation lifetime
-// (five minutes for a direct transaction). A retry landing after the hold has
-// already expired is not wasted: the tracer settles a late confirm by counting
-// the spend without touching the capacity its expiry sweep already returned. So
-// the ledger would rather deliver the confirm late — the spend counted, the
-// window logged — than stop trying because the hold is gone.
+// Budget is sized against the DIRECT transaction's hold, which the tracer gives
+// five minutes. Six minutes deliberately outlasts it, because a retry landing
+// after the hold expired is not wasted: the tracer settles a late confirm by
+// counting the spend without touching the capacity its expiry sweep already
+// returned. The ledger would rather deliver the confirm late — the spend
+// counted, the window logged — than stop trying because the hold is gone.
+//
+// It does NOT outlast a PENDING transaction's hold, and nothing sensible could:
+// that one is thirty days by default (RESERVATION_LONG_LIVED_TTL_HOURS). Those
+// are the transitions /commit and /cancel carry by transaction id, and if the
+// budget runs out on one, the row simply stays RESERVED. That is the safe
+// direction while it lasts — the capacity is still held, so the limit
+// over-enforces rather than under-enforces — but it is not a fix: when the
+// tracer's own sweep finally expires the row, a confirm that was never
+// delivered becomes a spend that is never counted. Six minutes covers a tracer
+// restart, which is the failure this retrier exists for; a pending transition
+// lost for longer needs the durable store, not a longer timer.
 type reservationRetryPolicy struct {
 	// MaxAttempts is how many further attempts follow the inline one.
 	MaxAttempts int
@@ -125,7 +136,7 @@ func (r *reservationRetrier) schedule(ctx context.Context, reserver TracerReserv
 		// place the ledger knowingly gives up on a spend, and an operator has
 		// to see it as a saturation signal, not as a one-off.
 		logger.Log(ctx, libLog.LevelError,
-			"Tracer reservation transition dropped: too many retries already in flight; the spend will not be counted against the limit",
+			"Tracer reservation transition dropped: too many retries already in flight; "+transition.lossConsequence(),
 			append(transition.logFields(),
 				libLog.Int("retries_in_flight", r.policy.MaxInFlight),
 				libLog.Err(cause)))
@@ -177,12 +188,11 @@ func (r *reservationRetrier) run(ctx context.Context, reserver TracerReserver, l
 		if err == nil {
 			span.SetAttributes(attribute.Int("app.reservation.retry_attempts", attempt))
 
-			// Worth a Warn rather than a Debug: between the failed inline
-			// attempt and this one the limit was under-enforced, because the
-			// capacity was held (or, past the expiry, already returned) while
-			// the spend went uncounted.
+			// Worth a Warn rather than a Debug: the limit did not match reality
+			// in the window between the failed inline attempt and this one, and
+			// which way it was wrong depends on the action.
 			logger.Log(ctx, libLog.LevelWarn,
-				"Tracer reservation transition delivered on retry; the limit was under-enforced until now",
+				"Tracer reservation transition delivered on retry; "+transition.delayConsequence(),
 				append(transition.logFields(),
 					libLog.Int("attempts", attempt),
 					libLog.String("elapsed", time.Since(started).String())))
@@ -228,15 +238,17 @@ func (r *reservationRetrier) delay(attempt int) time.Duration {
 }
 
 // reportExhausted is the last word on a transition the ledger could not place.
-// It is an Error, not a Warn: for a confirm it means a transaction whose money
-// moved will never be counted against the customer's spending limit, so the
-// limit under-enforces until someone acts on this line.
+// It is an Error, not a Warn, and it says which of the two failures happened:
+// a confirm that never landed is money that moved and will never be counted, a
+// release that never landed is capacity held against a transaction that moved
+// nothing. They need opposite remediations, so the message names the direction
+// rather than assuming the confirm case.
 func (r *reservationRetrier) reportExhausted(ctx context.Context, span trace.Span, logger libLog.Logger, transition reservationTransition, cause error, attempts int, started time.Time) {
 	libOpentelemetry.HandleSpanError(span, "Tracer reservation "+transition.Action+" could not be delivered", cause)
 	span.SetAttributes(attribute.Bool("app.reservation.retry_exhausted", true))
 
 	logger.Log(ctx, libLog.LevelError,
-		"Tracer reservation transition could not be delivered; the spend will not be counted against the limit",
+		"Tracer reservation transition could not be delivered; "+transition.lossConsequence(),
 		append(transition.logFields(),
 			libLog.Int("attempts", attempts),
 			libLog.String("elapsed", time.Since(started).String()),

--- a/components/ledger/internal/services/command/transaction_reservation_retry.go
+++ b/components/ledger/internal/services/command/transaction_reservation_retry.go
@@ -89,6 +89,14 @@ type reservationRetrier struct {
 	policy reservationRetryPolicy
 	slots  chan struct{}
 	wg     sync.WaitGroup
+
+	// inFlight names the transitions still being retried, so a shutdown can
+	// report the ones it is about to abandon. Without it a rolling deploy drops
+	// up to MaxInFlight confirms with no log line at all, which is the one hole
+	// the "never lose a spend silently" contract cannot afford.
+	inFlightMu sync.Mutex
+	inFlight   map[uint64]reservationTransition
+	nextSeq    uint64
 }
 
 // newReservationRetrier builds a retrier for the given policy.
@@ -98,8 +106,57 @@ func newReservationRetrier(policy reservationRetryPolicy) *reservationRetrier {
 	}
 
 	return &reservationRetrier{
-		policy: policy,
-		slots:  make(chan struct{}, policy.MaxInFlight),
+		policy:   policy,
+		slots:    make(chan struct{}, policy.MaxInFlight),
+		inFlight: make(map[uint64]reservationTransition),
+	}
+}
+
+// track registers a sequence as in flight and returns the function that
+// deregisters it.
+func (r *reservationRetrier) track(transition reservationTransition) func() {
+	r.inFlightMu.Lock()
+
+	r.nextSeq++
+	seq := r.nextSeq
+	r.inFlight[seq] = transition
+
+	r.inFlightMu.Unlock()
+
+	return func() {
+		r.inFlightMu.Lock()
+		delete(r.inFlight, seq)
+		r.inFlightMu.Unlock()
+	}
+}
+
+// reportOutstanding names every transition still being retried. It is called at
+// the end of the graceful-drain window, when anything still here is about to die
+// with the process: the retry is in-process, so a restart loses it. Losing it is
+// a known residual; losing it WITHOUT a log line is not, because the whole point
+// of this path is that a spend never goes missing quietly.
+func (r *reservationRetrier) reportOutstanding(ctx context.Context, logger libLog.Logger) {
+	r.inFlightMu.Lock()
+	outstanding := make([]reservationTransition, 0, len(r.inFlight))
+
+	for _, transition := range r.inFlight {
+		outstanding = append(outstanding, transition)
+	}
+
+	r.inFlightMu.Unlock()
+
+	if len(outstanding) == 0 {
+		return
+	}
+
+	logger.Log(ctx, libLog.LevelError,
+		"Shutting down with tracer reservation transitions still undelivered; they are abandoned here",
+		libLog.Int("undelivered", len(outstanding)))
+
+	for _, transition := range outstanding {
+		logger.Log(ctx, libLog.LevelError,
+			"Tracer reservation transition abandoned at shutdown; "+transition.lossConsequence(),
+			transition.logFields())
 	}
 }
 
@@ -148,10 +205,13 @@ func (r *reservationRetrier) schedule(ctx context.Context, reserver TracerReserv
 
 	r.wg.Add(1)
 
+	untrack := r.track(transition)
+
 	libRuntime.SafeGoWithContextAndComponent(detached, logger, reservationRetryComponent,
 		"reservation.retry_transition", libRuntime.KeepRunning, func(c context.Context) {
 			defer r.wg.Done()
 			defer func() { <-r.slots }()
+			defer untrack()
 
 			c, cancel := context.WithTimeout(c, r.policy.Budget)
 			defer cancel()
@@ -253,4 +313,11 @@ func (r *reservationRetrier) reportExhausted(ctx context.Context, span trace.Spa
 			libLog.Int("attempts", attempts),
 			libLog.String("elapsed", time.Since(started).String()),
 			libLog.Err(cause)))
+}
+
+// ReportOutstandingReservationRetries names every confirm or release the ledger
+// still owes the tracer, at the point the process is about to stop trying. The
+// composition root calls it at the end of the graceful-drain window.
+func ReportOutstandingReservationRetries(ctx context.Context, logger libLog.Logger) {
+	sharedReservationRetrier.reportOutstanding(ctx, logger)
 }

--- a/components/ledger/internal/services/command/transaction_reservation_retry.go
+++ b/components/ledger/internal/services/command/transaction_reservation_retry.go
@@ -1,0 +1,244 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package command
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	libBackoff "github.com/LerianStudio/lib-commons/v7/commons/backoff"
+	libObservability "github.com/LerianStudio/lib-observability/v4"
+	libLog "github.com/LerianStudio/lib-observability/v4/log"
+	libRuntime "github.com/LerianStudio/lib-observability/v4/runtime"
+	libOpentelemetry "github.com/LerianStudio/lib-observability/v4/tracing"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// reservationRetryComponent scopes the retrier's panic-observability signals
+// (panic_recovered_total, structured logs, span events) in dashboards.
+const reservationRetryComponent = "ledger.tracer-reservation-retry"
+
+// reservationRetryPolicy bounds how hard, and for how long, the ledger keeps
+// trying to hand the tracer a confirm or release the first attempt could not
+// deliver.
+//
+// Budget is deliberately LONGER than the tracer's default reservation lifetime
+// (five minutes for a direct transaction). A retry landing after the hold has
+// already expired is not wasted: the tracer settles a late confirm by counting
+// the spend without touching the capacity its expiry sweep already returned. So
+// the ledger would rather deliver the confirm late — the spend counted, the
+// window logged — than stop trying because the hold is gone.
+type reservationRetryPolicy struct {
+	// MaxAttempts is how many further attempts follow the inline one.
+	MaxAttempts int
+	// BaseDelay is the first backoff step; each attempt doubles it.
+	BaseDelay time.Duration
+	// MaxDelay caps one backoff step before jitter is applied.
+	MaxDelay time.Duration
+	// Budget is the wall-clock ceiling on the whole retry sequence.
+	Budget time.Duration
+	// MaxInFlight bounds concurrent retry sequences process-wide. It is the
+	// backstop against a tracer outage turning every transaction into a
+	// long-lived goroutine.
+	MaxInFlight int
+}
+
+// defaultReservationRetryPolicy is the shipped budget: roughly six minutes of
+// trying, spread over twenty attempts, with at most 256 sequences alive at once.
+var defaultReservationRetryPolicy = reservationRetryPolicy{
+	MaxAttempts: 20,
+	BaseDelay:   250 * time.Millisecond,
+	MaxDelay:    45 * time.Second,
+	Budget:      6 * time.Minute,
+	MaxInFlight: 256,
+}
+
+// reservationRetrier redelivers reservation transitions the inline attempt could
+// not place, off the request path.
+//
+// It never blocks a caller: the transaction's money has already moved and the
+// response is owed now, so the retry runs on a detached goroutine and the
+// request returns regardless of whether the tracer is reachable. What the
+// retrier guarantees is that a transient tracer — a restart, a rollout, a
+// network blip, a 5xx — no longer costs the ledger a spend, and that the
+// transitions it genuinely cannot place are named in the log instead of
+// disappearing.
+//
+// Concurrency is capped by a counting semaphore rather than by a queue. A
+// sequence holds its slot for as long as it keeps retrying, so under a total
+// tracer outage the first MaxInFlight transitions are retried and every further
+// one is reported immediately as undeliverable. That is a deliberate trade:
+// bounded memory and a loud, honest log beats an unbounded goroutine population
+// on the money path.
+type reservationRetrier struct {
+	policy reservationRetryPolicy
+	slots  chan struct{}
+	wg     sync.WaitGroup
+}
+
+// newReservationRetrier builds a retrier for the given policy.
+func newReservationRetrier(policy reservationRetryPolicy) *reservationRetrier {
+	if policy.MaxInFlight <= 0 {
+		policy.MaxInFlight = 1
+	}
+
+	return &reservationRetrier{
+		policy: policy,
+		slots:  make(chan struct{}, policy.MaxInFlight),
+	}
+}
+
+// sharedReservationRetrier is the process-wide retrier the transaction seams
+// use. The concurrency cap is a property of the process, not of a request, so
+// the semaphore is shared.
+var sharedReservationRetrier = newReservationRetrier(defaultReservationRetryPolicy)
+
+// scheduleReservationRetry hands a failed transition to the shared retrier. A
+// nil reserver means the tracer integration is off and there is nothing to
+// redeliver.
+func (uc *UseCase) scheduleReservationRetry(ctx context.Context, logger libLog.Logger, transition reservationTransition, cause error) {
+	if uc.TracerReserver == nil {
+		return
+	}
+
+	sharedReservationRetrier.schedule(ctx, uc.TracerReserver, logger, transition, cause)
+}
+
+// schedule starts a retry sequence for one transition, or reports it as
+// undeliverable when the process is already at its concurrency cap.
+//
+// The context is detached from the request with context.WithoutCancel: the
+// request's context is cancelled the moment the response is written, and a
+// confirm the ledger owes the tracer must outlive the request that created it.
+// Detaching keeps the values the transport needs — the tenant the tracer client
+// reads off the context, and the trace correlation — while dropping only the
+// cancellation.
+func (r *reservationRetrier) schedule(ctx context.Context, reserver TracerReserver, logger libLog.Logger, transition reservationTransition, cause error) {
+	select {
+	case r.slots <- struct{}{}:
+	default:
+		// At capacity. Say so instead of silently dropping: this is the one
+		// place the ledger knowingly gives up on a spend, and an operator has
+		// to see it as a saturation signal, not as a one-off.
+		logger.Log(ctx, libLog.LevelError,
+			"Tracer reservation transition dropped: too many retries already in flight; the spend will not be counted against the limit",
+			append(transition.logFields(),
+				libLog.Int("retries_in_flight", r.policy.MaxInFlight),
+				libLog.Err(cause)))
+
+		return
+	}
+
+	detached := context.WithoutCancel(ctx)
+
+	r.wg.Add(1)
+
+	libRuntime.SafeGoWithContextAndComponent(detached, logger, reservationRetryComponent,
+		"reservation.retry_transition", libRuntime.KeepRunning, func(c context.Context) {
+			defer r.wg.Done()
+			defer func() { <-r.slots }()
+
+			c, cancel := context.WithTimeout(c, r.policy.Budget)
+			defer cancel()
+
+			r.run(c, reserver, logger, transition, cause)
+		})
+}
+
+// run is the retry sequence for one transition. It returns as soon as the
+// tracer accepts the transition, and otherwise keeps trying until the attempt
+// count or the wall-clock budget runs out.
+func (r *reservationRetrier) run(ctx context.Context, reserver TracerReserver, logger libLog.Logger, transition reservationTransition, cause error) {
+	_, tracer, _, _ := libObservability.NewTrackingFromContext(ctx)
+
+	ctx, span := tracer.Start(ctx, "command.reservation_retry")
+	defer span.End()
+
+	span.SetAttributes(
+		attribute.String("app.reservation.action", transition.Action),
+		attribute.String("app.request.transaction_id", transition.TransactionID.String()),
+	)
+
+	lastErr := cause
+	started := time.Now()
+
+	for attempt := 1; attempt <= r.policy.MaxAttempts; attempt++ {
+		if waitErr := libBackoff.WaitContext(ctx, r.delay(attempt)); waitErr != nil {
+			r.reportExhausted(ctx, span, logger, transition, lastErr, attempt-1, started)
+
+			return
+		}
+
+		err := r.deliver(ctx, reserver, transition)
+		if err == nil {
+			span.SetAttributes(attribute.Int("app.reservation.retry_attempts", attempt))
+
+			// Worth a Warn rather than a Debug: between the failed inline
+			// attempt and this one the limit was under-enforced, because the
+			// capacity was held (or, past the expiry, already returned) while
+			// the spend went uncounted.
+			logger.Log(ctx, libLog.LevelWarn,
+				"Tracer reservation transition delivered on retry; the limit was under-enforced until now",
+				append(transition.logFields(),
+					libLog.Int("attempts", attempt),
+					libLog.String("elapsed", time.Since(started).String())))
+
+			return
+		}
+
+		lastErr = err
+	}
+
+	r.reportExhausted(ctx, span, logger, transition, lastErr, r.policy.MaxAttempts, started)
+}
+
+// deliver makes one attempt, choosing the address the transition carries. Both
+// forms are idempotent on the tracer's side, which is what makes retrying safe:
+// a confirm only settles a reservation still in a settleable state, so a repeat
+// after a response the ledger never saw moves no counter a second time.
+func (r *reservationRetrier) deliver(ctx context.Context, reserver TracerReserver, transition reservationTransition) error {
+	if transition.byTransaction() {
+		if transition.Action == reservationActionRelease {
+			return reserver.ReleaseByTransaction(ctx, transition.TransactionID)
+		}
+
+		return reserver.ConfirmByTransaction(ctx, transition.TransactionID)
+	}
+
+	if transition.Action == reservationActionRelease {
+		return reserver.Release(ctx, transition.ReservationID)
+	}
+
+	return reserver.Confirm(ctx, transition.ReservationID)
+}
+
+// delay is the wait before the given attempt: exponential from BaseDelay,
+// capped at MaxDelay before full jitter spreads a fleet's retries out.
+func (r *reservationRetrier) delay(attempt int) time.Duration {
+	step := libBackoff.Exponential(r.policy.BaseDelay, attempt-1)
+	if r.policy.MaxDelay > 0 && step > r.policy.MaxDelay {
+		step = r.policy.MaxDelay
+	}
+
+	return libBackoff.FullJitter(step)
+}
+
+// reportExhausted is the last word on a transition the ledger could not place.
+// It is an Error, not a Warn: for a confirm it means a transaction whose money
+// moved will never be counted against the customer's spending limit, so the
+// limit under-enforces until someone acts on this line.
+func (r *reservationRetrier) reportExhausted(ctx context.Context, span trace.Span, logger libLog.Logger, transition reservationTransition, cause error, attempts int, started time.Time) {
+	libOpentelemetry.HandleSpanError(span, "Tracer reservation "+transition.Action+" could not be delivered", cause)
+	span.SetAttributes(attribute.Bool("app.reservation.retry_exhausted", true))
+
+	logger.Log(ctx, libLog.LevelError,
+		"Tracer reservation transition could not be delivered; the spend will not be counted against the limit",
+		append(transition.logFields(),
+			libLog.Int("attempts", attempts),
+			libLog.String("elapsed", time.Since(started).String()),
+			libLog.Err(cause)))
+}

--- a/components/ledger/internal/services/command/transaction_reservation_retry_test.go
+++ b/components/ledger/internal/services/command/transaction_reservation_retry_test.go
@@ -573,6 +573,63 @@ func TestRetryKeepsTheTenantAfterTheRequestEnds(t *testing.T) {
 	}
 }
 
+// TestShutdownNamesTheTransitionsItAbandons closes the one hole the retry's own
+// design leaves. The sequences are in-process, so a rolling deploy kills whatever
+// is still trying. Losing them is a stated residual; losing them with no log line
+// is not, because the whole contract of this path is that a spend never goes
+// missing quietly, and a deploy is a routine event rather than an outage.
+func TestShutdownNamesTheTransitionsItAbandons(t *testing.T) {
+	policy := fastRetryPolicy()
+	policy.MaxAttempts = 500
+	policy.BaseDelay = 20 * time.Millisecond
+	policy.MaxDelay = 20 * time.Millisecond
+
+	retrier := newReservationRetrier(policy)
+
+	stillDown := &scriptedReserver{confirm: func(_ int) error {
+		return fmt.Errorf("still down: %w", tracer.ErrTracerUnavailable)
+	}}
+
+	stranded := retryTransition()
+	retrier.schedule(context.Background(), stillDown, &capturingLogger{}, stranded,
+		fmt.Errorf("inline: %w", tracer.ErrTracerUnavailable))
+
+	// Let the sequence get going, then take the shutdown snapshot.
+	require.Eventually(t, func() bool {
+		attempts, _ := stillDown.attempts()
+
+		return attempts > 0
+	}, 2*time.Second, 5*time.Millisecond, "the retry sequence must be running before shutdown is simulated")
+
+	logger := &capturingLogger{}
+	retrier.reportOutstanding(context.Background(), logger)
+
+	reported := rendered(logger.atLevelOrMoreSevere(libLog.LevelError))
+	require.NotEmpty(t, reported, "a shutdown that abandons a confirm must say so")
+
+	assert.Contains(t, reported, "abandoned at shutdown")
+	assert.Contains(t, reported, stranded.TransactionID.String())
+	assert.Contains(t, reported, stranded.ReservationID.String())
+	assert.Contains(t, reported, "1234.56")
+	assert.Contains(t, reported, "the spend will not be counted against the limit")
+}
+
+// TestShutdownIsSilentWhenNothingIsOwed keeps the report from becoming noise on
+// the overwhelmingly common shutdown, where the tracer was reachable throughout.
+func TestShutdownIsSilentWhenNothingIsOwed(t *testing.T) {
+	retrier := newReservationRetrier(fastRetryPolicy())
+
+	delivered := &scriptedReserver{confirm: failNTimes(1)}
+	retrier.schedule(context.Background(), delivered, &capturingLogger{}, retryTransition(),
+		fmt.Errorf("inline: %w", tracer.ErrTracerUnavailable))
+	retrier.wait()
+
+	logger := &capturingLogger{}
+	retrier.reportOutstanding(context.Background(), logger)
+
+	assert.Empty(t, logger.snapshot(), "a clean shutdown must log nothing about undelivered transitions")
+}
+
 // TestAnchorHandsAFailedTransitionToTheRetrier wires the two halves together:
 // the seams the transaction pipelines call must route a failure into the shared
 // retrier rather than swallowing it.

--- a/components/ledger/internal/services/command/transaction_reservation_retry_test.go
+++ b/components/ledger/internal/services/command/transaction_reservation_retry_test.go
@@ -1,0 +1,485 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package command
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	libLog "github.com/LerianStudio/lib-observability/v4/log"
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/trace/noop"
+
+	"github.com/LerianStudio/midaz/v4/components/ledger/internal/adapters/tracer"
+	"github.com/LerianStudio/midaz/v4/pkg/mmodel"
+)
+
+// fastRetryPolicy is the shipped policy compressed so a test finishes in
+// milliseconds. Only the durations change; the shape of the sequence does not.
+func fastRetryPolicy() reservationRetryPolicy {
+	return reservationRetryPolicy{
+		MaxAttempts: 8,
+		BaseDelay:   time.Millisecond,
+		MaxDelay:    4 * time.Millisecond,
+		Budget:      5 * time.Second,
+		MaxInFlight: 8,
+	}
+}
+
+// wait blocks until every scheduled retry sequence has finished. It lives in the
+// test file because only tests need it: production never joins on a retry, which
+// is the whole point of running it off the request path.
+func (r *reservationRetrier) wait() {
+	r.wg.Wait()
+}
+
+// withFastSharedRetrier swaps the process-wide retrier for a compressed one for
+// the duration of one test, and drains it on cleanup. Without it a test whose
+// stub never accepts would leave the shipped six-minute sequence running for the
+// rest of the test binary's life.
+func withFastSharedRetrier(t *testing.T) {
+	t.Helper()
+
+	previous := sharedReservationRetrier
+	fast := newReservationRetrier(fastRetryPolicy())
+	sharedReservationRetrier = fast
+
+	t.Cleanup(func() {
+		fast.wait()
+
+		sharedReservationRetrier = previous
+	})
+}
+
+// scriptedReserver is a TracerReserver whose confirm behaviour a test scripts.
+// It records every call so the number of attempts is assertable.
+type scriptedReserver struct {
+	mu sync.Mutex
+
+	confirmCalls     int
+	confirmByTxn     int
+	releaseCalls     int
+	releaseByTxn     int
+	confirmDelivered bool
+
+	// confirm returns the error for attempt n (1-indexed); nil means accept.
+	confirm func(attempt int) error
+}
+
+func (s *scriptedReserver) Reserve(_ context.Context, _ tracer.ReserveRequest) (*tracer.ReserveResult, error) {
+	return &tracer.ReserveResult{}, nil
+}
+
+func (s *scriptedReserver) Confirm(_ context.Context, _ uuid.UUID) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.confirmCalls++
+
+	err := s.confirm(s.confirmCalls)
+	if err == nil {
+		s.confirmDelivered = true
+	}
+
+	return err
+}
+
+func (s *scriptedReserver) Release(_ context.Context, _ uuid.UUID) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.releaseCalls++
+
+	return nil
+}
+
+func (s *scriptedReserver) ConfirmByTransaction(_ context.Context, _ uuid.UUID) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.confirmByTxn++
+
+	err := s.confirm(s.confirmByTxn)
+	if err == nil {
+		s.confirmDelivered = true
+	}
+
+	return err
+}
+
+func (s *scriptedReserver) ReleaseByTransaction(_ context.Context, _ uuid.UUID) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.releaseByTxn++
+
+	return nil
+}
+
+func (s *scriptedReserver) attempts() (int, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return s.confirmCalls + s.confirmByTxn, s.confirmDelivered
+}
+
+// failNTimes accepts only after n refusals.
+func failNTimes(n int) func(int) error {
+	return func(attempt int) error {
+		if attempt <= n {
+			return fmt.Errorf("tracer refused attempt %d: %w", attempt, tracer.ErrTracerUnavailable)
+		}
+
+		return nil
+	}
+}
+
+// retryTransition is the confirm a test redelivers.
+func retryTransition() reservationTransition {
+	return reservationTransition{
+		Action:        reservationActionConfirm,
+		TransactionID: uuid.New(),
+		ReservationID: uuid.New(),
+		Amount:        decimal.RequireFromString("400.00"),
+		Asset:         "BRL",
+	}
+}
+
+// TestRetryDeliversAConfirmTheTransportRefused is the core repair: a confirm the
+// tracer refused is not a lost spend any more. The ledger keeps offering it
+// until the tracer takes it.
+func TestRetryDeliversAConfirmTheTransportRefused(t *testing.T) {
+	logger := &capturingLogger{}
+	reserver := &scriptedReserver{confirm: failNTimes(2)}
+	retrier := newReservationRetrier(fastRetryPolicy())
+
+	cause := fmt.Errorf("inline attempt: %w", tracer.ErrTracerUnavailable)
+	retrier.schedule(context.Background(), reserver, logger, retryTransition(), cause)
+	retrier.wait()
+
+	attempts, delivered := reserver.attempts()
+	assert.True(t, delivered, "the committed spend must reach the tracer and be counted against the limit")
+	assert.Equal(t, 3, attempts, "two refusals then acceptance")
+
+	reported := rendered(logger.atLevelOrMoreSevere(libLog.LevelWarn))
+	assert.Contains(t, reported, "under-enforced until now",
+		"a confirm that only landed on retry must say the limit was under-enforced in between")
+}
+
+// TestRetryDeliversAConfirmThatTimedOut uses the real HTTP client against a real
+// server, so the first attempts fail on the client's own 250ms per-operation
+// deadline rather than on a stubbed error. No synthetic load: the handler simply
+// waits for its request context to be cancelled.
+func TestRetryDeliversAConfirmThatTimedOut(t *testing.T) {
+	var requests int32
+
+	var mu sync.Mutex
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		requests++
+		stall := requests <= 2
+		mu.Unlock()
+
+		if stall {
+			// Hold the request open until the client's deadline cancels it.
+			<-r.Context().Done()
+
+			return
+		}
+
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	client, err := tracer.NewTracerClient(server.URL)
+	require.NoError(t, err)
+
+	logger := &capturingLogger{}
+	retrier := newReservationRetrier(fastRetryPolicy())
+
+	started := time.Now()
+	retrier.schedule(context.Background(), client, logger,
+		retryTransition(), fmt.Errorf("inline: %w", tracer.ErrTracerUnavailable))
+	retrier.wait()
+
+	mu.Lock()
+	got := requests
+	mu.Unlock()
+
+	assert.Equal(t, int32(3), got, "two timed-out attempts then one accepted")
+	assert.GreaterOrEqual(t, time.Since(started), 500*time.Millisecond,
+		"each stalled attempt costs the client's 250ms per-operation budget, so two of them cost at least 500ms")
+
+	reported := rendered(logger.atLevelOrMoreSevere(libLog.LevelWarn))
+	assert.Contains(t, reported, "delivered on retry")
+	assert.NotContains(t, reported, "could not be delivered")
+}
+
+// TestRetryKeepsTryingPastTheHoldExpiry covers the third failure shape: the
+// confirm that only arrives after the hold has already expired. The tracer
+// settles a late confirm by counting the spend, so the ledger must NOT stop
+// trying once the hold is gone — stopping would be the one choice that loses
+// the spend for good.
+func TestRetryKeepsTryingPastTheHoldExpiry(t *testing.T) {
+	// A hold that expires shortly after the retry sequence starts. The tracer
+	// refuses everything until then; the first attempt after it is the late
+	// confirm.
+	holdExpiresAt := time.Now().Add(60 * time.Millisecond)
+
+	var (
+		mu             sync.Mutex
+		lateConfirm    bool
+		acceptedAtTime time.Time
+	)
+
+	reserver := &scriptedReserver{}
+	reserver.confirm = func(_ int) error {
+		mu.Lock()
+		defer mu.Unlock()
+
+		if time.Now().Before(holdExpiresAt) {
+			return fmt.Errorf("tracer unreachable: %w", tracer.ErrTracerUnavailable)
+		}
+
+		lateConfirm = true
+		acceptedAtTime = time.Now()
+
+		return nil
+	}
+
+	policy := fastRetryPolicy()
+	policy.MaxAttempts = 200
+	policy.BaseDelay = time.Millisecond
+	policy.MaxDelay = 5 * time.Millisecond
+
+	retrier := newReservationRetrier(policy)
+	retrier.schedule(context.Background(), reserver, &capturingLogger{},
+		retryTransition(), fmt.Errorf("inline: %w", tracer.ErrTracerUnavailable))
+	retrier.wait()
+
+	_, delivered := reserver.attempts()
+	require.True(t, delivered, "the spend must still be counted even though the hold had already expired")
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	assert.True(t, lateConfirm)
+	assert.False(t, acceptedAtTime.Before(holdExpiresAt),
+		"the confirm that landed is the one issued after the hold expired")
+}
+
+// TestShippedRetryBudgetOutlastsTheHold locks the load-bearing relationship
+// between the two services' clocks. The tracer gives a direct transaction's hold
+// a five-minute lifetime (reservationTTL in components/tracer's reservation
+// service) and sweeps it at expiry. If the ledger gave up before that, every
+// tracer outage longer than the retry budget but shorter than the hold would
+// lose a spend that a slightly more patient ledger would have counted.
+func TestShippedRetryBudgetOutlastsTheHold(t *testing.T) {
+	const tracerDirectHoldLifetime = 5 * time.Minute
+
+	assert.Greater(t, defaultReservationRetryPolicy.Budget, tracerDirectHoldLifetime,
+		"the ledger must still be trying when the tracer's own hold expires")
+	assert.Positive(t, defaultReservationRetryPolicy.MaxAttempts)
+	assert.Positive(t, defaultReservationRetryPolicy.MaxInFlight)
+}
+
+// TestRetryReportsATransitionItCannotDeliver is the visibility floor. When every
+// attempt fails there IS a lost spend, and it must be legible: severity at least
+// Warn, naming the transaction, the reservation and the amount.
+func TestRetryReportsATransitionItCannotDeliver(t *testing.T) {
+	// A closed port: the dial is refused immediately, so the sequence exhausts
+	// its attempts without waiting on any timeout.
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	closedAddr := listener.Addr().String()
+	require.NoError(t, listener.Close())
+
+	client, err := tracer.NewTracerClient("http://" + closedAddr)
+	require.NoError(t, err)
+
+	logger := &capturingLogger{}
+	transition := retryTransition()
+
+	retrier := newReservationRetrier(fastRetryPolicy())
+	retrier.schedule(context.Background(), client, logger, transition,
+		fmt.Errorf("inline: %w", tracer.ErrTracerUnavailable))
+	retrier.wait()
+
+	reported := rendered(logger.atLevelOrMoreSevere(libLog.LevelWarn))
+	require.NotEmpty(t, reported, "an undeliverable confirm must never be silent")
+
+	assert.Contains(t, reported, "could not be delivered")
+	assert.Contains(t, reported, "will not be counted against the limit")
+	assert.Contains(t, reported, transition.TransactionID.String())
+	assert.Contains(t, reported, transition.ReservationID.String())
+	assert.Contains(t, reported, "400")
+	assert.Contains(t, reported, "BRL")
+
+	errors := logger.atLevelOrMoreSevere(libLog.LevelError)
+	assert.NotEmpty(t, errors, "a spend the ledger gave up on is an Error, not a Warn")
+}
+
+// TestRetryReportsATransitionItHasNoCapacityFor proves the concurrency cap fails
+// loudly. Under a total tracer outage the retrier runs out of slots; the
+// transitions it turns away are the honest residual and must be reported, not
+// dropped.
+func TestRetryReportsATransitionItHasNoCapacityFor(t *testing.T) {
+	policy := fastRetryPolicy()
+	policy.MaxInFlight = 1
+	policy.MaxAttempts = 100
+	policy.BaseDelay = 20 * time.Millisecond
+	policy.MaxDelay = 20 * time.Millisecond
+
+	retrier := newReservationRetrier(policy)
+
+	occupy := &scriptedReserver{confirm: func(_ int) error {
+		return fmt.Errorf("still down: %w", tracer.ErrTracerUnavailable)
+	}}
+
+	// Fill the single slot with a sequence that will keep retrying.
+	retrier.schedule(context.Background(), occupy, &capturingLogger{}, retryTransition(),
+		fmt.Errorf("inline: %w", tracer.ErrTracerUnavailable))
+
+	logger := &capturingLogger{}
+	turnedAway := retryTransition()
+	rejected := &scriptedReserver{confirm: func(_ int) error { return nil }}
+
+	retrier.schedule(context.Background(), rejected, logger, turnedAway,
+		fmt.Errorf("inline: %w", tracer.ErrTracerUnavailable))
+
+	reported := rendered(logger.atLevelOrMoreSevere(libLog.LevelError))
+	assert.Contains(t, reported, "too many retries already in flight")
+	assert.Contains(t, reported, turnedAway.TransactionID.String())
+	assert.Contains(t, reported, "400")
+
+	attempts, _ := rejected.attempts()
+	assert.Zero(t, attempts, "a turned-away transition is reported, never quietly retried later")
+
+	retrier.wait()
+}
+
+// TestRepeatedConfirmDoesNotCountTheSpendTwice mirrors, on the ledger side, the
+// rule the tracer enforces in the database: a confirm settles a reservation only
+// while it is still settleable (RESERVED or EXPIRED), and the row flip is
+// guarded on the status read under the lock. A second confirm therefore flips
+// nothing and moves no counter.
+//
+// The tracer owns that guarantee — see settleableByConfirmPredicate and
+// applyConfirm in components/tracer's usage_reservation_repository, and the
+// service mapping of ErrReservationAlreadyTerminal to a 200. This test proves
+// the ledger's retry does not depend on anything weaker: it re-offers the same
+// transition and requires the counted spend to stay at one.
+func TestRepeatedConfirmDoesNotCountTheSpendTwice(t *testing.T) {
+	var (
+		mu           sync.Mutex
+		countedSpend int
+		settled      bool
+	)
+
+	// tracerLike models the settleable-status rule: the first confirm settles
+	// and counts, every later one is an accepted no-op.
+	tracerLike := &scriptedReserver{}
+	tracerLike.confirm = func(attempt int) error {
+		mu.Lock()
+		defer mu.Unlock()
+
+		if attempt == 1 {
+			// The tracer accepted and settled, but the response never reached
+			// the ledger — the case that makes a repeat necessary.
+			countedSpend++
+			settled = true
+
+			return fmt.Errorf("response lost: %w", tracer.ErrTracerUnavailable)
+		}
+
+		if settled {
+			return nil // already terminal: accepted, nothing flipped
+		}
+
+		countedSpend++
+		settled = true
+
+		return nil
+	}
+
+	retrier := newReservationRetrier(fastRetryPolicy())
+	retrier.schedule(context.Background(), tracerLike, &capturingLogger{}, retryTransition(),
+		fmt.Errorf("inline: %w", tracer.ErrTracerUnavailable))
+	retrier.wait()
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	assert.Equal(t, 1, countedSpend, "a repeated confirm must not count the spend twice")
+}
+
+// TestAnchorHandsAFailedTransitionToTheRetrier wires the two halves together:
+// the seams the transaction pipelines call must route a failure into the shared
+// retrier rather than swallowing it.
+func TestAnchorHandsAFailedTransitionToTheRetrier(t *testing.T) {
+	withFastSharedRetrier(t)
+
+	ctx := context.Background()
+	_, span := noop.NewTracerProvider().Tracer("t").Start(ctx, "test")
+
+	t.Run("direct create, by reservation id", func(t *testing.T) {
+		reserver := &scriptedReserver{confirm: failNTimes(1)}
+		uc := &UseCase{TracerReserver: reserver}
+
+		uc.confirmReservations(ctx, span, &capturingLogger{}, reservationHandle{
+			ReservationIDs: []uuid.UUID{uuid.New()},
+			TransactionID:  uuid.New(),
+			Amount:         decimal.RequireFromString("400.00"),
+			Asset:          "BRL",
+		})
+
+		sharedReservationRetrier.wait()
+
+		attempts, delivered := reserver.attempts()
+		assert.True(t, delivered, "the spend reaches the tracer on the retry")
+		assert.Equal(t, 2, attempts, "one inline attempt plus one retry")
+	})
+
+	t.Run("pending commit, by transaction id", func(t *testing.T) {
+		reserver := &scriptedReserver{confirm: failNTimes(1)}
+		uc := &UseCase{TracerReserver: reserver}
+
+		uc.confirmReservationsByTransaction(ctx, span, &capturingLogger{},
+			mmodel.TracerSettings{Mode: mmodel.TracerModeEnforce},
+			reservationHandle{
+				TransactionID: uuid.New(),
+				Amount:        decimal.RequireFromString("250.00"),
+				Asset:         "BRL",
+			}, false)
+
+		sharedReservationRetrier.wait()
+
+		attempts, delivered := reserver.attempts()
+		assert.True(t, delivered)
+		assert.Equal(t, 2, attempts)
+	})
+
+	t.Run("a tracer that is off schedules nothing", func(t *testing.T) {
+		uc := &UseCase{TracerReserver: nil}
+
+		uc.confirmReservations(ctx, span, &capturingLogger{}, reservationHandle{
+			ReservationIDs: []uuid.UUID{uuid.New()},
+			TransactionID:  uuid.New(),
+		})
+
+		sharedReservationRetrier.wait()
+	})
+}

--- a/components/ledger/internal/services/command/transaction_reservation_retry_test.go
+++ b/components/ledger/internal/services/command/transaction_reservation_retry_test.go
@@ -146,13 +146,16 @@ func failNTimes(n int) func(int) error {
 	}
 }
 
-// retryTransition is the confirm a test redelivers.
+// retryTransition is the confirm a test redelivers. The amount carries non-zero
+// decimals on purpose: shopspring renders "400.00" as "400", and a bare "400" also
+// occurs inside random UUID hex, so asserting on it would pass without the amount
+// ever being logged. "1234.56" cannot appear in a uuid.
 func retryTransition() reservationTransition {
 	return reservationTransition{
 		Action:        reservationActionConfirm,
 		TransactionID: uuid.New(),
 		ReservationID: uuid.New(),
-		Amount:        decimal.RequireFromString("400.00"),
+		Amount:        decimal.RequireFromString("1234.56"),
 		Asset:         "BRL",
 	}
 }
@@ -281,17 +284,30 @@ func TestRetryKeepsTryingPastTheHoldExpiry(t *testing.T) {
 		"the confirm that landed is the one issued after the hold expired")
 }
 
-// TestShippedRetryBudgetOutlastsTheHold locks the load-bearing relationship
-// between the two services' clocks. The tracer gives a direct transaction's hold
-// a five-minute lifetime (reservationTTL in components/tracer's reservation
-// service) and sweeps it at expiry. If the ledger gave up before that, every
-// tracer outage longer than the retry budget but shorter than the hold would
-// lose a spend that a slightly more patient ledger would have counted.
-func TestShippedRetryBudgetOutlastsTheHold(t *testing.T) {
-	const tracerDirectHoldLifetime = 5 * time.Minute
+// TestShippedRetryBudgetOutlastsTheDirectHold locks the relationship between the
+// two services' clocks for DIRECT transactions, and only for those. The tracer
+// gives a direct hold a five-minute lifetime (reservationTTL in components/tracer's
+// reservation service) and sweeps it at expiry; if the ledger gave up first, a
+// tracer outage longer than the budget but shorter than the hold would lose a
+// spend that a slightly more patient ledger would have counted.
+//
+// The relationship is INVERTED for a pending transaction and the test says so
+// rather than pretending otherwise: that hold is thirty days by default, four
+// orders of magnitude past any retry budget worth having. A pending transition
+// the budget cannot place leaves the row RESERVED -- capacity held, limit
+// over-enforcing -- until the tracer's own sweep expires it, at which point an
+// undelivered confirm becomes an uncounted spend. That gap is the durable-store
+// problem, not a timer to lengthen.
+func TestShippedRetryBudgetOutlastsTheDirectHold(t *testing.T) {
+	const (
+		tracerDirectHoldLifetime    = 5 * time.Minute
+		tracerLongLivedHoldLifetime = 720 * time.Hour
+	)
 
 	assert.Greater(t, defaultReservationRetryPolicy.Budget, tracerDirectHoldLifetime,
-		"the ledger must still be trying when the tracer's own hold expires")
+		"the ledger must still be trying when a direct transaction's hold expires")
+	assert.Less(t, defaultReservationRetryPolicy.Budget, tracerLongLivedHoldLifetime,
+		"and must NOT be sized against the pending hold; a thirty-day retry sequence is not the answer there")
 	assert.Positive(t, defaultReservationRetryPolicy.MaxAttempts)
 	assert.Positive(t, defaultReservationRetryPolicy.MaxInFlight)
 }
@@ -326,11 +342,70 @@ func TestRetryReportsATransitionItCannotDeliver(t *testing.T) {
 	assert.Contains(t, reported, "will not be counted against the limit")
 	assert.Contains(t, reported, transition.TransactionID.String())
 	assert.Contains(t, reported, transition.ReservationID.String())
-	assert.Contains(t, reported, "400")
+	assert.Contains(t, reported, "1234.56")
 	assert.Contains(t, reported, "BRL")
 
 	errors := logger.atLevelOrMoreSevere(libLog.LevelError)
 	assert.NotEmpty(t, errors, "a spend the ledger gave up on is an Error, not a Warn")
+}
+
+// TestRetryReportsALostReleaseAsHeldCapacity is the release half of the loss
+// report, and it exists because the confirm half is not merely incomplete for a
+// release -- it is false. A release that never lands means NO money moved and
+// the customer's capacity is stuck; telling an operator that "the spend will not
+// be counted" sends them hunting an uncounted spend that does not exist, while
+// the customer sits denied inside their own limit.
+func TestRetryReportsALostReleaseAsHeldCapacity(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	closedAddr := listener.Addr().String()
+	require.NoError(t, listener.Close())
+
+	client, err := tracer.NewTracerClient("http://" + closedAddr)
+	require.NoError(t, err)
+
+	logger := &capturingLogger{}
+
+	transition := retryTransition()
+	transition.Action = reservationActionRelease
+
+	retrier := newReservationRetrier(fastRetryPolicy())
+	retrier.schedule(context.Background(), client, logger, transition,
+		fmt.Errorf("inline: %w", tracer.ErrTracerUnavailable))
+	retrier.wait()
+
+	reported := rendered(logger.atLevelOrMoreSevere(libLog.LevelError))
+	require.NotEmpty(t, reported, "an undeliverable release must never be silent either")
+
+	assert.Contains(t, reported, "capacity stays held",
+		"the report must describe held capacity, which is what a lost release actually costs")
+	assert.Contains(t, reported, "over-enforces",
+		"and must name the direction: a lost release makes the limit too strict, not too loose")
+	assert.NotContains(t, reported, "the spend will not be counted",
+		"a lost release is not an uncounted spend; no money moved")
+	assert.Contains(t, reported, transition.TransactionID.String())
+	assert.Contains(t, reported, "1234.56")
+}
+
+// TestRetryReportsALateReleaseAsOverEnforcement is the same distinction on the
+// success path: a release that only lands on retry held the customer's capacity
+// in the meantime, which is the opposite of what a late confirm did.
+func TestRetryReportsALateReleaseAsOverEnforcement(t *testing.T) {
+	logger := &capturingLogger{}
+	reserver := &scriptedReserver{confirm: failNTimes(0)}
+
+	transition := retryTransition()
+	transition.Action = reservationActionRelease
+
+	retrier := newReservationRetrier(fastRetryPolicy())
+	retrier.schedule(context.Background(), reserver, logger, transition,
+		fmt.Errorf("inline: %w", tracer.ErrTracerUnavailable))
+	retrier.wait()
+
+	reported := rendered(logger.atLevelOrMoreSevere(libLog.LevelWarn))
+	assert.Contains(t, reported, "over-enforced until now")
+	assert.NotContains(t, reported, "under-enforced until now")
 }
 
 // TestRetryReportsATransitionItHasNoCapacityFor proves the concurrency cap fails
@@ -364,7 +439,7 @@ func TestRetryReportsATransitionItHasNoCapacityFor(t *testing.T) {
 	reported := rendered(logger.atLevelOrMoreSevere(libLog.LevelError))
 	assert.Contains(t, reported, "too many retries already in flight")
 	assert.Contains(t, reported, turnedAway.TransactionID.String())
-	assert.Contains(t, reported, "400")
+	assert.Contains(t, reported, "1234.56")
 
 	attempts, _ := rejected.attempts()
 	assert.Zero(t, attempts, "a turned-away transition is reported, never quietly retried later")

--- a/components/ledger/internal/services/command/transaction_reservation_retry_test.go
+++ b/components/ledger/internal/services/command/transaction_reservation_retry_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 	"time"
 
+	tmcore "github.com/LerianStudio/lib-commons/v7/commons/tenant-manager/core"
 	libLog "github.com/LerianStudio/lib-observability/v4/log"
 	"github.com/google/uuid"
 	"github.com/shopspring/decimal"
@@ -424,6 +425,77 @@ func TestRepeatedConfirmDoesNotCountTheSpendTwice(t *testing.T) {
 	defer mu.Unlock()
 
 	assert.Equal(t, 1, countedSpend, "a repeated confirm must not count the spend twice")
+}
+
+// tenantSpy records the tenant each retry attempt carried on its context.
+type tenantSpy struct {
+	mu    sync.Mutex
+	seen  []string
+	calls int
+}
+
+func (s *tenantSpy) Reserve(_ context.Context, _ tracer.ReserveRequest) (*tracer.ReserveResult, error) {
+	return &tracer.ReserveResult{}, nil
+}
+
+func (s *tenantSpy) Confirm(ctx context.Context, _ uuid.UUID) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.calls++
+	s.seen = append(s.seen, tmcore.GetTenantIDContext(ctx))
+
+	if s.calls < 3 {
+		return fmt.Errorf("down: %w", tracer.ErrTracerUnavailable)
+	}
+
+	return nil
+}
+
+func (s *tenantSpy) Release(_ context.Context, _ uuid.UUID) error              { return nil }
+func (s *tenantSpy) ConfirmByTransaction(_ context.Context, _ uuid.UUID) error { return nil }
+func (s *tenantSpy) ReleaseByTransaction(_ context.Context, _ uuid.UUID) error { return nil }
+
+func (s *tenantSpy) tenants() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return append([]string(nil), s.seen...)
+}
+
+// TestRetryKeepsTheTenantAfterTheRequestEnds guards the two properties that make
+// a detached retry correct in a multi-tenant deployment.
+//
+// The first is that it runs at all: the request's context is cancelled the
+// moment the response is written, and a retry bound to it would die before its
+// first attempt. The second is that it still speaks for the right customer —
+// the tracer client reads the tenant off the context it is handed, so a
+// detachment that dropped the tenant would send the confirm to the wrong
+// tenant's data, or to none, which on a spending limit is worse than not
+// sending it.
+func TestRetryKeepsTheTenantAfterTheRequestEnds(t *testing.T) {
+	const tenant = "acme-tenant-1"
+
+	requestCtx, endRequest := context.WithCancel(tmcore.ContextWithTenantID(context.Background(), tenant))
+
+	spy := &tenantSpy{}
+	retrier := newReservationRetrier(fastRetryPolicy())
+
+	retrier.schedule(requestCtx, spy, &capturingLogger{}, retryTransition(),
+		fmt.Errorf("inline: %w", tracer.ErrTracerUnavailable))
+
+	// The response is written and the request context is cancelled while the
+	// ledger still owes the tracer a confirm.
+	endRequest()
+
+	retrier.wait()
+
+	seen := spy.tenants()
+	require.NotEmpty(t, seen, "the retry must outlive the request whose context was cancelled")
+
+	for attempt, got := range seen {
+		assert.Equal(t, tenant, got, "attempt %d must still speak for the tenant that owns the transaction", attempt+1)
+	}
 }
 
 // TestAnchorHandsAFailedTransitionToTheRetrier wires the two halves together:

--- a/components/ledger/internal/services/command/transaction_reservation_transition.go
+++ b/components/ledger/internal/services/command/transaction_reservation_transition.go
@@ -1,0 +1,88 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package command
+
+import (
+	libLog "github.com/LerianStudio/lib-observability/v4/log"
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+)
+
+// The two phase-two actions the ledger owes the tracer once the balance move is
+// decided: confirm consumes the held capacity, release gives it back.
+const (
+	reservationActionConfirm = "confirm"
+	reservationActionRelease = "release"
+)
+
+// reservationTransition is one confirm or release the ledger owes the tracer,
+// carrying everything needed to REPORT it as well as to address it.
+//
+// Addressing needs only an id. Reporting needs the rest: a confirm that never
+// reaches the tracer is a committed spend the customer's limit will never
+// count, and an operator who has to act on that needs the transaction and the
+// amount from the log line itself — the tracer's own store is not available to
+// join against when the tracer is the thing that is down.
+//
+// LimitID is deliberately absent. The ledger never learns it: the reserve
+// response returns reservation ids only, and which limits those ids belong to
+// is the tracer's own resolution. The reservation id is the handle that leads
+// there once the tracer is reachable again.
+type reservationTransition struct {
+	// Action is confirm or release.
+	Action string
+
+	// TransactionID is the transaction whose capacity is being settled. It is
+	// always set, and it is the address the by-transaction form uses.
+	TransactionID uuid.UUID
+
+	// ReservationID addresses one held reservation. It is uuid.Nil for the
+	// by-transaction form, which settles every reservation the transaction
+	// holds in one call.
+	ReservationID uuid.UUID
+
+	// Amount and Asset are the fee-inclusive value the reservation held. They
+	// are what makes a lost confirm quantifiable.
+	Amount decimal.Decimal
+	Asset  string
+}
+
+// byTransaction reports whether this transition is addressed by transaction id
+// rather than by a single reservation id.
+func (t reservationTransition) byTransaction() bool {
+	return t.ReservationID == uuid.Nil
+}
+
+// logFields renders the transition's identity for a structured log line. The
+// reservation id is emitted only when the transition carries one, so the
+// by-transaction form does not log a nil uuid that reads like a real handle.
+func (t reservationTransition) logFields() []libLog.Field {
+	fields := []libLog.Field{
+		libLog.String("reservation_action", t.Action),
+		libLog.String("transaction_id", t.TransactionID.String()),
+		libLog.String("amount", t.Amount.String()),
+		libLog.String("asset", t.Asset),
+		libLog.Bool("by_transaction", t.byTransaction()),
+	}
+
+	if !t.byTransaction() {
+		fields = append(fields, libLog.String("reservation_id", t.ReservationID.String()))
+	}
+
+	return fields
+}
+
+// transitionByTransaction builds the by-transaction form of a transition from a
+// handle that carries the identity but no reservation ids — the shape /commit
+// and /cancel work with, where the create-time handle did not survive into the
+// request.
+func (h reservationHandle) transitionByTransaction(action string) reservationTransition {
+	return reservationTransition{
+		Action:        action,
+		TransactionID: h.TransactionID,
+		Amount:        h.Amount,
+		Asset:         h.Asset,
+	}
+}

--- a/components/ledger/internal/services/command/transaction_reservation_transition.go
+++ b/components/ledger/internal/services/command/transaction_reservation_transition.go
@@ -55,6 +55,33 @@ func (t reservationTransition) byTransaction() bool {
 	return t.ReservationID == uuid.Nil
 }
 
+// lossConsequence names, in the operator's terms, what it costs when this
+// transition is never placed. The two actions fail in OPPOSITE directions and a
+// single sentence written for one is false for the other: a lost confirm means
+// money moved that the limit will never count, so the cap under-enforces; a lost
+// release means capacity held against a transaction that moved no money at all,
+// so the cap over-enforces and denies the customer inside their own limit. The
+// remediation differs too, which is why this belongs in the message an operator
+// is paged on and not only in a structured field.
+func (t reservationTransition) lossConsequence() string {
+	if t.Action == reservationActionRelease {
+		return "the capacity stays held against a transaction that moved no money, so the limit over-enforces until the hold expires"
+	}
+
+	return "the spend will not be counted against the limit"
+}
+
+// delayConsequence is the same distinction for a transition that did land, late:
+// it names what was wrong in the window between the failed first attempt and the
+// delivery.
+func (t reservationTransition) delayConsequence() string {
+	if t.Action == reservationActionRelease {
+		return "the limit over-enforced until now"
+	}
+
+	return "the limit was under-enforced until now"
+}
+
 // logFields renders the transition's identity for a structured log line. The
 // reservation id is emitted only when the transition carries one, so the
 // by-transaction form does not log a nil uuid that reads like a real handle.

--- a/components/ledger/internal/services/command/transaction_reservation_transition_test.go
+++ b/components/ledger/internal/services/command/transaction_reservation_transition_test.go
@@ -1,0 +1,165 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package command
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+
+	libLog "github.com/LerianStudio/lib-observability/v4/log"
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/trace/noop"
+
+	"github.com/LerianStudio/midaz/v4/components/ledger/internal/adapters/tracer"
+	"github.com/LerianStudio/midaz/v4/pkg/mmodel"
+)
+
+// capturedLogLine is one structured line a test logger recorded.
+type capturedLogLine struct {
+	Level  int
+	Msg    string
+	Fields string
+}
+
+// capturingLogger records every structured line so a test can assert on what an
+// operator would actually see. Safe for concurrent use because the retrier logs
+// from a background goroutine.
+type capturingLogger struct {
+	mu    sync.Mutex
+	lines []capturedLogLine
+}
+
+func (l *capturingLogger) Log(_ context.Context, level int, msg string, fields ...any) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	l.lines = append(l.lines, capturedLogLine{Level: level, Msg: msg, Fields: fmt.Sprint(fields...)})
+}
+
+func (l *capturingLogger) With(_ ...any) libLog.Logger      { return l }
+func (l *capturingLogger) WithGroup(_ string) libLog.Logger { return l }
+func (l *capturingLogger) Enabled(_ int) bool               { return true }
+func (l *capturingLogger) Sync(_ context.Context) error     { return nil }
+
+// snapshot returns a copy of the recorded lines.
+func (l *capturingLogger) snapshot() []capturedLogLine {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	return append([]capturedLogLine(nil), l.lines...)
+}
+
+// atLevelOrMoreSevere returns the lines logged at the given level or a more
+// severe one. lib-observability inverts the usual scale: Error=0, Warn=1,
+// Info=2, Debug=3, so "at Warn or higher" is level <= LevelWarn.
+func (l *capturingLogger) atLevelOrMoreSevere(level int) []capturedLogLine {
+	var out []capturedLogLine
+
+	for _, line := range l.snapshot() {
+		if line.Level <= level {
+			out = append(out, line)
+		}
+	}
+
+	return out
+}
+
+// rendered joins a set of lines into one searchable blob.
+func rendered(lines []capturedLogLine) string {
+	parts := make([]string, 0, len(lines))
+	for _, line := range lines {
+		parts = append(parts, fmt.Sprintf("level=%d msg=%q fields=%s", line.Level, line.Msg, line.Fields))
+	}
+
+	return strings.Join(parts, "\n")
+}
+
+// TestLostConfirmIsReportedWithTheTransactionAndAmount is the visibility
+// contract. A confirm the tracer did not accept means a committed spend the
+// customer's limit has not counted; the line an operator reads has to say which
+// transaction and how much, because the tracer's own store — the only other
+// place that mapping exists — may be exactly what is unreachable.
+func TestLostConfirmIsReportedWithTheTransactionAndAmount(t *testing.T) {
+	ctx := context.Background()
+	_, span := noop.NewTracerProvider().Tracer("t").Start(ctx, "test")
+
+	transactionID := uuid.New()
+	reservationID := uuid.New()
+	amount := decimal.RequireFromString("1234.56")
+
+	t.Run("by reservation id", func(t *testing.T) {
+		logger := &capturingLogger{}
+		reserver := &stubReserver{confirmErr: fmt.Errorf("down: %w", tracer.ErrTracerUnavailable)}
+		uc := &UseCase{TracerReserver: reserver}
+
+		uc.confirmReservations(ctx, span, logger, reservationHandle{
+			ReservationIDs: []uuid.UUID{reservationID},
+			TransactionID:  transactionID,
+			Amount:         amount,
+			Asset:          "BRL",
+		})
+
+		reported := rendered(logger.atLevelOrMoreSevere(libLog.LevelWarn))
+		require.NotEmpty(t, reported, "a lost confirm must be reported at Warn or a more severe level")
+
+		assert.Contains(t, reported, transactionID.String(), "the report must name the transaction whose spend went uncounted")
+		assert.Contains(t, reported, reservationID.String(), "the report must name the reservation that still holds capacity")
+		assert.Contains(t, reported, "1234.56", "the report must name how much spending went uncounted")
+		assert.Contains(t, reported, "BRL", "the report must name the asset the amount is denominated in")
+	})
+
+	t.Run("by transaction id", func(t *testing.T) {
+		logger := &capturingLogger{}
+		reserver := &stubReserver{confirmByTxnErr: fmt.Errorf("down: %w", tracer.ErrTracerUnavailable)}
+		uc := &UseCase{TracerReserver: reserver}
+
+		uc.confirmReservationsByTransaction(ctx, span, logger,
+			mmodel.TracerSettings{Mode: mmodel.TracerModeEnforce},
+			reservationHandle{TransactionID: transactionID, Amount: amount, Asset: "BRL"}, false)
+
+		reported := rendered(logger.atLevelOrMoreSevere(libLog.LevelWarn))
+		require.NotEmpty(t, reported, "a lost by-transaction confirm must be reported at Warn or a more severe level")
+
+		assert.Contains(t, reported, transactionID.String())
+		assert.Contains(t, reported, "1234.56")
+		assert.Contains(t, reported, "BRL")
+		assert.NotContains(t, reported, uuid.Nil.String(),
+			"the by-transaction form holds no reservation id and must not log a nil uuid that reads like a real handle")
+	})
+}
+
+// TestReserveHandleCarriesTheIdentityItWillNeedToReport proves the identity is
+// captured at reserve time rather than reconstructed later: by the time a
+// confirm fails, the only thing in hand is the handle.
+func TestReserveHandleCarriesTheIdentityItWillNeedToReport(t *testing.T) {
+	ctx, span, logger := anchorDeps()
+
+	transactionID := uuid.New()
+	ids := []uuid.UUID{uuid.New()}
+	reserver := &stubReserver{result: &tracer.ReserveResult{ReservationIDs: ids}}
+	uc := &UseCase{TracerReserver: reserver}
+
+	out := uc.reserveTransaction(ctx, span, logger,
+		mmodel.TracerSettings{Mode: mmodel.TracerModeEnforce, FailPosture: mmodel.TracerFailPostureOpen},
+		transactionID, decimal.RequireFromString("42.50"), "USD", fixedReserveAccountID,
+		fixedReserveTimestamp, reservationTTLDefault, false)
+
+	require.Equal(t, reservationProceed, out.Kind)
+	assert.Equal(t, transactionID, out.Handle.TransactionID)
+	assert.True(t, decimal.RequireFromString("42.50").Equal(out.Handle.Amount))
+	assert.Equal(t, "USD", out.Handle.Asset)
+
+	transitions := out.Handle.transitions(reservationActionConfirm)
+	require.Len(t, transitions, 1)
+	assert.Equal(t, reservationActionConfirm, transitions[0].Action)
+	assert.Equal(t, ids[0], transitions[0].ReservationID)
+	assert.False(t, transitions[0].byTransaction())
+}

--- a/components/ledger/internal/services/command/transaction_reservation_transition_test.go
+++ b/components/ledger/internal/services/command/transaction_reservation_transition_test.go
@@ -88,6 +88,8 @@ func rendered(lines []capturedLogLine) string {
 // transaction and how much, because the tracer's own store — the only other
 // place that mapping exists — may be exactly what is unreachable.
 func TestLostConfirmIsReportedWithTheTransactionAndAmount(t *testing.T) {
+	withFastSharedRetrier(t)
+
 	ctx := context.Background()
 	_, span := noop.NewTracerProvider().Tracer("t").Start(ctx, "test")
 

--- a/components/ledger/internal/services/command/transition_pending_run.go
+++ b/components/ledger/internal/services/command/transition_pending_run.go
@@ -40,3 +40,23 @@ type pendingTransitionRun struct {
 
 	result *mmodel.BalanceAtomicResult
 }
+
+// reservationIdentity is the identity the tracer's by-transaction confirm/release
+// is addressed and REPORTED with. The create-time reserve handle does not survive
+// into the separate /commit or /cancel request, so the transaction id is the
+// address; the amount and asset come off the persisted transaction so a transition
+// that cannot be delivered is still legible as a quantity of uncounted spending.
+// A transaction persisted without an amount yields the decimal zero rather than
+// panicking on the nil pointer — reporting a zero is a worse log line, never a
+// dropped transition.
+func (run *pendingTransitionRun) reservationIdentity() reservationHandle {
+	identity := reservationHandle{Asset: run.tran.AssetCode}
+
+	identity.TransactionID = run.tran.IDtoUUID()
+
+	if run.tran.Amount != nil {
+		identity.Amount = *run.tran.Amount
+	}
+
+	return identity
+}

--- a/components/tracer/.env.example
+++ b/components/tracer/.env.example
@@ -140,14 +140,18 @@ CLEANUP_RETENTION_DAYS=90
 # ----------------
 # Background worker that releases expired two-phase reservations (returns held
 # capacity when a ledger transaction crashes between reserve and confirm/release).
-# RESERVATION_REAPER_ENABLED: Enable/disable the reaper (default: false)
-# RESERVATION_REAPER_INTERVAL_SECONDS: Sub-minute sweep cadence in seconds (default: 30)
+# RESERVATION_REAPER_ENABLED: Enable/disable the reaper (default: true). It is the
+#   only path that returns capacity once a reservation passes the expiry the API
+#   reported, so leave it on unless you have another way to reclaim held capacity.
+#   Set to false to disable it explicitly.
+# RESERVATION_REAPER_INTERVAL_SECONDS: Sub-minute sweep cadence in seconds
+#   (default: 30, must be 1..3600; an invalid value stops startup)
 # RESERVATION_LONG_LIVED_TTL_HOURS: Lifetime of a PENDING-transaction (longLived)
 #   reservation in hours (default: 720 = 30 days). PENDING transactions persist
 #   indefinitely with no other sweep, so this is the pragmatic ceiling at which the
 #   reaper still converges a genuinely abandoned pending. Direct transactions use a
 #   fixed short TTL and ignore this knob.
-RESERVATION_REAPER_ENABLED=false
+RESERVATION_REAPER_ENABLED=true
 RESERVATION_REAPER_INTERVAL_SECONDS=30
 RESERVATION_LONG_LIVED_TTL_HOURS=720
 

--- a/components/tracer/internal/adapters/postgres/usage_counter_repository.go
+++ b/components/tracer/internal/adapters/postgres/usage_counter_repository.go
@@ -42,6 +42,15 @@ const usageCountersTable = "usage_counters"
 // 3. If WHERE guard fails: CTE returns 0 rows
 // 4. Outer query uses COALESCE: if CTE empty, fallback to SELECT + false flag
 //
+// The DO UPDATE guard reads reserved_usage as well as current_usage, so the
+// synchronous validation path and the two-phase reserve path defend the SAME
+// ceiling on a shared counter bucket. Without the reserved_usage term the
+// synchronous writer cannot see capacity a reservation is holding, and a
+// deployment using both paths against one limit could commit close to twice the
+// configured cap. The INSERT branch needs no such term: it only runs when the
+// bucket does not exist yet, so there is nothing held to account for, and the
+// caller's amount-vs-cap pre-check covers it.
+//
 // Parameters: $1=counterID, $2=limitID, $3=scopeKey, $4=periodKey, $5=amount (INSERT),
 //
 //	$6=now (INSERT last_updated_at), $7=amount (UPDATE), $8=now (UPDATE last_updated_at),
@@ -55,7 +64,7 @@ const upsertAndIncrementCTEQuery = `
 			current_usage = usage_counters.current_usage + $7,
 			last_updated_at = $8,
 			expires_at = $11
-		WHERE usage_counters.current_usage + $9 <= $10
+		WHERE usage_counters.current_usage + usage_counters.reserved_usage + $9 <= $10
 		RETURNING current_usage, true as succeeded
 	)
 	SELECT 

--- a/components/tracer/internal/adapters/postgres/usage_counter_repository_integration_test.go
+++ b/components/tracer/internal/adapters/postgres/usage_counter_repository_integration_test.go
@@ -632,3 +632,54 @@ func TestUsageCounterRepository_UpsertAndIncrementAtomic_Boundary_Integration(t 
 	t.Logf("SUCCESS: Boundary test with pre-seeded %s, %d goroutines with amount=%s and maxAmount=%s: %d succeeded, %d failed (ErrUsageCounterExceedsLimit), final usage = %s",
 		preSeededUsage.String(), numGoroutines, amount.String(), maxAmount.String(), successCount, failCount, finalUsage.String())
 }
+
+// TestIntegration_UsageCounter_SynchronousIncrement_SeesHeldCapacity proves both
+// writers on one counter bucket defend the SAME ceiling.
+//
+// The two-phase reserve path holds capacity in reserved_usage and guards on
+// current_usage + reserved_usage + amount <= maxAmount. The synchronous
+// validation path increments current_usage and, before this fix, guarded on
+// current_usage alone — so outstanding holds were invisible to it and a
+// deployment using both paths against one limit could commit close to twice the
+// configured cap.
+//
+// Scenario: cap 1000, 900 already held by a reservation, then a synchronous
+// amount of 900. The synchronous write MUST be refused.
+func TestIntegration_UsageCounter_SynchronousIncrement_SeesHeldCapacity(t *testing.T) {
+	testutil.SetupTestTracing(t)
+
+	db := testutil.SetupIntegrationDB(t)
+	adapter := &testutil.IntegrationDBAdapter{DB: db}
+	repo := NewUsageCounterRepositoryWithConnection(adapter)
+
+	limitID := createTestLimit(t, db, 9031)
+	t.Cleanup(func() { cleanupTestLimit(t, db, limitID) })
+
+	scopeKey := "acct:9031-" + testutil.MustDeterministicUUID(9131).String()[:8]
+	periodKey := "2026-06"
+
+	ctx := context.Background()
+	maxAmount := decimal.NewFromInt(1000)
+	held := decimal.NewFromInt(900)
+
+	reserved, err := repo.UpsertAndReserveAtomic(ctx, db, limitID, scopeKey, periodKey, held, maxAmount, nil)
+	require.NoError(t, err, "the reserve must hold 900 under a cap of 1000")
+	require.True(t, held.Equal(reserved), "want reserved_usage 900, got %s", reserved)
+
+	// The synchronous path on the SAME counter bucket. 900 committed on top of 900
+	// held would put the customer at 1800 against a cap of 1000.
+	_, err = repo.UpsertAndIncrementAtomic(ctx, db, limitID, scopeKey, periodKey, held, maxAmount, nil)
+	require.ErrorIs(t, err, constant.ErrUsageCounterExceedsLimit,
+		"the synchronous check must count capacity already held by a reservation")
+
+	current, stillHeld := readCounterDecimal(t, db, limitID, scopeKey, periodKey)
+	assert.True(t, current.IsZero(), "a refused synchronous write must not move current_usage; got %s", current)
+	assert.True(t, held.Equal(stillHeld), "a refused synchronous write must not disturb the hold; got %s", stillHeld)
+
+	// The remaining headroom is still spendable synchronously: 100 fits under the cap.
+	headroom := decimal.NewFromInt(100)
+
+	newUsage, err := repo.UpsertAndIncrementAtomic(ctx, db, limitID, scopeKey, periodKey, headroom, maxAmount, nil)
+	require.NoError(t, err, "a synchronous amount inside the real headroom must still be allowed")
+	assert.True(t, headroom.Equal(newUsage), "want current_usage 100, got %s", newUsage)
+}

--- a/components/tracer/internal/adapters/postgres/usage_counter_repository_test.go
+++ b/components/tracer/internal/adapters/postgres/usage_counter_repository_test.go
@@ -95,7 +95,7 @@ const upsertAtomicSQL = `
 				current_usage = usage_counters.current_usage + $7,
 				last_updated_at = $8,
 				expires_at = $11
-			WHERE usage_counters.current_usage + $9 <= $10
+			WHERE usage_counters.current_usage + usage_counters.reserved_usage + $9 <= $10
 			RETURNING current_usage, true as succeeded
 		)
 		SELECT 

--- a/components/tracer/internal/adapters/postgres/usage_counter_reserve_test.go
+++ b/components/tracer/internal/adapters/postgres/usage_counter_reserve_test.go
@@ -74,6 +74,23 @@ func TestUsageCounterReserveCTEThreeTermGuard(t *testing.T) {
 		"reserve CTE must NOT use the legacy two-term increment guard")
 }
 
+// TestUsageCounterIncrementCTEThreeTermGuard locks the same ceiling on the OTHER
+// writer. The synchronous validation path shares a counter bucket with the reserve
+// path, so its DO UPDATE guard must read reserved_usage too. A two-term guard here
+// lets committed spending plus outstanding holds run to nearly twice the cap.
+func TestUsageCounterIncrementCTEThreeTermGuard(t *testing.T) {
+	normalized := regexp.MustCompile(`\s+`).ReplaceAllString(upsertAndIncrementCTEQuery, " ")
+
+	assert.Contains(t, normalized,
+		"WHERE usage_counters.current_usage + usage_counters.reserved_usage + $9 <= $10",
+		"increment CTE must guard on the three-term sum current_usage + reserved_usage + amount")
+	assert.Contains(t, normalized,
+		"current_usage = usage_counters.current_usage + $7",
+		"increment CTE UPDATE must increment current_usage, not reserved_usage")
+	assert.False(t, strings.Contains(normalized, "WHERE usage_counters.current_usage + $9 <= $10"),
+		"increment CTE must NOT regress to the two-term guard that ignores held capacity")
+}
+
 func TestUsageCounterRepository_UpsertAndReserveAtomic(t *testing.T) {
 	testutil.SetupTestTracing(t)
 

--- a/components/tracer/internal/adapters/postgres/usage_reservation_repository.go
+++ b/components/tracer/internal/adapters/postgres/usage_reservation_repository.go
@@ -47,6 +47,37 @@ const reserveScopeLockSQL = `SELECT pg_advisory_xact_lock($1)`
 // starve the pool.
 const reserveLockTimeout = 3 * time.Second
 
+// insertReservationReturningIDSQL inserts the reservation row idempotently on the
+// (transaction_id, limit_id, scope_key, period_key) tuple and returns the id of
+// the row that owns the capacity, together with whether THIS call created it.
+//
+// The two branches are mutually exclusive by construction: the data-modifying CTE
+// runs to completion first, so either it produced a row (a first insert, inserted
+// = true) or it produced none and the NOT EXISTS lets the plain SELECT return the
+// pre-existing row (a replay, inserted = false).
+//
+// Returning the existing row's id on the replay is what keeps a retried reserve's
+// handle valid. Without it the caller keeps its freshly generated id, which
+// matches no row, and the ledger's confirm against that handle fails with
+// ErrReservationNotFound while the capacity stays held.
+const insertReservationReturningIDSQL = `
+	WITH inserted AS (
+		INSERT INTO usage_reservations (
+			id, limit_id, scope_key, period_key, amount, status,
+			transaction_id, reservation_expires_at, created_at
+		)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+		ON CONFLICT (transaction_id, limit_id, scope_key, period_key) DO NOTHING
+		RETURNING id
+	)
+	SELECT id, true AS inserted FROM inserted
+	UNION ALL
+	SELECT id, false AS inserted
+	FROM usage_reservations
+	WHERE transaction_id = $7 AND limit_id = $2 AND scope_key = $3 AND period_key = $4
+	  AND NOT EXISTS (SELECT 1 FROM inserted)
+`
+
 // reserveLockTimeoutSQL bounds the reserve transaction's lock wait. set_config with
 // is_local=true is the SET LOCAL equivalent that accepts a bind parameter, so the
 // timeout applies only within the current transaction and reverts at commit/rollback,
@@ -60,10 +91,12 @@ const reserveLockTimeoutSQL = `SELECT set_config('lock_timeout', $1, true)`
 // move, AND the caller's audit write all commit in ONE transaction owned by the
 // service (mirroring the RuleRepository/LimitRepository *WithTx pattern).
 //
-//   - ReserveWithTx: inserts the reservation row (idempotent on the 4-tuple) FIRST,
-//     then seeds usage_counters.reserved_usage via the reserve CTE (guarded on
+//   - ReserveWithTx: inserts the reservation row (idempotent on the 4-tuple) FIRST
+//     and reads back the id of the row that owns the capacity, then seeds
+//     usage_counters.reserved_usage via the reserve CTE (guarded on
 //     current_usage + reserved_usage + amount <= maxAmount) only when that insert
-//     added a new row, so a replay never moves the counter twice.
+//     added a new row, so a replay never moves the counter twice and never hands
+//     back a handle that owns no row.
 //   - ConfirmWithTx: moves the amount reserved_usage -> current_usage AND flips the
 //     row to CONFIRMED, guarded WHERE status='RESERVED'.
 //   - ReleaseWithTx: returns the amount from reserved_usage AND flips the row to
@@ -120,8 +153,13 @@ func (r *UsageReservationRepository) AcquireReserveScopeLock(ctx context.Context
 // limit_id, scope_key, period_key) tuple FIRST, then — only when that insert added a
 // new row — seeds the counter's reserved_usage via the reserve CTE, both on the
 // supplied transaction handle. A replay for an existing 4-tuple hits ON CONFLICT DO
-// NOTHING (zero rows affected) and returns without touching the counter, so the held
-// capacity is never counted twice.
+// NOTHING and returns without touching the counter, so the held capacity is never
+// counted twice.
+//
+// On BOTH branches reservation.ID is overwritten with the id of the row that owns
+// the capacity. On a first insert that is the caller's own generated id; on a
+// replay it is the existing row's id, so the handle the caller goes on to confirm
+// or release with always addresses a real row.
 //
 // maxAmount is the limit ceiling the reserve CTE guards against; it is supplied by
 // the caller (the limit it resolved) and is NOT stored on the reservation row.
@@ -156,18 +194,14 @@ func (r *UsageReservationRepository) ReserveWithTx(ctx context.Context, db pgdb.
 		return err
 	}
 
-	insertSQL := `
-		INSERT INTO usage_reservations (
-			id, limit_id, scope_key, period_key, amount, status,
-			transaction_id, reservation_expires_at, created_at
-		)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
-		ON CONFLICT (transaction_id, limit_id, scope_key, period_key) DO NOTHING
-	`
+	var (
+		rowID    uuid.UUID
+		inserted bool
+	)
 
-	result, err := db.ExecContext(
+	err := db.QueryRowContext(
 		ctx,
-		insertSQL,
+		insertReservationReturningIDSQL,
 		reservation.ID,
 		reservation.LimitID,
 		reservation.ScopeKey,
@@ -177,21 +211,36 @@ func (r *UsageReservationRepository) ReserveWithTx(ctx context.Context, db pgdb.
 		reservation.TransactionID,
 		reservation.ReservationExpiresAt,
 		reservation.CreatedAt,
-	)
+	).Scan(&rowID, &inserted)
+
+	if errors.Is(err, sql.ErrNoRows) {
+		// Neither branch produced a row: the conflicting row was written by a
+		// transaction this statement's snapshot cannot see. The per-account
+		// advisory lock the reserve takes first makes that unreachable in
+		// production; fail closed rather than hand back a handle that owns
+		// nothing, which is the very defect this query exists to prevent.
+		err = errors.New("reserve resolved no owning reservation row")
+
+		libOtel.HandleSpanError(span, "Reserve resolved no owning reservation row", err)
+
+		return err
+	}
+
 	if err != nil {
 		libOtel.HandleSpanError(span, "Failed to insert reservation row", err)
 		return fmt.Errorf("failed to insert reservation row: %w", err)
 	}
 
-	inserted, err := result.RowsAffected()
-	if err != nil {
-		libOtel.HandleSpanError(span, "Failed to read reservation rows affected", err)
-		return fmt.Errorf("failed to read reservation rows affected: %w", err)
-	}
+	// The row that owns the capacity is authoritative over the caller's generated
+	// id. On a first insert they are the same; on a replay this adopts the
+	// existing row's id so the handle the caller confirms or releases with
+	// addresses a real row.
+	reservation.ID = rowID
 
-	// Zero rows means the 4-tuple already exists: an idempotent replay. The capacity
-	// was reserved on the first call, so return without re-moving the counter.
-	if inserted == 0 {
+	// Not inserted means the 4-tuple already exists: an idempotent replay. The
+	// capacity was reserved on the first call, so return without re-moving the
+	// counter.
+	if !inserted {
 		span.SetAttributes(attribute.Bool("app.reservation_replay", true))
 
 		logger.With(

--- a/components/tracer/internal/adapters/postgres/usage_reservation_repository.go
+++ b/components/tracer/internal/adapters/postgres/usage_reservation_repository.go
@@ -30,6 +30,19 @@ import (
 // Using a constant prevents SQL injection via table name interpolation.
 const usageReservationsTable = "usage_reservations"
 
+// Status predicates for the by-transaction lookups. They are fixed literals, never
+// built from caller input, so composing them into the statement text is safe.
+//
+// A confirm settles an EXPIRED row as well as a RESERVED one, because the ledger
+// only confirms a transaction that committed and that spend has to reach the
+// customer's cap even though the sweep already returned its hold. A release must
+// not: the hold was returned once when the row expired, and releasing it again
+// would take the same capacity out of the bucket twice.
+const (
+	settleableByConfirmPredicate = `status IN ('RESERVED', 'EXPIRED')`
+	settleableByReleasePredicate = `status = 'RESERVED'`
+)
+
 // reserveScopeLockSQL takes a transaction-scoped advisory lock. pg_advisory_xact_lock
 // blocks until the key is free and releases it automatically at commit or rollback,
 // so no explicit unlock is needed and a crashed transaction never leaks the lock.
@@ -277,12 +290,33 @@ func (r *UsageReservationRepository) ReserveWithTx(ctx context.Context, db pgdb.
 	return nil
 }
 
-// ConfirmWithTx moves a RESERVED reservation's amount from reserved_usage into
-// current_usage on the counter and flips the row to CONFIRMED, on the supplied
-// handle, guarded WHERE status='RESERVED'. A retried confirm against an
-// already-terminal row is a no-op: the row read sees a terminal status and the
-// counter move is NEVER issued, so the method returns ErrReservationAlreadyTerminal
+// settleableByConfirm reports whether a confirm can still settle a reservation in
+// this state.
+//
+// RESERVED is the ordinary case. EXPIRED is the LATE confirm: the sweep returned
+// the hold at its stated expiry on the presumption the transaction was abandoned,
+// and then the ledger's confirm arrived because the transaction really did commit.
+// The money moved, so the spend must land on the customer's cap; discarding it
+// would under-enforce the limit for the rest of the period. CONFIRMED and RELEASED
+// are genuinely terminal and stay idempotent no-ops.
+func settleableByConfirm(status model.ReservationStatus) bool {
+	return status == model.StatusReserved || status == model.StatusExpired
+}
+
+// ConfirmWithTx settles a reservation onto the counter and flips the row to
+// CONFIRMED, on the supplied handle. A RESERVED row moves its amount from
+// reserved_usage into current_usage. An EXPIRED row is the late confirm: the sweep
+// already returned its hold, so only current_usage grows and the hold bucket is
+// left alone. Both flips are guarded on the status that was read under the row
+// lock, so a concurrent transition loses cleanly.
+//
+// A retried confirm against a CONFIRMED or RELEASED row is a no-op: the counter
+// move is NEVER issued and the method returns ErrReservationAlreadyTerminal
 // without a double-move. A missing reservation maps to ErrReservationNotFound.
+//
+// Settling an EXPIRED row can push counted spending above the limit's ceiling.
+// That is the honest state: the customer really did spend it, and the capacity the
+// sweep handed back may already have been taken by another transaction.
 func (r *UsageReservationRepository) ConfirmWithTx(ctx context.Context, db pgdb.DB, reservationID uuid.UUID) error {
 	if db == nil {
 		return pgdb.ErrNilConnection
@@ -301,40 +335,12 @@ func (r *UsageReservationRepository) ConfirmWithTx(ctx context.Context, db pgdb.
 		return err
 	}
 
-	if res.Status != model.StatusReserved {
+	if !settleableByConfirm(res.Status) {
 		return constant.ErrReservationAlreadyTerminal
 	}
 
-	now := time.Now().UTC()
-
-	counterUpdate := sq.Update(usageCountersTable).
-		Set("current_usage", sq.Expr("current_usage + ?", res.Amount)).
-		Set("reserved_usage", sq.Expr("reserved_usage - ?", res.Amount)).
-		Set("last_updated_at", now).
-		Where(sq.Eq{
-			"limit_id":   res.LimitID,
-			"scope_key":  res.ScopeKey,
-			"period_key": res.PeriodKey,
-		}).
-		PlaceholderFormat(sq.Dollar)
-
-	if err := r.execCounterMove(ctx, span, db, counterUpdate); err != nil {
+	if err := r.applyConfirm(ctx, span, db, res); err != nil {
 		return err
-	}
-
-	rowUpdate := sq.Update(usageReservationsTable).
-		Set("status", string(model.StatusConfirmed)).
-		Set("confirmed_at", now).
-		Where(sq.Eq{"id": reservationID, "status": string(model.StatusReserved)}).
-		PlaceholderFormat(sq.Dollar)
-
-	affected, err := r.execRowFlip(ctx, span, db, rowUpdate)
-	if err != nil {
-		return err
-	}
-
-	if affected == 0 {
-		return constant.ErrReservationAlreadyTerminal
 	}
 
 	logger.With(
@@ -442,9 +448,10 @@ func (r *UsageReservationRepository) ConfirmByTransactionWithTx(ctx context.Cont
 
 	logger = logging.WithTrace(ctx, logger)
 
-	reservations, err := r.lockReservedByTransaction(ctx, db, transactionID)
+	reservations, err := r.lockSettleableByTransaction(ctx, db, transactionID,
+		settleableByConfirmPredicate)
 	if err != nil {
-		libOtel.HandleSpanError(span, "Failed to load reserved rows for transaction", err)
+		libOtel.HandleSpanError(span, "Failed to load settleable rows for transaction", err)
 		return nil, err
 	}
 
@@ -493,7 +500,10 @@ func (r *UsageReservationRepository) ReleaseByTransactionWithTx(ctx context.Cont
 		return nil, constant.ErrReservationInvalidStatus
 	}
 
-	reservations, err := r.lockReservedByTransaction(ctx, db, transactionID)
+	// RESERVED only: an EXPIRED row's hold was already returned by the sweep, and
+	// releasing it again would decrement the same capacity twice.
+	reservations, err := r.lockSettleableByTransaction(ctx, db, transactionID,
+		settleableByReleasePredicate)
 	if err != nil {
 		libOtel.HandleSpanError(span, "Failed to load reserved rows for transaction", err)
 		return nil, err
@@ -517,18 +527,34 @@ func (r *UsageReservationRepository) ReleaseByTransactionWithTx(ctx context.Cont
 	return reservations, nil
 }
 
-// applyConfirm moves a single RESERVED reservation's amount from reserved_usage to
-// current_usage and flips the row to CONFIRMED, on the supplied handle. It is the
-// shared per-row body of ConfirmByTransactionWithTx; the row is already locked and
-// known RESERVED by the by-transaction selector, so the WHERE status='RESERVED'
-// guard on the flip stays as a belt-and-braces against a concurrent transition.
+// applyConfirm settles one reservation onto the counter and flips the row to
+// CONFIRMED, on the supplied handle. It is the shared per-row body of BOTH
+// ConfirmWithTx and ConfirmByTransactionWithTx, so the by-id and by-transaction
+// routes can never drift on the counter arithmetic.
+//
+// The counter move depends on the state the row was locked in:
+//
+//   - RESERVED: the hold is still outstanding, so the amount moves out of
+//     reserved_usage and into current_usage.
+//   - EXPIRED: the sweep already returned the hold, so ONLY current_usage grows.
+//     Draining reserved_usage a second time would take capacity the counter no
+//     longer holds and drive the bucket toward its non-negative floor.
+//
+// The row flip is guarded on the status read under the lock, so a concurrent
+// transition loses cleanly and the caller sees zero rows affected.
 func (r *UsageReservationRepository) applyConfirm(ctx context.Context, span trace.Span, db pgdb.DB, res *model.Reservation) error {
 	now := time.Now().UTC()
+	lateConfirm := res.Status == model.StatusExpired
 
 	counterUpdate := sq.Update(usageCountersTable).
 		Set("current_usage", sq.Expr("current_usage + ?", res.Amount)).
-		Set("reserved_usage", sq.Expr("reserved_usage - ?", res.Amount)).
-		Set("last_updated_at", now).
+		Set("last_updated_at", now)
+
+	if !lateConfirm {
+		counterUpdate = counterUpdate.Set("reserved_usage", sq.Expr("reserved_usage - ?", res.Amount))
+	}
+
+	counterUpdate = counterUpdate.
 		Where(sq.Eq{
 			"limit_id":   res.LimitID,
 			"scope_key":  res.ScopeKey,
@@ -543,11 +569,36 @@ func (r *UsageReservationRepository) applyConfirm(ctx context.Context, span trac
 	rowUpdate := sq.Update(usageReservationsTable).
 		Set("status", string(model.StatusConfirmed)).
 		Set("confirmed_at", now).
-		Where(sq.Eq{"id": res.ID, "status": string(model.StatusReserved)}).
+		Where(sq.Eq{"id": res.ID, "status": string(res.Status)}).
 		PlaceholderFormat(sq.Dollar)
 
-	if _, err := r.execRowFlip(ctx, span, db, rowUpdate); err != nil {
+	affected, err := r.execRowFlip(ctx, span, db, rowUpdate)
+	if err != nil {
 		return err
+	}
+
+	if affected == 0 {
+		return constant.ErrReservationAlreadyTerminal
+	}
+
+	if lateConfirm {
+		// The limit was under-enforced between the sweep and this confirm: the
+		// capacity was available to other transactions while this spend was in
+		// flight. Say so loudly — a silent late confirm is how a cap quietly
+		// stops matching reality.
+		span.SetAttributes(attribute.Bool("app.reservation_late_confirm", true))
+
+		logger, _, _, _ := libObservability.NewTrackingFromContext(ctx)
+
+		logging.WithTrace(ctx, logger).With(
+			libLog.String("operation", "repository.usage_reservation.confirm"),
+			libLog.String("reservation_id", res.ID.String()),
+			libLog.String("transaction_id", res.TransactionID.String()),
+			libLog.String("limit_id", res.LimitID.String()),
+			libLog.String("amount", res.Amount.String()),
+			libLog.String("reservation_expires_at", res.ReservationExpiresAt.UTC().Format(time.RFC3339)),
+		).Log(ctx, libLog.LevelWarn,
+			"Confirmed a reservation the expiry sweep had already released; the spend is counted now, but the limit was under-enforced until this point")
 	}
 
 	return nil
@@ -586,18 +637,26 @@ func (r *UsageReservationRepository) applyRelease(ctx context.Context, span trac
 	return nil
 }
 
-// lockReservedByTransaction reads every RESERVED reservation row for a transaction
-// FOR UPDATE so the per-row counter moves and flips see a stable status under a
-// concurrent by-id confirm/release or the reaper. The lookup rides the 4-tuple
-// unique index (transaction_id leads). A transaction with no RESERVED rows returns
-// an empty slice, NOT an error — the by-transaction confirm/release is idempotent
-// over "nothing to do".
-func (r *UsageReservationRepository) lockReservedByTransaction(ctx context.Context, db pgdb.DB, transactionID uuid.UUID) ([]*model.Reservation, error) {
-	const selectSQL = `
+// lockSettleableByTransaction reads every reservation row for a transaction whose
+// status is in statuses, FOR UPDATE, so the per-row counter moves and flips see a
+// stable status under a concurrent by-id confirm/release or the sweep. The lookup
+// rides the 4-tuple unique index (transaction_id leads). A transaction with no
+// matching rows returns an empty slice, NOT an error — the by-transaction
+// confirm/release is idempotent over "nothing to do".
+//
+// The status set differs by caller, and the difference is load-bearing. A confirm
+// also settles EXPIRED rows, because the transaction committed and its spend must
+// be counted even though the sweep already returned the hold. A release must NOT:
+// an expired hold was returned once already, and releasing it again would take the
+// same capacity out of the bucket twice.
+func (r *UsageReservationRepository) lockSettleableByTransaction(ctx context.Context, db pgdb.DB, transactionID uuid.UUID, statusPredicate string) ([]*model.Reservation, error) {
+	// statusPredicate is one of the two package constants below, never caller
+	// input, so it is safe to compose into the statement text.
+	selectSQL := `
 		SELECT id, limit_id, scope_key, period_key, amount, status,
 		       transaction_id, reservation_expires_at, created_at, confirmed_at, released_at
 		FROM usage_reservations
-		WHERE transaction_id = $1 AND status = 'RESERVED'
+		WHERE transaction_id = $1 AND ` + statusPredicate + `
 		FOR UPDATE
 	`
 

--- a/components/tracer/internal/adapters/postgres/usage_reservation_repository_integration_test.go
+++ b/components/tracer/internal/adapters/postgres/usage_reservation_repository_integration_test.go
@@ -539,3 +539,71 @@ func TestIntegration_UsageReservationRepository_FractionalCap_Denies(t *testing.
 	assert.True(t, half.Equal(reserved),
 		"denied reserve must leave reserved_usage at the first 0.50; got %s", reserved)
 }
+
+// TestIntegration_UsageReservationRepository_ReserveReplay_HandleOwnsExistingRow
+// reproduces the ledger's ordinary at-least-once retry end to end: reserve,
+// retry the SAME reserve, then confirm with the handle the retry returned, and
+// assert what the cap counted.
+//
+// The retry builds a SECOND model.NewReservation for the same 4-tuple, which is
+// exactly what the reservation service does per call — a FRESH row id. Before the
+// fix ReserveWithTx left that fresh id untouched on the replay branch, so the
+// caller held a handle matching zero rows: the confirm failed with
+// ErrReservationNotFound, the ledger swallowed it at Warn, and a spend that
+// actually committed was never counted against the customer's cap.
+func TestIntegration_UsageReservationRepository_ReserveReplay_HandleOwnsExistingRow(t *testing.T) {
+	testutil.SetupTestTracing(t)
+
+	db := testutil.SetupIntegrationDB(t)
+	repo := newReservationRepoIntegration(db)
+
+	limitID := createTestLimit(t, db, 8531)
+	t.Cleanup(func() { cleanupTestLimit(t, db, limitID) })
+
+	scopeKey := "acct:8531-" + testutil.MustDeterministicUUID(8541).String()[:8]
+	periodKey := "2026-06"
+
+	ctx := context.Background()
+	now := testutil.FixedTime()
+	txID := testutil.MustDeterministicUUID(8551)
+	amount := decimal.NewFromInt(400)
+	maxAmount := decimal.NewFromInt(1000)
+
+	newReserve := func() *model.Reservation {
+		res, err := model.NewReservation(limitID, txID, scopeKey, periodKey, amount, now.Add(5*time.Minute), now)
+		require.NoError(t, err)
+
+		return res
+	}
+
+	first := newReserve()
+	require.NoError(t, inRealTx(t, db, func(tx *sql.Tx) error {
+		return repo.ReserveWithTx(ctx, tx, first, maxAmount)
+	}))
+
+	// The retry: same 4-tuple, fresh row id, exactly as the service generates it.
+	retry := newReserve()
+	require.NotEqual(t, first.ID, retry.ID, "the retry must start with a fresh id, as the service generates it")
+
+	require.NoError(t, inRealTx(t, db, func(tx *sql.Tx) error {
+		return repo.ReserveWithTx(ctx, tx, retry, maxAmount)
+	}))
+
+	assert.Equal(t, first.ID, retry.ID,
+		"a replayed reserve must hand back the id of the row that owns the held capacity")
+
+	current, reserved := readCounterDecimal(t, db, limitID, scopeKey, periodKey)
+	assert.True(t, current.IsZero(), "replay must not touch current_usage; got %s", current)
+	assert.True(t, amount.Equal(reserved), "replay must not double-hold; want 400 got %s", reserved)
+
+	// The ledger commits and confirms with the handle the RETRY returned.
+	require.NoError(t, inRealTx(t, db, func(tx *sql.Tx) error {
+		return repo.ConfirmWithTx(ctx, tx, retry.ID)
+	}), "confirm with the retried reserve's handle must find the row")
+
+	current, reserved = readCounterDecimal(t, db, limitID, scopeKey, periodKey)
+	assert.True(t, amount.Equal(current),
+		"the committed spend must be counted against the cap; want 400 got %s", current)
+	assert.True(t, reserved.IsZero(), "confirm must drain the hold; got %s", reserved)
+	assert.Equal(t, string(model.StatusConfirmed), readReservationStatus(t, db, first.ID))
+}

--- a/components/tracer/internal/adapters/postgres/usage_reservation_repository_integration_test.go
+++ b/components/tracer/internal/adapters/postgres/usage_reservation_repository_integration_test.go
@@ -607,3 +607,142 @@ func TestIntegration_UsageReservationRepository_ReserveReplay_HandleOwnsExisting
 	assert.True(t, reserved.IsZero(), "confirm must drain the hold; got %s", reserved)
 	assert.Equal(t, string(model.StatusConfirmed), readReservationStatus(t, db, first.ID))
 }
+
+// TestIntegration_UsageReservationRepository_ConfirmAfterExpiry_CountsTheSpendOnce
+// covers the window the sweep opens: the sweep returns a hold's capacity at its
+// stated expiry without waiting for the ledger, and then the ledger's confirm
+// arrives for a transaction that really did commit.
+//
+// The spend happened, so the cap must reflect it exactly once. The expiry already
+// returned the hold, so the late confirm adds the amount to counted spending and
+// must NOT touch the hold bucket again.
+func TestIntegration_UsageReservationRepository_ConfirmAfterExpiry_CountsTheSpendOnce(t *testing.T) {
+	testutil.SetupTestTracing(t)
+
+	db := testutil.SetupIntegrationDB(t)
+	repo := newReservationRepoIntegration(db)
+
+	limitID := createTestLimit(t, db, 8561)
+	t.Cleanup(func() { cleanupTestLimit(t, db, limitID) })
+
+	scopeKey := "acct:8561-" + testutil.MustDeterministicUUID(8571).String()[:8]
+	periodKey := "2026-06"
+
+	ctx := context.Background()
+	now := testutil.FixedTime()
+	amount := decimal.NewFromInt(400)
+
+	res, err := model.NewReservation(
+		limitID,
+		testutil.MustDeterministicUUID(8581),
+		scopeKey,
+		periodKey,
+		amount,
+		now.Add(5*time.Minute),
+		now,
+	)
+	require.NoError(t, err)
+
+	require.NoError(t, inRealTx(t, db, func(tx *sql.Tx) error {
+		return repo.ReserveWithTx(ctx, tx, res, decimal.NewFromInt(1000))
+	}))
+
+	current, held := readCounterDecimal(t, db, limitID, scopeKey, periodKey)
+	assert.True(t, current.IsZero(), "after reserve: counted spending must be 0, got %s", current)
+	assert.True(t, amount.Equal(held), "after reserve: hold must be 400, got %s", held)
+
+	// The sweep expires it. This is exactly what the reaper does per row.
+	require.NoError(t, inRealTx(t, db, func(tx *sql.Tx) error {
+		return repo.ReleaseWithTx(ctx, tx, res.ID, model.StatusExpired)
+	}))
+
+	current, held = readCounterDecimal(t, db, limitID, scopeKey, periodKey)
+	assert.True(t, current.IsZero(), "after expiry: counted spending must still be 0, got %s", current)
+	assert.True(t, held.IsZero(), "after expiry: the hold must be returned, got %s", held)
+	assert.Equal(t, string(model.StatusExpired), readReservationStatus(t, db, res.ID))
+
+	// The ledger committed and confirms late. The spend must land on the cap.
+	require.NoError(t, inRealTx(t, db, func(tx *sql.Tx) error {
+		return repo.ConfirmWithTx(ctx, tx, res.ID)
+	}), "a confirm for a transaction that committed must not be discarded because its hold expired")
+
+	current, held = readCounterDecimal(t, db, limitID, scopeKey, periodKey)
+	assert.True(t, amount.Equal(current),
+		"after the late confirm: the committed spend must be counted; want 400 got %s", current)
+	assert.True(t, held.IsZero(), "after the late confirm: the hold must stay returned, got %s", held)
+	assert.Equal(t, string(model.StatusConfirmed), readReservationStatus(t, db, res.ID))
+
+	// Retrying the late confirm must not count the spend twice.
+	err = inRealTx(t, db, func(tx *sql.Tx) error {
+		return repo.ConfirmWithTx(ctx, tx, res.ID)
+	})
+	require.ErrorIs(t, err, constant.ErrReservationAlreadyTerminal)
+
+	current, held = readCounterDecimal(t, db, limitID, scopeKey, periodKey)
+	assert.True(t, amount.Equal(current), "a retried late confirm must not double-count; got %s", current)
+	assert.True(t, held.IsZero())
+}
+
+// TestIntegration_UsageReservationRepository_ConfirmByTransactionAfterExpiry_CountsTheSpendOnce
+// is the same window on the pending-transaction route, where the ledger holds only
+// the transaction id at commit time.
+func TestIntegration_UsageReservationRepository_ConfirmByTransactionAfterExpiry_CountsTheSpendOnce(t *testing.T) {
+	testutil.SetupTestTracing(t)
+
+	db := testutil.SetupIntegrationDB(t)
+	repo := newReservationRepoIntegration(db)
+
+	limitID := createTestLimit(t, db, 8562)
+	t.Cleanup(func() { cleanupTestLimit(t, db, limitID) })
+
+	scopeKey := "acct:8562-" + testutil.MustDeterministicUUID(8572).String()[:8]
+	periodKey := "2026-06"
+
+	ctx := context.Background()
+	now := testutil.FixedTime()
+	txID := testutil.MustDeterministicUUID(8582)
+	amount := decimal.NewFromInt(250)
+
+	res, err := model.NewReservation(limitID, txID, scopeKey, periodKey, amount, now.Add(5*time.Minute), now)
+	require.NoError(t, err)
+
+	require.NoError(t, inRealTx(t, db, func(tx *sql.Tx) error {
+		return repo.ReserveWithTx(ctx, tx, res, decimal.NewFromInt(1000))
+	}))
+
+	require.NoError(t, inRealTx(t, db, func(tx *sql.Tx) error {
+		return repo.ReleaseWithTx(ctx, tx, res.ID, model.StatusExpired)
+	}))
+
+	current, held := readCounterDecimal(t, db, limitID, scopeKey, periodKey)
+	require.True(t, current.IsZero())
+	require.True(t, held.IsZero())
+
+	var flipped []*model.Reservation
+
+	require.NoError(t, inRealTx(t, db, func(tx *sql.Tx) error {
+		var cErr error
+		flipped, cErr = repo.ConfirmByTransactionWithTx(ctx, tx, txID)
+
+		return cErr
+	}))
+	assert.Len(t, flipped, 1, "the pending commit must find the expired hold and settle it")
+
+	current, held = readCounterDecimal(t, db, limitID, scopeKey, periodKey)
+	assert.True(t, amount.Equal(current),
+		"the committed pending spend must be counted; want 250 got %s", current)
+	assert.True(t, held.IsZero())
+	assert.Equal(t, string(model.StatusConfirmed), readReservationStatus(t, db, res.ID))
+
+	// Re-running the commit confirm must be a no-op.
+	require.NoError(t, inRealTx(t, db, func(tx *sql.Tx) error {
+		var cErr error
+		flipped, cErr = repo.ConfirmByTransactionWithTx(ctx, tx, txID)
+
+		return cErr
+	}))
+	assert.Empty(t, flipped)
+
+	current, _ = readCounterDecimal(t, db, limitID, scopeKey, periodKey)
+	assert.True(t, amount.Equal(current), "a re-run must not double-count; got %s", current)
+}

--- a/components/tracer/internal/adapters/postgres/usage_reservation_repository_test.go
+++ b/components/tracer/internal/adapters/postgres/usage_reservation_repository_test.go
@@ -70,15 +70,15 @@ func newTestReservation(t *testing.T) *model.Reservation {
 }
 
 // reserveInsertSQL is the expected reservation-row INSERT, asserting the 4-tuple
-// ON CONFLICT DO NOTHING idempotency grain.
-const reserveInsertSQL = `
-		INSERT INTO usage_reservations (
-			id, limit_id, scope_key, period_key, amount, status,
-			transaction_id, reservation_expires_at, created_at
-		)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
-		ON CONFLICT (transaction_id, limit_id, scope_key, period_key) DO NOTHING
-	`
+// ON CONFLICT DO NOTHING idempotency grain and that the owning row's id is read
+// back on both branches.
+const reserveInsertSQL = insertReservationReturningIDSQL
+
+// reserveInsertColumns is the row shape the reserve insert scans: the id of the
+// row that owns the capacity, and whether this call created it.
+func reserveInsertColumns() []string {
+	return []string{"id", "inserted"}
+}
 
 func TestUsageReservationRepository_AcquireReserveScopeLock(t *testing.T) {
 	testutil.SetupTestTracing(t)
@@ -144,10 +144,10 @@ func TestUsageReservationRepository_Reserve(t *testing.T) {
 
 		res := newTestReservation(t)
 
-		// Reservation row insert (4-tuple ON CONFLICT grain) runs first; 1 row affected
-		// means a new reservation.
-		mock.ExpectExec(regexp.QuoteMeta(reserveInsertSQL)).
-			WillReturnResult(sqlmock.NewResult(0, 1))
+		// Reservation row insert (4-tuple ON CONFLICT grain) runs first; inserted=true
+		// means a new reservation and the returned id is the caller's own.
+		mock.ExpectQuery(regexp.QuoteMeta(reserveInsertSQL)).
+			WillReturnRows(sqlmock.NewRows(reserveInsertColumns()).AddRow(res.ID, true))
 		// A new row was inserted, so the reserve CTE (counter seed) follows and returns
 		// succeeded=true.
 		mock.ExpectQuery(regexp.QuoteMeta(upsertReserveSQL)).
@@ -162,15 +162,42 @@ func TestUsageReservationRepository_Reserve(t *testing.T) {
 		defer cleanup()
 
 		res := newTestReservation(t)
+		generatedID := res.ID
+		owningID := testutil.MustDeterministicUUID(8009)
 
-		// ON CONFLICT DO NOTHING suppresses the insert (0 rows affected): the 4-tuple
-		// already exists. The counter CTE MUST NOT run, so the replay holds capacity
+		require.NotEqual(t, generatedID, owningID)
+
+		// ON CONFLICT DO NOTHING suppresses the insert (inserted=false): the 4-tuple
+		// already exists, and the query returns the id of the row that already holds
+		// the capacity. The counter CTE MUST NOT run, so the replay holds capacity
 		// exactly once. ExpectationsWereMet on cleanup asserts no stray counter query.
-		mock.ExpectExec(regexp.QuoteMeta(reserveInsertSQL)).
-			WillReturnResult(sqlmock.NewResult(0, 0))
+		mock.ExpectQuery(regexp.QuoteMeta(reserveInsertSQL)).
+			WillReturnRows(sqlmock.NewRows(reserveInsertColumns()).AddRow(owningID, false))
 
 		err := repo.ReserveWithTx(context.Background(), db, res, maxAmountTest)
 		require.NoError(t, err)
+
+		// The handle the caller keeps must address the row that owns the capacity, not
+		// the id it generated for this attempt — otherwise its confirm/release hits
+		// ErrReservationNotFound and the hold is never settled.
+		assert.Equal(t, owningID, res.ID,
+			"a replayed reserve must adopt the existing row's id")
+	})
+
+	t.Run("Replay - no owning row fails closed", func(t *testing.T) {
+		repo, db, mock, cleanup := setupUsageReservationRepository(t)
+		defer cleanup()
+
+		res := newTestReservation(t)
+
+		// Neither branch produced a row. The reserve MUST fail rather than return a
+		// handle that owns nothing.
+		mock.ExpectQuery(regexp.QuoteMeta(reserveInsertSQL)).
+			WillReturnRows(sqlmock.NewRows(reserveInsertColumns()))
+
+		err := repo.ReserveWithTx(context.Background(), db, res, maxAmountTest)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no owning reservation row")
 	})
 
 	t.Run("Fractional amount is inserted without truncation", func(t *testing.T) {
@@ -197,7 +224,7 @@ func TestUsageReservationRepository_Reserve(t *testing.T) {
 		// WithArgs guards the changed line: the exact fractional amount (not a
 		// truncated integer) MUST reach both the row insert and the reserve CTE. The row
 		// insert runs first; its $5 amount carries the exact fraction on the row.
-		mock.ExpectExec(regexp.QuoteMeta(reserveInsertSQL)).
+		mock.ExpectQuery(regexp.QuoteMeta(reserveInsertSQL)).
 			WithArgs(
 				res.ID,                             // $1 reservation id
 				res.LimitID,                        // $2 limit id
@@ -209,7 +236,7 @@ func TestUsageReservationRepository_Reserve(t *testing.T) {
 				sqlmock.AnyArg(),                   // $8 reservation_expires_at
 				sqlmock.AnyArg(),                   // $9 created_at
 			).
-			WillReturnResult(sqlmock.NewResult(0, 1))
+			WillReturnRows(sqlmock.NewRows(reserveInsertColumns()).AddRow(res.ID, true))
 		// A new row was inserted, so the reserve CTE follows. It binds the amount three
 		// times ($5 INSERT seed, $7 UPDATE increment, $9 WHERE-guard check) and the cap
 		// once ($10); the counter id, timestamps and expiry are non-deterministic. A
@@ -239,11 +266,11 @@ func TestUsageReservationRepository_Reserve(t *testing.T) {
 
 		res := newTestReservation(t)
 
-		// A new row inserts first (1 row affected); the reserve CTE then fails its WHERE
+		// A new row inserts first (inserted=true); the reserve CTE then fails its WHERE
 		// guard (succeeded=false) -> ErrUsageCounterExceedsLimit. The caller rolls the
 		// transaction back, which unwinds the row inserted above.
-		mock.ExpectExec(regexp.QuoteMeta(reserveInsertSQL)).
-			WillReturnResult(sqlmock.NewResult(0, 1))
+		mock.ExpectQuery(regexp.QuoteMeta(reserveInsertSQL)).
+			WillReturnRows(sqlmock.NewRows(reserveInsertColumns()).AddRow(res.ID, true))
 		mock.ExpectQuery(regexp.QuoteMeta(upsertReserveSQL)).
 			WillReturnRows(sqlmock.NewRows([]string{"reserved_usage", "succeeded"}).AddRow("1000", false))
 

--- a/components/tracer/internal/bootstrap/config.go
+++ b/components/tracer/internal/bootstrap/config.go
@@ -984,6 +984,14 @@ type limitServiceDeps struct {
 	service          *services.LimitService
 	usageCounterRepo *postgres.UsageCounterRepository
 	limitRepo        *postgres.LimitRepository
+	// reservationRepo backs the two-phase reservation lifecycle. It lives here
+	// rather than inside the HTTP wiring because the TTL reaper needs the same
+	// instance, and the multi-tenant supervisor is assembled before the HTTP
+	// server.
+	reservationRepo *postgres.UsageReservationRepository
+	// reaperRepo is the narrow sweep surface the reservation reaper consumes:
+	// find the RESERVED rows past their TTL and release each as EXPIRED.
+	reaperRepo *postgres.ReservationReaperRepository
 }
 
 // initLimitService creates the limit service with all its dependencies.
@@ -1047,10 +1055,18 @@ func initLimitService(pgConn pgdb.Connection, auditWriter command.AuditWriter, c
 
 	service := services.NewLimitService(createLimitCmd, updateLimitCmd, activateLimitCmd, deactivateLimitCmd, draftLimitCmd, deleteLimitCmd, getLimitQuery, listLimitsQuery, usageCounterRepo)
 
+	// The reservation repository and the reaper's sweep surface over it are built
+	// once here so the HTTP reserve/confirm/release seam and the TTL reaper share
+	// one instance in both boot modes.
+	reservationRepo := postgres.NewUsageReservationRepositoryWithConnection(usageCounterRepo)
+	reaperRepo := postgres.NewReservationReaperRepository(pgConn, txBeginner, reservationRepo)
+
 	return &limitServiceDeps{
 		service:          service,
 		usageCounterRepo: usageCounterRepo,
 		limitRepo:        limitRepo,
+		reservationRepo:  reservationRepo,
+		reaperRepo:       reaperRepo,
 	}, nil
 }
 
@@ -1124,7 +1140,7 @@ func initHTTPServer(
 	// checker as the limit resolver and the shared audit writer / txBeginner so
 	// the reserve/confirm/release counter moves commit atomically with their
 	// audit rows — the same atomicity discipline as the validate path.
-	reservationRepo := postgres.NewUsageReservationRepositoryWithConnection(limitDeps.usageCounterRepo)
+	reservationRepo := limitDeps.reservationRepo
 
 	longLivedTTL, err := parseReservationLongLivedTTLHours(cfg.ReservationLongLivedTTLHours)
 	if err != nil {
@@ -1319,6 +1335,42 @@ func initCleanupWorker(ctx context.Context, cfg *Config, usageCounterRepo *postg
 	return cleanupWorker, nil
 }
 
+// initReaperWorker creates the single-tenant reservation reaper if enabled. The
+// reaper is the only path that returns capacity held by a reservation the ledger
+// never confirmed or released, so without it a crashed transaction's hold is
+// permanent and later transactions are denied against a limit whose real usage is
+// lower.
+func initReaperWorker(
+	ctx context.Context,
+	cfg *Config,
+	reaperRepo *postgres.ReservationReaperRepository,
+	auditor *command.RecordAuditEventCommand,
+	logger libLog.Logger,
+	clk clock.Clock,
+) (*workers.ReservationReaperWorker, error) {
+	reaperConfig, err := LoadReservationReaperConfig(ctx, cfg, logger)
+	if err != nil {
+		return nil, fmt.Errorf("invalid reservation reaper configuration: %w", err)
+	}
+
+	if reaperConfig == nil {
+		return nil, nil
+	}
+
+	// tenantID is empty in single-tenant mode; the supervisor passes the real tenantID in MT mode.
+	reaperWorker, err := workers.NewReservationReaperWorker(reaperRepo, auditor, *reaperConfig, logger, clk, "")
+	if err != nil {
+		return nil, fmt.Errorf("failed to create reservation reaper worker: %w", err)
+	}
+
+	logger.With(
+		libLog.String("component", "reservation_reaper_worker"),
+		libLog.String("reap_interval", reaperConfig.ReapInterval.String()),
+	).Log(ctx, libLog.LevelInfo, "Reservation reaper worker initialized")
+
+	return reaperWorker, nil
+}
+
 // buildMultiTenantStack assembles the multi-tenant metrics sink and the
 // multi-tenant components in a single call. In single-tenant mode the metrics
 // sink is a zero-cost no-op and mtComponents stays nil; both modes share the
@@ -1332,6 +1384,7 @@ func buildMultiTenantStack(
 	ruleCache *cache.RuleCache,
 	ruleSyncRepo *postgres.RuleSyncRepository,
 	limitDeps *limitServiceDeps,
+	auditWriter *command.RecordAuditEventCommand,
 	celAdapter *cel.Adapter,
 	clk clock.Clock,
 ) (*componentsMT, metrics.MultiTenantMetrics, error) {
@@ -1348,7 +1401,7 @@ func buildMultiTenantStack(
 	// (rare fallback path that should never fire in production).
 	mtMetrics := metrics.NewMultiTenantMetrics(cfg.MultiTenantEnabled, mtFactory, logger)
 
-	mtComponents, err := initMultiTenant(ctx, cfg, logger, ruleCache, ruleSyncRepo, limitDeps, celAdapter, clk, mtMetrics)
+	mtComponents, err := initMultiTenant(ctx, cfg, logger, ruleCache, ruleSyncRepo, limitDeps, auditWriter, celAdapter, clk, mtMetrics)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -1372,6 +1425,7 @@ func initMultiTenant(
 	ruleCache *cache.RuleCache,
 	ruleSyncRepo *postgres.RuleSyncRepository,
 	limitDeps *limitServiceDeps,
+	auditWriter *command.RecordAuditEventCommand,
 	celAdapter *cel.Adapter,
 	clk clock.Clock,
 	mtMetrics metrics.MultiTenantMetrics,
@@ -1401,6 +1455,22 @@ func initMultiTenant(
 
 	if cleanupEnabled {
 		resolvedCleanup = *cleanupCfg
+	}
+
+	// The reservation reaper mirrors the cleanup worker's disabled-signal
+	// propagation: LoadReservationReaperConfig returns nil when the reaper is
+	// off, and nil means the supervisor must not spawn per-tenant reapers.
+	reaperCfg, err := LoadReservationReaperConfig(ctx, cfg, logger)
+	if err != nil {
+		return nil, err
+	}
+
+	var resolvedReaper workers.ReservationReaperWorkerConfig
+
+	reaperEnabled := reaperCfg != nil
+
+	if reaperEnabled {
+		resolvedReaper = *reaperCfg
 	}
 
 	syncCBConfig := workers.DefaultSyncCircuitBreakerConfig()
@@ -1438,6 +1508,12 @@ func initMultiTenant(
 			MaxTenants: cfg.MultiTenantMaxTenantPools,
 			Service:    cfg.ApplicationName,
 			Metrics:    mtMetrics,
+			// Per-tenant reservation reaper. buildSupervisorDeps only overwrites
+			// the fields it names, so these survive onto the supervisor.
+			ReaperRepo:          limitDeps.reaperRepo,
+			ReaperAuditor:       auditWriter,
+			ReaperConfig:        resolvedReaper,
+			ReaperWorkerEnabled: reaperEnabled,
 		},
 	)
 	if err != nil {
@@ -1487,6 +1563,7 @@ func initWorkers(
 	ctx context.Context,
 	cfg *Config,
 	limitDeps *limitServiceDeps,
+	auditWriter *command.RecordAuditEventCommand,
 	syncWorker *workers.RuleSyncWorker,
 	serverAPI *HTTPServer,
 	grpcServer *GRPCServer,
@@ -1524,7 +1601,13 @@ func initWorkers(
 		return nil, err
 	}
 
+	reaperWorker, err := initReaperWorker(ctx, cfg, limitDeps.reaperRepo, auditWriter, logger, clk)
+	if err != nil {
+		return nil, err
+	}
+
 	svc.cleanupWorker = cleanupWorker
+	svc.reaperWorker = reaperWorker
 	svc.syncWorker = syncWorker
 
 	return svc, nil
@@ -1901,7 +1984,7 @@ func InitServers(ctx context.Context) (*Service, error) {
 		return nil, err
 	}
 
-	mtComponents, mtMetrics, err := buildMultiTenantStack(ctx, cfg, logger, telemetry, ruleCache, ruleSyncRepo, limitDeps, celAdapter, clk)
+	mtComponents, mtMetrics, err := buildMultiTenantStack(ctx, cfg, logger, telemetry, ruleCache, ruleSyncRepo, limitDeps, auditWriter, celAdapter, clk)
 	if err != nil {
 		return nil, err
 	}
@@ -1948,7 +2031,7 @@ func InitServers(ctx context.Context) (*Service, error) {
 	// finalizeStartup also builds the opt-in reservation gRPC server and runs the
 	// startup self-probe BEFORE the HTTP server begins accepting traffic; folded
 	// into one helper to keep InitServers under the gocyclo budget.
-	svc, err := finalizeStartup(ctx, cfg, limitDeps, syncWorker, serverAPI, reservationService, postgresConn, healthChecker, logger, telemetry, clk, mtComponents, streamingEmitter, streamingClose)
+	svc, err := finalizeStartup(ctx, cfg, limitDeps, auditWriter, syncWorker, serverAPI, reservationService, postgresConn, healthChecker, logger, telemetry, clk, mtComponents, streamingEmitter, streamingClose)
 	if err != nil {
 		return nil, err
 	}
@@ -2114,6 +2197,7 @@ func finalizeStartup(
 	ctx context.Context,
 	cfg *Config,
 	limitDeps *limitServiceDeps,
+	auditWriter *command.RecordAuditEventCommand,
 	syncWorker *workers.RuleSyncWorker,
 	serverAPI *HTTPServer,
 	reservationService *services.ReservationService,
@@ -2136,7 +2220,7 @@ func finalizeStartup(
 		return nil, err
 	}
 
-	svc, err := initWorkers(ctx, cfg, limitDeps, syncWorker, serverAPI, grpcServer, postgresConn, healthChecker, logger, clk, mtComponents, streamingEmitter, streamingClose)
+	svc, err := initWorkers(ctx, cfg, limitDeps, auditWriter, syncWorker, serverAPI, grpcServer, postgresConn, healthChecker, logger, clk, mtComponents, streamingEmitter, streamingClose)
 	if err != nil {
 		return nil, err
 	}

--- a/components/tracer/internal/bootstrap/config.go
+++ b/components/tracer/internal/bootstrap/config.go
@@ -201,8 +201,11 @@ type Config struct {
 	CleanupIntervalHours string `env:"CLEANUP_INTERVAL_HOURS"`
 
 	// Reservation Reaper Worker
-	// ReservationReaperEnabled enables/disables the background reservation reaper (default: false).
-	// Set RESERVATION_REAPER_ENABLED=true to release expired two-phase reservations.
+	// ReservationReaperEnabled enables/disables the background reservation reaper
+	// (default: true, applied by ApplyReservationReaperDefaults because
+	// SetConfigFromEnvVars cannot tell "unset" from "false"). The reaper is the
+	// only path that returns capacity held past a reservation's stated expiry.
+	// Set RESERVATION_REAPER_ENABLED=false to turn it off explicitly.
 	ReservationReaperEnabled bool `env:"RESERVATION_REAPER_ENABLED"`
 	// ReservationReaperIntervalSeconds is the sub-minute interval between reaper sweeps in seconds (default: 30).
 	ReservationReaperIntervalSeconds string `env:"RESERVATION_REAPER_INTERVAL_SECONDS"`
@@ -599,9 +602,34 @@ func LoadCleanupWorkerConfig(ctx context.Context, cfg *Config, logger libLog.Log
 	}, nil
 }
 
+// ApplyReservationReaperDefaults turns the expired-reservation sweep ON unless
+// the operator explicitly disabled it.
+//
+// Every reservation is written with an expiry that the API returns to the
+// client, and the sweep is the ONLY path that returns capacity when that expiry
+// passes: confirm and release both require the ledger to come back, and the
+// ledger deliberately swallows a lost confirm or release because the sweep is
+// its stated backstop. Off by default, an expiry is a number the product reports
+// and never acts on, and a ledger transaction that crashed mid-flight holds a
+// slice of the customer's cap until the counter's period rolls — never, for a
+// custom period.
+//
+// lib-commons SetConfigFromEnvVars cannot distinguish "unset" from "false", so
+// probe the raw variable, mirroring the MULTI_TENANT_REDIS_TLS default.
+// RESERVATION_REAPER_ENABLED=false still disables the sweep.
+func ApplyReservationReaperDefaults(cfg *Config) {
+	if cfg == nil {
+		return
+	}
+
+	if _, present := os.LookupEnv("RESERVATION_REAPER_ENABLED"); !present {
+		cfg.ReservationReaperEnabled = true
+	}
+}
+
 // LoadReservationReaperConfig creates a ReservationReaperWorkerConfig from
-// environment configuration. Returns a nil config (no error) when the reaper is
-// disabled (RESERVATION_REAPER_ENABLED=false, the default) so the caller can
+// environment configuration. Returns a nil config (no error) when the operator
+// disabled the reaper (RESERVATION_REAPER_ENABLED=false) so the caller can
 // propagate the "disabled" signal end-to-end exactly like LoadCleanupWorkerConfig.
 // Returns an error if config or logger is nil, or if the interval is invalid.
 func LoadReservationReaperConfig(ctx context.Context, cfg *Config, logger libLog.Logger) (*workers.ReservationReaperWorkerConfig, error) {
@@ -1857,6 +1885,10 @@ func InitServers(ctx context.Context) (*Service, error) {
 	// Required because lib-commons v4 SetConfigFromEnvVars does not honor
 	// `envDefault` struct tags; this is the single source of truth for defaults.
 	ApplyMultiTenantDefaults(cfg)
+
+	// The expired-reservation sweep is on unless explicitly disabled: it is the
+	// only path that returns capacity held past a reservation's stated expiry.
+	ApplyReservationReaperDefaults(cfg)
 
 	// initCoreInfra also builds the streaming emitter once logger + telemetry
 	// are up. Disabled (the default) yields a NoopEmitter plus a no-op close

--- a/components/tracer/internal/bootstrap/reservation_reaper_wiring_test.go
+++ b/components/tracer/internal/bootstrap/reservation_reaper_wiring_test.go
@@ -5,6 +5,7 @@
 package bootstrap
 
 import (
+	"os"
 	"testing"
 	"time"
 
@@ -103,6 +104,42 @@ func TestLoadReservationReaperConfig(t *testing.T) {
 
 			require.NotNil(t, got)
 			assert.Equal(t, tt.expectedInterval, got.ReapInterval)
+		})
+	}
+}
+
+// TestApplyReservationReaperDefaults covers the posture of the sweep an operator
+// never configured. Every reservation carries an expiry the API returns, and the
+// sweep is the only path that returns capacity when that expiry passes, so it
+// must run unless the operator explicitly turned it off.
+func TestApplyReservationReaperDefaults(t *testing.T) {
+	tests := []struct {
+		name        string
+		envValue    string
+		envSet      bool
+		wantEnabled bool
+	}{
+		{name: "unset enables the sweep", wantEnabled: true},
+		{name: "explicit false disables the sweep", envValue: "false", envSet: true, wantEnabled: false},
+		{name: "explicit true keeps the sweep", envValue: "true", envSet: true, wantEnabled: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.envSet {
+				t.Setenv("RESERVATION_REAPER_ENABLED", tt.envValue)
+			} else {
+				t.Setenv("RESERVATION_REAPER_ENABLED", "")
+				require.NoError(t, os.Unsetenv("RESERVATION_REAPER_ENABLED"))
+			}
+
+			// The bool mirrors what lib-commons parsed from the environment: it
+			// cannot tell "unset" from "false", so both arrive here as false.
+			cfg := &Config{ReservationReaperEnabled: tt.envValue == "true"}
+
+			ApplyReservationReaperDefaults(cfg)
+
+			assert.Equal(t, tt.wantEnabled, cfg.ReservationReaperEnabled)
 		})
 	}
 }

--- a/components/tracer/internal/bootstrap/reservation_reaper_wiring_test.go
+++ b/components/tracer/internal/bootstrap/reservation_reaper_wiring_test.go
@@ -1,0 +1,209 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package bootstrap
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/LerianStudio/midaz/v4/components/tracer/internal/adapters/postgres"
+	"github.com/LerianStudio/midaz/v4/components/tracer/internal/services/command"
+	"github.com/LerianStudio/midaz/v4/components/tracer/internal/services/workers"
+	"github.com/LerianStudio/midaz/v4/components/tracer/internal/testutil"
+	"github.com/LerianStudio/midaz/v4/components/tracer/pkg/clock"
+)
+
+// reaperWiringDeps returns the reaper's two collaborators. Neither is exercised
+// during construction, so a repository over nil handles is enough to prove the
+// boot path assembles the worker.
+func reaperWiringDeps() (*limitServiceDeps, *command.RecordAuditEventCommand) {
+	reservationRepo := postgres.NewUsageReservationRepositoryWithConnection(nil)
+	deps := &limitServiceDeps{
+		reservationRepo: reservationRepo,
+		reaperRepo:      postgres.NewReservationReaperRepository(nil, nil, reservationRepo),
+	}
+
+	return deps, command.NewRecordAuditEventCommand(nil)
+}
+
+// TestLoadReservationReaperConfig covers the two knobs that had no reader at
+// boot: the enable flag and the sweep cadence. An operator who sets either one
+// must see it take effect, and a mistyped cadence must stop startup instead of
+// passing silently.
+func TestLoadReservationReaperConfig(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name             string
+		enabled          bool
+		intervalSeconds  string
+		expectNilConfig  bool
+		expectedInterval time.Duration
+		expectErrText    string
+	}{
+		{
+			name:            "disabled returns nil config",
+			enabled:         false,
+			expectNilConfig: true,
+		},
+		{
+			name:             "enabled with the default cadence",
+			enabled:          true,
+			expectedInterval: workers.DefaultReservationReaperInterval,
+		},
+		{
+			name:             "enabled with an operator cadence",
+			enabled:          true,
+			intervalSeconds:  "5",
+			expectedInterval: 5 * time.Second,
+		},
+		{
+			name:            "a mistyped cadence is rejected",
+			enabled:         true,
+			intervalSeconds: "thirty",
+			expectErrText:   "RESERVATION_REAPER_INTERVAL_SECONDS",
+		},
+		{
+			name:            "an out-of-range cadence is rejected",
+			enabled:         true,
+			intervalSeconds: "7200",
+			expectErrText:   "RESERVATION_REAPER_INTERVAL_SECONDS",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := &Config{
+				ReservationReaperEnabled:         tt.enabled,
+				ReservationReaperIntervalSeconds: tt.intervalSeconds,
+			}
+
+			got, err := LoadReservationReaperConfig(t.Context(), cfg, testutil.NewMockLogger())
+
+			if tt.expectErrText != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectErrText)
+
+				return
+			}
+
+			require.NoError(t, err)
+
+			if tt.expectNilConfig {
+				assert.Nil(t, got)
+				return
+			}
+
+			require.NotNil(t, got)
+			assert.Equal(t, tt.expectedInterval, got.ReapInterval)
+		})
+	}
+}
+
+// TestInitReaperWorker builds the reaper the way boot does. Nothing constructed
+// this worker before, so the sweep the enable flag promised never ran and an
+// invalid cadence never failed startup.
+func TestInitReaperWorker(t *testing.T) {
+	t.Parallel()
+
+	limitDeps, auditor := reaperWiringDeps()
+
+	t.Run("enabled builds the worker", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := &Config{ReservationReaperEnabled: true, ReservationReaperIntervalSeconds: "5"}
+
+		worker, err := initReaperWorker(t.Context(), cfg, limitDeps.reaperRepo, auditor,
+			testutil.NewMockLogger(), clock.RealClock{})
+		require.NoError(t, err)
+		assert.NotNil(t, worker, "an operator who enables the reaper must get a sweep")
+	})
+
+	t.Run("disabled builds nothing", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := &Config{ReservationReaperEnabled: false}
+
+		worker, err := initReaperWorker(t.Context(), cfg, limitDeps.reaperRepo, auditor,
+			testutil.NewMockLogger(), clock.RealClock{})
+		require.NoError(t, err)
+		assert.Nil(t, worker)
+	})
+
+	t.Run("a mistyped cadence stops startup", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := &Config{ReservationReaperEnabled: true, ReservationReaperIntervalSeconds: "thirty"}
+
+		worker, err := initReaperWorker(t.Context(), cfg, limitDeps.reaperRepo, auditor,
+			testutil.NewMockLogger(), clock.RealClock{})
+		require.Error(t, err)
+		assert.Nil(t, worker)
+	})
+}
+
+// TestInitWorkers_SingleTenantRegistersReaper proves the composed single-tenant
+// boot path ends with a reaper on the Service, which is what Run() registers
+// with the launcher.
+func TestInitWorkers_SingleTenantRegistersReaper(t *testing.T) {
+	t.Parallel()
+
+	limitDeps, auditor := reaperWiringDeps()
+
+	t.Run("enabled", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := &Config{ReservationReaperEnabled: true, ReservationReaperIntervalSeconds: "5"}
+
+		svc, err := initWorkers(t.Context(), cfg, limitDeps, auditor, nil, nil, nil, nil, nil,
+			testutil.NewMockLogger(), clock.RealClock{}, nil, nil, nil)
+		require.NoError(t, err)
+		require.NotNil(t, svc)
+		assert.NotNil(t, svc.reaperWorker, "single-tenant boot must carry the reservation reaper")
+	})
+
+	t.Run("disabled", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := &Config{ReservationReaperEnabled: false}
+
+		svc, err := initWorkers(t.Context(), cfg, limitDeps, auditor, nil, nil, nil, nil, nil,
+			testutil.NewMockLogger(), clock.RealClock{}, nil, nil, nil)
+		require.NoError(t, err)
+		require.NotNil(t, svc)
+		assert.Nil(t, svc.reaperWorker)
+	})
+}
+
+// TestBuildSupervisorDeps_PreservesReaperWiring locks the mechanism the
+// multi-tenant path depends on: the reaper fields are set on the caller's
+// supervisor extras, and buildSupervisorDeps must carry them through rather than
+// blanking them with the MT-sourced fields it does own.
+func TestBuildSupervisorDeps_PreservesReaperWiring(t *testing.T) {
+	t.Parallel()
+
+	deps, extras := newWiringTestDeps(t)
+
+	reservationRepo := postgres.NewUsageReservationRepositoryWithConnection(nil)
+	reaperRepo := postgres.NewReservationReaperRepository(nil, nil, reservationRepo)
+	auditor := command.NewRecordAuditEventCommand(nil)
+
+	extras.ReaperRepo = reaperRepo
+	extras.ReaperAuditor = auditor
+	extras.ReaperConfig = workers.ReservationReaperWorkerConfig{ReapInterval: 5 * time.Second}
+	extras.ReaperWorkerEnabled = true
+
+	got := buildSupervisorDeps(&Config{ApplicationName: "tracer"}, extras, deps, deps.Compiler, nil, nil)
+
+	assert.True(t, got.ReaperWorkerEnabled, "per-tenant reapers must stay enabled through the deps build")
+	assert.Equal(t, reaperRepo, got.ReaperRepo)
+	assert.Equal(t, auditor, got.ReaperAuditor)
+	assert.Equal(t, 5*time.Second, got.ReaperConfig.ReapInterval)
+}

--- a/components/tracer/internal/bootstrap/service.go
+++ b/components/tracer/internal/bootstrap/service.go
@@ -43,7 +43,11 @@ type Service struct {
 	grpcServer    *GRPCServer
 	postgresConn  *libPostgres.Client
 	cleanupWorker *workers.UsageCleanupWorker
-	syncWorker    *workers.RuleSyncWorker
+	// reaperWorker sweeps reservations whose TTL elapsed without a confirm or
+	// release and returns their held capacity. Nil when the reaper is disabled,
+	// and always nil in multi-tenant mode (the supervisor spawns one per tenant).
+	reaperWorker *workers.ReservationReaperWorker
+	syncWorker   *workers.RuleSyncWorker
 
 	// Multi-tenant components (nil in single-tenant mode).
 	pgManager     *tmpostgres.Manager
@@ -166,6 +170,10 @@ func (app *Service) Run() {
 	// Single-tenant: register singleton workers with the Launcher.
 	if app.cleanupWorker != nil {
 		opts = append(opts, libCommons.RunApp("Usage Cleanup Worker", app.cleanupWorker))
+	}
+
+	if app.reaperWorker != nil {
+		opts = append(opts, libCommons.RunApp("Reservation Reaper Worker", app.reaperWorker))
 	}
 
 	if app.syncWorker != nil {

--- a/components/tracer/internal/services/reservation_service_test.go
+++ b/components/tracer/internal/services/reservation_service_test.go
@@ -19,6 +19,7 @@ import (
 
 	pgdb "github.com/LerianStudio/midaz/v4/components/tracer/internal/adapters/postgres/db"
 	pgdbMocks "github.com/LerianStudio/midaz/v4/components/tracer/internal/adapters/postgres/db/mocks"
+	"github.com/LerianStudio/midaz/v4/components/tracer/internal/services/command"
 	servicesMocks "github.com/LerianStudio/midaz/v4/components/tracer/internal/services/mocks"
 	"github.com/LerianStudio/midaz/v4/components/tracer/internal/services/query"
 	"github.com/LerianStudio/midaz/v4/components/tracer/internal/testutil"
@@ -177,6 +178,56 @@ func TestReservationService_Reserve(t *testing.T) {
 		require.NoError(t, err)
 		require.False(t, result.Denied)
 		assert.Len(t, result.ReservationIDs, 2)
+	})
+
+	t.Run("A replayed reserve hands back the existing row's id", func(t *testing.T) {
+		svc, deps := newReservationServiceDeps(t)
+
+		input := testCheckLimitsInput(t)
+		specs := twoSpecs()
+
+		// The id the retried reserve collapses onto. The repository overwrites the
+		// reservation's id with the row that owns the capacity, so the handle the
+		// ledger confirms or releases with must be THIS id, not the one the service
+		// generated for the retry.
+		owningID := testutil.MustDeterministicUUID(7099)
+
+		deps.resolver.EXPECT().
+			ResolveReservations(gomock.Any(), input).
+			Return(specs[:1], false, nil).
+			Times(1)
+
+		deps.expectTxCommit()
+		deps.expectScopeLock()
+
+		deps.repo.EXPECT().
+			ReserveWithTx(gomock.Any(), deps.tx, gomock.Any(), decEq(decimal.NewFromInt(10000))).
+			DoAndReturn(func(_ context.Context, _ any, r *model.Reservation, _ decimal.Decimal) error {
+				r.ID = owningID
+
+				return nil
+			}).
+			Times(1)
+
+		var auditedID uuid.UUID
+
+		deps.auditWriter.EXPECT().
+			RecordReservationEventWithTx(gomock.Any(), deps.tx, model.AuditEventReservationReserved, model.AuditActionReserve, gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, _ any, _ model.AuditEventType, _ model.AuditAction, id uuid.UUID, _ command.ReservationAuditContext) error {
+				auditedID = id
+
+				return nil
+			}).
+			Times(1)
+
+		result, err := svc.Reserve(context.Background(), txID, input, false)
+		require.NoError(t, err)
+		require.False(t, result.Denied)
+		require.Len(t, result.ReservationIDs, 1)
+		assert.Equal(t, owningID, result.ReservationIDs[0],
+			"the handle returned must address the row that owns the held capacity")
+		assert.Equal(t, owningID, auditedID,
+			"the audit row must reference the reservation that owns the held capacity")
 	})
 
 	t.Run("Fractional spec amount reaches the reservation row intact", func(t *testing.T) {

--- a/docs/architecture/ledger-tracer-topology.md
+++ b/docs/architecture/ledger-tracer-topology.md
@@ -96,16 +96,35 @@ collapsing the two into one failure/scale unit.
   the balance commit; a reject returns *before* any balance moves (`create_transaction_v2.go`).
   The tracer must therefore be **low-latency**, but each reservation's work is bounded per transaction.
 
-- **Confirm / Release are post-commit and best-effort (non-blocking).** After a successful balance
+- **Confirm / Release are post-commit and non-blocking.** After a successful balance
   commit, `confirmReservations` runs for non-PENDING transactions; on a commit failure
   `releaseReservations` runs (`services/command/create_transaction_v2.go`); PENDING defers confirm to
   `/commit` and release to `/cancel`, which the versioned transition use case answers
   (`services/command/commit_transaction.go`, `transitionPendingV2`, which names
   `confirmReservationsByTransaction` / `releaseReservationsByTransaction`).
-  Transport failures on confirm/release are logged at Warn,
-  span-recorded, and **never propagated** — the TTL reaper is the durability backstop
-  (`transaction_reservation_anchor.go:246-261, 282-289`). A tracer outage during the confirm/release
-  window degrades to reaper reconciliation, not request failure.
+  Transport failures on confirm/release are logged at Warn, span-recorded and **never propagated**,
+  so a tracer outage during this window never fails a transaction whose balances already moved.
+  They are **not dropped**, though: the failed transition is handed to
+  `transaction_reservation_retry.go`, which redelivers it off the request path with exponential
+  backoff and jitter — about six minutes across twenty attempts, capped at 256 concurrent sequences
+  process-wide. The retry is safe because the tracer, not the ledger, guarantees the repeat is free:
+  a confirm settles a reservation only while it is still settleable and the row flip is guarded on
+  the status read under the lock, so re-delivering a confirm whose response was lost moves no counter
+  twice.
+
+  The budget deliberately outlasts the tracer's own five-minute hold, because a confirm that arrives
+  after the hold expired is still worth delivering — the tracer counts the spend without disturbing
+  the capacity its expiry sweep already returned.
+
+  Two failures remain and both are reported at Error naming the transaction, the reservation and the
+  amount: a sequence that exhausts its budget, and a transition turned away because the concurrency
+  cap is full. The expiry sweep is no longer the durability story for a confirm; it is the backstop
+  for the CAPACITY only, and it returns capacity without ever counting the spend.
+
+  Residual, and deliberately not solved here: the retry is in-process, so a ledger restart with
+  sequences in flight loses them. Closing that needs durable state for the pending transition (the
+  `outbox` primitives in lib-commons, or reservation state on the transaction row) plus a sweeper —
+  a persistence decision, not a defect fix.
 
 Net: the tracer can stay a small replica set and tolerate occasional saturation on the post-commit path,
 while the pre-commit reserve path is the only latency-sensitive RPC — which is what co-scheduling (§2)


### PR DESCRIPTION
## What changed

Eleven commits, one per finding, all on the spending-limit path between the
Midaz ledger and Tracer. Every commit builds and tests standalone, because this
org merges with merge commits and never squashes.

### The customer-visible failure

A customer could be **denied inside their own spending limit**, or spend **past
it**, depending on which of these fired.

1. **A replayed reserve returned a handle matching zero rows.** The ledger's
   later confirm then failed `NotFound`, so a committed spend was never counted
   against the cap. The reserve now returns the owning row.
2. **The synchronous limit check ignored held capacity.** A customer with holds
   already in place was measured as if they had none, so the check allowed more
   than the cap.
3. **The reservation reaper only ran in one of the two boot modes.** In the
   other, expired holds accumulated forever and the customer stayed denied
   inside their limit.
4. **Reservation expiry could be skipped silently.** It is now enforced unless
   an operator explicitly disables it.
5. **A spend confirmed after the sweep released its hold was discarded and
   reported as a success.** That is free headroom: on a cap of 1000 with a hold
   of 400, the 400 came back and the spend was never counted.
6. **A confirmation the ledger could not deliver was tried once and forgotten**,
   at Warn, with no transaction and no amount in the line. The ledger now keeps
   offering the confirmation for about six minutes, off the request path, so the
   money path never waits on Tracer. A confirmation that genuinely cannot be
   placed is named at Error with the transaction, the reservation, the amount and
   the asset — and so is every confirmation still owed when the ledger process
   shuts down, which a rolling deploy does routinely and which previously
   produced no log line at all.

### One finding stays PARTIAL, deliberately

Both halves of the confirm finding are closed: the confirm is no longer
attempted once, and no longer lost silently. **Durable** it is not. The retry
lives in the process, so a ledger restart mid-sequence still loses the confirm —
loudly now, and a `SIGKILL` skips even the report.

Closing that needs a per-tenant table and a seventh background worker, which is
an architecture decision, not an implementation one. The recommendation is the
outbox pattern, with two alternatives costed, written up in the findings
registry rather than guessed at here.

### Two corrections found by review

- The operator messages the retrier emits were confirm-shaped and were being
  emitted verbatim for a lost **release**, where the consequence runs the other
  way: capacity stuck held, not an uncounted spend. An operator paged on that
  would have chased the wrong remediation. Two tests now hold the two shapes
  apart.
- The claim that the retry budget outlasts the hold was true for the five-minute
  direct hold and false for the thirty-day pending one. The claim and its test
  are scoped, and the pending case is documented as a residual whose direction is
  the safe one.

## Docs debt this creates for us

Three environment variables on the Tracer reference page are wrong or missing
and will be corrected in the documentation repo, not here:
`RESERVATION_REAPER_ENABLED` (default `true`) and
`RESERVATION_REAPER_INTERVAL_SECONDS` (default `30`, range 1–3600) are absent,
and `RESERVATION_LONG_LIVED_TTL_HOURS` is documented with the wrong default. The
page also says an expiry is only recorded, and it must say that a spend
confirmed after expiry is still counted.

## Verification

Build, `go vet`, `gofmt`, the full `./components/ledger/... ./pkg/...` suite,
`-race` on command and bootstrap, three consecutive race runs over the fifteen
new tests with no flake, the Tracer suite unregressed, and golangci-lint v2.13.2
across the whole ledger at 0 issues.

Every behaviour change was proven by direction, not by assertion: the production
change was reverted in the working tree, the test was confirmed red, and the
change restored. The measured before and after for each is in the commit bodies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Failed reservation confirmations and releases are retried asynchronously with bounded backoff, improving delivery after timeouts or temporary failures.
  - Late confirmations remain idempotent, including after reservations expire.
  - Shutdown reporting identifies reservation transitions that could not be completed.

- **Bug Fixes**
  - Capacity checks now include both active usage and reserved capacity.
  - Replayed reservations no longer duplicate capacity holds.
  - Expired confirmations correctly restore counted usage without double-counting.

- **Configuration**
  - Reservation cleanup is enabled by default, with validated sweep intervals.

- **Documentation**
  - Updated guidance describes asynchronous retries, expiration handling, and restart behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->