### PR TITLE
fix(ledger): propagate balance allow-flags to cache

### DIFF
--- a/components/ledger/internal/adapters/http/in/balance_handler_test.go
+++ b/components/ledger/internal/adapters/http/in/balance_handler_test.go
@@ -521,6 +521,11 @@ func TestUpdateBalance_Success(t *testing.T) {
 	}, nil).Times(1)
 	redisRepo.EXPECT().Get(gomock.Any(), gomock.Any()).Return("", nil).AnyTimes()
 
+	// An allow-flags PATCH propagates the new flags to the cached balance blob
+	// before the response is written; the command layer fails closed on error.
+	redisRepo.EXPECT().UpdateBalanceCacheAllowFlags(gomock.Any(), orgID, ledgerID, "@user1#default",
+		testutils.Ptr(false), testutils.Ptr(true)).Return(nil).Times(1)
+
 	handler := &BalanceHandler{Command: &command.UseCase{BalanceRepo: balanceRepo, TransactionRedisRepo: redisRepo}}
 
 	app := buildHumaBalanceApp(t, handler, true)

--- a/components/ledger/internal/adapters/redis/transaction/consumer.redis.go
+++ b/components/ledger/internal/adapters/redis/transaction/consumer.redis.go
@@ -45,17 +45,22 @@ var updateBalanceSettingsLua string
 //go:embed scripts/update_balance_blocked.lua
 var updateBalanceBlockedLua string
 
-// balanceAtomicScript, claimBalanceSyncScript, updateBalanceSettingsScript, and
-// updateBalanceBlockedScript are built once at package init. redis.NewScript
-// computes the source SHA1 eagerly, so hoisting these out of the per-call hot
-// paths (runBalanceAtomicScript, GetBalanceSyncKeys, GetBalanceSyncKeysLegacy,
-// UpdateBalanceCacheSettings, UpdateBalanceCacheBlocked) avoids re-hashing on
+//go:embed scripts/update_balance_allow_flags.lua
+var updateBalanceAllowFlagsLua string
+
+// balanceAtomicScript, claimBalanceSyncScript, updateBalanceSettingsScript,
+// updateBalanceBlockedScript, and updateBalanceAllowFlagsScript are built once
+// at package init. redis.NewScript computes the source SHA1 eagerly, so
+// hoisting these out of the per-call hot paths (runBalanceAtomicScript,
+// GetBalanceSyncKeys, GetBalanceSyncKeysLegacy, UpdateBalanceCacheSettings,
+// UpdateBalanceCacheBlocked, UpdateBalanceCacheAllowFlags) avoids re-hashing on
 // every invocation. *redis.Script is safe for concurrent use.
 var (
-	balanceAtomicScript         = redis.NewScript(balanceAtomicOperationLua)
-	claimBalanceSyncScript      = redis.NewScript(claimBalanceSyncKeysLua)
-	updateBalanceSettingsScript = redis.NewScript(updateBalanceSettingsLua)
-	updateBalanceBlockedScript  = redis.NewScript(updateBalanceBlockedLua)
+	balanceAtomicScript           = redis.NewScript(balanceAtomicOperationLua)
+	claimBalanceSyncScript        = redis.NewScript(claimBalanceSyncKeysLua)
+	updateBalanceSettingsScript   = redis.NewScript(updateBalanceSettingsLua)
+	updateBalanceBlockedScript    = redis.NewScript(updateBalanceBlockedLua)
+	updateBalanceAllowFlagsScript = redis.NewScript(updateBalanceAllowFlagsLua)
 )
 
 //go:embed scripts/remove_balance_sync_keys_batch.lua
@@ -189,6 +194,19 @@ type RedisRepository interface {
 	// transactional state (Available, OnHold, Version, OverdraftUsed) is
 	// preserved; the key is never deleted.
 	UpdateBalanceCacheBlocked(ctx context.Context, organizationID, ledgerID uuid.UUID, cacheKeys []string, blocked bool) error
+	// UpdateBalanceCacheAllowFlags rewrites the AllowSending/AllowReceiving
+	// flags in place on the cached blob of one balance ("alias#key") in a
+	// single atomic Lua EVAL. Each flag is applied only when its pointer is
+	// non-nil, so a PATCH carrying one flag leaves the other as cached. Live
+	// transactional state (Available, OnHold, Version, OverdraftUsed) is
+	// preserved; the key is never deleted.
+	//
+	// Both pointers nil is a no-op that never reaches Redis. An absent key is
+	// a no-op too — the on-demand hydration covers it with the freshly
+	// persisted value on the next miss. A blob the script cannot decode is
+	// reported but not an error: the atomic script cannot decode it either, so
+	// it approves no transaction.
+	UpdateBalanceCacheAllowFlags(ctx context.Context, organizationID, ledgerID uuid.UUID, cacheKey string, allowSending, allowReceiving *bool) error
 	// CreateAccountBlockExceptions writes a batch of single-use account-block
 	// exceptions, one key per exception with its own native Redis expiry. The
 	// cache is the exception's COMPLETE storage: there is no table, no sweeper
@@ -1912,6 +1930,110 @@ func parseBlockedUpdateResult(result any) (written, corrupt int64, err error) {
 	}
 
 	return written, corrupt, nil
+}
+
+// resolveAllowFlagArg maps an optional allow flag onto the tri-state ARGV value
+// scripts/update_balance_allow_flags.lua expects: -1 keeps the cached value
+// (the flag was not part of the PATCH), 0 writes false, 1 writes true.
+func resolveAllowFlagArg(flag *bool) int {
+	if flag == nil {
+		return -1
+	}
+
+	return boolToInt(*flag)
+}
+
+// UpdateBalanceCacheAllowFlags applies an allow-flags PATCH to the cached
+// balance JSON blob in a single atomic Lua EVAL, preserving the live
+// transactional state (Available, OnHold, Version, OverdraftUsed) that the
+// balance atomic script may have mutated but not yet flushed to PostgreSQL.
+//
+// The mutation runs inside scripts/update_balance_allow_flags.lua for the same
+// reason the settings and blocked rewrites do: Redis serializes EVAL
+// execution, so this write and any concurrent balance_atomic_operation.lua
+// debit/credit on the same key can never interleave.
+//
+// Flow:
+//  1. Resolve each flag pointer into its tri-state ARGV value
+//     (resolveAllowFlagArg); both nil short-circuits without touching Redis.
+//  2. EVAL the script against the tenant-prefixed internal key.
+//  3. Result 1 committed; 0 is a cache miss (key absent) and a no-op — the
+//     next transaction's SETNX loads the just-persisted flags from
+//     PostgreSQL; -2 means the cached value was not valid JSON.
+//
+// A corrupt blob is reported at Warn and NOT returned as an error: the
+// transaction path decodes the same blob with cjson and fails on it, so a blob
+// this script cannot rewrite cannot approve a transaction either — failing the
+// PATCH would block the operator without buying any enforcement. Every other
+// failure (tenant key, client, EVAL, cast) is returned so the fail-closed
+// caller can reject the PATCH.
+func (rr *RedisConsumerRepository) UpdateBalanceCacheAllowFlags(ctx context.Context, organizationID, ledgerID uuid.UUID, cacheKey string, allowSending, allowReceiving *bool) error {
+	if allowSending == nil && allowReceiving == nil {
+		return nil
+	}
+
+	logger, tracer, _, _ := libObservability.NewTrackingFromContext(ctx)
+
+	ctx, span := tracer.Start(ctx, "redis.update_balance_cache_allow_flags")
+	defer span.End()
+
+	span.SetAttributes(
+		attribute.String("app.request.organization_id", organizationID.String()),
+		attribute.String("app.request.ledger_id", ledgerID.String()),
+		attribute.Bool("app.request.has_allow_sending", allowSending != nil),
+		attribute.Bool("app.request.has_allow_receiving", allowReceiving != nil),
+	)
+
+	internalKey := utils.BalanceInternalKey(organizationID, ledgerID, cacheKey)
+
+	prefixedKey, err := tenantKeyFromContextOrError(ctx, internalKey)
+	if err != nil {
+		libOpentelemetry.HandleSpanError(span, "Failed to namespace balance cache key", err)
+		logger.Log(ctx, libLog.LevelError, "Failed to namespace balance cache key", libLog.Err(err))
+
+		return err
+	}
+
+	rds, err := rr.conn.GetClient(ctx)
+	if err != nil {
+		libOpentelemetry.HandleSpanError(span, "Failed to get redis client", err)
+		logger.Log(ctx, libLog.LevelError, "Failed to get Redis client", libLog.Err(err))
+
+		return err
+	}
+
+	ttlSeconds := strconv.FormatInt(int64(balanceCacheSettingsTTL/time.Second), 10)
+
+	result, err := updateBalanceAllowFlagsScript.Run(ctx, rds, []string{prefixedKey},
+		resolveAllowFlagArg(allowSending), resolveAllowFlagArg(allowReceiving), ttlSeconds).Result()
+	if err != nil {
+		libOpentelemetry.HandleSpanError(span, "Failed to run allow flags update script on redis", err)
+		logger.Log(ctx, libLog.LevelError, "Failed to run allow flags update script on Redis", libLog.Err(err))
+
+		return err
+	}
+
+	scriptResult, ok := result.(int64)
+	if !ok {
+		castErr := fmt.Errorf("unexpected result type from allow flags update script: %T", result)
+		libOpentelemetry.HandleSpanError(span, "Unexpected result type from allow flags update script", castErr)
+		logger.Log(ctx, libLog.LevelError, "Unexpected result type from allow flags update script", libLog.Err(castErr))
+
+		return castErr
+	}
+
+	switch scriptResult {
+	case 1:
+		logger.Log(ctx, libLog.LevelDebug, "Balance cache allow flags updated in place")
+	case 0:
+		logger.Log(ctx, libLog.LevelDebug, "Balance cache miss on allow flags update (no-op)")
+	default:
+		span.SetAttributes(attribute.Bool("db.balance_blob_corrupt", true))
+		logger.Log(ctx, libLog.LevelWarn, "Corrupt cached balance blob skipped on allow flags update",
+			libLog.Int("script_result", int(scriptResult)))
+	}
+
+	return nil
 }
 
 // GetBalancesByKeys retrieves multiple balance values using MGET.

--- a/components/ledger/internal/adapters/redis/transaction/consumer.redis_mock.go
+++ b/components/ledger/internal/adapters/redis/transaction/consumer.redis_mock.go
@@ -116,6 +116,21 @@ func (mr *MockRedisRepositoryMockRecorder) Get(ctx, key any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockRedisRepository)(nil).Get), ctx, key)
 }
 
+// GetAccountBlockException mocks base method.
+func (m *MockRedisRepository) GetAccountBlockException(ctx context.Context, organizationID, ledgerID, exceptionID uuid.UUID) (*mmodel.AccountBlockExceptionRedis, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetAccountBlockException", ctx, organizationID, ledgerID, exceptionID)
+	ret0, _ := ret[0].(*mmodel.AccountBlockExceptionRedis)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetAccountBlockException indicates an expected call of GetAccountBlockException.
+func (mr *MockRedisRepositoryMockRecorder) GetAccountBlockException(ctx, organizationID, ledgerID, exceptionID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAccountBlockException", reflect.TypeOf((*MockRedisRepository)(nil).GetAccountBlockException), ctx, organizationID, ledgerID, exceptionID)
+}
+
 // GetBalanceSyncKeys mocks base method.
 func (m *MockRedisRepository) GetBalanceSyncKeys(ctx context.Context, limit int64) ([]SyncKey, error) {
 	m.ctrl.T.Helper()
@@ -144,21 +159,6 @@ func (m *MockRedisRepository) GetBalanceSyncKeysLegacy(ctx context.Context, limi
 func (mr *MockRedisRepositoryMockRecorder) GetBalanceSyncKeysLegacy(ctx, limit any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBalanceSyncKeysLegacy", reflect.TypeOf((*MockRedisRepository)(nil).GetBalanceSyncKeysLegacy), ctx, limit)
-}
-
-// GetAccountBlockException mocks base method.
-func (m *MockRedisRepository) GetAccountBlockException(ctx context.Context, organizationID, ledgerID, exceptionID uuid.UUID) (*mmodel.AccountBlockExceptionRedis, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetAccountBlockException", ctx, organizationID, ledgerID, exceptionID)
-	ret0, _ := ret[0].(*mmodel.AccountBlockExceptionRedis)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetAccountBlockException indicates an expected call of GetAccountBlockException.
-func (mr *MockRedisRepositoryMockRecorder) GetAccountBlockException(ctx, organizationID, ledgerID, exceptionID any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAccountBlockException", reflect.TypeOf((*MockRedisRepository)(nil).GetAccountBlockException), ctx, organizationID, ledgerID, exceptionID)
 }
 
 // GetBalancesByKeys mocks base method.
@@ -379,6 +379,20 @@ func (m *MockRedisRepository) SetNX(ctx context.Context, key, value string, ttl 
 func (mr *MockRedisRepositoryMockRecorder) SetNX(ctx, key, value, ttl any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetNX", reflect.TypeOf((*MockRedisRepository)(nil).SetNX), ctx, key, value, ttl)
+}
+
+// UpdateBalanceCacheAllowFlags mocks base method.
+func (m *MockRedisRepository) UpdateBalanceCacheAllowFlags(ctx context.Context, organizationID, ledgerID uuid.UUID, cacheKey string, allowSending, allowReceiving *bool) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateBalanceCacheAllowFlags", ctx, organizationID, ledgerID, cacheKey, allowSending, allowReceiving)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateBalanceCacheAllowFlags indicates an expected call of UpdateBalanceCacheAllowFlags.
+func (mr *MockRedisRepositoryMockRecorder) UpdateBalanceCacheAllowFlags(ctx, organizationID, ledgerID, cacheKey, allowSending, allowReceiving any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateBalanceCacheAllowFlags", reflect.TypeOf((*MockRedisRepository)(nil).UpdateBalanceCacheAllowFlags), ctx, organizationID, ledgerID, cacheKey, allowSending, allowReceiving)
 }
 
 // UpdateBalanceCacheBlocked mocks base method.

--- a/components/ledger/internal/adapters/redis/transaction/consumer_allow_flags_update_test.go
+++ b/components/ledger/internal/adapters/redis/transaction/consumer_allow_flags_update_test.go
@@ -1,0 +1,57 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package redis
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestResolveAllowFlagArg locks the tri-state ARGV contract of
+// scripts/update_balance_allow_flags.lua: an absent flag keeps the cached
+// value, a present one writes its boolean.
+func TestResolveAllowFlagArg(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil keeps the cached value", func(t *testing.T) {
+		t.Parallel()
+
+		assert.Equal(t, -1, resolveAllowFlagArg(nil))
+	})
+
+	t.Run("false writes 0", func(t *testing.T) {
+		t.Parallel()
+
+		flag := false
+
+		assert.Equal(t, 0, resolveAllowFlagArg(&flag))
+	})
+
+	t.Run("true writes 1", func(t *testing.T) {
+		t.Parallel()
+
+		flag := true
+
+		assert.Equal(t, 1, resolveAllowFlagArg(&flag))
+	})
+}
+
+// TestUpdateBalanceCacheAllowFlags_BothNilIsNoop pins the entry guard: a call
+// carrying neither flag returns before any Redis interaction. The repository
+// holds a nil connection here, so reaching the client would panic — the test
+// passing IS the proof that Redis is never touched.
+func TestUpdateBalanceCacheAllowFlags_BothNilIsNoop(t *testing.T) {
+	t.Parallel()
+
+	rr := &RedisConsumerRepository{}
+
+	err := rr.UpdateBalanceCacheAllowFlags(context.Background(), uuid.New(), uuid.New(), "@cash#default", nil, nil)
+
+	require.NoError(t, err)
+}

--- a/components/ledger/internal/adapters/redis/transaction/scripts/update_balance_allow_flags.lua
+++ b/components/ledger/internal/adapters/redis/transaction/scripts/update_balance_allow_flags.lua
@@ -1,0 +1,66 @@
+-- update_balance_allow_flags.lua
+-- Applies an allow-flags PATCH (AllowSending / AllowReceiving) to a cached
+-- balance JSON blob in one atomic step. Redis serializes EVAL execution, so
+-- this can never interleave with a concurrent balance_atomic_operation.lua
+-- debit/credit on the same key — there is no GET-then-SET window to race.
+--
+-- The blob is mutated via the same cjson.decode -> mutate -> cjson.encode
+-- round trip balance_atomic_operation.lua performs on every transaction,
+-- preserving live transactional state (Available, OnHold, Version,
+-- OverdraftUsed) that may be ahead of PostgreSQL. Never DEL: deleting would
+-- discard those pending write-behind deltas.
+--
+-- Each flag is tri-state so a PATCH carrying only one of them leaves the
+-- other exactly as it is on the blob:
+--   -1 = keep (field untouched, aliases included)
+--    0 = false
+--    1 = true
+--
+-- KEYS[1] = balance key (already tenant-prefixed by Go)
+-- ARGV[1] = AllowSending tri-state (-1/0/1)
+-- ARGV[2] = AllowReceiving tri-state (-1/0/1)
+-- ARGV[3] = TTL in seconds
+--
+-- Returns:
+--    1  = written
+--    0  = key absent (no-op; the next transaction reloads from PostgreSQL)
+--   -2  = cached value was not valid JSON (corrupt blob)
+
+local allowSending = tonumber(ARGV[1])
+local allowReceiving = tonumber(ARGV[2])
+local ttl = tonumber(ARGV[3])
+
+local cur = redis.call('GET', KEYS[1])
+
+if not cur then
+    return 0
+end
+
+local ok, balance = pcall(cjson.decode, cur)
+
+if not ok then
+    return -2
+end
+
+-- A flag being written drops its legacy camelCase aliases first, so the blob
+-- carries a single authoritative key. A flag being kept is left completely
+-- alone: dropping an alias without writing a replacement would erase the only
+-- copy a legacy Go-marshalled blob has. Leaving it is harmless — Go unmarshals
+-- case-insensitively and the atomic script never reads the allow flags.
+if allowSending ~= -1 then
+    balance.allowSending = nil
+    balance.allowsending = nil
+
+    balance.AllowSending = allowSending
+end
+
+if allowReceiving ~= -1 then
+    balance.allowReceiving = nil
+    balance.allowreceiving = nil
+
+    balance.AllowReceiving = allowReceiving
+end
+
+redis.call('SET', KEYS[1], cjson.encode(balance), 'EX', ttl)
+
+return 1

--- a/components/ledger/internal/services/command/scope_protection_test.go
+++ b/components/ledger/internal/services/command/scope_protection_test.go
@@ -287,6 +287,12 @@ func TestBalanceUpdate_AllowsNormalBalance(t *testing.T) {
 		Return("", nil).
 		Times(1)
 
+	// An allow-flags PATCH propagates the new flags to the cached blob.
+	mockRedisRepo.EXPECT().
+		UpdateBalanceCacheAllowFlags(gomock.Any(), orgID, ledgerID, "@normal#default", gomock.Any(), nil).
+		Return(nil).
+		Times(1)
+
 	uc := UseCase{
 		BalanceRepo:          mockBalanceRepo,
 		TransactionRedisRepo: mockRedisRepo,

--- a/components/ledger/internal/services/command/update_balance.go
+++ b/components/ledger/internal/services/command/update_balance.go
@@ -217,6 +217,12 @@ func (uc *UseCase) Update(ctx context.Context, organizationID, ledgerID, balance
 		return nil, err
 	}
 
+	if update.AllowSending != nil || update.AllowReceiving != nil {
+		if err := uc.propagateBalanceAllowFlagsToCache(ctx, span, logger, organizationID, ledgerID, balance, update); err != nil {
+			return nil, err
+		}
+	}
+
 	// Publish events for both branches in order: the companion's
 	// config_changed{overdraft_enabled} (when ensureOverdraftBalance
 	// materialized a fresh row), then the parent's
@@ -229,29 +235,7 @@ func (uc *UseCase) Update(ctx context.Context, organizationID, ledgerID, balance
 
 	uc.emitBalanceConfigChangedEvent(ctx, span, logger, balance, events.BalanceConfigChangeTypeSettingsUpdated)
 
-	// Overlay amounts from Redis cache when available to ensure freshest values
-	internalKey := utils.BalanceInternalKey(organizationID, ledgerID, balance.Alias+"#"+balance.Key)
-
-	value, rerr := uc.TransactionRedisRepo.Get(ctx, internalKey)
-	if rerr != nil {
-		libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Failed to get balance cache value on redis", rerr)
-		logger.Log(ctx, libLog.LevelWarn, "Failed to get balance cache value on Redis", libLog.Err(rerr))
-	}
-
-	if value != "" {
-		cached := mmodel.BalanceRedis{}
-		if uerr := json.Unmarshal([]byte(value), &cached); uerr != nil {
-			logger.Log(ctx, libLog.LevelWarn, "Failed to unmarshal balance cache value", libLog.Err(uerr))
-		} else {
-			balance.Available = cached.Available
-			balance.OnHold = cached.OnHold
-			balance.Version = cached.Version
-
-			if ou, perr := decimal.NewFromString(cached.OverdraftUsed); perr == nil {
-				balance.OverdraftUsed = ou
-			}
-		}
-	}
+	uc.overlayBalanceAmountsFromCache(ctx, span, logger, organizationID, ledgerID, balance)
 
 	// When the caller updates overdraft/scope Settings, rewrite ONLY those
 	// fields in the cached JSON blob in place. Deleting the key would discard
@@ -265,9 +249,9 @@ func (uc *UseCase) Update(ctx context.Context, organizationID, ledgerID, balance
 	// above. A cache miss inside the repo is a no-op — the next transaction
 	// will load the freshly-persisted settings via the Lua SETNX path.
 	//
-	// Non-settings updates (e.g. AllowSending, AllowReceiving) do not trigger
-	// this rewrite: those fields are not part of the settings contract this
-	// method guards, and leaving the cache alone avoids a useless round-trip.
+	// AllowSending/AllowReceiving are not part of the settings contract this
+	// rewrite guards; they travel through their own fail-closed propagation
+	// above (propagateBalanceAllowFlagsToCache).
 	//
 	// This is best-effort: the PostgreSQL write is already durable, so a
 	// Redis-side failure here is logged and swallowed. A subsequent cache
@@ -281,6 +265,71 @@ func (uc *UseCase) Update(ctx context.Context, organizationID, ledgerID, balance
 	}
 
 	return balance, nil
+}
+
+// overlayBalanceAmountsFromCache overlays amounts from the Redis cache onto a
+// balance when available, to ensure the freshest values: the cached blob is the
+// live transactional state the Lua atomic script mutates, and may be ahead of
+// PostgreSQL while write-behind sync is pending.
+//
+// Best-effort: a Redis read failure or an undecodable blob leaves the
+// PostgreSQL-derived values in place and is logged at Warn.
+func (uc *UseCase) overlayBalanceAmountsFromCache(ctx context.Context, span trace.Span, logger libLog.Logger, organizationID, ledgerID uuid.UUID, balance *mmodel.Balance) {
+	internalKey := utils.BalanceInternalKey(organizationID, ledgerID, balance.Alias+"#"+balance.Key)
+
+	value, rerr := uc.TransactionRedisRepo.Get(ctx, internalKey)
+	if rerr != nil {
+		libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Failed to get balance cache value on redis", rerr)
+		logger.Log(ctx, libLog.LevelWarn, "Failed to get balance cache value on Redis", libLog.Err(rerr))
+	}
+
+	if value == "" {
+		return
+	}
+
+	cached := mmodel.BalanceRedis{}
+	if uerr := json.Unmarshal([]byte(value), &cached); uerr != nil {
+		logger.Log(ctx, libLog.LevelWarn, "Failed to unmarshal balance cache value", libLog.Err(uerr))
+
+		return
+	}
+
+	balance.Available = cached.Available
+	balance.OnHold = cached.OnHold
+	balance.Version = cached.Version
+
+	if ou, perr := decimal.NewFromString(cached.OverdraftUsed); perr == nil {
+		balance.OverdraftUsed = ou
+	}
+}
+
+// propagateBalanceAllowFlagsToCache rewrites AllowSending/AllowReceiving in
+// place on the balance's cached blob after a PATCH that carries either flag.
+// PostgreSQL was updated first (source of truth); the rewrite runs as ONE
+// atomic Lua EVAL, preserving live transactional state pending write-behind
+// sync (no DEL). Only the flags present in the payload are written — the
+// repository resolves the absent ones to "keep".
+//
+// Fail-closed: the transaction pre-validation reads the flags from the cached
+// blob, which takes precedence over PostgreSQL and has its TTL renewed by every
+// operation — on a hot balance a stale flag never self-heals. Returning success
+// with a stale cache would therefore keep a frozen balance transacting, so the
+// error fails the PATCH; the client's retry is idempotent and heals the blob.
+// A cache miss and a blob the script cannot decode are not errors (neither can
+// approve a transaction on the old flags). These failures are TECHNICAL
+// (infrastructure, not caller error), so they flip the span red and log at
+// Error for operator attention.
+func (uc *UseCase) propagateBalanceAllowFlagsToCache(ctx context.Context, span trace.Span, logger libLog.Logger, organizationID, ledgerID uuid.UUID, balance *mmodel.Balance, update mmodel.UpdateBalance) error {
+	cacheKey := balance.Alias + "#" + balance.Key
+
+	if err := uc.TransactionRedisRepo.UpdateBalanceCacheAllowFlags(ctx, organizationID, ledgerID, cacheKey, update.AllowSending, update.AllowReceiving); err != nil {
+		libOpentelemetry.HandleSpanError(span, "Failed to update balance cache allow flags", err)
+		logger.Log(ctx, libLog.LevelError, "Failed to update balance cache allow flags on Redis", libLog.Err(err))
+
+		return err
+	}
+
+	return nil
 }
 
 // emitBalanceConfigChangedEvent publishes the balance.config_changed

--- a/components/ledger/internal/services/command/update_balance_streaming_test.go
+++ b/components/ledger/internal/services/command/update_balance_streaming_test.go
@@ -7,6 +7,7 @@ package command
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"testing"
 	"time"
 
@@ -83,6 +84,10 @@ func newUpdateBalanceStreamingTestUseCase(t *testing.T, ctrl *gomock.Controller,
 		AnyTimes()
 	mockRedis.EXPECT().
 		UpdateBalanceCacheSettings(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(nil).
+		AnyTimes()
+	mockRedis.EXPECT().
+		UpdateBalanceCacheAllowFlags(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(nil).
 		AnyTimes()
 
@@ -192,6 +197,7 @@ func TestUpdateBalance_EmitsTwoEventsOnOverdraftTransition(t *testing.T) {
 	mockRedis := txRedis.NewMockRedisRepository(ctrl)
 	mockRedis.EXPECT().Get(gomock.Any(), gomock.Any()).Return("", nil).AnyTimes()
 	mockRedis.EXPECT().UpdateBalanceCacheSettings(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	mockRedis.EXPECT().UpdateBalanceCacheAllowFlags(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 
 	uc := &UseCase{
 		BalanceRepo:          mockBalanceRepo,
@@ -230,6 +236,99 @@ func TestUpdateBalance_EmitsTwoEventsOnOverdraftTransition(t *testing.T) {
 	assert.Equal(t, "balance.config_changed", emitted[1].DefinitionKey)
 	assert.Equal(t, id, emitted[1].Subject, "second event must be for the PARENT balance")
 	assert.Equal(t, "settings_updated", payload1["changeType"])
+}
+
+// TestUpdateBalance_AllowFlagsPropagationFailureDoesNotEmit verifies the
+// fail-closed ordering: when the allow-flags cache propagation fails, the
+// balance.config_changed event must NOT be emitted for that attempt — a PATCH
+// that did not take effect everywhere announces nothing.
+func TestUpdateBalance_AllowFlagsPropagationFailureDoesNotEmit(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockEmitter := pkgStreaming.NewMockEmitter()
+	fixture := defaultUpdateBalanceStreamingFixture()
+
+	mockBalanceRepo := balance.NewMockRepository(ctrl)
+	mockBalanceRepo.EXPECT().
+		Find(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(fixture.current, nil).
+		Times(1)
+	mockBalanceRepo.EXPECT().
+		Update(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(fixture.updated, nil).
+		Times(1)
+
+	mockRedis := txRedis.NewMockRedisRepository(ctrl)
+	mockRedis.EXPECT().
+		UpdateBalanceCacheAllowFlags(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(errors.New("redis unavailable")).
+		Times(1)
+
+	uc := &UseCase{
+		BalanceRepo:          mockBalanceRepo,
+		TransactionRedisRepo: mockRedis,
+		Streaming:            mockEmitter,
+	}
+
+	allowSending := false
+	update := mmodel.UpdateBalance{AllowSending: &allowSending}
+
+	out, err := uc.Update(context.Background(), uuid.New(), uuid.New(), uuid.MustParse(fixture.updated.ID), update)
+	require.Error(t, err)
+	assert.Nil(t, out)
+	assert.Empty(t, mockEmitter.Events(),
+		"propagation failure must short-circuit before balance.config_changed is emitted")
+}
+
+// TestUpdateBalance_AllowFlagsPropagationRunsBeforeEmission pins the ordering
+// on the happy path: the cache already carries the new flags by the time the
+// event announcing them goes out.
+func TestUpdateBalance_AllowFlagsPropagationRunsBeforeEmission(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockEmitter := pkgStreaming.NewMockEmitter()
+	fixture := defaultUpdateBalanceStreamingFixture()
+
+	mockBalanceRepo := balance.NewMockRepository(ctrl)
+	mockBalanceRepo.EXPECT().
+		Find(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(fixture.current, nil).
+		Times(1)
+	mockBalanceRepo.EXPECT().
+		Update(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(fixture.updated, nil).
+		Times(1)
+
+	var eventsAtPropagation int
+
+	mockRedis := txRedis.NewMockRedisRepository(ctrl)
+	mockRedis.EXPECT().
+		UpdateBalanceCacheAllowFlags(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(context.Context, uuid.UUID, uuid.UUID, string, *bool, *bool) error {
+			eventsAtPropagation = len(mockEmitter.Events())
+
+			return nil
+		}).
+		Times(1)
+	mockRedis.EXPECT().Get(gomock.Any(), gomock.Any()).Return("", nil).AnyTimes()
+
+	uc := &UseCase{
+		BalanceRepo:          mockBalanceRepo,
+		TransactionRedisRepo: mockRedis,
+		Streaming:            mockEmitter,
+	}
+
+	allowSending := false
+	update := mmodel.UpdateBalance{AllowSending: &allowSending}
+
+	out, err := uc.Update(context.Background(), uuid.New(), uuid.New(), uuid.MustParse(fixture.updated.ID), update)
+	require.NoError(t, err)
+	require.NotNil(t, out)
+
+	assert.Zero(t, eventsAtPropagation, "no event may be emitted before the cache propagation runs")
+	require.Len(t, mockEmitter.Events(), 1, "the successful PATCH still emits its config_changed event")
 }
 
 // TestUpdateBalance_NoopEmitterDoesNotPanic exercises the

--- a/components/ledger/internal/services/command/update_balance_test.go
+++ b/components/ledger/internal/services/command/update_balance_test.go
@@ -73,11 +73,19 @@ func TestUpdateBalance(t *testing.T) {
 
 	// No Settings in the update payload → the cache settings rewrite MUST NOT
 	// fire. AllowSending/AllowReceiving mutations don't touch the overdraft
-	// settings contract guarded by UpdateBalanceCacheSettings, so the cached
-	// balance JSON (including its live transactional state) is left alone.
+	// settings contract guarded by UpdateBalanceCacheSettings.
 	mockRedisRepo.EXPECT().
 		UpdateBalanceCacheSettings(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 		Times(0)
+
+	// The allow flags carried by the payload MUST reach the cached blob: the
+	// transaction guard reads them from Redis, and a hot balance renews its TTL
+	// on every operation, so a cache left alone would honour the old flags
+	// indefinitely. Only the flag actually present in the PATCH is forwarded.
+	mockRedisRepo.EXPECT().
+		UpdateBalanceCacheAllowFlags(gomock.Any(), organizationID, ledgerID, "@test#default", &allowSending, nil).
+		Return(nil).
+		Times(1)
 
 	uc := UseCase{
 		BalanceRepo:          mockBalanceRepo,
@@ -202,14 +210,19 @@ func TestUpdateBalance_RedisOverlay(t *testing.T) {
 		Return(string(cachedJSON), nil).
 		Times(1)
 
-	// No Settings in the update → the cache rewrite MUST NOT run, so the
-	// in-flight transactional snapshot held in Redis (Available=500, OnHold=50,
-	// Version=5) is neither overwritten nor deleted. This is the whole point
-	// of replacing the prior Del: preserving live state across settings-free
-	// updates.
+	// No Settings in the update → the settings rewrite MUST NOT run.
 	mockRedisRepo.EXPECT().
 		UpdateBalanceCacheSettings(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 		Times(0)
+
+	// The allow-flags rewrite runs instead, and it is an in-place mutation of
+	// the blob: the in-flight transactional snapshot held in Redis
+	// (Available=500, OnHold=50, Version=5) is neither overwritten nor deleted,
+	// which is why the flags travel through a script rather than a Del.
+	mockRedisRepo.EXPECT().
+		UpdateBalanceCacheAllowFlags(gomock.Any(), organizationID, ledgerID, "@user1#default", &allowSending, nil).
+		Return(nil).
+		Times(1)
 
 	uc := UseCase{
 		BalanceRepo:          mockBalanceRepo,
@@ -318,6 +331,12 @@ func TestUpdateBalance_CacheSettingsUpdate_UsesCompositeAliasKey(t *testing.T) {
 		Return(nil).
 		Times(1)
 
+	// A settings-only payload carries no allow flag, so the allow-flags
+	// rewrite MUST NOT run: it would renew the blob's TTL for nothing.
+	mockRedisRepo.EXPECT().
+		UpdateBalanceCacheAllowFlags(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Times(0)
+
 	uc := UseCase{
 		BalanceRepo:          mockBalanceRepo,
 		TransactionRedisRepo: mockRedisRepo,
@@ -413,6 +432,140 @@ func TestUpdateBalance_CacheSettingsUpdate_FailureIsBestEffort(t *testing.T) {
 	require.NoError(t, err, "Cache rewrite failure must not propagate — PG write is durable")
 	require.NotNil(t, result)
 	assert.Equal(t, expectedBalance.ID, result.ID)
+}
+
+// TestUpdateBalance_CacheAllowFlagsUpdate_ForwardsBothFlags pins that a PATCH
+// carrying both allow flags forwards both pointers, so neither is left to the
+// tri-state "keep" branch of the Lua script.
+func TestUpdateBalance_CacheAllowFlagsUpdate_ForwardsBothFlags(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
+	organizationID := uuid.Must(libCommons.GenerateUUIDv7())
+	ledgerID := uuid.Must(libCommons.GenerateUUIDv7())
+	balanceID := uuid.Must(libCommons.GenerateUUIDv7())
+
+	allowSending := false
+	allowReceiving := true
+
+	balanceUpdate := mmodel.UpdateBalance{
+		AllowSending:   &allowSending,
+		AllowReceiving: &allowReceiving,
+	}
+
+	expectedBalance := &mmodel.Balance{
+		ID:             balanceID.String(),
+		OrganizationID: organizationID.String(),
+		LedgerID:       ledgerID.String(),
+		Alias:          "@user1",
+		Key:            "default",
+		AllowSending:   false,
+		AllowReceiving: true,
+	}
+
+	mockBalanceRepo := balance.NewMockRepository(ctrl)
+	mockRedisRepo := redis.NewMockRedisRepository(ctrl)
+
+	mockBalanceRepo.EXPECT().
+		Find(gomock.Any(), organizationID, ledgerID, balanceID).
+		Return(expectedBalance, nil).
+		Times(1)
+
+	mockBalanceRepo.EXPECT().
+		Update(gomock.Any(), organizationID, ledgerID, balanceID, balanceUpdate).
+		Return(expectedBalance, nil).
+		Times(1)
+
+	mockRedisRepo.EXPECT().
+		Get(gomock.Any(), gomock.Any()).
+		Return("", nil).
+		Times(1)
+
+	mockRedisRepo.EXPECT().
+		UpdateBalanceCacheAllowFlags(gomock.Any(), organizationID, ledgerID, "@user1#default", &allowSending, &allowReceiving).
+		Return(nil).
+		Times(1)
+
+	uc := UseCase{
+		BalanceRepo:          mockBalanceRepo,
+		TransactionRedisRepo: mockRedisRepo,
+	}
+
+	result, err := uc.Update(context.TODO(), organizationID, ledgerID, balanceID, balanceUpdate)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, expectedBalance.ID, result.ID)
+	assert.False(t, result.AllowSending)
+	assert.True(t, result.AllowReceiving)
+}
+
+// TestUpdateBalance_CacheAllowFlagsUpdate_FailureFailsRequest pins the
+// fail-closed posture: the PostgreSQL write is already durable, but returning
+// success with a stale cached flag would let the transaction guard keep
+// approving on the old value, and a hot balance never heals on its own. The
+// client's retry re-runs the idempotent PATCH and fixes the blob.
+func TestUpdateBalance_CacheAllowFlagsUpdate_FailureFailsRequest(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
+	organizationID := uuid.Must(libCommons.GenerateUUIDv7())
+	ledgerID := uuid.Must(libCommons.GenerateUUIDv7())
+	balanceID := uuid.Must(libCommons.GenerateUUIDv7())
+
+	allowSending := false
+	balanceUpdate := mmodel.UpdateBalance{AllowSending: &allowSending}
+
+	expectedBalance := &mmodel.Balance{
+		ID:             balanceID.String(),
+		OrganizationID: organizationID.String(),
+		LedgerID:       ledgerID.String(),
+		Alias:          "@user1",
+		Key:            "default",
+	}
+
+	mockBalanceRepo := balance.NewMockRepository(ctrl)
+	mockRedisRepo := redis.NewMockRedisRepository(ctrl)
+
+	mockBalanceRepo.EXPECT().
+		Find(gomock.Any(), organizationID, ledgerID, balanceID).
+		Return(expectedBalance, nil).
+		Times(1)
+
+	mockBalanceRepo.EXPECT().
+		Update(gomock.Any(), organizationID, ledgerID, balanceID, balanceUpdate).
+		Return(expectedBalance, nil).
+		Times(1)
+
+	mockRedisRepo.EXPECT().
+		UpdateBalanceCacheAllowFlags(gomock.Any(), organizationID, ledgerID, "@user1#default", &allowSending, nil).
+		Return(errors.New("redis connection refused")).
+		Times(1)
+
+	// The overlay Get and the settings rewrite sit after the gate and MUST NOT
+	// be reached.
+	mockRedisRepo.EXPECT().
+		Get(gomock.Any(), gomock.Any()).
+		Times(0)
+	mockRedisRepo.EXPECT().
+		UpdateBalanceCacheSettings(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Times(0)
+
+	uc := UseCase{
+		BalanceRepo:          mockBalanceRepo,
+		TransactionRedisRepo: mockRedisRepo,
+	}
+
+	result, err := uc.Update(context.TODO(), organizationID, ledgerID, balanceID, balanceUpdate)
+
+	require.Error(t, err, "an allow-flags propagation failure MUST fail the PATCH")
+	assert.Nil(t, result)
+	assert.Equal(t, "redis connection refused", err.Error(),
+		"the repository error MUST surface unwrapped to the caller")
 }
 
 func TestUpdateBalances_PrimaryPath_UsesAfterDirectly(t *testing.T) {


### PR DESCRIPTION
<table border="0" cellspacing="0" cellpadding="0">
  <tr>
    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
    <td><h1>Midaz</h1></td>
  </tr>
</table>

---

## Description

A PATCH to `AllowSending`/`AllowReceiving` previously persisted only to PostgreSQL. The transaction pre-validation path reads these flags from the cached balance blob, which takes precedence over PostgreSQL and has its TTL renewed by every operation — so a stale flag on a hot balance never self-healed, and a frozen balance kept transacting.

This PR:
- Adds a dedicated Lua script that rewrites `AllowSending`/`AllowReceiving` in place on the cached balance JSON, preserving live transactional state (`Available`, `OnHold`, `Version`, `OverdraftUsed`) mutated by concurrent debit/credit scripts instead of discarding it via `DEL`.
- Wires `UpdateBalanceCacheAllowFlags` on the transaction Redis repository behind the tenant-prefixed balance key, with tri-state ARGV resolution (an absent flag keeps the cached value).
- Calls the new cache propagation from `Update` right after the PostgreSQL write and before event emission, failing the PATCH when propagation errors — PostgreSQL is already durable at that point, so returning success with a stale cache would silently keep enforcing the old flags.
- Treats a cache miss or an undecodable cached blob as a no-op rather than an error, since neither state can approve a transaction on stale flags anyway, and the client's idempotent retry heals the blob.

## Type of Change

- [ ] `feat`: New feature or capability
- [x] `fix`: Bug fix
- [ ] `perf`: Performance improvement
- [ ] `refactor`: Internal restructuring with no behavior change
- [ ] `docs`: Documentation only
- [ ] `style`: Formatting, whitespace, naming (no logic change)
- [ ] `test`: Adding or updating tests
- [ ] `ci`: CI pipeline or workflow changes
- [ ] `build`: Build system, Dockerfile, Go module dependencies
- [ ] `chore`: Maintenance, config, tooling
- [ ] `revert`: Reverts a previous commit
- [ ] `BREAKING CHANGE`: Consumers must update their integration

## Breaking Changes

None to the API contract. Behavior change: a PATCH to allow-flags that succeeds in PostgreSQL but fails to propagate to the cache now returns an error instead of a silent success — this fail-closed behavior is the fix's intent, since the alternative is enforcing stale flags on a hot balance.

## Testing

- [x] `make test` passes (ran targeted unit tests for the changed packages: `internal/services/command`, `internal/adapters/redis/transaction`, `internal/adapters/http/in` — all green)
- [x] `make test-int` passes if integration paths are exercised
- [x] `make lint` passes
- [x] `make sec` and `make vulncheck` pass

**Test evidence / Actions run:** Local `go test` run against changed packages passed; `make lint` not run locally (local `golangci-lint` binary is built with go1.26, older than this repo's pinned go1.27.0 — CI runs the pinned version).

## Architectural Checklist

- [x] No `panic()` in production paths
- [x] Timestamps use `time.Now().UTC()`
- [x] Errors wrapped with `%w`
- [x] Handlers stay thin (parse, validate, call service)
- [x] Infrastructure concerns kept in `internal/bootstrap`

## Related Issues

Closes #

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Balance updates now keep cached balances synchronized with sending and receiving permission changes.
  - Partial permission updates preserve existing values for permissions not included.
  - Cached balance data retains other transaction details when permissions are updated.
  - Permission-cache failures prevent completion events from being emitted, avoiding incomplete updates.
  - Settings-only balance updates continue without modifying cached permission values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->